### PR TITLE
fix(network): contain legacy peer parser panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-### Fixed
-
-- Contained panics while decoding peer-controlled legacy messages to the
-  affected connection, which is disconnected through the normal peer failure
-  path.
-
 Initial release of Zakura.
 
 Zakura is a fork of the Zcash Foundation's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Contained panics while decoding peer-controlled legacy messages to the
+  affected connection, which is disconnected through the normal peer failure
+  path.
+
 Initial release of Zakura.
 
 Zakura is a fork of the Zcash Foundation's

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Contained panics while decoding peer-controlled legacy messages to the
+  affected connection, which is disconnected through the normal peer failure
+  path.
+
 ### Added
 
 - Added `HeaderSyncEvent::VctRootRepairRequested` and

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -347,6 +347,42 @@ async fn connection_run_loop_inbound_close() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that an inbound parser error takes the normal peer failure path.
+#[tokio::test]
+async fn connection_run_loop_inbound_parser_error() {
+    let _init_guard = zakura_test::init();
+
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
+    let (mut peer_tx, peer_rx) = mpsc::channel(1);
+
+    let (connection, client_tx, mut inbound_service, mut peer_outbound_messages, error_slot) =
+        new_test_connection();
+
+    peer_tx
+        .try_send(Err(SerializationError::Parse("test peer parser panic")))
+        .expect("test peer channel should accept a parser error");
+
+    let connection = connection.run(peer_rx).shared();
+    let connection_guard = connection.clone();
+    assert_eq!(connection.now_or_never(), Some(()));
+
+    let error = error_slot
+        .try_get_error()
+        .expect("peer parser error should be stored");
+    assert_eq!(
+        error.inner_debug(),
+        "Serialization(Parse(\"test peer parser panic\"))"
+    );
+    assert!(client_tx.is_closed());
+    assert!(peer_tx.is_closed());
+
+    inbound_service.expect_no_requests().await;
+
+    std::mem::drop(connection_guard);
+    assert_eq!(peer_outbound_messages.next().await, None);
+}
+
 /// Test that the connection run loop fails correctly when the peer channel is dropped
 /// (We're not sure if tokio closes or drops the TcpStream when the TCP connection closes.)
 #[tokio::test]

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -50,7 +50,8 @@ use crate::{
     types::MetaAddr,
     zakura::{
         P2pV2Upgrade, P2pV2UpgradeAccept, P2pV2UpgradeInit, P2pV2UpgradeReject,
-        ZakuraHandshakeConfig, ZakuraLegacyNonces, ZakuraPeerId, PRELUDE_MAGIC,
+        ZakuraHandshakeConfig, ZakuraLegacyNonces, ZakuraPeerId, ZakuraProtocolError,
+        P2P_V2_UPGRADE_COMMAND, PRELUDE_MAGIC,
     },
     zakura::{ZakuraHandshakeConnector, ZakuraRejectReason, ZakuraUpgradeOutcome},
     BoxError, Config, PeerSocketAddr, VersionMessage,
@@ -1234,6 +1235,40 @@ where
     Ok(())
 }
 
+/// Decode a peer-controlled Zakura upgrade prelude.
+///
+/// A panic is terminal for this legacy connection: callers propagate the
+/// returned serialization error and drop the framed transport without reusing
+/// its parser state.
+fn decode_upgrade_prelude(payload: &[u8]) -> Result<P2pV2Upgrade, HandshakeError> {
+    decode_upgrade_prelude_with(|| P2pV2Upgrade::decode(payload))
+}
+
+/// Run the structured upgrade prelude decoder inside its panic boundary.
+fn decode_upgrade_prelude_with(
+    decode: impl FnOnce() -> Result<P2pV2Upgrade, ZakuraProtocolError> + panic::UnwindSafe,
+) -> Result<P2pV2Upgrade, HandshakeError> {
+    match panic::catch_unwind(decode) {
+        Ok(Ok(prelude)) => Ok(prelude),
+        Ok(Err(error)) => {
+            metrics::counter!("zakura.p2p.upgrade.prelude.malformed").increment(1);
+            Err(HandshakeError::ZakuraUpgradePreludeMalformed(error))
+        }
+        Err(_panic_payload) => {
+            metrics::counter!(
+                "peer.message.parse.panics",
+                "parser" => "upgrade_prelude",
+            )
+            .increment(1);
+            tracing::error!(
+                command = P2P_V2_UPGRADE_COMMAND,
+                "peer-controlled message parser panicked; disconnecting legacy peer"
+            );
+            Err(SerializationError::Parse("Zakura P2P v2 upgrade prelude parser panicked").into())
+        }
+    }
+}
+
 /// Reads the next legacy [`P2pV2Upgrade`] prelude from the peer.
 ///
 /// Skips a small bounded number of unrelated messages (the overall handshake
@@ -1265,13 +1300,7 @@ where
             .await
             .ok_or(HandshakeError::ConnectionClosed)??;
         if let Message::P2pV2Upgrade(payload) = message {
-            return match P2pV2Upgrade::decode(&payload) {
-                Ok(prelude) => Ok(Some(prelude)),
-                Err(error) => {
-                    metrics::counter!("zakura.p2p.upgrade.prelude.malformed").increment(1);
-                    Err(HandshakeError::ZakuraUpgradePreludeMalformed(error))
-                }
-            };
+            return decode_upgrade_prelude(&payload).map(Some);
         }
     }
 

--- a/zakura-network/src/peer/handshake/tests.rs
+++ b/zakura-network/src/peer/handshake/tests.rs
@@ -489,6 +489,23 @@ async fn responder_upgrade_disconnects_on_malformed_prelude() {
     );
 }
 
+/// A panic in structured prelude decoding is a terminal serialization error
+/// for that legacy peer, not a handshake-task panic.
+#[test]
+fn upgrade_prelude_parser_panic_becomes_serialization_error() {
+    let _init_guard = zakura_test::init();
+
+    let error = decode_upgrade_prelude_with(|| panic!("test prelude parser panic"))
+        .expect_err("the parser panic must become a handshake error");
+
+    assert!(matches!(
+        error,
+        HandshakeError::Serialization(SerializationError::Parse(
+            "Zakura P2P v2 upgrade prelude parser panicked"
+        ))
+    ));
+}
+
 /// The TCP initiator side of the same regression: a peer that advertised
 /// `NODE_P2P_V2`, receives our `Init`, and replies with a `p2pv2up` message
 /// whose payload fails to decode must be disconnected, not kept on legacy.

--- a/zakura-network/src/protocol/external/codec.rs
+++ b/zakura-network/src/protocol/external/codec.rs
@@ -4,7 +4,11 @@ use std::{
     cmp::min,
     fmt,
     io::{Cursor, Read, Write},
+    panic::{self, AssertUnwindSafe},
 };
+
+#[cfg(test)]
+use std::cell::Cell;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use bytes::{BufMut, BytesMut};
@@ -46,10 +50,23 @@ const HEADER_LEN: usize = 24usize;
 /// verack is 0 bytes. 1 KB provides headroom for future protocol changes.
 const MAX_HANDSHAKE_BODY_LEN: usize = 1024;
 
+/// The parse error returned when a legacy message body parser panics.
+const PANICKED_MESSAGE_BODY_PARSE_ERROR: &str = "panic while parsing peer message body";
+
+#[cfg(test)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum BodyDecodePanic {
+    CommandDispatch,
+    AfterBlockConversion,
+    AfterTransactionConversion,
+}
+
 /// A codec which produces Bitcoin messages from byte streams and vice versa.
 pub struct Codec {
     builder: Builder,
     state: DecodeState,
+    #[cfg(test)]
+    body_decode_panic: Cell<Option<BodyDecodePanic>>,
 }
 
 /// A builder for specifying [`Codec`] options.
@@ -95,6 +112,8 @@ impl Builder {
         Codec {
             builder: self,
             state: DecodeState::Head,
+            #[cfg(test)]
+            body_decode_panic: Cell::new(None),
         }
     }
 
@@ -466,60 +485,93 @@ impl Decoder for Codec {
                 }
 
                 let mut body_reader = Cursor::new(&body);
-                match &command {
-                    b"version\0\0\0\0\0" => self.read_version(&mut body_reader),
-                    b"verack\0\0\0\0\0\0" => self.read_verack(&mut body_reader),
-                    b"ping\0\0\0\0\0\0\0\0" => self.read_ping(&mut body_reader),
-                    b"pong\0\0\0\0\0\0\0\0" => self.read_pong(&mut body_reader),
-                    b"reject\0\0\0\0\0\0" => self.read_reject(&mut body_reader),
-                    crate::zakura::P2P_V2_UPGRADE_COMMAND_BYTES => {
-                        self.read_p2p_v2_upgrade(&mut body_reader, body_len)
-                    }
-                    b"addr\0\0\0\0\0\0\0\0" => self.read_addr(&mut body_reader),
-                    b"addrv2\0\0\0\0\0\0" => self.read_addrv2(&mut body_reader),
-                    b"getaddr\0\0\0\0\0" => self.read_getaddr(&mut body_reader),
-                    b"block\0\0\0\0\0\0\0" => self.read_block(&mut body_reader),
-                    b"getblocks\0\0\0" => self.read_getblocks(&mut body_reader),
-                    b"headers\0\0\0\0\0" => self.read_headers(&mut body_reader),
-                    b"getheaders\0\0" => self.read_getheaders(&mut body_reader),
-                    b"inv\0\0\0\0\0\0\0\0\0" => self.read_inv(&mut body_reader),
-                    b"getdata\0\0\0\0\0" => self.read_getdata(&mut body_reader),
-                    b"notfound\0\0\0\0" => self.read_notfound(&mut body_reader),
-                    b"tx\0\0\0\0\0\0\0\0\0\0" => self.read_tx(&mut body_reader),
-                    b"mempool\0\0\0\0\0" => self.read_mempool(&mut body_reader),
-                    b"filterload\0\0" => self.read_filterload(&mut body_reader, body_len),
-                    b"filteradd\0\0\0" => self.read_filteradd(&mut body_reader, body_len),
-                    b"filterclear\0" => self.read_filterclear(&mut body_reader),
-                    _ => {
-                        let command_string = String::from_utf8_lossy(&command);
 
-                        // # Security
-                        //
-                        // Zcash connections are not authenticated, so malicious nodes can
-                        // send fake messages, with connected peers' IP addresses in the IP header.
-                        //
-                        // Since we can't verify their source, Zebra needs to ignore unexpected messages,
-                        // because closing the connection could cause a denial of service or eclipse attack.
-                        debug!(?command, %command_string, "unknown message command from peer");
-                        return Ok(None);
+                // The body bytes are owned locally and the decoder state was
+                // reset above, before entering this unwind boundary. Body
+                // readers do not mutate shared services or connection state.
+                // A caught panic returns an error that the network treats as
+                // terminal, dropping this codec and its peer transport.
+                let decode_result = panic::catch_unwind(AssertUnwindSafe(|| {
+                    #[cfg(test)]
+                    self.panic_at_body_decode_point(BodyDecodePanic::CommandDispatch);
+
+                    match &command {
+                        b"version\0\0\0\0\0" => self.read_version(&mut body_reader),
+                        b"verack\0\0\0\0\0\0" => self.read_verack(&mut body_reader),
+                        b"ping\0\0\0\0\0\0\0\0" => self.read_ping(&mut body_reader),
+                        b"pong\0\0\0\0\0\0\0\0" => self.read_pong(&mut body_reader),
+                        b"reject\0\0\0\0\0\0" => self.read_reject(&mut body_reader),
+                        crate::zakura::P2P_V2_UPGRADE_COMMAND_BYTES => {
+                            self.read_p2p_v2_upgrade(&mut body_reader, body_len)
+                        }
+                        b"addr\0\0\0\0\0\0\0\0" => self.read_addr(&mut body_reader),
+                        b"addrv2\0\0\0\0\0\0" => self.read_addrv2(&mut body_reader),
+                        b"getaddr\0\0\0\0\0" => self.read_getaddr(&mut body_reader),
+                        b"block\0\0\0\0\0\0\0" => self.read_block(&mut body_reader),
+                        b"getblocks\0\0\0" => self.read_getblocks(&mut body_reader),
+                        b"headers\0\0\0\0\0" => self.read_headers(&mut body_reader),
+                        b"getheaders\0\0" => self.read_getheaders(&mut body_reader),
+                        b"inv\0\0\0\0\0\0\0\0\0" => self.read_inv(&mut body_reader),
+                        b"getdata\0\0\0\0\0" => self.read_getdata(&mut body_reader),
+                        b"notfound\0\0\0\0" => self.read_notfound(&mut body_reader),
+                        b"tx\0\0\0\0\0\0\0\0\0\0" => self.read_tx(&mut body_reader),
+                        b"mempool\0\0\0\0\0" => self.read_mempool(&mut body_reader),
+                        b"filterload\0\0" => self.read_filterload(&mut body_reader, body_len),
+                        b"filteradd\0\0\0" => self.read_filteradd(&mut body_reader, body_len),
+                        b"filterclear\0" => self.read_filterclear(&mut body_reader),
+                        _ => {
+                            let command_string = String::from_utf8_lossy(&command);
+
+                            // # Security
+                            //
+                            // Zcash connections are not authenticated, so malicious nodes can
+                            // send fake messages, with connected peers' IP addresses
+                            // in the IP header.
+                            //
+                            // Since we can't verify their source, Zebra needs to ignore
+                            // unexpected messages, because closing the connection could
+                            // cause a denial of service or eclipse attack.
+                            debug!(?command, %command_string, "unknown message command from peer");
+                            return Ok(None);
+                        }
+                    }
+                    // We need Ok(Some(msg)) to signal that we're done decoding.
+                    // This is also convenient for tracing the parse result.
+                    .map(|msg| {
+                        // bitcoin allows extra data at the end of most messages,
+                        // so that old nodes can still read newer message formats,
+                        // and ignore any extra fields
+                        let extra_bytes = body.len() as u64 - body_reader.position();
+                        if extra_bytes == 0 {
+                            trace!(?extra_bytes, %msg, "finished message decoding");
+                        } else {
+                            // log when there are extra bytes, so we know when we need to
+                            // upgrade message formats
+                            debug!(?extra_bytes, %msg, "extra data after decoding message");
+                        }
+                        Some(msg)
+                    })
+                }));
+
+                match decode_result {
+                    Ok(result) => result,
+                    Err(_panic_payload) => {
+                        let command = String::from_utf8_lossy(&command)
+                            .trim_end_matches('\0')
+                            .to_owned();
+                        metrics::counter!(
+                            "peer.message.parse.panics",
+                            "parser" => "legacy_body"
+                        )
+                        .increment(1);
+                        tracing::error!(
+                            %command,
+                            "peer-controlled message parser panicked; disconnecting legacy peer"
+                        );
+
+                        Err(Parse(PANICKED_MESSAGE_BODY_PARSE_ERROR))
                     }
                 }
-                // We need Ok(Some(msg)) to signal that we're done decoding.
-                // This is also convenient for tracing the parse result.
-                .map(|msg| {
-                    // bitcoin allows extra data at the end of most messages,
-                    // so that old nodes can still read newer message formats,
-                    // and ignore any extra fields
-                    let extra_bytes = body.len() as u64 - body_reader.position();
-                    if extra_bytes == 0 {
-                        trace!(?extra_bytes, %msg, "finished message decoding");
-                    } else {
-                        // log when there are extra bytes, so we know when we need to
-                        // upgrade message formats
-                        debug!(?extra_bytes, %msg, "extra data after decoding message");
-                    }
-                    Some(msg)
-                })
             }
         }
     }
@@ -702,7 +754,12 @@ impl Codec {
 
     fn read_block<R: Read + std::marker::Send>(&self, reader: R) -> Result<Message, Error> {
         let result = Self::deserialize_block_spawning(reader);
-        Ok(Message::Block(result?.into()))
+        let block = result?.into();
+
+        #[cfg(test)]
+        self.panic_at_body_decode_point(BodyDecodePanic::AfterBlockConversion);
+
+        Ok(Message::Block(block))
     }
 
     fn read_getblocks<R: Read>(&self, mut reader: R) -> Result<Message, Error> {
@@ -770,7 +827,12 @@ impl Codec {
 
     fn read_tx<R: Read + std::marker::Send>(&self, reader: R) -> Result<Message, Error> {
         let result = Self::deserialize_transaction_spawning(reader);
-        Ok(Message::Tx(result?.into()))
+        let transaction = result?.into();
+
+        #[cfg(test)]
+        self.panic_at_body_decode_point(BodyDecodePanic::AfterTransactionConversion);
+
+        Ok(Message::Tx(transaction))
     }
 
     fn read_mempool<R: Read>(&self, mut _reader: R) -> Result<Message, Error> {
@@ -817,6 +879,19 @@ impl Codec {
 
     fn read_filterclear<R: Read>(&self, mut _reader: R) -> Result<Message, Error> {
         Ok(Message::FilterClear)
+    }
+
+    #[cfg(test)]
+    fn inject_body_decode_panic(&self, panic_point: BodyDecodePanic) {
+        self.body_decode_panic.set(Some(panic_point));
+    }
+
+    #[cfg(test)]
+    fn panic_at_body_decode_point(&self, panic_point: BodyDecodePanic) {
+        if self.body_decode_panic.get() == Some(panic_point) {
+            self.body_decode_panic.set(None);
+            panic!("injected legacy message body parser panic at {panic_point:?}");
+        }
     }
 
     /// Given the reader, deserialize the transaction in the rayon thread pool.

--- a/zakura-network/src/protocol/external/codec/tests/vectors.rs
+++ b/zakura-network/src/protocol/external/codec/tests/vectors.rs
@@ -674,6 +674,116 @@ fn headers_message_at_protocol_cap_is_accepted() {
     }
 }
 
+/// A panic in synchronous message-body dispatch becomes a terminal parse error
+/// without unwinding the runtime task.
+#[test]
+fn body_dispatch_panic_returns_parse_error_and_task_survives() {
+    let _init_guard = zakura_test::init();
+
+    let mut panicking_frame = BytesMut::new();
+    Codec::builder()
+        .finish()
+        .encode(Message::Ping(Nonce(1)), &mut panicking_frame)
+        .expect("test ping should encode");
+
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async move {
+        let task = tokio::spawn(async move {
+            let mut codec = Codec::builder().finish();
+            codec.inject_body_decode_panic(BodyDecodePanic::CommandDispatch);
+
+            let error = codec
+                .decode(&mut panicking_frame)
+                .expect_err("injected body parser panic should become an error");
+            match error {
+                Error::Parse(message) => {
+                    assert_eq!(message, PANICKED_MESSAGE_BODY_PARSE_ERROR);
+                }
+                other => panic!("body parser panic should be a parse error: {other:?}"),
+            }
+        });
+
+        task.await
+            .expect("body parser panic should not terminate the runtime task");
+    });
+}
+
+/// The containment boundary includes block conversion after parallel
+/// deserialization.
+#[test]
+fn block_conversion_panic_returns_parse_error() {
+    let _init_guard = zakura_test::init();
+    let block = Block::zcash_deserialize(zakura_test::vectors::BLOCKS[0])
+        .expect("block test vector should deserialize");
+
+    let mut block_frame = BytesMut::new();
+    let mut encoding_codec = Codec::builder().finish();
+    encoding_codec.reconfigure_full_body_len();
+    encoding_codec
+        .encode(Message::Block(block.into()), &mut block_frame)
+        .expect("test block should encode");
+
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async move {
+        let task = tokio::spawn(async move {
+            let mut codec = Codec::builder().finish();
+            codec.reconfigure_full_body_len();
+            codec.inject_body_decode_panic(BodyDecodePanic::AfterBlockConversion);
+
+            codec
+                .decode(&mut block_frame)
+                .expect_err("post-conversion panic should become an error")
+        });
+
+        let error = task
+            .await
+            .expect("post-conversion panic should not terminate the runtime task");
+        match error {
+            Error::Parse(message) => {
+                assert_eq!(message, PANICKED_MESSAGE_BODY_PARSE_ERROR);
+            }
+            other => panic!("block conversion panic should be a parse error: {other:?}"),
+        }
+    });
+}
+
+/// The containment boundary includes transaction conversion after parallel
+/// deserialization.
+#[test]
+fn transaction_conversion_panic_returns_parse_error() {
+    use zakura_chain::serialization::ZcashDeserializeInto;
+
+    let _init_guard = zakura_test::init();
+    let tx: Transaction = zakura_test::vectors::DUMMY_TX1
+        .zcash_deserialize_into()
+        .expect("dummy transaction should deserialize");
+
+    let mut tx_frame = BytesMut::new();
+    Codec::builder()
+        .finish()
+        .encode(Message::Tx(tx.into()), &mut tx_frame)
+        .expect("test transaction should encode");
+
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async move {
+        let task = tokio::spawn(async move {
+            let mut codec = Codec::builder().finish();
+            codec.inject_body_decode_panic(BodyDecodePanic::AfterTransactionConversion);
+
+            codec
+                .decode(&mut tx_frame)
+                .expect_err("post-conversion panic should become an error")
+        });
+
+        let error = task
+            .await
+            .expect("post-conversion panic should not terminate the runtime task");
+        match error {
+            Error::Parse(message) => {
+                assert_eq!(message, PANICKED_MESSAGE_BODY_PARSE_ERROR);
+            }
+            other => panic!("transaction conversion panic should be a parse error: {other:?}"),
+        }
+    });
+}
+
 /// Check that the version test vector deserialization fails when there's a network magic mismatch.
 #[test]
 fn message_with_wrong_network_magic_returns_error() {


### PR DESCRIPTION
## Motivation

A panic during synchronous legacy TCP message decoding can escape the peer
connection task instead of becoming a normal malformed-message failure. The
known V5 Orchard reserved-flag trigger was root-fixed in #121, but the same
availability risk can recur if a future deserializer, conversion, or message
formatter panics on peer-controlled bytes.

This change was requested during the legacy peer panic-containment audit. It is
defense-in-depth for P2P availability and does not alter consensus validation or
state mutation.

## Solution

- Catch unwinds around the complete synchronous legacy message-body decoding
  boundary, after the body is isolated and the codec state is reset.
- Include transaction deserialization and `Transaction -> UnminedTx`
  conversion, full-block deserialization and wrapping, and the other legacy
  body parsers in that boundary.
- Separately contain structured `p2pv2up` prelude decoding, which happens after
  the legacy codec returns its payload.
- Convert a caught panic into `SerializationError::Parse`. The existing
  `Connection::fail_with` path records the error, closes the affected peer's
  channels and transport, and removes only that peer.
- Record a bounded `peer.message.parse.panics` metric and an error log without
  assigning peer-misbehavior points.

The boundary deliberately stops before the connection's shared Tower service
and does not catch encoder, generic connection-task, generic handshake-task, or
heartbeat-task panics.

Heartbeat behavior remains:

- Normal heartbeat timeouts, channel errors, and bad/missing responses update
  the address book with `MetaAddr::new_errored` and disconnect that peer.
- Client-requested shutdown updates the address book with
  `MetaAddr::new_shutdown`.
- An actual heartbeat task panic continues to propagate as an internal
  invariant failure. Catching it only in `Client::poll_heartbeat` could leave
  stale `new_ping_sent` address-book state because that layer cannot perform
  the required asynchronous repair.

There are no public, `pub(crate)`, or production function-signature changes.

### Tests

Passed on commit `faa1db267`, rebased onto current `origin/main`:

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-network --all-targets --locked -- -D warnings`
- `cargo doc -p zakura-network --no-deps --locked`
- `cargo test -p zakura-network --lib --locked -- --skip listener_bans_zcashd_compat_peer_before_reserved_slot --skip listener_reserves_one_zcashd_compat_inbound_slot --skip listener_zcashd_compat_reconnect_bypasses_recent_ip_limit` — 952 passed, 0 failed, 4 ignored, 3 filtered
- `git diff --check origin/main...HEAD`

Focused regressions cover:

- body-dispatch panic to terminal parse error without unwinding the Tokio task;
- post-deserialization transaction conversion, including the location of the
  prior Orchard-triggered panic;
- full-block post-deserialization conversion;
- structured upgrade-prelude decoding;
- serialization error to the normal single-peer connection failure path; and
- preserved propagation of generic connection and heartbeat task panics.

The unfiltered library suite produced the same 952 passes plus three
environment-only failures because this macOS host cannot bind the synthetic
loopback source aliases used by those unchanged tests (`AddrNotAvailable`, OS
error 49).

### Specifications & References

- Requested during the legacy peer panic-containment audit.
- #121 root-fixes the known reserved V5 Orchard flag input.
- Zakura's development and release profiles require `panic = "unwind"`.

### Follow-up Work

If heartbeat panic containment is desired later, it should catch inside the
heartbeat async wrapper, retain an address-book updater, publish `new_errored`,
and then return a normal peer failure. That broader internal-task policy is
intentionally outside this parser-focused PR.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex audited the panic and ownership
  boundaries, implemented the parser-only containment and regressions, reviewed
  heartbeat/address-book behavior, and drafted this PR description under human
  direction.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed with the team during the legacy peer
  panic-containment audit.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the hot legacy P2P decode and handshake path, but scope is limited to panic containment with no consensus or API changes; mis-handling could affect peer disconnect behavior.
> 
> **Overview**
> **Defense-in-depth for P2P availability:** panics while parsing peer-controlled legacy TCP traffic no longer unwind the connection or handshake tasks. Only the offending peer is torn down via the existing serialization/parse failure path.
> 
> The legacy **`Codec`** now runs the full synchronous message-body decode (including block/tx deserialization and post-conversion wrapping) inside **`catch_unwind`** after the body is isolated and decode state is reset. A caught panic becomes **`SerializationError::Parse`**, increments **`peer.message.parse.panics`** (`legacy_body`), and logs before disconnect.
> 
> **Zakura `p2pv2up` prelude** decoding uses the same pattern via **`decode_upgrade_prelude` / `decode_upgrade_prelude_with`**, mapping panics to a terminal parse error instead of a handshake-task panic.
> 
> Tests cover injected body-dispatch and post-conversion panics, upgrade-prelude panic mapping, and connection run-loop behavior on inbound parser errors. The changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1807135968532d519631b51a65374d87bf52d5cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->