### PR TITLE
fix(ci): update custom config output matcher

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -145,7 +145,7 @@ jobs:
           - id: custom-conf
             name: Custom config
             env_vars: -e CONFIG_FILE_PATH=/home/zebra/zakurad/tests/common/configs/custom-conf.toml
-            grep_patterns: -e "extra_coinbase_data:\\sSome\\(\\\"Do you even shield\\?\\\"\\)"
+            grep_patterns: -e "extra_coinbase_data:\\sSome\\(ExtraCoinbaseData\\(\\\"Do you even shield\\?\\\"\\)\\)"
 
           # RPC configuration tests
           - id: rpc-conf


### PR DESCRIPTION
## Motivation

The Docker custom-config test waited for an outdated debug representation of `extra_coinbase_data`. The expected text never matched, so `docker logs --follow` continued until the job timeout and caused the aggregate Docker config check to fail.

## Solution

Update the custom-config grep pattern to include the `ExtraCoinbaseData` wrapper now emitted by the configuration debug output.

### Tests

- Verified the updated extended regular expression against `extra_coinbase_data: Some(ExtraCoinbaseData(\"Do you even shield?\"))`.
- `git diff --check` — passed.
- IDE diagnostics — no errors.
- `actionlint .github/workflows/test-docker.yml` — the changed matcher is accepted; actionlint still reports the existing unrelated SC2086 warning at line 207.

Risk classification: low risk; this is a one-line CI matcher update. Full workspace Rust checks were skipped under the repository's risk-based verification policy.

### Specifications & References

- Failed workflow: https://github.com/zakura-core/zakura/actions/runs/29225249269/job/86748505165

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used: Cursor was used to diagnose the failed workflow, update and validate the matcher, and draft this PR description.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [x] Documentation and changelogs are up to date; no changelog entry is needed for this CI-only fix.