### PR TITLE
fix(docker): disable v2 p2p in mining stack, not just QUIC ports

### DIFF
--- a/docker/mining/README.md
+++ b/docker/mining/README.md
@@ -22,6 +22,10 @@ Docker Compose setup for running a Zcash mining pool with Zebra and S-NOMP.
 - **S-NOMP**: Stratum mining pool - distributes work to miners, submits blocks
 - **Redis**: Stores share counts and pool statistics
 
+The included full node explicitly uses the legacy TCP P2P stack. Native Zakura
+QUIC transport is disabled, matching the single TCP peer port published by the
+Compose configuration.
+
 All block rewards go to the address configured in `MINER_ADDRESS`.
 
 ## Quick Start

--- a/docker/mining/docker-compose.yml
+++ b/docker/mining/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     container_name: zakura
     environment:
       - ZAKURA_NETWORK__NETWORK=${NETWORK:-Testnet}
+      # The mining stack only publishes the legacy TCP peer port, so keep the
+      # native Zakura QUIC transport disabled on every network.
+      - ZAKURA_NETWORK__P2P_STACK=legacy
       - ZAKURA_RPC__LISTEN_ADDR=0.0.0.0:${RPC_PORT:-18232}
       - ZAKURA_RPC__ENABLE_COOKIE_AUTH=false
       - ZAKURA_SYNC__PARALLEL_CPU_THREADS=12


### PR DESCRIPTION
## Motivation

The Docker mining stack defaults to Testnet. With no explicit P2P stack,
Testnet resolves to dual-stack mode and starts the native Zakura QUIC endpoint
on UDP 8234, even though the Compose file publishes only the legacy TCP peer
port.

The mining deployment should run only the transport it intentionally exposes.

## Solution

- Pin the Zakura container to `ZAKURA_NETWORK__P2P_STACK=legacy`.
- Document that the mining stack uses legacy TCP P2P and disables native QUIC.

### Tests

- `cargo test -p zakura-network canonical_p2p_stack_names_parse --locked`
- Parsed `docker/mining/docker-compose.yml` as YAML and asserted that the Zakura
  environment contains `ZAKURA_NETWORK__P2P_STACK=legacy`.
- `git diff --check`

Docker is not installed in the local validation environment, so
`docker compose config` could not be run.

### Specifications & References

This aligns the runtime P2P stack with the single legacy TCP peer port published
by the mining Compose configuration.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex was used to audit the transport startup
  path, implement the Compose and documentation changes, run validation, and
  prepare this PR.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/)
  format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment-only environment and docs change; no runtime consensus or networking logic in the node binary is modified.
> 
> **Overview**
> The Docker mining stack now **forces legacy TCP P2P** by setting `ZAKURA_NETWORK__P2P_STACK=legacy` on the Zakura service, so Testnet no longer starts dual-stack mode and a native QUIC listener on UDP 8234 when Compose only maps the TCP peer port.
> 
> `docker/mining/README.md` notes that the mining full node uses legacy TCP and disables native Zakura QUIC, aligned with the published peer port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f7fb1c96fe7a7d92eb724a0b982c77aff15f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
