### PR TITLE
ci: run gating workflows on `main` instead of `ironwood-main`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
   # night, and on demand. Pushes to short-lived dev branches no longer trigger
   # it (it is not a merge gate).
   push:
-    branches: [ironwood-main, "release/**"]
+    branches: [main, "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/gitbook.yml
+++ b/.github/workflows/gitbook.yml
@@ -3,7 +3,7 @@ name: Valarbook
 on:
   workflow_dispatch:
   push:
-    branches: [ironwood-main]
+    branches: [main]
     paths:
       - book/valarbook/**
       - .github/workflows/gitbook.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -13,7 +13,7 @@ on:
       - supply-chain/**
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,7 +1,7 @@
 # This workflow automates the creation and updating of draft releases. It compiles PR titles into the draft release notes.
 # https://github.com/valargroup/zebra/releases
 #
-# - Updates the draft release upon each merge into 'ironwood-main'.
+# - Updates the draft release upon each merge into 'main'.
 # - Utilizes the release-drafter GitHub Action to accumulate PR titles since the last release into a draft release note.
 # - Suitable permissions are set for creating releases and handling pull requests.
 #
@@ -10,10 +10,10 @@
 name: Release Drafter
 
 on:
-  # Automatically update the draft release every time a PR merges to `ironwood-main`
+  # Automatically update the draft release every time a PR merges to `main`
   push:
     branches:
-      - ironwood-main
+      - main
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action
@@ -41,7 +41,7 @@ jobs:
       - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
         with:
           config-name: release-drafter.yml
-          commitish: ironwood-main
+          commitish: main
           #disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/status-checks.patch.yml
+++ b/.github/workflows/status-checks.patch.yml
@@ -7,7 +7,7 @@ name: Status Check Patch
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths-ignore:
       # This MUST be an exact inverse of paths in lint.yml, tests-unit.yml, and test-crates.yml
       # to ensure mutual exclusion - only one set of workflows runs

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -2,7 +2,7 @@ name: Test Crate Build
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -12,7 +12,7 @@ on:
       - .github/workflows/test-crates.yml
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -2,7 +2,7 @@ name: Test Docker Config
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - "**/*.rs"
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - "**/*.rs"
@@ -12,7 +12,7 @@ on:
       - .github/workflows/tests-unit.yml
 
   push:
-    branches: [ironwood-main]
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/zakura-e2e.yml
+++ b/.github/workflows/zakura-e2e.yml
@@ -7,21 +7,21 @@ name: Zakura E2E
 #   - a pull request touches Zakura-relevant paths, OR carries the
 #     `run-zakura-e2e` label (gating is done in the `changes` job below);
 #   - a push touches Zakura-relevant paths, for the regular Zakura gate jobs;
-#   - every push to `ironwood-main`, for the block-sync fuzz scenarios;
+#   - every push to `main`, for the block-sync fuzz scenarios;
 #   - the change is in the merge queue (`merge_group` ignores path filters), so a
 #     change that breaks Zakura sync indirectly is still caught before it lands;
 #   - nightly / on demand, for the long four-node modes.
 on:
   # No `paths:` filter here on purpose:
   # - PR/push Zakura gating is handled by the `changes` job.
-  # - block-sync fuzz must run after every merge to `ironwood-main`, even when
+  # - block-sync fuzz must run after every merge to `main`, even when
   #   the merged PR did not touch an obviously Zakura-specific path.
   pull_request:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
   push:
-    branches: [ironwood-main, "feat/**", "release/**"]
+    branches: [main, "feat/**", "release/**"]
 
   # Always run in the merge queue, so a change that breaks Zakura sync
   # indirectly is still caught at landing.
@@ -202,11 +202,11 @@ jobs:
   zakura-blocksync-fuzz:
     name: Zakura block-sync fuzz scenarios
     # These are long scenario/fuzz-style simulations, not normal PR unit tests.
-    # Run them after merges to `ironwood-main`, nightly, and on demand so
+    # Run them after merges to `main`, nightly, and on demand so
     # regressions are still visible without making every PR wait on the flakiest
     # block-sync scenarios.
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/ironwood-main') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     permissions:


### PR DESCRIPTION
## Motivation

The CI gate on Zakura isn't running due to the name of the last branch.

## Solution

Repoint the `push`/`pull_request` branch filters from `ironwood-main` to `main` (Zakura's actual trunk) across the gating workflows: `lint`, `tests-unit`, `test-crates`, `test-docker`, `status-checks.patch`, `coverage`, `gitbook`, `zakura-e2e`. No `paths:` filters were changed, so `status-checks.patch.yml`'s "exact inverse" mutual-exclusion with lint/tests-unit/test-crates is preserved.

Also fixed the two same-class automation references inside the touched files:
- `zakura-e2e.yml` — the block-sync fuzz `if:` gate (`github.ref == 'refs/heads/ironwood-main'` → `main`).
- `release-drafter.yml` — push branch + `commitish` (`ironwood-main` → `main`) so the draft release updates on merges to `main`.

### Tests

CI itself is the test: opening this PR should now trigger Lint / Unit Tests / Test Crate Build / Test Docker Config / Zakura E2E, none of which fired on recent PRs. Verified locally that the only remaining `ironwood-main` references are the intentionally-excluded ones below.

### Follow-up Work

Left out of this PR because they are separate/semantic decisions rather than the CI gate, and each still references `ironwood-main`:

- `upstream-sync.yml` — `target_ref` default (`ironwood-main`) controls where upstream-sync PRs are opened; changing it changes behavior, not just a filter.
- `sync-confidence.yml` — its `push` trigger is already disabled (manual-dispatch only); `ironwood-main` there is also a GHCR image-tag name that must stay consistent between the build and run jobs.
- `deploy-zcashd-compat.yml` / `zakura-testnet-deploy.yml` — manual-dispatch `default:` input values (harmless; overridable at dispatch time).
- `README.md` — a prose mention.

### AI Disclosure

- [x] AI tools were used: Claude Code — diagnosed the dark-CI root cause and authored the branch-filter repoint.