### PR TITLE
fix(zakura): mainnet binary-only deploy + guards against destructive mis-deploy

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -62,6 +62,19 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref }}
 
+      - name: Verify deployer supports binary-only mode
+        # The checked-out deploy.py comes from `inputs.ref`; this fleet's config
+        # sets `manage_config = false`. If the checked-out deploy.py predates that
+        # support it would silently run a destructive config-managed deploy, so
+        # fail fast instead. deploy.py also now rejects unknown config keys.
+        run: |
+          set -euo pipefail
+          if ! grep -q 'manage_config' deploy/deployer/deploy.py; then
+            echo "::error::deploy.py at ref '${{ inputs.ref }}' lacks manage_config support." \
+                 "Deploy from a ref whose deploy.py supports binary-only mode."
+            exit 1
+          fi
+
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -8,24 +8,14 @@ name: Deploy Zakura mainnet fleet
 # builds a native zakurad binary on that runner, then uses deploy/deployer/
 # deploy.py to scp/install it across the fleet.
 #
-# ONE-TIME MIGRATION — the mainnet nodes were hand-provisioned with a
-# `zebrad.service` unit and a /usr/local/bin/zebrad binary. This deployer
-# installs the standardized `zakurad.service` + /usr/local/bin/zakurad, and does
-# not touch the old unit, so before the first restart deploy each node needs:
-#     systemctl disable --now zebrad
-#     rm -f /etc/systemd/system/zebrad.service \
-#           /etc/systemd/system/zebrad.service.d/10-vct-legacy.conf
-#     systemctl daemon-reload
-# Otherwise the old zebrad process keeps the state DB locked and zakurad cannot
-# start. See deploy/deployer/README.md.
-#
-# DO NOT RESYNC — the cache paths below point at the location the nodes already
-# use (/root/.cache/zakura, the zakurad default for HOME=/root), identity_dir is
-# pinned to /root/.zakura so each node keeps its iroh node id, and
-# cache_dir_migrate_from moves a pre-rename /root/.cache/zebra dir into place on
-# first restart if the zakura target does not yet exist. Confirm each node's live
-# `[state] cache_dir` before the first restart; a mismatched path resyncs an
-# archive node from genesis.
+# BINARY-ONLY DEPLOY. The mainnet nodes were provisioned by hand with rich,
+# per-node configs (external_addr, an inline zakura_node_secret_key that pins
+# each node's iroh identity, custom peers, and mempool/sync tuning) and their
+# state DB at /root/.cache/zebra. To avoid changing node identities or resyncing,
+# this deploy sets manage_config = false: it only swaps /usr/local/bin/zebrad and
+# restarts the existing `zebrad` service, leaving the config, unit, and cache
+# untouched. Rebuilding those configs into the deployer's managed model is
+# separate future work.
 
 on:
   workflow_dispatch:
@@ -41,7 +31,7 @@ on:
         required: false
         default: false
       no_restart:
-        description: "Stage binary/config/unit without restarting zakurad"
+        description: "Stage the binary without restarting the node"
         type: boolean
         required: false
         default: false
@@ -141,34 +131,32 @@ jobs:
 
           cat > nodes.ci.toml <<EOF
           [defaults]
-          service_name    = "zakurad"
-          bin_path        = "/usr/local/bin/zakurad"
-          config_path     = "/etc/zakura/zakura.toml"
+          # Binary-only: swap the binary and restart the existing service; leave
+          # the hand-tuned config, unit, and /root/.cache/zebra state untouched.
+          deploy_kind     = "systemd"
+          manage_config   = false
+          service_name    = "zebrad"
+          bin_path        = "/usr/local/bin/zebrad"
           network         = "Mainnet"
-          listen_addr     = "[::]:8233"
+          # Read-only fields below: consumed by the status dashboard's SSH probe,
+          # not written to any node (manage_config = false).
           rpc_listen_addr = "0.0.0.0:8232"
-          rpc_enable_cookie_auth = false
-          storage_mode    = "archive"
-          v2_p2p          = true
-          legacy_p2p      = true
-          metrics_endpoint = "127.0.0.1:9999"
-          tracing_filter  = "info,zebra_network::zakura=info"
-          # Mainnet keeps checkpoint sync + the VCT fast-sync path (zakurad defaults).
-          checkpoint_sync = true
-          vct_fast_sync   = true
-          # Reuse the paths the hand-provisioned nodes already use so no node resyncs.
-          identity_dir    = "/root/.zakura"
-          state_cache_dir = "/root/.cache/zakura"
-          network_cache_dir = "/root/.cache/zakura"
-          # Move a pre-rename cache into place on first restart if it exists and the
-          # zakura target does not (mirrors the testnet zebra->zakura migration).
-          cache_dir_migrate_from = "/root/.cache/zebra"
-          log_file        = "/root/logs/zakura.log"
+          log_file        = "/root/logs/zebrad.log"
 
-          # The built-in mainnet Zakura bootstrap peers (zebra-network/src/zakura/
-          # handler.rs) are already correct, so we only pin the listen address.
+          # Public mainnet node ids (zebra-network/src/zakura/handler.rs). Used by
+          # the dashboard to label each host; not deployed to the nodes.
           [defaults.zakura]
-          listen_addr = "0.0.0.0:8234"
+          bootstrap_peers = [
+              "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+              "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+              "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+              "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+              "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+              "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+              "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+              "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+              "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+          ]
 
           [[nodes]]
           name       = "asia-0"

--- a/.github/workflows/zakura-mainnet-rollback.yml
+++ b/.github/workflows/zakura-mainnet-rollback.yml
@@ -1,0 +1,98 @@
+name: Rollback Zakura mainnet node
+
+# Emergency rollback for a single mainnet node: capture diagnostics, then restore
+# the previous binary from <bin_path>.bak (kept by the deploy workflow) and
+# restart the existing service. Runs on the zakura-mainnet-deployer runner and
+# SSHes to the target with the runner's identity.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ssh_target:
+        description: "root@<ip> of the node to roll back"
+        required: true
+        type: string
+        default: root@159.65.183.89
+      service:
+        description: "systemd service to restart"
+        required: false
+        type: string
+        default: zebrad
+      bin_path:
+        description: "binary path (its .bak is restored)"
+        required: false
+        type: string
+        default: /usr/local/bin/zebrad
+      restore_bak:
+        description: "Restore <bin_path>.bak (uncheck to only capture diagnostics)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zakura-mainnet-deploy
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    name: "Rollback ${{ inputs.ssh_target }}"
+    runs-on: [self-hosted, "${{ vars.ZAKURA_MAINNET_RUNNER_LABEL || 'zakura-mainnet-deployer' }}"]
+    timeout-minutes: 20
+    environment: zakura-mainnet
+
+    steps:
+      - name: Start SSH agent when deploy key is configured
+        env:
+          ZAKURA_MAINNET_DEPLOY_SSH_KEY: ${{ secrets.ZAKURA_MAINNET_DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ZAKURA_MAINNET_DEPLOY_SSH_KEY}" ]; then
+            echo "using the runner's existing SSH identity."
+            exit 0
+          fi
+          ssh_agent_sock="$RUNNER_TEMP/ssh-agent.sock"
+          ssh-agent -a "$ssh_agent_sock" > "$RUNNER_TEMP/ssh-agent.env"
+          SSH_AUTH_SOCK="$ssh_agent_sock" ssh-add - <<< "$ZAKURA_MAINNET_DEPLOY_SSH_KEY"
+          echo "SSH_AUTH_SOCK=$ssh_agent_sock" >> "$GITHUB_ENV"
+
+      - name: Pin host key
+        run: |
+          set -euo pipefail
+          host="$(echo '${{ inputs.ssh_target }}' | sed 's/.*@//')"
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keyscan -T 30 -H "$host" >> ~/.ssh/known_hosts 2>/dev/null || true
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Capture diagnostics
+        run: |
+          set -euo pipefail
+          ssh -o BatchMode=yes -o ConnectTimeout=20 '${{ inputs.ssh_target }}' \
+            "SERVICE='${{ inputs.service }}' BIN='${{ inputs.bin_path }}' bash -s" <<'EOF'
+          set -uo pipefail
+          echo "=== uptime / load ==="; uptime
+          echo "=== service ==="; systemctl show -p ActiveState -p SubState -p MainPID -p ActiveEnterTimestamp --value "$SERVICE"
+          echo "=== binaries ==="; ls -l "$BIN" "${BIN}.bak" 2>&1
+          echo "=== version ==="; "$BIN" --version 2>&1 | head -1
+          echo "=== recent journal ==="; journalctl -u "$SERVICE" -n 40 --no-pager 2>/dev/null | tail -40
+          echo "=== tail node log ==="; tail -n 60 /root/logs/zebrad.log 2>/dev/null
+          EOF
+
+      - name: Restore previous binary and restart
+        if: ${{ inputs.restore_bak }}
+        run: |
+          set -euo pipefail
+          ssh -o BatchMode=yes -o ConnectTimeout=20 '${{ inputs.ssh_target }}' \
+            "SERVICE='${{ inputs.service }}' BIN='${{ inputs.bin_path }}' bash -s" <<'EOF'
+          set -euo pipefail
+          if [ ! -x "${BIN}.bak" ]; then echo "no ${BIN}.bak to restore" >&2; exit 1; fi
+          systemctl stop "$SERVICE" || true
+          for _ in 1 2 3 4 5 6 7 8 9 10; do systemctl is-active --quiet "$SERVICE" || break; sleep 1; done
+          install -m 755 "${BIN}.bak" "$BIN"
+          systemctl start "$SERVICE"
+          sleep 3
+          systemctl is-active "$SERVICE"
+          echo "restored ${BIN}.bak; running:"; "$BIN" --version 2>&1 | head -1
+          EOF

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -173,8 +173,9 @@ and deploys it to:
 - `asia-south-0` — `root@139.59.64.115`
 - `asia-pacific-0` — `root@168.144.173.250`
 
-All nine are systemd-managed `zakurad.service` nodes. One-time runner bootstrap
-from an operator machine with SSH access and CI credentials in `~/agents-env`:
+All nine run a hand-provisioned `zebrad` systemd service. One-time runner
+bootstrap from an operator machine with SSH access and CI credentials in
+`~/agents-env`:
 
 ```bash
 cd deploy/deployer
@@ -182,32 +183,21 @@ cd deploy/deployer
 ```
 
 The workflow is manual (`workflow_dispatch`) with the same inputs as testnet
-(`ref` defaults to `main`, plus `force_rebuild`, `no_restart`, `node`). Its
-generated CI config uses Mainnet ports, public RPC at `0.0.0.0:8232`, and pins
-`identity_dir = "/root/.zakura"` so each node keeps its iroh node id (those node
-ids are the built-in mainnet Zakura bootstrap peers). It writes
-`/etc/zakura/zakura.toml` and points `state_cache_dir`/`network_cache_dir` at
-`/root/.cache/zakura` — the location the hand-provisioned nodes already use — so
-CI restarts against the existing database instead of resyncing. As on testnet, a
-`cache_dir_migrate_from = "/root/.cache/zebra"` is set: if an older pre-rename
-`zebra` cache exists and the `zakura` target does not, the deployer stops the
-node and moves the directory before starting. **Confirm each node's live
-`[state] cache_dir` before the first restart** — a mismatched path resyncs an
-archive node.
+(`ref` defaults to `main`, plus `force_rebuild`, `no_restart`, `node`).
 
-> One-time migration: the nodes were hand-provisioned with a `zebrad.service`
-> unit and `/usr/local/bin/zebrad`, plus a vestigial `10-vct-legacy.conf` drop-in
-> (`VCT_LEGACY=1`, unread by zakurad). Because the deployer installs the
-> standardized `zakurad.service` and does not touch the old unit, disable and
-> remove it on each node before the first restart deploy, or the old process
-> keeps the state DB locked:
->
-> ```bash
-> systemctl disable --now zebrad
-> rm -f /etc/systemd/system/zebrad.service \
->       /etc/systemd/system/zebrad.service.d/10-vct-legacy.conf
-> systemctl daemon-reload
-> ```
+**Binary-only deploy (`manage_config = false`).** The mainnet nodes were
+provisioned by hand with rich, per-node configs — `external_addr`, custom peers,
+mempool/sync tuning, and an inline `zakura_node_secret_key` that pins each node's
+iroh identity (the node ids hardcoded as bootstrap peers in
+`zebra-network/src/zakura/handler.rs`) — and their state DB lives at
+`/root/.cache/zebra`. Rendering the deployer's managed config over that would
+change every node id and drop the tuning. So the generated CI config sets
+`manage_config = false`: the deployer swaps `/usr/local/bin/zebrad` and restarts
+the existing `zebrad` service, leaving the config, unit, and cache untouched. The
+`rpc_listen_addr` / `log_file` / `[defaults.zakura] bootstrap_peers` in that
+config are read-only inputs for the dashboard's SSH probe, not deployed to nodes.
+Reproducing these configs in the deployer's managed model is separate future
+work.
 
 The workflow refreshes a fleet status dashboard on `us-east-0`:
 

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -147,6 +147,18 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
     with config_path.open("rb") as fh:
         data = tomllib.load(fh)
 
+    # Reject unknown keys so an intent like `manage_config = false` can never be
+    # silently dropped by an older deploy.py — that once turned a preserve-config
+    # deploy into a destructive one. `name`/`ssh_string`/`commit` are per-node only.
+    known_default_keys = set(DEFAULTS)
+    known_node_keys = known_default_keys | {"name", "ssh_string", "commit"}
+    unknown_defaults = set(data.get("defaults", {})) - known_default_keys
+    if unknown_defaults:
+        raise DeployError(
+            f"unknown key(s) in [defaults]: {', '.join(sorted(unknown_defaults))} "
+            f"(this deploy.py may be older than the config)"
+        )
+
     defaults = dict(DEFAULTS)
     defaults.update(data.get("defaults", {}))
 
@@ -160,6 +172,13 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
         for required in ("name", "ssh_string", "commit"):
             if required not in raw:
                 raise DeployError(f"node missing required field '{required}': {raw}")
+        unknown_node = set(raw) - known_node_keys
+        if unknown_node:
+            raise DeployError(
+                f"unknown key(s) in [[nodes]] {raw.get('name', '?')}: "
+                f"{', '.join(sorted(unknown_node))} "
+                f"(this deploy.py may be older than the config)"
+            )
         name = raw["name"]
         if name in seen:
             raise DeployError(f"duplicate node name: {name}")

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -40,6 +40,10 @@ SSH_COMMON_OPTS = [
 
 DEFAULTS = {
     "deploy_kind": "systemd",
+    # When false (systemd deploys only): leave the node's config, unit, and state
+    # cache untouched — just swap the binary and restart the existing service.
+    # For fleets provisioned outside the deployer with hand-tuned configs.
+    "manage_config": True,
     "service_name": "zakurad",
     "bin_path": "/usr/local/bin/zakurad",
     "config_path": "/etc/zakura/zakura.toml",
@@ -83,6 +87,7 @@ class Node:
     ssh_string: str
     commit: str
     deploy_kind: str
+    manage_config: bool
     service_name: str
     bin_path: str
     config_path: str
@@ -166,6 +171,7 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             ssh_string=merged["ssh_string"],
             commit=merged["commit"],
             deploy_kind=merged["deploy_kind"],
+            manage_config=merged["manage_config"],
             service_name=merged["service_name"],
             bin_path=merged["bin_path"],
             config_path=merged["config_path"],
@@ -576,6 +582,55 @@ fi
 """
 
 
+# Binary-only deploy (manage_config = false): swap the binary in place and
+# restart the existing service, leaving the node's config, unit, and state cache
+# untouched. Used for fleets provisioned outside the deployer.
+BINARY_ONLY_INSTALL_SCRIPT = r"""
+set -euo pipefail
+
+BIN_PATH={bin_path}
+SERVICE={service}
+NO_RESTART={no_restart}
+
+mkdir -p "$(dirname "$BIN_PATH")"
+
+if [ -x "$BIN_PATH" ]; then
+    cp -a "$BIN_PATH" "${{BIN_PATH}}.bak"
+fi
+install -m 755 /tmp/zakurad-deploy.new "$BIN_PATH"
+rm -f /tmp/zakurad-deploy.new
+
+if [ "$NO_RESTART" = "1" ]; then
+    echo "installed binary (restart skipped)"
+    exit 0
+fi
+
+restart_service() {{
+    systemctl stop "$SERVICE" || true
+    # Wait for the old process to release the state DB before starting again.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        systemctl is-active --quiet "$SERVICE" || break
+        sleep 1
+    done
+    systemctl start "$SERVICE"
+    sleep 3
+    systemctl is-active --quiet "$SERVICE"
+}}
+
+if ! restart_service; then
+    echo "service unhealthy after deploy; rolling back to ${{BIN_PATH}}.bak" >&2
+    if [ -x "${{BIN_PATH}}.bak" ]; then
+        install -m 755 "${{BIN_PATH}}.bak" "$BIN_PATH"
+        restart_service || true
+    fi
+    exit 1
+fi
+
+systemctl is-active "$SERVICE"
+"$BIN_PATH" --version || true
+"""
+
+
 def ssh_with_stdin(node: Node, script: str) -> subprocess.CompletedProcess:
     """Run an install script on the node via `ssh ... bash -s`, feeding it on stdin."""
     return subprocess.run(node.ssh_cmd("bash", "-s"), input=script, text=True)
@@ -612,6 +667,24 @@ def cmd_deploy(args) -> int:
         try:
             if node.deploy_kind not in ("systemd", "process"):
                 return (node.name, False, f"unknown deploy_kind: {node.deploy_kind}")
+
+            # Binary-only: don't render or ship a config/unit; just swap the
+            # binary and restart the existing service. Only meaningful for
+            # systemd nodes (the restart target is service_name).
+            if not node.manage_config:
+                if node.deploy_kind != "systemd":
+                    return (node.name, False, "manage_config=false requires deploy_kind=systemd")
+                run(node.scp_to(str(binary), "/tmp/zakurad-deploy.new"), capture=True)
+                script = BINARY_ONLY_INSTALL_SCRIPT.format(
+                    bin_path=shlex.quote(node.bin_path),
+                    service=shlex.quote(node.service_name),
+                    no_restart="1" if args.no_restart else "0",
+                )
+                proc = ssh_with_stdin(node, script)
+                if proc.returncode != 0:
+                    return (node.name, False, f"install/restart failed (rc={proc.returncode})")
+                return (node.name, True, f"deployed {node.sha[:9]} (binary-only)")
+
             cfg = render_node_config(node)
             cfg_tmp = BUILD_CACHE_DIR / f".cfg-{node.name}.toml"
             cfg_tmp.write_text(cfg)

--- a/deploy/deployer/nodes.example.toml
+++ b/deploy/deployer/nodes.example.toml
@@ -10,6 +10,8 @@ config_path     = "/etc/zakura/zakura.toml"
 log_file        = "/var/log/zakura/zakura.log"   # deterministic log path
 state_cache_dir = "/var/lib/zakura"
 cache_dir_migrate_from = ""                    # optional old cache dir to move during restart deploys
+# manage_config = true                       # false = only swap the binary + restart the existing
+#                                            # service, leaving config/unit/cache untouched (systemd only)
 network         = "Mainnet"
 listen_addr     = "[::]:8233"
 # identity_dir  = "/root/.zakura"           # empty = zakurad default; pins the iroh node_id


### PR DESCRIPTION
## Motivation

Deploying `main`'s managed config to the hand-provisioned mainnet nodes would change each node's identity and drop tuning. A test deploy also exposed a sharp edge: dispatched with the default `ref=main`, the workflow checked out **main's** `deploy.py` (no `manage_config` support), silently ignored the config's `manage_config = false`, and started us-east-0 into a **fresh empty DB** (sync from genesis) instead of a binary-only swap. Node recovered (real 257GB DB + identity intact); stray DB removed.

## Solution

- **Binary-only mode** (`manage_config = false`): swap the binary + restart the existing `zebrad` service, leaving config/unit/cache untouched. Mainnet workflow uses it.
- **Reject unknown config keys** in `deploy.py` — an intent like `manage_config = false` can never again be silently dropped by an older deploy.py.
- **Workflow fail-fast**: abort if the checked-out `deploy.py` lacks `manage_config` support (wrong ref).

The `zakura-mainnet-deploy` workflow is **disabled on main** until this merges.

### Tests
- `deploy.py` compiles; testnet (6) + mainnet (9) CI configs still load; unknown key now raises `DeployError`.
- Binary-only staging + restart both ran green via CI earlier; dashboard probes all 9 nodes.

### AI Disclosure
- [x] AI tools were used: Claude Code — implemented the mode, guards, and the node recovery.
