### PR TITLE
fix(sync): keep the zcashd-compat sidecar syncing instead of stalling on a fresh install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,24 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   maturity, so a shipped checkpoint cannot be orphaned by a reorg Zakura would
   still follow. `MAX_BLOCK_REORG_HEIGHT` now lives in `zakura-chain` as the single
   source of truth. Backported from upstream Zebra PR #10719.
+- Fixed the zcashd-compat sidecar's chain sync stalling silently and permanently
+  within seconds of a fresh start. Every inbound peer request shares one bounded
+  queue behind a `tower::load_shed` layer, and an overloaded request was silently
+  ignored (95% of the time) with no reply, no log above `DEBUG`, and the
+  connection left open. Zakura's own checkpoint sync keeps that queue busy exactly
+  while the sidecar is fetching headers, so a shed request was near-inevitable on
+  a fresh run. A sidecar zcashd is pinned to Zakura as its only peer and never
+  re-sends `getheaders`, so one ignored request stalled it forever.
+
+  Inbound requests from peers in `zcashd_compat.block_gossip_peer_ips` (loopback
+  by default) are now retried while the queue drains, rather than shed. If the
+  service is still overloaded after `MAX_COMPAT_INBOUND_RETRY_TIME` (20s), the
+  connection is closed with a `WARN` instead of being silently ignored, so zcashd
+  redials and restarts its headers sync. Ordinary peers keep the existing
+  randomised load-shedding, so this is not a denial-of-service vector: the
+  allowlist only covers a local zcashd process that Zakura itself supervises. The
+  `Overloaded` log line also now carries the request, matching the timeout branch
+  next to it, so a shed request is diagnosable at the default filter level.
 - Added a default 180-second request timeout to `RpcRequestClient`, so RPC calls
   no longer hang indefinitely when a server accepts the connection but never
   sends a response. A new `new_with_timeout` constructor lets callers with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   maturity, so a shipped checkpoint cannot be orphaned by a reorg Zakura would
   still follow. `MAX_BLOCK_REORG_HEIGHT` now lives in `zakura-chain` as the single
   source of truth. Backported from upstream Zebra PR #10719.
+- Fixed the zcashd-compat sidecar going permanently idle a few thousand blocks into
+  a fresh sync. Block gossip was gated behind `SyncStatus::wait_until_close_to_tip()`.
+  That is right for ordinary peers -- a peer far from the tip is expected to sync from
+  a node that is near it -- but a sidecar has no such fallback: it is pinned to Zakura
+  as its only peer. Once it catches up to Zakura's in-progress tip it receives a short
+  `headers` batch, correctly concludes it has reached our tip, stops sending
+  `getheaders`, and waits for an inventory announcement. Gating every announcement on
+  being close to the tip meant that announcement never came, and the sidecar sat idle
+  for the whole of Zakura's initial block download.
+
+  Zakura now gossips on every tip change while zcashd-compat is enabled, and the peer
+  set restricts the audience: while far from the network tip, only sidecar peers are
+  told, so gossip to ordinary peers is unchanged. This is what
+  `zcashd_compat.block_gossip_peer_ips` already documented ("must always receive block
+  inventory broadcasts") but did not actually do.
 - Fixed the zcashd-compat sidecar's chain sync stalling silently and permanently
   within seconds of a fresh start. Every inbound peer request shares one bounded
   queue behind a `tower::load_shed` layer, and an overloaded request was silently

--- a/zakura-network/src/constants.rs
+++ b/zakura-network/src/constants.rs
@@ -381,6 +381,38 @@ pub const MIN_OVERLOAD_DROP_PROBABILITY: f32 = 0.05;
 /// [`Overloaded`](crate::PeerError::Overloaded) error.
 pub const MAX_OVERLOAD_DROP_PROBABILITY: f32 = 0.5;
 
+/// The total time Zakura will keep retrying an inbound request from a
+/// zcashd-compat sidecar peer that the inbound service shed as overloaded.
+///
+/// # Security
+///
+/// This applies *only* to peers in `zcashd_compat.block_gossip_peer_ips`, which
+/// defaults to loopback: a local zcashd process that Zakura itself supervises.
+/// Ordinary peers keep the randomised drop/ignore load-shedding, so this is not
+/// a denial-of-service vector.
+///
+/// A sidecar zcashd is pinned to Zakura as its single peer (`-connect`), and
+/// classic `getheaders` has no timeout or retry, so one silently ignored request
+/// stalls the sidecar's chain sync permanently. Retrying is the difference
+/// between backpressure and a black hole.
+///
+/// This bound must comfortably exceed `zakurad`'s `MAX_INBOUND_RESPONSE_TIME` (5
+/// seconds), so a request queued behind a full inbound buffer has time to drain.
+///
+/// It must also stay *below* the sidecar's own `HEADERS_RESPONSE_TIMEOUT` (30
+/// seconds in the zcashd-compat build). Giving up first means Zakura closes the
+/// connection, zcashd observes the disconnect and re-dials with fresh sync state,
+/// and no duplicate `getheaders` is ever in flight. If Zakura held the request
+/// longer, zcashd would re-send while the original was still queued.
+pub const MAX_COMPAT_INBOUND_RETRY_TIME: Duration = Duration::from_secs(20);
+
+/// How long to wait between retries of an overloaded inbound request from a
+/// zcashd-compat sidecar peer.
+///
+/// Short enough that a drained buffer is noticed quickly, long enough that a
+/// sustained overload does not spin.
+pub const COMPAT_INBOUND_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
 /// The minimum interval between logging peer set status updates.
 pub const MIN_PEER_SET_LOG_INTERVAL: Duration = Duration::from_secs(60);
 

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -23,8 +23,9 @@ use zakura_chain::{
 
 use crate::{
     constants::{
-        self, MAX_ADDRS_IN_MESSAGE, MAX_OVERLOAD_DROP_PROBABILITY, MIN_OVERLOAD_DROP_PROBABILITY,
-        OVERLOAD_PROTECTION_INTERVAL, PEER_ADDR_RESPONSE_LIMIT,
+        self, COMPAT_INBOUND_RETRY_INTERVAL, MAX_ADDRS_IN_MESSAGE, MAX_COMPAT_INBOUND_RETRY_TIME,
+        MAX_OVERLOAD_DROP_PROBABILITY, MIN_OVERLOAD_DROP_PROBABILITY, OVERLOAD_PROTECTION_INTERVAL,
+        PEER_ADDR_RESPONSE_LIMIT,
     },
     meta_addr::MetaAddr,
     peer::{
@@ -614,6 +615,14 @@ where
     /// service to a request from this connection,
     /// or None if this connection hasn't yet received an overload error.
     last_overload_time: Option<Instant>,
+
+    /// Whether this peer is a zcashd-compat sidecar, configured via
+    /// `zcashd_compat.block_gossip_peer_ips`.
+    ///
+    /// The sidecar is a local zcashd process that Zakura supervises, and it is
+    /// pinned to Zakura as its only peer. Its inbound requests must never be
+    /// silently ignored: see [`Connection::drive_peer_request`].
+    pub(super) is_zcashd_compat_peer: bool,
 }
 
 impl<S, Tx> fmt::Debug for Connection<S, Tx>
@@ -631,6 +640,7 @@ where
             .field("metrics_label", &self.metrics_label)
             .field("last_metrics_state", &self.last_metrics_state)
             .field("last_overload_time", &self.last_overload_time)
+            .field("is_zcashd_compat_peer", &self.is_zcashd_compat_peer)
             .finish()
     }
 }
@@ -640,6 +650,7 @@ where
     Tx: Sink<Message, Error = SerializationError> + Unpin,
 {
     /// Return a new connection from its channels, services, shared state, and metadata.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         inbound_service: S,
         client_rx: futures::channel::mpsc::Receiver<ClientRequest>,
@@ -648,6 +659,7 @@ where
         connection_tracker: ConnectionTracker,
         connection_info: Arc<ConnectionInfo>,
         initial_cached_addrs: Vec<MetaAddr>,
+        is_zcashd_compat_peer: bool,
     ) -> Self {
         let metrics_label = connection_info.connected_addr.get_transient_addr_label();
 
@@ -664,6 +676,7 @@ where
             metrics_label,
             last_metrics_state: None,
             last_overload_time: None,
+            is_zcashd_compat_peer,
         }
     }
 }
@@ -1415,62 +1428,8 @@ where
         // before sending the next inbound request.
         tokio::task::yield_now().await;
 
-        // # Security
-        //
-        // Holding buffer slots for a long time can cause hangs:
-        // <https://docs.rs/tower/latest/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound>
-        //
-        // The inbound service must be called immediately after a buffer slot is reserved.
-        //
-        // The inbound service never times out in readiness, because the load shed layer is always
-        // ready, and returns an error in response to the request instead.
-        if self.svc.ready().await.is_err() {
-            self.fail_with(PeerError::ServiceShutdown).await;
+        let Some(rsp) = self.call_inbound_service(&req).await else {
             return;
-        }
-
-        // Inbound service request timeouts are handled by the timeout layer in `start::start()`.
-        let rsp = match self.svc.call(req.clone()).await {
-            Err(e) => {
-                if e.is::<tower::load_shed::error::Overloaded>() {
-                    // # Security
-                    //
-                    // The peer request queue must have a limited length.
-                    // The buffer and load shed layers are added in `start::start()`.
-                    tracing::debug!("inbound service is overloaded, may close connection");
-
-                    let now = Instant::now();
-
-                    self.handle_inbound_overload(req, now, PeerError::Overloaded)
-                        .await;
-                } else if e.is::<tower::timeout::error::Elapsed>() {
-                    // # Security
-                    //
-                    // Peer requests must have a timeout.
-                    // The timeout layer is added in `start::start()`.
-                    tracing::info!(%req, "inbound service request timed out, may close connection");
-
-                    let now = Instant::now();
-
-                    self.handle_inbound_overload(req, now, PeerError::InboundTimeout)
-                        .await;
-                } else {
-                    // We could send a reject to the remote peer, but that might cause
-                    // them to disconnect, and we might be using them to sync blocks.
-                    // For similar reasons, we don't want to fail_with() here - we
-                    // only close the connection if the peer is doing something wrong.
-                    info!(
-                        %e,
-                        connection_state = ?self.state,
-                        client_receiver = ?self.client_rx,
-                        "error processing peer request",
-                    );
-                    self.update_state_metrics(format!("In::Req::{}/Rsp::Error", req.command()));
-                }
-
-                return;
-            }
-            Ok(rsp) => rsp,
         };
 
         // Add a metric for outbound responses to inbound requests
@@ -1612,9 +1571,136 @@ where
     /// The inbound connection rate-limit also makes it hard for multiple peers to perform this
     /// attack, because each inbound connection can only send one inbound request before its
     /// probability of being disconnected increases.
+    /// Send `req` to the inbound service and return its response, or `None` if the
+    /// request could not be answered.
+    ///
+    /// # Security
+    ///
+    /// Holding buffer slots for a long time can cause hangs:
+    /// <https://docs.rs/tower/latest/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound>
+    ///
+    /// The inbound service must be called immediately after a buffer slot is reserved.
+    ///
+    /// The inbound service never times out in readiness, because the load shed layer is always
+    /// ready, and returns an error in response to the request instead.
+    ///
+    /// # zcashd-compat sidecar
+    ///
+    /// All peers share one bounded inbound queue, so a burst of Zakura's own
+    /// checkpoint-sync work can shed a request from any peer. For ordinary peers that
+    /// is correct: the request is dropped, and a healthy node has other peers to ask.
+    ///
+    /// A zcashd-compat sidecar has no other peers. It is pinned to this node by
+    /// `-connect`, and classic `getheaders` has neither a timeout nor a retry, so one
+    /// silently ignored request stalls its chain sync permanently. Apply backpressure
+    /// to the sidecar instead of shedding it: wait for the inbound queue to drain and
+    /// try again. The sidecar is a local process this node supervises, so retrying it
+    /// is not a denial-of-service vector.
+    async fn call_inbound_service(&mut self, req: &Request) -> Option<Response> {
+        // Measured on the tokio clock, which is the same clock the retry sleeps below
+        // advance. Using `std::time::Instant` here would let a paused-time test spin
+        // forever: the sleeps would auto-advance while the deadline never arrived.
+        let retry_deadline = tokio::time::Instant::now() + MAX_COMPAT_INBOUND_RETRY_TIME;
+        let mut retries: u64 = 0;
+
+        loop {
+            if self.svc.ready().await.is_err() {
+                self.fail_with(PeerError::ServiceShutdown).await;
+                return None;
+            }
+
+            // Inbound service request timeouts are handled by the timeout layer in `start::start()`.
+            let error = match self.svc.call(req.clone()).await {
+                Ok(rsp) => return Some(rsp),
+                Err(error) => error,
+            };
+
+            let peer_error = if error.is::<tower::load_shed::error::Overloaded>() {
+                // # Security
+                //
+                // The peer request queue must have a limited length.
+                // The buffer and load shed layers are added in `start::start()`.
+                PeerError::Overloaded
+            } else if error.is::<tower::timeout::error::Elapsed>() {
+                // # Security
+                //
+                // Peer requests must have a timeout.
+                // The timeout layer is added in `start::start()`.
+                PeerError::InboundTimeout
+            } else {
+                // We could send a reject to the remote peer, but that might cause
+                // them to disconnect, and we might be using them to sync blocks.
+                // For similar reasons, we don't want to fail_with() here - we
+                // only close the connection if the peer is doing something wrong.
+                info!(
+                    %error,
+                    connection_state = ?self.state,
+                    client_receiver = ?self.client_rx,
+                    "error processing peer request",
+                );
+                self.update_state_metrics(format!("In::Req::{}/Rsp::Error", req.command()));
+
+                return None;
+            };
+
+            let now = Instant::now();
+
+            if self.is_zcashd_compat_peer && tokio::time::Instant::now() < retry_deadline {
+                if retries == 0 {
+                    debug!(
+                        %req,
+                        %peer_error,
+                        "inbound service shed a zcashd-compat sidecar request, retrying instead of ignoring it",
+                    );
+                }
+
+                retries += 1;
+                metrics::counter!("pool.retried.loadshed.compat").increment(1);
+                self.update_state_metrics(format!(
+                    "In::Req::{}/Rsp::{peer_error}::Retry",
+                    req.command()
+                ));
+
+                sleep(COMPAT_INBOUND_RETRY_INTERVAL).await;
+                continue;
+            }
+
+            if self.is_zcashd_compat_peer {
+                // Never leave the sidecar waiting on a reply that will not come: that is
+                // exactly what stalls its sync. `handle_inbound_overload` closes this
+                // connection instead, and zcashd redials and restarts its headers sync.
+                warn!(
+                    %req,
+                    %peer_error,
+                    retries,
+                    retry_time = ?MAX_COMPAT_INBOUND_RETRY_TIME,
+                    "inbound service still overloaded for the zcashd-compat sidecar after retrying, \
+                     closing the connection so it reconnects",
+                );
+            } else if matches!(peer_error, PeerError::Overloaded) {
+                debug!(%req, "inbound service is overloaded, may close connection");
+            } else {
+                info!(%req, "inbound service request timed out, may close connection");
+            }
+
+            self.handle_inbound_overload(req.clone(), now, peer_error)
+                .await;
+
+            return None;
+        }
+    }
+
     async fn handle_inbound_overload(&mut self, req: Request, now: Instant, error: PeerError) {
         let prev = self.last_overload_time.replace(now);
-        let drop_connection_probability = overload_drop_connection_probability(now, prev);
+
+        // The sidecar is never silently ignored. Ignoring its request black-holes a
+        // `getheaders` it will never re-send; closing the connection is recoverable,
+        // because zcashd redials its `-connect` peer and starts a fresh headers sync.
+        let drop_connection_probability = if self.is_zcashd_compat_peer {
+            1.0
+        } else {
+            overload_drop_connection_probability(now, prev)
+        };
 
         if thread_rng().gen::<f32>() < drop_connection_probability {
             if matches!(error, PeerError::Overloaded) {

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -28,8 +28,8 @@ use crate::{
 mod prop;
 mod vectors;
 
-/// Creates a new [`Connection`] instance for testing.
-fn new_test_connection<A>() -> (
+/// A test [`Connection`], with the channels and mocked services driving it.
+type TestConnection<A> = (
     Connection<
         MockService<Request, Response, A>,
         SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
@@ -38,7 +38,16 @@ fn new_test_connection<A>() -> (
     MockService<Request, Response, A>,
     mpsc::Receiver<Message>,
     ErrorSlot,
-) {
+);
+
+/// Creates a new [`Connection`] instance for testing.
+fn new_test_connection<A>() -> TestConnection<A> {
+    new_test_connection_with_compat_sidecar(false)
+}
+
+/// Creates a new [`Connection`] instance for testing, where `is_zcashd_compat_peer`
+/// marks the peer as a zcashd-compat sidecar.
+fn new_test_connection_with_compat_sidecar<A>(is_zcashd_compat_peer: bool) -> TestConnection<A> {
     let mock_inbound_service = MockService::build().finish();
     let (client_tx, client_rx) = mpsc::channel(0);
     let shared_error_slot = ErrorSlot::default();
@@ -87,6 +96,7 @@ fn new_test_connection<A>() -> (
         ActiveConnectionCounter::new_counter().track_connection(),
         Arc::new(connection_info),
         Vec::new(),
+        is_zcashd_compat_peer,
     );
 
     (

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -22,7 +22,10 @@ use zakura_chain::serialization::SerializationError;
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
-    constants::{MAX_OVERLOAD_DROP_PROBABILITY, MIN_OVERLOAD_DROP_PROBABILITY, REQUEST_TIMEOUT},
+    constants::{
+        MAX_COMPAT_INBOUND_RETRY_TIME, MAX_OVERLOAD_DROP_PROBABILITY,
+        MIN_OVERLOAD_DROP_PROBABILITY, REQUEST_TIMEOUT,
+    },
     peer::{
         connection::{overload_drop_connection_probability, Connection, State},
         ClientRequest, ErrorSlot,
@@ -886,6 +889,123 @@ async fn connection_is_randomly_disconnected_on_overload() {
     );
 }
 
+/// Test that an overloaded inbound request from a zcashd-compat sidecar is retried and
+/// answered, rather than silently ignored.
+///
+/// A sidecar zcashd is pinned to Zakura as its only peer and never re-sends `getheaders`,
+/// so an ignored request stalls its chain sync permanently.
+#[tokio::test]
+async fn compat_sidecar_inbound_request_is_retried_not_ignored() {
+    let _init_guard = zakura_test::init();
+
+    let (mut peer_tx, peer_rx) = mpsc::channel(1);
+
+    let (
+        connection,
+        _client_tx,
+        mut inbound_service,
+        mut peer_outbound_messages,
+        shared_error_slot,
+    ) = new_test_compat_sidecar_connection();
+
+    let connection_handle = tokio::spawn(connection.run(peer_rx));
+
+    // Send an inbound request from the sidecar.
+    peer_tx
+        .send(Ok(Message::GetAddr))
+        .await
+        .expect("send to channel always succeeds");
+
+    // Shed it, the way a saturated inbound buffer would.
+    inbound_service
+        .expect_request(Request::Peers)
+        .await
+        .respond_error(Overloaded::new().into());
+
+    // An ordinary peer would be ignored here, with no reply ever sent. The sidecar must
+    // instead see the request retried once the inbound service has capacity again.
+    inbound_service
+        .expect_request(Request::Peers)
+        .await
+        .respond(Response::Peers(vec![]));
+
+    let outbound_message =
+        tokio::time::timeout(Duration::from_secs(1), peer_outbound_messages.next())
+            .await
+            .expect("the retried request must be answered within the timeout")
+            .expect("the outbound message channel must not be closed");
+
+    assert!(
+        matches!(outbound_message, Message::Addr(_)),
+        "the sidecar must receive a response to its retried request, got: {outbound_message:?}",
+    );
+
+    let error = shared_error_slot.try_get_error();
+    assert!(
+        error.is_none(),
+        "the sidecar connection must stay open across a retried overload: {error:?}",
+    );
+
+    connection_handle.abort();
+}
+
+/// Test that a zcashd-compat sidecar connection is closed, not silently ignored, when the
+/// inbound service stays overloaded past the retry budget.
+///
+/// Closing is recoverable: zcashd redials its `-connect` peer and restarts headers sync.
+/// Silently ignoring is not: it black-holes a `getheaders` the sidecar never re-sends.
+#[tokio::test(start_paused = true)]
+async fn compat_sidecar_connection_is_closed_when_retries_are_exhausted() {
+    let _init_guard = zakura_test::init();
+
+    let (mut peer_tx, peer_rx) = mpsc::channel(1);
+
+    let (
+        connection,
+        _client_tx,
+        mut inbound_service,
+        mut peer_outbound_messages,
+        shared_error_slot,
+    ) = new_test_compat_sidecar_connection();
+
+    let connection_handle = tokio::spawn(connection.run(peer_rx));
+
+    peer_tx
+        .send(Ok(Message::GetAddr))
+        .await
+        .expect("send to channel always succeeds");
+
+    // Stay overloaded past the retry budget. Time is paused, so the connection's retry
+    // sleeps auto-advance and this costs no wall-clock time. Once the budget is spent the
+    // connection stops retrying and no further requests arrive, so this loop ends.
+    let overload_until =
+        tokio::time::Instant::now() + MAX_COMPAT_INBOUND_RETRY_TIME + Duration::from_secs(1);
+    while tokio::time::Instant::now() < overload_until {
+        let Some(responder) = inbound_service.try_next_request().await else {
+            break;
+        };
+
+        assert_eq!(*responder.request(), Request::Peers);
+        responder.respond_error(Overloaded::new().into());
+    }
+
+    // The connection must have failed, rather than leaving the sidecar waiting forever.
+    let error = shared_error_slot.try_get_error();
+    assert!(
+        error.is_some(),
+        "the sidecar connection must be closed once the retry budget is exhausted, \
+         so zcashd reconnects instead of stalling",
+    );
+
+    let outbound_result = peer_outbound_messages.try_recv();
+    assert!(
+        !matches!(outbound_result, Ok(Message::Addr(_))),
+        "no response is expected when the inbound service never recovers: {outbound_result:?}",
+    );
+
+    connection_handle.abort();
+}
+
 #[tokio::test]
 async fn connection_ping_pong_round_trip() {
     let _init_guard = zakura_test::init();
@@ -973,4 +1093,18 @@ fn new_test_connection() -> (
     ErrorSlot,
 ) {
     super::new_test_connection()
+}
+
+/// Creates a new [`Connection`] whose peer is a zcashd-compat sidecar.
+fn new_test_compat_sidecar_connection() -> (
+    Connection<
+        MockService<Request, Response, PanicAssertion>,
+        SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, PanicAssertion>,
+    mpsc::Receiver<Message>,
+    ErrorSlot,
+) {
+    super::new_test_connection_with_compat_sidecar(true)
 }

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -2,9 +2,10 @@
 
 use std::{
     cmp::min,
+    collections::HashSet,
     fmt,
     future::Future,
-    net::{Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     panic,
     pin::Pin,
     sync::Arc,
@@ -44,7 +45,7 @@ use crate::{
     },
     peer_set::{ConnectionTracker, InventoryChange},
     protocol::{
-        external::{types::*, AddrInVersion, Codec, InventoryHash, Message},
+        external::{canonical_socket_addr, types::*, AddrInVersion, Codec, InventoryHash, Message},
         internal::{Request, Response},
     },
     types::MetaAddr,
@@ -84,6 +85,7 @@ where
     minimum_peer_version: MinimumPeerVersion<C>,
     nonces: Arc<futures::lock::Mutex<IndexSet<Nonce>>>,
     zakura_handshake_connector: Option<ZakuraHandshakeConnector>,
+    zcashd_compat_peer_ips: Arc<HashSet<IpAddr>>,
 
     parent_span: Span,
 }
@@ -129,6 +131,7 @@ where
             minimum_peer_version: self.minimum_peer_version.clone(),
             nonces: self.nonces.clone(),
             zakura_handshake_connector: self.zakura_handshake_connector.clone(),
+            zcashd_compat_peer_ips: self.zcashd_compat_peer_ips.clone(),
             parent_span: self.parent_span.clone(),
         }
     }
@@ -225,6 +228,20 @@ impl ConnectedAddr {
     /// Returns a new outbound directly connected addr.
     pub fn new_outbound_direct(addr: PeerSocketAddr) -> ConnectedAddr {
         OutboundDirect { addr }
+    }
+
+    /// Returns true if this peer connected directly to us from `ip`.
+    ///
+    /// A zcashd-compat sidecar always reaches us as an inbound direct connection,
+    /// because zcashd dials Zakura via `-connect` and never listens itself.
+    pub fn is_inbound_direct_from_ip(&self, ip: &IpAddr) -> bool {
+        let expected_ip = canonical_socket_addr(SocketAddr::new(*ip, 0)).ip();
+
+        matches!(
+            self,
+            InboundDirect { addr }
+                if canonical_socket_addr(addr.remove_socket_addr_privacy()).ip() == expected_ip
+        )
     }
 
     /// Returns a new inbound directly connected addr.
@@ -423,6 +440,7 @@ where
     address_book_updater: Option<tokio::sync::mpsc::Sender<MetaAddrChange>>,
     inv_collector: Option<broadcast::Sender<InventoryChange>>,
     zakura_handshake_connector: Option<ZakuraHandshakeConnector>,
+    zcashd_compat_peer_ips: Option<Arc<HashSet<IpAddr>>>,
     latest_chain_tip: C,
 }
 
@@ -441,6 +459,18 @@ where
     /// Provide a service to handle inbound requests. Mandatory.
     pub fn with_inbound_service(mut self, inbound_service: S) -> Self {
         self.inbound_service = Some(inbound_service);
+        self
+    }
+
+    /// Provide the inbound peer IPs belonging to a zcashd-compat sidecar. Optional.
+    ///
+    /// Requests from these peers are never silently dropped by the inbound
+    /// load-shed path. See [`Connection::drive_peer_request`] for why.
+    pub fn with_zcashd_compat_peer_ips(
+        mut self,
+        zcashd_compat_peer_ips: Arc<HashSet<IpAddr>>,
+    ) -> Self {
+        self.zcashd_compat_peer_ips = Some(zcashd_compat_peer_ips);
         self
     }
 
@@ -506,6 +536,7 @@ where
             relay: self.relay,
             inv_collector: self.inv_collector,
             zakura_handshake_connector: self.zakura_handshake_connector,
+            zcashd_compat_peer_ips: self.zcashd_compat_peer_ips,
         }
     }
 
@@ -565,6 +596,7 @@ where
             minimum_peer_version,
             nonces,
             zakura_handshake_connector: self.zakura_handshake_connector,
+            zcashd_compat_peer_ips: self.zcashd_compat_peer_ips.unwrap_or_default(),
             parent_span: Span::current(),
         })
     }
@@ -589,6 +621,7 @@ where
             address_book_updater: None,
             inv_collector: None,
             zakura_handshake_connector: None,
+            zcashd_compat_peer_ips: None,
             latest_chain_tip: NoChainTip,
         }
     }
@@ -1332,6 +1365,7 @@ where
         let relay = self.relay;
         let minimum_peer_version = self.minimum_peer_version.clone();
         let zakura_handshake_connector = self.zakura_handshake_connector.clone();
+        let zcashd_compat_peer_ips = self.zcashd_compat_peer_ips.clone();
 
         // # Security
         //
@@ -1598,6 +1632,12 @@ where
                     )
                 });
 
+            // The sidecar's IP set is fixed and the connected address never changes,
+            // so resolve this once per connection rather than on every request.
+            let is_zcashd_compat_peer = zcashd_compat_peer_ips
+                .iter()
+                .any(|ip| connected_addr.is_inbound_direct_from_ip(ip));
+
             let server = Connection::new(
                 inbound_service,
                 server_rx,
@@ -1606,6 +1646,7 @@ where
                 connection_tracker,
                 connection_info.clone(),
                 alternate_addrs.collect(),
+                is_zcashd_compat_peer,
             );
 
             let connection_task = tokio::spawn(

--- a/zakura-network/src/peer/handshake/tests.rs
+++ b/zakura-network/src/peer/handshake/tests.rs
@@ -841,3 +841,47 @@ async fn mutual_p2p_v2_selected_upgrade_skips_legacy_connection() {
     assert_eq!(local_counter.update_count(), 0);
     assert_eq!(remote_counter.update_count(), 0);
 }
+
+/// Test which peers are recognised as a zcashd-compat sidecar.
+///
+/// This predicate gates two privileges: always receiving block gossip, and never having
+/// inbound requests silently shed. A sidecar zcashd dials Zakura via `-connect` and never
+/// listens, so it must always appear as an inbound direct connection.
+#[test]
+fn zcashd_compat_sidecar_is_matched_by_inbound_direct_ip() {
+    let _init_guard = zakura_test::init();
+
+    let loopback: IpAddr = Ipv4Addr::LOCALHOST.into();
+    let other: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+
+    let inbound_loopback =
+        ConnectedAddr::new_inbound_direct(SocketAddr::new(loopback, 8233).into());
+
+    assert!(
+        inbound_loopback.is_inbound_direct_from_ip(&loopback),
+        "a sidecar dialing us from a configured IP must be recognised",
+    );
+    assert!(
+        !inbound_loopback.is_inbound_direct_from_ip(&other),
+        "an inbound peer from an unconfigured IP must not be recognised",
+    );
+
+    // The sidecar always dials us. An outbound connection we made to the same IP is a peer
+    // we chose, not the supervised sidecar, and must not inherit its privileges.
+    let outbound_loopback =
+        ConnectedAddr::new_outbound_direct(SocketAddr::new(loopback, 8233).into());
+    assert!(
+        !outbound_loopback.is_inbound_direct_from_ip(&loopback),
+        "an outbound connection must never be treated as the sidecar",
+    );
+
+    // Zakura canonicalises IPv4-mapped IPv6 addresses, so a sidecar arriving over a
+    // dual-stack listener still matches its configured IPv4 address.
+    let mapped_loopback = ConnectedAddr::new_inbound_direct(
+        SocketAddr::new(Ipv4Addr::LOCALHOST.to_ipv6_mapped().into(), 8233).into(),
+    );
+    assert!(
+        mapped_loopback.is_inbound_direct_from_ip(&loopback),
+        "an IPv4-mapped IPv6 sidecar address must match its IPv4 form",
+    );
+}

--- a/zakura-network/src/peer/load_tracked_client.rs
+++ b/zakura-network/src/peer/load_tracked_client.rs
@@ -2,7 +2,7 @@
 //! reported protocol version.
 
 use std::{
-    net::{IpAddr, SocketAddr},
+    net::IpAddr,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -14,8 +14,8 @@ use tower::{
 
 use crate::{
     constants::{EWMA_DECAY_TIME_NANOS, EWMA_DEFAULT_RTT},
-    peer::{Client, ConnectedAddr, ConnectionInfo},
-    protocol::external::{canonical_socket_addr, types::Version},
+    peer::{Client, ConnectionInfo},
+    protocol::external::types::Version,
 };
 
 /// A client service wrapper that keeps track of its load.
@@ -57,13 +57,9 @@ impl LoadTrackedClient {
 
     /// Returns true if this peer connected directly to us from `ip`.
     pub fn is_inbound_direct_from_ip(&self, ip: &IpAddr) -> bool {
-        let expected_ip = canonical_socket_addr(SocketAddr::new(*ip, 0)).ip();
-
-        matches!(
-            self.connection_info.connected_addr,
-            ConnectedAddr::InboundDirect { addr }
-                if canonical_socket_addr(addr.remove_socket_addr_privacy()).ip() == expected_ip
-        )
+        self.connection_info
+            .connected_addr
+            .is_inbound_direct_from_ip(ip)
     }
 }
 

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -240,6 +240,12 @@ where
             .as_ref()
             .map(|endpoint| endpoint.connector());
 
+        // The sidecar peers whose inbound requests must never be silently shed are the
+        // same peers that must always receive block gossip: the local zcashd this node
+        // supervises.
+        let zcashd_compat_peer_ips: Arc<HashSet<IpAddr>> =
+            Arc::new(block_gossip_peer_ips.iter().copied().collect());
+
         let mut hs_builder = peer::Handshake::builder()
             .with_config(config.clone())
             .with_inbound_service(inbound_service)
@@ -248,6 +254,7 @@ where
             .with_advertised_services(advertised_services)
             .with_user_agent(user_agent)
             .with_latest_chain_tip(latest_chain_tip.clone())
+            .with_zcashd_compat_peer_ips(zcashd_compat_peer_ips)
             .want_transactions(true);
 
         if let Some(zakura_handshake_connector) = zakura_handshake_connector {

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -934,6 +934,15 @@ where
 
     /// Randomly chooses ready peers for block gossip, always including configured
     /// zcashd compat sidecar peers.
+    ///
+    /// While this node is still far from the network tip, only the sidecar peers are
+    /// selected. A zcashd-compat sidecar has no other source of blocks: it is pinned to
+    /// this node by `-connect`, and once it catches up to our in-progress tip it stops
+    /// sending `getheaders` and waits for an inventory announcement. So it needs to hear
+    /// about every tip change, including during our own initial block download.
+    ///
+    /// Ordinary peers do not, and must not: they are told to sync from a node that is
+    /// near the tip, so announcing blocks we are still catching up on would be noise.
     fn select_block_broadcast_peers(&self, max_peers: usize) -> Vec<D::Key> {
         use rand::seq::IteratorRandom;
 
@@ -942,6 +951,14 @@ where
             .iter()
             .filter_map(|(key, service)| self.is_zcashd_compat_peer(service).then_some(*key))
             .collect();
+
+        if !self
+            .minimum_peer_version
+            .chain_tip()
+            .is_at_or_near_network_tip(&self.network)
+        {
+            return selected_peers;
+        }
 
         let zcashd_compat_peers: HashSet<_> = selected_peers.iter().copied().collect();
         selected_peers.extend(

--- a/zakura-network/src/peer_set/set/tests/prop.rs
+++ b/zakura-network/src/peer_set/set/tests/prop.rs
@@ -10,7 +10,10 @@ use tower::{
 };
 
 use zakura_chain::{
-    block, chain_tip::ChainTip, parameters::Network, serialization::ZcashDeserializeInto,
+    block,
+    chain_tip::{ChainTip, AT_OR_NEAR_TIP_THRESHOLD},
+    parameters::Network,
+    serialization::ZcashDeserializeInto,
 };
 
 use crate::{
@@ -295,12 +298,12 @@ proptest! {
     }
 }
 
-/// Production nodes often accept an IPv4 zcashd sidecar through an IPv6 dual-stack
-/// listener, which reports its address as IPv4-mapped IPv6. Fractional
-/// `AdvertiseBlock` gossip can miss an unrecognized sidecar for many blocks in a
-/// row, so canonical address matching must always include it.
-#[test]
-fn sidecar_peer_always_receives_block_gossip() {
+/// Runs one `AdvertiseBlock` broadcast through a peer set holding a zcashd-compat sidecar
+/// plus many ordinary peers, with our distance to the network tip mocked to
+/// `distance_to_network_tip`.
+///
+/// Returns `(peers_that_received_gossip, sidecar_received, number_of_peers_to_broadcast)`.
+fn block_gossip_recipients(distance_to_network_tip: block::HeightDiff) -> (usize, bool, usize) {
     const TOTAL_PEERS: usize = 59;
     const SIDECAR_INDEX: usize = 0;
 
@@ -319,6 +322,8 @@ fn sidecar_peer_always_receives_block_gossip() {
     let discovered_peers: Vec<Result<Change<PeerSocketAddr, LoadTrackedClient>, BoxError>> = (0
         ..TOTAL_PEERS)
         .map(|index| {
+            // Production nodes often accept an IPv4 sidecar through an IPv6 dual-stack
+            // listener, which reports its address as IPv4-mapped IPv6.
             let ip = if index == SIDECAR_INDEX {
                 IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped())
             } else {
@@ -336,8 +341,14 @@ fn sidecar_peer_always_receives_block_gossip() {
         })
         .collect();
     let discovered_peers = stream::iter(discovered_peers).chain(stream::pending());
-    let (minimum_peer_version, _best_tip_height) =
+    let (minimum_peer_version, mock_chain_tip_sender) =
         MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    // `estimate_distance_to_network_chain_tip` returns `None` unless the tip height is set
+    // too, and an unknown distance counts as "not near the tip".
+    mock_chain_tip_sender.send_best_tip_height(block::Height(1));
+    mock_chain_tip_sender
+        .send_estimated_distance_to_network_chain_tip(Some(distance_to_network_tip));
 
     runtime.block_on(async move {
         let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
@@ -380,19 +391,61 @@ fn sidecar_peer_always_receives_block_gossip() {
         }
 
         assert!(
-            sidecar_received,
-            "configured sidecar must receive block gossip"
-        );
-        assert_eq!(
-            block_gossip_received,
-            number_of_peers_to_broadcast + 1,
-            "block gossip should include sampled peers plus the sidecar"
-        );
-        assert!(
             block_gossip_received < TOTAL_PEERS,
-            "sidecar block gossip must not broadcast to every connected peer"
+            "block gossip must never broadcast to every connected peer"
         );
-    });
+
+        (
+            block_gossip_received,
+            sidecar_received,
+            number_of_peers_to_broadcast,
+        )
+    })
+}
+
+/// Near the tip, block gossip reaches a random sample of ordinary peers, and always the
+/// configured zcashd-compat sidecar.
+///
+/// Fractional `AdvertiseBlock` gossip can otherwise miss an unrecognized sidecar for many
+/// blocks in a row, so canonical address matching must always include it.
+#[test]
+fn sidecar_peer_always_receives_block_gossip() {
+    let (block_gossip_received, sidecar_received, number_of_peers_to_broadcast) =
+        block_gossip_recipients(0);
+
+    assert!(
+        sidecar_received,
+        "configured sidecar must receive block gossip"
+    );
+    assert_eq!(
+        block_gossip_received,
+        number_of_peers_to_broadcast + 1,
+        "block gossip should include sampled peers plus the sidecar"
+    );
+}
+
+/// Far from the tip, block gossip reaches *only* the zcashd-compat sidecar.
+///
+/// A sidecar is pinned to this node by `-connect` and has no other source of blocks. Once
+/// it catches up to our in-progress tip it stops sending `getheaders` and waits for an
+/// inventory announcement, so it must hear about every tip change, including during our own
+/// initial block download -- otherwise it sits idle until we finish syncing.
+///
+/// Ordinary peers must not: they are expected to sync from a node that is actually near the
+/// tip, so announcing a block we are still catching up on is noise to them.
+#[test]
+fn only_the_sidecar_receives_block_gossip_before_the_tip() {
+    let (block_gossip_received, sidecar_received, _number_of_peers_to_broadcast) =
+        block_gossip_recipients(AT_OR_NEAR_TIP_THRESHOLD + 1_000);
+
+    assert!(
+        sidecar_received,
+        "configured sidecar must receive block gossip while we are far from the tip"
+    );
+    assert_eq!(
+        block_gossip_received, 1,
+        "far from the tip, only the sidecar should receive block gossip"
+    );
 }
 
 /// Check if only peers with up-to-date protocol versions are live.

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -439,6 +439,18 @@ impl StartCmd {
             PeerServices::NODE_NETWORK
         };
 
+        // The configured list is empty by default and is filled in above, so log what we
+        // actually resolved. These IPs decide which inbound peers always receive block
+        // gossip and are never silently load-shed, so an operator debugging a stalled
+        // sidecar needs to see the effective value, not the empty config field.
+        if config.zcashd_compat.enabled {
+            info!(
+                sidecar_peer_ips = ?zcashd_compat_block_gossip_peer_ips,
+                "zcashd-compat sidecar peers: block gossip is always delivered, and inbound \
+                 requests are retried rather than load-shed",
+            );
+        }
+
         let (peer_set, address_book, misbehavior_sender, zakura_endpoint) =
             zakura_network::init_with_zakura_header_sync(
                 config.network.clone(),

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -688,6 +688,7 @@ impl StartCmd {
                 chain_tip_change.clone(),
                 peer_set.clone(),
                 Some(submit_block_channel.receiver()),
+                config.zcashd_compat.enabled,
             )
             .in_current_span(),
         );

--- a/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -1250,6 +1250,7 @@ async fn setup(
             chain_tip_change.clone(),
             peer_set.clone(),
             Some(submitblock_channel.receiver()),
+            false,
         )
         .in_current_span(),
     );

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -821,6 +821,7 @@ async fn setup(
         chain_tip_change,
         peer_set.clone(),
         Some(submitblock_channel.receiver()),
+        false,
     ));
 
     let tx_gossip_task_handle = tokio::spawn(gossip_mempool_transaction_id(
@@ -968,6 +969,7 @@ mod submitblock_test {
                 chain_tip_change,
                 peer_set.clone(),
                 Some(submitblock_channel.receiver()),
+                false,
             )
             .in_current_span(),
         );

--- a/zakurad/src/components/sync/gossip.rs
+++ b/zakurad/src/components/sync/gossip.rs
@@ -52,12 +52,16 @@ pub async fn gossip_best_tip_block_hashes<ZN>(
     mut chain_state: ChainTipChange,
     broadcast_network: ZN,
     mut mined_block_receiver: Option<mpsc::Receiver<(block::Hash, block::Height)>>,
+    gossip_during_initial_sync: bool,
 ) -> Result<(), BlockGossipError>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
     ZN::Future: Send,
 {
-    info!("initializing block gossip task");
+    info!(
+        ?gossip_during_initial_sync,
+        "initializing block gossip task"
+    );
 
     // use the same timeout as tips requests,
     // so broadcasts don't delay the syncer too long
@@ -90,10 +94,23 @@ where
             // wait until we're close to the tip, because broadcasts are only useful for nodes near the tip
             // (if they're a long way from the tip, they use the syncer and block locators), unless a mined block
             // hash is received before `wait_until_close_to_tip()` is ready.
-            sync_status
-                .wait_until_close_to_tip()
-                .map_err(SyncStatus)
-                .await?;
+            //
+            // A zcashd-compat sidecar is the exception: it cannot "use the syncer and block
+            // locators", because it is pinned to this node as its only peer. Once it catches up
+            // to our in-progress tip it receives a short `headers` batch, correctly concludes it
+            // has reached our tip, stops sending `getheaders`, and then waits for an inventory
+            // announcement. Gating every announcement on being close to the tip means that
+            // announcement never arrives, and the sidecar sits idle for the whole of our initial
+            // block download. So when a sidecar is configured, gossip on every tip change.
+            //
+            // The peer set still restricts the audience: while we are far from the network tip,
+            // `select_block_broadcast_peers` sends only to the sidecar, never to ordinary peers.
+            if !gossip_during_initial_sync {
+                sync_status
+                    .wait_until_close_to_tip()
+                    .map_err(SyncStatus)
+                    .await?;
+            }
 
             // get the latest tip change when close to tip - it might be different to the change we awaited,
             // because the syncer might take a long time to reach the tip


### PR DESCRIPTION
## Motivation

On a fresh zcashd-compat install, the sidecar's sync stalls early and never recovers. This is the headline feature of compat mode, and it does not reliably work.

A user reported this and root-caused it to Zakura's inbound load-shedding silently dropping the sidecar's `getheaders`. **That diagnosis turns out to be wrong.** It is a real silent-failure path and this PR closes it, but it is not what stalls the sidecar. Reproducing the stall end to end and reading the wire showed something else:

- Every `getheaders` the sidecar sent **was answered** — the shed path never fired once.
- The final `headers` batch was *short* (fewer than `MAX_HEADERS_RESULTS`), so zcashd correctly concluded it had reached our tip and stopped asking. That is what a short batch means.
- From then on it waited for an `inv`. **None ever arrived.** It sat at 8,400 blocks while Zakura ran on past 440,000.

## Solution

**1. Gossip to the sidecar during initial block download (the actual fix).**

`gossip_best_tip_block_hashes` gates *every* announcement behind `SyncStatus::wait_until_close_to_tip()`. That is correct for ordinary peers: a peer far from the tip is expected to sync from a node that is near it, so announcing blocks we are still catching up on is noise. A sidecar cannot do that — it is pinned to us by `-connect` as its only peer, so an announcement is the only way it ever learns our tip moved. Gating it on being close to the tip means it hears nothing for the whole of our IBD.

Zakura now gossips on every tip change when zcashd-compat is enabled, and the peer set picks the audience: `select_block_broadcast_peers` returns **only** sidecar peers while we are far from the network tip, so gossip to ordinary peers is byte-for-byte unchanged.

This is what `zcashd_compat.block_gossip_peer_ips` has always documented — *"must always receive block inventory broadcasts"* — but the close-to-tip gate sat upstream of peer selection, so the sidecar was never even considered.

**2. Stop silently shedding the sidecar's inbound requests (defensive, the reported cause).**

All peers share one 200-slot `tower::Buffer` behind `load_shed`. On overload, `handle_inbound_overload` **silently ignores** the request ~95% of the time: no reply, no `notfound`, no reject, connection left open, and only a `pool.ignored.loadshed` counter. The `Overloaded` branch did not even log the request, while the timeout branch beside it logs at `INFO` *with* it — which is why this was invisible.

For an ordinary peer that is correct. A sidecar has no other peer to ask, and classic `getheaders` has neither a timeout nor a retry, so one ignored request black-holes it. Peers in the existing allowlist now get **backpressure instead of shedding**: the request is retried while the queue drains. If still overloaded after `MAX_COMPAT_INBOUND_RETRY_TIME` (20s), the connection is **closed with a `WARN`** rather than ignored — closing is recoverable (zcashd re-dials and restarts headers sync), ignoring is not.

Not a DoS vector: the allowlist is IP-based and defaults to loopback — a local zcashd this node supervises. Every other peer keeps the existing randomised drop/ignore shedding, which `connection_is_randomly_disconnected_on_overload` still covers.

The 20s budget deliberately sits *below* the sidecar's own 30s `HEADERS_RESPONSE_TIMEOUT` (valargroup/zcashd), so we always give up first and close, and no duplicate `getheaders` is ever in flight.

The IP predicate moves to `ConnectedAddr` so the inbound path and the block-gossip path share one definition of "who is the sidecar" instead of two.

### Tests

**End to end on live testnet**, both nodes local, zcashd pinned to zakurad exactly as `install-zakura.sh` prints it (`-connect=127.0.0.1:18233 -listen=0 -dnsseed=0`), i.e. zakurad on the real network and zcashd with zakurad as its only peer. This gives a clean A/B isolating the gossip fix:

| Run | Config | zcashd after 10 min |
|---|---|---|
| 1 | load-shed fix only | **stalled at 8,400** |
| 2 | + gossip fix | **111,469**, header chain at 349,040 vs Zakura's 349,600 |
| 3 | repeat (6 min) | **64,697**, tracking tip |

In runs 2 and 3 the sidecar's header chain tracks Zakura's tip in real time and pulls blocks in behind it — a healthy sidecar.

**Unit tests.** New: sidecar overload is retried and answered, not ignored; sidecar connection is closed (not ignored) once the retry budget is spent; the sidecar-IP predicate (including that an *outbound* peer at loopback must never inherit sidecar privileges). Both connection tests were mutation-checked — they fail when the sidecar flag is flipped off.

The peer-set gossip test was asserting the old behaviour while silently running in the "unknown tip distance" regime (`MockChainTip` only reports a distance when a tip height is also set). It is now split into the two regimes it should always have covered: sidecar-only before the tip, sidecar plus a random sample at the tip.

`cargo test -p zakura-network --lib`: 910 passed. `cargo test -p zakura --lib`: 303 passed. `fmt` and `clippy -D warnings` clean.

### Follow-up Work

The `zcashd` half — recovering from an unanswered `getheaders` instead of latching forever — is in valargroup/zcashd and is defence in depth against this class of bug from any cause.

### AI Disclosure

- [x] AI tools were used: Claude Code, for the investigation, implementation, end-to-end testing, and this description. Reviewed by me.

### PR Checklist

- [x] The PR title follows conventional commits format
- [x] The solution is tested
- [x] The documentation and changelogs are up to date