### PR TITLE
fix(zcashd-compat): fix docker-split zcashd arg formatting (spurious empty arg)

### DIFF
--- a/scripts/install-zcashd-compat.sh
+++ b/scripts/install-zcashd-compat.sh
@@ -1407,6 +1407,22 @@ print_zcashd_flag_lines() {
   printf '  -printtoconsole\n'
 }
 
+# zcashd container flag block (fixed in-container datadir/conf paths). Emits one
+# flag per line so no command-substitution/heredoc line-join can splice two
+# flags together with an escaped space.
+print_docker_zcashd_flag_lines() {
+  local arg
+  while IFS= read -r arg; do
+    [[ -n "$arg" ]] && printf '  %s \\\n' "$arg"
+  done < <(zcashd_network_args)
+  printf '  -datadir=/home/zcashd/.zcash \\\n'
+  printf '  -conf=/home/zcashd/.zcash/zcash.conf \\\n'
+  while IFS= read -r arg; do
+    [[ -n "$arg" ]] && printf '  %s \\\n' "$arg"
+  done < <(zcashd_p2p_pinning_args)
+  printf '  -printtoconsole\n'
+}
+
 print_split_binary_commands() {
   cat <<EOF
 $(style "$GREEN$BOLD" "Start Zakura in terminal 1:")
@@ -1480,11 +1496,7 @@ $(style "$GREEN$BOLD" "Start zcashd container in terminal 2:")
 docker run --rm -it --name zakura-compat-zcashd --network host \\
   --mount type=bind,src=$(shell_quote "$ZCASHD_DATADIR"),dst=/home/zcashd/.zcash \\
   $(shell_quote "$ZCASHD_DOCKER_IMAGE") \\
-$(while IFS= read -r arg; do [[ -n "$arg" ]] && printf '  %s \\\n' "$arg"; done < <(zcashd_network_args))\
-  -datadir=/home/zcashd/.zcash \\
-  -conf=/home/zcashd/.zcash/zcash.conf \\
-$(while IFS= read -r arg; do [[ -n "$arg" ]] && printf '  %s \\\n' "$arg"; done < <(zcashd_p2p_pinning_args))\
-  -printtoconsole
+$(print_docker_zcashd_flag_lines)
 EOF
 }
 

--- a/scripts/install-zcashd-compat.sh
+++ b/scripts/install-zcashd-compat.sh
@@ -1213,8 +1213,12 @@ prepare_binary_paths() {
 # datadir has none, so bootstrap a minimal one rather than printing a command
 # that cannot run. Never overwrite an existing file.
 ensure_zcashd_conf() {
+  # split-binary/build-from-source run zcashd directly; docker-split-containers
+  # runs a standalone zcashd container (nobody bootstraps its conf, unlike
+  # docker-supervised where the in-container Zakura node creates it). All three
+  # need a zcash.conf to exist, or zcashd refuses to start.
   case "$MODE" in
-    split-binary | build-from-source) ;;
+    split-binary | build-from-source | docker-split-containers) ;;
     *) return ;;
   esac
 
@@ -1668,7 +1672,14 @@ case "$MODE" in
     prepare_binary_paths
     ensure_zcashd_conf
     ;;
-  docker-split-containers | docker-supervised)
+  docker-split-containers)
+    # Bootstrap the standalone zcashd container's conf before prepare_docker_mounts
+    # so its recursive chown to the container runtime user covers the new file.
+    ensure_zcashd_conf
+    prepare_docker_mounts
+    prepare_docker_images
+    ;;
+  docker-supervised)
     prepare_docker_mounts
     prepare_docker_images
     ;;


### PR DESCRIPTION
## Motivation

The `docker-split-containers` printed command (added in #38) splices two zcashd flags onto one line, producing a spurious empty argument when an operator copy-pastes it. Found while building a #36 image locally to run docker-split end-to-end.

The zcashd container block used inline `$(while ... printf '  %s \\\n' ...)` command substitutions inside the heredoc. Command substitution strips the trailing newline, so the last emitted flag ends in ` \`; the heredoc's own `\`-continuation then joins it with the next literal line:

```
  -testnet \  -datadir=/home/zcashd/.zcash \
  ...
  -discover=0 \  -printtoconsole
```

A shell tokenizes `-testnet \  -datadir` as `-testnet`, a literal single-space argument (`\ ` = escaped space), then `-datadir`. zcashd then receives an empty parameter and errors. Verified argv before the fix:

```
9:[-testnet]  10:[ ]  11:[-datadir=...]   ...   17:[-discover=0]  18:[ ]  19:[-printtoconsole]
```

## Solution

Move the whole zcashd container flag block into a `print_docker_zcashd_flag_lines` helper (mirroring the working `print_zcashd_flag_lines` used by the binary modes), which emits one flag per line. No command-substitution/heredoc join can occur.

After the fix the pasted command tokenizes to exactly the intended argv, no empty tokens:

```
9:[-testnet] 10:[-datadir=...] 11:[-conf=...] 12:[-connect=127.0.0.1:18233] 13:[-listen=0] ... 17:[-printtoconsole]
```

## Tests

- `bash -n scripts/install-zcashd-compat.sh` — passes.
- Re-tokenized the printed `docker-split-containers` zcashd command through a stub `args()` function; confirmed no spurious `[ ]` tokens remain (Mainnet and Testnet).
- `docker-supervised` and the binary modes were already correct (they don't use the inline-loop pattern) — verified no other occurrences remain.

## Context

Follow-up to #38. Only `docker-split-containers` was affected.

### AI Disclosure

- [x] AI tools were used: Claude Code — found and fixed while setting up a local docker E2E of the zcashd-compat modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)