### PR TITLE
Add mainnet zcashd-compat to fleet dashboard

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -140,7 +140,8 @@ jobs:
             64.227.44.93 \
             161.35.156.226 \
             139.59.64.115 \
-            168.144.173.250; do
+            168.144.173.250 \
+            159.203.113.196; do
             ssh-keyscan -T 30 -H "$host" >> ~/.ssh/known_hosts
           done
           chmod 600 ~/.ssh/known_hosts
@@ -223,6 +224,14 @@ jobs:
           name       = "asia-pacific-0"
           ssh_string = "root@168.144.173.250"
           commit     = "${{ inputs.ref }}"
+
+          [[nodes]]
+          name       = "zakura-compat"
+          ssh_string = "root@159.203.113.196"
+          commit     = "${{ inputs.ref }}"
+          service_name = "zebrad-compat"
+          log_file   = ""
+          rpc_listen_addr = ""
           EOF
 
       - name: Build deployer binary
@@ -288,7 +297,22 @@ jobs:
           dashboard_dir="/opt/zakura-mainnet-dashboard"
           sudo install -d -m 755 "$dashboard_dir"
           sudo install -m 755 deploy/runner/zebra-cluster-status.py "$dashboard_dir/zebra-cluster-status.py"
-          sudo install -m 644 deploy/deployer/nodes.ci.toml "$dashboard_dir/nodes.toml"
+          cp deploy/deployer/nodes.ci.toml "$RUNNER_TEMP/dashboard.nodes.toml"
+          cat >> "$RUNNER_TEMP/dashboard.nodes.toml" <<'EOF'
+
+          [[nodes]]
+          name       = "zcashd-compat"
+          ssh_string = "root@159.203.113.196"
+          probe_kind = "zcashd"
+          service_name = ""
+          bin_path = "/mnt/snapshots/import-zebra/zcashd-compat/bin/v6.2.1-alpha.7/x86_64-pc-linux-gnu/zcashd"
+          log_file = ""
+          rpc_listen_addr = "[::1]:8232"
+          rpc_auth = "cookie"
+          rpc_config_path = "/mnt/snapshots/runtime/zcashd/.cookie"
+          process_pattern = "zcashd .*-zebra-compat"
+          EOF
+          sudo install -m 644 "$RUNNER_TEMP/dashboard.nodes.toml" "$dashboard_dir/nodes.toml"
 
           sudo tee /etc/systemd/system/zakura-mainnet-dashboard.service >/dev/null <<'EOF'
           [Unit]

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -310,7 +310,7 @@ jobs:
           rpc_listen_addr = "127.0.0.1:18231"
           rpc_auth = "zcash_conf"
           rpc_config_path = "/root/unity/zcashd-testnet.toml"
-          process_pattern = "zcashd -conf=/root/unity/zcashd-testnet.toml"
+          process_pattern = "zcashd.*zcashd-testnet.toml"
           EOF
           sudo install -m 644 "$RUNNER_TEMP/dashboard.nodes.toml" "$dashboard_dir/nodes.toml"
 

--- a/deploy/runner/zebra-cluster-status.py
+++ b/deploy/runner/zebra-cluster-status.py
@@ -158,10 +158,16 @@ def zakura_node_ids_by_host(zakura: object) -> dict[str, str]:
 def rpc_url_for(listen_addr: str) -> str:
     if not listen_addr:
         return ""
-    match = re.search(r":(\d+)$", listen_addr)
-    if not match:
-        return ""
-    return f"http://127.0.0.1:{match.group(1)}/"
+    if listen_addr.startswith("[") and "]:" in listen_addr:
+        host, _, port = listen_addr.partition("]:")
+        port = port.lstrip(":")
+        if not port:
+            return ""
+        return f"http://{host}]:{port}/"
+    if ":" in listen_addr:
+        host, port = listen_addr.rsplit(":", 1)
+        return f"http://{host}:{port}/"
+    return ""
 
 
 REMOTE_PROBE = r"""
@@ -203,6 +209,20 @@ def process_is_running(pattern):
     proc = run(["pgrep", "-f", pattern])
     return proc.returncode == 0
 
+def process_start_time(pattern):
+    if not pattern:
+        return ""
+    proc = run(["pgrep", "-f", pattern])
+    if proc.returncode != 0:
+        return ""
+    pid = proc.stdout.strip().splitlines()[0].strip()
+    if not pid.isdigit():
+        return ""
+    ps_proc = run(["ps", "-o", "lstart=", "-p", pid])
+    if ps_proc.returncode != 0:
+        return ""
+    return ps_proc.stdout.strip()
+
 def parse_zcash_conf(path):
     values = {}
     if not path:
@@ -227,7 +247,17 @@ def rpc_headers():
             password = config.get("rpcpassword", password)
         except Exception as error:
             out["rpc_auth_error"] = str(error)
-    if rpc_auth in ("basic", "zcash_conf") and user and password:
+    elif rpc_auth == "cookie":
+        try:
+            with open(rpc_config_path, encoding="utf-8") as fh:
+                token = fh.read().strip()
+            if ":" in token:
+                user, password = token.split(":", 1)
+            else:
+                user, password = token, ""
+        except Exception as error:
+            out["rpc_auth_error"] = str(error)
+    if rpc_auth in ("basic", "zcash_conf", "cookie") and user and password:
         token = base64.b64encode(f"{user}:{password}".encode()).decode()
         headers["Authorization"] = f"Basic {token}"
     return headers
@@ -258,7 +288,7 @@ try:
         )
     elif out.get("process_running") is True:
         out["active_state"] = "active"
-        out["last_restarted"] = ""
+        out["last_restarted"] = process_start_time(process_pattern)
     elif out.get("process_running") is False:
         out["active_state"] = "inactive"
         out["last_restarted"] = ""
@@ -283,6 +313,15 @@ try:
         proc = run(["bash", "-lc", grep])
         line = proc.stdout.strip()
         out["commit"] = line.rsplit(" ", 1)[-1] if line else ""
+    if not out.get("commit") and service:
+        proc = run([
+            "journalctl", "-u", service, "-g", "git commit:",
+            "-n", "1", "--no-pager", "-o", "cat",
+        ])
+        if proc.returncode == 0:
+            match = re.search(r"git commit: ([0-9a-f]+)", proc.stdout)
+            if match:
+                out["commit"] = match.group(1)
     if not out.get("commit") and out.get("version"):
         match = re.search(r"\b([0-9a-f]{7,40})(?:-dirty)?\b", out["version"])
         if match:
@@ -298,6 +337,15 @@ try:
         proc = run(["bash", "-lc", grep])
         line = proc.stdout.strip()
         out["node_id"] = line.split("=", 1)[-1].strip('"') if line else ""
+    if not out.get("node_id") and service:
+        proc = run([
+            "journalctl", "-u", service, "-g", "node_id=",
+            "-n", "1", "--no-pager", "-o", "cat",
+        ])
+        if proc.returncode == 0:
+            match = re.search(r"node_id=([^, ]+)", proc.stdout)
+            if match:
+                out["node_id"] = match.group(1).strip('"')
 except Exception as error:
     out["node_id_error"] = str(error)
 


### PR DESCRIPTION
## Summary
- Register the mainnet zcashd-compat host (`159.203.113.196`) in the mainnet deploy fleet as `zakura-compat` and add a separate `zcashd-compat` dashboard probe row (mirroring testnet).
- Improve `zebra-cluster-status.py` for compat nodes: cookie-file RPC auth, correct IPv6 RPC URLs, journalctl commit fallback for systemd hosts without log files, and process start time for nodes monitored by `process_pattern` instead of a unit.
- Broaden testnet `zcashd-compat` process matching to `zcashd.*zcashd-testnet.toml`.

## Test plan
- [x] Manually deployed updated dashboard to mainnet (`159.65.183.89:8090`) — 11/11 healthy, `zakura-compat` + `zcashd-compat` show commit and last restarted
- [x] Manually deployed updated dashboard to testnet (`status.testnet.zakura.valargroup.dev`) — 7/7 healthy, compat rows show commit and last restarted
- [ ] Run **Deploy Zakura mainnet fleet** workflow after merge to persist dashboard config via CI
- [ ] Run **Deploy Zakura testnet fleet** workflow after merge to persist testnet process pattern via CI