### PR TITLE
ci(zakura): add mainnet fleet deploy + status dashboard

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -1,0 +1,317 @@
+name: Deploy Zakura mainnet fleet
+
+# Manual fleet deploy for the Zakura mainnet nodes.
+#
+# Runs on a self-hosted Linux x86_64 runner, expected to be installed on
+# us-east-0 (159.65.183.89) with the `zakura-mainnet-deployer` label (see
+# deploy/deployer/mainnet/bootstrap-zakura-mainnet-runner.sh). The deployer
+# builds a native zakurad binary on that runner, then uses deploy/deployer/
+# deploy.py to scp/install it across the fleet.
+#
+# ONE-TIME MIGRATION — the mainnet nodes were hand-provisioned with a
+# `zebrad.service` unit and a /usr/local/bin/zebrad binary. This deployer
+# installs the standardized `zakurad.service` + /usr/local/bin/zakurad, and does
+# not touch the old unit, so before the first restart deploy each node needs:
+#     systemctl disable --now zebrad
+#     rm -f /etc/systemd/system/zebrad.service \
+#           /etc/systemd/system/zebrad.service.d/10-vct-legacy.conf
+#     systemctl daemon-reload
+# Otherwise the old zebrad process keeps the state DB locked and zakurad cannot
+# start. See deploy/deployer/README.md.
+#
+# DO NOT RESYNC — the cache paths below point at the location the nodes already
+# use (/root/.cache/zakura, the zakurad default for HOME=/root), identity_dir is
+# pinned to /root/.zakura so each node keeps its iroh node id, and
+# cache_dir_migrate_from moves a pre-rename /root/.cache/zebra dir into place on
+# first restart if the zakura target does not yet exist. Confirm each node's live
+# `[state] cache_dir` before the first restart; a mismatched path resyncs an
+# archive node from genesis.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git branch, tag, or SHA to build and deploy"
+        required: true
+        type: string
+        default: main
+      force_rebuild:
+        description: "Rebuild even if a cached binary for this commit exists"
+        type: boolean
+        required: false
+        default: false
+      no_restart:
+        description: "Stage binary/config/unit without restarting zakurad"
+        type: boolean
+        required: false
+        default: false
+      node:
+        description: "Optional single deployer node name; blank deploys the whole fleet"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zakura-mainnet-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: "Deploy Zakura mainnet ${{ inputs.ref }}"
+    runs-on: [self-hosted, "${{ vars.ZAKURA_MAINNET_RUNNER_LABEL || 'zakura-mainnet-deployer' }}"]
+    timeout-minutes: 180
+    environment: zakura-mainnet
+
+    steps:
+      - name: Checkout deploy ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          cache-on-failure: true
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y --no-install-recommends \
+            build-essential \
+            clang \
+            cmake \
+            git \
+            libclang-dev \
+            pkg-config \
+            protobuf-compiler \
+            python3
+
+      - name: Start SSH agent when deploy key is configured
+        env:
+          ZAKURA_MAINNET_DEPLOY_SSH_KEY: ${{ secrets.ZAKURA_MAINNET_DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ZAKURA_MAINNET_DEPLOY_SSH_KEY}" ]; then
+            echo "ZAKURA_MAINNET_DEPLOY_SSH_KEY is not set; using the runner's existing SSH identity."
+            exit 0
+          fi
+
+          ssh_agent_sock="$RUNNER_TEMP/ssh-agent.sock"
+          ssh-agent -a "$ssh_agent_sock" > "$RUNNER_TEMP/ssh-agent.env"
+          SSH_AUTH_SOCK="$ssh_agent_sock" ssh-add - <<< "$ZAKURA_MAINNET_DEPLOY_SSH_KEY"
+          echo "SSH_AUTH_SOCK=$ssh_agent_sock" >> "$GITHUB_ENV"
+
+      - name: Pin fleet host keys
+        run: |
+          set -euo pipefail
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          : > ~/.ssh/known_hosts
+          for host in \
+            165.22.54.66 \
+            104.131.184.123 \
+            159.65.183.89 \
+            143.244.184.176 \
+            159.203.38.10 \
+            64.227.44.93 \
+            161.35.156.226 \
+            139.59.64.115 \
+            168.144.173.250; do
+            ssh-keyscan -T 30 -H "$host" >> ~/.ssh/known_hosts
+          done
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Generate deployer fleet config
+        working-directory: deploy/deployer
+        run: |
+          set -euo pipefail
+
+          cat > nodes.ci.toml <<EOF
+          [defaults]
+          service_name    = "zakurad"
+          bin_path        = "/usr/local/bin/zakurad"
+          config_path     = "/etc/zakura/zakura.toml"
+          network         = "Mainnet"
+          listen_addr     = "[::]:8233"
+          rpc_listen_addr = "0.0.0.0:8232"
+          rpc_enable_cookie_auth = false
+          storage_mode    = "archive"
+          v2_p2p          = true
+          legacy_p2p      = true
+          metrics_endpoint = "127.0.0.1:9999"
+          tracing_filter  = "info,zebra_network::zakura=info"
+          # Mainnet keeps checkpoint sync + the VCT fast-sync path (zakurad defaults).
+          checkpoint_sync = true
+          vct_fast_sync   = true
+          # Reuse the paths the hand-provisioned nodes already use so no node resyncs.
+          identity_dir    = "/root/.zakura"
+          state_cache_dir = "/root/.cache/zakura"
+          network_cache_dir = "/root/.cache/zakura"
+          # Move a pre-rename cache into place on first restart if it exists and the
+          # zakura target does not (mirrors the testnet zebra->zakura migration).
+          cache_dir_migrate_from = "/root/.cache/zebra"
+          log_file        = "/root/logs/zakura.log"
+
+          # The built-in mainnet Zakura bootstrap peers (zebra-network/src/zakura/
+          # handler.rs) are already correct, so we only pin the listen address.
+          [defaults.zakura]
+          listen_addr = "0.0.0.0:8234"
+
+          [[nodes]]
+          name       = "asia-0"
+          ssh_string = "root@165.22.54.66"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "us-0"
+          ssh_string = "root@104.131.184.123"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "us-east-0"
+          ssh_string = "root@159.65.183.89"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "us-west-0"
+          ssh_string = "root@143.244.184.176"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "canada-0"
+          ssh_string = "root@159.203.38.10"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "europe-west-0"
+          ssh_string = "root@64.227.44.93"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "europe-central-0"
+          ssh_string = "root@161.35.156.226"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "asia-south-0"
+          ssh_string = "root@139.59.64.115"
+          commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "asia-pacific-0"
+          ssh_string = "root@168.144.173.250"
+          commit     = "${{ inputs.ref }}"
+          EOF
+
+      - name: Build deployer binary
+        working-directory: deploy/deployer
+        run: |
+          set -euo pipefail
+
+          args=(--config nodes.ci.toml)
+          if [ "${{ inputs.force_rebuild }}" = "true" ]; then
+            args+=(--force)
+          fi
+          if [ -n "${{ inputs.node }}" ]; then
+            args+=(--node "${{ inputs.node }}")
+          fi
+
+          python3 deploy.py build "${args[@]}"
+
+      - name: Deploy fleet
+        working-directory: deploy/deployer
+        run: |
+          set -euo pipefail
+
+          args=(--config nodes.ci.toml)
+          if [ "${{ inputs.force_rebuild }}" = "true" ]; then
+            args+=(--force)
+          fi
+          if [ "${{ inputs.no_restart }}" = "true" ]; then
+            args+=(--no-restart)
+          fi
+          if [ -n "${{ inputs.node }}" ]; then
+            args+=(--node "${{ inputs.node }}")
+          fi
+
+          python3 deploy.py deploy "${args[@]}"
+
+      - name: Show fleet status
+        if: always()
+        working-directory: deploy/deployer
+        run: |
+          set -euo pipefail
+
+          args=(--config nodes.ci.toml)
+          if [ -n "${{ inputs.node }}" ]; then
+            args+=(--node "${{ inputs.node }}")
+          fi
+
+          python3 deploy.py status "${args[@]}"
+
+      - name: Install cluster status dashboard
+        if: always()
+        run: |
+          set -euo pipefail
+
+          dashboard_dir="/opt/zakura-mainnet-dashboard"
+          sudo install -d -m 755 "$dashboard_dir"
+          sudo install -m 755 deploy/runner/zebra-cluster-status.py "$dashboard_dir/zebra-cluster-status.py"
+          sudo install -m 644 deploy/deployer/nodes.ci.toml "$dashboard_dir/nodes.toml"
+
+          sudo tee /etc/systemd/system/zakura-mainnet-dashboard.service >/dev/null <<'EOF'
+          [Unit]
+          Description=Zakura mainnet cluster status dashboard
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=simple
+          WorkingDirectory=/opt/zakura-mainnet-dashboard
+          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zebra-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --interval 10 --stale-after 300 --upgrade-height 0
+          Restart=always
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+
+          sudo systemctl daemon-reload
+          sudo systemctl enable zakura-mainnet-dashboard.service
+          sudo systemctl restart zakura-mainnet-dashboard.service
+          sudo systemctl --no-pager --full status zakura-mainnet-dashboard.service || true
+
+      - name: Fetch recent logs on failure
+        if: failure()
+        working-directory: deploy/deployer
+        run: |
+          set -euo pipefail
+
+          args=(--config nodes.ci.toml --lines 300)
+          if [ -n "${{ inputs.node }}" ]; then
+            args+=(--node "${{ inputs.node }}")
+          fi
+
+          python3 deploy.py logs fetch "${args[@]}" || true
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: zakura-mainnet-deploy-logs-${{ github.run_id }}
+          path: deploy/deployer/logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -156,6 +156,77 @@ python3 deploy/runner/zebra-cluster-status.py \
   --target-spacing 7.5
 ```
 
+## GitHub Actions mainnet fleet deploy
+
+`.github/workflows/zakura-mainnet-deploy.yml` runs the same deployer for the
+mainnet fleet on a Linux x86_64 self-hosted runner, expected to be `us-east-0`
+with the `zakura-mainnet-deployer` label. It builds the native `zakurad` binary
+and deploys it to:
+
+- `asia-0` — `root@165.22.54.66`
+- `us-0` — `root@104.131.184.123`
+- `us-east-0` — `root@159.65.183.89`
+- `us-west-0` — `root@143.244.184.176`
+- `canada-0` — `root@159.203.38.10`
+- `europe-west-0` — `root@64.227.44.93`
+- `europe-central-0` — `root@161.35.156.226`
+- `asia-south-0` — `root@139.59.64.115`
+- `asia-pacific-0` — `root@168.144.173.250`
+
+All nine are systemd-managed `zakurad.service` nodes. One-time runner bootstrap
+from an operator machine with SSH access and CI credentials in `~/agents-env`:
+
+```bash
+cd deploy/deployer
+./mainnet/bootstrap-zakura-mainnet-runner.sh
+```
+
+The workflow is manual (`workflow_dispatch`) with the same inputs as testnet
+(`ref` defaults to `main`, plus `force_rebuild`, `no_restart`, `node`). Its
+generated CI config uses Mainnet ports, public RPC at `0.0.0.0:8232`, and pins
+`identity_dir = "/root/.zakura"` so each node keeps its iroh node id (those node
+ids are the built-in mainnet Zakura bootstrap peers). It writes
+`/etc/zakura/zakura.toml` and points `state_cache_dir`/`network_cache_dir` at
+`/root/.cache/zakura` — the location the hand-provisioned nodes already use — so
+CI restarts against the existing database instead of resyncing. As on testnet, a
+`cache_dir_migrate_from = "/root/.cache/zebra"` is set: if an older pre-rename
+`zebra` cache exists and the `zakura` target does not, the deployer stops the
+node and moves the directory before starting. **Confirm each node's live
+`[state] cache_dir` before the first restart** — a mismatched path resyncs an
+archive node.
+
+> One-time migration: the nodes were hand-provisioned with a `zebrad.service`
+> unit and `/usr/local/bin/zebrad`, plus a vestigial `10-vct-legacy.conf` drop-in
+> (`VCT_LEGACY=1`, unread by zakurad). Because the deployer installs the
+> standardized `zakurad.service` and does not touch the old unit, disable and
+> remove it on each node before the first restart deploy, or the old process
+> keeps the state DB locked:
+>
+> ```bash
+> systemctl disable --now zebrad
+> rm -f /etc/systemd/system/zebrad.service \
+>       /etc/systemd/system/zebrad.service.d/10-vct-legacy.conf
+> systemctl daemon-reload
+> ```
+
+The workflow refreshes a fleet status dashboard on `us-east-0`:
+
+- service: `zakura-mainnet-dashboard.service`
+- URL: `http://159.65.183.89:8090/`
+- install dir: `/opt/zakura-mainnet-dashboard`
+
+It is the same `zebra-cluster-status.py` as testnet, launched with
+`--upgrade-height 0`, which hides the upgrade-ETA cards (mainnet has no pending
+Zakura activation to count down to). Manual run:
+
+```bash
+python3 deploy/runner/zebra-cluster-status.py \
+  --config deploy/deployer/nodes.toml \
+  --host 0.0.0.0 \
+  --port 8090 \
+  --upgrade-height 0
+```
+
 ## How the build cache works
 
 `commit` is resolved to a full SHA (`git rev-parse`). The binary is cached at

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -47,6 +47,7 @@ DEFAULTS = {
     "state_cache_dir": "/var/lib/zakura",
     "network": "Mainnet",
     "listen_addr": "[::]:8233",
+    "identity_dir": "",     # e.g. "/root/.zakura" -> pins the iroh node_id; "" uses zakurad default
     "network_cache_dir": "",
     "cache_dir_migrate_from": "",
     "rpc_listen_addr": "",  # empty -> RPC stays disabled
@@ -89,6 +90,7 @@ class Node:
     state_cache_dir: str
     network: str
     listen_addr: str
+    identity_dir: str
     network_cache_dir: str
     cache_dir_migrate_from: str
     rpc_listen_addr: str
@@ -171,6 +173,7 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             state_cache_dir=merged["state_cache_dir"],
             network=merged["network"],
             listen_addr=merged["listen_addr"],
+            identity_dir=merged["identity_dir"],
             network_cache_dir=merged["network_cache_dir"],
             cache_dir_migrate_from=merged["cache_dir_migrate_from"],
             rpc_listen_addr=merged["rpc_listen_addr"],
@@ -366,9 +369,13 @@ def render_node_config(node: Node) -> str:
     network_cache_line = (
         f'cache_dir = "{node.network_cache_dir}"' if node.network_cache_dir else "# cache_dir unset (zakurad default)"
     )
+    identity_dir_line = (
+        f'identity_dir = "{node.identity_dir}"' if node.identity_dir else "# identity_dir unset (zakurad default)"
+    )
     return render_template("zakura.toml", {
         "NETWORK": node.network,
         "LISTEN_ADDR": node.listen_addr,
+        "IDENTITY_DIR": identity_dir_line,
         "NETWORK_CACHE_DIR": network_cache_line,
         "STATE_CACHE_DIR": node.state_cache_dir,
         "STORAGE_MODE": node.storage_mode,

--- a/deploy/deployer/mainnet/bootstrap-zakura-mainnet-runner.sh
+++ b/deploy/deployer/mainnet/bootstrap-zakura-mainnet-runner.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Register us-east-0 as the GitHub Actions runner used by
+# .github/workflows/zakura-mainnet-deploy.yml.
+#
+# Run from this repository on an operator machine with SSH access to the node.
+# CI credentials are loaded from ~/agents-env by default; secret values are never
+# printed.
+
+set -euo pipefail
+
+RUNNER_HOST="${RUNNER_HOST:-159.65.183.89}"
+RUNNER_SSH="${RUNNER_SSH:-root@${RUNNER_HOST}}"
+RUNNER_LABELS="${RUNNER_LABELS:-zakura-mainnet-deployer,zakura-mainnet,linux-x64}"
+RUNNER_NAME="${RUNNER_NAME:-zakura-mainnet-1}"
+RUNNER_DIR="${RUNNER_DIR:-/opt/actions-runner/zakura-mainnet-deployer}"
+ENV_FILE="${ENV_FILE:-$HOME/agents-env}"
+FORCE_REGISTER="${FORCE_REGISTER:-0}"
+
+if [ ! -f "$ENV_FILE" ] && [ -f "$HOME/agent-global.env" ]; then
+    ENV_FILE="$HOME/agent-global.env"
+fi
+
+if [ -f "$ENV_FILE" ] && bash -n "$ENV_FILE" >/dev/null 2>&1; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+    set +a
+elif [ -f "$ENV_FILE" ]; then
+    echo "warning: env file is not shell-parseable, relying on existing gh auth/env: $ENV_FILE" >&2
+else
+    echo "warning: env file not found: $ENV_FILE" >&2
+fi
+
+repo_slug="${GITHUB_REPOSITORY:-}"
+if [ -z "$repo_slug" ]; then
+    remote_url="$(git config --get remote.origin.url)"
+    repo_slug="$(python3 - "$remote_url" <<'PY'
+import re
+import sys
+
+url = sys.argv[1]
+patterns = [
+    r"github\.com[:/](?P<slug>[^/]+/[^/.]+)(?:\.git)?$",
+    r"https://github\.com/(?P<slug>[^/]+/[^/.]+)(?:\.git)?$",
+]
+for pattern in patterns:
+    match = re.search(pattern, url)
+    if match:
+        print(match.group("slug"))
+        raise SystemExit
+raise SystemExit(f"could not infer GitHub repository from remote.origin.url: {url}")
+PY
+)"
+fi
+
+repo_url="https://github.com/${repo_slug}"
+
+github_api() {
+    if command -v gh >/dev/null 2>&1; then
+        GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh api "$@"
+        return
+    fi
+
+    token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    if [ -z "$token" ]; then
+        echo "GH_TOKEN or GITHUB_TOKEN is required when gh is unavailable" >&2
+        exit 1
+    fi
+
+    method="GET"
+    path=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            -X)
+                method="$2"
+                shift 2
+                ;;
+            *)
+                path="$1"
+                shift
+                ;;
+        esac
+    done
+
+    curl -fsSL \
+        -X "$method" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${token}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/${path#/}"
+}
+
+registration_token="$(
+    github_api -X POST "repos/${repo_slug}/actions/runners/registration-token" \
+        | python3 -c 'import json, sys; print(json.load(sys.stdin)["token"])'
+)"
+
+remove_token="$(
+    github_api -X POST "repos/${repo_slug}/actions/runners/remove-token" \
+        | python3 -c 'import json, sys; print(json.load(sys.stdin)["token"])'
+)"
+
+runner_version="$(
+    github_api "repos/actions/runner/releases/latest" \
+        | python3 -c 'import json, sys; print(json.load(sys.stdin)["tag_name"].lstrip("v"))'
+)"
+
+quote() {
+    printf "%q" "$1"
+}
+
+echo "Bootstrapping ${RUNNER_NAME} at ${RUNNER_SSH} for ${repo_slug}"
+
+ssh \
+    -o BatchMode=yes \
+    -o StrictHostKeyChecking=accept-new \
+    "$RUNNER_SSH" \
+    "RUNNER_TOKEN=$(quote "$registration_token") REMOVE_TOKEN=$(quote "$remove_token") REPO_URL=$(quote "$repo_url") RUNNER_NAME=$(quote "$RUNNER_NAME") RUNNER_LABELS=$(quote "$RUNNER_LABELS") RUNNER_DIR=$(quote "$RUNNER_DIR") RUNNER_VERSION=$(quote "$runner_version") FORCE_REGISTER=$(quote "$FORCE_REGISTER") bash -s" <<'REMOTE'
+set -euo pipefail
+
+export RUNNER_ALLOW_RUNASROOT=1
+
+apt-get -qq update
+apt-get -qq install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    git \
+    jq \
+    libclang-dev \
+    libicu-dev \
+    pkg-config \
+    protobuf-compiler \
+    python3 \
+    tar
+
+if ! command -v cargo >/dev/null 2>&1; then
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+fi
+
+if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck disable=SC1091
+    . "$HOME/.cargo/env"
+fi
+
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+if [ ! -x ./config.sh ]; then
+    archive="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+    curl -fsSLO "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${archive}"
+    tar xzf "$archive"
+    rm -f "$archive"
+fi
+
+if systemctl list-unit-files | grep -q "actions.runner.*${RUNNER_NAME}.*service"; then
+    if [ "$FORCE_REGISTER" != "1" ]; then
+        echo "runner service already installed; use FORCE_REGISTER=1 to re-register"
+        systemctl --no-pager --full status "actions.runner.*${RUNNER_NAME}*.service" || true
+        exit 0
+    fi
+    ./svc.sh stop || true
+    ./svc.sh uninstall || true
+fi
+
+if [ -f .runner ]; then
+    if [ "$FORCE_REGISTER" = "1" ]; then
+        ./config.sh remove --unattended --token "$REMOVE_TOKEN" || true
+    else
+        echo "runner is already configured; use FORCE_REGISTER=1 to re-register"
+        exit 0
+    fi
+fi
+
+./config.sh \
+    --unattended \
+    --url "$REPO_URL" \
+    --token "$RUNNER_TOKEN" \
+    --name "$RUNNER_NAME" \
+    --labels "$RUNNER_LABELS" \
+    --work _work \
+    --replace
+
+./svc.sh install root
+./svc.sh start
+./svc.sh status
+REMOTE
+
+echo "Runner bootstrap complete."

--- a/deploy/deployer/nodes.example.toml
+++ b/deploy/deployer/nodes.example.toml
@@ -12,6 +12,7 @@ state_cache_dir = "/var/lib/zakura"
 cache_dir_migrate_from = ""                    # optional old cache dir to move during restart deploys
 network         = "Mainnet"
 listen_addr     = "[::]:8233"
+# identity_dir  = "/root/.zakura"           # empty = zakurad default; pins the iroh node_id
 rpc_listen_addr = ""                        # empty = RPC disabled; e.g. "0.0.0.0:8232"
 storage_mode    = "archive"                 # "archive" serves all history; "pruned" does not
 v2_p2p          = true                       # run the Zakura v2 overlay

--- a/deploy/deployer/templates/zakura.toml
+++ b/deploy/deployer/templates/zakura.toml
@@ -4,6 +4,7 @@
 [network]
 network = "{{NETWORK}}"
 listen_addr = "{{LISTEN_ADDR}}"
+{{IDENTITY_DIR}}
 {{NETWORK_CACHE_DIR}}
 v2_p2p = {{V2_P2P}}
 legacy_p2p = {{LEGACY_P2P}}

--- a/deploy/runner/zebra-cluster-status.py
+++ b/deploy/runner/zebra-cluster-status.py
@@ -538,6 +538,11 @@ class ClusterCollector:
         }
 
     def upgrade_estimate(self, now: float) -> dict:
+        # A non-positive upgrade height means there is no pending activation to
+        # count down to (e.g. mainnet); the dashboard hides the upgrade cards.
+        if self.upgrade_height <= 0:
+            return {"enabled": False}
+
         current_height = self.height_history[-1][1] if self.height_history else None
         blocks_remaining = (
             max(self.upgrade_height - current_height, 0)
@@ -559,6 +564,7 @@ class ClusterCollector:
             eta_at = now + eta_seconds
 
         return {
+            "enabled": True,
             "height": self.upgrade_height,
             "current_height": current_height,
             "blocks_remaining": blocks_remaining,
@@ -930,19 +936,19 @@ tbody tr:hover td { background: rgba(46, 42, 66, 0.35); }
       <span>Stale window</span>
       <strong id="stale-window">...</strong>
     </article>
-    <article class="summary-card">
+    <article class="summary-card upgrade-card">
       <span>Upgrade height</span>
       <strong id="upgrade-height">...</strong>
     </article>
-    <article class="summary-card">
+    <article class="summary-card upgrade-card">
       <span>Blocks remaining</span>
       <strong id="blocks-remaining">...</strong>
     </article>
-    <article class="summary-card">
+    <article class="summary-card upgrade-card">
       <span>Upgrade ETA</span>
       <strong id="upgrade-eta">...</strong>
     </article>
-    <article class="summary-card">
+    <article class="summary-card upgrade-card">
       <span>Block time</span>
       <strong id="block-time">...</strong>
       <small id="block-time-source">...</small>
@@ -1060,14 +1066,20 @@ async function tick() {
   document.getElementById('last-poll').textContent = poll;
   document.getElementById('stale-window').textContent = Math.round(data.stale_after) + 's';
   const upgrade = data.upgrade || {};
-  const etaAt = upgrade.eta_at ? new Date(upgrade.eta_at * 1000).toLocaleString() : 'waiting for block movement';
-  document.getElementById('upgrade-height').textContent = formatNumber(upgrade.height);
-  document.getElementById('blocks-remaining').textContent = upgrade.activated ? 'activated' : formatNumber(upgrade.blocks_remaining);
-  document.getElementById('upgrade-eta').textContent = upgrade.activated ? 'activated' : countdown(upgrade.eta_seconds) + ' / ' + etaAt;
-  document.getElementById('block-time').textContent = formatBlockTime(upgrade.seconds_per_block);
-  document.getElementById('block-time-source').textContent = upgrade.source === 'observed'
-    ? 'recent average'
-    : 'default estimate';
+  const upgradeEnabled = upgrade.enabled !== false;
+  document.querySelectorAll('.upgrade-card').forEach((card) => {
+    card.style.display = upgradeEnabled ? '' : 'none';
+  });
+  if (upgradeEnabled) {
+    const etaAt = upgrade.eta_at ? new Date(upgrade.eta_at * 1000).toLocaleString() : 'waiting for block movement';
+    document.getElementById('upgrade-height').textContent = formatNumber(upgrade.height);
+    document.getElementById('blocks-remaining').textContent = upgrade.activated ? 'activated' : formatNumber(upgrade.blocks_remaining);
+    document.getElementById('upgrade-eta').textContent = upgrade.activated ? 'activated' : countdown(upgrade.eta_seconds) + ' / ' + etaAt;
+    document.getElementById('block-time').textContent = formatBlockTime(upgrade.seconds_per_block);
+    document.getElementById('block-time-source').textContent = upgrade.source === 'observed'
+      ? 'recent average'
+      : 'default estimate';
+  }
   document.getElementById('summary').textContent = data.healthy + ' / ' + data.total + ' nodes healthy';
   const body = document.getElementById('rows');
   body.innerHTML = data.rows.map((row) => `
@@ -1136,7 +1148,7 @@ def main() -> None:
         "--upgrade-height",
         type=int,
         default=DEFAULT_UPGRADE_HEIGHT,
-        help="testnet upgrade activation height to estimate",
+        help="upgrade activation height to estimate; 0 hides the upgrade cards (e.g. mainnet)",
     )
     parser.add_argument(
         "--target-spacing",


### PR DESCRIPTION
## Motivation

The nine Zakura **mainnet** nodes were hand-provisioned (bespoke `zebrad.service`,
config at `/root/.config/zebrad.toml`, no fleet-wide tooling), so there was no
repeatable way to roll a new commit across them and no visibility into fleet
health. Testnet already has this via `deploy/deployer/deploy.py` +
`zakura-testnet-deploy.yml` + the `zebra-cluster-status.py` dashboard. This PR
brings mainnet onto the same tooling.

## Solution

- **New workflow `zakura-mainnet-deploy.yml`** — manual `workflow_dispatch` that
  builds `zakurad` on a self-hosted runner (`us-east-0`, label
  `zakura-mainnet-deployer`) and deploys to all nine nodes via the existing
  deployer, then installs a status dashboard on `:8090`. Mirrors the testnet
  workflow (host-key pinning, optional SSH deploy key, per-node status, failure
  log capture).
- **`deploy.py` + `templates/zakura.toml` + `nodes.example.toml`** — add an
  optional `identity_dir` key. It renders into `[network]` only when set, so
  existing fleets (testnet) render byte-for-byte unchanged. Mainnet pins
  `/root/.zakura` so each node keeps its iroh node id (those ids are the built-in
  mainnet bootstrap peers in `zebra-network/src/zakura/handler.rs`).
- **`zebra-cluster-status.py`** — `--upgrade-height 0` now hides the four
  upgrade/ETA summary cards; mainnet has no pending Zakura activation to count
  down to. Default (`4134000`) behavior for testnet is unchanged.
- **Resync safety** — the generated config points `state_cache_dir` /
  `network_cache_dir` at `/root/.cache/zakura` (the location the nodes already
  use) and sets `cache_dir_migrate_from = "/root/.cache/zebra"`, reusing the
  migration mechanism added for testnet in #33 so a pre-rename cache is moved
  into place on first restart instead of resyncing.
- **`README.md`** — documents the mainnet fleet, runner bootstrap, dashboard, and
  the one-time `zebrad.service` → `zakurad.service` migration each node needs.

### Tests

- `python3 -m py_compile` on `deploy.py` and `zebra-cluster-status.py`; `bash -n`
  on the bootstrap script; YAML parse of the workflow.
- Extracted both the **testnet and mainnet** `nodes.ci.toml` heredocs and loaded
  them through the patched `deploy.py`: testnet = 6 nodes (5 `systemd` + 1
  `process`, `identity_dir` unset → unchanged), mainnet = 9 `systemd` nodes
  (`identity_dir=/root/.zakura`, `cache_dir_migrate_from=/root/.cache/zebra`).
  Every node renders with valid TOML and no unfilled placeholders.
- Ran the dashboard locally: `--upgrade-height 0` → `/data` reports
  `upgrade={"enabled": false}` and the upgrade cards hide; `--upgrade-height
  4134000` → cards render as before.
- Not yet run against the live fleet: SSH access to the nodes was unavailable, so
  the per-node `[state] cache_dir` confirmation and a single-node `us-east-0`
  canary remain as pre-first-deploy steps (documented in the workflow header).

### Follow-up Work

- Confirm each node's live `[state] cache_dir` and run a `no_restart` +
  single-node canary on `us-east-0` before the first full-fleet restart.
- Bootstrap the `zakura-mainnet-deployer` self-hosted runner on `us-east-0` and
  add the `ZAKURA_MAINNET_DEPLOY_SSH_KEY` secret / `zakura-mainnet` environment.

### AI Disclosure

- [x] AI tools were used: Claude Code — authored the workflow, the `identity_dir`
  and dashboard changes, and the docs; reconciled against `main` after the #33/#36
  deploy-infra changes. All changes reviewed by the author.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`
- [ ] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
