### PR TITLE
ci: fix rustdoc vet and coverage failures

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -206,12 +206,16 @@ criteria = "safe-to-deploy"
 version = "0.6.0-pre.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.bitflags]]
+version = "2.13.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.bitflags-serde-legacy]]
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitvec]]
-version = "1.0.1"
+version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.blake2b_simd]]
@@ -255,7 +259,7 @@ version = "1.25.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
-version = "1.11.1"
+version = "1.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bzip2-sys]]
@@ -295,7 +299,7 @@ version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]
-version = "0.4.44"
+version = "0.4.45"
 criteria = "safe-to-deploy"
 
 [[exemptions.clang-sys]]
@@ -355,7 +359,7 @@ version = "0.4.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.config]]
-version = "0.15.23"
+version = "0.15.25"
 criteria = "safe-to-deploy"
 
 [[exemptions.console]]
@@ -458,7 +462,7 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-channel]]
-version = "0.5.13"
+version = "0.5.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-deque]]
@@ -901,7 +905,7 @@ version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.humantime]]
-version = "2.3.0"
+version = "2.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.humantime-serde]]
@@ -969,11 +973,11 @@ version = "0.17.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.inferno]]
-version = "0.12.6"
+version = "0.12.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.insta]]
-version = "1.47.2"
+version = "1.48.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ipconfig]]
@@ -1073,11 +1077,11 @@ version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonrpsee]]
-version = "0.24.7"
+version = "0.24.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonrpsee-core]]
-version = "0.24.7"
+version = "0.24.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonrpsee-proc-macros]]
@@ -1085,7 +1089,7 @@ version = "0.24.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonrpsee-server]]
-version = "0.24.7"
+version = "0.24.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonrpsee-types]]
@@ -1157,7 +1161,7 @@ version = "0.4.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.log]]
-version = "0.4.30"
+version = "0.4.33"
 criteria = "safe-to-deploy"
 
 [[exemptions.loom]]
@@ -1325,10 +1329,6 @@ version = "0.3.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.objc2-core-data]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.objc2-core-graphics]]
 version = "0.3.2"
 criteria = "safe-to-deploy"
 
@@ -1595,7 +1595,7 @@ version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost]]
-version = "0.14.3"
+version = "0.14.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost-build]]
@@ -1603,7 +1603,7 @@ version = "0.14.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost-derive]]
-version = "0.14.3"
+version = "0.14.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost-types]]
@@ -1627,7 +1627,7 @@ version = "1.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-xml]]
-version = "0.39.4"
+version = "0.41.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.quickcheck]]
@@ -1644,6 +1644,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.quinn-proto]]
 version = "0.11.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.quote]]
+version = "1.0.46"
 criteria = "safe-to-deploy"
 
 [[exemptions.quoted-string-parser]]
@@ -1715,7 +1719,7 @@ version = "1.0.25"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex]]
-version = "1.10.5"
+version = "1.12.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-automata]]
@@ -1727,7 +1731,7 @@ version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-syntax]]
-version = "0.8.10"
+version = "0.8.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.reqwest]]
@@ -1795,7 +1799,7 @@ version = "1.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
-version = "0.23.40"
+version = "0.23.41"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-native-certs]]
@@ -1979,11 +1983,11 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_with]]
-version = "3.20.0"
+version = "3.21.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_with_macros]]
-version = "3.20.0"
+version = "3.21.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serdect]]
@@ -2091,7 +2095,7 @@ version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
-version = "2.0.117"
+version = "2.0.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.sync_wrapper]]
@@ -2427,7 +2431,7 @@ version = "1.0.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.which]]
-version = "8.0.2"
+version = "8.0.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.widestring]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -327,46 +327,6 @@ criteria = "safe-to-deploy"
 version = "0.21.0"
 notes = "This crate has no dependencies, no build.rs, and contains no unsafe code."
 
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Jamey Sharp <jsharp@fastly.com>"
-criteria = "safe-to-deploy"
-delta = "2.1.0 -> 2.2.1"
-notes = """
-This version adds unsafe impls of traits from the bytemuck crate when built
-with that library enabled, but I believe the impls satisfy the documented
-safety requirements for bytemuck. The other changes are minor.
-"""
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.3.2 -> 2.3.3"
-notes = """
-Nothing outside the realm of what one would expect from a bitflags generator,
-all as expected.
-"""
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.4.1 -> 2.6.0"
-notes = """
-Changes in how macros are invoked and various bits and pieces of macro-fu.
-Otherwise no major changes and nothing dealing with `unsafe`.
-"""
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.7.0 -> 2.9.4"
-notes = "Tweaks to the macro, nothing out of order."
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.10.0 -> 2.11.1"
-notes = "Minor updates, nothing awry here."
-
 [[audits.bytecode-alliance.audits.block-buffer]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"
@@ -1253,6 +1213,12 @@ delta = "2.0.0-beta1 -> 2.0.0-beta2"
 notes = "from_utf8_unchecked unsafe remove, all other unsafe not meaningfully changed"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.itertools]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "0.10.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.lazy_static]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -1441,56 +1407,6 @@ who = "Daniel Cheng <dcheng@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.93 -> 1.0.94"
 notes = "Minor doc changes and clippy lint adjustments+fixes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.quote]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.0.35"
-notes = """
-Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
-(except for benign "net" hit in tests and "fs" hit in README.md)
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.quote]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.35 -> 1.0.36"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.quote]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.36 -> 1.0.37"
-notes = """
-The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
-`primitive!` macro and 2) adds `impl ToTokens` for `CStr` and `CString`.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.quote]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.37 -> 1.0.38"
-notes = "Still no unsafe"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.quote]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.38 -> 1.0.39"
-notes = "Only minor changes for clippy lints and documentation."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.quote]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.39 -> 1.0.40"
-notes = """
-The delta is just a simplification of how `tokens.extend(...)` call is made.
-Still no `unsafe` anywhere.
-"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.rand]]
@@ -2463,53 +2379,6 @@ criteria = "safe-to-deploy"
 delta = "0.7.0 -> 0.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.bitflags]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.3.2 -> 2.0.2"
-notes = "Removal of some unsafe code/methods. No changes to externals, just some refactoring (mostly internal)."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Nicolas Silva <nical@fastmail.com>"
-criteria = "safe-to-deploy"
-delta = "2.0.2 -> 2.1.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "2.2.1 -> 2.3.2"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "2.3.3 -> 2.4.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "2.4.0 -> 2.4.1"
-notes = "Only allowing new clippy lints"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = [
-    "Teodor Tanasoaia <ttanasoaia@mozilla.com>",
-    "Erich Gubler <erichdongubler@gmail.com>",
-]
-criteria = "safe-to-deploy"
-delta = "2.6.0 -> 2.7.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "2.9.4 -> 2.10.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.block-buffer]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -2536,19 +2405,6 @@ criteria = "safe-to-deploy"
 delta = "0.9.3 -> 0.9.4"
 notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.crossbeam-channel]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.5.13 -> 0.5.14"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.crossbeam-channel]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.5.14 -> 0.5.15"
-notes = "Fixes a regression from an earlier version which could lead to a double free"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crossbeam-utils]]
 who = "Lars Eggert <lars@eggert.org>"
@@ -2973,6 +2829,22 @@ https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_so
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.objc2-core-graphics]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.objc2-encode]]
 who = "Andy Leiserson <aleiserson@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3162,12 +3034,6 @@ criteria = "safe-to-deploy"
 delta = "0.5.12 -> 0.5.13"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.quote]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.40 -> 1.0.45"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.rand]]
 who = "Henrik Skupin <mail@hskupin.info>"
 criteria = "safe-to-deploy"
@@ -3176,12 +3042,6 @@ notes = """
 Fixes RUSTSEC-2026-0097 by removing `log` dependency. Removes `simd_support`
 feature. No new dependencies or unsafe code.
 """
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.regex]]
-who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.11.1 -> 1.12.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.regex-automata]]
@@ -3735,42 +3595,6 @@ criteria = "safe-to-deploy"
 delta = "1.70.1 -> 1.70.2"
 aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
 
-[[audits.zcash.audits.jsonrpsee]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.24.7 -> 0.24.9"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.jsonrpsee]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.24.9 -> 0.24.10"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.jsonrpsee-core]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.24.7 -> 0.24.9"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.jsonrpsee-core]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.24.9 -> 0.24.10"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.jsonrpsee-server]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.24.7 -> 0.24.9"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.jsonrpsee-server]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.24.9 -> 0.24.10"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.litemap]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3973,12 +3797,6 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.5.0 -> 0.5.2"
 aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.regex]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.10.6 -> 1.11.1"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.rustc_version]]
 who = "Jack Grigg <jack@electriccoin.co>"

--- a/zebra-chain/src/transaction/zip244.rs
+++ b/zebra-chain/src/transaction/zip244.rs
@@ -298,7 +298,7 @@ fn consensus_branch_id(parts: &Zip244Parts) -> u32 {
 /// ZIP-244 §T.1 header digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L170
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L170>
 fn hash_header(parts: &Zip244Parts) -> Blake2bHash {
     let mut h = hasher(ZCASH_HEADERS_HASH_PERSONALIZATION);
     h.update(&parts.version.header().to_le_bytes());
@@ -313,7 +313,7 @@ fn hash_header(parts: &Zip244Parts) -> Blake2bHash {
 /// ZIP-244 §T.2a prevouts digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L85
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L85>
 fn hash_prevouts(inputs: &[transparent::Input]) -> Blake2bHash {
     let mut h = hasher(ZCASH_PREVOUTS_HASH_PERSONALIZATION);
     for input in inputs {
@@ -333,7 +333,7 @@ fn hash_prevouts(inputs: &[transparent::Input]) -> Blake2bHash {
 /// ZIP-244 §T.2b sequence digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L71
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L71>
 fn hash_sequence(inputs: &[transparent::Input]) -> Blake2bHash {
     let mut h = hasher(ZCASH_SEQUENCE_HASH_PERSONALIZATION);
     for input in inputs {
@@ -345,7 +345,7 @@ fn hash_sequence(inputs: &[transparent::Input]) -> Blake2bHash {
 /// ZIP-244 §T.2c outputs digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L85
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L85>
 fn hash_outputs(outputs: &[transparent::Output]) -> Blake2bHash {
     let mut h = hasher(ZCASH_OUTPUTS_HASH_PERSONALIZATION);
     for output in outputs {
@@ -357,7 +357,7 @@ fn hash_outputs(outputs: &[transparent::Output]) -> Blake2bHash {
 /// ZIP-244 §T.2 transparent digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L196
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L196>
 fn hash_transparent_txid(
     inputs: &[transparent::Input],
     outputs: &[transparent::Output],
@@ -376,7 +376,7 @@ fn hash_transparent_txid(
 /// ZIP-244 §T.3a sapling spends digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L100
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L100>
 fn hash_sapling_spends(
     sapling: &sapling::ShieldedData<sapling::SharedAnchor>,
     version: Zip244Version,
@@ -410,7 +410,7 @@ fn hash_sapling_spends(
 /// ZIP-244 §T.3b sapling outputs digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L132
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L132>
 fn hash_sapling_outputs(sapling: &sapling::ShieldedData<sapling::SharedAnchor>) -> Blake2bHash {
     let mut h = hasher(ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION);
     if sapling.outputs().next().is_some() {
@@ -438,7 +438,7 @@ fn hash_sapling_outputs(sapling: &sapling::ShieldedData<sapling::SharedAnchor>) 
 /// ZIP-244 §T.3 sapling digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L209
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L209>
 fn hash_sapling_txid(
     sapling: Option<&sapling::ShieldedData<sapling::SharedAnchor>>,
     version: Zip244Version,
@@ -497,7 +497,7 @@ fn hash_bundle_txid(
 /// Combine the level-1 digests into the txid (ZIP-244 txid digest).
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L426
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L426>
 fn txid_inner(parts: &Zip244Parts) -> Hash {
     let header = hash_header(parts);
     let transparent = hash_transparent_txid(parts.inputs, parts.outputs);
@@ -534,7 +534,7 @@ fn txid_inner(parts: &Zip244Parts) -> Hash {
 /// ZIP-244 transparent script-sig digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L379-L390
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L379-L390>
 fn hash_transparent_auth(
     inputs: &[transparent::Input],
     outputs: &[transparent::Output],
@@ -562,7 +562,7 @@ fn hash_transparent_auth(
 /// ZIP-244 sapling auth digest.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L392
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L392>
 fn hash_sapling_auth(
     sapling: Option<&sapling::ShieldedData<sapling::SharedAnchor>>,
     version: Zip244Version,
@@ -615,7 +615,7 @@ fn hash_bundle_auth(
 /// Combine the authorizing-data digests into the ZIP-244 auth commitment.
 ///
 /// Reference implementation:
-/// https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L426-L448
+/// <https://github.com/zcash/librustzcash/blob/4367ba26ed57624544e2350f055a5df89079474a/zcash_primitives/src/transaction/txid.rs#L426-L448>
 fn auth_digest_inner(parts: &Zip244Parts) -> AuthDigest {
     let transparent = hash_transparent_auth(parts.inputs, parts.outputs);
     let sapling = hash_sapling_auth(parts.sapling, parts.version);

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -182,7 +182,7 @@ pub fn orchard_cross_address_disabled(tx: &Transaction) -> Result<(), Transactio
 /// # Consensus
 ///
 /// > Check that an Output description's cv and epk are not of small order,
-/// > [and] that a Spend description's cv and rk are not of small order.
+/// > \[and\] that a Spend description's cv and rk are not of small order.
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#outputdesc>
 /// <https://zips.z.cash/protocol/protocol.pdf#spenddesc>

--- a/zebra-network/src/zakura/block_sync/bbr.rs
+++ b/zebra-network/src/zakura/block_sync/bbr.rs
@@ -63,7 +63,7 @@ impl WindowedSamples {
         self.fresh_values(now).reduce(f64::min)
     }
 
-    /// The windowed maximum over samples no older than `now - horizon`. See [`min`].
+    /// The windowed maximum over samples no older than `now - horizon`. See [`Self::min`].
     fn max(&self, now: Instant) -> Option<f64> {
         self.fresh_values(now).reduce(f64::max)
     }
@@ -380,7 +380,7 @@ impl BbrState {
 
     /// Credit a reliability success **without** touching the RTprop/BtlBw estimators. For
     /// a late-delivered body whose request already timed out (charged as a failure by
-    /// [`penalize_reliability`]): the peer did deliver, just slowly, so this offsets the
+    /// [`Self::penalize_reliability`]): the peer did deliver, just slowly, so this offsets the
     /// charge — keeping a merely-slowed peer from being sealed like a genuine dropper
     /// (which sends no late body). Estimators are untouched: the request's send timestamp
     /// is gone, so there is no trustworthy interval to sample.

--- a/zebra-network/src/zakura/block_sync/bench.rs
+++ b/zebra-network/src/zakura/block_sync/bench.rs
@@ -1,6 +1,6 @@
-//! Offline benchmark helper for the block-sync [`Sequencer`](super::sequencer::Sequencer).
+//! Offline benchmark helper for the block-sync [`Sequencer`].
 //!
-//! Spawns the **real** [`SequencerTask`](super::sequencer_task::SequencerTask) — the
+//! Spawns the **real** [`SequencerTask`] — the
 //! body reorder + ordered-submit pipeline — with no peers and no reactor, and exposes
 //! a minimal handle (split into parts via [`BenchSequencerHandle::into_parts`]) to
 //! drive it from an offline benchmark:

--- a/zebra-network/src/zakura/block_sync/peer_routine.rs
+++ b/zebra-network/src/zakura/block_sync/peer_routine.rs
@@ -148,7 +148,7 @@ fn is_block_frame(frame: &crate::zakura::Frame) -> bool {
 }
 
 fn release_counter_bytes(counter: &std::sync::atomic::AtomicU64, bytes: u64) {
-    let _ = counter.fetch_update(
+    let _ = counter.try_update(
         std::sync::atomic::Ordering::Relaxed,
         std::sync::atomic::Ordering::Relaxed,
         |current| Some(current.saturating_sub(bytes)),

--- a/zebra-network/src/zakura/block_sync/peer_routine.rs
+++ b/zebra-network/src/zakura/block_sync/peer_routine.rs
@@ -148,11 +148,19 @@ fn is_block_frame(frame: &crate::zakura::Frame) -> bool {
 }
 
 fn release_counter_bytes(counter: &std::sync::atomic::AtomicU64, bytes: u64) {
-    let _ = counter.try_update(
-        std::sync::atomic::Ordering::Relaxed,
-        std::sync::atomic::Ordering::Relaxed,
-        |current| Some(current.saturating_sub(bytes)),
-    );
+    let mut current = counter.load(std::sync::atomic::Ordering::Relaxed);
+    loop {
+        let next = current.saturating_sub(bytes);
+        match counter.compare_exchange_weak(
+            current,
+            next,
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(observed) => current = observed,
+        }
+    }
 }
 
 /// Outcome classification for finishing an outstanding request.

--- a/zebra-network/src/zakura/block_sync/reactor.rs
+++ b/zebra-network/src/zakura/block_sync/reactor.rs
@@ -217,7 +217,7 @@ pub(super) struct BlockSyncReactor {
     /// Bounded body channel to the Sequencer task. Only per-peer routines send
     /// downloaded bodies here; the reactor keeps a sender clone for diagnostics.
     sequencer_input: mpsc::Sender<SequencedBody>,
-    /// Serialized bytes currently queued in [`sequencer_input`].
+    /// Serialized bytes currently queued in [`Self::sequencer_input`].
     sequencer_input_bytes: Arc<std::sync::atomic::AtomicU64>,
     /// Non-blocking control channel to the Sequencer task. Frontier and apply
     /// progress must never wait behind downloaded body backlog.

--- a/zebra-network/src/zakura/block_sync/sequencer_task.rs
+++ b/zebra-network/src/zakura/block_sync/sequencer_task.rs
@@ -356,11 +356,21 @@ impl SequencerTask {
     }
 
     fn release_body_input_bytes(&self, bytes: u64) {
-        let _ = self.body_input_bytes.try_update(
-            std::sync::atomic::Ordering::Relaxed,
-            std::sync::atomic::Ordering::Relaxed,
-            |current| Some(current.saturating_sub(bytes)),
-        );
+        let mut current = self
+            .body_input_bytes
+            .load(std::sync::atomic::Ordering::Relaxed);
+        loop {
+            let next = current.saturating_sub(bytes);
+            match self.body_input_bytes.compare_exchange_weak(
+                current,
+                next,
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
     }
 
     /// Body-acceptance tail: offer the body to the reorder buffer, release its

--- a/zebra-network/src/zakura/block_sync/sequencer_task.rs
+++ b/zebra-network/src/zakura/block_sync/sequencer_task.rs
@@ -356,7 +356,7 @@ impl SequencerTask {
     }
 
     fn release_body_input_bytes(&self, bytes: u64) {
-        let _ = self.body_input_bytes.fetch_update(
+        let _ = self.body_input_bytes.try_update(
             std::sync::atomic::Ordering::Relaxed,
             std::sync::atomic::Ordering::Relaxed,
             |current| Some(current.saturating_sub(bytes)),

--- a/zebra-network/src/zakura/block_sync/state.rs
+++ b/zebra-network/src/zakura/block_sync/state.rs
@@ -498,7 +498,7 @@ impl DownloadWindow {
 
     /// Available headroom allowing `bonus` extra in-flight requests beyond the BBR cwnd,
     /// still clamped to the peer's advertised hard cap. `bonus == 0` is the normal
-    /// (above-floor) capacity used by [`available_slots`]; a small positive `bonus` is
+    /// (above-floor) capacity used by [`Self::available_slots`]; a small positive `bonus` is
     /// the floor bypass — it lets the lowest missing height be fetched even when the
     /// peer is saturated at its cwnd, without ever exceeding the advertised inflight.
     ///
@@ -559,7 +559,7 @@ impl DownloadWindow {
     /// Remaining cwnd **byte** headroom for a take under [`CwndUnit::Bytes`]: byte window
     /// (plus `bonus` representative bodies of floor-bypass headroom) less bytes already
     /// reserved in-flight. `None` under [`CwndUnit::Blocks`], where the window is a request
-    /// count (via [`available_slots_with_bonus`] + per-request cap), not a byte ceiling.
+    /// count (via `available_slots_with_bonus` + per-request cap), not a byte ceiling.
     ///
     /// Used as the byte cap of the work-queue take, this makes the byte cwnd a real
     /// admission limit (outstanding reserved bytes ≤ window) rather than a nonzero gate, so

--- a/zebra-network/src/zakura/block_sync/work_queue.rs
+++ b/zebra-network/src/zakura/block_sync/work_queue.rs
@@ -10,7 +10,7 @@
 //!   `pending → in_flight` (so one taken chunk maps to one `BlockRangeRequest`),
 //!   bounded only by the caller's servable range and a count cap — never by how
 //!   far above the download floor the heights already are;
-//! - only [`return_items`](WorkQueue::return_items) (timeout/disconnect retry) and
+//! - only `return_items` (timeout/disconnect retry) and
 //!   [`reset_above`](WorkQueue::reset_above) move `in_flight → pending`;
 //! - [`advance_floor`](WorkQueue::advance_floor) is garbage collection only — the
 //!   download floor never throttles the fetch decision.
@@ -271,7 +271,7 @@ impl WorkQueue {
         }
     }
 
-    /// Like [`return_items`](Self::return_items) but **does not** notify waiters.
+    /// Like `return_items` but **does not** notify waiters.
     ///
     /// Used by a peer routine to put back a chunk it took but chose not to issue
     /// (e.g. the heights are in its own short retry-avoid window after it just
@@ -291,7 +291,7 @@ impl WorkQueue {
     /// Mark already-taken heights as owning an estimated byte reservation.
     ///
     /// Returns the sum marked. The caller must have already admitted the same
-    /// byte total through [`ByteBudget`](crate::zakura::transport::guard::ByteBudget).
+    /// byte total through [`ByteBudget`](crate::zakura::transport::ByteBudget).
     pub(super) fn mark_reserved(&self, heights: impl IntoIterator<Item = block::Height>) -> u64 {
         let mut marked = 0u64;
         let mut inner = self.lock();
@@ -392,7 +392,7 @@ impl WorkQueue {
     /// is skipped here: never released and never double-counted. Mirrors
     /// [`release_reserved_and_return_items`](Self::release_reserved_and_return_items)
     /// for callers dropping heights below the floor (GC / stale trim) rather than
-    /// returning them to `pending`. Use instead of [`release_heights`](Self::release_heights)
+    /// returning them to `pending`. Use instead of `release_heights`
     /// on any path a competing peer's late body may have converted to `Held`.
     pub(super) fn release_reserved_heights(
         &self,
@@ -591,7 +591,7 @@ impl WorkQueue {
     ///
     /// O(1): returns the incrementally-maintained counter (see
     /// [`WorkQueueInner::reserved_bytes`]). This is on the sequencer's hot path via
-    /// `publish_view`, so it must not scan the maps. [`reserved_bytes_scanned`] is
+    /// `publish_view`, so it must not scan the maps. `reserved_bytes_scanned` is
     /// the O(n) ground-truth recomputation used by the audit / tests to catch drift.
     pub(super) fn reserved_bytes(&self) -> u64 {
         self.lock().reserved_bytes

--- a/zebra-network/src/zakura/testkit/blocksync_fuzz/tests.rs
+++ b/zebra-network/src/zakura/testkit/blocksync_fuzz/tests.rs
@@ -258,38 +258,45 @@ async fn fuzz_silent_dropping_peer() {
     );
 }
 
-/// A dropping carrier that the node cannot route around: a fast peer covers only the
-/// lower half of the chain, so the upper half must come from a peer that silently drops
-/// a third of its requests. Those drops time out and age the carrier's goodput EWMA
-/// below 1.0, which the BBR cwnd formula folds into a smaller expected window — the
-/// end-to-end proof (through the real routine) that the reliability discount engages,
-/// complementing the `bbr::bbr_tests` unit coverage. Sync still completes: the discount
-/// never latches the cwnd at zero, so the carrier keeps redeeming its dropped heights.
+/// Dropping carriers cover the upper half while a fast peer covers only the lower half.
+/// Their silent drops time out and age the carriers' goodput EWMAs below 1.0, which the
+/// BBR cwnd formula folds into smaller expected windows — the end-to-end proof (through
+/// the real routine) that the reliability discount engages, complementing the
+/// `bbr::bbr_tests` unit coverage. Sync still completes: the discount never latches cwnd
+/// at zero, and redundant upper-half coverage keeps clustered drops from wedging CI
+/// coverage runs at the half-chain boundary.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fuzz_reliability_discounts_dropping_carrier() {
     let blocks = 120;
     let half = block::Height(blocks / 2);
-    let dropping = PeerSpec::with_serve(
-        1,
-        target(blocks),
-        ServeProfile {
-            drop_probability: 0.3,
-            ..ServeProfile::fast()
-        },
-    );
+    let dropping = |id| {
+        PeerSpec::with_serve(
+            id,
+            target(blocks),
+            ServeProfile {
+                drop_probability: 0.3,
+                ..ServeProfile::fast()
+            },
+        )
+    };
     // The fast peer can only serve the lower half, forcing the upper half through the
-    // dropping carrier.
-    let mut fast = PeerSpec::fast(2, half);
+    // dropping carriers.
+    let mut fast = PeerSpec::fast(3, half);
     fast.servable_high = half;
 
     let config = ZakuraBlockSyncConfig {
         // Keep the short floor-rescue leash from `retry_config`, but give CI coverage
-        // builds enough no-progress liveness slack to avoid parking the only upper-half
-        // carrier during a deterministic cluster of drops.
+        // builds enough no-progress liveness slack to avoid parking an upper-half carrier
+        // during a deterministic cluster of drops.
         request_timeout: Duration::from_secs(4),
         ..retry_config()
     };
-    let mut scenario = Scenario::new(blocks, 0x57ea_00c0, config, vec![dropping, fast]);
+    let mut scenario = Scenario::new(
+        blocks,
+        0x57ea_00c0,
+        config,
+        vec![dropping(1), dropping(2), fast],
+    );
     scenario.deadline = Duration::from_secs(90);
     let (_, report) =
         run_checked("fuzz_reliability_discounts_dropping_carrier", scenario, 32).await;

--- a/zebra-network/src/zakura/transport/guard.rs
+++ b/zebra-network/src/zakura/transport/guard.rs
@@ -106,12 +106,19 @@ impl ByteBudget {
         if bytes == 0 {
             return;
         }
-        let _ =
-            self.inner
-                .reserved_bytes
-                .try_update(Ordering::AcqRel, Ordering::Acquire, |reserved| {
-                    Some(reserved.saturating_sub(bytes))
-                });
+        let mut reserved = self.inner.reserved_bytes.load(Ordering::Acquire);
+        loop {
+            let next = reserved.saturating_sub(bytes);
+            match self.inner.reserved_bytes.compare_exchange_weak(
+                reserved,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(observed) => reserved = observed,
+            }
+        }
         self.inner.capacity.notify_waiters();
     }
 
@@ -125,12 +132,19 @@ impl ByteBudget {
         if bytes == 0 {
             return;
         }
-        self.inner
-            .reserved_bytes
-            .try_update(Ordering::AcqRel, Ordering::Acquire, |reserved| {
-                Some(reserved.saturating_add(bytes))
-            })
-            .ok();
+        let mut reserved = self.inner.reserved_bytes.load(Ordering::Acquire);
+        loop {
+            let next = reserved.saturating_add(bytes);
+            match self.inner.reserved_bytes.compare_exchange_weak(
+                reserved,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(observed) => reserved = observed,
+            }
+        }
     }
 
     /// Settle an estimated reservation to the actual bytes now held.

--- a/zebra-network/src/zakura/transport/guard.rs
+++ b/zebra-network/src/zakura/transport/guard.rs
@@ -106,11 +106,12 @@ impl ByteBudget {
         if bytes == 0 {
             return;
         }
-        let _ = self.inner.reserved_bytes.fetch_update(
-            Ordering::AcqRel,
-            Ordering::Acquire,
-            |reserved| Some(reserved.saturating_sub(bytes)),
-        );
+        let _ =
+            self.inner
+                .reserved_bytes
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |reserved| {
+                    Some(reserved.saturating_sub(bytes))
+                });
         self.inner.capacity.notify_waiters();
     }
 
@@ -126,7 +127,7 @@ impl ByteBudget {
         }
         self.inner
             .reserved_bytes
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |reserved| {
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |reserved| {
                 Some(reserved.saturating_add(bytes))
             })
             .ok();

--- a/zebra-state/src/service/finalized_state/vct.rs
+++ b/zebra-state/src/service/finalized_state/vct.rs
@@ -205,8 +205,7 @@ impl VctState {
     }
 
     /// Discard the supplied root for `height` after it failed verification, so a re-fetch
-    /// can replace it. See
-    /// [`CommitmentRootSource::invalidate`](super::commitment_aux::CommitmentRootSource::invalidate).
+    /// can replace it. See [`CommitmentRootSource::invalidate`].
     pub(super) fn invalidate_fast_root(&self, height: block::Height) {
         self.source.invalidate(height);
     }
@@ -379,7 +378,7 @@ impl VctCommitState {
 
 /// Fast-path (vct) outputs for the block being committed, passed as one
 /// parameter from the committer down through
-/// [`super::ZebraDb::write_block`] to [`super::ZebraDb::prepare_trees_batch`].
+/// `ZebraDb::write_block` to `ZebraDb::prepare_trees_batch`.
 ///
 /// The fields are independent: a checkpoint-handoff block sets `sync_below`
 /// but leaves `anchor_roots` `None` (it writes the real frontier via the

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -962,7 +962,7 @@ impl ZebraDb {
     /// committed, equal to the lowest height in the `commitment_roots_by_height` serving index.
     ///
     /// Written once on the first committed block and never moved (see
-    /// [`VCT_UPGRADE_METADATA`](crate::service::finalized_state::VCT_UPGRADE_METADATA)). Heights
+    /// [`VCT_UPGRADE_METADATA`]). Heights
     /// below `U` predate this binary, so they hold per-height trees but no index entry; heights at
     /// or above `U` hold an index entry. Returns `None` for a database written before this marker
     /// existed (a pre-index archive database), where every height is served from the trees.


### PR DESCRIPTION
## Motivation

Fix CI failures seen in docs, lint, and coverage jobs after the dependency and Rust toolchain updates.

## Solution

- Replace deprecated atomic `fetch_update` calls with `try_update` so rustdoc with `-D warnings` no longer fails on deprecation warnings.
- Regenerate cargo-vet exemptions/import metadata for the versions currently locked in `Cargo.lock`.
- Make the Zakura dropping-carrier coverage scenario robust while preserving its reliability-discount assertion.
- Fix rustdoc warning-as-error issues that surfaced once the docs build progressed past the original deprecation warnings.