### PR TITLE
fix(ci): stop rebuilding release assets when a pre-release is promoted

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,14 +1,18 @@
 # This workflow builds and publishes zakurad release assets and Docker images
-# when a release is published.
+# when a release tag is pushed. Tags containing a hyphen (v1.0.0-rc0,
+# v0.0.1-alpha.1) are created as GitHub pre-releases; tags without a hyphen
+# (v1.0.0) are created as full releases and also move the :latest Docker tags.
+#
+# Editing a release's pre-release checkbox on GitHub does not trigger this
+# workflow and never rebuilds or re-uploads anything. Real releases get their
+# own non-hyphenated tag. To repair or re-upload assets for an existing tag,
+# run workflow_dispatch with publish_assets_to_release.
 name: Release binaries
 
 on:
   push:
     tags:
       - "v*"
-  release:
-    types:
-      - released
   workflow_dispatch:
     inputs:
       release_tag:
@@ -40,18 +44,13 @@ jobs:
       - name: Resolve release tag
         id: resolve
         env:
-          EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           REF_TYPE: ${{ github.ref_type }}
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
-          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "release" ]; then
-            release_tag="$EVENT_RELEASE_TAG"
-            checkout_ref="$EVENT_RELEASE_TAG"
-          elif [ "$REF_TYPE" = "tag" ]; then
+          if [ "$REF_TYPE" = "tag" ]; then
             release_tag="$REF_NAME"
             checkout_ref="$REF_NAME"
           else
@@ -193,7 +192,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_assets_to_release
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_assets_to_release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -394,14 +393,14 @@ jobs:
           driver: docker
 
       - name: Login to DockerHub
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: valargroup
           password: ${{ secrets.DOCKERHUB_TOKEN_VALARGROUP }}
 
       - name: Build runtime image
-        if: github.event_name != 'release' && !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           IMAGE_TAG: valargroup/zakura:release-ci-${{ matrix.name }}
@@ -423,7 +422,7 @@ jobs:
           docker image inspect "$IMAGE_TAG" >/dev/null
 
       - name: Build and push runtime image
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -445,7 +444,7 @@ jobs:
 
   publish-docker-manifest:
     name: Publish Docker multi-arch manifest
-    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
     runs-on: ubuntu-latest
     needs: [resolve-release, build]
     steps:
@@ -460,13 +459,14 @@ jobs:
 
       - name: Create and verify Docker manifest
         env:
-          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
         run: |
           set -euo pipefail
           image_version="${RELEASE_TAG#v}"
           tags=(-t "valargroup/zakura:${image_version}")
-          if [ "$EVENT_NAME" = "release" ]; then
+          # Only full releases (no hyphen in the tag) move :latest;
+          # pre-release tags like v1.0.0-rc0 never touch it.
+          if [[ "$RELEASE_TAG" != *-* ]]; then
             tags+=(-t "valargroup/zakura:latest")
           fi
 
@@ -507,7 +507,7 @@ jobs:
           driver: docker
 
       - name: Login to DockerHub
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: valargroup
@@ -523,7 +523,7 @@ jobs:
             --platform "$DOCKER_PLATFORM"
 
       - name: Build zcashd compat runtime image
-        if: github.event_name != 'release' && !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           IMAGE_TAG: valargroup/zakura:zcashd-compat-release-ci-${{ matrix.name }}
@@ -546,7 +546,7 @@ jobs:
           docker image inspect "$IMAGE_TAG" >/dev/null
 
       - name: Build and push zcashd compat runtime image
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -569,7 +569,7 @@ jobs:
 
   publish-zcashd-compat-docker-manifest:
     name: Publish zcashd compat Docker amd64 manifest
-    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
     runs-on: ubuntu-latest
     needs: [resolve-release, resolve-zcashd-compat-manifest, build-zcashd-compat]
     steps:
@@ -584,13 +584,14 @@ jobs:
 
       - name: Create and verify zcashd compat Docker manifest
         env:
-          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
         run: |
           set -euo pipefail
           image_version="${RELEASE_TAG#v}"
           tags=(-t "valargroup/zakura:zcashd-compat-${image_version}")
-          if [ "$EVENT_NAME" = "release" ]; then
+          # Only full releases (no hyphen in the tag) move :latest;
+          # pre-release tags like v1.0.0-rc0 never touch it.
+          if [[ "$RELEASE_TAG" != *-* ]]; then
             tags+=(-t "valargroup/zakura:zcashd-compat-latest")
           fi
 
@@ -624,4 +625,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: publish-zakurad-assets,publish-docker-manifest
+          allowed-skips: publish-zakurad-assets,publish-docker-manifest,publish-zcashd-compat-docker-manifest


### PR DESCRIPTION
While reviewing `v1.0.0-rc0` today I noticed it was marked as a full release, which seemed wrong for an rc, so I switched it back to a pre-release. Digging into the run history afterwards:

- The tag-push run correctly created `v1.0.0-rc0` as a pre-release (hyphenated tags get `--prerelease`).
- It was then manually promoted to a full release a couple of minutes later — because promotion is currently the only mechanism that pushes the `:latest` / `zcashd-compat-latest` Docker tags (the manifest jobs only add `:latest` on `release` events).
- That promotion fired the `release: released` trigger, which **rebuilt all the binaries and re-uploaded the release assets with `--clobber`**, silently replacing what the tag push had published ~20 minutes earlier.

So toggling the pre-release checkbox currently does much more than I realized: it rebuilds and overwrites published artifacts as a side effect.

## This PR..

Make editing the pre-release checkbox a pure metadata operation, and give `:latest` a home that doesn't require promotion:

- Remove the `release: types: [released]` trigger entirely. Promotion (in either direction) no longer runs CI, so it can't rebuild or clobber anything.
- Move `:latest` tagging into the tag-push flow: full-release tags (no hyphen, e.g. `v1.0.0`) also tag the multi-arch manifests as `:latest` / `zcashd-compat-latest`; pre-release tags never touch them. Real releases get their own tag rather than being promoted in place.
- Repairing a release's assets remains explicit via `workflow_dispatch` with `publish_assets_to_release`.
- Add `publish-zcashd-compat-docker-manifest` to the success job's `allowed-skips` — it was missing, so a `workflow_dispatch` run without the Docker-publish flag would fail the green check.

Note for operators: after this merges, promoting a pre-release does nothing in CI. If you want `:latest` moved, cut a real (non-hyphenated) tag.

### Tests

- YAML validated locally.
- The `release`-event path is removed rather than modified, and the tag-push path's conditions are simplifications of the existing expressions (`github.event_name == 'release'` can never be true on the remaining triggers), so tag-push behavior is unchanged apart from the new no-hyphen `:latest` rule. Will verify on the next rc tag push.