### PR TITLE
build(zebrad): rename node binary from zebrad to zakurad

### DIFF
--- a/.github/workflows/deploy-zcashd-compat.yml
+++ b/.github/workflows/deploy-zcashd-compat.yml
@@ -99,7 +99,7 @@ jobs:
 
           ssh_options=(-o StrictHostKeyChecking=yes -o UserKnownHostsFile="$HOME/.ssh/known_hosts")
 
-          scp "${ssh_options[@]}" target/release/zebrad "$DEPLOY_USER@$DEPLOY_HOST:/usr/local/bin/zebrad.new"
+          scp "${ssh_options[@]}" target/release/zakurad "$DEPLOY_USER@$DEPLOY_HOST:/usr/local/bin/zebrad.new"
           scp "${ssh_options[@]}" target/release/zebra-watchdog "$DEPLOY_USER@$DEPLOY_HOST:/usr/local/bin/zebra-watchdog.new"
           scp "${ssh_options[@]}" deploy/zcashd-compat/sync-check.sh "$DEPLOY_USER@$DEPLOY_HOST:/tmp/zcashd-compat-sync-check.sh"
           scp "${ssh_options[@]}" deploy/watchdog/systemd/zebra-watchdog.service "$DEPLOY_USER@$DEPLOY_HOST:/tmp/zebra-watchdog.service"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -129,10 +129,10 @@ jobs:
             --build-arg "FEATURES=${FEATURES}" \
             --output "type=local,dest=./out" \
             .
-          test -x ./out/usr/local/bin/zebrad
+          test -x ./out/usr/local/bin/zakurad
 
       - name: Validate binary
-        run: ./out/usr/local/bin/zebrad --version
+        run: ./out/usr/local/bin/zakurad --version
 
       - name: Package archive and metadata
         env:
@@ -140,7 +140,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ./artifacts/bin ./artifacts/metadata
-          cp ./out/usr/local/bin/zebrad ./artifacts/bin/zebrad
+          cp ./out/usr/local/bin/zakurad ./artifacts/bin/zebrad
           archive_name="zebrad-${RELEASE_TAG}-${{ matrix.name }}.tar.gz"
           (
             cd ./artifacts

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -219,7 +219,7 @@ jobs:
           fi
 
           # For long-running commands (zebrad start), run detached and follow logs
-          docker run ${{ matrix.env_vars }} --detach --name ${{ matrix.id }} -t zebrad-test:${{ github.sha }} zebrad start
+          docker run ${{ matrix.env_vars }} --detach --name ${{ matrix.id }} -t zebrad-test:${{ github.sha }} zakurad start
           # Use a subshell to handle the broken pipe error gracefully
           (
             trap "" PIPE;

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -270,7 +270,7 @@ def build_commit(root: Path, sha: str, *, force: bool = False) -> Path:
         # Respect CARGO_TARGET_DIR (set per-worktree or shared) when locating the
         # output, falling back to the in-worktree target dir.
         target_dir = os.environ.get("CARGO_TARGET_DIR")
-        built = (Path(target_dir) if target_dir else work / "target") / "release" / "zebrad"
+        built = (Path(target_dir) if target_dir else work / "target") / "release" / "zakurad"
         if not built.is_file():
             raise DeployError(f"expected binary not found after build: {built}")
         tmp = target.with_suffix(".tmp")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,10 +106,10 @@ COPY --link --chown=${UID}:${GID} ./ ${HOME}
 # Build Zebra test binaries using nextest, but don't run them.
 # This also copies the necessary binaries to /usr/local/bin.
 RUN [ -n "${SHORT_SHA}" ] && export SHORT_SHA="${SHORT_SHA}" || true; \
-    cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zebrad --bin zebra-rollback-state --bin zebra-prune-state && \
+    cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zakurad --bin zebra-rollback-state --bin zebra-prune-state && \
     cargo nextest run --locked --release --no-run --features "${FEATURES}" && \
     # Copy binaries to standard location
-    cp ${CARGO_TARGET_DIR}/release/zebrad /usr/local/bin && \
+    cp ${CARGO_TARGET_DIR}/release/zakurad /usr/local/bin && \
     cp ${CARGO_TARGET_DIR}/release/zebra-rollback-state /usr/local/bin && \
     cp ${CARGO_TARGET_DIR}/release/zebra-prune-state /usr/local/bin && \
     # Only copy zebra-checkpoints if the feature is enabled
@@ -165,8 +165,8 @@ RUN --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
     --mount=type=cache,target=${CARGO_TARGET_DIR} \
     --mount=type=cache,target=${CARGO_HOME} \
     [ -n "${SHORT_SHA}" ] && export SHORT_SHA="${SHORT_SHA}" || true; \
-    cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zebrad --bin zebra-rollback-state --bin zebra-prune-state && \
-    cp ${CARGO_TARGET_DIR}/release/zebrad /usr/local/bin && \
+    cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zakurad --bin zebra-rollback-state --bin zebra-prune-state && \
+    cp ${CARGO_TARGET_DIR}/release/zakurad /usr/local/bin && \
     cp ${CARGO_TARGET_DIR}/release/zebra-rollback-state /usr/local/bin && \
     cp ${CARGO_TARGET_DIR}/release/zebra-prune-state /usr/local/bin
 
@@ -221,13 +221,13 @@ RUN chown -R ${UID}:${GID} ${HOME}
 # User with UID=${UID} is created above and used via setpriv in entrypoint.sh.
 # setpriv is part of util-linux, already included in debian:trixie-slim.
 
-COPY --link --from=release /usr/local/bin/zebrad /usr/local/bin/
+COPY --link --from=release /usr/local/bin/zakurad /usr/local/bin/
 COPY --link --from=release /usr/local/bin/zebra-rollback-state /usr/local/bin/
 COPY --link --from=release /usr/local/bin/zebra-prune-state /usr/local/bin/
 COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT [ "entrypoint.sh" ]
-CMD ["zebrad"]
+CMD ["zakurad"]
 
 # zcashd-compat runtime image, expects an externally prepared build context named
 # `zcashd_compat` with a Linux executable at /bin/zcashd.

--- a/docker/docker-compose.zakura-regtest-e2e.yml
+++ b/docker/docker-compose.zakura-regtest-e2e.yml
@@ -1,15 +1,15 @@
 # Lightweight Zakura dual-stack regtest e2e — a smoke test, deliberately small.
 #
 # Three zebrad nodes on a fresh Regtest chain. The key cost-saving choice: there
-# is NO in-container compilation. Each node runs the HOST-built `zebrad` binary
+# is NO in-container compilation. Each node runs the HOST-built `zakurad` binary
 # bind-mounted into a stock `debian:trixie-slim` (which already ships glibc 2.41,
 # libstdc++, and libgcc — everything the binary needs). The previous e2e did a
 # full `cargo build --release` per service, which is what exhausted disk/CPU.
 #
 # Build the binary once on the host, then bring the cluster up:
 #
-#   cargo build -p zebrad --bin zebrad          # debug is fine for regtest
-#   ZEBRAD_BIN=$(pwd)/target/debug/zebrad \
+#   cargo build -p zebrad --bin zakurad         # debug is fine for regtest
+#   ZEBRAD_BIN=$(pwd)/target/debug/zakurad \
 #     docker compose -f docker/docker-compose.zakura-regtest-e2e.yml up -d
 #
 # Or just run docker/zakura-regtest-e2e/run.sh, which does all of the above and
@@ -40,9 +40,9 @@ services:
   zakura-node-1:
     <<: *zakura-node
     container_name: zakura-node-1
-    entrypoint: ["/usr/local/bin/zebrad", "--config", "/etc/zebrad/node1.toml", "start"]
+    entrypoint: ["/usr/local/bin/zakurad", "--config", "/etc/zebrad/node1.toml", "start"]
     volumes:
-      - ${ZEBRAD_BIN:-../target/debug/zebrad}:/usr/local/bin/zebrad:ro
+      - ${ZEBRAD_BIN:-../target/debug/zakurad}:/usr/local/bin/zakurad:ro
       - ${ZAKURA_NODE1_CONFIG:-./zakura-regtest-e2e/node1.toml}:/etc/zebrad/node1.toml:ro
       - ${ZAKURA_E2E_TRACE_DIR:-/tmp/zakura-regtest-e2e-traces}:/traces
 
@@ -51,9 +51,9 @@ services:
     container_name: zakura-node-2
     depends_on:
       - zakura-node-1
-    entrypoint: ["/usr/local/bin/zebrad", "--config", "/etc/zebrad/node2.toml", "start"]
+    entrypoint: ["/usr/local/bin/zakurad", "--config", "/etc/zebrad/node2.toml", "start"]
     volumes:
-      - ${ZEBRAD_BIN:-../target/debug/zebrad}:/usr/local/bin/zebrad:ro
+      - ${ZEBRAD_BIN:-../target/debug/zakurad}:/usr/local/bin/zakurad:ro
       - ${ZAKURA_NODE2_CONFIG:-./zakura-regtest-e2e/node2.toml}:/etc/zebrad/node2.toml:ro
       - ${ZAKURA_E2E_TRACE_DIR:-/tmp/zakura-regtest-e2e-traces}:/traces
 
@@ -62,9 +62,9 @@ services:
     container_name: zakura-node-3
     depends_on:
       - zakura-node-1
-    entrypoint: ["/usr/local/bin/zebrad", "--config", "/etc/zebrad/node3.toml", "start"]
+    entrypoint: ["/usr/local/bin/zakurad", "--config", "/etc/zebrad/node3.toml", "start"]
     volumes:
-      - ${ZEBRAD_BIN:-../target/debug/zebrad}:/usr/local/bin/zebrad:ro
+      - ${ZEBRAD_BIN:-../target/debug/zakurad}:/usr/local/bin/zakurad:ro
       - ${ZAKURA_NODE3_CONFIG:-./zakura-regtest-e2e/node3.toml}:/etc/zebrad/node3.toml:ro
       - ${ZAKURA_E2E_TRACE_DIR:-/tmp/zakura-regtest-e2e-traces}:/traces
 
@@ -73,8 +73,8 @@ services:
     container_name: zakura-node-4
     depends_on:
       - zakura-node-1
-    entrypoint: ["/usr/local/bin/zebrad", "--config", "/etc/zebrad/node4.toml", "start"]
+    entrypoint: ["/usr/local/bin/zakurad", "--config", "/etc/zebrad/node4.toml", "start"]
     volumes:
-      - ${ZEBRAD_BIN:-../target/debug/zebrad}:/usr/local/bin/zebrad:ro
+      - ${ZEBRAD_BIN:-../target/debug/zakurad}:/usr/local/bin/zakurad:ro
       - ${ZAKURA_NODE4_CONFIG:-./zakura-regtest-e2e/node4.toml}:/etc/zebrad/node4.toml:ro
       - ${ZAKURA_E2E_TRACE_DIR:-/tmp/zakura-regtest-e2e-traces}:/traces

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -86,19 +86,20 @@ if [[ -n ${CONFIG_FILE_PATH} && -f ${CONFIG_FILE_PATH} ]]; then
 fi
 
 # Main Script Logic
-# - If "$1" is "--", "-", or "zebrad", run `zebrad` with the remaining params.
+# - If "$1" is "--", "-", "zakurad", or "zebrad" (legacy alias), run `zakurad`
+#   with the remaining params.
 # - If "$1" is "test", handle test execution
 # - Otherwise run "$@" directly.
 case "$1" in
---* | -* | zebrad)
+--* | -* | zakurad | zebrad)
   shift
-  exec_as_user zebrad "${CONFIG_ARGS[@]}" "$@"
+  exec_as_user zakurad "${CONFIG_ARGS[@]}" "$@"
   ;;
 test)
   shift
-  if [[ "$1" == "zebrad" ]]; then
+  if [[ "$1" == "zakurad" || "$1" == "zebrad" ]]; then
     shift
-    exec_as_user zebrad "${CONFIG_ARGS[@]}" "$@"
+    exec_as_user zakurad "${CONFIG_ARGS[@]}" "$@"
   elif [[ -n "${NEXTEST_PROFILE}" ]]; then
     # All test filtering and scoping logic is handled by .config/nextest.toml
     echo "Running tests with nextest profile: ${NEXTEST_PROFILE}"

--- a/docker/ubuntu-package.Dockerfile
+++ b/docker/ubuntu-package.Dockerfile
@@ -35,9 +35,9 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/workspace/target \
 #     RUSTFLAGS="${RUSTFLAGS}" \
-    cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zebrad && \
-    install -D target/release/zebrad /out/zebrad
+    cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zakurad && \
+    install -D target/release/zakurad /out/zakurad
 
 FROM scratch AS artifact
 
-COPY --from=build /out/zebrad /zebrad
+COPY --from=build /out/zakurad /zakurad

--- a/docker/zakura-regtest-e2e/diag.sh
+++ b/docker/zakura-regtest-e2e/diag.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/../docker-compose.zakura-regtest-e2e.yml"
 REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-export ZEBRAD_BIN="${ZEBRAD_BIN:-${REPO_DIR}/target/debug/zebrad}"
+export ZEBRAD_BIN="${ZEBRAD_BIN:-${REPO_DIR}/target/debug/zakurad}"
 
 rpc() { curl -s --max-time 10 -H 'content-type: application/json' \
   --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$2\",\"params\":${3:-[]}}" "http://127.0.0.1:$1/"; }

--- a/docker/zakura-regtest-e2e/run.sh
+++ b/docker/zakura-regtest-e2e/run.sh
@@ -149,11 +149,11 @@ command -v docker >/dev/null || fail "docker is required"
 command -v jq >/dev/null || fail "jq is required to parse RPC responses"
 command -v python3 >/dev/null || fail "python3 is required to run the trace oracle"
 
-# Ensure a host-built zebrad binary exists; build it (debug) if not.
-ZEBRAD_BIN="${ZEBRAD_BIN:-${REPO_DIR}/target/debug/zebrad}"
+# Ensure a host-built zakurad binary exists; build it (debug) if not.
+ZEBRAD_BIN="${ZEBRAD_BIN:-${REPO_DIR}/target/debug/zakurad}"
 if [[ ! -x "${ZEBRAD_BIN}" ]]; then
-  log "building host zebrad (debug) — no in-container build"
-  ( cd "${REPO_DIR}" && CXXFLAGS="-include cstdint" cargo build -p zebrad --bin zebrad )
+  log "building host zakurad (debug) — no in-container build"
+  ( cd "${REPO_DIR}" && CXXFLAGS="-include cstdint" cargo build -p zebrad --bin zakurad )
 fi
 [[ -x "${ZEBRAD_BIN}" ]] || fail "zebrad binary not found at ${ZEBRAD_BIN}"
 export ZEBRAD_BIN

--- a/make/zcashd-compat.mk
+++ b/make/zcashd-compat.mk
@@ -13,7 +13,7 @@
 	compat-test-mainnet \
 	compat-test-testnet
 
-ZEBRAD_BIN ?= $(CURDIR)/target/release/zebrad
+ZEBRAD_BIN ?= $(CURDIR)/target/release/zakurad
 ZCASHD_BIN ?= /root/unity/zcash/src/zcashd
 ZCASH_CLI_BIN ?= /root/unity/zcash/src/zcash-cli
 
@@ -92,7 +92,7 @@ compat-docker-start:
 		-p 8233:8233 \
 		-p 127.0.0.1:8232:8232 \
 		"$(ZEBRA_DOCKER_IMAGE)" \
-		zebrad start --zcashd-compat
+		zakurad start --zcashd-compat
 
 compat-zebrad-start-supervised-managed:
 	@echo "Starting zebrad in zcashd-compat mode with managed zcashd download..."
@@ -138,7 +138,7 @@ compat-zcashd-start-standalone:
 
 compat-zebrad-status:
 	@echo "Checking zebrad process..."
-	@if pgrep -f "zebrad start --zcashd-compat" >/dev/null; then \
+	@if pgrep -f "zakurad start --zcashd-compat" >/dev/null; then \
 		echo "zebrad process: OK"; \
 	else \
 		echo "zebrad process: NOT RUNNING"; \

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -585,10 +585,10 @@ collect_source_checks() {
     add_error "Zebra source tree is missing Cargo.toml: $REPO_ROOT"
   fi
 
-  ZEBRAD_PATH="${ZEBRAD_PATH:-$REPO_ROOT/target/release/zebrad}"
+  ZEBRAD_PATH="${ZEBRAD_PATH:-$REPO_ROOT/target/release/zakurad}"
 
   if [[ -e "$ZEBRAD_PATH" && ! -x "$ZEBRAD_PATH" ]]; then
-    add_error "zebrad binary $ZEBRAD_PATH exists but is not executable by the current user"
+    add_error "zakurad binary $ZEBRAD_PATH exists but is not executable by the current user"
   fi
 }
 
@@ -745,7 +745,7 @@ print_source_commands() {
   cat <<EOF
 git clone https://github.com/valargroup/zebra.git
 
-cd $(shell_quote "$REPO_ROOT") && cargo build --release --bin zebrad
+cd $(shell_quote "$REPO_ROOT") && cargo build --release --bin zakurad
 
 $(style "$GREEN$BOLD" "Start Zebra:")
 ZEBRA_STATE__CACHE_DIR=$(shell_quote "$ZEBRA_STATE_DIR") \\

--- a/scripts/install-zcashd-compat.sh
+++ b/scripts/install-zcashd-compat.sh
@@ -961,11 +961,11 @@ collect_source_checks() {
     add_error "zcash build script is missing or not executable: $UNITY_ROOT/zcash/zcutil/build.sh"
   fi
 
-  ZEBRAD_PATH="${ZEBRAD_PATH:-$REPO_ROOT/target/release/zebrad}"
+  ZEBRAD_PATH="${ZEBRAD_PATH:-$REPO_ROOT/target/release/zakurad}"
   ZCASHD_PATH="${ZCASHD_PATH:-$UNITY_ROOT/zcash/src/zcashd}"
 
   if [[ -e "$ZEBRAD_PATH" && ! -x "$ZEBRAD_PATH" ]]; then
-    add_error "zebrad binary $ZEBRAD_PATH exists but is not executable by the current user"
+    add_error "zakurad binary $ZEBRAD_PATH exists but is not executable by the current user"
   fi
 
   if [[ -e "$ZCASHD_PATH" && ! -x "$ZCASHD_PATH" ]]; then
@@ -1319,7 +1319,7 @@ print_source_commands() {
 git clone https://github.com/valargroup/zebra.git
 git clone https://github.com/valargroup/zcashd.git
 
-cd $(shell_quote "$REPO_ROOT") && cargo build --release --bin zebrad
+cd $(shell_quote "$REPO_ROOT") && cargo build --release --bin zakurad
 cd $(shell_quote "$UNITY_ROOT/zcash") && ./zcutil/build.sh -j"\$(nproc)"
 
 $(style "$GREEN$BOLD" "Start Zebra in terminal 1:")

--- a/zebra-test/scripts/shutdown-errors
+++ b/zebra-test/scripts/shutdown-errors
@@ -19,7 +19,7 @@ SHUTDOWN_DELAY_LIMIT=30
 echo "Building Zebra"
 echo
 
-cargo build --bin zebrad || exit $?
+cargo build --bin zakurad || exit $?
 
 EXIT_STATUS=0
 while [ $EXIT_STATUS -eq 0 ] && [ $SHUTDOWN_DELAY -le $SHUTDOWN_DELAY_LIMIT ]; do
@@ -29,17 +29,17 @@ while [ $EXIT_STATUS -eq 0 ] && [ $SHUTDOWN_DELAY -le $SHUTDOWN_DELAY_LIMIT ]; d
 
     # shut down Zebra if this script exits while it's running,
     # but ignore "no such job" errors if Zebra has already exited
-    trap "kill %?zebrad 2> /dev/null" EXIT
+    trap "kill %?zakurad 2> /dev/null" EXIT
 
-    target/debug/zebrad start &
+    target/debug/zakurad start &
     sleep $SHUTDOWN_DELAY
 
     echo
     echo "Killing Zebra after $SHUTDOWN_DELAY seconds"
     echo
 
-    kill %?zebrad
-    wait %?zebrad
+    kill %?zakurad
+    wait %?zakurad
     EXIT_STATUS=$?
 
     # fix up the exit status caused by 'kill'

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -22,9 +22,9 @@ rust-version = "1.91"
 
 # Settings that impact runtime behaviour
 
-# make `cargo run` use `zebrad` by default
+# make `cargo run` use `zakurad` by default
 # when run in the workspace directory
-default-run = "zebrad"
+default-run = "zakurad"
 
 # `cargo release` settings
 [package.metadata.release]
@@ -135,7 +135,7 @@ lightwalletd-grpc-tests = ["tonic-prost-build"]
 #
 # To activate this feature, run:
 # ```sh
-# RUSTFLAGS="--cfg tokio_unstable" cargo build --no-default-features --features="tokio-console" --bin zebrad
+# RUSTFLAGS="--cfg tokio_unstable" cargo build --no-default-features --features="tokio-console" --bin zakurad
 # ```
 #
 # The console-subscriber is incompatible with the tracing/max_level_* features.

--- a/zebrad/src/bin/zakurad/main.rs
+++ b/zebrad/src/bin/zakurad/main.rs
@@ -1,10 +1,10 @@
-//! Main entry point for Zebrad
+//! Main entry point for zakurad
 
 use zebrad::application::{boot, APPLICATION};
 
-/// Process entry point for `zebrad`
+/// Process entry point for `zakurad`
 fn main() {
-    // Enable backtraces by default for zebrad, but allow users to override it.
+    // Enable backtraces by default for zakurad, but allow users to override it.
     if std::env::var_os("RUST_BACKTRACE").is_none() {
         std::env::set_var("RUST_BACKTRACE", "1");
         // Disable library backtraces (i.e. eyre) to avoid performance hit for

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -844,8 +844,8 @@ fn last_config_is_stored() -> Result<()> {
          {} \n\
          \n\
          Or run: \n\
-         cargo build --bin zebrad && \n\
-         zebrad generate | \n\
+         cargo build --bin zakurad && \n\
+         zakurad generate | \n\
          sed 's/cache_dir = \".*\"/cache_dir = \"cache_dir\"/' | \n\
          sed 's/identity_dir = \".*\"/identity_dir = \"identity_dir\"/' > \n\
          {}",

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -338,8 +338,8 @@ impl ZebraCheckpointsTestDirExt for TempDir {
             return zebra_checkpoints;
         };
 
-        // Fall back to assuming zebra-checkpoints is in the same directory as zebrad.
-        let mut zebra_checkpoints_path: PathBuf = env!("CARGO_BIN_EXE_zebrad").into();
+        // Fall back to assuming zebra-checkpoints is in the same directory as zakurad.
+        let mut zebra_checkpoints_path: PathBuf = env!("CARGO_BIN_EXE_zakurad").into();
         assert!(
             zebra_checkpoints_path.pop(),
             "must have at least one path component",

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -140,7 +140,7 @@ where
 
         args.merge_with(extra_args);
 
-        self.spawn_child_with_command(env!("CARGO_BIN_EXE_zebrad"), args)
+        self.spawn_child_with_command(env!("CARGO_BIN_EXE_zakurad"), args)
     }
 
     fn with_config(self, config: &mut ZebradConfig) -> Result<Self> {


### PR DESCRIPTION
## Motivation

Rename the node binary from `zebrad` to `zakurad`. This first PR does the
**binary target** rename plus the **in-repo build / run / deploy plumbing** that
would otherwise break — and deliberately leaves everything user-facing or
external as `zebrad` for follow-up decisions.

Scope was kept narrow on purpose: crate/package names, config/log filenames,
deployed host paths, the P2P user-agent, metrics names, the downloadable release
tarball, and docs are **not** touched here. A categorized inventory of those
remaining sites (with recommendations, risk, and coupling per group) lives
outside the repo at `art/inbox/rename/rename-sites.md`.

## Solution

**Binary target (compile/test-critical):**

- `git mv zebrad/src/bin/zebrad/ → zebrad/src/bin/zakurad/` — Cargo auto-derives
  the bin name from the dir, so this renames the target while the package stays
  `name = "zebrad"`.
- `zebrad/Cargo.toml`: `default-run = "zakurad"` (+ tokio-console `--bin` comment).
- `env!("CARGO_BIN_EXE_zebrad")` → `_zakurad` in `tests/common/launch.rs` and
  `tests/common/checkpoints.rs` (mandatory — the test harness won't compile
  otherwise, since Cargo now exports `CARGO_BIN_EXE_zakurad`).

**In-repo build/run/deploy plumbing (renamed the build-artifact / process refs):**

- Docker: `Dockerfile` (`--bin zakurad`, `cp`/`COPY` paths, `CMD ["zakurad"]`),
  `entrypoint.sh` (execs `zakurad`, still accepts `zebrad` as a **legacy alias**),
  `ubuntu-package.Dockerfile`.
- Regtest e2e: `docker-compose.zakura-regtest-e2e.yml` (entrypoints + bind-mount
  source/dest for all nodes), `run.sh`, `diag.sh`.
- `make/zcashd-compat.mk`: `ZEBRAD_BIN` default, docker-run arg, `pgrep` pattern.
- CI: `release-binaries.yml` (binary path extracted from the image),
  `deploy-zcashd-compat.yml` (scp **source** artifact), `test-docker.yml` (run arg).
- `deploy/deployer/deploy.py`: the built-artifact source path it reads.
- `scripts/install-zakura.sh`, `scripts/install-zcashd-compat.sh`: the
  build-from-source path only.
- `zebra-test/scripts/shutdown-errors`: build/run path + `%?zakurad` job specs.

**Intentionally left as `zebrad`** (see the inventory for the full list): the
crate name, `zebrad.toml` / `zebrad.log`, `/usr/local/bin/zebrad` on live hosts +
systemd units, the `/Zebra:` P2P user-agent, `zebrad.build.info` metrics, and the
released `zebrad-<tag>.tar.gz` archive (so the binary an end user *downloads* is
still named `zebrad` for now; the dev/docker build yields `zakurad`).

### Tests

- `cargo build -p zebrad --bin zakurad` → succeeds; `cargo metadata` lists the
  package's bins as `zakurad`, `zebra-rollback-state`, `zebra-prune-state` (no
  `zebrad`).
- `cargo test -p zebrad --no-run` → compiles, confirming `CARGO_BIN_EXE_zakurad`
  resolves in the acceptance harness.
- `cargo fmt -p zebrad -- --check` → clean.
- Smoke: `zakurad --version` prints `zebrad 5.0.0-rc.3` (the version banner uses
  the **crate** name, so version/`is_zebrad_version` tests are unaffected);
  `zakurad --help` shows `Usage: zakurad …` (usage uses argv[0]; no test asserts
  on it).

### Follow-up Work

Sequenced groups in `art/inbox/rename/rename-sites.md`:

1. Release-archive identifiers + docker/host `/usr/local/bin` install path
   (so a downloaded/deployed binary is actually named `zakurad`).
2. Config/log filenames + the `zebrad/tests/common/configs/*` fixtures.
3. Docs sweep (`book/`, `docs/`, README).
4. Separate deliberate decisions (maybe never): crate name (drags metrics + the
   `--version` banner) and the P2P user-agent.

No CHANGELOG entry added (per repo convention the zakura changelog is not yet in
use, and the externally-downloaded artifact name is unchanged in this PR).

### AI Disclosure

- [x] AI tools were used: Claude Code — mapped the rename surface, made the edits,
  and drafted this description; changes reviewed by the author.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [ ] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date. <!-- docs sweep deferred; see Follow-up -->
