### PR TITLE
fix(ci): restore continuous sync SSH audits

### DIFF
--- a/.github/workflows/zakura-continuous-sync.yml
+++ b/.github/workflows/zakura-continuous-sync.yml
@@ -49,40 +49,72 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "ACTION=audit" >> "$GITHUB_ENV"
-            echo "NODE=" >> "$GITHUB_ENV"
-            echo "NO_START=false" >> "$GITHUB_ENV"
+            {
+              echo "ACTION=audit"
+              echo "NODE="
+              echo "NO_START=false"
+            } >> "$GITHUB_ENV"
           else
-            echo "ACTION=${{ inputs.action }}" >> "$GITHUB_ENV"
-            echo "NODE=${{ inputs.node }}" >> "$GITHUB_ENV"
-            echo "NO_START=${{ inputs.no_start }}" >> "$GITHUB_ENV"
+            {
+              echo "ACTION=${{ inputs.action }}"
+              echo "NODE=${{ inputs.node }}"
+              echo "NO_START=${{ inputs.no_start }}"
+            } >> "$GITHUB_ENV"
           fi
 
       - name: Configure SSH
         env:
-          ZAKURA_CONTINUOUS_SYNC_SSH_KEY: ${{ secrets.ZAKURA_CONTINUOUS_SYNC_SSH_KEY }}
+          DO_SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
         run: |
           set -euo pipefail
+          if [ -z "${DO_SSH_PRIVATE_KEY}" ]; then
+            echo "::error::DO_SSH_PRIVATE_KEY is required for the continuous sync fleet"
+            exit 1
+          fi
+
+          mapfile -t ssh_targets < <(
+            python3 - <<'PY'
+          import tomllib
+
+          with open("deploy/continuous-sync/nodes.toml", "rb") as config_file:
+              config = tomllib.load(config_file)
+
+          for node in config.get("nodes", []):
+              print(node["ssh_string"])
+          PY
+          )
+          if [ "${#ssh_targets[@]}" -eq 0 ]; then
+            echo "::error::No continuous sync nodes found in nodes.toml"
+            exit 1
+          fi
+
           install -d -m 700 ~/.ssh
           : > ~/.ssh/known_hosts
-          for host in 138.68.43.212 138.197.218.91 134.209.49.92; do
+          for target in "${ssh_targets[@]}"; do
+            host="${target##*@}"
             ssh-keyscan -T 30 -H "$host" >> ~/.ssh/known_hosts
           done
           chmod 600 ~/.ssh/known_hosts
 
-          if [ -n "${ZAKURA_CONTINUOUS_SYNC_SSH_KEY}" ]; then
-            install -m 600 /dev/null ~/.ssh/zakura-continuous-sync
-            printf '%s\n' "${ZAKURA_CONTINUOUS_SYNC_SSH_KEY}" > ~/.ssh/zakura-continuous-sync
-            cat >> ~/.ssh/config <<'EOF'
-          Host 138.68.43.212 138.197.218.91 134.209.49.92
-            IdentityFile ~/.ssh/zakura-continuous-sync
-            IdentitiesOnly yes
-            User root
-          EOF
-            chmod 600 ~/.ssh/config
-          else
-            echo "ZAKURA_CONTINUOUS_SYNC_SSH_KEY is not set; using the runner's default SSH identity."
-          fi
+          install -m 600 /dev/null ~/.ssh/zakura-continuous-sync
+          printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > ~/.ssh/zakura-continuous-sync
+          ssh-keygen -y -f ~/.ssh/zakura-continuous-sync >/dev/null
+          {
+            printf 'Host'
+            for target in "${ssh_targets[@]}"; do
+              printf ' %s' "${target##*@}"
+            done
+            printf '\n  IdentityFile ~/.ssh/zakura-continuous-sync\n'
+            printf '  IdentitiesOnly yes\n'
+          } > ~/.ssh/config
+          chmod 600 ~/.ssh/config
+
+          for target in "${ssh_targets[@]}"; do
+            if ! ssh -o BatchMode=yes -o ConnectTimeout=15 "$target" true; then
+              echo "::error::Continuous sync SSH authentication failed for $target; verify the DO_SSH_PRIVATE_KEY secret and zebra-ci authorized key"
+              exit 1
+            fi
+          done
 
       - name: Deploy controllers
         if: env.ACTION == 'deploy'

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -101,10 +101,13 @@ GitHub Actions:
 4. Use `no_start=true` to install files without handing the node to the
    controller.
 
-The workflow uses `ZAKURA_CONTINUOUS_SYNC_SSH_KEY` when present. If the secret is
-empty, it uses the runner's default SSH identity. Slack audit alerts use the
-existing `SLACK_WEB_HOOK` secret. Per-host completion/failure alerts use the
-root-only `/etc/zakura-alerts.env` file already used by the temporary monitor.
+The workflow uses the repository's `DO_SSH_PRIVATE_KEY` secret and requires its
+matching `zebra-ci` public key in each host's `/root/.ssh/authorized_keys`. It
+validates the key and every host connection before running an operation, so SSH
+configuration failures stop the workflow instead of being reported as node
+health failures. Slack audit alerts use the existing `SLACK_WEB_HOOK` secret.
+Per-host completion/failure alerts use the root-only
+`/etc/zakura-alerts.env` file already used by the temporary monitor.
 
 ## Status and Audit
 
@@ -183,8 +186,11 @@ below `min_free_bytes`, it halts and alerts instead of filling the host.
 For a fresh Ubuntu x86_64 host:
 
 1. Ensure Roman's SSH key can log in as root.
-2. Clone this repository to `/root/zakura`.
-3. Install build prerequisites:
+2. Add the DigitalOcean `zebra-ci` public key (fingerprint
+   `12:4f:db:a1:b1:25:47:c0:92:73:08:76:4d:30:b4:30`) to
+   `/root/.ssh/authorized_keys`.
+3. Clone this repository to `/root/zakura`.
+4. Install build prerequisites:
 
    ```bash
    apt-get update
@@ -193,10 +199,10 @@ For a fresh Ubuntu x86_64 host:
      protobuf-compiler python3
    ```
 
-4. Install the Rust toolchain specified by `rust-toolchain.toml`.
-5. Copy or recreate `/etc/zakura-alerts.env` with the Slack webhook value.
-6. Update `nodes.toml` with the new host address if it changed.
-7. Deploy only that node:
+5. Install the Rust toolchain specified by `rust-toolchain.toml`.
+6. Copy or recreate `/etc/zakura-alerts.env` with the Slack webhook value.
+7. Update `nodes.toml` with the new host address if it changed.
+8. Deploy only that node:
 
    ```bash
    python3 deploy/continuous-sync/deploy.py \


### PR DESCRIPTION
## Motivation

Scheduled continuous-sync audits could not authenticate to any fleet node because the workflow referenced an unset SSH secret and then continued without a usable identity. The resulting Slack alert reported SSH failures as node-health failures.

## Solution

- reuse the repository's existing `DO_SSH_PRIVATE_KEY` / `zebra-ci` identity
- fail early when the key is absent, invalid, or unauthorized on any fleet host
- load SSH targets from `deploy/continuous-sync/nodes.toml` instead of duplicating IPs in the workflow
- document the required host authorization and replacement-node bootstrap step
- authorize the matching `zebra-ci` public key on the three current fleet hosts

### Tests

- `actionlint .github/workflows/zakura-continuous-sync.yml`
- `npx --yes markdownlint-cli deploy/continuous-sync/README.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics: no errors
- verified all three SSH targets load from `nodes.toml`
- verified the `zebra-ci` fingerprint is installed exactly once on each fleet host

Risk classification: low-risk CI/configuration change. Rust formatting, clippy, and tests were skipped under the repository's risk-based verification policy because no Rust or runtime node logic changed.

### Specifications & References

- [Continuous-sync audit incident](https://zcashzcaloors.slack.com/archives/C0BG341Q9TQ/p1783793218128629)

### Follow-up Work

The running controller services have a separate operational state issue: nodes 1 and 2 are inactive and node 3 is failed while `zakurad` remains active. They were not restarted because doing so begins a destructive fresh-sync cycle.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor investigated the authentication failure, updated the workflow and documentation, ran validation, and drafted this PR description.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team through the linked incident and requested remediation.
- [x] The solution is tested as described above.
- [x] The documentation is updated; no changelog entry is needed for an internal CI fix.