### PR TITLE
ci(zakura): add fleet Slack watchdog

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -231,6 +231,15 @@ jobs:
 
           python3 deploy.py build "${args[@]}"
 
+      - name: Suppress fleet watchdog alerts during deploy
+        if: ${{ !inputs.no_restart }}
+        run: |
+          set -euo pipefail
+
+          sudo install -d -m 755 /run/zakura-fleet-watchdog
+          printf '%s\n' "$(( $(date +%s) + 1200 ))" \
+            | sudo tee /run/zakura-fleet-watchdog/deploy-suppressed-until >/dev/null
+
       - name: Deploy fleet
         working-directory: deploy/deployer
         run: |
@@ -293,6 +302,40 @@ jobs:
           sudo systemctl enable zakura-mainnet-dashboard.service
           sudo systemctl restart zakura-mainnet-dashboard.service
           sudo systemctl --no-pager --full status zakura-mainnet-dashboard.service || true
+
+      - name: Install fleet watchdog
+        if: always()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_WEB_HOOK: ${{ secrets.SLACK_WEB_HOOK }}
+        run: |
+          set -euo pipefail
+
+          watchdog_dir="/opt/zakura-fleet-watchdog"
+          sudo install -d -m 755 "$watchdog_dir"
+          sudo install -d -m 755 /var/lib/zakura-fleet-watchdog
+          sudo install -d -m 755 /etc/zakura-fleet-watchdog
+          sudo install -m 755 deploy/runner/zebra-cluster-watchdog.py "$watchdog_dir/zebra-cluster-watchdog.py"
+          sudo install -m 644 deploy/runner/fleet-watchdog.toml "$watchdog_dir/fleets.toml"
+          sudo install -m 644 deploy/runner/zakura-fleet-watchdog.service /etc/systemd/system/zakura-fleet-watchdog.service
+
+          tmp_env="$(mktemp)"
+          if [ -n "${SLACK_BOT_TOKEN}" ]; then
+            printf 'SLACK_BOT_TOKEN=%s\n' "${SLACK_BOT_TOKEN}" > "$tmp_env"
+          elif [ -n "${SLACK_WEB_HOOK}" ]; then
+            printf 'SLACK_WEB_HOOK=%s\n' "${SLACK_WEB_HOOK}" > "$tmp_env"
+          elif sudo test -f /etc/zakura-fleet-watchdog/env; then
+            sudo cp /etc/zakura-fleet-watchdog/env "$tmp_env"
+          else
+            : > "$tmp_env"
+          fi
+          sudo install -m 600 "$tmp_env" /etc/zakura-fleet-watchdog/env
+          rm -f "$tmp_env"
+
+          sudo systemctl daemon-reload
+          sudo systemctl enable zakura-fleet-watchdog.service
+          sudo systemctl restart zakura-fleet-watchdog.service
+          sudo systemctl --no-pager --full status zakura-fleet-watchdog.service || true
 
       - name: Fetch recent logs on failure
         if: failure()

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -101,7 +101,14 @@ jobs:
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           : > ~/.ssh/known_hosts
-          for host in 167.99.103.111 167.99.110.145 138.68.229.254 164.92.209.78 206.189.148.0 206.189.208.228; do
+          for host in \
+            167.99.103.111 \
+            167.99.110.145 \
+            138.68.229.254 \
+            164.92.209.78 \
+            206.189.148.0 \
+            206.189.208.228 \
+            159.65.183.89; do
             ssh-keyscan -T 30 -H "$host" >> ~/.ssh/known_hosts
           done
           chmod 600 ~/.ssh/known_hosts
@@ -216,6 +223,17 @@ jobs:
           fi
 
           python3 deploy.py build "${args[@]}"
+
+      - name: Suppress fleet watchdog alerts during deploy
+        if: ${{ !inputs.no_restart }}
+        run: |
+          set -euo pipefail
+
+          ssh_options=(-o BatchMode=yes -o ConnectTimeout=15)
+          if ! ssh "${ssh_options[@]}" root@159.65.183.89 \
+            'install -d -m 755 /run/zakura-fleet-watchdog && printf "%s\n" "$(( $(date +%s) + 1200 ))" > /run/zakura-fleet-watchdog/deploy-suppressed-until'; then
+            echo "warning: could not refresh fleet watchdog suppression on us-east-0"
+          fi
 
       - name: Deploy fleet
         working-directory: deploy/deployer

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -227,6 +227,51 @@ python3 deploy/runner/zebra-cluster-status.py \
   --upgrade-height 0
 ```
 
+The mainnet workflow also installs a Slack watchdog on `us-east-0`:
+
+- service: `zakura-fleet-watchdog.service`
+- install dir: `/opt/zakura-fleet-watchdog`
+- state file: `/var/lib/zakura-fleet-watchdog/state.json`
+- env file: `/etc/zakura-fleet-watchdog/env`
+- suppression file: `/run/zakura-fleet-watchdog/deploy-suppressed-until`
+
+The watchdog polls the mainnet dashboard locally at
+`http://127.0.0.1:8090/data` and the testnet dashboard at
+`http://167.99.103.111:8090/data`. It posts transition alerts to Slack
+`#gh-alerts` via either `SLACK_BOT_TOKEN` plus channel ID `C0BCQ7PP32A`, or an
+incoming webhook in `SLACK_WEB_HOOK` / `SLACK_WEBHOOK_URL`. A node alert fires
+when either of these conditions stays true for at least 10 minutes:
+
+- `health` is `down` or `rpc_error`
+- `seconds_since_advanced` is at least 600 seconds
+
+Down alerts take precedence over stalled alerts, so a node only produces one
+active alert at a time. The watchdog also alerts if a dashboard endpoint is
+unreachable for at least 10 minutes, and posts one recovery message when a node
+or dashboard recovers. Persistent failures do not post on every poll cycle.
+
+Restart deploys write a 20-minute suppression marker before touching the fleet.
+The mainnet workflow writes it locally on `us-east-0`; the testnet workflow
+refreshes it on `us-east-0` over SSH on a best-effort basis. While the marker is
+in the future, new failure alerts are logged but not posted to Slack.
+
+Manual dry run from `us-east-0`:
+
+```bash
+python3 /opt/zakura-fleet-watchdog/zebra-cluster-watchdog.py \
+  --config /opt/zakura-fleet-watchdog/fleets.toml \
+  --state-file /tmp/zakura-fleet-watchdog-state.json \
+  --once \
+  --dry-run
+```
+
+Local status checks:
+
+```bash
+systemctl status zakura-fleet-watchdog
+journalctl -u zakura-fleet-watchdog -f
+```
+
 ## How the build cache works
 
 `commit` is resolved to a full SHA (`git rev-parse`). The binary is cached at

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -1,0 +1,66 @@
+# Zakura Runner Services
+
+This directory contains helper services and scripts that run on Zakura deploy or
+benchmark hosts. The deploy workflows copy the tracked service files here onto
+the self-hosted runners.
+
+## Fleet Slack Watchdog
+
+`zebra-cluster-watchdog.py` is a small stdlib-only Python service that polls the
+mainnet and testnet cluster status dashboards and posts Slack transition alerts
+when a fleet node remains unhealthy.
+
+It is installed by `.github/workflows/zakura-mainnet-deploy.yml` on `us-east-0`:
+
+- systemd service: `zakura-fleet-watchdog.service`
+- install dir: `/opt/zakura-fleet-watchdog`
+- config: `/opt/zakura-fleet-watchdog/fleets.toml`
+- state: `/var/lib/zakura-fleet-watchdog/state.json`
+- Slack env: `/etc/zakura-fleet-watchdog/env`
+- deploy suppression marker: `/run/zakura-fleet-watchdog/deploy-suppressed-until`
+
+The default config in `fleet-watchdog.toml` watches:
+
+- mainnet: `http://127.0.0.1:8090/data`
+- testnet: `http://167.99.103.111:8090/data`
+
+Alerts fire only after a sustained condition:
+
+- `health` is `down` or `rpc_error` for at least 10 minutes
+- `seconds_since_advanced` is at least 600 seconds for at least 10 minutes
+- a dashboard endpoint is unreachable for at least 10 minutes
+
+Down alerts take precedence over stalled alerts, so each node has at most one
+active alert. The watchdog posts only on transitions: first failure after the
+threshold, then recovery. Persistent failures do not post every poll.
+
+Slack delivery supports either:
+
+- `SLACK_BOT_TOKEN` with channel ID `C0BCQ7PP32A`
+- an incoming webhook in `SLACK_WEB_HOOK`, `SLACK_WEBHOOK_URL`, or
+  `SLACK_WEBHOOK`
+
+Do not commit real Slack credentials. Install them on the runner in
+`/etc/zakura-fleet-watchdog/env` with mode `600`, or provide the corresponding
+GitHub Actions environment secret so the deploy workflow writes the env file.
+
+Manual checks on `us-east-0`:
+
+```bash
+systemctl status zakura-fleet-watchdog
+journalctl -u zakura-fleet-watchdog -f
+```
+
+One-shot dry run:
+
+```bash
+python3 /opt/zakura-fleet-watchdog/zebra-cluster-watchdog.py \
+  --config /opt/zakura-fleet-watchdog/fleets.toml \
+  --state-file /tmp/zakura-fleet-watchdog-state.json \
+  --once \
+  --dry-run
+```
+
+During restart deploys, the workflows write a Unix timestamp 20 minutes in the
+future to `/run/zakura-fleet-watchdog/deploy-suppressed-until`. While that marker
+is active, new failure alerts are logged locally but not posted to Slack.

--- a/deploy/runner/fleet-watchdog.toml
+++ b/deploy/runner/fleet-watchdog.toml
@@ -1,0 +1,9 @@
+[[fleets]]
+name = "testnet"
+url = "http://167.99.103.111:8090/data"
+dashboard_url = "http://167.99.103.111:8090/"
+
+[[fleets]]
+name = "mainnet"
+url = "http://127.0.0.1:8090/data"
+dashboard_url = "http://159.65.183.89:8090/"

--- a/deploy/runner/zakura-fleet-watchdog.service
+++ b/deploy/runner/zakura-fleet-watchdog.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Zakura fleet Slack watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/zakura-fleet-watchdog
+EnvironmentFile=-/etc/zakura-fleet-watchdog/env
+StateDirectory=zakura-fleet-watchdog
+RuntimeDirectory=zakura-fleet-watchdog
+ExecStart=/usr/bin/python3 /opt/zakura-fleet-watchdog/zebra-cluster-watchdog.py --config /opt/zakura-fleet-watchdog/fleets.toml --state-file /var/lib/zakura-fleet-watchdog/state.json --interval 60 --down-after 600 --stalled-after 600 --dashboard-down-after 600
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/runner/zebra-cluster-watchdog.py
+++ b/deploy/runner/zebra-cluster-watchdog.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Slack watchdog for Zakura fleet status dashboards.
+
+Polls one or more `zebra-cluster-status.py` `/data` endpoints, tracks sustained
+node failures in a small JSON state file, and posts transition alerts to Slack.
+
+Only the Python stdlib is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import tomllib
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SLACK_CHANNEL = "C0BCQ7PP32A"
+DOWN_HEALTH = {"down", "rpc_error"}
+STATE_VERSION = 1
+
+
+@dataclass(frozen=True)
+class Fleet:
+    name: str
+    url: str
+    dashboard_url: str
+
+
+def load_fleets(config_path: Path) -> list[Fleet]:
+    with config_path.open("rb") as config_file:
+        data = tomllib.load(config_file)
+
+    fleets = []
+    seen = set()
+    for raw in data.get("fleets", []):
+        for required in ("name", "url"):
+            if required not in raw:
+                raise SystemExit(f"fleet missing required field '{required}': {raw}")
+
+        name = str(raw["name"])
+        if name in seen:
+            raise SystemExit(f"duplicate fleet name: {name}")
+        seen.add(name)
+
+        url = str(raw["url"])
+        dashboard_url = str(raw.get("dashboard_url") or url.removesuffix("/data"))
+        fleets.append(Fleet(name=name, url=url, dashboard_url=dashboard_url))
+
+    if not fleets:
+        raise SystemExit(f"no [[fleets]] defined in {config_path}")
+
+    return fleets
+
+
+def load_state(state_path: Path) -> dict[str, Any]:
+    if not state_path.exists():
+        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+
+    with state_path.open(encoding="utf-8") as state_file:
+        state = json.load(state_file)
+
+    if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
+        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+
+    state.setdefault("nodes", {})
+    state.setdefault("fleets", {})
+    return state
+
+
+def save_state(state_path: Path, state: dict[str, Any]) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = state_path.with_suffix(f"{state_path.suffix}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as state_file:
+        json.dump(state, state_file, indent=2, sort_keys=True)
+        state_file.write("\n")
+    tmp_path.replace(state_path)
+
+
+def fetch_json(url: str, timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = response.read()
+
+    decoded = json.loads(body.decode("utf-8"))
+    if not isinstance(decoded, dict):
+        raise ValueError(f"expected JSON object from {url}")
+    return decoded
+
+
+def coerce_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def format_duration(seconds: float) -> str:
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+
+    minutes, seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m" if seconds == 0 else f"{minutes}m {seconds}s"
+
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h" if minutes == 0 else f"{hours}h {minutes}m"
+
+
+def suppression_until(path: Path) -> float | None:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        print(f"warning: could not read suppression file {path}: {error}", file=sys.stderr)
+        return None
+
+    try:
+        return float(raw)
+    except ValueError:
+        print(f"warning: invalid suppression timestamp in {path}: {raw}", file=sys.stderr)
+        return None
+
+
+def post_slack(text: str, args: argparse.Namespace) -> bool:
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    webhook = (
+        os.environ.get("SLACK_WEBHOOK_URL", "")
+        or os.environ.get("SLACK_WEB_HOOK", "")
+        or os.environ.get("SLACK_WEBHOOK", "")
+    )
+    if args.dry_run:
+        print(f"dry-run Slack message:\n{text}\n")
+        return True
+
+    if webhook:
+        return post_slack_webhook(webhook, text, args)
+
+    if not token:
+        print(f"Slack credential not set; would post:\n{text}\n")
+        return True
+
+    payload = json.dumps({"channel": args.slack_channel, "text": text}).encode("utf-8")
+    request = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=args.slack_timeout) as response:
+            body = response.read()
+    except (OSError, urllib.error.URLError) as error:
+        print(f"Slack post failed: {error}", file=sys.stderr)
+        return False
+
+    try:
+        decoded = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as error:
+        print(f"Slack returned invalid JSON: {error}", file=sys.stderr)
+        return False
+
+    if not decoded.get("ok"):
+        print(f"Slack post failed: {decoded}", file=sys.stderr)
+        return False
+
+    return True
+
+
+def post_slack_webhook(webhook: str, text: str, args: argparse.Namespace) -> bool:
+    payload = json.dumps({"text": text}).encode("utf-8")
+    request = urllib.request.Request(
+        webhook,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=args.slack_timeout) as response:
+            body = response.read().decode("utf-8", errors="replace").strip()
+    except (OSError, urllib.error.URLError) as error:
+        print(f"Slack webhook post failed: {error}", file=sys.stderr)
+        return False
+
+    if response.status < 200 or response.status >= 300 or body != "ok":
+        print(
+            f"Slack webhook post failed: status={response.status} body={body}",
+            file=sys.stderr,
+        )
+        return False
+
+    return True
+
+
+def node_condition(
+    row: dict[str, Any],
+    now: float,
+    grace_since: float,
+    args: argparse.Namespace,
+) -> tuple[str, float, float]:
+    health = str(row.get("health") or "unknown")
+    seconds_since_advanced = coerce_float(row.get("seconds_since_advanced"))
+
+    if health == "starting" and now - grace_since < args.starting_grace:
+        return ("ok", now, 0)
+
+    if health in DOWN_HEALTH:
+        return ("down", now, args.down_after)
+
+    if (
+        seconds_since_advanced is not None
+        and seconds_since_advanced >= args.stalled_after
+    ):
+        return ("stalled", now - seconds_since_advanced, args.stalled_after)
+
+    return ("ok", now, 0)
+
+
+def update_alert_state(
+    state_bucket: dict[str, Any],
+    key: str,
+    condition: str,
+    bad_since: float,
+    threshold: float,
+    alert_text: str,
+    recovery_text: str,
+    now: float,
+    suppressed: bool,
+    args: argparse.Namespace,
+) -> None:
+    entry = state_bucket.get(key, {"condition": "ok", "alerting": False})
+    was_alerting = bool(entry.get("alerting"))
+
+    if condition == "ok":
+        if was_alerting:
+            if post_slack(recovery_text, args):
+                state_bucket[key] = {"condition": "ok", "alerting": False}
+            return
+
+        state_bucket[key] = {"condition": "ok", "alerting": False}
+        return
+
+    if entry.get("condition") == condition:
+        bad_since = min(float(entry.get("bad_since", bad_since)), bad_since)
+        alerting = was_alerting
+    else:
+        alerting = False
+
+    age = now - bad_since
+    next_entry = {
+        "condition": condition,
+        "bad_since": bad_since,
+        "alerting": alerting,
+        "last_seen": now,
+    }
+
+    if not alerting and age >= threshold:
+        if suppressed:
+            print(f"suppressed alert for {key}: {condition} for {format_duration(age)}")
+        elif post_slack(alert_text, args):
+            next_entry["alerting"] = True
+            next_entry["last_alert_at"] = now
+
+    state_bucket[key] = next_entry
+
+
+def node_alert_text(fleet: Fleet, row: dict[str, Any], condition: str, age: float) -> str:
+    name = row.get("name") or "unknown"
+    health = row.get("health") or "unknown"
+    height = row.get("height")
+    detail = row.get("detail") or "no detail"
+    height_text = str(height) if height is not None else "-"
+
+    return (
+        f":rotating_light: *Zakura {fleet.name}* - `{name}` {condition} "
+        f"for {format_duration(age)}\n"
+        f"health: {health} - height: {height_text} - detail: {detail}\n"
+        f"dashboard: {fleet.dashboard_url}"
+    )
+
+
+def node_recovery_text(fleet: Fleet, row: dict[str, Any], previous: dict[str, Any]) -> str:
+    name = row.get("name") or "unknown"
+    condition = previous.get("condition") or "unhealthy"
+    height = row.get("height")
+    height_text = str(height) if height is not None else "-"
+
+    return (
+        f":white_check_mark: *Zakura {fleet.name}* - `{name}` recovered "
+        f"from {condition}\n"
+        f"health: {row.get('health') or 'unknown'} - height: {height_text}\n"
+        f"dashboard: {fleet.dashboard_url}"
+    )
+
+
+def fleet_alert_text(fleet: Fleet, error: Exception, age: float) -> str:
+    return (
+        f":rotating_light: *Zakura {fleet.name}* dashboard unreachable "
+        f"for {format_duration(age)}\n"
+        f"endpoint: {fleet.url}\n"
+        f"error: {error}"
+    )
+
+
+def fleet_recovery_text(fleet: Fleet, previous: dict[str, Any]) -> str:
+    condition = previous.get("condition") or "unreachable"
+    return (
+        f":white_check_mark: *Zakura {fleet.name}* dashboard recovered "
+        f"from {condition}\n"
+        f"endpoint: {fleet.url}"
+    )
+
+
+class Watchdog:
+    def __init__(self, fleets: list[Fleet], args: argparse.Namespace):
+        self.fleets = fleets
+        self.args = args
+        self.started_at = time.time()
+        self.fetch_recovered_at: dict[str, float] = {}
+
+    def run_once(self, state: dict[str, Any]) -> None:
+        now = time.time()
+        suppressed_until = suppression_until(self.args.suppression_file)
+        suppressed = suppressed_until is not None and suppressed_until > now
+
+        for fleet in self.fleets:
+            try:
+                snapshot = fetch_json(fleet.url, self.args.request_timeout)
+            except Exception as error:
+                self.handle_fleet_error(state, fleet, error, now, suppressed)
+                continue
+
+            self.handle_fleet_recovered(state, fleet, now)
+            rows = snapshot.get("rows", [])
+            if not isinstance(rows, list):
+                rows = []
+
+            for row in rows:
+                if isinstance(row, dict):
+                    self.handle_node(state, fleet, row, now, suppressed)
+
+    def handle_fleet_error(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        error: Exception,
+        now: float,
+        suppressed: bool,
+    ) -> None:
+        key = fleet.name
+        bucket = state.setdefault("fleets", {})
+        entry = bucket.get(key, {})
+        bad_since = (
+            float(entry.get("bad_since", now))
+            if entry.get("condition") == "unreachable"
+            else now
+        )
+        age = now - bad_since
+        update_alert_state(
+            bucket,
+            key,
+            "unreachable",
+            bad_since,
+            self.args.dashboard_down_after,
+            fleet_alert_text(fleet, error, age),
+            fleet_recovery_text(fleet, entry),
+            now,
+            suppressed,
+            self.args,
+        )
+
+    def handle_fleet_recovered(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        now: float,
+    ) -> None:
+        key = fleet.name
+        bucket = state.setdefault("fleets", {})
+        previous = dict(bucket.get(key, {}))
+        if previous.get("condition") == "unreachable":
+            self.fetch_recovered_at[fleet.name] = now
+
+        update_alert_state(
+            bucket,
+            key,
+            "ok",
+            now,
+            0,
+            "",
+            fleet_recovery_text(fleet, previous),
+            now,
+            False,
+            self.args,
+        )
+
+    def handle_node(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        row: dict[str, Any],
+        now: float,
+        suppressed: bool,
+    ) -> None:
+        node_name = str(row.get("name") or "unknown")
+        key = f"{fleet.name}/{node_name}"
+        bucket = state.setdefault("nodes", {})
+        previous = dict(bucket.get(key, {}))
+        grace_since = max(self.started_at, self.fetch_recovered_at.get(fleet.name, 0))
+        condition, bad_since, threshold = node_condition(row, now, grace_since, self.args)
+        if condition != "ok" and previous.get("condition") == condition:
+            bad_since = min(float(previous.get("bad_since", bad_since)), bad_since)
+        age = now - bad_since
+
+        update_alert_state(
+            bucket,
+            key,
+            condition,
+            bad_since,
+            threshold,
+            node_alert_text(fleet, row, condition, age),
+            node_recovery_text(fleet, row, previous),
+            now,
+            suppressed,
+            self.args,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Alert Slack when Zakura fleet dashboard nodes stay unhealthy."
+    )
+    parser.add_argument("--config", required=True, type=Path, help="fleet TOML config")
+    parser.add_argument(
+        "--state-file",
+        type=Path,
+        default=Path("/var/lib/zakura-fleet-watchdog/state.json"),
+        help="JSON file used to persist alert state",
+    )
+    parser.add_argument("--interval", type=float, default=60.0, help="poll interval seconds")
+    parser.add_argument(
+        "--down-after",
+        type=float,
+        default=600.0,
+        help="alert after down/rpc_error has persisted this many seconds",
+    )
+    parser.add_argument(
+        "--stalled-after",
+        type=float,
+        default=600.0,
+        help="alert after no block progress for this many seconds",
+    )
+    parser.add_argument(
+        "--dashboard-down-after",
+        type=float,
+        default=600.0,
+        help="alert after a dashboard fetch failure persists this many seconds",
+    )
+    parser.add_argument(
+        "--starting-grace",
+        type=float,
+        default=120.0,
+        help="ignore starting nodes for this many seconds after startup or fetch recovery",
+    )
+    parser.add_argument(
+        "--suppression-file",
+        type=Path,
+        default=Path("/run/zakura-fleet-watchdog/deploy-suppressed-until"),
+        help="Unix timestamp file that suppresses failure alerts while in the future",
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=20.0,
+        help="dashboard request timeout seconds",
+    )
+    parser.add_argument(
+        "--slack-timeout",
+        type=float,
+        default=20.0,
+        help="Slack API request timeout seconds",
+    )
+    parser.add_argument(
+        "--slack-channel",
+        default=os.environ.get("SLACK_CHANNEL_ID", DEFAULT_SLACK_CHANNEL),
+        help="Slack channel ID for alerts",
+    )
+    parser.add_argument("--once", action="store_true", help="poll once, update state, and exit")
+    parser.add_argument("--dry-run", action="store_true", help="log Slack messages instead")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    fleets = load_fleets(args.config)
+    watchdog = Watchdog(fleets, args)
+
+    while True:
+        state = load_state(args.state_file)
+        watchdog.run_once(state)
+        save_state(args.state_file, state)
+
+        if args.once:
+            return 0
+
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Motivation

Create persistent alerts for the Zakura mainnet and testnet fleets when a node is down, has RPC errors, or stops advancing for a sustained period. The existing dashboards already expose this health data, but there was no continuous alert path to `#gh-alerts`.

## Solution

- Add a stdlib-only fleet watchdog that polls the mainnet and testnet dashboard `/data` endpoints, persists per-node alert state, and sends one Slack alert on failure and one on recovery.
- Support both Slack bot-token delivery and incoming webhooks, with deploy suppression during restart deploys.
- Install the watchdog from the mainnet deploy workflow and refresh suppression from both deploy workflows.
- Document the service, thresholds, manual dry-run command, and operational status checks.

### Tests

- `python3` AST syntax check for `deploy/runner/zebra-cluster-watchdog.py`
- `python3 deploy/runner/zebra-cluster-watchdog.py --config deploy/runner/fleet-watchdog.toml --state-file /tmp/zakura-fleet-watchdog-pr-state.json --once --dry-run`
- `git diff --check`
- `ReadLints` for the changed workflow, Python, and README files
- Deployed manually to `us-east-0`; verified `zakura-fleet-watchdog.service` is active, dashboard polling writes state, remote dry-run succeeds, and the deployed webhook send path returns `post_slack_ok=true`

Markdown lint was not run locally because `markdownlint`, `markdownlint-cli`, `npx`, `npm`, `pnpm`, `yarn`, and `mdl` are unavailable on this machine.

### Specifications & References

Uses the existing Zakura cluster dashboard JSON fields: `health`, `height`, `seconds_since_advanced`, and `detail`.

### Follow-up Work

- Add `SLACK_WEB_HOOK` or `SLACK_BOT_TOKEN` as the mainnet environment secret so future workflow installs can refresh the remote env file automatically.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor/GPT for implementation assistance, deployment checks, and PR description drafting.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in chat with the repository owner/operator beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. Changelog not updated because this is internal deploy tooling, not a user-visible node behavior change.