### PR TITLE
fix(ci): publish zakurad release assets and installer fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -209,10 +209,10 @@ for c in zebra-test tower-fallback zebra-chain tower-batch-control zebra-node-se
   - [ ] Update [`zebrad/zcashd-compat-manifest.json`](https://github.com/valargroup/zebra/blob/ironwood-main/zebrad/zcashd-compat-manifest.json) to the intended `zcashd` compat release (it is the single source of truth: zebrad embeds it at compile time and CI/Docker builds read it directly).
   - [ ] Confirm the manifest contains only the `x86_64-pc-linux-gnu` artifact before publishing zcashd-compat Docker images.
   - [ ] Confirm the workflow logs show the expected `/usr/local/bin/zcashd --version` for the zcashd-compat linux/amd64 image variant.
-- [ ] Wait for the [the Docker images to be published successfully](https://github.com/valargroup/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
-- [ ] Confirm `release-binaries.yml` published `zebrad-<tag>-linux-x86_64.tar.gz`, `zebrad-<tag>-linux-aarch64.tar.gz`, `zebrad-manifest-<tag>.json`, `install-zakura.sh`, `install-zcashd-compat.sh`, and `SHA256SUMS.txt` to the GitHub release.
-- [ ] Wait for the new tag in the [Docker Hub zebra space](https://hub.docker.com/r/valaroman/zebra/tags)
-- [ ] Confirm `valaroman/zebra:<version>` includes `linux/amd64` and `linux/arm64`, and `valaroman/zebra:zcashd-compat-<version>` includes only `linux/amd64`.
+- [ ] Wait for the [the Docker images to be published successfully](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Arelease).
+- [ ] Confirm `release-binaries.yml` published `zakurad-<tag>-linux-x86_64.tar.gz`, `zakurad-<tag>-linux-aarch64.tar.gz`, `zakurad-manifest-<tag>.json`, `install-zakura.sh`, `install-zcashd-compat.sh`, and `SHA256SUMS.txt` to the GitHub release.
+- [ ] Wait for the new tag in the [Docker Hub zakura space](https://hub.docker.com/r/valargroup/zakura/tags)
+- [ ] Confirm `valargroup/zakura:<version>` includes `linux/amd64` and `linux/arm64`, and `valargroup/zakura:zcashd-compat-<version>` includes only `linux/amd64`.
 - [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/valargroup/repo/zebra/queues) using Mergify.
 - [ ] Remove `do-not-merge` from the PRs you added it to
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -12,11 +12,11 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag to publish assets to (for example v2.6.0)"
+        description: "Release tag to build and publish assets for (for example v0.0.1-alpha.1)"
         required: false
         type: string
       publish_assets_to_release:
-        description: "Upload zakurad assets to the GitHub release tag"
+        description: "Upload zakurad assets to the GitHub release tag (use to repair an existing release)"
         required: false
         type: boolean
         default: false
@@ -56,7 +56,14 @@ jobs:
             checkout_ref="$REF_NAME"
           else
             release_tag="$INPUT_RELEASE_TAG"
-            checkout_ref="$GITHUB_SHA"
+            # workflow_dispatch builds from the release tag so republished assets
+            # match the tagged source tree (older tags may still ship a zebrad
+            # binary, which the packaging step renames to zakurad).
+            if [ -n "$release_tag" ]; then
+              checkout_ref="$release_tag"
+            else
+              checkout_ref="$GITHUB_SHA"
+            fi
           fi
 
           if [ -z "$release_tag" ]; then
@@ -129,19 +136,27 @@ jobs:
             --build-arg "FEATURES=${FEATURES}" \
             --output "type=local,dest=./out" \
             .
-          test -x ./out/usr/local/bin/zakurad
+          if [ -x ./out/usr/local/bin/zakurad ]; then
+            echo "release_binary=zakurad" >> "$GITHUB_ENV"
+          elif [ -x ./out/usr/local/bin/zebrad ]; then
+            echo "release_binary=zebrad" >> "$GITHUB_ENV"
+          else
+            echo "Expected ./out/usr/local/bin/zakurad or ./out/usr/local/bin/zebrad" >&2
+            exit 1
+          fi
 
       - name: Validate binary
-        run: ./out/usr/local/bin/zakurad --version
+        run: ./out/usr/local/bin/${{ env.release_binary }} --version
 
       - name: Package archive and metadata
         env:
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+          RELEASE_BINARY: ${{ env.release_binary }}
         run: |
           set -euo pipefail
           mkdir -p ./artifacts/bin ./artifacts/metadata
-          cp ./out/usr/local/bin/zakurad ./artifacts/bin/zakurad
-          cp ./out/usr/local/bin/zakurad ./artifacts/bin/zebrad
+          cp "./out/usr/local/bin/${RELEASE_BINARY}" ./artifacts/bin/zakurad
+          cp "./out/usr/local/bin/${RELEASE_BINARY}" ./artifacts/bin/zebrad
           archive_name="zakurad-${RELEASE_TAG}-${{ matrix.name }}.tar.gz"
           (
             cd ./artifacts
@@ -211,10 +226,13 @@ jobs:
               raise SystemExit("No metadata files found.")
 
           artifacts = []
+          x86_sha256 = ""
           for file_path in metadata_files:
               item = json.loads(Path(file_path).read_text(encoding="utf-8"))
               item["url"] = f"{base_url}/{item['archive']}"
               artifacts.append(item)
+              if item.get("platform_id") == "linux-x86_64":
+                  x86_sha256 = item.get("sha256", "")
 
           manifest = {
               "schema_version": 1,
@@ -227,6 +245,9 @@ jobs:
               json.dumps(manifest, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
+          if not x86_sha256:
+              raise SystemExit("Missing linux-x86_64 archive sha256 in metadata.")
+          Path("./publish/final/x86_64.sha256").write_text(x86_sha256 + "\n", encoding="utf-8")
           PY
 
           find ./publish -type f -name 'zakurad-*.tar.gz' -exec cp {} ./publish/final/ \;
@@ -239,9 +260,11 @@ jobs:
 
           release_tag = os.environ["RELEASE_TAG"]
           image_version = release_tag.removeprefix("v")
+          x86_sha256 = Path("./publish/final/x86_64.sha256").read_text(encoding="utf-8").strip()
           installers = {
               "install-zcashd-compat.sh": {
                   "ZAKURA_RELEASE_TAG": release_tag,
+                  "ZAKURA_ARCHIVE_SHA256": x86_sha256,
                   "ZAKURA_DOCKER_IMAGE": f"valargroup/zakura:{image_version}",
                   "ZAKURA_COMPAT_DOCKER_IMAGE": f"valargroup/zakura:zcashd-compat-{image_version}",
               },
@@ -315,6 +338,16 @@ jobs:
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
         run: |
           set -euo pipefail
+          # Drop stale pre-rename assets so installers only see zakurad archives.
+          legacy_assets=(
+            "zebrad-${RELEASE_TAG}-linux-x86_64.tar.gz"
+            "zebrad-${RELEASE_TAG}-linux-aarch64.tar.gz"
+            "zebrad-manifest-${RELEASE_TAG}.json"
+          )
+          for asset in "${legacy_assets[@]}"; do
+            gh release delete-asset "$RELEASE_TAG" "$asset" --repo "$REPOSITORY" --yes 2>/dev/null || true
+          done
+
           gh release upload "$RELEASE_TAG" \
             ./publish/final/zakurad-*.tar.gz \
             ./publish/final/zakurad-manifest-*.json \

--- a/book/valarbook/index.html
+++ b/book/valarbook/index.html
@@ -587,7 +587,7 @@
                   <li><strong>Disk:</strong> at least 1 TiB combined capacity across the filesystems used by Zakura state and zcashd datadir.</li>
                 </ul>
                 <p class="body-copy">
-                  Startup fails below the minimums: 4 logical CPUs, 16 GiB RAM, 300 GiB per data volume (600 GiB if Zakura state and the zcashd datadir share a filesystem). Bypass only with <code>--unsafe-low-specs</code>. Linux x86_64 only.
+                  Startup fails below the minimums: 4 logical CPUs, 16 GiB RAM, 300 GiB per data volume (550 GiB if Zakura state and the zcashd datadir share a filesystem). Bypass only with <code>--unsafe-low-specs</code>. Linux x86_64 only.
                 </p>
               </div>
               <div class="prereq-group">

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -232,6 +232,7 @@ read_prompt() {
   local prompt="$1"
   local __replyvar="$2"
   local reply
+  local read_opts=(-r)
 
   if ((PROMPT_FD == -1)); then
     if ((PROMPT_INPUT_ERROR_REPORTED == 0)); then
@@ -242,12 +243,15 @@ read_prompt() {
     return 1
   fi
 
+  # readline editing (backspace/delete, cursor movement) requires -e on a tty.
+  if [[ -t "$PROMPT_FD" ]]; then
+    read_opts=(-e -r)
+  fi
+
   if ((PROMPT_FD == 0)); then
-    printf '%s' "$prompt"
-    IFS= read -r reply || return 1
+    read "${read_opts[@]}" -p "$prompt" reply || return 1
   else
-    printf '%s' "$prompt" > /dev/tty
-    IFS= read -r -u "$PROMPT_FD" reply || return 1
+    read "${read_opts[@]}" -u "$PROMPT_FD" -p "$prompt" reply || return 1
   fi
 
   printf -v "$__replyvar" '%s' "$reply"

--- a/scripts/install-zcashd-compat.sh
+++ b/scripts/install-zcashd-compat.sh
@@ -262,6 +262,7 @@ sanitize_terminal_input() {
 read_prompt() {
   local prompt="$1"
   local var_name="$2"
+  local read_opts=(-r)
 
   if ((PROMPT_FD < 0)); then
     if ((PROMPT_INPUT_ERROR_REPORTED == 0)); then
@@ -271,7 +272,12 @@ read_prompt() {
     return 1
   fi
 
-  read -r -u "$PROMPT_FD" -p "$prompt" "$var_name"
+  # readline editing (backspace/delete, cursor movement) requires -e on a tty.
+  if [[ -t "$PROMPT_FD" ]]; then
+    read_opts=(-e -r)
+  fi
+
+  read "${read_opts[@]}" -u "$PROMPT_FD" -p "$prompt" "$var_name"
 }
 
 prompt_value() {
@@ -652,7 +658,7 @@ recommend_datadir_defaults() {
   # Empty fallback locations share a filesystem, so size them for both datadirs
   # when both prompt defaults are being selected together.
   if ((ZAKURA_STATE_DIR_SET == 0 && ZCASHD_DATADIR_SET == 0)); then
-    SYNTHETIC_INSTALL_MIN_BYTES=$((600 * 1024 * 1024 * 1024))
+    SYNTHETIC_INSTALL_MIN_BYTES=$((550 * 1024 * 1024 * 1024))
   else
     SYNTHETIC_INSTALL_MIN_BYTES=$((300 * 1024 * 1024 * 1024))
   fi
@@ -996,7 +1002,7 @@ collect_disk_checks() {
   read -r zcashd_device zcashd_size <<<"$zcashd_info"
 
   if [[ "$zebra_device" == "$zcashd_device" ]]; then
-    required=$((600 * gib))
+    required=$((550 * gib))
     combined="$zebra_size"
     if ((zebra_size < required)); then
       add_low_spec_error "zakura state + zcashd datadir mount (paths: $ZAKURA_STATE_DIR, $ZCASHD_DATADIR) has provisioned capacity $(human_gib "$zebra_size"), minimum required is $(human_gib "$required")"

--- a/zebrad/tests/common/zcashd_compat/launch.rs
+++ b/zebrad/tests/common/zcashd_compat/launch.rs
@@ -144,7 +144,7 @@ pub async fn spawn_zebrad_with_zcashd_compat() -> Result<ZcashdCompatSetup> {
     let zebra_compat_rpc_addr = compat_cfg.zebra_compat_rpc_addr;
     let zcashd_own_rpc_addr = compat_cfg.zcashd_own_rpc_addr;
 
-    // `--unsafe-low-specs` skips the hardware preflight minimums (600 GiB disk
+    // `--unsafe-low-specs` skips the hardware preflight minimums (550 GiB disk
     // etc.), which regtest doesn't need and CI runners don't have.
     let mut zebrad = dir.with_config(&mut zebrad_config)?.spawn_child(args![
         "start",


### PR DESCRIPTION
## Motivation

The `v0.0.1-alpha.1` release was published with pre-rename `zebrad-*` assets, but the installers now download `zakurad-*` archives. That mismatch causes a 404 during install. This PR fixes release publishing for older tags and bundles a few related installer improvements.

## Solution

### Release pipeline (`release-binaries.yml`)
- Accept either `zakurad` or legacy `zebrad` binaries when packaging release archives.
- Package both `./bin/zakurad` and `./bin/zebrad` into `zakurad-*.tar.gz` so installers can extract `./bin/zakurad`.
- Fix `workflow_dispatch` to check out the release tag (not `GITHUB_SHA`) when republishing an existing release.
- Pin `ZAKURA_ARCHIVE_SHA256` in published `install-zcashd-compat.sh`.
- Delete stale `zebrad-*` / `zebrad-manifest-*` assets before uploading canonical `zakurad-*` files.

### Installer UX and requirements
- Enable readline editing (`read -e`) on TTY prompts in `install-zakura.sh` and `install-zcashd-compat.sh`.
- Lower the shared filesystem disk minimum from 600 GiB to 550 GiB in the installer, docs, and test comment.

### Docs
- Update the release checklist to reference `zakurad-*` assets and `valargroup/zakura` Docker images.

### Tests

- [x] Validated `release-binaries.yml` YAML syntax locally.
- [ ] Full CI not run locally (low-risk CI/docs/installer change; CI will validate on PR).

**Risk classification:** Low — CI workflow, installer, and documentation changes only.

### Follow-up Work

After merge, repair `v0.0.1-alpha.1` by running **Release binaries** via `workflow_dispatch` with:
- `release_tag`: `v0.0.1-alpha.1`
- `publish_assets_to_release`: `true`

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor for release pipeline fixes, installer tweaks, and PR preparation.