### PR TITLE
fix(zcashd-compat): reserve sidecar inbound admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- zcashd-compat sidecars now get one bounded reserved inbound legacy P2P slot,
+  shared across configured `block_gossip_peer_ips`, so they can reconnect even
+  when ordinary inbound slots or same-IP peer limits are saturated.
 - Fixed a Zakura block-sync stall after header reanchors / tip resets: the
   post-reset producer refill no longer skips when peer-registry outstanding is
   still briefly inflated, so downloads resume instead of leaving an empty work

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -211,6 +211,13 @@ manage_zcashd = false
 block_gossip_peer_ips = ["127.0.0.1"]
 ```
 
+Zakura also reserves one bounded inbound legacy P2P slot for the configured
+sidecar IP list. That reserved connection bypasses the normal per-IP
+handshake/recent-connection limit, but it still counts toward the total inbound
+connection limit and still has to pass IP bans, handshake validation, and peer
+protocol checks. The reservation is shared by all configured sidecar IPs, so
+extra simultaneous sidecar-like connections are rejected.
+
 zcashd-compat mode requires the legacy Zcash P2P stack, because zcashd speaks the
 legacy Zcash P2P protocol. Every `network.p2p_stack` value runs it except
 `"zakura"`. Do not enable state pruning on the fronting Zakura — a pruned node does
@@ -219,12 +226,10 @@ not advertise `NODE_NETWORK` and zcashd will not sync from it.
 > [!WARNING]
 > When the fronting Zakura runs in Docker with a published P2P port, all
 > connections arriving through `docker-proxy` (including a sidecar zcashd
-> connecting to `127.0.0.1:8233` on the host) share one source IP. Zakura's
-> `network.max_connections_per_ip` defaults to **1**, so the sidecar can lose
-> that single slot to a proxied public peer and silently never connect. Set
-> `ZAKURA_NETWORK__MAX_CONNECTIONS_PER_IP=8` (or similar) on a Dockerised
-> front — the installer's Docker modes do this for you — or attach the
-> sidecar to the container network directly.
+> connecting to `127.0.0.1:8233` on the host) share one source IP. Zakura
+> identifies zcashd-compat sidecars by configured inbound source IP before the
+> handshake, not by a cryptographic process identity. Only configure
+> `block_gossip_peer_ips` for local or private addresses you control.
 
 ### Verify the integration
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -286,7 +286,7 @@ where
     // Connect the rx end to a PeerSet, wrapping new peers in load instruments.
     let peer_set = PeerSet::new(
         &config,
-        block_gossip_peer_ips,
+        block_gossip_peer_ips.clone(),
         discovered_peers,
         demand_tx.clone(),
         handle_rx,
@@ -315,6 +315,7 @@ where
             listen_handshaker,
             peerset_tx.clone(),
             bans_receiver,
+            block_gossip_peer_ips,
         );
         task_handles.push(tokio::spawn(listen_fut.in_current_span()));
 
@@ -718,6 +719,7 @@ async fn accept_inbound_connections<S>(
     handshaker: S,
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     bans_receiver: watch::Receiver<Arc<IndexMap<IpAddr, std::time::Instant>>>,
+    zcashd_compat_peer_ips: Vec<IpAddr>,
 ) -> Result<(), BoxError>
 where
     S: Service<peer::HandshakeRequest<TcpStream>, Response = peer::Client, Error = BoxError>
@@ -731,6 +733,15 @@ where
         config.peerset_inbound_connection_limit(),
         "Inbound Connections",
     );
+    let mut active_zcashd_compat_connections =
+        ActiveConnectionCounter::new_counter_with(1, "zcashd-compat Inbound Connection");
+    let zcashd_compat_peer_ips: HashSet<_> = zcashd_compat_peer_ips.into_iter().collect();
+    let zcashd_compat_reserved_slots = usize::from(
+        !zcashd_compat_peer_ips.is_empty() && config.peerset_inbound_connection_limit() > 0,
+    );
+    let public_inbound_connection_limit = config
+        .peerset_inbound_connection_limit()
+        .saturating_sub(zcashd_compat_reserved_slots);
 
     let mut handshakes: FuturesUnordered<Pin<Box<dyn Future<Output = ()> + Send>>> =
         FuturesUnordered::new();
@@ -760,8 +771,29 @@ where
                 continue;
             }
 
-            if active_inbound_connections.update_count()
-                >= config.peerset_inbound_connection_limit()
+            let active_public_inbound_connections = active_inbound_connections.update_count();
+            let active_zcashd_compat_inbound_connections =
+                active_zcashd_compat_connections.update_count();
+            let active_total_inbound_connections =
+                active_public_inbound_connections + active_zcashd_compat_inbound_connections;
+            let is_zcashd_compat_peer = zcashd_compat_peer_ips.contains(&addr.ip());
+            let connection_tracker = if is_zcashd_compat_peer {
+                if active_zcashd_compat_inbound_connections >= zcashd_compat_reserved_slots
+                    || active_total_inbound_connections >= config.peerset_inbound_connection_limit()
+                {
+                    // Too many zcashd-compat or total open inbound connections already.
+                    // Close the connection.
+                    std::mem::drop(tcp_stream);
+                    // Allow invalid connections to be cleared quickly,
+                    // but still put a limit on our CPU and network usage from failed connections.
+                    tokio::time::sleep(constants::MIN_INBOUND_PEER_FAILED_CONNECTION_INTERVAL)
+                        .await;
+                    continue;
+                }
+
+                active_zcashd_compat_connections.track_connection()
+            } else if active_public_inbound_connections >= public_inbound_connection_limit
+                || active_total_inbound_connections >= config.peerset_inbound_connection_limit()
                 || recent_inbound_connections.is_past_limit_or_add(addr.ip())
             {
                 // Too many open inbound connections or pending handshakes already.
@@ -771,13 +803,12 @@ where
                 // but still put a limit on our CPU and network usage from failed connections.
                 tokio::time::sleep(constants::MIN_INBOUND_PEER_FAILED_CONNECTION_INTERVAL).await;
                 continue;
-            }
-
-            // The peer already opened a connection to us.
-            // So we want to increment the connection count as soon as possible.
-            let connection_tracker = active_inbound_connections.track_connection();
+            } else {
+                active_inbound_connections.track_connection()
+            };
             debug!(
-                inbound_connections = ?active_inbound_connections.update_count(),
+                inbound_connections = ?active_total_inbound_connections,
+                ?is_zcashd_compat_peer,
                 "handshaking on an open inbound peer connection"
             );
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -21,8 +21,12 @@ use std::{
 
 use chrono::Utc;
 use futures::{channel::mpsc, FutureExt, StreamExt};
-use indexmap::IndexSet;
-use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinHandle};
+use indexmap::{IndexMap, IndexSet};
+use tokio::{
+    io::AsyncWriteExt,
+    net::{TcpSocket, TcpStream},
+    task::JoinHandle,
+};
 use tower::{service_fn, Layer, Service, ServiceExt};
 
 use zebra_chain::{chain_tip::NoChainTip, parameters::Network, serialization::DateTime32};
@@ -32,14 +36,14 @@ use crate::{
     config::CacheDir,
     constants, init,
     meta_addr::{MetaAddr, PeerAddrState},
-    peer::{self, ClientTestHarness, HandshakeRequest, OutboundConnectorRequest},
+    peer::{self, ClientTestHarness, ConnectedAddr, HandshakeRequest, OutboundConnectorRequest},
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
             DiscoveredPeer,
         },
         set::MorePeers,
-        ActiveConnectionCounter, CandidateSet,
+        ActiveConnectionCounter, CandidateSet, ConnectionTracker,
     },
     protocol::types::PeerServices,
     AddressBook, BoxError, Config, PeerSocketAddr, Request, Response,
@@ -65,6 +69,9 @@ const PEER_CACHE_UPDATER_TEST_DURATION: Duration = Duration::from_secs(25);
 ///
 /// Using a very short time can make the listener not run at all.
 const LISTENER_TEST_DURATION: Duration = Duration::from_secs(10);
+
+/// The amount of time to run zcashd-compat listener tests.
+const ZCASHD_COMPAT_LISTENER_TEST_DURATION: Duration = Duration::from_millis(500);
 
 /// The amount of time to make the inbound connection acceptor wait between peer connections.
 const MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS: Duration = Duration::from_millis(25);
@@ -946,6 +953,241 @@ async fn listener_peer_limit_one_handshake_ok_stay_open() {
     );
 }
 
+/// Test the listener reserves one inbound slot for a configured zcashd-compat peer.
+#[tokio::test]
+async fn listener_reserves_one_zcashd_compat_inbound_slot() {
+    let _init_guard = zebra_test::init();
+
+    // This test requires an IPv4 network stack with 127.0.0.1 as localhost.
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let public_ip = Ipv4Addr::LOCALHOST;
+    let zcashd_compat_ip = Ipv4Addr::new(127, 0, 0, 2);
+    let (peer_tracker_tx, mut peer_tracker_rx) = mpsc::unbounded();
+
+    let success_stay_open_inbound_handshaker =
+        service_fn(move |req: HandshakeRequest<TcpStream>| {
+            let peer_tracker_tx = peer_tracker_tx.clone();
+            async move {
+                let HandshakeRequest {
+                    data_stream: tcp_stream,
+                    connected_addr,
+                    connection_tracker,
+                } = req;
+
+                let ConnectedAddr::InboundDirect { addr } = connected_addr else {
+                    unreachable!("inbound listener handshakes use inbound direct addresses");
+                };
+
+                let (fake_client, _harness) = ClientTestHarness::build()
+                    .with_connected_addr(connected_addr)
+                    .finish();
+
+                peer_tracker_tx
+                    .unbounded_send((addr.ip(), tcp_stream, connection_tracker))
+                    .expect("unexpected error sending to unbounded channel");
+
+                Ok(fake_client)
+            }
+        });
+
+    let mut config = Config {
+        listen_addr: "127.0.0.1:0".parse().unwrap(),
+        peerset_initial_target_size: 2,
+        max_connections_per_ip: usize::MAX,
+        ..Config::default()
+    };
+    let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
+    config.listen_addr = listen_addr;
+
+    let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(4);
+    let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
+
+    let listen_fut = accept_inbound_connections(
+        config.clone(),
+        tcp_listener,
+        MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
+        success_stay_open_inbound_handshaker,
+        peerset_tx,
+        bans_rx,
+        vec![zcashd_compat_ip.into()],
+    );
+    let listen_task_handle = tokio::spawn(listen_fut);
+
+    let public_connection = connect_from(public_ip, listen_addr).await;
+    let rejected_public_connection = connect_from(public_ip, listen_addr).await;
+    let zcashd_compat_connection = connect_from(zcashd_compat_ip, listen_addr).await;
+    let rejected_zcashd_compat_connection = connect_from(zcashd_compat_ip, listen_addr).await;
+
+    tokio::time::sleep(ZCASHD_COMPAT_LISTENER_TEST_DURATION).await;
+
+    listen_task_handle.abort();
+    tokio::task::yield_now().await;
+    assert_listener_task_cancelled(listen_task_handle);
+
+    let accepted_ips = drain_accepted_inbound_ips(&mut peer_tracker_rx);
+    let peer_change_count = drain_discovered_peers(&mut peerset_rx);
+
+    assert_eq!(
+        peer_change_count,
+        config.peerset_inbound_connection_limit(),
+        "accepted connections must stay within the total inbound limit"
+    );
+    assert_eq!(
+        accepted_ips.iter().filter(|ip| **ip == public_ip).count(),
+        1,
+        "ordinary inbound peers should only use the public slot"
+    );
+    assert_eq!(
+        accepted_ips
+            .iter()
+            .filter(|ip| **ip == zcashd_compat_ip)
+            .count(),
+        1,
+        "zcashd-compat peers should only use the single reserved slot"
+    );
+
+    std::mem::drop(public_connection);
+    std::mem::drop(rejected_public_connection);
+    std::mem::drop(zcashd_compat_connection);
+    std::mem::drop(rejected_zcashd_compat_connection);
+}
+
+/// Test the listener does not add zcashd-compat peers to the recent-IP throttle.
+#[tokio::test]
+async fn listener_zcashd_compat_reconnect_bypasses_recent_ip_limit() {
+    let _init_guard = zebra_test::init();
+
+    // This test requires an IPv4 network stack with 127.0.0.1 as localhost.
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let zcashd_compat_ip = Ipv4Addr::new(127, 0, 0, 2);
+    let success_disconnect_inbound_handshaker =
+        service_fn(|req: HandshakeRequest<TcpStream>| async move {
+            let HandshakeRequest {
+                data_stream: tcp_stream,
+                connected_addr,
+                connection_tracker,
+            } = req;
+
+            let (fake_client, _harness) = ClientTestHarness::build()
+                .with_connected_addr(connected_addr)
+                .finish();
+
+            std::mem::drop(connection_tracker);
+            std::mem::drop(tcp_stream);
+            tokio::task::yield_now().await;
+
+            Ok(fake_client)
+        });
+
+    let mut config = Config {
+        listen_addr: "127.0.0.1:0".parse().unwrap(),
+        peerset_initial_target_size: 1,
+        max_connections_per_ip: 1,
+        ..Config::default()
+    };
+    let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
+    config.listen_addr = listen_addr;
+
+    let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(2);
+    let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
+
+    let listen_fut = accept_inbound_connections(
+        config,
+        tcp_listener,
+        MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
+        success_disconnect_inbound_handshaker,
+        peerset_tx,
+        bans_rx,
+        vec![zcashd_compat_ip.into()],
+    );
+    let listen_task_handle = tokio::spawn(listen_fut);
+
+    let first_connection = connect_from(zcashd_compat_ip, listen_addr).await;
+    tokio::time::sleep(MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS * 2).await;
+    let second_connection = connect_from(zcashd_compat_ip, listen_addr).await;
+
+    tokio::time::sleep(ZCASHD_COMPAT_LISTENER_TEST_DURATION).await;
+
+    listen_task_handle.abort();
+    tokio::task::yield_now().await;
+    assert_listener_task_cancelled(listen_task_handle);
+
+    assert_eq!(
+        drain_discovered_peers(&mut peerset_rx),
+        2,
+        "rapid zcashd-compat reconnects should bypass the recent-IP throttle"
+    );
+
+    std::mem::drop(first_connection);
+    std::mem::drop(second_connection);
+}
+
+/// Test bans are applied before the zcashd-compat reserved slot.
+#[tokio::test]
+async fn listener_bans_zcashd_compat_peer_before_reserved_slot() {
+    let _init_guard = zebra_test::init();
+
+    // This test requires an IPv4 network stack with 127.0.0.1 as localhost.
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let zcashd_compat_ip = Ipv4Addr::new(127, 0, 0, 2);
+    let unreachable_inbound_handshaker = service_fn(|_| async {
+        unreachable!("banned zcashd-compat peer should never reach the handshaker")
+    });
+
+    let mut config = Config {
+        listen_addr: "127.0.0.1:0".parse().unwrap(),
+        peerset_initial_target_size: 1,
+        ..Config::default()
+    };
+    let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
+    config.listen_addr = listen_addr;
+
+    let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(1);
+    let (bans_tx, bans_rx) = tokio::sync::watch::channel(
+        [(zcashd_compat_ip.into(), std::time::Instant::now())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>()
+            .into(),
+    );
+
+    let listen_fut = accept_inbound_connections(
+        config,
+        tcp_listener,
+        MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
+        unreachable_inbound_handshaker,
+        peerset_tx,
+        bans_rx,
+        vec![zcashd_compat_ip.into()],
+    );
+    let listen_task_handle = tokio::spawn(listen_fut);
+
+    let banned_connection = connect_from(zcashd_compat_ip, listen_addr).await;
+
+    tokio::time::sleep(ZCASHD_COMPAT_LISTENER_TEST_DURATION).await;
+
+    listen_task_handle.abort();
+    tokio::task::yield_now().await;
+    assert_listener_task_cancelled(listen_task_handle);
+
+    assert_eq!(
+        drain_discovered_peers(&mut peerset_rx),
+        0,
+        "banned zcashd-compat peers must not be admitted"
+    );
+
+    std::mem::drop(bans_tx);
+    std::mem::drop(banned_connection);
+}
+
 /// Test the listener with the default inbound peer limit, and a handshaker that always errors.
 #[tokio::test]
 async fn listener_peer_limit_default_handshake_error() {
@@ -1650,6 +1892,53 @@ where
     (config, peerset_rx)
 }
 
+async fn connect_from(source_ip: Ipv4Addr, listen_addr: SocketAddr) -> TcpStream {
+    let socket = TcpSocket::new_v4().expect("test should create an IPv4 TCP socket");
+    socket
+        .bind(SocketAddr::new(source_ip.into(), 0))
+        .expect("test should bind to a loopback source address");
+    socket
+        .connect(listen_addr)
+        .await
+        .expect("test should connect to the inbound listener")
+}
+
+fn drain_accepted_inbound_ips(
+    peer_tracker_rx: &mut mpsc::UnboundedReceiver<(IpAddr, TcpStream, ConnectionTracker)>,
+) -> Vec<Ipv4Addr> {
+    let mut accepted_ips = Vec::new();
+
+    while let Ok((ip, peer_connection, peer_tracker)) = peer_tracker_rx.try_recv() {
+        let IpAddr::V4(ip) = ip else {
+            panic!("zcashd-compat listener tests only use IPv4 peers");
+        };
+
+        accepted_ips.push(ip);
+        std::mem::drop(peer_connection);
+        std::mem::drop(peer_tracker);
+    }
+
+    accepted_ips
+}
+
+fn drain_discovered_peers(peerset_rx: &mut mpsc::Receiver<DiscoveredPeer>) -> usize {
+    let mut peer_count = 0;
+
+    while peerset_rx.try_recv().is_ok() {
+        peer_count += 1;
+    }
+
+    peer_count
+}
+
+fn assert_listener_task_cancelled(listen_task_handle: JoinHandle<Result<(), BoxError>>) {
+    let listen_result = listen_task_handle.now_or_never();
+    assert!(
+        listen_result.is_none() || matches!(listen_result, Some(Err(ref e)) if e.is_cancelled()),
+        "unexpected error or panic in inbound peer listener task: {listen_result:?}",
+    );
+}
+
 /// Run an inbound peer listener with `peerset_initial_target_size` and `handshaker`.
 ///
 /// Binds the local listener to an unused localhost port.
@@ -1701,6 +1990,7 @@ where
         listen_handshaker,
         peerset_tx.clone(),
         bans_rx,
+        Vec::new(),
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -247,6 +247,9 @@ where
     /// Inbound peer IPs that must always receive block inventory broadcasts.
     block_gossip_peer_ips: HashSet<IpAddr>,
 
+    /// Peer-set keys for the single configured zcashd-compat sidecar connection.
+    zcashd_compat_peer_keys: HashSet<D::Key>,
+
     // Peer Tracking: Busy Peers
     //
     /// Connected peers that are handling a Zebra request,
@@ -372,6 +375,7 @@ where
             inventory_registry: InventoryRegistry::new(inv_stream),
             queued_broadcast_all: None,
             block_gossip_peer_ips: block_gossip_peer_ips.into_iter().collect(),
+            zcashd_compat_peer_keys: HashSet::new(),
 
             // Busy peers
             unready_services: FuturesUnordered::new(),
@@ -571,6 +575,7 @@ where
                         warn!(?key, "service is banned, dropping service");
                         std::mem::drop(svc);
                         let cancel = self.cancel_handles.remove(&key);
+                        self.zcashd_compat_peer_keys.remove(&key);
                         debug_assert!(
                             cancel.is_some(),
                             "missing cancel handle for banned unready peer"
@@ -594,6 +599,9 @@ where
                         duplicate_connection = self.cancel_handles.contains_key(&key),
                         "service was canceled, dropping service"
                     );
+                    if !self.cancel_handles.contains_key(&key) {
+                        self.zcashd_compat_peer_keys.remove(&key);
+                    }
                 }
                 Some(Err((key, UnreadyError::CancelHandleDropped(_)))) => {
                     // Similarly, services with dropped cancel handes can have duplicates.
@@ -602,6 +610,9 @@ where
                         duplicate_connection = self.cancel_handles.contains_key(&key),
                         "cancel handle was dropped, dropping service"
                     );
+                    if !self.cancel_handles.contains_key(&key) {
+                        self.zcashd_compat_peer_keys.remove(&key);
+                    }
                 }
 
                 // Unready -> Errored
@@ -609,6 +620,7 @@ where
                     debug!(%error, "service failed while unready, dropping service");
 
                     let cancel = self.cancel_handles.remove(&key);
+                    self.zcashd_compat_peer_keys.remove(&key);
                     assert!(cancel.is_some(), "missing cancel handle");
                 }
             }
@@ -650,6 +662,7 @@ where
                 Ok(()) => {
                     if self.bans_receiver.borrow().contains_key(&key.ip()) {
                         debug!(?key, "service ip is banned, dropping service");
+                        self.zcashd_compat_peer_keys.remove(&key);
                         std::mem::drop(svc);
                         continue;
                     }
@@ -662,6 +675,7 @@ where
                     debug!(%error, "service failed while ready, dropping service");
 
                     // Ready services can just be dropped, they don't need any cleanup.
+                    self.zcashd_compat_peer_keys.remove(&key);
                     std::mem::drop(svc);
                 }
             }
@@ -687,6 +701,11 @@ where
             .chain(self.cancel_handles.keys())
             .filter(|addr| addr.ip() == ip)
             .count()
+    }
+
+    /// Returns the number of configured zcashd-compat peer connections.
+    fn num_zcashd_compat_peers(&self) -> usize {
+        self.zcashd_compat_peer_keys.len()
     }
 
     /// Returns `true` if Zebra is already connected to the IP and port in `addr`.
@@ -742,13 +761,31 @@ where
                         continue;
                     }
 
+                    let is_zcashd_compat_peer = self.is_zcashd_compat_peer(&svc);
+
                     // # Security
                     //
-                    // drop the new peer if there are already `max_conns_per_ip` peers with
-                    // the same IP address in the peer set.
-                    if self.num_peers_with_ip(key.ip()) >= self.max_conns_per_ip {
+                    // Drop extra configured sidecar peers. The listener reserves one
+                    // zcashd-compat slot, shared across all configured sidecar IPs.
+                    if is_zcashd_compat_peer && self.num_zcashd_compat_peers() >= 1 {
                         std::mem::drop(svc);
                         continue;
+                    }
+
+                    // # Security
+                    //
+                    // Drop the new peer if there are already `max_conns_per_ip` peers with
+                    // the same IP address in the peer set. The single configured sidecar peer is
+                    // admitted through the listener's reserved compat slot instead.
+                    if !is_zcashd_compat_peer
+                        && self.num_peers_with_ip(key.ip()) >= self.max_conns_per_ip
+                    {
+                        std::mem::drop(svc);
+                        continue;
+                    }
+
+                    if is_zcashd_compat_peer {
+                        self.zcashd_compat_peer_keys.insert(key);
                     }
 
                     self.push_unready(key, svc);
@@ -763,8 +800,18 @@ where
     fn disconnect_from_outdated_peers(&mut self) {
         if let Some(minimum_version) = self.minimum_peer_version.changed() {
             // It is ok to drop ready services, they don't need anything cancelled.
-            self.ready_services
-                .retain(|_address, peer| peer.remote_version() >= minimum_version);
+            let outdated_peers: Vec<_> = self
+                .ready_services
+                .iter()
+                .filter_map(|(address, peer)| {
+                    (peer.remote_version() < minimum_version).then_some(*address)
+                })
+                .collect();
+
+            for address in outdated_peers {
+                self.ready_services.remove(&address);
+                self.zcashd_compat_peer_keys.remove(&address);
+            }
         }
     }
 
@@ -809,6 +856,7 @@ where
     /// If the peer does not exist, does nothing.
     fn remove(&mut self, key: &D::Key) {
         self.find_response_stalls.clear(*key);
+        self.zcashd_compat_peer_keys.remove(key);
 
         if let Some(ready_service) = self.take_ready_service(key) {
             // A ready service has no work to cancel, so just drop it.
@@ -836,6 +884,7 @@ where
         if svc.remote_version() >= self.minimum_peer_version.current() {
             self.ready_services.insert(key, svc);
         } else {
+            self.zcashd_compat_peer_keys.remove(&key);
             std::mem::drop(svc);
         }
     }
@@ -859,6 +908,7 @@ where
         if peer_version >= self.minimum_peer_version.current() {
             self.cancel_handles.insert(key, tx);
         } else {
+            self.zcashd_compat_peer_keys.remove(&key);
             // Cancel any request made to the service because it is using an outdated protocol
             // version.
             let _ = tx.send(CancelClientWork);

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -2,9 +2,9 @@
 
 use std::{cmp::max, collections::HashSet, iter, net::SocketAddr, sync::Arc, time::Duration};
 
-use futures::FutureExt as _;
+use futures::{stream, FutureExt as _, StreamExt};
 use tokio::time::timeout;
-use tower::{Service, ServiceExt};
+use tower::{discover::Change, Service, ServiceExt};
 
 use zebra_chain::{
     block,
@@ -13,10 +13,12 @@ use zebra_chain::{
 
 use crate::{
     constants::DEFAULT_MAX_CONNS_PER_IP,
-    peer::{ClientRequest, MinimumPeerVersion},
+    peer::{
+        ClientRequest, ClientTestHarness, ConnectedAddr, LoadTrackedClient, MinimumPeerVersion,
+    },
     peer_set::{inventory_registry::InventoryStatus, stall_tracker::FIND_RESPONSE_STALL_THRESHOLD},
     protocol::external::{types::Version, InventoryHash},
-    PeerSocketAddr, Request, Response, SharedPeerError,
+    BoxError, PeerSocketAddr, Request, Response, SharedPeerError,
 };
 use indexmap::IndexMap;
 use tokio::sync::watch;
@@ -225,6 +227,84 @@ fn peer_set_rejects_connections_past_per_ip_limit() {
         assert_eq!(
             peer_ready.ready_services.len(),
             crate::constants::DEFAULT_MAX_CONNS_PER_IP
+        );
+    });
+}
+
+#[test]
+fn peer_set_allows_one_zcashd_compat_peer_past_per_ip_limit() {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let shared_ip = "127.0.0.1".parse().unwrap();
+    let outbound_peer_address: PeerSocketAddr = SocketAddr::new(shared_ip, 1).into();
+    let sidecar_peer_address: PeerSocketAddr = SocketAddr::new(shared_ip, 2).into();
+    let duplicate_sidecar_peer_address: PeerSocketAddr = SocketAddr::new(shared_ip, 3).into();
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+    tokio::time::pause();
+
+    let (outbound_peer, _outbound_handle) = ClientTestHarness::build()
+        .with_version(peer_version)
+        .with_connected_addr(ConnectedAddr::new_outbound_direct(outbound_peer_address))
+        .finish();
+    let (sidecar_peer, _sidecar_handle) = ClientTestHarness::build()
+        .with_version(peer_version)
+        .with_connected_addr(ConnectedAddr::new_inbound_direct(sidecar_peer_address))
+        .finish();
+    let (duplicate_sidecar_peer, _duplicate_sidecar_handle) = ClientTestHarness::build()
+        .with_version(peer_version)
+        .with_connected_addr(ConnectedAddr::new_inbound_direct(
+            duplicate_sidecar_peer_address,
+        ))
+        .finish();
+
+    let discovered_peers: Vec<Result<Change<PeerSocketAddr, LoadTrackedClient>, BoxError>> = vec![
+        Ok(Change::Insert(outbound_peer_address, outbound_peer.into())),
+        Ok(Change::Insert(sidecar_peer_address, sidecar_peer.into())),
+        Ok(Change::Insert(
+            duplicate_sidecar_peer_address,
+            duplicate_sidecar_peer.into(),
+        )),
+    ];
+    let discovered_peers = stream::iter(discovered_peers).chain(stream::pending());
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_block_gossip_peer_ips(vec![shared_ip])
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version.clone())
+            .max_conns_per_ip(1)
+            .build();
+
+        let peer_ready = peer_set
+            .ready()
+            .await
+            .expect("peer set service is always ready");
+
+        assert_eq!(
+            peer_ready.ready_services.len(),
+            2,
+            "peer set should keep one existing same-IP peer and one zcashd-compat sidecar"
+        );
+        assert!(
+            peer_ready
+                .ready_services
+                .contains_key(&outbound_peer_address),
+            "existing same-IP outbound peer should remain connected"
+        );
+        assert!(
+            peer_ready
+                .ready_services
+                .contains_key(&sidecar_peer_address),
+            "one zcashd-compat sidecar should bypass the per-IP peer-set limit"
+        );
+        assert!(
+            !peer_ready
+                .ready_services
+                .contains_key(&duplicate_sidecar_peer_address),
+            "a second zcashd-compat sidecar should be dropped"
         );
     });
 }


### PR DESCRIPTION
## Summary
- Reserve one bounded inbound legacy P2P slot for configured zcashd-compat sidecar IPs while preserving the total inbound connection cap.
- Let the admitted direct inbound sidecar bypass only the same-IP admission/peer-set limits, while keeping bans, handshake validation, protocol checks, and duplicate sidecar rejection intact.
- Document the source-IP trust boundary and add regression coverage for saturation, reconnects, bans, duplicates, and block-gossip behavior.
