### PR TITLE
Treat RPC-disabled status nodes as healthy

### DIFF
--- a/deploy/runner/zebra-cluster-status.py
+++ b/deploy/runner/zebra-cluster-status.py
@@ -524,12 +524,18 @@ class ClusterCollector:
         active_state = probe.get("active_state") or "unknown"
         process_running = probe.get("process_running")
         service_active = active_state == "active" and process_running is not False
+        rpc_disabled = (
+            not node.rpc_listen_addr
+            or probe.get("rpc_error") == "RPC disabled in deployer config"
+        )
         rpc_ok = height is not None and not probe.get("rpc_error")
         recent = (
             seconds_since_advanced is not None
             and seconds_since_advanced <= self.stale_after
         )
-        healthy = service_active and rpc_ok and recent
+        # Nodes with RPC intentionally disabled (e.g. zakura-compat front) are
+        # healthy when the process/service is up; height comes from the sidecar row.
+        healthy = service_active and (rpc_disabled or (rpc_ok and recent))
 
         if probe.get("error"):
             health = "down"
@@ -540,6 +546,9 @@ class ClusterCollector:
         elif not service_active:
             health = "down"
             detail = f"systemd state: {active_state}"
+        elif rpc_disabled:
+            health = "healthy"
+            detail = "service active (RPC probe disabled)"
         elif not rpc_ok:
             health = "rpc_error"
             detail = str(probe.get("rpc_error") or "RPC height unavailable")


### PR DESCRIPTION
## Summary
- Follow-up to #55: `zakura-compat` intentionally sets `rpc_listen_addr = ""` (height comes from the `zcashd-compat` sidecar row). Without this change the dashboard marks it `rpc_error` with "RPC disabled in deployer config".
- Treat nodes with RPC probe disabled as healthy when the systemd/process check is up.

## Test plan
- [x] Manually verified on mainnet dashboard after deploying this script: `zakura-compat` shows healthy with detail "service active (RPC probe disabled)"; `zcashd-compat` still reports height
- [ ] After merge, run **Deploy Zakura mainnet fleet** (or at least the dashboard install step) so `us-east-0` picks up the script from `main`