### PR TITLE
chore(make): use release zakurad for local dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "Available targets:"
 	@echo ""
 	@echo "  Dev Zakura (local node):"
-	@echo "  zakura-build-dev                 Build debug zakurad"
+	@echo "  zakura-build-dev                 Build release zakurad"
 	@echo "  zakura-dev-init                  Create ~/.local/zakura-dev config + dirs"
 	@echo "  zakura-start-dev                 Start local dev node (pruned, VCT, v2-only)"
 	@echo ""

--- a/make/zakura-dev.mk
+++ b/make/zakura-dev.mk
@@ -9,14 +9,14 @@ ZAKURA_DEV_IDENTITY ?= $(ZAKURA_DEV_HOME)/identity
 ZAKURA_DEV_CONFIG ?= $(ZAKURA_DEV_HOME)/zakura.toml
 ZAKURA_DEV_CONFIG_TEMPLATE ?= $(CURDIR)/make/zakura-dev.toml
 
-ZAKURA_DEV_ZAKURAD_BIN ?= $(CURDIR)/target/debug/zakurad
+ZAKURA_DEV_ZAKURAD_BIN ?= $(CURDIR)/target/release/zakurad
 ifneq ($(filter command line environment override,$(origin ZAKURAD_BIN)),)
 ZAKURA_DEV_ZAKURAD_BIN := $(ZAKURAD_BIN)
 endif
 NETWORK ?= Mainnet
 
 zakura-build-dev:
-	cargo build --bin zakurad
+	cargo build --release --bin zakurad
 
 zakura-dev-init:
 	@set -eu; \


### PR DESCRIPTION
## Motivation

Follow-up to #60. Local `make zakura-start-dev` was defaulting to a debug `zakurad`, which syncs too slowly for useful mainnet checkpoint sync (~few blocks/s).

## Solution

- `zakura-build-dev` builds with `cargo build --release --bin zakurad`
- `zakura-start-dev` defaults to `target/release/zakurad` (still overridable via `ZAKURAD_BIN`)
- Help text updated to say "release"

### Tests

- [x] `make -n zakura-build-dev` shows `cargo build --release --bin zakurad`
- [x] `make -n zakura-start-dev` points at `target/release/zakurad`
- [x] `make help` shows "Build release zakurad"
- Skipped full cargo build/tests: low-risk Makefile-only change

### Follow-up Work

- Depends on / includes #60 until that lands; after #60 merges, rebase this branch onto `main` if needed.

### AI Disclosure

- [x] AI tools were used: Cursor for the Makefile edit and PR creation

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`
- [x] The PR follows the contribution guidelines
- [ ] This change was discussed in an issue or with the team beforehand
- [x] The solution is tested
- [x] The documentation and changelogs are up to date (N/A — Makefile help only)