### PR TITLE
feat(sync): add tree-aux root diagnostics

### DIFF
--- a/.cursor/skills/deploy-nodes/SKILL.md
+++ b/.cursor/skills/deploy-nodes/SKILL.md
@@ -164,8 +164,8 @@ On failure, the workflow uploads deploy logs as a GitHub Actions artifact.
 
 ## Hard Guards
 
-- Do not dispatch mainnet without explicit user confirmation of the `ref`.
-- Do not change cache paths or resync mainnet archive nodes. The workflow pins
+- Do not dispatch mainnet without explicit user confirmation of the `ref`, unless explicitly allowed to be overriden and confirmed by user.
+- Do not change cache paths or resync mainnet archive nodesm, unless explicitly allowed and confirmed by yser. The workflow pins
   existing cache and identity paths so nodes keep their state DB and iroh node id.
 - `node` must match a deployer config name exactly (case-sensitive).
 - Only one deploy per network runs at a time (`cancel-in-progress: false`).

--- a/zakura-jsonl-trace/src/lib.rs
+++ b/zakura-jsonl-trace/src/lib.rs
@@ -47,9 +47,10 @@ pub const NODE_ID_ENV: &str = "ZEBRA_NODE_ID";
 
 /// Returns the process-wide node identifier used to tag JSONL trace records.
 ///
-/// Resolution order: `ZEBRA_NODE_ID`, then `HOSTNAME`, then `"unknown"`. The
-/// value is resolved once on first call and cached for the lifetime of the
-/// process so every trace record from this node reports the same id.
+/// Resolution order: `ZEBRA_NODE_ID`, `HOSTNAME`, `/etc/hostname`, then
+/// `"unknown"`. The value is resolved once on first call and cached for the
+/// lifetime of the process so every trace record from this node reports the
+/// same id.
 pub fn node_id() -> &'static str {
     static NODE_ID: OnceLock<String> = OnceLock::new();
     NODE_ID
@@ -57,6 +58,8 @@ pub fn node_id() -> &'static str {
             std::env::var(NODE_ID_ENV)
                 .ok()
                 .or_else(|| std::env::var("HOSTNAME").ok())
+                .or_else(|| std::fs::read_to_string("/etc/hostname").ok())
+                .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "unknown".to_string())
         })

--- a/zakura-network/src/zakura/header_sync/error.rs
+++ b/zakura-network/src/zakura/header_sync/error.rs
@@ -55,12 +55,22 @@ pub enum HeaderSyncWireError {
     },
 
     /// An inbound `Headers` response carried a root for the wrong height.
-    #[error("Zakura header-sync Headers tree-aux root height {root_height:?} does not match expected height {expected_height:?}")]
+    #[error(
+        "Zakura header-sync Headers tree-aux root height {root_height:?} does not match \
+         expected height {expected_height:?} at offset {offset} \
+         (first={first_root_height:?}, last={last_root_height:?})"
+    )]
     TreeAuxRootHeightMismatch {
+        /// Zero-based root offset within the response.
+        offset: usize,
         /// Expected root height.
         expected_height: block::Height,
         /// Actual root height.
         root_height: block::Height,
+        /// First encoded root height.
+        first_root_height: block::Height,
+        /// Last encoded root height.
+        last_root_height: block::Height,
     },
 
     /// A boolean marker field used a value other than 0 or 1.

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -639,6 +639,7 @@ impl HeaderSyncReactor {
         if self.state.parked_peers.contains(&peer) {
             return;
         }
+        record_wire_validation_metrics(&error);
         self.trace_peer_violation(&peer, HeaderSyncMisbehavior::MalformedMessage);
         tracing::debug!(?peer, ?error, "malformed Zakura header-sync frame");
         self.report_misbehavior(peer, HeaderSyncMisbehavior::MalformedMessage)
@@ -654,6 +655,7 @@ impl HeaderSyncReactor {
         if self.state.parked_peers.contains(&peer) {
             return;
         }
+        record_wire_validation_metrics(&error);
         self.trace_peer_violation(&peer, reason);
         tracing::debug!(?peer, ?error, ?reason, "invalid Zakura header-sync message");
         self.report_misbehavior(peer, reason).await;
@@ -836,7 +838,7 @@ impl HeaderSyncReactor {
             requested_count,
             returned_count,
             false,
-            0,
+            TreeAuxTraceSummary::default(),
         );
         if let Some(peer_state) = self.state.peers.get_mut(&peer) {
             peer_state.finish_serving_headers();
@@ -871,7 +873,7 @@ impl HeaderSyncReactor {
             tree_aux_roots.clear();
         };
         let returned_count = u32::try_from(headers.len()).unwrap_or(u32::MAX);
-        let served_tree_aux_roots_len = u32::try_from(tree_aux_roots.len()).unwrap_or(u32::MAX);
+        let served_tree_aux_roots = TreeAuxTraceSummary::new(&tree_aux_roots);
         let send_result = peer_state.session.try_send_headers_with_sizes_and_roots(
             headers,
             body_sizes,
@@ -888,7 +890,7 @@ impl HeaderSyncReactor {
                 requested_count,
                 returned_count,
                 want_tree_aux_roots,
-                served_tree_aux_roots_len,
+                served_tree_aux_roots,
             ),
             Err(error) => {
                 tracing::debug!(
@@ -1217,7 +1219,7 @@ impl HeaderSyncReactor {
                 peer_max_headers_per_response,
                 in_flight_count,
                 outstanding.range.want_tree_aux_roots,
-                u32::try_from(tree_aux_roots.len()).unwrap_or(u32::MAX),
+                &tree_aux_roots,
             );
             if let Some(peer_state) = self.state.peers.get_mut(&peer) {
                 peer_state.outstanding.push(OutstandingRange {
@@ -1239,7 +1241,7 @@ impl HeaderSyncReactor {
             peer_max_headers_per_response,
             in_flight_count,
             outstanding.range.want_tree_aux_roots,
-            u32::try_from(tree_aux_roots.len()).unwrap_or(u32::MAX),
+            &tree_aux_roots,
         );
         if header_count > outstanding.expected_max_count || header_count > outstanding.range.count {
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::ResponseTooLong)
@@ -1319,8 +1321,24 @@ impl HeaderSyncReactor {
             self.schedule().await;
             return;
         }
-        if validate_tree_aux_root_heights(outstanding.range.start_height, &tree_aux_roots).is_err()
+        if let Err(error) =
+            validate_tree_aux_root_heights(outstanding.range.start_height, &tree_aux_roots)
         {
+            tracing::debug!(
+                ?peer,
+                ?error,
+                start_height = ?outstanding.range.start_height,
+                count = ?header_count,
+                "Zakura header-sync rejected tree-aux root heights"
+            );
+            self.trace_range_validation_rejected(
+                &peer,
+                outstanding.range,
+                header_count,
+                "tree_aux_heights",
+                header_sync_wire_error_kind(&error),
+            );
+            metrics::counter!("sync.header.tree_aux.height_mismatch").increment(1);
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::MalformedMessage)
                 .await;
             self.retry_or_finish_outstanding(&peer, outstanding);
@@ -2055,6 +2073,7 @@ impl HeaderSyncReactor {
                     Some(header_sync_wire_error_kind(error)),
                 );
                 insert_peer(row, hs_trace::PEER, peer);
+                trace_wire_error_fields(row, error);
             }
             HeaderSyncEvent::WireProtocolFailure {
                 peer,
@@ -2073,6 +2092,7 @@ impl HeaderSyncReactor {
                     Some(header_sync_wire_error_kind(error)),
                 );
                 insert_peer(row, hs_trace::PEER, peer);
+                trace_wire_error_fields(row, error);
             }
             HeaderSyncEvent::StateFrontiersChanged(frontiers) => {
                 insert_optional_str(row, hs_trace::KIND, Some("state_frontiers_changed"));
@@ -2350,9 +2370,10 @@ impl HeaderSyncReactor {
         advertised_cap: u32,
         in_flight_count: usize,
         want_tree_aux_roots: bool,
-        tree_aux_roots_len: u32,
+        tree_aux_roots: &[BlockCommitmentRoots],
     ) {
         self.emit_trace(hs_trace::HEADER_HEADERS_RECEIVED, |row| {
+            let roots = TreeAuxTraceSummary::new(tree_aux_roots);
             insert_peer(row, hs_trace::PEER, peer);
             insert_height(row, hs_trace::RANGE_START, start_height);
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(count));
@@ -2360,11 +2381,8 @@ impl HeaderSyncReactor {
             insert_u64(row, hs_trace::EXPECTED_COUNT, u64::from(expected_max_count));
             insert_u64(row, hs_trace::IN_FLIGHT_COUNT, in_flight_count as u64);
             insert_bool(row, hs_trace::WANT_TREE_AUX_ROOTS, want_tree_aux_roots);
-            insert_u64(
-                row,
-                hs_trace::TREE_AUX_ROOTS_LEN,
-                u64::from(tree_aux_roots_len),
-            );
+            insert_u64(row, hs_trace::TREE_AUX_ROOTS_LEN, u64::from(roots.len));
+            roots.insert_into(row);
         });
     }
 
@@ -2375,7 +2393,7 @@ impl HeaderSyncReactor {
         requested_count: u32,
         returned_count: u32,
         want_tree_aux_roots: bool,
-        tree_aux_roots_len: u32,
+        roots: TreeAuxTraceSummary,
     ) {
         self.emit_trace(hs_trace::HEADER_HEADERS_SERVED, |row| {
             insert_peer(row, hs_trace::PEER, peer);
@@ -2383,11 +2401,8 @@ impl HeaderSyncReactor {
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(returned_count));
             insert_u64(row, hs_trace::EXPECTED_COUNT, u64::from(requested_count));
             insert_bool(row, hs_trace::WANT_TREE_AUX_ROOTS, want_tree_aux_roots);
-            insert_u64(
-                row,
-                hs_trace::TREE_AUX_ROOTS_LEN,
-                u64::from(tree_aux_roots_len),
-            );
+            insert_u64(row, hs_trace::TREE_AUX_ROOTS_LEN, u64::from(roots.len));
+            roots.insert_into(row);
         });
     }
 
@@ -2629,6 +2644,66 @@ fn set_header_connectivity_gauges(connected_peers: usize, healthy_peers: usize) 
     metrics::gauge!("zakura.p2p.healthy_peers").set(healthy_peers as f64);
 }
 
+#[derive(Default)]
+struct TreeAuxTraceSummary {
+    len: u32,
+    first_height: Option<block::Height>,
+    last_height: Option<block::Height>,
+}
+
+impl TreeAuxTraceSummary {
+    fn new(roots: &[BlockCommitmentRoots]) -> Self {
+        Self {
+            len: u32::try_from(roots.len()).unwrap_or(u32::MAX),
+            first_height: roots.first().map(|root| root.height),
+            last_height: roots.last().map(|root| root.height),
+        }
+    }
+
+    fn insert_into(&self, row: &mut serde_json::Map<String, Value>) {
+        if let Some(height) = self.first_height {
+            insert_height(row, hs_trace::FIRST_ROOT_HEIGHT, height);
+        }
+        if let Some(height) = self.last_height {
+            insert_height(row, hs_trace::LAST_ROOT_HEIGHT, height);
+        }
+    }
+}
+
+fn record_wire_validation_metrics(error: &HeaderSyncWireError) {
+    let error_kind = header_sync_wire_error_kind(error);
+    metrics::counter!(
+        "sync.header.validation.rejected",
+        "stage" => "wire",
+        "error_kind" => error_kind
+    )
+    .increment(1);
+    if matches!(error, HeaderSyncWireError::TreeAuxRootHeightMismatch { .. }) {
+        metrics::counter!("sync.header.tree_aux.height_mismatch").increment(1);
+    }
+}
+
+fn trace_wire_error_fields(row: &mut serde_json::Map<String, Value>, error: &HeaderSyncWireError) {
+    if let HeaderSyncWireError::TreeAuxRootHeightMismatch {
+        offset,
+        expected_height,
+        root_height,
+        first_root_height,
+        last_root_height,
+    } = error
+    {
+        insert_u64(
+            row,
+            hs_trace::ROOT_MISMATCH_OFFSET,
+            u64::try_from(*offset).unwrap_or(u64::MAX),
+        );
+        insert_height(row, hs_trace::EXPECTED_ROOT_HEIGHT, *expected_height);
+        insert_height(row, hs_trace::ACTUAL_ROOT_HEIGHT, *root_height);
+        insert_height(row, hs_trace::FIRST_ROOT_HEIGHT, *first_root_height);
+        insert_height(row, hs_trace::LAST_ROOT_HEIGHT, *last_root_height);
+    }
+}
+
 fn header_sync_wire_error_kind(error: &HeaderSyncWireError) -> &'static str {
     match error {
         HeaderSyncWireError::OversizedPayload { .. } => "oversized_payload",
@@ -2699,7 +2774,11 @@ fn trace_header_sync_message_fields(
             );
         }
         HeaderSyncMessage::Headers { headers, .. } => {
-            insert_u64(row, hs_trace::RANGE_COUNT, headers.len() as u64);
+            insert_u64(
+                row,
+                hs_trace::RANGE_COUNT,
+                u64::try_from(headers.len()).unwrap_or(u64::MAX),
+            );
         }
         HeaderSyncMessage::GetHeaders {
             start_height,

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1214,13 +1214,23 @@ fn headers_codec_rejects_body_size_mismatch_truncation_and_trailing_bytes() {
         })
     ));
 
-    assert!(matches!(
-        validate_tree_aux_root_heights(block::Height(1), &[root_at(block::Height(2))]),
+    let roots = [root_at(block::Height(1)), root_at(block::Height(3))];
+    match validate_tree_aux_root_heights(block::Height(1), &roots) {
         Err(HeaderSyncWireError::TreeAuxRootHeightMismatch {
-            expected_height: block::Height(1),
-            root_height: block::Height(2),
-        })
-    ));
+            offset,
+            expected_height,
+            root_height,
+            first_root_height,
+            last_root_height,
+        }) => {
+            assert_eq!(offset, 1);
+            assert_eq!(expected_height, block::Height(2));
+            assert_eq!(root_height, block::Height(3));
+            assert_eq!(first_root_height, block::Height(1));
+            assert_eq!(last_root_height, block::Height(3));
+        }
+        result => panic!("expected tree-aux root height mismatch, got {result:?}"),
+    }
 
     let mut truncated_mid_size = message.encode().unwrap();
     truncated_mid_size.pop();
@@ -4663,6 +4673,61 @@ async fn rejected_non_linking_range_traces_link_stage_and_error_kind() {
                 hs_trace::ERROR_KIND,
                 TraceValue::Str("first_header_does_not_link"),
             ),
+        ],
+    );
+
+    let _ = capture.finish().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tree_aux_height_mismatch_traces_structured_diagnostics() {
+    let network = regtest_network();
+    let anchor = (block::Height(0), network.genesis_hash());
+    let mut capture =
+        TraceCapture::for_test("tree_aux_height_mismatch_traces_structured_diagnostics").unwrap();
+    let mut startup = startup_for(network, anchor, Some(anchor));
+    startup.trace = ZakuraTrace::new(capture.tracer(), "01");
+    let mut fixture = spawn_test_reactor(startup);
+    let peer_id = peer(65);
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::WireProtocolFailure {
+            peer: peer_id.clone(),
+            reason: HeaderSyncMisbehavior::MalformedMessage,
+            error: Arc::new(HeaderSyncWireError::TreeAuxRootHeightMismatch {
+                offset: 7,
+                expected_height: block::Height(108),
+                root_height: block::Height(208),
+                first_root_height: block::Height(201),
+                last_root_height: block::Height(300),
+            }),
+        })
+        .await
+        .unwrap();
+
+    match next_non_query_action(&mut fixture.actions).await {
+        HeaderSyncAction::Misbehavior { peer, reason } => {
+            assert_eq!(peer, peer_id);
+            assert_eq!(reason, HeaderSyncMisbehavior::MalformedMessage);
+        }
+        action => panic!("unexpected action: {action:?}"),
+    }
+
+    capture.flush().await;
+    let reader = capture.reader().unwrap();
+    reader.table(HEADER_SYNC_TABLE.table()).assert_row(
+        hs_trace::HEADER_EVENT_RECEIVED,
+        &[
+            (
+                hs_trace::ERROR_KIND,
+                TraceValue::Str("tree_aux_root_height_mismatch"),
+            ),
+            (hs_trace::ROOT_MISMATCH_OFFSET, TraceValue::U64(7)),
+            (hs_trace::EXPECTED_ROOT_HEIGHT, TraceValue::U64(108)),
+            (hs_trace::ACTUAL_ROOT_HEIGHT, TraceValue::U64(208)),
+            (hs_trace::FIRST_ROOT_HEIGHT, TraceValue::U64(201)),
+            (hs_trace::LAST_ROOT_HEIGHT, TraceValue::U64(300)),
         ],
     );
 

--- a/zakura-network/src/zakura/header_sync/validation.rs
+++ b/zakura-network/src/zakura/header_sync/validation.rs
@@ -354,18 +354,27 @@ pub(super) fn validate_tree_aux_root_heights(
     roots: &[BlockCommitmentRoots],
 ) -> Result<(), HeaderSyncWireError> {
     for (offset, root) in roots.iter().enumerate() {
-        let offset = u32::try_from(offset)
+        let height_offset = u32::try_from(offset)
             .map_err(|_| HeaderSyncWireError::NumericOverflow("tree-aux root height offset"))?;
         let expected_height = block::Height(
             start_height
                 .0
-                .checked_add(offset)
+                .checked_add(height_offset)
                 .ok_or(HeaderSyncWireError::NumericOverflow("tree-aux root height"))?,
         );
         if root.height != expected_height {
             return Err(HeaderSyncWireError::TreeAuxRootHeightMismatch {
+                offset,
                 expected_height,
                 root_height: root.height,
+                first_root_height: roots
+                    .first()
+                    .expect("a mismatching root exists because the loop is processing it")
+                    .height,
+                last_root_height: roots
+                    .last()
+                    .expect("a mismatching root exists because the loop is processing it")
+                    .height,
             });
         }
     }

--- a/zakura-network/src/zakura/trace.rs
+++ b/zakura-network/src/zakura/trace.rs
@@ -379,6 +379,16 @@ pub mod header_sync_trace {
     pub const BEST_HEADER_TIP: &str = "best_header_tip";
     /// Number of header-carried tree-aux roots present on this send/receive.
     pub const TREE_AUX_ROOTS_LEN: &str = "tree_aux_roots_len";
+    /// First encoded tree-aux root height.
+    pub const FIRST_ROOT_HEIGHT: &str = "first_root_height";
+    /// Last encoded tree-aux root height.
+    pub const LAST_ROOT_HEIGHT: &str = "last_root_height";
+    /// Zero-based index of the first mismatching root.
+    pub const ROOT_MISMATCH_OFFSET: &str = "root_mismatch_offset";
+    /// Expected height of the first mismatching root.
+    pub const EXPECTED_ROOT_HEIGHT: &str = "expected_root_height";
+    /// Actual height of the first mismatching root.
+    pub const ACTUAL_ROOT_HEIGHT: &str = "actual_root_height";
     /// Destination peer count field.
     pub const DESTINATION_PEER_COUNT: &str = "destination_peer_count";
     /// Active reactor service sessions after this event.

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -1556,6 +1556,14 @@ where
     C: AsRef<Chain>,
 {
     let capped_count = count.min(MAX_HEADER_SYNC_HEIGHT_RANGE);
+    let end = (start + i64::from(capped_count.saturating_sub(1))).unwrap_or(start);
+    let source = match db.vct_upgrade_height() {
+        None => "trees",
+        Some(upgrade) if start >= upgrade => "compact_index",
+        Some(upgrade) if end < upgrade => "trees",
+        Some(_) => "mixed",
+    };
+    metrics::counter!("state.block_roots.response", "source" => source).increment(1);
     let mut roots =
         Vec::with_capacity(usize::try_from(capped_count).expect("capped root count fits in usize"));
 

--- a/zakura-state/src/service/finalized_state/commitment_aux.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux.rs
@@ -3,7 +3,13 @@
 
 #[cfg(test)]
 use std::collections::HashMap;
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use thiserror::Error;
 use zakura_chain::{
@@ -462,17 +468,28 @@ pub(crate) fn produce_block_roots(
         // archival node holds the body for these heights). Zero only if the body is somehow
         // absent, in which case the recipient simply re-fetches from a node that has it.
         let block = db.block(height.into());
-        let (sapling_tx, orchard_tx, ironwood_tx, auth_data_root) = block
-            .as_ref()
-            .map(|block| {
+        let (sapling_tx, orchard_tx, ironwood_tx, auth_data_root) =
+            if let Some(block) = block.as_ref() {
                 (
                     block.sapling_transactions_count(),
                     block.orchard_transactions_count(),
                     block.ironwood_transactions_count(),
                     block.auth_data_root(),
                 )
-            })
-            .unwrap_or((0, 0, 0, AuthDataRoot::from([0u8; 32])));
+            } else {
+                metrics::counter!("state.block_roots.zero_aux_fallback").increment(1);
+                static ZERO_AUX_FALLBACKS: AtomicU64 = AtomicU64::new(0);
+                let occurrences = ZERO_AUX_FALLBACKS.fetch_add(1, Ordering::Relaxed) + 1;
+                if occurrences.is_power_of_two() {
+                    tracing::error!(
+                        ?height,
+                        occurrences,
+                        "serving tree-aux roots with zero transaction counts and auth-data root \
+                         because the finalized block body is unavailable"
+                    );
+                }
+                (0, 0, 0, AuthDataRoot::from([0u8; 32]))
+            };
         roots.push(BlockCommitmentRoots {
             height,
             sapling_root: sapling.root(),

--- a/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
@@ -795,4 +795,148 @@ mod tests {
             fail_height.0
         );
     }
+
+    /// Validates the exact tree-aux records an archive database would serve for arbitrary ranges.
+    ///
+    /// This check needs only one read-only database and is intended for diagnosing a serving node.
+    /// It verifies contiguous encoded heights and compares every served root, transaction count,
+    /// and auth-data root with the database's block and per-height tree data.
+    ///
+    /// Run:
+    /// ```text
+    /// VCT_ARCHIVE_DB=<archive-db> \
+    /// VCT_RANGES=187401-188400,200401-201400 \
+    ///   cargo test -p zakura-state --lib validates_served_vct_ranges_from_read_only_db \
+    ///   -- --ignored --nocapture
+    /// ```
+    #[ignore]
+    #[test]
+    #[allow(clippy::print_stderr)] // intentional progress output for a manual diagnostic
+    fn validates_served_vct_ranges_from_read_only_db() {
+        use std::path::PathBuf;
+
+        use crate::{
+            constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
+            service::finalized_state::{
+                commitment_aux::serve_block_roots, ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE,
+            },
+            Config,
+        };
+
+        let archive_dir = std::env::var_os("VCT_ARCHIVE_DB")
+            .expect("set VCT_ARCHIVE_DB to an archive state cache directory");
+        let ranges = std::env::var("VCT_RANGES")
+            .expect("set VCT_RANGES to comma-separated inclusive ranges, for example 10-20,30-40");
+
+        let config = Config {
+            cache_dir: PathBuf::from(archive_dir),
+            ephemeral: false,
+            ..Default::default()
+        };
+        let archive_db = ZakuraDb::new(
+            &config,
+            STATE_DATABASE_KIND,
+            &state_database_format_version_in_code(),
+            &Mainnet,
+            true,
+            STATE_COLUMN_FAMILIES_IN_CODE
+                .iter()
+                .map(ToString::to_string),
+            true,
+        )
+        .expect("opening the archive database read-only should succeed");
+
+        let mut checked = 0usize;
+        for range in ranges
+            .split(',')
+            .map(str::trim)
+            .filter(|range| !range.is_empty())
+        {
+            let (start, end) = range
+                .split_once('-')
+                .unwrap_or_else(|| panic!("range {range:?} must use START-END syntax"));
+            let start: u32 = start
+                .parse()
+                .unwrap_or_else(|_| panic!("invalid start height in range {range:?}"));
+            let end: u32 = end
+                .parse()
+                .unwrap_or_else(|_| panic!("invalid end height in range {range:?}"));
+            assert!(start <= end, "range start must not exceed end: {range:?}");
+
+            let roots = serve_block_roots(&archive_db, Height(start)..=Height(end));
+            let expected_len = usize::try_from(end - start + 1)
+                .expect("a u32 range length fits in usize on supported targets");
+            assert_eq!(
+                roots.len(),
+                expected_len,
+                "served roots must fully cover range {range:?}"
+            );
+
+            for (offset, roots) in roots.into_iter().enumerate() {
+                let offset =
+                    u32::try_from(offset).expect("the bounded diagnostic range offset fits in u32");
+                let height = Height(
+                    start
+                        .checked_add(offset)
+                        .expect("the validated range end fits in u32"),
+                );
+                assert_eq!(
+                    roots.height, height,
+                    "served root height is misaligned in range {range:?}"
+                );
+
+                let block = archive_db
+                    .block(height.into())
+                    .unwrap_or_else(|| panic!("archive body is missing at {height:?}"));
+                let sapling = archive_db
+                    .sapling_tree_by_height(&height)
+                    .unwrap_or_else(|| panic!("Sapling tree is missing at {height:?}"));
+                let orchard = archive_db
+                    .orchard_tree_by_height(&height)
+                    .unwrap_or_else(|| panic!("Orchard tree is missing at {height:?}"));
+                let ironwood = archive_db
+                    .ironwood_tree_by_height(&height)
+                    .map(|tree| tree.root())
+                    .unwrap_or_else(|| ironwood::tree::NoteCommitmentTree::default().root());
+
+                assert_eq!(
+                    roots.sapling_root,
+                    sapling.root(),
+                    "Sapling root at {height:?}"
+                );
+                assert_eq!(
+                    roots.orchard_root,
+                    orchard.root(),
+                    "Orchard root at {height:?}"
+                );
+                assert_eq!(roots.ironwood_root, ironwood, "Ironwood root at {height:?}");
+                assert_eq!(
+                    roots.sapling_tx,
+                    block.sapling_transactions_count(),
+                    "Sapling transaction count at {height:?}"
+                );
+                assert_eq!(
+                    roots.orchard_tx,
+                    block.orchard_transactions_count(),
+                    "Orchard transaction count at {height:?}"
+                );
+                assert_eq!(
+                    roots.ironwood_tx,
+                    block.ironwood_transactions_count(),
+                    "Ironwood transaction count at {height:?}"
+                );
+                assert_eq!(
+                    roots.auth_data_root,
+                    block.auth_data_root(),
+                    "auth-data root at {height:?}"
+                );
+                checked += 1;
+            }
+
+            eprintln!("validated served tree-aux records for {start}..={end}");
+        }
+
+        assert!(checked > 0, "VCT_RANGES did not contain any ranges");
+        eprintln!("validated {checked} served tree-aux records");
+    }
 }

--- a/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
@@ -846,23 +846,71 @@ mod tests {
         )
         .expect("opening the archive database read-only should succeed");
 
-        let mut checked = 0usize;
-        for range in ranges
+        let ranges: Vec<_> = ranges
             .split(',')
             .map(str::trim)
             .filter(|range| !range.is_empty())
-        {
-            let (start, end) = range
-                .split_once('-')
-                .unwrap_or_else(|| panic!("range {range:?} must use START-END syntax"));
-            let start: u32 = start
-                .parse()
-                .unwrap_or_else(|_| panic!("invalid start height in range {range:?}"));
-            let end: u32 = end
-                .parse()
-                .unwrap_or_else(|_| panic!("invalid end height in range {range:?}"));
-            assert!(start <= end, "range start must not exceed end: {range:?}");
+            .map(|range| {
+                let (start, end) = range
+                    .split_once('-')
+                    .unwrap_or_else(|| panic!("range {range:?} must use START-END syntax"));
+                let start: u32 = start
+                    .parse()
+                    .unwrap_or_else(|_| panic!("invalid start height in range {range:?}"));
+                let end: u32 = end
+                    .parse()
+                    .unwrap_or_else(|_| panic!("invalid end height in range {range:?}"));
+                assert!(start <= end, "range start must not exceed end: {range:?}");
+                (start, end)
+            })
+            .collect();
+        assert!(!ranges.is_empty(), "VCT_RANGES did not contain any ranges");
 
+        let root_at = |height: Height| {
+            serve_block_roots(&archive_db, height..=height)
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| panic!("served root is missing at {height:?}"))
+        };
+        let verification_item_at = |height: Height| {
+            let roots = root_at(height);
+            assert_eq!(roots.height, height, "served root height at {height:?}");
+            let block = archive_db
+                .block(height.into())
+                .unwrap_or_else(|| panic!("archive body is missing at {height:?}"));
+            assert_eq!(
+                roots.sapling_tx,
+                block.sapling_transactions_count(),
+                "Sapling transaction count at {height:?}"
+            );
+            assert_eq!(
+                roots.orchard_tx,
+                block.orchard_transactions_count(),
+                "Orchard transaction count at {height:?}"
+            );
+            assert_eq!(
+                roots.ironwood_tx,
+                block.ironwood_transactions_count(),
+                "Ironwood transaction count at {height:?}"
+            );
+            assert_eq!(
+                roots.auth_data_root,
+                block.auth_data_root(),
+                "auth-data root at {height:?}"
+            );
+            CommitmentRootVerification::with_roots(
+                block,
+                roots.sapling_root,
+                roots.orchard_root,
+                roots.ironwood_root,
+                Some(roots.auth_data_root),
+                false,
+            )
+        };
+
+        let mut checked = 0usize;
+        for &(start, end) in &ranges {
+            let range = format!("{start}-{end}");
             let roots = serve_block_roots(&archive_db, Height(start)..=Height(end));
             let expected_len = usize::try_from(end - start + 1)
                 .expect("a u32 range length fits in usize on supported targets");
@@ -936,7 +984,72 @@ mod tests {
             eprintln!("validated served tree-aux records for {start}..={end}");
         }
 
-        assert!(checked > 0, "VCT_RANGES did not contain any ranges");
         eprintln!("validated {checked} served tree-aux records");
+
+        let heartwood = NetworkUpgrade::Heartwood
+            .activation_height(&Mainnet)
+            .expect("Heartwood has a mainnet activation height")
+            .0;
+        for &(start, end) in ranges.iter().filter(|(start, _)| *start < heartwood) {
+            let items = (start..=end).map(|height| verification_item_at(Height(height)));
+            verify_commitment_roots(&Mainnet, empty_history_tree(), items).unwrap_or_else(
+                |(height, error)| panic!("pre-Heartwood roots failed at {height:?}: {error}"),
+            );
+            eprintln!("validated direct pre-Heartwood commitments for {start}..={end}");
+        }
+
+        let mut epoch_ends = std::collections::BTreeMap::new();
+        for &(start, end) in ranges.iter().filter(|(start, _)| *start >= heartwood) {
+            let upgrade = NetworkUpgrade::current(&Mainnet, Height(start));
+            assert_eq!(
+                NetworkUpgrade::current(&Mainnet, Height(end)),
+                upgrade,
+                "diagnostic range {start}..={end} must not cross a network upgrade"
+            );
+            let activation = upgrade
+                .activation_height(&Mainnet)
+                .expect("an active mainnet upgrade has an activation height")
+                .0;
+            epoch_ends
+                .entry((activation, upgrade))
+                .and_modify(|max_end: &mut u32| *max_end = (*max_end).max(end))
+                .or_insert(end);
+        }
+
+        for ((activation, upgrade), end) in epoch_ends {
+            let activation_item = verification_item_at(Height(activation));
+            let activation_block = activation_item
+                .block
+                .expect("served root verification items contain block bodies");
+            let (sapling_root, orchard_root, ironwood_root) = activation_item
+                .roots
+                .expect("served root verification items contain roots");
+            let history_tree = HistoryTree::from_block(
+                &Mainnet,
+                activation_block,
+                &sapling_root,
+                &orchard_root,
+                &ironwood_root,
+            )
+            .expect("network-upgrade activation starts a history-tree epoch");
+            let confirm_end = end
+                .checked_add(1)
+                .expect("diagnostic range end has a successor");
+            let items =
+                (activation + 1..=confirm_end).map(|height| verification_item_at(Height(height)));
+
+            verify_commitment_roots(&Mainnet, history_tree, items).unwrap_or_else(
+                |(height, error)| {
+                    panic!(
+                        "{upgrade:?} MMR linkage failed at {height:?} while validating through \
+                         {confirm_end}: {error}"
+                    )
+                },
+            );
+            eprintln!(
+                "validated {upgrade:?} MMR linkage for {activation}..={end} \
+                 (confirmed by {confirm_end})"
+            );
+        }
     }
 }

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, Instant},
 };
 
@@ -740,13 +741,21 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
                                 &block_roots,
                             )
                             .unwrap_or_else(|error| {
-                                debug!(
-                                    ?peer,
-                                    ?start,
-                                    requested_count = count,
-                                    ?error,
-                                    "serving header range without tree aux roots"
-                                );
+                                metrics::counter!("sync.header.tree_aux.sender_alignment_failure")
+                                    .increment(1);
+                                static ALIGNMENT_FAILURES: AtomicU64 = AtomicU64::new(0);
+                                let occurrences =
+                                    ALIGNMENT_FAILURES.fetch_add(1, Ordering::Relaxed) + 1;
+                                if occurrences.is_power_of_two() {
+                                    warn!(
+                                        ?peer,
+                                        ?start,
+                                        requested_count = count,
+                                        occurrences,
+                                        ?error,
+                                        "serving header range without tree aux roots"
+                                    );
+                                }
 
                                 Vec::new()
                             })


### PR DESCRIPTION
## Motivation

A continuous-sync node repeatedly stalled at checkpoint boundaries after receiving malformed or miscorrelated header tree-aux roots. Existing traces identify only the broad error kind, which is insufficient to distinguish shifted ranges, sender-side root gaps, and local response-correlation failures.

## Solution

- record bounded root-range diagnostics on header send, receive, and validation failures, including first/last heights and mismatch offsets
- add low-cardinality validation and root-source metrics plus rate-limited fallback warnings
- improve trace node labels for systemd environments where `HOSTNAME` is unavailable
- add a read-only archive diagnostic that validates served roots, transaction counts, and auth-data roots against local database contents

### Tests

- `cargo fmt --all -- --check`
- `CXX=clang++ CXXFLAGS=\"-include cstdint\" cargo clippy --workspace --all-targets -- -D warnings`
- focused header-sync structured-diagnostic and codec tests
- archive diagnostic test compiles and fails closed without its required environment
- `CXX=clang++ CXXFLAGS=\"-include cstdint\" cargo test --workspace` reached one network-dependent failure: `restart_stop_at_height` timed out downloading testnet genesis with no peers; the isolated rerun passed

### Specifications & References

- Incident diagnostics from `temp-zakura-sync-test-1`

### Follow-up Work

- Use the new traces on the continuous-sync fleet to determine whether malformed ranges originate at the serving database or from stale request/response correlation.

### AI Disclosure

- [x] AI tools were used: Cursor (GPT-5.6 Sol) assisted with incident analysis, observability implementation, focused tests, and PR description drafting.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team during incident response.
- [x] The solution is tested; the full-suite network-dependent retry is documented above.
- [x] Documentation and changelog updates are not required for internal diagnostics.