### PR TITLE
fix(sync): mark mined block gossip after broadcast completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   post-reset producer refill no longer skips when peer-registry outstanding is
   still briefly inflated, so downloads resume instead of leaving an empty work
   queue (`max_outstanding = 0`).
+- Fixed mined block gossip suppressing the committed-tip fallback before
+  `AdvertiseBlockToAll` completed. The gossip task now marks a submitted block
+  hash as seen only after the all-peers broadcast returns successfully within
+  the broadcast timeout, and preserves that mark across spawned tip-change
+  futures. If the mined broadcast times out, the committed-tip path still sends
+  `AdvertiseBlock` as a fallback.
 - Fixed misleading Zakura connectivity telemetry: header-sync now records
   record-only peer violations as `header_peer_violation_recorded` instead of
   `header_peer_disconnect_requested`, header-sync exposes the authoritative

--- a/zakura-state/src/service/chain_tip.rs
+++ b/zakura-state/src/service/chain_tip.rs
@@ -560,11 +560,6 @@ impl ChainTipChange {
         self.last_change_hash = Some(hash);
     }
 
-    /// Returns the most recent block hash provided by this instance.
-    pub fn last_change_hash(&self) -> Option<block::Hash> {
-        self.last_change_hash
-    }
-
     /// Clone this monitor for another async task in the same long-running service.
     ///
     /// Unlike [`Clone::clone`], this preserves [`Self::last_change_hash`], so callers can

--- a/zakura-state/src/service/chain_tip.rs
+++ b/zakura-state/src/service/chain_tip.rs
@@ -560,6 +560,23 @@ impl ChainTipChange {
         self.last_change_hash = Some(hash);
     }
 
+    /// Returns the most recent block hash provided by this instance.
+    pub fn last_change_hash(&self) -> Option<block::Hash> {
+        self.last_change_hash
+    }
+
+    /// Clone this monitor for another async task in the same long-running service.
+    ///
+    /// Unlike [`Clone::clone`], this preserves [`Self::last_change_hash`], so callers can
+    /// suppress duplicate gossip across multiple spawned futures.
+    pub fn clone_for_task(&self) -> Self {
+        Self {
+            latest_chain_tip: self.latest_chain_tip.clone(),
+            last_change_hash: self.last_change_hash,
+            network: self.network.clone(),
+        }
+    }
+
     /// Return an action based on `block` and the last change we returned.
     fn action(&self, block: ChainTipBlock) -> TipAction {
         // check for an edge case that's dealt with by other code

--- a/zakurad/src/components/sync/gossip.rs
+++ b/zakurad/src/components/sync/gossip.rs
@@ -10,7 +10,7 @@ use tokio::sync::{mpsc, watch};
 use tower::{timeout::Timeout, Service, ServiceExt};
 use tracing::Instrument;
 
-use zakura_chain::{block, chain_tip::ChainTip};
+use zakura_chain::block;
 use zakura_network as zn;
 use zakura_state::ChainTipChange;
 
@@ -40,20 +40,6 @@ pub enum BlockGossipError {
 
     #[error("permanent peer set failure")]
     PeerSetReadiness(zn::BoxError),
-}
-
-/// Mark the chain tip hash as gossiped after a successful mined block broadcast.
-///
-/// This suppresses the committed tip gossip path for the same hash, but only
-/// after the all-peers broadcast completes successfully.
-fn apply_mined_block_mark(
-    chain_state: &mut ChainTipChange,
-    mined_block_channel_empty: bool,
-    hash: block::Hash,
-) {
-    if mined_block_channel_empty && chain_state.latest_chain_tip().best_tip_hash() == Some(hash) {
-        chain_state.mark_last_change_hash(hash);
-    }
 }
 
 /// Run continuously, gossiping newly verified [`block::Hash`]es to peers.
@@ -89,14 +75,11 @@ where
         mpsc::channel(MINED_BLOCK_MARK_CHANNEL_CAPACITY);
 
     loop {
+        // Apply marks from completed mined-block broadcasts. A successful
+        // AdvertiseBlockToAll means peers were already told about this hash, so
+        // always record it — even if another mined submission is still queued.
         while let Ok(hash) = mined_block_mark_receiver.try_recv() {
-            apply_mined_block_mark(
-                &mut chain_state,
-                mined_block_receiver
-                    .as_ref()
-                    .is_none_or(mpsc::Receiver::is_empty),
-                hash,
-            );
+            chain_state.mark_last_change_hash(hash);
         }
 
         // TODO: Refactor this into a struct and move the contents of this loop into its own method.
@@ -106,7 +89,7 @@ where
         // TODO: Move the contents of this async block to its own method
         let tip_change_close_to_network_tip_fut = async move {
             /// A brief duration to wait after a tip change for a new message in the mined block channel.
-            // TODO: Add a test to check that Zebra does not advertise mined blocks to peers twice.
+            // TODO: Add a test to check that Zakura does not advertise mined blocks to peers twice.
             const WAIT_FOR_BLOCK_SUBMISSION_DELAY: Duration = Duration::from_micros(100);
 
             // wait for at least the network timeout between gossips
@@ -154,11 +137,7 @@ where
                     },
 
                     Some(mark_hash) = mined_block_mark_receiver.recv() => {
-                        apply_mined_block_mark(
-                            &mut chain_state,
-                            mined_block_receiver.is_empty(),
-                            mark_hash,
-                        );
+                        chain_state.mark_last_change_hash(mark_hash);
                         continue;
                     },
                 }
@@ -169,7 +148,7 @@ where
                     },
 
                     Some(mark_hash) = mined_block_mark_receiver.recv() => {
-                        apply_mined_block_mark(&mut chain_state, true, mark_hash);
+                        chain_state.mark_last_change_hash(mark_hash);
                         continue;
                     },
                 }

--- a/zakurad/src/components/sync/gossip.rs
+++ b/zakurad/src/components/sync/gossip.rs
@@ -21,6 +21,14 @@ use crate::{
 
 use BlockGossipError::*;
 
+/// How many completed mined block broadcasts can wait to mark the chain tip.
+/// In normal operations, we expect at most 1 pending mark.
+/// The main loop can be busy for several seconds in the committed-tip path.
+/// During that window, multiple mined-block broadcasts could finish and
+/// try to send marks. A capacity of 16 with 25-75s block times
+/// is chosen arbitrarily high to be safe.
+const MINED_BLOCK_MARK_CHANNEL_CAPACITY: usize = 16;
+
 /// Errors that can occur when gossiping committed blocks
 #[derive(Error, Debug)]
 pub enum BlockGossipError {
@@ -32,6 +40,22 @@ pub enum BlockGossipError {
 
     #[error("permanent peer set failure")]
     PeerSetReadiness(zn::BoxError),
+}
+
+/// Mark the chain tip hash as gossiped after a successful mined block broadcast.
+///
+/// This suppresses the committed tip gossip path for the same hash, but only
+/// after the all-peers broadcast completes successfully.
+fn apply_mined_block_mark(
+    chain_state: &mut ChainTipChange,
+    mined_block_channel_empty: bool,
+    hash: block::Hash,
+) {
+    if mined_block_channel_empty
+        && chain_state.latest_chain_tip().best_tip_hash() == Some(hash)
+    {
+        chain_state.mark_last_change_hash(hash);
+    }
 }
 
 /// Run continuously, gossiping newly verified [`block::Hash`]es to peers.
@@ -63,10 +87,23 @@ where
     // so broadcasts don't delay the syncer too long
     let mut broadcast_network = Timeout::new(broadcast_network, TIPS_RESPONSE_TIMEOUT);
 
+    let (mined_block_mark_sender, mut mined_block_mark_receiver) =
+        mpsc::channel(MINED_BLOCK_MARK_CHANNEL_CAPACITY);
+
     loop {
+        while let Ok(hash) = mined_block_mark_receiver.try_recv() {
+            apply_mined_block_mark(
+                &mut chain_state,
+                mined_block_receiver
+                    .as_ref()
+                    .is_none_or(mpsc::Receiver::is_empty),
+                hash,
+            );
+        }
+
         // TODO: Refactor this into a struct and move the contents of this loop into its own method.
         let mut sync_status = sync_status.clone();
-        let mut chain_tip = chain_state.clone();
+        let mut chain_tip = chain_state.clone_for_task();
 
         // TODO: Move the contents of this async block to its own method
         let tip_change_close_to_network_tip_fut = async move {
@@ -116,10 +153,28 @@ where
 
                     Some(tip_change) = mined_block_receiver.recv() => {
                        ((tip_change, "sending mined block broadcast", chain_state), true)
-                    }
+                    },
+
+                    Some(mark_hash) = mined_block_mark_receiver.recv() => {
+                        apply_mined_block_mark(
+                            &mut chain_state,
+                            mined_block_receiver.is_empty(),
+                            mark_hash,
+                        );
+                        continue;
+                    },
                 }
             } else {
-                (tip_change_close_to_network_tip_fut.await?, false)
+                tokio::select! {
+                    tip_change_close_to_network_tip = tip_change_close_to_network_tip_fut => {
+                        (tip_change_close_to_network_tip?, false)
+                    },
+
+                    Some(mark_hash) = mined_block_mark_receiver.recv() => {
+                        apply_mined_block_mark(&mut chain_state, true, mark_hash);
+                        continue;
+                    },
+                }
             };
 
         chain_state = updated_chain_state;
@@ -144,19 +199,16 @@ where
         // Await the broadcast future in a spawned task to avoid waiting on
         // `AdvertiseBlockToAll` requests when there are unready peers.
         // Broadcast requests don't return errors, and we'd just want to ignore them anyway.
-        tokio::spawn(broadcast_fut);
-
-        // TODO: Move this logic for marking the last change hash as seen to its own method.
-
-        // Mark the last change hash of `chain_state` as the last block submission hash to avoid
-        // advertising a block hash to some peers twice.
-        if is_block_submission
-            && mined_block_receiver
-                .as_ref()
-                .is_some_and(|rx| rx.is_empty())
-            && chain_state.latest_chain_tip().best_tip_hash() == Some(hash)
-        {
-            chain_state.mark_last_change_hash(hash);
+        if is_block_submission {
+            let mark_tx = mined_block_mark_sender.clone();
+            let submission_hash = hash;
+            tokio::spawn(async move {
+                if broadcast_fut.await.is_ok() {
+                    let _ = mark_tx.send(submission_hash).await;
+                }
+            });
+        } else {
+            tokio::spawn(broadcast_fut);
         }
     }
 }

--- a/zakurad/src/components/sync/gossip.rs
+++ b/zakurad/src/components/sync/gossip.rs
@@ -51,9 +51,7 @@ fn apply_mined_block_mark(
     mined_block_channel_empty: bool,
     hash: block::Hash,
 ) {
-    if mined_block_channel_empty
-        && chain_state.latest_chain_tip().best_tip_hash() == Some(hash)
-    {
+    if mined_block_channel_empty && chain_state.latest_chain_tip().best_tip_hash() == Some(hash) {
         chain_state.mark_last_change_hash(hash);
     }
 }

--- a/zakurad/src/components/sync/gossip.rs
+++ b/zakurad/src/components/sync/gossip.rs
@@ -75,9 +75,14 @@ where
         mpsc::channel(MINED_BLOCK_MARK_CHANNEL_CAPACITY);
 
     loop {
-        // Apply marks from completed mined-block broadcasts. A successful
-        // AdvertiseBlockToAll means peers were already told about this hash, so
-        // always record it — even if another mined submission is still queued.
+        // Drain local completion notifications from spawned mined-block
+        // broadcasts before deciding whether the committed-tip fallback should
+        // run. These are not peer acknowledgements: a hash appears here only
+        // after our `AdvertiseBlockToAll` future completed successfully.
+        //
+        // `try_recv()` keeps this non-blocking. `Empty` just means no completed
+        // broadcast has reported back yet, so the gossip loop can keep making
+        // progress.
         while let Ok(hash) = mined_block_mark_receiver.try_recv() {
             chain_state.mark_last_change_hash(hash);
         }

--- a/zakurad/src/components/sync/tests.rs
+++ b/zakurad/src/components/sync/tests.rs
@@ -1,5 +1,6 @@
 //! Syncer tests
 
 mod fallback;
+mod gossip;
 mod timing;
 mod vectors;

--- a/zakurad/src/components/sync/tests/gossip.rs
+++ b/zakurad/src/components/sync/tests/gossip.rs
@@ -1,0 +1,203 @@
+//! Integration tests for block hash gossip.
+
+#![allow(clippy::unwrap_in_result)]
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::{task::JoinHandle, time::timeout};
+use tower::{builder::ServiceBuilder, util::BoxService, Service, ServiceExt};
+use tracing::Instrument;
+
+use zakura_chain::{
+    block::{Block, Height},
+    fmt::humantime_seconds,
+    parameters::Network::Mainnet,
+    serialization::ZcashDeserializeInto,
+};
+use zakura_network::{Request, Response};
+use zakura_rpc::SubmitBlockChannel;
+use zakura_state::{Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
+use zakura_test::mock_service::{MockService, PanicAssertion};
+
+use crate::components::sync::{
+    self, BlockGossipError, SyncStatus, PEER_GOSSIP_DELAY, TIPS_RESPONSE_TIMEOUT,
+};
+
+const MAX_PEER_SET_REQUEST_DELAY: Duration = Duration::from_secs(30);
+
+struct GossipTestSetup {
+    peer_set: MockService<Request, Response, PanicAssertion>,
+    submitblock_sender: tokio::sync::mpsc::Sender<(zakura_chain::block::Hash, Height)>,
+    state_service: BoxService<zakura_state::Request, zakura_state::Response, crate::BoxError>,
+    gossip_task_handle: JoinHandle<Result<(), BlockGossipError>>,
+}
+
+async fn setup_gossip_test() -> GossipTestSetup {
+    let _init_guard = zakura_test::init();
+
+    let network = Mainnet;
+    let state_config = StateConfig::ephemeral();
+    let (state, _read_only_state, _latest_chain_tip, mut chain_tip_change) =
+        zakura_state::init(state_config, &network, Height::MAX, 0).await;
+
+    let mut state_service = ServiceBuilder::new().buffer(1).service(state);
+
+    let genesis_block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    state_service
+        .ready()
+        .await
+        .unwrap()
+        .call(zakura_state::Request::CommitCheckpointVerifiedBlock(
+            genesis_block.into(),
+        ))
+        .await
+        .unwrap();
+
+    if let Err(timeout_error) = timeout(
+        CHAIN_TIP_UPDATE_WAIT_LIMIT,
+        chain_tip_change.wait_for_tip_change(),
+    )
+    .await
+    .map(|change_result| change_result.expect("unexpected chain tip update failure"))
+    {
+        panic!(
+            "timeout waiting for genesis chain tip change after {}: {timeout_error:?}",
+            humantime_seconds(CHAIN_TIP_UPDATE_WAIT_LIMIT),
+        );
+    }
+
+    let block_one: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    state_service
+        .clone()
+        .oneshot(zakura_state::Request::CommitCheckpointVerifiedBlock(
+            block_one.clone().into(),
+        ))
+        .await
+        .unwrap();
+
+    let (sync_status, mut recent_syncs) = SyncStatus::new();
+    SyncStatus::sync_close_to_tip(&mut recent_syncs);
+
+    let mut peer_set = MockService::build()
+        .with_max_request_delay(MAX_PEER_SET_REQUEST_DELAY)
+        .for_unit_tests();
+
+    let submitblock_channel = SubmitBlockChannel::new();
+    let submitblock_sender = submitblock_channel.sender();
+    let gossip_task_handle = tokio::spawn(
+        sync::gossip_best_tip_block_hashes(
+            sync_status,
+            chain_tip_change,
+            peer_set.clone(),
+            Some(submitblock_channel.receiver()),
+        )
+        .in_current_span(),
+    );
+
+    // The genesis block gossip is skipped because block 1 is committed before the task starts.
+    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+    peer_set
+        .expect_request(Request::AdvertiseBlock(block_one.hash(), None))
+        .await
+        .respond(Response::Nil);
+
+    GossipTestSetup {
+        peer_set,
+        submitblock_sender,
+        state_service: BoxService::new(state_service),
+        gossip_task_handle,
+    }
+}
+
+/// After a successful mined block broadcast, the gossip task marks the tip as seen and does not
+/// send a duplicate committed-tip gossip for the same hash.
+#[tokio::test(flavor = "multi_thread")]
+async fn mined_block_marks_tip_after_successful_broadcast() {
+    let GossipTestSetup {
+        mut peer_set,
+        submitblock_sender,
+        mut state_service,
+        gossip_task_handle: _gossip_task_handle,
+    } = setup_gossip_test().await;
+
+    let block_two: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_2_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+
+    state_service
+        .ready()
+        .await
+        .unwrap()
+        .call(zakura_state::Request::CommitCheckpointVerifiedBlock(
+            block_two.clone().into(),
+        ))
+        .await
+        .unwrap();
+
+    submitblock_sender
+        .send((block_two.hash(), block_two.coinbase_height().unwrap()))
+        .await
+        .expect("mined block notification should be accepted");
+
+    peer_set
+        .expect_request(Request::AdvertiseBlockToAll(block_two.hash()))
+        .await
+        .respond(Response::Nil);
+
+    // Allow the spawned broadcast task to send the mark notification.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // The committed tip gossip path should not advertise the same hash again.
+    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+    peer_set.expect_no_requests().await;
+}
+
+/// If a mined block broadcast times out, the committed tip gossip path should still advertise the
+/// hash as a fallback.
+#[tokio::test(flavor = "multi_thread")]
+async fn mined_block_broadcast_timeout_uses_committed_tip_fallback() {
+    let GossipTestSetup {
+        mut peer_set,
+        submitblock_sender,
+        mut state_service,
+        gossip_task_handle: _gossip_task_handle,
+    } = setup_gossip_test().await;
+
+    let block_two: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_2_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+
+    state_service
+        .ready()
+        .await
+        .unwrap()
+        .call(zakura_state::Request::CommitCheckpointVerifiedBlock(
+            block_two.clone().into(),
+        ))
+        .await
+        .unwrap();
+
+    submitblock_sender
+        .send((block_two.hash(), block_two.coinbase_height().unwrap()))
+        .await
+        .expect("mined block notification should be accepted");
+
+    let slow_broadcast = peer_set
+        .expect_request(Request::AdvertiseBlockToAll(block_two.hash()))
+        .await;
+
+    // Hold the mined block broadcast open past the gossip timeout so it fails without marking.
+    tokio::time::sleep(TIPS_RESPONSE_TIMEOUT + Duration::from_secs(1)).await;
+    drop(slow_broadcast);
+
+    // The committed tip gossip path should advertise the same hash as a fallback.
+    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+    peer_set
+        .expect_request(Request::AdvertiseBlock(block_two.hash(), None))
+        .await
+        .respond(Response::Nil);
+}

--- a/zakurad/src/components/sync/tests/gossip.rs
+++ b/zakurad/src/components/sync/tests/gossip.rs
@@ -156,6 +156,67 @@ async fn mined_block_marks_tip_after_successful_broadcast() {
     peer_set.expect_no_requests().await;
 }
 
+/// A successful mined-block broadcast still suppresses the committed-tip fallback for that hash
+/// even when another mined-block notification is already queued.
+#[tokio::test(flavor = "multi_thread")]
+async fn mined_block_mark_survives_pending_submit_queue() {
+    let GossipTestSetup {
+        mut peer_set,
+        submitblock_sender,
+        mut state_service,
+        gossip_task_handle: _gossip_task_handle,
+    } = setup_gossip_test().await;
+
+    let block_two: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_2_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let height = block_two.coinbase_height().unwrap();
+    let hash = block_two.hash();
+
+    state_service
+        .ready()
+        .await
+        .unwrap()
+        .call(zakura_state::Request::CommitCheckpointVerifiedBlock(
+            block_two.clone().into(),
+        ))
+        .await
+        .unwrap();
+
+    // First mined notification — start AdvertiseBlockToAll but hold the response open.
+    submitblock_sender
+        .send((hash, height))
+        .await
+        .expect("mined block notification should be accepted");
+
+    let first_broadcast = peer_set
+        .expect_request(Request::AdvertiseBlockToAll(hash))
+        .await;
+
+    // Queue a second notification while the first broadcast is still in flight so the
+    // submit-block channel is nonempty when the first mark arrives.
+    submitblock_sender
+        .send((hash, height))
+        .await
+        .expect("second mined block notification should be accepted");
+
+    first_broadcast.respond(Response::Nil);
+
+    // Second mined path also fires AdvertiseBlockToAll for the queued notification.
+    peer_set
+        .expect_request(Request::AdvertiseBlockToAll(hash))
+        .await
+        .respond(Response::Nil);
+
+    // Allow spawned broadcast tasks to deliver marks.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Without unconditional marking, the first mark would be dropped while the queue was
+    // nonempty and the committed-tip path could still AdvertiseBlock(hash).
+    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+    peer_set.expect_no_requests().await;
+}
+
 /// If a mined block broadcast times out, the committed tip gossip path should still advertise the
 /// hash as a fallback.
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

Closes [ZCA-759](https://linear.app/zcale/issue/ZCA-759/mined-block-advertisement-can-timeout-before-broadcast-completes).

When a miner submits a block via `submitblock`, the gossip task can take the mined-block fast path (`AdvertiseBlockToAll`) instead of the slower committed-tip path (`AdvertiseBlock`). Previously, the task marked the tip hash as already gossiped **immediately after spawning** the broadcast future—not after it completed.

That was unsafe because:

1. The peer set is wrapped in a small `tower::Buffer` (capacity 3) shared by sync, downloads, mempool gossip, and block gossip.
2. The broadcast call is wrapped in a 6s `TIPS_RESPONSE_TIMEOUT` and spawned without being awaited.
3. Under load—or when `broadcast_all` is waiting on unready peers—the spawned future can time out or be dropped before peers receive the block.

Once marked, the committed-tip fallback was suppressed: `ChainTipChange` treated the hash as handled and would not send `AdvertiseBlock` for that tip. The node could end up with **no reliable advertisement** of a locally mined block. This is especially painful in zcashd-compat setups where zcashd is a single pinned peer.

## Solution

Mark the tip hash as gossiped **only after** the mined-block broadcast future returns `Ok` within the timeout. The gossip loop itself stays non-blocking.

### Implementation details

**Mark-on-completion channel**

- Added an internal mpsc channel between the spawned broadcast task and the main gossip loop.
- On successful `AdvertiseBlockToAll`, the spawned task sends the block hash back; on timeout/error, it sends nothing.
- The main loop always applies `mark_last_change_hash` for received marks. A successful all-peers broadcast means peers were already told about that hash, so we do not drop the mark when another mined submission is still queued (or if tip has already moved).

**Non-blocking mark delivery**

- Marks are drained at the top of each loop iteration (`try_recv`).
- The mark receiver is also a third branch in the loop `select!`, so a completed broadcast can update dedup state promptly—even while the committed-tip path is sleeping through `PEER_GOSSIP_DELAY` (7s).

**Preserve dedup across spawned tip monitors**

- Each loop iteration clones `ChainTipChange` for the committed-tip async block.
- Plain `Clone` resets `last_change_hash` to `None` (intended for new monitors), which meant marks on the main monitor were invisible to spawned futures—dedup could not work reliably even before this fix.
- Added `ChainTipChange::clone_for_task()` to preserve `last_change_hash` across long-lived gossip iterations, and switched the gossip task to use it.

**Fallback behavior**

- If the mined broadcast times out (6s) before returning `Ok`, no mark is applied.
- The committed-tip path still runs after `PEER_GOSSIP_DELAY` and sends `AdvertiseBlock` as a partial fallback (~⅓ of ready peers).
- The 6s broadcast timeout finishing before the 7s gossip delay keeps dedup and fallback cleanly separated in the common case.

## Tests

Added integration tests in `zebrad/src/components/sync/tests/gossip.rs`:

- `mined_block_marks_tip_after_successful_broadcast` — after a successful `AdvertiseBlockToAll`, no duplicate `AdvertiseBlock` for the same hash after `PEER_GOSSIP_DELAY`.
- `mined_block_broadcast_timeout_uses_committed_tip_fallback` — if `AdvertiseBlockToAll` is held past `TIPS_RESPONSE_TIMEOUT`, the committed-tip path sends `AdvertiseBlock` as fallback.
- `mined_block_mark_survives_pending_submit_queue` — successful `AdvertiseBlockToAll` still suppresses committed-tip `AdvertiseBlock` when another mined notification is queued while the first broadcast completes.