### PR TITLE
ci(deploy): keep dashboard rpc auth out of mainnet fleet TOML

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -238,11 +238,7 @@ jobs:
           commit     = "${{ inputs.ref }}"
           service_name = "zebrad-compat"
           log_file   = ""
-          # Dashboard-only probe of zebrad's local RPC (same pattern as other
-          # mainnet nodes). Does not configure zcashd RPC ingest.
           rpc_listen_addr = "127.0.0.1:8232"
-          rpc_auth   = "cookie"
-          rpc_config_path = "/root/.cache/zebra/.cookie"
           EOF
 
       - name: Build deployer binary
@@ -309,6 +305,18 @@ jobs:
           sudo install -d -m 755 "$dashboard_dir"
           sudo install -m 755 deploy/runner/zebra-cluster-status.py "$dashboard_dir/zebra-cluster-status.py"
           cp deploy/deployer/nodes.ci.toml "$RUNNER_TEMP/dashboard.nodes.toml"
+          # Dashboard-only: deploy.py rejects these fields, so add cookie RPC
+          # auth for zakura-compat into this copy (not the deploy config).
+          awk '
+            { print }
+            $0 ~ /^name[[:space:]]*=[[:space:]]*"zakura-compat"/ { in_compat = 1 }
+            in_compat && $0 ~ /^rpc_listen_addr[[:space:]]*=[[:space:]]*"127\.0\.0\.1:8232"/ {
+              print "rpc_auth   = \"cookie\""
+              print "rpc_config_path = \"/root/.cache/zakura/.cookie\""
+              in_compat = 0
+            }
+          ' "$RUNNER_TEMP/dashboard.nodes.toml" > "$RUNNER_TEMP/dashboard.nodes.toml.tmp"
+          mv "$RUNNER_TEMP/dashboard.nodes.toml.tmp" "$RUNNER_TEMP/dashboard.nodes.toml"
           cat >> "$RUNNER_TEMP/dashboard.nodes.toml" <<'EOF'
 
           [[nodes]]
@@ -316,12 +324,14 @@ jobs:
           ssh_string = "root@159.203.113.196"
           probe_kind = "zcashd"
           service_name = ""
-          bin_path = "/mnt/snapshots/import-zebra/zcashd-compat/bin/v6.2.1-alpha.7/x86_64-pc-linux-gnu/zcashd"
+          # Managed download path from zcashd-compat-manifest.json (alpha.4+).
+          bin_path = "/mnt/snapshots/import-zebra/zcashd-compat/bin/v0.0.1-compat-alpha.4/x86_64-pc-linux-gnu/zcashd"
           log_file = ""
           rpc_listen_addr = "[::1]:8232"
           rpc_auth = "cookie"
           rpc_config_path = "/mnt/snapshots/runtime/zcashd/.cookie"
-          process_pattern = "zcashd .*-zebra-compat"
+          # P2P sidecar (post -zebra-compat): supervised with -connect=127.0.0.1:8233.
+          process_pattern = "zcashd .*-connect=127.0.0.1:8233"
           EOF
           sudo install -m 644 "$RUNNER_TEMP/dashboard.nodes.toml" "$dashboard_dir/nodes.toml"
 


### PR DESCRIPTION
## Motivation

Mainnet fleet deploys fail at `deploy.py build` because `nodes.ci.toml` includes `rpc_auth` / `rpc_config_path` on `zakura-compat`, which `deploy.py` rejects as unknown keys (see [run 29067575796](https://github.com/zakura-core/zakura/actions/runs/29067575796)).

Those fields are only needed by `zebra-cluster-status.py`, not by the deployer.

## Solution

- Remove `rpc_auth` / `rpc_config_path` from the deployer-generated `nodes.ci.toml`.
- Inject cookie auth for `zakura-compat` only into the dashboard `nodes.toml` copy (same idea as the existing `zcashd-compat` append).
- Update the mainnet `zcashd-compat` dashboard probe to the managed [v0.0.1-compat-alpha.4](https://github.com/valargroup/zcashd/releases/tag/v0.0.1-compat-alpha.4) path and P2P sidecar process pattern (`-connect=127.0.0.1:8233`).

### Tests

- Local: `deploy.py status` loads a sample fleet TOML without `rpc_*` keys.
- Local: awk inject inserts cookie auth after `zakura-compat`'s `rpc_listen_addr`.
- Did not re-run the full mainnet deploy workflow (low-risk CI YAML-only change).

### AI Disclosure

- [x] Used Cursor (Composer) to draft the workflow fix and PR description