### PR TITLE
fix(state): avoid VCT successor body deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Prevent verified-commitment-trees checkpoint sync from stalling at checkpoint
+  boundaries by authenticating a block's supplied roots with its already-validated
+  successor header, without waiting for the successor block body to finish checkpoint
+  verification.
 - Handle the `invalidateblock` and `reconsiderblock` state-control RPC edge
   cases (invalidating a non-finalized chain root, invalidating same-height
   sibling fork tips, and repeated reconsideration of the same block) without

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- VCT checkpoint writes now use the validated header store for the H+1 root witness,
+  avoiding a circular wait for the next checkpoint range's block bodies.
 - `read::history_tree` now returns the finalized history tree only when the
   requested hash or height exactly matches the finalized tip.
 

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -740,12 +740,11 @@ impl FinalizedState {
                         // write worker only buffers direct successors, so this should
                         // never fire.
                         let next_vct_block = next_vct_block.filter(|next_vct_block| {
-                            let links =
-                                next_vct_block.block.header.previous_block_hash == block_hash;
+                            let links = next_vct_block.header.previous_block_hash == block_hash;
                             if !links {
                                 tracing::warn!(
                                     ?height,
-                                    witness_parent = ?next_vct_block.block.header.previous_block_hash,
+                                    witness_parent = ?next_vct_block.header.previous_block_hash,
                                     expected_parent = ?block_hash,
                                     "VCT: ignoring a successor witness that does not link \
                                      to the block being committed"
@@ -782,7 +781,8 @@ impl FinalizedState {
                         if let Some(next_vct_block) = &next_vct_block {
                             verification_items.push(
                                 commitment_aux_verify::CommitmentRootVerification::header_only(
-                                    next_vct_block.block.clone(),
+                                    next_vct_block.header.clone(),
+                                    next_vct_block.height,
                                     next_vct_block.auth_data_root,
                                 ),
                             );
@@ -805,10 +805,8 @@ impl FinalizedState {
                             })?;
 
                         if let Some(next_vct_block) = &next_vct_block {
-                            self.vct.mark_prevalidated(
-                                (height + 1).expect("checkpoint block heights are valid"),
-                                next_vct_block.block.hash(),
-                            );
+                            self.vct
+                                .mark_prevalidated(next_vct_block.height, next_vct_block.hash);
                         } else if self
                             .vct
                             .source()
@@ -1131,6 +1129,40 @@ impl FinalizedState {
         self.vct
             .source()
             .is_some_and(|v| v.vct_root_needs_successor(height, &self.network()))
+    }
+
+    /// Returns a VCT successor witness from the contextually validated Zakura
+    /// header store, without requiring the successor's block body.
+    pub(crate) fn vct_successor_from_header_store(
+        &self,
+        height: block::Height,
+        hash: block::Hash,
+    ) -> Option<NextVctBlock> {
+        let successor_height = (height + 1)?;
+        let header = self.db.zakura_header(successor_height)?;
+        if header.previous_block_hash != hash {
+            tracing::warn!(
+                ?height,
+                ?hash,
+                ?successor_height,
+                successor_parent = ?header.previous_block_hash,
+                "VCT: ignoring a stored successor header that does not link to the block being committed"
+            );
+            return None;
+        }
+
+        let roots = self
+            .db
+            .zakura_header_commitment_roots_by_height_range(successor_height..=successor_height)
+            .into_iter()
+            .next()
+            .filter(|roots| roots.height == successor_height)?;
+
+        Some(NextVctBlock::from_header(
+            header,
+            successor_height,
+            roots.auth_data_root,
+        ))
     }
 
     /// Verify checkpoint handoff frontiers against this block's supplied roots.

--- a/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
@@ -11,9 +11,12 @@
 use std::sync::Arc;
 
 use zakura_chain::{
-    block::{merkle::AuthDataRoot, Block, Height},
+    block::{merkle::AuthDataRoot, Block, Header, Height},
     history_tree::HistoryTree,
     ironwood, orchard,
+    parallel::commitment_aux_verify::{
+        header_commitment_is_valid_for_chain_history, SuppliedRootsError,
+    },
     parameters::{Network, NetworkUpgrade},
     sapling,
 };
@@ -25,7 +28,9 @@ use crate::{service::check, ValidateContextError};
 /// One block-sized step in supplied commitment-root verification.
 #[derive(Clone, Debug)]
 pub(crate) struct CommitmentRootVerification {
-    pub(crate) block: Arc<Block>,
+    pub(crate) block: Option<Arc<Block>>,
+    pub(crate) header: Arc<Header>,
+    pub(crate) height: Height,
     pub(crate) roots: Option<(
         sapling::tree::Root,
         orchard::tree::Root,
@@ -46,8 +51,13 @@ impl CommitmentRootVerification {
         precomputed_auth_data_root: Option<AuthDataRoot>,
         skip_parent_check: bool,
     ) -> Self {
+        let height = block
+            .coinbase_height()
+            .expect("checkpoint-verified blocks have a coinbase height");
         CommitmentRootVerification {
-            block,
+            header: block.header.clone(),
+            height,
+            block: Some(block),
             roots: Some((sapling_root, orchard_root, ironwood_root)),
             precomputed_auth_data_root,
             skip_parent_check,
@@ -59,11 +69,14 @@ impl CommitmentRootVerification {
     /// This confirms the roots already accumulated in the running tree, which is useful
     /// for the final one-block lag: the roots at height `H` are checked by height `H + 1`.
     pub(crate) fn header_only(
-        block: Arc<Block>,
+        header: Arc<Header>,
+        height: Height,
         precomputed_auth_data_root: Option<AuthDataRoot>,
     ) -> Self {
         CommitmentRootVerification {
-            block,
+            block: None,
+            header,
+            height,
             roots: None,
             precomputed_auth_data_root,
             skip_parent_check: false,
@@ -190,14 +203,12 @@ where
     for block_verify in blocks_to_verify {
         let CommitmentRootVerification {
             block,
+            header,
+            height,
             roots,
             precomputed_auth_data_root,
             skip_parent_check,
         } = block_verify;
-
-        let height = block
-            .coinbase_height()
-            .expect("checkpoint-verified blocks have a coinbase height");
 
         // Validate this block's header commitment against the current (parent) tree,
         // i.e. against every root already folded in.
@@ -213,20 +224,42 @@ where
         // with step 3 of the prior iteration so verification can be skipped in that case
         // for perf reasons.
         if !skip_parent_check {
-            // This block + history tree up to and including the previous block.
-            check::block_commitment_is_valid_for_chain_history(
-                block.clone(),
-                network,
-                &history_tree,
-                precomputed_auth_data_root,
-            )
-            .map_err(|error| (height, error))?;
+            if let Some(block) = &block {
+                // This block + history tree up to and including the previous block.
+                check::block_commitment_is_valid_for_chain_history(
+                    block.clone(),
+                    network,
+                    &history_tree,
+                    precomputed_auth_data_root,
+                )
+                .map_err(|error| (height, error))?;
+            } else {
+                let auth_data_root = precomputed_auth_data_root
+                    .expect("header-only VCT witnesses have a stored precomputed auth-data root");
+                header_commitment_is_valid_for_chain_history(
+                    &header,
+                    height,
+                    network,
+                    &history_tree,
+                    auth_data_root,
+                )
+                .map_err(|error| match error {
+                    SuppliedRootsError::InvalidHeaderCommitment(error) => {
+                        ValidateContextError::InvalidBlockCommitment(error)
+                    }
+                    SuppliedRootsError::HistoryTree(error) => {
+                        ValidateContextError::HistoryTreeError(error)
+                    }
+                })
+                .map_err(|error| (height, error))?;
+            }
         }
 
         let Some((sapling_root, orchard_root, ironwood_root)) = roots else {
             continue;
         };
 
+        let block = block.expect("verification items with supplied roots have a block body");
         verify_supplied_sapling_root_below_heartwood(network, &block, &sapling_root)
             .map_err(|error| (height, error))?;
         verify_supplied_orchard_root_below_nu5(network, height, &orchard_root)
@@ -342,7 +375,12 @@ mod tests {
             None,
             true,
         );
-        assert!(Arc::ptr_eq(&with_roots.block, &block));
+        assert!(Arc::ptr_eq(
+            with_roots.block.as_ref().expect("roots item has a block"),
+            &block
+        ));
+        assert!(Arc::ptr_eq(&with_roots.header, &block.header));
+        assert_eq!(with_roots.height, block.coinbase_height().unwrap());
         assert_eq!(
             with_roots.roots,
             Some((sapling_root, orchard_root, ironwood_root))
@@ -350,10 +388,20 @@ mod tests {
         assert_eq!(with_roots.precomputed_auth_data_root, None);
         assert!(with_roots.skip_parent_check);
 
-        let header_only = CommitmentRootVerification::header_only(block.clone(), None);
-        assert!(Arc::ptr_eq(&header_only.block, &block));
+        let height = block.coinbase_height().unwrap();
+        let header_only = CommitmentRootVerification::header_only(
+            block.header.clone(),
+            height,
+            Some(block.auth_data_root()),
+        );
+        assert!(header_only.block.is_none());
+        assert!(Arc::ptr_eq(&header_only.header, &block.header));
+        assert_eq!(header_only.height, height);
         assert_eq!(header_only.roots, None);
-        assert_eq!(header_only.precomputed_auth_data_root, None);
+        assert_eq!(
+            header_only.precomputed_auth_data_root,
+            Some(block.auth_data_root())
+        );
         assert!(!header_only.skip_parent_check);
     }
 
@@ -572,7 +620,7 @@ mod tests {
     /// next block (the V1 `ChainHistoryRoot` path), and rejects a wrong root at the
     /// *next* block (the one-block lag).
     #[test]
-    fn verifies_real_roots_and_rejects_a_wrong_root_at_next_height() {
+    fn verifies_real_roots_with_header_only_successor_and_rejects_a_wrong_root() {
         let activation = NetworkUpgrade::Heartwood
             .activation_height(&Mainnet)
             .expect("mainnet has Heartwood")
@@ -587,7 +635,11 @@ mod tests {
         // Positive: the real roots reconstruct a tree the next block's header commits to.
         let ok_items = vec![
             verification_item(act_block.clone(), act_root, empty_orchard_root),
-            verification_item(next_block.clone(), next_root, empty_orchard_root),
+            CommitmentRootVerification::header_only(
+                next_block.header.clone(),
+                Height(activation + 1),
+                Some(next_block.auth_data_root()),
+            ),
         ];
         verify_commitment_roots(&Mainnet, empty_history_tree(), ok_items)
             .expect("real roots verify against the headers");
@@ -598,7 +650,11 @@ mod tests {
         assert_ne!(act_root, next_root, "test needs two distinct roots");
         let bad_items = vec![
             verification_item(act_block, next_root, empty_orchard_root),
-            verification_item(next_block, next_root, empty_orchard_root),
+            CommitmentRootVerification::header_only(
+                next_block.header.clone(),
+                Height(activation + 1),
+                Some(next_block.auth_data_root()),
+            ),
         ];
         let (fail_height, _error) =
             verify_commitment_roots(&Mainnet, empty_history_tree(), bad_items)

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -5,8 +5,10 @@ use std::{collections::HashMap, env, error::Error, fs, sync::Arc};
 use tempfile::TempDir;
 use tokio::sync::oneshot;
 
+use zakura_chain::serialization::ZcashDeserializeInto;
 use zakura_chain::{
     block::{Block, Height},
+    parallel::commitment_aux::BlockCommitmentRoots,
     parameters::{
         testnet::{ConfiguredActivationHeights, ParametersBuilder},
         NetworkUpgrade,
@@ -39,10 +41,71 @@ type OrchardTree = Arc<zakura_chain::orchard::tree::NoteCommitmentTree>;
 type SproutTree = Arc<zakura_chain::sprout::tree::NoteCommitmentTree>;
 
 fn next_vct_block(block: Arc<Block>) -> Option<NextVctBlock> {
-    Some(NextVctBlock {
-        block,
-        auth_data_root: None,
-    })
+    Some(NextVctBlock::from_block(block, None))
+}
+
+#[test]
+fn vct_successor_witness_uses_stored_header_without_body() {
+    let _init_guard = zakura_test::init();
+    let network = zakura_chain::parameters::Network::Mainnet;
+    let mut state = FinalizedState::new(
+        &Config::ephemeral(),
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    );
+    let genesis = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .expect("genesis block deserializes");
+    let block1 = zakura_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .expect("block 1 deserializes");
+
+    state
+        .commit_finalized_direct(
+            CheckpointVerifiedBlock::from(genesis.clone()).into(),
+            None,
+            None,
+            "header-only VCT successor test genesis",
+        )
+        .expect("genesis commits");
+
+    let roots = BlockCommitmentRoots {
+        height: Height(1),
+        sapling_root: zakura_chain::sapling::tree::NoteCommitmentTree::default().root(),
+        orchard_root: zakura_chain::orchard::tree::NoteCommitmentTree::default().root(),
+        ironwood_root: zakura_chain::ironwood::tree::NoteCommitmentTree::default().root(),
+        sapling_tx: 0,
+        orchard_tx: 0,
+        ironwood_tx: 0,
+        auth_data_root: block1.auth_data_root(),
+    };
+    let mut batch = DiskWriteBatch::new();
+    batch
+        .prepare_header_range_batch_with_roots(
+            &state.db,
+            genesis.hash(),
+            std::slice::from_ref(&block1.header),
+            &[0],
+            &[roots],
+        )
+        .expect("block 1 header is contextually valid");
+    state
+        .db
+        .write_batch(batch)
+        .expect("header range batch writes");
+
+    assert!(
+        state.db.block(Height(1).into()).is_none(),
+        "the successor body must remain absent"
+    );
+    let witness = state
+        .vct_successor_from_header_store(Height(0), genesis.hash())
+        .expect("the stored header and auth-data root form a successor witness");
+    assert_eq!(witness.header, block1.header);
+    assert_eq!(witness.height, Height(1));
+    assert_eq!(witness.hash, block1.hash());
+    assert_eq!(witness.auth_data_root, Some(block1.auth_data_root()));
 }
 
 /// A handoff frontier over empty trees at `height`, for sources whose test does not
@@ -584,10 +647,8 @@ fn vct_frozen_frontier_hole_refuses_instead_of_recomputing() -> Result<()> {
             let mut error_height = None;
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
-                let next = (i < last).then(|| NextVctBlock {
-                    block: blocks[i + 1].block.clone(),
-                    auth_data_root: None,
-                });
+                let next = (i < last)
+                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
                 match fast.commit_finalized_direct(cv.into(), None, next, "vct hole fast") {
                     Ok(_) => {}
                     Err(error) => {
@@ -1301,10 +1362,8 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             prop_assert!(!fast.vct_fast_needs_successor(handoff), "the trusted handoff frontier authenticates the handoff root without a successor");
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
-                let next = (i < last).then(|| NextVctBlock {
-                    block: blocks[i + 1].block.clone(),
-                    auth_data_root: None,
-                });
+                let next = (i < last)
+                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
                 fast.commit_finalized_direct(cv.into(), None, next, "vct fast handoff")
                     .expect("verified fast commit succeeds");
             }
@@ -1382,10 +1441,8 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             let mut handoff_error = None;
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
-                let next = (i < last).then(|| NextVctBlock {
-                    block: blocks[i + 1].block.clone(),
-                    auth_data_root: None,
-                });
+                let next = (i < last)
+                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
                 match bad_handoff.commit_finalized_direct(cv.into(), None, next, "vct bad handoff") {
                     Ok(_) => {}
                     Err(error) => {
@@ -1441,10 +1498,8 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             let mut ironwood_handoff_error = None;
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
-                let next = (i < last).then(|| NextVctBlock {
-                    block: blocks[i + 1].block.clone(),
-                    auth_data_root: None,
-                });
+                let next = (i < last)
+                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
                 match bad_ironwood_handoff.commit_finalized_direct(cv.into(), None, next, "vct bad ironwood handoff") {
                     Ok(_) => {}
                     Err(error) => {
@@ -1571,10 +1626,8 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
                 );
                 for i in 0..=handoff_index {
                     let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
-                    let next = (i < handoff_index).then(|| NextVctBlock {
-                        block: blocks[i + 1].block.clone(),
-                        auth_data_root: None,
-                    });
+                    let next = (i < handoff_index)
+                        .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
                     fast.commit_finalized_direct(cv.into(), None, next, "vct switch fast prefix")
                         .expect("verified fast prefix commits");
                 }
@@ -1650,10 +1703,8 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
             );
             for i in (seed + 1)..=post_handoff_tip {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
-                let next = (i < post_handoff_tip).then(|| NextVctBlock {
-                    block: blocks[i + 1].block.clone(),
-                    auth_data_root: None,
-                });
+                let next = (i < post_handoff_tip)
+                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
                 fast_suffix
                     .commit_finalized_direct(cv.into(), None, next, "vct switch fast suffix")
                     .expect("fast suffix commits after manual prefix");

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 #[cfg(test)]
 use zakura_chain::parallel::tree::NoteCommitmentTrees;
 use zakura_chain::{
-    block::{self, merkle::AuthDataRoot, Block},
+    block::{self, merkle::AuthDataRoot, Block, Header},
     ironwood, orchard,
     parameters::{Network, NetworkUpgrade},
     sapling, sprout,
@@ -25,14 +25,51 @@ use super::{
     ZakuraDb,
 };
 
-/// A buffered VCT successor block used to authenticate the current block's
-/// supplied note-commitment roots.
+/// A VCT successor header used to authenticate the current block's supplied
+/// note-commitment roots.
 #[derive(Clone, Debug)]
 pub struct NextVctBlock {
-    /// The successor block whose header commits to the current block's VCT roots.
-    pub(crate) block: Arc<Block>,
+    /// The successor header that commits to the current block's VCT roots.
+    pub(crate) header: Arc<Header>,
+    /// The successor header's height.
+    pub(crate) height: block::Height,
+    /// The successor header's hash, used for prevalidation deduplication.
+    pub(crate) hash: block::Hash,
     /// The successor block's precomputed ZIP-244 auth-data root, if available.
     pub(crate) auth_data_root: Option<AuthDataRoot>,
+}
+
+impl NextVctBlock {
+    /// Build a successor witness from a checkpoint-verified block.
+    pub(crate) fn from_block(block: Arc<Block>, auth_data_root: Option<AuthDataRoot>) -> Self {
+        let height = block
+            .coinbase_height()
+            .expect("checkpoint-verified successor blocks have a coinbase height");
+        let auth_data_root = Some(auth_data_root.unwrap_or_else(|| block.auth_data_root()));
+
+        Self {
+            header: block.header.clone(),
+            height,
+            hash: block.hash(),
+            auth_data_root,
+        }
+    }
+
+    /// Build a successor witness from a contextually validated stored header.
+    pub(crate) fn from_header(
+        header: Arc<Header>,
+        height: block::Height,
+        auth_data_root: AuthDataRoot,
+    ) -> Self {
+        let hash = block::Hash::from(&header);
+
+        Self {
+            header,
+            height,
+            hash,
+            auth_data_root: Some(auth_data_root),
+        }
+    }
 }
 
 /// Embedded verified final note-commitment frontiers for Mainnet.

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -418,28 +418,33 @@ impl WriteBlockWorkerTask {
             // block's supplied roots against the successor's header.
             vct_write_manager.fill_successor(finalized_block_write_receiver, &ordered_block);
 
-            // A non-handoff VCT fast block's supplied roots are authenticated by
-            // its successor's header. If the successor is not buffered yet, keep
-            // this block local and wait instead of surfacing a checkpoint commit
-            // error through the invalid-block reset path.
-            if vct_write_manager.is_lookahead_empty()
-                && finalized_state.vct_fast_needs_successor(ordered_block.0.height)
-            {
-                tracing::trace!(
-                    height = ?ordered_block.0.height,
-                    hash = ?ordered_block.0.hash,
-                    "VCT: deferring fast checkpoint commit until successor is buffered"
-                );
-                vct_write_manager.defer(ordered_block);
-                std::thread::park_timeout(Duration::from_millis(10));
+            // Prefer a buffered body successor, but fall back to the already-validated
+            // Zakura header store. Requiring the body here creates a circular dependency
+            // at checkpoint boundaries: H waits for H+1 while H+1 cannot be submitted
+            // until its entire checkpoint range is verified.
+            let needs_vct_successor =
+                finalized_state.vct_fast_needs_successor(ordered_block.0.height);
+            let next_vct_block = vct_write_manager.next_vct_block().or_else(|| {
+                if needs_vct_successor {
+                    finalized_state.vct_successor_from_header_store(
+                        ordered_block.0.height,
+                        ordered_block.0.hash,
+                    )
+                } else {
+                    None
+                }
+            });
+
+            if needs_vct_successor && next_vct_block.is_none() {
+                let height = ordered_block.0.height;
+                let wait = vct_write_manager.on_retryable_error(height, false, ordered_block);
+                std::thread::park_timeout(wait);
                 continue;
             }
 
-            // The buffered VCT successor (if any) lets the committer verify this block's
-            // verified-commitment-trees fixture roots before trusting them: a block's
-            // roots are only committed by the next block's header. Its auth data root
-            // is already precomputed by the checkpoint verifier.
-            let next_vct_block = vct_write_manager.next_vct_block();
+            // The successor header authenticates the current block's supplied roots.
+            // Header-sync stores its ZIP-244 auth-data root alongside the contextually
+            // validated header, so this check does not require the successor body.
             let prev_note_commitment_trees = prev_finalized_note_commitment_trees.take();
             let prev_note_commitment_trees_for_retry = prev_note_commitment_trees.clone();
 

--- a/zakura-state/src/service/write/vct_write.rs
+++ b/zakura-state/src/service/write/vct_write.rs
@@ -111,23 +111,12 @@ impl VctWriteManager {
         }
     }
 
-    /// `true` when no block is buffered as the look-ahead successor.
-    pub(super) fn is_lookahead_empty(&self) -> bool {
-        self.lookahead.is_empty()
-    }
-
     /// The buffered successor block's header data, used to verify the
     /// current block's supplied vct roots before trusting them.
     pub(super) fn next_vct_block(&self) -> Option<NextVctBlock> {
-        self.lookahead.front().map(|next| NextVctBlock {
-            block: next.0.block.clone(),
-            auth_data_root: next.0.auth_data_root,
-        })
-    }
-
-    /// Parks `block` for retry instead of committing it now.
-    pub(super) fn defer(&mut self, block: QueuedCheckpointVerified) {
-        self.retry = Some(block);
+        self.lookahead
+            .front()
+            .map(|next| NextVctBlock::from_block(next.0.block.clone(), next.0.auth_data_root))
     }
 
     /// A successful commit clears any vct root stall: logs recovery and
@@ -163,13 +152,14 @@ impl VctWriteManager {
         // requires is available — roots are not individually re-requested, so
         // the node will not advance (it will not, by design, recompute against
         // the stale frontier). Surface it loudly.
-        match self.stall {
-            Some((stuck, _)) if stuck == height => {}
+        let new_stall = match self.stall {
+            Some((stuck, _)) if stuck == height => false,
             _ => {
                 self.stall = Some((height, Instant::now()));
                 self.stall_logged = false;
+                true
             }
-        }
+        };
         if !self.stall_logged
             && self
                 .stall
@@ -179,20 +169,26 @@ impl VctWriteManager {
                 ?height,
                 root_unavailable,
                 stalled_for = ?VCT_ROOT_STALL_WARN_AFTER,
-                "VCT: checkpoint commit stalled with no verifiable supplied root; \
-                 roots are not re-requested, so the node cannot advance without a \
-                 re-delivery of this header range (it will not recompute against \
-                 the frozen frontier)"
+                "VCT: checkpoint commit stalled waiting for a verifiable supplied root \
+                 or successor witness; the node will not recompute against the frozen frontier"
             );
             metrics::gauge!("state.vct.root.stalled.height").set(f64::from(height.0));
             self.stall_logged = true;
-        } else {
+        } else if new_stall {
             tracing::warn!(
                 ?height,
                 block_height = ?block.0.height,
                 block_hash = ?block.0.hash,
                 root_unavailable,
                 "VCT: supplied root not yet verifiable; retrying checkpoint commit in place"
+            );
+        } else {
+            tracing::trace!(
+                ?height,
+                block_height = ?block.0.height,
+                block_hash = ?block.0.hash,
+                root_unavailable,
+                "VCT: supplied root still not verifiable; retrying checkpoint commit in place"
             );
         }
 

--- a/zakura-state/src/service/write/vct_write/tests.rs
+++ b/zakura-state/src/service/write/vct_write/tests.rs
@@ -58,18 +58,6 @@ fn take_ready_prefers_retry_over_lookahead() {
 }
 
 #[test]
-fn defer_makes_block_the_next_ready_block() {
-    let mut manager = VctWriteManager::default();
-    let block = queued_block(1);
-    let hash = block.0.hash;
-
-    manager.defer(block);
-
-    let ready = manager.take_ready().expect("deferred block is ready");
-    assert_eq!(ready.0.hash, hash);
-}
-
-#[test]
 fn fill_successor_only_buffers_one_linking_block_at_a_time() {
     let mut manager = VctWriteManager::default();
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -127,8 +115,8 @@ fn fill_successor_discards_non_successors_and_keeps_the_linking_block() {
     let witness = manager
         .next_vct_block()
         .expect("successor is buffered")
-        .block;
-    assert_eq!(witness.header.previous_block_hash, current.0.hash);
+        .header;
+    assert_eq!(witness.previous_block_hash, current.0.hash);
 }
 
 /// With no linking block buffered anywhere, the look-ahead ends up empty, so the
@@ -142,7 +130,7 @@ fn fill_successor_empties_the_lookahead_when_no_successor_exists() {
 
     manager.fill_successor(&mut rx, &current);
 
-    assert!(manager.is_lookahead_empty());
+    assert!(manager.lookahead.is_empty());
     assert!(manager.next_vct_block().is_none());
 }
 
@@ -157,7 +145,14 @@ fn next_vct_block_reflects_the_lookahead_front() {
     manager.lookahead.push_back(block);
 
     let next_vct_block = manager.next_vct_block().expect("look-ahead has a block");
-    assert_eq!(next_vct_block.block, expected_block);
+    assert_eq!(next_vct_block.header, expected_block.header);
+    assert_eq!(next_vct_block.hash, expected_block.hash());
+    assert_eq!(
+        next_vct_block.height,
+        expected_block
+            .coinbase_height()
+            .expect("fake block has a height")
+    );
     assert_eq!(next_vct_block.auth_data_root, expected_auth_data_root);
 }
 
@@ -178,7 +173,7 @@ fn reset_clears_the_lookahead() {
 
     manager.reset(&mut finalized_state);
 
-    assert!(manager.is_lookahead_empty());
+    assert!(manager.lookahead.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Archive checkpoint sync can permanently stall at a hard-coded checkpoint boundary when the VCT finalized writer reaches height H before H+1 has crossed the next checkpoint verifier range.

The writer previously required the H+1 block body as the one-block VCT authentication witness. At a checkpoint boundary, H+1 cannot enter the finalized-body channel until the following 400-block range verifies, creating a circular wait that can saturate all 401 apply slots.

## Solution

- Represent a VCT successor witness using its header, explicit height, hash, and ZIP-244 auth-data root rather than requiring an entire block body.
- Prefer the buffered H+1 body when available, then fall back to the contextually validated Zakura header store and its stored auth-data root.
- Require the stored witness to be exactly H+1 and to link directly to H before using its header commitment.
- Route a genuinely missing witness through the existing VCT stall tracker, with one initial warning, trace-level polling, and error-level escalation after 30 seconds.
- Document the user-visible fix in the root and `zakura-state` changelogs.

### Tests

- `cargo fmt --all -- --check`
- `CXX=clang++ CXXFLAGS="-include cstdint" cargo check -p zakura-state --lib`
- `CXX=clang++ CXXFLAGS="-include cstdint" cargo clippy -p zakura-state --all-targets -- -D warnings`
- `CXX=clang++ CXXFLAGS="-include cstdint" cargo test -p zakura-state --lib` (342 passed, 2 ignored)
- Focused regression coverage confirms:
  - H roots are authenticated by a real H+1 header-only witness.
  - The stored H+1 witness is available while its body remains absent.
  - VCT look-ahead and tracked retry behavior remain correct.

The explicit C++ flags work around vendored RocksDB 8.10 headers failing to include `<cstdint>` under the host's GCC 15 / Clang 22 toolchains; no RocksDB source was changed.

### Specifications & References

This implements the VCT one-block authentication rule without coupling it to checkpoint body-range completion.

### AI Disclosure

- [x] AI tools were used: OpenAI Codex investigated the trace/code path and implemented the Rust changes, regression tests, changelog entries, validation, and PR description under human direction.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team before opening the draft PR.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
