### PR TITLE
fix(deploy): route fleet watchdog alerts to zakura-alerts

### DIFF
--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -228,7 +228,7 @@ The mainnet workflow also installs a Slack watchdog on `us-east-0`:
 The watchdog polls the mainnet dashboard locally at
 `http://127.0.0.1:8090/data` and the testnet dashboard at
 `http://167.99.103.111:8090/data`. It posts transition alerts to Slack
-`#gh-alerts` via either `SLACK_BOT_TOKEN` plus channel ID `C0BCQ7PP32A`, or an
+`#zakura-alerts` via either `SLACK_BOT_TOKEN` plus channel ID `C0BG341Q9TQ`, or an
 incoming webhook in `SLACK_WEB_HOOK` / `SLACK_WEBHOOK_URL`. A node alert fires
 when either of these conditions stays true for at least 10 minutes:
 

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -36,7 +36,7 @@ threshold, then recovery. Persistent failures do not post every poll.
 
 Slack delivery supports either:
 
-- `SLACK_BOT_TOKEN` with channel ID `C0BCQ7PP32A`
+- `SLACK_BOT_TOKEN` with channel ID `C0BG341Q9TQ` (`#zakura-alerts`)
 - an incoming webhook in `SLACK_WEB_HOOK`, `SLACK_WEBHOOK_URL`, or
   `SLACK_WEBHOOK`
 

--- a/deploy/runner/zakura-fleet-watchdog.service
+++ b/deploy/runner/zakura-fleet-watchdog.service
@@ -9,7 +9,7 @@ WorkingDirectory=/opt/zakura-fleet-watchdog
 EnvironmentFile=-/etc/zakura-fleet-watchdog/env
 StateDirectory=zakura-fleet-watchdog
 RuntimeDirectory=zakura-fleet-watchdog
-ExecStart=/usr/bin/python3 /opt/zakura-fleet-watchdog/zebra-cluster-watchdog.py --config /opt/zakura-fleet-watchdog/fleets.toml --state-file /var/lib/zakura-fleet-watchdog/state.json --interval 60 --down-after 600 --stalled-after 600 --dashboard-down-after 600
+ExecStart=/usr/bin/python3 /opt/zakura-fleet-watchdog/zebra-cluster-watchdog.py --config /opt/zakura-fleet-watchdog/fleets.toml --state-file /var/lib/zakura-fleet-watchdog/state.json --interval 60 --down-after 600 --stalled-after 600 --dashboard-down-after 600 --slack-channel C0BG341Q9TQ
 Restart=always
 RestartSec=5
 

--- a/deploy/runner/zebra-cluster-watchdog.py
+++ b/deploy/runner/zebra-cluster-watchdog.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 
 
-DEFAULT_SLACK_CHANNEL = "C0BCQ7PP32A"
+DEFAULT_SLACK_CHANNEL = "C0BG341Q9TQ"
 DOWN_HEALTH = {"down", "rpc_error"}
 STATE_VERSION = 1
 
@@ -144,41 +144,41 @@ def post_slack(text: str, args: argparse.Namespace) -> bool:
         print(f"dry-run Slack message:\n{text}\n")
         return True
 
+    if token:
+        payload = json.dumps({"channel": args.slack_channel, "text": text}).encode("utf-8")
+        request = urllib.request.Request(
+            "https://slack.com/api/chat.postMessage",
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=args.slack_timeout) as response:
+                body = response.read()
+        except (OSError, urllib.error.URLError) as error:
+            print(f"Slack post failed: {error}", file=sys.stderr)
+            return False
+
+        try:
+            decoded = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as error:
+            print(f"Slack returned invalid JSON: {error}", file=sys.stderr)
+            return False
+
+        if not decoded.get("ok"):
+            print(f"Slack post failed: {decoded}", file=sys.stderr)
+            return False
+
+        return True
+
     if webhook:
         return post_slack_webhook(webhook, text, args)
 
-    if not token:
-        print(f"Slack credential not set; would post:\n{text}\n")
-        return True
-
-    payload = json.dumps({"channel": args.slack_channel, "text": text}).encode("utf-8")
-    request = urllib.request.Request(
-        "https://slack.com/api/chat.postMessage",
-        data=payload,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json; charset=utf-8",
-        },
-        method="POST",
-    )
-
-    try:
-        with urllib.request.urlopen(request, timeout=args.slack_timeout) as response:
-            body = response.read()
-    except (OSError, urllib.error.URLError) as error:
-        print(f"Slack post failed: {error}", file=sys.stderr)
-        return False
-
-    try:
-        decoded = json.loads(body.decode("utf-8"))
-    except json.JSONDecodeError as error:
-        print(f"Slack returned invalid JSON: {error}", file=sys.stderr)
-        return False
-
-    if not decoded.get("ok"):
-        print(f"Slack post failed: {decoded}", file=sys.stderr)
-        return False
-
+    print(f"Slack credential not set; would post:\n{text}\n")
     return True
 
 


### PR DESCRIPTION
## Summary
- Route fleet watchdog Slack alerts to `#zakura-alerts` (`C0BG341Q9TQ`) instead of `#gh-alerts`.
- Pin the systemd watchdog command to the alert channel so old `SLACK_CHANNEL_ID` environment values do not override the intended destination.
- Prefer `SLACK_BOT_TOKEN` delivery over webhook delivery when both are configured, since webhooks are bound to their configured Slack channel.

## Motivation / Why
A fleet watchdog alert for zcashd-compat was delivered to the wrong Slack channel. Operational alerts should go to `#zakura-alerts`, and the deployed service should use a deterministic channel even if the runner environment contains older Slack configuration.

## Tests
- `python3 -m py_compile deploy/runner/zebra-cluster-watchdog.py`

## AI Assistance
Used Cursor to inspect the watchdog Slack routing, update the channel configuration, and prepare this PR.