### PR TITLE
fix(rename): repair remaining zakurad build-artifact refs

### DIFF
--- a/deploy/runner/perf.sh
+++ b/deploy/runner/perf.sh
@@ -190,7 +190,7 @@ cmd_build_local() {
   local bench_dir bench_tmp
   bench_dir="$(dirname "$BENCH_BIN")"
   bench_tmp="$(mktemp "${bench_dir}/.$(basename "$BENCH_BIN").XXXXXX")"
-  if install -m 0755 "$CARGO_TARGET_DIR/release/zebrad" "$bench_tmp"; then
+  if install -m 0755 "$CARGO_TARGET_DIR/release/zakurad" "$bench_tmp"; then
     mv -f "$bench_tmp" "$BENCH_BIN"
   else
     rm -f "$bench_tmp"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,7 @@ const DEFAULT_FEATURES: &str = "default-release-binaries";
 const DEFAULT_UBUNTU_IMAGE: &str = "ubuntu:22.04";
 const DEFAULT_RUST_VERSION: &str = "1.91";
 const DEFAULT_IMAGE_TAG: &str = "zebra-ubuntu-package:local";
-const OUTPUT_BINARY_NAME: &str = "zebrad";
+const OUTPUT_BINARY_NAME: &str = "zakurad";
 
 type BoxError = Box<dyn Error>;
 
@@ -88,7 +88,7 @@ fn package_ubuntu() -> Result<(), BoxError> {
     let copy_result = run_command(
         Command::new("docker")
             .arg("cp")
-            .arg(format!("{container_id}:/zebrad"))
+            .arg(format!("{container_id}:/zakurad"))
             .arg(&output_path),
     );
 


### PR DESCRIPTION
## Motivation

The `zebrad` → `zakurad` binary rename (PR #23) left two build/run plumbing sites still hard-coding the old artifact name. They silently break now that `cargo build -p zebrad` emits `zakurad`:

- `cargo xtask package ubuntu` copied `/zebrad` out of the build container and named the output `zebrad`, but the Ubuntu package Dockerfile now emits `/zakurad` — so the `docker cp` step failed.
- `deploy/runner/perf.sh` built the bench binary and then installed from `$CARGO_TARGET_DIR/release/zebrad`, which no longer exists.

## Solution

- `xtask/src/main.rs`: set `OUTPUT_BINARY_NAME` to `zakurad` and copy `/zakurad` from the container.
- `deploy/runner/perf.sh`: install the bench binary from `$CARGO_TARGET_DIR/release/zakurad`.

Only the *built binary artifact* references are touched. The deliberately-kept `zebrad` references — crate/package name (`-p zebrad`), host install paths, release-archive members, and docs branding — are left as-is.

## Testing

- `cargo build -p xtask` builds.
- `cargo metadata` shows the `zebrad` package's bin targets are `zakurad`, `zebra-prune-state`, `zebra-rollback-state` — no `zebrad` bin.
- `bash -n deploy/runner/perf.sh` passes.
- Audited the tree for remaining build-critical old-name references (`--bin zebrad`, `CARGO_BIN_EXE_zebrad`, `target/{debug,release}/zebrad`, `docker cp …:/zebrad`) — none remain.

## AI disclosure

Used Claude Code to locate the rename misses and make the edits. The contributor is the responsible author.
