### PR TITLE
chore(make): add local Zakura dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,15 @@
 
 include make/zcashd-compat.mk
 include make/perf.mk
+include make/zakura-dev.mk
 
 help:
 	@echo "Available targets:"
+	@echo ""
+	@echo "  Dev Zakura (local node):"
+	@echo "  zakura-build-dev                 Build debug zakurad"
+	@echo "  zakura-dev-init                  Create ~/.local/zakura-dev config + dirs"
+	@echo "  zakura-start-dev                 Start local dev node (pruned, VCT, v2-only)"
 	@echo ""
 	@echo "  Perf harness (deterministic isolated-cohort bench):"
 	@echo "  perf-build-local                 Build the instrumented (commit-metrics) bench binary"

--- a/make/zakura-dev.mk
+++ b/make/zakura-dev.mk
@@ -1,0 +1,45 @@
+.PHONY: \
+	zakura-build-dev \
+	zakura-dev-init \
+	zakura-start-dev
+
+ZAKURA_DEV_HOME ?= $(HOME)/.local/zakura-dev
+ZAKURA_DEV_CACHE ?= $(ZAKURA_DEV_HOME)/cache
+ZAKURA_DEV_IDENTITY ?= $(ZAKURA_DEV_HOME)/identity
+ZAKURA_DEV_CONFIG ?= $(ZAKURA_DEV_HOME)/zakura.toml
+ZAKURA_DEV_CONFIG_TEMPLATE ?= $(CURDIR)/make/zakura-dev.toml
+
+ZAKURA_DEV_ZAKURAD_BIN ?= $(CURDIR)/target/debug/zakurad
+ifneq ($(filter command line environment override,$(origin ZAKURAD_BIN)),)
+ZAKURA_DEV_ZAKURAD_BIN := $(ZAKURAD_BIN)
+endif
+NETWORK ?= Mainnet
+
+zakura-build-dev:
+	cargo build --bin zakurad
+
+zakura-dev-init:
+	@set -eu; \
+	case "$(NETWORK)" in \
+		Mainnet|Testnet) ;; \
+		*) echo "unsupported NETWORK=$(NETWORK); use Mainnet or Testnet" >&2; exit 2 ;; \
+	esac; \
+	mkdir -p "$(ZAKURA_DEV_CACHE)" "$(ZAKURA_DEV_IDENTITY)"; \
+	if [ -f "$(ZAKURA_DEV_CONFIG)" ]; then \
+		echo "Using existing Zakura dev config: $(ZAKURA_DEV_CONFIG)"; \
+	else \
+		echo "Rendering Zakura dev config: $(ZAKURA_DEV_CONFIG)"; \
+		NETWORK="$(NETWORK)" \
+		CACHE_DIR="$(ZAKURA_DEV_CACHE)" \
+		IDENTITY_DIR="$(ZAKURA_DEV_IDENTITY)" \
+		TEMPLATE="$(ZAKURA_DEV_CONFIG_TEMPLATE)" \
+		OUTPUT="$(ZAKURA_DEV_CONFIG)" \
+		python3 -c 'import os, pathlib; peers = {"Mainnet": ["1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234", "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234", "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234", "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234", "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234", "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234", "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234", "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234", "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234"], "Testnet": ["57ad39fad4f0bca46cf1ea831772a99d5027b372fef2be5a0ea68e1b5bb4da49@167.99.103.111:8234", "4faac8f988a7820690d63b57a385cd6f833638b068e774550712c05e4b692426@167.99.110.145:8234", "9ce6b95aa197d169399788fe01dd8a88140e81d23d00b4739aeeb1113c6247a2@138.68.229.254:8234", "2bbb907b5d90598ef49f2e637066586b311a64587479be6ed43e8388587fcd2a@164.92.209.78:8234", "50999835f48f4a048c0e9042e5332844c9673943d7fab1f7e993bae698c27ea3@206.189.148.0:8234"]}; network = os.environ["NETWORK"]; peer_lines = "\n".join(f"    \"{peer}\"," for peer in peers[network]); template = pathlib.Path(os.environ["TEMPLATE"]); output = pathlib.Path(os.environ["OUTPUT"]); text = template.read_text(); text = text.replace("@@NETWORK@@", network).replace("@@CACHE_DIR@@", os.environ["CACHE_DIR"]).replace("@@IDENTITY_DIR@@", os.environ["IDENTITY_DIR"]).replace("@@BOOTSTRAP_PEERS@@", peer_lines); output.write_text(text)'; \
+	fi
+
+zakura-start-dev: zakura-dev-init
+	@if [ ! -x "$(ZAKURA_DEV_ZAKURAD_BIN)" ]; then \
+		echo "Missing $(ZAKURA_DEV_ZAKURAD_BIN); run: make zakura-build-dev" >&2; \
+		exit 2; \
+	fi
+	"$(ZAKURA_DEV_ZAKURAD_BIN)" -c "$(ZAKURA_DEV_CONFIG)" start

--- a/make/zakura-dev.toml
+++ b/make/zakura-dev.toml
@@ -1,0 +1,36 @@
+# Local Zakura dev config template.
+#
+# Rendered by `make zakura-dev-init` into:
+#   ${ZAKURA_DEV_HOME}/zakura.toml
+#
+# Tokens wrapped in @@ are substituted by make/zakura-dev.mk.
+
+[network]
+network = "@@NETWORK@@"
+listen_addr = "0.0.0.0:8233"
+cache_dir = "@@CACHE_DIR@@"
+identity_dir = "@@IDENTITY_DIR@@"
+v2_p2p = true
+legacy_p2p = false
+
+[network.zakura]
+# Bind on all interfaces: iroh uses one UDP socket for send+recv, so a loopback
+# bind breaks outbound connections to external peers.
+listen_addr = "0.0.0.0:8234"
+# Selected by `NETWORK` in make/zakura-dev.mk.
+bootstrap_peers = [
+@@BOOTSTRAP_PEERS@@
+]
+
+[network.zakura.block_sync]
+# In v2-only mode, Zakura owns block-body download while the legacy syncer only
+# handles tip discovery.
+replace_legacy_syncer = true
+
+[consensus]
+checkpoint_sync = true
+vct_fast_sync = true
+
+[state]
+cache_dir = "@@CACHE_DIR@@"
+storage_mode = "pruned"


### PR DESCRIPTION
## Motivation

Add a one-command local dev entry point for running Zakura in the desired development mode without hand-writing config files.

## Solution

- Add `make/zakura-dev.mk` with `zakura-build-dev`, `zakura-dev-init`, and `zakura-start-dev` targets.
- Add `make/zakura-dev.toml`, rendered into `~/.local/zakura-dev/zakura.toml` on first init.
- Configure the dev node for pruned storage, checkpoint sync, explicit VCT fast sync, v2 P2P enabled, and legacy P2P disabled.
- Wire the dev targets into the root `Makefile` help output.

### Tests

- `make -n zakura-dev-init NETWORK=Testnet`
- `make -n zakura-start-dev`
- `make help`
- Isolated render smoke test with `ZAKURA_DEV_HOME` under `/tmp`, verifying Testnet config, v2-only mode, checkpoint sync, VCT fast sync, pruned storage, and bootstrap peer substitution.
- `ReadLints` on `Makefile`, `make/zakura-dev.mk`, and `make/zakura-dev.toml`: no issues.

