### PR TITLE
Probe mainnet zakura-compat tip via local zebrad RPC

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -231,7 +231,11 @@ jobs:
           commit     = "${{ inputs.ref }}"
           service_name = "zebrad-compat"
           log_file   = ""
-          rpc_listen_addr = ""
+          # Dashboard-only probe of zebrad's local RPC (same pattern as other
+          # mainnet nodes). Does not configure zcashd RPC ingest.
+          rpc_listen_addr = "127.0.0.1:8232"
+          rpc_auth   = "cookie"
+          rpc_config_path = "/root/.cache/zebra/.cookie"
           EOF
 
       - name: Build deployer binary


### PR DESCRIPTION
## Summary
- Re-enable dashboard-only RPC probing for mainnet `zakura-compat` (`127.0.0.1:8232` + cookie), matching how other mainnet Zakura nodes and testnet `zakura-compat` get height / block hash / last advanced.
- This does not configure zcashd RPC ingest; it only tells the status page to read zebrad's existing local RPC.

## Test plan
- [x] Updated live mainnet dashboard `nodes.toml` and restarted — `zakura-compat` now shows height, block hash, and last advanced
- [ ] After merge, next **Deploy Zakura mainnet fleet** run will persist the config