### PR TITLE
chore(network): trace block sync cleanup anomalies

### DIFF
--- a/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -48,7 +48,7 @@ use super::{
         DownloadWindow, LivenessOutcome, OutstandingBlockRange, ReceivedBlockTracker,
         ThroughputMeter,
     },
-    work_queue::{WorkItem, WorkQueue},
+    work_queue::{WorkItem, WorkQueue, WorkReturnOutcome},
     BlockSyncAction, BlockSyncMessage, BlockSyncMisbehavior, BlockSyncPeerSession, BlockSyncStatus,
     ZakuraBlockSyncConfig, ZakuraPeerId, ZakuraTrace, MSG_BS_BLOCK,
 };
@@ -169,6 +169,16 @@ enum Disposition {
     Satisfied,
     RetryOriginal,
     RetryMissing,
+}
+
+impl Disposition {
+    fn trace_label(self) -> &'static str {
+        match self {
+            Self::Satisfied => "satisfied",
+            Self::RetryOriginal => "retry_original",
+            Self::RetryMissing => "retry_missing",
+        }
+    }
 }
 
 /// The per-peer pipe-routine. Owns its `FramedRecv` (transport read), the session
@@ -576,8 +586,12 @@ impl PeerRoutine {
         // `reset_above`) and release their reservations exactly once.
         let outstanding = std::mem::take(&mut self.window.outstanding);
         for outstanding in outstanding {
-            let released = self.return_unreceived_to_queue(&outstanding);
-            self.budget.release(released);
+            let unreceived: Vec<_> = unreceived_heights(&outstanding).collect();
+            let outcome = self
+                .work
+                .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+            self.budget.release(outcome.released_bytes);
+            self.trace_work_returned("view_reset", &outstanding, unreceived.len(), outcome);
         }
         self.retry_avoid.clear();
         // Clear our (now-empty) registry outstanding and refresh slot diagnostics.
@@ -1110,8 +1124,12 @@ impl PeerRoutine {
             // Return only the unreceived heights — received ones are buffered (in
             // `in_flight` until committed); re-queuing them would re-fetch a body
             // we already hold (the WorkQueue single-owner invariant forbids it).
-            let released = self.return_unreceived_to_queue(outstanding);
-            self.budget.release(released);
+            let unreceived: Vec<_> = unreceived_heights(outstanding).collect();
+            let outcome = self
+                .work
+                .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+            self.budget.release(outcome.released_bytes);
+            self.trace_work_returned("request_timeout", outstanding, unreceived.len(), outcome);
         }
         // Bias away from immediately re-grabbing the heights this peer just timed
         // out, so another peer can contest them (the peer-local timeout bias).
@@ -1769,13 +1787,22 @@ impl PeerRoutine {
             // be re-fetched, so both retry dispositions return only the still-reserved
             // unreceived heights to `pending`. `return_items` is idempotent.
             Disposition::RetryOriginal | Disposition::RetryMissing => {
-                let released = self.return_unreceived_to_queue(&outstanding);
-                self.budget.release(released);
+                let unreceived: Vec<_> = unreceived_heights(&outstanding).collect();
+                let outcome = self
+                    .work
+                    .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+                self.budget.release(outcome.released_bytes);
+                self.trace_work_returned(
+                    disposition.trace_label(),
+                    &outstanding,
+                    unreceived.len(),
+                    outcome,
+                );
                 // This peer just failed these heights (RangeUnavailable / short
                 // BlocksDone): bias away from re-grabbing them so another peer
                 // contests the range first (and so the routine cannot self-wake
                 // into a re-take spin off its own `return_items`).
-                self.note_retry_avoid(unreceived_heights(&outstanding));
+                self.note_retry_avoid(unreceived);
             }
         }
         self.publish_outstanding();
@@ -1809,11 +1836,6 @@ impl PeerRoutine {
         } else {
             self.publish_outstanding();
         }
-    }
-
-    fn return_unreceived_to_queue(&self, outstanding: &OutstandingBlockRange) -> u64 {
-        self.work
-            .release_reserved_and_return_items(unreceived_heights(outstanding))
     }
 
     fn apply_budget_delta(&mut self, delta: i128) {
@@ -1991,6 +2013,36 @@ impl PeerRoutine {
             bs_insert_height(row, "servable_low", low);
             bs_insert_height(row, "servable_high", high);
             bs_insert_u64(row, bs_trace::RANGE_COUNT, count as u64);
+        });
+    }
+
+    fn trace_work_returned(
+        &self,
+        reason: &'static str,
+        outstanding: &OutstandingBlockRange,
+        unreceived_count: usize,
+        outcome: WorkReturnOutcome,
+    ) {
+        let unreceived_count = u64::try_from(unreceived_count).unwrap_or(u64::MAX);
+        if outcome.missing_count == 0
+            && outcome.held_count == 0
+            && outcome.released_count == 0
+            && outcome.returned_count == unreceived_count
+        {
+            return;
+        }
+
+        self.emit(bs_trace::BLOCK_WORK_RETURNED, |row| {
+            bs_insert_peer(row, bs_trace::PEER, &self.peer);
+            bs_insert_str(row, bs_trace::REASON, reason);
+            bs_insert_height(row, bs_trace::RANGE_START, outstanding.request.start_height);
+            bs_insert_u64(
+                row,
+                bs_trace::RANGE_COUNT,
+                u64::from(outstanding.request.count),
+            );
+            bs_insert_u64(row, "unreceived_count", unreceived_count);
+            insert_work_return_outcome(row, outcome);
         });
     }
 
@@ -2266,6 +2318,24 @@ fn elapsed_ms_u64(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
+fn insert_work_return_outcome(
+    row: &mut serde_json::Map<String, serde_json::Value>,
+    outcome: WorkReturnOutcome,
+) {
+    bs_insert_u64(row, "released_bytes", outcome.released_bytes);
+    bs_insert_u64(row, "returned_count", outcome.returned_count);
+    bs_insert_u64(row, "already_pending_count", outcome.already_pending_count);
+    bs_insert_u64(row, "held_count", outcome.held_count);
+    bs_insert_u64(row, "released_count", outcome.released_count);
+    bs_insert_u64(row, "missing_count", outcome.missing_count);
+    if let Some(height) = outcome.min_height {
+        bs_insert_height(row, "return_min_height", height);
+    }
+    if let Some(height) = outcome.max_height {
+        bs_insert_height(row, "return_max_height", height);
+    }
+}
+
 /// The still-unreceived heights of an outstanding request (the ones that return
 /// to `pending` on retry/timeout — never the received-and-buffered ones, which
 /// stay claimed in `work.in_flight`).
@@ -2309,18 +2379,22 @@ impl Drop for PeerRoutine {
     /// The reactor owns entry insert (on connect) and remove (on disconnect/
     /// admission-reject); see `handle_peer_disconnected`.
     fn drop(&mut self) {
-        for outstanding in self.window.outstanding.drain(..) {
+        let outstanding_ranges: Vec<_> = self.window.outstanding.drain(..).collect();
+        for outstanding in outstanding_ranges {
             // Held-aware: a height a competing peer delivered late is owned by the
             // Sequencer, so return + release only still-reserved unreceived heights.
-            let released = self.work.release_reserved_and_return_items(
-                outstanding
-                    .request
-                    .expected_blocks
-                    .iter()
-                    .filter(|expected| !outstanding.has_received(expected.height))
-                    .map(|expected| expected.height),
-            );
-            self.budget.release(released);
+            let unreceived: Vec<_> = outstanding
+                .request
+                .expected_blocks
+                .iter()
+                .filter(|expected| !outstanding.has_received(expected.height))
+                .map(|expected| expected.height)
+                .collect();
+            let outcome = self
+                .work
+                .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+            self.budget.release(outcome.released_bytes);
+            self.trace_work_returned("peer_routine_drop", &outstanding, unreceived.len(), outcome);
         }
         self.registry.clear_outstanding(&self.peer, self.generation);
     }

--- a/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/zakura-network/src/zakura/block_sync/reactor.rs
@@ -403,14 +403,35 @@ impl BlockSyncReactor {
             let released = self
                 .state
                 .work_queue
-                .release_reserved_and_return_items([claim.height]);
-            self.state.budget.release(released);
+                .release_reserved_and_return_items_detailed([claim.height]);
+            self.state.budget.release(released.released_bytes);
+            self.emit_trace(bs_trace::BLOCK_FLOOR_WATCHDOG_CANCELLED, |row| {
+                bs_insert_peer(row, bs_trace::PEER, &claim.peer);
+                bs_insert_height(row, bs_trace::HEIGHT, claim.height);
+                bs_insert_u64(row, bs_trace::ESTIMATED_BYTES, claim.meta.estimated_bytes);
+                bs_insert_u64(row, "released_bytes", released.released_bytes);
+                bs_insert_u64(row, "returned_count", released.returned_count);
+                bs_insert_u64(row, "already_pending_count", released.already_pending_count);
+                bs_insert_u64(row, "held_count", released.held_count);
+                bs_insert_u64(row, "released_count", released.released_count);
+                bs_insert_u64(row, "missing_count", released.missing_count);
+                bs_insert_u64(
+                    row,
+                    "pending_after",
+                    u64::from(self.state.work_queue.pending_contains(claim.height)),
+                );
+                bs_insert_u64(
+                    row,
+                    "in_flight_after",
+                    u64::from(self.state.work_queue.in_flight_contains(claim.height)),
+                );
+            });
             metrics::counter!("sync.block.floor_watchdog.cancelled").increment(1);
             tracing::debug!(
                 peer = ?claim.peer,
                 height = ?claim.height,
                 estimated_bytes = claim.meta.estimated_bytes,
-                released,
+                released = released.released_bytes,
                 "force-cancelled expired Zakura block-sync floor request"
             );
         }

--- a/zakura-network/src/zakura/block_sync/sequencer_task.rs
+++ b/zakura-network/src/zakura/block_sync/sequencer_task.rs
@@ -17,7 +17,7 @@
 
 use super::{
     events::*,
-    reactor::{bs_insert_height, bs_insert_u64},
+    reactor::{bs_insert_height, bs_insert_str, bs_insert_u64},
     reorder::BufferedBlockBody,
     sequencer::*,
     state::*,
@@ -455,6 +455,14 @@ impl SequencerTask {
                 ))
             && reset_tip_matches_local_work
         {
+            self.trace_frontier_reset_classified(
+                "growth",
+                &frontiers,
+                preserve_active_successors,
+                peer_has_successor_after,
+                peer_outstanding_conflicts_at_tip,
+                reset_tip_matches_local_work,
+            );
             // Growth-classified reset: treat it as a frontier advance, releasing
             // applied bodies.
             self.handle_frontier_advance(frontiers, true).await;
@@ -478,10 +486,26 @@ impl SequencerTask {
                 frontiers.verified_block_hash,
             )
         {
+            self.trace_frontier_reset_classified(
+                "preserved_stale",
+                &frontiers,
+                preserve_active_successors,
+                peer_has_successor_after,
+                peer_outstanding_conflicts_at_tip,
+                reset_tip_matches_local_work,
+            );
             self.handle_frontier_advance(frontiers, true).await;
             return;
         }
 
+        self.trace_frontier_reset_classified(
+            "destructive",
+            &frontiers,
+            preserve_active_successors,
+            peer_has_successor_after,
+            peer_outstanding_conflicts_at_tip,
+            reset_tip_matches_local_work,
+        );
         let remember_released_applies = frontiers.verified_block_tip > frontiers.finalized_height
             && frontiers.verified_block_tip <= self.sequencer.floor();
 
@@ -659,6 +683,61 @@ impl SequencerTask {
             row.insert(
                 bs_trace::RESULT.to_string(),
                 serde_json::Value::String(outcome.to_string()),
+            );
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn trace_frontier_reset_classified(
+        &self,
+        classification: &'static str,
+        frontiers: &BlockSyncFrontiers,
+        preserve_active_successors: bool,
+        peer_has_successor_after: bool,
+        peer_outstanding_conflicts_at_tip: bool,
+        reset_tip_matches_local_work: bool,
+    ) {
+        self.trace.emit_with(BLOCK_SYNC_TABLE, |row| {
+            bs_insert_str(
+                row,
+                bs_trace::EVENT,
+                bs_trace::BLOCK_FRONTIER_RESET_CLASSIFIED,
+            );
+            bs_insert_str(row, bs_trace::RESULT, classification);
+            bs_insert_height(
+                row,
+                bs_trace::VERIFIED_BLOCK_TIP,
+                frontiers.verified_block_tip,
+            );
+            bs_insert_height(row, "previous_verified_tip", self.sequencer.verified_tip());
+            bs_insert_height(row, "previous_download_floor", self.sequencer.floor());
+            bs_insert_u64(
+                row,
+                "preserve_active_successors",
+                u64::from(preserve_active_successors),
+            );
+            bs_insert_u64(
+                row,
+                "peer_has_successor_after",
+                u64::from(peer_has_successor_after),
+            );
+            bs_insert_u64(
+                row,
+                "peer_outstanding_conflicts_at_tip",
+                u64::from(peer_outstanding_conflicts_at_tip),
+            );
+            bs_insert_u64(
+                row,
+                "reset_tip_matches_local_work",
+                u64::from(reset_tip_matches_local_work),
+            );
+            bs_insert_u64(
+                row,
+                "has_local_successor_after",
+                u64::from(
+                    next_height(frontiers.verified_block_tip)
+                        .is_some_and(|next| self.sequencer.has_buffered_at_or_above(next)),
+                ),
             );
         });
     }

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -2125,12 +2125,16 @@ fn watchdog_after_held_settle_releases_once() {
     budget.release(20);
     assert_eq!(budget.reserved(), 80);
 
-    let watchdog_released = queue.release_reserved_and_return_items([block::Height(1)]);
+    let outcome = queue.release_reserved_and_return_items_detailed([block::Height(1)]);
+    let watchdog_released = outcome.released_bytes;
     budget.release(watchdog_released);
     assert_eq!(
         watchdog_released, 0,
         "watchdog must not release a held body owned by the sequencer handoff"
     );
+    assert_eq!(outcome.held_count, 1);
+    assert_eq!(outcome.returned_count, 0);
+    assert_eq!(outcome.missing_count, 0);
     assert!(queue.in_flight_contains(block::Height(1)));
     assert_eq!(budget.reserved(), 80);
 
@@ -2148,10 +2152,21 @@ fn late_delivery_after_watchdog_cancellation_does_not_resurrect_released_claim()
     assert!(budget.try_reserve(100));
     assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
 
-    let watchdog_released = queue.release_reserved_and_return_items([block::Height(1)]);
+    let outcome = queue.release_reserved_and_return_items_detailed([block::Height(1)]);
+    let watchdog_released = outcome.released_bytes;
     budget.release(watchdog_released);
+    assert_eq!(outcome.returned_count, 1);
+    assert_eq!(outcome.held_count, 0);
+    assert_eq!(outcome.missing_count, 0);
     assert_eq!(budget.reserved(), 0);
     assert!(queue.pending_contains(block::Height(1)));
+
+    let duplicate =
+        queue.release_reserved_and_return_items_detailed([block::Height(1), block::Height(2)]);
+    assert_eq!(duplicate.already_pending_count, 1);
+    assert_eq!(duplicate.missing_count, 1);
+    assert_eq!(duplicate.min_height, Some(block::Height(1)));
+    assert_eq!(duplicate.max_height, Some(block::Height(2)));
 
     assert_eq!(
         queue.settle_active_reserved_height(block::Height(1), 80),

--- a/zakura-network/src/zakura/block_sync/work_queue.rs
+++ b/zakura-network/src/zakura/block_sync/work_queue.rs
@@ -49,6 +49,31 @@ pub(super) struct WorkItem {
     pub(super) budget: BlockBudgetLedger,
 }
 
+/// Diagnostics for an attempted `in_flight -> pending` retry transition.
+///
+/// A retry cleanup can legitimately encounter a body that another path already
+/// settled to `Held`, or a height that another owner already removed. Keeping
+/// those outcomes separate makes a lost floor height attributable from traces.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct WorkReturnOutcome {
+    /// Reserved bytes released while moving items back to `pending`.
+    pub(super) released_bytes: u64,
+    /// Reserved items successfully moved back to `pending`.
+    pub(super) returned_count: u64,
+    /// Requested heights that were already back in `pending`.
+    pub(super) already_pending_count: u64,
+    /// Items still present in `in_flight`, but already settled to `Held`.
+    pub(super) held_count: u64,
+    /// Items present in `in_flight` with an unexpected `Released` ledger.
+    pub(super) released_count: u64,
+    /// Requested heights absent from both `pending` and `in_flight`.
+    pub(super) missing_count: u64,
+    /// Lowest height considered by the cleanup.
+    pub(super) min_height: Option<block::Height>,
+    /// Highest height considered by the cleanup.
+    pub(super) max_height: Option<block::Height>,
+}
+
 #[derive(Debug)]
 struct WorkQueueInner {
     pending: std::collections::BTreeMap<block::Height, WorkItem>,
@@ -451,16 +476,50 @@ impl WorkQueue {
         &self,
         heights: impl IntoIterator<Item = block::Height>,
     ) -> u64 {
+        self.release_reserved_and_return_items_detailed(heights)
+            .released_bytes
+    }
+
+    /// Release and return still-reserved items, preserving the outcome of every
+    /// requested height for low-volume lifecycle tracing.
+    pub(super) fn release_reserved_and_return_items_detailed(
+        &self,
+        heights: impl IntoIterator<Item = block::Height>,
+    ) -> WorkReturnOutcome {
         let mut moved = false;
-        let mut released = 0u64;
+        let mut outcome = WorkReturnOutcome::default();
         {
             let mut inner = self.lock();
             for height in heights {
+                outcome.min_height = Some(
+                    outcome
+                        .min_height
+                        .map_or(height, |current| current.min(height)),
+                );
+                outcome.max_height = Some(
+                    outcome
+                        .max_height
+                        .map_or(height, |current| current.max(height)),
+                );
                 let Some(item) = inner.in_flight.get(&height) else {
+                    if inner.pending.contains_key(&height) {
+                        outcome.already_pending_count =
+                            outcome.already_pending_count.saturating_add(1);
+                    } else {
+                        outcome.missing_count = outcome.missing_count.saturating_add(1);
+                    }
                     continue;
                 };
-                if !item.budget.is_reserved() {
-                    continue;
+                match item.budget {
+                    BlockBudgetLedger::Held(_) => {
+                        outcome.held_count = outcome.held_count.saturating_add(1);
+                        continue;
+                    }
+                    BlockBudgetLedger::Released => {
+                        outcome.released_count = outcome.released_count.saturating_add(1);
+                        continue;
+                    }
+                    BlockBudgetLedger::Reserved(_) => {}
                 }
                 let mut item = inner
                     .in_flight
@@ -468,16 +527,18 @@ impl WorkQueue {
                     .expect("reserved item exists because it was just checked");
                 // Only reserved items reach here, so the released bytes are exactly
                 // the reserved charge leaving the queue.
-                released = released.saturating_add(item.budget.release());
+                outcome.released_bytes =
+                    outcome.released_bytes.saturating_add(item.budget.release());
+                outcome.returned_count = outcome.returned_count.saturating_add(1);
                 inner.pending.insert(height, item);
                 moved = true;
             }
-            inner.reserved_bytes = inner.reserved_bytes.saturating_sub(released);
+            inner.reserved_bytes = inner.reserved_bytes.saturating_sub(outcome.released_bytes);
         }
         if moved {
             self.available.notify_waiters();
         }
-        released
+        outcome
     }
 
     /// Garbage-collect committed heights: raise the floor to `max(self.floor,

--- a/zakura-network/src/zakura/trace.rs
+++ b/zakura-network/src/zakura/trace.rs
@@ -300,6 +300,10 @@ pub mod block_sync_trace {
     pub const BLOCK_WORK_EXTENDED: &str = "block_work_extended";
     /// A peer claimed a contiguous chunk of pending work for issuance.
     pub const BLOCK_WORK_TAKEN: &str = "block_work_taken";
+    /// A request cleanup found an anomalous outcome returning work to `pending`.
+    pub const BLOCK_WORK_RETURNED: &str = "block_work_returned";
+    /// The floor watchdog force-cancelled an expired request claim.
+    pub const BLOCK_FLOOR_WATCHDOG_CANCELLED: &str = "block_floor_watchdog_cancelled";
     /// A `try_fill` pass ended having issued no request: the routine went idle this wake.
     /// Carries [`FILL_STOP_REASON`] plus the slot/budget/work snapshot so a trace can
     /// attribute carrier idle ("bubble") time to a cause rather than inferring it.
@@ -314,6 +318,8 @@ pub mod block_sync_trace {
     pub const BLOCK_FRONTIERS_CHANGED: &str = "block_frontiers_changed";
     /// Chain tip reset rolled the body frontier back.
     pub const BLOCK_CHAIN_TIP_RESET: &str = "block_chain_tip_reset";
+    /// Sequencer classified a frontier reset as growth, preservation, or destructive.
+    pub const BLOCK_FRONTIER_RESET_CLASSIFIED: &str = "block_frontier_reset_classified";
     /// Periodic reactor state snapshot (the key stall-diagnosis row).
     pub const BLOCK_SYNC_STATE: &str = "block_sync_state";
     /// Periodic per-peer BBR controller heartbeat, emitted on a fixed cadence even while


### PR DESCRIPTION
## Motivation

A mainnet node stalled immediately after checkpoint height 3,278,006 with the next body absent while roughly 99,000 later bodies remained buffered. Existing traces narrowed the failure to request cleanup and frontier-reset bookkeeping, but did not identify the exact terminal path that lost the floor-height work item.

## Solution

- classify frontier resets as growth, preserved stale updates, or destructive resets with the predicates used by the decision
- record detailed work-return outcomes for anomalous timeout, retry, reset, and peer-drop cleanup paths
- trace floor-watchdog cancellation outcomes and post-cleanup queue membership
- keep trace volume bounded by omitting normal successful work returns; the existing bounded JSONL channel still drops rows under writer pressure
- test reserved, held, already-pending, and missing work-return classifications

### Tests

- `cargo fmt --all -- --check` — passed on the final changes
- `cargo test -p zakura-network zakura::block_sync::tests --lib` — 179 passed before the final trace-volume filter
- `cargo clippy --workspace --all-targets -- -D warnings` — passed before the final trace-volume filter
- `cargo test --workspace` — started, then stopped before completion at operator request rather than waiting for long-running integration tests
- IDE diagnostics — clean

### Specifications & References

This is observability-only: it does not intentionally change protocol, scheduling, retry, timeout, or consensus decisions.

### Follow-up Work

Use these events during the next reproduced floor-gap stall to identify whether work was missing, held, already pending, or successfully returned at each cleanup boundary.

### AI Disclosure

- [x] AI tools were used: Cursor (GPT-5.6 Sol) investigated production traces, implemented the diagnostics, and updated tests.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`
- [x] The PR follows the contribution guidelines
- [x] This change was discussed with the team beforehand
- [x] The focused block-sync solution is tested
- [x] Documentation and changelogs are up to date; no user-visible changelog entry is required