### PR TITLE
ci(release): gate release builds on tag matching the zakura package version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -99,6 +99,22 @@ Choose a release level for `zakurad`. Release levels are based on user-visible c
 - significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
 - otherwise, it is a `patch` release
 
+**This step is mandatory for every release, including release candidates.**
+Release binaries are built without `.git`, so `zakurad --version` reports the
+`zakura` package version, not the tag — v1.0.0-rc1 was tagged without this bump
+and its binaries self-report `1.0.0-rc0`. The `release-binaries.yml` workflow
+refuses to build or publish assets for a tag that does not match the package
+version.
+
+- [ ] Bump the `zakura` package version to the release version:
+
+```sh
+cargo release version --verbose --execute --allow-branch '*' -p zakura patch # [ major | minor ]
+```
+
+- [ ] On the release commit, check that the version matches the tag you are
+      about to create: `./scripts/check-release-version.sh v<version>`
+
 ## Update Crate Versions and Crate Change Logs
 
 If you're publishing crates for the first time, [log in to crates.io](https://github.com/zakura-core/zakura/dev/crate-owners.html#logging-in-to-cratesio),
@@ -168,6 +184,9 @@ The end of support height is calculated from the current blockchain height:
 - [ ] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/zakura-core/zakura/releases)
 - [ ] Set the tag name to the version tag,
       for example: `v1.0.0`
+      (the tag must match the `zakura` package version — verify with
+      `./scripts/check-release-version.sh v<version>`; a mismatched tag fails
+      `release-binaries.yml` and publishes nothing)
 - [ ] Set the release to target the `ironwood-main` branch
 - [ ] Set the release title to `Zakura` followed by the version tag,
       for example: `Zakura 1.0.0`

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -7,6 +7,13 @@
 # workflow and never rebuilds or re-uploads anything. Real releases get their
 # own non-hyphenated tag. To repair or re-upload assets for an existing tag,
 # run workflow_dispatch with publish_assets_to_release.
+#
+# The tag must match the `zakura` package version: release binaries are built
+# in Docker without `.git`, so `zakurad --version` reports CARGO_PKG_VERSION,
+# and a tag pushed without bumping the package version ships binaries that
+# self-report the wrong release (this happened with v1.0.0-rc1). The
+# check-release-version job gates every build and publish job on that match;
+# run ./scripts/check-release-version.sh before pushing a tag.
 name: Release binaries
 
 on:
@@ -26,6 +33,11 @@ on:
         default: false
       publish_docker_to_dockerhub:
         description: "Publish Docker images to Docker Hub"
+        required: false
+        type: boolean
+        default: false
+      skip_version_check:
+        description: "Skip the tag / zakura package version match check (only for repairing releases tagged with a mismatched version, like v1.0.0-rc1)"
         required: false
         type: boolean
         default: false
@@ -73,6 +85,25 @@ jobs:
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
           echo "checkout_ref=$checkout_ref" >> "$GITHUB_OUTPUT"
 
+  check-release-version:
+    name: Check release tag matches package version
+    runs-on: ubuntu-latest
+    needs: [resolve-release]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.resolve-release.outputs.checkout_ref }}
+
+      # Tag pushes cannot set inputs, so the check always runs for new tags;
+      # skip_version_check only unblocks workflow_dispatch repairs of releases
+      # that were tagged with a mismatched version before this gate existed.
+      - name: Check the zakura package version matches the release tag
+        if: ${{ !inputs.skip_version_check }}
+        env:
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+        run: ./scripts/check-release-version.sh "$RELEASE_TAG"
+
   resolve-zcashd-compat-manifest:
     name: Resolve zcashd compat manifest
     runs-on: ubuntu-latest
@@ -97,7 +128,7 @@ jobs:
   build-zakurad-assets:
     name: Build zakurad assets (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
-    needs: [resolve-release]
+    needs: [resolve-release, check-release-version]
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +176,31 @@ jobs:
           fi
 
       - name: Validate binary
-        run: ./out/usr/local/bin/${{ env.release_binary }} --version
+        env:
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+          SKIP_VERSION_CHECK: ${{ inputs.skip_version_check }}
+        run: |
+          set -euo pipefail
+          version_output="$(./out/usr/local/bin/${{ env.release_binary }} --version)"
+          echo "$version_output"
+
+          if [ "$SKIP_VERSION_CHECK" = "true" ]; then
+            echo "Skipping binary version check (skip_version_check input set)."
+            exit 0
+          fi
+
+          # Docker builds have no .git, so the binary reports
+          # CARGO_PKG_VERSION plus "+g<commit>" build metadata; the release
+          # version must match the tag exactly.
+          binary_version="$(printf '%s\n' "$version_output" | head -n1)"
+          binary_version="${binary_version##* }"
+          binary_version="${binary_version%%+*}"
+          tag_version="${RELEASE_TAG#v}"
+          if [ "$binary_version" != "$tag_version" ]; then
+            echo "Binary self-reports version ${binary_version}, but the release tag is ${RELEASE_TAG}." >&2
+            echo "Bump the zakura package version on the release branch before tagging." >&2
+            exit 1
+          fi
 
       - name: Package archive and metadata
         env:
@@ -364,7 +419,7 @@ jobs:
 
   build:
     name: Build Release Docker (${{ matrix.name }})
-    needs: [resolve-release]
+    needs: [resolve-release, check-release-version]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -483,7 +538,7 @@ jobs:
   build-zcashd-compat:
     name: Build Release Docker zcashd Compat (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
-    needs: [resolve-release, resolve-zcashd-compat-manifest]
+    needs: [resolve-release, resolve-zcashd-compat-manifest, check-release-version]
     strategy:
       fail-fast: false
       matrix:
@@ -610,6 +665,7 @@ jobs:
     if: always()
     needs:
       - resolve-release
+      - check-release-version
       - resolve-zcashd-compat-manifest
       - build-zakurad-assets
       - publish-zakurad-assets

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -129,3 +129,5 @@ To help ensure that you have sufficient time and a clear path to update, this is
 ## Release candidate & release process
 
 Our release checklist is available as a template, which defines each step our team needs to follow to create a new pre-release or release, and to also build and push the binaries to the official channels [Release Checklist Template](https://github.com/zakura-core/zakura/blob/ironwood-main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md).
+
+Every release tag must match the `zakura` package version: release binaries are built without `.git`, so `zakurad --version` reports the package version, not the tag. The `release-binaries.yml` workflow checks this and refuses to build or publish assets for a mismatched tag. Before pushing a tag, verify the release commit with `./scripts/check-release-version.sh v<version>`.

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Check that a release tag matches the `zakura` package version.
+#
+# Release binaries are built in Docker without `.git`, so `zakurad --version`
+# reports CARGO_PKG_VERSION, not the tag: tagging without bumping the package
+# version ships binaries that self-report the wrong release (v1.0.0-rc1 shipped
+# reporting 1.0.0-rc0). Run this on the release commit before pushing the tag;
+# release-binaries.yml runs the same check and refuses to build or publish
+# assets for a mismatched tag.
+#
+# Usage:
+#   ./scripts/check-release-version.sh <release-tag>
+#   ./scripts/check-release-version.sh v1.0.0-rc2
+set -euo pipefail
+
+if [ $# -ne 1 ] || [ -z "$1" ]; then
+  echo "Usage: $0 <release-tag> (for example v1.0.0-rc2)" >&2
+  exit 1
+fi
+RELEASE_TAG="$1"
+
+for cmd in cargo jq; do
+  command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd" >&2; exit 1; }
+done
+
+case "$RELEASE_TAG" in
+  v*) ;;
+  *)
+    echo "Release tag '${RELEASE_TAG}' must start with 'v'." >&2
+    exit 1
+    ;;
+esac
+tag_version="${RELEASE_TAG#v}"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+# --no-deps only reads the workspace manifests, so this works offline and
+# without a Cargo.lock.
+package_version="$(
+  cargo metadata --format-version 1 --no-deps --manifest-path "${repo_root}/Cargo.toml" \
+    | jq -r '.packages[] | select(.name == "zakura") | .version'
+)"
+
+if [ -z "$package_version" ]; then
+  echo "Could not find the 'zakura' package in the workspace." >&2
+  exit 1
+fi
+
+if [ "$package_version" != "$tag_version" ]; then
+  cat >&2 <<EOF
+Release tag ${RELEASE_TAG} does not match the 'zakura' package version.
+
+  tag version:     ${tag_version}
+  package version: ${package_version}
+
+Bump the package version on the release branch before tagging, for example:
+
+  cargo release version --verbose --execute --allow-branch '*' -p zakura <level>
+
+See .github/PULL_REQUEST_TEMPLATE/release-checklist.md ("Update Zakura Version").
+EOF
+  exit 1
+fi
+
+echo "Release tag ${RELEASE_TAG} matches the 'zakura' package version (${package_version})."


### PR DESCRIPTION
## Motivation

v1.0.0-rc1 was tagged without bumping the `zakura` package version, so its binaries self-report `zakurad --version` = `1.0.0-rc0` and advertise `/Zakura:1.0.0-rc0/` — the same class of mismatch #81 fixed for rc0. Release binaries are built in Docker without `.git`, so the binary falls back to `CARGO_PKG_VERSION`, and nothing in the release pipeline checked that the tag matched it. This PR makes that mismatch impossible to ship again. (No pre-existing issue; this addresses the rc1 identity regression found during release prep.)

## Solution

- New `check-release-version` job in `release-binaries.yml`, gating all build jobs (and transitively every publish job): it fails fast if the tag (minus `v`) doesn't equal the `zakura` package version, so a mismatched tag builds and publishes nothing.
- The "Validate binary" step now also asserts the built binary's self-reported version (build metadata stripped) equals the tag — belt-and-suspenders against any stamping divergence.
- New reusable script `scripts/check-release-version.sh <tag>` used by CI and by the pre-tag runbook step.
- New `skip_version_check` workflow_dispatch input so asset-repair runs for releases tagged before this gate (rc0/rc1) aren't blocked. Tag pushes can't set inputs, so new tags are always checked.
- Release checklist: the "Update Zakura Version" section now has mandatory checkboxes to bump the `zakura` package and run the check before tagging (rc1 happened because the section explained release levels but never said to bump). Matching notes added at the tag-creation step and in `book/src/dev/release-process.md`. The hotfix checklist delegates to the same section, so it inherits the steps.

Deliberately out of scope: this gate checks only the node package.

### Tests

- `scripts/check-release-version.sh v1.0.0-rc0` passes against the current tree (package is `1.0.0-rc0`); `scripts/check-release-version.sh v1.0.0-rc1` fails with a clear remediation message — i.e. the script reproduces the exact rc1 mismatch.
- The binary-version parsing in "Validate binary" was exercised standalone with a simulated `zakurad 1.0.0-rc0+g05a8794c1234` output against both matching and mismatching tags.
- Workflow YAML validated with a YAML parser. The gate job follows the existing hygiene patterns (SHA-pinned actions, `persist-credentials: false`, tag passed via env, not template interpolation).
- Not tested: a live tag-push run of the workflow (requires pushing a `v*` tag, which publishes assets). The `skip_version_check` repair path can be verified with a `workflow_dispatch` run for `v1.0.0-rc1` once merged.

### Specifications & References

- rc1 mismatch documented in the release-prep survey (SUMMARY.md §6.2 / CRATE_SUMMARY.md §4, not committed)
- #81 (original version-identity fix for rc0), #95 (installer pinned to rc1)

### Follow-up Work

- Bump the `zakura` package before cutting the next tag — this PR gates, it doesn't bump.
- Version unification of the 11 fork-owned crates at the release version, plus the one-line `configured_user_agent` dedup (`zakura-network/src/peer/handshake.rs`).

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code wrote the workflow gate, check script, and checklist/docs updates; reviewed by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.