### PR TITLE
ci: retry zakura block-sync driver tests to absorb load-induced flakes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,6 +48,14 @@ default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced
 filter = 'package(zakura-network) and test(~zakura)'
 retries = 2
 
+# The `zakura` binary's header/block-sync driver tests (`commands::start::
+# zakura_header_sync_driver_tests`) drive the same real-time reactor harness with real
+# sleeps and timeouts, so they flake under the same load conditions. The override above
+# only matches `zakura-network`, so retry this package's driver tests as well.
+[[profile.all-tests.overrides]]
+filter = 'package(zakura) and test(~zakura_header_sync_driver_tests)'
+retries = 2
+
 # --- Full Tests profile ---
 # Broader coverage for `ironwood-main`, scheduled, manual, and merge-queue runs,
 # while still keeping the known slow/flaky integration buckets in dedicated
@@ -61,6 +69,12 @@ default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced
 # `all-tests` override above).
 [[profile.full-tests.overrides]]
 filter = 'package(zakura-network) and test(~zakura)'
+retries = 2
+
+# The `zakura` binary's header/block-sync driver tests flake under the same load (see the
+# matching `all-tests` override above).
+[[profile.full-tests.overrides]]
+filter = 'package(zakura) and test(~zakura_header_sync_driver_tests)'
 retries = 2
 
 # --- Individual Test Profiles ---


### PR DESCRIPTION
## Motivation

Unit-test shards intermittently fail on the `zakura` binary's header/block-sync
driver tests — e.g. `commands::start::zakura_header_sync_driver_tests::block_sync_driver_throughput_probe_advances_without_consensus_commit`
failed one shard on an unrelated PR (#89), panicking on an "unexpected read
request" because the driver missed a wall-clock deadline under load.

These tests drive the **real** reactor through a real-time (wall-clock) scenario
harness with real sleeps and `tokio::time::timeout`s. Under a loaded CI runner
the nextest suite oversubscribes the cores, so a scenario can miss its deadline
even when the logic is correct — a load-induced flake, not a regression (a
genuine stall fails every attempt, so retries don't mask real bugs).

The `all-tests` / `full-tests` nextest profiles **already** retry this exact
class of test, but the existing override only matches `package(zakura-network)`:

```toml
[[profile.all-tests.overrides]]
filter = 'package(zakura-network) and test(~zakura)'
retries = 2
```

The driver tests in question live in `package(zakura)` (the `zakurad` binary),
so they got **zero** retries and a single contended miss failed the whole shard.

## Solution

Extend the retry override to also cover the `zakura`-package driver tests, in
both the `all-tests` and `full-tests` profiles:

```toml
[[profile.all-tests.overrides]]
filter = 'package(zakura) and test(~zakura_header_sync_driver_tests)'
retries = 2
```

Scope is deliberately narrow — the filter matches only the 47 tests in the
`commands::start::zakura_header_sync_driver_tests` module (all of which use the
real-time reactor harness), not the whole package. Retries only cost wall-clock
time when a test actually flakes, so passing runs are unaffected.

## Tests

- `.config/nextest.toml` parses (validated with `tomllib`).
- `cargo nextest list -E 'package(zakura) and test(~zakura_header_sync_driver_tests)'`
  selects exactly the 47 driver-module tests, including the one that flaked on #89,
  and nothing outside that module.
- The flaky test passes 60/60 locally (it only misses under contended CI load),
  confirming this is a scheduling flake rather than a logic regression.

## Specifications & References

- Mirrors the existing `package(zakura-network)` retry overrides in the same file
  (and the `zakura-integration` / `zakura-network-dependent` profiles, which already
  retry real-time reactor tests).

### AI Disclosure

- [x] AI tools were used: **Claude Code (Opus)** — diagnosed the shard failure as a
  load-induced flake in an already-retried test class not covered by the existing
  filter, wrote the override, validated the filter scope, and drafted this PR. The
  contributor is the responsible author.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] The solution is tested (see Tests).
- [x] No user-visible/library behavior changes (CI-only config), so no changelog entry.
