### PR TITLE
fix(sync): repair evicted VCT roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Cargo files
 /coverage-target/
+/out/
 # Legacy Zebra state (alpha versions only)
 .zakura-state/
 # Nix configs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Repair evicted verified-commitment-trees supplied roots instead of stalling
+  sync forever. When the finalized writer rejects and evicts a well-formed but
+  invalid supplied root, header sync now re-requests the canonical `H`/`H+1`
+  header/root tuple through a bounded repair lane (one episode per stalled
+  height: six serial peer attempts within four minutes, pinned to the node's
+  own canonical hashes). The state writer remains the final verifier, and the
+  node stays fail-closed with an operator signal if repair exhausts.
 - Prevent verified-commitment-trees checkpoint sync from stalling at checkpoint
   boundaries by authenticating a block's supplied roots with its already-validated
   successor header, without waiting for the successor block body to finish checkpoint

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `HeaderSyncEvent::VctRootRepairRequested` and
+  `HeaderSyncEvent::VctRootRepairResolved`, plus a bounded VCT supplied-root
+  repair lane in the header-sync reactor: one episode per stalled height with
+  serial idle-peer attempts pinned to the node's own canonical hashes,
+  bypassing covered-range suppression without advancing the sync frontier.
 - `MinimumPeerVersion::chain_tip()` for checking tip state from peer routing
   logic.
 - Added `zebra_network::zakura`, a default-off iroh scaffold that exposes a

--- a/zakura-network/src/zakura/header_sync/events.rs
+++ b/zakura-network/src/zakura/header_sync/events.rs
@@ -231,6 +231,22 @@ pub enum HeaderSyncEvent {
     },
     /// State finalized or verified-body frontiers changed.
     StateFrontiersChanged(HeaderSyncFrontiers),
+    /// State needs a bounded re-delivery of VCT supplied roots for a covered height.
+    VctRootRepairRequested {
+        /// Height whose supplied root is missing or was evicted after rejection.
+        height: block::Height,
+        /// State repair generation.
+        generation: u64,
+        /// Parent hash for `height - 1`, used as the first header anchor.
+        anchor_hash: block::Hash,
+        /// Canonical hashes expected in the repair response, starting at `height`.
+        expected_hashes: Vec<(block::Height, block::Hash)>,
+    },
+    /// State successfully committed the formerly parked VCT height.
+    VctRootRepairResolved {
+        /// State repair generation that was resolved.
+        generation: u64,
+    },
     /// State successfully committed a header range.
     HeaderRangeCommitted {
         /// First committed height.
@@ -297,6 +313,8 @@ impl HeaderSyncEvent {
             Self::WireDecodeFailed { .. } => "wire_decode_failed",
             Self::WireProtocolFailure { .. } => "wire_protocol_failure",
             Self::StateFrontiersChanged(_) => "state_frontiers_changed",
+            Self::VctRootRepairRequested { .. } => "vct_root_repair_requested",
+            Self::VctRootRepairResolved { .. } => "vct_root_repair_resolved",
             Self::HeaderRangeCommitted { .. } => "header_range_committed",
             Self::HeaderRangeCommitFailed { .. } => "header_range_commit_failed",
             Self::HeaderRangeResponseFinished { .. } => "header_range_response_finished",

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -8,6 +8,8 @@ use crate::zakura::{
     ZakuraHeaderSyncCandidateState,
 };
 
+const STALE_REPAIR_GENERATION: &str = "stale_repair_generation";
+
 /// Spawn a header-sync reactor and return its handle plus action stream.
 pub fn spawn_header_sync_reactor(
     startup: HeaderSyncStartup,
@@ -1216,8 +1218,6 @@ impl HeaderSyncReactor {
         if let Err(reason) =
             self.validate_vct_repair_response(&outstanding, &headers, &tree_aux_roots)
         {
-            self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
-                .await;
             tracing::debug!(
                 ?peer,
                 ?reason,
@@ -1225,6 +1225,12 @@ impl HeaderSyncReactor {
                 count = header_count,
                 "Zakura header-sync rejected VCT root repair response"
             );
+            if reason == STALE_REPAIR_GENERATION {
+                self.schedule().await;
+                return;
+            }
+            self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
+                .await;
             self.finish_vct_repair_attempt(&peer);
             self.schedule().await;
             return;
@@ -1369,7 +1375,7 @@ impl HeaderSyncReactor {
             .as_ref()
             .filter(|repair| repair.generation == generation)
         else {
-            return Err("stale_repair_generation");
+            return Err(STALE_REPAIR_GENERATION);
         };
         if headers.len() != repair.expected_hashes.len()
             || tree_aux_roots.len() != repair.expected_hashes.len()
@@ -1620,7 +1626,8 @@ impl HeaderSyncReactor {
             .iter()
             .filter(|(peer_id, peer)| {
                 peer.received_status
-                    && peer.available_slots() > 0
+                    && peer.outstanding.is_empty()
+                    && peer.late_covered_responses == 0
                     && peer.advertised_tip >= repair.range.end_height()
                     && !repair.tried_peers.contains(*peer_id)
             })

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -685,7 +685,14 @@ impl HeaderSyncReactor {
             return;
         }
 
-        let Some(repair) = VctRootRepair::new(height, generation, anchor_hash, expected_hashes)
+        let previous_episode = self
+            .state
+            .repair
+            .as_ref()
+            .filter(|repair| repair.height == height)
+            .map(|repair| (repair.tried_peers.clone(), repair.started_at));
+
+        let Some(mut repair) = VctRootRepair::new(height, generation, anchor_hash, expected_hashes)
         else {
             tracing::warn!(
                 ?height,
@@ -695,6 +702,10 @@ impl HeaderSyncReactor {
             metrics::counter!("sync.header.vct_repair.invalid_request").increment(1);
             return;
         };
+        if let Some((tried_peers, started_at)) = previous_episode {
+            repair.tried_peers = tried_peers;
+            repair.started_at = started_at;
+        }
 
         tracing::warn!(
             ?height,

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -746,9 +746,32 @@ impl HeaderSyncReactor {
             None,
             None,
         );
+        let completed_repair_peer = self
+            .state
+            .repair
+            .as_ref()
+            .and_then(|repair| repair.in_flight.as_ref())
+            .filter(|repair_peer| {
+                self.state.pending_commits.iter().any(|(key, range)| {
+                    &key.peer == *repair_peer
+                        && range.priority == RangePriority::Repair
+                        && range.is_within(start_height, tip_height)
+                })
+            })
+            .cloned();
         self.state
             .pending_commits
             .retain(|_, range| !range.is_within(start_height, tip_height));
+        if let Some(repair_peer) = completed_repair_peer {
+            if let Some(repair) = self.state.repair.as_mut() {
+                if repair.in_flight.as_ref() == Some(&repair_peer) {
+                    // Committing the repair range finishes this peer's attempt, but does
+                    // not prove the VCT root issue is fixed. Keep the repair active until
+                    // the state writer reports it resolved, and free this peer slot.
+                    repair.in_flight = None;
+                }
+            }
+        }
         self.state
             .schedule
             .mark_range_covered(start_height, tip_height);
@@ -1426,20 +1449,24 @@ impl HeaderSyncReactor {
         let Some(repair) = self.state.repair.as_mut() else {
             return;
         };
+        let was_exhausted = repair.exhausted;
         if !repair.finish_attempt(peer, Instant::now()) {
             return;
         }
-        if repair.exhausted {
-            tracing::error!(
-                height = ?repair.height,
-                generation = repair.generation,
-                attempts = repair.tried_peers.len(),
-                "VCT supplied-root repair exhausted bounded peer attempts; node remains fail-closed"
-            );
-            metrics::counter!("sync.header.vct_repair.exhausted").increment(1);
-            metrics::gauge!("sync.header.vct_repair.stalled.height")
-                .set(f64::from(repair.height.0));
+        if !was_exhausted && repair.exhausted {
+            Self::report_vct_repair_exhausted(repair);
         }
+    }
+
+    fn report_vct_repair_exhausted(repair: &VctRootRepair) {
+        tracing::error!(
+            height = ?repair.height,
+            generation = repair.generation,
+            attempts = repair.tried_peers.len(),
+            "VCT supplied-root repair exhausted bounded peer attempts or wall time; node remains fail-closed"
+        );
+        metrics::counter!("sync.header.vct_repair.exhausted").increment(1);
+        metrics::gauge!("sync.header.vct_repair.stalled.height").set(f64::from(repair.height.0));
     }
 
     async fn handle_possible_stale_anchor_link_failure(
@@ -1626,6 +1653,19 @@ impl HeaderSyncReactor {
 
     async fn schedule_vct_repair(&mut self) -> bool {
         let now = Instant::now();
+        let newly_exhausted = self
+            .state
+            .repair
+            .as_mut()
+            .is_some_and(|repair| repair.refresh_exhausted(now));
+        if newly_exhausted {
+            let repair = self
+                .state
+                .repair
+                .as_ref()
+                .expect("repair exists after its exhaustion transition");
+            Self::report_vct_repair_exhausted(repair);
+        }
         let Some(repair) = self.state.repair.as_ref() else {
             return false;
         };
@@ -1638,7 +1678,13 @@ impl HeaderSyncReactor {
             .peers
             .iter()
             .filter(|(peer_id, peer)| {
-                peer.received_status
+                !self.state.parked_peers.contains(*peer_id)
+                    && !self
+                        .state
+                        .advisory
+                        .get(*peer_id)
+                        .is_some_and(|advisory| advisory.is_backed_off(now))
+                    && peer.received_status
                     && peer.outstanding.is_empty()
                     && peer.late_covered_responses == 0
                     && peer.advertised_tip >= repair.range.end_height()

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1631,6 +1631,7 @@ impl HeaderSyncReactor {
                     && peer.outstanding.is_empty()
                     && peer.late_covered_responses == 0
                     && peer.advertised_tip >= repair.range.end_height()
+                    && peer.max_headers_per_response >= repair.range.count
                     && !repair.tried_peers.contains(*peer_id)
             })
             .map(|(peer_id, _)| peer_id.clone())
@@ -1645,9 +1646,6 @@ impl HeaderSyncReactor {
         };
         let range = repair.range;
         let peer_cap = peer.max_headers_per_response;
-        if peer_cap < range.count {
-            return false;
-        }
         if let Err(error) = peer
             .session
             .try_send_get_headers(range.start_height, range.count, true)

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1415,7 +1415,9 @@ impl HeaderSyncReactor {
         let Some(repair) = self.state.repair.as_mut() else {
             return;
         };
-        repair.finish_attempt(peer, Instant::now());
+        if !repair.finish_attempt(peer, Instant::now()) {
+            return;
+        }
         if repair.exhausted {
             tracing::error!(
                 height = ?repair.height,

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -195,6 +195,23 @@ impl HeaderSyncReactor {
             HeaderSyncEvent::StateFrontiersChanged(frontiers) => {
                 self.handle_state_frontiers_changed(frontiers).await;
             }
+            HeaderSyncEvent::VctRootRepairRequested {
+                height,
+                generation,
+                anchor_hash,
+                expected_hashes,
+            } => {
+                self.handle_vct_root_repair_requested(
+                    height,
+                    generation,
+                    anchor_hash,
+                    expected_hashes,
+                )
+                .await;
+            }
+            HeaderSyncEvent::VctRootRepairResolved { generation } => {
+                self.handle_vct_root_repair_resolved(generation).await;
+            }
             HeaderSyncEvent::HeaderRangeCommitted {
                 start_height,
                 tip_height,
@@ -483,6 +500,7 @@ impl HeaderSyncReactor {
         self.state.parked_peers.remove(&peer);
         self.state.advisory.remove(&peer);
         self.state.schedule.forget_peer(&peer);
+        self.finish_vct_repair_attempt(&peer);
         if was_connected {
             self.publish_connectivity_metrics();
             self.trace_peer_disconnected(&peer, self.state.peers.len());
@@ -649,6 +667,58 @@ impl HeaderSyncReactor {
         self.schedule().await;
     }
 
+    async fn handle_vct_root_repair_requested(
+        &mut self,
+        height: block::Height,
+        generation: u64,
+        anchor_hash: block::Hash,
+        expected_hashes: Vec<(block::Height, block::Hash)>,
+    ) {
+        if self
+            .state
+            .repair
+            .as_ref()
+            .is_some_and(|repair| repair.generation == generation)
+        {
+            return;
+        }
+
+        let Some(repair) = VctRootRepair::new(height, generation, anchor_hash, expected_hashes)
+        else {
+            tracing::warn!(
+                ?height,
+                generation,
+                "ignoring invalid VCT root repair request"
+            );
+            metrics::counter!("sync.header.vct_repair.invalid_request").increment(1);
+            return;
+        };
+
+        tracing::warn!(
+            ?height,
+            generation,
+            count = repair.range.count,
+            "scheduling bounded VCT supplied-root repair"
+        );
+        metrics::counter!("sync.header.vct_repair.requested").increment(1);
+        self.state.repair = Some(repair);
+        self.schedule().await;
+    }
+
+    async fn handle_vct_root_repair_resolved(&mut self, generation: u64) {
+        if self
+            .state
+            .repair
+            .as_ref()
+            .is_some_and(|repair| repair.generation == generation)
+        {
+            self.state.repair = None;
+            metrics::gauge!("sync.header.vct_repair.stalled.height").set(0.0);
+            metrics::counter!("sync.header.vct_repair.resolved").increment(1);
+        }
+        self.schedule().await;
+    }
+
     async fn handle_header_range_committed(
         &mut self,
         start_height: block::Height,
@@ -699,11 +769,16 @@ impl HeaderSyncReactor {
                 .await;
         }
         let key = PendingCommitKey {
-            peer,
+            peer: peer.clone(),
             start_height,
             count,
         };
         if let Some(range) = self.state.pending_commits.remove(&key) {
+            if range.priority == RangePriority::Repair {
+                self.finish_vct_repair_attempt(&peer);
+                self.schedule().await;
+                return;
+            }
             if kind == HeaderSyncCommitFailureKind::Local {
                 self.state.schedule.clear_assignment(range);
             }
@@ -1075,21 +1150,27 @@ impl HeaderSyncReactor {
         if validate_body_sizes_len(headers.len(), body_sizes.len()).is_err()
             || validate_tree_aux_roots_len(headers.len(), tree_aux_roots.len()).is_err()
         {
-            self.report_misbehavior(peer, HeaderSyncMisbehavior::MalformedMessage)
+            self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::MalformedMessage)
                 .await;
-            self.state.schedule.retry(outstanding.range);
+            self.retry_or_finish_outstanding(&peer, outstanding);
             self.schedule().await;
             return;
         }
         if !outstanding.range.want_tree_aux_roots && !tree_aux_roots.is_empty() {
-            self.report_misbehavior(peer, HeaderSyncMisbehavior::MalformedMessage)
+            self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::MalformedMessage)
                 .await;
-            self.state.schedule.retry(outstanding.range);
+            self.retry_or_finish_outstanding(&peer, outstanding);
             self.schedule().await;
             return;
         }
 
         if headers.is_empty() {
+            if matches!(outstanding.purpose, RangePurpose::VctRepair { .. }) {
+                self.record_advisory_unconfirmed(&peer);
+                self.finish_vct_repair_attempt(&peer);
+                self.schedule().await;
+                return;
+            }
             self.record_advisory_unconfirmed(&peer);
             let deadline = Instant::now() + self.empty_headers_retry_delay();
             self.trace_headers_received(
@@ -1127,7 +1208,24 @@ impl HeaderSyncReactor {
         if header_count > outstanding.expected_max_count || header_count > outstanding.range.count {
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::ResponseTooLong)
                 .await;
-            self.state.schedule.retry(outstanding.range);
+            self.retry_or_finish_outstanding(&peer, outstanding);
+            self.schedule().await;
+            return;
+        }
+
+        if let Err(reason) =
+            self.validate_vct_repair_response(&outstanding, &headers, &tree_aux_roots)
+        {
+            self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
+                .await;
+            tracing::debug!(
+                ?peer,
+                ?reason,
+                start_height = ?outstanding.range.start_height,
+                count = header_count,
+                "Zakura header-sync rejected VCT root repair response"
+            );
+            self.finish_vct_repair_attempt(&peer);
             self.schedule().await;
             return;
         }
@@ -1162,7 +1260,8 @@ impl HeaderSyncReactor {
                 "link",
                 header_sync_wire_error_kind(&error),
             );
-            if matches!(error, HeaderSyncWireError::FirstHeaderDoesNotLink)
+            if matches!(outstanding.purpose, RangePurpose::Sync)
+                && matches!(error, HeaderSyncWireError::FirstHeaderDoesNotLink)
                 && self.restore_outstanding_after_late_covered_response(&peer, outstanding)
             {
                 return;
@@ -1176,15 +1275,15 @@ impl HeaderSyncReactor {
             }
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
                 .await;
-            self.state.schedule.retry(outstanding.range);
+            self.retry_or_finish_outstanding(&peer, outstanding);
             self.schedule().await;
             return;
         }
         if validate_tree_aux_root_heights(outstanding.range.start_height, &tree_aux_roots).is_err()
         {
-            self.report_misbehavior(peer, HeaderSyncMisbehavior::MalformedMessage)
+            self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::MalformedMessage)
                 .await;
-            self.state.schedule.retry(outstanding.range);
+            self.retry_or_finish_outstanding(&peer, outstanding);
             self.schedule().await;
             return;
         }
@@ -1205,7 +1304,7 @@ impl HeaderSyncReactor {
             );
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
                 .await;
-            self.state.schedule.retry(outstanding.range);
+            self.retry_or_finish_outstanding(&peer, outstanding);
             self.schedule().await;
             return;
         }
@@ -1230,7 +1329,7 @@ impl HeaderSyncReactor {
                 );
                 self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
                     .await;
-                self.state.schedule.retry(outstanding.range);
+                self.retry_or_finish_outstanding(&peer, outstanding);
                 self.schedule().await;
                 return;
             }
@@ -1253,6 +1352,75 @@ impl HeaderSyncReactor {
             tree_aux_roots,
             finalized: outstanding.range.finalized,
         });
+    }
+
+    fn validate_vct_repair_response(
+        &self,
+        outstanding: &OutstandingRange,
+        headers: &[Arc<block::Header>],
+        tree_aux_roots: &[BlockCommitmentRoots],
+    ) -> Result<(), &'static str> {
+        let RangePurpose::VctRepair { generation, .. } = outstanding.purpose else {
+            return Ok(());
+        };
+        let Some(repair) = self
+            .state
+            .repair
+            .as_ref()
+            .filter(|repair| repair.generation == generation)
+        else {
+            return Err("stale_repair_generation");
+        };
+        if headers.len() != repair.expected_hashes.len()
+            || tree_aux_roots.len() != repair.expected_hashes.len()
+        {
+            return Err("wrong_repair_count");
+        }
+        for ((expected_height, expected_hash), (index, header)) in repair
+            .expected_hashes
+            .iter()
+            .zip(headers.iter().enumerate())
+        {
+            let Some(actual_height) = repair
+                .height
+                .0
+                .checked_add(u32::try_from(index).map_err(|_| "height_offset_overflow")?)
+                .map(block::Height)
+            else {
+                return Err("height_overflow");
+            };
+            if *expected_height != actual_height
+                || block::Hash::from(header.as_ref()) != *expected_hash
+            {
+                return Err("noncanonical_header");
+            }
+        }
+        Ok(())
+    }
+
+    fn retry_or_finish_outstanding(&mut self, peer: &ZakuraPeerId, outstanding: OutstandingRange) {
+        match outstanding.purpose {
+            RangePurpose::Sync => self.state.schedule.retry(outstanding.range),
+            RangePurpose::VctRepair { .. } => self.finish_vct_repair_attempt(peer),
+        }
+    }
+
+    fn finish_vct_repair_attempt(&mut self, peer: &ZakuraPeerId) {
+        let Some(repair) = self.state.repair.as_mut() else {
+            return;
+        };
+        repair.finish_attempt(peer, Instant::now());
+        if repair.exhausted {
+            tracing::error!(
+                height = ?repair.height,
+                generation = repair.generation,
+                attempts = repair.tried_peers.len(),
+                "VCT supplied-root repair exhausted bounded peer attempts; node remains fail-closed"
+            );
+            metrics::counter!("sync.header.vct_repair.exhausted").increment(1);
+            metrics::gauge!("sync.header.vct_repair.stalled.height")
+                .set(f64::from(repair.height.0));
+        }
     }
 
     async fn handle_possible_stale_anchor_link_failure(
@@ -1305,17 +1473,25 @@ impl HeaderSyncReactor {
             while index < peer.outstanding.len() {
                 if peer.outstanding[index].deadline <= now {
                     let outstanding = peer.outstanding.remove(index);
-                    timed_out.push((outstanding.range, outstanding.clear_assignment_on_timeout));
+                    timed_out.push((outstanding, peer.session.peer_id().clone()));
                 } else {
                     index += 1;
                 }
             }
         }
-        for (range, clear_assignment) in timed_out {
-            if clear_assignment {
-                self.state.schedule.clear_assignment(range);
+        for (outstanding, peer) in timed_out {
+            match outstanding.purpose {
+                RangePurpose::Sync => {
+                    if outstanding.clear_assignment_on_timeout {
+                        self.state.schedule.clear_assignment(outstanding.range);
+                    }
+                    self.state.schedule.retry(outstanding.range);
+                }
+                RangePurpose::VctRepair { .. } => {
+                    metrics::counter!("sync.header.vct_repair.timeout").increment(1);
+                    self.finish_vct_repair_attempt(&peer);
+                }
             }
-            self.state.schedule.retry(range);
         }
         self.schedule().await;
     }
@@ -1331,6 +1507,10 @@ impl HeaderSyncReactor {
 
         self.state.refresh_forward_range(&self.startup);
         self.state.refresh_backward_range(&self.startup);
+
+        if self.schedule_vct_repair().await {
+            return;
+        }
 
         let mut peer_ids: Vec<ZakuraPeerId> = self.state.peers.keys().cloned().collect();
         peer_ids.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
@@ -1401,6 +1581,7 @@ impl HeaderSyncReactor {
                 deadline,
                 expected_max_count: count,
                 clear_assignment_on_timeout: false,
+                purpose: RangePurpose::Sync,
             };
             if let Some(peer) = self.state.peers.get_mut(&peer_id) {
                 peer.outstanding.push(outstanding);
@@ -1422,6 +1603,92 @@ impl HeaderSyncReactor {
                 })
                 .await;
         }
+    }
+
+    async fn schedule_vct_repair(&mut self) -> bool {
+        let now = Instant::now();
+        let Some(repair) = self.state.repair.as_ref() else {
+            return false;
+        };
+        if !repair.can_attempt(now) {
+            return false;
+        }
+
+        let mut peer_ids: Vec<_> = self
+            .state
+            .peers
+            .iter()
+            .filter(|(peer_id, peer)| {
+                peer.received_status
+                    && peer.available_slots() > 0
+                    && peer.advertised_tip >= repair.range.end_height()
+                    && !repair.tried_peers.contains(*peer_id)
+            })
+            .map(|(peer_id, _)| peer_id.clone())
+            .collect();
+        peer_ids.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+        let Some(peer_id) = peer_ids.into_iter().next() else {
+            return false;
+        };
+
+        let Some(peer) = self.state.peers.get(&peer_id) else {
+            return false;
+        };
+        let range = repair.range;
+        let peer_cap = peer.max_headers_per_response;
+        if peer_cap < range.count {
+            return false;
+        }
+        if let Err(error) = peer
+            .session
+            .try_send_get_headers(range.start_height, range.count, true)
+        {
+            tracing::debug!(
+                peer = ?peer_id,
+                start_height = ?range.start_height,
+                count = range.count,
+                ?error,
+                "failed to queue VCT repair GetHeaders"
+            );
+            return false;
+        }
+
+        let (height, generation) = {
+            let repair = self
+                .state
+                .repair
+                .as_mut()
+                .expect("repair existed when scheduling started");
+            repair.mark_attempt(peer_id.clone());
+            (repair.height, repair.generation)
+        };
+        let outstanding = OutstandingRange {
+            range,
+            deadline: Instant::now() + self.startup.request_timeout,
+            expected_max_count: range.count,
+            clear_assignment_on_timeout: false,
+            purpose: RangePurpose::VctRepair { height, generation },
+        };
+        if let Some(peer) = self.state.peers.get_mut(&peer_id) {
+            peer.outstanding.push(outstanding);
+        }
+
+        metrics::counter!("sync.header.vct_repair.request.sent").increment(1);
+        self.trace_get_headers_sent(&peer_id, range, range.count, peer_cap);
+        #[cfg(test)]
+        let _ = self
+            .actions
+            .send(HeaderSyncAction::SendMessage {
+                peer: peer_id,
+                msg: HeaderSyncMessage::GetHeaders {
+                    start_height: range.start_height,
+                    count: range.count,
+                    want_tree_aux_roots: true,
+                },
+            })
+            .await;
+
+        true
     }
 
     fn send_status(&mut self, peer: &ZakuraPeerId) -> bool {
@@ -1747,6 +2014,21 @@ impl HeaderSyncReactor {
                 insert_optional_str(row, hs_trace::KIND, Some("state_frontiers_changed"));
                 insert_height(row, "finalized_height", frontiers.finalized_height);
                 insert_height(row, "verified_block_tip", frontiers.verified_block_tip);
+            }
+            HeaderSyncEvent::VctRootRepairRequested {
+                height,
+                generation,
+                expected_hashes,
+                ..
+            } => {
+                insert_optional_str(row, hs_trace::KIND, Some("vct_root_repair_requested"));
+                insert_height(row, hs_trace::HEIGHT, *height);
+                insert_u64(row, hs_trace::RANGE_COUNT, expected_hashes.len() as u64);
+                insert_u64(row, "generation", *generation);
+            }
+            HeaderSyncEvent::VctRootRepairResolved { generation } => {
+                insert_optional_str(row, hs_trace::KIND, Some("vct_root_repair_resolved"));
+                insert_u64(row, "generation", *generation);
             }
             HeaderSyncEvent::HeaderRangeCommitted {
                 start_height,
@@ -2248,6 +2530,7 @@ impl HeaderSyncReactor {
                     .state
                     .schedule
                     .is_covered(peer.outstanding[index].range)
+                    && matches!(peer.outstanding[index].purpose, RangePurpose::Sync)
                 {
                     peer.outstanding.remove(index);
                     peer.late_covered_responses = peer.late_covered_responses.saturating_add(1);

--- a/zakura-network/src/zakura/header_sync/scheduler.rs
+++ b/zakura-network/src/zakura/header_sync/scheduler.rs
@@ -76,6 +76,7 @@ impl RangeScheduler {
         let queue = match priority {
             RangePriority::Forward => &mut self.forward,
             RangePriority::Backward => &mut self.backward,
+            RangePriority::Repair => return,
         };
         if !queue.contains(&range)
             && !queue.iter().any(|queued| {
@@ -129,6 +130,7 @@ impl RangeScheduler {
         let queue = match original.priority {
             RangePriority::Forward => &mut self.forward,
             RangePriority::Backward => &mut self.backward,
+            RangePriority::Repair => return,
         };
         for queued in queue {
             if *queued == original {
@@ -148,6 +150,7 @@ impl RangeScheduler {
         match range.priority {
             RangePriority::Forward => self.forward.push_front(range),
             RangePriority::Backward => self.backward.push_front(range),
+            RangePriority::Repair => {}
         }
     }
 

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -8,6 +8,16 @@ pub(super) const HEADER_SYNC_ADVISORY_BACKOFF: Duration = Duration::from_secs(60
 pub(super) const HEADER_SYNC_ADVISORY_TTL: Duration = DEFAULT_LIVE_SERVICE_SUMMARY_TTL;
 pub(super) const HEADER_SYNC_STALE_ANCHOR_LINK_FAILURES: u32 = 3;
 pub(super) const HEADER_SYNC_STALE_ANCHOR_DISTINCT_PEERS: usize = 2;
+pub(super) const VCT_ROOT_REPAIR_MAX_ATTEMPTS: usize = 6;
+pub(super) const VCT_ROOT_REPAIR_MAX_WALL_TIME: Duration = Duration::from_secs(240);
+pub(super) const VCT_ROOT_REPAIR_BACKOFFS: [Duration; VCT_ROOT_REPAIR_MAX_ATTEMPTS] = [
+    Duration::from_secs(0),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(4),
+    Duration::from_secs(8),
+    Duration::from_secs(16),
+];
 
 #[derive(Clone, Debug)]
 pub(super) struct HeaderSyncCore {
@@ -23,6 +33,7 @@ pub(super) struct HeaderSyncCore {
     pub(super) pending_new_blocks: HashSet<block::Hash>,
     pub(super) schedule: RangeScheduler,
     pub(super) pending_commits: HashMap<PendingCommitKey, RangeRequest>,
+    pub(super) repair: Option<VctRootRepair>,
     pub(super) advisory: HashMap<ZakuraPeerId, HeaderSyncAdvisoryPeerState>,
     pub(super) stale_anchor: StaleAnchorFailures,
 }
@@ -45,6 +56,7 @@ impl HeaderSyncCore {
             pending_new_blocks: HashSet::new(),
             schedule: RangeScheduler::new(),
             pending_commits: HashMap::new(),
+            repair: None,
             advisory: HashMap::new(),
             stale_anchor: StaleAnchorFailures::default(),
         })
@@ -120,6 +132,95 @@ impl HeaderSyncCore {
             want_tree_aux_roots: true,
             priority: RangePriority::Backward,
         });
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct VctRootRepair {
+    pub(super) height: block::Height,
+    pub(super) generation: u64,
+    pub(super) range: RangeRequest,
+    pub(super) expected_hashes: Vec<(block::Height, block::Hash)>,
+    pub(super) tried_peers: HashSet<ZakuraPeerId>,
+    pub(super) in_flight: Option<ZakuraPeerId>,
+    pub(super) started_at: Instant,
+    pub(super) next_attempt_at: Instant,
+    pub(super) exhausted: bool,
+}
+
+impl VctRootRepair {
+    pub(super) fn new(
+        height: block::Height,
+        generation: u64,
+        anchor_hash: block::Hash,
+        expected_hashes: Vec<(block::Height, block::Hash)>,
+    ) -> Option<Self> {
+        let count = u32::try_from(expected_hashes.len()).ok()?;
+        if count == 0 || count > 2 {
+            return None;
+        }
+        let first_height = expected_hashes.first()?.0;
+        if first_height != height {
+            return None;
+        }
+        if !expected_hashes
+            .iter()
+            .enumerate()
+            .all(|(index, (candidate_height, _))| {
+                u32::try_from(index)
+                    .ok()
+                    .and_then(|offset| height.0.checked_add(offset))
+                    .map(block::Height)
+                    == Some(*candidate_height)
+            })
+        {
+            return None;
+        }
+
+        Some(Self {
+            height,
+            generation,
+            range: RangeRequest {
+                start_height: height,
+                count,
+                anchor_hash,
+                finalized: false,
+                want_tree_aux_roots: true,
+                priority: RangePriority::Repair,
+            },
+            expected_hashes,
+            tried_peers: HashSet::new(),
+            in_flight: None,
+            started_at: Instant::now(),
+            next_attempt_at: Instant::now(),
+            exhausted: false,
+        })
+    }
+
+    pub(super) fn can_attempt(&self, now: Instant) -> bool {
+        !self.exhausted
+            && self.in_flight.is_none()
+            && self.tried_peers.len() < VCT_ROOT_REPAIR_MAX_ATTEMPTS
+            && now.duration_since(self.started_at) < VCT_ROOT_REPAIR_MAX_WALL_TIME
+            && now >= self.next_attempt_at
+    }
+
+    pub(super) fn mark_attempt(&mut self, peer: ZakuraPeerId) {
+        self.tried_peers.insert(peer.clone());
+        self.in_flight = Some(peer);
+    }
+
+    pub(super) fn finish_attempt(&mut self, peer: &ZakuraPeerId, now: Instant) {
+        if self.in_flight.as_ref() == Some(peer) {
+            self.in_flight = None;
+        }
+        let attempt_index = self.tried_peers.len().min(VCT_ROOT_REPAIR_MAX_ATTEMPTS - 1);
+        self.next_attempt_at = now + VCT_ROOT_REPAIR_BACKOFFS[attempt_index];
+        if self.tried_peers.len() >= VCT_ROOT_REPAIR_MAX_ATTEMPTS
+            || now.duration_since(self.started_at) >= VCT_ROOT_REPAIR_MAX_WALL_TIME
+        {
+            self.exhausted = true;
+        }
     }
 }
 
@@ -345,6 +446,7 @@ pub(super) struct OutstandingRange {
     pub(super) deadline: Instant,
     pub(super) expected_max_count: u32,
     pub(super) clear_assignment_on_timeout: bool,
+    pub(super) purpose: RangePurpose,
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -373,6 +475,7 @@ impl RangeRequest {
 pub(super) enum RangePriority {
     Forward,
     Backward,
+    Repair,
 }
 
 impl RangePriority {
@@ -380,6 +483,16 @@ impl RangePriority {
         match self {
             RangePriority::Forward => "forward",
             RangePriority::Backward => "backward",
+            RangePriority::Repair => "repair",
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum RangePurpose {
+    Sync,
+    VctRepair {
+        height: block::Height,
+        generation: u64,
+    },
 }

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -215,13 +215,28 @@ impl VctRootRepair {
             return false;
         }
         self.in_flight = None;
-        let attempt_index = self.tried_peers.len().min(VCT_ROOT_REPAIR_MAX_ATTEMPTS - 1);
+        let attempt_index = self
+            .tried_peers
+            .len()
+            .saturating_sub(1)
+            .min(VCT_ROOT_REPAIR_MAX_ATTEMPTS - 1);
         self.next_attempt_at = now + VCT_ROOT_REPAIR_BACKOFFS[attempt_index];
-        if self.tried_peers.len() >= VCT_ROOT_REPAIR_MAX_ATTEMPTS
-            || now.duration_since(self.started_at) >= VCT_ROOT_REPAIR_MAX_WALL_TIME
+        self.refresh_exhausted(now);
+        true
+    }
+
+    /// Marks an episode exhausted once either bound has elapsed.
+    ///
+    /// Returns `true` only for the transition so callers emit operator signals once.
+    pub(super) fn refresh_exhausted(&mut self, now: Instant) -> bool {
+        if self.exhausted
+            || (self.tried_peers.len() < VCT_ROOT_REPAIR_MAX_ATTEMPTS
+                && now.duration_since(self.started_at) < VCT_ROOT_REPAIR_MAX_WALL_TIME)
         {
-            self.exhausted = true;
+            return false;
         }
+
+        self.exhausted = true;
         true
     }
 }

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -210,10 +210,11 @@ impl VctRootRepair {
         self.in_flight = Some(peer);
     }
 
-    pub(super) fn finish_attempt(&mut self, peer: &ZakuraPeerId, now: Instant) {
-        if self.in_flight.as_ref() == Some(peer) {
-            self.in_flight = None;
+    pub(super) fn finish_attempt(&mut self, peer: &ZakuraPeerId, now: Instant) -> bool {
+        if self.in_flight.as_ref() != Some(peer) {
+            return false;
         }
+        self.in_flight = None;
         let attempt_index = self.tried_peers.len().min(VCT_ROOT_REPAIR_MAX_ATTEMPTS - 1);
         self.next_attempt_at = now + VCT_ROOT_REPAIR_BACKOFFS[attempt_index];
         if self.tried_peers.len() >= VCT_ROOT_REPAIR_MAX_ATTEMPTS
@@ -221,6 +222,7 @@ impl VctRootRepair {
         {
             self.exhausted = true;
         }
+        true
     }
 }
 

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -4,7 +4,7 @@ use super::{
     error::*,
     events::*,
     reactor::*,
-    state::{VctRootRepair, VCT_ROOT_REPAIR_MAX_ATTEMPTS, VCT_ROOT_REPAIR_MAX_WALL_TIME},
+    state::{VctRootRepair, VCT_ROOT_REPAIR_BACKOFFS, VCT_ROOT_REPAIR_MAX_WALL_TIME},
     validation::*,
     wire::*,
 };
@@ -1523,6 +1523,21 @@ fn mainnet_repair_event(generation: u64) -> HeaderSyncEvent {
     }
 }
 
+fn mainnet_repair_event_at_two(generation: u64) -> HeaderSyncEvent {
+    let block1 = mainnet_block(&BLOCK_MAINNET_1_BYTES);
+    let block2 = mainnet_block(&BLOCK_MAINNET_2_BYTES);
+    let block3 = mainnet_block(&BLOCK_MAINNET_3_BYTES);
+    HeaderSyncEvent::VctRootRepairRequested {
+        height: block::Height(2),
+        generation,
+        anchor_hash: block1.hash(),
+        expected_hashes: vec![
+            (block::Height(2), block2.hash()),
+            (block::Height(3), block3.hash()),
+        ],
+    }
+}
+
 #[test]
 fn vct_repair_episode_enforces_attempt_and_time_bounds() {
     let mut repair = VctRootRepair::new(
@@ -1542,11 +1557,17 @@ fn vct_repair_episode_enforces_attempt_and_time_bounds() {
     )
     .expect("valid repair shape");
 
-    for attempt in 0..VCT_ROOT_REPAIR_MAX_ATTEMPTS {
+    for (attempt, backoff) in VCT_ROOT_REPAIR_BACKOFFS.iter().copied().enumerate() {
         assert!(repair.can_attempt(repair.next_attempt_at));
         let peer_id = peer(120 + u8::try_from(attempt).expect("attempt fits in u8"));
         repair.mark_attempt(peer_id.clone());
-        assert!(repair.finish_attempt(&peer_id, repair.next_attempt_at));
+        let finished_at = repair.next_attempt_at;
+        assert!(repair.finish_attempt(&peer_id, finished_at));
+        assert_eq!(
+            repair.next_attempt_at,
+            finished_at + backoff,
+            "each failure uses the backoff with the same zero-based attempt index"
+        );
     }
 
     assert!(repair.exhausted);
@@ -1562,8 +1583,12 @@ fn vct_repair_episode_enforces_attempt_and_time_bounds() {
         )],
     )
     .expect("single-header handoff repair is valid");
-    timed.started_at = Instant::now() - VCT_ROOT_REPAIR_MAX_WALL_TIME;
-    assert!(!timed.can_attempt(Instant::now()));
+    let now = Instant::now();
+    timed.started_at = now - VCT_ROOT_REPAIR_MAX_WALL_TIME;
+    assert!(timed.refresh_exhausted(now));
+    assert!(timed.exhausted);
+    assert!(!timed.refresh_exhausted(now));
+    assert!(!timed.can_attempt(now));
 }
 
 #[test]
@@ -1589,6 +1614,33 @@ fn vct_repair_ignores_unrelated_peer_disconnects() {
     assert_eq!(repair.in_flight.as_ref(), Some(&repair_peer));
     assert_eq!(repair.next_attempt_at, next_attempt_at);
     assert!(!repair.exhausted);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn vct_repair_wall_time_exhaustion_emits_operator_signal_without_an_attempt() {
+    let metrics = metric_snapshot(&["sync.header.vct_repair.exhausted"]);
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    tokio::task::yield_now().await;
+    tokio::time::advance(VCT_ROOT_REPAIR_MAX_WALL_TIME).await;
+
+    // Connecting a peer without a Status runs the scheduler but cannot start an
+    // attempt, exercising expiry on the otherwise quiet path.
+    connect_peer(&fixture, peer(132)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    assert_metric_incremented(&metrics, "sync.header.vct_repair.exhausted");
+    assert_eq!(gauge_value("sync.header.vct_repair.stalled.height"), 1.0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -1699,6 +1751,209 @@ async fn vct_repair_scheduler_skips_peers_with_insufficient_response_capacity() 
         next_outbound_get_headers(&mut fixture.actions).await;
     assert_eq!(requested_peer, capable_peer);
     assert_eq!((start_height, count), (block::Height(1), 2));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_timeout_retries_another_peer() {
+    let metrics = metric_snapshot(&["sync.header.vct_repair.timeout"]);
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut startup = startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    );
+    startup.request_timeout = std::time::Duration::from_millis(10);
+    let mut fixture = spawn_test_reactor(startup);
+    let first_peer = peer(109);
+    let second_peer = peer(110);
+
+    for peer_id in [&first_peer, &second_peer] {
+        connect_peer(&fixture, peer_id.clone()).await;
+        advertise_tip(&fixture, peer_id.clone(), block::Height(0), best.0, 2, 1).await;
+    }
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+
+    assert_eq!(
+        next_outbound_get_headers(&mut fixture.actions).await.0,
+        first_peer
+    );
+    assert_eq!(
+        next_outbound_get_headers(&mut fixture.actions).await.0,
+        second_peer
+    );
+    assert_metric_incremented(&metrics, "sync.header.vct_repair.timeout");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_disconnect_retries_another_peer() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut startup = startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    );
+    startup.request_timeout = std::time::Duration::from_millis(10);
+    let mut fixture = spawn_test_reactor(startup);
+    let first_peer = peer(111);
+    let second_peer = peer(112);
+
+    for peer_id in [&first_peer, &second_peer] {
+        connect_peer(&fixture, peer_id.clone()).await;
+        advertise_tip(&fixture, peer_id.clone(), block::Height(0), best.0, 2, 1).await;
+    }
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    assert_eq!(
+        next_outbound_get_headers(&mut fixture.actions).await.0,
+        first_peer
+    );
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::PeerDisconnected(first_peer))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        next_outbound_get_headers(&mut fixture.actions).await.0,
+        second_peer
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_commit_failure_retries_another_peer() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+    let first_peer = peer(113);
+    let second_peer = peer(114);
+
+    for peer_id in [&first_peer, &second_peer] {
+        connect_peer(&fixture, peer_id.clone()).await;
+        advertise_tip(&fixture, peer_id.clone(), block::Height(0), best.0, 2, 1).await;
+    }
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    assert_eq!(
+        next_outbound_get_headers(&mut fixture.actions).await.0,
+        first_peer
+    );
+    fixture
+        .handle
+        .send(HeaderSyncEvent::WireMessage {
+            peer: first_peer.clone(),
+            msg: finalized_headers_message_from(
+                block::Height(1),
+                vec![
+                    mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                    mainnet_header(&BLOCK_MAINNET_2_BYTES),
+                ],
+            ),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        if matches!(
+            next_action(&mut fixture.actions).await,
+            HeaderSyncAction::CommitHeaderRange { .. }
+        ) {
+            break;
+        }
+    }
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
+            peer: first_peer,
+            start_height: block::Height(1),
+            count: 2,
+            kind: HeaderSyncCommitFailureKind::Local,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        next_outbound_get_headers(&mut fixture.actions).await.0,
+        second_peer
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_scheduler_skips_advisory_backoff_across_episode_heights() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+    let backed_off_peer = peer(115);
+    let eligible_peer = peer(116);
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::AdvisoryHeaderSummary {
+            peer: backed_off_peer.clone(),
+            summary: advisory_header_summary(block::Height(10), 1),
+        })
+        .await
+        .unwrap();
+    connect_peer(&fixture, backed_off_peer.clone()).await;
+    advertise_tip(
+        &fixture,
+        backed_off_peer.clone(),
+        block::Height(0),
+        best.0,
+        2,
+        1,
+    )
+    .await;
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    assert_eq!(
+        next_outbound_get_headers(&mut fixture.actions).await.0,
+        backed_off_peer
+    );
+    fixture
+        .handle
+        .send(HeaderSyncEvent::WireMessage {
+            peer: backed_off_peer.clone(),
+            msg: finalized_headers_message_from(block::Height(1), Vec::new()),
+        })
+        .await
+        .unwrap();
+
+    connect_peer(&fixture, eligible_peer.clone()).await;
+    fixture
+        .handle
+        .send(mainnet_repair_event_at_two(2))
+        .await
+        .unwrap();
+    advertise_tip(
+        &fixture,
+        eligible_peer.clone(),
+        block::Height(0),
+        best.0,
+        2,
+        1,
+    )
+    .await;
+
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, eligible_peer);
+    assert_eq!((start_height, count), (block::Height(2), 2));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1546,7 +1546,7 @@ fn vct_repair_episode_enforces_attempt_and_time_bounds() {
         assert!(repair.can_attempt(repair.next_attempt_at));
         let peer_id = peer(120 + u8::try_from(attempt).expect("attempt fits in u8"));
         repair.mark_attempt(peer_id.clone());
-        repair.finish_attempt(&peer_id, repair.next_attempt_at);
+        assert!(repair.finish_attempt(&peer_id, repair.next_attempt_at));
     }
 
     assert!(repair.exhausted);
@@ -1564,6 +1564,31 @@ fn vct_repair_episode_enforces_attempt_and_time_bounds() {
     .expect("single-header handoff repair is valid");
     timed.started_at = Instant::now() - VCT_ROOT_REPAIR_MAX_WALL_TIME;
     assert!(!timed.can_attempt(Instant::now()));
+}
+
+#[test]
+fn vct_repair_ignores_unrelated_peer_disconnects() {
+    let mut repair = VctRootRepair::new(
+        block::Height(1),
+        1,
+        Network::Mainnet.genesis_hash(),
+        vec![(
+            block::Height(1),
+            mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+        )],
+    )
+    .expect("single-header handoff repair is valid");
+    let repair_peer = peer(130);
+    repair.mark_attempt(repair_peer.clone());
+    let next_attempt_at = repair.next_attempt_at;
+
+    assert!(!repair.finish_attempt(
+        &peer(131),
+        repair.started_at + VCT_ROOT_REPAIR_MAX_WALL_TIME
+    ));
+    assert_eq!(repair.in_flight.as_ref(), Some(&repair_peer));
+    assert_eq!(repair.next_attempt_at, next_attempt_at);
+    assert!(!repair.exhausted);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1837,6 +1837,69 @@ async fn stale_vct_repair_response_is_dropped_without_peer_misbehavior() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn vct_repair_generation_change_keeps_tried_peers_at_same_height() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+    let first_peer = peer(103);
+    let second_peer = peer(104);
+
+    for peer_id in [&first_peer, &second_peer] {
+        connect_peer(&fixture, peer_id.clone()).await;
+        advertise_tip(&fixture, peer_id.clone(), block::Height(0), best.0, 2, 1).await;
+    }
+
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    let (requested_peer, _, _) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, first_peer);
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::WireMessage {
+            peer: first_peer.clone(),
+            msg: finalized_headers_message_from(
+                block::Height(1),
+                vec![
+                    mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                    mainnet_header(&BLOCK_MAINNET_2_BYTES),
+                ],
+            ),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        if matches!(
+            next_action(&mut fixture.actions).await,
+            HeaderSyncAction::CommitHeaderRange { .. }
+        ) {
+            break;
+        }
+    }
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeCommitted {
+            start_height: block::Height(1),
+            tip_height: block::Height(2),
+            tip_hash: mainnet_block(&BLOCK_MAINNET_2_BYTES).hash(),
+        })
+        .await
+        .unwrap();
+
+    fixture.handle.send(mainnet_repair_event(2)).await.unwrap();
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, second_peer);
+    assert_eq!((start_height, count), (block::Height(1), 2));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn vct_repair_scheduler_requires_an_idle_peer() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1,5 +1,13 @@
 use super::*;
-use super::{config::*, error::*, events::*, reactor::*, validation::*, wire::*};
+use super::{
+    config::*,
+    error::*,
+    events::*,
+    reactor::*,
+    state::{VctRootRepair, VCT_ROOT_REPAIR_MAX_ATTEMPTS, VCT_ROOT_REPAIR_MAX_WALL_TIME},
+    validation::*,
+    wire::*,
+};
 use crate::zakura::{
     framed_channel,
     testkit::{TraceCapture, TraceValue},
@@ -1497,6 +1505,211 @@ async fn restart_rebuilds_schedule_from_durable_best_tip_and_peer_status() {
             assert_eq!(start_height, block::Height(5));
             assert_eq!(count, 4);
             break;
+        }
+    }
+}
+
+fn mainnet_repair_event(generation: u64) -> HeaderSyncEvent {
+    let block1 = mainnet_block(&BLOCK_MAINNET_1_BYTES);
+    let block2 = mainnet_block(&BLOCK_MAINNET_2_BYTES);
+    HeaderSyncEvent::VctRootRepairRequested {
+        height: block::Height(1),
+        generation,
+        anchor_hash: Network::Mainnet.genesis_hash(),
+        expected_hashes: vec![
+            (block::Height(1), block1.hash()),
+            (block::Height(2), block2.hash()),
+        ],
+    }
+}
+
+#[test]
+fn vct_repair_episode_enforces_attempt_and_time_bounds() {
+    let mut repair = VctRootRepair::new(
+        block::Height(1),
+        1,
+        Network::Mainnet.genesis_hash(),
+        vec![
+            (
+                block::Height(1),
+                mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+            ),
+            (
+                block::Height(2),
+                mainnet_block(&BLOCK_MAINNET_2_BYTES).hash(),
+            ),
+        ],
+    )
+    .expect("valid repair shape");
+
+    for attempt in 0..VCT_ROOT_REPAIR_MAX_ATTEMPTS {
+        assert!(repair.can_attempt(repair.next_attempt_at));
+        let peer_id = peer(120 + u8::try_from(attempt).expect("attempt fits in u8"));
+        repair.mark_attempt(peer_id.clone());
+        repair.finish_attempt(&peer_id, repair.next_attempt_at);
+    }
+
+    assert!(repair.exhausted);
+    assert!(!repair.can_attempt(repair.next_attempt_at));
+
+    let mut timed = VctRootRepair::new(
+        block::Height(1),
+        2,
+        Network::Mainnet.genesis_hash(),
+        vec![(
+            block::Height(1),
+            mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+        )],
+    )
+    .expect("single-header handoff repair is valid");
+    timed.started_at = Instant::now() - VCT_ROOT_REPAIR_MAX_WALL_TIME;
+    assert!(!timed.can_attempt(Instant::now()));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_bypasses_covered_range_and_commits_exact_h_and_successor() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+    let peer_id = peer(101);
+
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(4),
+        2,
+        1,
+    )
+    .await;
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeCommitted {
+            start_height: block::Height(1),
+            tip_height: block::Height(4),
+            tip_hash: best.1,
+        })
+        .await
+        .unwrap();
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, peer_id);
+    assert_eq!(start_height, block::Height(1));
+    assert_eq!(count, 2);
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::WireMessage {
+            peer: peer_id.clone(),
+            msg: finalized_headers_message_from(
+                block::Height(1),
+                vec![
+                    mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                    mainnet_header(&BLOCK_MAINNET_2_BYTES),
+                ],
+            ),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        match next_action(&mut fixture.actions).await {
+            HeaderSyncAction::CommitHeaderRange {
+                peer,
+                start_height,
+                headers,
+                tree_aux_roots,
+                finalized,
+                ..
+            } => {
+                assert_eq!(peer, peer_id);
+                assert_eq!(start_height, block::Height(1));
+                assert_eq!(headers.len(), 2);
+                assert_eq!(tree_aux_roots.len(), 2);
+                assert!(
+                    !finalized,
+                    "repair ranges are canonical but not checkpoint-terminating"
+                );
+                break;
+            }
+            HeaderSyncAction::Misbehavior { peer, reason } => {
+                panic!("unexpected repair misbehavior from {peer:?}: {reason:?}");
+            }
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_rejects_noncanonical_response_before_commit() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+    let peer_id = peer(102);
+    let mut event = mainnet_repair_event(1);
+    if let HeaderSyncEvent::VctRootRepairRequested {
+        expected_hashes, ..
+    } = &mut event
+    {
+        expected_hashes[1].1 = block::Hash([99; 32]);
+    }
+
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(4),
+        2,
+        1,
+    )
+    .await;
+    fixture.handle.send(event).await.unwrap();
+    let (_requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((start_height, count), (block::Height(1), 2));
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::WireMessage {
+            peer: peer_id.clone(),
+            msg: finalized_headers_message_from(
+                block::Height(1),
+                vec![
+                    mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                    mainnet_header(&BLOCK_MAINNET_2_BYTES),
+                ],
+            ),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        match next_action(&mut fixture.actions).await {
+            HeaderSyncAction::Misbehavior { peer, reason } => {
+                assert_eq!(peer, peer_id);
+                assert_eq!(reason, HeaderSyncMisbehavior::InvalidRange);
+                break;
+            }
+            HeaderSyncAction::CommitHeaderRange { .. } => {
+                panic!("noncanonical repair response must not be committed")
+            }
+            _ => {}
         }
     }
 }

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1675,6 +1675,33 @@ async fn vct_repair_bypasses_covered_range_and_commits_exact_h_and_successor() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn vct_repair_scheduler_skips_peers_with_insufficient_response_capacity() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+    let low_capacity_peer = peer(101);
+    let capable_peer = peer(102);
+
+    for (peer_id, capacity) in [(low_capacity_peer, 1), (capable_peer.clone(), 2)] {
+        connect_peer(&fixture, peer_id.clone()).await;
+        advertise_tip(&fixture, peer_id, block::Height(0), best.0, capacity, 1).await;
+    }
+
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, capable_peer);
+    assert_eq!((start_height, count), (block::Height(1), 2));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn vct_repair_rejects_noncanonical_response_before_commit() {
     let best = (
         block::Height(4),

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1715,6 +1715,169 @@ async fn vct_repair_rejects_noncanonical_response_before_commit() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn stale_vct_repair_response_is_dropped_without_peer_misbehavior() {
+    let best = (
+        block::Height(4),
+        mainnet_block(&BLOCK_MAINNET_4_BYTES).hash(),
+    );
+    let mut fixture = spawn_test_reactor(startup_for(
+        Network::Mainnet,
+        (block::Height(0), Network::Mainnet.genesis_hash()),
+        Some(best),
+    ));
+    let stale_peer = peer(103);
+    let current_peer = peer(104);
+
+    for peer_id in [&stale_peer, &current_peer] {
+        connect_peer(&fixture, peer_id.clone()).await;
+        advertise_tip(
+            &fixture,
+            peer_id.clone(),
+            block::Height(0),
+            block::Height(4),
+            2,
+            1,
+        )
+        .await;
+    }
+
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, stale_peer);
+    assert_eq!((start_height, count), (block::Height(1), 2));
+
+    fixture.handle.send(mainnet_repair_event(2)).await.unwrap();
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, current_peer);
+    assert_eq!((start_height, count), (block::Height(1), 2));
+
+    for peer_id in [stale_peer, current_peer.clone()] {
+        fixture
+            .handle
+            .send(HeaderSyncEvent::WireMessage {
+                peer: peer_id,
+                msg: finalized_headers_message_from(
+                    block::Height(1),
+                    vec![
+                        mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                        mainnet_header(&BLOCK_MAINNET_2_BYTES),
+                    ],
+                ),
+            })
+            .await
+            .unwrap();
+    }
+
+    loop {
+        match next_action(&mut fixture.actions).await {
+            HeaderSyncAction::CommitHeaderRange { peer, .. } => {
+                assert_eq!(peer, current_peer);
+                break;
+            }
+            HeaderSyncAction::Misbehavior { peer, reason } => {
+                panic!("stale repair response reported {peer:?} for {reason:?}")
+            }
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_scheduler_requires_an_idle_peer() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let busy_peer = peer(105);
+    let idle_peer = peer(106);
+
+    connect_peer(&fixture, busy_peer.clone()).await;
+    connect_peer(&fixture, idle_peer.clone()).await;
+    advertise_tip(
+        &fixture,
+        busy_peer.clone(),
+        block::Height(0),
+        block::Height(10),
+        2,
+        2,
+    )
+    .await;
+    let (requested_peer, _, _) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, busy_peer);
+
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    advertise_tip(
+        &fixture,
+        idle_peer.clone(),
+        block::Height(0),
+        block::Height(10),
+        2,
+        2,
+    )
+    .await;
+
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, idle_peer);
+    assert_eq!((start_height, count), (block::Height(1), 2));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn vct_repair_scheduler_avoids_peers_with_late_covered_responses() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let late_peer = peer(107);
+    let idle_peer = peer(108);
+
+    connect_peer(&fixture, late_peer.clone()).await;
+    connect_peer(&fixture, idle_peer.clone()).await;
+    advertise_tip(
+        &fixture,
+        late_peer.clone(),
+        block::Height(0),
+        block::Height(10),
+        2,
+        2,
+    )
+    .await;
+    let (requested_peer, _, _) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, late_peer);
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeCommitted {
+            start_height: block::Height(1),
+            tip_height: block::Height(10),
+            tip_hash: block::Hash([10; 32]),
+        })
+        .await
+        .unwrap();
+    fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
+    advertise_tip(
+        &fixture,
+        idle_peer.clone(),
+        block::Height(0),
+        block::Height(10),
+        2,
+        2,
+    )
+    .await;
+
+    let (requested_peer, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, idle_peer);
+    assert_eq!((start_height, count), (block::Height(1), 2));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn handle_sends_events_and_peer_connect_sends_status_first() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `VctRootRepairStatus`, `VctRootRepairState`, and
+  `ReadStateService::subscribe_vct_root_repairs`: a watch channel the finalized
+  writer uses to request a bounded re-delivery of missing or evicted VCT
+  supplied roots through header sync. A queue reset withdraws any published
+  repair need.
+
 ### Fixed
 
 - VCT checkpoint writes now use the validated header store for the H+1 root witness,

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -87,7 +87,7 @@ pub use service::finalized_state::{
 };
 pub use service::{
     finalized_state::{DiskWriteBatch, FromDisk, IntoDisk, WriteDisk, ZakuraDb},
-    ReadStateService,
+    ReadStateService, VctRootRepairState, VctRootRepairStatus,
 };
 
 // Allow use in external tests

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -85,6 +85,7 @@ mod tests;
 
 pub use finalized_state::{OutputLocation, TransactionIndex, TransactionLocation};
 use write::NonFinalizedWriteMessage;
+pub use write::{VctRootRepairState, VctRootRepairStatus};
 
 use self::queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified, SentHashes};
 
@@ -242,6 +243,9 @@ pub struct ReadStateService {
     ///
     /// Used to check for panics when writing blocks.
     block_write_task: Option<Arc<std::thread::JoinHandle<()>>>,
+
+    /// Watch channel publishing the next VCT supplied-root repair needed by the finalized writer.
+    vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
 }
 
 impl Drop for StateService {
@@ -401,6 +405,7 @@ impl StateService {
             block_write_sender,
             invalid_block_write_reset_receiver,
             non_finalized_rejected_receiver,
+            vct_root_repair_receiver,
             block_write_task,
         ) = write::BlockWriteSender::spawn(
             finalized_state_for_writing,
@@ -415,6 +420,7 @@ impl StateService {
             &finalized_state,
             block_write_task,
             non_finalized_state_receiver,
+            vct_root_repair_receiver,
         );
 
         let full_verifier_utxo_lookahead = max_checkpoint_height
@@ -1051,12 +1057,14 @@ impl ReadStateService {
         finalized_state: &FinalizedState,
         block_write_task: Option<Arc<std::thread::JoinHandle<()>>>,
         non_finalized_state_receiver: WatchReceiver<NonFinalizedState>,
+        vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
     ) -> Self {
         let read_service = Self {
             network: finalized_state.network(),
             db: finalized_state.db.clone(),
             non_finalized_state_receiver,
             block_write_task,
+            vct_root_repair_receiver,
         };
 
         tracing::debug!("created new read-only state service");
@@ -1067,6 +1075,11 @@ impl ReadStateService {
     /// Return the tip of the current best chain.
     pub fn best_tip(&self) -> Option<(block::Height, block::Hash)> {
         read::best_tip(&self.latest_non_finalized_state(), &self.db)
+    }
+
+    /// Subscribe to VCT supplied-root repair needs discovered by the finalized writer.
+    pub fn subscribe_vct_root_repairs(&self) -> tokio::sync::watch::Receiver<VctRootRepairStatus> {
+        self.vct_root_repair_receiver.clone()
     }
 
     /// Gets a clone of the latest non-finalized state from the `non_finalized_state_receiver`
@@ -2247,12 +2260,15 @@ pub fn init_read_only(
     )?;
     let (non_finalized_state_sender, non_finalized_state_receiver) =
         tokio::sync::watch::channel(NonFinalizedState::new(network));
+    let (_vct_root_repair_sender, vct_root_repair_receiver) =
+        tokio::sync::watch::channel(VctRootRepairStatus::default());
 
     Ok((
         ReadStateService::new(
             &finalized_state,
             None,
             WatchReceiver::new(non_finalized_state_receiver),
+            vct_root_repair_receiver,
         ),
         finalized_state.db.clone(),
         non_finalized_state_sender,

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -54,7 +54,7 @@ fn vct_successor_witness_uses_stored_header_without_body() {
         #[cfg(feature = "elasticsearch")]
         false,
     )
-    .expect("opening an ephemeral database should succeed");
+    .expect("opening an ephemeral finalized state succeeds");
     let genesis = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
         .zcash_deserialize_into::<Arc<Block>>()
         .expect("genesis block deserializes");

--- a/zakura-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zakura-state/src/service/non_finalized_state/tests/vectors.rs
@@ -338,7 +338,7 @@ fn new_invalidate_test_state(network: &Network) -> (NonFinalizedState, Finalized
         #[cfg(feature = "elasticsearch")]
         false,
     )
-    .expect("opening an ephemeral database should succeed");
+    .expect("opening an ephemeral finalized state succeeds");
     finalized_state.set_finalized_value_pool(ValueBalance::<NonNegative>::fake_populated_pool());
     (state, finalized_state)
 }

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -43,6 +43,40 @@ mod vct_write;
 
 use vct_write::VctWriteManager;
 
+/// Status published by the finalized write loop when a VCT fast-sync height needs a
+/// replacement supplied root.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct VctRootRepairStatus {
+    /// The state of the current root repair need.
+    pub state: VctRootRepairState,
+    /// Monotonic generation for repair attempts. A new generation means the previous
+    /// replacement candidate was absent or rejected and the networking layer should try
+    /// another bounded repair candidate.
+    pub generation: u64,
+}
+
+impl Default for VctRootRepairStatus {
+    fn default() -> Self {
+        Self {
+            state: VctRootRepairState::Idle,
+            generation: 0,
+        }
+    }
+}
+
+/// Dependency-neutral VCT root repair state.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum VctRootRepairState {
+    /// No VCT root repair is currently required.
+    Idle,
+    /// The finalized writer cannot commit this height until a verifiable supplied root is
+    /// re-delivered through header sync.
+    Unavailable {
+        /// Height whose supplied roots are missing from the VCT source.
+        height: block::Height,
+    },
+}
+
 /// The maximum size of the parent error map.
 ///
 /// We allow enough space for multiple concurrent chain forks with errors.
@@ -181,6 +215,7 @@ struct WriteBlockWorkerTask {
     non_finalized_rejected_sender: UnboundedSender<block::Hash>,
     chain_tip_sender: ChainTipSender,
     non_finalized_state_sender: watch::Sender<NonFinalizedState>,
+    vct_root_repair_sender: watch::Sender<VctRootRepairStatus>,
     /// If `Some`, the non-finalized state is written to this backup directory
     /// synchronously before each channel update, instead of via the async backup task.
     backup_dir_path: Option<PathBuf>,
@@ -257,6 +292,7 @@ impl BlockWriteSender {
         Self,
         tokio::sync::mpsc::UnboundedReceiver<block::Hash>,
         tokio::sync::mpsc::UnboundedReceiver<block::Hash>,
+        watch::Receiver<VctRootRepairStatus>,
         Option<Arc<std::thread::JoinHandle<()>>>,
     ) {
         // Security: The number of blocks in these channels is limited by
@@ -269,6 +305,8 @@ impl BlockWriteSender {
             tokio::sync::mpsc::unbounded_channel();
         let (non_finalized_rejected_sender, non_finalized_rejected_receiver) =
             tokio::sync::mpsc::unbounded_channel();
+        let (vct_root_repair_sender, vct_root_repair_receiver) =
+            watch::channel(VctRootRepairStatus::default());
 
         let seed_zakura_header_from_best_chain_commits = finalized_state
             .db
@@ -288,6 +326,7 @@ impl BlockWriteSender {
                     non_finalized_rejected_sender,
                     chain_tip_sender,
                     non_finalized_state_sender,
+                    vct_root_repair_sender,
                     backup_dir_path,
                 }
                 .run()
@@ -302,6 +341,7 @@ impl BlockWriteSender {
             },
             invalid_block_write_reset_receiver,
             non_finalized_rejected_receiver,
+            vct_root_repair_receiver,
             Some(Arc::new(task)),
         )
     }
@@ -328,6 +368,7 @@ impl WriteBlockWorkerTask {
             non_finalized_rejected_sender,
             chain_tip_sender,
             non_finalized_state_sender,
+            vct_root_repair_sender,
             seed_zakura_header_from_best_chain_commits,
             backup_dir_path,
         } = &mut self;
@@ -337,7 +378,7 @@ impl WriteBlockWorkerTask {
 
         // Look-ahead buffering and root-stall tracking for the VCT fast-sync
         // checkpoint path. See [`VctWriteManager`].
-        let mut vct_write_manager = VctWriteManager::default();
+        let mut vct_write_manager = VctWriteManager::new(vct_root_repair_sender.clone());
 
         // Write all the finalized blocks sent by the state,
         // until the state closes the finalized block channel's sender.
@@ -437,7 +478,8 @@ impl WriteBlockWorkerTask {
 
             if needs_vct_successor && next_vct_block.is_none() {
                 let height = ordered_block.0.height;
-                let wait = vct_write_manager.on_retryable_error(height, false, ordered_block);
+                let wait =
+                    vct_write_manager.on_retryable_error(height, false, false, ordered_block);
                 std::thread::park_timeout(wait);
                 continue;
             }
@@ -489,6 +531,7 @@ impl WriteBlockWorkerTask {
                         let wait = vct_write_manager.on_retryable_error(
                             height,
                             root_unavailable.is_some(),
+                            next_block_took_vct_path,
                             ordered_block,
                         );
                         std::thread::park_timeout(wait);

--- a/zakura-state/src/service/write/vct_write.rs
+++ b/zakura-state/src/service/write/vct_write.rs
@@ -6,13 +6,14 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::{mpsc::UnboundedReceiver, watch};
 use tracing::info;
 use zakura_chain::block::Height;
 
 use crate::service::{
     finalized_state::{FinalizedState, NextVctBlock},
     queued_blocks::QueuedCheckpointVerified,
+    write::{VctRootRepairState, VctRootRepairStatus},
 };
 
 /// Delay between retryable VCT root-miss commit attempts. Nothing actively re-requests a
@@ -40,7 +41,6 @@ const VCT_ROOT_STALL_WARN_AFTER: Duration = Duration::from_secs(30);
 /// successor and to retry/escalate a stuck height, so their invariants
 /// (single log per stall, look-ahead cleared on reset) live next to the data
 /// they guard.
-#[derive(Default)]
 pub(super) struct VctWriteManager {
     /// One-block look-ahead: the current block's supplied roots are
     /// authenticated by the successor's header commitment.
@@ -53,9 +53,33 @@ pub(super) struct VctWriteManager {
     /// Whether the current stall has already been escalated to an
     /// error-level log and gauge.
     stall_logged: bool,
+    /// Broadcasts missing-root repair needs to node orchestration.
+    root_repair_sender: watch::Sender<VctRootRepairStatus>,
+    /// Last repair status published by this manager.
+    root_repair_status: VctRootRepairStatus,
+}
+
+impl Default for VctWriteManager {
+    fn default() -> Self {
+        let (root_repair_sender, _root_repair_receiver) =
+            watch::channel(VctRootRepairStatus::default());
+        Self::new(root_repair_sender)
+    }
 }
 
 impl VctWriteManager {
+    /// Creates a manager with a dependency-neutral VCT repair watch channel.
+    pub(super) fn new(root_repair_sender: watch::Sender<VctRootRepairStatus>) -> Self {
+        Self {
+            lookahead: VecDeque::new(),
+            retry: None,
+            stall: None,
+            stall_logged: false,
+            root_repair_sender,
+            root_repair_status: VctRootRepairStatus::default(),
+        }
+    }
+
     /// Takes the next locally-buffered block ready to commit (a parked retry,
     /// then the look-ahead), if any.
     pub(super) fn take_ready(&mut self) -> Option<QueuedCheckpointVerified> {
@@ -133,6 +157,7 @@ impl VctWriteManager {
             self.stall = None;
             self.stall_logged = false;
         }
+        self.publish_root_repair_idle();
     }
 
     /// Tracks and, past the warn threshold, escalates a retryable vct root
@@ -142,9 +167,13 @@ impl VctWriteManager {
         &mut self,
         height: Height,
         root_unavailable: bool,
+        had_root_candidate: bool,
         block: QueuedCheckpointVerified,
     ) -> Duration {
         metrics::counter!("state.vct.root.retry.count").increment(1);
+        if root_unavailable {
+            self.publish_root_repair_needed(height, had_root_candidate);
+        }
 
         // Escalate a stall that persists on the same height past the warn
         // threshold: a transient wait resolves in a few polls and stays
@@ -199,6 +228,33 @@ impl VctWriteManager {
         } else {
             VCT_AWAIT_SUCCESSOR_WAIT
         }
+    }
+
+    fn publish_root_repair_needed(&mut self, height: Height, had_root_candidate: bool) {
+        let same_height =
+            self.root_repair_status.state == VctRootRepairState::Unavailable { height };
+        if same_height && !had_root_candidate {
+            return;
+        }
+
+        self.root_repair_status = VctRootRepairStatus {
+            state: VctRootRepairState::Unavailable { height },
+            generation: self.root_repair_status.generation.saturating_add(1),
+        };
+        let _ = self.root_repair_sender.send(self.root_repair_status);
+        metrics::counter!("state.vct.root.repair.requested").increment(1);
+    }
+
+    fn publish_root_repair_idle(&mut self) {
+        if self.root_repair_status.state == VctRootRepairState::Idle {
+            return;
+        }
+
+        self.root_repair_status = VctRootRepairStatus {
+            state: VctRootRepairState::Idle,
+            generation: self.root_repair_status.generation,
+        };
+        let _ = self.root_repair_sender.send(self.root_repair_status);
     }
 }
 

--- a/zakura-state/src/service/write/vct_write.rs
+++ b/zakura-state/src/service/write/vct_write.rs
@@ -88,9 +88,16 @@ impl VctWriteManager {
 
     /// Clears the look-ahead and any cached successor prevalidation, for a
     /// queue reset (wrong-height block, or a hard commit failure).
+    ///
+    /// Also withdraws any published root-repair need: after a reset the queue
+    /// is redelivered from upstream, so the stall that requested the repair may
+    /// no longer exist and a still-active repair episode would go stale. A
+    /// stall that persists across the reset re-publishes with a new generation
+    /// on its next commit attempt.
     pub(super) fn reset(&mut self, finalized_state: &mut FinalizedState) {
         self.lookahead.clear();
         finalized_state.clear_vct_prevalidated_next();
+        self.publish_root_repair_idle();
     }
 
     /// Buffers the direct successor of `current` into the look-ahead, if available.

--- a/zakura-state/src/service/write/vct_write/tests.rs
+++ b/zakura-state/src/service/write/vct_write/tests.rs
@@ -5,7 +5,11 @@ use zakura_chain::{block::Height, serialization::ZcashDeserializeInto};
 
 use super::{VctWriteManager, VCT_AWAIT_SUCCESSOR_WAIT, VCT_ROOT_RETRY_WAIT};
 use crate::{
-    request::CheckpointVerifiedBlock, service::queued_blocks::QueuedCheckpointVerified,
+    request::CheckpointVerifiedBlock,
+    service::{
+        queued_blocks::QueuedCheckpointVerified,
+        write::{VctRootRepairState, VctRootRepairStatus},
+    },
     tests::FakeChainHelper,
 };
 
@@ -193,7 +197,7 @@ fn on_commit_success_clears_an_escalated_stall() {
 
     // Force the stall past the warn threshold so it gets escalated (logged).
     manager.stall = Some((height, Instant::now() - Duration::from_secs(31)));
-    manager.on_retryable_error(height, true, queued_block(1));
+    manager.on_retryable_error(height, true, false, queued_block(1));
     assert!(manager.stall_logged, "the stall should have been escalated");
 
     manager.on_commit_success();
@@ -207,10 +211,10 @@ fn on_retryable_error_keeps_the_same_stall_start_for_a_repeated_height() {
     let mut manager = VctWriteManager::default();
     let height = Height(5);
 
-    manager.on_retryable_error(height, true, queued_block(1));
+    manager.on_retryable_error(height, true, false, queued_block(1));
     let first_seen = manager.stall.expect("a stall is now tracked").1;
 
-    manager.on_retryable_error(height, true, queued_block(2));
+    manager.on_retryable_error(height, true, false, queued_block(2));
     let still_first_seen = manager.stall.expect("the stall is still tracked").1;
 
     assert_eq!(
@@ -223,10 +227,10 @@ fn on_retryable_error_keeps_the_same_stall_start_for_a_repeated_height() {
 fn on_retryable_error_resets_the_stall_for_a_different_height() {
     let mut manager = VctWriteManager::default();
 
-    manager.on_retryable_error(Height(1), true, queued_block(1));
+    manager.on_retryable_error(Height(1), true, false, queued_block(1));
     manager.stall_logged = true; // simulate an already-escalated stall
 
-    manager.on_retryable_error(Height(2), true, queued_block(2));
+    manager.on_retryable_error(Height(2), true, false, queued_block(2));
 
     assert_eq!(manager.stall.map(|(h, _)| h), Some(Height(2)));
     assert!(
@@ -241,12 +245,12 @@ fn on_retryable_error_escalates_past_the_warn_threshold() {
     let height = Height(7);
 
     // Below the threshold: not escalated yet.
-    manager.on_retryable_error(height, true, queued_block(1));
+    manager.on_retryable_error(height, true, false, queued_block(1));
     assert!(!manager.stall_logged);
 
     // Backdate the stall past the warn threshold and retry the same height.
     manager.stall = Some((height, Instant::now() - Duration::from_secs(31)));
-    manager.on_retryable_error(height, true, queued_block(2));
+    manager.on_retryable_error(height, true, false, queued_block(2));
     assert!(manager.stall_logged);
 }
 
@@ -256,7 +260,7 @@ fn on_retryable_error_parks_the_block_for_retry() {
     let block = queued_block(1);
     let hash = block.0.hash;
 
-    manager.on_retryable_error(Height(1), true, block);
+    manager.on_retryable_error(Height(1), true, false, block);
 
     let ready = manager
         .take_ready()
@@ -268,9 +272,65 @@ fn on_retryable_error_parks_the_block_for_retry() {
 fn on_retryable_error_wait_depends_on_root_availability() {
     let mut manager = VctWriteManager::default();
 
-    let missing_root_wait = manager.on_retryable_error(Height(1), true, queued_block(1));
+    let missing_root_wait = manager.on_retryable_error(Height(1), true, false, queued_block(1));
     assert_eq!(missing_root_wait, VCT_ROOT_RETRY_WAIT);
 
-    let successor_wait = manager.on_retryable_error(Height(2), false, queued_block(2));
+    let successor_wait = manager.on_retryable_error(Height(2), false, false, queued_block(2));
     assert_eq!(successor_wait, VCT_AWAIT_SUCCESSOR_WAIT);
+}
+
+#[test]
+fn root_repair_signal_deduplicates_repeated_missing_root_polls() {
+    let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let mut manager = VctWriteManager::new(tx);
+
+    manager.on_retryable_error(Height(42), true, false, queued_block(1));
+    let first = *rx.borrow_and_update();
+    assert_eq!(
+        first.state,
+        VctRootRepairState::Unavailable { height: Height(42) }
+    );
+    assert_eq!(first.generation, 1);
+
+    manager.on_retryable_error(Height(42), true, false, queued_block(2));
+    assert!(
+        !rx.has_changed().expect("watch channel remains open"),
+        "polling the same absent root must not flood repair notifications"
+    );
+}
+
+#[test]
+fn root_repair_signal_advances_generation_after_rejected_replacement() {
+    let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let mut manager = VctWriteManager::new(tx);
+
+    manager.on_retryable_error(Height(42), true, false, queued_block(1));
+    let first = *rx.borrow_and_update();
+    assert_eq!(first.generation, 1);
+
+    manager.on_retryable_error(Height(42), true, true, queued_block(2));
+    let second = *rx.borrow_and_update();
+    assert_eq!(second.generation, 2);
+    assert_eq!(second.state, first.state);
+}
+
+#[test]
+fn root_repair_signal_ignores_await_successor_and_clears_on_commit() {
+    let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let mut manager = VctWriteManager::new(tx);
+
+    manager.on_retryable_error(Height(42), false, false, queued_block(1));
+    assert!(
+        !rx.has_changed().expect("watch channel remains open"),
+        "await-successor stalls do not need root repair"
+    );
+
+    manager.on_retryable_error(Height(42), true, false, queued_block(2));
+    assert!(matches!(
+        rx.borrow_and_update().state,
+        VctRootRepairState::Unavailable { .. }
+    ));
+
+    manager.on_commit_success();
+    assert_eq!(rx.borrow_and_update().state, VctRootRepairState::Idle);
 }

--- a/zakura-state/src/service/write/vct_write/tests.rs
+++ b/zakura-state/src/service/write/vct_write/tests.rs
@@ -334,3 +334,45 @@ fn root_repair_signal_ignores_await_successor_and_clears_on_commit() {
     manager.on_commit_success();
     assert_eq!(rx.borrow_and_update().state, VctRootRepairState::Idle);
 }
+
+#[test]
+fn reset_withdraws_published_root_repair_need() {
+    let _init_guard = zakura_test::init();
+    let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let mut manager = VctWriteManager::new(tx);
+    let mut finalized_state = crate::service::finalized_state::FinalizedState::new(
+        &crate::Config::ephemeral(),
+        &zakura_chain::parameters::Network::Mainnet,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .expect("opening an ephemeral finalized state succeeds");
+
+    manager.on_retryable_error(Height(42), true, false, queued_block(1));
+    let published = *rx.borrow_and_update();
+    assert_eq!(
+        published.state,
+        VctRootRepairState::Unavailable { height: Height(42) }
+    );
+
+    manager.reset(&mut finalized_state);
+    let withdrawn = *rx.borrow_and_update();
+    assert_eq!(
+        withdrawn.state,
+        VctRootRepairState::Idle,
+        "a queue reset must withdraw the published repair need"
+    );
+    assert_eq!(
+        withdrawn.generation, published.generation,
+        "withdrawing a repair must not consume a new generation"
+    );
+
+    // A stall that persists across the reset re-publishes under a new generation.
+    manager.on_retryable_error(Height(42), true, false, queued_block(2));
+    let republished = *rx.borrow_and_update();
+    assert_eq!(
+        republished.state,
+        VctRootRepairState::Unavailable { height: Height(42) }
+    );
+    assert_eq!(republished.generation, published.generation + 1);
+}

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -97,9 +97,10 @@ use zakura_network::types::PeerServices;
 use zakura_rpc::{methods::RpcImpl, server::RpcServer, SubmitBlockChannel};
 
 use zakura::{
-    drive_block_sync_actions, drive_zakura_header_sync_actions, mirror_zakura_full_block_commits,
-    query_block_sync_frontiers, zakura_header_sync_driver_startup, BlocksyncThroughputProbe,
-    BlocksyncThroughputSummary, ZakuraHeaderSyncDriverHandles,
+    drive_block_sync_actions, drive_vct_root_repairs, drive_zakura_header_sync_actions,
+    mirror_zakura_full_block_commits, query_block_sync_frontiers,
+    zakura_header_sync_driver_startup, BlocksyncThroughputProbe, BlocksyncThroughputSummary,
+    ZakuraHeaderSyncDriverHandles,
 };
 
 use crate::{
@@ -491,6 +492,16 @@ impl StartCmd {
                     .in_current_span(),
                 );
                 endpoint.push_header_sync_task(driver_task).await;
+
+                let vct_repair_task = tokio::spawn(
+                    drive_vct_root_repairs(
+                        read_only_state_service.clone(),
+                        header_sync.clone(),
+                        shutdown.clone().cancelled_owned(),
+                    )
+                    .in_current_span(),
+                );
+                endpoint.push_header_sync_task(vct_repair_task).await;
 
                 if let (Some(block_sync), Some(block_actions)) = (
                     endpoint.block_sync(),

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -1,4 +1,7 @@
-use std::{future::Future, time::Instant};
+use std::{
+    future::Future,
+    time::{Duration, Instant},
+};
 
 use color_eyre::eyre::{eyre, Report};
 use tokio::{pin, select, sync::mpsc};
@@ -185,35 +188,66 @@ pub(crate) async fn drive_vct_root_repairs(
     header_sync: zakura_network::zakura::HeaderSyncHandle,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) {
-    let mut repairs = read_state.subscribe_vct_root_repairs();
+    let repairs = read_state.subscribe_vct_root_repairs();
+    drive_vct_root_repair_updates(repairs, shutdown, move |status| {
+        let read_state = read_state.clone();
+        let header_sync = header_sync.clone();
+        async move {
+            match status.state {
+                zakura_state::VctRootRepairState::Idle => header_sync
+                    .send(HeaderSyncEvent::VctRootRepairResolved {
+                        generation: status.generation,
+                    })
+                    .await
+                    .is_ok(),
+                zakura_state::VctRootRepairState::Unavailable { height } => {
+                    let Some(event) =
+                        vct_root_repair_event(read_state, height, status.generation).await
+                    else {
+                        return false;
+                    };
+                    header_sync.send(event).await.is_ok()
+                }
+            }
+        }
+    })
+    .await;
+}
+
+async fn drive_vct_root_repair_updates<Deliver, Delivery>(
+    mut repairs: tokio::sync::watch::Receiver<zakura_state::VctRootRepairStatus>,
+    shutdown: impl Future<Output = ()>,
+    mut deliver: Deliver,
+) where
+    Deliver: FnMut(zakura_state::VctRootRepairStatus) -> Delivery,
+    Delivery: Future<Output = bool>,
+{
+    const RETRY_DELAY: Duration = Duration::from_millis(500);
+
     pin!(shutdown);
+    let mut status = *repairs.borrow_and_update();
+    // A repair can already be pending when this driver subscribes. Idle is not
+    // sent initially because there cannot yet be a driver-owned repair to clear.
+    let mut delivery_pending = matches!(
+        status.state,
+        zakura_state::VctRootRepairState::Unavailable { .. }
+    );
 
     loop {
+        if delivery_pending {
+            delivery_pending = !deliver(status).await;
+        }
+
         select! {
             _ = &mut shutdown => return,
             changed = repairs.changed() => {
                 if changed.is_err() {
                     return;
                 }
+                status = *repairs.borrow_and_update();
+                delivery_pending = true;
             }
-        }
-
-        let status = *repairs.borrow_and_update();
-        match status.state {
-            zakura_state::VctRootRepairState::Idle => {
-                let _ = header_sync
-                    .send(HeaderSyncEvent::VctRootRepairResolved {
-                        generation: status.generation,
-                    })
-                    .await;
-            }
-            zakura_state::VctRootRepairState::Unavailable { height } => {
-                if let Some(event) =
-                    vct_root_repair_event(read_state.clone(), height, status.generation).await
-                {
-                    let _ = header_sync.send(event).await;
-                }
-            }
+            _ = tokio::time::sleep(RETRY_DELAY), if delivery_pending => {}
         }
     }
 }
@@ -270,6 +304,60 @@ async fn vct_root_repair_event(
         anchor_hash: *anchor_hash,
         expected_hashes,
     })
+}
+
+#[cfg(test)]
+mod vct_root_repair_driver_tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn retries_transient_delivery_failure_without_another_watch_change() {
+        let status = zakura_state::VctRootRepairStatus {
+            state: zakura_state::VctRootRepairState::Unavailable {
+                height: block::Height(42),
+            },
+            generation: 1,
+        };
+        let (_repairs_tx, repairs_rx) = tokio::sync::watch::channel(status);
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let delivery_attempts = attempts.clone();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+        let driver = tokio::spawn(drive_vct_root_repair_updates(
+            repairs_rx,
+            async move {
+                let _ = shutdown_rx.await;
+            },
+            move |delivered_status| {
+                assert_eq!(delivered_status, status);
+                let attempt = delivery_attempts.fetch_add(1, Ordering::SeqCst);
+                async move { attempt > 0 }
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_millis(500)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            2,
+            "a successful delivery must stop timer retries"
+        );
+
+        shutdown_tx.send(()).expect("driver is still running");
+        driver.await.expect("driver shuts down cleanly");
+    }
 }
 
 pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVerifier>(

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -180,6 +180,98 @@ pub(crate) struct ZakuraHeaderSyncDriverHandles {
     pub(crate) header_sync: zakura_network::zakura::HeaderSyncHandle,
 }
 
+pub(crate) async fn drive_vct_root_repairs(
+    read_state: zakura_state::ReadStateService,
+    header_sync: zakura_network::zakura::HeaderSyncHandle,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) {
+    let mut repairs = read_state.subscribe_vct_root_repairs();
+    pin!(shutdown);
+
+    loop {
+        select! {
+            _ = &mut shutdown => return,
+            changed = repairs.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+            }
+        }
+
+        let status = *repairs.borrow_and_update();
+        match status.state {
+            zakura_state::VctRootRepairState::Idle => {
+                let _ = header_sync
+                    .send(HeaderSyncEvent::VctRootRepairResolved {
+                        generation: status.generation,
+                    })
+                    .await;
+            }
+            zakura_state::VctRootRepairState::Unavailable { height } => {
+                if let Some(event) =
+                    vct_root_repair_event(read_state.clone(), height, status.generation).await
+                {
+                    let _ = header_sync.send(event).await;
+                }
+            }
+        }
+    }
+}
+
+async fn vct_root_repair_event(
+    read_state: zakura_state::ReadStateService,
+    height: block::Height,
+    generation: u64,
+) -> Option<HeaderSyncEvent> {
+    let anchor_height = height.0.checked_sub(1).map(block::Height)?;
+    let response = read_state
+        .oneshot(zakura_state::ReadRequest::HeadersByHeightRange {
+            start: anchor_height,
+            count: 3,
+        })
+        .await
+        .ok()?;
+    let zakura_state::ReadResponse::Headers(headers) = response else {
+        return None;
+    };
+    if headers.len() < 2 {
+        return None;
+    }
+
+    let (stored_anchor_height, anchor_hash, anchor_header) = &headers[0];
+    if *stored_anchor_height != anchor_height {
+        return None;
+    }
+    let mut expected_hashes: Vec<(block::Height, block::Hash)> = Vec::new();
+    for (expected_offset, (candidate_height, candidate_hash, candidate_header)) in
+        headers.iter().skip(1).take(2).enumerate()
+    {
+        let expected_height = height.0.checked_add(u32::try_from(expected_offset).ok()?)?;
+        if *candidate_height != block::Height(expected_height) {
+            return None;
+        }
+        let expected_parent = if expected_offset == 0 {
+            *anchor_hash
+        } else {
+            expected_hashes.last().map(|(_, hash)| *hash)?
+        };
+        if candidate_header.previous_block_hash != expected_parent {
+            return None;
+        }
+        expected_hashes.push((*candidate_height, *candidate_hash));
+    }
+    if expected_hashes.is_empty() || block::Hash::from(anchor_header.as_ref()) != *anchor_hash {
+        return None;
+    }
+
+    Some(HeaderSyncEvent::VctRootRepairRequested {
+        height,
+        generation,
+        anchor_hash: *anchor_hash,
+        expected_hashes,
+    })
+}
+
 pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVerifier>(
     mut actions: mpsc::Receiver<HeaderSyncAction>,
     handles: ZakuraHeaderSyncDriverHandles,

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -223,6 +223,10 @@ async fn drive_vct_root_repair_updates<Deliver, Delivery>(
     Delivery: Future<Output = bool>,
 {
     const RETRY_DELAY: Duration = Duration::from_millis(500);
+    /// One warning per this many consecutive failed deliveries (~30s at
+    /// [`RETRY_DELAY`]), so a permanently undeliverable repair status is
+    /// visible to operators instead of an invisible silent retry loop.
+    const RETRY_WARN_EVERY: u32 = 60;
 
     pin!(shutdown);
     let mut status = *repairs.borrow_and_update();
@@ -232,10 +236,24 @@ async fn drive_vct_root_repair_updates<Deliver, Delivery>(
         status.state,
         zakura_state::VctRootRepairState::Unavailable { .. }
     );
+    let mut consecutive_failures: u32 = 0;
 
     loop {
         if delivery_pending {
             delivery_pending = !deliver(status).await;
+            if delivery_pending {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if consecutive_failures.is_multiple_of(RETRY_WARN_EVERY) {
+                    tracing::warn!(
+                        ?status,
+                        consecutive_failures,
+                        "VCT root repair status could not be delivered to header sync \
+                         (state read or event send keeps failing); still retrying"
+                    );
+                }
+            } else {
+                consecutive_failures = 0;
+            }
         }
 
         select! {
@@ -246,6 +264,7 @@ async fn drive_vct_root_repair_updates<Deliver, Delivery>(
                 }
                 status = *repairs.borrow_and_update();
                 delivery_pending = true;
+                consecutive_failures = 0;
             }
             _ = tokio::time::sleep(RETRY_DELAY), if delivery_pending => {}
         }

--- a/zakurad/src/commands/start/zakura/mod.rs
+++ b/zakurad/src/commands/start/zakura/mod.rs
@@ -139,7 +139,7 @@ pub(crate) use header_sync_driver::{
     root_covered_query_best_header_tip, tree_aux_roots_for_served_header_range,
 };
 pub(crate) use header_sync_driver::{
-    drive_zakura_header_sync_actions, mirror_zakura_full_block_commits,
+    drive_vct_root_repairs, drive_zakura_header_sync_actions, mirror_zakura_full_block_commits,
     zakura_header_sync_driver_startup, ZakuraHeaderSyncDriverHandles,
 };
 pub(crate) use throughput_probe::{BlocksyncThroughputProbe, BlocksyncThroughputSummary};


### PR DESCRIPTION
## Motivation

A continuous sync node can fail closed indefinitely after a well-formed but invalid VCT supplied root is evicted. The finalized writer correctly refuses to recompute against the frozen frontier, but header sync previously treated the historical header range as covered and did not re-request replacement root data.

## Solution

- Add a dependency-neutral VCT root repair status from the finalized writer and bridge it in `zakurad` to header sync.
- Add a bounded VCT repair lane that bypasses covered-range suppression for the canonical `H/H+1` header/root tuple without advancing the normal header frontier.
- Bound repair DoS exposure to one global episode, serial peer attempts, two-header responses, six peers, four minutes, and existing frame limits.
- Keep state as the final verifier and preserve fail-closed behavior when repair exhausts.
- Ignore local Docker build output via `/out/`.

### Tests

- [x] `cargo fmt --all -- --check`
- [x] `CXX=clang++ CXXFLAGS="-include cstdint" cargo clippy -p zakura-state -p zakura-network -p zakura --all-targets -- -D warnings`
- [x] `CXX=clang++ CXXFLAGS="-include cstdint" cargo test -p zakura-state --lib root_repair -- --nocapture` (4 passed on `eae7dd618`, including the queue-reset repair-withdrawal test).
- [x] `CXX=clang++ CXXFLAGS="-include cstdint" cargo test -p zakura-network --lib vct_repair -- --nocapture` (14 passed on `eae7dd618`).
- [x] `CXX=clang++ CXXFLAGS="-include cstdint" cargo test -p zakura --lib vct_root_repair -- --nocapture` (1 passed on `eae7dd618`; repair-status delivery retry driver).
- [x] Built and deployed a linux/amd64 `zakurad` artifact to `temp-zakura-sync-test-1`; node restarted from genesis and was healthy/syncing.
- [x] `roman-dev-2` Docker regtest passed at `eae7dd618ebacb2f775a3c97196bc4d8916ca0f3`: `ZAKURA_REGTEST_E2E=1 ZAKURA_E2E_MODE=pr-gate cargo test -p zakura --test zakura_regtest_e2e -- --ignored --nocapture` (1 passed; finished in 172.37s).

### Specifications & References

Observed incident: `temp-zakura-sync-test-1` stalled at height 3,198,406 after one rejected supplied root and repeated unavailable-root retries.

### Follow-up Work

- No remaining regtest follow-up from this validation pass.
- Consider adding a fuller process-level hostile-peer VCT repair mode once the e2e harness can inject a single malformed root deterministically.

### AI Disclosure

- [x] AI tools were used: Cursor/OpenAI implemented the VCT repair path, tests, verification, deployment support, and PR draft under human direction.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
