### PR TITLE
ci: ephemeral per-PR DigitalOcean test nodes (bake/run/reap)

### DIFF
--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Runs ON the bake droplet (zakura-pr-node-bake.yml): installs build deps and
+# rustup, clones the repo and warms a release cargo cache, bakes a loopback SSH
+# identity so deploy.py can target root@localhost on the run droplets, fills the
+# attached per-network volumes with extracted chain state, and cleans the
+# droplet for imaging.
+#
+# Config via /root/bake.env (sourced by the caller before exec):
+#   GH_REPO                  owner/name of this repository
+#   GH_CLONE_TOKEN           token used once for the clone; the remote URL is
+#                            reset token-free afterwards, nothing is baked
+#   MAINNET_VOLUME_NAME      DO volume that gets tip/ + sandblast/ mainnet state
+#   TESTNET_VOLUME_NAME      DO volume that gets tip/ testnet state
+#   TIP_MAINNET_LATEST_JSON  latest.json pointer for the mainnet pruned tip
+#   SANDBLAST_URL            pinned pre-spam-region mainnet archive snapshot
+#   SANDBLAST_SHA256         its sha256
+#   TESTNET_SNAPSHOTS_BASE   testnet snapshots site (serves /snapshots.json)
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+# A freshly-booted droplet runs apt at boot (cloud-init / unattended-upgrades);
+# wait for it to release the dpkg lock instead of racing it.
+cloud-init status --wait >/dev/null 2>&1 || true
+for _ in $(seq 1 120); do pgrep -x apt-get >/dev/null || break; sleep 5; done
+apt-get -o DPkg::Lock::Timeout=600 update -qq
+apt-get -o DPkg::Lock::Timeout=600 install -y -qq \
+  build-essential clang cmake pkg-config libssl-dev protobuf-compiler \
+  git curl zstd jq python3
+
+# --------------------------------------------------------------------------- #
+# Rust toolchain + repo clone + warm release build
+# --------------------------------------------------------------------------- #
+
+curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+# deploy.py runs bare `cargo` from a non-login SSH shell where ~/.cargo/env has
+# not been sourced, so the toolchain must be reachable from the default PATH.
+ln -sf /root/.cargo/bin/cargo /root/.cargo/bin/rustc /root/.cargo/bin/rustup /usr/local/bin/
+
+git clone "https://x-access-token:${GH_CLONE_TOKEN}@github.com/${GH_REPO}.git" /root/zakura
+# Strip the token from the baked image; run droplets fetch with a fresh
+# per-run token via an http.extraheader instead.
+git -C /root/zakura remote set-url origin "https://github.com/${GH_REPO}.git"
+
+# Warm the shared target dir that deploy.py's per-run worktree builds reuse.
+cd /root/zakura
+export CARGO_TARGET_DIR=/root/cargo-target
+cargo build --release --locked -p zebrad
+/root/cargo-target/release/zebrad --version
+
+# --------------------------------------------------------------------------- #
+# Loopback SSH identity: deploy.py drives the node over root@localhost
+# --------------------------------------------------------------------------- #
+
+if [ ! -f /root/.ssh/pr_node_loopback ]; then
+  ssh-keygen -t ed25519 -N '' -f /root/.ssh/pr_node_loopback
+fi
+grep -qxF "$(cat /root/.ssh/pr_node_loopback.pub)" /root/.ssh/authorized_keys 2>/dev/null || \
+  cat /root/.ssh/pr_node_loopback.pub >> /root/.ssh/authorized_keys
+cat > /root/.ssh/config <<'CFG'
+Host localhost
+    IdentityFile /root/.ssh/pr_node_loopback
+    StrictHostKeyChecking accept-new
+CFG
+chmod 600 /root/.ssh/config
+# Self-test now so the localhost host key is also baked into known_hosts.
+ssh -o BatchMode=yes root@localhost true
+
+# --------------------------------------------------------------------------- #
+# Fill the state volumes
+# --------------------------------------------------------------------------- #
+
+mount_volume() {
+  local mnt="$2" dev="/dev/disk/by-id/scsi-0DO_Volume_$1"
+  for _ in $(seq 1 30); do [ -e "$dev" ] && break; sleep 2; done
+  [ -e "$dev" ] || { echo "volume device not found: $dev" >&2; return 1; }
+  blkid "$dev" >/dev/null 2>&1 || mkfs.ext4 -q "$dev"
+  mkdir -p "$mnt"
+  mount "$dev" "$mnt"
+}
+
+# Download to the (large) volume, verify sha256 when given, extract into
+# <mount>/<mode>/ so the node's state cache_dir can point straight at it,
+# and assert the expected state/v*/<network> tree came out.
+fetch_state() {
+  local url="$1" sha="$2" dest="$3" network="$4"
+  local tarball="${dest%/}.tar.zst"
+  echo "Fetching ${url} -> ${dest}"
+  df -h "$(dirname "$dest")"
+  curl -fL --retry 3 --retry-delay 10 -o "$tarball" "$url"
+  if [ -n "$sha" ]; then
+    echo "${sha}  ${tarball}" | sha256sum -c -
+  fi
+  mkdir -p "$dest"
+  zstd -dc "$tarball" | tar -x -C "$dest"
+  rm -f "$tarball"
+  ls -d "$dest"/state/v*/"$network" >/dev/null || {
+    echo "extracted state not found under ${dest}/state/v*/${network}" >&2
+    return 1
+  }
+  echo "Restored $(ls -d "$dest"/state/v*/"$network")"
+}
+
+MAINNET_MNT=/mnt/bake-mainnet
+TESTNET_MNT=/mnt/bake-testnet
+mount_volume "$MAINNET_VOLUME_NAME" "$MAINNET_MNT"
+mount_volume "$TESTNET_VOLUME_NAME" "$TESTNET_MNT"
+
+# Mainnet tip: resolve the daily pruned snapshot through its latest.json pointer.
+TIP_META=$(curl -fsSL --retry 3 "$TIP_MAINNET_LATEST_JSON")
+TIP_URL=$(echo "$TIP_META" | jq -er '.url')
+TIP_SHA=$(echo "$TIP_META" | jq -er '.sha256')
+echo "Mainnet tip: $(echo "$TIP_META" | jq -r '"\(.filename) height=\(.height) db=\(.db_format_version)"')"
+fetch_state "$TIP_URL" "$TIP_SHA" "$MAINNET_MNT/tip" mainnet
+
+# Mainnet sandblast: pinned archive just before the 2022 spam region.
+fetch_state "$SANDBLAST_URL" "$SANDBLAST_SHA256" "$MAINNET_MNT/sandblast" mainnet
+
+# Testnet tip: newest enabled pruned entry from the snapshots site metadata.
+TESTNET_META=$(curl -fsSL --retry 3 "$TESTNET_SNAPSHOTS_BASE/snapshots.json")
+ENTRY=$(echo "$TESTNET_META" | jq -er \
+  '[.snapshots[] | select(.enabled and .kind == "pruned")] | sort_by(.published) | last')
+[ "$ENTRY" != "null" ] || { echo "no enabled pruned testnet snapshot found" >&2; exit 1; }
+TN_FILE=$(echo "$ENTRY" | jq -er '.file')
+TN_SHA=$(echo "$ENTRY" | jq -er '.sha256')
+TN_BASE=$(echo "$TESTNET_META" | jq -r '.siteBaseUrl // empty')
+echo "Testnet tip: $(echo "$ENTRY" | jq -r '"\(.file) height=\(.height) db=\(.dbFormat)"')"
+if [ -n "$TN_BASE" ] && curl -fsIL --retry 2 "${TN_BASE}/files/${TN_FILE}" >/dev/null 2>&1; then
+  fetch_state "${TN_BASE}/files/${TN_FILE}" "$TN_SHA" "$TESTNET_MNT/tip" testnet
+else
+  fetch_state "${TESTNET_SNAPSHOTS_BASE}/files/${TN_FILE}" "$TN_SHA" "$TESTNET_MNT/tip" testnet
+fi
+
+sync
+umount "$MAINNET_MNT" "$TESTNET_MNT"
+
+# --------------------------------------------------------------------------- #
+# Clean the droplet for imaging
+# --------------------------------------------------------------------------- #
+
+apt-get clean
+truncate -s 0 /etc/machine-id
+# Without this, droplets created from the image skip first-boot cloud-init and
+# never receive the CI's DO SSH key (which looks like a network failure).
+cloud-init clean --logs
+
+echo "Bake complete."

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -45,7 +45,7 @@ git -C /root/zakura remote set-url origin "https://github.com/${GH_REPO}.git"
 # Warm the shared target dir that deploy.py's per-run worktree builds reuse.
 cd /root/zakura
 export CARGO_TARGET_DIR=/root/cargo-target
-cargo build --release --locked -p zebrad
+cargo build --release --locked -p zakura
 /root/cargo-target/release/zakurad --version
 
 # --------------------------------------------------------------------------- #

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -87,7 +87,11 @@ fetch_state() {
   local tarball="${dest%/}.tar.zst"
   echo "Fetching ${url} -> ${dest}"
   df -h "$(dirname "$dest")"
-  curl -fL --retry 3 --retry-delay 10 -o "$tarball" "$url"
+  # --http1.1: the CDN intermittently kills long HTTP/2 streams (INTERNAL_ERROR).
+  # --retry-all-errors + -C -: resume interrupted multi-GB transfers instead of
+  # failing the whole bake (plain --retry does not cover mid-stream resets).
+  curl -fL --http1.1 --retry 8 --retry-delay 15 --retry-all-errors -C - \
+    -o "$tarball" "$url"
   if [ -n "$sha" ]; then
     echo "${sha}  ${tarball}" | sha256sum -c -
   fi

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -46,7 +46,7 @@ git -C /root/zakura remote set-url origin "https://github.com/${GH_REPO}.git"
 cd /root/zakura
 export CARGO_TARGET_DIR=/root/cargo-target
 cargo build --release --locked -p zebrad
-/root/cargo-target/release/zebrad --version
+/root/cargo-target/release/zakurad --version
 
 # --------------------------------------------------------------------------- #
 # Loopback SSH identity: deploy.py drives the node over root@localhost

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -57,13 +57,16 @@ if [ ! -f /root/.ssh/pr_node_loopback ]; then
 fi
 grep -qxF "$(cat /root/.ssh/pr_node_loopback.pub)" /root/.ssh/authorized_keys 2>/dev/null || \
   cat /root/.ssh/pr_node_loopback.pub >> /root/.ssh/authorized_keys
+# No host-key checking for loopback: droplets created from this image
+# regenerate their SSH host keys on first boot, so a baked known_hosts entry
+# would make every deploy.py connection fail with a changed-key error.
 cat > /root/.ssh/config <<'CFG'
 Host localhost
     IdentityFile /root/.ssh/pr_node_loopback
-    StrictHostKeyChecking accept-new
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
 CFG
 chmod 600 /root/.ssh/config
-# Self-test now so the localhost host key is also baked into known_hosts.
 ssh -o BatchMode=yes root@localhost true
 
 # --------------------------------------------------------------------------- #

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -41,6 +41,8 @@ git clone "https://x-access-token:${GH_CLONE_TOKEN}@github.com/${GH_REPO}.git" /
 # Strip the token from the baked image; run droplets fetch with a fresh
 # per-run token via an http.extraheader instead.
 git -C /root/zakura remote set-url origin "https://github.com/${GH_REPO}.git"
+rm -f /root/bake.env
+unset GH_CLONE_TOKEN
 
 # Warm the shared target dir that deploy.py's per-run worktree builds reuse.
 cd /root/zakura

--- a/.github/workflows/scripts/pr-node-monitor.py
+++ b/.github/workflows/scripts/pr-node-monitor.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Monitor a running zakurad node and emit a run summary.
+
+Runs ON the ephemeral PR-node droplet (invoked by pr-node-run.sh). Samples the
+node's JSON-RPC endpoint, systemd unit state, and memory use on an interval for
+a fixed duration, then scans the node log for errors/panics and writes
+summary.json (machine) + summary.md (human, posted as the PR comment).
+
+Stdlib only, mirroring deploy/deployer/deploy.py.
+
+Exit status: 0 for an ok/degraded run, 1 for a failed run (service inactive at
+the end, a panic, an unexpected restart, or RPC never came up).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+# The node gets this long to open the state DB and bind RPC before failing
+# samples start counting against it.
+RPC_GRACE_SECS = 300
+
+
+def rpc_call(url: str, method: str):
+    payload = json.dumps(
+        {"jsonrpc": "1.0", "id": "pr-node-monitor", "method": method, "params": []}
+    ).encode()
+    req = urllib.request.Request(
+        url, data=payload, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())["result"]
+
+
+def systemd_props(service: str) -> dict[str, str]:
+    out = subprocess.run(
+        ["systemctl", "show", service, "--property=ActiveState,NRestarts,MainPID"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    return dict(line.split("=", 1) for line in out.splitlines() if "=" in line)
+
+
+def rss_mib(pid: str) -> float | None:
+    try:
+        status = Path(f"/proc/{pid}/status").read_text()
+    except OSError:
+        return None
+    m = re.search(r"^VmRSS:\s+(\d+)\s+kB", status, re.MULTILINE)
+    return round(int(m.group(1)) / 1024, 1) if m else None
+
+
+def take_sample(args) -> dict:
+    sample: dict = {"elapsed": None, "height": None, "estimated": None, "peers": None}
+    try:
+        info = rpc_call(args.rpc_url, "getblockchaininfo")
+        sample["height"] = info.get("blocks")
+        sample["estimated"] = info.get("estimatedheight")
+    except Exception as exc:  # noqa: BLE001 — any RPC failure is just a missed sample
+        sample["rpc_error"] = str(exc)
+    try:
+        sample["peers"] = len(rpc_call(args.rpc_url, "getpeerinfo"))
+    except Exception:  # noqa: BLE001
+        pass
+    props = systemd_props(args.service)
+    sample["active_state"] = props.get("ActiveState")
+    sample["restarts"] = int(props.get("NRestarts") or 0)
+    pid = props.get("MainPID", "0")
+    sample["rss_mib"] = rss_mib(pid) if pid != "0" else None
+    return sample
+
+
+def scan_logs(log_file: str, service: str) -> dict:
+    errors = warns = 0
+    last_errors: list[str] = []
+    try:
+        with open(log_file, errors="replace") as fh:
+            for line in fh:
+                if " ERROR " in line:
+                    errors += 1
+                    last_errors.append(line.rstrip()[:300])
+                    last_errors = last_errors[-5:]
+                elif " WARN " in line:
+                    warns += 1
+    except OSError:
+        pass
+    # Panics go to stderr (the journal), not the tracing log file.
+    journal = subprocess.run(
+        ["journalctl", "-u", service, "--no-pager", "-o", "cat"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    panics = len(re.findall(r"panicked at", journal)) + len(
+        re.findall(r"panicked at", "".join(last_errors))
+    )
+    return {"errors": errors, "warns": warns, "panics": panics, "last_errors": last_errors}
+
+
+def fmt(value, suffix: str = "") -> str:
+    return f"{value}{suffix}" if value is not None else "n/a"
+
+
+def build_summary(meta: dict, samples: list[dict], logs: dict, duration_min: float) -> dict:
+    heighted = [s for s in samples if s["height"] is not None]
+    start_h = heighted[0]["height"] if heighted else None
+    end_h = heighted[-1]["height"] if heighted else None
+    progress = (end_h - start_h) if heighted else None
+    last = samples[-1] if samples else {}
+    peers = [s["peers"] for s in samples if s["peers"] is not None]
+    rss = [s["rss_mib"] for s in samples if s["rss_mib"] is not None]
+    restarts = max((s["restarts"] for s in samples), default=0)
+
+    if (
+        last.get("active_state") != "active"
+        or logs["panics"] > 0
+        or restarts > 0
+        or not heighted
+    ):
+        verdict = "failed"
+    elif logs["errors"] > 0 or (progress is not None and progress <= 0):
+        verdict = "degraded"
+    else:
+        verdict = "ok"
+
+    return {
+        **meta,
+        "verdict": verdict,
+        "duration_minutes": duration_min,
+        "start_height": start_h,
+        "end_height": end_h,
+        "blocks_synced": progress,
+        "blocks_per_hour": (
+            round(progress / duration_min * 60) if progress is not None and duration_min else None
+        ),
+        "estimated_tip_at_end": last.get("estimated"),
+        "peers_last": peers[-1] if peers else None,
+        "peers_min": min(peers) if peers else None,
+        "peak_rss_mib": max(rss) if rss else None,
+        "service_active_at_end": last.get("active_state"),
+        "service_restarts": restarts,
+        "log_errors": logs["errors"],
+        "log_warns": logs["warns"],
+        "panics": logs["panics"],
+        "last_errors": logs["last_errors"],
+    }
+
+
+def write_markdown(out: Path, summary: dict, samples: list[dict], notes_file: str | None):
+    icon = {"ok": "✅", "degraded": "⚠️", "failed": "❌"}[summary["verdict"]]
+    mode, network = summary.get("mode", "?"), summary.get("network", "?")
+    lines = [
+        f"## Zakura PR node run — {mode}/{network} {icon}",
+        "",
+        "| | |",
+        "|---|---|",
+        f"| Verdict | **{summary['verdict']}** |",
+        f"| Commit | `{summary.get('sha', '?')}` |",
+        f"| Duration | {summary['duration_minutes']:g} min |",
+        f"| Height | {fmt(summary['start_height'])} → {fmt(summary['end_height'])} "
+        f"(+{fmt(summary['blocks_synced'])}) |",
+        f"| Blocks/hour | {fmt(summary['blocks_per_hour'])} |",
+        f"| Estimated tip at end | {fmt(summary['estimated_tip_at_end'])} |",
+        f"| Peers (min/last) | {fmt(summary['peers_min'])} / {fmt(summary['peers_last'])} |",
+        f"| Peak RSS | {fmt(summary['peak_rss_mib'], ' MiB')} |",
+        f"| Service at end | {fmt(summary['service_active_at_end'])}, "
+        f"{summary['service_restarts']} restart(s) |",
+        f"| Log errors/warns/panics | {summary['log_errors']} / {summary['log_warns']} / "
+        f"{summary['panics']} |",
+    ]
+
+    shown = [s for s in samples if s["height"] is not None]
+    if shown:
+        # Subsample to ~12 rows so an hour-long run stays readable.
+        step = max(1, len(shown) // 12)
+        picked = shown[::step]
+        if picked[-1] is not shown[-1]:
+            picked.append(shown[-1])
+        lines += ["", "### Height over time", "", "| Elapsed | Height | Peers | RSS (MiB) |", "|---|---|---|---|"]
+        for s in picked:
+            lines.append(
+                f"| {int(s['elapsed'] // 60)}m | {fmt(s['height'])} | {fmt(s['peers'])} "
+                f"| {fmt(s['rss_mib'])} |"
+            )
+
+    if summary["last_errors"]:
+        lines += ["", "### Last errors", "", "```"]
+        lines += summary["last_errors"]
+        lines += ["```"]
+
+    if notes_file and Path(notes_file).is_file():
+        lines += ["", "### Notes", "", Path(notes_file).read_text().rstrip()]
+
+    (out / "summary.md").write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duration-minutes", type=float, required=True)
+    parser.add_argument("--interval", type=float, default=30)
+    parser.add_argument("--rpc-url", default="http://127.0.0.1:8232")
+    parser.add_argument("--service", default="zakurad")
+    parser.add_argument("--log-file", default="/var/log/zakura/zakura.log")
+    parser.add_argument("--notes", default=None, help="markdown notes file to append")
+    parser.add_argument("--meta", default="", help="comma-separated key=value run metadata")
+    parser.add_argument("--out", required=True, help="output directory")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    meta = dict(kv.split("=", 1) for kv in args.meta.split(",") if "=" in kv)
+
+    start = time.monotonic()
+    deadline = start + args.duration_minutes * 60
+    samples: list[dict] = []
+    while True:
+        sample = take_sample(args)
+        sample["elapsed"] = time.monotonic() - start
+        samples.append(sample)
+        status = (
+            f"[{int(sample['elapsed'])}s] height={fmt(sample['height'])} "
+            f"peers={fmt(sample['peers'])} rss={fmt(sample['rss_mib'])}MiB "
+            f"state={sample['active_state']}"
+        )
+        print(status, flush=True)
+        # Bail out early once the node is clearly gone (past the startup grace).
+        if sample["elapsed"] > RPC_GRACE_SECS and sample["active_state"] == "failed":
+            print("service failed; stopping monitor early", flush=True)
+            break
+        if time.monotonic() + args.interval > deadline:
+            break
+        time.sleep(args.interval)
+
+    logs = scan_logs(args.log_file, args.service)
+    summary = build_summary(meta, samples, logs, args.duration_minutes)
+    (out / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    write_markdown(out, summary, samples, args.notes)
+    print(f"verdict: {summary['verdict']}", flush=True)
+    return 1 if summary["verdict"] == "failed" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/pr-node-run.sh
+++ b/.github/workflows/scripts/pr-node-run.sh
@@ -61,6 +61,8 @@ GIT_AUTH=$(printf 'x-access-token:%s' "${GH_CLONE_TOKEN}" | base64 -w0)
 git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
   fetch --no-tags origin "${REFSPEC}"
 git checkout --detach "${SHA}"
+rm -f /root/run.env
+unset GH_CLONE_TOKEN GIT_AUTH
 
 # ---------------------------------------------------------------------------- #
 # Preflight: baked state DB format vs the PR tree's format
@@ -112,6 +114,7 @@ commit = "${SHA}"
 network = "${NET_TOML}"
 state_cache_dir = "${STATE_CACHE_DIR}"
 storage_mode = "${STORAGE_MODE}"
+p2p_stack = "default"
 rpc_listen_addr = "127.0.0.1:8232"
 rpc_enable_cookie_auth = false
 metrics_endpoint = "127.0.0.1:9999"

--- a/.github/workflows/scripts/pr-node-run.sh
+++ b/.github/workflows/scripts/pr-node-run.sh
@@ -55,7 +55,10 @@ fi
 # ---------------------------------------------------------------------------- #
 
 cd /root/zakura
-git -c http.extraheader="AUTHORIZATION: bearer ${GH_CLONE_TOKEN}" \
+# git-over-HTTPS wants basic auth (the bearer form is API-only); this is the
+# same header actions/checkout configures.
+GIT_AUTH=$(printf 'x-access-token:%s' "${GH_CLONE_TOKEN}" | base64 -w0)
+git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
   fetch --no-tags origin "${REFSPEC}"
 git checkout --detach "${SHA}"
 

--- a/.github/workflows/scripts/pr-node-run.sh
+++ b/.github/workflows/scripts/pr-node-run.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Runs ON the ephemeral PR-node droplet (zakura-pr-node.yml): mounts the cloned
+# state volume, checks out the PR commit in the baked repo clone, builds zakurad
+# incrementally against the baked cargo cache via deploy.py (over the baked
+# root@localhost loopback), deploys it as the zakurad systemd service, and
+# monitors it for the requested duration.
+#
+# Config via /root/run.env (sourced by the caller before exec):
+#   GH_REPO / GH_CLONE_TOKEN  repo slug + per-run token for the PR-ref fetch
+#   MODE                      tip | sandblast | genesis
+#   NETWORK                   mainnet | testnet
+#   SHA / REFSPEC             commit to test + refspec that reaches it
+#   DURATION_MINUTES          how long to monitor the running node
+#   VOLUME_NAME               state volume name ("" in genesis mode)
+set -euo pipefail
+
+OUT_DIR=/root/out
+NOTES="$OUT_DIR/notes.md"
+mkdir -p "$OUT_DIR"
+
+note() {
+  echo "$1"
+  echo "- $1" >> "$NOTES"
+}
+
+cloud-init status --wait >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------- #
+# State: mount the per-run clone of the baked volume snapshot
+# ---------------------------------------------------------------------------- #
+
+if [ "$MODE" = "genesis" ]; then
+  STATE_CACHE_DIR=/var/lib/zakura
+  STORAGE_MODE=archive
+  mkdir -p "$STATE_CACHE_DIR"
+  df -h /
+else
+  DEV="/dev/disk/by-id/scsi-0DO_Volume_${VOLUME_NAME}"
+  for _ in $(seq 1 30); do [ -e "$DEV" ] && break; sleep 2; done
+  [ -e "$DEV" ] || { echo "state volume device not found: $DEV" >&2; exit 1; }
+  mkdir -p /mnt/snapshots
+  mount "$DEV" /mnt/snapshots
+  STATE_CACHE_DIR="/mnt/snapshots/${MODE}"
+  case "$MODE" in
+    tip)       STORAGE_MODE=pruned ;;
+    sandblast) STORAGE_MODE=archive ;;
+    *)         echo "unknown snapshot mode: $MODE" >&2; exit 1 ;;
+  esac
+  [ -d "$STATE_CACHE_DIR" ] || { echo "no ${MODE}/ state on the volume" >&2; exit 1; }
+  df -h /mnt/snapshots
+fi
+
+# ---------------------------------------------------------------------------- #
+# Source: fetch the PR ref into the baked clone
+# ---------------------------------------------------------------------------- #
+
+cd /root/zakura
+git -c http.extraheader="AUTHORIZATION: bearer ${GH_CLONE_TOKEN}" \
+  fetch --no-tags origin "${REFSPEC}"
+git checkout --detach "${SHA}"
+
+# ---------------------------------------------------------------------------- #
+# Preflight: baked state DB format vs the PR tree's format
+# ---------------------------------------------------------------------------- #
+
+CODE_VER=$(grep -oE 'DATABASE_FORMAT_VERSION: .* [0-9]+' zebra-state/src/constants.rs | grep -oE '[0-9]+' | tail -n1)
+if [ "$MODE" != "genesis" ]; then
+  DIR_VER=$(find "$STATE_CACHE_DIR/state" -mindepth 1 -maxdepth 1 -type d -name 'v*' 2>/dev/null | \
+    sed 's#.*/v##' | sort -n | tail -1)
+  if [ -z "$DIR_VER" ]; then
+    note "**WARNING:** no state/v* directory found under \`$STATE_CACHE_DIR\` — the node will sync from scratch."
+  elif [ "$DIR_VER" = "$CODE_VER" ]; then
+    note "State DB format v${DIR_VER} matches the PR tree."
+  elif [ "$DIR_VER" = "$((CODE_VER - 1))" ]; then
+    note "State snapshot is v${DIR_VER}, PR tree is v${CODE_VER}: zakurad restores the previous major format in place (a format upgrade runs during the test)."
+  else
+    note "**WARNING: DB format mismatch** — snapshot is v${DIR_VER} but the PR tree is v${CODE_VER}. The baked state will be ignored and the node syncs from scratch; re-bake the image or use genesis mode."
+  fi
+fi
+
+# ---------------------------------------------------------------------------- #
+# Build + deploy via deploy.py against the baked loopback SSH identity
+# ---------------------------------------------------------------------------- #
+
+case "$NETWORK" in
+  mainnet) NET_TOML=Mainnet ;;
+  testnet) NET_TOML=Testnet ;;
+  *) echo "unknown network: $NETWORK" >&2; exit 1 ;;
+esac
+
+cat > /root/fleet.toml <<TOML
+[[nodes]]
+name = "pr-node"
+ssh_string = "root@localhost"
+commit = "${SHA}"
+network = "${NET_TOML}"
+state_cache_dir = "${STATE_CACHE_DIR}"
+storage_mode = "${STORAGE_MODE}"
+rpc_listen_addr = "127.0.0.1:8232"
+rpc_enable_cookie_auth = false
+metrics_endpoint = "127.0.0.1:9999"
+TOML
+
+export CARGO_TARGET_DIR=/root/cargo-target
+BUILD_START=$(date +%s)
+python3 deploy/deployer/deploy.py build --config /root/fleet.toml
+note "Incremental build took $(( $(date +%s) - BUILD_START ))s (warm baked cache)."
+
+python3 deploy/deployer/deploy.py deploy --config /root/fleet.toml
+python3 deploy/deployer/deploy.py status --config /root/fleet.toml || true
+
+# ---------------------------------------------------------------------------- #
+# Monitor for the requested duration, then package outputs
+# ---------------------------------------------------------------------------- #
+
+MONITOR_RC=0
+python3 /root/pr-node-monitor.py \
+  --duration-minutes "${DURATION_MINUTES}" \
+  --interval 30 \
+  --rpc-url http://127.0.0.1:8232 \
+  --service zakurad \
+  --log-file /var/log/zakura/zakura.log \
+  --notes "$NOTES" \
+  --meta "mode=${MODE},network=${NETWORK},sha=${SHA}" \
+  --out "$OUT_DIR" || MONITOR_RC=$?
+
+tail -n 2000 /var/log/zakura/zakura.log > "$OUT_DIR/zakura-tail.log" 2>/dev/null || true
+zstd -T0 -q -f /var/log/zakura/zakura.log -o "$OUT_DIR/zakura-full.log.zst" 2>/dev/null || true
+
+exit "$MONITOR_RC"

--- a/.github/workflows/scripts/pr-node-run.sh
+++ b/.github/workflows/scripts/pr-node-run.sh
@@ -66,7 +66,7 @@ git checkout --detach "${SHA}"
 # Preflight: baked state DB format vs the PR tree's format
 # ---------------------------------------------------------------------------- #
 
-CODE_VER=$(grep -oE 'DATABASE_FORMAT_VERSION: .* [0-9]+' zebra-state/src/constants.rs | grep -oE '[0-9]+' | tail -n1)
+CODE_VER=$(grep -oE 'DATABASE_FORMAT_VERSION: .* [0-9]+' zakura-state/src/constants.rs | grep -oE '[0-9]+' | tail -n1)
 if [ "$MODE" != "genesis" ]; then
   DIR_VER=$(find "$STATE_CACHE_DIR/state" -mindepth 1 -maxdepth 1 -type d -name 'v*' 2>/dev/null | \
     sed 's#.*/v##' | sort -n | tail -1)

--- a/.github/workflows/scripts/pr-node-run.sh
+++ b/.github/workflows/scripts/pr-node-run.sh
@@ -85,6 +85,19 @@ fi
 # Build + deploy via deploy.py against the baked loopback SSH identity
 # ---------------------------------------------------------------------------- #
 
+# Enforce the loopback SSH config regardless of what the image baked: this
+# droplet regenerated its host keys on first boot, so any recorded localhost
+# host key is stale and would fail deploy.py's connections as a changed key.
+cat > /root/.ssh/config <<'CFG'
+Host localhost
+    IdentityFile /root/.ssh/pr_node_loopback
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+CFG
+chmod 600 /root/.ssh/config
+rm -f /root/.ssh/known_hosts
+ssh -o BatchMode=yes root@localhost true
+
 case "$NETWORK" in
   mainnet) NET_TOML=Mainnet ;;
   testnet) NET_TOML=Testnet ;;

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -129,6 +129,7 @@ jobs:
           } > /tmp/bake.env
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
             /tmp/bake.env .github/workflows/scripts/pr-node-bake.sh "root@${IP}:/root/"
+          rm -f /tmp/bake.env
           # Keepalives: the cold build and snapshot downloads are long and low-output.
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             -o ServerAliveInterval=30 -o ServerAliveCountMax=240 -i /tmp/do_ssh "root@${IP}" \

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -1,0 +1,203 @@
+name: PR node image bake
+
+# Bakes the golden assets for the ephemeral PR-node workflow (zakura-pr-node.yml):
+#   - one base droplet image: build deps + rustup + repo clone + warm cargo
+#     release cache + a loopback SSH identity for deploy.py,
+#   - one volume snapshot per network with extracted chain state
+#     (mainnet: tip/ + sandblast/, testnet: tip/).
+# Runs weekly so the tip states and the cargo cache never drift far from main;
+# PR-node runs sync the remaining gap during their hour.
+
+on:
+  workflow_dispatch:
+    inputs:
+      droplet_size:
+        description: "Bake droplet size (its disk becomes the image's minimum disk)"
+        required: false
+        default: c-8
+      region:
+        description: "DO region (must host the run droplets too)"
+        required: false
+        default: nyc3
+  schedule:
+    - cron: "0 4 * * 1" # weekly Monday 04:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zakura-pr-node-bake
+  cancel-in-progress: false
+
+jobs:
+  bake:
+    runs-on: ubuntu-latest
+    # Cold cargo build + three snapshot downloads + a ~50GB image snapshot.
+    timeout-minutes: 210
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install doctl
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          DOCTL_VERSION=1.120.0
+          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
+          sudo install /tmp/doctl /usr/local/bin/doctl
+          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
+
+      - name: Write SSH key
+        env:
+          DO_SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+        run: |
+          install -m 600 /dev/null /tmp/do_ssh
+          printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh
+
+      - name: Create state volumes + bake droplet
+        id: droplet
+        env:
+          REGION: ${{ inputs.region || 'nyc3' }}
+          DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
+          SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
+        run: |
+          set -euo pipefail
+          MAINNET_VOL="zakura-pr-bake-mainnet-${GITHUB_RUN_ID}"
+          TESTNET_VOL="zakura-pr-bake-testnet-${GITHUB_RUN_ID}"
+          MAINNET_VOL_ID=$(doctl compute volume create "$MAINNET_VOL" \
+            --region "${REGION}" --size 300GiB --format ID --no-header)
+          TESTNET_VOL_ID=$(doctl compute volume create "$TESTNET_VOL" \
+            --region "${REGION}" --size 100GiB --format ID --no-header)
+          {
+            echo "mainnet_vol=$MAINNET_VOL"
+            echo "testnet_vol=$TESTNET_VOL"
+            echo "mainnet_vol_id=$MAINNET_VOL_ID"
+            echo "testnet_vol_id=$TESTNET_VOL_ID"
+          } >> "$GITHUB_OUTPUT"
+
+          NAME="zakura-pr-bake-${GITHUB_RUN_ID}"
+          doctl compute droplet create "$NAME" \
+            --region "${REGION}" \
+            --size "${DROPLET_SIZE}" \
+            --image ubuntu-24-04-x64 \
+            --ssh-keys "${SSH_FINGERPRINT}" \
+            --volumes "${MAINNET_VOL_ID}" \
+            --volumes "${TESTNET_VOL_ID}" \
+            --tag-name zakura-image-bake \
+            --wait --format ID,PublicIPv4 --no-header > /tmp/droplet.txt
+          echo "id=$(awk '{print $1}' /tmp/droplet.txt)" >> "$GITHUB_OUTPUT"
+          echo "ip=$(awk '{print $2}' /tmp/droplet.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for SSH
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i /tmp/do_ssh "root@${IP}" true 2>/dev/null; then
+              echo "SSH up"; exit 0
+            fi
+            sleep 10
+          done
+          echo "SSH did not come up in time"; exit 1
+
+      - name: Run bake script
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+          GH_CLONE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAINNET_VOLUME_NAME: ${{ steps.droplet.outputs.mainnet_vol }}
+          TESTNET_VOLUME_NAME: ${{ steps.droplet.outputs.testnet_vol }}
+          TIP_MAINNET_LATEST_JSON: ${{ vars.ZAKURA_PR_NODE_TIP_LATEST_JSON || 'https://zebra.valargroup.org/mainnet-pruned/latest.json' }}
+          # Pre-spam-region archive snapshot; same artifact checkpoint-sync-bench pins.
+          SANDBLAST_URL: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_URL || 'https://zebra.valargroup.org/mainnet/historical/zebra-mainnet-20260616T032721Z-1707210.tar.zst' }}
+          SANDBLAST_SHA256: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_SHA256 || '19ac5d24eaa4e912cc8bbd4e7f5f2aaa2b6c132854e75d93678316016f0f2769' }}
+          TESTNET_SNAPSHOTS_BASE: ${{ vars.ZAKURA_TESTNET_SNAPSHOTS_URL || 'http://167.99.103.111:8091' }}
+        run: |
+          set -euo pipefail
+          umask 077
+          {
+            printf 'GH_REPO=%q\n'                 "${GITHUB_REPOSITORY}"
+            printf 'GH_CLONE_TOKEN=%q\n'          "${GH_CLONE_TOKEN}"
+            printf 'MAINNET_VOLUME_NAME=%q\n'     "${MAINNET_VOLUME_NAME}"
+            printf 'TESTNET_VOLUME_NAME=%q\n'     "${TESTNET_VOLUME_NAME}"
+            printf 'TIP_MAINNET_LATEST_JSON=%q\n' "${TIP_MAINNET_LATEST_JSON}"
+            printf 'SANDBLAST_URL=%q\n'           "${SANDBLAST_URL}"
+            printf 'SANDBLAST_SHA256=%q\n'        "${SANDBLAST_SHA256}"
+            printf 'TESTNET_SNAPSHOTS_BASE=%q\n'  "${TESTNET_SNAPSHOTS_BASE}"
+          } > /tmp/bake.env
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            /tmp/bake.env .github/workflows/scripts/pr-node-bake.sh "root@${IP}:/root/"
+          # Keepalives: the cold build and snapshot downloads are long and low-output.
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=240 -i /tmp/do_ssh "root@${IP}" \
+            'set -euo pipefail; set -a; . /root/bake.env; set +a; bash /root/pr-node-bake.sh'
+
+      - name: Snapshot state volumes
+        env:
+          MAINNET_VOL_ID: ${{ steps.droplet.outputs.mainnet_vol_id }}
+          TESTNET_VOL_ID: ${{ steps.droplet.outputs.testnet_vol_id }}
+        run: |
+          set -euo pipefail
+          STAMP=$(date -u +%Y%m%d-%H%M)
+          doctl compute volume snapshot "${MAINNET_VOL_ID}" --snapshot-name "zakura-pr-state-mainnet-${STAMP}"
+          doctl compute volume snapshot "${TESTNET_VOL_ID}" --snapshot-name "zakura-pr-state-testnet-${STAMP}"
+
+      - name: Snapshot droplet image
+        env:
+          DROPLET_ID: ${{ steps.droplet.outputs.id }}
+        run: |
+          set -euo pipefail
+          doctl compute droplet-action power-off "${DROPLET_ID}" --wait
+          STAMP=$(date -u +%Y%m%d-%H%M)
+          ACTION_ID=$(doctl compute droplet-action snapshot "${DROPLET_ID}" \
+            --snapshot-name "zakura-pr-node-${STAMP}" --format ID --no-header)
+          # Poll instead of --wait: image snapshots of large disks routinely
+          # exceed doctl's action wait and the status is worth logging.
+          for _ in $(seq 1 180); do
+            STATUS=$(doctl compute droplet-action get "${DROPLET_ID}" \
+              --action-id "${ACTION_ID}" --format Status --no-header)
+            echo "snapshot action: ${STATUS}"
+            case "${STATUS}" in
+              completed) exit 0 ;;
+              errored)   echo "image snapshot failed"; exit 1 ;;
+            esac
+            sleep 30
+          done
+          echo "image snapshot did not complete in time"; exit 1
+
+      - name: Cleanup droplet + volumes, prune old assets
+        if: always()
+        env:
+          DROPLET_ID: ${{ steps.droplet.outputs.id }}
+          MAINNET_VOL_ID: ${{ steps.droplet.outputs.mainnet_vol_id }}
+          TESTNET_VOL_ID: ${{ steps.droplet.outputs.testnet_vol_id }}
+        run: |
+          set +e
+          if [ -n "${DROPLET_ID}" ]; then
+            for _ in 1 2 3; do
+              doctl compute droplet delete "${DROPLET_ID}" -f && break
+              sleep 5
+            done
+          fi
+          # Volumes detach asynchronously after the droplet delete.
+          for VOL_ID in "${MAINNET_VOL_ID}" "${TESTNET_VOL_ID}"; do
+            [ -z "${VOL_ID}" ] && continue
+            for _ in $(seq 1 12); do
+              doctl compute volume delete "${VOL_ID}" -f && break
+              sleep 10
+            done
+          done
+          # Keep the newest 2 images and 2 volume snapshots per network so runs
+          # never depend on the latest bake having succeeded.
+          doctl compute image list-user --format ID,Name --no-header | \
+            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | head -n -2 | \
+            while read -r _name id; do doctl compute image delete "$id" -f; done
+          for NET in mainnet testnet; do
+            doctl compute snapshot list --resource volume --format ID,Name --no-header | \
+              awk -v pre="zakura-pr-state-${NET}-" 'index($2, pre) == 1 {print $2, $1}' | \
+              sort | head -n -2 | \
+              while read -r _name id; do doctl compute snapshot delete "$id" -f; done
+          done
+          true

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -9,6 +9,11 @@ name: PR node image bake
 # PR-node runs sync the remaining gap during their hour.
 
 on:
+  # TEMP(feat/pr-node): registers this workflow for dispatch while the file is
+  # not yet on the default branch; remove before merge.
+  push:
+    branches: [feat/pr-node]
+    paths: [.github/workflows/zakura-pr-node-bake.yml]
   workflow_dispatch:
     inputs:
       droplet_size:

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -9,11 +9,6 @@ name: PR node image bake
 # PR-node runs sync the remaining gap during their hour.
 
 on:
-  # TEMP(feat/pr-node): registers this workflow for dispatch while the file is
-  # not yet on the default branch; remove before merge.
-  push:
-    branches: [feat/pr-node]
-    paths: [.github/workflows/zakura-pr-node-bake.yml]
   workflow_dispatch:
     inputs:
       droplet_size:

--- a/.github/workflows/zakura-pr-node-reaper.yml
+++ b/.github/workflows/zakura-pr-node-reaper.yml
@@ -71,13 +71,17 @@ jobs:
           reap_tag zakura-image-bake $(( 6 * 3600 ))
 
       - name: Reap detached state volumes
+        env:
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '24' }}
         run: |
           set -euo pipefail
           # Give volumes from the droplet sweep above a moment to detach.
           sleep 30
           # Detached zakura-pr-* volumes are always garbage in this system:
           # live runs keep theirs attached, and 2h clears the create->attach
-          # window with a wide margin.
+          # window with a wide margin. A dispatch with a lower max_age_hours
+          # (an emergency sweep) lowers this TTL with it.
+          VOL_TTL=$(( MAX_AGE_HOURS * 3600 < 2 * 3600 ? MAX_AGE_HOURS * 3600 : 2 * 3600 ))
           doctl compute volume list --format ID,Name,CreatedAt,DropletIDs --no-header | \
           while read -r id name created droplets; do
             [ -z "$id" ] && continue
@@ -85,7 +89,7 @@ jobs:
             case "$droplets" in *[0-9]*) continue ;; esac
             created_epoch=$(date -d "$created" +%s 2>/dev/null) || continue
             age=$(( $(date +%s) - created_epoch ))
-            if [ "$age" -gt $(( 2 * 3600 )) ]; then
+            if [ "$age" -gt "$VOL_TTL" ]; then
               echo "deleting detached volume $name (id $id, age ${age}s)"
               doctl compute volume delete "$id" -f || true
             fi

--- a/.github/workflows/zakura-pr-node-reaper.yml
+++ b/.github/workflows/zakura-pr-node-reaper.yml
@@ -1,0 +1,105 @@
+name: PR node reaper
+
+# Hourly cleanup backstop for the ephemeral PR-node fleet (zakura-pr-node.yml /
+# zakura-pr-node-bake.yml). Run droplets are intentionally kept alive after
+# their run for SSH inspection; this deletes them (and every other leaked
+# resource) on a TTL so nothing accrues cost indefinitely:
+#   - zakura-pr-node droplets older than max_age_hours (default 24h)
+#   - zakura-image-bake droplets older than 6h (failed bakes)
+#   - detached zakura-pr-* volumes older than 2h (run/bake leftovers)
+#   - zakura-pr-node-* images and zakura-pr-state-* volume snapshots beyond
+#     the newest 2 each
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_age_hours:
+        description: "Delete run droplets older than this many hours"
+        required: false
+        default: "24"
+  schedule:
+    - cron: "17 * * * *" # hourly
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zakura-pr-node-reaper
+  cancel-in-progress: false
+
+jobs:
+  reap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Install doctl
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          DOCTL_VERSION=1.120.0
+          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
+          sudo install /tmp/doctl /usr/local/bin/doctl
+          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
+
+      - name: Reap expired droplets
+        env:
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '24' }}
+        run: |
+          set -euo pipefail
+          reap_tag() {
+            local tag="$1" max_age_secs="$2"
+            # NOTE: `date -d` is GNU coreutils (present on ubuntu-latest).
+            doctl compute droplet list --tag-name "$tag" --format ID,Name,Created --no-header | \
+            while read -r id name created; do
+              [ -z "$id" ] && continue
+              created_epoch=$(date -d "$created" +%s 2>/dev/null) || continue
+              age=$(( $(date +%s) - created_epoch ))
+              if [ "$age" -gt "$max_age_secs" ]; then
+                echo "deleting droplet $name (id $id, age ${age}s)"
+                doctl compute droplet delete "$id" -f || true
+              fi
+            done
+          }
+          reap_tag zakura-pr-node    $(( MAX_AGE_HOURS * 3600 ))
+          reap_tag zakura-image-bake $(( 6 * 3600 ))
+
+      - name: Reap detached state volumes
+        run: |
+          set -euo pipefail
+          # Give volumes from the droplet sweep above a moment to detach.
+          sleep 30
+          # Detached zakura-pr-* volumes are always garbage in this system:
+          # live runs keep theirs attached, and 2h clears the create->attach
+          # window with a wide margin.
+          doctl compute volume list --format ID,Name,CreatedAt,DropletIDs --no-header | \
+          while read -r id name created droplets; do
+            [ -z "$id" ] && continue
+            case "$name" in zakura-pr-*) ;; *) continue ;; esac
+            case "$droplets" in *[0-9]*) continue ;; esac
+            created_epoch=$(date -d "$created" +%s 2>/dev/null) || continue
+            age=$(( $(date +%s) - created_epoch ))
+            if [ "$age" -gt $(( 2 * 3600 )) ]; then
+              echo "deleting detached volume $name (id $id, age ${age}s)"
+              doctl compute volume delete "$id" -f || true
+            fi
+          done
+
+      - name: Prune old images and volume snapshots
+        run: |
+          set -euo pipefail
+          doctl compute image list-user --format ID,Name --no-header | \
+            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | head -n -2 | \
+            while read -r name id; do
+              echo "deleting image $name (id $id)"
+              doctl compute image delete "$id" -f || true
+            done
+          for NET in mainnet testnet; do
+            doctl compute snapshot list --resource volume --format ID,Name --no-header | \
+              awk -v pre="zakura-pr-state-${NET}-" 'index($2, pre) == 1 {print $2, $1}' | \
+              sort | head -n -2 | \
+              while read -r name id; do
+                echo "deleting volume snapshot $name (id $id)"
+                doctl compute snapshot delete "$id" -f || true
+              done
+          done

--- a/.github/workflows/zakura-pr-node-reaper.yml
+++ b/.github/workflows/zakura-pr-node-reaper.yml
@@ -11,12 +11,6 @@ name: PR node reaper
 #     the newest 2 each
 
 on:
-  # TEMP(feat/pr-node): registers this workflow for dispatch while the file is
-  # not yet on the default branch; remove before merge. The push run performs a
-  # normal (harmless, idempotent) sweep.
-  push:
-    branches: [feat/pr-node]
-    paths: [.github/workflows/zakura-pr-node-reaper.yml]
   workflow_dispatch:
     inputs:
       max_age_hours:

--- a/.github/workflows/zakura-pr-node-reaper.yml
+++ b/.github/workflows/zakura-pr-node-reaper.yml
@@ -47,18 +47,18 @@ jobs:
           MAX_AGE_HOURS: ${{ inputs.max_age_hours || '24' }}
         run: |
           set -euo pipefail
+          # JSON output: `doctl droplet list --format` has no creation-time
+          # column (it silently renders `<nil>`), so age-based sweeps must go
+          # through `created_at` in the JSON.
           reap_tag() {
             local tag="$1" max_age_secs="$2"
-            # NOTE: `date -d` is GNU coreutils (present on ubuntu-latest).
-            doctl compute droplet list --tag-name "$tag" --format ID,Name,Created --no-header | \
+            doctl compute droplet list --tag-name "$tag" --output json | \
+              jq -r --argjson now "$(date +%s)" --argjson max "$max_age_secs" \
+                '(. // [])[] | select(($now - (.created_at | fromdateiso8601)) > $max)
+                 | "\(.id) \(.name) \(.created_at)"' | \
             while read -r id name created; do
-              [ -z "$id" ] && continue
-              created_epoch=$(date -d "$created" +%s 2>/dev/null) || continue
-              age=$(( $(date +%s) - created_epoch ))
-              if [ "$age" -gt "$max_age_secs" ]; then
-                echo "deleting droplet $name (id $id, age ${age}s)"
-                doctl compute droplet delete "$id" -f || true
-              fi
+              echo "deleting droplet $name (id $id, created $created)"
+              doctl compute droplet delete "$id" -f || true
             done
           }
           reap_tag zakura-pr-node    $(( MAX_AGE_HOURS * 3600 ))
@@ -76,17 +76,18 @@ jobs:
           # window with a wide margin. A dispatch with a lower max_age_hours
           # (an emergency sweep) lowers this TTL with it.
           VOL_TTL=$(( MAX_AGE_HOURS * 3600 < 2 * 3600 ? MAX_AGE_HOURS * 3600 : 2 * 3600 ))
-          doctl compute volume list --format ID,Name,CreatedAt,DropletIDs --no-header | \
-          while read -r id name created droplets; do
-            [ -z "$id" ] && continue
-            case "$name" in zakura-pr-*) ;; *) continue ;; esac
-            case "$droplets" in *[0-9]*) continue ;; esac
-            created_epoch=$(date -d "$created" +%s 2>/dev/null) || continue
-            age=$(( $(date +%s) - created_epoch ))
-            if [ "$age" -gt "$VOL_TTL" ]; then
-              echo "deleting detached volume $name (id $id, age ${age}s)"
-              doctl compute volume delete "$id" -f || true
-            fi
+          # JSON output: like droplets, the volume table has no usable
+          # creation-time column.
+          doctl compute volume list --output json | \
+            jq -r --argjson now "$(date +%s)" --argjson max "$VOL_TTL" \
+              '(. // [])[]
+               | select(.name | startswith("zakura-pr-"))
+               | select((.droplet_ids // []) == [])
+               | select(($now - (.created_at | fromdateiso8601)) > $max)
+               | "\(.id) \(.name) \(.created_at)"' | \
+          while read -r id name created; do
+            echo "deleting detached volume $name (id $id, created $created)"
+            doctl compute volume delete "$id" -f || true
           done
 
       - name: Prune old images and volume snapshots

--- a/.github/workflows/zakura-pr-node-reaper.yml
+++ b/.github/workflows/zakura-pr-node-reaper.yml
@@ -11,6 +11,12 @@ name: PR node reaper
 #     the newest 2 each
 
 on:
+  # TEMP(feat/pr-node): registers this workflow for dispatch while the file is
+  # not yet on the default branch; remove before merge. The push run performs a
+  # normal (harmless, idempotent) sweep.
+  push:
+    branches: [feat/pr-node]
+    paths: [.github/workflows/zakura-pr-node-reaper.yml]
   workflow_dispatch:
     inputs:
       max_age_hours:

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -1,0 +1,354 @@
+name: PR node
+
+# Ephemeral 1-hour real-node test for a PR (or any ref) on DigitalOcean.
+#
+# Boots a droplet from the pre-baked PR-node image (deps + warm cargo cache,
+# see zakura-pr-node-bake.yml), attaches a clone of the chosen chain-state
+# volume snapshot, builds zakurad from the PR branch incrementally, runs it for
+# `duration_minutes`, and posts a metrics summary as a PR comment.
+#
+# The droplet is kept alive afterwards for SSH inspection and is deleted by
+# zakura-pr-node-reaper.yml within 24h (or immediately with
+# teardown_after_run=true).
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to test (exactly one of pr_number / ref)"
+        required: false
+      ref:
+        description: "Branch, tag, or SHA to test (exactly one of pr_number / ref)"
+        required: false
+      snapshot_mode:
+        description: "Chain state to start from"
+        type: choice
+        options: [tip, sandblast, genesis]
+        default: tip
+      network:
+        description: "Network (sandblast is mainnet-only)"
+        type: choice
+        options: [mainnet, testnet]
+        default: mainnet
+      duration_minutes:
+        description: "How long to monitor the running node"
+        required: false
+        default: "60"
+      droplet_size:
+        description: "Droplet size (disk must be >= the baked image's disk)"
+        required: false
+        default: c-8
+      teardown_after_run:
+        description: "Delete the droplet immediately after the run"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: zakura-pr-node-${{ inputs.pr_number || inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  node:
+    runs-on: ubuntu-latest
+    # duration_minutes (<=60 typically) + incremental build + provisioning overhead.
+    timeout-minutes: 110
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate inputs and resolve target
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REF: ${{ inputs.ref }}
+          MODE: ${{ inputs.snapshot_mode }}
+          NETWORK: ${{ inputs.network }}
+        run: |
+          set -euo pipefail
+          if [ "${MODE}" = "sandblast" ] && [ "${NETWORK}" != "mainnet" ]; then
+            echo "snapshot_mode=sandblast is mainnet-only (the spam region is a mainnet range)" >&2
+            exit 1
+          fi
+          if { [ -n "${PR_NUMBER}" ] && [ -n "${REF}" ]; } || { [ -z "${PR_NUMBER}" ] && [ -z "${REF}" ]; }; then
+            echo "provide exactly one of pr_number / ref" >&2
+            exit 1
+          fi
+          if [ -n "${PR_NUMBER}" ]; then
+            SHA=$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json headRefOid --jq .headRefOid)
+            REFSPEC="refs/pull/${PR_NUMBER}/head"
+            PR="${PR_NUMBER}"
+            SLUG="pr${PR_NUMBER}"
+          else
+            SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${REF}" --jq .sha)
+            if [ "${REF}" = "${SHA}" ]; then
+              REFSPEC="${SHA}"
+            else
+              REFSPEC="${REF}"
+            fi
+            # Best-effort: post the summary to an open PR whose head is this ref.
+            PR=$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${REF}" --state open \
+                   --json number --jq '.[0].number // empty' 2>/dev/null || true)
+            SLUG=$(echo "${REF}" | tr -c 'a-zA-Z0-9' '-' | tr -s '-' | sed 's/^-//; s/-$//' | cut -c1-24)
+          fi
+          echo "Testing ${SHA} (${REFSPEC}), PR: ${PR:-none}"
+          {
+            echo "sha=${SHA}"
+            echo "refspec=${REFSPEC}"
+            echo "pr=${PR}"
+            echo "slug=${SLUG}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install doctl
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          DOCTL_VERSION=1.120.0
+          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
+          sudo install /tmp/doctl /usr/local/bin/doctl
+          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
+
+      - name: Write SSH key
+        env:
+          DO_SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+        run: |
+          install -m 600 /dev/null /tmp/do_ssh
+          printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh
+
+      - name: Pick baked image and state snapshot
+        id: baked
+        env:
+          MODE: ${{ inputs.snapshot_mode }}
+          NETWORK: ${{ inputs.network }}
+        run: |
+          set -euo pipefail
+          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
+            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
+          if [ -z "${IMAGE}" ]; then
+            echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
+            exit 1
+          fi
+          echo "image_id=${IMAGE}" >> "$GITHUB_OUTPUT"
+          if [ "${MODE}" = "genesis" ]; then
+            echo "vol_snap_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          SNAP=$(doctl compute snapshot list --resource volume --format ID,Name --no-header | \
+            awk -v pre="zakura-pr-state-${NETWORK}-" 'index($2, pre) == 1 {print $2, $1}' | \
+            sort | tail -1 | awk '{print $2}')
+          if [ -z "${SNAP}" ]; then
+            echo "no zakura-pr-state-${NETWORK}-* volume snapshot found; run the bake workflow first" >&2
+            exit 1
+          fi
+          echo "vol_snap_id=${SNAP}" >> "$GITHUB_OUTPUT"
+
+      - name: Create droplet (+ state volume)
+        id: droplet
+        env:
+          MODE: ${{ inputs.snapshot_mode }}
+          DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
+          SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
+          IMAGE_ID: ${{ steps.baked.outputs.image_id }}
+          VOL_SNAP_ID: ${{ steps.baked.outputs.vol_snap_id }}
+          SLUG: ${{ steps.target.outputs.slug }}
+        run: |
+          set -euo pipefail
+          VOLUME_ARGS=()
+          VOLUME_NAME=""
+          VOLUME_ID=""
+          if [ "${MODE}" != "genesis" ]; then
+            VOLUME_NAME="zakura-pr-vol-${GITHUB_RUN_ID}"
+            SIZE=$(doctl compute snapshot get "${VOL_SNAP_ID}" --format MinDiskSize --no-header)
+            VOLUME_ID=$(doctl compute volume create "${VOLUME_NAME}" \
+              --region nyc3 --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
+              --format ID --no-header)
+            VOLUME_ARGS=(--volumes "${VOLUME_ID}")
+          fi
+          NAME="zakura-pr-${SLUG}-${GITHUB_RUN_ID}"
+          doctl compute droplet create "$NAME" \
+            --region nyc3 \
+            --size "${DROPLET_SIZE}" \
+            --image "${IMAGE_ID}" \
+            --ssh-keys "${SSH_FINGERPRINT}" \
+            "${VOLUME_ARGS[@]}" \
+            --tag-name zakura-pr-node \
+            --wait --format ID,PublicIPv4 --no-header > /tmp/droplet.txt
+          {
+            echo "id=$(awk '{print $1}' /tmp/droplet.txt)"
+            echo "ip=$(awk '{print $2}' /tmp/droplet.txt)"
+            echo "volume_name=${VOLUME_NAME}"
+            echo "volume_id=${VOLUME_ID}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Wait for SSH
+        id: sshwait
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i /tmp/do_ssh "root@${IP}" true 2>/dev/null; then
+              echo "SSH up"; exit 0
+            fi
+            sleep 10
+          done
+          echo "SSH did not come up in time"; exit 1
+
+      - name: Build, deploy, and monitor the node
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+          GH_CLONE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: ${{ inputs.snapshot_mode }}
+          NETWORK: ${{ inputs.network }}
+          SHA: ${{ steps.target.outputs.sha }}
+          REFSPEC: ${{ steps.target.outputs.refspec }}
+          DURATION_MINUTES: ${{ inputs.duration_minutes || '60' }}
+          VOLUME_NAME: ${{ steps.droplet.outputs.volume_name }}
+        run: |
+          set -euo pipefail
+          umask 077
+          {
+            printf 'GH_REPO=%q\n'           "${GITHUB_REPOSITORY}"
+            printf 'GH_CLONE_TOKEN=%q\n'    "${GH_CLONE_TOKEN}"
+            printf 'MODE=%q\n'              "${MODE}"
+            printf 'NETWORK=%q\n'           "${NETWORK}"
+            printf 'SHA=%q\n'               "${SHA}"
+            printf 'REFSPEC=%q\n'           "${REFSPEC}"
+            printf 'DURATION_MINUTES=%q\n'  "${DURATION_MINUTES}"
+            printf 'VOLUME_NAME=%q\n'       "${VOLUME_NAME}"
+          } > /tmp/run.env
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            /tmp/run.env \
+            .github/workflows/scripts/pr-node-run.sh \
+            .github/workflows/scripts/pr-node-monitor.py \
+            "root@${IP}:/root/"
+          # Keepalives: the monitored hour is long and low-output.
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=240 -i /tmp/do_ssh "root@${IP}" \
+            'set -euo pipefail; set -a; . /root/run.env; set +a; bash /root/pr-node-run.sh'
+
+      - name: Collect run outputs
+        if: always() && steps.droplet.outputs.ip != ''
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+        run: |
+          set +e
+          mkdir -p /tmp/out
+          scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            "root@${IP}:/root/out/*" /tmp/out/
+          ls -la /tmp/out
+          true
+
+      - name: Write step summary
+        if: always() && steps.droplet.outputs.ip != ''
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+          TEARDOWN: ${{ inputs.teardown_after_run }}
+        run: |
+          set -euo pipefail
+          {
+            if [ -f /tmp/out/summary.md ]; then
+              cat /tmp/out/summary.md
+            else
+              printf '## Zakura PR node run\n\nNo summary was produced — see the job log.\n'
+            fi
+            echo ""
+            if [ "${TEARDOWN}" = "true" ]; then
+              echo "_Droplet deleted after the run (teardown_after_run=true)._"
+            else
+              echo "**Inspect the node:** \`ssh root@${IP}\` (deleted by the reaper ~24h after creation)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post PR comment
+        if: always() && steps.target.outputs.pr != '' && steps.droplet.outputs.ip != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR: ${{ steps.target.outputs.pr }}
+          MODE: ${{ inputs.snapshot_mode }}
+          NETWORK: ${{ inputs.network }}
+          IP: ${{ steps.droplet.outputs.ip }}
+          TEARDOWN: ${{ inputs.teardown_after_run }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = `<!-- zakura-pr-node:${process.env.MODE}:${process.env.NETWORK} -->`;
+            let summary;
+            try {
+              summary = fs.readFileSync('/tmp/out/summary.md', 'utf8');
+            } catch {
+              summary = '## Zakura PR node run\n\nNo summary was produced — see the workflow log.';
+            }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const footer = process.env.TEARDOWN === 'true'
+              ? '_Droplet deleted after the run._'
+              : `**Inspect the node:** \`ssh root@${process.env.IP}\` (deleted by the reaper ~24h after creation).`;
+            const body = `${marker}\n${summary}\n\n${footer}\n\n[Workflow run](${runUrl})`;
+            const issue_number = Number(process.env.PR);
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.startsWith(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Upload artifacts
+        if: always() && steps.droplet.outputs.ip != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: zakura-pr-node-${{ github.run_id }}
+          path: /tmp/out/
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Teardown (immediate or on unreachable droplet)
+        if: always()
+        env:
+          DROPLET_ID: ${{ steps.droplet.outputs.id }}
+          VOLUME_ID: ${{ steps.droplet.outputs.volume_id }}
+          TEARDOWN: ${{ inputs.teardown_after_run }}
+          SSH_FAILED: ${{ steps.sshwait.outcome == 'failure' }}
+        run: |
+          set +e
+          # A droplet we can never SSH into is useless to keep for inspection.
+          if [ "${TEARDOWN}" != "true" ] && [ "${SSH_FAILED}" != "true" ]; then
+            echo "Droplet kept for inspection; the reaper deletes it ~24h after creation."
+            exit 0
+          fi
+          if [ -n "${DROPLET_ID}" ]; then
+            for _ in 1 2 3; do
+              doctl compute droplet delete "${DROPLET_ID}" -f && break
+              sleep 5
+            done
+          fi
+          if [ -n "${VOLUME_ID}" ]; then
+            # The volume detaches asynchronously after the droplet delete.
+            for _ in $(seq 1 12); do
+              doctl compute volume delete "${VOLUME_ID}" -f && break
+              sleep 10
+            done
+          fi
+          true

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -228,6 +228,7 @@ jobs:
             .github/workflows/scripts/pr-node-run.sh \
             .github/workflows/scripts/pr-node-monitor.py \
             "root@${IP}:/root/"
+          rm -f /tmp/run.env
           # Keepalives: the monitored hour is long and low-output.
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             -o ServerAliveInterval=30 -o ServerAliveCountMax=240 -i /tmp/do_ssh "root@${IP}" \

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -12,6 +12,12 @@ name: PR node
 # teardown_after_run=true).
 
 on:
+  # TEMP(feat/pr-node): registers this workflow for dispatch while the file is
+  # not yet on the default branch; remove before merge. The push run fails fast
+  # in input validation (no pr_number/ref), which is expected.
+  push:
+    branches: [feat/pr-node]
+    paths: [.github/workflows/zakura-pr-node.yml]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -12,12 +12,6 @@ name: PR node
 # teardown_after_run=true).
 
 on:
-  # TEMP(feat/pr-node): registers this workflow for dispatch while the file is
-  # not yet on the default branch; remove before merge. The push run fails fast
-  # in input validation (no pr_number/ref), which is expected.
-  push:
-    branches: [feat/pr-node]
-    paths: [.github/workflows/zakura-pr-node.yml]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -264,6 +264,15 @@ systemctl status zakura-fleet-watchdog
 journalctl -u zakura-fleet-watchdog -f
 ```
 
+## Ephemeral PR test nodes
+
+`.github/workflows/zakura-pr-node.yml` reuses this deployer on a throwaway
+DigitalOcean droplet to test a single PR against a real node for ~1 hour: the
+droplet image bakes a repo clone, a warm `CARGO_TARGET_DIR`, and a
+`root@localhost` SSH identity, so the workflow just writes a one-node config and
+runs `deploy.py build` / `deploy` / `status` on the droplet itself. See
+`docs/pr-node-do-setup.md`.
+
 ## How the build cache works
 
 `commit` is resolved to a full SHA (`git rev-parse`). The binary is cached at

--- a/docs/pr-node-do-setup.md
+++ b/docs/pr-node-do-setup.md
@@ -1,0 +1,106 @@
+# PR node on DigitalOcean — ephemeral 1-hour real-node PR testing
+
+The `PR node` workflow (`zakura-pr-node.yml`) boots a droplet in `nyc3` from a
+pre-baked image (build deps + warm cargo release cache + a repo clone), attaches
+a clone of a pre-baked chain-state volume, builds `zakurad` from a PR branch
+incrementally, runs it for ~1 hour, and posts a metrics summary as a PR comment.
+The droplet stays up afterwards for SSH inspection and is auto-deleted by the
+reaper within 24 hours.
+
+## Workflows
+
+- **`zakura-pr-node-bake.yml`** (weekly + manual) — bakes the golden assets:
+  one `zakura-pr-node-<stamp>` droplet image and one
+  `zakura-pr-state-{mainnet,testnet}-<stamp>` volume snapshot per network.
+  The mainnet volume holds `tip/` (daily pruned snapshot) and `sandblast/`
+  (archive pinned at height 1,707,210 — just before the 2022 "sandblasting"
+  spam region, so a run stress-syncs through high-density blocks). The testnet
+  volume holds `tip/`. Keeps the newest 2 of each asset.
+- **`zakura-pr-node.yml`** (manual) — the entrypoint; see Running below.
+- **`zakura-pr-node-reaper.yml`** (hourly + manual) — deletes run droplets
+  older than 24h, failed bake droplets older than 6h, detached `zakura-pr-*`
+  volumes older than 2h, and prunes images/volume snapshots beyond the
+  newest 2.
+
+## Prerequisites
+
+Reuses the sync-confidence DO credentials (see
+`docs/sync-confidence-do-setup.md` — no new secrets):
+
+- Secrets: `DIGITALOCEAN_ACCESS_TOKEN`, `DO_SSH_PRIVATE_KEY`.
+- Variables: `DO_SSH_KEY_FINGERPRINT`.
+- Optional variable overrides for the bake's snapshot sources:
+  `ZAKURA_PR_NODE_TIP_LATEST_JSON`, `ZAKURA_PR_NODE_SANDBLAST_URL` /
+  `ZAKURA_PR_NODE_SANDBLAST_SHA256`, `ZAKURA_TESTNET_SNAPSHOTS_URL`.
+
+Run the bake workflow once before the first PR-node run.
+
+## Running
+
+From the Actions tab or the CLI:
+
+```bash
+# Test PR #123 from a tip snapshot on mainnet for an hour (the default):
+gh workflow run zakura-pr-node.yml -f pr_number=123
+
+# Stress-sync PR #123 through the sandblast region for 30 minutes:
+gh workflow run zakura-pr-node.yml -f pr_number=123 -f snapshot_mode=sandblast -f duration_minutes=30
+
+# Checkpoint-sync a branch from genesis on testnet, delete the droplet after:
+gh workflow run zakura-pr-node.yml -f ref=my-branch -f snapshot_mode=genesis \
+  -f network=testnet -f teardown_after_run=true
+```
+
+Inputs: exactly one of `pr_number` / `ref`; `snapshot_mode` ∈ `tip` (start near
+the chain tip and follow it), `sandblast` (mainnet-only archive at 1,707,210),
+`genesis` (fresh checkpoint sync, no volume); `network` ∈ `mainnet`/`testnet`;
+`duration_minutes` (default 60); `droplet_size` (default `c-8`; its disk must be
+≥ the baked image's disk, so ≥ the bake `droplet_size`); `teardown_after_run`.
+
+The summary lands in the job step summary, as an upserted PR comment (one per
+mode×network, matched by a hidden marker), and in a `zakura-pr-node-<run id>`
+artifact together with `summary.json` and the node logs. Runs for a bare `ref`
+without an open PR skip the comment.
+
+## Inspecting a kept node
+
+The step summary prints the droplet IP. On the droplet:
+
+```bash
+systemctl status zakurad
+tail -f /var/log/zakura/zakura.log
+cd /root/zakura && python3 deploy/deployer/deploy.py status --config /root/fleet.toml
+```
+
+The node keeps running (and syncing) until the reaper deletes the droplet ~24h
+after creation. Re-dispatching for the same PR updates the existing comment.
+
+## How it stays fast
+
+The bake pre-installs apt/rustup toolchains, pre-clones the repo, warms
+`CARGO_TARGET_DIR=/root/cargo-target` with a release build of `main`, and bakes
+a `root@localhost` SSH identity so `deploy/deployer/deploy.py` is reused
+unmodified on the droplet (worktree build keyed on the PR SHA, systemd install
+with rollback, status/log commands). A PR run only pays: volume clone + droplet
+boot (~2 min), incremental `cargo build` of the diff vs `main`, then the
+monitored run itself.
+
+## DB format-version note
+
+Snapshots store `state/v<N>/`. zakurad restores a state one major version back
+(a reusable-format upgrade runs in place); anything older is ignored and the
+node syncs from scratch — the run summary calls this out. After a DB format
+bump lands on `main`, re-run the bake so the volume snapshots catch up.
+
+## Cost note
+
+Per run: `c-8` droplet ~$0.25/h (~$6 if kept the full 24h) + the state volume
+(300 GiB ≈ $30/mo pro-rated, so ≪$1/day). Standing: 2 images + 2×2 volume
+snapshots ≈ $30–40/mo. If runs were force-killed, check:
+
+```bash
+doctl compute droplet list --tag-name zakura-pr-node
+doctl compute volume list | grep zakura-pr-
+```
+
+or just dispatch the reaper workflow.


### PR DESCRIPTION
## Motivation

Fast-testing a PR against a real node today means occupying a dev box, the shared cluster, or a local machine for an hour, blocking their use for other work. This adds ephemeral, self-cleaning DigitalOcean test nodes with a one-click entrypoint: pick a PR and a snapshot mode, get a running node minutes later, and a metrics summary posted back to the PR.

## Solution

Three workflows plus three on-droplet scripts:

- **`zakura-pr-node.yml`** (entrypoint, `workflow_dispatch`): inputs `pr_number`/`ref`, `snapshot_mode` ∈ [`tip`, `sandblast`, `genesis`], `network` ∈ [`mainnet`, `testnet`], `duration_minutes`, `droplet_size`, `teardown_after_run`. Boots a droplet from the pre-baked image, attaches a clone of the per-network state volume snapshot, fetches the PR ref into the baked repo clone, builds incrementally against the baked warm cargo cache, deploys via **`deploy/deployer/deploy.py` unmodified** over a baked `root@localhost` SSH identity, monitors for the duration, then posts an upserted PR comment (one per mode×network, hidden-marker matched) + step summary + log artifacts. The droplet is kept for SSH inspection.
- **`zakura-pr-node-bake.yml`** (weekly + manual): bakes the golden image (apt deps, rustup, repo clone, warm `cargo build --release -p zebrad` in `CARGO_TARGET_DIR=/root/cargo-target`, loopback SSH identity) and two state volume snapshots — mainnet (`tip/` daily pruned + `sandblast/` archive pinned at height 1,707,210, just before the 2022 sandblasting spam region) and testnet (`tip/`). Keeps the newest 2 of each asset.
- **`zakura-pr-node-reaper.yml`** (hourly + manual `max_age_hours`): deletes run droplets >24h, failed bake droplets >6h, detached `zakura-pr-*` volumes, and prunes images/volume snapshots beyond keep-last-2.

Setup/usage docs in `docs/pr-node-do-setup.md`. Reuses the existing sync-confidence DO secrets; no new secrets.

Measured dev UX: droplet boot ≈2 min, incremental build of a PR diff ≈3.5 min on the warm cache (vs 9 min cold), node running against real chain state ≈6–8 min after dispatch.

### Tests

All runs dispatched from this branch:

- Bake (image + 2 volume snapshots): [run 29068313839](https://github.com/zakura-core/zakura/actions/runs/29068313839) ✅
- `genesis`/`testnet` 10 min, `teardown_after_run=true`: [run 29070858584](https://github.com/zakura-core/zakura/actions/runs/29070858584) ✅ — synced +169,882 blocks, verdict ok, artifacts + step summary produced, droplet torn down.
- `tip`/`mainnet` 10 min vs PR #66: [run 29071455433](https://github.com/zakura-core/zakura/actions/runs/29071455433) ✅ — restored the baked pruned tip state, caught up to and followed the live tip, [PR comment posted](https://github.com/zakura-core/zakura/pull/66#issuecomment-4932359756).
- `sandblast`/`mainnet` 15 min vs PR #66: [run 29072068062](https://github.com/zakura-core/zakura/actions/runs/29072068062) ✅ — synced +56,018 spam-region blocks; the monitor flagged peak RSS 15.4 GiB on the 16 GiB droplet (exactly the signal this harness exists to surface).
- Input validation: `sandblast`+`testnet` correctly rejected ([run 29072074799](https://github.com/zakura-core/zakura/actions/runs/29072074799) ❌ by design).
- Reaper with `max_age_hours=0`: [run 29073234442](https://github.com/zakura-core/zakura/actions/runs/29073234442) ✅ — deleted both kept droplets and their volumes (verified empty via the DO API afterwards).
- 60-min `tip`/`mainnet` run against this PR: [run 29073311746](https://github.com/zakura-core/zakura/actions/runs/29073311746) ✅ — followed the live tip for the hour (+495 blocks, 0 restarts, verdict ok); summary posted as the comment below.
- Comment upsert: a follow-up 10-min `tip`/`mainnet` run ([run 29076348177](https://github.com/zakura-core/zakura/actions/runs/29076348177) ✅, `teardown_after_run=true`) updated the same comment in place — still exactly one `tip:mainnet` comment on this PR.
- Lint: `actionlint`, `shellcheck`, `python3 -m py_compile` clean. The generated one-node config was validated against `deploy.py`'s strict loader.

### Specifications & References

- Droplet lifecycle patterns copied from `.github/workflows/do-sync-test.yml` (doctl create/wait/keepalive/sweep).
- Sandblast snapshot is the same pinned artifact `checkpoint-sync-bench.yml` uses (`zebra-mainnet-20260616T032721Z-1707210.tar.zst`).
- Mainnet tip resolves through `https://zebra.valargroup.org/mainnet-pruned/latest.json`; testnet tip through the snapshots site `snapshots.json`.

### Follow-up Work

- **Pre-existing bug found while testing:** the orphan sweep in `do-sync-test.yml` uses `doctl compute droplet list --format ID,Created`, but doctl's droplet table has no creation-time column — it silently renders `<nil>` (exit 0), so `date -d` fails and the sweep has never deleted anything. This PR's reaper uses `--output json` + `created_at` instead; `do-sync-test.yml` needs the same fix in a follow-up.

- zcashd-compat flavors (compat mainnet/testnet volume snapshots seeded from published zcashd datadir archives; run mode starting zcashd `-connect`-locked to `zebrad --zcashd-compat` with drift metrics in the summary).
- Optional pruned sandblast snapshot for faster volume bakes; optional PR-comment trigger (`/pr-node tip`).
- The daily mainnet pruned snapshot is still DB format v27 (Zakura is v28); tip runs restore it in place via the reusable major upgrade, and the run summary calls this out. Re-bake after v28 snapshots publish.

### AI Disclosure

- [x] AI tools were used: Claude Code authored the workflows, scripts, and docs, and ran the end-to-end test matrix above; reviewed by me.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
