### PR TITLE
ci(deploy): add Docker compatibility node to mainnet fleet

### DIFF
--- a/.cursor/skills/deploy-nodes/SKILL.md
+++ b/.cursor/skills/deploy-nodes/SKILL.md
@@ -52,21 +52,21 @@ For mainnet deploys, confirm the `ref` explicitly with the user before dispatch.
 | `zakura-testnet-as` | `206.189.148.0` | systemd |
 | `zakura-compat` | `206.189.208.228` | process-managed; shares host with `zcashd` sidecar |
 
-### Mainnet (9 nodes)
+### Mainnet (11 nodes)
 
-| Node name | Host |
-| --- | --- |
-| `asia-0` | `165.22.54.66` |
-| `us-0` | `104.131.184.123` |
-| `us-east-0` | `159.65.183.89` |
-| `us-west-0` | `143.244.184.176` |
-| `canada-0` | `159.203.38.10` |
-| `europe-west-0` | `64.227.44.93` |
-| `europe-central-0` | `161.35.156.226` |
-| `asia-south-0` | `139.59.64.115` |
-| `asia-pacific-0` | `168.144.173.250` |
-
-All mainnet nodes are systemd-managed `zakurad.service` nodes.
+| Node name | Host | Notes |
+| --- | --- | --- |
+| `asia-0` | `165.22.54.66` | systemd |
+| `us-0` | `104.131.184.123` | systemd |
+| `us-east-0` | `159.65.183.89` | systemd |
+| `us-west-0` | `143.244.184.176` | systemd |
+| `canada-0` | `159.203.38.10` | systemd |
+| `europe-west-0` | `64.227.44.93` | systemd |
+| `europe-central-0` | `161.35.156.226` | systemd |
+| `asia-south-0` | `139.59.64.115` | systemd |
+| `asia-pacific-0` | `168.144.173.250` | systemd |
+| `zakura-compat` | `159.203.113.196` | systemd `zebrad-compat`; shares host with `zcashd` |
+| `zakura-compat-docker` | `178.128.66.48` | Docker container `zakura-compat`; shares host with `zakura-compat-zcashd` |
 
 ## Preflight
 

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -81,9 +81,10 @@ jobs:
         # fail fast instead. deploy.py also now rejects unknown config keys.
         run: |
           set -euo pipefail
-          if ! grep -q 'manage_config' deploy/deployer/deploy.py; then
-            echo "::error::deploy.py at ref '${{ inputs.ref }}' lacks manage_config support." \
-                 "Deploy from a ref whose deploy.py supports binary-only mode."
+          if ! grep -q 'manage_config' deploy/deployer/deploy.py ||
+             ! grep -q 'container_name' deploy/deployer/deploy.py; then
+            echo "::error::deploy.py at ref '${{ inputs.ref }}' lacks binary-only Docker support." \
+                 "Deploy from a ref whose deploy.py supports manage_config and container_name."
             exit 1
           fi
 
@@ -145,7 +146,8 @@ jobs:
             161.35.156.226 \
             139.59.64.115 \
             168.144.173.250 \
-            159.203.113.196; do
+            159.203.113.196 \
+            178.128.66.48; do
             ssh-keyscan -T 30 -H "$host" >> ~/.ssh/known_hosts
           done
           chmod 600 ~/.ssh/known_hosts
@@ -239,6 +241,16 @@ jobs:
           service_name = "zebrad-compat"
           log_file   = ""
           rpc_listen_addr = "127.0.0.1:8232"
+
+          [[nodes]]
+          name       = "zakura-compat-docker"
+          ssh_string = "root@178.128.66.48"
+          commit     = "${{ inputs.ref }}"
+          deploy_kind = "docker"
+          container_name = "zakura-compat"
+          service_name = ""
+          log_file   = ""
+          rpc_listen_addr = "127.0.0.1:8232"
           EOF
 
       - name: Build deployer binary
@@ -306,14 +318,23 @@ jobs:
           sudo install -m 755 deploy/runner/zebra-cluster-status.py "$dashboard_dir/zebra-cluster-status.py"
           cp deploy/deployer/nodes.ci.toml "$RUNNER_TEMP/dashboard.nodes.toml"
           # Dashboard-only: deploy.py rejects these fields, so add cookie RPC
-          # auth for zakura-compat into this copy (not the deploy config).
+          # auth for the compatibility nodes into this copy (not the deploy config).
           awk '
             { print }
             $0 ~ /^name[[:space:]]*=[[:space:]]*"zakura-compat"/ { in_compat = 1 }
+            $0 ~ /^name[[:space:]]*=[[:space:]]*"zakura-compat-docker"/ {
+              in_compat = 0
+              in_compat_docker = 1
+            }
             in_compat && $0 ~ /^rpc_listen_addr[[:space:]]*=[[:space:]]*"127\.0\.0\.1:8232"/ {
               print "rpc_auth   = \"cookie\""
               print "rpc_config_path = \"/root/.cache/zakura/.cookie\""
               in_compat = 0
+            }
+            in_compat_docker && $0 ~ /^rpc_listen_addr[[:space:]]*=[[:space:]]*"127\.0\.0\.1:8232"/ {
+              print "rpc_auth   = \"cookie\""
+              print "rpc_config_path = \"/mnt/zcashd-compat-docker-data/zcashd-data/.cookie\""
+              in_compat_docker = 0
             }
           ' "$RUNNER_TEMP/dashboard.nodes.toml" > "$RUNNER_TEMP/dashboard.nodes.toml.tmp"
           mv "$RUNNER_TEMP/dashboard.nodes.toml.tmp" "$RUNNER_TEMP/dashboard.nodes.toml"
@@ -332,6 +353,18 @@ jobs:
           rpc_config_path = "/mnt/snapshots/runtime/zcashd/.cookie"
           # P2P sidecar (post -zebra-compat): supervised with -connect=127.0.0.1:8233.
           process_pattern = "zcashd .*-connect=127.0.0.1:8233"
+
+          [[nodes]]
+          name       = "zcashd-compat-docker"
+          ssh_string = "root@178.128.66.48"
+          probe_kind = "zcashd"
+          service_name = ""
+          container_name = "zakura-compat-zcashd"
+          bin_path = "/usr/local/bin/zcashd"
+          log_file = ""
+          rpc_listen_addr = "127.0.0.1:8232"
+          rpc_auth = "cookie"
+          rpc_config_path = "/mnt/zcashd-compat-docker-data/zcashd-data/.cookie"
           EOF
           sudo install -m 644 "$RUNNER_TEMP/dashboard.nodes.toml" "$dashboard_dir/nodes.toml"
 

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -74,6 +74,9 @@ DEFAULTS = {
     "working_dir": "",
     "start_command": "",
     "process_pattern": "",
+    # Docker deploys replace the binary in an existing container without
+    # recreating it, preserving its mounts, networking, and image configuration.
+    "container_name": "",
 }
 
 
@@ -110,6 +113,7 @@ class Node:
     working_dir: str
     start_command: str
     process_pattern: str
+    container_name: str
     port: object = None
     # resolved at runtime
     sha: str = ""
@@ -258,6 +262,7 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             working_dir=merged["working_dir"],
             start_command=merged["start_command"],
             process_pattern=merged["process_pattern"],
+            container_name=merged["container_name"],
             port=merged["port"],
         ))
 
@@ -693,6 +698,54 @@ systemctl is-active "$SERVICE"
 """
 
 
+# Binary-only deploy into an existing Docker container. The updated binary
+# remains in the container's writable layer, so Compose must not recreate the
+# container after this deploy unless its image has also been updated.
+DOCKER_BINARY_ONLY_INSTALL_SCRIPT = r"""
+set -euo pipefail
+
+CONTAINER={container}
+BIN_PATH={bin_path}
+NO_RESTART={no_restart}
+
+docker inspect "$CONTAINER" >/dev/null
+docker cp /tmp/zakurad-deploy.new "$CONTAINER:/tmp/zakurad-deploy.new"
+rm -f /tmp/zakurad-deploy.new
+
+docker exec --user 0 "$CONTAINER" sh -c \
+    'if [ -x "$1" ]; then cp -a "$1" "$1.bak"; fi
+     install -m 755 /tmp/zakurad-deploy.new "$1.new"
+     mv -f "$1.new" "$1"
+     rm -f /tmp/zakurad-deploy.new' sh "$BIN_PATH"
+
+if [ "$NO_RESTART" = "1" ]; then
+    echo "installed container binary (restart skipped)"
+    exit 0
+fi
+
+if ! docker restart "$CONTAINER" >/dev/null; then
+    restart_failed=1
+else
+    restart_failed=0
+    sleep 3
+fi
+
+if [ "$restart_failed" = "1" ] ||
+   ! docker inspect --format '{{{{.State.Running}}}}' "$CONTAINER" | grep -qx true; then
+    echo "container unhealthy after deploy; rolling back to $BIN_PATH.bak" >&2
+    docker stop "$CONTAINER" >/dev/null || true
+    if docker cp "$CONTAINER:$BIN_PATH.bak" /tmp/zakurad-deploy.rollback; then
+        docker cp /tmp/zakurad-deploy.rollback "$CONTAINER:$BIN_PATH"
+        rm -f /tmp/zakurad-deploy.rollback
+    fi
+    docker start "$CONTAINER" >/dev/null || true
+    exit 1
+fi
+
+docker exec "$CONTAINER" "$BIN_PATH" --version || true
+"""
+
+
 def ssh_with_stdin(node: Node, script: str) -> subprocess.CompletedProcess:
     """Run an install script on the node via `ssh ... bash -s`, feeding it on stdin."""
     return subprocess.run(node.ssh_cmd("bash", "-s"), input=script, text=True)
@@ -727,21 +780,33 @@ def cmd_deploy(args) -> int:
     def work(node: Node) -> tuple[str, bool, str]:
         binary = by_sha[node.sha]
         try:
-            if node.deploy_kind not in ("systemd", "process"):
+            if node.deploy_kind not in ("systemd", "process", "docker"):
                 return (node.name, False, f"unknown deploy_kind: {node.deploy_kind}")
 
             # Binary-only: don't render or ship a config/unit; just swap the
-            # binary and restart the existing service. Only meaningful for
-            # systemd nodes (the restart target is service_name).
+            # binary and restart the existing service or container.
             if not node.manage_config:
-                if node.deploy_kind != "systemd":
-                    return (node.name, False, "manage_config=false requires deploy_kind=systemd")
+                if node.deploy_kind not in ("systemd", "docker"):
+                    return (
+                        node.name,
+                        False,
+                        "manage_config=false requires deploy_kind=systemd or docker",
+                    )
+                if node.deploy_kind == "docker" and not node.container_name:
+                    return (node.name, False, "docker deploy requires container_name")
                 run(node.scp_to(str(binary), "/tmp/zakurad-deploy.new"), capture=True)
-                script = BINARY_ONLY_INSTALL_SCRIPT.format(
-                    bin_path=shlex.quote(node.bin_path),
-                    service=shlex.quote(node.service_name),
-                    no_restart="1" if args.no_restart else "0",
-                )
+                if node.deploy_kind == "docker":
+                    script = DOCKER_BINARY_ONLY_INSTALL_SCRIPT.format(
+                        container=shlex.quote(node.container_name),
+                        bin_path=shlex.quote(node.bin_path),
+                        no_restart="1" if args.no_restart else "0",
+                    )
+                else:
+                    script = BINARY_ONLY_INSTALL_SCRIPT.format(
+                        bin_path=shlex.quote(node.bin_path),
+                        service=shlex.quote(node.service_name),
+                        no_restart="1" if args.no_restart else "0",
+                    )
                 proc = ssh_with_stdin(node, script)
                 if proc.returncode != 0:
                     return (node.name, False, f"install/restart failed (rc={proc.returncode})")
@@ -866,22 +931,34 @@ def cmd_status(args) -> int:
         # commit, so also read the running build's git commit from the startup
         # diagnostic line in the node's log (`git commit: <sha>`). The configured
         # ref is appended so requested-vs-running is visible at a glance.
-        if node.service_name:
+        if node.deploy_kind == "docker":
+            service_probe = (
+                f"docker inspect --format '{{{{.State.Status}}}}' "
+                f"{shlex.quote(node.container_name)} 2>/dev/null"
+            )
+            version_probe = (
+                f"docker exec {shlex.quote(node.container_name)} "
+                f"{shlex.quote(node.bin_path)} --version 2>/dev/null | head -1"
+            )
+        elif node.service_name:
             service_probe = f"systemctl is-active {shlex.quote(node.service_name)} 2>/dev/null"
+            version_probe = f"{shlex.quote(node.bin_path)} --version 2>/dev/null | head -1"
         elif node.process_pattern:
             service_probe = (
                 f"pgrep -f {shlex.quote(node.process_pattern)} >/dev/null 2>&1 "
                 "&& printf 'active\\n' || printf 'inactive\\n'"
             )
+            version_probe = f"{shlex.quote(node.bin_path)} --version 2>/dev/null | head -1"
         else:
             service_probe = "printf 'unknown\\n'"
+            version_probe = f"{shlex.quote(node.bin_path)} --version 2>/dev/null | head -1"
         log_probe = (
             f"grep -aoE 'git commit: [0-9a-f]+' {shlex.quote(node.log_file)} 2>/dev/null | tail -1"
             if node.log_file else "true"
         )
         probe = (
             f"{service_probe}; "
-            f"{shlex.quote(node.bin_path)} --version 2>/dev/null | head -1; "
+            f"{version_probe}; "
             f"{log_probe}"
         )
         proc = ssh_capture_script(node, probe)

--- a/deploy/runner/zebra-cluster-status.py
+++ b/deploy/runner/zebra-cluster-status.py
@@ -56,6 +56,7 @@ DEFAULTS = {
     "rpc_user": "",
     "rpc_password": "",
     "process_pattern": "",
+    "container_name": "",
     "port": None,
 }
 
@@ -74,6 +75,7 @@ class Node:
     rpc_user: str
     rpc_password: str
     process_pattern: str
+    container_name: str
     node_id: str
     port: object = None
 
@@ -119,6 +121,7 @@ def load_nodes(config_path: Path) -> list[Node]:
                 rpc_user=merged["rpc_user"],
                 rpc_password=merged["rpc_password"],
                 process_pattern=merged["process_pattern"],
+                container_name=merged["container_name"],
                 node_id=node_ids_by_host.get(ssh_host(merged["ssh_string"]), ""),
                 port=merged["port"],
             )
@@ -190,7 +193,8 @@ import urllib.request
     rpc_user,
     rpc_password,
     rpc_config_path,
-) = sys.argv[1:11]
+    container_name,
+) = sys.argv[1:12]
 
 out = {
     "service": service,
@@ -222,6 +226,22 @@ def process_start_time(pattern):
     if ps_proc.returncode != 0:
         return ""
     return ps_proc.stdout.strip()
+
+def container_state(name):
+    if not name:
+        return None, ""
+    proc = run(["docker", "inspect", "--format",
+                "{{.State.Status}}|{{.State.StartedAt}}", name])
+    if proc.returncode != 0:
+        return "missing", ""
+    status, _, started_at = proc.stdout.strip().partition("|")
+    return status, started_at
+
+def container_logs(name):
+    if not name:
+        return ""
+    proc = run(["docker", "logs", "--tail", "1000", name])
+    return (proc.stdout or "") + (proc.stderr or "")
 
 def parse_zcash_conf(path):
     values = {}
@@ -270,7 +290,11 @@ except Exception as error:
     out["process_error"] = str(error)
 
 try:
-    if service:
+    if container_name:
+        status, started_at = container_state(container_name)
+        out["active_state"] = "active" if status == "running" else status
+        out["last_restarted"] = started_at
+    elif service:
         proc = run(["systemctl", "show", service, "--no-pager",
                     "-p", "ActiveState",
                     "-p", "ActiveEnterTimestamp",
@@ -300,13 +324,23 @@ except Exception as error:
     out["systemd_error"] = str(error)
 
 try:
-    proc = run([bin_path, "--version"])
+    command = (
+        ["docker", "exec", container_name, bin_path, "--version"]
+        if container_name
+        else [bin_path, "--version"]
+    )
+    proc = run(command)
     out["version"] = (proc.stdout or proc.stderr).splitlines()[0].strip()
 except Exception as error:
     out["version_error"] = str(error)
 
 try:
-    if log_file:
+    if container_name:
+        logs = container_logs(container_name)
+        matches = re.findall(r"git commit: ([0-9a-f]+)", logs)
+        if matches:
+            out["commit"] = matches[-1]
+    elif log_file:
         grep = "grep -aoE 'git commit: [0-9a-f]+' {} 2>/dev/null | tail -1".format(
             shlex.quote(log_file)
         )
@@ -330,7 +364,12 @@ except Exception as error:
     out["commit_error"] = str(error)
 
 try:
-    if log_file:
+    if container_name:
+        logs = container_logs(container_name)
+        matches = re.findall(r'node_id=([^, ]+)', logs)
+        if matches:
+            out["node_id"] = matches[-1].strip('"')
+    elif log_file:
         grep = "grep -aoE 'node_id=[^, ]+' {} 2>/dev/null | tail -1".format(
             shlex.quote(log_file)
         )
@@ -418,7 +457,8 @@ def probe_node(node: Node) -> dict:
         f"{shlex.quote(node.rpc_auth)} "
         f"{shlex.quote(node.rpc_user)} "
         f"{shlex.quote(node.rpc_password)} "
-        f"{shlex.quote(node.rpc_config_path)} <<'PY'\n"
+        f"{shlex.quote(node.rpc_config_path)} "
+        f"{shlex.quote(node.container_name)} <<'PY'\n"
         f"{REMOTE_PROBE}\n"
         "PY\n"
     )


### PR DESCRIPTION
## Motivation

Add the Docker-hosted mainnet compatibility pair at `178.128.66.48` to fleet deployment and status monitoring without replacing its Compose configuration, persistent chain state, or Zakura identity.

Requested directly by the Zakura operator; there is no linked issue.

## Solution

- add `zakura-compat-docker` to the mainnet deploy fleet and expose both it and `zcashd-compat-docker` on the status dashboard
- support binary-only deployment into an existing Docker container, including restart checks and rollback
- make dashboard probes container-aware for process state, restart time, binary version, logs, node ID, and RPC health
- document the expanded mainnet fleet

### Tests

- `python3 -m py_compile deploy/deployer/deploy.py deploy/runner/zebra-cluster-status.py`
- syntax-check the rendered Docker install script with `bash -n`
- `actionlint -ignore 'SC2024' .github/workflows/zakura-mainnet-deploy.yml` (`SC2024` is an unrelated pre-existing warning)
- `markdownlint .cursor/skills/deploy-nodes/SKILL.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics for all changed files
- live read-only `deploy.py status` probe against `zakura-compat-docker`
- live dashboard probes verified both Docker rows healthy and advancing

Risk classification: low. This is a focused Python/CI/configuration change under 300 LOC and does not touch consensus, P2P, cryptography, serialization, or database migrations. Rust workspace checks were skipped under the repository's risk-based verification policy.

### Specifications & References

- Docker host: `178.128.66.48`
- Zakura container: `zakura-compat`
- zcashd container: `zakura-compat-zcashd`

### Follow-up Work

The current Docker deploy updates the container's writable layer, so a future Compose recreation restores the image's original binary. The durable solution should:

1. Build an immutable Zakura image for every deployable commit and set OCI labels including `org.opencontainers.image.revision` and `org.opencontainers.image.source`.
2. Publish and deploy by image digest, updating Compose and running `docker compose pull && docker compose up -d` instead of copying a binary into a running container.
3. Have the dashboard read the running container's image digest and OCI revision label, with binary/log parsing only as a fallback.
4. Verify the expected digest/revision plus RPC health after rollout, and roll back to the previously recorded digest on failure.

This also fixes the currently blank commit field for `zakura-compat-docker`, whose image, version output, and logs contain no revision metadata.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor was used to implement Docker deployment/dashboard support, perform targeted validation, and draft this PR description.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`
- [x] The PR follows the contribution guidelines
- [x] This change was discussed directly with the Zakura operator
- [x] The solution is tested
- [x] Operational documentation is updated; no changelog entry is needed for this deployment-only change