### PR TITLE
fix(zcashd-compat): bump sidecar release to rc2

### DIFF
--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -33,10 +33,10 @@ ZAKURA_DOCKER_IDENTITY_DIR="/home/zebra/.zakura"
 
 MANIFEST_PATH="$REPO_ROOT/zebrad/zcashd-compat-manifest.json"
 TARGET_TRIPLE="x86_64-pc-linux-gnu"
-ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc0/zcashd-zebra-compat-v1.0.0-compat-rc0-linux-x86_64.tar.gz"
-ZCASHD_RUNTIME_ARCHIVE_SHA256="892c749bc629dc408598b33994b8b0d8e3e90ad5c8f755b214dce5b850083f12"
+ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc2/zcashd-zebra-compat-v1.0.0-compat-rc2-linux-x86_64.tar.gz"
+ZCASHD_RUNTIME_ARCHIVE_SHA256="9636bfe642a7542f92a31132ecce1139a290df1a9e674e8373167831369a905d"
 ZCASHD_RUNTIME_ARCHIVE_MEMBER_BINARY_PATH="./bin/zcashd"
-ZCASHD_DEFAULT_DOCKER_IMAGE="valargroup/zcashd:v1.0.0-compat-rc0"
+ZCASHD_DEFAULT_DOCKER_IMAGE="valargroup/zcashd:v1.0.0-compat-rc2"
 
 INSTALL_PROFILE=""
 INSTALL_PROFILE_SET=0

--- a/zebrad/zcashd-compat-manifest.json
+++ b/zebrad/zcashd-compat-manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "release_tag": "v1.0.0-compat-rc0",
+  "release_tag": "v1.0.0-compat-rc2",
   "artifacts": [
     {
       "target_triple": "x86_64-pc-linux-gnu",
-      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc0/zcashd-zebra-compat-v1.0.0-compat-rc0-linux-x86_64.tar.gz",
-      "runtime_archive_sha256": "892c749bc629dc408598b33994b8b0d8e3e90ad5c8f755b214dce5b850083f12",
+      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc2/zcashd-zebra-compat-v1.0.0-compat-rc2-linux-x86_64.tar.gz",
+      "runtime_archive_sha256": "9636bfe642a7542f92a31132ecce1139a290df1a9e674e8373167831369a905d",
       "runtime_archive_member_binary_path": "./bin/zcashd"
     }
   ]


### PR DESCRIPTION
## Motivation

Use the latest zcashd compatibility release, which removes the compatibility EOS policy while preserving sidecar behavior.

## Solution

- Pin the installer archive and Docker image to `v1.0.0-compat-rc2`.
- Update the committed compatibility manifest to the rc2 archive URL and SHA-256 digest.

### Tests

- `bash -n scripts/install-zakura.sh`
- `jq -e . zebrad/zcashd-compat-manifest.json`
- `GITHUB_OUTPUT=/dev/stdout scripts/resolve-zcashd-compat-manifest.sh --require-targets x86_64-pc-linux-gnu --write-github-output`
- IDE diagnostics: no errors in changed files
- Full workspace tests and lints were skipped because this is a low-risk configuration-only pin update.

### Specifications & References

- https://github.com/valargroup/zcashd/releases/tag/v1.0.0-compat-rc2

### AI Disclosure

- [x] AI tools were used: Cursor updated the release pins, verified the manifest, and prepared the PR description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand; no issue was provided.
- [x] The solution is tested proportionally to its low-risk scope.
- [x] Documentation and changelogs are not required for this internal release-pin update.