### PR TITLE
ci(zakura): persist CARGO_TARGET_DIR for mainnet deployer builds

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -55,6 +55,14 @@ jobs:
     timeout-minutes: 180
     environment: zakura-mainnet
 
+    # Persist Cargo build artifacts across runs, outside the checked-out workspace
+    # (which actions/checkout wipes). deploy.py builds each commit in a throwaway
+    # git worktree and honors CARGO_TARGET_DIR, so an unchanged commit relinks in
+    # seconds instead of a ~18-minute cold rebuild — essential for one-node-at-a-
+    # time fleet rollouts that all build the same tag.
+    env:
+      CARGO_TARGET_DIR: /root/.cache/zakura-deployer-target
+
     steps:
       - name: Checkout deploy ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4


### PR DESCRIPTION
## Motivation

Every `zakura-mainnet-deploy` dispatch does a ~18-minute cold Cargo build. `actions/checkout` wipes the deployer's in-workspace `.build-cache`, and Swatinem's cache doesn't cover the throwaway git worktree the deployer builds in — so nothing is reused. A one-node-at-a-time fleet rollout (9 dispatches, all building the same tag) becomes ~2.5h of rebuilds.

## Solution

Set a job-level `CARGO_TARGET_DIR` to a persistent path on the runner, outside the checked-out workspace. `deploy.py` already honors `CARGO_TARGET_DIR`, so an unchanged commit relinks in seconds instead of recompiling from scratch.

### Tests
- Workflow YAML validates.
- Being exercised live during the current mainnet one-by-one rollout (first build cold, subsequent same-tag builds fast).

### AI Disclosure
- [x] AI tools were used: Claude Code.
