### PR TITLE
chore(release): update installer for zcashd rc3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8798,7 +8798,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.0-rc0"
+version = "1.0.0-rc2"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -11,14 +11,14 @@ fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UNITY_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
 
-ZAKURA_RELEASE_TAG="v1.0.0-rc1"
+ZAKURA_RELEASE_TAG="v1.0.0-rc2"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
-# sha256 of ZAKURA_ARCHIVE from the release's SHA256SUMS.txt.
-ZAKURA_ARCHIVE_SHA256="10a9ce52c2a436b35f5869cacce8a1ff8d197069bb3b775cacf7a0eaed991d12"
+# Replaced with the archive checksum by release-binaries.yml before publishing.
+ZAKURA_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc1"
-ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc1"
+ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc2"
+ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc2"
 ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="valargroup/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 # Persistent Zakura iroh identity (NodeId secret). Kept outside the state cache so
@@ -31,10 +31,10 @@ ZAKURA_DOCKER_IDENTITY_DIR="/home/zebra/.zakura"
 
 MANIFEST_PATH="$REPO_ROOT/zakurad/zcashd-compat-manifest.json"
 TARGET_TRIPLE="x86_64-pc-linux-gnu"
-ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc2/zcashd-zebra-compat-v1.0.0-compat-rc2-linux-x86_64.tar.gz"
-ZCASHD_RUNTIME_ARCHIVE_SHA256="9636bfe642a7542f92a31132ecce1139a290df1a9e674e8373167831369a905d"
+ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc3/zcashd-zebra-compat-v1.0.0-compat-rc3-linux-x86_64.tar.gz"
+ZCASHD_RUNTIME_ARCHIVE_SHA256="b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2"
 ZCASHD_RUNTIME_ARCHIVE_MEMBER_BINARY_PATH="./bin/zcashd"
-ZCASHD_DEFAULT_DOCKER_IMAGE="valargroup/zcashd:v1.0.0-compat-rc2"
+ZCASHD_DEFAULT_DOCKER_IMAGE="valargroup/zcashd:v1.0.0-compat-rc3"
 
 INSTALL_PROFILE=""
 MODE=""

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zakura"
-version = "1.0.0-rc0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true

--- a/zakurad/tests/common/configs/v1.0.0-rc2.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc2.toml
@@ -1,0 +1,200 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakurad/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the native Zakura P2P v2 stack only.
+# - "dual": both stacks, with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[network.zakura.block_sync]
+bbr_cwnd_gain_percent = 300
+bbr_cwnd_unit = "bytes"
+bbr_delay_gradient_percent = 150
+bbr_delivery_rate_window = "10s"
+bbr_min_cwnd = 4
+bbr_min_cwnd_bytes = 2524288
+bbr_probe_bw_gain_percent = 125
+bbr_probe_rtt_duration = "200ms"
+bbr_probe_rtt_interval = "10s"
+bbr_reliability_weight_percent = 100
+bbr_rtprop_window = "10s"
+bbr_startup_growth_percent = 200
+floor_bypass_slots = 2
+floor_peer_avoid_cooldown = "8s"
+floor_rescue_timeout = "2s"
+initial_block_probe_requests = 1
+initial_inflight_requests = 64
+max_blocks_per_response = 1
+max_inflight_block_bytes = 6442450944
+max_inflight_requests = 32000
+max_reorder_lookahead_bytes = 6408896512
+max_requests_without_block_progress = 64
+max_response_bytes = 33554432
+max_submitted_block_applies = 401
+no_progress_peer_cooldown = "3m"
+request_timeout = "8s"
+size_deviation_tolerance = 200
+status_refresh_interval = "30s"
+
+[network.zakura.block_sync.peer_limits]
+inbound_queue_depth = 128
+max_inbound_peers = 256
+max_outbound_peers = 256
+max_pending_escalations = 32
+outbound_queue_depth = 128
+
+[network.zakura.header_sync]
+accept_new_blocks = true
+max_headers_per_response = 1000
+max_inflight_requests = 10
+status_refresh_interval = "30s"
+
+[network.zakura.header_sync.peer_limits]
+inbound_queue_depth = 128
+max_inbound_peers = 256
+max_outbound_peers = 256
+max_pending_escalations = 32
+outbound_queue_depth = 128
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"
+

--- a/zakurad/zcashd-compat-manifest.json
+++ b/zakurad/zcashd-compat-manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "release_tag": "v1.0.0-compat-rc2",
+  "release_tag": "v1.0.0-compat-rc3",
   "artifacts": [
     {
       "target_triple": "x86_64-pc-linux-gnu",
-      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc2/zcashd-zebra-compat-v1.0.0-compat-rc2-linux-x86_64.tar.gz",
-      "runtime_archive_sha256": "9636bfe642a7542f92a31132ecce1139a290df1a9e674e8373167831369a905d",
+      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc3/zcashd-zebra-compat-v1.0.0-compat-rc3-linux-x86_64.tar.gz",
+      "runtime_archive_sha256": "b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2",
       "runtime_archive_member_binary_path": "./bin/zcashd"
     }
   ]


### PR DESCRIPTION
## Motivation

Prepare the upcoming Zakura v1.0.0-rc2 release to consume the latest zcashd compatibility runtime and published Docker image.

## Solution

- Pin the installer and compatibility manifest to `v1.0.0-compat-rc3` and its published SHA-256 checksum.
- Point Docker split-container installs at `valargroup/zcashd:v1.0.0-compat-rc3`.
- Pre-bump Zakura installer release and Docker references to `v1.0.0-rc2`.
- Use a zero checksum sentinel in the source installer until `release-binaries.yml` substitutes the built RC2 archive checksum in the published installer.

### Tests

- `shellcheck scripts/install-zakura.sh`
- `bash -n scripts/install-zakura.sh`
- Manifest resolution for `x86_64-pc-linux-gnu`
- `git diff --check`
- IDE diagnostics: no errors
- Confirmed `valargroup/zcashd:v1.0.0-compat-rc3` is published with a linux/amd64 manifest

Classified as low risk because this only updates release metadata and installer pins. Broader workspace tests were skipped under the repository's risk-based verification policy.

### Specifications & References

- zcashd compatibility release: https://github.com/valargroup/zcashd/releases/tag/v1.0.0-compat-rc3
- Stacked on #103, which bumps the Zakura package version to v1.0.0-rc2.

### Follow-up Work

- Merge #103 before this PR.
- Publish the Zakura v1.0.0-rc2 tag; the release workflow will publish the Zakura and combined compatibility Docker images and inject the real archive checksum into the release installer.

### AI Disclosure

- [x] AI tools were used: Cursor updated release pins, verified the manifest and Docker image, ran focused checks, and prepared this PR.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The change is focused on RC2 release preparation.
- [x] Focused installer and manifest checks pass.
- [x] Documentation and changelogs do not require changes for release metadata updates.