### PR TITLE
chore(installer): target v1.0.0-rc1

### DIFF
--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -11,16 +11,14 @@ fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UNITY_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
 
-ZAKURA_RELEASE_TAG="v1.0.0-rc0"
+ZAKURA_RELEASE_TAG="v1.0.0-rc1"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
-# sha256 of ZAKURA_ARCHIVE from the release's SHA256SUMS.txt. Pin it once the
-# zakurad-named release artifact is published: an unpinned download in a
-# `curl | bash` installer is a supply-chain hole. Empty = skip verification.
-ZAKURA_ARCHIVE_SHA256=""
+# sha256 of ZAKURA_ARCHIVE from the release's SHA256SUMS.txt.
+ZAKURA_ARCHIVE_SHA256="10a9ce52c2a436b35f5869cacce8a1ff8d197069bb3b775cacf7a0eaed991d12"
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc0"
-ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc0"
+ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc1"
+ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc1"
 ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="valargroup/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 # Persistent Zakura iroh identity (NodeId secret). Kept outside the state cache so


### PR DESCRIPTION
## Motivation

Keep the standalone installer aligned with the published Zakura v1.0.0-rc1 release.

## Solution

- update the Zakura release and Docker image tags from rc0 to rc1
- pin the published SHA-256 checksum for the rc1 Linux x86_64 archive
- retain the existing zcashd v1.0.0-compat-rc2 release configuration

### Tests

- `bash -n scripts/install-zakura.sh`
- IDE diagnostics: no errors

This is a low-risk installer metadata update, so workspace-wide Rust tests and lints were not run.

### Specifications & References

- https://github.com/zakura-core/zakura/releases/tag/v1.0.0-rc1
- https://github.com/valargroup/zcashd/releases/tag/v1.0.0-compat-rc2

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used: Cursor (GPT-5.6 Sol) updated the release metadata, verified published checksums, and drafted this PR.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.