### PR TITLE
fix(zcashd-compat): bump zcashd release to alpha.3

### DIFF
--- a/scripts/install-zcashd-compat.sh
+++ b/scripts/install-zcashd-compat.sh
@@ -24,8 +24,8 @@ ZEBRA_DOCKER_RUNTIME_GID=10001
 
 MANIFEST_PATH="$REPO_ROOT/zebrad/zcashd-compat-manifest.json"
 TARGET_TRIPLE="x86_64-pc-linux-gnu"
-ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v0.0.1-compat-alpha.2/zcashd-zebra-compat-v0.0.1-compat-alpha.2-linux-x86_64.tar.gz"
-ZCASHD_RUNTIME_ARCHIVE_SHA256="b504a508467bf0a7d8b251009e0f9bd1637107eeeb97d5a9dd9ba47336f16a90"
+ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v0.0.1-compat-alpha.3/zcashd-zebra-compat-v0.0.1-compat-alpha.3-linux-x86_64.tar.gz"
+ZCASHD_RUNTIME_ARCHIVE_SHA256="a2deaf9cfb89e8a1b34664ace0393336b7b5095a8fe0b4c7fb67b3715012ef47"
 ZCASHD_RUNTIME_ARCHIVE_MEMBER_BINARY_PATH="./bin/zcashd"
 
 MODE=""
@@ -1220,7 +1220,7 @@ prepare_docker_images() {
         add_error "Docker image is missing or could not be pulled: $ZEBRA_DOCKER_IMAGE"
 
       if [[ -z "$ZCASHD_DOCKER_IMAGE" ]]; then
-        ZCASHD_DOCKER_IMAGE="valargroup/zcashd:v0.0.1-compat-alpha.2@sha256:5693dad0d403609a5d0ebdfdaed6a853546e4ffecd1264334495a079f2c6033f"
+        ZCASHD_DOCKER_IMAGE="valargroup/zcashd:v0.0.1-compat-alpha.3@sha256:d9c80e8469f99406cc7e51238ae67708421d739a7446f52f941a7ea44b3af354"
       fi
 
       docker_image_available_or_pull "$ZCASHD_DOCKER_IMAGE" ||

--- a/zebrad/zcashd-compat-manifest.json
+++ b/zebrad/zcashd-compat-manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "release_tag": "v0.0.1-compat-alpha.2",
+  "release_tag": "v0.0.1-compat-alpha.3",
   "artifacts": [
     {
       "target_triple": "x86_64-pc-linux-gnu",
-      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v0.0.1-compat-alpha.2/zcashd-zebra-compat-v0.0.1-compat-alpha.2-linux-x86_64.tar.gz",
-      "runtime_archive_sha256": "b504a508467bf0a7d8b251009e0f9bd1637107eeeb97d5a9dd9ba47336f16a90",
+      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v0.0.1-compat-alpha.3/zcashd-zebra-compat-v0.0.1-compat-alpha.3-linux-x86_64.tar.gz",
+      "runtime_archive_sha256": "a2deaf9cfb89e8a1b34664ace0393336b7b5095a8fe0b4c7fb67b3715012ef47",
       "runtime_archive_member_binary_path": "./bin/zcashd"
     }
   ]


### PR DESCRIPTION
## Motivation

Point the zcashd-compat manifest and installer defaults at the latest `valargroup/zcashd` compat release.

## Solution

- Bump the embedded zcashd-compat manifest from `v0.0.1-compat-alpha.2` to `v0.0.1-compat-alpha.3`.
- Update `install-zcashd-compat.sh` to use the matching runtime tarball SHA and default Docker image digest.

### Tests

- `jq -e '.release_tag == "v0.0.1-compat-alpha.3" and (.artifacts | length == 1) and .artifacts[0].runtime_archive_sha256 == "a2deaf9cfb89e8a1b34664ace0393336b7b5095a8fe0b4c7fb67b3715012ef47"' zebrad/zcashd-compat-manifest.json >/dev/null`
- `bash -n scripts/install-zcashd-compat.sh`
- `GITHUB_OUTPUT=/dev/stdout ./scripts/resolve-zcashd-compat-manifest.sh --write-github-output`
- `git diff --check -- zebrad/zcashd-compat-manifest.json scripts/install-zcashd-compat.sh`

### Specifications & References

- zcashd release: https://github.com/valargroup/zcashd/releases/tag/v0.0.1-compat-alpha.3

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor was used to update the release pins, run validation, and draft this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.