### PR TITLE
fix(zcashd-compat): align watchdog + bootstrap conf with the P2P sidecar

### DIFF
--- a/deploy/watchdog/README.md
+++ b/deploy/watchdog/README.md
@@ -48,7 +48,7 @@ The initial registry contains a single check:
 Mirrors the predicates of the legacy `deploy/zcashd-compat/sync-check.sh`:
 
 1. a `zebrad .*--zcashd-compat` process is running (`pgrep -f`),
-2. a `zcashd .*-zebra-compat` process is running (`pgrep -f`),
+2. a `zcashd .*-connect` process is running (`pgrep -f`),
 3. zcashd `getzebracompatinfo` reports `service_state == "ready"`,
    `zebra.reachable == true`, and `zebra.identity_verified == true`,
 4. `abs(zebra getblockcount - zcashd getblockcount) <= HEIGHT_MAX_DRIFT`.
@@ -79,7 +79,7 @@ environment variable names match the legacy sync-check script and the
 | `ZCASHD_RPC_URL`          | `--zcashd-rpc-url`          | `http://[::1]:8232`                   | zcashd JSON-RPC endpoint |
 | `ZCASHD_COOKIE_FILE`      | `--zcashd-cookie-file`      | `/mnt/snapshots/runtime/zcashd/.cookie` | zcashd RPC cookie file |
 | `ZEBRAD_PROCESS_PATTERN`  | `--zebrad-process-pattern`  | `zebrad .*--zcashd-compat`            | `pgrep -f` pattern for zebrad |
-| `ZCASHD_PROCESS_PATTERN`  | `--zcashd-process-pattern`  | `zcashd .*-zebra-compat`              | `pgrep -f` pattern for zcashd |
+| `ZCASHD_PROCESS_PATTERN`  | `--zcashd-process-pattern`  | `zcashd .*-connect`              | `pgrep -f` pattern for zcashd |
 | `HEIGHT_MAX_DRIFT`        | `--height-max-drift`        | `10`                                  | Max allowed height drift |
 | `SYNC_CHECK_TIMEOUT`      | `--sync-check-timeout`      | `600`                                 | One-shot `check` total timeout (seconds) |
 | `SYNC_CHECK_INTERVAL`     | `--sync-check-interval`     | `15`                                  | One-shot `check` retry interval (seconds) |

--- a/deploy/watchdog/src/config.rs
+++ b/deploy/watchdog/src/config.rs
@@ -57,11 +57,15 @@ pub struct Config {
     pub zebrad_process_pattern: String,
 
     /// `pgrep -f` pattern that must match a running zcashd process.
+    ///
+    /// The P2P sidecar zcashd is pinned to the local Zakura node with `-connect`
+    /// and no longer takes the legacy RPC-ingest `-zebra-compat` flag, so match
+    /// on `-connect` (mirroring `deploy/zcashd-compat/sync-check.sh`).
     #[arg(
         global = true,
         long,
         env = "ZCASHD_PROCESS_PATTERN",
-        default_value = "zcashd .*-zebra-compat"
+        default_value = "zcashd .*-connect"
     )]
     pub zcashd_process_pattern: String,
 
@@ -131,7 +135,7 @@ mod tests {
         assert_eq!(config.zebra_rpc_url, "http://127.0.0.1:8232");
         assert_eq!(config.zcashd_rpc_url, "http://[::1]:8232");
         assert_eq!(config.zebrad_process_pattern, "zebrad .*--zcashd-compat");
-        assert_eq!(config.zcashd_process_pattern, "zcashd .*-zebra-compat");
+        assert_eq!(config.zcashd_process_pattern, "zcashd .*-connect");
         assert_eq!(config.height_max_drift, 10);
         assert_eq!(config.sync_check_timeout, 600);
         assert_eq!(config.sync_check_interval, 15);

--- a/zebrad/src/components/zcashd_compat/datadir.rs
+++ b/zebrad/src/components/zcashd_compat/datadir.rs
@@ -31,8 +31,10 @@ const ZCASH_CONF_FILENAME: &str = "zcash.conf";
 /// Minimal config that lets zcashd start in zcashd-compat mode on first use.
 pub const BOOTSTRAP_ZCASH_CONF: &str = "\
 i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
-# zcashd-compat: P2P is disabled; chain data comes from zebrad RPC.
-# Do not add bind=, connect=, addnode=, or listen=1 here.
+# zcashd-compat P2P sidecar: zcashd peers only with the local Zakura node.
+# Peer selection is pinned on the zcashd command line (-connect/-listen=0);
+# do not add bind=, connect=, addnode=, or listen=1 here -- these accumulate
+# and cannot be overridden by the supervisor's flags.
 ";
 
 const DEPRECATION_ACK: &str = "i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025";


### PR DESCRIPTION
## Motivation

The switch from RPC ingest to a P2P sidecar (#19) left two operator-facing surfaces still referencing the removed `-zebra-compat` RPC-ingest flag. #38 fixed the installer's printed start commands; this PR fixes the two remaining spots so the whole zcashd-compat surface is consistent with the sidecar contract.

## Solution

**1. Watchdog process pattern (functional bug).** `deploy/watchdog/src/config.rs` defaulted `ZCASHD_PROCESS_PATTERN` to `zcashd .*-zebra-compat`. The P2P sidecar zcashd is launched with `-connect=<zakura p2p>` and **no** `-zebra-compat` flag (see the supervisor's argv and #38's installer output), so this pattern never matches a healthy sidecar — the watchdog's zcashd liveness check (`pgrep -f`) would always report **NOT RUNNING**. The reference shell script `deploy/zcashd-compat/sync-check.sh:17` already uses `zcashd .*-connect`; the Rust default was not updated in lockstep. Changed the default to `zcashd .*-connect` and updated the README table + the config unit test.

**2. Bootstrap `zcash.conf` comment (stale/misleading).** `zebrad/.../zcashd_compat/datadir.rs` bootstraps a minimal conf whose comment claimed *"P2P is disabled; chain data comes from zebrad RPC"* — the opposite of the sidecar design, where zcashd peers to Zakura over P2P via `-connect`. Corrected the comment to describe the sidecar (peer selection pinned on the command line). The conf's effective content (the deprecation-ack line) is unchanged.

## Tests

- `cargo test -p zakura-compat-watchdog` (deploy/watchdog) — 18 passed, including the updated default-pattern assertion.
- `cargo test -p zebrad --lib zcashd_compat::datadir` — the bootstrap tests compare the written file against the `BOOTSTRAP_ZCASH_CONF` constant, so the comment change is self-consistent.
- No behavior change beyond the watchdog default and documentation/comment text.

## Context

Follow-up to #38 (installer P2P-sidecar fixes). Found while validating the zcashd-compat modes end-to-end against local testnet snapshots: the operator's live watchdog was health-checking with the old pattern.

### AI Disclosure

- [x] AI tools were used: Claude Code — identified the inconsistencies during E2E validation of #38 and made these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)