### PR TITLE
fix(ci): fix tag existence check in create-release publish step

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -217,12 +217,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          existing_sha="$(
-            gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}" \
-              --jq '.object.sha' 2>/dev/null || true
-          )"
-          if [ -n "$existing_sha" ] && [ "$existing_sha" != "$TARGET_SHA" ]; then
-            echo "Tag ${RELEASE_TAG} already points to ${existing_sha}, not ${TARGET_SHA}." >&2
+          # On HTTP errors `gh api` prints the JSON error body to stdout, so
+          # branch on the exit status instead of the captured output, and only
+          # treat a 404 (tag does not exist yet) as the create-tag path.
+          ref_status=0
+          ref_json="$(gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}" 2>/dev/null)" || ref_status=$?
+          if [ "$ref_status" -eq 0 ]; then
+            existing_sha="$(echo "$ref_json" | jq -r '.object.sha')"
+            if [ "$existing_sha" != "$TARGET_SHA" ]; then
+              echo "Tag ${RELEASE_TAG} already points to ${existing_sha}, not ${TARGET_SHA}." >&2
+              exit 1
+            fi
+          elif [ "$(echo "$ref_json" | jq -r '.status? // empty' 2>/dev/null)" != "404" ]; then
+            echo "Failed to look up tag ${RELEASE_TAG}: ${ref_json}" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Motivation

The first run of the protected **Create release** workflow for `v1.0.0-rc3` ([run 29233844868](https://github.com/zakura-core/zakura/actions/runs/29233844868)) built and verified all assets, then failed in the *Publish staged release* step with:

```
Tag v1.0.0-rc3 already points to {"message":"Not Found",...,"status":"404"}, not bbef37848...
```

On HTTP errors, `gh api` prints the JSON error body to **stdout** (the `--jq` filter is not applied to error responses) and only the `gh: Not Found (HTTP 404)` line to stderr. The old check used `2>/dev/null || true`, so when the tag did not exist yet — the workflow's primary path — the command substitution captured the 404 body as `existing_sha`, and the "tag already points elsewhere" guard fired on a tag that doesn't exist. As written, the workflow could never create a fresh tag.

## Solution

Branch on the exit status of `gh api` instead of on its captured stdout:

- exit 0 → tag exists: keep the idempotency guard (matching SHA proceeds, mismatched SHA hard-fails)
- non-zero with a `404` body → tag does not exist: proceed to create the draft release/tag
- any other failure (auth, rate limit, 5xx, network) → fail loudly with the response body, instead of being silently swallowed by `|| true` as before

No cleanup of the failed rc3 run is needed: the step failed before creating anything, so there is no tag, draft release, or uploaded asset for `v1.0.0-rc3`. After this merges, re-running **Create release** for rc3 should go clean.

### Tests

- Exercised the exact new shell snippet locally with a stubbed `gh` across five scenarios: tag missing (404) → proceeds; tag exists at target SHA → proceeds; tag exists at wrong SHA → fails; non-404 API error (401) → fails; `gh` fails with empty output → fails. All pass.
- Reproduced the underlying `gh` behavior against the live API: `gh api repos/zakura-core/zakura/git/ref/tags/v1.0.0-rc3` prints the 404 JSON to stdout, confirming the diagnosis.
- Verified the workflow YAML still parses.

### Specifications & References

- Failed run: https://github.com/zakura-core/zakura/actions/runs/29233844868
- Protected release workflow introduced in #104

### Follow-up Work

None — re-run the Create release workflow for `v1.0.0-rc3` after merge.

### AI Disclosure

- [x] AI tools were used: Claude Code diagnosed the failure and wrote the fix, the stubbed-`gh` test script, and this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand (fixes the failed rc3 release run).
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date (CI-only change, no changelog entry needed).