### PR TITLE
fix(network): use non-deprecated atomic update API

### DIFF
--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -258,7 +258,7 @@ impl HeaderSyncPeerSession {
         let id = self
             .inner
             .next_request_id
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
             .map_err(|_| {
                 OrderedSendError::Encode("header-sync request ID counter exhausted".into())
             })?;

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -255,13 +255,21 @@ impl HeaderSyncPeerSession {
             return Ok(None);
         }
 
-        let id = self
-            .inner
-            .next_request_id
-            .try_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
-            .map_err(|_| {
+        let mut id = self.inner.next_request_id.load(Ordering::Relaxed);
+        loop {
+            let next_id = id.checked_add(1).ok_or_else(|| {
                 OrderedSendError::Encode("header-sync request ID counter exhausted".into())
             })?;
+            match self.inner.next_request_id.compare_exchange_weak(
+                id,
+                next_id,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(current_id) => id = current_id,
+            }
+        }
         HeaderSyncRequestId::new(id)
             .ok_or_else(|| {
                 OrderedSendError::Encode("header-sync request ID counter exhausted".into())


### PR DESCRIPTION
## Motivation

The stable Rust toolchain deprecates `AtomicU64::fetch_update`, so `-D warnings` rejects the existing code. Its replacement, `try_update`, was stabilized in Rust 1.95 and is therefore unavailable at Zakura's Rust 1.91 MSRV.

## Solution

Replace `fetch_update` with an MSRV-compatible `compare_exchange_weak` loop. The new implementation preserves the existing behavior:

- atomically increments request IDs
- rejects counter exhaustion instead of wrapping
- returns the allocated pre-increment ID
- retains relaxed memory ordering

### Tests

- `cargo fmt --all -- --check` — pass
- IDE diagnostics — pass
- GitHub Actions MSRV, Clippy, and test checks — pending

Full local Clippy and test suites were not run because other long-running repository builds were active.

### Specifications & References

- Zakura MSRV: Rust 1.91

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor implemented the MSRV-compatible atomic update loop and prepared the PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested. (CI is pending.)
- [x] Documentation and changelog updates are not needed for this internal compatibility fix.