### PR TITLE
chore(release): prepare v1.0.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Bumped Zakura's unified Cargo package graph and installer defaults to
+  `1.0.0-rc3`, replacing temporary `librustzcash` Git pins with the published
+  crates.io releases.
 - Prepared the Zakura crate graph for publication at `1.0.0-rc2`. Install the
   `zakura` package with Cargo to obtain the `zakurad` executable; Zakura-owned
   libraries now share the release version, including the renamed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,7 +1955,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cabbc6cab07562fe1b94868f65f6af2871d9cbc5#cabbc6cab07562fe1b94868f65f6af2871d9cbc5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -7108,7 +7109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8764,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "abscissa_core",
  "anyhow",
@@ -8852,7 +8853,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -8922,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8975,7 +8976,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-jsonl-trace"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "tempfile",
  "tokio",
@@ -8985,7 +8986,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9033,7 +9034,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -9047,7 +9048,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9117,7 +9118,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "hex",
  "lazy_static",
@@ -9135,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "bincode",
  "chrono",
@@ -9186,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-test"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "color-eyre",
  "futures",
@@ -9213,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-tower-batch-control"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -9235,7 +9236,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-tower-fallback"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -9247,7 +9248,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "color-eyre",
  "hex",
@@ -9297,7 +9298,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cabbc6cab07562fe1b94868f65f6af2871d9cbc5#cabbc6cab07562fe1b94868f65f6af2871d9cbc5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,11 +180,6 @@ zcash_script = "0.4.5"
 config = { version = "0.15.14", features = ["toml"] }
 which = "8.0.0"
 
-[patch.crates-io]
-# TEMPORARY: Pin librustzcash crates to https://github.com/zcash/librustzcash/pull/2509
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "cabbc6cab07562fe1b94868f65f6af2871d9cbc5" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "cabbc6cab07562fe1b94868f65f6af2871d9cbc5" }
-
 [workspace.metadata.release]
 
 # We always do releases from the main branch

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0-rc2 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0-rc3 zakura
 ```
 
 You can start Zakura by running

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -10,11 +10,11 @@
 #
 # Usage:
 #   ./scripts/check-release-version.sh <release-tag>
-#   ./scripts/check-release-version.sh v1.0.0-rc2
+#   ./scripts/check-release-version.sh v1.0.0-rc3
 set -euo pipefail
 
 if [ $# -ne 1 ] || [ -z "$1" ]; then
-  echo "Usage: $0 <release-tag> (for example v1.0.0-rc2)" >&2
+  echo "Usage: $0 <release-tag> (for example v1.0.0-rc3)" >&2
   exit 1
 fi
 RELEASE_TAG="$1"

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -11,14 +11,14 @@ fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UNITY_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
 
-ZAKURA_RELEASE_TAG="v1.0.0-rc2"
+ZAKURA_RELEASE_TAG="v1.0.0-rc3"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
 # Replaced with the archive checksum by release-binaries.yml before publishing.
-ZAKURA_ARCHIVE_SHA256="2638fc24eafd11d151a8f0558f79b6358ba0d304bafd7fbfe503ed299759c522"
+ZAKURA_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc2"
-ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc2"
+ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc3"
+ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc3"
 ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="valargroup/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 # Persistent Zakura iroh identity (NodeId secret). Kept outside the state cache so

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -28,9 +28,6 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [imports.zcashd]
 url = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[policy.equihash]
-audit-as-crates-io = true
-
 [policy.zakura]
 audit-as-crates-io = false
 
@@ -66,9 +63,6 @@ audit-as-crates-io = false
 
 [policy.zakura-utils]
 audit-as-crates-io = false
-
-[policy.zcash_encoding]
-audit-as-crates-io = true
 
 [[exemptions.abscissa_core]]
 version = "0.7.0"
@@ -655,7 +649,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.equihash]]
-version = "0.3.0@git:cabbc6cab07562fe1b94868f65f6af2871d9cbc5"
+version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.erased-serde]]
@@ -2711,7 +2705,7 @@ version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
-version = "0.4.0@git:cabbc6cab07562fe1b94868f65f6af2871d9cbc5"
+version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_script]]

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-tower-batch-control"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal
@@ -43,10 +43,10 @@ rand = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-test = { workspace = true }
-tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc2" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc3" }
 tower-test = { workspace = true }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3" }
 
 [lints]
 workspace = true

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-tower-fallback"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license.workspace = true
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3" }
 
 [lints]
 workspace = true

--- a/zakura-chain/Cargo.toml
+++ b/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "Core Zcash data structures"
 license.workspace = true
@@ -133,7 +133,7 @@ proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3", optional = true }
 bounded-vec = { version = "0.9.0", features = ["serde"] }
 
 [dev-dependencies]
@@ -154,7 +154,7 @@ rand_chacha = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3" }
 
 [[bench]]
 name = "block"

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true
@@ -65,13 +65,13 @@ libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
 
-tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc2" }
-tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0-rc2" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc3" }
+tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0-rc3" }
 
-zakura-script = { path = "../zakura-script", version = "1.0.0-rc2" }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc2" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc3" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc3" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc3" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3" }
 
 zcash_protocol.workspace = true
 
@@ -96,9 +96,9 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc2", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3" }
 
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/zakura-jsonl-trace/Cargo.toml
+++ b/zakura-jsonl-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-jsonl-trace"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -93,8 +93,8 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["async-error"] }
-zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["async-error"] }
+zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc3" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -106,8 +106,8 @@ static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3" }
 
 [lints]
 workspace = true

--- a/zakura-node-services/Cargo.toml
+++ b/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "The interfaces of some Zebra node services"
 license.workspace = true
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain" , version = "1.0.0-rc3" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2" }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc2" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3" }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc3" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc3", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "1.0.0-rc2" }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc2" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc3" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc3" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -140,20 +140,20 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc2", features = [
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc3", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc2", features = [
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc3", features = [
     "proptest-impl",
 ] }
 
-zakura-test = { path = "../zakura-test", version = "1.0.0-rc2" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc3" }
 
 [lints]
 workspace = true

--- a/zakura-script/Cargo.toml
+++ b/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }
@@ -37,7 +37,7 @@ lazy_static = { workspace = true }
 ripemd = { workspace = true }
 secp256k1 = { workspace = true }
 sha2 = { workspace = true }
-zakura-test = { path = "../zakura-test", version = "1.0.0-rc2" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc3" }
 
 [lints]
 workspace = true

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "State contextual verification and storage code for Zebra"
 license.workspace = true
@@ -82,14 +82,14 @@ sapling-crypto = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["async-error"] }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc3" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
 
 # test feature proptest-impl
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3", optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 derive-getters.workspace = true
@@ -114,8 +114,8 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc3" }
 
 [lints]
 workspace = true

--- a/zakura-test/Cargo.toml
+++ b/zakura-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-test"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "Test harnesses and test vectors for Zebra"
 license.workspace = true

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "Developer tools for Zebra maintenance and testing"
 license.workspace = true
@@ -60,11 +60,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc3" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3" }
 
 # These crates are needed for the block-template-to-proposal binary
-zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc2" }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc3" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zakura"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -152,20 +152,20 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2" }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2" }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc2" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc2", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc2" }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc2" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3" }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3" }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc3" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc3", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc3" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc3" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "1.0.0-rc2" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc3" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc2", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc3", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -305,12 +305,12 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc2", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc2", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc2", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc2", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc3", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc3", features = ["proptest-impl"] }
 
-zakura-test = { path = "../zakura-test", version = "1.0.0-rc2" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc3" }
 
 # Used by the checkpoint generation tests via the zakura-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -321,7 +321,7 @@ zakura-test = { path = "../zakura-test", version = "1.0.0-rc2" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc2" }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc3" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_358_200;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_409_600;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.

--- a/zakurad/tests/common/configs/v1.0.0-rc3.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc3.toml
@@ -1,0 +1,200 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the native Zakura P2P v2 stack only.
+# - "dual": both stacks, with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[network.zakura.block_sync]
+bbr_cwnd_gain_percent = 300
+bbr_cwnd_unit = "bytes"
+bbr_delay_gradient_percent = 150
+bbr_delivery_rate_window = "10s"
+bbr_min_cwnd = 4
+bbr_min_cwnd_bytes = 2524288
+bbr_probe_bw_gain_percent = 125
+bbr_probe_rtt_duration = "200ms"
+bbr_probe_rtt_interval = "10s"
+bbr_reliability_weight_percent = 100
+bbr_rtprop_window = "10s"
+bbr_startup_growth_percent = 200
+floor_bypass_slots = 2
+floor_peer_avoid_cooldown = "8s"
+floor_rescue_timeout = "2s"
+initial_block_probe_requests = 1
+initial_inflight_requests = 64
+max_blocks_per_response = 1
+max_inflight_block_bytes = 6442450944
+max_inflight_requests = 32000
+max_reorder_lookahead_bytes = 6408896512
+max_requests_without_block_progress = 64
+max_response_bytes = 33554432
+max_submitted_block_applies = 401
+no_progress_peer_cooldown = "3m"
+request_timeout = "8s"
+size_deviation_tolerance = 200
+status_refresh_interval = "30s"
+
+[network.zakura.block_sync.peer_limits]
+inbound_queue_depth = 128
+max_inbound_peers = 256
+max_outbound_peers = 256
+max_pending_escalations = 32
+outbound_queue_depth = 128
+
+[network.zakura.header_sync]
+accept_new_blocks = true
+max_headers_per_response = 1000
+max_inflight_requests = 10
+status_refresh_interval = "30s"
+
+[network.zakura.header_sync.peer_limits]
+inbound_queue_depth = 128
+max_inbound_peers = 256
+max_outbound_peers = 256
+max_pending_escalations = 32
+outbound_queue_depth = 128
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"
+


### PR DESCRIPTION
## Motivation

Prepare the repository for the `v1.0.0-rc3` release so tagged binaries, Cargo packages, installer defaults, and support-window metadata agree on the release identity.

## Solution

- bump the 13-package Zakura Cargo graph and internal requirements to `1.0.0-rc3`
- update installer, Docker image, README, changelog, and release-version references
- add the version-keyed RC3 configuration compatibility fixture
- move temporary `equihash` and `zcash_encoding` Git pins to their published crates.io packages and update cargo-vet policy
- refresh the estimated release height used by end-of-support checks

### Tests

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --profile check-no-git-dependencies --locked --run-ignored=only`
- `cargo test -p zakura-chain -p zakura-consensus`
- `cargo test -p zakura --test acceptance config_tests -- --test-threads=1`
- serial reruns passed for `activate_mempool_mainnet`, `restart_stop_at_height`, and `sync_one_checkpoint_mainnet`
- `cargo vet`
- Markdown lint, shell syntax, release-tag/version validation, and IDE diagnostics

`cargo test --workspace` reached the acceptance suite but concurrent environment-heavy tests failed or stalled. The three reported failures passed when rerun serially; the stalled full-suite run was stopped.

### Specifications & References

- Release target: `v1.0.0-rc3`
- Published `equihash` and `zcash_encoding` sources were compared with the temporary pinned revisions before removing the patches.

### Follow-up Work

The automated checkpoint updater currently references a workflow name that is not registered in this repository, so no trusted checkpoint artifacts were available to import in this PR.

### AI Disclosure

- [x] AI tools were used: Cursor GPT-5.6 Sol prepared the release metadata, dependency-source updates, config fixture, validation, and PR description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The change is focused on RC3 release preparation.
- [x] The solution is tested as documented above.
- [x] Documentation and changelog entries are updated.