### PR TITLE
ci(deploy): migrate fleet configs to network.p2p_stack

### DIFF
--- a/.github/workflows/checkpoint-sync-bench.yml
+++ b/.github/workflows/checkpoint-sync-bench.yml
@@ -66,26 +66,14 @@ on:
       download_concurrency_limit:
         required: false
         default: "150"
-      target_should_use_v2_p2p:
-        description: "Run the target/primary binary with Zakura P2P v2 and its block syncer"
-        type: boolean
+      target_p2p_stack:
+        description: "Target/primary P2P stack: zebra | zakura | dual (aliases: v1/legacy, v2, combined)"
         required: false
-        default: true
-      target_should_use_legacy_p2p:
-        description: "Run the target/primary binary with legacy TCP P2P enabled"
-        type: boolean
+        default: "zakura"
+      baseline_p2p_stack:
+        description: "Baseline/base P2P stack: zebra | zakura | dual (aliases: v1/legacy, v2, combined)"
         required: false
-        default: false
-      baseline_should_use_v2_p2p:
-        description: "Run the baseline/base binary with Zakura P2P v2 and its block syncer"
-        type: boolean
-        required: false
-        default: false
-      baseline_should_use_legacy_p2p:
-        description: "Run the baseline/base binary with legacy TCP P2P enabled"
-        type: boolean
-        required: false
-        default: true
+        default: "zebra"
       baseline_tag:
         description: "Optional (download mode): baseline release tag for a speedup comparison. Ignored when skip_baseline is true."
         required: false
@@ -125,10 +113,8 @@ jobs:
           PEERSET_SIZE: ${{ inputs.peerset_size }}
           CKPT_LIMIT: ${{ inputs.checkpoint_verify_concurrency_limit }}
           DL_LIMIT: ${{ inputs.download_concurrency_limit }}
-          TARGET_SHOULD_USE_V2_P2P: ${{ inputs.target_should_use_v2_p2p && '1' || '0' }}
-          TARGET_SHOULD_USE_LEGACY_P2P: ${{ inputs.target_should_use_legacy_p2p && '1' || '0' }}
-          BASELINE_SHOULD_USE_V2_P2P: ${{ inputs.baseline_should_use_v2_p2p && '1' || '0' }}
-          BASELINE_SHOULD_USE_LEGACY_P2P: ${{ inputs.baseline_should_use_legacy_p2p && '1' || '0' }}
+          TARGET_P2P_STACK: ${{ inputs.target_p2p_stack }}
+          BASELINE_P2P_STACK: ${{ inputs.baseline_p2p_stack }}
           SNAPSHOT_URL: ${{ vars.BENCH_SNAPSHOT_URL || 'https://zebra.valargroup.org/mainnet/historical/zebra-mainnet-20260616T032721Z-1707210.tar.zst' }}
           SNAPSHOT_SHA256: ${{ vars.BENCH_SNAPSHOT_SHA256 || '19ac5d24eaa4e912cc8bbd4e7f5f2aaa2b6c132854e75d93678316016f0f2769' }}
           START_HEIGHT: ${{ vars.BENCH_SNAPSHOT_START_HEIGHT || '1707210' }}

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -16,6 +16,10 @@ name: Deploy Zakura mainnet fleet
 # restarts the existing `zebrad` service, leaving the config, unit, and cache
 # untouched. Rebuilding those configs into the deployer's managed model is
 # separate future work.
+#
+# After PR #21, hand configs should use network.p2p_stack (zebra|zakura|dual|
+# default) rather than the deprecated v2_p2p/legacy_p2p bools. This workflow does
+# not rewrite node configs; p2p_stack below is dashboard/metadata only.
 
 on:
   workflow_dispatch:
@@ -160,6 +164,9 @@ jobs:
           service_name    = "zebrad"
           bin_path        = "/usr/local/bin/zebrad"
           network         = "Mainnet"
+          # Dashboard/metadata only (manage_config = false does not render this).
+          # Mainnet binary default is zebra; dual/zakura must be set on-node.
+          p2p_stack       = "default"
           # Read-only fields below: consumed by the status dashboard's SSH probe,
           # not written to any node (manage_config = false).
           rpc_listen_addr = "0.0.0.0:8232"

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -128,8 +128,7 @@ jobs:
           rpc_listen_addr = "0.0.0.0:18232"
           rpc_enable_cookie_auth = false
           storage_mode    = "archive"
-          v2_p2p          = true
-          legacy_p2p      = true
+          p2p_stack       = "dual"
           metrics_endpoint = "127.0.0.1:9999"
           tracing_filter  = "info,zebra_network::zakura=info"
           checkpoint_sync = false
@@ -205,7 +204,7 @@ jobs:
           working_dir = "/root/unity/zakura"
           start_command = "target/release/zakurad -c /root/unity/zakura-testnet.toml start"
           process_pattern = "target/release/zakurad -c /root/unity/zakura-testnet.toml start"
-          v2_p2p = false
+          p2p_stack = "zebra"
           checkpoint_sync = true
           EOF
 

--- a/book/src/dev/private-zakura-network.md
+++ b/book/src/dev/private-zakura-network.md
@@ -14,7 +14,8 @@ magic, and activation heights), so it validates exactly what production does.
 
 This only scopes the **Zakura v2 overlay**. A dev node may still maintain legacy
 TCP connections to public peers; the isolation applies to the v2 stack that is
-under test. The tag has no effect unless `v2_p2p` is enabled.
+under test. The tag has no effect unless Zakura P2P is enabled
+(`p2p_stack = "zakura"` or `"dual"`).
 
 ## Configuration
 
@@ -40,8 +41,8 @@ max_connections_per_ip = 16
 
 ```toml
 [network]
-# Keep v2 enabled so the Zakura overlay runs.
-v2_p2p = true
+# Keep Zakura P2P enabled so the overlay runs.
+p2p_stack = "dual"
 ```
 
 ## How it works

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -97,12 +97,14 @@ The workflow is manual (`workflow_dispatch`). Inputs:
 
 The generated CI config uses Testnet ports, public RPC at `0.0.0.0:18232`, and
 explicitly sets `vct_fast_sync = false`, which keeps checkpoint sync available
-while forcing the legacy non-VCT path. It also writes `/etc/zakura/zakura.toml`
-and uses each node's existing `/mnt/<node-name>-data/zakura-cache` snapshot
-directory, so CI restarts the current `zakurad.service` against the existing state
-instead of creating a fresh database. If an older `/mnt/<node-name>-data/zebra-cache`
-directory exists and the `zakura-cache` target does not, the deployer stops that
-node and moves the directory before starting with the new config. The compat
+while forcing the legacy non-VCT path. Fleet nodes use `p2p_stack = "dual"`;
+`zakura-compat` uses `p2p_stack = "zebra"` (legacy TCP only). It also writes
+`/etc/zakura/zakura.toml` and uses each node's existing
+`/mnt/<node-name>-data/zakura-cache` snapshot directory, so CI restarts the
+current `zakurad.service` against the existing state instead of creating a
+fresh database. If an older `/mnt/<node-name>-data/zebra-cache` directory
+exists and the `zakura-cache` target does not, the deployer stops that node
+and moves the directory before starting with the new config. The compat
 Zakura process uses the same snapshot layout on its host.
 
 The workflow also refreshes a simple fleet status dashboard on

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -196,10 +196,12 @@ iroh identity (the node ids hardcoded as bootstrap peers in
 change every node id and drop the tuning. So the generated CI config sets
 `manage_config = false`: the deployer swaps `/usr/local/bin/zebrad` and restarts
 the existing `zebrad` service, leaving the config, unit, and cache untouched. The
-`rpc_listen_addr` / `log_file` / `[defaults.zakura] bootstrap_peers` in that
-config are read-only inputs for the dashboard's SSH probe, not deployed to nodes.
-Reproducing these configs in the deployer's managed model is separate future
-work.
+`rpc_listen_addr` / `log_file` / `p2p_stack` /
+`[defaults.zakura] bootstrap_peers` in that config are read-only inputs for the
+dashboard's SSH probe, not deployed to nodes. On-node configs should use
+`network.p2p_stack` (not the deprecated `v2_p2p` /
+`legacy_p2p` bools). Reproducing these configs in the deployer's managed model
+is separate future work.
 
 The workflow refreshes a fleet status dashboard on `us-east-0`:
 

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -59,8 +59,8 @@ DEFAULTS = {
     "port": None,           # ssh port; None -> ssh default
     # Match zakurad's own defaults so existing fleets render unchanged.
     "storage_mode": "archive",
-    "v2_p2p": True,
-    "legacy_p2p": True,
+    # One of: default | zebra | zakura | dual (aliases: v1/legacy, v2, combined).
+    "p2p_stack": "dual",
     "metrics_endpoint": "",  # e.g. "127.0.0.1:9100" -> renders [metrics]; "" omits it
     "tracing_filter": "",    # e.g. "info,zebra_network::zakura=debug"; "" uses zakurad default
     "checkpoint_sync": True,
@@ -101,8 +101,7 @@ class Node:
     rpc_listen_addr: str
     rpc_enable_cookie_auth: object
     storage_mode: str
-    v2_p2p: bool
-    legacy_p2p: bool
+    p2p_stack: str
     metrics_endpoint: str
     tracing_filter: str
     checkpoint_sync: bool
@@ -141,6 +140,36 @@ class Node:
 # Config loading
 # --------------------------------------------------------------------------- #
 
+# Canonical names accepted by zakurad's network.p2p_stack (plus the aliases the
+# binary also accepts). Deployer configs should use a canonical name.
+P2P_STACK_VALUES = {
+    "default",
+    "zebra", "v1", "legacy",
+    "zakura", "v2",
+    "dual", "combined",
+}
+# Deprecated deployer keys from before network.p2p_stack; reject with a pointer.
+DEPRECATED_P2P_KEYS = {"v2_p2p", "legacy_p2p", "enable_p2p_v2", "default_p2p"}
+
+
+def normalize_p2p_stack(value: object, *, where: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise DeployError(f"{where}: p2p_stack must be a non-empty string")
+    stack = value.strip().lower()
+    if stack not in P2P_STACK_VALUES:
+        raise DeployError(
+            f"{where}: unknown p2p_stack {value!r}; "
+            f"expected one of: default, zebra, zakura, dual"
+        )
+    # Prefer canonical names in rendered node configs.
+    return {
+        "v1": "zebra",
+        "legacy": "zebra",
+        "v2": "zakura",
+        "combined": "dual",
+    }.get(stack, stack)
+
+
 def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
     if not config_path.is_file():
         raise DeployError(f"config not found: {config_path}")
@@ -152,7 +181,15 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
     # deploy into a destructive one. `name`/`ssh_string`/`commit` are per-node only.
     known_default_keys = set(DEFAULTS)
     known_node_keys = known_default_keys | {"name", "ssh_string", "commit"}
-    unknown_defaults = set(data.get("defaults", {})) - known_default_keys
+    defaults_raw = data.get("defaults", {})
+    deprecated_defaults = set(defaults_raw) & DEPRECATED_P2P_KEYS
+    if deprecated_defaults:
+        raise DeployError(
+            f"deprecated key(s) in [defaults]: {', '.join(sorted(deprecated_defaults))}; "
+            f"use p2p_stack = \"dual\"|\"zebra\"|\"zakura\"|\"default\" instead "
+            f"(see network.p2p_stack / PR #21)"
+        )
+    unknown_defaults = set(defaults_raw) - known_default_keys
     if unknown_defaults:
         raise DeployError(
             f"unknown key(s) in [defaults]: {', '.join(sorted(unknown_defaults))} "
@@ -160,7 +197,7 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
         )
 
     defaults = dict(DEFAULTS)
-    defaults.update(data.get("defaults", {}))
+    defaults.update(defaults_raw)
 
     raw_nodes = data.get("nodes", [])
     if not raw_nodes:
@@ -172,6 +209,12 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
         for required in ("name", "ssh_string", "commit"):
             if required not in raw:
                 raise DeployError(f"node missing required field '{required}': {raw}")
+        deprecated_node = set(raw) & DEPRECATED_P2P_KEYS
+        if deprecated_node:
+            raise DeployError(
+                f"deprecated key(s) in [[nodes]] {raw.get('name', '?')}: "
+                f"{', '.join(sorted(deprecated_node))}; use p2p_stack instead"
+            )
         unknown_node = set(raw) - known_node_keys
         if unknown_node:
             raise DeployError(
@@ -204,8 +247,9 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             rpc_listen_addr=merged["rpc_listen_addr"],
             rpc_enable_cookie_auth=merged["rpc_enable_cookie_auth"],
             storage_mode=merged["storage_mode"],
-            v2_p2p=merged["v2_p2p"],
-            legacy_p2p=merged["legacy_p2p"],
+            p2p_stack=normalize_p2p_stack(
+                merged["p2p_stack"], where=f"[[nodes]] {name}"
+            ),
             metrics_endpoint=merged["metrics_endpoint"],
             tracing_filter=merged["tracing_filter"],
             checkpoint_sync=merged["checkpoint_sync"],
@@ -404,8 +448,7 @@ def render_node_config(node: Node) -> str:
         "NETWORK_CACHE_DIR": network_cache_line,
         "STATE_CACHE_DIR": node.state_cache_dir,
         "STORAGE_MODE": node.storage_mode,
-        "V2_P2P": "true" if node.v2_p2p else "false",
-        "LEGACY_P2P": "true" if node.legacy_p2p else "false",
+        "P2P_STACK": node.p2p_stack,
         "ZAKURA_BLOCK": render_zakura_block(node.zakura),
         "METRICS_BLOCK": metrics_block,
         "TRACING_FILTER": filter_line,

--- a/deploy/deployer/nodes.example.toml
+++ b/deploy/deployer/nodes.example.toml
@@ -17,8 +17,7 @@ listen_addr     = "[::]:8233"
 # identity_dir  = "/root/.zakura"           # empty = zakurad default; pins the iroh node_id
 rpc_listen_addr = ""                        # empty = RPC disabled; e.g. "0.0.0.0:8232"
 storage_mode    = "archive"                 # "archive" serves all history; "pruned" does not
-v2_p2p          = true                       # run the Zakura v2 overlay
-legacy_p2p      = true                       # keep legacy TCP P2P (set false to isolate to v2)
+p2p_stack       = "dual"                     # zebra | zakura | dual | default
 # port          = 22                        # optional non-default ssh port
 
 # Optional fleet-wide Zakura settings, rendered into [network.zakura] on every

--- a/deploy/deployer/templates/zakura.toml
+++ b/deploy/deployer/templates/zakura.toml
@@ -6,8 +6,7 @@ network = "{{NETWORK}}"
 listen_addr = "{{LISTEN_ADDR}}"
 {{IDENTITY_DIR}}
 {{NETWORK_CACHE_DIR}}
-v2_p2p = {{V2_P2P}}
-legacy_p2p = {{LEGACY_P2P}}
+p2p_stack = "{{P2P_STACK}}"
 {{ZAKURA_BLOCK}}
 [state]
 cache_dir = "{{STATE_CACHE_DIR}}"

--- a/deploy/runner/.nodes-rendered.toml
+++ b/deploy/runner/.nodes-rendered.toml
@@ -4,7 +4,7 @@
 # cohort.env) and passes it to deploy/deployer/deploy.py. Do not run deploy.py
 # against this file directly — the tokens are not valid TOML until rendered.
 #
-# Tokens: feat/pre-release-main roman-perf-1800 ["912e382c9790d241d1f5f31e38f331932b85b0e8848e35e16f49bf76c3c43674@167.99.162.47:8234","cbd797cb28c5e53dbc19e4d5d6d60e5dcd9b5667808eb5703131c67cd67a30fa@167.172.201.36:8234"] false archive
+# Tokens: feat/pre-release-main roman-perf-1800 ["912e382c9790d241d1f5f31e38f331932b85b0e8848e35e16f49bf76c3c43674@167.99.162.47:8234","cbd797cb28c5e53dbc19e4d5d6d60e5dcd9b5667808eb5703131c67cd67a30fa@167.172.201.36:8234"] zakura archive
 
 [defaults]
 service_name    = "zakurad"
@@ -15,8 +15,7 @@ state_cache_dir = "/root/.cache/zakura"      # the big-volume snapshot (symlink 
 network         = "Mainnet"
 listen_addr     = "[::]:8233"
 storage_mode    = "archive"
-v2_p2p          = true
-legacy_p2p      = false                  # seed phase: true (sync from public); freeze phase: false
+p2p_stack       = "zakura"                  # seed phase: dual (sync from public); freeze phase: zakura
 metrics_endpoint = "127.0.0.1:9100"          # loopback Prometheus; scrape via ssh for cohort/peer counts
 tracing_filter   = "info,zebra_network::zakura=debug,zebra_network::zakura::discovery=debug"
 

--- a/deploy/runner/nodes.toml.tmpl
+++ b/deploy/runner/nodes.toml.tmpl
@@ -4,7 +4,7 @@
 # cohort.env) and passes it to deploy/deployer/deploy.py. Do not run deploy.py
 # against this file directly — the tokens are not valid TOML until rendered.
 #
-# Tokens: @@COMMIT@@ @@COHORT@@ @@BOOTSTRAP@@ @@LEGACY@@ @@STORAGE@@
+# Tokens: @@COMMIT@@ @@COHORT@@ @@BOOTSTRAP@@ @@P2P_STACK@@ @@STORAGE@@
 
 [defaults]
 service_name    = "zakurad"
@@ -15,8 +15,7 @@ state_cache_dir = "/root/.cache/zakura"      # the big-volume snapshot (symlink 
 network         = "Mainnet"
 listen_addr     = "[::]:8233"
 storage_mode    = "@@STORAGE@@"
-v2_p2p          = true
-legacy_p2p      = @@LEGACY@@                  # seed phase: true (sync from public); freeze phase: false
+p2p_stack       = "@@P2P_STACK@@"            # seed phase: dual (sync from public); freeze phase: zakura
 metrics_endpoint = "127.0.0.1:9100"          # loopback Prometheus; scrape via ssh for cohort/peer counts
 tracing_filter   = "info,zebra_network::zakura=debug,zebra_network::zakura::discovery=debug"
 

--- a/deploy/runner/perf.sh
+++ b/deploy/runner/perf.sh
@@ -80,14 +80,14 @@ bootstrap_toml() {
   fi
 }
 
-# Render nodes.toml.tmpl -> a temp deployer config. Args: legacy(true|false)
+# Render nodes.toml.tmpl -> a temp deployer config. Args: p2p_stack (dual|zakura|...)
 render_nodes() {
-  local legacy="$1" out
+  local p2p_stack="$1" out
   out="$(mktemp /tmp/perf-nodes.XXXXXX.toml)"
   sed -e "s#@@COMMIT@@#${SERVE_COMMIT}#g" \
       -e "s#@@COHORT@@#${COHORT_TAG}#g" \
       -e "s#@@BOOTSTRAP@@#$(bootstrap_toml)#g" \
-      -e "s#@@LEGACY@@#${legacy}#g" \
+      -e "s#@@P2P_STACK@@#${p2p_stack}#g" \
       -e "s#@@STORAGE@@#archive#g" \
       "$NODES_TMPL" > "$out"
   echo "$out"
@@ -108,15 +108,15 @@ deployer() { python3 "$DEPLOYER" "$@"; }
 # --- subcommands ------------------------------------------------------------
 
 cmd_seed_serving() {
-  note "deploying serving nodes with legacy_p2p=true (sync from public mainnet to >= ${SEED_HEIGHT})"
-  local nodes; nodes="$(render_nodes true)"
+  note "deploying serving nodes with p2p_stack=dual (sync from public mainnet to >= ${SEED_HEIGHT})"
+  local nodes; nodes="$(render_nodes dual)"
   deployer deploy --config "$nodes"
   note "seeding. Poll with: $0 status   (wait until both heights >= ${SEED_HEIGHT})"
 }
 
 cmd_peers() {
   mkdir -p "$LOG_DIR"
-  local nodes; nodes="$(render_nodes true)"
+  local nodes; nodes="$(render_nodes dual)"
   note "fetching node logs to read each Zakura identity"
   deployer logs fetch --config "$nodes" --out-dir "$LOG_DIR"
 
@@ -125,7 +125,7 @@ cmd_peers() {
           | grep -oE 'node_id=[0-9a-f]+' | tail -1 | cut -d= -f2 || true)"
   id_b="$(grep -h 'Zakura P2P endpoint ready' "$LOG_DIR/serve-b.log" 2>/dev/null \
           | grep -oE 'node_id=[0-9a-f]+' | tail -1 | cut -d= -f2 || true)"
-  [ -n "$id_a" ] || die "could not read serve-a node_id (is v2_p2p up? check $LOG_DIR/serve-a.log)"
+  [ -n "$id_a" ] || die "could not read serve-a node_id (is Zakura P2P up? check $LOG_DIR/serve-a.log)"
   [ -n "$id_b" ] || die "could not read serve-b node_id (check $LOG_DIR/serve-b.log)"
 
   local peer_a="${id_a}@${NODE_A_IP}:${ZAKURA_PORT}"
@@ -141,14 +141,14 @@ cmd_peers() {
 cmd_freeze_serving() {
   [ -n "${NODE_A_PEER:-}" ] && [ -n "${NODE_B_PEER:-}" ] \
     || die "NODE_*_PEER empty — run '$0 peers' first"
-  note "redeploying serving nodes with legacy_p2p=false (freeze) — they now serve a static range"
-  local nodes; nodes="$(render_nodes false)"
+  note "redeploying serving nodes with p2p_stack=zakura (freeze) — they now serve a static range"
+  local nodes; nodes="$(render_nodes zakura)"
   deployer deploy --config "$nodes"
   note "frozen. Serving cohort '${COHORT_TAG}' to the bench node only."
 }
 
 cmd_status() {
-  local nodes; nodes="$(render_nodes false)"
+  local nodes; nodes="$(render_nodes zakura)"
   deployer status --config "$nodes"
 }
 

--- a/deploy/runner/runbook.md
+++ b/deploy/runner/runbook.md
@@ -32,10 +32,12 @@ branch containing #262), then:
 
 ```bash
 cd deploy/runner
-./perf.sh seed-serving     # deploy both nodes (legacy_p2p=true) → sync from public mainnet
+# deploy both nodes (p2p_stack=dual) → sync from public mainnet
+./perf.sh seed-serving
 ./perf.sh status           # repeat until both heights >= SEED_HEIGHT
 ./perf.sh peers            # capture each node_id@ip:8234 from logs into cohort.env
-./perf.sh freeze-serving   # redeploy legacy_p2p=false → static cohort servers
+# redeploy p2p_stack=zakura → static cohort servers
+./perf.sh freeze-serving
 ```
 
 Frozen = seeded once past the bench range, then cut off from public so the nodes
@@ -43,9 +45,10 @@ serve a byte-identical range every run (no public dependency, no self-sync
 jitter). Each node's iroh identity persists in its state cache dir — **never wipe
 it**, or the captured peer ids change.
 
-The deployer renders the cohort config itself: `deploy/deployer/deploy.py` reads a
-fleet-wide `[defaults.zakura]` table plus `storage_mode` / `v2_p2p` /
-`legacy_p2p`, so there is no hand-editing of `/etc/zakura` on the nodes.
+The deployer renders the cohort config itself:
+`deploy/deployer/deploy.py` reads a fleet-wide `[defaults.zakura]` table plus
+`storage_mode` / `p2p_stack`, so there is no hand-editing of `/etc/zakura` on
+the nodes.
 
 ## Run loop (the repeatable part)
 
@@ -69,8 +72,8 @@ fleet-wide `[defaults.zakura]` table plus `storage_mode` / `v2_p2p` /
 
 ## Bench config knobs that matter (`zebra-bench-config.toml`)
 
-- `[network]` `v2_p2p=true`, `legacy_p2p=false` — v2-only, so the bench node's
-  only peers are the cohort.
+- `[network]` `p2p_stack="zakura"` — Zakura-only, so the bench node's only
+  peers are the cohort.
 - `[network.zakura]` `listen_addr="0.0.0.0:8234"` — **not loopback** (iroh uses one
   UDP socket for send+recv, so a loopback bind breaks outbound). `dev_network` and
   `bootstrap_peers` are token-filled by `perf.sh` from `cohort.env`.

--- a/deploy/runner/zebra-bench-config.toml
+++ b/deploy/runner/zebra-bench-config.toml
@@ -15,10 +15,9 @@
 network     = "Mainnet"
 listen_addr = "0.0.0.0:@@LISTEN@@"
 cache_dir   = "@@FORK@@"
-v2_p2p      = true      # Zakura v2 block/header sync + tree_aux → VCT fast path
-legacy_p2p  = false     # pure v2: no legacy peers. Zakura header-sync self-drives block-sync via
-                        # replace_legacy_syncer=true below — the two MUST be set together (without
-                        # replace_legacy_syncer it falls back to legacy obtain_tips and hard-stalls).
+p2p_stack   = "zakura"  # pure Zakura P2P v2: block/header sync + tree_aux → VCT fast path
+                        # (with replace_legacy_syncer=true below — the two MUST be set together;
+                        # without replace_legacy_syncer it falls back to legacy obtain_tips and hard-stalls).
 
 [network.zakura]
 # Bind on all interfaces — iroh uses one UDP socket for send+recv, so a loopback
@@ -28,7 +27,7 @@ listen_addr     = "0.0.0.0:8234"
 # Private cohort: peer ONLY with our two controlled serving nodes. `perf.sh run`
 # substitutes @@COHORT@@ / @@BOOTSTRAP@@ from deploy/runner/cohort.env (the same
 # tag + peers the serving fleet runs), so this bench node is isolated from the
-# churny public Zakura fleet. With legacy_p2p=false above, the cohort is its only
+# churny public Zakura fleet. With p2p_stack=zakura above, the cohort is its only
 # source of peers. To run against the public fleet instead, set CONFIG_SRC to a
 # config with the old curated bootstrap_peers and no dev_network.
 dev_network     = "@@COHORT@@"

--- a/deploy/runner/zebra-bench-mainnet-config.toml
+++ b/deploy/runner/zebra-bench-mainnet-config.toml
@@ -16,8 +16,7 @@
 network     = "Mainnet"
 listen_addr = "0.0.0.0:@@LISTEN@@"
 cache_dir   = "@@FORK@@"
-v2_p2p      = true      # Zakura v2 block/header sync + tree_aux -> VCT fast path
-legacy_p2p  = false     # pure v2: public Zakura bootstrap peers below are the entrypoint
+p2p_stack   = "zakura"  # pure Zakura P2P v2: block/header sync + tree_aux -> VCT fast path
 
 [network.zakura]
 # Bind on all interfaces - iroh uses one UDP socket for send+recv, so a loopback

--- a/deploy/runner/zebra-mainnet-bench-config.toml
+++ b/deploy/runner/zebra-mainnet-bench-config.toml
@@ -16,8 +16,7 @@
 network     = "Mainnet"
 listen_addr = "0.0.0.0:@@LISTEN@@"
 cache_dir   = "@@FORK@@"
-v2_p2p      = true      # Zakura v2 block/header sync + tree_aux -> VCT fast path
-legacy_p2p  = false     # pure v2: public Zakura bootstrap peers below are the entrypoint
+p2p_stack   = "zakura"  # pure Zakura P2P v2: block/header sync + tree_aux -> VCT fast path
 
 [network.zakura]
 # Bind on all interfaces - iroh uses one UDP socket for send+recv, so a loopback

--- a/make/zakura-dev.toml
+++ b/make/zakura-dev.toml
@@ -10,8 +10,7 @@ network = "@@NETWORK@@"
 listen_addr = "0.0.0.0:8233"
 cache_dir = "@@CACHE_DIR@@"
 identity_dir = "@@IDENTITY_DIR@@"
-v2_p2p = true
-legacy_p2p = false
+p2p_stack = "zakura"
 
 [network.zakura]
 # Bind on all interfaces: iroh uses one UDP socket for send+recv, so a loopback
@@ -23,7 +22,7 @@ bootstrap_peers = [
 ]
 
 [network.zakura.block_sync]
-# In v2-only mode, Zakura owns block-body download while the legacy syncer only
+# In zakura-only mode, Zakura owns block-body download while the legacy syncer only
 # handles tip discovery.
 replace_legacy_syncer = true
 

--- a/scripts/checkpoint-sync-bench.sh
+++ b/scripts/checkpoint-sync-bench.sh
@@ -24,10 +24,9 @@
 #   FEED_PEER             single pinned peer ip:port           (default 167.99.162.47:8233)
 #   CKPT_LIMIT            checkpoint_verify_concurrency_limit  (default 1500)
 #   DL_LIMIT              download_concurrency_limit           (default 150)
-#   TARGET_SHOULD_USE_V2_P2P    1 = target uses Zakura P2P v2 + block syncer    (default 0)
-#   TARGET_SHOULD_USE_LEGACY_P2P 1 = target uses legacy TCP P2P                (default 1)
-#   BASELINE_SHOULD_USE_V2_P2P  1 = baseline uses Zakura P2P v2 + block syncer  (default 0)
-#   BASELINE_SHOULD_USE_LEGACY_P2P 1 = baseline uses legacy TCP P2P            (default 1)
+#   TARGET_P2P_STACK            zebra | zakura | dual (aliases: v1/legacy, v2, combined)
+#                               default: zakura. Older TARGET_SHOULD_USE_* bools still work.
+#   BASELINE_P2P_STACK          same as TARGET_P2P_STACK for the baseline run (default: zebra)
 #   SNAPSHOT_URL          primary snapshot .tar.zst URL
 #   SNAPSHOT_SHA256       expected sha256 of the .tar.zst
 #   START_HEIGHT          snapshot tip height                  (default 1707210)
@@ -65,10 +64,13 @@ FEED_PEER="${FEED_PEER-167.99.162.47:8233}"
 CKPT_LIMIT="${CKPT_LIMIT:-1500}"
 DL_LIMIT="${DL_LIMIT:-150}"
 PEERSET_SIZE="${PEERSET_SIZE:-1}"   # 1 = strict single pinned peer; raise to allow DNS-seeder fallback
-TARGET_SHOULD_USE_V2_P2P="${TARGET_SHOULD_USE_V2_P2P:-0}"
-TARGET_SHOULD_USE_LEGACY_P2P="${TARGET_SHOULD_USE_LEGACY_P2P:-1}"
-BASELINE_SHOULD_USE_V2_P2P="${BASELINE_SHOULD_USE_V2_P2P:-0}"
-BASELINE_SHOULD_USE_LEGACY_P2P="${BASELINE_SHOULD_USE_LEGACY_P2P:-1}"
+TARGET_P2P_STACK="${TARGET_P2P_STACK:-}"
+BASELINE_P2P_STACK="${BASELINE_P2P_STACK:-}"
+# Deprecated bool inputs (pre-p2p_stack); honored only when the new vars are unset.
+TARGET_SHOULD_USE_V2_P2P="${TARGET_SHOULD_USE_V2_P2P:-}"
+TARGET_SHOULD_USE_LEGACY_P2P="${TARGET_SHOULD_USE_LEGACY_P2P:-}"
+BASELINE_SHOULD_USE_V2_P2P="${BASELINE_SHOULD_USE_V2_P2P:-}"
+BASELINE_SHOULD_USE_LEGACY_P2P="${BASELINE_SHOULD_USE_LEGACY_P2P:-}"
 START_HEIGHT="${START_HEIGHT:-1707210}"
 SNAPSHOT_URL="${SNAPSHOT_URL:-https://zebra.valargroup.org/mainnet/historical/zebra-mainnet-20260616T032721Z-1707210.tar.zst}"
 SNAPSHOT_SHA256="${SNAPSHOT_SHA256:-19ac5d24eaa4e912cc8bbd4e7f5f2aaa2b6c132854e75d93678316016f0f2769}"
@@ -118,10 +120,45 @@ normalize_bool() {
 }
 
 SKIP_BASELINE="$(normalize_bool "$SKIP_BASELINE")"
-TARGET_SHOULD_USE_V2_P2P="$(normalize_bool "$TARGET_SHOULD_USE_V2_P2P")"
-TARGET_SHOULD_USE_LEGACY_P2P="$(normalize_bool "$TARGET_SHOULD_USE_LEGACY_P2P")"
-BASELINE_SHOULD_USE_V2_P2P="$(normalize_bool "$BASELINE_SHOULD_USE_V2_P2P")"
-BASELINE_SHOULD_USE_LEGACY_P2P="$(normalize_bool "$BASELINE_SHOULD_USE_LEGACY_P2P")"
+
+# Map a stack name (or deprecated v2/legacy bool pair) onto a canonical p2p_stack.
+normalize_p2p_stack() {
+  local raw="${1:-}"
+  case "${raw,,}" in
+    "" ) echo "" ;;
+    default) echo "default" ;;
+    zebra|v1|legacy) echo "zebra" ;;
+    zakura|v2) echo "zakura" ;;
+    dual|combined) echo "dual" ;;
+    *) die "invalid p2p_stack '$raw' (use zebra, zakura, dual, or default)" ;;
+  esac
+}
+
+# Resolve TARGET/BASELINE stack from the new string input, else the deprecated bools.
+stack_from_bools() {
+  local v2="$1" legacy="$2" default_stack="$3"
+  if [[ -z "$v2" && -z "$legacy" ]]; then
+    echo "$default_stack"
+    return
+  fi
+  v2="$(normalize_bool "${v2:-0}")"
+  legacy="$(normalize_bool "${legacy:-1}")"
+  case "$v2$legacy" in
+    11) echo "dual" ;;
+    10) echo "zakura" ;;
+    01) echo "zebra" ;;
+    *) die "invalid P2P bools v2=$v2 legacy=$legacy (enable at least one stack)" ;;
+  esac
+}
+
+TARGET_P2P_STACK="$(normalize_p2p_stack "$TARGET_P2P_STACK")"
+BASELINE_P2P_STACK="$(normalize_p2p_stack "$BASELINE_P2P_STACK")"
+if [[ -z "$TARGET_P2P_STACK" ]]; then
+  TARGET_P2P_STACK="$(stack_from_bools "$TARGET_SHOULD_USE_V2_P2P" "$TARGET_SHOULD_USE_LEGACY_P2P" "zakura")"
+fi
+if [[ -z "$BASELINE_P2P_STACK" ]]; then
+  BASELINE_P2P_STACK="$(stack_from_bools "$BASELINE_SHOULD_USE_V2_P2P" "$BASELINE_SHOULD_USE_LEGACY_P2P" "zebra")"
+fi
 
 # Always tear down a launched node + its fork, even on FATAL/interrupt, so a failed
 # run never leaves an orphan zakurad thrashing the box or a fork eating disk.
@@ -386,14 +423,19 @@ PY
 }
 
 # ---- 3-7. one benchmark run for a given tag ----------------------------------
-# usage: run_one TAG OUTPREFIX SHOULD_USE_V2_P2P SHOULD_USE_LEGACY_P2P ; sets RESULT_* globals
+# usage: run_one TAG OUTPREFIX P2P_STACK ; sets RESULT_* globals
 run_one() {
   local tag="$1" prefix="$2"
-  local should_use_v2_p2p="$3"
-  local should_use_legacy_p2p="$4"
-  if [[ "$should_use_v2_p2p" != "1" && "$should_use_legacy_p2p" != "1" ]]; then
-    die "$prefix run requested v2_p2p=0 and legacy_p2p=0; enable at least one P2P stack"
-  fi
+  local p2p_stack
+  p2p_stack="$(normalize_p2p_stack "$3")"
+  [[ -n "$p2p_stack" && "$p2p_stack" != "default" ]] \
+    || die "$prefix run needs an explicit p2p_stack (zebra|zakura|dual), got '${3:-}'"
+  local runs_zakura=0 runs_legacy=0
+  case "$p2p_stack" in
+    zebra) runs_legacy=1 ;;
+    zakura) runs_zakura=1 ;;
+    dual) runs_zakura=1; runs_legacy=1 ;;
+  esac
   resolve_binary "$tag"; local zakurad="$ZAKURAD_BIN"
   local run_id="${prefix}-$$-$(date +%s)"
   local fork="$BENCH_HOME/forks/$run_id"
@@ -407,7 +449,9 @@ run_one() {
   find "$fork" -name LOCK -delete 2>/dev/null || true
   rm -rf "$trace_dir"; mkdir -p "$trace_dir"
 
-  # $1 = write the P2P toggles (present only on v5.0.0+ "Zakura" releases)
+  # $1 = p2p_stack | deprecated_bools | none
+  # Modern binaries want network.p2p_stack. Mid-era Zakura tags only know the
+  # deprecated v2_p2p/legacy_p2p bools. Pre-Zakura tags reject both.
   write_config() {
     {
       echo '[network]'
@@ -417,20 +461,25 @@ run_one() {
       # pin a single peer when given; otherwise fall back to the default DNS seeders
       [[ -n "$FEED_PEER" ]] && echo "initial_mainnet_peers = [\"$FEED_PEER\"]"
       echo "peerset_initial_target_size = $PEERSET_SIZE"
-      if [[ "$1" == "with_p2p_toggles" ]]; then
-        if [[ "$should_use_legacy_p2p" == "1" ]]; then
-          echo 'legacy_p2p = true'
-        else
-          echo 'legacy_p2p = false'
-        fi
-        if [[ "$should_use_v2_p2p" == "1" ]]; then
-          echo 'v2_p2p = true'   # enables Zakura P2P v2 and the Zakura block syncer
-        else
-          echo 'v2_p2p = false'  # legacy ChainSync body downloader
-        fi
-      fi
+      case "$1" in
+        p2p_stack)
+          echo "p2p_stack = \"$p2p_stack\""
+          ;;
+        deprecated_bools)
+          if [[ "$runs_legacy" == "1" ]]; then
+            echo 'legacy_p2p = true'
+          else
+            echo 'legacy_p2p = false'
+          fi
+          if [[ "$runs_zakura" == "1" ]]; then
+            echo 'v2_p2p = true'
+          else
+            echo 'v2_p2p = false'
+          fi
+          ;;
+      esac
       echo ''
-      if [[ "$1" == "with_p2p_toggles" && "$should_use_v2_p2p" == "1" ]]; then
+      if [[ "$1" != "none" && "$runs_zakura" == "1" ]]; then
         echo '[network.zakura]'
         echo "trace_dir = \"$trace_dir\""
         echo 'bootstrap_peers = ['
@@ -458,19 +507,29 @@ run_one() {
     } > "$cfg"
   }
 
-  local pid t0 mode="with_p2p_toggles"
-  log "starting zakurad ($tag), v2_p2p=$should_use_v2_p2p, legacy_p2p=$should_use_legacy_p2p, stop_height=$STOP_HEIGHT, peer=${FEED_PEER:-DNS-seeders}, peerset=$PEERSET_SIZE, cap=${WALL_CAP}s, metrics=:$METRICS_PORT, listen=:$LISTEN_PORT"
+  local pid t0 mode="p2p_stack"
+  log "starting zakurad ($tag), p2p_stack=$p2p_stack, stop_height=$STOP_HEIGHT, peer=${FEED_PEER:-DNS-seeders}, peerset=$PEERSET_SIZE, cap=${WALL_CAP}s, metrics=:$METRICS_PORT, listen=:$LISTEN_PORT"
   write_config "$mode"
   "$zakurad" -c "$cfg" start >"$logf" 2>&1 &
   pid=$!; CUR_PID="$pid"; t0=$(date +%s); sleep 3
   if ! kill -0 "$pid" 2>/dev/null; then
-    # version-skew fallback: older tags lack v2_p2p/legacy_p2p -> deny_unknown_fields.
+    # version-skew fallbacks: mid-era tags lack p2p_stack; pre-Zakura tags lack both.
+    if grep -qiE 'unknown field|p2p_stack|deny_unknown|error parsing config|failed to parse' "$logf"; then
+      log "config rejected p2p_stack (likely pre-PR#21 tag); retrying with deprecated v2_p2p/legacy_p2p"
+      mode="deprecated_bools"
+      write_config "$mode"
+      "$zakurad" -c "$cfg" start >"$logf" 2>&1 &
+      pid=$!; CUR_PID="$pid"; t0=$(date +%s); sleep 3
+    fi
+  fi
+  if ! kill -0 "$pid" 2>/dev/null; then
     if grep -qiE 'unknown field|v2_p2p|legacy_p2p|deny_unknown|error parsing config|failed to parse' "$logf"; then
-      if [[ "$should_use_v2_p2p" == "1" || "$should_use_legacy_p2p" != "1" ]]; then
-        die "requested v2_p2p=$should_use_v2_p2p legacy_p2p=$should_use_legacy_p2p for $tag, but this binary rejected the v2_p2p/legacy_p2p config fields"
+      if [[ "$runs_zakura" == "1" || "$runs_legacy" != "1" ]]; then
+        die "requested p2p_stack=$p2p_stack for $tag, but this binary rejected the P2P config fields"
       fi
-      log "config rejected (likely pre-Zakura tag); retrying without v2_p2p/legacy_p2p"
-      write_config "without_p2p_toggles"
+      log "config rejected (likely pre-Zakura tag); retrying without P2P stack fields"
+      mode="none"
+      write_config "$mode"
       "$zakurad" -c "$cfg" start >"$logf" 2>&1 &
       pid=$!; CUR_PID="$pid"; t0=$(date +%s); sleep 3
     fi
@@ -540,7 +599,7 @@ run_one() {
   errs="$(grep -iE 'panic|ERROR committing|resetting state queue' "$logf" 2>/dev/null \
             | grep -viE 'zebra_network|peer' | head -3 || true)"
   cp "$logf" "$OUT_DIR/node-$prefix.log" 2>/dev/null || true
-  [[ "$should_use_v2_p2p" == "1" ]] && zip_trace_dir "$trace_dir" "$OUT_DIR/zakura-traces-$prefix.zip"
+  [[ "$runs_zakura" == "1" ]] && zip_trace_dir "$trace_dir" "$OUT_DIR/zakura-traces-$prefix.zip"
 
   local blocks=$((end_height - START_HEIGHT))
   local total=$((t_end - t0))
@@ -553,10 +612,6 @@ run_one() {
   pbps="$(awk -v b="$blocks" -v t="$post"  'BEGIN{printf "%.2f", b/t}')"
   (( end_height < STOP_HEIGHT )) && stalled="yes (capped before stop_height)"
 
-  rm -rf "$fork" "$cfg"   # reclaim divergent SSTs; keep csv/log artifacts
-  CUR_PID=""; CUR_FORK=""
-
-  # Bottleneck verdict: classify the recorded series into commit / download / verify.
   # The archive keeps the canonical run; copy the series + verdict into the artifact dir.
   RESULT_VERDICT=""; RESULT_VERDICT_MD=""
   if [[ -n "$rec_dir" && -f "$rec_dir/samples.jsonl" ]]; then
@@ -575,9 +630,9 @@ run_one() {
   RESULT_TAG="$tag"; RESULT_START="$START_HEIGHT"; RESULT_END="$end_height"
   RESULT_BLOCKS="$blocks"; RESULT_TIME="$total"; RESULT_POST="$post"
   RESULT_BPS="$bps"; RESULT_PBPS="$pbps"; RESULT_STALLED="$stalled"; RESULT_ERRS="$errs"
-  RESULT_V2_P2P="$should_use_v2_p2p"
-  RESULT_LEGACY_P2P="$should_use_legacy_p2p"
+  RESULT_P2P_STACK="$p2p_stack"
 }
+
 
 print_one() {
   local title="$1"
@@ -585,8 +640,7 @@ print_one() {
 
 === checkpoint-sync benchmark ${title} ===
 release:        $RESULT_TAG
-v2_p2p:         $RESULT_V2_P2P
-legacy_p2p:     $RESULT_LEGACY_P2P
+p2p_stack:      $RESULT_P2P_STACK
 feed:           ${FEED_PEER:-DNS seeders (public mainnet)}  (peerset=$PEERSET_SIZE)
 start height:   $RESULT_START
 end height:     $RESULT_END
@@ -600,8 +654,8 @@ EOF
 }
 
 summary_row() { # markdown row -> step summary
-  printf '| %s | %s | %s | %s | %s | %s | %s | %s |\n' \
-    "$1" "$RESULT_V2_P2P" "$RESULT_LEGACY_P2P" "$RESULT_END" "$RESULT_BLOCKS" "${RESULT_TIME}s" "$RESULT_BPS" "$RESULT_PBPS"
+  printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
+    "$1" "$RESULT_P2P_STACK" "$RESULT_END" "$RESULT_BLOCKS" "${RESULT_TIME}s" "$RESULT_BPS" "$RESULT_PBPS"
 }
 
 # ---- main --------------------------------------------------------------------
@@ -635,13 +689,13 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-$OUT_DIR/summary.md}"
     echo "- GitHub run: [${GITHUB_RUN_ID:-open}]($GITHUB_RUN_URL)"
   fi
   if [[ -n "$BASELINE_SPEC" ]]; then
-    echo "- P2P mode: target v2_p2p=$TARGET_SHOULD_USE_V2_P2P legacy_p2p=$TARGET_SHOULD_USE_LEGACY_P2P, baseline v2_p2p=$BASELINE_SHOULD_USE_V2_P2P legacy_p2p=$BASELINE_SHOULD_USE_LEGACY_P2P"
+    echo "- P2P mode: target p2p_stack=$TARGET_P2P_STACK, baseline p2p_stack=$BASELINE_P2P_STACK"
   else
-    echo "- P2P mode: target v2_p2p=$TARGET_SHOULD_USE_V2_P2P legacy_p2p=$TARGET_SHOULD_USE_LEGACY_P2P, baseline skipped"
+    echo "- P2P mode: target p2p_stack=$TARGET_P2P_STACK, baseline skipped"
   fi
   echo ""
-  echo "| binary | v2_p2p | legacy_p2p | end height | blocks covered | time taken | blocks/s | post-commit blk/s |"
-  echo "|--------|-------:|-----------:|-----------:|---------------:|-----------:|---------:|------------------:|"
+  echo "| binary | p2p_stack | end height | blocks covered | time taken | blocks/s | post-commit blk/s |"
+  echo "|--------|----------:|-----------:|---------------:|-----------:|---------:|------------------:|"
 } >> "$SUMMARY"
 
 # append a recorded run's bottleneck-verdict banner below the throughput table
@@ -649,16 +703,16 @@ append_verdict() { [[ -n "$1" && -f "$1" ]] && { echo ""; cat "$1"; } >> "$SUMMA
 
 if [[ -n "$BASELINE_SPEC" ]]; then
   log "A/B mode: baseline='$BASELINE_SPEC' vs primary='$PRIMARY_SPEC'"
-  run_one "$BASELINE_SPEC" "baseline" "$BASELINE_SHOULD_USE_V2_P2P" "$BASELINE_SHOULD_USE_LEGACY_P2P"; print_one "(baseline)"; summary_row "$BASELINE_SPEC (baseline)" >> "$SUMMARY"
+  run_one "$BASELINE_SPEC" "baseline" "$BASELINE_P2P_STACK"; print_one "(baseline)"; summary_row "$BASELINE_SPEC (baseline)" >> "$SUMMARY"
   B_BPS="$RESULT_BPS"; B_VERDICT_MD="$RESULT_VERDICT_MD"
-  run_one "$PRIMARY_SPEC" "primary" "$TARGET_SHOULD_USE_V2_P2P" "$TARGET_SHOULD_USE_LEGACY_P2P";  print_one "(primary)";  summary_row "$PRIMARY_SPEC (primary)"  >> "$SUMMARY"
+  run_one "$PRIMARY_SPEC" "primary" "$TARGET_P2P_STACK";  print_one "(primary)";  summary_row "$PRIMARY_SPEC (primary)"  >> "$SUMMARY"
   R_BPS="$RESULT_BPS"; R_VERDICT_MD="$RESULT_VERDICT_MD"
   SPEEDUP="$(awk -v r="$R_BPS" -v b="$B_BPS" 'BEGIN{ if (b>0) printf "%.2f", r/b; else print "n/a" }')"
   { echo ""; echo "**Speedup:** ${B_BPS} → ${R_BPS} blocks/s = **${SPEEDUP}×**"; } >> "$SUMMARY"
   printf '\n=== A/B: %s -> %s = %s× faster ===\n' "$B_BPS" "$R_BPS" "$SPEEDUP"
   append_verdict "$B_VERDICT_MD"; append_verdict "$R_VERDICT_MD"
 else
-  run_one "$PRIMARY_SPEC" "primary" "$TARGET_SHOULD_USE_V2_P2P" "$TARGET_SHOULD_USE_LEGACY_P2P"; print_one ""; summary_row "$PRIMARY_SPEC" >> "$SUMMARY"
+  run_one "$PRIMARY_SPEC" "primary" "$TARGET_P2P_STACK"; print_one ""; summary_row "$PRIMARY_SPEC" >> "$SUMMARY"
   append_verdict "$RESULT_VERDICT_MD"
 fi
 


### PR DESCRIPTION
## Summary
- Migrate deployer, testnet deploy workflow, perf harness, and checkpoint-sync bench from deprecated `v2_p2p`/`legacy_p2p` to `network.p2p_stack` after [#21](https://github.com/zakura-core/zakura/pull/21).
- Testnet fleet defaults to `p2p_stack = "dual"`; `zakura-compat` stays `p2p_stack = "zebra"`.
- Bench workflow inputs collapse to `target_p2p_stack` / `baseline_p2p_stack`, with version-skew fallbacks for older binaries.

## Test plan
- [x] `deploy.py` smoke: renders `p2p_stack`, rejects deprecated keys
- [ ] Deploy testnet one-by-one from this branch; confirm each node config shows `p2p_stack` and service stays healthy

## AI disclosure
Used Cursor to port configs, update CI/deploy templates, and dispatch the testnet roll.