### PR TITLE
fix(network): evict stale Zakura peer on restart within the idle window

### DIFF
--- a/.github/workflows/checkpoint-sync-bench.yml
+++ b/.github/workflows/checkpoint-sync-bench.yml
@@ -17,7 +17,7 @@ on:
       build_ref:
         description: "Git branch/tag/SHA to build on the host (cached by commit SHA). Primary mode."
         required: false
-        default: "ironwood-main"
+        default: "main"
       force_rebuild:
         description: "Rebuild even if a binary for this commit SHA is already cached"
         type: boolean

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
   # night, and on demand. Pushes to short-lived dev branches no longer trigger
   # it (it is not a merge gate).
   push:
-    branches: [ironwood-main, "release/**"]
+    branches: [main, "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/deploy-zcashd-compat.yml
+++ b/.github/workflows/deploy-zcashd-compat.yml
@@ -7,7 +7,7 @@ on:
         description: "Git ref to build and deploy"
         required: true
         type: string
-        default: ironwood-main
+        default: main
       host:
         description: "Target host or IP address"
         required: true

--- a/.github/workflows/gitbook.yml
+++ b/.github/workflows/gitbook.yml
@@ -3,7 +3,7 @@ name: Valarbook
 on:
   workflow_dispatch:
   push:
-    branches: [ironwood-main]
+    branches: [main]
     paths:
       - book/valarbook/**
       - .github/workflows/gitbook.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -13,7 +13,7 @@ on:
       - supply-chain/**
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/status-checks.patch.yml
+++ b/.github/workflows/status-checks.patch.yml
@@ -7,7 +7,7 @@ name: Status Check Patch
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths-ignore:
       # This MUST be an exact inverse of paths in lint.yml, tests-unit.yml, and test-crates.yml
       # to ensure mutual exclusion - only one set of workflows runs

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -2,7 +2,7 @@ name: Test Crate Build
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -12,7 +12,7 @@ on:
       - .github/workflows/test-crates.yml
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -2,7 +2,7 @@ name: Test Docker Config
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - "**/*.rs"
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - "**/*.rs"
@@ -12,7 +12,7 @@ on:
       - .github/workflows/tests-unit.yml
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -25,7 +25,7 @@ on:
       target_ref:
         description: "Fork branch to target"
         type: string
-        default: ironwood-main
+        default: main
       candidate_pr:
         description: "Optional upstream PR number override for debugging"
         type: string
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -87,7 +87,7 @@ jobs:
           SOURCE_REPO: ${{ inputs.source_repo || 'ZcashFoundation/zebra' }}
           SOURCE_REF: ${{ inputs.source_ref || 'main' }}
           TARGET_REPO: ${{ github.repository }}
-          TARGET_REF: ${{ inputs.target_ref || 'ironwood-main' }}
+          TARGET_REF: ${{ inputs.target_ref || 'main' }}
           CANDIDATE_PR: ${{ inputs.candidate_pr || '' }}
           LIMIT: ${{ inputs.limit || '25' }}
         run: |
@@ -126,7 +126,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -188,7 +188,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -215,7 +215,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -245,7 +245,7 @@ jobs:
         id: create-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UPSTREAM_SYNC_TARGET_REF: ${{ inputs.target_ref || 'ironwood-main' }}
+          UPSTREAM_SYNC_TARGET_REF: ${{ inputs.target_ref || 'main' }}
         run: .github/scripts/upstream-sync-run.sh create-human-review-pr
 
       - name: Verify PR state
@@ -272,7 +272,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -322,7 +322,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.pr-meta.outputs.branch }}
-          base: ${{ inputs.target_ref || 'ironwood-main' }}
+          base: ${{ inputs.target_ref || 'main' }}
           title: ${{ steps.pr-meta.outputs.title }}
           body-path: .github/upstream-sync/work/pr-body.md
           commit-message: ${{ steps.pr-meta.outputs.title }}

--- a/.github/workflows/zakura-e2e.yml
+++ b/.github/workflows/zakura-e2e.yml
@@ -14,11 +14,11 @@ name: Zakura E2E
 on:
   # No `paths:` filter here on purpose — see the `changes` job for PR gating.
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "zebra-network/**"
       - "zebrad/src/components/sync/**"

--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -13,12 +13,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
-
-  schedule:
-    # Run this job every Friday at mid-day UTC
-    # This is limited to the Zebra and lightwalletd Full Sync jobs
-    - cron: 0 12 * * 5
-
   workflow_dispatch:
     inputs:
       network:
@@ -50,58 +44,6 @@ on:
         required: false
         type: boolean
         default: false
-
-  pull_request:
-    branches: [main]
-    types: [labeled, synchronize, reopened]
-
-  push:
-    # Run only on main branch updates that modify Rust code or dependencies.
-    branches:
-      - main
-    paths:
-      # code and tests
-      - "**/*.rs"
-      # hard-coded checkpoints and proptest regressions
-      - "**/*.txt"
-      # test data snapshots
-      - "**/*.snap"
-      # dependencies
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      # configuration files
-      - .cargo/config.toml
-      - "**/clippy.toml"
-      # supply chain security
-      - "**/deny.toml"
-      # workflow definitions
-      - docker/**
-      - .dockerignore
-      - .github/workflows/zfnd-ci-integration-tests-gcp.yml
-      - .github/workflows/zfnd-deploy-integration-tests-gcp.yml
-      - .github/workflows/zfnd-find-cached-disks.yml
-      - .github/workflows/zfnd-build-docker-image.yml
-
-  workflow_call:
-    inputs:
-      network:
-        default: Mainnet
-        type: string
-      regenerate-disks:
-        default: false
-        type: boolean
-      run-full-sync:
-        default: false
-        type: boolean
-      run-lwd-sync:
-        default: false
-        type: boolean
-      force_save_to_disk:
-        default: false
-        type: boolean
-      no_cache:
-        default: false
-        type: boolean
 
 permissions:
   contents: read

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,10 +1,7 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: ["**"]
+  workflow_dispatch:
 
 permissions: {}
 

--- a/zebra-network/src/zakura/handler.rs
+++ b/zebra-network/src/zakura/handler.rs
@@ -103,13 +103,23 @@ pub const DEFAULT_ZAKURA_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10)
 /// Minimum age of an incumbent Zakura connection before a duplicate connection
 /// for the same identity is allowed to evict it.
 ///
-/// Duplicates can be ordinary redial races while the incumbent is healthy and
-/// actively serving block sync. Evicting those incumbents drops in-flight body
-/// ranges and makes a fresh sync repeatedly re-download the same windows. Keep
-/// the incumbent through the transport idle timeout; genuinely dead connections
-/// are reaped by QUIC idle cleanup, and duplicate redials after that point can
-/// reclaim the slot without disturbing active transfers.
-pub const ZAKURA_DUPLICATE_EVICT_MIN_AGE: Duration = Duration::from_secs(300);
+/// A duplicate for an already-connected identity is either a brief
+/// simultaneous-open race (both directions dial at once; the incumbent is
+/// brand-new, healthy, and must be kept so the connection does not flap) or a
+/// peer that has restarted and is redialing (the incumbent is a dead, stale
+/// connection that should be evicted so the redial reclaims the slot). Age
+/// distinguishes the two: a couple of keepalive intervals is long enough to
+/// clear the simultaneous-open race but short enough that a restarted peer is
+/// not stalled.
+///
+/// This MUST stay well below [`DEFAULT_ZAKURA_QUIC_IDLE_TIMEOUT`] (and the
+/// discovery redial settle window): the whole point of evicting here is to free
+/// the slot in milliseconds instead of waiting out the ~150s idle reaper. A
+/// value at or above the idle timeout makes the eviction shortcut unreachable —
+/// the dead incumbent is reaped by the idle timeout first, so a restarted peer
+/// stalls ~150s waiting for its own dead connection, which broke pure-Zakura
+/// genesis bootstrap on restart.
+pub const ZAKURA_DUPLICATE_EVICT_MIN_AGE: Duration = Duration::from_secs(15);
 /// QUIC stream receive window used by Zakura endpoints.
 pub const DEFAULT_ZAKURA_STREAM_RECEIVE_WINDOW: u32 = 3 * 1024 * 1024;
 /// QUIC connection receive window used by Zakura endpoints.
@@ -5373,6 +5383,56 @@ mod tests {
         assert!(
             stale_incumbent.is_cancelled(),
             "a stale incumbent is evicted so the restarted peer's redial reclaims the slot",
+        );
+        assert!(
+            !newcomer.is_cancelled(),
+            "the rejected newcomer's token is never registered, so it is left to redial",
+        );
+
+        Ok(())
+    }
+
+    // Regression: a peer that restarts within the QUIC idle window (the common
+    // case — a restart takes seconds, far less than the 150s idle timeout) must
+    // still get its stale incumbent evicted promptly. The eviction shortcut
+    // exists precisely to beat the ~150s idle reaper, so its threshold must be
+    // BELOW the idle timeout; otherwise a restarted peer stalls ~150s waiting for
+    // its own dead connection to be reaped (the e2e restart-matrix genesis-
+    // bootstrap failure).
+    #[tokio::test(start_paused = true)]
+    async fn same_peer_reconnect_within_idle_window_evicts_stale_incumbent() -> Result<(), BoxError>
+    {
+        let supervisor = ZakuraSupervisorHandle::new(4);
+        let peer = test_peer(11);
+
+        // Incumbent: the peer's connection from before it restarts.
+        let incumbent = CancellationToken::new();
+        register_test_peer(&supervisor, peer.clone(), incumbent.clone()).await;
+
+        // A realistic restart gap: tens of seconds — well under the 150s QUIC
+        // idle timeout, so the dead incumbent has NOT been reaped when the peer
+        // redials with the same identity.
+        tokio::time::advance(Duration::from_secs(30)).await;
+
+        let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+        let outbound_handle = ZakuraPeerHandle::new_for_tests(peer.clone(), outbound_tx);
+        let newcomer = CancellationToken::new();
+        let registration = supervisor
+            .register(
+                peer.clone(),
+                None,
+                [peer.as_bytes()[0]; TRANSCRIPT_HASH_BYTES],
+                outbound_handle,
+                newcomer.clone(),
+                ZAKURA_CAP_LEGACY_GOSSIP | ZAKURA_CAP_HEADER_SYNC,
+            )
+            .await;
+
+        assert!(matches!(registration, ZakuraRegistration::Duplicate { .. }));
+        assert!(
+            incumbent.is_cancelled(),
+            "a peer that restarts within the idle window must have its stale \
+             incumbent evicted in seconds, not wait out the ~150s QUIC idle reaper",
         );
         assert!(
             !newcomer.is_cancelled(),


### PR DESCRIPTION
## Motivation

The Zakura e2e `restart-matrix` nightly was failing: a pure-Zakura node (`legacy_p2p=false`) restarted from scratch could not bootstrap genesis, and the harness assertion "node2 did not bootstrap genesis before height-0 restart" fired.

Root cause: production Zakura nodes keep a stable node identity across restarts (and the e2e configures node2 that way deliberately), so on restart node2 redials its seed with the same iroh node_id. The seed still holds node2's pre-restart connection, so the redial arrives as a duplicate. The duplicate handler is designed to evict a stale incumbent "in milliseconds … instead of waiting for the dead connection's QUIC idle timeout (~150s)", but the eviction threshold `ZAKURA_DUPLICATE_EVICT_MIN_AGE` was **300s — twice the 150s idle timeout** — so the shortcut could never fire before the idle reaper removed the connection. node2 stalled ~150s with no ready Zakura peer and never downloaded genesis. (The `RemoteNonceReuse` "self-connection" log lines in the same window are the seed dialing its own legacy port over host networking — a red herring.)

## Solution

Lower `ZAKURA_DUPLICATE_EVICT_MIN_AGE` to **15s**: comfortably above a simultaneous-open race (so a brand-new healthy incumbent is still kept) but well below the 150s QUIC idle timeout and the 60s redial settle window, so a same-identity restart reconnect clears the stale incumbent in seconds — the behavior the eviction-site comment already documents. Also reconciles the constant's doc-comment, which still described the superseded "rely on the idle reaper" strategy.

## Test evidence

Adds `same_peer_reconnect_within_idle_window_evicts_stale_incumbent` (the existing eviction tests only aged the incumbent past the 300s threshold, never the realistic restart-within-the-idle-window case). It fails at 300s and passes at 15s. `cargo test -p zebra-network zakura::handler::tests::` → 42 passed, 0 failed; the pre-existing "keep a fresh incumbent" and per-IP-cap eviction tests are unaffected.

## AI disclosure

Investigated and implemented with Claude Code (trace forensics from the failing CI artifacts, code analysis, the fix, and this description), test-first. The author is responsible for the change.
