### PR TITLE
chore(installer): bump release pins to v0.0.1-alpha.5

### DIFF
--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -11,16 +11,16 @@ fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UNITY_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
 
-ZAKURA_RELEASE_TAG="v0.0.1-alpha.3"
+ZAKURA_RELEASE_TAG="v0.0.1-alpha.5"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
 # sha256 of ZAKURA_ARCHIVE from the release's SHA256SUMS.txt. Pin it once the
 # zakurad-named release artifact is published: an unpinned download in a
 # `curl | bash` installer is a supply-chain hole. Empty = skip verification.
-ZAKURA_ARCHIVE_SHA256="ddee615b96e5d6bd3668eefc8a8eeec038b43293c52682dc8e68403c032df1a9"
+ZAKURA_ARCHIVE_SHA256=""
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="valargroup/zakura:0.0.1-alpha.3"
-ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-0.0.1-alpha.3"
+ZAKURA_DOCKER_IMAGE="valargroup/zakura:0.0.1-alpha.5"
+ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-0.0.1-alpha.5"
 ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="valargroup/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 ZAKURA_DOCKER_RUNTIME_UID=10001
@@ -139,6 +139,14 @@ print_section() {
     printf '%s\n' "$(style "$DIM" "----------------------------------------")"
   else
     printf '\n%s\n' "$title"
+  fi
+}
+
+print_release_target() {
+  if ((USE_ANSI)); then
+    printf '\n%s Zakura release %s\n' "$(style "$BLUE" "[info]")" "$(style "$BOLD" "$ZAKURA_RELEASE_TAG")"
+  else
+    printf '\nZakura release %s\n' "$ZAKURA_RELEASE_TAG"
   fi
 }
 
@@ -2504,6 +2512,7 @@ done
 
 resolve_install_profile
 finalize_checks
+print_release_target
 
 case "$INSTALL_PROFILE" in
   default)


### PR DESCRIPTION
## Motivation

The installer still pinned `v0.0.1-alpha.3` release artifacts and Docker images, which are behind the current release line and caused operators to pull binaries without network-aware zcashd-compat preflight checks (for example, mainnet disk recommendations on testnet).

## Solution

- Bump default release pins in `scripts/install-zakura.sh` to `v0.0.1-alpha.5` (binary URL, Docker images).
- Clear `ZAKURA_ARCHIVE_SHA256` so the release workflow can pin the checksum when `v0.0.1-alpha.5` assets are published.
- Print the target release tag at installer startup via `print_release_target()`.

## Test plan

- [x] `bash scripts/install-zakura.sh --self-test-disk-limits`
- [x] `bash scripts/install-zakura.sh --install-profile zcashd-compat --mode docker-supervised --network Testnet --non-interactive --dry-run` (shows `Zakura release v0.0.1-alpha.5` and testnet-appropriate disk checks)
- [ ] Full binary download / Docker pull after `v0.0.1-alpha.5` release assets are published

## Follow-up Work

Publish `v0.0.1-alpha.5` via `release-binaries` so the updated installer pins resolve to published artifacts.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor for the installer pin bump and startup banner