### PR TITLE
fix(ci): handle new-branch pushes in zakura-e2e change detection

### DIFF
--- a/.github/workflows/zakura-e2e.yml
+++ b/.github/workflows/zakura-e2e.yml
@@ -73,9 +73,18 @@ jobs:
               "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
               --jq '.[].path')
           else
-            changed=$(gh api \
-              "repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" \
-              --jq '.files[].filename')
+            before="${{ github.event.before }}"
+            # The first push of a branch (and force-pushes that orphan the old
+            # tip) have no usable `before` commit, so the compare would 404;
+            # fall back to comparing against the default branch.
+            if [[ "$before" == "0000000000000000000000000000000000000000" ]] || \
+               ! changed=$(gh api \
+                 "repos/${{ github.repository }}/compare/${before}...${{ github.sha }}" \
+                 --jq '.files[].filename'); then
+              changed=$(gh api \
+                "repos/${{ github.repository }}/compare/${{ github.event.repository.default_branch }}...${{ github.sha }}" \
+                --jq '.files[].filename')
+            fi
           fi
 
           if printf '%s\n' "$changed" | grep -qE '^(zakura-network/|zakurad/src/components/sync/|zakurad/tests/zakura_regtest_e2e\.rs|docker/zakura-regtest-e2e/|docker/docker-compose\.zakura-regtest-e2e\.yml|\.github/workflows/zakura-e2e\.yml)'; then


### PR DESCRIPTION
First pushes of new `feat/**/release/**` branches (and force-pushes that orphan the old tip) made the changes job fail, because `github.event.before` is the zero SHA and the compare API 404s on it — see the failed run on the first push of `feat/release-signing`. Fall back to diffing against the default branch when before is unusable, so change detection works instead of erroring.