### PR TITLE
fix(chain): reject reserved V5 Orchard flags

### DIFF
--- a/zakura-chain/src/transaction/serialize.rs
+++ b/zakura-chain/src/transaction/serialize.rs
@@ -29,6 +29,14 @@ use crate::sapling;
 const ALLOW_CROSS_ADDRESS_BIT: bool = true;
 const ORCHARD_SPEND_OUTPUT_FLAG_BITS: u8 = 0b0000_0011;
 
+fn orchard_allowed_flag_bits(allow_cross_address_bit: bool) -> u8 {
+    if allow_cross_address_bit {
+        ORCHARD_SPEND_OUTPUT_FLAG_BITS | orchard::Flags::ENABLE_CROSS_ADDRESS.bits()
+    } else {
+        ORCHARD_SPEND_OUTPUT_FLAG_BITS
+    }
+}
+
 impl ZcashDeserialize for jubjub::Fq {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         let possible_scalar = jubjub::Fq::from_bytes(&reader.read_32_bytes()?);
@@ -460,11 +468,7 @@ fn serialize_orchard_flags<W: io::Write>(
     mut writer: W,
     allow_cross_address_bit: bool,
 ) -> Result<(), io::Error> {
-    let valid_bits = if allow_cross_address_bit {
-        ORCHARD_SPEND_OUTPUT_FLAG_BITS | orchard::Flags::ENABLE_CROSS_ADDRESS.bits()
-    } else {
-        ORCHARD_SPEND_OUTPUT_FLAG_BITS
-    };
+    let valid_bits = orchard_allowed_flag_bits(allow_cross_address_bit);
 
     if flags.bits() & !valid_bits != 0 {
         return Err(io::Error::new(
@@ -554,18 +558,11 @@ fn deserialize_orchard_flags<R: io::Read>(
     allow_cross_address_bit: bool,
 ) -> Result<orchard::Flags, SerializationError> {
     let bits = reader.read_u8()?;
-    if allow_cross_address_bit {
-        if bits & !(ORCHARD_SPEND_OUTPUT_FLAG_BITS | orchard::Flags::ENABLE_CROSS_ADDRESS.bits())
-            == 0
-        {
-            Some(orchard::Flags::from_bits_retain(bits))
-        } else {
-            None
-        }
+    if bits & !orchard_allowed_flag_bits(allow_cross_address_bit) == 0 {
+        Ok(orchard::Flags::from_bits_retain(bits))
     } else {
-        orchard::Flags::from_bits(bits)
+        Err(SerializationError::Parse("invalid reserved orchard flags"))
     }
-    .ok_or(SerializationError::Parse("invalid reserved orchard flags"))
 }
 
 // we can't split ShieldedData out of Option<ShieldedData> deserialization,

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -157,6 +157,56 @@ fn v5_orchard_cross_address_flag_fails_serialization() {
 }
 
 #[test]
+fn v5_orchard_cross_address_flag_fails_deserialization() {
+    let _init_guard = zakura_test::init();
+
+    let mut tx = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find(|transaction| transaction.orchard_shielded_data().is_some())
+        .expect("test vectors include an Orchard transaction");
+
+    let original_bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("valid V5 transaction should serialize");
+
+    let Transaction::V5 {
+        orchard_shielded_data: Some(orchard_shielded_data),
+        ..
+    } = &mut tx
+    else {
+        unreachable!("test transaction is V5 with Orchard shielded data");
+    };
+
+    orchard_shielded_data
+        .flags
+        .toggle(crate::orchard::Flags::ENABLE_SPENDS);
+
+    let toggled_bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("V5 Orchard spend flag should serialize");
+    let differing_indices: Vec<_> = original_bytes
+        .iter()
+        .zip(&toggled_bytes)
+        .enumerate()
+        .filter_map(|(index, (original, toggled))| (original != toggled).then_some(index))
+        .collect();
+    let [flags_index] = differing_indices.as_slice() else {
+        panic!("toggling the Orchard spend flag should change exactly one byte");
+    };
+
+    let mut malformed_bytes = original_bytes;
+    malformed_bytes[*flags_index] = crate::orchard::Flags::ENABLE_CROSS_ADDRESS.bits();
+
+    let error = Transaction::zcash_deserialize(&malformed_bytes[..])
+        .expect_err("V5 Orchard flags must reject reserved cross-address bit");
+
+    assert!(matches!(
+        error,
+        SerializationError::Parse("invalid reserved orchard flags")
+    ));
+}
+
+#[test]
 fn doesnt_deserialize_transaction_with_invalid_value_balance() {
     let _init_guard = zakura_test::init();
 


### PR DESCRIPTION
## Motivation

V5 transaction deserialization accepted the Orchard cross-address flag even
though that bit is reserved before Ironwood. The resulting transaction could
not be re-serialized, causing inbound peer transaction handling to panic while
constructing an `UnminedTx`.

This fixes the confirmed denial-of-service report by restoring the invariant
that successfully deserialized transactions can be serialized.

## Solution

- Use one version-aware allowed-bits helper for both Orchard flag serialization
  and deserialization.
- Explicitly reject flag bits outside the V5 spend/output mask instead of
  relying on `Flags::from_bits`, which recognizes the cross-address bit as a
  defined flag.
- Add a regression test that mutates a serialized V5 Orchard transaction and
  verifies the reserved cross-address bit is rejected during deserialization.

### Tests

- `cargo fmt --all -- --check`
- `cargo test -p zakura-chain --lib` (310 passed)
- `git diff --check`

### Specifications & References

The V5 transaction encoding reserves Orchard flag bits 2 through 7. The
cross-address flag is only accepted by the Ironwood-aware format.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex implemented the parser fix, added the
  regression test, and drafted this PR description under human direction.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in a confirmed security report.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date; no changelog entry is
  needed for rejecting malformed peer input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches untrusted peer transaction deserialization on a confirmed DoS path, but the change is narrow flag-bit validation with a regression test and restores serialize/deserialize consistency.
> 
> **Overview**
> **V5 Orchard `flagsOrchard` parsing** now treats the cross-address bit as reserved (pre-Ironwood), matching serialization and the protocol spec.
> 
> A shared `orchard_allowed_flag_bits` helper drives both `serialize_orchard_flags` and `deserialize_orchard_flags`. For V5 (`allow_cross_address_bit: false`), only the spend/output mask is allowed; any other set bits fail with `invalid reserved orchard flags` instead of being accepted via `Flags::from_bits` / `from_bits_retain`.
> 
> A new regression test mutates a serialized V5 Orchard transaction so the flags byte is only the cross-address bit and asserts deserialization rejects it (complementing the existing serialization test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c576731559142396413b46caeb4a48095b938f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->