### PR TITLE
fix(deploy): read Zakura trace log in mainnet dashboard

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -170,7 +170,7 @@ jobs:
           # Read-only fields below: consumed by the status dashboard's SSH probe,
           # not written to any node (manage_config = false).
           rpc_listen_addr = "0.0.0.0:8232"
-          log_file        = "/root/logs/zebrad.log"
+          log_file        = "/root/logs/zakura-tracing.log"
 
           # Public mainnet node ids (zebra-network/src/zakura/handler.rs). Used by
           # the dashboard to label each host; not deployed to the nodes.


### PR DESCRIPTION
## Motivation

The mainnet dashboard looked for commit metadata in `/root/logs/zebrad.log`, while the normalized fleet configuration writes runtime traces to `/root/logs/zakura-tracing.log`. This caused healthy nodes to display an unknown or stale commit.

This operational fix was requested and validated directly with the mainnet fleet operator; there is no linked issue.

## Solution

Update the generated dashboard fleet configuration to probe `/root/logs/zakura-tracing.log`.

### Tests

- Deployed commit `4a38acf` across the mainnet fleet and normalized the systemd trace path.
- Verified the live dashboard resolves every node's commit and reports 11/11 healthy nodes.
- Checked IDE diagnostics for the workflow: no errors.
- Classified as low risk (one-line dashboard configuration change); skipped local build and test suites per repository verification policy.

### Specifications & References

- Deployment verification: https://github.com/zakura-core/zakura/actions/runs/29076346882

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used: Cursor GPT-5.6 Sol diagnosed the trace-path mismatch, updated the workflow, verified the live fleet, and drafted this PR.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed directly with the mainnet fleet operator.
- [x] The solution is tested against the live dashboard.
- [x] Documentation and changelogs are not required for this internal deployment fix.