### PR TITLE
chore: add Cursor pre-PR checks rule

### DIFF
--- a/.cursor/rules/pr-verification-policy.mdc
+++ b/.cursor/rules/pr-verification-policy.mdc
@@ -1,0 +1,19 @@
+---
+description: Classify PR risk before deciding which local checks to run
+alwaysApply: true
+---
+
+# PR Verification Policy
+
+Avoid running tests and linters after every micro change. Build times are slow in this repository, and agents should not be blocked locally when CI can catch failures.
+
+Before opening or preparing a PR, classify the change:
+
+- High risk: run all relevant CI-equivalent tests and lints before PRing.
+  - Use this for changes over 300 LOC, or changes touching consensus, P2P, cryptography, serialization, database migrations, or other validation-critical logic.
+- Low risk: PR without local checks unless the user asks otherwise.
+  - Use this for small PRs, configuration changes, CI boilerplate, docs-only changes, or other low-risk edits.
+
+When touching Markdown files, always run the Markdown linter for the changed files even if the PR is otherwise low risk.
+
+If checks are skipped, say so clearly in the final response or PR summary, including the risk classification and reason.

--- a/.cursor/rules/pre-pr-checks.mdc
+++ b/.cursor/rules/pre-pr-checks.mdc
@@ -1,5 +1,5 @@
 ---
-description: Require local verification before opening pull requests
+description: Use risk-based local verification before opening pull requests
 alwaysApply: true
 ---
 
@@ -8,8 +8,7 @@ alwaysApply: true
 Before opening or preparing a pull request in this repository:
 
 - Check IDE diagnostics for recently edited files with `ReadLints`.
-- Run `cargo fmt --all -- --check`.
-- Run `cargo clippy --workspace --all-targets -- -D warnings`.
+- Follow the risk-based verification policy in `pr-verification-policy.mdc`.
 
 If any check fails, fix the issue and rerun the failing check before creating the PR.
 

--- a/.cursor/rules/pre-pr-checks.mdc
+++ b/.cursor/rules/pre-pr-checks.mdc
@@ -1,0 +1,16 @@
+---
+description: Require local verification before opening pull requests
+alwaysApply: true
+---
+
+# Pre-PR Checks
+
+Before opening or preparing a pull request in this repository:
+
+- Check IDE diagnostics for recently edited files with `ReadLints`.
+- Run `cargo fmt --all -- --check`.
+- Run `cargo clippy --workspace --all-targets -- -D warnings`.
+
+If any check fails, fix the issue and rerun the failing check before creating the PR.
+
+If a check cannot be run because it is too expensive, blocked, or the user explicitly asks to skip it, say so clearly in the PR summary or final response.


### PR DESCRIPTION
## Motivation

Keep local agent workflows aligned with this repository's PR expectations by making the pre-PR validation steps persistent in Cursor.

## Solution

Add an always-applied Cursor rule that reminds agents to check IDE diagnostics and run the required formatting and Clippy checks before opening or preparing pull requests.
