### PR TITLE
fix(network): disable v2 p2p by default on mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
-- Added `network.default_p2p = true`, which follows Zebra's binary P2P defaults
-  during upgrades and ignores `network.legacy_p2p` and `network.v2_p2p`: legacy
-  P2P is on for Mainnet, Testnet, and Regtest; Zakura P2P v2 is off on Mainnet
-  and on for Testnet and Regtest. Set `network.default_p2p = false` only when
-  both stack flags should be fixed manual overrides.
+- Replaced the `network.legacy_p2p` and `network.v2_p2p` booleans with a single
+  `network.p2p_stack` setting, which selects `"zebra"` (aliases `"v1"`,
+  `"legacy"`) for the legacy TCP Zcash P2P stack, `"zakura"` (alias `"v2"`) for
+  the native Zakura P2P v2 stack, or `"dual"` (alias `"combined"`) for both.
+  It defaults to `"default"`, which follows Zebra's binary default for the
+  configured network so it can change during upgrades: currently `"zebra"` on
+  Mainnet, and `"dual"` on Testnet and Regtest.
+  The old booleans are deprecated but still parsed, so existing configs keep
+  working. Setting them alongside `network.p2p_stack` is an error, and setting
+  both to `false` — which used to start a node with no peer-to-peer networking
+  at all — is now rejected.
 - Verified-commitment-trees fast sync is now enabled by default when checkpoint
   sync is enabled. Operators can keep checkpoint sync but opt out of the new
   path by setting `consensus.vct_fast_sync = false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Added `network.default_p2p = true`, which follows Zebra's binary P2P defaults
+  during upgrades and ignores `network.legacy_p2p` and `network.v2_p2p`: legacy
+  P2P is on for Mainnet, Testnet, and Regtest; Zakura P2P v2 is off on Mainnet
+  and on for Testnet and Regtest. Set `network.default_p2p = false` only when
+  both stack flags should be fixed manual overrides.
 - Verified-commitment-trees fast sync is now enabled by default when checkpoint
   sync is enabled. Operators can keep checkpoint sync but opt out of the new
   path by setting `consensus.vct_fast_sync = false`.

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -186,12 +186,10 @@ when Zakura listens on an unspecified address. Set
 `zcashd_compat.p2p_connect_addr` when zcashd must reach Zakura through a
 different address (for example across containers).
 
-zcashd-compat mode requires `network.legacy_p2p = true` (the default):
-zcashd speaks the legacy Zcash P2P protocol, and startup fails if the legacy
-listener is disabled. This is independent of Zakura's native P2P endpoint
-(`network.v2_p2p`), which can stay enabled alongside it. Do not enable state
-pruning on the fronting Zakura — a pruned node does not advertise
-`NODE_NETWORK` and zcashd will not sync from it.
+zcashd-compat mode requires the legacy Zcash P2P stack, because zcashd speaks the
+legacy Zcash P2P protocol. Every `network.p2p_stack` value runs it except
+`"zakura"`. Do not enable state pruning on the fronting Zakura — a pruned node does
+not advertise `NODE_NETWORK` and zcashd will not sync from it.
 
 > [!WARNING]
 > When the fronting Zakura runs in Docker with a published P2P port, all

--- a/docker/zakura-regtest-e2e/node1.toml
+++ b/docker/zakura-regtest-e2e/node1.toml
@@ -7,8 +7,7 @@
 network = "Regtest"
 listen_addr = "127.0.0.1:18233"
 # Dual stack: legacy TCP listener AND the Zakura QUIC endpoint.
-v2_p2p = true
-legacy_p2p = true
+p2p_stack = "dual"
 # No peer disk cache; this node is the bootstrap seed.
 cache_dir = false
 initial_testnet_peers = []

--- a/docker/zakura-regtest-e2e/node2.toml
+++ b/docker/zakura-regtest-e2e/node2.toml
@@ -16,12 +16,11 @@ network = "Regtest"
 # stalling the kind-6 catch-up. With a stable identity the restart is a normal
 # same-peer reconnect that node1's duplicate-eviction path clears in seconds.
 zakura_node_secret_key = "0202020202020202020202020202020202020202020202020202020202020202"
-# Inert with legacy_p2p = false (no TCP listener is opened), but the field is
+# Inert under the zakura-only stack (no TCP listener is opened), but the field is
 # required, so keep it on a distinct loopback port for clarity.
 listen_addr = "127.0.0.1:18333"
-v2_p2p = true
 # No legacy stack: no TCP listener, no outbound crawler, no legacy peers.
-legacy_p2p = false
+p2p_stack = "zakura"
 cache_dir = false
 # Pure Zakura: discover nothing over legacy; only the Zakura bootstrap peer below.
 initial_testnet_peers = []

--- a/docker/zakura-regtest-e2e/node3.toml
+++ b/docker/zakura-regtest-e2e/node3.toml
@@ -1,4 +1,4 @@
-# Zakura regtest e2e — node 3 (legacy-only: v2_p2p disabled).
+# Zakura regtest e2e — node 3 (legacy-only: no Zakura P2P v2).
 #
 # This is the backwards-compatibility peer: it speaks only the legacy Zcash TCP
 # protocol and must still coexist with the dual-stack nodes and receive blocks
@@ -8,8 +8,7 @@
 network = "Regtest"
 listen_addr = "127.0.0.1:18433"
 # Legacy stack only — no Zakura endpoint.
-v2_p2p = false
-legacy_p2p = true
+p2p_stack = "zebra"
 cache_dir = false
 initial_testnet_peers = ["127.0.0.1:18233"]
 # Host networking puts every node on 127.0.0.1; raise the per-IP cap above 1.

--- a/docker/zakura-regtest-e2e/node4.toml
+++ b/docker/zakura-regtest-e2e/node4.toml
@@ -9,8 +9,7 @@
 [network]
 network = "Regtest"
 listen_addr = "127.0.0.1:18533"
-v2_p2p = true
-legacy_p2p = true
+p2p_stack = "dual"
 cache_dir = false
 initial_testnet_peers = ["127.0.0.1:18233"]
 # Host networking puts every node on 127.0.0.1; raise the per-IP cap above 1.

--- a/docker/zakura-regtest-e2e/run.sh
+++ b/docker/zakura-regtest-e2e/run.sh
@@ -5,9 +5,9 @@
 # Topology (all on 127.0.0.1 via host networking):
 #   node1  dual-stack seed (legacy TCP + Zakura)  rpc 18232  metrics 19001
 #          fixed iroh identity, stable Zakura QUIC port 18234
-#   node2  PURE Zakura-only (legacy_p2p = false)  rpc 18332  metrics 19002
+#   node2  PURE Zakura-only (p2p_stack = zakura)   rpc 18332  metrics 19002
 #          joins solely by dialing node1's Zakura bootstrap_peers entry
-#   node3  legacy-only (v2_p2p = false)           rpc 18432  metrics 19003  -> node1
+#   node3  legacy-only (p2p_stack = zebra)        rpc 18432  metrics 19003  -> node1
 #   node4  dual-stack (legacy TCP + Zakura)       rpc 18532  metrics 19004  -> node1
 #          dials node1 over legacy TCP, then upgrades to Zakura
 #
@@ -637,7 +637,7 @@ done
 [[ "${n3}" -ge 1 ]] || fail "legacy-only node3 never peered with node1 over legacy TCP"
 snapshot_timeline "legacy-peers-ready"
 
-log "asserting pure-Zakura node2 has no legacy peers (legacy_p2p = false)"
+log "asserting pure-Zakura node2 has no legacy peers (p2p_stack = zakura)"
 # node2 has no legacy stack at all, so it must never have a legacy TCP peer; its
 # only connectivity is the Zakura bootstrap dial to node1.
 n2_legacy=$(peer_count 18332)

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `zebra_network::zakura`, a default-off iroh scaffold that exposes a
   relay/discovery-off endpoint builder and reserves the persistent Zakura iroh
   node secret-key path and config field.
-- Added `PeerServices::NODE_P2P_V2`, the `default_p2p`, `v2_p2p`, and
-  `legacy_p2p` network configs, and a neutral legacy-handshake upgrade hook for
-  mutually capable Zakura peers.
+- Added `PeerServices::NODE_P2P_V2`, the `Config::p2p_stack` network config and
+  its `P2pStack` enum, and a neutral legacy-handshake upgrade hook for mutually
+  capable Zakura peers. `Config::legacy_p2p()` and `Config::v2_p2p()` resolve
+  `p2p_stack` against the configured network; `Config::for_test` now takes a
+  `P2pStack` instead of a `bool`.
 - Added bounded Zakura P2P v2 upgrade prelude and control-handshake wire types,
   including transcript binding, native-vs-upgraded control validation, and
   duplicate-peer handling scaffolding.

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -14,9 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `zebra_network::zakura`, a default-off iroh scaffold that exposes a
   relay/discovery-off endpoint builder and reserves the persistent Zakura iroh
   node secret-key path and config field.
-- Added `PeerServices::NODE_P2P_V2`, the default-on `v2_p2p` and `legacy_p2p`
-  network configs, and a neutral legacy-handshake upgrade hook for mutually
-  capable Zakura peers.
+- Added `PeerServices::NODE_P2P_V2`, the `default_p2p`, `v2_p2p`, and
+  `legacy_p2p` network configs, and a neutral legacy-handshake upgrade hook for
+  mutually capable Zakura peers.
 - Added bounded Zakura P2P v2 upgrade prelude and control-handshake wire types,
   including transcript binding, native-vs-upgraded control validation, and
   duplicate-peer handling scaffolding.

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -14,7 +14,7 @@ use std::{
 use indexmap::IndexSet;
 use iroh::SecretKey;
 use rand::rngs::OsRng;
-use serde::{de, Deserialize, Deserializer, Serializer};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use tokio::fs;
 
 use tracing::Span;
@@ -222,6 +222,20 @@ pub struct Config {
     /// This value is not used by the legacy TCP peer set.
     pub zakura_node_secret_key: Option<ZakuraNodeSecretKey>,
 
+    /// Follow Zebra's default P2P stack selection for the configured network.
+    ///
+    /// This is enabled by default so Zebra can change network defaults during upgrades. When this
+    /// is `true`, Zebra ignores [`legacy_p2p`](Self::legacy_p2p) and
+    /// [`v2_p2p`](Self::v2_p2p) in `zebrad.toml`, and uses the selected network's binary defaults
+    /// instead.
+    ///
+    /// The current defaults are: legacy P2P on for Mainnet, Testnet, and Regtest; Zakura P2P v2
+    /// off on Mainnet; and Zakura P2P v2 on for Testnet and Regtest.
+    ///
+    /// Set `default_p2p = false` only when you want [`legacy_p2p`](Self::legacy_p2p) and
+    /// [`v2_p2p`](Self::v2_p2p) to be fixed manual overrides.
+    pub default_p2p: bool,
+
     /// Enable the experimental Zakura P2P v2 endpoint, capability advertisement, and upgrade hook.
     ///
     /// When enabled, Zebra starts a native Zakura endpoint, advertises the P2P v2 service bit during
@@ -229,14 +243,18 @@ pub struct Config {
     /// before constructing a legacy peer connection if [`legacy_p2p`](Self::legacy_p2p) is also
     /// enabled.
     ///
+    /// In `zebrad.toml`, this setting is used only when [`default_p2p`](Self::default_p2p) is
+    /// `false`.
+    ///
     /// Until the Zakura supervisor and endpoint connector support legacy upgrades, mutually
     /// capable peers continue on the legacy Zebra path after a temporary Zakura upgrade rejection.
     pub v2_p2p: bool,
 
     /// Enable the legacy TCP Zcash P2P listener, initial peer dialing, and peer crawler.
     ///
-    /// This is enabled by default to keep the current Zebra networking behavior. Disable it to run
-    /// only the native Zakura P2P v2 endpoint when [`v2_p2p`](Self::v2_p2p) is enabled.
+    /// In `zebrad.toml`, this setting is used only when [`default_p2p`](Self::default_p2p) is
+    /// `false`. Disable it to run only the native Zakura P2P v2 endpoint when
+    /// [`v2_p2p`](Self::v2_p2p) is enabled.
     pub legacy_p2p: bool,
 
     /// Native Zakura endpoint, connection, and bootstrap settings.
@@ -770,7 +788,8 @@ impl Default for Config {
             cache_dir: CacheDir::default(),
             identity_dir: default_network_identity_dir(),
             zakura_node_secret_key: None,
-            v2_p2p: true,
+            default_p2p: true,
+            v2_p2p: default_v2_p2p_for_network(&Network::Mainnet),
             legacy_p2p: true,
             zakura: ZakuraConfig::default(),
             crawl_new_peer_interval: DEFAULT_CRAWL_NEW_PEER_INTERVAL,
@@ -785,6 +804,81 @@ impl Default for Config {
             peerset_initial_target_size: DEFAULT_PEERSET_INITIAL_TARGET_SIZE,
             max_connections_per_ip: DEFAULT_MAX_CONNS_PER_IP,
         }
+    }
+}
+
+fn default_v2_p2p_for_network(network: &Network) -> bool {
+    !matches!(network, Network::Mainnet)
+}
+
+fn default_p2p_for_network(network: &Network) -> (bool, bool) {
+    let legacy_p2p = true;
+    let v2_p2p = default_v2_p2p_for_network(network);
+
+    (legacy_p2p, v2_p2p)
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum V2P2pPreference {
+    #[default]
+    Default,
+    Explicit(bool),
+}
+
+impl V2P2pPreference {
+    fn resolve(self, network: &Network) -> bool {
+        match self {
+            V2P2pPreference::Default => default_v2_p2p_for_network(network),
+            V2P2pPreference::Explicit(v2_p2p) => v2_p2p,
+        }
+    }
+}
+
+impl Serialize for V2P2pPreference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            V2P2pPreference::Default => serializer.serialize_str("default"),
+            V2P2pPreference::Explicit(v2_p2p) => serializer.serialize_bool(*v2_p2p),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for V2P2pPreference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct V2P2pPreferenceVisitor;
+
+        impl de::Visitor<'_> for V2P2pPreferenceVisitor {
+            type Value = V2P2pPreference;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("true, false, or \"default\"")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(V2P2pPreference::Explicit(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    "default" => Ok(V2P2pPreference::Default),
+                    _ => Err(E::invalid_value(de::Unexpected::Str(value), &self)),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(V2P2pPreferenceVisitor)
     }
 }
 
@@ -852,9 +946,10 @@ struct DConfig {
     identity_dir: PathBuf,
     #[serde(default, skip_serializing)]
     zakura_node_secret_key: Option<ZakuraNodeSecretKey>,
-    #[serde(alias = "enable_p2p_v2")]
-    v2_p2p: bool,
-    legacy_p2p: bool,
+    default_p2p: bool,
+    #[serde(default, alias = "enable_p2p_v2")]
+    v2_p2p: V2P2pPreference,
+    legacy_p2p: Option<bool>,
     zakura: ZakuraConfig,
     peerset_initial_target_size: usize,
     #[serde(alias = "new_peer_interval", with = "humantime_serde")]
@@ -875,8 +970,9 @@ impl Default for DConfig {
             cache_dir: config.cache_dir,
             identity_dir: config.identity_dir,
             zakura_node_secret_key: config.zakura_node_secret_key,
-            v2_p2p: config.v2_p2p,
-            legacy_p2p: config.legacy_p2p,
+            default_p2p: true,
+            v2_p2p: V2P2pPreference::Explicit(config.v2_p2p),
+            legacy_p2p: None,
             zakura: config.zakura,
             peerset_initial_target_size: config.peerset_initial_target_size,
             crawl_new_peer_interval: config.crawl_new_peer_interval,
@@ -935,6 +1031,7 @@ impl From<Config> for DConfig {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
+            default_p2p,
             v2_p2p,
             legacy_p2p,
             zakura,
@@ -963,6 +1060,7 @@ impl From<Config> for DConfig {
 
             other_kind => DNetwork::DefaultForKind(other_kind),
         };
+        let v2_p2p = V2P2pPreference::Explicit(v2_p2p);
 
         DConfig {
             listen_addr: listen_addr.to_string(),
@@ -974,8 +1072,9 @@ impl From<Config> for DConfig {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
+            default_p2p,
             v2_p2p,
-            legacy_p2p,
+            legacy_p2p: Some(legacy_p2p),
             zakura,
             peerset_initial_target_size,
             crawl_new_peer_interval,
@@ -999,6 +1098,7 @@ impl<'de> Deserialize<'de> for Config {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
+            default_p2p,
             v2_p2p,
             legacy_p2p,
             zakura,
@@ -1027,6 +1127,12 @@ impl<'de> Deserialize<'de> for Config {
             (DNetwork::DefaultForKind(NetworkKind::Regtest), None) => {
                 Network::new_regtest(Default::default())
             }
+        };
+
+        let (legacy_p2p, v2_p2p) = if default_p2p {
+            default_p2p_for_network(&network)
+        } else {
+            (legacy_p2p.unwrap_or(true), v2_p2p.resolve(&network))
         };
 
         let listen_addr = match listen_addr.parse::<SocketAddr>().or_else(|_| format!("{listen_addr}:{}", network.default_port()).parse()) {
@@ -1121,6 +1227,7 @@ impl<'de> Deserialize<'de> for Config {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
+            default_p2p,
             v2_p2p,
             legacy_p2p,
             zakura,

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -684,6 +684,24 @@ impl Config {
 
         Ok(load_or_generate_zakura_secret_key(&key_file))
     }
+
+    /// Builds a network config for tests with the P2P stack pinned as an explicit
+    /// override (`default_p2p = false`), so [`v2_p2p`](Self::v2_p2p) and
+    /// [`legacy_p2p`](Self::legacy_p2p) are used verbatim instead of being
+    /// re-derived from the network's binary defaults.
+    ///
+    /// The legacy stack is enabled and `v2_p2p` is set to the argument. Override
+    /// other fields with struct-update syntax, e.g.
+    /// `Config { network, ..Config::for_test(true) }`.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn for_test(v2_p2p: bool) -> Config {
+        Config {
+            default_p2p: false,
+            v2_p2p,
+            legacy_p2p: true,
+            ..Config::default()
+        }
+    }
 }
 
 /// Loads a persisted Zakura secret key from `key_file`, or generates, persists, and

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -101,6 +101,64 @@ pub enum ZakuraSecretKeyError {
 /// or failed DNS attempt.
 const MAX_SINGLE_SEED_PEER_DNS_RETRIES: usize = 0;
 
+/// The peer-to-peer stack Zebra runs, selected by `network.p2p_stack` in `zebrad.toml`.
+///
+/// Each stack has one canonical name and, for readability, some aliases. Only the canonical
+/// name is written back out when a config is serialized.
+///
+/// [`P2pStack::Default`] is a placeholder for the configured network's binary default; it is
+/// turned into one of the three real stacks by [`P2pStack::resolve`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum P2pStack {
+    /// Follow the configured network's binary default, which can change between releases.
+    #[default]
+    Default,
+
+    /// The legacy TCP Zcash P2P stack only.
+    #[serde(alias = "v1", alias = "legacy")]
+    Zebra,
+
+    /// The native Zakura P2P v2 stack only.
+    #[serde(alias = "v2")]
+    Zakura,
+
+    /// Both stacks: mutually capable peers are upgraded to Zakura P2P v2, and the legacy
+    /// stack stays available for peers that can't upgrade.
+    #[serde(alias = "combined")]
+    Dual,
+}
+
+impl P2pStack {
+    /// Resolves [`P2pStack::Default`] to the binary default for `network`, and returns every
+    /// other stack unchanged.
+    ///
+    /// Mainnet defaults to [`P2pStack::Zebra`] until Zakura P2P v2 is proven there. Every other
+    /// network defaults to [`P2pStack::Dual`], so Zakura P2P v2 gets exercised while legacy
+    /// peers stay reachable.
+    pub fn resolve(self, network: &Network) -> P2pStack {
+        match self {
+            P2pStack::Default if matches!(network, Network::Mainnet) => P2pStack::Zebra,
+            P2pStack::Default => P2pStack::Dual,
+            resolved => resolved,
+        }
+    }
+
+    /// Returns `true` if this stack runs the legacy TCP Zcash P2P listener, dialer, and crawler.
+    ///
+    /// [`P2pStack::Default`] runs neither stack: resolve it with [`P2pStack::resolve`] first.
+    fn runs_legacy(self) -> bool {
+        matches!(self, P2pStack::Zebra | P2pStack::Dual)
+    }
+
+    /// Returns `true` if this stack runs the native Zakura P2P v2 endpoint.
+    ///
+    /// [`P2pStack::Default`] runs neither stack: resolve it with [`P2pStack::resolve`] first.
+    fn runs_zakura(self) -> bool {
+        matches!(self, P2pStack::Zakura | P2pStack::Dual)
+    }
+}
+
 /// Configuration for networking code.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, default, into = "DConfig")]
@@ -222,46 +280,25 @@ pub struct Config {
     /// This value is not used by the legacy TCP peer set.
     pub zakura_node_secret_key: Option<ZakuraNodeSecretKey>,
 
-    /// Follow Zebra's default P2P stack selection for the configured network.
+    /// The peer-to-peer stack Zebra runs.
     ///
-    /// This is enabled by default so Zebra can change network defaults during upgrades. When this
-    /// is `true`, Zebra ignores [`legacy_p2p`](Self::legacy_p2p) and
-    /// [`v2_p2p`](Self::v2_p2p) in `zebrad.toml`, and uses the selected network's binary defaults
-    /// instead.
+    /// | `zebrad.toml` value | Aliases | Stack |
+    /// |---|---|---|
+    /// | `"default"` | | The configured network's binary default |
+    /// | `"zebra"` | `"v1"`, `"legacy"` | The legacy TCP Zcash P2P stack only |
+    /// | `"zakura"` | `"v2"` | The native Zakura P2P v2 stack only |
+    /// | `"dual"` | `"combined"` | Both stacks, with legacy fallback |
     ///
-    /// The current defaults are: legacy P2P on for Mainnet, Testnet, and Regtest; Zakura P2P v2
-    /// off on Mainnet; and Zakura P2P v2 on for Testnet and Regtest.
-    ///
-    /// Set `default_p2p = false` only when you want [`legacy_p2p`](Self::legacy_p2p) and
-    /// [`v2_p2p`](Self::v2_p2p) to be fixed manual overrides.
-    pub default_p2p: bool,
-
-    /// Enable the experimental Zakura P2P v2 endpoint, capability advertisement, and upgrade hook.
-    ///
-    /// When enabled, Zebra starts a native Zakura endpoint, advertises the P2P v2 service bit during
-    /// the legacy Zcash handshake, and routes mutually capable peers to the Zakura upgrade hook
-    /// before constructing a legacy peer connection if [`legacy_p2p`](Self::legacy_p2p) is also
-    /// enabled.
-    ///
-    /// In `zebrad.toml`, this setting is used only when [`default_p2p`](Self::default_p2p) is
-    /// `false`.
-    ///
-    /// Until the Zakura supervisor and endpoint connector support legacy upgrades, mutually
-    /// capable peers continue on the legacy Zebra path after a temporary Zakura upgrade rejection.
-    pub v2_p2p: bool,
-
-    /// Enable the legacy TCP Zcash P2P listener, initial peer dialing, and peer crawler.
-    ///
-    /// In `zebrad.toml`, this setting is used only when [`default_p2p`](Self::default_p2p) is
-    /// `false`. Disable it to run only the native Zakura P2P v2 endpoint when
-    /// [`v2_p2p`](Self::v2_p2p) is enabled.
-    pub legacy_p2p: bool,
+    /// Leave this at `"default"` so Zebra can change the per-network default during upgrades.
+    /// See [`P2pStack::resolve`] for the current defaults, and [`legacy_p2p`](Self::legacy_p2p)
+    /// and [`v2_p2p`](Self::v2_p2p) for the resolved stack.
+    pub p2p_stack: P2pStack,
 
     /// Native Zakura endpoint, connection, and bootstrap settings.
     ///
-    /// When `v2_p2p` is false, these settings are parsed but no iroh endpoint is started. The total
-    /// intended connection budget is roughly `peerset_initial_target_size + zakura.max_connections`;
-    /// tune both together.
+    /// When [`v2_p2p`](Self::v2_p2p) is false, these settings are parsed but no iroh endpoint is
+    /// started. The total intended connection budget is roughly
+    /// `peerset_initial_target_size + zakura.max_connections`; tune both together.
     pub zakura: ZakuraConfig,
 
     /// The initial target size for the peer set.
@@ -685,20 +722,39 @@ impl Config {
         Ok(load_or_generate_zakura_secret_key(&key_file))
     }
 
-    /// Builds a network config for tests with the P2P stack pinned as an explicit
-    /// override (`default_p2p = false`), so [`v2_p2p`](Self::v2_p2p) and
-    /// [`legacy_p2p`](Self::legacy_p2p) are used verbatim instead of being
-    /// re-derived from the network's binary defaults.
+    /// Returns `true` if Zebra should run the legacy TCP Zcash P2P listener, initial peer
+    /// dialing, and peer crawler on the configured network.
+    pub fn legacy_p2p(&self) -> bool {
+        self.p2p_stack.resolve(&self.network).runs_legacy()
+    }
+
+    /// Returns `true` if Zebra should run the native Zakura P2P v2 endpoint on the configured
+    /// network, advertise the P2P v2 service bit during the legacy Zcash handshake, and route
+    /// mutually capable peers to the Zakura upgrade hook.
+    pub fn v2_p2p(&self) -> bool {
+        self.p2p_stack.resolve(&self.network).runs_zakura()
+    }
+
+    /// Builds a network config for tests with [`p2p_stack`](Self::p2p_stack) pinned to
+    /// `p2p_stack`, so the stack is never re-derived from the network's binary defaults.
     ///
-    /// The legacy stack is enabled and `v2_p2p` is set to the argument. Override
-    /// other fields with struct-update syntax, e.g.
-    /// `Config { network, ..Config::for_test(true) }`.
+    /// Override other fields with struct-update syntax, e.g.
+    /// `Config { network, ..Config::for_test(P2pStack::Dual) }`.
+    ///
+    /// # Panics
+    ///
+    /// If `p2p_stack` is [`P2pStack::Default`]: a test that doesn't pin its stack silently
+    /// changes behaviour when the per-network defaults change.
     #[cfg(any(test, feature = "proptest-impl"))]
-    pub fn for_test(v2_p2p: bool) -> Config {
+    pub fn for_test(p2p_stack: P2pStack) -> Config {
+        assert_ne!(
+            p2p_stack,
+            P2pStack::Default,
+            "tests must pin an explicit P2P stack",
+        );
+
         Config {
-            default_p2p: false,
-            v2_p2p,
-            legacy_p2p: true,
+            p2p_stack,
             ..Config::default()
         }
     }
@@ -806,9 +862,7 @@ impl Default for Config {
             cache_dir: CacheDir::default(),
             identity_dir: default_network_identity_dir(),
             zakura_node_secret_key: None,
-            default_p2p: true,
-            v2_p2p: default_v2_p2p_for_network(&Network::Mainnet),
-            legacy_p2p: true,
+            p2p_stack: P2pStack::Default,
             zakura: ZakuraConfig::default(),
             crawl_new_peer_interval: DEFAULT_CRAWL_NEW_PEER_INTERVAL,
 
@@ -825,78 +879,42 @@ impl Default for Config {
     }
 }
 
-fn default_v2_p2p_for_network(network: &Network) -> bool {
-    !matches!(network, Network::Mainnet)
-}
+/// Maps the deprecated `legacy_p2p` and `v2_p2p` booleans onto a [`P2pStack`], so configs
+/// written for older releases keep loading under `deny_unknown_fields`.
+///
+/// Setting `p2p_stack` alongside either deprecated field is rejected rather than resolved by
+/// precedence: the two spellings can disagree, and silently picking a winner would start a
+/// stack the operator didn't ask for.
+///
+/// A deprecated field that is absent falls back to the default it had in the releases that
+/// understood these fields, which is `true` for both.
+fn p2p_stack_from_config<'de, D>(
+    p2p_stack: Option<P2pStack>,
+    legacy_p2p: Option<bool>,
+    v2_p2p: Option<bool>,
+) -> Result<P2pStack, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match (p2p_stack, legacy_p2p, v2_p2p) {
+        (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(de::Error::custom(
+            "network.p2p_stack can't be combined with the deprecated network.legacy_p2p or \
+             network.v2_p2p settings; use network.p2p_stack on its own",
+        )),
 
-fn default_p2p_for_network(network: &Network) -> (bool, bool) {
-    let legacy_p2p = true;
-    let v2_p2p = default_v2_p2p_for_network(network);
+        (Some(p2p_stack), None, None) => Ok(p2p_stack),
 
-    (legacy_p2p, v2_p2p)
-}
+        (None, None, None) => Ok(P2pStack::Default),
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-enum V2P2pPreference {
-    #[default]
-    Default,
-    Explicit(bool),
-}
-
-impl V2P2pPreference {
-    fn resolve(self, network: &Network) -> bool {
-        match self {
-            V2P2pPreference::Default => default_v2_p2p_for_network(network),
-            V2P2pPreference::Explicit(v2_p2p) => v2_p2p,
-        }
-    }
-}
-
-impl Serialize for V2P2pPreference {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            V2P2pPreference::Default => serializer.serialize_str("default"),
-            V2P2pPreference::Explicit(v2_p2p) => serializer.serialize_bool(*v2_p2p),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for V2P2pPreference {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct V2P2pPreferenceVisitor;
-
-        impl de::Visitor<'_> for V2P2pPreferenceVisitor {
-            type Value = V2P2pPreference;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("true, false, or \"default\"")
-            }
-
-            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(V2P2pPreference::Explicit(value))
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                match value {
-                    "default" => Ok(V2P2pPreference::Default),
-                    _ => Err(E::invalid_value(de::Unexpected::Str(value), &self)),
-                }
-            }
-        }
-
-        deserializer.deserialize_any(V2P2pPreferenceVisitor)
+        (None, legacy_p2p, v2_p2p) => match (legacy_p2p.unwrap_or(true), v2_p2p.unwrap_or(true)) {
+            (true, true) => Ok(P2pStack::Dual),
+            (true, false) => Ok(P2pStack::Zebra),
+            (false, true) => Ok(P2pStack::Zakura),
+            (false, false) => Err(de::Error::custom(
+                "network.legacy_p2p and network.v2_p2p are both false, which disables all \
+                 peer-to-peer networking; set network.p2p_stack instead",
+            )),
+        },
     }
 }
 
@@ -964,10 +982,15 @@ struct DConfig {
     identity_dir: PathBuf,
     #[serde(default, skip_serializing)]
     zakura_node_secret_key: Option<ZakuraNodeSecretKey>,
-    default_p2p: bool,
-    #[serde(default, alias = "enable_p2p_v2")]
-    v2_p2p: V2P2pPreference,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    p2p_stack: Option<P2pStack>,
+    /// Deprecated, superseded by `p2p_stack`. Accepted so configs written for older releases
+    /// keep loading, and never written back out.
+    #[serde(default, skip_serializing)]
     legacy_p2p: Option<bool>,
+    /// Deprecated, superseded by `p2p_stack`. See `legacy_p2p`.
+    #[serde(default, alias = "enable_p2p_v2", skip_serializing)]
+    v2_p2p: Option<bool>,
     zakura: ZakuraConfig,
     peerset_initial_target_size: usize,
     #[serde(alias = "new_peer_interval", with = "humantime_serde")]
@@ -988,9 +1011,9 @@ impl Default for DConfig {
             cache_dir: config.cache_dir,
             identity_dir: config.identity_dir,
             zakura_node_secret_key: config.zakura_node_secret_key,
-            default_p2p: true,
-            v2_p2p: V2P2pPreference::Explicit(config.v2_p2p),
+            p2p_stack: Some(config.p2p_stack),
             legacy_p2p: None,
+            v2_p2p: None,
             zakura: config.zakura,
             peerset_initial_target_size: config.peerset_initial_target_size,
             crawl_new_peer_interval: config.crawl_new_peer_interval,
@@ -1049,9 +1072,7 @@ impl From<Config> for DConfig {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
-            default_p2p,
-            v2_p2p,
-            legacy_p2p,
+            p2p_stack,
             zakura,
             peerset_initial_target_size,
             crawl_new_peer_interval,
@@ -1078,7 +1099,6 @@ impl From<Config> for DConfig {
 
             other_kind => DNetwork::DefaultForKind(other_kind),
         };
-        let v2_p2p = V2P2pPreference::Explicit(v2_p2p);
 
         DConfig {
             listen_addr: listen_addr.to_string(),
@@ -1090,9 +1110,9 @@ impl From<Config> for DConfig {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
-            default_p2p,
-            v2_p2p,
-            legacy_p2p: Some(legacy_p2p),
+            p2p_stack: Some(p2p_stack),
+            legacy_p2p: None,
+            v2_p2p: None,
             zakura,
             peerset_initial_target_size,
             crawl_new_peer_interval,
@@ -1116,14 +1136,16 @@ impl<'de> Deserialize<'de> for Config {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
-            default_p2p,
-            v2_p2p,
+            p2p_stack,
             legacy_p2p,
+            v2_p2p,
             zakura,
             peerset_initial_target_size,
             crawl_new_peer_interval,
             max_connections_per_ip,
         } = DConfig::deserialize(deserializer)?;
+
+        let p2p_stack = p2p_stack_from_config::<D>(p2p_stack, legacy_p2p, v2_p2p)?;
 
         let network = match (dnetwork, testnet_parameters) {
             (DNetwork::ConfiguredTestnet(params), _) => {
@@ -1145,12 +1167,6 @@ impl<'de> Deserialize<'de> for Config {
             (DNetwork::DefaultForKind(NetworkKind::Regtest), None) => {
                 Network::new_regtest(Default::default())
             }
-        };
-
-        let (legacy_p2p, v2_p2p) = if default_p2p {
-            default_p2p_for_network(&network)
-        } else {
-            (legacy_p2p.unwrap_or(true), v2_p2p.resolve(&network))
         };
 
         let listen_addr = match listen_addr.parse::<SocketAddr>().or_else(|_| format!("{listen_addr}:{}", network.default_port()).parse()) {
@@ -1245,9 +1261,7 @@ impl<'de> Deserialize<'de> for Config {
             cache_dir,
             identity_dir,
             zakura_node_secret_key,
-            default_p2p,
-            v2_p2p,
-            legacy_p2p,
+            p2p_stack,
             zakura,
             peerset_initial_target_size,
             crawl_new_peer_interval,

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -97,10 +97,8 @@ fn testnet_params_serialization_roundtrip() {
             .to_network()
             .expect("failed to build configured network"),
         initial_testnet_peers: [].into(),
-        ..Config::default()
+        ..Config::for_test(true)
     };
-    config.legacy_p2p = true;
-    config.v2_p2p = true;
     config.zakura.apply_network_defaults(&config.network);
 
     let serialized = toml::to_string(&config).unwrap();
@@ -720,10 +718,8 @@ fn funding_streams_serialization_roundtrip() {
             .to_network()
             .expect("failed to build configured network"),
         initial_testnet_peers: [].into(),
-        ..Config::default()
+        ..Config::for_test(true)
     };
-    config.legacy_p2p = true;
-    config.v2_p2p = true;
     config.zakura.apply_network_defaults(&config.network);
 
     let serialized = toml::to_string(&config).unwrap();
@@ -746,10 +742,8 @@ fn temporary_orchard_disabling_soft_fork_height_serialization_roundtrip() {
             .to_network()
             .expect("failed to build configured network"),
         initial_testnet_peers: [].into(),
-        ..Config::default()
+        ..Config::for_test(true)
     };
-    config.legacy_p2p = true;
-    config.v2_p2p = true;
     config.zakura.apply_network_defaults(&config.network);
 
     let serialized = toml::to_string(&config).unwrap();

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -99,6 +99,8 @@ fn testnet_params_serialization_roundtrip() {
         initial_testnet_peers: [].into(),
         ..Config::default()
     };
+    config.legacy_p2p = true;
+    config.v2_p2p = true;
     config.zakura.apply_network_defaults(&config.network);
 
     let serialized = toml::to_string(&config).unwrap();
@@ -163,29 +165,66 @@ fn identity_dir_defaults_and_roundtrips() {
 }
 
 #[test]
-fn p2p_protocol_flags_default_on_and_roundtrip() {
+fn p2p_protocol_flags_default_by_network_and_roundtrip() {
     let _init_guard = zebra_test::init();
 
-    assert!(Config::default().v2_p2p);
+    assert!(Config::default().default_p2p);
+    assert!(!Config::default().v2_p2p);
     assert!(Config::default().legacy_p2p);
     assert_eq!(
         Config::default().zakura.bootstrap_peers,
         default_zakura_bootstrap_peers()
     );
 
-    let config: Config = toml::from_str(
+    let mainnet_config: Config = toml::from_str("network = 'Mainnet'").unwrap();
+    assert!(!mainnet_config.v2_p2p);
+    assert!(mainnet_config.legacy_p2p);
+
+    let testnet_config: Config = toml::from_str("network = 'Testnet'").unwrap();
+    assert!(testnet_config.default_p2p);
+    assert!(testnet_config.v2_p2p);
+    assert!(testnet_config.legacy_p2p);
+
+    let regtest_config: Config = toml::from_str("network = 'Regtest'").unwrap();
+    assert!(regtest_config.v2_p2p);
+    assert!(regtest_config.legacy_p2p);
+
+    let default_testnet_config: Config = toml::from_str(
         r#"
+        network = 'Testnet'
+        v2_p2p = "default"
+        "#,
+    )
+    .unwrap();
+    assert!(default_testnet_config.v2_p2p);
+
+    let explicit_testnet_config: Config = toml::from_str(
+        r#"
+        network = 'Testnet'
+        default_p2p = false
         v2_p2p = false
         legacy_p2p = false
         "#,
     )
     .unwrap();
-    assert!(!config.v2_p2p);
-    assert!(!config.legacy_p2p);
+    assert!(!explicit_testnet_config.v2_p2p);
+    assert!(!explicit_testnet_config.legacy_p2p);
+
+    let config: Config = toml::from_str(
+        r#"
+        default_p2p = false
+        v2_p2p = true
+        legacy_p2p = true
+        "#,
+    )
+    .unwrap();
+    assert!(config.v2_p2p);
+    assert!(config.legacy_p2p);
 
     let serialized = toml::to_string(&config).unwrap();
-    assert!(serialized.contains("v2_p2p = false"));
-    assert!(serialized.contains("legacy_p2p = false"));
+    assert!(serialized.contains("default_p2p = false"));
+    assert!(serialized.contains("v2_p2p = true"));
+    assert!(serialized.contains("legacy_p2p = true"));
 
     let deserialized: Config = toml::from_str(&serialized).unwrap();
     assert_eq!(config, deserialized);
@@ -322,10 +361,101 @@ fn zakura_dev_network_defaults_off_and_roundtrips() {
 fn p2p_v2_old_enable_config_alias_still_parses() {
     let _init_guard = zebra_test::init();
 
-    let config: Config = toml::from_str("enable_p2p_v2 = false").unwrap();
+    let config: Config = toml::from_str("default_p2p = false\nenable_p2p_v2 = false").unwrap();
 
+    assert!(!config.default_p2p);
     assert!(!config.v2_p2p);
     assert!(config.legacy_p2p);
+}
+
+#[test]
+fn p2p_v2_default_config_value_follows_network_defaults() {
+    let _init_guard = zebra_test::init();
+
+    let mainnet_config: Config = toml::from_str(
+        r#"
+        network = "Mainnet"
+        v2_p2p = "default"
+        "#,
+    )
+    .unwrap();
+    assert!(!mainnet_config.v2_p2p);
+
+    let testnet_config: Config = toml::from_str(
+        r#"
+        network = "Testnet"
+        v2_p2p = "default"
+        "#,
+    )
+    .unwrap();
+    assert!(testnet_config.v2_p2p);
+
+    let invalid = toml::from_str::<Config>("v2_p2p = 'enabled'")
+        .expect_err("only true, false, and default are valid v2_p2p values");
+    assert!(
+        invalid.to_string().contains("expected true, false, or"),
+        "unexpected invalid v2_p2p error: {invalid}",
+    );
+}
+
+#[test]
+fn default_p2p_overrides_user_p2p_flags_for_upgrades() {
+    let _init_guard = zebra_test::init();
+
+    let mainnet_config: Config = toml::from_str(
+        r#"
+        network = "Mainnet"
+        default_p2p = true
+        legacy_p2p = false
+        v2_p2p = true
+        "#,
+    )
+    .unwrap();
+    assert!(mainnet_config.default_p2p);
+    assert!(mainnet_config.legacy_p2p);
+    assert!(!mainnet_config.v2_p2p);
+
+    let testnet_config: Config = toml::from_str(
+        r#"
+        network = "Testnet"
+        default_p2p = true
+        legacy_p2p = false
+        v2_p2p = false
+        "#,
+    )
+    .unwrap();
+    assert!(testnet_config.legacy_p2p);
+    assert!(testnet_config.v2_p2p);
+
+    let regtest_config: Config = toml::from_str(
+        r#"
+        network = "Regtest"
+        default_p2p = true
+        legacy_p2p = false
+        v2_p2p = false
+        "#,
+    )
+    .unwrap();
+    assert!(regtest_config.legacy_p2p);
+    assert!(regtest_config.v2_p2p);
+}
+
+#[test]
+fn default_p2p_false_preserves_user_p2p_flags() {
+    let _init_guard = zebra_test::init();
+
+    let manual_mainnet_config: Config = toml::from_str(
+        r#"
+        network = "Mainnet"
+        default_p2p = false
+        legacy_p2p = false
+        v2_p2p = true
+        "#,
+    )
+    .unwrap();
+    assert!(!manual_mainnet_config.default_p2p);
+    assert!(!manual_mainnet_config.legacy_p2p);
+    assert!(manual_mainnet_config.v2_p2p);
 }
 
 #[test]
@@ -334,6 +464,7 @@ fn p2p_v2_old_config_without_zakura_fields_uses_safe_defaults() {
 
     let config: Config = toml::from_str(
         r#"
+        network = "Testnet"
         listen_addr = "127.0.0.1:8233"
         peerset_initial_target_size = 25
         "#,
@@ -345,7 +476,7 @@ fn p2p_v2_old_config_without_zakura_fields_uses_safe_defaults() {
     assert!(config.legacy_p2p);
     assert_eq!(
         config.zakura.bootstrap_peers,
-        default_zakura_bootstrap_peers()
+        default_testnet_zakura_bootstrap_peers()
     );
     assert!(config.zakura.max_connections > 0);
     assert_eq!(
@@ -423,6 +554,7 @@ fn p2p_v2_config_roundtrip_keeps_dconfig_zakura_fields() {
 
     let config: Config = toml::from_str(
         r#"
+        default_p2p = false
         v2_p2p = true
         legacy_p2p = true
 
@@ -449,6 +581,7 @@ fn p2p_v2_config_roundtrip_keeps_dconfig_zakura_fields() {
     .unwrap();
 
     let serialized = toml::to_string(&config).unwrap();
+    assert!(serialized.contains("default_p2p = false"));
     assert!(serialized.contains("v2_p2p = true"));
     assert!(serialized.contains("legacy_p2p = true"));
     assert!(serialized.contains("[zakura]"));
@@ -531,6 +664,7 @@ fn zakura_bootstrap_peers_parse_in_nested_config() {
 
     let config: Config = toml::from_str(
         r#"
+        default_p2p = false
         v2_p2p = true
 
         [zakura]
@@ -588,6 +722,8 @@ fn funding_streams_serialization_roundtrip() {
         initial_testnet_peers: [].into(),
         ..Config::default()
     };
+    config.legacy_p2p = true;
+    config.v2_p2p = true;
     config.zakura.apply_network_defaults(&config.network);
 
     let serialized = toml::to_string(&config).unwrap();
@@ -612,6 +748,8 @@ fn temporary_orchard_disabling_soft_fork_height_serialization_roundtrip() {
         initial_testnet_peers: [].into(),
         ..Config::default()
     };
+    config.legacy_p2p = true;
+    config.v2_p2p = true;
     config.zakura.apply_network_defaults(&config.network);
 
     let serialized = toml::to_string(&config).unwrap();
@@ -722,6 +860,7 @@ fn zakura_secret_key_honors_configured_key_and_disabled_cache() {
     let disabled = Config {
         cache_dir: CacheDir::disabled(),
         zakura_node_secret_key: None,
+        default_p2p: false,
         v2_p2p: true,
         ..Config::default()
     };

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -20,7 +20,7 @@ use crate::{
         DEFAULT_ZAKURA_BOOTSTRAP_PEERS, DEFAULT_ZAKURA_LISTEN_ADDR,
         DEFAULT_ZAKURA_MAX_CONNS_PER_IP,
     },
-    CacheDir, Config,
+    CacheDir, Config, P2pStack,
 };
 
 use super::super::load_or_generate_zakura_secret_key;
@@ -97,7 +97,7 @@ fn testnet_params_serialization_roundtrip() {
             .to_network()
             .expect("failed to build configured network"),
         initial_testnet_peers: [].into(),
-        ..Config::for_test(true)
+        ..Config::for_test(P2pStack::Dual)
     };
     config.zakura.apply_network_defaults(&config.network);
 
@@ -163,69 +163,74 @@ fn identity_dir_defaults_and_roundtrips() {
 }
 
 #[test]
-fn p2p_protocol_flags_default_by_network_and_roundtrip() {
+fn p2p_stack_defaults_by_network_and_roundtrips() {
     let _init_guard = zebra_test::init();
 
-    assert!(Config::default().default_p2p);
-    assert!(!Config::default().v2_p2p);
-    assert!(Config::default().legacy_p2p);
+    // An unset `p2p_stack` follows the network's binary default: Mainnet is legacy-only,
+    // every other network runs both stacks.
+    assert_eq!(Config::default().p2p_stack, P2pStack::Default);
+    assert!(Config::default().legacy_p2p());
+    assert!(!Config::default().v2_p2p());
     assert_eq!(
         Config::default().zakura.bootstrap_peers,
         default_zakura_bootstrap_peers()
     );
 
-    let mainnet_config: Config = toml::from_str("network = 'Mainnet'").unwrap();
-    assert!(!mainnet_config.v2_p2p);
-    assert!(mainnet_config.legacy_p2p);
+    for (network, stack) in [
+        ("Mainnet", P2pStack::Zebra),
+        ("Testnet", P2pStack::Dual),
+        ("Regtest", P2pStack::Dual),
+    ] {
+        let config: Config = toml::from_str(&format!("network = '{network}'")).unwrap();
 
-    let testnet_config: Config = toml::from_str("network = 'Testnet'").unwrap();
-    assert!(testnet_config.default_p2p);
-    assert!(testnet_config.v2_p2p);
-    assert!(testnet_config.legacy_p2p);
+        assert_eq!(config.p2p_stack, P2pStack::Default);
+        assert_eq!(config.p2p_stack.resolve(&config.network), stack);
+        assert_eq!(config.legacy_p2p(), stack != P2pStack::Zakura);
+        assert_eq!(config.v2_p2p(), stack != P2pStack::Zebra);
+    }
 
-    let regtest_config: Config = toml::from_str("network = 'Regtest'").unwrap();
-    assert!(regtest_config.v2_p2p);
-    assert!(regtest_config.legacy_p2p);
+    // Overriding `network` with struct-update syntax resolves against the new network, so a
+    // struct-built config and the equivalent `zebrad.toml` always agree.
+    let testnet = Config {
+        network: Network::new_default_testnet(),
+        ..Config::default()
+    };
+    assert!(testnet.legacy_p2p());
+    assert!(testnet.v2_p2p());
 
-    let default_testnet_config: Config = toml::from_str(
-        r#"
-        network = 'Testnet'
-        v2_p2p = "default"
-        "#,
-    )
-    .unwrap();
-    assert!(default_testnet_config.v2_p2p);
+    // An explicit stack overrides the network default in both directions.
+    let mainnet_dual: Config = toml::from_str("network = 'Mainnet'\np2p_stack = 'dual'").unwrap();
+    assert!(mainnet_dual.legacy_p2p());
+    assert!(mainnet_dual.v2_p2p());
 
-    let explicit_testnet_config: Config = toml::from_str(
-        r#"
-        network = 'Testnet'
-        default_p2p = false
-        v2_p2p = false
-        legacy_p2p = false
-        "#,
-    )
-    .unwrap();
-    assert!(!explicit_testnet_config.v2_p2p);
-    assert!(!explicit_testnet_config.legacy_p2p);
+    let testnet_zebra: Config = toml::from_str("network = 'Testnet'\np2p_stack = 'zebra'").unwrap();
+    assert!(testnet_zebra.legacy_p2p());
+    assert!(!testnet_zebra.v2_p2p());
 
-    let config: Config = toml::from_str(
-        r#"
-        default_p2p = false
-        v2_p2p = true
-        legacy_p2p = true
-        "#,
-    )
-    .unwrap();
-    assert!(config.v2_p2p);
-    assert!(config.legacy_p2p);
+    // Every stack round-trips through its canonical name, and the deprecated flags are
+    // never written back out.
+    for stack in [
+        P2pStack::Default,
+        P2pStack::Zebra,
+        P2pStack::Zakura,
+        P2pStack::Dual,
+    ] {
+        let config = Config {
+            p2p_stack: stack,
+            ..Config::default()
+        };
 
-    let serialized = toml::to_string(&config).unwrap();
-    assert!(serialized.contains("default_p2p = false"));
-    assert!(serialized.contains("v2_p2p = true"));
-    assert!(serialized.contains("legacy_p2p = true"));
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(!serialized.contains("legacy_p2p"));
+        assert!(!serialized.contains("v2_p2p"));
 
-    let deserialized: Config = toml::from_str(&serialized).unwrap();
-    assert_eq!(config, deserialized);
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(config, deserialized);
+        assert_eq!(deserialized.p2p_stack, stack);
+    }
+
+    let serialized = toml::to_string(&Config::default()).unwrap();
+    assert!(serialized.contains("p2p_stack = \"default\""));
 }
 
 #[test]
@@ -356,104 +361,94 @@ fn zakura_dev_network_defaults_off_and_roundtrips() {
 }
 
 #[test]
-fn p2p_v2_old_enable_config_alias_still_parses() {
+fn p2p_stack_aliases_parse_to_the_canonical_stack() {
     let _init_guard = zebra_test::init();
 
-    let config: Config = toml::from_str("default_p2p = false\nenable_p2p_v2 = false").unwrap();
+    for (value, stack) in [
+        ("default", P2pStack::Default),
+        ("zebra", P2pStack::Zebra),
+        ("v1", P2pStack::Zebra),
+        ("legacy", P2pStack::Zebra),
+        ("zakura", P2pStack::Zakura),
+        ("v2", P2pStack::Zakura),
+        ("dual", P2pStack::Dual),
+        ("combined", P2pStack::Dual),
+    ] {
+        let config: Config = toml::from_str(&format!("p2p_stack = '{value}'"))
+            .unwrap_or_else(|error| panic!("p2p_stack = '{value}' should parse: {error}"));
 
-    assert!(!config.default_p2p);
-    assert!(!config.v2_p2p);
-    assert!(config.legacy_p2p);
+        assert_eq!(config.p2p_stack, stack, "p2p_stack = '{value}'");
+    }
 }
 
 #[test]
-fn p2p_v2_default_config_value_follows_network_defaults() {
+fn p2p_stack_rejects_unknown_values() {
     let _init_guard = zebra_test::init();
 
-    let mainnet_config: Config = toml::from_str(
-        r#"
-        network = "Mainnet"
-        v2_p2p = "default"
-        "#,
-    )
-    .unwrap();
-    assert!(!mainnet_config.v2_p2p);
+    let error = toml::from_str::<Config>("p2p_stack = 'enabled'")
+        .expect_err("'enabled' is not a P2P stack");
 
-    let testnet_config: Config = toml::from_str(
-        r#"
-        network = "Testnet"
-        v2_p2p = "default"
-        "#,
-    )
-    .unwrap();
-    assert!(testnet_config.v2_p2p);
-
-    let invalid = toml::from_str::<Config>("v2_p2p = 'enabled'")
-        .expect_err("only true, false, and default are valid v2_p2p values");
     assert!(
-        invalid.to_string().contains("expected true, false, or"),
-        "unexpected invalid v2_p2p error: {invalid}",
+        error.to_string().contains("unknown variant"),
+        "unexpected p2p_stack error: {error}",
     );
 }
 
 #[test]
-fn default_p2p_overrides_user_p2p_flags_for_upgrades() {
+fn deprecated_p2p_flags_map_onto_p2p_stack() {
     let _init_guard = zebra_test::init();
 
-    let mainnet_config: Config = toml::from_str(
-        r#"
-        network = "Mainnet"
-        default_p2p = true
-        legacy_p2p = false
-        v2_p2p = true
-        "#,
-    )
-    .unwrap();
-    assert!(mainnet_config.default_p2p);
-    assert!(mainnet_config.legacy_p2p);
-    assert!(!mainnet_config.v2_p2p);
+    // Both flags absent means the config predates them, so it follows the network default.
+    let config: Config = toml::from_str("network = 'Mainnet'").unwrap();
+    assert_eq!(config.p2p_stack, P2pStack::Default);
 
-    let testnet_config: Config = toml::from_str(
-        r#"
-        network = "Testnet"
-        default_p2p = true
-        legacy_p2p = false
-        v2_p2p = false
-        "#,
-    )
-    .unwrap();
-    assert!(testnet_config.legacy_p2p);
-    assert!(testnet_config.v2_p2p);
+    // A flag that is absent falls back to the `true` default it had in the releases that
+    // understood these flags.
+    for (toml, stack) in [
+        ("legacy_p2p = true\nv2_p2p = true", P2pStack::Dual),
+        ("legacy_p2p = true\nv2_p2p = false", P2pStack::Zebra),
+        ("legacy_p2p = false\nv2_p2p = true", P2pStack::Zakura),
+        ("enable_p2p_v2 = false", P2pStack::Zebra),
+        ("legacy_p2p = false", P2pStack::Zakura),
+        ("v2_p2p = true", P2pStack::Dual),
+    ] {
+        let config: Config =
+            toml::from_str(toml).unwrap_or_else(|error| panic!("{toml:?} should parse: {error}"));
 
-    let regtest_config: Config = toml::from_str(
-        r#"
-        network = "Regtest"
-        default_p2p = true
-        legacy_p2p = false
-        v2_p2p = false
-        "#,
-    )
-    .unwrap();
-    assert!(regtest_config.legacy_p2p);
-    assert!(regtest_config.v2_p2p);
+        assert_eq!(config.p2p_stack, stack, "{toml:?}");
+    }
 }
 
 #[test]
-fn default_p2p_false_preserves_user_p2p_flags() {
+fn deprecated_p2p_flags_reject_disabling_all_networking() {
     let _init_guard = zebra_test::init();
 
-    let manual_mainnet_config: Config = toml::from_str(
-        r#"
-        network = "Mainnet"
-        default_p2p = false
-        legacy_p2p = false
-        v2_p2p = true
-        "#,
-    )
-    .unwrap();
-    assert!(!manual_mainnet_config.default_p2p);
-    assert!(!manual_mainnet_config.legacy_p2p);
-    assert!(manual_mainnet_config.v2_p2p);
+    let error = toml::from_str::<Config>("legacy_p2p = false\nv2_p2p = false")
+        .expect_err("a node with no P2P stack can't sync");
+
+    assert!(
+        error.to_string().contains("disables all"),
+        "unexpected both-flags-false error: {error}",
+    );
+}
+
+#[test]
+fn deprecated_p2p_flags_conflict_with_p2p_stack() {
+    let _init_guard = zebra_test::init();
+
+    for toml in [
+        "p2p_stack = 'dual'\nlegacy_p2p = true",
+        "p2p_stack = 'dual'\nv2_p2p = true",
+        "p2p_stack = 'zebra'\nenable_p2p_v2 = false",
+    ] {
+        let error = toml::from_str::<Config>(toml)
+            .expect_err("p2p_stack and the deprecated flags can disagree, so both is an error");
+
+        assert!(
+            error.to_string().contains("can't be combined"),
+            "unexpected conflict error for {toml:?}: {error}",
+        );
+    }
 }
 
 #[test]
@@ -470,8 +465,8 @@ fn p2p_v2_old_config_without_zakura_fields_uses_safe_defaults() {
     .unwrap();
 
     assert_eq!(config.listen_addr.to_string(), "127.0.0.1:8233");
-    assert!(config.v2_p2p);
-    assert!(config.legacy_p2p);
+    assert!(config.v2_p2p());
+    assert!(config.legacy_p2p());
     assert_eq!(
         config.zakura.bootstrap_peers,
         default_testnet_zakura_bootstrap_peers()
@@ -552,9 +547,7 @@ fn p2p_v2_config_roundtrip_keeps_dconfig_zakura_fields() {
 
     let config: Config = toml::from_str(
         r#"
-        default_p2p = false
-        v2_p2p = true
-        legacy_p2p = true
+        p2p_stack = "dual"
 
         [zakura]
         bootstrap_peers = ["ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6@127.0.0.1:8233"]
@@ -579,9 +572,7 @@ fn p2p_v2_config_roundtrip_keeps_dconfig_zakura_fields() {
     .unwrap();
 
     let serialized = toml::to_string(&config).unwrap();
-    assert!(serialized.contains("default_p2p = false"));
-    assert!(serialized.contains("v2_p2p = true"));
-    assert!(serialized.contains("legacy_p2p = true"));
+    assert!(serialized.contains("p2p_stack = \"dual\""));
     assert!(serialized.contains("[zakura]"));
     assert!(serialized.contains("bootstrap_peers"));
     assert!(serialized.contains("max_connections = 7"));
@@ -662,8 +653,7 @@ fn zakura_bootstrap_peers_parse_in_nested_config() {
 
     let config: Config = toml::from_str(
         r#"
-        default_p2p = false
-        v2_p2p = true
+        p2p_stack = "dual"
 
         [zakura]
         bootstrap_peers = ["ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6@127.0.0.1:8233"]
@@ -675,8 +665,8 @@ fn zakura_bootstrap_peers_parse_in_nested_config() {
     )
     .unwrap();
 
-    assert!(config.v2_p2p);
-    assert!(config.legacy_p2p);
+    assert!(config.v2_p2p());
+    assert!(config.legacy_p2p());
     assert_eq!(config.zakura.bootstrap_peers.len(), 1);
     assert_eq!(config.zakura.max_connections, 4);
     assert_eq!(
@@ -718,7 +708,7 @@ fn funding_streams_serialization_roundtrip() {
             .to_network()
             .expect("failed to build configured network"),
         initial_testnet_peers: [].into(),
-        ..Config::for_test(true)
+        ..Config::for_test(P2pStack::Dual)
     };
     config.zakura.apply_network_defaults(&config.network);
 
@@ -742,7 +732,7 @@ fn temporary_orchard_disabling_soft_fork_height_serialization_roundtrip() {
             .to_network()
             .expect("failed to build configured network"),
         initial_testnet_peers: [].into(),
-        ..Config::for_test(true)
+        ..Config::for_test(P2pStack::Dual)
     };
     config.zakura.apply_network_defaults(&config.network);
 
@@ -854,8 +844,7 @@ fn zakura_secret_key_honors_configured_key_and_disabled_cache() {
     let disabled = Config {
         cache_dir: CacheDir::disabled(),
         zakura_node_secret_key: None,
-        default_p2p: false,
-        v2_p2p: true,
+        p2p_stack: P2pStack::Dual,
         ..Config::default()
     };
     let disabled_key_file = disabled.identity_dir.join("mainnet.zakura-iroh-secret-key");

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -86,6 +86,7 @@ where
 {
     let config = Config {
         network: network.clone(),
+        default_p2p: false,
         v2_p2p: false,
         ..Config::default()
     };

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -11,7 +11,7 @@ use zebra_chain::{chain_tip::NoChainTip, parameters::Network};
 use crate::{
     peer::{self, Client, ConnectedAddr, HandshakeRequest},
     peer_set::ActiveConnectionCounter,
-    BoxError, Config, PeerSocketAddr, Request, Response,
+    BoxError, Config, P2pStack, PeerSocketAddr, Request, Response,
 };
 
 // Wait until `arti-client`'s dependency `x25519-dalek v1.2.0` is updated to a higher version. (#5492)
@@ -86,8 +86,9 @@ where
 {
     let config = Config {
         network: network.clone(),
-        default_p2p: false,
-        v2_p2p: false,
+        // Isolated connections are legacy-only: they must not advertise the Zakura P2P v2
+        // service bit, or attempt an upgrade that would deanonymise the caller.
+        p2p_stack: P2pStack::Zebra,
         ..Config::default()
     };
 

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -184,7 +184,7 @@ pub use crate::{
 pub use crate::{
     address_book::AddressBook,
     address_book_peers::AddressBookPeers,
-    config::{CacheDir, Config},
+    config::{CacheDir, Config, P2pStack},
     isolated::{connect_isolated, connect_isolated_tcp_direct},
     meta_addr::{PeerAddrState, PeerSocketAddr},
     peer::{

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -598,7 +598,7 @@ where
 fn configured_advertised_services(config: &Config, mut services: PeerServices) -> PeerServices {
     services.remove(PeerServices::NODE_P2P_V2);
 
-    if config.v2_p2p {
+    if config.v2_p2p() {
         services |= PeerServices::NODE_P2P_V2;
     }
 
@@ -607,7 +607,7 @@ fn configured_advertised_services(config: &Config, mut services: PeerServices) -
 
 /// Return the user-agent Zebra should advertise for this handshake.
 fn configured_user_agent(config: &Config, user_agent: String) -> String {
-    if !config.v2_p2p {
+    if !config.v2_p2p() {
         return user_agent;
     }
 
@@ -623,7 +623,7 @@ fn configured_user_agent(config: &Config, user_agent: String) -> String {
 
 /// Returns true when the legacy handshake should try to route this peer to Zakura P2P v2.
 fn should_attempt_zakura_upgrade(config: &Config, connection_info: &ConnectionInfo) -> bool {
-    config.v2_p2p
+    config.v2_p2p()
         && connection_info
             .remote
             .services

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -42,11 +42,7 @@ fn peer_addr(port: u16) -> PeerSocketAddr {
 }
 
 fn test_config(v2_p2p: bool) -> Config {
-    Config {
-        default_p2p: false,
-        v2_p2p,
-        ..Config::default()
-    }
+    Config::for_test(v2_p2p)
 }
 
 fn upgraded_outcome() -> ZakuraUpgradeOutcome {

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -17,6 +17,7 @@ use crate::{
         Peer as ZakuraServicePeer, Service as ZakuraService, Stream, ZakuraPeerId,
         ZakuraUpgradeOutcome,
     },
+    P2pStack,
 };
 use tokio::io::duplex;
 use tower::ServiceExt;
@@ -41,8 +42,8 @@ fn peer_addr(port: u16) -> PeerSocketAddr {
     SocketAddr::from((Ipv4Addr::LOCALHOST, port)).into()
 }
 
-fn test_config(v2_p2p: bool) -> Config {
-    Config::for_test(v2_p2p)
+fn test_config(p2p_stack: P2pStack) -> Config {
+    Config::for_test(p2p_stack)
 }
 
 fn upgraded_outcome() -> ZakuraUpgradeOutcome {
@@ -207,7 +208,7 @@ async fn start_test_zakura_endpoint() -> crate::zakura::ZakuraEndpoint {
     let key_byte = u8::try_from(key_index).expect("key index is in 1..=255 due to modulo");
     let secret = format!("{key_byte:02x}").repeat(32);
     let config: Config = toml::from_str(&format!(
-        "default_p2p = false\nv2_p2p = true\nzakura_node_secret_key = '{secret}'"
+        "p2p_stack = 'dual'\nzakura_node_secret_key = '{secret}'"
     ))
     .expect("test Zakura config with explicit identity key must parse");
 
@@ -236,12 +237,12 @@ async fn mutual_p2p_v2_legacy_upgrade_forms_zakura_connection() {
     let mut remote_counter = ActiveConnectionCounter::new_counter();
 
     let local_handshake = test_handshake_with_connector(
-        test_config(true),
+        test_config(P2pStack::Dual),
         address_book_tx.clone(),
         local_endpoint.connector(),
     );
     let remote_handshake = test_handshake_with_connector(
-        test_config(true),
+        test_config(P2pStack::Dual),
         address_book_tx,
         remote_endpoint.connector(),
     );
@@ -310,7 +311,7 @@ async fn responder_upgrade_keeps_legacy_when_native_dial_never_registers() {
     let responder_endpoint = start_test_zakura_endpoint().await;
     let connector = responder_endpoint.connector();
 
-    let network = test_config(true).network;
+    let network = test_config(P2pStack::Dual).network;
     let config = ZakuraHandshakeConfig::for_network(&network);
 
     // The legacy `version` nonces the responder observed for this peer.
@@ -428,7 +429,7 @@ async fn responder_upgrade_keeps_legacy_when_native_dial_never_registers() {
 async fn responder_upgrade_disconnects_on_malformed_prelude() {
     let _init_guard = zebra_test::init();
 
-    let network = test_config(true).network;
+    let network = test_config(P2pStack::Dual).network;
     let config = ZakuraHandshakeConfig::for_network(&network);
     let nonces = ZakuraLegacyNonces {
         local_zebra_nonce: Nonce(0x1111_1111_1111_1111),
@@ -500,7 +501,7 @@ async fn responder_upgrade_disconnects_on_malformed_prelude() {
 async fn initiator_upgrade_disconnects_on_malformed_prelude() {
     let _init_guard = zebra_test::init();
 
-    let network = test_config(true).network;
+    let network = test_config(P2pStack::Dual).network;
     let config = ZakuraHandshakeConfig::for_network(&network);
     let nonces = ZakuraLegacyNonces {
         local_zebra_nonce: Nonce(0x3333_3333_3333_3333),
@@ -565,13 +566,13 @@ async fn p2p_v2_service_bit_advertisement_follows_config() {
     let _init_guard = zebra_test::init();
 
     assert!(!configured_advertised_services(
-        &test_config(false),
+        &test_config(P2pStack::Zebra),
         PeerServices::NODE_NETWORK | PeerServices::NODE_P2P_V2,
     )
     .contains(PeerServices::NODE_P2P_V2));
 
     let (disabled_peer_seen_by_enabled, enabled_peer_seen_by_disabled) =
-        negotiate_test_pair(test_config(true), test_config(false)).await;
+        negotiate_test_pair(test_config(P2pStack::Dual), test_config(P2pStack::Zebra)).await;
 
     assert!(!disabled_peer_seen_by_enabled
         .remote
@@ -624,8 +625,7 @@ fn zakura_upgrade_errors_are_neutral_disconnects() {
 fn p2p_v2_upgrade_uses_main_version_services_only() {
     let _init_guard = zebra_test::init();
 
-    let mut config = test_config(true);
-    config.v2_p2p = true;
+    let config = test_config(P2pStack::Dual);
 
     let addr = peer_addr(18233);
     let inconsistent_remote = VersionMessage {
@@ -677,15 +677,15 @@ fn p2p_v2_upgrade_requires_local_enable_and_remote_service_bit() {
     };
 
     assert!(!should_attempt_zakura_upgrade(
-        &test_config(false),
+        &test_config(P2pStack::Zebra),
         &connection_info(PeerServices::NODE_NETWORK | PeerServices::NODE_P2P_V2),
     ));
     assert!(!should_attempt_zakura_upgrade(
-        &test_config(true),
+        &test_config(P2pStack::Dual),
         &connection_info(PeerServices::NODE_NETWORK),
     ));
     assert!(should_attempt_zakura_upgrade(
-        &test_config(true),
+        &test_config(P2pStack::Dual),
         &connection_info(PeerServices::NODE_NETWORK | PeerServices::NODE_P2P_V2),
     ));
 }
@@ -703,13 +703,13 @@ async fn remote_p2p_v2_with_local_disabled_continues_legacy() {
     let mut remote_counter = ActiveConnectionCounter::new_counter();
 
     let local_handshake = test_handshake(
-        test_config(false),
+        test_config(P2pStack::Zebra),
         address_book_tx.clone(),
         local_calls.clone(),
         upgraded_outcome(),
     );
     let remote_handshake = test_handshake(
-        test_config(true),
+        test_config(P2pStack::Dual),
         address_book_tx,
         remote_calls.clone(),
         upgraded_outcome(),
@@ -746,10 +746,12 @@ async fn mutual_p2p_v2_without_connector_fails_closed() {
     let mut local_counter = ActiveConnectionCounter::new_counter();
     let mut remote_counter = ActiveConnectionCounter::new_counter();
 
-    let local_handshake =
-        test_handshake_without_zakura_connector(test_config(true), address_book_tx.clone());
+    let local_handshake = test_handshake_without_zakura_connector(
+        test_config(P2pStack::Dual),
+        address_book_tx.clone(),
+    );
     let remote_handshake =
-        test_handshake_without_zakura_connector(test_config(true), address_book_tx);
+        test_handshake_without_zakura_connector(test_config(P2pStack::Dual), address_book_tx);
 
     let local_task = tokio::spawn(local_handshake.oneshot(HandshakeRequest {
         data_stream: local_stream,
@@ -800,13 +802,13 @@ async fn mutual_p2p_v2_selected_upgrade_skips_legacy_connection() {
     let mut remote_counter = ActiveConnectionCounter::new_counter();
 
     let local_handshake = test_handshake(
-        test_config(true),
+        test_config(P2pStack::Dual),
         address_book_tx.clone(),
         local_calls.clone(),
         upgraded_outcome(),
     );
     let remote_handshake = test_handshake(
-        test_config(true),
+        test_config(P2pStack::Dual),
         address_book_tx,
         remote_calls.clone(),
         upgraded_outcome(),

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -43,6 +43,7 @@ fn peer_addr(port: u16) -> PeerSocketAddr {
 
 fn test_config(v2_p2p: bool) -> Config {
     Config {
+        default_p2p: false,
         v2_p2p,
         ..Config::default()
     }
@@ -210,7 +211,7 @@ async fn start_test_zakura_endpoint() -> crate::zakura::ZakuraEndpoint {
     let key_byte = u8::try_from(key_index).expect("key index is in 1..=255 due to modulo");
     let secret = format!("{key_byte:02x}").repeat(32);
     let config: Config = toml::from_str(&format!(
-        "v2_p2p = true\nzakura_node_secret_key = '{secret}'"
+        "default_p2p = false\nv2_p2p = true\nzakura_node_secret_key = '{secret}'"
     ))
     .expect("test Zakura config with explicit identity key must parse");
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -143,7 +143,7 @@ where
     S::Future: Send + 'static,
     C: ChainTip + Clone + Send + Sync + 'static,
 {
-    let (tcp_listener, listen_addr) = if config.legacy_p2p {
+    let (tcp_listener, listen_addr) = if config.legacy_p2p() {
         let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
         (Some(tcp_listener), listen_addr)
     } else {
@@ -409,7 +409,7 @@ where
             let dual_stack = crate::zakura::ZakuraDualStackService::new_with_trace(
                 peer_set,
                 supervisor,
-                config.legacy_p2p,
+                config.legacy_p2p(),
                 trace,
             );
             Buffer::new(BoxService::new(dual_stack), constants::PEERSET_BUFFER_SIZE)

--- a/zebra-network/src/zakura/handler.rs
+++ b/zebra-network/src/zakura/handler.rs
@@ -5507,22 +5507,10 @@ mod tests {
         assert!(should_run_freshness_reaper(0, 0));
     }
 
-    fn v2_enabled_config() -> Config {
-        Config {
-            default_p2p: false,
-            v2_p2p: true,
-            ..Config::default()
-        }
-    }
-
     #[tokio::test]
     async fn v2_p2p_false_leaves_header_sync_disabled() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config {
-            default_p2p: false,
-            v2_p2p: false,
-            ..Config::default()
-        };
+        let config = Config::for_test(false);
 
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
@@ -5536,7 +5524,7 @@ mod tests {
     #[tokio::test]
     async fn v2_p2p_true_starts_header_sync_handle() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = v2_enabled_config();
+        let config = Config::for_test(true);
 
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
@@ -5552,7 +5540,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_header_sync_task() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = v2_enabled_config();
+        let config = Config::for_test(true);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
@@ -5588,7 +5576,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_maintained_native_dial_loop() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = v2_enabled_config();
+        let config = Config::for_test(true);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
@@ -5626,7 +5614,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_discovery_candidate_dialer() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = v2_enabled_config();
+        let config = Config::for_test(true);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
@@ -5679,7 +5667,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn failed_legacy_upgrade_does_not_leak_maintained_dial() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = v2_enabled_config();
+        let config = Config::for_test(true);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })

--- a/zebra-network/src/zakura/handler.rs
+++ b/zebra-network/src/zakura/handler.rs
@@ -5507,10 +5507,19 @@ mod tests {
         assert!(should_run_freshness_reaper(0, 0));
     }
 
+    fn v2_enabled_config() -> Config {
+        Config {
+            default_p2p: false,
+            v2_p2p: true,
+            ..Config::default()
+        }
+    }
+
     #[tokio::test]
     async fn v2_p2p_false_leaves_header_sync_disabled() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
         let config = Config {
+            default_p2p: false,
             v2_p2p: false,
             ..Config::default()
         };
@@ -5527,13 +5536,13 @@ mod tests {
     #[tokio::test]
     async fn v2_p2p_true_starts_header_sync_handle() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::default();
+        let config = v2_enabled_config();
 
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
         .await?
-        .expect("v2_p2p is enabled by default");
+        .expect("v2_p2p is enabled in test config");
 
         assert!(endpoint.header_sync().is_some());
         endpoint.shutdown().await;
@@ -5543,11 +5552,12 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_header_sync_task() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let endpoint = spawn_zakura_endpoint(&Config::default(), |_supervisor, _trace| {
+        let config = v2_enabled_config();
+        let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
         .await?
-        .expect("v2_p2p is enabled by default");
+        .expect("v2_p2p is enabled in test config");
         let header_sync = endpoint
             .header_sync()
             .expect("header sync handle exists for a v2 endpoint");
@@ -5578,11 +5588,12 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_maintained_native_dial_loop() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let endpoint = spawn_zakura_endpoint(&Config::default(), |_supervisor, _trace| {
+        let config = v2_enabled_config();
+        let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
         .await?
-        .expect("v2_p2p is enabled by default");
+        .expect("v2_p2p is enabled in test config");
 
         // 192.0.2.0/24 is TEST-NET-1 (RFC 5737): guaranteed unreachable, so the
         // maintained loop stays in connect/backoff and never finishes on its own.
@@ -5615,12 +5626,12 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_discovery_candidate_dialer() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::default();
+        let config = v2_enabled_config();
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
         .await?
-        .expect("v2_p2p is enabled by default");
+        .expect("v2_p2p is enabled in test config");
 
         let limits = ZakuraLocalLimits::from_config(&config);
         let handshake = ZakuraHandshakeConfig::for_network(&config.network);
@@ -5668,11 +5679,12 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn failed_legacy_upgrade_does_not_leak_maintained_dial() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let endpoint = spawn_zakura_endpoint(&Config::default(), |_supervisor, _trace| {
+        let config = v2_enabled_config();
+        let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
         .await?
-        .expect("v2_p2p is enabled by default");
+        .expect("v2_p2p is enabled in test config");
 
         // The Accept the attacker would advertise: a real 32-byte iroh node id
         // (so `node_addr_from_hints` builds a `NodeAddr` and the dial spawns)

--- a/zebra-network/src/zakura/handler.rs
+++ b/zebra-network/src/zakura/handler.rs
@@ -2729,7 +2729,7 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
     sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
     header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
 ) -> Result<Option<ZakuraEndpoint>, BoxError> {
-    if !config.v2_p2p {
+    if !config.v2_p2p() {
         return Ok(None);
     }
 
@@ -4576,6 +4576,7 @@ mod tests {
             ZakuraDiscoveryLocalConfig, LOCAL_MAX_MESSAGE_BYTES, MAX_HS_MESSAGE_BYTES,
             MSG_HS_STATUS, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC, ZAKURA_CAP_LEGACY_GOSSIP,
         },
+        P2pStack,
     };
     use iroh::{
         endpoint::Connection,
@@ -5510,7 +5511,7 @@ mod tests {
     #[tokio::test]
     async fn v2_p2p_false_leaves_header_sync_disabled() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::for_test(false);
+        let config = Config::for_test(P2pStack::Zebra);
 
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
@@ -5524,7 +5525,7 @@ mod tests {
     #[tokio::test]
     async fn v2_p2p_true_starts_header_sync_handle() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::for_test(true);
+        let config = Config::for_test(P2pStack::Dual);
 
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
@@ -5540,7 +5541,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_header_sync_task() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::for_test(true);
+        let config = Config::for_test(P2pStack::Dual);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
@@ -5576,7 +5577,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_maintained_native_dial_loop() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::for_test(true);
+        let config = Config::for_test(P2pStack::Dual);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
@@ -5614,7 +5615,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_shutdown_stops_discovery_candidate_dialer() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::for_test(true);
+        let config = Config::for_test(P2pStack::Dual);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })
@@ -5667,7 +5668,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn failed_legacy_upgrade_does_not_leak_maintained_dial() -> Result<(), BoxError> {
         let _guard = zebra_test::init();
-        let config = Config::for_test(true);
+        let config = Config::for_test(P2pStack::Dual);
         let endpoint = spawn_zakura_endpoint(&config, |_supervisor, _trace| {
             Arc::new(NoopService) as Arc<dyn Service>
         })

--- a/zebra-network/src/zakura/legacy_gossip.rs
+++ b/zebra-network/src/zakura/legacy_gossip.rs
@@ -1627,7 +1627,7 @@ enum DualStackRoute {
 /// returned by [`crate::init`] when `v2_p2p` is enabled, so the syncer, mempool,
 /// and inbound downloads transparently gossip and fetch over Zakura too.
 ///
-/// Routing (with `legacy_enabled` = `config.legacy_p2p`):
+/// Routing (with `legacy_enabled` = `config.legacy_p2p()`):
 /// - Advertisements fan out concurrently to the legacy peer set (when
 ///   `legacy_enabled`) and the Zakura gossip adapter. Advertise is
 ///   fire-and-forget, so per-path errors are logged and swallowed and the

--- a/zebrad/src/commands/generate.rs
+++ b/zebrad/src/commands/generate.rs
@@ -97,61 +97,32 @@ fn document_network_p2p_config(config: &str) -> String {
     let Some(network_start) = lines.iter().position(|line| line == "[network]") else {
         return config.to_string();
     };
-    let mut network_end = lines
+    let network_end = lines
         .iter()
         .enumerate()
         .skip(network_start + 1)
         .find_map(|(index, line)| line.starts_with('[').then_some(index))
         .unwrap_or(lines.len());
 
-    let Some(v2_p2p_index) = lines[network_start + 1..network_end]
+    let Some(p2p_stack_index) = lines[network_start + 1..network_end]
         .iter()
-        .position(|line| line.starts_with("v2_p2p = "))
-        .map(|index| index + network_start + 1)
-    else {
-        return config.to_string();
-    };
-
-    let Some(default_p2p_index) = lines[network_start + 1..network_end]
-        .iter()
-        .position(|line| line.starts_with("default_p2p = "))
-        .map(|index| index + network_start + 1)
-    else {
-        return config.to_string();
-    };
-
-    let default_p2p_line = lines[default_p2p_index].clone();
-    let v2_p2p_line = lines[v2_p2p_index].clone();
-    let mut p2p_indexes = [default_p2p_index, v2_p2p_index];
-    p2p_indexes.sort();
-
-    for index in p2p_indexes.into_iter().rev() {
-        lines.remove(index);
-        network_end -= 1;
-    }
-
-    let Some(legacy_p2p_index) = lines[network_start + 1..network_end]
-        .iter()
-        .position(|line| line.starts_with("legacy_p2p = "))
+        .position(|line| line.starts_with("p2p_stack = "))
         .map(|index| index + network_start + 1)
     else {
         return config.to_string();
     };
 
     let comments = [
-        "# P2P stack selection:",
-        "# - default_p2p = true ignores legacy_p2p and v2_p2p, using Zebra's binary defaults.",
-        "# - default_p2p = false makes legacy_p2p and v2_p2p manual overrides.",
-        "# Defaults: Mainnet legacy on/v2 off; Testnet and Regtest legacy on/v2 on.",
+        "# The peer-to-peer stack to run:",
+        "# - \"zebra\" (aka \"v1\", \"legacy\"): the legacy TCP Zcash P2P stack only.",
+        "# - \"zakura\" (aka \"v2\"): the native Zakura P2P v2 stack only.",
+        "# - \"dual\" (aka \"combined\"): both stacks, with legacy fallback.",
+        "# - \"default\": Zebra's default for this network, which can change between",
+        "#   releases. Currently \"zebra\" on Mainnet, and \"dual\" everywhere else.",
     ]
     .map(ToString::to_string);
-    let comments_len = comments.len();
 
-    lines.splice(legacy_p2p_index..legacy_p2p_index, comments);
-    let default_p2p_insert_index = legacy_p2p_index + comments_len;
-    lines.insert(default_p2p_insert_index, default_p2p_line);
-    let v2_p2p_insert_index = default_p2p_insert_index + 1;
-    lines.insert(v2_p2p_insert_index, v2_p2p_line);
+    lines.splice(p2p_stack_index..p2p_stack_index, comments);
 
     let mut output = lines.join("\n");
     if had_trailing_newline {

--- a/zebrad/src/commands/generate.rs
+++ b/zebrad/src/commands/generate.rs
@@ -73,7 +73,8 @@ impl Runnable for GenerateCmd {
         // this avoids a ValueAfterTable error
         // https://github.com/alexcrichton/toml-rs/issues/145
         let conf = toml::Value::try_from(default_config).unwrap();
-        output += &toml::to_string_pretty(&conf).expect("default config should be serializable");
+        let conf = toml::to_string_pretty(&conf).expect("default config should be serializable");
+        output += &document_network_p2p_config(&conf);
         match self.output_file {
             Some(ref output_file) => {
                 use std::{fs::File, io::Write};
@@ -87,4 +88,74 @@ impl Runnable for GenerateCmd {
             }
         }
     }
+}
+
+fn document_network_p2p_config(config: &str) -> String {
+    let had_trailing_newline = config.ends_with('\n');
+    let mut lines = config.lines().map(ToString::to_string).collect::<Vec<_>>();
+
+    let Some(network_start) = lines.iter().position(|line| line == "[network]") else {
+        return config.to_string();
+    };
+    let mut network_end = lines
+        .iter()
+        .enumerate()
+        .skip(network_start + 1)
+        .find_map(|(index, line)| line.starts_with('[').then_some(index))
+        .unwrap_or(lines.len());
+
+    let Some(v2_p2p_index) = lines[network_start + 1..network_end]
+        .iter()
+        .position(|line| line.starts_with("v2_p2p = "))
+        .map(|index| index + network_start + 1)
+    else {
+        return config.to_string();
+    };
+
+    let Some(default_p2p_index) = lines[network_start + 1..network_end]
+        .iter()
+        .position(|line| line.starts_with("default_p2p = "))
+        .map(|index| index + network_start + 1)
+    else {
+        return config.to_string();
+    };
+
+    let default_p2p_line = lines[default_p2p_index].clone();
+    let v2_p2p_line = lines[v2_p2p_index].clone();
+    let mut p2p_indexes = [default_p2p_index, v2_p2p_index];
+    p2p_indexes.sort();
+
+    for index in p2p_indexes.into_iter().rev() {
+        lines.remove(index);
+        network_end -= 1;
+    }
+
+    let Some(legacy_p2p_index) = lines[network_start + 1..network_end]
+        .iter()
+        .position(|line| line.starts_with("legacy_p2p = "))
+        .map(|index| index + network_start + 1)
+    else {
+        return config.to_string();
+    };
+
+    let comments = [
+        "# P2P stack selection:",
+        "# - default_p2p = true ignores legacy_p2p and v2_p2p, using Zebra's binary defaults.",
+        "# - default_p2p = false makes legacy_p2p and v2_p2p manual overrides.",
+        "# Defaults: Mainnet legacy on/v2 off; Testnet and Regtest legacy on/v2 on.",
+    ]
+    .map(ToString::to_string);
+    let comments_len = comments.len();
+
+    lines.splice(legacy_p2p_index..legacy_p2p_index, comments);
+    let default_p2p_insert_index = legacy_p2p_index + comments_len;
+    lines.insert(default_p2p_insert_index, default_p2p_line);
+    let v2_p2p_insert_index = default_p2p_insert_index + 1;
+    lines.insert(v2_p2p_insert_index, v2_p2p_line);
+
+    let mut output = lines.join("\n");
+    if had_trailing_newline {
+        output.push('\n');
+    }
+    output
 }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -1631,7 +1631,11 @@ mod zakura_header_sync_driver_tests {
 
     #[test]
     fn zakura_block_sync_replaces_chain_sync_when_v2_p2p_is_enabled() {
-        let mut config = zebra_network::Config::default();
+        let mut config = zebra_network::Config {
+            default_p2p: false,
+            v2_p2p: true,
+            ..Default::default()
+        };
 
         assert!(use_zakura_block_sync(&config));
 
@@ -2171,6 +2175,8 @@ mod zakura_header_sync_driver_tests {
         let genesis_hash = network.genesis_hash();
         let mut config = zebra_network::Config {
             network: network.clone(),
+            default_p2p: false,
+            v2_p2p: true,
             ..zebra_network::Config::default()
         };
         config.zakura.listen_addr = None;
@@ -2279,6 +2285,8 @@ mod zakura_header_sync_driver_tests {
         let genesis_hash = network.genesis_hash();
         let mut config = zebra_network::Config {
             network: network.clone(),
+            default_p2p: false,
+            v2_p2p: true,
             ..zebra_network::Config::default()
         };
         config.zakura.listen_addr = None;

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -1631,11 +1631,7 @@ mod zakura_header_sync_driver_tests {
 
     #[test]
     fn zakura_block_sync_replaces_chain_sync_when_v2_p2p_is_enabled() {
-        let mut config = zebra_network::Config {
-            default_p2p: false,
-            v2_p2p: true,
-            ..Default::default()
-        };
+        let mut config = zebra_network::Config::for_test(true);
 
         assert!(use_zakura_block_sync(&config));
 
@@ -2175,9 +2171,7 @@ mod zakura_header_sync_driver_tests {
         let genesis_hash = network.genesis_hash();
         let mut config = zebra_network::Config {
             network: network.clone(),
-            default_p2p: false,
-            v2_p2p: true,
-            ..zebra_network::Config::default()
+            ..zebra_network::Config::for_test(true)
         };
         config.zakura.listen_addr = None;
         let endpoint = zebra_network::zakura::spawn_zakura_endpoint_with_header_sync_driver(
@@ -2285,9 +2279,7 @@ mod zakura_header_sync_driver_tests {
         let genesis_hash = network.genesis_hash();
         let mut config = zebra_network::Config {
             network: network.clone(),
-            default_p2p: false,
-            v2_p2p: true,
-            ..zebra_network::Config::default()
+            ..zebra_network::Config::for_test(true)
         };
         config.zakura.listen_addr = None;
         let endpoint = zebra_network::zakura::spawn_zakura_endpoint_with_header_sync_driver(

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -166,7 +166,7 @@ fn check_tcp_slow_start_after_idle() {
 }
 
 fn use_zakura_block_sync(config: &zebra_network::Config) -> bool {
-    config.v2_p2p
+    config.v2_p2p()
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -192,9 +192,10 @@ impl StartCmd {
             return Ok(());
         };
 
-        if !config.network.v2_p2p {
+        if !config.network.v2_p2p() {
             return Err(eyre!(
-                "sync.debug_blocksync_throughput_target_height requires network.v2_p2p = true"
+                "sync.debug_blocksync_throughput_target_height requires the Zakura P2P v2 \
+                 stack; set network.p2p_stack to \"zakura\" or \"dual\""
             ));
         }
 
@@ -322,7 +323,7 @@ impl StartCmd {
         info!("opening database, this may take a few minutes");
 
         let mut state_config = config.state.clone();
-        state_config.enable_zakura_header_seed_from_committed_blocks = config.network.v2_p2p;
+        state_config.enable_zakura_header_seed_from_committed_blocks = config.network.v2_p2p();
         // State owns the VCT commit path, but users configure its checkpoint-sync controls
         // together under `[consensus]`.
         state_config.checkpoint_sync = config.consensus.checkpoint_sync;
@@ -370,7 +371,7 @@ impl StartCmd {
             .buffer(Self::state_buffer_bound())
             .service(state_service);
 
-        let zakura_header_sync_driver_startup = if config.network.v2_p2p {
+        let zakura_header_sync_driver_startup = if config.network.v2_p2p() {
             Some(
                 zakura_header_sync_driver_startup(
                     read_only_state_service.clone(),
@@ -749,7 +750,7 @@ impl StartCmd {
             // Zakura stall; a Zakura-only node has no legacy peers to drive body sync. The
             // fallback resumes legacy ChainSync as the body-sync driver while the Zakura
             // reactors stay alive as a serving/advertising bridge for zakura-only peers.
-            let legacy_fallback = config.network.v2_p2p && config.network.legacy_p2p;
+            let legacy_fallback = config.network.v2_p2p() && config.network.legacy_p2p();
             tokio::spawn(
                 syncer
                     .bootstrap_genesis_then_pause(
@@ -1072,10 +1073,11 @@ impl config::Override<ZebradConfig> for StartCmd {
         }
 
         if config.zcashd_compat.enabled {
-            if !config.network.legacy_p2p {
+            if !config.network.legacy_p2p() {
                 return Err(std::io::Error::other(
-                    "zcashd-compat P2P sidecar mode requires network.legacy_p2p = true, \
-                     because zcashd syncs from Zebra over the legacy Zcash P2P protocol",
+                    "zcashd-compat P2P sidecar mode requires the legacy Zcash P2P stack, \
+                     because zcashd syncs from Zebra over it; set network.p2p_stack to \
+                     \"zebra\" or \"dual\"",
                 )
                 .into());
             }
@@ -1121,6 +1123,7 @@ mod tests {
     use super::StartCmd;
     use crate::components::zcashd_compat;
     use crate::config::ZebradConfig;
+    use zebra_network::P2pStack;
 
     #[test]
     fn zcashd_compat_flag_enables_mode() {
@@ -1165,7 +1168,7 @@ mod tests {
             unsafe_low_specs: false,
         };
         let mut config = ZebradConfig::default();
-        config.network.v2_p2p = false;
+        config.network.p2p_stack = P2pStack::Zebra;
         config.sync.debug_blocksync_throughput_target_height = Some(100);
 
         let error = cmd
@@ -1174,7 +1177,7 @@ mod tests {
 
         assert!(
             error.to_string().contains(
-                "sync.debug_blocksync_throughput_target_height requires network.v2_p2p = true"
+                "sync.debug_blocksync_throughput_target_height requires the Zakura P2P v2 stack"
             ),
             "unexpected error: {error}"
         );
@@ -1227,13 +1230,15 @@ mod tests {
         let mut config = ZebradConfig::default();
         config.zcashd_compat.enabled = true;
         config.zcashd_compat.manage_zcashd = false;
-        config.network.legacy_p2p = false;
+        config.network.p2p_stack = P2pStack::Zakura;
 
         let error = cmd
             .override_config(config)
             .expect_err("the P2P sidecar should require the legacy P2P listener");
         assert!(
-            error.to_string().contains("legacy_p2p"),
+            error
+                .to_string()
+                .contains("requires the legacy Zcash P2P stack"),
             "unexpected error: {error}"
         );
     }
@@ -1431,6 +1436,7 @@ mod zakura_header_sync_driver_tests {
         Service as ZakuraService, Stream as ZakuraStream, ZakuraHeaderSyncDriverStartup,
         BLOCK_SYNC_TABLE, COMMIT_STATE_TABLE, DEFAULT_HS_RANGE,
     };
+    use zebra_network::P2pStack;
     use zebra_test::vectors::{BLOCK_MAINNET_1_BYTES, BLOCK_MAINNET_2_BYTES};
 
     use super::zakura::{
@@ -1631,11 +1637,11 @@ mod zakura_header_sync_driver_tests {
 
     #[test]
     fn zakura_block_sync_replaces_chain_sync_when_v2_p2p_is_enabled() {
-        let mut config = zebra_network::Config::for_test(true);
+        let mut config = zebra_network::Config::for_test(P2pStack::Dual);
 
         assert!(use_zakura_block_sync(&config));
 
-        config.v2_p2p = false;
+        config.p2p_stack = P2pStack::Zebra;
         assert!(!use_zakura_block_sync(&config));
     }
 
@@ -2171,7 +2177,7 @@ mod zakura_header_sync_driver_tests {
         let genesis_hash = network.genesis_hash();
         let mut config = zebra_network::Config {
             network: network.clone(),
-            ..zebra_network::Config::for_test(true)
+            ..zebra_network::Config::for_test(P2pStack::Dual)
         };
         config.zakura.listen_addr = None;
         let endpoint = zebra_network::zakura::spawn_zakura_endpoint_with_header_sync_driver(
@@ -2279,7 +2285,7 @@ mod zakura_header_sync_driver_tests {
         let genesis_hash = network.genesis_hash();
         let mut config = zebra_network::Config {
             network: network.clone(),
-            ..zebra_network::Config::for_test(true)
+            ..zebra_network::Config::for_test(P2pStack::Dual)
         };
         config.zakura.listen_addr = None;
         let endpoint = zebra_network::zakura::spawn_zakura_endpoint_with_header_sync_driver(

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -21,7 +21,7 @@ use zebra_consensus::{error::TransactionError, router::RouterError, transaction}
 use zebra_network::{
     canonical_peer_addr, connect_isolated_tcp_direct_with_inbound,
     types::{InventoryHash, PeerServices},
-    CacheDir, Config as NetworkConfig, InventoryResponse, PeerError, Request, Response,
+    CacheDir, Config as NetworkConfig, InventoryResponse, P2pStack, PeerError, Request, Response,
     SharedPeerError,
 };
 use zebra_node_services::mempool;
@@ -62,7 +62,7 @@ async fn inbound_peers_empty_address_book() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         listen_addr,
-    ) = setup(None, false).await;
+    ) = setup(None, P2pStack::Zebra).await;
 
     // yield and sleep until the address book lock is released.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -151,7 +151,7 @@ async fn dual_stack_node_coexists_with_legacy_tcp_peer() -> Result<(), crate::Bo
         tx_gossip_task_handle,
         // real open socket addresses
         listen_addr,
-    ) = setup(Some(Response::Peers(Vec::new())), true).await;
+    ) = setup(Some(Response::Peers(Vec::new())), P2pStack::Dual).await;
 
     // yield and sleep until the address book lock is released.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -215,7 +215,7 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, false).await;
+    ) = setup(None, P2pStack::Zebra).await;
 
     let test_block = block::Hash([0x11; 32]);
 
@@ -298,7 +298,7 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, false).await;
+    ) = setup(None, P2pStack::Zebra).await;
 
     let test_tx = UnminedTxId::from_legacy_id(TxHash([0x22; 32]));
     let test_wtx: UnminedTxId = WtxId {
@@ -430,7 +430,7 @@ async fn outbound_tx_unrelated_response_notfound() -> Result<(), crate::BoxError
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(Some(unrelated_response), false).await;
+    ) = setup(Some(unrelated_response), P2pStack::Zebra).await;
 
     let test_tx5 = UnminedTxId::from_legacy_id(TxHash([0x55; 32]));
     let test_wtx67: UnminedTxId = WtxId {
@@ -579,7 +579,7 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(Some(repeated_response), false).await;
+    ) = setup(Some(repeated_response), P2pStack::Zebra).await;
 
     let missing_tx_id = UnminedTxId::from_legacy_id(TxHash([0x22; 32]));
 
@@ -671,7 +671,7 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
 /// Uses fake verifiers, and does not run a block syncer task.
 async fn setup(
     isolated_peer_response: Option<Response>,
-    enable_v2_p2p: bool,
+    p2p_stack: P2pStack,
 ) -> (
     // real services
     // connected peer which responds with isolated_peer_response
@@ -733,8 +733,7 @@ async fn setup(
 
         // Optionally run the Zakura P2P-v2 endpoint alongside the legacy TCP
         // stack so the dual-stack wiring is exercised (coexistence tests).
-        default_p2p: false,
-        v2_p2p: enable_v2_p2p,
+        p2p_stack,
 
         ..NetworkConfig::default()
     };

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -733,6 +733,7 @@ async fn setup(
 
         // Optionally run the Zakura P2P-v2 endpoint alongside the legacy TCP
         // stack so the dual-stack wiring is exercised (coexistence tests).
+        default_p2p: false,
         v2_p2p: enable_v2_p2p,
 
         ..NetworkConfig::default()

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -621,8 +621,9 @@ pub struct Config {
     /// commit, and Zebra exits successfully when the synthetic verified body tip
     /// reaches this height.
     ///
-    /// This mode requires `network.v2_p2p = true`, is intentionally hidden from
-    /// generated configs, and is only for throughput debugging.
+    /// This mode requires the Zakura P2P v2 stack (`network.p2p_stack` set to
+    /// `"zakura"` or `"dual"`), is intentionally hidden from generated configs, and is
+    /// only for throughput debugging.
     #[serde(skip_serializing)]
     pub debug_blocksync_throughput_target_height: Option<u32>,
 }

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -39,6 +39,7 @@ pub fn default_test_config(net: &Network) -> ZebradConfig {
         listen_addr: "127.0.0.1:0".parse().unwrap(),
         // Keep acceptance tests on legacy gossip until Zakura P2P v2 supports
         // the inventory/block propagation those tests depend on.
+        default_p2p: false,
         v2_p2p: false,
         legacy_p2p: true,
         crawl_new_peer_interval: TEST_DURATION,

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -39,9 +39,7 @@ pub fn default_test_config(net: &Network) -> ZebradConfig {
         listen_addr: "127.0.0.1:0".parse().unwrap(),
         // Keep acceptance tests on legacy gossip until Zakura P2P v2 supports
         // the inventory/block propagation those tests depend on.
-        default_p2p: false,
-        v2_p2p: false,
-        legacy_p2p: true,
+        p2p_stack: zebra_network::P2pStack::Zebra,
         crawl_new_peer_interval: TEST_DURATION,
         ..zebra_network::Config::default()
     };

--- a/zebrad/tests/common/configs/v5.0.0-rc.3.toml
+++ b/zebrad/tests/common/configs/v5.0.0-rc.3.toml
@@ -75,12 +75,17 @@ initial_testnet_peers = [
     "dnsseed.testnet.z.cash:18233",
     "testnet.seeder.zfnd.org:18233",
 ]
+# P2P stack selection:
+# - default_p2p = true ignores legacy_p2p and v2_p2p, using Zebra's binary defaults.
+# - default_p2p = false makes legacy_p2p and v2_p2p manual overrides.
+# Defaults: Mainnet legacy on/v2 off; Testnet and Regtest legacy on/v2 on.
+default_p2p = true
+v2_p2p = false
 legacy_p2p = true
 listen_addr = "[::]:8233"
 max_connections_per_ip = 1
 network = "Mainnet"
 peerset_initial_target_size = 100
-v2_p2p = true
 
 [network.zakura]
 bootstrap_peers = [

--- a/zebrad/tests/common/configs/v5.0.0-rc.3.toml
+++ b/zebrad/tests/common/configs/v5.0.0-rc.3.toml
@@ -75,16 +75,16 @@ initial_testnet_peers = [
     "dnsseed.testnet.z.cash:18233",
     "testnet.seeder.zfnd.org:18233",
 ]
-# P2P stack selection:
-# - default_p2p = true ignores legacy_p2p and v2_p2p, using Zebra's binary defaults.
-# - default_p2p = false makes legacy_p2p and v2_p2p manual overrides.
-# Defaults: Mainnet legacy on/v2 off; Testnet and Regtest legacy on/v2 on.
-default_p2p = true
-v2_p2p = false
-legacy_p2p = true
 listen_addr = "[::]:8233"
 max_connections_per_ip = 1
 network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "zebra" (aka "v1", "legacy"): the legacy TCP Zcash P2P stack only.
+# - "zakura" (aka "v2"): the native Zakura P2P v2 stack only.
+# - "dual" (aka "combined"): both stacks, with legacy fallback.
+# - "default": Zebra's default for this network, which can change between
+#   releases. Currently "zebra" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
 peerset_initial_target_size = 100
 
 [network.zakura]


### PR DESCRIPTION
## Motivation

Port https://github.com/valargroup/zebra/pull/503 into `zakura-core/zakura`, including the latest local follow-up commit `d8d20b5e4` (`test(network): consolidate p2p test configs into Config::for_test`).

Mainnet should not enable the experimental Zakura P2P v2 stack by default yet. Testnet and Regtest should continue defaulting to dual-stack behavior so test-network and development workflows keep exercising both stacks unless explicitly overridden.

Generated configs should also avoid pinning a resolved Mainnet bool when the operator really wants the node to follow the selected network default.

## Solution

- Add `network.default_p2p`, enabled by default, to follow binary P2P stack defaults for the selected network.
- Resolve default P2P stack selection after the configured network is known: legacy P2P on for Mainnet, Testnet, and Regtest; Zakura P2P v2 off on Mainnet and on for Testnet and Regtest.
- Keep explicit `network.v2_p2p` and `network.legacy_p2p` as manual overrides when `network.default_p2p = false`.
- Preserve the legacy `enable_p2p_v2` alias.
- Add `Config::for_test(v2_p2p)` so tests can pin manual P2P stack overrides without repeating `default_p2p = false` literals.
- Keep generated config comments and `legacy_p2p` / `v2_p2p` close together so operators can see how to change P2P stack selection.
- Update tests, generated config fixture, and changelog.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p zebra-network config::tests::vectors:: -- --nocapture`
- `cargo clippy -p zebra-network --tests -- -D warnings`
- `env CXXFLAGS='-include cstdint' cargo test -p zebrad commands::start::zakura_header_sync_driver_tests -- --nocapture`

## Issue

No issue linked.

## AI disclosure

Used OpenAI Codex to inspect the source PR and follow-up commit, port the config defaulting change into the Zakura worktree, run local checks, commit, push, open this draft PR, and update test evidence. The contributor remains responsible for review and correctness.
