### PR TITLE
feat(release): maintainer minisign signatures and CI provenance attestation

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -191,6 +191,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || inputs.publish_assets_to_release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -285,10 +287,22 @@ jobs:
           PY
           (
             cd ./publish/final
-            rm -f SHA256SUMS.txt
+            # x86_64.sha256 is an intermediate used to pin the installer above;
+            # it is not uploaded to the release, so keep it out of the signed
+            # checksums file.
+            rm -f SHA256SUMS.txt x86_64.sha256
             sha256sum ./* > ../SHA256SUMS.txt
             mv ../SHA256SUMS.txt SHA256SUMS.txt
           )
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 #v4.1.1
+        with:
+          subject-path: |
+            ./publish/final/zakurad-*.tar.gz
+            ./publish/final/zakurad-manifest-*.json
+            ./publish/final/install-zakura.sh
+            ./publish/final/SHA256SUMS.txt
 
       - name: Ensure release exists
         env:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 include make/zcashd-compat.mk
 include make/perf.mk
 include make/zakura-dev.mk
+include make/release.mk
 
 help:
 	@echo "Available targets:"
@@ -38,3 +39,6 @@ help:
 	@echo "  compat-test-regtest              Run full zcashd-compat test suite (regtest, spawns processes)"
 	@echo "  compat-test-mainnet              Run read-only zcashd-compat tests against live mainnet"
 	@echo "  compat-test-testnet              Run read-only zcashd-compat tests against live testnet"
+	@echo ""
+	@echo "  Release:"
+	@echo "  sign-release TAG=vX.Y.Z          Sign a release's SHA256SUMS.txt with the maintainer minisign key (see VERIFY.md)"

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -1,0 +1,62 @@
+# Verifying Zakura Releases
+
+Release artifacts can be authenticated with two independent checks. The
+maintainer signature is the stronger claim — a human signed off on the
+release. The build provenance attestation proves the artifacts were built
+unmodified by this repository's CI.
+
+## Maintainer signature (minisign)
+
+`SHA256SUMS.txt` on every full release is signed by the Zakura lead
+maintainer's [minisign](https://jedisct1.github.io/minisign/) key:
+
+```
+RWTZkHOmfhxdQf43RZJyOawUNvMSlbPH539O9Y2Sir/ZHTihqnSO1RZn
+```
+
+Pre-releases (tags containing a hyphen, such as `v1.0.0-rc0`) may not carry a
+maintainer signature.
+
+To verify an archive (example: linux-x86_64 for `v1.0.0`):
+
+```sh
+TAG=v1.0.0
+BASE="https://github.com/zakura-core/zakura/releases/download/${TAG}"
+curl -fsSLO "${BASE}/zakurad-${TAG}-linux-x86_64.tar.gz"
+curl -fsSLO "${BASE}/SHA256SUMS.txt"
+curl -fsSLO "${BASE}/SHA256SUMS.txt.minisig"
+
+# 1. The checksums file is signed by the maintainer key.
+minisign -Vm SHA256SUMS.txt -P RWTZkHOmfhxdQf43RZJyOawUNvMSlbPH539O9Y2Sir/ZHTihqnSO1RZn
+
+# 2. The archive matches the signed checksums.
+sha256sum -c --ignore-missing SHA256SUMS.txt
+```
+
+`--ignore-missing` is needed because `SHA256SUMS.txt` covers every release
+asset and you typically download only one platform's archive. On macOS, use
+`shasum -a 256 -c --ignore-missing SHA256SUMS.txt`.
+
+The signature's trusted comment names the release tag (for example
+`zakura v1.0.0 SHA256SUMS.txt`); check that it matches the tag you
+downloaded so a valid signature from one release cannot be replayed on
+another.
+
+## Build provenance (GitHub attestation)
+
+CI attests every release asset with
+[GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations).
+With the [GitHub CLI](https://cli.github.com/) installed:
+
+```sh
+gh attestation verify zakurad-v1.0.0-linux-x86_64.tar.gz --repo zakura-core/zakura
+```
+
+This proves the file was built by the `release-binaries` workflow in this
+repository at the tagged commit, and has not been modified since.
+
+## Docker images
+
+The Docker images on Docker Hub (`valargroup/zakura`) are not yet signed;
+verify the binary archives above, or build images from source. Image signing
+is planned follow-up work.

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,0 +1,5 @@
+.PHONY: sign-release
+
+sign-release:
+	@test -n "$(TAG)" || { echo "TAG is required, e.g. make sign-release TAG=v1.0.0" >&2; exit 1; }
+	./scripts/sign-release.sh "$(TAG)"

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Sign a published release's SHA256SUMS.txt with the maintainer's minisign key
+# and upload the detached signature as a release asset.
+#
+# Run on a trusted machine that holds the minisign secret key:
+#   ./scripts/sign-release.sh v1.0.0
+#
+# Environment:
+#   REPOSITORY    GitHub repository (default: zakura-core/zakura)
+#   MINISIGN_KEY  Path to the minisign secret key (default: minisign's default)
+set -euo pipefail
+
+# Must match the key published in VERIFY.md; the signature is verified against
+# this before upload so a signature from the wrong key never ships.
+MAINTAINER_PUBKEY="RWTZkHOmfhxdQf43RZJyOawUNvMSlbPH539O9Y2Sir/ZHTihqnSO1RZn"
+REPOSITORY="${REPOSITORY:-zakura-core/zakura}"
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <release-tag>" >&2
+  exit 1
+fi
+RELEASE_TAG="$1"
+
+for cmd in gh minisign; do
+  command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd" >&2; exit 1; }
+done
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+echo "Fetching asset list for ${RELEASE_TAG}..."
+gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+  --jq '.assets[] | "\(.name) \(.digest // "-")"' > "${workdir}/assets.txt"
+
+gh release download "$RELEASE_TAG" --repo "$REPOSITORY" \
+  --pattern SHA256SUMS.txt --dir "$workdir"
+
+# Cross-check SHA256SUMS.txt against the digests GitHub reports for the
+# uploaded assets, so we never sign sums that don't match what users download.
+fail=0
+while read -r name digest; do
+  case "$name" in
+    SHA256SUMS.txt | *.minisig) continue ;;
+  esac
+  expected="$(awk -v f="./${name}" '$2 == f {print $1}' "${workdir}/SHA256SUMS.txt")"
+  if [ -z "$expected" ]; then
+    echo "ERROR: asset ${name} is not listed in SHA256SUMS.txt" >&2
+    fail=1
+  elif [ "$digest" = "-" ]; then
+    echo "WARNING: GitHub reports no digest for ${name}; cannot cross-check" >&2
+  elif [ "sha256:${expected}" != "$digest" ]; then
+    echo "ERROR: digest mismatch for ${name}: sums=${expected} github=${digest#sha256:}" >&2
+    fail=1
+  fi
+done < "${workdir}/assets.txt"
+
+# Entries listed in the sums file that were never uploaded to the release.
+while read -r _ path; do
+  name="${path#./}"
+  if ! awk -v n="$name" '$1 == n {found = 1} END {exit !found}' "${workdir}/assets.txt"; then
+    echo "WARNING: SHA256SUMS.txt lists ${name}, which is not an uploaded asset" >&2
+  fi
+done < "${workdir}/SHA256SUMS.txt"
+
+if [ "$fail" -ne 0 ]; then
+  echo "Refusing to sign ${RELEASE_TAG}: fix the release assets first (workflow_dispatch with publish_assets_to_release)." >&2
+  exit 1
+fi
+
+sign_args=(-Sm "${workdir}/SHA256SUMS.txt" -t "zakura ${RELEASE_TAG} SHA256SUMS.txt")
+if [ -n "${MINISIGN_KEY:-}" ]; then
+  sign_args+=(-s "$MINISIGN_KEY")
+fi
+minisign "${sign_args[@]}"
+
+# Refuse to upload anything the published maintainer key can't verify.
+minisign -Vm "${workdir}/SHA256SUMS.txt" -P "$MAINTAINER_PUBKEY"
+
+gh release upload "$RELEASE_TAG" "${workdir}/SHA256SUMS.txt.minisig" \
+  --repo "$REPOSITORY" --clobber
+
+echo
+echo "Uploaded SHA256SUMS.txt.minisig to ${RELEASE_TAG}."
+echo "Users verify with:"
+echo "  minisign -Vm SHA256SUMS.txt -P ${MAINTAINER_PUBKEY}"


### PR DESCRIPTION
## Motivation

Zakura releases currently ship a `SHA256SUMS.txt`, but nothing signs it — a user has no way to check that the artifacts they downloaded are the ones I signed off on, and no way to check they came out of this repo's CI unmodified. I want a public, documented verification process for releases.

Separately, `SHA256SUMS.txt` currently lists `x86_64.sha256`, a build intermediate that is never uploaded as a release asset, so a plain `sha256sum -c` errors on a missing file.

## Solution

Two independent verification layers, plus the checksums fix:

- **Maintainer signature (endorsement).** After reviewing a release I sign its `SHA256SUMS.txt` with a minisign key held on a trusted machine, and upload the detached signature as a release asset. `scripts/sign-release.sh` (or `make sign-release TAG=v1.0.0`) drives this: it cross-checks every uploaded asset against the digests GitHub reports (refusing to sign on mismatch or unlisted assets), signs with a trusted comment naming the tag (so a signature can't be replayed on a different release), verifies the result against the published public key before uploading, then uploads `SHA256SUMS.txt.minisig`. The secret key never touches CI — a compromised runner can't forge an endorsement.
- **Build provenance (CI attestation).** The publish job now attests all release assets with `actions/attest-build-provenance`, so anyone can run `gh attestation verify <asset> --repo zakura-core/zakura` to confirm the asset was built by this repo's release workflow at the tagged commit.
- **`VERIFY.md`** documents the public key and the consumer-facing steps: `minisign -Vm SHA256SUMS.txt -P <key>`, then `sha256sum -c --ignore-missing SHA256SUMS.txt`. Intended to be linked from release notes and the website.
- **Checksums fix:** the `x86_64.sha256` intermediate (used to pin the installer) is deleted before `SHA256SUMS.txt` is generated, so the signed file only lists real assets.

Pre-releases may go unsigned; the absence of a `.minisig` marks a release as not yet endorsed. Docker images are not signed yet (follow-up).

### Tests

- Dry-ran the script's digest cross-check against the live `v1.0.0-rc0` release: all four assets match GitHub's reported digests, and the phantom `x86_64.sha256` entry is correctly flagged as a warning.
- Workflow YAML validated locally; the attestation step is additive and SHA-pinned (`v4.1.1`) like the other actions. Will confirm attestation and the corrected `SHA256SUMS.txt` on the next tag push.
- Planning to exercise the full sign-and-verify loop on `v1.0.0-rc0` as a live test.

### AI Disclosure

- [x] AI tools were used: Claude Code, for drafting the signing script, workflow changes, and verification docs.
