### PR TITLE
chore(release): prepare crates.io package graph

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -57,7 +57,7 @@ filter = 'package(zakura) and test(~zakura_header_sync_driver_tests)'
 retries = 2
 
 # --- Full Tests profile ---
-# Broader coverage for `ironwood-main`, scheduled, manual, and merge-queue runs,
+# Broader coverage for `main`, scheduled, manual, and merge-queue runs,
 # while still keeping the known slow/flaky integration buckets in dedicated
 # profiles that can use retries, serial execution, trace artifacts, and
 # no-fail-fast without hiding fast unit failures.

--- a/.cursor/skills/deploy-nodes/SKILL.md
+++ b/.cursor/skills/deploy-nodes/SKILL.md
@@ -15,7 +15,7 @@ Dispatch the manual fleet deploy workflows in `zakura-core/zakura`:
 
 | Network | Workflow | GitHub Environment | Default `ref` |
 | --- | --- | --- | --- |
-| testnet | `zakura-testnet-deploy.yml` | `zakura-testnet` | `ironwood-main` |
+| testnet | `zakura-testnet-deploy.yml` | `zakura-testnet` | `main` |
 | mainnet | `zakura-mainnet-deploy.yml` | `zakura-mainnet` | `main` |
 
 Both workflows build a native `zakurad` binary on a self-hosted runner, then use
@@ -115,8 +115,8 @@ gh workflow run zakura-testnet-deploy.yml \
 Examples:
 
 ```bash
-gh workflow run zakura-testnet-deploy.yml --repo zakura-core/zakura -f ref=ironwood-main -f node=zakura-testnet-1
-gh workflow run zakura-testnet-deploy.yml --repo zakura-core/zakura -f ref=ironwood-main -f node=zakura-compat
+gh workflow run zakura-testnet-deploy.yml --repo zakura-core/zakura -f ref=main -f node=zakura-testnet-1
+gh workflow run zakura-testnet-deploy.yml --repo zakura-core/zakura -f ref=main -f node=zakura-compat
 ```
 
 ## Dispatch — Single Mainnet Node

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -15,8 +15,8 @@ They can be skipped for urgent releases.
 
 To check consensus correctness, we want to test that the state format is valid through the sync-confidence ranges. (Format upgrades are tested in CI on each PR.)
 
-- [ ] Make sure there has been [at least one successful sync-confidence run](https://github.com/zakura-core/zakura/actions/workflows/sync-confidence.yml?query=branch%3Aironwood-main) since the last state change, or
-- [ ] Start a manual workflow run of [`sync-confidence.yml`](https://github.com/zakura-core/zakura/actions/workflows/sync-confidence.yml) from `ironwood-main`.
+- [ ] Make sure there has been [at least one successful sync-confidence run](https://github.com/zakura-core/zakura/actions/workflows/sync-confidence.yml?query=branch%3Amain) since the last state change, or
+- [ ] Start a manual workflow run of [`sync-confidence.yml`](https://github.com/zakura-core/zakura/actions/workflows/sync-confidence.yml) from `main`.
 
 State format changes can be made in `zakura-state` or `zakura-chain`. The state format can be changed by data that is sent to the state, data created within the state using `zakura-chain`, or serialization formats in `zakura-state` or `zakura-chain`.
 
@@ -28,7 +28,7 @@ After the test has been started, or if it has finished already:
 
 For performance and security, we want to update the Zakura checkpoints in every release.
 
-- [ ] You can copy the latest checkpoints from CI by following [the zakura-checkpoints README](https://github.com/zakura-core/zakura/blob/ironwood-main/zakura-utils/README.md#zakura-checkpoints).
+- [ ] You can copy the latest checkpoints from CI by following [the zakura-checkpoints README](https://github.com/zakura-core/zakura/blob/main/zakura-utils/README.md#zakura-checkpoints).
 
 ## Missed Dependency Updates
 
@@ -38,16 +38,16 @@ This step can be skipped if there is a large pending dependency upgrade. (For ex
 
 Here's how we make sure we got everything:
 
-- [ ] Run `cargo update` on the latest `ironwood-main` branch, and keep the output
+- [ ] Run `cargo update` on the latest `main` branch, and keep the output
 - [ ] Until we bump the workspace MSRV to 1.88 or higher, `home` must be downgraded manually: `cargo update home@0.5.12 --precise 0.5.11`
-- [ ] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/zakura-core/zakura/blob/ironwood-main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
+- [ ] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/zakura-core/zakura/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
 - [ ] If needed, remove resolved duplicate dependencies from `deny.toml`
 - [ ] Open a separate PR with the changes
 - [ ] Add the output of `cargo update` to that PR as a comment
 
 # Prepare and Publish the Release
 
-Follow the steps in the [release checklist](https://github.com/zakura-core/zakura/blob/ironwood-main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md) to prepare the release:
+Follow the steps in the [release checklist](https://github.com/zakura-core/zakura/blob/main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md) to prepare the release:
 
 Release PR:
 

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -10,7 +10,7 @@ A hotfix release should only be created when a bug or critical issue is discover
 
 ## Create the Release PR
 
-- [ ] Create a branch to fix the issue based on the tag of the release being fixed (not the `ironwood-main` branch).
+- [ ] Create a branch to fix the issue based on the tag of the release being fixed (not the `main` branch).
       for example: `hotfix-v2.3.1` - this needs to be different to the tag name
 - [ ] Make the required changes
 - [ ] Create a hotfix release PR by adding `&template=hotfix-release-checklist.md` to the comparing url ([Example](https://github.com/zakura-core/zakura/compare/bump-v1.0.0?expand=1&template=hotfix-release-checklist.md)).
@@ -38,7 +38,7 @@ follow semver, depending on the thing being fixed.
 
 ## Create the GitHub Pre-Release (if Zakura hotfix)
 
-- [ ] Wait for the hotfix release PR to be reviewed, approved, and merged into `ironwood-main`.
+- [ ] Wait for the hotfix release PR to be reviewed and approved.
 - [ ] Create a new release
 - [ ] Set the tag name to the version tag,
       for example: `v2.3.1`
@@ -67,7 +67,7 @@ follow semver, depending on the thing being fixed.
 - [ ] Run `cargo clean` in the zakura repo
 - [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute --allow-branch {hotfix-release-branch}`
 - [ ] Check that the published version of Zakura can be installed from `crates.io`:
-      `cargo install --locked --force --version 2.minor.patch zakurad && ~/.cargo/bin/zakurad`
+      `cargo install --locked --force --version 2.minor.patch zakura && ~/.cargo/bin/zakurad`
       and put the output in a comment on the PR.
 
 ## Publish Docker Images (if Zakura hotfix)
@@ -75,10 +75,10 @@ follow semver, depending on the thing being fixed.
 - [ ] Wait for the [the Docker images to be published successfully](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Arelease).
 - [ ] Wait for the new tag in the [Docker Hub zakura space](https://hub.docker.com/r/valaroman/zakura/tags)
 
-## Merge hotfix into ironwood-main
+## Merge hotfix into main
 
-- [ ] Solve any conflicts between the hotfix branch and `ironwood-main`. Do not force-push
-      into the branch! We need to include the commit that was released into `ironwood-main`.
+- [ ] Solve any conflicts between the hotfix branch and `main`. Do not force-push
+      into the branch! We need to include the commit that was released into `main`.
 - [ ] Get the PR reviewed again if changes were made
 - [ ] Admin-merge the PR with a merge commit (if by the time you are following
       this we have switched to merge commits by default, then just remove

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -8,13 +8,13 @@ assignees: ""
 
 # Prepare for the Release
 
-- [ ] Make sure there has been [at least one successful sync-confidence run on `ironwood-main`](https://github.com/zakura-core/zakura/actions/workflows/sync-confidence.yml?query=branch%3Aironwood-main) since the last state change, or start a manual sync-confidence run.
+- [ ] Make sure there has been [at least one successful sync-confidence run on `main`](https://github.com/zakura-core/zakura/actions/workflows/sync-confidence.yml?query=branch%3Amain) since the last state change, or start a manual sync-confidence run.
 
 # Checkpoints
 
 For performance and security, we want to update the Zakura checkpoints in every release.
 
-- [ ] You can copy the latest checkpoints from CI by following [the zakura-checkpoints README](https://github.com/zakura-core/zakura/blob/ironwood-main/zakura-utils/README.md#zakura-checkpoints).
+- [ ] You can copy the latest checkpoints from CI by following [the zakura-checkpoints README](https://github.com/zakura-core/zakura/blob/main/zakura-utils/README.md#zakura-checkpoints).
 
 # Missed Dependency Updates
 
@@ -24,9 +24,9 @@ This step can be skipped if there is a large pending dependency upgrade. (For ex
 
 Here's how we make sure we got everything:
 
-- [ ] Run `cargo update` on the latest `ironwood-main` branch, and keep the output
+- [ ] Run `cargo update` on the latest `main` branch, and keep the output
 - [ ] Until we bump the workspace MSRV to 1.88 or higher, `home` must be downgraded manually: `cargo update home@0.5.12 --precise 0.5.11`
-- [ ] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/zakura-core/zakura/blob/ironwood-main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
+- [ ] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/zakura-core/zakura/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
 - [ ] If needed, remove resolved duplicate dependencies from `deny.toml`
 - [ ] Open a separate PR with the changes
 - [ ] Add the output of `cargo update` to that PR as a comment
@@ -37,7 +37,7 @@ These steps can be done a few days before the release, in the same PR:
 
 ## Change Log
 
-**Important**: Any merge into `ironwood-main` deletes any edits to the draft changelog.
+**Important**: Any merge into `main` deletes any edits to the draft changelog.
 Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.
 
 We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/zakura-core/zakura/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
@@ -160,7 +160,7 @@ cargo release replace --verbose --execute --allow-branch '*' -p zakura
 The end of support height is calculated from the current blockchain height:
 
 - [ ] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
-- [ ] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/zakura-core/zakura/blob/ironwood-main/zakurad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.
+- [ ] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/zakura-core/zakura/blob/main/zakurad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.
 
 <details>
 
@@ -187,7 +187,7 @@ The end of support height is calculated from the current blockchain height:
       (the tag must match the `zakura` package version — verify with
       `./scripts/check-release-version.sh v<version>`; a mismatched tag fails
       `release-binaries.yml` and publishes nothing)
-- [ ] Set the release to target the `ironwood-main` branch
+- [ ] Set the release to target the `main` branch
 - [ ] Set the release title to `Zakura` followed by the version tag,
       for example: `Zakura 1.0.0`
 - [ ] Replace the prepopulated draft changelog in the release description with the final changelog you created;
@@ -217,17 +217,17 @@ The end of support height is calculated from the current blockchain height:
       have been changed, but keep their overall order:
 
 ```
-for c in zakura-test tower-fallback zakura-chain tower-batch-control zakura-node-services zakura-script zakura-state zakura-consensus zakura-network zakura-rpc zakura-utils zakurad; do cargo release publish --verbose --execute -p $c; done
+for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakura-tower-batch-control zakura-node-services zakura-script zakura-state zakura-consensus zakura-network zakura-rpc zakura-utils zakura; do cargo release publish --verbose --execute -p $c; done
 ```
 
 - [ ] Check that Zakura can be installed from `crates.io`:
-      `cargo install --locked --force --version <version> zakurad && ~/.cargo/bin/zakurad`
+      `cargo install --locked --force --version <version> zakura && ~/.cargo/bin/zakurad`
       and put the output in a comment on the PR.
 
 ## Publish Docker Images
 
 - [ ] Confirm the pinned zcashd compat manifest is ready before publishing:
-  - [ ] Update [`zakurad/zcashd-compat-manifest.json`](https://github.com/zakura-core/zakura/blob/ironwood-main/zakurad/zcashd-compat-manifest.json) to the intended `zcashd` compat release (it is the single source of truth: zakurad embeds it at compile time and CI/Docker builds read it directly).
+  - [ ] Update [`zakurad/zcashd-compat-manifest.json`](https://github.com/zakura-core/zakura/blob/main/zakurad/zcashd-compat-manifest.json) to the intended `zcashd` compat release (it is the single source of truth: zakurad embeds it at compile time and CI/Docker builds read it directly).
   - [ ] Confirm the manifest contains only the `x86_64-pc-linux-gnu` artifact before publishing zcashd-compat Docker images.
   - [ ] Confirm the workflow logs show the expected `/usr/local/bin/zcashd --version` for the zcashd-compat linux/amd64 image variant.
 - [ ] Wait for the [the Docker images to be published successfully](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Arelease).

--- a/.github/scripts/upstream-sync-discover.py
+++ b/.github/scripts/upstream-sync-discover.py
@@ -593,7 +593,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--source-repo", default="ZcashFoundation/zebra")
     parser.add_argument("--source-ref", default="main")
     parser.add_argument("--target-repo", default=os.environ.get("GITHUB_REPOSITORY", "valargroup/zebra"))
-    parser.add_argument("--target-ref", default="ironwood-main")
+    parser.add_argument("--target-ref", default="main")
     parser.add_argument("--candidate-pr", default="")
     parser.add_argument("--limit", type=int, default=MAX_LIMIT)
     parser.add_argument("--output-dir", type=Path, default=Path(".github/upstream-sync/work"))

--- a/.github/scripts/upstream-sync-run.sh
+++ b/.github/scripts/upstream-sync-run.sh
@@ -275,7 +275,7 @@ case "$COMMAND" in
 
     BRANCH="$(jq -r '.branch_name' "$RESULT_JSON")"
     TITLE="$(jq -r '.pr_title' "$RESULT_JSON")"
-    TARGET_REF="${UPSTREAM_SYNC_TARGET_REF:-ironwood-main}"
+    TARGET_REF="${UPSTREAM_SYNC_TARGET_REF:-main}"
     case "$BRANCH" in
       upstream-sync/pr-[0-9]*) ;;
       *)

--- a/.github/upstream-sync/fixtures/current-compare.json
+++ b/.github/upstream-sync/fixtures/current-compare.json
@@ -3,7 +3,7 @@
   "source_ref": "main",
   "source_ref_sha": "upstream-main-fixture",
   "target_repo": "valargroup/zebra",
-  "target_ref": "ironwood-main",
+  "target_ref": "main",
   "target_ref_sha": "4d82758ce7297a38d8acd147558dd89629d553d0",
   "merge_base": "1e6519ea91e2d3035c20aadd4d9a40dcac2eed3a",
   "ahead_count": 80,

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -152,7 +152,7 @@ _The diagram above illustrates the parallel execution patterns in our CI/CD syst
 - **Release Binaries** (`release-binaries.yml`): Build and publish release artifacts
 - **Release Drafter** (`release-drafter.yml`): Automates release notes
 - **Integration Tests on GCP** (`zfnd-ci-integration-tests-gcp.yml`): Stateful tests, cached disks, lwd flows
-- **Sync Confidence** (`sync-confidence.yml`): Full-validation sync of fixed pre/post-NU6.2 mainnet ranges on ephemeral DigitalOcean droplets (nyc3) restoring cached state from Spaces. The automatic `push` and `schedule` triggers are currently disabled (manual dispatch only) until `ironwood-main` ships DB format 28.3.0 and matching snapshots. See `docs/sync-confidence-do-setup.md`.
+- **Sync Confidence** (`sync-confidence.yml`): Full-validation sync of fixed pre/post-NU6.2 mainnet ranges on ephemeral DigitalOcean droplets (nyc3) restoring cached state from Spaces. The automatic `push` and `schedule` triggers are currently disabled (manual dispatch only) until `main` ships DB format 28.3.0 and matching snapshots. See `docs/sync-confidence-do-setup.md`.
 - **Upstream PR Sync Pilot** (`upstream-sync.yml`): Manual one-PR upstream discovery, Codex adaptation, and draft PR creation for fork maintenance
 
 ### Supporting/Re-usable Workflows

--- a/.github/workflows/sync-confidence.yml
+++ b/.github/workflows/sync-confidence.yml
@@ -5,12 +5,12 @@ name: Sync confidence
 # ephemeral DigitalOcean droplets that restore pruned cached state from Spaces.
 #
 # Triggers (push + schedule are currently disabled — see the note on `on:` below):
-# - push to ironwood-main: (re)build the test image and publish the `ironwood-main` tag
+# - push to main: (re)build the test image and publish the `main` tag
 #   to GHCR. No sync test runs on merge, so merges stay cheap.
-# - schedule (every 12h): reuse the latest `ironwood-main` image (no rebuild) and run
+# - schedule (every 12h): reuse the latest `main` image (no rebuild) and run
 #   both windows.
 # - workflow_dispatch: by default build the image from the dispatched ref and run both
-#   windows (so you can test a branch); uncheck `build_image` to reuse the `ironwood-main`
+#   windows (so you can test a branch); uncheck `build_image` to reuse the `main`
 #   image instead.
 #
 # The consumer opens the pruned snapshots in pruned storage mode and runs the image's
@@ -20,15 +20,15 @@ name: Sync confidence
 
 on:
   # NOTE: the `push` (image build) and `schedule` (12h sync) triggers are intentionally
-  # disabled until ironwood-main ships DB format 28.3.0 and matching pruned snapshots.
-  # The sync-confidence snapshots are format 28.3.0, so an image built from ironwood-main
+  # disabled until main ships DB format 28.3.0 and matching pruned snapshots.
+  # The sync-confidence snapshots are format 28.3.0, so an image built from main
   # before then would FormatMismatch when opening them and red the timer. Re-enable by
   # restoring the `push` and `schedule` blocks (see docs/sync-confidence-do-setup.md).
   # `workflow_dispatch` stays available so the job can still be run manually.
   workflow_dispatch:
     inputs:
       build_image:
-        description: "Build the image from this ref (checked) or reuse the last ironwood-main image (unchecked)"
+        description: "Build the image from this ref (checked) or reuse the last main image (unchecked)"
         type: boolean
         default: true
 
@@ -41,8 +41,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build + push the GHCR test image. Runs on merge to ironwood-main (publishes the
-  # `ironwood-main` tag the scheduled runs reuse) and on a build_image=true dispatch
+  # Build + push the GHCR test image. Runs on merge to main (publishes the
+  # `main` tag the scheduled runs reuse) and on a build_image=true dispatch
   # (publishes a sha tag for that ref). Skipped on schedule and build_image=false dispatch.
   # NOTE: same image used for snapshot generation (make-sync-confidence-snapshots.sh) —
   # keep build-args and the Dockerfile target in sync.
@@ -71,7 +71,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}-tests
           # sha tag first => steps.meta.outputs.version (the job's image_ref). The branch
-          # tag (e.g. `ironwood-main`) is the stable tag scheduled runs reuse.
+          # tag (e.g. `main`) is the stable tag scheduled runs reuse.
           tags: |
             type=sha,prefix=sha-,format=short
             type=ref,event=branch
@@ -92,7 +92,7 @@ jobs:
   pre-nu62:
     needs: build
     # Run on schedule and dispatch (never on merge — merge only refreshes the image).
-    # Tolerate a skipped build: schedule / build_image=false reuse the ironwood-main image.
+    # Tolerate a skipped build: schedule / build_image=false reuse the main image.
     if: ${{ !cancelled() && github.event_name != 'push' && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
     permissions:
       contents: read
@@ -106,9 +106,9 @@ jobs:
       state_key: pre-nu62
       nextest_profile: sync-range-pre-nu62
       test_variables: "ZAKURA_NETWORK__NETWORK=Mainnet,TEST_SYNC_RANGE=1"
-      # Stable ironwood-main image on schedule / build_image=false; the freshly-built sha
+      # Stable main image on schedule / build_image=false; the freshly-built sha
       # image on a build_image dispatch.
-      image_ref: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.build_image)) && format('ghcr.io/{0}-tests:ironwood-main', github.repository) || needs.build.outputs.image_ref }}
+      image_ref: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.build_image)) && format('ghcr.io/{0}-tests:main', github.repository) || needs.build.outputs.image_ref }}
       droplet_size: g-8vcpu-32gb
 
   post-nu62:
@@ -126,7 +126,7 @@ jobs:
       state_key: post-nu62
       nextest_profile: sync-range-post-nu62
       test_variables: "ZAKURA_NETWORK__NETWORK=Mainnet,TEST_SYNC_RANGE=1"
-      image_ref: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.build_image)) && format('ghcr.io/{0}-tests:ironwood-main', github.repository) || needs.build.outputs.image_ref }}
+      image_ref: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.build_image)) && format('ghcr.io/{0}-tests:main', github.repository) || needs.build.outputs.image_ref }}
       droplet_size: g-8vcpu-32gb
 
   # Alert Slack #gh-alerts on any failure (the unattended 12h timer is the main case).

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -25,7 +25,7 @@ on:
       target_ref:
         description: "Fork branch to target"
         type: string
-        default: ironwood-main
+        default: main
       candidate_pr:
         description: "Optional upstream PR number override for debugging"
         type: string
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -87,7 +87,7 @@ jobs:
           SOURCE_REPO: ${{ inputs.source_repo || 'ZcashFoundation/zebra' }}
           SOURCE_REF: ${{ inputs.source_ref || 'main' }}
           TARGET_REPO: ${{ github.repository }}
-          TARGET_REF: ${{ inputs.target_ref || 'ironwood-main' }}
+          TARGET_REF: ${{ inputs.target_ref || 'main' }}
           CANDIDATE_PR: ${{ inputs.candidate_pr || '' }}
           LIMIT: ${{ inputs.limit || '25' }}
         run: |
@@ -126,7 +126,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -188,7 +188,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -215,7 +215,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -245,7 +245,7 @@ jobs:
         id: create-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UPSTREAM_SYNC_TARGET_REF: ${{ inputs.target_ref || 'ironwood-main' }}
+          UPSTREAM_SYNC_TARGET_REF: ${{ inputs.target_ref || 'main' }}
         run: .github/scripts/upstream-sync-run.sh create-human-review-pr
 
       - name: Verify PR state
@@ -272,7 +272,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          ref: ${{ inputs.target_ref || 'ironwood-main' }}
+          ref: ${{ inputs.target_ref || 'main' }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -322,7 +322,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.pr-meta.outputs.branch }}
-          base: ${{ inputs.target_ref || 'ironwood-main' }}
+          base: ${{ inputs.target_ref || 'main' }}
           title: ${{ steps.pr-meta.outputs.title }}
           body-path: .github/upstream-sync/work/pr-body.md
           commit-message: ${{ steps.pr-meta.outputs.title }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Prepared the Zakura crate graph for publication at `1.0.0-rc2`. Install the
+  `zakura` package with Cargo to obtain the `zakurad` executable; Zakura-owned
+  libraries now share the release version, including the renamed
+  `zakura-tower-batch-control` and `zakura-tower-fallback` packages.
 - Corrected Zakura's release identity and build provenance. `zakurad --version`
   now reports the `1.0.0-rc0` release with source-commit build metadata, and
   Docker images expose OCI version, revision, source, and title labels. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7551,40 +7551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-batch-control"
-version = "1.0.1"
-dependencies = [
- "color-eyre",
- "ed25519-zebra",
- "futures",
- "futures-core",
- "pin-project",
- "rand 0.8.6",
- "rayon",
- "tokio",
- "tokio-test",
- "tokio-util",
- "tower 0.4.13",
- "tower-fallback",
- "tower-test",
- "tracing",
- "tracing-futures",
- "zakura-test",
-]
-
-[[package]]
-name = "tower-fallback"
-version = "0.2.41"
-dependencies = [
- "futures-core",
- "pin-project",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "zakura-test",
-]
-
-[[package]]
 name = "tower-http"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8886,7 +8852,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "9.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -8956,7 +8922,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "8.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8989,8 +8955,6 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tower 0.4.13",
- "tower-batch-control",
- "tower-fallback",
  "tracing",
  "tracing-error",
  "tracing-futures",
@@ -9000,6 +8964,8 @@ dependencies = [
  "zakura-script",
  "zakura-state",
  "zakura-test",
+ "zakura-tower-batch-control",
+ "zakura-tower-fallback",
  "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
@@ -9009,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-jsonl-trace"
-version = "0.1.0"
+version = "1.0.0-rc2"
 dependencies = [
  "tempfile",
  "tokio",
@@ -9019,7 +8985,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "8.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9067,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "7.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -9081,7 +9047,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "9.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9151,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "8.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "hex",
  "lazy_static",
@@ -9169,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "8.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "bincode",
  "chrono",
@@ -9220,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-test"
-version = "3.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "color-eyre",
  "futures",
@@ -9246,8 +9212,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zakura-tower-batch-control"
+version = "1.0.0-rc2"
+dependencies = [
+ "color-eyre",
+ "ed25519-zebra",
+ "futures",
+ "futures-core",
+ "pin-project",
+ "rand 0.8.6",
+ "rayon",
+ "tokio",
+ "tokio-test",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-test",
+ "tracing",
+ "tracing-futures",
+ "zakura-test",
+ "zakura-tower-fallback",
+]
+
+[[package]]
+name = "zakura-tower-fallback"
+version = "1.0.0-rc2"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "zakura-test",
+]
+
+[[package]]
 name = "zakura-utils"
-version = "7.0.0"
+version = "1.0.0-rc2"
 dependencies = [
  "color-eyre",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,8 +187,8 @@ zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "cab
 
 [workspace.metadata.release]
 
-# We always do releases from the ironwood-main branch
-allow-branch = ["ironwood-main"]
+# We always do releases from the main branch
+allow-branch = ["main"]
 
 # Compilation settings
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ export CXXFLAGS="$CXXFLAGS -include cstdint"
 Once you have the dependencies in place, you can install Zakura with:
 
 ```sh
-cargo install --locked zakurad
+cargo install --locked zakura
 ```
 
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v4.5.3 zakurad
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0-rc2 zakura
 ```
 
 You can start Zakura by running
@@ -139,7 +139,7 @@ The Zakura maintainers provide the following resources:
     - [Zakura Health Endpoints](book/src/user/health.md) — liveness/readiness checks for Kubernetes and load balancers
 
 - The [documentation of the public
-  APIs](https://docs.rs/zakurad/latest/zakurad/#zakura-crates) for the latest
+  APIs](https://docs.rs/zakura/latest/zakurad/#zakura-crates) for the latest
   releases of the individual Zakura crates.
 
 - The [documentation of the internal APIs](https://zakura-core.github.io/zakura/internal)

--- a/book/src/api.md
+++ b/book/src/api.md
@@ -3,7 +3,7 @@
 The Zakura maintainers provide the following API documentation:
 
 - The [documentation of the public
-  APIs](https://docs.rs/zakurad/latest/zakurad/#zakura-crates) for the latest
+  APIs](https://docs.rs/zakura/latest/zakurad/#zakura-crates) for the latest
   releases of the individual Zakura crates.
 
 - You can also build internal documentation locally by running

--- a/book/src/dev.md
+++ b/book/src/dev.md
@@ -4,7 +4,7 @@ This section contains the contribution guide and design documentation. It does
 not contain:
 
 - The [documentation of the public
-  APIs](https://docs.rs/zakurad/latest/zakurad/#zakura-crates) for the latest
+  APIs](https://docs.rs/zakura/latest/zakurad/#zakura-crates) for the latest
   releases of the individual Zakura crates.
 
 - You can also build internal documentation locally by running

--- a/book/src/dev/crate-owners.md
+++ b/book/src/dev/crate-owners.md
@@ -113,18 +113,18 @@ To change owners of current Zakura crates:
 ```sh
 $ git clone https://github.com/zakura-core/zakura
 $ cd zakura
-$ for crate in tower-* zakura*; do pushd $crate; cargo owner --add oxarbitrage; cargo owner --remove dconnolly; popd; done
+$ for crate in zakura* tower-*; do pushd $crate; cargo owner --add oxarbitrage; cargo owner --remove dconnolly; popd; done
 ~/zakura/tower-batch-control ~/zakura
     Updating crates.io index
-       Owner user oxarbitrage already has a pending invitation to be an owner of crate tower-batch-control
+       Owner user oxarbitrage already has a pending invitation to be an owner of crate zakura-tower-batch-control
     Updating crates.io index
-       Owner removing ["dconnolly"] from crate tower-batch-control
+       Owner removing ["dconnolly"] from crate zakura-tower-batch-control
 ~/zakura
 ~/zakura/tower-fallback ~/zakura
     Updating crates.io index
-       Owner user oxarbitrage has been invited to be an owner of crate tower-fallback
+       Owner user oxarbitrage has been invited to be an owner of crate zakura-tower-fallback
     Updating crates.io index
-       Owner removing ["dconnolly"] from crate tower-fallback
+       Owner removing ["dconnolly"] from crate zakura-tower-fallback
 ~/zakura
 ...
 ```

--- a/book/src/dev/overview.md
+++ b/book/src/dev/overview.md
@@ -124,7 +124,7 @@ into several components:
   of blocks and transactions: all consensus
   rules that can be checked independently of the chain state, such as
   verification of signatures, proofs, and scripts. Internally, the library
-  uses [`tower-batch-control`](https://docs.rs/tower_batch_control) to
+  uses [`zakura-tower-batch-control`](https://docs.rs/zakura-tower-batch-control) to
   perform automatic, transparent batch processing of contemporaneous
   verification requests.
 
@@ -136,7 +136,7 @@ into several components:
   such as updating the nullifier set or checking that transaction inputs remain
   unspent.
 
-- [`zakurad`](https://docs.rs/zakurad) contains the full
+- [`zakura`](https://docs.rs/zakura) contains the full
   node, which connects these components together and implements logic to handle
   inbound requests from peers and the chain sync process.
 

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -75,7 +75,7 @@ Zakura's tagging relates directly to versions published on Docker. We will refer
 
 ### Feature Flags
 
-To keep the `ironwood-main` branch in a releasable state, experimental features must be gated behind a [Rust feature flag](https://doc.rust-lang.org/cargo/reference/features.html).
+To keep the `main` branch in a releasable state, experimental features must be gated behind a [Rust feature flag](https://doc.rust-lang.org/cargo/reference/features.html).
 Breaking changes should also be gated behind a feature flag, unless the team decides they are urgent.
 (For example, security fixes which also break backwards compatibility.)
 
@@ -120,7 +120,7 @@ To help ensure that you have sufficient time and a clear path to update, this is
 
 | Deprecation stages | Details                                                                                                                                                                                                                                                                                                                                                                                |
 | :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Announcement       | We announce deprecated RPCs and features in the [change log](https://github.com/zakura-core/zakura/blob/ironwood-main/CHANGELOG.md "Zakura change log"). When we announce a deprecation, we also announce a recommended update path.                                                                                                                                                          |
+| Announcement       | We announce deprecated RPCs and features in the [change log](https://github.com/zakura-core/zakura/blob/main/CHANGELOG.md "Zakura change log"). When we announce a deprecation, we also announce a recommended update path.                                                                                                                                                          |
 | Deprecation period | When a RPC or a feature is deprecated, it is still present until the next major release. A deprecation can be announced in any release, but the removal of a deprecated RPC or feature happens only in major release. Until a deprecated RPC or feature is removed, it is maintained according to the Tier 1 support policy, meaning that only critical and security issues are fixed. |
 | Rust APIs          | The Rust APIs of the Zakura crates are currently unstable and unsupported. Use the `zakurad` commands or JSON-RPCs to interact with Zakura.                                                                                                                                                                                                                                               |
 
@@ -128,6 +128,6 @@ To help ensure that you have sufficient time and a clear path to update, this is
 
 ## Release candidate & release process
 
-Our release checklist is available as a template, which defines each step our team needs to follow to create a new pre-release or release, and to also build and push the binaries to the official channels [Release Checklist Template](https://github.com/zakura-core/zakura/blob/ironwood-main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md).
+Our release checklist is available as a template, which defines each step our team needs to follow to create a new pre-release or release, and to also build and push the binaries to the official channels [Release Checklist Template](https://github.com/zakura-core/zakura/blob/main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md).
 
 Every release tag must match the `zakura` package version: release binaries are built without `.git`, so `zakurad --version` reports the package version, not the tag. The `release-binaries.yml` workflow checks this and refuses to build or publish assets for a mismatched tag. Before pushing a tag, verify the release commit with `./scripts/check-release-version.sh v<version>`.

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -72,7 +72,7 @@ docker build -f ./docker/Dockerfile --target runtime \
 ```
 
 All available Cargo features are listed at
-<https://docs.rs/zakurad/latest/zakurad/index.html#zakura-feature-flags>.
+<https://docs.rs/zakura/latest/zakurad/index.html#zakura-feature-flags>.
 
 ## Configuring Zakura
 

--- a/book/src/user/elasticsearch.md
+++ b/book/src/user/elasticsearch.md
@@ -49,7 +49,7 @@ You are now ready to start bumping data into elasticsearch with Zakura.
 Elasticsearch is an optional and experimental feature, we need to build and install with the `elasticsearch` rust feature enabled using the following command:
 
 ```sh
-cargo install --features elasticsearch --locked --git https://github.com/zakura-core/zakura zakurad
+cargo install --features elasticsearch --locked --git https://github.com/zakura-core/zakura zakura
 ```
 
 Zakura binary will be at `~/.cargo/bin/zakurad`.

--- a/book/src/user/health.md
+++ b/book/src/user/health.md
@@ -63,4 +63,4 @@ readinessProbe:
 - Readiness combines a moving‑average “near tip” signal with a hard block‑lag cap.
 - Adjust thresholds based on your SLA and desired routing behavior.
 
-[health_config]: https://docs.rs/zakurad/latest/zakurad/components/health/struct.Config.html
+[health_config]: https://docs.rs/zakura/latest/zakurad/components/health/struct.Config.html

--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -9,7 +9,7 @@ front end that you can visualize:
 1. Build zakura with `prometheus` feature:
 
    ```bash
-   cargo install --features prometheus --locked --git https://github.com/zakura-core/zakura zakurad
+   cargo install --features prometheus --locked --git https://github.com/zakura-core/zakura zakura
    ```
 
 2. Create a `zakurad.toml` file that we can edit:
@@ -60,4 +60,4 @@ front end that you can visualize:
 
 ![image info](grafana.png)
 
-[metrics_section]: https://docs.rs/zakurad/latest/zakurad/components/metrics/struct.Config.html
+[metrics_section]: https://docs.rs/zakura/latest/zakurad/components/metrics/struct.Config.html

--- a/book/src/user/run.md
+++ b/book/src/user/run.md
@@ -28,7 +28,7 @@ no config is present. The contents of the config file is a TOML encoding of the
 internal config structure. All config options are documented
 in the [ZakuradConfig documentation][config-options].
 
-[config-options]: https://docs.rs/zakurad/latest/zakurad/config/struct.ZakuradConfig.html
+[config-options]: https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
 [config-locations]: https://docs.rs/dirs/latest/dirs/fn.preference_dir.html
 
 ### Configuring Progress Bars
@@ -64,7 +64,7 @@ cargo install --features="<feature1> <feature2> ..." ...
 ```
 
 The full list of all features is in [the API
-documentation](https://docs.rs/zakurad/latest/zakurad/index.html#zakura-feature-flags).
+documentation](https://docs.rs/zakura/latest/zakurad/index.html#zakura-feature-flags).
 Some debugging and monitoring features are disabled in release builds to
 increase performance.
 

--- a/book/src/user/startup.md
+++ b/book/src/user/startup.md
@@ -28,7 +28,7 @@ Some important parts of the config are:
 - `state.cache_dir`: where the cached state is stored on disk
 - `rpc.listen_addr`: optional JSON-RPC listener port
 
-See [the full list of configuration options](https://docs.rs/zakurad/latest/zakurad/config/struct.ZakuradConfig.html).
+See [the full list of configuration options](https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html).
 
 ```text
 zakurad::commands::start: Starting zakurad

--- a/book/src/user/tracing.md
+++ b/book/src/user/tracing.md
@@ -55,10 +55,10 @@ values are read at runtime, so container images do not need CI-specific build
 arguments, and the `ZEBRA_*` environment namespace remains reserved for Zakura
 configuration.
 
-[tracing_section]: https://docs.rs/zakurad/latest/zakurad/components/tracing/struct.InnerConfig.html
-[filter]: https://docs.rs/zakurad/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.filter
-[flamegraph]: https://docs.rs/zakurad/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.flamegraph
+[tracing_section]: https://docs.rs/zakura/latest/zakurad/components/tracing/struct.InnerConfig.html
+[filter]: https://docs.rs/zakura/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.filter
+[flamegraph]: https://docs.rs/zakura/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.flamegraph
 [flamegraphs]: http://www.brendangregg.com/flamegraphs.html
 [systemd_journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
-[use_journald]: https://docs.rs/zakurad/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.use_journald
+[use_journald]: https://docs.rs/zakura/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.use_journald
 [sentry]: https://sentry.io/welcome/

--- a/book/src/user/troubleshooting.md
+++ b/book/src/user/troubleshooting.md
@@ -51,7 +51,7 @@ Make sure you're using a release build on your native architecture.
 ### Syncer Lookahead Limit
 
 If your connection is slow, try
-[downloading fewer blocks at a time](https://docs.rs/zakurad/latest/zakurad/components/sync/struct.Config.html#structfield.lookahead_limit):
+[downloading fewer blocks at a time](https://docs.rs/zakura/latest/zakurad/components/sync/struct.Config.html#structfield.lookahead_limit):
 
 ```toml
 [sync]

--- a/deny.toml
+++ b/deny.toml
@@ -24,7 +24,7 @@ ignore = [
     "RUSTSEC-2024-0384", # instant — transitive via iroh
     "RUSTSEC-2024-0436", # paste — transitive via iroh/netdev/stun-rs
     "RUSTSEC-2023-0089", # atomic-polyfill — transitive via iroh-metrics/postcard
-    "RUSTSEC-2025-0134", # rustls-pemfile (unmaintained) — transitive via zakura-rpc; also present on ironwood-main
+    "RUSTSEC-2025-0134", # rustls-pemfile (unmaintained) — transitive via zakura-rpc; also present on main
     # quick-xml (namespace-resolver unbounded alloc + O(n^2) duplicate-attribute scan on
     # untrusted XML) — both transitive via inferno, only under the optional `flamegraph`
     # dev/profiling feature (not in release binaries) and only over the node's own profiling

--- a/docker/default-zakura-config.toml
+++ b/docker/default-zakura-config.toml
@@ -9,7 +9,7 @@
 #
 # The config format, including a complete list of sections and fields, is
 # documented here:
-# https://docs.rs/zakurad/latest/zakurad/config/struct.ZakuradConfig.html
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
 
 [network]
 network = "Mainnet"

--- a/docs/sync-confidence-do-setup.md
+++ b/docs/sync-confidence-do-setup.md
@@ -31,19 +31,19 @@ state objects after a DB format-version bump by re-running the snapshots workflo
 ## Running
 
 > **Currently disabled.** The `push` and `schedule` triggers below are commented out in
-> `sync-confidence.yml` until `ironwood-main` ships DB format 28.3.0 and matching pruned
-> snapshots (the snapshots are 28.3.0, so an `ironwood-main` image built before then would
+> `sync-confidence.yml` until `main` ships DB format 28.3.0 and matching pruned
+> snapshots (the snapshots are 28.3.0, so a `main` image built before then would
 > `FormatMismatch` on open). Only manual dispatch is active. Re-enable by restoring the
 > `push` and `schedule` blocks in `sync-confidence.yml`.
 
 Once the snapshots exist and the package is public, **Sync confidence**:
 
-- **on merge to `ironwood-main`** rebuilds and publishes the `ironwood-main` test image
+- **on merge to `main`** rebuilds and publishes the `main` test image
   to GHCR — no sync test runs, so merges stay cheap;
-- **every 12 hours (schedule)** reuses that `ironwood-main` image (no rebuild) and syncs
+- **every 12 hours (schedule)** reuses that `main` image (no rebuild) and syncs
   both windows;
 - **on manual dispatch** builds the image from the dispatched ref and syncs both windows
-  by default; uncheck `build_image` to reuse the `ironwood-main` image instead.
+  by default; uncheck `build_image` to reuse the `main` image instead.
 
 Each window restores its pruned tarball and syncs its 5k-block range. A red means a
 sync/consensus regression or a broken DB-format migration — the consumer runs the image's

--- a/docs/upstream-sync/README.md
+++ b/docs/upstream-sync/README.md
@@ -1,7 +1,7 @@
 # Upstream Triage
 
 This directory tracks upstream Zebra pull requests that the Valar fork has
-evaluated for `ironwood-main`.
+evaluated for `main`.
 
 The automation is intentionally conservative:
 
@@ -22,7 +22,7 @@ unless they carry an important production bug fix for this fork.
 
 Skipped and already-present triage decisions are recorded on the
 `upstream-sync/state` branch in `.github/upstream-sync/triage-ledger.jsonl`.
-This avoids churn on `ironwood-main` just to remember skipped upstream PRs.
+This avoids churn on `main` just to remember skipped upstream PRs.
 `needs_human` decisions open a draft PR with an empty commit and no file
 changes, so reviewers have a visible place to decide whether to close it, add a
 manual fix, or keep investigating.

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -31,12 +31,6 @@ url = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audi
 [policy.equihash]
 audit-as-crates-io = true
 
-[policy.tower-batch-control]
-audit-as-crates-io = false
-
-[policy.tower-fallback]
-audit-as-crates-io = false
-
 [policy.zakura]
 audit-as-crates-io = false
 
@@ -62,6 +56,12 @@ audit-as-crates-io = false
 audit-as-crates-io = false
 
 [policy.zakura-test]
+audit-as-crates-io = false
+
+[policy.zakura-tower-batch-control]
+audit-as-crates-io = false
+
+[policy.zakura-tower-fallback]
 audit-as-crates-io = false
 
 [policy.zakura-utils]

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tower-batch-control"
-version = "1.0.1"
+name = "zakura-tower-batch-control"
+version = "1.0.0-rc2"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal
@@ -22,6 +22,9 @@ keywords = ["tower", "batch"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["algorithms", "asynchronous"]
 
+[lib]
+name = "tower_batch_control"
+
 [dependencies]
 futures = { workspace = true }
 futures-core = { workspace = true }
@@ -40,10 +43,10 @@ rand = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-test = { workspace = true }
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc2" }
 tower-test = { workspace = true }
 
-zakura-test = { path = "../zakura-test/", version = "3.0.0" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
 
 [lints]
 workspace = true

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tower-fallback"
-version = "0.2.41"
+name = "zakura-tower-fallback"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license.workspace = true
@@ -16,6 +16,9 @@ keywords = ["tower", "batch"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["algorithms", "asynchronous"]
 
+[lib]
+name = "tower_fallback"
+
 [dependencies]
 pin-project = { workspace = true }
 tower = { workspace = true }
@@ -25,7 +28,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "3.0.0" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
 
 [lints]
 workspace = true

--- a/zakura-chain/Cargo.toml
+++ b/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "9.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "Core Zcash data structures"
 license.workspace = true
@@ -133,7 +133,7 @@ proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
-zakura-test = { path = "../zakura-test/", version = "3.0.0", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2", optional = true }
 bounded-vec = { version = "0.9.0", features = ["serde"] }
 
 [dev-dependencies]
@@ -154,7 +154,7 @@ rand_chacha = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "3.0.0" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
 
 [[bench]]
 name = "block"

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "8.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true
@@ -65,13 +65,13 @@ libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
-tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc2" }
+tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0-rc2" }
 
-zakura-script = { path = "../zakura-script", version = "8.0.0" }
-zakura-state = { path = "../zakura-state", version = "8.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "7.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "9.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc2" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc2" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
 
 zcash_protocol.workspace = true
 
@@ -96,9 +96,9 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "8.0.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "9.0.0", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "3.0.0" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc2", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
 
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/zakura-jsonl-trace/Cargo.toml
+++ b/zakura-jsonl-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-jsonl-trace"
-version = "0.1.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "8.0.0"
+version = "1.0.0-rc2"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -93,8 +93,8 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "9.0.0", features = ["async-error"] }
-zakura-jsonl-trace = { path = "../zakura-jsonl-trace" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["async-error"] }
+zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc2" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -106,8 +106,8 @@ static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
 
 [lints]
 workspace = true

--- a/zakura-node-services/Cargo.toml
+++ b/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "7.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "The interfaces of some Zebra node services"
 license.workspace = true
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "9.0.0" }
+zakura-chain = { path = "../zakura-chain" , version = "1.0.0-rc2" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "9.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "9.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
-zakura-network = { path = "../zakura-network", version = "8.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "7.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2" }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc2" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "8.0.0" }
-zakura-state = { path = "../zakura-state", version = "8.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc2" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc2" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -140,20 +140,20 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "9.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "8.0.0", features = [
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc2", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "8.0.0", features = [
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc2", features = [
     "proptest-impl",
 ] }
 
-zakura-test = { path = "../zakura-test", version = "3.0.0" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc2" }
 
 [lints]
 workspace = true

--- a/zakura-script/Cargo.toml
+++ b/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "8.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "9.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }
@@ -37,7 +37,7 @@ lazy_static = { workspace = true }
 ripemd = { workspace = true }
 secp256k1 = { workspace = true }
 sha2 = { workspace = true }
-zakura-test = { path = "../zakura-test", version = "3.0.0" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc2" }
 
 [lints]
 workspace = true

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "8.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "State contextual verification and storage code for Zebra"
 license.workspace = true
@@ -82,14 +82,14 @@ sapling-crypto = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "7.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "9.0.0", features = ["async-error"] }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
 
 # test feature proptest-impl
-zakura-test = { path = "../zakura-test/", version = "3.0.0", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2", optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 derive-getters.workspace = true
@@ -114,8 +114,8 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "9.0.0", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "3.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
 
 [lints]
 workspace = true

--- a/zakura-test/Cargo.toml
+++ b/zakura-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-test"
-version = "3.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "Test harnesses and test vectors for Zebra"
 license.workspace = true

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "7.0.0"
+version = "1.0.0-rc2"
 authors.workspace = true
 description = "Developer tools for Zebra maintenance and testing"
 license.workspace = true
@@ -60,11 +60,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "7.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "9.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
 
 # These crates are needed for the block-template-to-proposal binary
-zakura-rpc = { path = "../zakura-rpc", version = "9.0.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc2" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -152,20 +152,20 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "9.0.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
-zakura-network = { path = "../zakura-network", version = "8.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "7.0.0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "9.0.0" }
-zakura-state = { path = "../zakura-state", version = "8.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2" }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc2" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc2" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc2" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "8.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc2" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "7.0.0", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc2", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -305,12 +305,12 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "9.0.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "8.0.0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "8.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc2", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc2", features = ["proptest-impl"] }
 
-zakura-test = { path = "../zakura-test", version = "3.0.0" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc2" }
 
 # Used by the checkpoint generation tests via the zakura-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -321,7 +321,7 @@ zakura-test = { path = "../zakura-test", version = "3.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "7.0.0" }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc2" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zakurad/src/commands/generate.rs
+++ b/zakurad/src/commands/generate.rs
@@ -37,7 +37,7 @@ impl Runnable for GenerateCmd {
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://docs.rs/zakurad/latest/zakurad/config/struct.ZakuradConfig.html
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
 #
 # CONFIGURATION SOURCES (in order of precedence, highest to lowest):
 #

--- a/zakurad/src/lib.rs
+++ b/zakurad/src/lib.rs
@@ -110,8 +110,8 @@
 //! [The Zakura monorepo](https://github.com/zakura-core/zakura) is a collection of the following
 //! crates:
 //!
-//! - [tower-batch-control](https://docs.rs/tower-batch-control/latest/tower_batch_control/)
-//! - [tower-fallback](https://docs.rs/tower-fallback/latest/tower_fallback/)
+//! - [zakura-tower-batch-control](https://docs.rs/zakura-tower-batch-control/latest/tower_batch_control/)
+//! - [zakura-tower-fallback](https://docs.rs/zakura-tower-fallback/latest/tower_fallback/)
 //! - [zakura-chain](https://docs.rs/zakura-chain/latest/zakura_chain/)
 //! - [zakura-consensus](https://docs.rs/zakura-consensus/latest/zakura_consensus/)
 //! - [zakura-network](https://docs.rs/zakura-network/latest/zakura_network/)
@@ -121,7 +121,7 @@
 //! - [zakura-state](https://docs.rs/zakura-state/latest/zakura_state/)
 //! - [zakura-test](https://docs.rs/zakura-test/latest/zakura_test/)
 //! - [zakura-utils](https://docs.rs/zakura-utils/latest/zakura_utils/)
-//! - [zakurad](https://docs.rs/zakurad/latest/zakurad/)
+//! - [zakura](https://docs.rs/zakura/latest/zakurad/)
 //!
 //! The links in the list above point to the documentation of the public APIs of the crates. For
 //! the documentation of the internal APIs, follow <https://zakura-core.github.io/zakura/internal> that lists
@@ -133,7 +133,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/zakura-core/zakura/main/book/theme/favicon.png"
 )]
-#![doc(html_root_url = "https://docs.rs/zakurad")]
+#![doc(html_root_url = "https://docs.rs/zakura")]
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -1432,7 +1432,7 @@ fn sync_confidence_range(stop_height: block::Height) -> Result<()> {
 /// Full-validation sync of ~5k mainnet blocks ending just below NU6.2, from a
 /// cached state at the top mainnet checkpoint.
 ///
-/// Skipped unless `TEST_SYNC_RANGE` is set. Runs in CI on merge to `ironwood-main`
+/// Skipped unless `TEST_SYNC_RANGE` is set. Runs in CI on merge to `main`
 /// via the `sync-range-pre-nu62` nextest profile.
 #[allow(dead_code)]
 #[test]
@@ -1450,7 +1450,7 @@ fn sync_range_pre_nu62() -> Result<()> {
 /// Full-validation sync of ~5k mainnet blocks above NU6.2, from a cached state at
 /// height 3,375,000.
 ///
-/// Skipped unless `TEST_SYNC_RANGE` is set. Runs in CI on merge to `ironwood-main`
+/// Skipped unless `TEST_SYNC_RANGE` is set. Runs in CI on merge to `main`
 /// via the `sync-range-post-nu62` nextest profile.
 #[allow(dead_code)]
 #[test]

--- a/zakurad/tests/common/configs/v1.0.0-rc2.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc2.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://docs.rs/zakurad/latest/zakurad/config/struct.ZakuradConfig.html
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
 #
 # CONFIGURATION SOURCES (in order of precedence, highest to lowest):
 #


### PR DESCRIPTION
## Motivation

Prepare the RC2 workspace for incremental crates.io publication while keeping the temporary `equihash` and `zcash_encoding` git patches in place for separate follow-up work.

## Solution

- unify all publishable Zakura crates at `1.0.0-rc2`
- publish the locally modified Tower crates under the reserved `zakura-tower-*` names
- add registry versions to workspace path dependencies and correct dependency-order publishing instructions
- use `zakura` as the Cargo package while preserving `zakurad` as the installed binary
- update docs.rs links, release tooling, upstream-sync defaults, and release documentation to use `main`
- preserve the two temporary librustzcash git patches and their lockfile sources

## Test evidence

- `cargo package --workspace --allow-dirty --no-verify`
- `cargo publish --dry-run --locked --allow-dirty -p zakura-test`
- `cargo publish --dry-run --locked --allow-dirty -p zakura-jsonl-trace`
- `cargo check -p zakura-consensus --locked`
- `cargo nextest run --profile zakura-config --locked --features default-release-binaries --no-fail-fast`
- `cargo vet check`
- `cargo fmt --all -- --check`
- Markdown lint on all changed Markdown files
- `actionlint` on changed workflows
- `./scripts/check-release-version.sh v1.0.0-rc2`
- IDE diagnostics: no errors
- `git diff --check`

Downstream `cargo publish --dry-run` commands correctly stop until `zakura-test 1.0.0-rc2` is actually published and indexed. The release-only no-git-dependencies check remains intentionally blocked by the two explicitly retained git patches.

## Specifications & references

- Base release work: #103
- Issue: N/A — requested as part of RC2 release preparation

## AI disclosure

- [x] Cursor was used to audit the package graph, apply the manifest and documentation updates, and run the listed checks.