### PR TITLE
fix(ci): isolate environment-dependent test suites

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,9 @@ jobs:
       - uses: ./.github/actions/setup-zakura-build
       - name: Run coverage tests
         run: |
-          cargo llvm-cov --no-report nextest
+          # Use the CI-safe profile so real-time scenario tests run in their dedicated,
+          # retrying workflows instead of under slow coverage instrumentation.
+          cargo llvm-cov --no-report nextest --profile all-tests
           # TODO: Do we need --locked --release --features "default-release-binaries" here?
           cargo llvm-cov report --lcov --output-path lcov.info
         env:

--- a/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
@@ -823,10 +823,13 @@ mod tests {
             Config,
         };
 
-        let archive_dir = std::env::var_os("VCT_ARCHIVE_DB")
-            .expect("set VCT_ARCHIVE_DB to an archive state cache directory");
-        let ranges = std::env::var("VCT_RANGES")
-            .expect("set VCT_RANGES to comma-separated inclusive ranges, for example 10-20,30-40");
+        let (Some(archive_dir), Ok(ranges)) = (
+            std::env::var_os("VCT_ARCHIVE_DB"),
+            std::env::var("VCT_RANGES"),
+        ) else {
+            eprintln!("skipping: set VCT_ARCHIVE_DB (archive state) and VCT_RANGES (START-END)");
+            return;
+        };
 
         let config = Config {
             cache_dir: PathBuf::from(archive_dir),


### PR DESCRIPTION
## Motivation

Post-merge CI runs were failing for reasons unrelated to the merged changes:
- the full unit profile forced an ignored VCT archive diagnostic to run without its required external database;
- coverage instrumentation ran a real-time block-sync fuzz scenario outside its dedicated retrying job, causing its wall-clock deadline to expire.

## Solution

- Skip the manual VCT archive diagnostic when `VCT_ARCHIVE_DB` or `VCT_RANGES` is not configured, matching the existing environment-gated VCT diagnostic behavior.
- Run coverage through the CI-safe `all-tests` profile so real-time block-sync fuzz scenarios remain in the dedicated `zakura-blocksync-fuzz` workflow.

### Tests

- `git diff --check`
- Workflow and Rust file diagnostics report no lint errors.
- Full coverage was not run locally because it is a long instrumented CI build.

### Specifications & References

- Unit failure: https://github.com/zakura-core/zakura/actions/runs/29209110627
- Coverage failure: https://github.com/zakura-core/zakura/actions/runs/29209110601

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor GPT-5.6 Sol diagnosed the CI failures and implemented the test/workflow guards.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was requested by the maintainer after the linked CI failures.
- [x] The solution is tested as described above.
- [x] Documentation and changelog updates are not required for this CI-only fix.