### PR TITLE
chore(release): update installer archive checksum

### DIFF
--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -15,7 +15,7 @@ ZAKURA_RELEASE_TAG="v1.0.0-rc2"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
 # Replaced with the archive checksum by release-binaries.yml before publishing.
-ZAKURA_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
+ZAKURA_ARCHIVE_SHA256="2638fc24eafd11d151a8f0558f79b6358ba0d304bafd7fbfe503ed299759c522"
 ZAKURA_MEMBER="./bin/zakurad"
 ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc2"
 ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc2"


### PR DESCRIPTION
## Motivation

The v1.0.0-rc2 release workflow has completed, so the source installer must use the checksum of the published Linux x86_64 archive instead of the release placeholder.

## Solution

Replace `ZAKURA_ARCHIVE_SHA256` with the SHA-256 published for `zakurad-v1.0.0-rc2-linux-x86_64.tar.gz`.

### Tests

- Verified `2638fc24eafd11d151a8f0558f79b6358ba0d304bafd7fbfe503ed299759c522` against both the GitHub release asset digest and `SHA256SUMS.txt`.
- IDE diagnostics report no errors in `scripts/install-zakura.sh`.
- No local test suite run: low-risk, one-line release metadata update with no logic changes.

### Specifications & References

- Release workflow: https://github.com/zakura-core/zakura/actions/runs/29175013218
- Release: https://github.com/zakura-core/zakura/releases/tag/v1.0.0-rc2

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used: Cursor updated the checksum, verified release metadata, and prepared this PR.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] This is a focused release maintenance change requested after the release workflow.
- [x] The published checksum was independently cross-checked.
- [x] No documentation or changelog update is needed for this metadata-only correction.