### PR TITLE
fix(zcashd-compat): always gossip blocks to sidecar peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,6 +422,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   for the supervisor task before abandoning it. An interrupted shutdown was
   able to silently discard hours of ingested chainstate and force a long
   replay on the next start.
+- Always include configured `zcashd_compat.block_gossip_peer_ips` in block
+  inventory gossip, preventing pinned zcashd-compat peers from stalling when
+  normal fractional peer sampling misses them.
 - Make `zebra-rollback-state` rollback existing v5 databases without replaying
   note commitment trees from genesis for modern rollback targets whose removed
   blocks did not change the Sprout tree. If rolled-back blocks contain Sprout

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -186,6 +186,20 @@ when Zakura listens on an unspecified address. Set
 `zcashd_compat.p2p_connect_addr` when zcashd must reach Zakura through a
 different address (for example across containers).
 
+When `zcashd_compat.enabled = true`, Zakura always includes inbound sidecar
+peers in block inventory gossip, so zcashd does not depend on random peer
+sampling to learn about new blocks. If `block_gossip_peer_ips` is empty, Zakura
+defaults it to loopback addresses. For an externally managed sidecar that
+connects from another local or private IP, enable zcashd-compat without
+supervision and configure that address explicitly:
+
+```toml
+[zcashd_compat]
+enabled = true
+manage_zcashd = false
+block_gossip_peer_ips = ["127.0.0.1"]
+```
+
 zcashd-compat mode requires `network.legacy_p2p = true` (the default):
 zcashd speaks the legacy Zcash P2P protocol, and startup fails if the legacy
 listener is disabled. This is independent of Zakura's native P2P endpoint

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -25,8 +25,8 @@ use zebra_chain::block::Height;
 use crate::{
     constants,
     peer::{
-        error::SharedPeerError, CancelHeartbeatTask, Client, ClientRequest, ConnectionInfo,
-        ErrorSlot,
+        error::SharedPeerError, CancelHeartbeatTask, Client, ClientRequest, ConnectedAddr,
+        ConnectionInfo, ErrorSlot,
     },
     peer_set::InventoryChange,
     protocol::{
@@ -62,6 +62,7 @@ impl ClientTestHarness {
             version: None,
             connection_task: None,
             heartbeat_task: None,
+            connected_addr: None,
         }
     }
 
@@ -251,6 +252,7 @@ pub struct ClientTestHarnessBuilder<C = future::Ready<()>, H = future::Ready<()>
     connection_task: Option<C>,
     heartbeat_task: Option<H>,
     version: Option<Version>,
+    connected_addr: Option<ConnectedAddr>,
 }
 
 impl<C, H> ClientTestHarnessBuilder<C, H>
@@ -264,6 +266,12 @@ where
         self
     }
 
+    /// Configure the mocked connection address metadata for the peer.
+    pub fn with_connected_addr(mut self, connected_addr: ConnectedAddr) -> Self {
+        self.connected_addr = Some(connected_addr);
+        self
+    }
+
     /// Configure the mock connection task future to use.
     pub fn with_connection_task<NewC>(
         self,
@@ -273,6 +281,7 @@ where
             connection_task: Some(connection_task),
             heartbeat_task: self.heartbeat_task,
             version: self.version,
+            connected_addr: self.connected_addr,
         }
     }
 
@@ -285,6 +294,7 @@ where
             connection_task: self.connection_task,
             heartbeat_task: Some(heartbeat_task),
             version: self.version,
+            connected_addr: self.connected_addr,
         }
     }
 
@@ -324,7 +334,7 @@ where
         };
 
         let connection_info = Arc::new(ConnectionInfo {
-            connected_addr: crate::peer::ConnectedAddr::Isolated,
+            connected_addr: self.connected_addr.unwrap_or(ConnectedAddr::Isolated),
             local: remote.clone(),
             remote,
             negotiated_version,

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -2,6 +2,7 @@
 //! reported protocol version.
 
 use std::{
+    net::IpAddr,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -13,7 +14,7 @@ use tower::{
 
 use crate::{
     constants::{EWMA_DECAY_TIME_NANOS, EWMA_DEFAULT_RTT},
-    peer::{Client, ConnectionInfo},
+    peer::{Client, ConnectedAddr, ConnectionInfo},
     protocol::external::types::Version,
 };
 
@@ -52,6 +53,15 @@ impl LoadTrackedClient {
     /// Retrieve the peer's reported protocol version.
     pub fn remote_version(&self) -> Version {
         self.connection_info.remote.version
+    }
+
+    /// Returns true if this peer connected directly to us from `ip`.
+    pub fn is_inbound_direct_from_ip(&self, ip: &IpAddr) -> bool {
+        matches!(
+            self.connection_info.connected_addr,
+            ConnectedAddr::InboundDirect { addr }
+                if addr.remove_socket_addr_privacy().ip() == *ip
+        )
     }
 }
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -117,6 +117,7 @@ where
         latest_chain_tip,
         user_agent,
         advertised_services,
+        Vec::new(),
         None,
     )
     .await;
@@ -131,6 +132,7 @@ pub async fn init_with_zakura_header_sync<S, C>(
     latest_chain_tip: C,
     user_agent: String,
     advertised_services: PeerServices,
+    block_gossip_peer_ips: Vec<IpAddr>,
     header_sync_driver_startup: Option<crate::zakura::ZakuraHeaderSyncDriverStartup>,
 ) -> (
     Buffer<BoxService<Request, Response, BoxError>, Request>,
@@ -284,6 +286,7 @@ where
     // Connect the rx end to a PeerSet, wrapping new peers in load instruments.
     let peer_set = PeerSet::new(
         &config,
+        block_gossip_peer_ips,
         discovered_peers,
         demand_tx.clone(),
         handle_rx,

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -244,6 +244,9 @@ where
         HashSet<D::Key>,
     )>,
 
+    /// Inbound peer IPs that must always receive block inventory broadcasts.
+    block_gossip_peer_ips: HashSet<IpAddr>,
+
     // Peer Tracking: Busy Peers
     //
     /// Connected peers that are handling a Zebra request,
@@ -324,6 +327,7 @@ where
     ///
     /// Arguments:
     /// - `config`: configures the peer set connection limit;
+    /// - `block_gossip_peer_ips`: inbound peer IPs that must always receive block inventory broadcasts.
     /// - `discover`: handles peer connects and disconnects;
     /// - `demand_signal`: requests more peers when all peers are busy (unready);
     /// - `handle_rx`: receives background task handles,
@@ -339,6 +343,7 @@ where
     ///   [`crate::constants::DEFAULT_MAX_CONNS_PER_IP`].
     pub fn new(
         config: &Config,
+        block_gossip_peer_ips: Vec<IpAddr>,
         discover: D,
         demand_signal: mpsc::Sender<MorePeers>,
         handle_rx: tokio::sync::oneshot::Receiver<Vec<JoinHandle<Result<(), BoxError>>>>,
@@ -366,6 +371,7 @@ where
             // Request Routing
             inventory_registry: InventoryRegistry::new(inv_stream),
             queued_broadcast_all: None,
+            block_gossip_peer_ips: block_gossip_peer_ips.into_iter().collect(),
 
             // Busy peers
             unready_services: FuturesUnordered::new(),
@@ -926,6 +932,36 @@ where
             .choose_multiple(&mut rand::thread_rng(), max_peers)
     }
 
+    /// Randomly chooses ready peers for block gossip, always including configured
+    /// zcashd compat sidecar peers.
+    fn select_block_broadcast_peers(&self, max_peers: usize) -> Vec<D::Key> {
+        use rand::seq::IteratorRandom;
+
+        let mut selected_peers: Vec<_> = self
+            .ready_services
+            .iter()
+            .filter_map(|(key, service)| self.is_zcashd_compat_peer(service).then_some(*key))
+            .collect();
+
+        let zcashd_compat_peers: HashSet<_> = selected_peers.iter().copied().collect();
+        selected_peers.extend(
+            self.ready_services
+                .keys()
+                .filter(|key| !zcashd_compat_peers.contains(key))
+                .copied()
+                .choose_multiple(&mut rand::thread_rng(), max_peers),
+        );
+
+        selected_peers
+    }
+
+    /// Returns true if `service` is a configured zcashd sidecar peer.
+    fn is_zcashd_compat_peer(&self, service: &D::Service) -> bool {
+        self.block_gossip_peer_ips
+            .iter()
+            .any(|ip| service.is_inbound_direct_from_ip(ip))
+    }
+
     /// Accesses a ready endpoint by `key` and returns its current load.
     ///
     /// Returns `None` if the service is not in the ready service list.
@@ -1144,6 +1180,12 @@ where
     fn route_broadcast(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
         // Broadcasts ignore the response
         self.route_multiple(req, self.number_of_peers_to_broadcast())
+    }
+
+    /// Broadcasts a block inventory request to sampled peers and configured sidecars.
+    fn route_block_broadcast(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
+        let selected_peers = self.select_block_broadcast_peers(self.number_of_peers_to_broadcast());
+        self.send_multiple(req, selected_peers)
     }
 
     /// Broadcasts the same request to all ready peers, ignoring return values.
@@ -1440,7 +1482,7 @@ where
 
             // Broadcast advertisements to lots of peers
             Request::AdvertiseTransactionIds(_, _) => self.route_broadcast(req),
-            Request::AdvertiseBlock(_, _) => self.route_broadcast(req),
+            Request::AdvertiseBlock(_, _) => self.route_block_broadcast(req),
             Request::AdvertiseBlockToAll(_) => self.broadcast_all(req),
 
             // Choose a random less-loaded peer for all other requests

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -2,7 +2,10 @@
 
 #![allow(clippy::unwrap_in_result)]
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 
 use futures::{channel::mpsc, stream, Stream, StreamExt};
 use proptest::{collection::vec, prelude::*};
@@ -121,6 +124,7 @@ struct PeerSetBuilder<D, C> {
     address_book: Option<Arc<std::sync::Mutex<AddressBook>>>,
     minimum_peer_version: Option<MinimumPeerVersion<C>>,
     max_conns_per_ip: Option<usize>,
+    block_gossip_peer_ips: Vec<IpAddr>,
 }
 
 impl PeerSetBuilder<(), ()> {
@@ -131,6 +135,39 @@ impl PeerSetBuilder<(), ()> {
 }
 
 impl<D, C> PeerSetBuilder<D, C> {
+    /// Use the provided [`Config`] when constructing the [`PeerSet`] instance.
+    pub fn with_config(self, config: Config) -> PeerSetBuilder<D, C> {
+        PeerSetBuilder {
+            config: Some(config),
+            discover: self.discover,
+            demand_signal: self.demand_signal,
+            handle_rx: self.handle_rx,
+            inv_stream: self.inv_stream,
+            address_book: self.address_book,
+            minimum_peer_version: self.minimum_peer_version,
+            max_conns_per_ip: self.max_conns_per_ip,
+            block_gossip_peer_ips: self.block_gossip_peer_ips,
+        }
+    }
+
+    /// Always include these inbound peer IPs in block inventory broadcasts.
+    pub fn with_block_gossip_peer_ips(
+        self,
+        block_gossip_peer_ips: Vec<IpAddr>,
+    ) -> PeerSetBuilder<D, C> {
+        PeerSetBuilder {
+            config: self.config,
+            discover: self.discover,
+            demand_signal: self.demand_signal,
+            handle_rx: self.handle_rx,
+            inv_stream: self.inv_stream,
+            address_book: self.address_book,
+            minimum_peer_version: self.minimum_peer_version,
+            max_conns_per_ip: self.max_conns_per_ip,
+            block_gossip_peer_ips,
+        }
+    }
+
     /// Use the provided `discover` parameter when constructing the [`PeerSet`] instance.
     pub fn with_discover<NewD>(self, discover: NewD) -> PeerSetBuilder<NewD, C> {
         PeerSetBuilder {
@@ -142,6 +179,7 @@ impl<D, C> PeerSetBuilder<D, C> {
             address_book: self.address_book,
             minimum_peer_version: self.minimum_peer_version,
             max_conns_per_ip: self.max_conns_per_ip,
+            block_gossip_peer_ips: self.block_gossip_peer_ips,
         }
     }
 
@@ -159,6 +197,7 @@ impl<D, C> PeerSetBuilder<D, C> {
             address_book: self.address_book,
             minimum_peer_version: Some(minimum_peer_version),
             max_conns_per_ip: self.max_conns_per_ip,
+            block_gossip_peer_ips: self.block_gossip_peer_ips,
         }
     }
 
@@ -178,6 +217,7 @@ impl<D, C> PeerSetBuilder<D, C> {
             address_book: self.address_book,
             minimum_peer_version: self.minimum_peer_version,
             max_conns_per_ip: Some(max_conns_per_ip),
+            block_gossip_peer_ips: self.block_gossip_peer_ips,
         }
     }
 }
@@ -217,6 +257,7 @@ where
 
         let peer_set = PeerSet::new(
             &config,
+            self.block_gossip_peer_ips,
             discover,
             demand_signal,
             handle_rx,

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -1,10 +1,13 @@
 //! Randomised property tests for the peer set.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use futures::FutureExt;
+use futures::{stream, FutureExt, StreamExt};
 use proptest::prelude::*;
-use tower::{discover::Discover, BoxError, ServiceExt};
+use tower::{
+    discover::{Change, Discover},
+    BoxError, ServiceExt,
+};
 
 use zebra_chain::{
     block, chain_tip::ChainTip, parameters::Network, serialization::ZcashDeserializeInto,
@@ -12,10 +15,13 @@ use zebra_chain::{
 
 use crate::{
     constants::CURRENT_NETWORK_PROTOCOL_VERSION,
-    peer::{ClientTestHarness, LoadTrackedClient, MinimumPeerVersion, ReceiveRequestAttempt},
+    peer::{
+        ClientTestHarness, ConnectedAddr, LoadTrackedClient, MinimumPeerVersion,
+        ReceiveRequestAttempt,
+    },
     peer_set::PeerSet,
     protocol::external::types::Version,
-    PeerSocketAddr, Request,
+    Config, PeerSocketAddr, Request,
 };
 
 use super::{BlockHeightPairAcrossNetworkUpgrades, PeerSetBuilder, PeerVersions};
@@ -287,6 +293,105 @@ proptest! {
             Ok::<_, TestCaseError>(())
         })?;
     }
+}
+
+/// Production testnet nodes often have dozens of legacy peers plus one local zcashd
+/// sidecar. Fractional `AdvertiseBlock` gossip can miss the sidecar for many blocks
+/// in a row, so block gossip always includes configured sidecar peers.
+#[test]
+fn sidecar_peer_always_receives_block_gossip() {
+    const TOTAL_PEERS: usize = 59;
+    const SIDECAR_INDEX: usize = 0;
+
+    let block: block::Block = zebra_test::vectors::BLOCK_MAINNET_10_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let block_hash = block::Hash::from(&block);
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+
+    let config = Config::default();
+    let block_gossip_peer_ips = vec![IpAddr::V4(Ipv4Addr::LOCALHOST)];
+
+    let mut handles = Vec::with_capacity(TOTAL_PEERS);
+    let discovered_peers: Vec<Result<Change<PeerSocketAddr, LoadTrackedClient>, BoxError>> = (0
+        ..TOTAL_PEERS)
+        .map(|index| {
+            let ip = if index == SIDECAR_INDEX {
+                Ipv4Addr::LOCALHOST
+            } else {
+                Ipv4Addr::new(10, 0, 0, index as u8)
+            };
+            let peer_address: PeerSocketAddr = SocketAddr::new(ip.into(), index as u16 + 1).into();
+            let (client, harness) = ClientTestHarness::build()
+                .with_version(CURRENT_NETWORK_PROTOCOL_VERSION)
+                .with_connected_addr(ConnectedAddr::new_inbound_direct(peer_address))
+                .finish();
+
+            handles.push(harness);
+
+            Ok::<_, BoxError>(Change::Insert(peer_address, client.into()))
+        })
+        .collect();
+    let discovered_peers = stream::iter(discovered_peers).chain(stream::pending());
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_config(config)
+            .with_block_gossip_peer_ips(block_gossip_peer_ips)
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version.clone())
+            .max_conns_per_ip(usize::MAX)
+            .build();
+
+        let total_number_of_active_peers = check_if_only_up_to_date_peers_are_live(
+            &mut peer_set,
+            &mut handles,
+            CURRENT_NETWORK_PROTOCOL_VERSION,
+        )
+        .expect("all mock peers should connect");
+
+        assert_eq!(total_number_of_active_peers, TOTAL_PEERS);
+
+        let number_of_peers_to_broadcast = peer_set.number_of_peers_to_broadcast();
+        assert_eq!(number_of_peers_to_broadcast, 20);
+
+        let response_future =
+            peer_set.route_block_broadcast(Request::AdvertiseBlock(block_hash, None));
+        std::mem::drop(response_future);
+
+        let mut block_gossip_received = 0;
+        let mut sidecar_received = false;
+        for (index, handle) in handles.iter_mut().enumerate() {
+            if let ReceiveRequestAttempt::Request(client_request) =
+                handle.try_to_receive_outbound_client_request()
+            {
+                assert_eq!(
+                    client_request.request,
+                    Request::AdvertiseBlock(block_hash, None)
+                );
+                block_gossip_received += 1;
+                sidecar_received |= index == SIDECAR_INDEX;
+            }
+        }
+
+        assert!(
+            sidecar_received,
+            "configured sidecar must receive block gossip"
+        );
+        assert_eq!(
+            block_gossip_received,
+            number_of_peers_to_broadcast + 1,
+            "block gossip should include sampled peers plus the sidecar"
+        );
+        assert!(
+            block_gossip_received < TOTAL_PEERS,
+            "sidecar block gossip must not broadcast to every connected peer"
+        );
+    });
 }
 
 /// Check if only peers with up-to-date protocol versions are live.

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -75,7 +75,11 @@
 
 pub(crate) mod zakura;
 
-use std::{net::SocketAddr, path::Path, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    path::Path,
+    sync::Arc,
+};
 
 use abscissa_core::{config, Command, FrameworkError};
 use color_eyre::eyre::{eyre, Report};
@@ -245,6 +249,13 @@ impl StartCmd {
         }
     }
 
+    fn zcashd_compat_default_block_gossip_peer_ips() -> Vec<IpAddr> {
+        vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ]
+    }
+
     /// Returns the supervisor shutdown timeout when zcashd-compat `zcashd` supervision is active.
     ///
     /// This is the configured `shutdown_grace_period` plus a fixed margin, so the
@@ -277,6 +288,22 @@ impl StartCmd {
             })
         } else {
             config
+        };
+
+        if !config.zcashd_compat.enabled && !config.zcashd_compat.block_gossip_peer_ips.is_empty() {
+            return Err(eyre!(
+                "zcashd_compat.block_gossip_peer_ips requires zcashd_compat.enabled = true"
+            ));
+        }
+
+        let zcashd_compat_block_gossip_peer_ips = if config.zcashd_compat.enabled {
+            if config.zcashd_compat.block_gossip_peer_ips.is_empty() {
+                Self::zcashd_compat_default_block_gossip_peer_ips()
+            } else {
+                config.zcashd_compat.block_gossip_peer_ips.clone()
+            }
+        } else {
+            Vec::new()
         };
 
         Self::validate_consensus_config(&config)?;
@@ -418,6 +445,7 @@ impl StartCmd {
                 latest_chain_tip.clone(),
                 user_agent(),
                 advertised_services,
+                zcashd_compat_block_gossip_peer_ips,
                 zakura_header_sync_driver_startup,
             )
             .await;
@@ -1071,6 +1099,13 @@ impl config::Override<ZebradConfig> for StartCmd {
             config.zcashd_compat.enabled = true;
         }
 
+        if !config.zcashd_compat.enabled && !config.zcashd_compat.block_gossip_peer_ips.is_empty() {
+            return Err(std::io::Error::other(
+                "zcashd_compat.block_gossip_peer_ips requires zcashd_compat.enabled = true",
+            )
+            .into());
+        }
+
         if config.zcashd_compat.enabled {
             if !config.network.legacy_p2p {
                 return Err(std::io::Error::other(
@@ -1215,6 +1250,29 @@ mod tests {
 
         cmd.override_config(config)
             .expect("checkpoint_sync = false with vct_fast_sync unset is a valid config");
+    }
+
+    #[test]
+    fn block_gossip_peer_ips_require_zcashd_compat() {
+        let cmd = StartCmd {
+            filters: Vec::new(),
+            zcashd_compat: false,
+            unsafe_low_specs: false,
+        };
+        let mut config = ZebradConfig::default();
+        config.zcashd_compat.block_gossip_peer_ips =
+            vec![std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)];
+
+        let error = cmd
+            .override_config(config)
+            .expect_err("block gossip peers should require zcashd-compat");
+
+        assert!(
+            error
+                .to_string()
+                .contains("zcashd_compat.block_gossip_peer_ips requires"),
+            "error should explain the zcashd-compat requirement: {error}"
+        );
     }
 
     #[test]

--- a/zebrad/src/components/zcashd_compat/config.rs
+++ b/zebrad/src/components/zcashd_compat/config.rs
@@ -1,4 +1,8 @@
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+    time::Duration,
+};
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 
@@ -67,6 +71,13 @@ pub struct Config {
     /// Zebra through a different address, such as across containers.
     pub p2p_connect_addr: Option<SocketAddr>,
 
+    /// Inbound sidecar peer IPs that must always receive block inventory broadcasts.
+    ///
+    /// If empty while zcashd-compat is enabled, Zebra defaults this list to
+    /// loopback addresses. This setting is rejected when zcashd-compat is
+    /// disabled.
+    pub block_gossip_peer_ips: Vec<IpAddr>,
+
     /// Delay before the first `zcashd` spawn attempt.
     #[serde(with = "humantime_serde")]
     pub startup_delay: Duration,
@@ -107,6 +118,7 @@ impl Default for Config {
             zcashd_datadir: None,
             zcashd_extra_args: Vec::new(),
             p2p_connect_addr: None,
+            block_gossip_peer_ips: Vec::new(),
             startup_delay: Duration::from_secs(1),
             restart_backoff: Duration::from_secs(2),
             restart_backoff_max: Duration::from_secs(5 * 60),
@@ -142,6 +154,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
     use super::{Config, ZcashdBinarySource};
 
     #[test]
@@ -197,6 +211,21 @@ mod tests {
         assert_eq!(
             config.restart_backoff_max,
             std::time::Duration::from_secs(10 * 60)
+        );
+    }
+
+    #[test]
+    fn deserialize_block_gossip_peer_ips() {
+        let config: Config = toml::from_str(
+            r#"
+            block_gossip_peer_ips = ["127.0.0.1"]
+            "#,
+        )
+        .expect("sidecar block gossip peer IPs should deserialize");
+
+        assert_eq!(
+            config.block_gossip_peer_ips,
+            vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]
         );
     }
 

--- a/zebrad/tests/common/configs/v5.0.0-rc.3.toml
+++ b/zebrad/tests/common/configs/v5.0.0-rc.3.toml
@@ -182,6 +182,7 @@ use_color = true
 use_journald = false
 
 [zcashd_compat]
+block_gossip_peer_ips = []
 enabled = false
 manage_zcashd = false
 restart_backoff = "2s"
@@ -191,3 +192,4 @@ shutdown_grace_period = "5m"
 startup_delay = "1s"
 zcashd_extra_args = []
 zcashd_source = "path"
+


### PR DESCRIPTION
## Motivation

zcashd-compat runs zcashd as a pinned sidecar peer that depends on Zebra for block announcements. Zebra's normal committed-block gossip uses fractional peer sampling, so when Zebra has many ready peers the single zcashd sidecar can be skipped for multiple block inventory broadcasts. In practice that can leave zcashd believing it is at the tip while Zebra has advanced, causing multi-minute stalls until a later inventory announcement happens to reach it.

<img width="1278" height="546" alt="image" src="https://github.com/user-attachments/assets/836c490d-a320-47d1-ab67-849dc6d57b4e" />


## Solution

- Add `zcashd_compat.block_gossip_peer_ips` for inbound sidecar peer IPs that must always receive block inventory gossip.
- Default the compat block gossip peer list to loopback addresses when zcashd-compat is enabled, while rejecting non-empty values when zcashd-compat is disabled.
- Route `AdvertiseBlock` broadcasts to the normal sampled peer set plus any configured inbound sidecar peers, without switching committed block gossip to advertise-to-all.
- Document the new config and add a changelog entry.

### Tests

- `cargo test -p zebra-network sidecar_peer_always_receives_block_gossip`
- `cargo test -p zebrad deserialize_block_gossip_peer_ips`
- `cargo test -p zebrad block_gossip_peer_ips_require_zcashd_compat`

Full `cargo fmt`, `cargo clippy`, and full `cargo test` were not run locally.

### Specifications & References

- Adds a regression test with 59 peers showing the configured sidecar receives block gossip while the rest of the network remains fractionally sampled.