### PR TITLE
fix(consensus): proper regtest binding of equihash parameters

### DIFF
--- a/zakura-chain/src/work/equihash.rs
+++ b/zakura-chain/src/work/equihash.rs
@@ -20,8 +20,21 @@ use crate::serialization::AtLeastOne;
 /// The error type for Equihash validation.
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
-#[error("invalid equihash solution for BlockHeader")]
-pub struct Error(#[from] equihash::Error);
+pub enum Error {
+    /// The solution failed Equihash verification under the parameters
+    /// required by the active network.
+    #[error("invalid equihash solution for BlockHeader")]
+    Equihash(#[from] equihash::Error),
+
+    /// The solution's size does not match the Equihash parameters required by
+    /// the active network (for example, a 36-byte Regtest-shaped solution
+    /// submitted on Mainnet or Testnet).
+    #[error("equihash solution size is invalid for the {network} network")]
+    InvalidSolutionSize {
+        /// The network whose Equihash parameters the solution violated.
+        network: Network,
+    },
+}
 
 /// The error type for Equihash solving.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, thiserror::Error)]
@@ -74,16 +87,52 @@ impl Solution {
         }
     }
 
-    /// Returns `Ok(())` if `EquihashSolution` is valid for `header`
+    /// Returns `Ok(())` if this solution is a valid Equihash solution for
+    /// `header` under the Equihash parameters required by `network`.
+    ///
+    /// The `(n, k)` Equihash parameters are chosen from `network`, never from
+    /// the attacker-controlled solution length. A solution whose variant does
+    /// not match the parameters `network` requires is rejected: Mainnet and
+    /// Testnet require the memory-hard `(200, 9)` [`Solution::Common`]
+    /// solution, and the toy `(48, 5)` [`Solution::Regtest`] solution is only
+    /// accepted on Regtest. This prevents a peer from downgrading the proof of
+    /// work by choosing the on-wire solution length.
     #[allow(clippy::unwrap_in_result)]
-    pub fn check(&self, header: &Header) -> Result<(), Error> {
+    pub fn check(&self, header: &Header, network: &Network) -> Result<(), Error> {
         // TODO:
         // - Add Equihash parameters field to `testnet::Parameters`
         // - Update `Solution::Regtest` variant to hold a `Vec` to support arbitrary parameters - rename to `Other`
-        let (n, k) = match self {
-            Solution::Common(_) => (200, 9),
-            Solution::Regtest(_) => (REGTEST_N, REGTEST_K),
+        let (n, k) = match (network.is_regtest(), self) {
+            // Mainnet and Testnet require the memory-hard (200, 9) parameters,
+            // encoded as a 1344-byte `Common` solution.
+            (false, Solution::Common(_)) => (200, 9),
+            // Regtest accepts either the toy (48, 5) solution used by its
+            // genesis block or a full (200, 9) solution from a miner.
+            (true, Solution::Common(_)) => (200, 9),
+            (true, Solution::Regtest(_)) => (REGTEST_N, REGTEST_K),
+            // A 36-byte `Regtest`-shaped solution is not a valid proof of work
+            // on Mainnet or Testnet. Reject it before selecting parameters, so
+            // the attacker-controlled solution length cannot downgrade the PoW
+            // to the trivial (48, 5) parameter set.
+            (false, Solution::Regtest(_)) => {
+                return Err(Error::InvalidSolutionSize {
+                    network: network.clone(),
+                })
+            }
         };
+
+        self.check_equihash(header, n, k)
+    }
+
+    /// Returns `Ok(())` if this solution is valid for `header` under the given
+    /// Equihash `(n, k)` parameters.
+    ///
+    /// The parameters are supplied explicitly and must be chosen from a trusted
+    /// source, never derived from the solution length. Callers on the block
+    /// ingestion path must go through [`Solution::check`], which binds `(n, k)`
+    /// to the active network.
+    #[allow(clippy::unwrap_in_result)]
+    fn check_equihash(&self, header: &Header, n: u32, k: u32) -> Result<(), Error> {
         let nonce = &header.nonce;
 
         let mut input = Vec::new();
@@ -187,7 +236,11 @@ impl Solution {
                     .expect("unexpected invalid solution: incorrect length");
 
                 // TODO: work out why we sometimes get invalid solutions here
-                if let Err(error) = header.solution.check(&header) {
+                //
+                // The solver only ever produces (200, 9) `Common` solutions
+                // (see `solve_200_9` above), so verify against those parameters
+                // directly rather than binding to a network.
+                if let Err(error) = header.solution.check_equihash(&header, 200, 9) {
                     info!(?error, "found invalid solution for header");
                     continue;
                 }

--- a/zakura-chain/src/work/tests/prop.rs
+++ b/zakura-chain/src/work/tests/prop.rs
@@ -6,6 +6,7 @@ use proptest::{prelude::*, test_runner::Config};
 
 use crate::{
     block::{self, Block},
+    parameters::Network,
     serialization::{ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
 };
 
@@ -51,7 +52,10 @@ fn equihash_prop_test_solution() -> color_eyre::eyre::Result<()> {
     for block_bytes in zakura_test::vectors::BLOCKS.iter() {
         let block = Block::zcash_deserialize(&block_bytes[..])
             .expect("block test vector should deserialize");
-        block.header.solution.check(&block.header)?;
+        block
+            .header
+            .solution
+            .check(&block.header, &Network::Mainnet)?;
 
         // The equihash solution test can be really slow, so we use fewer cases by
         // default. Set the PROPTEST_CASES env var to override this default.
@@ -61,7 +65,7 @@ fn equihash_prop_test_solution() -> color_eyre::eyre::Result<()> {
                                       .unwrap_or(DEFAULT_TEST_INPUT_PROPTEST_CASES)),
                 |(fake_header in randomized_solutions(*block.header.as_ref()))| {
             fake_header.solution
-                .check(&fake_header)
+                .check(&fake_header, &Network::Mainnet)
                 .expect_err("block header should not validate on randomized solution");
         });
     }
@@ -91,11 +95,14 @@ fn equihash_prop_test_nonce() -> color_eyre::eyre::Result<()> {
     for block_bytes in zakura_test::vectors::BLOCKS.iter() {
         let block = Block::zcash_deserialize(&block_bytes[..])
             .expect("block test vector should deserialize");
-        block.header.solution.check(&block.header)?;
+        block
+            .header
+            .solution
+            .check(&block.header, &Network::Mainnet)?;
 
         proptest!(|(fake_header in randomized_nonce(*block.header.as_ref()))| {
             fake_header.solution
-                .check(&fake_header)
+                .check(&fake_header, &Network::Mainnet)
                 .expect_err("block header should not validate on randomized nonce");
         });
     }
@@ -127,7 +134,10 @@ fn equihash_prop_test_input() -> color_eyre::eyre::Result<()> {
     for block_bytes in zakura_test::vectors::BLOCKS.iter() {
         let block = Block::zcash_deserialize(&block_bytes[..])
             .expect("block test vector should deserialize");
-        block.header.solution.check(&block.header)?;
+        block
+            .header
+            .solution
+            .check(&block.header, &Network::Mainnet)?;
 
         proptest!(Config::with_cases(env::var("PROPTEST_CASES")
                                   .ok()
@@ -135,7 +145,7 @@ fn equihash_prop_test_input() -> color_eyre::eyre::Result<()> {
                                  .unwrap_or(DEFAULT_TEST_INPUT_PROPTEST_CASES)),
               |(fake_header in randomized_input(*block.header.as_ref()))| {
             fake_header.solution
-                .check(&fake_header)
+                .check(&fake_header, &Network::Mainnet)
                 .expect_err("equihash solution should not validate on randomized input");
         });
     }

--- a/zakura-chain/src/work/tests/vectors.rs
+++ b/zakura-chain/src/work/tests/vectors.rs
@@ -1,10 +1,11 @@
 use crate::{
     block::{Block, MAX_BLOCK_BYTES},
+    parameters::Network,
     serialization::{
         CompactSizeMessage, SerializationError, ZcashDeserialize, ZcashDeserializeInto,
         ZcashSerialize,
     },
-    work::equihash::{Solution, SOLUTION_SIZE},
+    work::equihash::{Error, Solution, REGTEST_SOLUTION_SIZE, SOLUTION_SIZE},
 };
 
 use super::super::*;
@@ -44,7 +45,10 @@ fn equihash_solution_test_vectors_are_valid() -> color_eyre::eyre::Result<()> {
         let block =
             Block::zcash_deserialize(&block[..]).expect("block test vector should deserialize");
 
-        block.header.solution.check(&block.header)?;
+        block
+            .header
+            .solution
+            .check(&block.header, &Network::Mainnet)?;
     }
 
     Ok(())
@@ -107,5 +111,50 @@ fn equihash_solution_rejects_oversize_compactsize_before_allocating() {
             SerializationError::Parse("incorrect equihash solution size"),
         ),
         "expected size-rejection Parse error, got: {err:?}",
+    );
+}
+
+/// Regression test for the Regtest-solution proof-of-work downgrade.
+///
+/// A 36-byte [`Solution::Regtest`] is only a valid proof of work under the toy
+/// `(48, 5)` Equihash parameters. It must never be accepted on Mainnet or
+/// Testnet, which require the memory-hard `(200, 9)` parameters. Previously the
+/// `(n, k)` parameters were selected from the solution length alone, so a peer
+/// could downgrade the PoW to `(48, 5)` by sending a short solution on Mainnet.
+#[test]
+fn regtest_solution_is_rejected_off_regtest() {
+    let _init_guard = zakura_test::init();
+
+    let block = Block::zcash_deserialize(zakura_test::vectors::BLOCKS[0])
+        .expect("block test vector should deserialize");
+    let mut header = *block.header;
+
+    // A short Regtest-shaped solution, as a malicious peer would send it.
+    header.solution = Solution::Regtest([0; REGTEST_SOLUTION_SIZE]);
+
+    // Rejected on Mainnet and Testnet by the network-parameter binding, before
+    // the Equihash verifier is ever reached.
+    for network in [Network::Mainnet, Network::new_default_testnet()] {
+        assert!(
+            matches!(
+                header.solution.check(&header, &network),
+                Err(Error::InvalidSolutionSize { .. }),
+            ),
+            "a 36-byte Regtest solution must be rejected on {network}",
+        );
+    }
+
+    // On Regtest the variant is permitted, so the check proceeds to Equihash
+    // verification rather than rejecting on size. (The all-zero solution is not
+    // a valid (48, 5) proof, so this is an Equihash error, not `Ok`, and in
+    // particular not `InvalidSolutionSize`.)
+    assert!(
+        !matches!(
+            header
+                .solution
+                .check(&header, &Network::new_regtest(Default::default())),
+            Err(Error::InvalidSolutionSize { .. }),
+        ),
+        "a Regtest solution must be accepted for verification on Regtest",
     );
 }

--- a/zakura-consensus/src/block.rs
+++ b/zakura-consensus/src/block.rs
@@ -233,7 +233,7 @@ where
                 // Do the difficulty checks first, to raise the threshold for
                 // attacks that use any other fields.
                 check::difficulty_is_valid(&block.header, &network, &height, &hash)?;
-                check::equihash_solution_is_valid(&block.header)?;
+                check::equihash_solution_is_valid(&block.header, &network)?;
             }
 
             // Next, check the Merkle root validity, to ensure that

--- a/zakura-consensus/src/block/check.rs
+++ b/zakura-consensus/src/block/check.rs
@@ -139,14 +139,21 @@ pub fn difficulty_is_valid(
     Ok(())
 }
 
-/// Returns `Ok(())` if the `EquihashSolution` is valid for `header`
-pub fn equihash_solution_is_valid(header: &Header) -> Result<(), equihash::Error> {
+/// Returns `Ok(())` if the `EquihashSolution` is valid for `header` on `network`
+pub fn equihash_solution_is_valid(
+    header: &Header,
+    network: &Network,
+) -> Result<(), equihash::Error> {
     // # Consensus
     //
     // > `solution` MUST represent a valid Equihash solution.
     //
     // https://zips.z.cash/protocol/protocol.pdf#blockheader
-    header.solution.check(header)
+    //
+    // The Equihash `(n, k)` parameters are bound to `network`, so a peer cannot
+    // downgrade the proof of work to the trivial Regtest `(48, 5)` parameters
+    // by sending a short 36-byte solution on Mainnet or Testnet.
+    header.solution.check(header, network)
 }
 
 /// Returns `Ok()` with the deferred pool balance change of the coinbase transaction if the block

--- a/zakura-consensus/src/block/tests.rs
+++ b/zakura-consensus/src/block/tests.rs
@@ -283,7 +283,7 @@ fn equihash_is_valid_for_historical_blocks() -> Result<(), Report> {
             .zcash_deserialize_into::<Block>()
             .expect("block is structurally valid");
 
-        check::equihash_solution_is_valid(&block.header)
+        check::equihash_solution_is_valid(&block.header, &Network::Mainnet)
             .expect("the equihash solution from a historical block should be valid");
     }
 

--- a/zakura-consensus/src/checkpoint.rs
+++ b/zakura-consensus/src/checkpoint.rs
@@ -610,7 +610,7 @@ where
             )?;
         } else {
             crate::block::check::difficulty_is_valid(&block.header, &self.network, &height, &hash)?;
-            crate::block::check::equihash_solution_is_valid(&block.header)?;
+            crate::block::check::equihash_solution_is_valid(&block.header, &self.network)?;
         }
 
         // See [ZIP-1015](https://zips.z.cash/zip-1015).

--- a/zakura-network/src/zakura/header_sync/validation.rs
+++ b/zakura-network/src/zakura/header_sync/validation.rs
@@ -271,22 +271,25 @@ pub(super) async fn validate_pow_spawn_blocking(
     headers: Vec<Arc<block::Header>>,
     network: &Network,
 ) -> Result<(), HeaderSyncWireError> {
-    let skip_pow_filter = network
-        .parameters()
-        .is_some_and(|parameters| parameters.is_regtest());
-    tokio::task::spawn_blocking(move || validate_pow_blocking(&headers, skip_pow_filter)).await?
+    let network = network.clone();
+    tokio::task::spawn_blocking(move || validate_pow_blocking(&headers, &network)).await?
 }
 
 pub(super) fn validate_pow_blocking(
     headers: &[Arc<block::Header>],
-    skip_pow_filter: bool,
+    network: &Network,
 ) -> Result<(), HeaderSyncWireError> {
+    let skip_pow_filter = network
+        .parameters()
+        .is_some_and(|parameters| parameters.is_regtest());
     if skip_pow_filter {
         return Ok(());
     }
 
     for header in headers {
-        header.solution.check(header)?;
+        // Bind the Equihash parameters to `network` so a short 36-byte
+        // Regtest-shaped solution cannot pass the PoW check on Mainnet/Testnet.
+        header.solution.check(header, network)?;
         let hash = block::Hash::from(header.as_ref());
         validate_difficulty_filter(hash, header.difficulty_threshold)?;
     }


### PR DESCRIPTION
Fixes an inadvertent consensus bug added where regtest equihash parameters are allowed on mainnet.