### PR TITLE
feat(zcashd-compat): switch zcashd-compat from RPC ingest to a P2P sidecar

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -197,3 +197,27 @@ default-filter = 'package(zebrad) and test(=lightwalletd_test_suite)'
 [profile.rpc-z-getsubtreesbyindex-snapshot]
 slow-timeout = { period = "30m", terminate-after = 2 }
 default-filter = 'package(zebrad) and test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test)'
+
+[profile.zcashd-compat-integration]
+# Run zcashd-compat tests one at a time to avoid port conflicts and resource exhaustion.
+test-threads = 1
+slow-timeout = { period = "15m", terminate-after = 2 }
+failure-output = "immediate"
+default-filter = 'package(zebrad) and test(~zcashd_compat)'
+
+[profile.zcashd-compat-soak]
+# Long-running local soak for the reorg churn stress test.
+test-threads = 1
+slow-timeout = { period = "4h", terminate-after = 1 }
+failure-output = "immediate"
+default-filter = 'package(zebrad) and test(=zcashd_compat_reorg_churn)'
+
+[profile.zcashd-compat-external]
+# External mode: connect to pre-running mainnet/testnet zebrad + zcashd.
+# Set TEST_ZCASHD_COMPAT_NETWORK, TEST_ZEBRAD_RPC_ADDR,
+# TEST_ZCASHD_RPC_ADDR, and auth env vars before running.
+# No block mining — 5 minutes per test is sufficient.
+test-threads = 1
+slow-timeout = { period = "5m", terminate-after = 2 }
+failure-output = "immediate"
+default-filter = 'package(zebrad) and test(~zcashd_compat)'

--- a/.github/workflows/zcashd-compat-regtest.yml
+++ b/.github/workflows/zcashd-compat-regtest.yml
@@ -1,13 +1,17 @@
 name: zcashd-compat Regtest
 
-# Runs the managed zcashd-compat Regtest integration suite after every merge to main.
+# Runs the managed zcashd-compat Regtest integration suite.
 #
-# The test harness spawns a fresh zebrad and zcashd (managed download) on
-# randomised ports, so no external infrastructure is required.
+# The test harness spawns a fresh zebrad and zcashd on randomised ports, so no
+# external infrastructure is required.
+#
+# TEMPORARILY manual-only: the suite now requires a P2P-sidecar zcashd build
+# (miner RPCs removed, -regtestacceptunvalidatedpow support), but the managed
+# download manifest still pins the previous RPC-ingest build. Re-enable the
+# push trigger once a sidecar zcashd release is cut and
+# zebrad/zcashd-compat-manifest.json is bumped. Until then run locally with
+# `make compat-test-regtest TEST_ZCASHD_PATH=/path/to/sidecar/zcashd`.
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
 
 concurrency:

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -117,6 +117,15 @@ zcashd speaks the legacy Zcash P2P protocol. Do not enable state pruning on
 the fronting Zebra — a pruned node does not advertise `NODE_NETWORK` and
 zcashd will not sync from it.
 
+> [!WARNING]
+> When the fronting Zebra runs in Docker with a published P2P port, all
+> connections arriving through `docker-proxy` (including a sidecar zcashd
+> connecting to `127.0.0.1:8233` on the host) share one source IP. Zebra's
+> `network.max_connections_per_ip` defaults to **1**, so the sidecar can lose
+> that single slot to a proxied public peer and silently never connect. Set
+> `ZEBRA_NETWORK__MAX_CONNECTIONS_PER_IP=8` (or similar) on a Dockerised
+> front, or attach the sidecar to the container network directly.
+
 ## Quick start (externally managed)
 
 Run Zebra normally (with `zcashd_compat.enabled = true` if you want the

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -2,559 +2,289 @@
 
 zcashd-compat mode is for operators — typically exchanges and custodial
 services — that want to migrate to Zebra while keeping the `zcashd` wallet and
-RPC surface their integration already depends on. Zebra becomes the consensus
-node: it syncs the Zcash network over P2P, and a `zcashd` running with P2P
-disabled ingests chain data, mempool data, and transaction forwarding from
-Zebra over JSON-RPC.
+RPC surface their integration already depends on. Zebra faces the Zcash P2P
+network and is the consensus node; `zcashd` runs as a **P2P sidecar** that
+makes a single outbound peer connection to the local Zebra node and listens
+for nothing. zcashd never touches the public network directly.
 
 Your systems keep talking to `zcashd` exactly as before:
 
 | Provided by `zcashd`, unchanged          | Moved to Zebra                              |
 |------------------------------------------|---------------------------------------------|
-| Wallet behavior and wallet RPC methods   | P2P networking and peer selection           |
-| Local block files, chainstate, indexes   | Block acquisition and best-chain selection  |
-| ZMQ notifications                        | Transaction relay to the network            |
-| Local RPC response semantics             | Expensive cryptographic block verification  |
+| Wallet behavior and wallet RPC methods   | Public P2P networking and peer selection    |
+| Local block files, chainstate, indexes   | Network-facing block and transaction relay  |
+| ZMQ notifications                        | Block templates for miners                  |
+| Local RPC response semantics             | DNS seeding and peer discovery              |
 
 ```text
-Zcash network ═P2P═▶ zebrad ◀─JSON-RPC (cookie auth, optional TLS)─ zcashd -zebra-compat ◀─wallet RPC, ZMQ─ your systems
+Zcash network ═P2P (8233)═▶ zebrad ◀═P2P, internal only═ zcashd ◀─wallet RPC, ZMQ─ your systems
+                            (front)   connect=zebra:8233   (sidecar)
 ```
+
+The whole topology is two lines of zcashd configuration:
+
+```text
+connect=<zebra-host>:8233   # one outbound peer: Zebra
+listen=0                    # no inbound P2P
+```
+
+`-connect` makes zcashd peer with the given address and *only* that address:
+zcashd itself then disables DNS seeding, inbound listening, and peer
+discovery. zcashd syncs blocks and relays transactions over the standard
+Zcash P2P protocol, with Zebra as its entire network.
 
 There are two ways to run the pair:
 
-- **Externally managed (default):** you run `zcashd -zebra-compat` yourself
-  against Zebra's zcashd-compat RPC endpoint.
+- **Externally managed (default):** you run `zcashd` yourself with
+  `connect=`/`listen=0` pointed at Zebra's P2P listener.
 - **Supervised:** Zebra spawns and manages `zcashd` itself when
-  `[zcashd_compat].manage_zcashd = true`.
+  `[zcashd_compat].manage_zcashd = true`, passing the peer-pinning arguments
+  automatically.
 
-The zcashd-side flags, trust model, sizing arithmetic, diagnostics, and
-recovery procedures are documented in
-  [zebra-compat Node Operation](https://github.com/valargroup/zcashd/blob/feat/unity/doc/zebra-compat.md);
-the Zebra-side sections of this page still apply.
+## The sidecar zcashd build
 
-## Quick start (externally managed)
+Use the sidecar `zcashd` build from
+[valargroup/zcashd](https://github.com/valargroup/zcashd) (branch
+`feat/p2p-sidecar`). It differs from stock `zcash/zcash` in three ways:
 
-Start Zebra's zcashd-compat RPC endpoint:
+1. **Miner RPCs are removed.** `getblocktemplate`, `submitblock`,
+   `getgenerate`, `setgenerate`, and `generate` are not registered and return
+   JSON-RPC `Method not found` (-32601). Zebra is the canonical source of
+   block templates (see [Mining](#mining-zebra-is-canonical)). Read-only
+   mining info RPCs (`getmininginfo`, `getnetworksolps`, `getblocksubsidy`,
+   `prioritisetransaction`) remain.
+2. **The upstream end-of-support halt is disabled.** Stock zcashd shuts
+   itself down at its deprecation height; the sidecar build logs a warning
+   and keeps serving its wallet/RPC surface. Consensus safety comes from
+   Zebra, which fully validates every block before relaying it to zcashd.
+3. **`-regtestacceptunvalidatedpow` (regtest only)** lets zcashd follow a
+   Zebra regtest chain, whose mined blocks carry null Equihash solutions.
+   It is rejected on any other network.
+
+Everything else — wallet, chainstate format, RPC semantics, ZMQ — is stock
+zcashd.
+
+## Quick start (supervised)
 
 ```console
 zebrad start --zcashd-compat
 ```
 
-On first start, Zebra:
+with a config like:
+
+```toml
+[zcashd_compat]
+enabled = true
+manage_zcashd = true
+zcashd_source = "path"
+zcashd_path = "/usr/local/bin/zcashd"
+zcashd_datadir = "/var/lib/zcashd"
+zcashd_extra_args = ["-rpcbind=127.0.0.1", "-rpcallowip=127.0.0.1"]
+```
+
+On start, Zebra:
 
 1. runs Linux hardware and filesystem preflight checks (see
-   [Hardware preflight](#hardware-preflight-linux));
-2. starts the dedicated zcashd-compat RPC listener on `127.0.0.1:28232` with
-   cookie authentication;
-3. waits for an externally managed `zcashd -zebra-compat` process to connect.
+   [Hardware preflight](#hardware-preflight-linux); `--unsafe-low-specs`
+   skips the minimums for test rigs);
+2. bootstraps the zcashd datadir and a minimal `zcash.conf` (including the
+   zcashd deprecation acknowledgement) if none exists;
+3. spawns `zcashd` pinned to Zebra's own P2P listener:
 
-The startup log banner shows the zcashd-compat RPC URL and cookie file.
+   ```text
+   zcashd -datadir=... -printtoconsole <your extra args> \
+          -connect=<zebra p2p addr> -listen=0 -dnsseed=0 -listenonion=0 -discover=0
+   ```
 
-To opt into supervision, set `manage_zcashd = true`. With the default
-`zcashd_source = "path"`, Zebra requires `zcashd_path` to point at a local
-binary. Set `zcashd_source = "managed"` to use Zebra's SHA256-pinned managed
-download.
+4. supervises it: restarts on unexpected exit with capped exponential
+   backoff, and shuts it down gracefully (SIGTERM, then a configurable grace
+   period) when Zebra stops.
+
+The forced peer-pinning arguments are placed *after* `zcashd_extra_args`
+because zcashd takes the last occurrence of a single-valued command-line
+argument. Peer-selection options (`-connect`, `-addnode`, `-seednode`) in
+`zcashd_extra_args` are rejected at startup: the sidecar must peer with Zebra
+alone.
+
+By default the supervisor derives the `-connect` address from Zebra's own
+bound legacy P2P listener (`network.listen_addr`), substituting `127.0.0.1`
+when Zebra listens on an unspecified address. Set
+`zcashd_compat.p2p_connect_addr` when zcashd must reach Zebra through a
+different address (for example across containers).
+
+zcashd-compat mode requires `network.legacy_p2p = true` (the default):
+zcashd speaks the legacy Zcash P2P protocol. Do not enable state pruning on
+the fronting Zebra — a pruned node does not advertise `NODE_NETWORK` and
+zcashd will not sync from it.
+
+## Quick start (externally managed)
+
+Run Zebra normally (with `zcashd_compat.enabled = true` if you want the
+dedicated compat RPC listener and preflight checks), then run zcashd yourself:
+
+```console
+zcashd -datadir=/var/lib/zcashd \
+       -connect=127.0.0.1:8233 -listen=0 -dnsseed=0 -listenonion=0 -discover=0 \
+       -printtoconsole
+```
+
+Or put the equivalent in `zcash.conf`:
+
+```text
+connect=127.0.0.1:8233
+listen=0
+i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
+```
+
+`make compat-zcashd-start-standalone` (see `make/zcashd-compat.mk`) wraps
+this command.
 
 ### Verify the integration
 
-`getzebracompatinfo` is the primary status surface on the zcashd side:
+Confirm zcashd is talking only to Zebra and exposes no P2P or mining surface:
 
 ```console
-zcash-cli getzebracompatinfo
+$ zcash-cli getpeerinfo
+# -> exactly ONE peer: the Zebra node ("subver": "/Zebra:.../", "inbound": false)
+
+$ zcash-cli getconnectioncount
+1
+
+$ zcash-cli getblocktemplate
+error code: -32601  # Method not found: miners must use Zebra
+
+$ ss -tlnp | grep 8233
+# -> only zebrad listening; zcashd has no P2P listener
 ```
 
-Confirm `zebra.identity_verified` is `true` and watch `readiness` move from
-`degraded` (syncing) to `ready` once the local `zcashd` tip catches up to
-Zebra's best tip. Expect `"p2p": false` and `"blocksource": "zebra"`.
+Then confirm the tips converge: heights track each other and
+`getbestblockhash` matches on both nodes once the drift reaches zero.
 
-Confirm `zcashd` has no peer-to-peer activity:
+`deploy/zcashd-compat/sync-check.sh` and `make compat-status-sync` automate
+the process/peer-pinning/height-drift checks, and the deploy watchdog's
+`zcashd_compat_sync` check mirrors them for continuous monitoring.
 
-```console
-zcash-cli getconnectioncount   # expect 0
-zcash-cli getpeerinfo          # expect []
-```
+The shield (single peer, no listener, no miner RPCs) is in effect immediately
+on startup; you do not need a fully synced chain to verify it.
 
-Confirm `zcashd` is not listening on the network P2P port (Zebra should be):
+## Mining: Zebra is canonical
 
-```console
-ss -ltnp 'sport = :8233'    # mainnet
-ss -ltnp 'sport = :18233'   # testnet
-```
-
-## What zcashd-compat mode does
-
-When you start Zebra with `zebrad start --zcashd-compat`, Zebra:
-
-- enables zcashd-compat mode (`[zcashd_compat].enabled = true`);
-- ensures a dedicated zcashd-compat RPC listen address is configured (defaults to `127.0.0.1:28232`);
-- uses dedicated cookie auth at `zcashd_compat.cookie_dir/zcashd_compat.cookie_file_name` by default;
-- optionally serves the dedicated zcashd-compat RPC listener over TLS;
-- raises the zcashd-compat RPC `max_response_body_size` to at least `128` MiB
-  for large batched block responses;
-- validates coordinated zcashd batch-size, zcashd response-budget, and Zebra
-  response-body settings before startup;
-- optionally spawns and supervises `zcashd -zebra-compat`.
-
-If zcashd-compat supervision is enabled, Zebra starts `zcashd` with:
-
-```text
--zebra-compat
--zebra-compat-url=<rpc_url>
-[-zebra-compat-cookiefile=<zcashd_compat.cookie_dir>/<zcashd_compat.cookie_file_name> | -zebra-compat-no-auth=1]
-[-zebra-compat-tls-ca-file=<zcashd_compat.tls_ca_file>]
--zebra-compat-zebra-rpc-max-response-body-bytes=<effective Zebra compat RPC limit>
--datadir=<zcashd_compat.zcashd_datadir or state.cache_dir/zcashd-compat-zcashd>
-[-testnet | -regtest]
--p2p=0
--listen=0
--printtoconsole
-[<zcashd_compat.zcashd_extra_args...>]
-```
-
-Zebra always passes `-p2p=0` and `-listen=0` before `zcashd_extra_args`. CLI
-arguments are parsed before `zcash.conf` and are not overwritten by config-file
-values, so legacy full-node configs with `listen=1` do not cause `zcashd` to
-bind the network P2P port (8233 mainnet / 18233 testnet) that Zebra already
-uses. `zcashd` also force-disables P2P boolean flags when `-zebra-compat` is
-active, including later `zcashd_extra_args` such as `-p2p=1` or `-listen=1`.
-Peer-selection options in `zcashd_extra_args` are rejected by `zcashd` startup
-validation rather than silently taking effect.
-
-Cookie auth remains the default in supervised mode. Zebra only passes
-`-zebra-compat-no-auth=1` when `[zcashd_compat].enable_cookie_auth = false`,
-which is accepted only for TLS-enabled zcashd-compat RPC listeners.
-
-## Configuration
-
-zcashd-compat mode adds a `[zcashd_compat]` section:
-
-```toml
-[zcashd_compat]
-enabled = false
-manage_zcashd = false
-zcashd_source = "path"                               # "path" or "managed"; used only when manage_zcashd = true
-zcashd_path = "/path/to/local/zcashd"               # required when supervised zcashd_source = "path"
-zcashd_datadir = "/path/to/zcashd/datadir"          # optional
-zcashd_extra_args = ["-debug=1"]                    # optional extra args
-listen_addr = "127.0.0.1:28232"                     # optional, default set when zcashd-compat is enabled
-cookie_dir = "/path/to/cookies"                     # optional, defaults to <cache_dir>
-cookie_file_name = ".zcashd-compat.cookie"          # optional, defaults to ".zcashd-compat.cookie"
-enable_cookie_auth = true                           # optional, defaults to true
-tls_cert_file = "/path/to/zebra.crt"                # optional, enables HTTPS with tls_key_file
-tls_key_file = "/path/to/zebra.key"                 # optional, required with tls_cert_file
-tls_ca_file = "/path/to/internal-ca.pem"            # optional, passed to supervised zcashd
-unsafe_allow_remote_http = false                    # optional, allows non-loopback listen_addr without TLS
-startup_delay = "1s"
-restart_backoff = "2s"                              # base exponential backoff
-restart_backoff_max = "5m"                          # maximum retry delay
-restart_reset_after = "1h"
-shutdown_grace_period = "300s"
-```
-
-When overriding `zcashd_extra_args` via environment variables, pass a JSON array string:
-
-```console
-ZEBRA_ZCASHD_COMPAT__ZCASHD_EXTRA_ARGS='["-conf=/path/to/zcash.conf","-debug=1"]'
-```
-
-`zebrad` always adds `-printtoconsole` automatically for supervised `zcashd`.
-
-If `manage_zcashd = false`, Zebra still applies the zcashd-compat RPC
-guardrails and startup validation, but does not spawn `zcashd`; see
-[Sync batch size and response limits](#sync-batch-size-and-response-limits)
-for the externally managed workflow.
-
-### zcashd binary resolution
-
-If `manage_zcashd = true`, Zebra resolves `zcashd` as follows:
-
-1. If `zcashd_path` is set, Zebra uses that local executable directly.
-2. `zcashd_source = "path"` requires `zcashd_path` to be set.
-3. `zcashd_source = "managed"` uses Zebra's embedded release manifest
-   to fetch a compatible `zcashd` archive, verify its SHA256, cache it, and run it.
-   Managed downloads are currently available only on `x86_64` Linux.
-
-Managed downloads are cached under:
-
-```text
-<state.cache_dir>/zcashd-compat/bin/<release_tag>/<target>/zcashd
-```
-
-If managed artifacts are unavailable for the local platform, including Linux
-`aarch64`, set `zcashd_path` to a local binary instead.
-
-Managed download failures (missing target artifact, hash mismatch, transport
-failures) fail closed before Zebra supervises `zcashd`.
-
-### zcashd datadir and `zcash.conf`
-
-Supervised `zcashd` still requires a normal datadir and `zcash.conf`. When
-`manage_zcashd = true`, Zebra creates the configured datadir if it is missing
-and bootstraps a minimal config file only when the effective `zcash.conf` is
-absent. Existing operator configs are never overwritten.
-
-Before creating the datadir or bootstrap config, Zebra checks that the effective
-datadir and `zcash.conf` location can be used by the current user. Existing
-`zcash.conf` files must be readable; if the config is missing, the parent
-directory must be writable so Zebra can create the bootstrap file.
-
-Minimum first-start `zcash.conf`:
-
-```conf
-i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
-# zcashd-compat: P2P is disabled; chain data comes from zebrad RPC.
-# Do not add bind=, connect=, addnode=, or listen=1 here.
-```
-
-`zcashd` refuses to start without this deprecation acknowledgement. If an
-existing config has missing or legacy P2P settings, Zebra logs clear warnings;
-some P2P flags are forced off, while peer configuration options can still make
-`zcashd` reject startup validation.
-
-### Migrating a legacy `zcash.conf` from full-node use
-
-Operators often reuse an existing `zcash.conf`. In compat mode:
-
-- `listen=1`, `p2p=1`, `dnsseed=1`, and `listenonion=1` in the file may remain
-  on disk but are overridden at startup (supervisor CLI plus `zcashd`
-  `-zebra-compat` preset). They do not need manual removal for those flags.
-  The same boolean flags are force-disabled if repeated in `zcashd_extra_args`.
-- Remove or avoid P2P peer options that fail startup validation: `bind=`,
-  `whitebind=`, `connect=`, `addnode=`, `seednode=`, and similar.
-
-You do not need to add `listen=0` to `zcashd_extra_args`; the supervisor
-already passes it.
-
-## Listeners, authentication, and TLS
-
-### Listener overview
-
-A zcashd-compat deployment involves several listeners with similar-sounding
-settings. Do not disable the wrong one:
-
-| Listener | Default / typical | Role in zcashd-compat |
-|---|---|---|
-| **Zebra network P2P** (`network.listen_addr`) | enabled | Zebra syncs blocks from the Zcash network. Keep enabled. |
-| **Zebra compat RPC** (`zcashd_compat.listen_addr`) | `127.0.0.1:28232` | Backend channel for supervised `zcashd -zebra-compat`. Cookie-auth by default; HTTPS/no-cookie is opt-in. Separate from `[rpc]`. |
-| **Zebra user RPC** (`[rpc].listen_addr`) | optional | Operator-facing Zebra JSON-RPC (for example `127.0.0.1:8232`). |
-| **zcashd network P2P** (`-listen`, port 8233/18233) | forced off | Must stay off; Zebra owns P2P. |
-| **zcashd wallet RPC** (`-rpcbind`, `-rpcport`) | operator choice | Unrelated to `-listen`; configure separately if needed. |
-
-The dedicated zcashd-compat RPC listener uses cookie authentication by default,
-independent of the operator-facing `[rpc]` listener. zcashd-compat uses a
-separate listener and separate authentication/TLS settings so operators can
-keep user-facing Zebra RPC and the zcashd backend channel isolated, even when
-both listeners share the same process.
-
-### TLS for the zcashd-compat listener
-
-To serve the zcashd-compat listener over HTTPS, configure both certificate and
-private-key files:
-
-```toml
-[zcashd_compat]
-listen_addr = "127.0.0.1:28232"
-tls_cert_file = "/path/to/zebra.crt"
-tls_key_file = "/path/to/zebra.key"
-tls_ca_file = "/path/to/internal-ca.pem"
-```
-
-Non-loopback `zcashd_compat.listen_addr` values require TLS. Loopback listeners
-can use the default plain HTTP channel because credentials stay on the local
-host. `zcashd_compat.unsafe_allow_remote_http = true` overrides the TLS
-requirement for deployments where another boundary secures the listener, such
-as a private container network or VPN; treat it like zcashd's
-`-zebra-compat-allow-remote-http` escape hatch and prefer TLS. If Zebra and
-supervised zcashd run in the same container, prefer keeping
-`zcashd_compat.listen_addr` on container loopback instead.
-
-The TLS certificate must include an IP Subject Alternative Name for the
-`listen_addr` IP (for example `IP:127.0.0.1`): supervised zcashd connects to
-the raw IP address and verifies the certificate against it, so a certificate
-with only DNS names fails verification.
-
-When `manage_zcashd = true`, Zebra uses an `https://` `-zebra-compat-url` and
-passes `-zebra-compat-tls-ca-file=<tls_ca_file>` to supervised zcashd. The CA
-file should contain the public CA certificate zcashd needs to verify Zebra's
-server certificate. It is not Zebra's private key.
-
-If TLS is enabled later on the same loopback supervised listener, zcashd keeps
-the existing trusted boundary active even though the supervisor changes the URL
-scheme from `http://` to `https://`. The boundary still must match the configured
-host, port, path, network, and genesis. For remote endpoints, changing the URL
-scheme is treated as a source change and requires the normal zcashd recovery
-checks.
-
-### Disabling cookie auth (TLS only)
-
-Cookie auth can be disabled for the dedicated zcashd-compat listener only when
-TLS is enabled:
-
-```toml
-[zcashd_compat]
-listen_addr = "127.0.0.1:28232"
-tls_cert_file = "/path/to/zebra.crt"
-tls_key_file = "/path/to/zebra.key"
-tls_ca_file = "/path/to/internal-ca.pem"
-enable_cookie_auth = false
-```
-
-In this mode, supervised zcashd receives `-zebra-compat-no-auth=1` instead of a
-cookie file. Use this only when another layer controls access to the HTTPS
-endpoint, such as Cloudflare Access, mTLS, IP allowlists, or a private network.
-Without cookie auth, any client that can reach the listener can call the exposed
-RPC methods.
-
-## Sync batch size and response limits
-
-Three settings must agree when increasing zebra-compat sync depth:
-
-- `-zebra-compat-sync-batch-size=<blocks>`: how many raw blocks zcashd asks
-  Zebra for in one JSON-RPC batch. zcashd defaults to `30`.
-- `-zebra-compat-sync-response-budget-mb=<MiB>`: zcashd's memory budget for one
-  batched raw-block response. zcashd defaults to `128` MiB, which allows a
-  memory-clamped maximum batch of `33` blocks.
-- `[rpc].max_response_body_size`: Zebra's HTTP response-body limit. Zebra floors
-  the zcashd-compat listener to at least `128` MiB, and jsonrpsee applies this
-  limit to the whole JSON-RPC batch response.
-
-Zebra fails startup if these settings are inconsistent in `zcashd_compat`
-configuration. For example, if `zcashd_extra_args` requests
-`-zebra-compat-sync-batch-size=80`, Zebra reports the missing or undersized
-settings needed to make that batch valid.
-
-For supervised zcashd, configure the zcashd-side batch and response budget in
-`zcashd_extra_args`; Zebra passes its effective response limit to zcashd
-automatically using
-`-zebra-compat-zebra-rpc-max-response-body-bytes=<bytes>`. For example, an
-80-block batch uses a round `320` MiB budget:
+Miners and pools must request block templates from **Zebra's** RPC, not
+zcashd's. Enable Zebra's RPC listener and set a miner address:
 
 ```toml
 [rpc]
-max_response_body_size = 335544320
+listen_addr = "127.0.0.1:8232"
 
+[mining]
+miner_address = "t1YourTransparentOrShieldedAddress"
+```
+
+Zebra's `getblocktemplate` and `submitblock` are always compiled in; no
+special build is needed. See [Mining Zcash with
+Zebra](https://zebra.zfnd.org/user/mining.html) for details. The sidecar
+zcashd returns `Method not found` for all template and submission RPCs, so a
+misconfigured miner fails loudly instead of building on a lagging view.
+
+## Initial sync and existing datadirs
+
+The sidecar syncs the whole chain through its single Zebra peer. That works,
+but initial block download through one peer is slow — for production
+migrations, **bring your existing synced zcashd datadir** and let the sidecar
+continue from its current height. The chainstate and block files are the
+stock zcashd format; no conversion is needed.
+
+zcashd still performs its own full validation of every block Zebra relays —
+the sidecar removes zcashd's *network exposure*, not its consensus checks.
+
+## Configuration reference
+
+```toml
 [zcashd_compat]
-zcashd_extra_args = [
-  "-zebra-compat-sync-batch-size=80",
-  "-zebra-compat-sync-response-budget-mb=320",
-]
+# Master switch; also enabled by the `--zcashd-compat` CLI flag.
+enabled = true
+
+# Spawn and supervise zcashd (true) or run it yourself (false, default).
+manage_zcashd = true
+
+# "path" (use zcashd_path) or "managed" (SHA256-pinned download).
+zcashd_source = "path"
+zcashd_path = "/usr/local/bin/zcashd"
+
+# zcashd datadir; defaults to a subdirectory of state.cache_dir.
+zcashd_datadir = "/var/lib/zcashd"
+
+# Extra zcashd arguments. Peer-selection options are rejected.
+zcashd_extra_args = ["-rpcbind=127.0.0.1", "-rpcallowip=127.0.0.1"]
+
+# Zebra P2P address zcashd connects to. Defaults to Zebra's own bound
+# legacy listener (loopback-substituted). Set for cross-container setups.
+# p2p_connect_addr = "10.0.0.2:8233"
+
+# Supervision lifecycle.
+startup_delay = "1s"
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
 ```
 
-If `manage_zcashd = false`, Zebra still applies zcashd-compat RPC guardrails and
-validates any zcashd batch/budget flags present in `zcashd_extra_args`, but it
-does not start zcashd and cannot pass command-line flags to it. Keep
-`[rpc].max_response_body_size` configured in Zebra, and pass the zcashd-side
-values explicitly to the external process:
+All values can also be set through environment variables, e.g.
+`ZEBRA_ZCASHD_COMPAT__ZCASHD_PATH=/usr/local/bin/zcashd`.
 
-```console
-zcashd -zebra-compat \
-  -zebra-compat-sync-batch-size=80 \
-  -zebra-compat-sync-response-budget-mb=320 \
-  -zebra-compat-zebra-rpc-max-response-body-bytes=335544320 \
-  -zebra-compat-url=http://127.0.0.1:8232 \
-  -zebra-compat-cookiefile=/path/to/zebra/.cookie
-```
+> [!WARNING]
+> Until the managed-download manifest is updated for the sidecar build,
+> `zcashd_source = "managed"` downloads the previous RPC-ingest zcashd, which
+> still contains the upstream end-of-support halt and miner RPCs. Use
+> `zcashd_source = "path"` with a sidecar build for now.
 
-See zcashd's `doc/zebra-compat.md` for the full batch-size and reorg-depth
-arithmetic.
+### Legacy dedicated RPC listener (deprecated)
+
+Earlier zcashd-compat versions ingested chain data from Zebra over a
+dedicated, cookie-authenticated Zebra RPC listener (default
+`127.0.0.1:28232`, configured by `listen_addr`, `cookie_dir`,
+`cookie_file_name`, `enable_cookie_auth`, `tls_cert_file`, `tls_key_file`,
+`unsafe_allow_remote_http`). The P2P sidecar does not use it. The listener is
+still started for operator tooling that queries Zebra through it, and the
+config keys still parse, but they are deprecated and will be removed. The
+`tls_ca_file` key is no longer used at all.
 
 ## Hardware preflight (Linux)
 
-When zcashd-compat mode is enabled, Zebra runs Linux-only startup preflight checks
-for CPU, effective RAM, mount-aware provisioned disk space, and filesystem
-permissions.
+When `zcashd_compat.enabled` is set, Zebra checks at startup that the host
+meets the minimum hardware requirements for running both nodes (CPU cores,
+memory, and free disk per mount). Startup fails below the minimums;
+`--unsafe-low-specs` overrides the failure for test environments. Warnings
+(not failures) are printed between the minimum and recommended tiers.
 
-If zcashd-compat mode is enabled on a non-Linux host, Zebra fails startup by
-default because zcashd-compat is currently Linux-only. You can explicitly bypass
-this guardrail with `--unsafe-low-specs`.
+## Monitoring and lifecycle
 
-If hardware is below minimum requirements, or required filesystem paths are not
-usable by the current user, Zebra fails closed by default. If hardware is below
-recommended requirements but above minimums, Zebra logs explicit warnings and
-continues.
+- The supervisor exports `zcashd_compat.supervisor.active` / `.disabled` /
+  `.exhausted` gauges.
+- zcashd's stdout/stderr are forwarded into Zebra's logs under the
+  `zcashd_compat.zcashd` target.
+- On Zebra shutdown the supervisor sends zcashd SIGTERM and waits
+  `shutdown_grace_period` before force-killing, so zcashd can flush its
+  chainstate and wallet.
+- `make compat-status-sync` / `deploy/zcashd-compat/sync-check.sh` check both
+  processes, peer pinning (`getconnectioncount == 1`), and height drift.
 
-Use `--unsafe-low-specs` to bypass minimum-check failures only when you
-explicitly accept degraded or unstable operation. This also downgrades
-filesystem permission failures to warnings, but it does not grant permissions:
-later datadir bootstrap, config creation, or managed `zcashd` download steps can
-still fail with the underlying operating-system error.
+## Testing
 
-### Minimum requirements (fail closed by default)
-
-- CPU: 4 logical CPUs available to the process
-- RAM: 16 GiB effective memory (host memory, constrained by cgroup limits when applicable)
-- Disk:
-  - Zebra state mount: at least 300 GiB provisioned capacity
-  - zcashd datadir mount: at least 300 GiB provisioned capacity
-  - If Zebra state and zcashd datadir are on the same filesystem, required
-    provisioned capacity is summed (600 GiB provisioned)
-
-### Recommended requirements (warn if below)
-
-- CPU: 8 logical CPUs available to the process
-- RAM: 32 GiB effective memory
-- Disk: at least 1 TiB combined capacity across the filesystems used by Zebra state
-  and zcashd datadir
-
-### Filesystem permission checks (fail closed by default)
-
-Zebra validates the paths that zcashd-compat needs before it creates any missing
-directories or config files. Permission problems are collected into the same
-aggregated preflight error as CPU, RAM, and disk failures, so operators can fix
-all reported paths at once.
-
-Preflight validates:
-
-- Zebra's state cache directory (`state.cache_dir`);
-- the zcashd-compat RPC cookie directory (`zcashd_compat.cookie_dir`);
-- the effective supervised `zcashd` datadir, including `-datadir=` overrides in
-  `zcashd_extra_args`;
-- the effective `zcash.conf` path, including `-conf=` overrides in
-  `zcashd_extra_args`;
-- explicit `zcashd_path` executability when `zcashd_source = "path"` or
-  `zcashd_path` is set;
-- the managed `zcashd` cache directory when `zcashd_source = "managed"` and the
-  cached binary is missing, stale, or has mismatched provenance.
-
-For paths that do not exist yet, Zebra checks the nearest existing ancestor and
-reports whether the target cannot be created because that ancestor is not
-writable by the current user. Existing `zcash.conf` files must be readable, and
-an existing `zcashd` binary must be executable.
-
-## Containers
-
-The standard container image does not enable zcashd-compat or include `zcashd`
-by default. Release builds publish a separate `zfnd/zebra-zcashd-compat` image,
-currently for `linux/amd64` only, or you can build a local compat image with:
+The integration suite runs zebrad + a supervised regtest zcashd end to end:
 
 ```console
-make compat-docker-build
+make compat-test-regtest TEST_ZCASHD_PATH=/path/to/sidecar/zcashd
 ```
 
-`make compat-docker-build` downloads a hash-pinned zcashd-compat archive,
-verifies its SHA256, and passes the extracted `zcashd` binary into the Docker
-build using a named BuildKit context. This keeps network fetching outside the
-Dockerfile and lets callers supply their own binary source.
+It covers startup, tip following over P2P, deep reorgs, restarts,
+transaction flow from zcashd's wallet through Zebra's mempool, and the
+miner-RPC removal. `make compat-test-mainnet` / `compat-test-testnet` run the
+read-only subset against a live deployment.
 
-To override the default source, set `ZCASHD_COMPAT_BUILD_CONTEXT` to a local
-directory that contains `./bin/zcashd`:
+## Upstream network upgrades
 
-```console
-make compat-docker-build \
-  ZCASHD_COMPAT_BUILD_CONTEXT=/path/to/extracted-zcashd-context
-```
-
-At runtime, enable the vendored binary with:
-
-```console
-ZCASHD_COMPAT_ENABLED=true
-```
-
-The container entrypoint does not set zcashd-compat config by default. If this
-environment variable is set and `/usr/local/bin/zcashd` exists, the entrypoint
-enables zcashd-compat mode and configures Zebra to use that local binary.
-
-The `compat-docker-start` target uses the safer single-container pattern:
-
-```console
-ZEBRA_ZCASHD_COMPAT__LISTEN_ADDR=127.0.0.1:28232
-```
-
-This listener is only used by the supervised `zcashd` process inside the same
-container, so it does not need to be published to the host and does not need
-`zcashd_compat.unsafe_allow_remote_http`. The target publishes zcashd's own RPC
-port on host loopback instead:
-
-```console
--p 127.0.0.1:8232:8232
-```
-
-## Monitoring and process lifecycle
-
-Use `zcash-cli getzebracompatinfo` as the primary monitoring surface for the
-integration: it reports overall `readiness` (`ready` / `degraded` / `failed` /
-`disabled`), sync state, retry and backoff counters, mempool-mirror and
-transaction-forwarding health, and the active trusted boundary. The
-[zcashd-side documentation](https://github.com/valargroup/zcashd/blob/feat/unity/doc/zebra-compat.md)
-describes the full readiness surface and the matching recovery procedures.
-
-When zcashd-compat supervision is enabled (`zcashd_compat.enabled = true` and
-`zcashd_compat.manage_zcashd = true`):
-
-- If `zcashd` exits unexpectedly, Zebra's zcashd-compat supervisor restarts it using
-  exponential backoff based on `restart_backoff`, capped at
-  `restart_backoff_max`. Retries continue indefinitely until Zebra shuts down.
-- If a supervised `zcashd` child runs for at least `restart_reset_after` before
-  exiting, Zebra resets the consecutive restart count before applying the next
-  restart decision. This keeps old, recovered exits from permanently consuming
-  the backoff ramp.
-- If the zcashd-compat supervisor later exits or returns a runtime error (for
-  example, spawn failures while running), Zebra logs a warning and keeps running
-  without zcashd supervision.
-- Zebra exposes zcashd-compat supervision state through metrics:
-  `zcashd_compat.supervisor.active`, `zcashd_compat.supervisor.disabled`, and
-  `zcashd_compat.supervisor.exhausted`.
-- In the default unlimited-retry policy, `zcashd_compat.supervisor.exhausted`
-  should remain `0`. Production monitoring should alert if
-  `zcashd_compat.supervisor.active` becomes `0`, or if logs show repeated
-  supervised `zcashd` restarts.
-- Startup-time zcashd-compat config validation is unchanged. For example, if
-  `zcashd_compat.manage_zcashd = true`, `zcashd_source = "path"`, and
-  `zcashd_path` is unset or cannot be resolved, Zebra startup fails with an
-  error.
-- If `zebrad` is shut down normally, it asks the zcashd-compat supervisor to stop
-  `zcashd` gracefully: SIGTERM first, then SIGKILL after
-  `shutdown_grace_period` if needed. A forced kill can interrupt `zcashd` wallet
-  or chainstate flushes, so size the grace period for the local data set: large
-  mainnet nodes can need several minutes, while small test nodes can override it
-  lower. The supervisor logs a warning with the child pid if the SIGKILL last
-  resort fires.
-- Zebra waits for the supervisor task itself for `shutdown_grace_period` plus a
-  fixed 30-second margin, so its own shutdown timeout cannot cut the graceful
-  SIGTERM sequence short. The SIGTERM → grace → SIGKILL path in the supervisor
-  is the only way Zebra force-kills `zcashd`: dropping the child handle (for
-  example on a `zebrad` panic or an aborted supervisor task) leaves `zcashd`
-  running so it can finish flushing.
-- Supervised `zcashd` runs in its own process group. Terminal signals aimed at
-  `zebrad`'s process group (for example Ctrl-C in a wrapper script, or a
-  group-wide kill) do not reach `zcashd` directly; the supervisor delivers
-  SIGTERM to it during graceful shutdown instead.
-- If `zebrad` is terminated ungracefully (for example `kill -9`), normal
-  shutdown handlers do not run, so `zcashd` remains running until it is stopped
-  externally. An orphaned `zcashd` keeps holding its datadir lock, so a
-  restarted supervised `zebrad` retries spawning with backoff until the orphan
-  exits or is stopped; this is visible in the supervisor logs and recovers on
-  its own once the orphan is gone.
-- Pair the supervisor settings with zcashd's `-zebra-compat-flush-interval`
-  (default 300 seconds): it bounds how much chainstate an unclean `zcashd` death
-  can lose, and therefore how much replay a restart needs. See the
-  [zcashd-side documentation](https://github.com/valargroup/zcashd/blob/feat/unity/doc/zebra-compat.md)
-  for the crash-recovery details.
-
-## Quick regtest loop
-
-1. Configure the network:
-
-   ```toml
-   [network]
-   network = "Regtest"
-   ```
-
-2. Start Zebra in zcashd-compat mode:
-
-   ```console
-   zebrad start --zcashd-compat
-   ```
-
-3. Confirm the startup log banner shows the zcashd-compat RPC URL and cookie file.
-
-4. Use `zcash-cli getzebracompatinfo` to verify Zebra identity and readiness.
-
-5. Generate blocks via Zebra RPC (`generate`) and verify `zcashd` follows.
-
-The zcashd-compat regtest suite also includes reorg regression and stress tests;
-use `make compat-test-soak` for extended local churn runs.
-
-Regtest interoperability can depend on matching assumptions between Zebra and
-`zcashd` builds. If regtest semantics diverge, use testnet for initial
-interoperability validation.
+The sidecar zcashd must keep up with Zcash network upgrades: when a network
+upgrade activates, zebrad requires peers to advertise that upgrade's minimum
+protocol version, and an out-of-date zcashd will be disconnected. Plan to
+deploy the updated sidecar build before each activation height.

--- a/deploy/watchdog/src/checks/zcashd_compat.rs
+++ b/deploy/watchdog/src/checks/zcashd_compat.rs
@@ -3,9 +3,9 @@
 //! Mirrors the predicates of `deploy/zcashd-compat/sync-check.sh`:
 //!
 //! - a `zebrad --zcashd-compat` process is running,
-//! - a `zcashd -zebra-compat` process is running,
-//! - `getzebracompatinfo` reports `service_state == "ready"`,
-//!   `zebra.reachable == true`, and `zebra.identity_verified == true`,
+//! - a sidecar `zcashd` process is running,
+//! - `getconnectioncount` on zcashd reports exactly one peer (the Zebra node
+//!   it is pinned to with `-connect`),
 //! - the absolute difference between zebrad and zcashd `getblockcount`
 //!   is within the configured maximum drift.
 
@@ -120,24 +120,29 @@ impl Check for ZcashdCompatSyncCheck {
             return CheckOutcome::fail("zcashd process is not running", details);
         }
 
-        let compat_info = match self.json_rpc(
-            &self.config.zcashd_rpc_url,
-            &self.config.zcashd_cookie_file,
-            "getzebracompatinfo",
-        ) {
-            Ok(result) => result,
+        let zcashd_peers = match self
+            .json_rpc(
+                &self.config.zcashd_rpc_url,
+                &self.config.zcashd_cookie_file,
+                "getconnectioncount",
+            )
+            .and_then(|result| block_count(&result))
+        {
+            Ok(peers) => peers,
             Err(error) => {
-                details.insert("predicate".into(), "getzebracompatinfo_rpc".into());
+                details.insert("predicate".into(), "zcashd_getconnectioncount".into());
                 details.insert("error".into(), error.to_string());
-                return CheckOutcome::fail("zcashd getzebracompatinfo RPC failed", details);
+                return CheckOutcome::fail("zcashd getconnectioncount RPC failed", details);
             }
         };
 
-        if let Err(reason) = compat_ready(&compat_info) {
-            details.insert("predicate".into(), "compat_ready".into());
-            details.insert("compat_status".into(), reason.clone());
+        details.insert("zcashd_connections".into(), zcashd_peers.to_string());
+        if zcashd_peers != 1 {
+            details.insert("predicate".into(), "peer_pinning".into());
             return CheckOutcome::fail(
-                format!("zcashd zebra-compat status is not ready: {reason}"),
+                format!(
+                    "sidecar zcashd must peer with exactly one node (Zebra), got {zcashd_peers}"
+                ),
                 details,
             );
         }
@@ -225,32 +230,6 @@ fn extract_result(body: Value) -> Result<Value, RpcError> {
         .ok_or_else(|| RpcError::UnexpectedResult("missing result field".into()))
 }
 
-/// Checks the `getzebracompatinfo` readiness predicates, returning a
-/// description of the observed state on failure.
-fn compat_ready(result: &Value) -> Result<(), String> {
-    let service_state = result.get("service_state").and_then(Value::as_str);
-    let zebra = result.get("zebra");
-    let reachable = zebra
-        .and_then(|zebra| zebra.get("reachable"))
-        .and_then(Value::as_bool);
-    let identity_verified = zebra
-        .and_then(|zebra| zebra.get("identity_verified"))
-        .and_then(Value::as_bool);
-
-    let ready = service_state == Some("ready")
-        && reachable == Some(true)
-        && identity_verified == Some(true);
-
-    if ready {
-        Ok(())
-    } else {
-        Err(format!(
-            "service_state={service_state:?} zebra.reachable={reachable:?} \
-             zebra.identity_verified={identity_verified:?}"
-        ))
-    }
-}
-
 /// Parses a `getblockcount` result as a block height.
 fn block_count(result: &Value) -> Result<u64, RpcError> {
     result
@@ -281,39 +260,6 @@ mod tests {
             extract_result(body),
             Err(RpcError::UnexpectedResult(_))
         ));
-    }
-
-    #[test]
-    fn compat_ready_accepts_ready_response() {
-        let result = json!({
-            "service_state": "ready",
-            "zebra": {"reachable": true, "identity_verified": true},
-        });
-        assert_eq!(compat_ready(&result), Ok(()));
-    }
-
-    #[test]
-    fn compat_ready_rejects_not_ready_states() {
-        let starting = json!({
-            "service_state": "starting",
-            "zebra": {"reachable": true, "identity_verified": true},
-        });
-        assert!(compat_ready(&starting).is_err());
-
-        let unreachable = json!({
-            "service_state": "ready",
-            "zebra": {"reachable": false, "identity_verified": true},
-        });
-        assert!(compat_ready(&unreachable).is_err());
-
-        let unverified = json!({
-            "service_state": "ready",
-            "zebra": {"reachable": true, "identity_verified": false},
-        });
-        assert!(compat_ready(&unverified).is_err());
-
-        let missing_fields = json!({});
-        assert!(compat_ready(&missing_fields).is_err());
     }
 
     #[test]

--- a/deploy/zcashd-compat/sync-check.sh
+++ b/deploy/zcashd-compat/sync-check.sh
@@ -8,7 +8,7 @@ ZCASHD_RPC_URL="${ZCASHD_RPC_URL:-http://[::1]:8232}"
 ZCASHD_COOKIE_FILE="${ZCASHD_COOKIE_FILE:-/mnt/snapshots/runtime/zcashd/.cookie}"
 
 ZEBRAD_PROCESS_PATTERN="${ZEBRAD_PROCESS_PATTERN:-zebrad .*--zcashd-compat}"
-ZCASHD_PROCESS_PATTERN="${ZCASHD_PROCESS_PATTERN:-zcashd .*-zebra-compat}"
+ZCASHD_PROCESS_PATTERN="${ZCASHD_PROCESS_PATTERN:-zcashd .*-connect}"
 
 HEIGHT_MAX_DRIFT="${HEIGHT_MAX_DRIFT:-10}"
 SYNC_CHECK_TIMEOUT="${SYNC_CHECK_TIMEOUT:-600}"
@@ -43,35 +43,6 @@ print(data["result"])
 '
 }
 
-compat_info_ready() {
-    python3 -c '
-import json
-import sys
-
-data = json.load(sys.stdin)
-if data.get("error") is not None:
-    raise SystemExit("RPC error: {}".format(data["error"]))
-
-result = data["result"]
-zebra = result.get("zebra", {})
-ready = (
-    result.get("service_state") == "ready"
-    and zebra.get("reachable") is True
-    and zebra.get("identity_verified") is True
-)
-
-print(
-    "service_state={service_state} zebra.reachable={reachable} "
-    "zebra.identity_verified={identity_verified}".format(
-        service_state=result.get("service_state"),
-        reachable=zebra.get("reachable"),
-        identity_verified=zebra.get("identity_verified"),
-    )
-)
-raise SystemExit(0 if ready else 1)
-'
-}
-
 require_uint() {
     local name="$1"
     local value="$2"
@@ -85,7 +56,7 @@ require_uint() {
 check_once() {
     local zebra_height
     local zcashd_height
-    local compat_response
+    local zcashd_peers
     local drift
 
     echo "Checking zebrad process..."
@@ -102,13 +73,14 @@ check_once() {
     fi
     echo "zcashd process: OK"
 
-    echo "Checking zcashd zebra-compat status..."
-    if ! compat_response="$(json_rpc "$ZCASHD_RPC_URL" "$ZCASHD_COOKIE_FILE" getzebracompatinfo)"; then
-        echo "zcashd getzebracompatinfo RPC failed"
+    echo "Checking zcashd peer pinning..."
+    if ! zcashd_peers="$(json_rpc "$ZCASHD_RPC_URL" "$ZCASHD_COOKIE_FILE" getconnectioncount | json_result)"; then
+        echo "zcashd getconnectioncount RPC failed"
         return 1
     fi
-    if ! printf '%s' "$compat_response" | compat_info_ready; then
-        echo "zcashd zebra-compat status is not ready"
+    echo "zcashd connections: $zcashd_peers"
+    if [[ "$zcashd_peers" != "1" ]]; then
+        echo "sidecar zcashd must peer with exactly one node (Zebra), got $zcashd_peers"
         return 1
     fi
 

--- a/make/zcashd-compat.mk
+++ b/make/zcashd-compat.mk
@@ -23,6 +23,10 @@ ZEBRA_STATE_CACHE_DIR ?= /mnt/data/zebra-state
 ZCASHD_DATADIR ?= /mnt/data/zcashd-mainnet
 ZCASHD_CONF ?= $(ZCASHD_DATADIR)/zcash.conf
 ZCASHD_EXTRA_ARGS ?= -printtoconsole
+# Zebra's legacy P2P listener; standalone zcashd pins its single peer to it.
+ZEBRA_P2P_ADDR ?= 127.0.0.1:8233
+# Dedicated zcashd-compat Zebra RPC listener (operator tooling only; the P2P
+# sidecar zcashd does not use it).
 ZCASHD_ZEBRA_RPC_URL ?= http://127.0.0.1:28232
 
 ZEBRA_COOKIE_DIR ?= $(ZEBRA_STATE_CACHE_DIR)
@@ -121,14 +125,16 @@ compat-zebrad-start-unsupervised:
 	"$(ZEBRAD_BIN)" start --zcashd-compat
 
 compat-zcashd-start-standalone:
-	@echo "Starting zcashd -zebra-compat as a standalone process..."
+	@echo "Starting zcashd as a standalone P2P sidecar of Zebra..."
 	"$(ZCASHD_BIN)" \
-		-zebra-compat \
-		-zebra-compat-url="$(ZCASHD_ZEBRA_RPC_URL)" \
-		-zebra-compat-cookiefile="$(ZEBRA_COOKIE_FILE)" \
 		-datadir="$(ZCASHD_DATADIR)" \
 		-conf="$(ZCASHD_CONF)" \
-		$(ZCASHD_EXTRA_ARGS)
+		$(ZCASHD_EXTRA_ARGS) \
+		-connect="$(ZEBRA_P2P_ADDR)" \
+		-listen=0 \
+		-dnsseed=0 \
+		-listenonion=0 \
+		-discover=0
 
 compat-zebrad-status:
 	@echo "Checking zebrad process..."
@@ -151,14 +157,18 @@ compat-zebrad-status:
 
 compat-zcashd-status:
 	@echo "Checking zcashd process..."
-	@if pgrep -f "zcashd.*-zebra-compat" >/dev/null; then \
+	@if pgrep -f "zcashd.*-connect" >/dev/null; then \
 		echo "zcashd process: OK"; \
 	else \
 		echo "zcashd process: NOT RUNNING"; \
 		exit 1; \
 	fi
-	@echo "Checking zcashd zebra-compat status..."
-	@"$(ZCASH_CLI_BIN)" -conf="$(ZCASHD_CONF)" -datadir="$(ZCASHD_DATADIR)" getzebracompatinfo >/dev/null
+	@echo "Checking zcashd peer pinning..."
+	@peers="$$( "$(ZCASH_CLI_BIN)" -conf="$(ZCASHD_CONF)" -datadir="$(ZCASHD_DATADIR)" getconnectioncount )"; \
+		echo "zcashd connections: $$peers (expected: 1, the Zebra node)"; \
+		if [ "$$peers" != "1" ]; then \
+			echo "WARNING: sidecar zcashd should have exactly one peer"; \
+		fi
 	@zcashd_height="$$( "$(ZCASH_CLI_BIN)" -conf="$(ZCASHD_CONF)" -datadir="$(ZCASHD_DATADIR)" getblockcount )"; \
 		echo "zcashd height: $$zcashd_height"
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -173,32 +173,11 @@ fn use_zakura_block_sync(config: &zebra_network::Config) -> bool {
 fn check_tcp_slow_start_after_idle() {}
 
 impl StartCmd {
-    /// Minimum response body size used in zcashd-compat mode.
+    /// Minimum response body size used by the dedicated zcashd-compat RPC listener.
     ///
-    /// zcashd defaults to a 128 MiB response budget. That allows a memory-clamped
-    /// batch of 33 raw blocks, whose worst-case response is 133,082,368 bytes.
-    /// jsonrpsee applies this limit to the whole JSON-RPC batch response.
-    ///
-    /// These `ZCASHD_COMPAT_*` constants mirror zcashd's batch/budget arithmetic
-    /// in `zcash/src/zebra_compat/zebra_client.cpp`
-    /// (`ZebraCompatSyncBatchSizeFromMemoryBudget` / `ZebraRpcMaxResponseBodySize`).
-    /// If the formula or constants change on either side, update both together,
-    /// or startup validation will accept configs the other process rejects.
+    /// The listener keeps a 128 MiB floor so bulk consumers of the retained
+    /// zcashd-compat RPC endpoint do not hit surprise body-size limits.
     const ZCASHD_COMPAT_MIN_MAX_RESPONSE_BODY_SIZE: usize = 128 * 1024 * 1024;
-    /// zcashd's default sync batch size.
-    const ZCASHD_COMPAT_DEFAULT_SYNC_BATCH_SIZE: u64 = 30;
-    /// Default zcashd raw-block sync response budget.
-    const ZCASHD_COMPAT_DEFAULT_SYNC_RESPONSE_BUDGET_MB: u64 = 128;
-    /// MiB in bytes, matching zcashd's `-zebra-compat-sync-response-budget-mb`.
-    const ZCASHD_COMPAT_MIB: u64 = 1024 * 1024;
-    /// zcashd's consensus maximum serialized block size.
-    const ZCASHD_COMPAT_MAX_BLOCK_BYTES: u64 = 2_000_000;
-    /// zcashd's per-block JSON-RPC response overhead allowance.
-    const ZCASHD_COMPAT_JSON_RPC_BLOCK_OVERHEAD_BYTES: u64 = 1024;
-    /// zcashd's whole-batch JSON-RPC response margin.
-    const ZCASHD_COMPAT_RPC_RESPONSE_BODY_MARGIN_BYTES: u64 = 1024 * 1024;
-    /// Conservative response budget needed per raw-block sync batch entry.
-    const ZCASHD_COMPAT_SYNC_RESPONSE_BUDGET_BYTES_PER_BLOCK: u64 = 4 * 1024 * 1024;
     /// Extra time Zebra waits for the zcashd-compat supervisor task beyond the
     /// child's `shutdown_grace_period`. The supervisor's `terminate_child` waits
     /// the full grace period before its SIGKILL last resort, so the outer wait
@@ -285,120 +264,24 @@ impl StartCmd {
         compat_rpc_config
     }
 
-    fn zcashd_compat_extra_arg_u64(
+    /// Returns the Zebra P2P address supervised zcashd should `-connect` to.
+    ///
+    /// Uses `zcashd_compat.p2p_connect_addr` when set, otherwise Zebra's bound
+    /// legacy P2P listener, substituting loopback for unspecified addresses so
+    /// zcashd gets a dialable target on the same host.
+    fn zcashd_compat_p2p_connect_addr(
         config: &ZebradConfig,
-        name: &str,
-    ) -> Result<Option<u64>, Report> {
-        let option_name = format!("-{name}=");
-        let long_option_name = format!("--{name}=");
-        let bare_option_name = format!("-{name}");
-        let bare_long_option_name = format!("--{name}");
-
-        config
-            .zcashd_compat
-            .zcashd_extra_args
-            .iter()
-            .filter_map(|arg| {
-                arg.strip_prefix(&option_name)
-                    .or_else(|| arg.strip_prefix(&long_option_name))
-                    .map(|value| (arg, Some(value)))
-                    .or_else(|| {
-                        (arg == &bare_option_name || arg == &bare_long_option_name)
-                            .then_some((arg, None))
-                    })
-            })
-            .map(|(arg, value)| {
-                let value = value.ok_or_else(|| {
-                    eyre!("zcashd_compat.zcashd_extra_args contains {arg:?} without a value")
-                })?;
-
-                value.parse::<u64>().map_err(|error| {
-                    eyre!(
-                        "zcashd_compat.zcashd_extra_args contains invalid {name} value {value:?}: {error}"
-                    )
-                })
-            })
-            .next_back()
-            .transpose()
-    }
-
-    fn validate_zcashd_compat_sync_batch_response_size(
-        config: &ZebradConfig,
-    ) -> Result<(), Report> {
-        let sync_batch_size =
-            Self::zcashd_compat_extra_arg_u64(config, "zebra-compat-sync-batch-size")?
-                .unwrap_or(Self::ZCASHD_COMPAT_DEFAULT_SYNC_BATCH_SIZE);
-        let sync_response_budget_mb =
-            Self::zcashd_compat_extra_arg_u64(config, "zebra-compat-sync-response-budget-mb")?
-                .unwrap_or(Self::ZCASHD_COMPAT_DEFAULT_SYNC_RESPONSE_BUDGET_MB)
-                .max(1);
-        let sync_response_budget_bytes = sync_response_budget_mb
-            .checked_mul(Self::ZCASHD_COMPAT_MIB)
-            .ok_or_else(|| {
-                eyre!(
-                    "zcashd-compat sync response budget {sync_response_budget_mb} MiB is too large"
-                )
-            })?;
-        let max_batch_size_for_response_budget =
-            if sync_response_budget_bytes <= Self::ZCASHD_COMPAT_RPC_RESPONSE_BODY_MARGIN_BYTES {
-                1
-            } else {
-                (sync_response_budget_bytes - Self::ZCASHD_COMPAT_RPC_RESPONSE_BODY_MARGIN_BYTES)
-                    / (2 * Self::ZCASHD_COMPAT_MAX_BLOCK_BYTES
-                        + Self::ZCASHD_COMPAT_JSON_RPC_BLOCK_OVERHEAD_BYTES)
-            }
-            .max(1);
-        let required_sync_response_budget_bytes =
-            Self::ZCASHD_COMPAT_RPC_RESPONSE_BODY_MARGIN_BYTES
-                .checked_add(
-                    sync_batch_size
-                        .checked_mul(
-                            2 * Self::ZCASHD_COMPAT_MAX_BLOCK_BYTES
-                                + Self::ZCASHD_COMPAT_JSON_RPC_BLOCK_OVERHEAD_BYTES,
-                        )
-                        .ok_or_else(|| {
-                            eyre!("zcashd-compat sync batch size {sync_batch_size} is too large")
-                        })?,
-                )
-                .ok_or_else(|| {
-                    eyre!("zcashd-compat sync batch size {sync_batch_size} is too large")
-                })?;
-        let required_sync_response_budget_mb =
-            required_sync_response_budget_bytes.div_ceil(Self::ZCASHD_COMPAT_MIB);
-        let required_max_response_body_size = sync_batch_size
-            .checked_mul(Self::ZCASHD_COMPAT_SYNC_RESPONSE_BUDGET_BYTES_PER_BLOCK)
-            .ok_or_else(|| eyre!("zcashd-compat sync batch size {sync_batch_size} is too large"))?;
-        let required_max_response_body_size: usize = required_max_response_body_size
-            .try_into()
-            .map_err(|_| eyre!("zcashd-compat sync batch size {sync_batch_size} is too large"))?;
-        let effective_max_response_body_size = config
-            .rpc
-            .max_response_body_size
-            .max(Self::ZCASHD_COMPAT_MIN_MAX_RESPONSE_BODY_SIZE);
-
-        let mut errors = Vec::new();
-        if sync_batch_size > max_batch_size_for_response_budget {
-            errors.push(format!(
-                "zcashd-compat sync batch size {sync_batch_size} requires \
-                 zcashd_compat.zcashd_extra_args to include \
-                 -zebra-compat-sync-response-budget-mb={required_sync_response_budget_mb} or higher; \
-                 configured effective value is {sync_response_budget_mb}"
-            ));
+        local_listener: SocketAddr,
+    ) -> SocketAddr {
+        if let Some(addr) = config.zcashd_compat.p2p_connect_addr {
+            return addr;
         }
 
-        if effective_max_response_body_size < required_max_response_body_size {
-            errors.push(format!(
-                "zcashd-compat sync batch size {sync_batch_size} requires \
-                 rpc.max_response_body_size = {required_max_response_body_size} or higher; \
-                 configured effective value is {effective_max_response_body_size}"
-            ));
+        if local_listener.ip().is_unspecified() {
+            SocketAddr::from(([127, 0, 0, 1], local_listener.port()))
+        } else {
+            local_listener
         }
-
-        if !errors.is_empty() {
-            return Err(eyre!("{}", errors.join("\n")));
-        }
-
-        Ok(())
     }
 
     fn validate_zcashd_compat_tls_config(config: &ZebradConfig) -> Result<(), Report> {
@@ -446,16 +329,6 @@ impl StartCmd {
                      or zcashd_compat.unsafe_allow_remote_http=true when a container or private network boundary secures the listener"
                 ));
             }
-        }
-
-        if config.zcashd_compat.enabled
-            && config.zcashd_compat.manage_zcashd
-            && config.zcashd_compat.tls_enabled()
-            && config.zcashd_compat.tls_ca_file.is_none()
-        {
-            return Err(eyre!(
-                "zcashd-compat supervision with TLS requires zcashd_compat.tls_ca_file so zcashd can verify Zebra"
-            ));
         }
 
         Ok(())
@@ -824,19 +697,21 @@ impl StartCmd {
         let (zcashd_compat_shutdown_tx, zcashd_compat_shutdown_rx) = watch::channel(false);
         let mut zcashd_compat_task_handle = if let Some(resolved_zcashd_path) = resolved_zcashd_path
         {
+            let local_listener = address_book
+                .lock()
+                .expect("unexpected panic in address book mutex guard")
+                .local_listener_socket_addr();
             let supervisor_config = zcashd_compat::SupervisorConfig::new(
                 &config.zcashd_compat,
                 resolved_zcashd_path,
                 &config.state.cache_dir,
                 config.network.network.kind(),
-                Self::zcashd_compat_rpc_url(&config)?,
-                Self::zcashd_compat_cookie_path(&config),
-                Self::zcashd_compat_rpc_config(&config).max_response_body_size,
+                Self::zcashd_compat_p2p_connect_addr(&config, local_listener),
             );
 
             info!(
-                rpc_url = %supervisor_config.rpc_url,
-                cookie_file = %supervisor_config.cookie_path.display(),
+                connect = %supervisor_config.zebra_p2p_addr,
+                compat_rpc_url = %Self::zcashd_compat_rpc_url(&config)?,
                 "zcashd-compat source enabled"
             );
 
@@ -1348,8 +1223,20 @@ impl config::Override<ZebradConfig> for StartCmd {
                 .into());
             }
 
-            Self::validate_zcashd_compat_sync_batch_response_size(&config)
+            if !config.network.legacy_p2p {
+                return Err(std::io::Error::other(
+                    "zcashd-compat P2P sidecar mode requires network.legacy_p2p = true, \
+                     because zcashd syncs from Zebra over the legacy Zcash P2P protocol",
+                )
+                .into());
+            }
+
+            if config.zcashd_compat.manage_zcashd {
+                zcashd_compat::reject_peer_selection_extra_args(
+                    &config.zcashd_compat.zcashd_extra_args,
+                )
                 .map_err(|err| std::io::Error::other(err.to_string()))?;
+            }
 
             if config.zcashd_compat.manage_zcashd {
                 match zcashd_compat::effective_zcashd_source(&config.zcashd_compat) {
@@ -1773,7 +1660,9 @@ mod tests {
     }
 
     #[test]
-    fn zcashd_compat_config_rejects_managed_tls_without_ca_file() {
+    fn zcashd_compat_config_allows_managed_tls_without_ca_file() {
+        // The P2P sidecar zcashd does not talk to the compat RPC listener, so
+        // supervision no longer requires a CA file when the listener uses TLS.
         let cmd = StartCmd {
             filters: Vec::new(),
             zcashd_compat: false,
@@ -1791,11 +1680,49 @@ mod tests {
         config.zcashd_compat.tls_cert_file = Some(cert_file);
         config.zcashd_compat.tls_key_file = Some(key_file);
 
+        cmd.override_config(config)
+            .expect("managed zcashd-compat should accept a TLS listener without a CA file");
+    }
+
+    #[test]
+    fn zcashd_compat_config_rejects_disabled_legacy_p2p() {
+        let cmd = StartCmd {
+            filters: Vec::new(),
+            zcashd_compat: false,
+            unsafe_low_specs: false,
+        };
+        let mut config = ZebradConfig::default();
+        config.zcashd_compat.enabled = true;
+        config.zcashd_compat.manage_zcashd = false;
+        config.network.legacy_p2p = false;
+
         let error = cmd
             .override_config(config)
-            .expect_err("managed TLS should require a CA file");
+            .expect_err("the P2P sidecar should require the legacy P2P listener");
         assert!(
-            error.to_string().contains("tls_ca_file"),
+            error.to_string().contains("legacy_p2p"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn zcashd_compat_config_rejects_peer_selection_extra_args() {
+        let cmd = StartCmd {
+            filters: Vec::new(),
+            zcashd_compat: false,
+            unsafe_low_specs: false,
+        };
+        let mut config = ZebradConfig::default();
+        config.zcashd_compat.enabled = true;
+        config.zcashd_compat.manage_zcashd = true;
+        config.zcashd_compat.zcashd_source = zcashd_compat::ConfigZcashdBinarySource::Managed;
+        config.zcashd_compat.zcashd_extra_args = vec!["-addnode=1.2.3.4".to_string()];
+
+        let error = cmd
+            .override_config(config)
+            .expect_err("peer-selection extra args should be rejected");
+        assert!(
+            error.to_string().contains("peer-selection"),
             "unexpected error: {error}"
         );
     }
@@ -1845,98 +1772,6 @@ mod tests {
         assert!(
             error.to_string().contains("tls_cert_file")
                 && error.to_string().contains("tls_key_file"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn zcashd_compat_config_rejects_large_sync_batch_without_matching_rpc_response_size() {
-        let cmd = StartCmd {
-            filters: Vec::new(),
-            zcashd_compat: false,
-            unsafe_low_specs: false,
-        };
-        let mut config = ZebradConfig::default();
-        config.zcashd_compat.enabled = true;
-        config.zcashd_compat.zcashd_extra_args =
-            vec!["-zebra-compat-sync-batch-size=80".to_string()];
-
-        let error = cmd
-            .override_config(config)
-            .expect_err("large zcashd sync batches should require a matching RPC response limit");
-
-        assert!(
-            error
-                .to_string()
-                .contains("rpc.max_response_body_size = 335544320"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn zcashd_compat_config_allows_large_sync_batch_with_matching_rpc_response_size() {
-        let cmd = StartCmd {
-            filters: Vec::new(),
-            zcashd_compat: false,
-            unsafe_low_specs: false,
-        };
-        let mut config = ZebradConfig::default();
-        config.zcashd_compat.enabled = true;
-        config.zcashd_compat.zcashd_extra_args = vec![
-            "-zebra-compat-sync-batch-size=80".to_string(),
-            "-zebra-compat-sync-response-budget-mb=320".to_string(),
-        ];
-        config.rpc.max_response_body_size = 320 * 1024 * 1024;
-
-        cmd.override_config(config)
-            .expect("large zcashd sync batches should allow a matching RPC response limit");
-    }
-
-    #[test]
-    fn zcashd_compat_config_rejects_large_sync_batch_without_matching_zcashd_response_budget() {
-        let cmd = StartCmd {
-            filters: Vec::new(),
-            zcashd_compat: false,
-            unsafe_low_specs: false,
-        };
-        let mut config = ZebradConfig::default();
-        config.zcashd_compat.enabled = true;
-        config.zcashd_compat.zcashd_extra_args =
-            vec!["-zebra-compat-sync-batch-size=80".to_string()];
-        config.rpc.max_response_body_size = 320 * 1024 * 1024;
-
-        let error = cmd.override_config(config).expect_err(
-            "large zcashd sync batches should require a matching zcashd response budget",
-        );
-
-        assert!(
-            error
-                .to_string()
-                .contains("-zebra-compat-sync-response-budget-mb=307"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn zcashd_compat_config_rejects_invalid_sync_batch_size() {
-        let cmd = StartCmd {
-            filters: Vec::new(),
-            zcashd_compat: false,
-            unsafe_low_specs: false,
-        };
-        let mut config = ZebradConfig::default();
-        config.zcashd_compat.enabled = true;
-        config.zcashd_compat.zcashd_extra_args =
-            vec!["-zebra-compat-sync-batch-size=eighty".to_string()];
-
-        let error = cmd
-            .override_config(config)
-            .expect_err("invalid zcashd sync batch sizes should be rejected");
-
-        assert!(
-            error
-                .to_string()
-                .contains("invalid zebra-compat-sync-batch-size value"),
             "unexpected error: {error}"
         );
     }

--- a/zebrad/src/components/zcashd_compat/config.rs
+++ b/zebrad/src/components/zcashd_compat/config.rs
@@ -59,9 +59,20 @@ pub struct Config {
     #[serde(default, deserialize_with = "deserialize_zcashd_extra_args")]
     pub zcashd_extra_args: Vec<String>,
 
-    /// Dedicated RPC listen address used by `zcashd -zebra-compat`.
+    /// The Zebra legacy P2P address supervised zcashd connects to via `-connect`.
+    ///
+    /// If unset, Zebra derives it from its own bound legacy P2P listener
+    /// (`network.listen_addr`), substituting `127.0.0.1` when the listener is
+    /// bound to an unspecified address. Set this only when zcashd must reach
+    /// Zebra through a different address, such as across containers.
+    pub p2p_connect_addr: Option<SocketAddr>,
+
+    /// Listen address for the dedicated zcashd-compat Zebra RPC listener.
     ///
     /// If unset, zcashd-compat startup defaults it to `127.0.0.1:28232`.
+    ///
+    /// This listener is retained for operator tooling; the P2P sidecar zcashd
+    /// no longer uses it to ingest chain data.
     ///
     /// Backward compatibility: this field also accepts the legacy `rpc_url` key and env var.
     #[serde(
@@ -96,7 +107,10 @@ pub struct Config {
     /// TLS private key for the dedicated zcashd-compat RPC listener.
     pub tls_key_file: Option<PathBuf>,
 
-    /// CA certificate file passed to supervised zcashd so it can verify Zebra's TLS certificate.
+    /// CA certificate file for the dedicated zcashd-compat RPC listener's clients.
+    ///
+    /// Unused by the P2P sidecar: supervised zcashd syncs over P2P and is not
+    /// given this file. The field is kept so existing configs still parse.
     pub tls_ca_file: Option<PathBuf>,
 
     /// Allow a non-loopback zcashd-compat RPC listener without TLS.
@@ -147,6 +161,7 @@ impl Default for Config {
             zcashd_path: None,
             zcashd_datadir: None,
             zcashd_extra_args: Vec::new(),
+            p2p_connect_addr: None,
             listen_addr: None,
             cookie_dir: default_cache_dir(),
             cookie_file_name: default_cookie_file_name(),

--- a/zebrad/src/components/zcashd_compat/mod.rs
+++ b/zebrad/src/components/zcashd_compat/mod.rs
@@ -19,6 +19,7 @@ pub use manifest::{
 };
 pub use preflight::run_preflight;
 pub use supervisor::{
-    is_command_resolvable, run as run_supervisor, set_supervision_config_disabled_metrics,
-    set_supervision_unexpectedly_disabled_metrics, SupervisorConfig,
+    is_command_resolvable, reject_peer_selection_extra_args, run as run_supervisor,
+    set_supervision_config_disabled_metrics, set_supervision_unexpectedly_disabled_metrics,
+    SupervisorConfig,
 };

--- a/zebrad/src/components/zcashd_compat/supervisor.rs
+++ b/zebrad/src/components/zcashd_compat/supervisor.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    net::SocketAddr,
     path::{Path, PathBuf},
     process::Stdio,
     time::{Duration, Instant},
@@ -30,16 +31,9 @@ pub struct SupervisorConfig {
     pub zcashd_path: PathBuf,
     /// Datadir for `zcashd`.
     pub zcashd_datadir: PathBuf,
-    /// RPC URL passed to `-zebra-compat-url`.
-    pub rpc_url: String,
-    /// Cookie file path passed to `-zebra-compat-cookiefile`.
-    pub cookie_path: PathBuf,
-    /// Whether supervised zcashd should authenticate to Zebra using the cookie file.
-    pub enable_cookie_auth: bool,
-    /// Optional CA file passed to zcashd for Zebra TLS verification.
-    pub tls_ca_file: Option<PathBuf>,
-    /// Zebra RPC response body limit passed to zcashd for startup validation.
-    pub zebra_rpc_max_response_body_size: usize,
+    /// Zebra's legacy P2P listen address, passed to zcashd as `-connect` so the
+    /// sidecar peers only with the local Zebra node.
+    pub zebra_p2p_addr: SocketAddr,
     /// Any extra user-provided arguments.
     pub extra_args: Vec<String>,
     /// Active Zebra network kind.
@@ -63,9 +57,7 @@ impl SupervisorConfig {
         zcashd_path: PathBuf,
         state_cache_dir: &Path,
         network: NetworkKind,
-        rpc_url: String,
-        cookie_path: PathBuf,
-        zebra_rpc_max_response_body_size: usize,
+        zebra_p2p_addr: SocketAddr,
     ) -> Self {
         let extra_args = zcashd_compat.zcashd_extra_args.clone();
         let zcashd_datadir = resolve_zcashd_datadir_path(
@@ -76,11 +68,7 @@ impl SupervisorConfig {
         Self {
             zcashd_path,
             zcashd_datadir,
-            rpc_url,
-            cookie_path,
-            enable_cookie_auth: zcashd_compat.enable_cookie_auth,
-            tls_ca_file: zcashd_compat.tls_ca_file.clone(),
-            zebra_rpc_max_response_body_size,
+            zebra_p2p_addr,
             extra_args,
             network,
             startup_delay: zcashd_compat.startup_delay,
@@ -93,46 +81,22 @@ impl SupervisorConfig {
 
     /// Builds the zcashd command-line arguments.
     pub fn command_args(&self) -> Vec<String> {
-        let mut args = vec![
-            "-zebra-compat".to_string(),
-            format!("-zebra-compat-url={}", self.rpc_url),
-            format!(
-                "-zebra-compat-zebra-rpc-max-response-body-bytes={}",
-                self.zebra_rpc_max_response_body_size
-            ),
-            format!("-datadir={}", self.zcashd_datadir.to_string_lossy()),
-        ];
-        if self.enable_cookie_auth {
-            args.push(format!(
-                "-zebra-compat-cookiefile={}",
-                self.cookie_path.to_string_lossy()
-            ));
-        } else {
-            args.push("-zebra-compat-no-auth=1".to_string());
-        }
-        if let Some(tls_ca_file) = &self.tls_ca_file {
-            args.push(format!(
-                "-zebra-compat-tls-ca-file={}",
-                tls_ca_file.to_string_lossy()
-            ));
-        }
+        let mut args = vec![format!(
+            "-datadir={}",
+            self.zcashd_datadir.to_string_lossy()
+        )];
 
         match self.network {
             NetworkKind::Mainnet => {}
             NetworkKind::Testnet => args.push("-testnet".to_string()),
-            NetworkKind::Regtest => args.push("-regtest".to_string()),
+            NetworkKind::Regtest => {
+                args.push("-regtest".to_string());
+                // Zebra skips proof-of-work on regtest, so its mined blocks
+                // carry null Equihash solutions that stock zcashd validation
+                // would reject with a peer ban.
+                args.push("-regtestacceptunvalidatedpow".to_string());
+            }
         }
-
-        // In compat mode zebrad owns P2P. zcashd must not listen on the network
-        // port (8233 mainnet / 18233 testnet). Operators often reuse a legacy
-        // full-node zcash.conf with listen=1, and CLI args are parsed before
-        // zcash.conf without being overwritten by it — so pass these explicitly
-        // as defense in depth. zcashd also force-disables P2P boolean flags
-        // when -zebra-compat is set, including later extra_args such as -p2p=1.
-        // Peer-selection extra_args are still rejected by zcashd startup
-        // validation rather than silently taking effect.
-        args.push("-p2p=0".to_string());
-        args.push("-listen=0".to_string());
 
         // Always include -printtoconsole and filter it out from extra_args
         args.push("-printtoconsole".to_string());
@@ -142,8 +106,59 @@ impl SupervisorConfig {
                 .filter(|arg| arg.as_str() != "-printtoconsole")
                 .cloned(),
         );
+
+        // zcashd peers only with the local Zebra node: `-connect` pins the
+        // single outbound peer, and zcashd itself then soft-disables DNS
+        // seeding, inbound listening, and discovery. The explicit flags are
+        // defense in depth against operator zcash.conf values. They come after
+        // extra_args because zcashd takes the *last* occurrence of a
+        // single-valued command-line argument. Multi-valued peer-selection
+        // options (-connect/-addnode/-seednode) accumulate instead, so
+        // [`reject_peer_selection_extra_args`] refuses them at startup.
+        args.push(format!("-connect={}", self.zebra_p2p_addr));
+        args.push("-listen=0".to_string());
+        args.push("-dnsseed=0".to_string());
+        args.push("-listenonion=0".to_string());
+        args.push("-discover=0".to_string());
+
         args
     }
+}
+
+/// zcashd options that add P2P peers and accumulate across the command line,
+/// so the supervisor's own `-connect` cannot override them.
+const PEER_SELECTION_OPTIONS: &[&str] = &["connect", "addnode", "seednode"];
+
+/// Rejects `zcashd_extra_args` entries that would change which peers the
+/// supervised zcashd talks to.
+///
+/// The P2P sidecar must connect only to the local Zebra node. Unlike
+/// single-valued boolean flags, every `-connect`/`-addnode`/`-seednode`
+/// occurrence adds a peer, and negated forms (`-noconnect`) clobber the
+/// supervisor's pinned `-connect`, so both are refused instead of overridden.
+///
+/// # Errors
+///
+/// Returns an error naming the first offending argument.
+pub fn reject_peer_selection_extra_args(extra_args: &[String]) -> Result<(), Report> {
+    for arg in extra_args {
+        let name = arg
+            .trim_start_matches('-')
+            .split('=')
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let name = name.strip_prefix("no").unwrap_or(&name);
+
+        if PEER_SELECTION_OPTIONS.contains(&name) {
+            return Err(eyre!(
+                "zcashd_compat.zcashd_extra_args contains {arg:?}: peer-selection options are not \
+                 allowed because the zcashd P2P sidecar must connect only to the local Zebra node"
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Runs the zcashd-compat zcashd supervisor until shutdown.
@@ -161,6 +176,7 @@ pub async fn run(
     config: SupervisorConfig,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<(), Report> {
+    reject_peer_selection_extra_args(&config.extra_args)?;
     ensure_zcashd_datadir(&config.zcashd_datadir, &config.extra_args)?;
     set_supervision_active_metrics();
 
@@ -206,8 +222,7 @@ pub async fn run(
         info!(
             path = %config.zcashd_path.display(),
             datadir = %config.zcashd_datadir.display(),
-            rpc_url = %config.rpc_url,
-            cookie = %config.cookie_path.display(),
+            connect = %config.zebra_p2p_addr,
             "started zcashd-compat zcashd child"
         );
 
@@ -628,89 +643,84 @@ mod tests {
     use zebra_chain::parameters::NetworkKind;
 
     use super::{
-        restart_backoff_delay, should_reset_restart_count, wait_for_delay_or_shutdown,
-        SupervisorConfig,
+        reject_peer_selection_extra_args, restart_backoff_delay, should_reset_restart_count,
+        wait_for_delay_or_shutdown, SupervisorConfig,
     };
 
-    #[test]
-    fn command_args_include_zcashd_compat_flags() {
-        let config = SupervisorConfig {
+    fn test_supervisor_config(extra_args: Vec<String>) -> SupervisorConfig {
+        SupervisorConfig {
             zcashd_path: PathBuf::from("zcashd"),
             zcashd_datadir: PathBuf::from("/tmp/zcashd-compat-datadir"),
-            rpc_url: "http://127.0.0.1:8232".to_string(),
-            cookie_path: PathBuf::from("/tmp/.cookie"),
-            enable_cookie_auth: true,
-            tls_ca_file: None,
-            zebra_rpc_max_response_body_size: 128 * 1024 * 1024,
-            extra_args: vec!["-debug=1".to_string()],
+            zebra_p2p_addr: "127.0.0.1:18233".parse().expect("valid socket address"),
+            extra_args,
             network: NetworkKind::Regtest,
             startup_delay: Duration::from_secs(1),
             restart_backoff: Duration::from_secs(2),
             restart_backoff_max: Duration::from_secs(5 * 60),
             restart_reset_after: Duration::from_secs(60 * 60),
             shutdown_grace_period: Duration::from_secs(300),
-        };
+        }
+    }
+
+    #[test]
+    fn command_args_pin_zcashd_to_zebra_p2p() {
+        let config = test_supervisor_config(vec!["-debug=1".to_string()]);
 
         let args = config.command_args();
 
-        assert!(args.contains(&"-zebra-compat".to_string()));
+        assert!(args.contains(&"-datadir=/tmp/zcashd-compat-datadir".to_string()));
         assert!(args.contains(&"-regtest".to_string()));
-        assert!(args
-            .iter()
-            .any(|a| a.starts_with("-zebra-compat-url=http://127.0.0.1:8232")));
-        assert!(args
-            .iter()
-            .any(|a| a.starts_with("-zebra-compat-cookiefile=/tmp/.cookie")));
-        assert!(args
-            .iter()
-            .any(|a| a == "-zebra-compat-zebra-rpc-max-response-body-bytes=134217728"));
-        assert!(args.contains(&"-p2p=0".to_string()));
+        assert!(args.contains(&"-regtestacceptunvalidatedpow".to_string()));
+        assert!(args.contains(&"-connect=127.0.0.1:18233".to_string()));
         assert!(args.contains(&"-listen=0".to_string()));
+        assert!(args.contains(&"-dnsseed=0".to_string()));
+        assert!(args.contains(&"-listenonion=0".to_string()));
+        assert!(args.contains(&"-discover=0".to_string()));
         assert!(args.contains(&"-printtoconsole".to_string()));
         assert!(args.contains(&"-debug=1".to_string()));
+        assert!(
+            !args.iter().any(|arg| arg.starts_with("-zebra-compat")),
+            "P2P sidecar must not pass RPC-ingest flags: {args:?}"
+        );
 
-        let p2p_idx = args
-            .iter()
-            .position(|a| a == "-p2p=0")
-            .expect("p2p override present");
-        let listen_idx = args
-            .iter()
-            .position(|a| a == "-listen=0")
-            .expect("listen override present");
+        // zcashd takes the last occurrence of a single-valued argument, so the
+        // forced P2P pinning flags must come after operator extra_args.
         let debug_idx = args
             .iter()
             .position(|a| a == "-debug=1")
             .expect("extra arg present");
-        assert!(p2p_idx < debug_idx);
-        assert!(listen_idx < debug_idx);
+        for forced in ["-listen=0", "-dnsseed=0", "-listenonion=0", "-discover=0"] {
+            let forced_idx = args
+                .iter()
+                .position(|a| a == forced)
+                .expect("forced flag present");
+            assert!(
+                forced_idx > debug_idx,
+                "{forced} must come after extra_args"
+            );
+        }
     }
 
     #[test]
-    fn command_args_use_explicit_no_auth_flag_when_cookie_auth_disabled() {
-        let config = SupervisorConfig {
-            zcashd_path: PathBuf::from("zcashd"),
-            zcashd_datadir: PathBuf::from("/tmp/zcashd-compat-datadir"),
-            rpc_url: "https://127.0.0.1:8232".to_string(),
-            cookie_path: PathBuf::from("/tmp/.cookie"),
-            enable_cookie_auth: false,
-            tls_ca_file: Some(PathBuf::from("/tmp/ca.pem")),
-            zebra_rpc_max_response_body_size: 128 * 1024 * 1024,
-            extra_args: Vec::new(),
-            network: NetworkKind::Regtest,
-            startup_delay: Duration::from_secs(1),
-            restart_backoff: Duration::from_secs(2),
-            restart_backoff_max: Duration::from_secs(5 * 60),
-            restart_reset_after: Duration::from_secs(60 * 60),
-            shutdown_grace_period: Duration::from_secs(300),
-        };
+    fn peer_selection_extra_args_are_rejected() {
+        for arg in [
+            "-connect=1.2.3.4:8233",
+            "--connect=1.2.3.4",
+            "-addnode=1.2.3.4",
+            "-seednode=1.2.3.4",
+            "-noconnect",
+            "-CONNECT=1.2.3.4",
+        ] {
+            let _rejected = reject_peer_selection_extra_args(&[arg.to_string()])
+                .expect_err("peer-selection extra args must be rejected");
+        }
 
-        let args = config.command_args();
-
-        assert!(args.contains(&"-zebra-compat-no-auth=1".to_string()));
-        assert!(args.contains(&"-zebra-compat-tls-ca-file=/tmp/ca.pem".to_string()));
-        assert!(!args
-            .iter()
-            .any(|arg| arg.starts_with("-zebra-compat-cookiefile=")));
+        reject_peer_selection_extra_args(&[
+            "-debug=1".to_string(),
+            "-rpcport=18232".to_string(),
+            "-maxconnections=8".to_string(),
+        ])
+        .expect("non-peer-selection extra args are allowed");
     }
 
     #[test]

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -4558,13 +4558,23 @@ async fn zcashd_compat_both_processes_start() -> Result<()> {
     common::zcashd_compat::startup::both_processes_start().await
 }
 
-/// After mining 5 blocks, `getzebracompatinfo` should report `readiness == "ready"`.
+/// The P2P sidecar zcashd follows Zebra's mined tip and peers with Zebra alone.
 ///
-/// See [`common::zcashd_compat::startup::readiness_after_mine`] for details.
+/// See [`common::zcashd_compat::startup::sidecar_follows_tip`] for details.
 #[tokio::test]
 #[ignore]
-async fn zcashd_compat_readiness_after_mine() -> Result<()> {
-    common::zcashd_compat::startup::readiness_after_mine().await
+async fn zcashd_compat_sidecar_follows_tip() -> Result<()> {
+    common::zcashd_compat::startup::sidecar_follows_tip().await
+}
+
+/// Miner-facing RPCs are removed from the sidecar zcashd; Zebra serves templates.
+///
+/// See [`common::zcashd_compat::startup::miner_rpcs_disabled`] for details.
+#[tokio::test]
+#[ignore]
+#[cfg(unix)]
+async fn zcashd_compat_miner_rpcs_disabled() -> Result<()> {
+    common::zcashd_compat::startup::miner_rpcs_disabled().await
 }
 
 /// Verifies that zcashd's RPC endpoint rejects requests with invalid credentials.
@@ -4695,36 +4705,28 @@ async fn zcashd_compat_reorg_equal_work_race() -> Result<()> {
     common::zcashd_compat::reorg::equal_work_race().await
 }
 
-/// See [`common::zcashd_compat::reorg::depth_at_batch_limit`] for details.
+/// See [`common::zcashd_compat::reorg::deep_reorg_depth33`] for details.
 #[tokio::test]
 #[ignore]
 #[cfg(unix)]
-async fn zcashd_compat_reorg_depth_at_batch_limit() -> Result<()> {
-    common::zcashd_compat::reorg::depth_at_batch_limit().await
+async fn zcashd_compat_reorg_deep_depth33() -> Result<()> {
+    common::zcashd_compat::reorg::deep_reorg_depth33().await
 }
 
-/// See [`common::zcashd_compat::reorg::large_batch_depth80`] for details.
+/// See [`common::zcashd_compat::reorg::deep_reorg_depth80`] for details.
 #[tokio::test]
 #[ignore]
 #[cfg(unix)]
-async fn zcashd_compat_reorg_large_batch_depth80() -> Result<()> {
-    common::zcashd_compat::reorg::large_batch_depth80().await
+async fn zcashd_compat_reorg_deep_depth80() -> Result<()> {
+    common::zcashd_compat::reorg::deep_reorg_depth80().await
 }
 
-/// See [`common::zcashd_compat::reorg::over_batch_branch_syncs`] for details.
+/// See [`common::zcashd_compat::reorg::deep_reorg_restart_recovers`] for details.
 #[tokio::test]
 #[ignore]
 #[cfg(unix)]
-async fn zcashd_compat_reorg_over_batch_branch_syncs() -> Result<()> {
-    common::zcashd_compat::reorg::over_batch_branch_syncs().await
-}
-
-/// See [`common::zcashd_compat::reorg::over_batch_branch_restart_recovers`] for details.
-#[tokio::test]
-#[ignore]
-#[cfg(unix)]
-async fn zcashd_compat_reorg_over_batch_branch_restart_recovers() -> Result<()> {
-    common::zcashd_compat::reorg::over_batch_branch_restart_recovers().await
+async fn zcashd_compat_reorg_deep_restart_recovers() -> Result<()> {
+    common::zcashd_compat::reorg::deep_reorg_restart_recovers().await
 }
 
 /// See [`common::zcashd_compat::reorg::restart_after_reorg`] for details.

--- a/zebrad/tests/common/zcashd_compat.rs
+++ b/zebrad/tests/common/zcashd_compat.rs
@@ -33,7 +33,7 @@ pub const TEST_ZCASHD_COMPAT: &str = "TEST_ZCASHD_COMPAT";
 // `ZebradConfig` rejects unknown fields. A `ZEBRA_`-prefixed test var would
 // make every spawned zebrad child abort at startup.
 
-/// Optional explicit path to a zcashd binary with zebra-compat support.
+/// Optional explicit path to a P2P-sidecar zcashd binary.
 /// If unset, the managed download is used in regtest mode.
 pub const TEST_ZCASHD_PATH: &str = "TEST_ZCASHD_PATH";
 
@@ -161,8 +161,8 @@ impl ZcashdRpcClient {
 
 /// Polls zcashd's `getblockcount` until it reaches `height`, up to 60 seconds.
 ///
-/// zcashd learns about newly mined blocks from zebrad via a polling worker,
-/// so tests that mine must wait for it to catch up before cross-checking.
+/// zcashd learns about newly mined blocks from zebrad over legacy P2P block
+/// gossip, so tests that mine must wait for it to catch up before cross-checking.
 pub async fn wait_for_zcashd_height(client: &ZcashdRpcClient, height: u64) -> Result<()> {
     let mut last_seen = None;
     for _ in 0..60u32 {
@@ -197,29 +197,6 @@ pub async fn setup_zcashd_compat() -> Result<Option<launch::ZcashdCompatSetup>> 
 
     match config::read_test_network_kind()? {
         NetworkKind::Regtest => launch::spawn_zebrad_with_zcashd_compat().await.map(Some),
-        kind => launch::connect_to_external_zcashd_compat(kind)
-            .await
-            .map(Some),
-    }
-}
-
-/// Sets up the zcashd-compat test environment with managed-regtest options.
-///
-/// Options are only applied in managed regtest mode. External mainnet/testnet
-/// validation connects to existing processes and ignores them.
-pub async fn setup_zcashd_compat_with_options(
-    options: config::ZcashdCompatTestOptions,
-) -> Result<Option<launch::ZcashdCompatSetup>> {
-    if zebra_skip_zcashd_compat_tests() {
-        return Ok(None);
-    }
-
-    use zebra_chain::parameters::NetworkKind;
-
-    match config::read_test_network_kind()? {
-        NetworkKind::Regtest => launch::spawn_zebrad_with_zcashd_compat_with_options(options)
-            .await
-            .map(Some),
         kind => launch::connect_to_external_zcashd_compat(kind)
             .await
             .map(Some),

--- a/zebrad/tests/common/zcashd_compat/config.rs
+++ b/zebrad/tests/common/zcashd_compat/config.rs
@@ -31,12 +31,6 @@ pub struct ZcashdCompatConfig {
 pub const ZCASHD_TEST_RPC_USER: &str = "zcashd_test";
 pub const ZCASHD_TEST_RPC_PASS: &str = "zebra_test_pass";
 
-/// Default zcashd sync batch size for managed regtest tests.
-pub const DEFAULT_TEST_SYNC_BATCH_SIZE: u64 = 33;
-/// Zebra RPC response body limit needed for the default zcashd sync batch size.
-pub const DEFAULT_TEST_RPC_MAX_RESPONSE_BODY_SIZE: usize =
-    DEFAULT_TEST_SYNC_BATCH_SIZE as usize * 4 * 1024 * 1024;
-
 /// Deterministic regtest miner keypair (secp256k1 secret key = 1, compressed).
 ///
 /// zebrad mines coinbase to this address; tx-flow tests import the private key
@@ -44,41 +38,12 @@ pub const DEFAULT_TEST_RPC_MAX_RESPONSE_BODY_SIZE: usize =
 pub const MINER_T_ADDR: &str = "tmLPctKo9j49rtCSKpwEBpLBeykiTGomGQs";
 pub const MINER_PRIV_WIF: &str = "cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA";
 
-/// Tunable zcashd-compat options for managed regtest tests.
-#[derive(Clone, Copy, Debug)]
-pub struct ZcashdCompatTestOptions {
-    /// zcashd's requested Zebra sync batch size.
-    pub sync_batch_size: u64,
-    /// Optional zcashd raw-block response budget in MiB.
-    pub sync_response_budget_mb: Option<u64>,
-    /// Optional Zebra RPC response body limit.
-    pub rpc_max_response_body_size: Option<usize>,
-}
-
-impl Default for ZcashdCompatTestOptions {
-    fn default() -> Self {
-        Self {
-            sync_batch_size: DEFAULT_TEST_SYNC_BATCH_SIZE,
-            sync_response_budget_mb: None,
-            rpc_max_response_body_size: Some(DEFAULT_TEST_RPC_MAX_RESPONSE_BODY_SIZE),
-        }
-    }
-}
-
 /// Builds a regtest zebrad config wired for zcashd-compat testing.
 ///
 /// `cookie_dir` must be the directory where zebrad will write the zcashd-compat
 /// cookie file.  In managed-spawn mode this is the testdir (kept alive by the
 /// `TestChild`).
 pub fn build_zcashd_compat_config(cookie_dir: PathBuf) -> Result<ZcashdCompatConfig> {
-    build_zcashd_compat_config_with_options(cookie_dir, ZcashdCompatTestOptions::default())
-}
-
-/// Builds a regtest zebrad config wired for zcashd-compat testing.
-pub fn build_zcashd_compat_config_with_options(
-    cookie_dir: PathBuf,
-    options: ZcashdCompatTestOptions,
-) -> Result<ZcashdCompatConfig> {
     let net = Network::new_regtest(
         ConfiguredActivationHeights {
             nu5: Some(1),
@@ -105,9 +70,6 @@ pub fn build_zcashd_compat_config_with_options(
     config.rpc.listen_addr = Some(zebra_rpc_addr);
     config.rpc.parallel_cpu_threads = 1;
     config.rpc.enable_cookie_auth = false;
-    if let Some(max_response_body_size) = options.rpc_max_response_body_size {
-        config.rpc.max_response_body_size = max_response_body_size;
-    }
 
     // Enable mempool from genesis so tx-flow tests work immediately
     config.mempool = mempool::Config {
@@ -155,18 +117,11 @@ pub fn build_zcashd_compat_config_with_options(
         // The wallet tests use `getnewaddress`, which is deny-by-default
         // deprecated in current zcashd.
         "-allowdeprecated=getnewaddress".to_string(),
-        format!("-zebra-compat-sync-batch-size={}", options.sync_batch_size),
-        "-zebra-compat-poll-interval=1".to_string(),
         // Regtest blocks mined on top of the 2011 genesis inherit old
         // median-time-past timestamps, which would keep zcashd in initial
         // block download forever and disable its wallet RPCs. 100 years.
         "-maxtipage=3153600000".to_string(),
     ];
-    if let Some(sync_response_budget_mb) = options.sync_response_budget_mb {
-        config.zcashd_compat.zcashd_extra_args.push(format!(
-            "-zebra-compat-sync-response-budget-mb={sync_response_budget_mb}"
-        ));
-    }
 
     Ok(ZcashdCompatConfig {
         zebrad_config: config,

--- a/zebrad/tests/common/zcashd_compat/launch.rs
+++ b/zebrad/tests/common/zcashd_compat/launch.rs
@@ -14,8 +14,7 @@ use zebra_test::{args, command::TestChild};
 
 use super::{
     config::{
-        build_zcashd_compat_config, build_zcashd_compat_config_with_options, ZcashdCompatConfig,
-        ZcashdCompatTestOptions, ZCASHD_TEST_RPC_PASS, ZCASHD_TEST_RPC_USER,
+        build_zcashd_compat_config, ZcashdCompatConfig, ZCASHD_TEST_RPC_PASS, ZCASHD_TEST_RPC_USER,
     },
     ZcashdRpcClient, TEST_ZCASHD_COOKIE_FILE, TEST_ZCASHD_RPC_ADDR, TEST_ZCASHD_RPC_PASSWORD,
     TEST_ZCASHD_RPC_USER, TEST_ZEBRAD_RPC_ADDR,
@@ -133,31 +132,12 @@ pub fn send_signal(pid: u32, signal: &str) -> Result<()> {
 /// Spawns a fresh regtest zebrad that supervises a zcashd-compat zcashd process,
 /// waits for both to be ready, and returns the test setup.
 pub async fn spawn_zebrad_with_zcashd_compat() -> Result<ZcashdCompatSetup> {
-    spawn_zebrad_with_zcashd_compat_with_config_builder(build_zcashd_compat_config).await
-}
-
-/// Spawns a fresh regtest zebrad with configurable zcashd-compat limits.
-pub async fn spawn_zebrad_with_zcashd_compat_with_options(
-    options: ZcashdCompatTestOptions,
-) -> Result<ZcashdCompatSetup> {
-    spawn_zebrad_with_zcashd_compat_with_config_builder(|cookie_dir| {
-        build_zcashd_compat_config_with_options(cookie_dir, options)
-    })
-    .await
-}
-
-async fn spawn_zebrad_with_zcashd_compat_with_config_builder<F>(
-    build_config: F,
-) -> Result<ZcashdCompatSetup>
-where
-    F: FnOnce(PathBuf) -> Result<ZcashdCompatConfig>,
-{
     let _init_guard = zebra_test::init();
 
     let dir = testdir()?;
     let cookie_dir = dir.path().to_path_buf();
 
-    let compat_cfg = build_config(cookie_dir.clone())?;
+    let compat_cfg: ZcashdCompatConfig = build_zcashd_compat_config(cookie_dir.clone())?;
     let mut zebrad_config = compat_cfg.zebrad_config;
 
     let zebra_rpc_addr = compat_cfg.zebra_rpc_addr;

--- a/zebrad/tests/common/zcashd_compat/reorg.rs
+++ b/zebrad/tests/common/zcashd_compat/reorg.rs
@@ -1,4 +1,8 @@
 //! Reorg regression and stress test bodies for the zcashd-compat integration suite.
+//!
+//! The sidecar zcashd follows Zebra over legacy P2P, so these tests assert
+//! standard most-work chain selection: zcashd reorgs when Zebra's replacement
+//! branch has strictly more work, and holds its first-seen tip on equal work.
 
 use std::time::{Duration, Instant};
 
@@ -6,19 +10,19 @@ use color_eyre::eyre::{eyre, Result};
 use tokio::time::sleep;
 
 use super::{
-    config::{self, ZcashdCompatTestOptions},
     launch::{send_signal, ZcashdCompatSetup},
-    setup_zcashd_compat, setup_zcashd_compat_with_options, ZcashdRpcClient,
-    TEST_ZCASHD_COMPAT_REORG_ITERATIONS, TEST_ZCASHD_COMPAT_RESTART_AFTER_REORG,
+    setup_zcashd_compat, ZcashdRpcClient, TEST_ZCASHD_COMPAT_REORG_ITERATIONS,
+    TEST_ZCASHD_COMPAT_RESTART_AFTER_REORG,
 };
 use crate::common::regtest::MiningRpcMethods;
 
-const SYNC_BATCH_SIZE_LIMIT: u64 = config::DEFAULT_TEST_SYNC_BATCH_SIZE;
 const DEFAULT_REORG_CHURN_ITERATIONS: u32 = 30;
 const CHAIN_HEIGHT_DEEP: u32 = 295;
 const STANDARD_SYNC_TIMEOUT: Duration = Duration::from_secs(90);
 const DEEP_REORG_SYNC_TIMEOUT: Duration = Duration::from_secs(120);
-const LARGE_BATCH_REORG_SYNC_TIMEOUT: Duration = Duration::from_secs(180);
+/// How long zcashd gets to (wrongly) follow an equal-work replacement tip
+/// before we assert it held its first-seen chain.
+const EQUAL_WORK_SETTLE: Duration = Duration::from_secs(10);
 
 /// Verifies that zcashd follows a basic Zebra depth-1 reorg.
 pub async fn basic_depth1() -> Result<()> {
@@ -36,14 +40,11 @@ pub async fn basic_depth1() -> Result<()> {
     force_zebra_reorg(&setup, 9, 2).await?;
     wait_for_tips_match(&setup, STANDARD_SYNC_TIMEOUT).await?;
 
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(info["sync"]["state"].as_str(), Some("synced"));
-    assert_eq!(info["sync"]["detail"].as_str(), Some("zebra_tip_matched"));
-
     setup.teardown()
 }
 
-/// Regression test for same-height equal-work reorgs that zcashd cannot activate immediately.
+/// Same-height equal-work replacement tips must not displace zcashd's
+/// first-seen chain until Zebra's branch takes the work lead.
 pub async fn equal_work_race() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
         return Ok(());
@@ -58,36 +59,33 @@ pub async fn equal_work_race() -> Result<()> {
 
     let old_zcashd_tip = zcashd_tip(&setup.zcashd_client).await?;
 
+    // Replace Zebra's tip block with a competing block at the same height.
     force_zebra_reorg(&setup, 9, 1).await?;
 
-    let info = wait_for_sync_detail(
-        &setup.zcashd_client,
-        "zebra_equal_work_reorg_not_activated",
-        STANDARD_SYNC_TIMEOUT,
-    )
-    .await?;
-    let zebra_tip = zebra_tip(&setup).await?;
-    let zcashd_tip = zcashd_tip(&setup.zcashd_client).await?;
+    // Give zcashd time to see (and wrongly follow) the replacement tip.
+    sleep(EQUAL_WORK_SETTLE).await;
 
-    assert_eq!(info["sync"]["state"].as_str(), Some("degraded"));
+    let zebra_tip = zebra_tip(&setup).await?;
+    let zcashd_tip_now = zcashd_tip(&setup.zcashd_client).await?;
+
     assert_eq!(
-        zcashd_tip, old_zcashd_tip,
+        zcashd_tip_now, old_zcashd_tip,
         "zcashd should keep the first-seen equal-work tip until Zebra extends"
     );
     assert_ne!(
-        zcashd_tip.1, zebra_tip.1,
+        zcashd_tip_now.1, zebra_tip.1,
         "the equal-work race requires same-height competing tips"
     );
 
+    // Once Zebra extends its branch it has strictly more work and zcashd follows.
     setup.zebra_client.generate(1).await?;
     wait_for_tips_match(&setup, STANDARD_SYNC_TIMEOUT).await?;
-    wait_for_readiness(&setup.zcashd_client, "ready", STANDARD_SYNC_TIMEOUT).await?;
 
     setup.teardown()
 }
 
-/// Verifies that zcashd can ingest a replacement branch at its batch-size limit.
-pub async fn depth_at_batch_limit() -> Result<()> {
+/// Verifies that zcashd follows a deep (33-block) replacement branch.
+pub async fn deep_reorg_depth33() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
         return Ok(());
     };
@@ -99,28 +97,15 @@ pub async fn depth_at_batch_limit() -> Result<()> {
     setup.zebra_client.generate(40).await?;
     wait_for_tips_match(&setup, STANDARD_SYNC_TIMEOUT).await?;
 
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(
-        info["limits"]["sync_batch_size"].as_u64(),
-        Some(SYNC_BATCH_SIZE_LIMIT),
-        "test assumes zcashd's memory-clamped sync batch limit is 33"
-    );
-
-    force_zebra_reorg(&setup, 8, SYNC_BATCH_SIZE_LIMIT as u32).await?;
+    force_zebra_reorg(&setup, 8, 33).await?;
     wait_for_tips_match(&setup, DEEP_REORG_SYNC_TIMEOUT).await?;
 
     setup.teardown()
 }
 
-/// Verifies that a raised response budget supports an 80-block replacement branch.
-pub async fn large_batch_depth80() -> Result<()> {
-    let Some(setup) = setup_zcashd_compat_with_options(ZcashdCompatTestOptions {
-        sync_batch_size: 80,
-        sync_response_budget_mb: Some(320),
-        rpc_max_response_body_size: Some(320 * 1024 * 1024),
-    })
-    .await?
-    else {
+/// Verifies that zcashd follows an 80-block replacement branch.
+pub async fn deep_reorg_depth80() -> Result<()> {
+    let Some(setup) = setup_zcashd_compat().await? else {
         return Ok(());
     };
 
@@ -129,60 +114,16 @@ pub async fn large_batch_depth80() -> Result<()> {
     }
 
     setup.zebra_client.generate(90).await?;
-    wait_for_tips_match(&setup, LARGE_BATCH_REORG_SYNC_TIMEOUT).await?;
-
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(info["limits"]["sync_batch_size"].as_u64(), Some(80));
-    assert_eq!(
-        info["limits"]["zebra_rpc_max_response_body_bytes"].as_u64(),
-        Some(321_130_496)
-    );
-
-    force_zebra_reorg(&setup, 11, 80).await?;
-    wait_for_tips_match(&setup, LARGE_BATCH_REORG_SYNC_TIMEOUT).await?;
-
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(info["sync"]["state"].as_str(), Some("synced"));
-    assert_eq!(info["sync"]["detail"].as_str(), Some("zebra_tip_matched"));
-
-    setup.teardown()
-}
-
-/// Verifies that a replacement branch longer than one sync batch still converges.
-///
-/// zcashd fetches the reorg activation prefix in `ZebraCompatSyncBatchSize()`
-/// chunks, then forward-syncs any remaining Zebra tip tail.
-pub async fn over_batch_branch_syncs() -> Result<()> {
-    let Some(setup) = setup_zcashd_compat().await? else {
-        return Ok(());
-    };
-
-    if !setup.can_mutate() {
-        return setup.teardown();
-    }
-
-    setup.zebra_client.generate(40).await?;
-    wait_for_tips_match(&setup, STANDARD_SYNC_TIMEOUT).await?;
-
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(
-        info["limits"]["sync_batch_size"].as_u64(),
-        Some(SYNC_BATCH_SIZE_LIMIT),
-        "test assumes zcashd's memory-clamped sync batch limit is 33"
-    );
-
-    force_zebra_reorg(&setup, 8, (SYNC_BATCH_SIZE_LIMIT + 1) as u32).await?;
     wait_for_tips_match(&setup, DEEP_REORG_SYNC_TIMEOUT).await?;
 
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(info["sync"]["state"].as_str(), Some("synced"));
-    assert_eq!(info["sync"]["detail"].as_str(), Some("zebra_tip_matched"));
+    force_zebra_reorg(&setup, 11, 80).await?;
+    wait_for_tips_match(&setup, DEEP_REORG_SYNC_TIMEOUT).await?;
 
     setup.teardown()
 }
 
-/// Verifies that an over-batch replacement branch remains healthy after restart.
-pub async fn over_batch_branch_restart_recovers() -> Result<()> {
+/// Verifies that a deep replacement branch remains healthy after restart.
+pub async fn deep_reorg_restart_recovers() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
         return Ok(());
     };
@@ -194,28 +135,20 @@ pub async fn over_batch_branch_restart_recovers() -> Result<()> {
     setup.zebra_client.generate(40).await?;
     wait_for_tips_match(&setup, STANDARD_SYNC_TIMEOUT).await?;
 
-    force_zebra_reorg(&setup, 8, (SYNC_BATCH_SIZE_LIMIT + 1) as u32).await?;
+    force_zebra_reorg(&setup, 8, 34).await?;
 
     wait_for_tips_match(&setup, DEEP_REORG_SYNC_TIMEOUT).await?;
 
     restart_zcashd_and_wait_for_tips(&setup).await?;
-
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(
-        info["sync"]["detail"].as_str(),
-        Some("zebra_tip_matched"),
-        "sync loop not healthy after over-batch reorg restart; detail: {:?}",
-        info["sync"]["detail"]
-    );
 
     setup.teardown()
 }
 
 /// Opt-in probe for zcashd supervisor restart after Zebra-side regtest reorgs.
 ///
-/// Exercises VerifyDB and LoadBlockIndex with trusted Zebra regtest side-branch
-/// block-index entries on disk after several reorgs. Opt-in because these restart
-/// probes are slow, not because of a known crash.
+/// Exercises VerifyDB and LoadBlockIndex with side-branch block-index entries
+/// on disk after several reorgs. Opt-in because these restart probes are slow,
+/// not because of a known crash.
 #[allow(clippy::print_stderr)]
 pub async fn restart_after_reorg() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
@@ -254,8 +187,8 @@ pub async fn restart_after_reorg() -> Result<()> {
 
 /// Interleaved reorg-then-restart across three cycles.
 ///
-/// Each restart boots from a chain that already survived one restart, so trusted-boundary
-/// advancement on disk and VerifyDB / LoadBlockIndex keep working across cycles.
+/// Each restart boots from a chain that already survived one restart, so
+/// VerifyDB / LoadBlockIndex keep working across cycles.
 #[allow(clippy::print_stderr)]
 pub async fn restart_cycles() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
@@ -289,24 +222,15 @@ pub async fn restart_cycles() -> Result<()> {
         restart_zcashd_and_wait_for_tips(&setup)
             .await
             .map_err(|e| eyre!("cycle {cycle}: restart: {e}"))?;
-
-        let info = compat_info(&setup.zcashd_client).await?;
-        assert_eq!(
-            info["sync"]["detail"].as_str(),
-            Some("zebra_tip_matched"),
-            "cycle {cycle}: sync loop not healthy after restart; detail: {:?}",
-            info["sync"]["detail"]
-        );
     }
 
     setup.teardown()
 }
 
-/// VerifyDB window coverage on a long trusted chain after reorg and restart.
+/// VerifyDB window coverage on a long chain after reorg and restart.
 ///
-/// When the active chain exceeds zcashd's default `-checkblocks=288` window, trusted Zebra
-/// regtest blocks must skip PoW checks in VerifyDB and LoadBlockIndex must not fail on
-/// disconnected side-branch entries below the trusted boundary.
+/// When the active chain exceeds zcashd's default `-checkblocks=288` window,
+/// restart must not fail on disconnected side-branch entries.
 #[allow(clippy::print_stderr)]
 pub async fn restart_deep_chain() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
@@ -332,22 +256,11 @@ pub async fn restart_deep_chain() -> Result<()> {
     wait_for_tips_match(&setup, DEEP_REORG_SYNC_TIMEOUT).await?;
     restart_zcashd_and_wait_for_tips(&setup).await?;
 
-    let info = compat_info(&setup.zcashd_client).await?;
-    assert_eq!(
-        info["sync"]["detail"].as_str(),
-        Some("zebra_tip_matched"),
-        "sync loop not healthy after deep-chain restart; detail: {:?}",
-        info["sync"]["detail"]
-    );
-
     setup.teardown()
 }
 
-/// Requires zcashd to recover when Zebra's best tip temporarily rolls behind zcashd's local tip.
-///
-/// zcashd must report `zebra_tip_behind_local` as a degraded, retryable state,
-/// then recover when Zebra mines a replacement branch. Sticky local-tip-ahead
-/// failures are regressions.
+/// Requires zcashd to hold its chain when Zebra's best tip temporarily rolls
+/// behind zcashd's local tip, then follow once Zebra takes the work lead again.
 pub async fn zebra_tip_behind_local() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
         return Ok(());
@@ -364,6 +277,7 @@ pub async fn zebra_tip_behind_local() -> Result<()> {
     let old_zebra_tip = zebra_tip(&setup).await?;
     assert_eq!(old_zcashd_tip, old_zebra_tip);
 
+    // Roll Zebra's tip back one block; Zebra is now behind zcashd.
     let params = serde_json::to_string(&vec![old_zebra_tip.1])?;
     let _: () = setup
         .zebra_client
@@ -371,28 +285,23 @@ pub async fn zebra_tip_behind_local() -> Result<()> {
         .await
         .map_err(|e| eyre!("zebrad invalidate tip block: {e}"))?;
 
-    let info = wait_for_sync_detail(
-        &setup.zcashd_client,
-        "zebra_tip_behind_local",
-        STANDARD_SYNC_TIMEOUT,
-    )
-    .await?;
+    // zcashd must keep its longer first-seen chain: nothing on the network
+    // has more work than its current tip.
+    sleep(EQUAL_WORK_SETTLE).await;
+    let zcashd_tip_now = zcashd_tip(&setup.zcashd_client).await?;
+    assert_eq!(
+        zcashd_tip_now, old_zcashd_tip,
+        "zcashd must hold its chain while Zebra's tip is behind"
+    );
 
-    assert_eq!(info["sync"]["state"].as_str(), Some("degraded"));
-
+    // Once Zebra mines a strictly-more-work replacement branch, zcashd follows.
     setup.zebra_client.generate(2).await?;
     wait_for_tips_match(&setup, DEEP_REORG_SYNC_TIMEOUT).await?;
-    wait_for_readiness(&setup.zcashd_client, "ready", STANDARD_SYNC_TIMEOUT).await?;
 
     setup.teardown()
 }
 
-/// No sticky failure when Zebra shrinks after a paused reorg has fully converged.
-///
-/// After zcashd completes reorg ingestion, an unpaused tip invalidation exercises
-/// tip-behind recovery without sticky `failed` sync state. The `reorgContext` transient
-/// (`zebra_tip_temporarily_behind_local_after_reorg`) is covered by zcashd unit tests;
-/// this integration test validates end-to-end recovery and asserts `zebra_tip_matched`.
+/// No sticky divergence when Zebra shrinks right after a reorg has converged.
 pub async fn reorg_context_zebra_tip_behind_recovers() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
         return Ok(());
@@ -426,19 +335,6 @@ pub async fn reorg_context_zebra_tip_behind_recovers() -> Result<()> {
         wait_for_tips_match(&setup, DEEP_REORG_SYNC_TIMEOUT)
             .await
             .map_err(|e| eyre!("round {round}: {e}"))?;
-
-        let info = compat_info(&setup.zcashd_client).await?;
-        assert_ne!(
-            info["sync"]["state"].as_str(),
-            Some("failed"),
-            "round {round}: zcashd entered sticky failure; detail: {:?}",
-            info["sync"]["detail"]
-        );
-        assert_eq!(
-            info["sync"]["detail"].as_str(),
-            Some("zebra_tip_matched"),
-            "round {round}: zcashd not synced after recovery"
-        );
     }
 
     setup.teardown()
@@ -522,13 +418,6 @@ fn tip_from_blockchain_info(node: &str, info: serde_json::Value) -> Result<(u64,
     Ok((height, hash))
 }
 
-async fn compat_info(client: &ZcashdRpcClient) -> Result<serde_json::Value> {
-    client
-        .json_result_from_call("getzebracompatinfo", "[]")
-        .await
-        .map_err(|e| eyre!("getzebracompatinfo: {e}"))
-}
-
 struct ZcashdPauseGuard {
     pid: u32,
     paused: bool,
@@ -571,7 +460,6 @@ async fn restart_zcashd_and_wait_for_tips(setup: &ZcashdCompatSetup) -> Result<(
         .map_err(|e| eyre!("zcashd stop: {e}"))?;
 
     wait_for_restarted_zcashd_rpc(setup, old_pid, STANDARD_SYNC_TIMEOUT).await?;
-    wait_for_readiness(&setup.zcashd_client, "ready", STANDARD_SYNC_TIMEOUT).await?;
     wait_for_tips_match(setup, STANDARD_SYNC_TIMEOUT).await
 }
 
@@ -610,8 +498,8 @@ async fn wait_for_restarted_zcashd_rpc(
 /// Forces a Zebra-side reorg while zcashd is paused so it observes the new best chain atomically.
 ///
 /// Paused reorgs avoid observable intermediate shorter-chain states during test
-/// orchestration. Unpaused depth >1 reorgs can leave zcashd in a transient retryable
-/// degraded state until Zebra's replacement branch extends.
+/// orchestration. Unpaused depth >1 reorgs can leave zcashd holding its chain
+/// until Zebra's replacement branch takes the work lead.
 async fn force_zebra_reorg(
     setup: &ZcashdCompatSetup,
     fork_height: u64,
@@ -662,62 +550,6 @@ async fn wait_for_tips_match(setup: &ZcashdCompatSetup, timeout: Duration) -> Re
         if Instant::now() >= deadline {
             return Err(eyre!(
                 "tips did not match within {timeout:?}; last seen: {last_seen:?}"
-            ));
-        }
-
-        sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn wait_for_sync_detail(
-    client: &ZcashdRpcClient,
-    expected: &str,
-    timeout: Duration,
-) -> Result<serde_json::Value> {
-    let deadline = Instant::now() + timeout;
-    let mut last_seen;
-
-    loop {
-        let info = compat_info(client).await?;
-        let detail = info["sync"]["detail"].as_str().map(str::to_string);
-
-        if detail.as_deref() == Some(expected) {
-            return Ok(info);
-        }
-
-        last_seen = Some(info);
-
-        if Instant::now() >= deadline {
-            return Err(eyre!(
-                "sync.detail did not become {expected:?} within {timeout:?}; last seen: {last_seen:?}"
-            ));
-        }
-
-        sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn wait_for_readiness(
-    client: &ZcashdRpcClient,
-    expected: &str,
-    timeout: Duration,
-) -> Result<serde_json::Value> {
-    let deadline = Instant::now() + timeout;
-    let mut last_seen;
-
-    loop {
-        let info = compat_info(client).await?;
-        let readiness = info["readiness"].as_str().map(str::to_string);
-
-        if readiness.as_deref() == Some(expected) {
-            return Ok(info);
-        }
-
-        last_seen = Some(info);
-
-        if Instant::now() >= deadline {
-            return Err(eyre!(
-                "readiness did not become {expected:?} within {timeout:?}; last seen: {last_seen:?}"
             ));
         }
 

--- a/zebrad/tests/common/zcashd_compat/startup.rs
+++ b/zebrad/tests/common/zcashd_compat/startup.rs
@@ -49,12 +49,14 @@ pub async fn both_processes_start() -> Result<()> {
     setup.teardown()
 }
 
-/// After mining 5 blocks, `getzebracompatinfo` on zcashd should report readiness.
+/// The P2P sidecar zcashd follows Zebra's tip and peers with Zebra alone.
 ///
-/// On managed (regtest) mode: mines 5 blocks, then asserts `readiness == "ready"`.
-/// On external mode: calls `getzebracompatinfo` without mining and checks the field
-/// is a non-null string (live chain may still be syncing).
-pub async fn readiness_after_mine() -> Result<()> {
+/// On managed (regtest) mode: mines 5 blocks via Zebra, waits for zcashd to
+/// reach the same height over P2P, and asserts the best block hashes match.
+/// On all modes: asserts zcashd has exactly one peer — the shield is
+/// "connect only to Zebra, listen for nothing", so a second peer is a
+/// misconfiguration even on live networks.
+pub async fn sidecar_follows_tip() -> Result<()> {
     let Some(setup) = setup_zcashd_compat().await? else {
         return Ok(());
     };
@@ -62,37 +64,82 @@ pub async fn readiness_after_mine() -> Result<()> {
     if setup.can_mutate() {
         setup.zebra_client.generate(5).await?;
         wait_for_zcashd_height(&setup.zcashd_client, 5).await?;
+
+        let zebra_best: String = setup
+            .zebra_client
+            .json_result_from_call("getbestblockhash", "[]")
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!("zebrad getbestblockhash: {e}"))?;
+        let zcashd_best: String = setup
+            .zcashd_client
+            .json_result_from_call("getbestblockhash", "[]")
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!("zcashd getbestblockhash: {e}"))?;
+
+        assert_eq!(
+            zcashd_best, zebra_best,
+            "zcashd should follow Zebra's best block over P2P"
+        );
     }
 
-    // Readiness flips to "ready" once several async components converge
-    // (tip match, mempool mirror, wallet notifications), so poll for up to
-    // 60 seconds in managed mode instead of asserting a single snapshot.
-    let mut readiness = String::new();
-    for attempt in 1..=60u32 {
-        let info: serde_json::Value = setup
+    let peers: Vec<serde_json::Value> = setup
+        .zcashd_client
+        .json_result_from_call("getpeerinfo", "[]")
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("zcashd getpeerinfo: {e}"))?;
+
+    assert_eq!(
+        peers.len(),
+        1,
+        "the sidecar zcashd must peer with exactly one node (Zebra), got: {peers:?}"
+    );
+    assert_eq!(
+        peers[0]["inbound"].as_bool(),
+        Some(false),
+        "the sidecar's single peer must be an outbound -connect to Zebra: {:?}",
+        peers[0]
+    );
+
+    setup.teardown()
+}
+
+/// Miner-facing RPCs are removed from the sidecar zcashd build; Zebra is the
+/// canonical block-template source.
+///
+/// Asserts `getblocktemplate`, `submitblock`, and `generate` return JSON-RPC
+/// "Method not found" on zcashd, and (in managed mode) that Zebra's
+/// `getblocktemplate` succeeds.
+pub async fn miner_rpcs_disabled() -> Result<()> {
+    let Some(setup) = setup_zcashd_compat().await? else {
+        return Ok(());
+    };
+
+    for method in ["getblocktemplate", "submitblock", "generate"] {
+        let error = setup
             .zcashd_client
-            .json_result_from_call("getzebracompatinfo", "[]")
+            .json_result_from_call::<serde_json::Value>(method, "[]")
             .await
-            .map_err(|e| color_eyre::eyre::eyre!("getzebracompatinfo: {e}"))?;
+            .expect_err("miner RPCs must be unavailable on the sidecar zcashd");
 
-        readiness = info["readiness"]
-            .as_str()
-            .ok_or_else(|| {
-                color_eyre::eyre::eyre!("missing or non-string `readiness` field: {info}")
-            })?
-            .to_string();
-
-        if !setup.can_mutate() || readiness == "ready" || attempt == 60 {
-            break;
-        }
-
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        assert!(
+            error.to_string().contains("-32601"),
+            "zcashd {method} should fail with RPC_METHOD_NOT_FOUND (-32601), got: {error}"
+        );
     }
 
     if setup.can_mutate() {
-        assert_eq!(
-            readiness, "ready",
-            "expected readiness=='ready' within 60 s of mining 5 blocks, got {readiness:?}"
+        // Mine one block first so Zebra has a non-genesis tip to build on.
+        setup.zebra_client.generate(1).await?;
+
+        let template: serde_json::Value = setup
+            .zebra_client
+            .json_result_from_call("getblocktemplate", "[]")
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!("zebrad getblocktemplate: {e}"))?;
+
+        assert!(
+            template["height"].is_number(),
+            "zebrad getblocktemplate should return a template: {template}"
         );
     }
 

--- a/zebrad/tests/common/zcashd_compat/tx_flow.rs
+++ b/zebrad/tests/common/zcashd_compat/tx_flow.rs
@@ -72,7 +72,13 @@ pub async fn transparent_tx_in_mempool() -> Result<()> {
         .await
         .map_err(|e| eyre!("sendtoaddress: {e}"))?;
 
-    // Poll zebrad's mempool until the txid appears (up to 30 s).
+    wait_for_zebra_mempool_tx(&setup, &txid).await?;
+
+    setup.teardown()
+}
+
+/// Polls zebrad's `getrawmempool` until `txid` appears (up to 30 s).
+async fn wait_for_zebra_mempool_tx(setup: &ZcashdCompatSetup, txid: &str) -> Result<()> {
     for attempt in 1..=30u32 {
         let mempool: Vec<String> = setup
             .zebra_client
@@ -80,8 +86,8 @@ pub async fn transparent_tx_in_mempool() -> Result<()> {
             .await
             .map_err(|e| eyre!("getrawmempool: {e}"))?;
 
-        if mempool.contains(&txid) {
-            return setup.teardown();
+        if mempool.iter().any(|entry| entry == txid) {
+            return Ok(());
         }
 
         if attempt == 30 {
@@ -92,7 +98,7 @@ pub async fn transparent_tx_in_mempool() -> Result<()> {
         sleep(Duration::from_secs(1)).await;
     }
 
-    setup.teardown()
+    Ok(())
 }
 
 /// Sends a transparent transaction via zcashd, mines a block, and confirms the
@@ -124,6 +130,11 @@ pub async fn transparent_tx_confirms() -> Result<()> {
         .json_result_from_call("sendtoaddress", &format!(r#"["{addr}", 0.001]"#))
         .await
         .map_err(|e| eyre!("sendtoaddress: {e}"))?;
+
+    // Wait for the transaction to relay from zcashd to zebrad over P2P before
+    // mining: zcashd trickles tx invs to peers, so mining immediately would
+    // build a block that misses the transaction.
+    wait_for_zebra_mempool_tx(&setup, &txid).await?;
 
     // Mine a block to confirm the transaction.
     setup.zebra_client.generate(1).await?;


### PR DESCRIPTION
## Motivation

The previous zcashd-compat design had zcashd ingest chain data from a dedicated Zebra RPC listener, which required a large ingest layer on the zcashd side and batch/budget plumbing on the Zebra side. This PR pivots zcashd-compat to the minimal **P2P sidecar** topology (as in ShieldedLabs' `zcashd-behind-zebra`): Zebra faces the network; zcashd makes a single outbound legacy-P2P connection to the local Zebra node and listens for nothing. Zebra needs no protocol changes to serve this — the change is confined to the supervisor, tests, ops checks, and docs. Miners use Zebra's `getblocktemplate` as canonical; the companion sidecar zcashd build (valargroup/zcashd#4) removes the miner RPCs and the upstream EOS auto-shutdown.

## Solution

- **Supervisor** (`zebrad/src/components/zcashd_compat/`): spawn zcashd with `-connect=<zebra p2p addr> -listen=0 -dnsseed=0 -listenonion=0 -discover=0` (placed after `zcashd_extra_args` because zcashd takes the last occurrence of single-valued CLI args), plus `-regtestacceptunvalidatedpow` on Regtest. Multi-valued peer-selection extra args (`-connect`/`-addnode`/`-seednode`, incl. negated forms) are rejected at startup since they accumulate and cannot be overridden. New `[zcashd_compat] p2p_connect_addr` override; default derives from Zebra's bound legacy P2P listener with loopback substituted for unspecified addresses. zcashd-compat now requires `network.legacy_p2p = true`.
- **Removed** the RPC-ingest batch/budget startup validation and the manage+TLS `tls_ca_file` requirement. The dedicated compat RPC listener (127.0.0.1:28232) is retained for operator tooling but no longer feeds zcashd; its config keys are documented as deprecated.
- **Integration tests**: readiness/limits assertions based on `getzebracompatinfo` replaced with P2P-native checks (tip convergence, exactly one outbound loopback peer); new `miner_rpcs_disabled` test; batch-limit reorg tests became plain deep-reorg tests; `tx_flow` now waits for zcashd→zebra P2P tx relay before mining (zcashd trickles tx invs). Restored the `zcashd-compat-{integration,soak,external}` nextest profiles dropped by the Zakura P2P commit, unbreaking `make compat-test-regtest`.
- **Ops**: `make compat-zcashd-start-standalone` runs the pinned-peer argv; status targets, `deploy/zcashd-compat/sync-check.sh`, and the watchdog check assert `getconnectioncount == 1` + height drift instead of `getzebracompatinfo`.
- **Docs**: `book/src/user/zcashd-compat.md` rewritten for the sidecar topology.
- **CI**: `zcashd-compat-regtest.yml` is temporarily `workflow_dispatch`-only — the managed zcashd manifest still pins the RPC-ingest build, which cannot run this suite.

### Tests

- `cargo test -p zebrad --lib -- zcashd_compat`: 99 passed; `cargo test -p zebra-watchdog`: 18 passed; clippy `-D warnings` and `cargo fmt --check` clean.
- Manual regtest smoke: zebra `generate 5` → supervised zcashd follows to the identical best hash over P2P; `getpeerinfo` shows exactly one outbound peer; miner RPCs return `-32601` on zcashd while zebra serves templates.
- Full integration suite (`make compat-test-regtest` with a local sidecar zcashd): **27/27 passed** (`cargo nextest --profile zcashd-compat-integration --run-ignored=only --no-fail-fast`, 28.7 min, test-threads=1). The first pass surfaced one genuine P2P race — `transparent_tx_confirms` mined before zcashd's trickled tx inv reached zebra's mempool — fixed in this PR by waiting for mempool arrival before mining.
- Mainnet verification (live datadir + production zebra image as the front): the datadir written by the previous fork loaded on the sidecar build with **no reindex**; the sidecar caught up **~27,400 blocks at ~1,800 blocks/min** (full validation) through its single pinned peer, where the previous RPC-ingest stack had fallen 27k blocks behind over three weeks. 30-minute tip-follow: **no divergence at any point** — best hashes identical whenever the sidecar reached zebra's height, and identical at the end of the window; `getconnectioncount == 1` (the zebra peer, outbound); `getblocktemplate`/`submitblock`/`generate` all `-32601` on mainnet.
- **Known latency caveat**: with the *old* zebra image (June, pre-#500 gossip fixes) as the front, the sidecar follows the tip in bursts (observed lag 0–20 blocks, worst ~15 min) because zebra only re-advertises some relayed blocks to inbound peers, and zcashd has no header polling at tip — it relies on announcements. A front running current `main` (which gossips every best-chain block) should remove this; an optional zcashd-side periodic `getheaders` tip-poll for the single-peer topology is listed as a follow-up.
- Also found and documented: `network.max_connections_per_ip` defaults to 1 and docker-proxy collapses all proxied source IPs, silently blocking a sidecar that connects through a published port; set `ZEBRA_NETWORK__MAX_CONNECTIONS_PER_IP` on Dockerised fronts.

### Follow-up Work

- Cut a sidecar zcashd release, bump `zebrad/zcashd-compat-manifest.json` + `deploy-zcashd-compat.yml` + the docker `runtime-zcashd-compat` context, then re-enable the regtest workflow's push trigger.
- Remove the deprecated dedicated compat RPC listener and its config keys.
- Bump the sidecar zcashd `PROTOCOL_VERSION` at each network upgrade (zebrad disconnects peers below the NU minimum), and rebase the sidecar patches onto each upstream zcashd release before activation heights.
- Consider a zcashd-side periodic `getheaders` tip-poll to decouple tip latency from the front's gossip reliability (single-peer topology has no announcement redundancy).
- Update the published quick-start site.

### AI Disclosure

Implemented with Claude Code (design, code, tests, and PR description), directed and reviewed by @p0mvn.
