### PR TITLE
fix(state): unwrap fallible test state initialization

### DIFF
--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -53,7 +53,8 @@ fn vct_successor_witness_uses_stored_header_without_body() {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
     let genesis = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
         .zcash_deserialize_into::<Arc<Block>>()
         .expect("genesis block deserializes");

--- a/zakura-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zakura-state/src/service/non_finalized_state/tests/vectors.rs
@@ -337,7 +337,8 @@ fn new_invalidate_test_state(network: &Network) -> (NonFinalizedState, Finalized
         network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
     finalized_state.set_finalized_value_pool(ValueBalance::<NonNegative>::fake_populated_pool());
     (state, finalized_state)
 }


### PR DESCRIPTION
## Motivation

Restore main's test-target compilation after #89 changed `FinalizedState::new` to return `Result`. Two recently added test fixtures still treated the constructor as infallible, causing the lint workflow in #140 to fail.

## Solution

Unwrap ephemeral finalized-state initialization in both affected test fixtures with the same invariant-explaining message used by neighboring tests.

### Tests

- `cargo fmt --all -- --check`
- `cargo check -p zakura-state --tests --locked`
- `cargo clippy -p zakura-state --tests --locked -- -D warnings`

### Specifications & References

- Regression from #89
- Observed in workflow run for #140

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor was used to diagnose the CI errors, update the two test fixtures, run focused verification, and draft this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was requested to repair failing CI on main.
- [x] The solution is tested.
- [x] Documentation and changelogs do not require updates for this test-only compilation fix.