### PR TITLE
fix(chain): test-gate placeholder NU7 branch ID

### DIFF
--- a/zakura-chain/src/parameters/network_upgrade.rs
+++ b/zakura-chain/src/parameters/network_upgrade.rs
@@ -239,6 +239,7 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Nu6_2, ConsensusBranchId(0x5437f330)),
     (Nu6_3, ConsensusBranchId(0x37a5165b)),
     // TODO: set below to (Nu7, ConsensusBranchId(0x77190ad8)), once the same value is set in librustzcash
+    #[cfg(any(test, feature = "zakura-test"))]
     (Nu7, ConsensusBranchId(0xfffffffe)),
     #[cfg(zcash_unstable = "zfuture")]
     (ZFuture, ConsensusBranchId(0xfffffffd)),


### PR DESCRIPTION
## Motivation

The placeholder NU7 consensus branch ID `0xfffffffe` was included in
`CONSENSUS_BRANCH_IDS` in production builds. This value is only intended for
tests until the final NU7 branch ID is available in `librustzcash`.

## Solution

Gate the placeholder NU7 entry behind `cfg(any(test, feature = "zakura-test"))`,
matching the Zcash Foundation implementation. Production builds no longer
expose the fake branch ID, while unit tests and downstream test utilities retain
access to it.

### Tests

- `cargo fmt --all -- --check`
- `cargo test -p zakura-chain --lib parameters::tests::branch_id_bijective`
- `cargo check -p zakura-chain --lib`
- `git diff --check`

### Specifications & References

- Zcash Foundation Zebra's test-gated NU7 placeholder implementation

### Follow-up Work

Replace the placeholder with the final NU7 consensus branch ID once the same
value is available in `librustzcash`.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex inspected the upstream implementation,
  applied the configuration gate, ran validation, and drafted this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single cfg guard on a placeholder consensus constant; production behavior removes a test-only ID rather than changing live NU6.3 rules.
> 
> **Overview**
> The placeholder NU7 consensus branch ID (`0xfffffffe`) is no longer part of **`CONSENSUS_BRANCH_IDS`** in normal production builds of `zakura-chain`.
> 
> That mapping is now behind **`cfg(any(test, feature = "zakura-test"))`**, aligned with Zebra, so release code does not advertise a fake branch ID while unit tests and crates that enable `zakura-test` can still resolve NU7 for checks like **`branch_id_bijective`**. The TODO to swap in the real NU7 ID from `librustzcash` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3492e8357b77de667eefc4d1c800db705bc566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->