### PR TITLE
chore(release): update new crate owners

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -17,4 +17,4 @@ push = false
 tag = false
 
 # Owners for new crates
-owners = [ 'oxarbitrage', 'conradoplg', 'zcashfoundation/owners' ]
+owners = [ 'valardragon', 'p0mvn', 'evan-forbes', 'czarcas7ic', 'ebfull' ]


### PR DESCRIPTION
## Motivation

Keep the default crates.io owner list aligned with the current Zakura maintainers.

## Solution

Replace the existing `release.toml` owners with:

- `valardragon`
- `p0mvn`
- `evan-forbes`
- `czarcas7ic`
- `ebfull`

### Tests

- IDE diagnostics: passed
- Local tests not run: low-risk release configuration-only change, per repository verification policy

### Specifications & References

- Requested directly by the team

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used: Cursor updated the configuration and prepared the PR.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is verified by inspection and IDE diagnostics.
- [x] Documentation and changelogs are not applicable to this configuration-only change.