### PR TITLE
docs(zcashd-compat): use main branch installer

### DIFF
--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -46,7 +46,7 @@ There are two ways to run the pair:
 The recommended way to set up either variant is the interactive installer:
 
 ```console
-curl -fsSL https://github.com/zakura-core/zakura/releases/latest/download/install-zakura.sh | bash
+curl -fsSL https://raw.githubusercontent.com/zakura-core/zakura/main/scripts/install-zakura.sh | bash
 ```
 
 Choose **2) With Zcashd compatibility** at the first prompt, then one of the

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -46,7 +46,7 @@ There are two ways to run the pair:
 The recommended way to set up either variant is the interactive installer:
 
 ```console
-curl -fsSL https://github.com/valargroup/zebra/releases/latest/download/install-zakura.sh | bash
+curl -fsSL https://github.com/zakura-core/zakura/releases/latest/download/install-zakura.sh | bash
 ```
 
 Choose **2) With Zcashd compatibility** at the first prompt, then one of the


### PR DESCRIPTION
## Motivation

The zcashd-compat quick-start command pointed to the old `valargroup/zebra` release repository instead of the installer maintained on Zakura's main branch.

## Solution

Update the command to fetch `scripts/install-zakura.sh` directly from `zakura-core/zakura`'s `main` branch.

### Tests

- Fetched the documented raw URL and passed its contents to `bash -n`
- Fetched the documented raw URL and ran `bash -s -- --help`; the installer printed its usage and exited successfully
- `markdownlint book/src/user/zcashd-compat.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics: no errors
- Full Rust tests skipped: low-risk, one-line documentation-only change

### Specifications & References

- Requested directly by the Zakura team

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor updated and tested the documentation command and prepared the PR.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date; no changelog entry is needed for a corrected documentation URL.