### PR TITLE
fix(sync): retry missing header ranges indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 Initial release of Zakura.
 
+### Fixed
+
+- Header sync now keeps timed-out ranges in a bounded, single-owner work queue,
+  retries them indefinitely with short peer-local avoidance, and commits
+  pipelined responses in height order.
+
 Zakura is a fork of the Zcash Foundation's
 [Zebra](https://github.com/ZcashFoundation/zebra), forked at Zebra v5.0.0. For
 the history of this codebase before the fork, see

--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -1606,6 +1606,16 @@ pub struct ZakuraProtocolHandler {
     endpoint: Option<Endpoint>,
 }
 
+fn random_stream_session_seed() -> u64 {
+    let mut rng = OsRng;
+    loop {
+        let seed = rng.next_u64();
+        if seed != 0 {
+            return seed;
+        }
+    }
+}
+
 /// Resolve the inbound peer's UDP source IP from the endpoint's node map so the
 /// per-IP connection cap can be enforced for Router-accepted connections.
 ///
@@ -1711,7 +1721,10 @@ impl ZakuraProtocolHandler {
             registry,
             trace,
             next_conn_id: Arc::new(AtomicU64::new(1)),
-            next_stream_id: Arc::new(AtomicU64::new(1)),
+            // Stream session IDs are local correlation generations, not wire
+            // sequence numbers. A random process seed prevents preserved traces
+            // and late completions from colliding after a node restart.
+            next_stream_id: Arc::new(AtomicU64::new(random_stream_session_seed())),
             admission: Arc::new(Semaphore::new(limits.max_connections)),
             pending_handshakes: Arc::new(Semaphore::new(limits.max_pending_handshakes)),
             shutdown: CancellationToken::new(),

--- a/zakura-network/src/zakura/header_sync/config.rs
+++ b/zakura-network/src/zakura/header_sync/config.rs
@@ -55,7 +55,11 @@ impl Default for HeaderSyncStatus {
 pub struct ZakuraHeaderSyncConfig {
     /// Maximum headers this node advertises per `GetHeaders` response.
     pub max_headers_per_response: u32,
-    /// Maximum concurrent `GetHeaders` requests this node advertises per peer.
+    /// Maximum concurrent `GetHeaders` requests per peer.
+    ///
+    /// This is both the inbound limit advertised to remote peers and the local
+    /// outbound requester ceiling. The effective requester limit is the minimum
+    /// of this value, the peer's advertisement, and the hard protocol cap of 16.
     pub max_inflight_requests: u16,
     /// How often this node sends unsolicited status refreshes after local frontier changes.
     #[serde(with = "humantime_serde")]

--- a/zakura-network/src/zakura/header_sync/events.rs
+++ b/zakura-network/src/zakura/header_sync/events.rs
@@ -222,7 +222,7 @@ pub enum HeaderSyncEvent {
         /// Decoded header-sync message.
         msg: HeaderSyncMessage,
     },
-    /// Inbound `Headers` response with an optional request ID.
+    /// Inbound `Headers` response with its mandatory request ID.
     WireHeaders {
         /// Serving peer.
         peer: ZakuraPeerId,
@@ -237,7 +237,7 @@ pub enum HeaderSyncEvent {
         /// Per-height commitment roots, parallel to `headers`.
         tree_aux_roots: Vec<BlockCommitmentRoots>,
     },
-    /// Inbound `GetHeaders` request with an optional request ID.
+    /// Inbound `GetHeaders` request with its mandatory request ID.
     WireGetHeaders {
         /// Requesting peer.
         peer: ZakuraPeerId,

--- a/zakura-network/src/zakura/header_sync/mod.rs
+++ b/zakura-network/src/zakura/header_sync/mod.rs
@@ -37,6 +37,7 @@ mod error;
 mod events;
 mod pipe;
 mod reactor;
+mod requester;
 mod service;
 mod state;
 #[cfg(test)]

--- a/zakura-network/src/zakura/header_sync/mod.rs
+++ b/zakura-network/src/zakura/header_sync/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cmp::min,
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     io::{self, Cursor, Read, Write},
     sync::Arc,
     time::Duration,
@@ -37,13 +37,13 @@ mod error;
 mod events;
 mod pipe;
 mod reactor;
-mod scheduler;
 mod service;
 mod state;
 #[cfg(test)]
 mod tests;
 mod validation;
 mod wire;
+mod work_queue;
 
 pub use config::{
     clamp_header_sync_request_count, header_sync_count_by_byte_budget,

--- a/zakura-network/src/zakura/header_sync/pipe.rs
+++ b/zakura-network/src/zakura/header_sync/pipe.rs
@@ -26,7 +26,7 @@ use std::{
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use super::{events::*, scheduler::*, service::HeaderSyncPeerCommand, wire::*, *};
+use super::{events::*, service::HeaderSyncPeerCommand, wire::*, work_queue::*, *};
 use crate::zakura::{
     Edge, Flow, FramedRecv, Node, NodeKind, Pipe, PipeCx, PipeShape, SinkReject, ZakuraPeerId,
 };

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -212,10 +212,11 @@ impl HeaderSyncReactor {
                 peer_state.outstanding.push(OutstandingRange {
                     request_id,
                     range: command.range,
-                    deadline: None,
+                    deadline: Some(Instant::now() + self.startup.request_timeout),
                     expected_max_count: command.expected_max_count,
                     clear_assignment_on_timeout: false,
                     purpose: command.purpose,
+                    phase: OutstandingPhase::Registered,
                 });
                 let _ = registered.send(());
             }
@@ -238,7 +239,10 @@ impl HeaderSyncReactor {
                     .iter_mut()
                     .find(|outstanding| outstanding.request_id == request_id)
                 {
-                    outstanding.deadline = Some(Instant::now() + self.startup.request_timeout);
+                    if outstanding.phase == OutstandingPhase::Registered {
+                        outstanding.deadline = Some(Instant::now() + self.startup.request_timeout);
+                        outstanding.phase = OutstandingPhase::Sent;
+                    }
                 }
                 let peer_cap = peer_state.max_headers_per_response;
                 metrics::counter!("sync.header.request.sent").increment(1);
@@ -801,7 +805,7 @@ impl HeaderSyncReactor {
         let _ = self.state.seen.insert(hash);
         self.update_verified_block_tip(height, hash);
         if height > self.state.best_header_tip {
-            self.reconcile_forward_coverage(height);
+            self.reconcile_forward_coverage(height, hash);
             self.publish_best_tip(height, hash).await;
             self.drain_buffered_with_permit(None).await;
         } else {
@@ -828,7 +832,7 @@ impl HeaderSyncReactor {
 
         self.update_verified_block_tip(height, hash);
         if height > self.state.best_header_tip {
-            self.reconcile_forward_coverage(height);
+            self.reconcile_forward_coverage(height, hash);
             self.publish_best_tip(height, hash).await;
             self.drain_buffered_with_permit(None).await;
         } else {
@@ -1062,6 +1066,14 @@ impl HeaderSyncReactor {
             .filter(|range| range.is_within(start_height, tip_height))
             .copied()
             .collect();
+        debug_assert!(
+            self.state.pending_commits.values().all(|range| {
+                range.end_height() < start_height
+                    || range.start_height > tip_height
+                    || range.is_within(start_height, tip_height)
+            }),
+            "a state commit completion covers every overlapping submitted header range in full"
+        );
         self.state
             .pending_commits
             .retain(|_, range| !range.is_within(start_height, tip_height));
@@ -1126,6 +1138,8 @@ impl HeaderSyncReactor {
             if range.priority == RangePriority::Forward
                 && range.start_height <= self.state.best_header_tip
             {
+                let suffix =
+                    range.suffix_after(self.state.best_header_tip, self.state.best_header_hash);
                 self.state.schedule.complete(range);
                 metrics::counter!(
                     "sync.header.work.covered",
@@ -1133,6 +1147,13 @@ impl HeaderSyncReactor {
                     "lane" => "forward"
                 )
                 .increment(1);
+                if let Some(suffix) = suffix {
+                    if kind == HeaderSyncCommitFailureKind::InvalidPeerRange {
+                        self.state.schedule.retry_avoiding(peer.clone(), suffix);
+                    } else {
+                        self.state.schedule.retry(suffix);
+                    }
+                }
                 self.schedule().await;
                 return;
             }
@@ -1539,6 +1560,7 @@ impl HeaderSyncReactor {
                 peer_state.outstanding.push(OutstandingRange {
                     deadline: Some(deadline),
                     clear_assignment_on_timeout: true,
+                    phase: OutstandingPhase::EmptyRetry,
                     ..outstanding
                 });
             }
@@ -1680,8 +1702,7 @@ impl HeaderSyncReactor {
             return;
         }
 
-        let end_height = height_after_count(outstanding.range.start_height, header_count)
-            .and_then(previous_height)
+        let end_height = range_end_height(outstanding.range.start_height, header_count)
             .expect("non-empty bounded range has an end height");
         if outstanding.range.finalized {
             let last_hash = headers
@@ -1787,6 +1808,19 @@ impl HeaderSyncReactor {
                     .buffered
                     .remove(&key)
                     .expect("candidate buffer exists until the reactor removes it");
+                if let (Some(suffix_start), Some(suffix_anchor)) = (
+                    next_height(buffered.range.end_height()),
+                    buffered
+                        .headers
+                        .last()
+                        .map(|header| block::Hash::from(header.as_ref())),
+                ) {
+                    self.state.schedule.clear_pending_anchor(
+                        buffered.range.priority,
+                        suffix_start,
+                        suffix_anchor,
+                    );
+                }
                 self.state
                     .schedule
                     .retry_avoiding(buffered.peer.clone(), buffered.range);
@@ -2052,6 +2086,7 @@ impl HeaderSyncReactor {
     async fn handle_timeouts(&mut self) {
         let now = Instant::now();
         let mut timed_out = Vec::new();
+        let mut blocked_sessions = HashSet::new();
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
             while index < peer.outstanding.len() {
@@ -2062,6 +2097,10 @@ impl HeaderSyncReactor {
                     let outstanding = peer.outstanding.remove(index);
                     let peer_id = peer.session.peer_id().clone();
                     let _ = peer.session.retire_expected_headers(outstanding.request_id);
+                    if outstanding.phase == OutstandingPhase::Registered {
+                        peer.session.cancel_token().cancel();
+                        blocked_sessions.insert(peer_id.clone());
+                    }
                     timed_out.push((outstanding, peer_id));
                 } else {
                     index += 1;
@@ -2084,17 +2123,18 @@ impl HeaderSyncReactor {
                 }
             }
         }
+        for peer in blocked_sessions {
+            metrics::counter!("sync.header.request.registration_timeout").increment(1);
+            self.handle_peer_disconnected(peer);
+        }
         self.schedule().await;
     }
 
     fn empty_headers_retry_delay(&self) -> Duration {
-        self.startup
-            .request_timeout
-            .min(EMPTY_HEADERS_RETRY_DELAY)
-            .min(HEADER_SYNC_RETRY_AVOIDANCE)
+        self.startup.request_timeout.min(EMPTY_HEADERS_RETRY_DELAY)
     }
 
-    fn next_maintenance_deadline(&self) -> Instant {
+    fn next_maintenance_deadline(&mut self) -> Instant {
         let now = Instant::now();
         let mut deadline = now + Duration::from_secs(60 * 60);
 
@@ -2395,6 +2435,7 @@ impl HeaderSyncReactor {
             expected_max_count: range.count,
             clear_assignment_on_timeout: false,
             purpose: RangePurpose::VctRepair { height, generation },
+            phase: OutstandingPhase::Sent,
         };
         if let Some(peer) = self.state.peers.get_mut(&peer_id) {
             peer.outstanding.push(outstanding);
@@ -3326,14 +3367,16 @@ impl HeaderSyncReactor {
         }
     }
 
-    /// Drop forward work whose start is now below a newly durable contiguous tip.
+    /// Reconcile forward work whose start is now below a newly durable contiguous tip.
     ///
-    /// A partially covered wire or buffered range cannot keep its old start key:
-    /// ordered drain would never visit it after the tip moves. Retire the whole
-    /// descriptor and let lazy production recreate only the uncovered suffix.
-    /// State-admitted commits remain locally owned until their completion event.
-    fn reconcile_forward_coverage(&mut self, height: block::Height) {
-        self.state.schedule.drop_pending_forward_through(height);
+    /// A partially covered descriptor cannot keep its old start key because ordered
+    /// drain will never visit it after the tip moves. Preserve its uncovered suffix,
+    /// including already validated buffered headers. State-admitted commits remain
+    /// locally owned until their completion event.
+    fn reconcile_forward_coverage(&mut self, height: block::Height, hash: block::Hash) {
+        self.state
+            .schedule
+            .trim_pending_forward_through(height, hash);
 
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
@@ -3346,6 +3389,9 @@ impl HeaderSyncReactor {
                     let outstanding = peer.outstanding.remove(index);
                     let _ = peer.session.retire_expected_headers(outstanding.request_id);
                     self.state.schedule.clear_assignment(outstanding.range);
+                    if let Some(suffix) = outstanding.range.suffix_after(height, hash) {
+                        self.state.schedule.ensure_forward(suffix);
+                    }
                     metrics::counter!(
                         "sync.header.work.covered",
                         "state" => "in_flight",
@@ -3368,8 +3414,27 @@ impl HeaderSyncReactor {
             })
             .collect();
         for key in buffered {
-            if let Some(buffered) = self.state.buffered.remove(&key) {
-                self.state.schedule.clear_assignment(buffered.range);
+            if let Some(mut buffered) = self.state.buffered.remove(&key) {
+                let original = buffered.range;
+                if let Some(suffix) = original.suffix_after(height, hash) {
+                    let covered_count = count_between(original.start_height, height);
+                    let covered_count = usize::try_from(covered_count)
+                        .expect("header range counts fit in usize on supported platforms");
+                    buffered.headers = buffered.headers.split_off(covered_count);
+                    if !buffered.body_sizes.is_empty() {
+                        buffered.body_sizes = buffered.body_sizes.split_off(covered_count);
+                    }
+                    if !buffered.tree_aux_roots.is_empty() {
+                        buffered.tree_aux_roots = buffered.tree_aux_roots.split_off(covered_count);
+                    }
+                    buffered.range = suffix;
+                    self.state.schedule.narrow_queued_range(original, suffix);
+                    self.state
+                        .buffered
+                        .insert((RangePriority::Forward, suffix.start_height), buffered);
+                } else {
+                    self.state.schedule.clear_assignment(original);
+                }
                 metrics::counter!(
                     "sync.header.work.covered",
                     "state" => "buffered",

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -125,6 +125,13 @@ impl HeaderSyncReactor {
                     };
                     self.handle_event(event).await;
                 }
+                event = self.requester_events.recv() => {
+                    let Some(event) = event else {
+                        exit_reason = "requester_event_channel_closed";
+                        break;
+                    };
+                    self.handle_requester_event(event).await;
+                }
                 event = self.events.recv() => {
                     let Some(event) = event else {
                         exit_reason = "events_channel_closed";
@@ -137,13 +144,6 @@ impl HeaderSyncReactor {
                     if let Some(permit) = permit {
                         self.drain_buffered_with_permit(Some(permit)).await;
                     }
-                }
-                event = self.requester_events.recv() => {
-                    let Some(event) = event else {
-                        exit_reason = "requester_event_channel_closed";
-                        break;
-                    };
-                    self.handle_requester_event(event).await;
                 }
                 changed = async {
                     match frontier_updates.as_mut() {
@@ -192,6 +192,33 @@ impl HeaderSyncReactor {
 
     async fn handle_requester_event(&mut self, event: HeaderRequesterEvent) {
         match event {
+            HeaderRequesterEvent::Register {
+                peer,
+                session_id,
+                generation,
+                command,
+                request_id,
+                registered,
+            } => {
+                if !self.is_current_requester(&peer, session_id, generation) {
+                    metrics::counter!("sync.header.request.late_registration").increment(1);
+                    return;
+                }
+                let Some(peer_state) = self.state.peers.get_mut(&peer) else {
+                    return;
+                };
+                peer_state.pending_request_sends =
+                    peer_state.pending_request_sends.saturating_sub(1);
+                peer_state.outstanding.push(OutstandingRange {
+                    request_id,
+                    range: command.range,
+                    deadline: None,
+                    expected_max_count: command.expected_max_count,
+                    clear_assignment_on_timeout: false,
+                    purpose: command.purpose,
+                });
+                let _ = registered.send(());
+            }
             HeaderRequesterEvent::Sent {
                 peer,
                 session_id,
@@ -206,16 +233,13 @@ impl HeaderSyncReactor {
                 let Some(peer_state) = self.state.peers.get_mut(&peer) else {
                     return;
                 };
-                peer_state.pending_request_sends =
-                    peer_state.pending_request_sends.saturating_sub(1);
-                peer_state.outstanding.push(OutstandingRange {
-                    request_id,
-                    range: command.range,
-                    deadline: Instant::now() + self.startup.request_timeout,
-                    expected_max_count: command.expected_max_count,
-                    clear_assignment_on_timeout: false,
-                    purpose: command.purpose,
-                });
+                if let Some(outstanding) = peer_state
+                    .outstanding
+                    .iter_mut()
+                    .find(|outstanding| outstanding.request_id == request_id)
+                {
+                    outstanding.deadline = Some(Instant::now() + self.startup.request_timeout);
+                }
                 let peer_cap = peer_state.max_headers_per_response;
                 metrics::counter!("sync.header.request.sent").increment(1);
                 self.trace_get_headers_sent(
@@ -245,6 +269,7 @@ impl HeaderSyncReactor {
                 session_id,
                 generation,
                 command,
+                request_id,
                 reason,
             } => {
                 if !self.is_current_requester(&peer, session_id, generation) {
@@ -252,8 +277,12 @@ impl HeaderSyncReactor {
                     return;
                 }
                 if let Some(peer_state) = self.state.peers.get_mut(&peer) {
-                    peer_state.pending_request_sends =
-                        peer_state.pending_request_sends.saturating_sub(1);
+                    if let Some(request_id) = request_id {
+                        let _ = peer_state.remove_outstanding_by_request_id(request_id);
+                    } else {
+                        peer_state.pending_request_sends =
+                            peer_state.pending_request_sends.saturating_sub(1);
+                    }
                 }
                 match command.purpose {
                     RangePurpose::Sync => self.state.schedule.retry(command.range),
@@ -1508,7 +1537,7 @@ impl HeaderSyncReactor {
             );
             if let Some(peer_state) = self.state.peers.get_mut(&peer) {
                 peer_state.outstanding.push(OutstandingRange {
-                    deadline,
+                    deadline: Some(deadline),
                     clear_assignment_on_timeout: true,
                     ..outstanding
                 });
@@ -2026,7 +2055,10 @@ impl HeaderSyncReactor {
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
             while index < peer.outstanding.len() {
-                if peer.outstanding[index].deadline <= now {
+                if peer.outstanding[index]
+                    .deadline
+                    .is_some_and(|deadline| deadline <= now)
+                {
                     let outstanding = peer.outstanding.remove(index);
                     let peer_id = peer.session.peer_id().clone();
                     let _ = peer.session.retire_expected_headers(outstanding.request_id);
@@ -2070,12 +2102,13 @@ impl HeaderSyncReactor {
             deadline = deadline.min(retry);
         }
         for peer in self.state.peers.values() {
-            if let Some(request) = peer
+            if let Some(request_deadline) = peer
                 .outstanding
                 .iter()
-                .min_by_key(|request| request.deadline)
+                .filter_map(|request| request.deadline)
+                .min()
             {
-                deadline = deadline.min(request.deadline);
+                deadline = deadline.min(request_deadline);
             }
             let status_deadline = if peer.status_differs_from_last_sent(self.local_status()) {
                 peer.meters.unsolicited.next_allowed
@@ -2358,7 +2391,7 @@ impl HeaderSyncReactor {
         let outstanding = OutstandingRange {
             request_id,
             range,
-            deadline: Instant::now() + self.startup.request_timeout,
+            deadline: Some(Instant::now() + self.startup.request_timeout),
             expected_max_count: range.count,
             clear_assignment_on_timeout: false,
             purpose: RangePurpose::VctRepair { height, generation },

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1,7 +1,7 @@
 use super::super::trace::{
     ordered_send_error_label, queue_send_trace as qs_trace, QUEUE_SEND_TABLE,
 };
-use super::{config::*, error::*, events::*, scheduler::*, state::*, validation::*, wire::*, *};
+use super::{config::*, error::*, events::*, state::*, validation::*, wire::*, work_queue::*, *};
 use crate::zakura::{
     FrontierChange, FrontierUpdate, HeaderSyncServiceSummary, OrderedSendError,
     ServiceAdmissionDecision, ServicePeerDirection, ServicePeerSnapshot,
@@ -597,6 +597,18 @@ impl HeaderSyncReactor {
     }
 
     fn handle_peer_disconnected(&mut self, peer: ZakuraPeerId) {
+        let buffered_ranges: Vec<_> = self
+            .state
+            .buffered
+            .iter()
+            .filter_map(|(key, buffered)| (buffered.peer == peer).then_some(*key))
+            .collect();
+        for key in buffered_ranges {
+            if let Some(buffered) = self.state.buffered.remove(&key) {
+                self.state.schedule.clear_assignment(buffered.range);
+                self.state.schedule.retry(buffered.range);
+            }
+        }
         let was_connected = self.state.peers.remove(&peer).is_some();
         self.state.parked_peers.remove(&peer);
         self.state.advisory.remove(&peer);
@@ -860,6 +872,9 @@ impl HeaderSyncReactor {
                 })
             })
             .cloned();
+        let completed_backward = self.state.pending_commits.values().any(|range| {
+            range.priority == RangePriority::Backward && range.is_within(start_height, tip_height)
+        });
         self.state
             .pending_commits
             .retain(|_, range| !range.is_within(start_height, tip_height));
@@ -882,6 +897,11 @@ impl HeaderSyncReactor {
         if tip_height > self.state.best_header_tip {
             self.publish_best_tip(tip_height, tip_hash).await;
         }
+        if completed_backward {
+            self.state.backward_frontier = Some((tip_height, tip_hash));
+        }
+        self.drain_buffered_forward().await;
+        self.drain_buffered_backward().await;
         self.notify_body_gaps().await;
         self.schedule().await;
     }
@@ -919,7 +939,11 @@ impl HeaderSyncReactor {
             if kind == HeaderSyncCommitFailureKind::Local {
                 self.state.schedule.clear_assignment(range);
             }
-            self.state.schedule.retry(range);
+            if kind == HeaderSyncCommitFailureKind::InvalidPeerRange {
+                self.state.schedule.retry_avoiding(peer.clone(), range);
+            } else {
+                self.state.schedule.retry(range);
+            }
         }
         self.schedule().await;
     }
@@ -1053,6 +1077,7 @@ impl HeaderSyncReactor {
                     clamp_advertised_range(status.max_headers_per_response);
                 peer_state.max_inflight_requests = status
                     .max_inflight_requests
+                    .min(self.startup.config.advertised_max_inflight_requests())
                     .clamp(1, LOCAL_MAX_HS_INFLIGHT_PER_PEER);
                 peer_state.received_status = true;
                 peer_state.last_received_status_at = Some(now);
@@ -1265,7 +1290,7 @@ impl HeaderSyncReactor {
         headers: Vec<Arc<block::Header>>,
         body_sizes: Vec<u32>,
         tree_aux_roots: Vec<BlockCommitmentRoots>,
-        outstanding: OutstandingRange,
+        mut outstanding: OutstandingRange,
         peer_max_headers_per_response: u32,
         in_flight_count: usize,
     ) {
@@ -1371,7 +1396,11 @@ impl HeaderSyncReactor {
                 outstanding.expected_max_count,
             ),
         };
-        if let Err(error) = validate_header_range_links(outstanding.range.anchor_hash, &headers) {
+        let validation_anchor = outstanding
+            .range
+            .anchor_hash
+            .unwrap_or(headers[0].previous_block_hash);
+        if let Err(error) = validate_header_range_links(validation_anchor, &headers) {
             debug!(
                 ?peer,
                 ?error,
@@ -1454,9 +1483,13 @@ impl HeaderSyncReactor {
                 .last()
                 .map(|header| block::Hash::from(header.as_ref()))
                 .expect("headers is non-empty");
-            if end_height != outstanding.range.end_height()
-                || self.startup.network.checkpoint_list().hash(end_height) != Some(last_hash)
-            {
+            let checkpoint_mismatch = self
+                .startup
+                .network
+                .checkpoint_list()
+                .hash(end_height)
+                .is_some_and(|checkpoint_hash| checkpoint_hash != last_hash);
+            if checkpoint_mismatch {
                 self.trace_range_validation_rejected(
                     &peer,
                     outstanding.range,
@@ -1472,6 +1505,65 @@ impl HeaderSyncReactor {
             }
         }
 
+        if header_count < outstanding.range.count {
+            let original = outstanding.range;
+            outstanding.range.count = header_count;
+            self.state
+                .schedule
+                .narrow_queued_range(original, outstanding.range);
+            if let Some(suffix_start) = height_after_count(original.start_height, header_count) {
+                let suffix = RangeRequest {
+                    start_height: suffix_start,
+                    count: original.count.saturating_sub(header_count),
+                    anchor_hash: headers
+                        .last()
+                        .map(|header| block::Hash::from(header.as_ref())),
+                    ..original
+                };
+                self.state.schedule.retry(suffix);
+                metrics::counter!("sync.header.work.returned", "reason" => "short_response")
+                    .increment(1);
+            }
+        }
+
+        if matches!(
+            outstanding.range.priority,
+            RangePriority::Forward | RangePriority::Backward
+        ) {
+            let priority = outstanding.range.priority;
+            let session_id = self
+                .state
+                .peers
+                .get(&peer)
+                .map(|state| state.session.session_id())
+                .expect("peer exists because its response is being buffered");
+            self.state.buffered.insert(
+                (outstanding.range.priority, outstanding.range.start_height),
+                BufferedHeaderRange {
+                    peer,
+                    session_id,
+                    range: outstanding.range,
+                    headers,
+                    body_sizes,
+                    tree_aux_roots,
+                },
+            );
+            metrics::counter!("sync.header.work.buffered").increment(1);
+            metrics::gauge!("sync.header.work.buffered.count")
+                .set(self.state.buffered.len() as f64);
+            if priority == RangePriority::Forward {
+                self.drain_buffered_forward().await;
+            } else {
+                self.drain_buffered_backward().await;
+            }
+            self.schedule().await;
+            return;
+        }
+
+        let anchor = outstanding
+            .range
+            .anchor_hash
+            .expect("backward and repair ranges always have a known anchor");
         self.state.pending_commits.insert(
             PendingCommitKey {
                 peer: peer.clone(),
@@ -1489,13 +1581,150 @@ impl HeaderSyncReactor {
         let _ = self.dispatch_action(HeaderSyncAction::CommitHeaderRange {
             peer,
             session_id,
-            anchor: outstanding.range.anchor_hash,
+            anchor,
             start_height: outstanding.range.start_height,
             headers,
             body_sizes,
             tree_aux_roots,
             finalized: outstanding.range.finalized,
         });
+    }
+
+    async fn drain_buffered_forward(&mut self) {
+        if self
+            .state
+            .pending_commits
+            .values()
+            .any(|range| range.priority == RangePriority::Forward)
+        {
+            return;
+        }
+        let Some(start_height) = next_height(self.state.best_header_tip) else {
+            return;
+        };
+        let Some(mut buffered) = self
+            .state
+            .buffered
+            .remove(&(RangePriority::Forward, start_height))
+        else {
+            return;
+        };
+
+        if let Err(error) =
+            validate_header_range_links(self.state.best_header_hash, &buffered.headers)
+        {
+            self.state.schedule.clear_assignment(buffered.range);
+            self.state
+                .schedule
+                .retry_avoiding(buffered.peer.clone(), buffered.range);
+            self.trace_range_validation_rejected(
+                &buffered.peer,
+                buffered.range,
+                u32::try_from(buffered.headers.len()).unwrap_or(u32::MAX),
+                "ordered_predecessor",
+                header_sync_wire_error_kind(&error),
+            );
+            self.report_misbehavior(buffered.peer, HeaderSyncMisbehavior::InvalidRange)
+                .await;
+            return;
+        }
+
+        let original = buffered.range;
+        buffered.range.anchor_hash = Some(self.state.best_header_hash);
+        self.state
+            .schedule
+            .narrow_queued_range(original, buffered.range);
+        let count =
+            u32::try_from(buffered.headers.len()).expect("decoded Headers length is capped by u32");
+        self.state.pending_commits.insert(
+            PendingCommitKey {
+                peer: buffered.peer.clone(),
+                start_height,
+                count,
+            },
+            buffered.range,
+        );
+        let _ = self.dispatch_action(HeaderSyncAction::CommitHeaderRange {
+            peer: buffered.peer,
+            session_id: buffered.session_id,
+            anchor: self.state.best_header_hash,
+            start_height,
+            headers: buffered.headers,
+            body_sizes: buffered.body_sizes,
+            tree_aux_roots: buffered.tree_aux_roots,
+            finalized: buffered.range.finalized,
+        });
+        metrics::counter!("sync.header.work.ordered_drain").increment(1);
+        metrics::gauge!("sync.header.work.buffered.count").set(self.state.buffered.len() as f64);
+    }
+
+    async fn drain_buffered_backward(&mut self) {
+        if self
+            .state
+            .pending_commits
+            .values()
+            .any(|range| range.priority == RangePriority::Backward)
+        {
+            return;
+        }
+        let Some((frontier_height, frontier_hash)) = self.state.backward_frontier else {
+            return;
+        };
+        let Some(start_height) = next_height(frontier_height) else {
+            return;
+        };
+        let Some(mut buffered) = self
+            .state
+            .buffered
+            .remove(&(RangePriority::Backward, start_height))
+        else {
+            return;
+        };
+
+        if let Err(error) = validate_header_range_links(frontier_hash, &buffered.headers) {
+            self.state.schedule.clear_assignment(buffered.range);
+            self.state
+                .schedule
+                .retry_avoiding(buffered.peer.clone(), buffered.range);
+            self.trace_range_validation_rejected(
+                &buffered.peer,
+                buffered.range,
+                u32::try_from(buffered.headers.len()).unwrap_or(u32::MAX),
+                "ordered_predecessor",
+                header_sync_wire_error_kind(&error),
+            );
+            self.report_misbehavior(buffered.peer, HeaderSyncMisbehavior::InvalidRange)
+                .await;
+            return;
+        }
+
+        let original = buffered.range;
+        buffered.range.anchor_hash = Some(frontier_hash);
+        self.state
+            .schedule
+            .narrow_queued_range(original, buffered.range);
+        let count =
+            u32::try_from(buffered.headers.len()).expect("decoded Headers length is capped by u32");
+        self.state.pending_commits.insert(
+            PendingCommitKey {
+                peer: buffered.peer.clone(),
+                start_height,
+                count,
+            },
+            buffered.range,
+        );
+        let _ = self.dispatch_action(HeaderSyncAction::CommitHeaderRange {
+            peer: buffered.peer,
+            session_id: buffered.session_id,
+            anchor: frontier_hash,
+            start_height,
+            headers: buffered.headers,
+            body_sizes: buffered.body_sizes,
+            tree_aux_roots: buffered.tree_aux_roots,
+            finalized: true,
+        });
+        metrics::counter!("sync.header.work.ordered_drain", "lane" => "backward").increment(1);
+        metrics::gauge!("sync.header.work.buffered.count").set(self.state.buffered.len() as f64);
     }
 
     fn validate_vct_repair_response(
@@ -1544,7 +1773,10 @@ impl HeaderSyncReactor {
 
     fn retry_or_finish_outstanding(&mut self, peer: &ZakuraPeerId, outstanding: OutstandingRange) {
         match outstanding.purpose {
-            RangePurpose::Sync => self.state.schedule.retry(outstanding.range),
+            RangePurpose::Sync => self
+                .state
+                .schedule
+                .retry_avoiding(peer.clone(), outstanding.range),
             RangePurpose::VctRepair { .. } => self.finish_vct_repair_attempt(peer),
         }
     }
@@ -1593,7 +1825,7 @@ impl HeaderSyncReactor {
 
         if !self.state.stale_anchor.should_reanchor() {
             self.state.schedule.clear_assignment(range);
-            self.state.schedule.retry(range);
+            self.state.schedule.retry_avoiding(peer.clone(), range);
             return true;
         }
 
@@ -1609,6 +1841,9 @@ impl HeaderSyncReactor {
         self.state.stale_anchor.reset();
         self.state.schedule.clear_forward();
         self.state
+            .buffered
+            .retain(|(priority, _), _| *priority != RangePriority::Forward);
+        self.state
             .pending_commits
             .retain(|_, range| range.priority != RangePriority::Forward);
         self.cancel_forward_outstanding();
@@ -1618,14 +1853,13 @@ impl HeaderSyncReactor {
     async fn handle_timeouts(&mut self) {
         let now = Instant::now();
         let mut timed_out = Vec::new();
-        let mut retired_request_ids = Vec::new();
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
             while index < peer.outstanding.len() {
                 if peer.outstanding[index].deadline <= now {
                     let outstanding = peer.outstanding.remove(index);
                     let peer_id = peer.session.peer_id().clone();
-                    retired_request_ids.push((peer_id.clone(), outstanding.request_id));
+                    let _ = peer.session.retire_expected_headers(outstanding.request_id);
                     timed_out.push((outstanding, peer_id));
                 } else {
                     index += 1;
@@ -1638,7 +1872,9 @@ impl HeaderSyncReactor {
                     if outstanding.clear_assignment_on_timeout {
                         self.state.schedule.clear_assignment(outstanding.range);
                     }
-                    self.state.schedule.retry(outstanding.range);
+                    self.state
+                        .schedule
+                        .retry_avoiding(peer.clone(), outstanding.range);
                 }
                 RangePurpose::VctRepair { .. } => {
                     metrics::counter!("sync.header.vct_repair.timeout").increment(1);
@@ -1646,23 +1882,20 @@ impl HeaderSyncReactor {
                 }
             }
         }
-        // Retiring the ID is enough: a response that arrives after its deadline is
-        // matched to the retired request and dropped, so it can never be mistaken for
-        // a newer one. The stream stays up.
-        for (peer, request_id) in retired_request_ids {
-            if let Some(peer) = self.state.peers.get(&peer) {
-                let _ = peer.session.retire_expected_headers(request_id);
-            }
-        }
         self.schedule().await;
     }
 
     fn empty_headers_retry_delay(&self) -> Duration {
-        self.startup.request_timeout.min(EMPTY_HEADERS_RETRY_DELAY)
+        self.startup
+            .request_timeout
+            .min(EMPTY_HEADERS_RETRY_DELAY)
+            .min(HEADER_SYNC_RETRY_AVOIDANCE)
     }
 
     async fn schedule(&mut self) {
         if !self.startup.range_state_actions_enabled {
+            metrics::counter!("sync.header.fill.stop", "reason" => "shutdown_or_disabled")
+                .increment(1);
             return;
         }
 
@@ -1688,17 +1921,24 @@ impl HeaderSyncReactor {
                 break;
             }
         }
+        self.publish_work_metrics();
     }
 
     async fn schedule_one_for_peer(&mut self, peer_id: &ZakuraPeerId) -> bool {
         let Some(peer) = self.state.peers.get(peer_id) else {
             return false;
         };
-        if !peer.received_status || peer.available_slots() == 0 {
+        if !peer.received_status {
+            metrics::counter!("sync.header.fill.stop", "reason" => "no_status").increment(1);
+            return false;
+        }
+        if peer.available_slots() == 0 {
+            metrics::counter!("sync.header.fill.stop", "reason" => "peer_slots_full").increment(1);
             return false;
         }
 
         let Some(mut range) = self.state.schedule.next_for_peer(peer_id, peer) else {
+            metrics::counter!("sync.header.fill.stop", "reason" => "no_eligible_work").increment(1);
             return false;
         };
         let original_range = range;
@@ -1709,14 +1949,20 @@ impl HeaderSyncReactor {
             self.startup.max_frame_bytes,
             range.want_tree_aux_roots,
         );
-        if range.finalized && count < range.count {
-            self.state.schedule.retry(range);
-            return false;
-        }
         range.count = count;
-        self.state
-            .schedule
-            .narrow_queued_range(original_range, range);
+        if count < original_range.count {
+            if let Some(suffix_start) = height_after_count(range.start_height, count) {
+                self.state.schedule.ensure(
+                    RangeRequest {
+                        start_height: suffix_start,
+                        count: original_range.count.saturating_sub(count),
+                        anchor_hash: None,
+                        ..original_range
+                    },
+                    original_range.priority,
+                );
+            }
+        }
 
         let peer_cap = peer.max_headers_per_response;
         let Some(peer) = self.state.peers.get(peer_id) else {
@@ -1731,6 +1977,12 @@ impl HeaderSyncReactor {
         ) {
             Ok(request_id) => request_id,
             Err(error) => {
+                let stop_reason = if matches!(&error, OrderedSendError::Full) {
+                    "outbound_full"
+                } else {
+                    "outbound_closed"
+                };
+                metrics::counter!("sync.header.fill.stop", "reason" => stop_reason).increment(1);
                 tracing::debug!(
                     peer = ?peer_id,
                     start_height = ?range.start_height,
@@ -1792,6 +2044,30 @@ impl HeaderSyncReactor {
             })
             .await;
         true
+    }
+
+    fn publish_work_metrics(&self) {
+        let in_flight = self
+            .state
+            .peers
+            .values()
+            .map(|peer| peer.outstanding.len())
+            .sum::<usize>();
+        metrics::gauge!("sync.header.work.pending.count")
+            .set(self.state.schedule.pending_len() as f64);
+        metrics::gauge!("sync.header.work.in_flight.count").set(in_flight as f64);
+        metrics::gauge!("sync.header.work.buffered.count").set(self.state.buffered.len() as f64);
+        metrics::gauge!("sync.header.work.committing.count")
+            .set(self.state.pending_commits.len() as f64);
+        metrics::gauge!("sync.header.work.resident_heights")
+            .set(self.state.schedule.resident_heights() as f64);
+        metrics::gauge!("sync.header.work.epoch").set(self.state.schedule.epoch as f64);
+        let oldest_age = self
+            .state
+            .schedule
+            .oldest_missing_since
+            .map_or(0.0, |started| started.elapsed().as_secs_f64());
+        metrics::gauge!("sync.header.work.oldest_missing_age_seconds").set(oldest_age);
     }
 
     async fn schedule_vct_repair(&mut self) -> bool {
@@ -2616,7 +2892,9 @@ impl HeaderSyncReactor {
             insert_peer(row, hs_trace::PEER, peer);
             insert_height(row, hs_trace::RANGE_START, range.start_height);
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(count));
-            insert_hash(row, hs_trace::ANCHOR_HASH, range.anchor_hash);
+            if let Some(anchor_hash) = range.anchor_hash {
+                insert_hash(row, hs_trace::ANCHOR_HASH, anchor_hash);
+            }
             insert_optional_str(row, hs_trace::VALIDATION_STAGE, Some(validation_stage));
             insert_optional_str(row, hs_trace::ERROR_KIND, Some(error_kind));
             insert_optional_str(
@@ -2787,6 +3065,9 @@ impl HeaderSyncReactor {
     /// was covered is matched to the retired ID and dropped, so it cannot be mistaken
     /// for a newer request or trigger a spurious link failure. The stream stays up.
     fn cancel_covered_outstanding(&mut self) {
+        self.state
+            .buffered
+            .retain(|_, buffered| !self.state.schedule.is_covered(buffered.range));
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
             while index < peer.outstanding.len() {

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -91,6 +91,29 @@ struct GetHeadersTraceMeta {
     stream_version: u16,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum RequesterEventOutcome {
+    None,
+    Schedule,
+}
+
+pub(super) fn complete_request_publication(
+    peer: &mut PeerHeaderState,
+    request_id: HeaderSyncRequestId,
+    deadline: Instant,
+) {
+    if let Some(outstanding) = peer
+        .outstanding
+        .iter_mut()
+        .find(|outstanding| outstanding.request_id == request_id)
+    {
+        if outstanding.phase == OutstandingPhase::Publishing {
+            outstanding.deadline = deadline;
+            outstanding.phase = OutstandingPhase::AwaitingResponse;
+        }
+    }
+}
+
 impl HeaderSyncReactor {
     async fn run(mut self) {
         let mut frontier_updates = self.startup.frontier_updates.clone();
@@ -130,7 +153,9 @@ impl HeaderSyncReactor {
                         exit_reason = "requester_event_channel_closed";
                         break;
                     };
-                    self.handle_requester_event(event).await;
+                    if self.handle_requester_event(event) == RequesterEventOutcome::Schedule {
+                        self.schedule().await;
+                    }
                 }
                 event = self.events.recv() => {
                     let Some(event) = event else {
@@ -190,129 +215,91 @@ impl HeaderSyncReactor {
         metrics::counter!("sync.header.reactor.event_finished", "kind" => kind).increment(1);
     }
 
-    async fn handle_requester_event(&mut self, event: HeaderRequesterEvent) {
+    fn handle_requester_event(&mut self, event: HeaderRequesterEvent) -> RequesterEventOutcome {
         match event {
-            HeaderRequesterEvent::Register {
-                peer,
-                session_id,
-                generation,
-                command,
+            HeaderRequesterEvent::Completed {
+                identity,
+                range,
                 request_id,
-                registered,
+                result,
             } => {
-                if !self.is_current_requester(&peer, session_id, generation) {
-                    metrics::counter!("sync.header.request.late_registration").increment(1);
-                    return;
-                }
-                let Some(peer_state) = self.state.peers.get_mut(&peer) else {
-                    return;
-                };
-                peer_state.pending_request_sends =
-                    peer_state.pending_request_sends.saturating_sub(1);
-                peer_state.outstanding.push(OutstandingRange {
-                    request_id,
-                    range: command.range,
-                    deadline: Some(Instant::now() + self.startup.request_timeout),
-                    expected_max_count: command.expected_max_count,
-                    clear_assignment_on_timeout: false,
-                    purpose: command.purpose,
-                    phase: OutstandingPhase::Registered,
-                });
-                let _ = registered.send(());
-            }
-            HeaderRequesterEvent::Sent {
-                peer,
-                session_id,
-                generation,
-                command,
-                request_id,
-            } => {
-                if !self.is_current_requester(&peer, session_id, generation) {
-                    metrics::counter!("sync.header.request.late_send").increment(1);
-                    return;
-                }
-                let Some(peer_state) = self.state.peers.get_mut(&peer) else {
-                    return;
-                };
-                if let Some(outstanding) = peer_state
-                    .outstanding
-                    .iter_mut()
-                    .find(|outstanding| outstanding.request_id == request_id)
-                {
-                    if outstanding.phase == OutstandingPhase::Registered {
-                        outstanding.deadline = Some(Instant::now() + self.startup.request_timeout);
-                        outstanding.phase = OutstandingPhase::Sent;
-                    }
-                }
-                let peer_cap = peer_state.max_headers_per_response;
-                metrics::counter!("sync.header.request.sent").increment(1);
-                self.trace_get_headers_sent(
-                    &peer,
-                    command.range,
-                    command.expected_max_count,
-                    peer_cap,
-                    GetHeadersTraceMeta {
-                        request_id,
-                        session_id,
-                        stream_version: ZAKURA_HEADER_SYNC_STREAM_VERSION,
-                    },
-                );
-                #[cfg(test)]
-                let _ = self.actions.try_send(HeaderSyncAction::SendMessage {
-                    peer,
-                    request_id: Some(request_id),
-                    msg: HeaderSyncMessage::GetHeaders {
-                        start_height: command.range.start_height,
-                        count: command.expected_max_count,
-                        want_tree_aux_roots: command.range.want_tree_aux_roots,
-                    },
-                });
-            }
-            HeaderRequesterEvent::Failed {
-                peer,
-                session_id,
-                generation,
-                command,
-                request_id,
-                reason,
-            } => {
-                if !self.is_current_requester(&peer, session_id, generation) {
-                    metrics::counter!("sync.header.request.late_send_failure").increment(1);
-                    return;
-                }
-                if let Some(peer_state) = self.state.peers.get_mut(&peer) {
-                    if let Some(request_id) = request_id {
-                        let _ = peer_state.remove_outstanding_by_request_id(request_id);
+                if !self.is_current_requester(&identity) {
+                    let metric = if result.is_ok() {
+                        "sync.header.request.late_send"
                     } else {
-                        peer_state.pending_request_sends =
-                            peer_state.pending_request_sends.saturating_sub(1);
+                        "sync.header.request.late_send_failure"
+                    };
+                    metrics::counter!(metric).increment(1);
+                    return RequesterEventOutcome::None;
+                }
+                match result {
+                    Ok(()) => {
+                        let Some(peer_state) = self.state.peers.get_mut(&identity.peer) else {
+                            return RequesterEventOutcome::None;
+                        };
+                        complete_request_publication(
+                            peer_state,
+                            request_id,
+                            Instant::now() + self.startup.request_timeout,
+                        );
+                        let peer_cap = peer_state.max_headers_per_response;
+                        metrics::counter!("sync.header.request.sent").increment(1);
+                        if range.priority == RangePriority::Repair {
+                            metrics::counter!("sync.header.vct_repair.request.sent").increment(1);
+                        }
+                        self.trace_get_headers_sent(
+                            &identity.peer,
+                            range,
+                            range.count,
+                            peer_cap,
+                            GetHeadersTraceMeta {
+                                request_id,
+                                session_id: identity.session_id,
+                                stream_version: ZAKURA_HEADER_SYNC_STREAM_VERSION,
+                            },
+                        );
+                        #[cfg(test)]
+                        let _ = self.actions.try_send(HeaderSyncAction::SendMessage {
+                            peer: identity.peer,
+                            request_id: Some(request_id),
+                            msg: HeaderSyncMessage::GetHeaders {
+                                start_height: range.start_height,
+                                count: range.count,
+                                want_tree_aux_roots: range.want_tree_aux_roots,
+                            },
+                        });
+                        RequesterEventOutcome::None
+                    }
+                    Err(error) => {
+                        let outstanding = self
+                            .state
+                            .peers
+                            .get_mut(&identity.peer)
+                            .and_then(|peer| peer.remove_outstanding_by_request_id(request_id));
+                        if let Some(outstanding) = outstanding {
+                            self.retry_failed_publication(
+                                &identity.peer,
+                                outstanding.range,
+                                outstanding.purpose,
+                            );
+                        }
+                        metrics::counter!(
+                            "sync.header.request.send_failed",
+                            "reason" => ordered_send_error_label(&error),
+                        )
+                        .increment(1);
+                        RequesterEventOutcome::Schedule
                     }
                 }
-                match command.purpose {
-                    RangePurpose::Sync => self.state.schedule.retry(command.range),
-                    RangePurpose::VctRepair { .. } => self.finish_vct_repair_attempt(&peer),
-                }
-                metrics::counter!(
-                    "sync.header.request.send_failed",
-                    "reason" => match reason {
-                        HeaderRequesterFailure::Closed => "closed",
-                        HeaderRequesterFailure::Encode => "encode",
-                    }
-                )
-                .increment(1);
-                self.schedule().await;
             }
-            HeaderRequesterEvent::Stopped {
-                peer,
-                session_id,
-                generation,
-            } => {
-                if self.is_current_requester(&peer, session_id, generation) {
+            HeaderRequesterEvent::Stopped { identity } => {
+                if self.is_current_requester(&identity) {
                     metrics::counter!("sync.header.requester.stopped").increment(1);
-                    self.handle_peer_disconnected(peer);
+                    self.handle_peer_disconnected(identity.peer);
                 } else {
                     metrics::counter!("sync.header.requester.stale_stop").increment(1);
                 }
+                RequesterEventOutcome::None
             }
         }
     }
@@ -541,10 +528,11 @@ impl HeaderSyncReactor {
             .is_some_and(|state| state.session.session_id() == session_id)
     }
 
-    fn is_current_requester(&self, peer: &ZakuraPeerId, session_id: u64, generation: u64) -> bool {
-        self.state.peers.get(peer).is_some_and(|state| {
-            state.session.session_id() == session_id && state.requester_generation == generation
-        })
+    fn is_current_requester(&self, identity: &HeaderRequesterIdentity) -> bool {
+        self.state
+            .peers
+            .get(&identity.peer)
+            .is_some_and(|state| state.requester_identity.as_ref() == Some(identity))
     }
 
     async fn handle_frontier_update(&mut self, update: FrontierUpdate) {
@@ -744,7 +732,7 @@ impl HeaderSyncReactor {
                 peer_state.last_received_status_at = None;
                 peer_state.reset_sent_status();
                 peer_state.outstanding.clear();
-                peer_state.pending_request_sends = 0;
+                peer_state.requester_identity = None;
                 peer_state.requester = None;
                 peer_state.served_headers_inflight = 0;
                 peer_state.served_header_request_ids.clear();
@@ -768,14 +756,19 @@ impl HeaderSyncReactor {
             });
         let requester_generation = self.next_requester_generation;
         self.next_requester_generation = self.next_requester_generation.wrapping_add(1).max(1);
+        let requester_identity = HeaderRequesterIdentity {
+            peer: peer.clone(),
+            session_id: requester_session.session_id(),
+            generation: requester_generation,
+        };
         let requester = spawn_header_requester(
             requester_session,
-            requester_generation,
+            requester_identity.clone(),
             self.requester_events_tx.clone(),
             self.startup.shutdown.clone(),
         );
         if let Some(peer_state) = self.state.peers.get_mut(&peer) {
-            peer_state.requester_generation = requester_generation;
+            peer_state.requester_identity = Some(requester_identity);
             peer_state.requester = Some(requester);
         }
         self.publish_connectivity_metrics();
@@ -1550,7 +1543,7 @@ impl HeaderSyncReactor {
                 &peer,
                 outstanding.range.start_height,
                 0,
-                outstanding.expected_max_count,
+                outstanding.range.count,
                 peer_max_headers_per_response,
                 in_flight_count,
                 outstanding.range.want_tree_aux_roots,
@@ -1558,8 +1551,7 @@ impl HeaderSyncReactor {
             );
             if let Some(peer_state) = self.state.peers.get_mut(&peer) {
                 peer_state.outstanding.push(OutstandingRange {
-                    deadline: Some(deadline),
-                    clear_assignment_on_timeout: true,
+                    deadline,
                     phase: OutstandingPhase::EmptyRetry,
                     ..outstanding
                 });
@@ -1573,13 +1565,13 @@ impl HeaderSyncReactor {
             &peer,
             outstanding.range.start_height,
             header_count,
-            outstanding.expected_max_count,
+            outstanding.range.count,
             peer_max_headers_per_response,
             in_flight_count,
             outstanding.range.want_tree_aux_roots,
             &tree_aux_roots,
         );
-        if header_count > outstanding.expected_max_count || header_count > outstanding.range.count {
+        if header_count > outstanding.range.count {
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::ResponseTooLong)
                 .await;
             self.retry_or_finish_outstanding(&peer, outstanding);
@@ -1616,11 +1608,11 @@ impl HeaderSyncReactor {
                 ExpectedHeadersResponse::new(
                     outstanding.request_id,
                     outstanding.range.start_height,
-                    outstanding.expected_max_count,
+                    outstanding.range.count,
                     outstanding.range.want_tree_aux_roots,
                 )
                 .expect("outstanding range uses a non-zero bounded count"),
-                outstanding.expected_max_count,
+                outstanding.range.count,
             ),
         };
         let validation_anchor = outstanding
@@ -2090,14 +2082,11 @@ impl HeaderSyncReactor {
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
             while index < peer.outstanding.len() {
-                if peer.outstanding[index]
-                    .deadline
-                    .is_some_and(|deadline| deadline <= now)
-                {
+                if peer.outstanding[index].deadline <= now {
                     let outstanding = peer.outstanding.remove(index);
                     let peer_id = peer.session.peer_id().clone();
                     let _ = peer.session.retire_expected_headers(outstanding.request_id);
-                    if outstanding.phase == OutstandingPhase::Registered {
+                    if outstanding.phase == OutstandingPhase::Publishing {
                         peer.session.cancel_token().cancel();
                         blocked_sessions.insert(peer_id.clone());
                     }
@@ -2110,7 +2099,7 @@ impl HeaderSyncReactor {
         for (outstanding, peer) in timed_out {
             match outstanding.purpose {
                 RangePurpose::Sync => {
-                    if outstanding.clear_assignment_on_timeout {
+                    if outstanding.phase == OutstandingPhase::EmptyRetry {
                         self.state.schedule.clear_assignment(outstanding.range);
                     }
                     self.state
@@ -2124,7 +2113,7 @@ impl HeaderSyncReactor {
             }
         }
         for peer in blocked_sessions {
-            metrics::counter!("sync.header.request.registration_timeout").increment(1);
+            metrics::counter!("sync.header.request.publication_timeout").increment(1);
             self.handle_peer_disconnected(peer);
         }
         self.schedule().await;
@@ -2145,7 +2134,7 @@ impl HeaderSyncReactor {
             if let Some(request_deadline) = peer
                 .outstanding
                 .iter()
-                .filter_map(|request| request.deadline)
+                .map(|request| request.deadline)
                 .min()
             {
                 deadline = deadline.min(request_deadline);
@@ -2178,7 +2167,7 @@ impl HeaderSyncReactor {
         self.state.refresh_forward_range(&self.startup);
         self.state.refresh_backward_range(&self.startup);
 
-        if self.schedule_vct_repair().await {
+        if self.schedule_vct_repair() {
             return;
         }
 
@@ -2191,7 +2180,7 @@ impl HeaderSyncReactor {
         loop {
             let mut scheduled_any = false;
             for peer_id in &peer_ids {
-                scheduled_any |= self.schedule_one_for_peer(peer_id).await;
+                scheduled_any |= self.schedule_one_for_peer(peer_id);
             }
             if !scheduled_any {
                 break;
@@ -2200,7 +2189,7 @@ impl HeaderSyncReactor {
         self.publish_work_metrics();
     }
 
-    async fn schedule_one_for_peer(&mut self, peer_id: &ZakuraPeerId) -> bool {
+    fn schedule_one_for_peer(&mut self, peer_id: &ZakuraPeerId) -> bool {
         let Some(peer) = self.state.peers.get(peer_id) else {
             return false;
         };
@@ -2268,34 +2257,91 @@ impl HeaderSyncReactor {
             }
         }
 
+        self.prepare_and_enqueue_request(peer_id, range, RangePurpose::Sync)
+    }
+
+    fn prepare_and_enqueue_request(
+        &mut self,
+        peer_id: &ZakuraPeerId,
+        range: RangeRequest,
+        purpose: RangePurpose,
+    ) -> bool {
         let Some(peer) = self.state.peers.get(peer_id) else {
+            self.retry_failed_publication(peer_id, range, purpose);
             return false;
         };
+        let session = peer.session.clone();
         let Some(requester) = peer.requester.clone() else {
-            self.state.schedule.retry(range);
+            self.retry_failed_publication(peer_id, range, purpose);
             metrics::counter!("sync.header.fill.stop", "reason" => "requester_stopped")
                 .increment(1);
             return false;
         };
-        let command = HeaderRequesterCommand {
-            range,
-            expected_max_count: count,
-            purpose: RangePurpose::Sync,
+        let prepared = match session.prepare_get_headers(
+            range.start_height,
+            range.count,
+            range.want_tree_aux_roots,
+        ) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                metrics::counter!(
+                    "sync.header.request.send_failed",
+                    "reason" => ordered_send_error_label(&error),
+                )
+                .increment(1);
+                self.retry_failed_publication(peer_id, range, purpose);
+                if matches!(error, OrderedSendError::Closed) {
+                    session.cancel_token().cancel();
+                }
+                return false;
+            }
         };
-        if let Err(error) = requester.try_send(command) {
-            let reason = match error {
-                mpsc::error::TrySendError::Full(_) => "requester_full",
-                mpsc::error::TrySendError::Closed(_) => "requester_closed",
-            };
-            metrics::counter!("sync.header.fill.stop", "reason" => reason).increment(1);
-            self.state.schedule.retry(range);
+        let request_id = prepared.request_id();
+        let outstanding = OutstandingRange {
+            request_id,
+            range,
+            deadline: Instant::now() + self.startup.request_timeout,
+            purpose,
+            phase: OutstandingPhase::Publishing,
+        };
+        if let Some(peer) = self.state.peers.get_mut(peer_id) {
+            peer.outstanding.push(outstanding);
+        } else {
+            self.retry_failed_publication(peer_id, range, purpose);
+            drop(prepared);
             return false;
         }
-        if let Some(peer) = self.state.peers.get_mut(peer_id) {
-            peer.pending_request_sends = peer.pending_request_sends.saturating_add(1);
+        if matches!(purpose, RangePurpose::Sync) {
+            self.state.schedule.mark_assigned(peer_id.clone(), range);
         }
-        self.state.schedule.mark_assigned(peer_id.clone(), range);
+
+        let command = HeaderRequesterCommand { range, prepared };
+        if let Err(error) = requester.try_send(command) {
+            let (reason, command) = match error {
+                mpsc::error::TrySendError::Full(command) => ("requester_full", command),
+                mpsc::error::TrySendError::Closed(command) => ("requester_closed", command),
+            };
+            metrics::counter!("sync.header.fill.stop", "reason" => reason).increment(1);
+            if let Some(peer) = self.state.peers.get_mut(peer_id) {
+                let _ = peer.remove_outstanding_by_request_id(request_id);
+            }
+            self.retry_failed_publication(peer_id, range, purpose);
+            drop(command);
+            return false;
+        }
         true
+    }
+
+    fn retry_failed_publication(
+        &mut self,
+        peer: &ZakuraPeerId,
+        range: RangeRequest,
+        purpose: RangePurpose,
+    ) {
+        match purpose {
+            RangePurpose::Sync => self.state.schedule.retry(range),
+            RangePurpose::VctRepair { .. } => self.finish_vct_repair_attempt(peer),
+        }
     }
 
     fn publish_work_metrics(&self) {
@@ -2348,7 +2394,7 @@ impl HeaderSyncReactor {
             .set(self.state.last_header_progress_at.elapsed().as_secs_f64());
     }
 
-    async fn schedule_vct_repair(&mut self) -> bool {
+    fn schedule_vct_repair(&mut self) -> bool {
         let now = Instant::now();
         let newly_exhausted = self
             .state
@@ -2394,31 +2440,7 @@ impl HeaderSyncReactor {
             return false;
         };
 
-        let Some(peer) = self.state.peers.get(&peer_id) else {
-            return false;
-        };
         let range = repair.range;
-        let peer_cap = peer.max_headers_per_response;
-        let session_id = peer.session.session_id();
-        let stream_version = ZAKURA_HEADER_SYNC_STREAM_VERSION;
-        let request_id =
-            match peer
-                .session
-                .try_send_get_headers(range.start_height, range.count, true)
-            {
-                Ok(request_id) => request_id,
-                Err(error) => {
-                    tracing::debug!(
-                        peer = ?peer_id,
-                        start_height = ?range.start_height,
-                        count = range.count,
-                        ?error,
-                        "failed to queue VCT repair GetHeaders"
-                    );
-                    return false;
-                }
-            };
-
         let (height, generation) = {
             let repair = self
                 .state
@@ -2428,46 +2450,11 @@ impl HeaderSyncReactor {
             repair.mark_attempt(peer_id.clone());
             (repair.height, repair.generation)
         };
-        let outstanding = OutstandingRange {
-            request_id,
-            range,
-            deadline: Some(Instant::now() + self.startup.request_timeout),
-            expected_max_count: range.count,
-            clear_assignment_on_timeout: false,
-            purpose: RangePurpose::VctRepair { height, generation },
-            phase: OutstandingPhase::Sent,
-        };
-        if let Some(peer) = self.state.peers.get_mut(&peer_id) {
-            peer.outstanding.push(outstanding);
-        }
-
-        metrics::counter!("sync.header.vct_repair.request.sent").increment(1);
-        self.trace_get_headers_sent(
+        self.prepare_and_enqueue_request(
             &peer_id,
             range,
-            range.count,
-            peer_cap,
-            GetHeadersTraceMeta {
-                request_id,
-                session_id,
-                stream_version,
-            },
-        );
-        #[cfg(test)]
-        let _ = self
-            .actions
-            .send(HeaderSyncAction::SendMessage {
-                peer: peer_id,
-                request_id: Some(request_id),
-                msg: HeaderSyncMessage::GetHeaders {
-                    start_height: range.start_height,
-                    count: range.count,
-                    want_tree_aux_roots: true,
-                },
-            })
-            .await;
-
-        true
+            RangePurpose::VctRepair { height, generation },
+        )
     }
 
     fn send_status(&mut self, peer: &ZakuraPeerId) -> bool {
@@ -3103,7 +3090,7 @@ impl HeaderSyncReactor {
         peer: &ZakuraPeerId,
         start_height: block::Height,
         count: u32,
-        expected_max_count: u32,
+        expected_count: u32,
         advertised_cap: u32,
         in_flight_count: usize,
         want_tree_aux_roots: bool,
@@ -3115,7 +3102,7 @@ impl HeaderSyncReactor {
             insert_height(row, hs_trace::RANGE_START, start_height);
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(count));
             insert_u64(row, hs_trace::ADVERTISED_CAP, u64::from(advertised_cap));
-            insert_u64(row, hs_trace::EXPECTED_COUNT, u64::from(expected_max_count));
+            insert_u64(row, hs_trace::EXPECTED_COUNT, u64::from(expected_count));
             insert_u64(row, hs_trace::IN_FLIGHT_COUNT, in_flight_count as u64);
             insert_bool(row, hs_trace::WANT_TREE_AUX_ROOTS, want_tree_aux_roots);
             insert_u64(row, hs_trace::TREE_AUX_ROOTS_LEN, u64::from(roots.len));

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1,7 +1,10 @@
 use super::super::trace::{
     ordered_send_error_label, queue_send_trace as qs_trace, QUEUE_SEND_TABLE,
 };
-use super::{config::*, error::*, events::*, state::*, validation::*, wire::*, work_queue::*, *};
+use super::{
+    config::*, error::*, events::*, requester::*, state::*, validation::*, wire::*, work_queue::*,
+    *,
+};
 use crate::zakura::{
     FrontierChange, FrontierUpdate, HeaderSyncServiceSummary, OrderedSendError,
     ServiceAdmissionDecision, ServicePeerDirection, ServicePeerSnapshot,
@@ -25,6 +28,8 @@ pub fn spawn_header_sync_reactor(
     let (events_tx, events_rx) = mpsc::channel(128);
     let (lifecycle_tx, lifecycle_rx) = mpsc::unbounded_channel();
     let (actions_tx, actions_rx) = mpsc::channel(128);
+    let (commit_permits_tx, commit_permits_rx) = mpsc::unbounded_channel();
+    let (requester_events_tx, requester_events_rx) = mpsc::unbounded_channel();
     let (tip_tx, tip_rx) = watch::channel((state.best_header_tip, state.best_header_hash));
     let (peers_tx, peers_rx) =
         watch::channel(ServicePeerSnapshot::new(0, 0, startup.config.peer_limits));
@@ -46,6 +51,12 @@ pub fn spawn_header_sync_reactor(
         events: events_rx,
         lifecycle: lifecycle_rx,
         actions: actions_tx,
+        commit_permits: commit_permits_rx,
+        commit_permits_tx,
+        commit_permit_waiting: false,
+        requester_events: requester_events_rx,
+        requester_events_tx,
+        next_requester_generation: 1,
         tip: tip_tx,
         peers: peers_tx,
         candidates: candidates_tx,
@@ -62,6 +73,12 @@ pub(super) struct HeaderSyncReactor {
     events: mpsc::Receiver<HeaderSyncEvent>,
     lifecycle: mpsc::UnboundedReceiver<HeaderSyncEvent>,
     actions: mpsc::Sender<HeaderSyncAction>,
+    commit_permits: mpsc::UnboundedReceiver<mpsc::OwnedPermit<HeaderSyncAction>>,
+    commit_permits_tx: mpsc::UnboundedSender<mpsc::OwnedPermit<HeaderSyncAction>>,
+    commit_permit_waiting: bool,
+    requester_events: mpsc::UnboundedReceiver<HeaderRequesterEvent>,
+    requester_events_tx: mpsc::UnboundedSender<HeaderRequesterEvent>,
+    next_requester_generation: u64,
     tip: watch::Sender<(block::Height, block::Hash)>,
     peers: watch::Sender<ServicePeerSnapshot>,
     candidates: watch::Sender<ZakuraHeaderSyncCandidateState>,
@@ -88,9 +105,9 @@ impl HeaderSyncReactor {
             });
         }
 
-        let mut ticks = time::interval(self.empty_headers_retry_delay());
         let exit_reason;
         loop {
+            let maintenance_deadline = self.next_maintenance_deadline();
             // Liveness watermark: a frozen reactor is otherwise invisible (the
             // process, transport, and other services keep running). Exposing the
             // loop count lets an external watcher detect a stall in seconds.
@@ -115,6 +132,19 @@ impl HeaderSyncReactor {
                     };
                     self.handle_event(event).await;
                 }
+                permit = self.commit_permits.recv(), if self.commit_permit_waiting => {
+                    self.commit_permit_waiting = false;
+                    if let Some(permit) = permit {
+                        self.drain_buffered_with_permit(Some(permit)).await;
+                    }
+                }
+                event = self.requester_events.recv() => {
+                    let Some(event) = event else {
+                        exit_reason = "requester_event_channel_closed";
+                        break;
+                    };
+                    self.handle_requester_event(event).await;
+                }
                 changed = async {
                     match frontier_updates.as_mut() {
                         Some(frontier_updates) => frontier_updates.changed().await,
@@ -132,7 +162,9 @@ impl HeaderSyncReactor {
                         Err(_) => frontier_updates_open = false,
                     }
                 }
-                _ = ticks.tick() => {
+                _ = time::sleep_until(maintenance_deadline) => {
+                    metrics::counter!("sync.header.reactor.maintenance_wakeups").increment(1);
+                    self.emit_trace(hs_trace::HEADER_MAINTENANCE_WAKEUP, |_| {});
                     metrics::counter!("sync.header.reactor.event_started", "kind" => "tick").increment(1);
                     self.handle_timeouts().await;
                     self.refresh_statuses();
@@ -156,6 +188,100 @@ impl HeaderSyncReactor {
         metrics::counter!("sync.header.reactor.event_started", "kind" => kind).increment(1);
         self.handle_event_inner(event).await;
         metrics::counter!("sync.header.reactor.event_finished", "kind" => kind).increment(1);
+    }
+
+    async fn handle_requester_event(&mut self, event: HeaderRequesterEvent) {
+        match event {
+            HeaderRequesterEvent::Sent {
+                peer,
+                session_id,
+                generation,
+                command,
+                request_id,
+            } => {
+                if !self.is_current_requester(&peer, session_id, generation) {
+                    metrics::counter!("sync.header.request.late_send").increment(1);
+                    return;
+                }
+                let Some(peer_state) = self.state.peers.get_mut(&peer) else {
+                    return;
+                };
+                peer_state.pending_request_sends =
+                    peer_state.pending_request_sends.saturating_sub(1);
+                peer_state.outstanding.push(OutstandingRange {
+                    request_id,
+                    range: command.range,
+                    deadline: Instant::now() + self.startup.request_timeout,
+                    expected_max_count: command.expected_max_count,
+                    clear_assignment_on_timeout: false,
+                    purpose: command.purpose,
+                });
+                let peer_cap = peer_state.max_headers_per_response;
+                metrics::counter!("sync.header.request.sent").increment(1);
+                self.trace_get_headers_sent(
+                    &peer,
+                    command.range,
+                    command.expected_max_count,
+                    peer_cap,
+                    GetHeadersTraceMeta {
+                        request_id,
+                        session_id,
+                        stream_version: ZAKURA_HEADER_SYNC_STREAM_VERSION,
+                    },
+                );
+                #[cfg(test)]
+                let _ = self.actions.try_send(HeaderSyncAction::SendMessage {
+                    peer,
+                    request_id: Some(request_id),
+                    msg: HeaderSyncMessage::GetHeaders {
+                        start_height: command.range.start_height,
+                        count: command.expected_max_count,
+                        want_tree_aux_roots: command.range.want_tree_aux_roots,
+                    },
+                });
+            }
+            HeaderRequesterEvent::Failed {
+                peer,
+                session_id,
+                generation,
+                command,
+                reason,
+            } => {
+                if !self.is_current_requester(&peer, session_id, generation) {
+                    metrics::counter!("sync.header.request.late_send_failure").increment(1);
+                    return;
+                }
+                if let Some(peer_state) = self.state.peers.get_mut(&peer) {
+                    peer_state.pending_request_sends =
+                        peer_state.pending_request_sends.saturating_sub(1);
+                }
+                match command.purpose {
+                    RangePurpose::Sync => self.state.schedule.retry(command.range),
+                    RangePurpose::VctRepair { .. } => self.finish_vct_repair_attempt(&peer),
+                }
+                metrics::counter!(
+                    "sync.header.request.send_failed",
+                    "reason" => match reason {
+                        HeaderRequesterFailure::Closed => "closed",
+                        HeaderRequesterFailure::Encode => "encode",
+                    }
+                )
+                .increment(1);
+                self.schedule().await;
+            }
+            HeaderRequesterEvent::Stopped {
+                peer,
+                session_id,
+                generation,
+            } => {
+                if self.is_current_requester(&peer, session_id, generation) {
+                    metrics::counter!("sync.header.requester.stopped").increment(1);
+                    self.handle_peer_disconnected(peer);
+                } else {
+                    metrics::counter!("sync.header.requester.stale_stop").increment(1);
+                }
+            }
+        }
     }
 
     async fn handle_event_inner(&mut self, event: HeaderSyncEvent) {
@@ -283,9 +409,22 @@ impl HeaderSyncReactor {
                 count,
                 kind,
             } => {
-                if self.is_current_session(&peer, session_id) {
-                    self.handle_header_range_commit_failed(peer, start_height, count, kind)
-                        .await;
+                if self.state.pending_commits.contains_key(&PendingCommitKey {
+                    peer: peer.clone(),
+                    session_id,
+                    start_height,
+                    count,
+                }) || (kind == HeaderSyncCommitFailureKind::InvalidPeerRange
+                    && self.is_current_session(&peer, session_id))
+                {
+                    self.handle_header_range_commit_failed(
+                        peer,
+                        session_id,
+                        start_height,
+                        count,
+                        kind,
+                    )
+                    .await;
                 } else {
                     metrics::counter!("sync.header.session.stale_completion").increment(1);
                 }
@@ -367,6 +506,12 @@ impl HeaderSyncReactor {
             .peers
             .get(peer)
             .is_some_and(|state| state.session.session_id() == session_id)
+    }
+
+    fn is_current_requester(&self, peer: &ZakuraPeerId, session_id: u64, generation: u64) -> bool {
+        self.state.peers.get(peer).is_some_and(|state| {
+            state.session.session_id() == session_id && state.requester_generation == generation
+        })
     }
 
     async fn handle_frontier_update(&mut self, update: FrontierUpdate) {
@@ -517,6 +662,7 @@ impl HeaderSyncReactor {
     async fn handle_peer_connected(&mut self, session: HeaderSyncPeerSession) {
         let peer = session.peer_id().clone();
         let direction = session.direction();
+        let requester_session = session.clone();
         if self
             .state
             .peers
@@ -548,9 +694,6 @@ impl HeaderSyncReactor {
 
         self.state.parked_peers.remove(&peer);
         self.state.schedule.forget_peer(&peer);
-        self.state
-            .pending_commits
-            .retain(|key, _range| key.peer != peer);
         let status_refresh_interval = self.startup.status_refresh_interval;
         self.state
             .peers
@@ -568,6 +711,8 @@ impl HeaderSyncReactor {
                 peer_state.last_received_status_at = None;
                 peer_state.reset_sent_status();
                 peer_state.outstanding.clear();
+                peer_state.pending_request_sends = 0;
+                peer_state.requester = None;
                 peer_state.served_headers_inflight = 0;
                 peer_state.served_header_request_ids.clear();
                 peer_state.highest_served_header_request_id = None;
@@ -588,6 +733,18 @@ impl HeaderSyncReactor {
                     DEFAULT_HS_INBOUND_NEW_BLOCK_MIN_INTERVAL,
                 )
             });
+        let requester_generation = self.next_requester_generation;
+        self.next_requester_generation = self.next_requester_generation.wrapping_add(1).max(1);
+        let requester = spawn_header_requester(
+            requester_session,
+            requester_generation,
+            self.requester_events_tx.clone(),
+            self.startup.shutdown.clone(),
+        );
+        if let Some(peer_state) = self.state.peers.get_mut(&peer) {
+            peer_state.requester_generation = requester_generation;
+            peer_state.requester = Some(requester);
+        }
         self.publish_connectivity_metrics();
         self.trace_peer_connected(&peer, direction, self.state.peers.len());
         self.publish_peer_snapshot();
@@ -597,18 +754,6 @@ impl HeaderSyncReactor {
     }
 
     fn handle_peer_disconnected(&mut self, peer: ZakuraPeerId) {
-        let buffered_ranges: Vec<_> = self
-            .state
-            .buffered
-            .iter()
-            .filter_map(|(key, buffered)| (buffered.peer == peer).then_some(*key))
-            .collect();
-        for key in buffered_ranges {
-            if let Some(buffered) = self.state.buffered.remove(&key) {
-                self.state.schedule.clear_assignment(buffered.range);
-                self.state.schedule.retry(buffered.range);
-            }
-        }
         let was_connected = self.state.peers.remove(&peer).is_some();
         self.state.parked_peers.remove(&peer);
         self.state.advisory.remove(&peer);
@@ -626,10 +771,13 @@ impl HeaderSyncReactor {
         self.state.pending_new_blocks.remove(&hash);
         let _ = self.state.seen.insert(hash);
         self.update_verified_block_tip(height, hash);
-        self.state.schedule.mark_height_covered(height);
-        self.cancel_covered_outstanding();
         if height > self.state.best_header_tip {
+            self.reconcile_forward_coverage(height);
             self.publish_best_tip(height, hash).await;
+            self.drain_buffered_with_permit(None).await;
+        } else {
+            self.state.schedule.mark_height_covered(height);
+            self.cancel_covered_outstanding();
         }
         self.schedule().await;
     }
@@ -650,10 +798,13 @@ impl HeaderSyncReactor {
         }
 
         self.update_verified_block_tip(height, hash);
-        self.state.schedule.mark_height_covered(height);
-        self.cancel_covered_outstanding();
         if height > self.state.best_header_tip {
+            self.reconcile_forward_coverage(height);
             self.publish_best_tip(height, hash).await;
+            self.drain_buffered_with_permit(None).await;
+        } else {
+            self.state.schedule.mark_height_covered(height);
+            self.cancel_covered_outstanding();
         }
 
         let destinations = self.eligible_tip_destinations(&peer, height);
@@ -875,9 +1026,19 @@ impl HeaderSyncReactor {
         let completed_backward = self.state.pending_commits.values().any(|range| {
             range.priority == RangePriority::Backward && range.is_within(start_height, tip_height)
         });
+        let completed_ranges: Vec<_> = self
+            .state
+            .pending_commits
+            .values()
+            .filter(|range| range.is_within(start_height, tip_height))
+            .copied()
+            .collect();
         self.state
             .pending_commits
             .retain(|_, range| !range.is_within(start_height, tip_height));
+        for range in completed_ranges {
+            self.state.schedule.complete(range);
+        }
         if let Some(repair_peer) = completed_repair_peer {
             if let Some(repair) = self.state.repair.as_mut() {
                 if repair.in_flight.as_ref() == Some(&repair_peer) {
@@ -909,6 +1070,7 @@ impl HeaderSyncReactor {
     async fn handle_header_range_commit_failed(
         &mut self,
         peer: ZakuraPeerId,
+        session_id: u64,
         start_height: block::Height,
         count: u32,
         kind: HeaderSyncCommitFailureKind,
@@ -927,10 +1089,24 @@ impl HeaderSyncReactor {
         }
         let key = PendingCommitKey {
             peer: peer.clone(),
+            session_id,
             start_height,
             count,
         };
         if let Some(range) = self.state.pending_commits.remove(&key) {
+            if range.priority == RangePriority::Forward
+                && range.start_height <= self.state.best_header_tip
+            {
+                self.state.schedule.complete(range);
+                metrics::counter!(
+                    "sync.header.work.covered",
+                    "state" => "committing",
+                    "lane" => "forward"
+                )
+                .increment(1);
+                self.schedule().await;
+                return;
+            }
             if range.priority == RangePriority::Repair {
                 self.finish_vct_repair_attempt(&peer);
                 self.schedule().await;
@@ -1526,205 +1702,199 @@ impl HeaderSyncReactor {
             }
         }
 
-        if matches!(
-            outstanding.range.priority,
-            RangePriority::Forward | RangePriority::Backward
-        ) {
-            let priority = outstanding.range.priority;
-            let session_id = self
-                .state
-                .peers
-                .get(&peer)
-                .map(|state| state.session.session_id())
-                .expect("peer exists because its response is being buffered");
-            self.state.buffered.insert(
-                (outstanding.range.priority, outstanding.range.start_height),
-                BufferedHeaderRange {
-                    peer,
-                    session_id,
-                    range: outstanding.range,
-                    headers,
-                    body_sizes,
-                    tree_aux_roots,
-                },
-            );
-            metrics::counter!("sync.header.work.buffered").increment(1);
-            metrics::gauge!("sync.header.work.buffered.count")
-                .set(self.state.buffered.len() as f64);
-            if priority == RangePriority::Forward {
-                self.drain_buffered_forward().await;
-            } else {
-                self.drain_buffered_backward().await;
-            }
-            self.schedule().await;
-            return;
-        }
-
-        let anchor = outstanding
-            .range
-            .anchor_hash
-            .expect("backward and repair ranges always have a known anchor");
-        self.state.pending_commits.insert(
-            PendingCommitKey {
-                peer: peer.clone(),
-                start_height: outstanding.range.start_height,
-                count: header_count,
-            },
-            outstanding.range,
-        );
         let session_id = self
             .state
             .peers
             .get(&peer)
             .map(|state| state.session.session_id())
-            .expect("peer exists because its outstanding response is being committed");
-        let _ = self.dispatch_action(HeaderSyncAction::CommitHeaderRange {
-            peer,
-            session_id,
-            anchor,
-            start_height: outstanding.range.start_height,
-            headers,
-            body_sizes,
-            tree_aux_roots,
-            finalized: outstanding.range.finalized,
-        });
+            .expect("peer exists because its response is being buffered");
+        if outstanding.range.priority != RangePriority::Repair {
+            self.state
+                .schedule
+                .mark_buffered(peer.clone(), outstanding.range);
+        }
+        self.state.buffered.insert(
+            (outstanding.range.priority, outstanding.range.start_height),
+            BufferedHeaderRange {
+                peer,
+                session_id,
+                range: outstanding.range,
+                headers,
+                body_sizes,
+                tree_aux_roots,
+            },
+        );
+        metrics::counter!("sync.header.work.buffered").increment(1);
+        metrics::gauge!("sync.header.work.buffered.count").set(self.state.buffered.len() as f64);
+        self.drain_buffered_with_permit(None).await;
+        self.schedule().await;
     }
 
     async fn drain_buffered_forward(&mut self) {
-        if self
+        self.drain_buffered_with_permit(None).await;
+    }
+
+    async fn drain_buffered_backward(&mut self) {
+        self.drain_buffered_with_permit(None).await;
+    }
+
+    async fn drain_buffered_with_permit(
+        &mut self,
+        mut reserved: Option<mpsc::OwnedPermit<HeaderSyncAction>>,
+    ) {
+        loop {
+            let candidate = self.next_buffered_commit();
+            let Some((key, anchor)) = candidate else {
+                return;
+            };
+
+            let invalid =
+                self.state.buffered.get(&key).and_then(|buffered| {
+                    validate_header_range_links(anchor, &buffered.headers).err()
+                });
+            if let Some(error) = invalid {
+                let buffered = self
+                    .state
+                    .buffered
+                    .remove(&key)
+                    .expect("candidate buffer exists until the reactor removes it");
+                self.state
+                    .schedule
+                    .retry_avoiding(buffered.peer.clone(), buffered.range);
+                self.trace_range_validation_rejected(
+                    &buffered.peer,
+                    buffered.range,
+                    u32::try_from(buffered.headers.len()).unwrap_or(u32::MAX),
+                    "ordered_predecessor",
+                    header_sync_wire_error_kind(&error),
+                );
+                self.report_misbehavior(buffered.peer, HeaderSyncMisbehavior::InvalidRange)
+                    .await;
+                continue;
+            }
+
+            let permit = if let Some(permit) = reserved.take() {
+                permit
+            } else {
+                match self.actions.clone().try_reserve_owned() {
+                    Ok(permit) => permit,
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        metrics::counter!("sync.header.commit.action_queue_full").increment(1);
+                        metrics::counter!(
+                            "sync.header.fill.stop",
+                            "reason" => "action_queue_full"
+                        )
+                        .increment(1);
+                        self.arm_commit_capacity_waiter();
+                        return;
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        metrics::counter!(
+                            "sync.header.fill.stop",
+                            "reason" => "action_queue_closed"
+                        )
+                        .increment(1);
+                        return;
+                    }
+                }
+            };
+
+            let mut buffered = self
+                .state
+                .buffered
+                .remove(&key)
+                .expect("candidate buffer exists until commit admission");
+            let original = buffered.range;
+            buffered.range.anchor_hash = Some(anchor);
+            self.state
+                .schedule
+                .narrow_queued_range(original, buffered.range);
+            let count = u32::try_from(buffered.headers.len())
+                .expect("decoded Headers length is capped by u32");
+            let commit_key = PendingCommitKey {
+                peer: buffered.peer.clone(),
+                session_id: buffered.session_id,
+                start_height: buffered.range.start_height,
+                count,
+            };
+            if buffered.range.priority != RangePriority::Repair {
+                self.state.schedule.mark_committing(
+                    buffered.peer.clone(),
+                    buffered.session_id,
+                    buffered.range,
+                );
+            }
+            self.state
+                .pending_commits
+                .insert(commit_key, buffered.range);
+            let lane = buffered.range.priority.label();
+            permit.send(HeaderSyncAction::CommitHeaderRange {
+                peer: buffered.peer,
+                session_id: buffered.session_id,
+                anchor,
+                start_height: buffered.range.start_height,
+                headers: buffered.headers,
+                body_sizes: buffered.body_sizes,
+                tree_aux_roots: buffered.tree_aux_roots,
+                finalized: buffered.range.finalized,
+            });
+            metrics::counter!("sync.header.work.ordered_drain", "lane" => lane).increment(1);
+            metrics::gauge!("sync.header.work.buffered.count")
+                .set(self.state.buffered.len() as f64);
+        }
+    }
+
+    fn next_buffered_commit(&self) -> Option<((RangePriority, block::Height), block::Hash)> {
+        if let Some((&key, buffered)) = self
+            .state
+            .buffered
+            .iter()
+            .find(|((priority, _), _)| *priority == RangePriority::Repair)
+        {
+            return buffered.range.anchor_hash.map(|anchor| (key, anchor));
+        }
+
+        if !self
             .state
             .pending_commits
             .values()
             .any(|range| range.priority == RangePriority::Forward)
         {
-            return;
-        }
-        let Some(start_height) = next_height(self.state.best_header_tip) else {
-            return;
-        };
-        let Some(mut buffered) = self
-            .state
-            .buffered
-            .remove(&(RangePriority::Forward, start_height))
-        else {
-            return;
-        };
-
-        if let Err(error) =
-            validate_header_range_links(self.state.best_header_hash, &buffered.headers)
-        {
-            self.state.schedule.clear_assignment(buffered.range);
-            self.state
-                .schedule
-                .retry_avoiding(buffered.peer.clone(), buffered.range);
-            self.trace_range_validation_rejected(
-                &buffered.peer,
-                buffered.range,
-                u32::try_from(buffered.headers.len()).unwrap_or(u32::MAX),
-                "ordered_predecessor",
-                header_sync_wire_error_kind(&error),
-            );
-            self.report_misbehavior(buffered.peer, HeaderSyncMisbehavior::InvalidRange)
-                .await;
-            return;
+            let start = next_height(self.state.best_header_tip)?;
+            let key = (RangePriority::Forward, start);
+            if self.state.buffered.contains_key(&key) {
+                return Some((key, self.state.best_header_hash));
+            }
         }
 
-        let original = buffered.range;
-        buffered.range.anchor_hash = Some(self.state.best_header_hash);
-        self.state
-            .schedule
-            .narrow_queued_range(original, buffered.range);
-        let count =
-            u32::try_from(buffered.headers.len()).expect("decoded Headers length is capped by u32");
-        self.state.pending_commits.insert(
-            PendingCommitKey {
-                peer: buffered.peer.clone(),
-                start_height,
-                count,
-            },
-            buffered.range,
-        );
-        let _ = self.dispatch_action(HeaderSyncAction::CommitHeaderRange {
-            peer: buffered.peer,
-            session_id: buffered.session_id,
-            anchor: self.state.best_header_hash,
-            start_height,
-            headers: buffered.headers,
-            body_sizes: buffered.body_sizes,
-            tree_aux_roots: buffered.tree_aux_roots,
-            finalized: buffered.range.finalized,
-        });
-        metrics::counter!("sync.header.work.ordered_drain").increment(1);
-        metrics::gauge!("sync.header.work.buffered.count").set(self.state.buffered.len() as f64);
-    }
-
-    async fn drain_buffered_backward(&mut self) {
-        if self
+        if !self
             .state
             .pending_commits
             .values()
             .any(|range| range.priority == RangePriority::Backward)
         {
+            let (height, hash) = self.state.backward_frontier?;
+            let start = next_height(height)?;
+            let key = (RangePriority::Backward, start);
+            if self.state.buffered.contains_key(&key) {
+                return Some((key, hash));
+            }
+        }
+        None
+    }
+
+    fn arm_commit_capacity_waiter(&mut self) {
+        if self.commit_permit_waiting {
             return;
         }
-        let Some((frontier_height, frontier_hash)) = self.state.backward_frontier else {
-            return;
-        };
-        let Some(start_height) = next_height(frontier_height) else {
-            return;
-        };
-        let Some(mut buffered) = self
-            .state
-            .buffered
-            .remove(&(RangePriority::Backward, start_height))
-        else {
-            return;
-        };
-
-        if let Err(error) = validate_header_range_links(frontier_hash, &buffered.headers) {
-            self.state.schedule.clear_assignment(buffered.range);
-            self.state
-                .schedule
-                .retry_avoiding(buffered.peer.clone(), buffered.range);
-            self.trace_range_validation_rejected(
-                &buffered.peer,
-                buffered.range,
-                u32::try_from(buffered.headers.len()).unwrap_or(u32::MAX),
-                "ordered_predecessor",
-                header_sync_wire_error_kind(&error),
-            );
-            self.report_misbehavior(buffered.peer, HeaderSyncMisbehavior::InvalidRange)
-                .await;
-            return;
-        }
-
-        let original = buffered.range;
-        buffered.range.anchor_hash = Some(frontier_hash);
-        self.state
-            .schedule
-            .narrow_queued_range(original, buffered.range);
-        let count =
-            u32::try_from(buffered.headers.len()).expect("decoded Headers length is capped by u32");
-        self.state.pending_commits.insert(
-            PendingCommitKey {
-                peer: buffered.peer.clone(),
-                start_height,
-                count,
-            },
-            buffered.range,
-        );
-        let _ = self.dispatch_action(HeaderSyncAction::CommitHeaderRange {
-            peer: buffered.peer,
-            session_id: buffered.session_id,
-            anchor: frontier_hash,
-            start_height,
-            headers: buffered.headers,
-            body_sizes: buffered.body_sizes,
-            tree_aux_roots: buffered.tree_aux_roots,
-            finalized: true,
+        self.commit_permit_waiting = true;
+        let actions = self.actions.clone();
+        let permits = self.commit_permits_tx.clone();
+        tokio::spawn(async move {
+            if let Ok(permit) = actions.reserve_owned().await {
+                let _ = permits.send(permit);
+            }
         });
-        metrics::counter!("sync.header.work.ordered_drain", "lane" => "backward").increment(1);
-        metrics::gauge!("sync.header.work.buffered.count").set(self.state.buffered.len() as f64);
     }
 
     fn validate_vct_repair_response(
@@ -1892,6 +2062,39 @@ impl HeaderSyncReactor {
             .min(HEADER_SYNC_RETRY_AVOIDANCE)
     }
 
+    fn next_maintenance_deadline(&self) -> Instant {
+        let now = Instant::now();
+        let mut deadline = now + Duration::from_secs(60 * 60);
+
+        if let Some(retry) = self.state.schedule.next_retry_deadline() {
+            deadline = deadline.min(retry);
+        }
+        for peer in self.state.peers.values() {
+            if let Some(request) = peer
+                .outstanding
+                .iter()
+                .min_by_key(|request| request.deadline)
+            {
+                deadline = deadline.min(request.deadline);
+            }
+            let status_deadline = if peer.status_differs_from_last_sent(self.local_status()) {
+                peer.meters.unsolicited.next_allowed
+            } else {
+                peer.meters
+                    .keepalive
+                    .next_allowed
+                    .max(peer.meters.unsolicited.next_allowed)
+            };
+            deadline = deadline.min(status_deadline);
+        }
+        if let Some(repair) = self.state.repair.as_ref() {
+            deadline = deadline.min(repair.next_attempt_at);
+            deadline = deadline.min(repair.started_at + VCT_ROOT_REPAIR_MAX_WALL_TIME);
+        }
+
+        deadline.max(now)
+    }
+
     async fn schedule(&mut self) {
         if !self.startup.range_state_actions_enabled {
             metrics::counter!("sync.header.fill.stop", "reason" => "shutdown_or_disabled")
@@ -1938,7 +2141,35 @@ impl HeaderSyncReactor {
         }
 
         let Some(mut range) = self.state.schedule.next_for_peer(peer_id, peer) else {
-            metrics::counter!("sync.header.fill.stop", "reason" => "no_eligible_work").increment(1);
+            let resident_cap = u64::from(
+                self.startup
+                    .config
+                    .advertised_max_headers_per_response()
+                    .saturating_mul(HEADER_SYNC_MAX_RESIDENT_BATCHES),
+            );
+            let reason = if self
+                .state
+                .schedule
+                .peer_retry_avoided(peer_id, peer.advertised_tip)
+            {
+                "retry_avoidance"
+            } else if !self.state.schedule.has_pending()
+                && self.state.schedule.resident_heights() >= resident_cap
+            {
+                "global_window_full"
+            } else {
+                "no_eligible_work"
+            };
+            metrics::counter!("sync.header.fill.stop", "reason" => reason).increment(1);
+            tracing::trace!(
+                ?peer_id,
+                reason,
+                available_slots = peer.available_slots(),
+                pending = self.state.schedule.pending_len(),
+                resident_heights = self.state.schedule.resident_heights(),
+                work_epoch = self.state.schedule.epoch,
+                "Zakura header-sync peer fill stopped"
+            );
             return false;
         };
         let original_range = range;
@@ -1964,101 +2195,67 @@ impl HeaderSyncReactor {
             }
         }
 
-        let peer_cap = peer.max_headers_per_response;
         let Some(peer) = self.state.peers.get(peer_id) else {
             return false;
         };
-        let session_id = peer.session.session_id();
-        let stream_version = ZAKURA_HEADER_SYNC_STREAM_VERSION;
-        let request_id = match peer.session.try_send_get_headers(
-            range.start_height,
-            count,
-            range.want_tree_aux_roots,
-        ) {
-            Ok(request_id) => request_id,
-            Err(error) => {
-                let stop_reason = if matches!(&error, OrderedSendError::Full) {
-                    "outbound_full"
-                } else {
-                    "outbound_closed"
-                };
-                metrics::counter!("sync.header.fill.stop", "reason" => stop_reason).increment(1);
-                tracing::debug!(
-                    peer = ?peer_id,
-                    start_height = ?range.start_height,
-                    count,
-                    ?error,
-                    "failed to queue Zakura header-sync GetHeaders"
-                );
-                self.trace_queue_send_failed(
-                    peer_id,
-                    "get_headers",
-                    &error,
-                    peer.session.outbound_capacity(),
-                    peer.session.outbound_max_capacity(),
-                    |row| {
-                        insert_height(row, qs_trace::RANGE_START, range.start_height);
-                        insert_u64(row, qs_trace::RANGE_COUNT, u64::from(count));
-                    },
-                );
-                self.state.schedule.retry(range);
-                return false;
-            }
+        let Some(requester) = peer.requester.clone() else {
+            self.state.schedule.retry(range);
+            metrics::counter!("sync.header.fill.stop", "reason" => "requester_stopped")
+                .increment(1);
+            return false;
         };
-
-        let outstanding = OutstandingRange {
-            request_id,
+        let command = HeaderRequesterCommand {
             range,
-            deadline: Instant::now() + self.startup.request_timeout,
             expected_max_count: count,
-            clear_assignment_on_timeout: false,
             purpose: RangePurpose::Sync,
         };
+        if let Err(error) = requester.try_send(command) {
+            let reason = match error {
+                mpsc::error::TrySendError::Full(_) => "requester_full",
+                mpsc::error::TrySendError::Closed(_) => "requester_closed",
+            };
+            metrics::counter!("sync.header.fill.stop", "reason" => reason).increment(1);
+            self.state.schedule.retry(range);
+            return false;
+        }
         if let Some(peer) = self.state.peers.get_mut(peer_id) {
-            peer.outstanding.push(outstanding);
+            peer.pending_request_sends = peer.pending_request_sends.saturating_add(1);
         }
         self.state.schedule.mark_assigned(peer_id.clone(), range);
-        metrics::counter!("sync.header.request.sent").increment(1);
-        self.trace_get_headers_sent(
-            peer_id,
-            range,
-            count,
-            peer_cap,
-            GetHeadersTraceMeta {
-                request_id,
-                session_id,
-                stream_version,
-            },
-        );
-        #[cfg(test)]
-        let _ = self
-            .actions
-            .send(HeaderSyncAction::SendMessage {
-                peer: peer_id.clone(),
-                request_id: Some(request_id),
-                msg: HeaderSyncMessage::GetHeaders {
-                    start_height: range.start_height,
-                    count,
-                    want_tree_aux_roots: range.want_tree_aux_roots,
-                },
-            })
-            .await;
         true
     }
 
     fn publish_work_metrics(&self) {
-        let in_flight = self
+        let (in_flight, buffered, committing) = self.state.schedule.active_counts();
+        let header_bytes = header_sync_header_bytes_for_network(&self.startup.network)
+            .saturating_add(HEADER_SYNC_BODY_SIZE_BYTES);
+        let buffered_headers = self
             .state
-            .peers
+            .buffered
             .values()
-            .map(|peer| peer.outstanding.len())
+            .map(|range| range.headers.len())
+            .sum::<usize>();
+        let buffered_bytes = self
+            .state
+            .buffered
+            .values()
+            .map(|range| {
+                let root_bytes = if range.tree_aux_roots.is_empty() {
+                    0
+                } else {
+                    HEADER_SYNC_BLOCK_COMMITMENT_ROOTS_BYTES
+                };
+                let per_header = header_bytes.saturating_add(root_bytes);
+                range.headers.len().saturating_mul(per_header)
+            })
             .sum::<usize>();
         metrics::gauge!("sync.header.work.pending.count")
             .set(self.state.schedule.pending_len() as f64);
         metrics::gauge!("sync.header.work.in_flight.count").set(in_flight as f64);
-        metrics::gauge!("sync.header.work.buffered.count").set(self.state.buffered.len() as f64);
-        metrics::gauge!("sync.header.work.committing.count")
-            .set(self.state.pending_commits.len() as f64);
+        metrics::gauge!("sync.header.work.buffered.count").set(buffered as f64);
+        metrics::gauge!("sync.header.work.buffered.headers").set(buffered_headers as f64);
+        metrics::gauge!("sync.header.work.buffered.estimated_bytes").set(buffered_bytes as f64);
+        metrics::gauge!("sync.header.work.committing.count").set(committing as f64);
         metrics::gauge!("sync.header.work.resident_heights")
             .set(self.state.schedule.resident_heights() as f64);
         metrics::gauge!("sync.header.work.epoch").set(self.state.schedule.epoch as f64);
@@ -2068,6 +2265,14 @@ impl HeaderSyncReactor {
             .oldest_missing_since
             .map_or(0.0, |started| started.elapsed().as_secs_f64());
         metrics::gauge!("sync.header.work.oldest_missing_age_seconds").set(oldest_age);
+        metrics::gauge!("sync.header.work.oldest_missing_height").set(
+            self.state
+                .schedule
+                .oldest_missing_height()
+                .map_or(0.0, |height| f64::from(height.0)),
+        );
+        metrics::gauge!("sync.header.work.last_progress_age_seconds")
+            .set(self.state.last_header_progress_at.elapsed().as_secs_f64());
     }
 
     async fn schedule_vct_repair(&mut self) -> bool {
@@ -2270,6 +2475,7 @@ impl HeaderSyncReactor {
     async fn publish_best_tip(&mut self, height: block::Height, hash: block::Hash) {
         self.state.best_header_tip = height;
         self.state.best_header_hash = hash;
+        self.state.last_header_progress_at = Instant::now();
         metrics::gauge!("sync.header.best_tip.height").set(height.0 as f64);
         self.trace_frontier_advanced(height, hash);
         let _ = self.tip.send((height, hash));
@@ -2282,6 +2488,7 @@ impl HeaderSyncReactor {
         let old = (self.state.best_header_tip, self.state.best_header_hash);
         self.state.best_header_tip = height;
         self.state.best_header_hash = hash;
+        self.state.last_header_progress_at = Instant::now();
         metrics::gauge!("sync.header.best_tip.height").set(height.0 as f64);
         self.trace_frontier_reanchored(height, hash);
         let _ = self.tip.send((height, hash));
@@ -3084,6 +3291,65 @@ impl HeaderSyncReactor {
                 }
             }
         }
+    }
+
+    /// Drop forward work whose start is now below a newly durable contiguous tip.
+    ///
+    /// A partially covered wire or buffered range cannot keep its old start key:
+    /// ordered drain would never visit it after the tip moves. Retire the whole
+    /// descriptor and let lazy production recreate only the uncovered suffix.
+    /// State-admitted commits remain locally owned until their completion event.
+    fn reconcile_forward_coverage(&mut self, height: block::Height) {
+        self.state.schedule.drop_pending_forward_through(height);
+
+        for peer in self.state.peers.values_mut() {
+            let mut index = 0;
+            while index < peer.outstanding.len() {
+                let outstanding = peer.outstanding[index];
+                if matches!(outstanding.purpose, RangePurpose::Sync)
+                    && outstanding.range.priority == RangePriority::Forward
+                    && outstanding.range.start_height <= height
+                {
+                    let outstanding = peer.outstanding.remove(index);
+                    let _ = peer.session.retire_expected_headers(outstanding.request_id);
+                    self.state.schedule.clear_assignment(outstanding.range);
+                    metrics::counter!(
+                        "sync.header.work.covered",
+                        "state" => "in_flight",
+                        "lane" => "forward"
+                    )
+                    .increment(1);
+                } else {
+                    index += 1;
+                }
+            }
+        }
+
+        let buffered: Vec<_> = self
+            .state
+            .buffered
+            .iter()
+            .filter_map(|(key, range)| {
+                (key.0 == RangePriority::Forward && range.range.start_height <= height)
+                    .then_some(*key)
+            })
+            .collect();
+        for key in buffered {
+            if let Some(buffered) = self.state.buffered.remove(&key) {
+                self.state.schedule.clear_assignment(buffered.range);
+                metrics::counter!(
+                    "sync.header.work.covered",
+                    "state" => "buffered",
+                    "lane" => "forward"
+                )
+                .increment(1);
+            }
+        }
+
+        if let Some(start) = next_height(self.state.best_header_tip) {
+            self.state.schedule.mark_range_covered(start, height);
+        }
+        self.publish_work_metrics();
     }
 
     /// Retire outstanding forward ranges dropped by a re-anchor, as in

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -2147,6 +2147,10 @@ impl HeaderSyncReactor {
                     .next_allowed
                     .max(peer.meters.unsolicited.next_allowed)
             };
+            let status_deadline = peer
+                .meters
+                .status_publication_retry_at
+                .map_or(status_deadline, |retry_at| status_deadline.max(retry_at));
             deadline = deadline.min(status_deadline);
         }
         if let Some(repair) = self.state.repair.as_ref() {
@@ -2494,6 +2498,7 @@ impl HeaderSyncReactor {
             Ok(()) => {
                 if let Some(peer_state) = self.state.peers.get_mut(peer) {
                     peer_state.record_sent_status(status);
+                    peer_state.meters.status_publication_retry_at = None;
                 }
                 metrics::counter!("sync.header.peer.status.sent").increment(1);
                 self.trace_status_sent(peer, status);
@@ -2506,6 +2511,10 @@ impl HeaderSyncReactor {
                 true
             }
             Err(error) => {
+                if let Some(peer_state) = self.state.peers.get_mut(peer) {
+                    peer_state.meters.status_publication_retry_at =
+                        Some(Instant::now() + STATUS_PUBLICATION_RETRY_DELAY);
+                }
                 metrics::counter!("sync.header.peer.status.send_failed").increment(1);
                 tracing::debug!(?peer, ?error, "failed to queue Zakura header-sync Status");
                 self.trace_queue_send_failed(
@@ -2578,8 +2587,8 @@ impl HeaderSyncReactor {
     /// unchanged: the connection freshness reaper only counts inbound messages,
     /// so without this two peers idle at the same tip reap their healthy
     /// connection every idle window. A failed send does not mark the meter, so
-    /// a peer whose initial status was lost to a dead session is retried on the
-    /// next tick instead of staying connected-but-mute.
+    /// a peer whose initial status was lost to a dead session is retried after
+    /// a short publication backoff instead of staying connected-but-mute.
     fn refresh_statuses(&mut self) {
         let now = Instant::now();
         let status = self.local_status();
@@ -2592,7 +2601,12 @@ impl HeaderSyncReactor {
             .peers
             .iter()
             .filter(|(_peer_id, peer)| {
-                peer.status_differs_from_last_sent(status) && peer.meters.unsolicited.is_ready(now)
+                peer.status_differs_from_last_sent(status)
+                    && peer.meters.unsolicited.is_ready(now)
+                    && peer
+                        .meters
+                        .status_publication_retry_at
+                        .is_none_or(|retry_at| now >= retry_at)
             })
             .map(|(peer_id, _peer)| peer_id.clone())
             .collect();
@@ -2609,6 +2623,10 @@ impl HeaderSyncReactor {
                 !peer.status_differs_from_last_sent(status)
                     && peer.meters.keepalive.is_ready(now)
                     && peer.meters.unsolicited.is_ready(now)
+                    && peer
+                        .meters
+                        .status_publication_retry_at
+                        .is_none_or(|retry_at| now >= retry_at)
             })
             .map(|(peer_id, _peer)| peer_id.clone())
             .collect();
@@ -2638,6 +2656,13 @@ impl HeaderSyncReactor {
                     return None;
                 }
                 if !peer.meters.unsolicited.is_ready(now) {
+                    return None;
+                }
+                if peer
+                    .meters
+                    .status_publication_retry_at
+                    .is_some_and(|retry_at| now < retry_at)
+                {
                     return None;
                 }
                 Some(peer_id.clone())

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -28,8 +28,16 @@ pub(super) enum HeaderRequesterFailure {
     Encode,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) enum HeaderRequesterEvent {
+    Register {
+        peer: ZakuraPeerId,
+        session_id: u64,
+        generation: u64,
+        command: HeaderRequesterCommand,
+        request_id: HeaderSyncRequestId,
+        registered: tokio::sync::oneshot::Sender<()>,
+    },
     Sent {
         peer: ZakuraPeerId,
         session_id: u64,
@@ -42,6 +50,7 @@ pub(super) enum HeaderRequesterEvent {
         session_id: u64,
         generation: u64,
         command: HeaderRequesterCommand,
+        request_id: Option<HeaderSyncRequestId>,
         reason: HeaderRequesterFailure,
     },
     Stopped {
@@ -94,15 +103,65 @@ async fn run_header_requester(
             }
         };
 
+        let prepared = match session.prepare_get_headers(
+            command.range.start_height,
+            command.expected_max_count,
+            command.range.want_tree_aux_roots,
+        ) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                let reason = if matches!(error, OrderedSendError::Closed) {
+                    HeaderRequesterFailure::Closed
+                } else {
+                    HeaderRequesterFailure::Encode
+                };
+                if events
+                    .send(HeaderRequesterEvent::Failed {
+                        peer: peer.clone(),
+                        session_id,
+                        generation,
+                        command,
+                        request_id: None,
+                        reason,
+                    })
+                    .is_err()
+                    || reason == HeaderRequesterFailure::Closed
+                {
+                    return;
+                }
+                continue;
+            }
+        };
+        let request_id = prepared.request_id();
+        let (registered, registration) = tokio::sync::oneshot::channel();
+        if events
+            .send(HeaderRequesterEvent::Register {
+                peer: peer.clone(),
+                session_id,
+                generation,
+                command,
+                request_id,
+                registered,
+            })
+            .is_err()
+        {
+            return;
+        }
+        let registered = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return,
+            _ = cancel.cancelled() => return,
+            registered = registration => registered,
+        };
+        if registered.is_err() {
+            return;
+        }
+
         let result = tokio::select! {
             biased;
             _ = shutdown.cancelled() => return,
             _ = cancel.cancelled() => return,
-            result = session.send_get_headers(
-                command.range.start_height,
-                command.expected_max_count,
-                command.range.want_tree_aux_roots,
-            ) => result,
+            result = prepared.send() => result,
         };
         match result {
             Ok(request_id) => {
@@ -131,6 +190,7 @@ async fn run_header_requester(
                         session_id,
                         generation,
                         command,
+                        request_id: Some(request_id),
                         reason,
                     })
                     .is_err()
@@ -222,7 +282,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn successful_send_reports_correlated_request_metadata() {
+    async fn request_waits_for_reactor_registration_before_publication() {
         let peer = peer(1);
         let (session, mut frames, _cancel) = session(peer.clone(), 1);
         let (events_tx, mut events_rx) = mpsc::unbounded_channel();
@@ -235,22 +295,46 @@ mod tests {
             .try_send(command)
             .expect("requester command queue has capacity");
 
-        let request_id = match next_event(&mut events_rx).await {
+        let (request_id, registered) = match next_event(&mut events_rx).await {
+            HeaderRequesterEvent::Register {
+                peer: event_peer,
+                session_id,
+                generation,
+                command: registered_command,
+                request_id,
+                registered,
+            } => {
+                assert_eq!(event_peer, peer);
+                assert_eq!(session_id, TEST_SESSION_ID);
+                assert_eq!(generation, TEST_GENERATION);
+                assert_command_eq(registered_command, command);
+                (request_id, registered)
+            }
+            event => panic!("unexpected requester event: {event:?}"),
+        };
+        assert!(time::timeout(Duration::from_millis(20), frames.recv())
+            .await
+            .is_err());
+        registered
+            .send(())
+            .expect("requester waits for reactor registration");
+
+        match next_event(&mut events_rx).await {
             HeaderRequesterEvent::Sent {
                 peer: event_peer,
                 session_id,
                 generation,
                 command: sent,
-                request_id,
+                request_id: sent_request_id,
             } => {
                 assert_eq!(event_peer, peer);
                 assert_eq!(session_id, TEST_SESSION_ID);
                 assert_eq!(generation, TEST_GENERATION);
                 assert_command_eq(sent, command);
-                request_id
+                assert_eq!(sent_request_id, request_id);
             }
             event => panic!("unexpected requester event: {event:?}"),
-        };
+        }
         let frame = time::timeout(Duration::from_secs(1), frames.recv())
             .await
             .expect("request frame arrives before timeout")
@@ -299,12 +383,14 @@ mod tests {
                 session_id,
                 generation,
                 command: failed,
+                request_id,
                 reason,
             } => {
                 assert_eq!(event_peer, peer);
                 assert_eq!(session_id, TEST_SESSION_ID);
                 assert_eq!(generation, TEST_GENERATION);
                 assert_command_eq(failed, invalid);
+                assert_eq!(request_id, None);
                 assert_eq!(reason, HeaderRequesterFailure::Encode);
             }
             event => panic!("unexpected requester event: {event:?}"),
@@ -313,6 +399,20 @@ mod tests {
         requester
             .try_send(valid)
             .expect("requester remains available after an encode failure");
+        let registered = match next_event(&mut events_rx).await {
+            HeaderRequesterEvent::Register {
+                command: registered_command,
+                registered,
+                ..
+            } => {
+                assert_command_eq(registered_command, valid);
+                registered
+            }
+            event => panic!("unexpected requester event: {event:?}"),
+        };
+        registered
+            .send(())
+            .expect("requester waits for reactor registration");
         assert!(matches!(
             next_event(&mut events_rx).await,
             HeaderRequesterEvent::Sent { command: sent, .. }
@@ -350,18 +450,35 @@ mod tests {
             .try_send(command)
             .expect("requester command queue has capacity");
 
+        let registered = match next_event(&mut events_rx).await {
+            HeaderRequesterEvent::Register {
+                command: registered_command,
+                registered,
+                ..
+            } => {
+                assert_command_eq(registered_command, command);
+                registered
+            }
+            event => panic!("unexpected requester event: {event:?}"),
+        };
+        registered
+            .send(())
+            .expect("requester waits for reactor registration");
+
         match next_event(&mut events_rx).await {
             HeaderRequesterEvent::Failed {
                 peer: event_peer,
                 session_id,
                 generation,
                 command: failed,
+                request_id,
                 reason,
             } => {
                 assert_eq!(event_peer, peer);
                 assert_eq!(session_id, TEST_SESSION_ID);
                 assert_eq!(generation, TEST_GENERATION);
                 assert_command_eq(failed, command);
+                assert!(request_id.is_some());
                 assert_eq!(reason, HeaderRequesterFailure::Closed);
             }
             event => panic!("unexpected requester event: {event:?}"),

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -159,3 +159,220 @@ impl Drop for HeaderRequesterExit {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SESSION_ID: u64 = 41;
+    const TEST_GENERATION: u64 = 73;
+
+    fn peer(byte: u8) -> ZakuraPeerId {
+        ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
+    }
+
+    fn command(start: u32, expected_max_count: u32) -> HeaderRequesterCommand {
+        HeaderRequesterCommand {
+            range: RangeRequest {
+                start_height: block::Height(start),
+                count: expected_max_count.max(1),
+                anchor_hash: None,
+                finalized: false,
+                want_tree_aux_roots: true,
+                priority: RangePriority::Forward,
+            },
+            expected_max_count,
+            purpose: RangePurpose::Sync,
+        }
+    }
+
+    fn session(
+        peer: ZakuraPeerId,
+        depth: usize,
+    ) -> (
+        HeaderSyncPeerSession,
+        crate::zakura::FramedRecv,
+        CancellationToken,
+    ) {
+        let (send, recv) = crate::zakura::framed_channel(depth);
+        let cancel = CancellationToken::new();
+        let session = HeaderSyncPeerSession::from_parts_with_direction_and_session_id(
+            peer,
+            crate::zakura::ServicePeerDirection::Inbound,
+            send,
+            cancel.clone(),
+            TEST_SESSION_ID,
+        );
+        (session, recv, cancel)
+    }
+
+    async fn next_event(
+        events: &mut mpsc::UnboundedReceiver<HeaderRequesterEvent>,
+    ) -> HeaderRequesterEvent {
+        time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("requester event arrives before timeout")
+            .expect("requester event channel stays open")
+    }
+
+    fn assert_command_eq(actual: HeaderRequesterCommand, expected: HeaderRequesterCommand) {
+        assert_eq!(actual.range, expected.range);
+        assert_eq!(actual.expected_max_count, expected.expected_max_count);
+        assert_eq!(actual.purpose, expected.purpose);
+    }
+
+    #[tokio::test]
+    async fn successful_send_reports_correlated_request_metadata() {
+        let peer = peer(1);
+        let (session, mut frames, _cancel) = session(peer.clone(), 1);
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let shutdown = CancellationToken::new();
+        let requester =
+            spawn_header_requester(session, TEST_GENERATION, events_tx, shutdown.clone());
+        let command = command(5, 2);
+
+        requester
+            .try_send(command)
+            .expect("requester command queue has capacity");
+
+        let request_id = match next_event(&mut events_rx).await {
+            HeaderRequesterEvent::Sent {
+                peer: event_peer,
+                session_id,
+                generation,
+                command: sent,
+                request_id,
+            } => {
+                assert_eq!(event_peer, peer);
+                assert_eq!(session_id, TEST_SESSION_ID);
+                assert_eq!(generation, TEST_GENERATION);
+                assert_command_eq(sent, command);
+                request_id
+            }
+            event => panic!("unexpected requester event: {event:?}"),
+        };
+        let frame = time::timeout(Duration::from_secs(1), frames.recv())
+            .await
+            .expect("request frame arrives before timeout")
+            .expect("request frame channel stays open");
+        let (message, decoded_request_id) =
+            HeaderSyncMessage::decode(&frame.payload, HeaderSyncDecodeContext::control())
+                .expect("request frame decodes");
+        assert_eq!(
+            message,
+            HeaderSyncMessage::GetHeaders {
+                start_height: command.range.start_height,
+                count: command.expected_max_count,
+                want_tree_aux_roots: command.range.want_tree_aux_roots,
+            }
+        );
+        assert_eq!(decoded_request_id, Some(request_id));
+
+        shutdown.cancel();
+        assert!(matches!(
+            next_event(&mut events_rx).await,
+            HeaderRequesterEvent::Stopped {
+                peer: event_peer,
+                session_id: TEST_SESSION_ID,
+                generation: TEST_GENERATION,
+            } if event_peer == peer
+        ));
+    }
+
+    #[tokio::test]
+    async fn encode_failure_reports_the_command_and_requester_continues() {
+        let peer = peer(2);
+        let (session, mut frames, _cancel) = session(peer.clone(), 1);
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let shutdown = CancellationToken::new();
+        let requester =
+            spawn_header_requester(session, TEST_GENERATION, events_tx, shutdown.clone());
+        let invalid = command(7, 0);
+        let valid = command(8, 1);
+
+        requester
+            .try_send(invalid)
+            .expect("requester command queue has capacity");
+        match next_event(&mut events_rx).await {
+            HeaderRequesterEvent::Failed {
+                peer: event_peer,
+                session_id,
+                generation,
+                command: failed,
+                reason,
+            } => {
+                assert_eq!(event_peer, peer);
+                assert_eq!(session_id, TEST_SESSION_ID);
+                assert_eq!(generation, TEST_GENERATION);
+                assert_command_eq(failed, invalid);
+                assert_eq!(reason, HeaderRequesterFailure::Encode);
+            }
+            event => panic!("unexpected requester event: {event:?}"),
+        }
+
+        requester
+            .try_send(valid)
+            .expect("requester remains available after an encode failure");
+        assert!(matches!(
+            next_event(&mut events_rx).await,
+            HeaderRequesterEvent::Sent { command: sent, .. }
+                if sent.range == valid.range
+                    && sent.expected_max_count == valid.expected_max_count
+                    && sent.purpose == valid.purpose
+        ));
+        time::timeout(Duration::from_secs(1), frames.recv())
+            .await
+            .expect("valid request frame arrives before timeout")
+            .expect("request frame channel stays open");
+
+        shutdown.cancel();
+        assert!(matches!(
+            next_event(&mut events_rx).await,
+            HeaderRequesterEvent::Stopped { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn closed_send_reports_failure_then_stops() {
+        let peer = peer(3);
+        let (session, frames, _cancel) = session(peer.clone(), 1);
+        drop(frames);
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let requester = spawn_header_requester(
+            session,
+            TEST_GENERATION,
+            events_tx,
+            CancellationToken::new(),
+        );
+        let command = command(9, 1);
+
+        requester
+            .try_send(command)
+            .expect("requester command queue has capacity");
+
+        match next_event(&mut events_rx).await {
+            HeaderRequesterEvent::Failed {
+                peer: event_peer,
+                session_id,
+                generation,
+                command: failed,
+                reason,
+            } => {
+                assert_eq!(event_peer, peer);
+                assert_eq!(session_id, TEST_SESSION_ID);
+                assert_eq!(generation, TEST_GENERATION);
+                assert_command_eq(failed, command);
+                assert_eq!(reason, HeaderRequesterFailure::Closed);
+            }
+            event => panic!("unexpected requester event: {event:?}"),
+        }
+        assert!(matches!(
+            next_event(&mut events_rx).await,
+            HeaderRequesterEvent::Stopped {
+                peer: event_peer,
+                session_id: TEST_SESSION_ID,
+                generation: TEST_GENERATION,
+            } if event_peer == peer
+        ));
+    }
+}

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -1,0 +1,161 @@
+use super::{state::*, wire::LOCAL_MAX_HS_INFLIGHT_PER_PEER, *};
+use crate::zakura::OrderedSendError;
+
+#[derive(Clone, Debug)]
+pub(super) struct HeaderRequesterHandle {
+    commands: mpsc::Sender<HeaderRequesterCommand>,
+}
+
+impl HeaderRequesterHandle {
+    pub(super) fn try_send(
+        &self,
+        command: HeaderRequesterCommand,
+    ) -> Result<(), mpsc::error::TrySendError<HeaderRequesterCommand>> {
+        self.commands.try_send(command)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(super) struct HeaderRequesterCommand {
+    pub(super) range: RangeRequest,
+    pub(super) expected_max_count: u32,
+    pub(super) purpose: RangePurpose,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum HeaderRequesterFailure {
+    Closed,
+    Encode,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum HeaderRequesterEvent {
+    Sent {
+        peer: ZakuraPeerId,
+        session_id: u64,
+        generation: u64,
+        command: HeaderRequesterCommand,
+        request_id: HeaderSyncRequestId,
+    },
+    Failed {
+        peer: ZakuraPeerId,
+        session_id: u64,
+        generation: u64,
+        command: HeaderRequesterCommand,
+        reason: HeaderRequesterFailure,
+    },
+    Stopped {
+        peer: ZakuraPeerId,
+        session_id: u64,
+        generation: u64,
+    },
+}
+
+pub(super) fn spawn_header_requester(
+    session: HeaderSyncPeerSession,
+    generation: u64,
+    events: mpsc::UnboundedSender<HeaderRequesterEvent>,
+    shutdown: CancellationToken,
+) -> HeaderRequesterHandle {
+    let (commands, receiver) = mpsc::channel(usize::from(LOCAL_MAX_HS_INFLIGHT_PER_PEER));
+    tokio::spawn(run_header_requester(
+        session, generation, receiver, events, shutdown,
+    ));
+    HeaderRequesterHandle { commands }
+}
+
+async fn run_header_requester(
+    session: HeaderSyncPeerSession,
+    generation: u64,
+    mut commands: mpsc::Receiver<HeaderRequesterCommand>,
+    events: mpsc::UnboundedSender<HeaderRequesterEvent>,
+    shutdown: CancellationToken,
+) {
+    let peer = session.peer_id().clone();
+    let session_id = session.session_id();
+    let cancel = session.cancel_token();
+    let _exit = HeaderRequesterExit {
+        peer: peer.clone(),
+        session_id,
+        generation,
+        events: events.clone(),
+    };
+
+    loop {
+        let command = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return,
+            _ = cancel.cancelled() => return,
+            command = commands.recv() => {
+                let Some(command) = command else {
+                    return;
+                };
+                command
+            }
+        };
+
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return,
+            _ = cancel.cancelled() => return,
+            result = session.send_get_headers(
+                command.range.start_height,
+                command.expected_max_count,
+                command.range.want_tree_aux_roots,
+            ) => result,
+        };
+        match result {
+            Ok(request_id) => {
+                if events
+                    .send(HeaderRequesterEvent::Sent {
+                        peer: peer.clone(),
+                        session_id,
+                        generation,
+                        command,
+                        request_id,
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(error) => {
+                let reason = if matches!(error, OrderedSendError::Closed) {
+                    HeaderRequesterFailure::Closed
+                } else {
+                    HeaderRequesterFailure::Encode
+                };
+                if events
+                    .send(HeaderRequesterEvent::Failed {
+                        peer: peer.clone(),
+                        session_id,
+                        generation,
+                        command,
+                        reason,
+                    })
+                    .is_err()
+                    || reason == HeaderRequesterFailure::Closed
+                {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+struct HeaderRequesterExit {
+    peer: ZakuraPeerId,
+    session_id: u64,
+    generation: u64,
+    events: mpsc::UnboundedSender<HeaderRequesterEvent>,
+}
+
+impl Drop for HeaderRequesterExit {
+    fn drop(&mut self) {
+        let _ = self.events.send(HeaderRequesterEvent::Stopped {
+            peer: self.peer.clone(),
+            session_id: self.session_id,
+            generation: self.generation,
+        });
+    }
+}

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -1,4 +1,4 @@
-use super::{state::*, wire::LOCAL_MAX_HS_INFLIGHT_PER_PEER, *};
+use super::{service::PreparedGetHeaders, state::*, wire::LOCAL_MAX_HS_INFLIGHT_PER_PEER, *};
 use crate::zakura::OrderedSendError;
 
 #[derive(Clone, Debug)]
@@ -15,78 +15,54 @@ impl HeaderRequesterHandle {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
 pub(super) struct HeaderRequesterCommand {
     pub(super) range: RangeRequest,
-    pub(super) expected_max_count: u32,
-    pub(super) purpose: RangePurpose,
+    pub(super) prepared: PreparedGetHeaders,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(super) enum HeaderRequesterFailure {
-    Closed,
-    Encode,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct HeaderRequesterIdentity {
+    pub(super) peer: ZakuraPeerId,
+    pub(super) session_id: u64,
+    pub(super) generation: u64,
 }
 
 #[derive(Debug)]
 pub(super) enum HeaderRequesterEvent {
-    Register {
-        peer: ZakuraPeerId,
-        session_id: u64,
-        generation: u64,
-        command: HeaderRequesterCommand,
+    Completed {
+        identity: HeaderRequesterIdentity,
+        range: RangeRequest,
         request_id: HeaderSyncRequestId,
-        registered: tokio::sync::oneshot::Sender<()>,
-    },
-    Sent {
-        peer: ZakuraPeerId,
-        session_id: u64,
-        generation: u64,
-        command: HeaderRequesterCommand,
-        request_id: HeaderSyncRequestId,
-    },
-    Failed {
-        peer: ZakuraPeerId,
-        session_id: u64,
-        generation: u64,
-        command: HeaderRequesterCommand,
-        request_id: Option<HeaderSyncRequestId>,
-        reason: HeaderRequesterFailure,
+        result: Result<(), OrderedSendError>,
     },
     Stopped {
-        peer: ZakuraPeerId,
-        session_id: u64,
-        generation: u64,
+        identity: HeaderRequesterIdentity,
     },
 }
 
 pub(super) fn spawn_header_requester(
     session: HeaderSyncPeerSession,
-    generation: u64,
+    identity: HeaderRequesterIdentity,
     events: mpsc::UnboundedSender<HeaderRequesterEvent>,
     shutdown: CancellationToken,
 ) -> HeaderRequesterHandle {
     let (commands, receiver) = mpsc::channel(usize::from(LOCAL_MAX_HS_INFLIGHT_PER_PEER));
     tokio::spawn(run_header_requester(
-        session, generation, receiver, events, shutdown,
+        session, identity, receiver, events, shutdown,
     ));
     HeaderRequesterHandle { commands }
 }
 
 async fn run_header_requester(
     session: HeaderSyncPeerSession,
-    generation: u64,
+    identity: HeaderRequesterIdentity,
     mut commands: mpsc::Receiver<HeaderRequesterCommand>,
     events: mpsc::UnboundedSender<HeaderRequesterEvent>,
     shutdown: CancellationToken,
 ) {
-    let peer = session.peer_id().clone();
-    let session_id = session.session_id();
     let cancel = session.cancel_token();
     let _exit = HeaderRequesterExit {
-        peer: peer.clone(),
-        session_id,
-        generation,
+        identity: identity.clone(),
         events: events.clone(),
     };
 
@@ -102,120 +78,39 @@ async fn run_header_requester(
                 command
             }
         };
-
-        let prepared = match session.prepare_get_headers(
-            command.range.start_height,
-            command.expected_max_count,
-            command.range.want_tree_aux_roots,
-        ) {
-            Ok(prepared) => prepared,
-            Err(error) => {
-                let reason = if matches!(error, OrderedSendError::Closed) {
-                    HeaderRequesterFailure::Closed
-                } else {
-                    HeaderRequesterFailure::Encode
-                };
-                if events
-                    .send(HeaderRequesterEvent::Failed {
-                        peer: peer.clone(),
-                        session_id,
-                        generation,
-                        command,
-                        request_id: None,
-                        reason,
-                    })
-                    .is_err()
-                    || reason == HeaderRequesterFailure::Closed
-                {
-                    return;
-                }
-                continue;
-            }
-        };
+        let HeaderRequesterCommand { range, prepared } = command;
         let request_id = prepared.request_id();
-        let (registered, registration) = tokio::sync::oneshot::channel();
-        if events
-            .send(HeaderRequesterEvent::Register {
-                peer: peer.clone(),
-                session_id,
-                generation,
-                command,
-                request_id,
-                registered,
-            })
-            .is_err()
-        {
-            return;
-        }
-        let registered = tokio::select! {
-            biased;
-            _ = shutdown.cancelled() => return,
-            _ = cancel.cancelled() => return,
-            registered = registration => registered,
-        };
-        if registered.is_err() {
-            return;
-        }
-
         let result = tokio::select! {
             biased;
             _ = shutdown.cancelled() => return,
             _ = cancel.cancelled() => return,
-            result = prepared.send() => result,
+            result = prepared.send() => result.map(|_| ()),
         };
-        match result {
-            Ok(request_id) => {
-                if events
-                    .send(HeaderRequesterEvent::Sent {
-                        peer: peer.clone(),
-                        session_id,
-                        generation,
-                        command,
-                        request_id,
-                    })
-                    .is_err()
-                {
-                    return;
-                }
-            }
-            Err(error) => {
-                let reason = if matches!(error, OrderedSendError::Closed) {
-                    HeaderRequesterFailure::Closed
-                } else {
-                    HeaderRequesterFailure::Encode
-                };
-                if events
-                    .send(HeaderRequesterEvent::Failed {
-                        peer: peer.clone(),
-                        session_id,
-                        generation,
-                        command,
-                        request_id: Some(request_id),
-                        reason,
-                    })
-                    .is_err()
-                    || reason == HeaderRequesterFailure::Closed
-                {
-                    return;
-                }
-            }
+        let transport_closed = matches!(result, Err(OrderedSendError::Closed));
+        if events
+            .send(HeaderRequesterEvent::Completed {
+                identity: identity.clone(),
+                range,
+                request_id,
+                result,
+            })
+            .is_err()
+            || transport_closed
+        {
+            return;
         }
     }
 }
 
 struct HeaderRequesterExit {
-    peer: ZakuraPeerId,
-    session_id: u64,
-    generation: u64,
+    identity: HeaderRequesterIdentity,
     events: mpsc::UnboundedSender<HeaderRequesterEvent>,
 }
 
 impl Drop for HeaderRequesterExit {
     fn drop(&mut self) {
         let _ = self.events.send(HeaderRequesterEvent::Stopped {
-            peer: self.peer.clone(),
-            session_id: self.session_id,
-            generation: self.generation,
+            identity: self.identity.clone(),
         });
     }
 }
@@ -231,18 +126,22 @@ mod tests {
         ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
     }
 
-    fn command(start: u32, expected_max_count: u32) -> HeaderRequesterCommand {
-        HeaderRequesterCommand {
-            range: RangeRequest {
-                start_height: block::Height(start),
-                count: expected_max_count.max(1),
-                anchor_hash: None,
-                finalized: false,
-                want_tree_aux_roots: true,
-                priority: RangePriority::Forward,
-            },
-            expected_max_count,
-            purpose: RangePurpose::Sync,
+    fn range(start: u32, count: u32) -> RangeRequest {
+        RangeRequest {
+            start_height: block::Height(start),
+            count,
+            anchor_hash: None,
+            finalized: false,
+            want_tree_aux_roots: true,
+            priority: RangePriority::Forward,
+        }
+    }
+
+    fn identity(peer: ZakuraPeerId) -> HeaderRequesterIdentity {
+        HeaderRequesterIdentity {
+            peer,
+            session_id: TEST_SESSION_ID,
+            generation: TEST_GENERATION,
         }
     }
 
@@ -275,79 +174,53 @@ mod tests {
             .expect("requester event channel stays open")
     }
 
-    fn assert_command_eq(actual: HeaderRequesterCommand, expected: HeaderRequesterCommand) {
-        assert_eq!(actual.range, expected.range);
-        assert_eq!(actual.expected_max_count, expected.expected_max_count);
-        assert_eq!(actual.purpose, expected.purpose);
-    }
-
     #[tokio::test]
-    async fn request_waits_for_reactor_registration_before_publication() {
+    async fn prepared_request_is_published_and_completed() {
         let peer = peer(1);
-        let (session, mut frames, _cancel) = session(peer.clone(), 1);
+        let requester_identity = identity(peer.clone());
+        let (session, mut frames, _cancel) = session(peer, 1);
+        let range = range(5, 2);
+        let prepared = session
+            .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
+            .expect("valid test request is prepared");
+        let request_id = prepared.request_id();
         let (events_tx, mut events_rx) = mpsc::unbounded_channel();
         let shutdown = CancellationToken::new();
-        let requester =
-            spawn_header_requester(session, TEST_GENERATION, events_tx, shutdown.clone());
-        let command = command(5, 2);
+        let requester = spawn_header_requester(
+            session,
+            requester_identity.clone(),
+            events_tx,
+            shutdown.clone(),
+        );
 
         requester
-            .try_send(command)
+            .try_send(HeaderRequesterCommand { range, prepared })
             .expect("requester command queue has capacity");
 
-        let (request_id, registered) = match next_event(&mut events_rx).await {
-            HeaderRequesterEvent::Register {
-                peer: event_peer,
-                session_id,
-                generation,
-                command: registered_command,
-                request_id,
-                registered,
-            } => {
-                assert_eq!(event_peer, peer);
-                assert_eq!(session_id, TEST_SESSION_ID);
-                assert_eq!(generation, TEST_GENERATION);
-                assert_command_eq(registered_command, command);
-                (request_id, registered)
-            }
-            event => panic!("unexpected requester event: {event:?}"),
-        };
-        assert!(time::timeout(Duration::from_millis(20), frames.recv())
-            .await
-            .is_err());
-        registered
-            .send(())
-            .expect("requester waits for reactor registration");
-
         match next_event(&mut events_rx).await {
-            HeaderRequesterEvent::Sent {
-                peer: event_peer,
-                session_id,
-                generation,
-                command: sent,
-                request_id: sent_request_id,
+            HeaderRequesterEvent::Completed {
+                identity,
+                range: completed_range,
+                request_id: completed_id,
+                result,
             } => {
-                assert_eq!(event_peer, peer);
-                assert_eq!(session_id, TEST_SESSION_ID);
-                assert_eq!(generation, TEST_GENERATION);
-                assert_command_eq(sent, command);
-                assert_eq!(sent_request_id, request_id);
+                assert_eq!(identity, requester_identity);
+                assert_eq!(completed_range, range);
+                assert_eq!(completed_id, request_id);
+                result.expect("prepared request is published");
             }
             event => panic!("unexpected requester event: {event:?}"),
         }
-        let frame = time::timeout(Duration::from_secs(1), frames.recv())
-            .await
-            .expect("request frame arrives before timeout")
-            .expect("request frame channel stays open");
+        let frame = frames.recv().await.expect("request frame is queued");
         let (message, decoded_request_id) =
             HeaderSyncMessage::decode(&frame.payload, HeaderSyncDecodeContext::control())
                 .expect("request frame decodes");
         assert_eq!(
             message,
             HeaderSyncMessage::GetHeaders {
-                start_height: command.range.start_height,
-                count: command.expected_max_count,
-                want_tree_aux_roots: command.range.want_tree_aux_roots,
+                start_height: range.start_height,
+                count: range.count,
+                want_tree_aux_roots: range.want_tree_aux_roots,
             }
         );
         assert_eq!(decoded_request_id, Some(request_id));
@@ -355,141 +228,49 @@ mod tests {
         shutdown.cancel();
         assert!(matches!(
             next_event(&mut events_rx).await,
-            HeaderRequesterEvent::Stopped {
-                peer: event_peer,
-                session_id: TEST_SESSION_ID,
-                generation: TEST_GENERATION,
-            } if event_peer == peer
+            HeaderRequesterEvent::Stopped { identity } if identity == requester_identity
         ));
     }
 
     #[tokio::test]
-    async fn encode_failure_reports_the_command_and_requester_continues() {
+    async fn closed_transport_reports_completion_failure_then_stops() {
         let peer = peer(2);
-        let (session, mut frames, _cancel) = session(peer.clone(), 1);
-        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
-        let shutdown = CancellationToken::new();
-        let requester =
-            spawn_header_requester(session, TEST_GENERATION, events_tx, shutdown.clone());
-        let invalid = command(7, 0);
-        let valid = command(8, 1);
-
-        requester
-            .try_send(invalid)
-            .expect("requester command queue has capacity");
-        match next_event(&mut events_rx).await {
-            HeaderRequesterEvent::Failed {
-                peer: event_peer,
-                session_id,
-                generation,
-                command: failed,
-                request_id,
-                reason,
-            } => {
-                assert_eq!(event_peer, peer);
-                assert_eq!(session_id, TEST_SESSION_ID);
-                assert_eq!(generation, TEST_GENERATION);
-                assert_command_eq(failed, invalid);
-                assert_eq!(request_id, None);
-                assert_eq!(reason, HeaderRequesterFailure::Encode);
-            }
-            event => panic!("unexpected requester event: {event:?}"),
-        }
-
-        requester
-            .try_send(valid)
-            .expect("requester remains available after an encode failure");
-        let registered = match next_event(&mut events_rx).await {
-            HeaderRequesterEvent::Register {
-                command: registered_command,
-                registered,
-                ..
-            } => {
-                assert_command_eq(registered_command, valid);
-                registered
-            }
-            event => panic!("unexpected requester event: {event:?}"),
-        };
-        registered
-            .send(())
-            .expect("requester waits for reactor registration");
-        assert!(matches!(
-            next_event(&mut events_rx).await,
-            HeaderRequesterEvent::Sent { command: sent, .. }
-                if sent.range == valid.range
-                    && sent.expected_max_count == valid.expected_max_count
-                    && sent.purpose == valid.purpose
-        ));
-        time::timeout(Duration::from_secs(1), frames.recv())
-            .await
-            .expect("valid request frame arrives before timeout")
-            .expect("request frame channel stays open");
-
-        shutdown.cancel();
-        assert!(matches!(
-            next_event(&mut events_rx).await,
-            HeaderRequesterEvent::Stopped { .. }
-        ));
-    }
-
-    #[tokio::test]
-    async fn closed_send_reports_failure_then_stops() {
-        let peer = peer(3);
-        let (session, frames, _cancel) = session(peer.clone(), 1);
+        let requester_identity = identity(peer.clone());
+        let (session, frames, _cancel) = session(peer, 1);
+        let range = range(9, 1);
+        let prepared = session
+            .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
+            .expect("valid test request is prepared");
+        let request_id = prepared.request_id();
         drop(frames);
         let (events_tx, mut events_rx) = mpsc::unbounded_channel();
         let requester = spawn_header_requester(
             session,
-            TEST_GENERATION,
+            requester_identity.clone(),
             events_tx,
             CancellationToken::new(),
         );
-        let command = command(9, 1);
 
         requester
-            .try_send(command)
+            .try_send(HeaderRequesterCommand { range, prepared })
             .expect("requester command queue has capacity");
 
-        let registered = match next_event(&mut events_rx).await {
-            HeaderRequesterEvent::Register {
-                command: registered_command,
-                registered,
-                ..
-            } => {
-                assert_command_eq(registered_command, command);
-                registered
-            }
-            event => panic!("unexpected requester event: {event:?}"),
-        };
-        registered
-            .send(())
-            .expect("requester waits for reactor registration");
-
         match next_event(&mut events_rx).await {
-            HeaderRequesterEvent::Failed {
-                peer: event_peer,
-                session_id,
-                generation,
-                command: failed,
-                request_id,
-                reason,
+            HeaderRequesterEvent::Completed {
+                identity,
+                range: completed_range,
+                request_id: completed_id,
+                result: Err(OrderedSendError::Closed),
             } => {
-                assert_eq!(event_peer, peer);
-                assert_eq!(session_id, TEST_SESSION_ID);
-                assert_eq!(generation, TEST_GENERATION);
-                assert_command_eq(failed, command);
-                assert!(request_id.is_some());
-                assert_eq!(reason, HeaderRequesterFailure::Closed);
+                assert_eq!(identity, requester_identity);
+                assert_eq!(completed_range, range);
+                assert_eq!(completed_id, request_id);
             }
             event => panic!("unexpected requester event: {event:?}"),
         }
         assert!(matches!(
             next_event(&mut events_rx).await,
-            HeaderRequesterEvent::Stopped {
-                peer: event_peer,
-                session_id: TEST_SESSION_ID,
-                generation: TEST_GENERATION,
-            } if event_peer == peer
+            HeaderRequesterEvent::Stopped { identity } if identity == requester_identity
         ));
     }
 }

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -242,6 +242,40 @@ impl HeaderSyncPeerSession {
         .map(|()| request_id)
     }
 
+    /// Reserve response correlation and wait asynchronously for outbound capacity.
+    ///
+    /// The frame is encoded once before waiting. If this future is cancelled while
+    /// waiting, the reservation guard synchronously removes the request ID from the
+    /// peer pipe so it cannot consume a later response.
+    pub(super) async fn send_get_headers(
+        &self,
+        start_height: block::Height,
+        count: u32,
+        want_tree_aux_roots: bool,
+    ) -> Result<HeaderSyncRequestId, OrderedSendError> {
+        let request_id = self.next_request_id()?;
+        let expected =
+            ExpectedHeadersResponse::new(request_id, start_height, count, want_tree_aux_roots)
+                .map_err(|error| OrderedSendError::Encode(Box::new(error)))?;
+        let frame = HeaderSyncMessage::GetHeaders {
+            start_height,
+            count,
+            want_tree_aux_roots,
+        }
+        .encode_frame(Some(request_id))
+        .map_err(|error| OrderedSendError::Encode(Box::new(error)))?;
+
+        let mut reservation =
+            ExpectedHeadersReservation::new(self.inner.commands.clone(), expected)?;
+        self.inner
+            .send
+            .send(frame)
+            .await
+            .map_err(|_| OrderedSendError::Closed)?;
+        reservation.disarm();
+        Ok(request_id)
+    }
+
     /// Send a typed header range response with one advisory body-size hint and
     /// tree-aux root payload per header.
     pub fn try_send_headers_with_sizes_and_roots(
@@ -278,6 +312,44 @@ impl HeaderSyncPeerSession {
             Ok(()) => Ok(()),
             Err(mpsc::error::TrySendError::Full(_frame)) => Err(OrderedSendError::Full),
             Err(mpsc::error::TrySendError::Closed(_frame)) => Err(OrderedSendError::Closed),
+        }
+    }
+}
+
+struct ExpectedHeadersReservation {
+    commands: Option<mpsc::UnboundedSender<HeaderSyncPeerCommand>>,
+    expected: ExpectedHeadersResponse,
+    armed: bool,
+}
+
+impl ExpectedHeadersReservation {
+    fn new(
+        commands: Option<mpsc::UnboundedSender<HeaderSyncPeerCommand>>,
+        expected: ExpectedHeadersResponse,
+    ) -> Result<Self, OrderedSendError> {
+        if let Some(commands) = &commands {
+            commands
+                .send(HeaderSyncPeerCommand::Reserve(expected))
+                .map_err(|_| OrderedSendError::Closed)?;
+        }
+        Ok(Self {
+            commands,
+            expected,
+            armed: true,
+        })
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ExpectedHeadersReservation {
+    fn drop(&mut self) {
+        if self.armed {
+            if let Some(commands) = &self.commands {
+                let _ = commands.send(HeaderSyncPeerCommand::Cancel(self.expected));
+            }
         }
     }
 }

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -823,6 +823,10 @@ impl Sink for HeaderSyncPassthroughSink {
 #[cfg(test)]
 mod request_id_tests {
     use super::*;
+    use crate::zakura::header_sync::{
+        requester::HeaderRequesterCommand,
+        state::{RangePriority, RangeRequest},
+    };
 
     #[test]
     fn request_id_exhaustion_remains_fail_closed() {
@@ -971,5 +975,49 @@ mod request_id_tests {
             HeaderSyncRequestId::new(1).expect("non-zero id")
         );
         assert_eq!(session.inner.next_request_id.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn requester_queue_failure_cancels_prepared_expectation() {
+        let (send, _recv) = crate::zakura::framed_channel(1);
+        let (commands_tx, mut commands_rx) = mpsc::unbounded_channel();
+        let peer_id = ZakuraPeerId::new(vec![5; 32]).expect("test peer id is valid");
+        let session = HeaderSyncPeerSession::from_parts_with_direction_and_commands(
+            peer_id,
+            1,
+            ServicePeerDirection::Outbound,
+            send,
+            CancellationToken::new(),
+            Some(commands_tx),
+        );
+        let range = RangeRequest {
+            start_height: block::Height(1),
+            count: 1,
+            anchor_hash: None,
+            finalized: false,
+            want_tree_aux_roots: true,
+            priority: RangePriority::Forward,
+        };
+        let prepared = session
+            .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
+            .expect("valid test request is prepared");
+        let reserved = match commands_rx.try_recv().expect("reservation is published") {
+            HeaderSyncPeerCommand::Reserve(expected) => expected,
+            command => panic!("expected reservation command, got {command:?}"),
+        };
+        let (requester_tx, requester_rx) = mpsc::channel(1);
+        drop(requester_rx);
+
+        let rejected = match requester_tx.try_send(HeaderRequesterCommand { range, prepared }) {
+            Err(mpsc::error::TrySendError::Closed(command)) => command,
+            _ => panic!("closed requester queue rejects the prepared command"),
+        };
+        drop(rejected);
+
+        let cancelled = match commands_rx.try_recv().expect("cancellation is published") {
+            HeaderSyncPeerCommand::Cancel(expected) => expected,
+            command => panic!("expected cancellation command, got {command:?}"),
+        };
+        assert_eq!(cancelled, reserved);
     }
 }

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -242,17 +242,13 @@ impl HeaderSyncPeerSession {
         .map(|()| request_id)
     }
 
-    /// Reserve response correlation and wait asynchronously for outbound capacity.
-    ///
-    /// The frame is encoded once before waiting. If this future is cancelled while
-    /// waiting, the reservation guard synchronously removes the request ID from the
-    /// peer pipe so it cannot consume a later response.
-    pub(super) async fn send_get_headers(
+    /// Prepare a correlated header request without making its frame visible to the peer.
+    pub(super) fn prepare_get_headers(
         &self,
         start_height: block::Height,
         count: u32,
         want_tree_aux_roots: bool,
-    ) -> Result<HeaderSyncRequestId, OrderedSendError> {
+    ) -> Result<PreparedGetHeaders, OrderedSendError> {
         let request_id = self.next_request_id()?;
         let expected =
             ExpectedHeadersResponse::new(request_id, start_height, count, want_tree_aux_roots)
@@ -265,15 +261,13 @@ impl HeaderSyncPeerSession {
         .encode_frame(Some(request_id))
         .map_err(|error| OrderedSendError::Encode(Box::new(error)))?;
 
-        let mut reservation =
-            ExpectedHeadersReservation::new(self.inner.commands.clone(), expected)?;
-        self.inner
-            .send
-            .send(frame)
-            .await
-            .map_err(|_| OrderedSendError::Closed)?;
-        reservation.disarm();
-        Ok(request_id)
+        let reservation = ExpectedHeadersReservation::new(self.inner.commands.clone(), expected)?;
+        Ok(PreparedGetHeaders {
+            request_id,
+            frame,
+            send: self.inner.send.clone(),
+            reservation,
+        })
     }
 
     /// Send a typed header range response with one advisory body-size hint and
@@ -313,6 +307,37 @@ impl HeaderSyncPeerSession {
             Err(mpsc::error::TrySendError::Full(_frame)) => Err(OrderedSendError::Full),
             Err(mpsc::error::TrySendError::Closed(_frame)) => Err(OrderedSendError::Closed),
         }
+    }
+}
+
+pub(super) struct PreparedGetHeaders {
+    request_id: HeaderSyncRequestId,
+    frame: Frame,
+    send: FramedSend,
+    reservation: ExpectedHeadersReservation,
+}
+
+impl PreparedGetHeaders {
+    pub(super) fn request_id(&self) -> HeaderSyncRequestId {
+        self.request_id
+    }
+
+    /// Wait for outbound capacity and publish the prepared frame.
+    ///
+    /// Dropping this future before publication synchronously cancels the pipe's
+    /// response reservation.
+    pub(super) async fn send(self) -> Result<HeaderSyncRequestId, OrderedSendError> {
+        let Self {
+            request_id,
+            frame,
+            send,
+            mut reservation,
+        } = self;
+        send.send(frame)
+            .await
+            .map_err(|_| OrderedSendError::Closed)?;
+        reservation.disarm();
+        Ok(request_id)
     }
 }
 

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -545,6 +545,11 @@ pub(super) struct HeaderSyncPeerMeters {
     pub(super) unsolicited: RateMeter,
     pub(super) inbound_status: RateMeter,
     pub(super) inbound_new_block: RateMeter,
+    /// Paces retries after the peer's outbound queue rejects a status.
+    ///
+    /// This deadline is separate from `unsolicited` and `keepalive` because
+    /// those meters record statuses that were successfully published.
+    pub(super) status_publication_retry_at: Option<Instant>,
     /// Gates redundant keepalive status sends.
     ///
     /// Floored above the remote's inbound status minimum interval so a
@@ -570,6 +575,7 @@ impl HeaderSyncPeerMeters {
             unsolicited: RateMeter::new(status_refresh_interval),
             inbound_status: RateMeter::new(inbound_status_min_interval),
             inbound_new_block: RateMeter::new(inbound_new_block_min_interval),
+            status_publication_retry_at: None,
             keepalive,
         }
     }

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -1,4 +1,6 @@
-use super::{error::*, events::*, validation::*, wire::*, work_queue::*, *};
+use super::{
+    error::*, events::*, requester::HeaderRequesterHandle, validation::*, wire::*, work_queue::*, *,
+};
 use crate::zakura::{
     HeaderSyncServiceSummary, ServicePeerDirection, DEFAULT_LIVE_SERVICE_SUMMARY_TTL,
 };
@@ -27,6 +29,7 @@ pub(super) struct HeaderSyncCore {
     pub(super) verified_block_hash: block::Hash,
     pub(super) best_header_tip: block::Height,
     pub(super) best_header_hash: block::Hash,
+    pub(super) last_header_progress_at: Instant,
     pub(super) peers: HashMap<ZakuraPeerId, PeerHeaderState>,
     pub(super) parked_peers: HashSet<ZakuraPeerId>,
     pub(super) seen: HeaderHashDedup,
@@ -63,6 +66,7 @@ impl HeaderSyncCore {
             verified_block_hash: startup.frontiers.verified_block_hash,
             best_header_tip,
             best_header_hash,
+            last_header_progress_at: Instant::now(),
             peers: HashMap::new(),
             parked_peers: HashSet::new(),
             seen: HeaderHashDedup::default(),
@@ -422,6 +426,9 @@ pub(super) struct PeerHeaderState {
     /// which the peer's inbound rate limiter would otherwise treat as spam.
     pub(super) last_sent_status: Option<HeaderSyncStatus>,
     pub(super) outstanding: Vec<OutstandingRange>,
+    pub(super) pending_request_sends: usize,
+    pub(super) requester_generation: u64,
+    pub(super) requester: Option<HeaderRequesterHandle>,
     pub(super) meters: HeaderSyncPeerMeters,
     pub(super) served_headers_inflight: u16,
     pub(super) served_header_request_ids: HashSet<HeaderSyncRequestId>,
@@ -450,6 +457,9 @@ impl PeerHeaderState {
             last_received_status_at: None,
             last_sent_status: None,
             outstanding: Vec::new(),
+            pending_request_sends: 0,
+            requester_generation: 0,
+            requester: None,
             meters: HeaderSyncPeerMeters::new(
                 status_refresh_interval,
                 inbound_status_min_interval,
@@ -462,7 +472,11 @@ impl PeerHeaderState {
     }
 
     pub(super) fn available_slots(&self) -> usize {
-        usize::from(self.max_inflight_requests).saturating_sub(self.outstanding.len())
+        usize::from(self.max_inflight_requests).saturating_sub(
+            self.outstanding
+                .len()
+                .saturating_add(self.pending_request_sends),
+        )
     }
 
     pub(super) fn remove_outstanding_by_request_id(

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -1,4 +1,4 @@
-use super::{error::*, events::*, scheduler::*, validation::*, wire::*, *};
+use super::{error::*, events::*, validation::*, wire::*, work_queue::*, *};
 use crate::zakura::{
     HeaderSyncServiceSummary, ServicePeerDirection, DEFAULT_LIVE_SERVICE_SUMMARY_TTL,
 };
@@ -31,7 +31,9 @@ pub(super) struct HeaderSyncCore {
     pub(super) parked_peers: HashSet<ZakuraPeerId>,
     pub(super) seen: HeaderHashDedup,
     pub(super) pending_new_blocks: HashSet<block::Hash>,
-    pub(super) schedule: RangeScheduler,
+    pub(super) schedule: HeaderWorkQueue,
+    pub(super) buffered: BTreeMap<(RangePriority, block::Height), BufferedHeaderRange>,
+    pub(super) backward_frontier: Option<(block::Height, block::Hash)>,
     pub(super) pending_commits: HashMap<PendingCommitKey, RangeRequest>,
     pub(super) repair: Option<VctRootRepair>,
     pub(super) advisory: HashMap<ZakuraPeerId, HeaderSyncAdvisoryPeerState>,
@@ -42,6 +44,17 @@ impl HeaderSyncCore {
     pub(super) fn new(startup: &HeaderSyncStartup) -> Result<Self, HeaderSyncStartError> {
         validate_anchor(&startup.network, startup.anchor)?;
         let (best_header_tip, best_header_hash) = startup.best_header_tip.unwrap_or(startup.anchor);
+        let backward_frontier = startup
+            .network
+            .checkpoint_list()
+            .max_height_in_range(..startup.anchor.0)
+            .and_then(|height| {
+                startup
+                    .network
+                    .checkpoint_list()
+                    .hash(height)
+                    .map(|hash| (height, hash))
+            });
 
         Ok(Self {
             anchor: startup.anchor,
@@ -54,7 +67,9 @@ impl HeaderSyncCore {
             parked_peers: HashSet::new(),
             seen: HeaderHashDedup::default(),
             pending_new_blocks: HashSet::new(),
-            schedule: RangeScheduler::new(),
+            schedule: HeaderWorkQueue::new(),
+            buffered: BTreeMap::new(),
+            backward_frontier,
             pending_commits: HashMap::new(),
             repair: None,
             advisory: HashMap::new(),
@@ -90,18 +105,58 @@ impl HeaderSyncCore {
             }
         }
 
-        let count = count_between(start, end);
-        if count == 0 {
+        let batch_count = clamp_header_sync_request_count(
+            startup.config.advertised_max_headers_per_response(),
+            startup.config.advertised_max_headers_per_response(),
+            &startup.network,
+            startup.max_frame_bytes,
+            true,
+        );
+        let resident_height_cap =
+            u64::from(batch_count.saturating_mul(HEADER_SYNC_MAX_RESIDENT_BATCHES));
+        let available = resident_height_cap.saturating_sub(self.schedule.resident_heights());
+        let Ok(available) = u32::try_from(available) else {
+            return;
+        };
+        if available == 0 {
             return;
         }
-        self.schedule.ensure_forward(RangeRequest {
-            start_height: start,
-            count,
-            anchor_hash: self.best_header_hash,
-            finalized,
-            want_tree_aux_roots: true,
-            priority: RangePriority::Forward,
-        });
+        let batch_start = self
+            .schedule
+            .highest_end(RangePriority::Forward)
+            .and_then(next_height)
+            .unwrap_or(start)
+            .max(start);
+        if batch_start > end {
+            return;
+        }
+        let count = count_between(batch_start, end).min(available);
+        let mut remaining = count;
+        let mut batch_start = batch_start;
+        let mut anchor_hash = (batch_start == start).then_some(self.best_header_hash);
+        while remaining > 0 {
+            let mut batch_len = remaining.min(batch_count);
+            let batch_end = height_after_count(batch_start, batch_len)
+                .and_then(previous_height)
+                .expect("bounded header work batch has an end height");
+            if let Some(checkpoint) = checkpoints.min_height_in_range(batch_start..=batch_end) {
+                batch_len = count_between(batch_start, checkpoint);
+            }
+            self.schedule.ensure_forward(RangeRequest {
+                start_height: batch_start,
+                count: batch_len,
+                anchor_hash,
+                finalized,
+                want_tree_aux_roots: true,
+                priority: RangePriority::Forward,
+            });
+            remaining = remaining.saturating_sub(batch_len);
+            let Some(next_start) = height_after_count(batch_start, batch_len) else {
+                break;
+            };
+            batch_start = next_start;
+            anchor_hash = None;
+        }
     }
 
     pub(super) fn refresh_backward_range(&mut self, startup: &HeaderSyncStartup) {
@@ -111,27 +166,66 @@ impl HeaderSyncCore {
         let checkpoints = startup.network.checkpoint_list();
         // v1 backfill schedules one checkpoint bracket below the configured anchor.
         // Iterating all deeper brackets is left to final node wiring/backfill policy.
-        let Some(previous_checkpoint) = checkpoints.max_height_in_range(..self.anchor.0) else {
+        let Some((frontier_height, frontier_hash)) = self.backward_frontier else {
             return;
         };
-        let Some(previous_hash) = checkpoints.hash(previous_checkpoint) else {
-            return;
-        };
-        let Some(start) = next_height(previous_checkpoint) else {
-            return;
-        };
-        let count = count_between(start, self.anchor.0);
-        if count == 0 {
+        if frontier_height >= self.anchor.0 {
             return;
         }
-        self.schedule.ensure_backward(RangeRequest {
-            start_height: start,
-            count,
-            anchor_hash: previous_hash,
-            finalized: true,
-            want_tree_aux_roots: true,
-            priority: RangePriority::Backward,
-        });
+        let Some(start) = next_height(frontier_height) else {
+            return;
+        };
+        let batch_count = clamp_header_sync_request_count(
+            startup.config.advertised_max_headers_per_response(),
+            startup.config.advertised_max_headers_per_response(),
+            &startup.network,
+            startup.max_frame_bytes,
+            true,
+        );
+        let resident_height_cap =
+            u64::from(batch_count.saturating_mul(HEADER_SYNC_MAX_RESIDENT_BATCHES));
+        let available = resident_height_cap.saturating_sub(self.schedule.resident_heights());
+        let Ok(available) = u32::try_from(available) else {
+            return;
+        };
+        if available == 0 {
+            return;
+        }
+        let batch_start = self
+            .schedule
+            .highest_end(RangePriority::Backward)
+            .and_then(next_height)
+            .unwrap_or(start)
+            .max(start);
+        if batch_start > self.anchor.0 {
+            return;
+        }
+        let mut remaining = count_between(batch_start, self.anchor.0).min(available);
+        let mut batch_start = batch_start;
+        let mut anchor_hash = (batch_start == start).then_some(frontier_hash);
+        while remaining > 0 {
+            let mut batch_len = remaining.min(batch_count);
+            let batch_end = height_after_count(batch_start, batch_len)
+                .and_then(previous_height)
+                .expect("bounded backward work batch has an end height");
+            if let Some(checkpoint) = checkpoints.min_height_in_range(batch_start..=batch_end) {
+                batch_len = count_between(batch_start, checkpoint);
+            }
+            self.schedule.ensure_backward(RangeRequest {
+                start_height: batch_start,
+                count: batch_len,
+                anchor_hash,
+                finalized: true,
+                want_tree_aux_roots: true,
+                priority: RangePriority::Backward,
+            });
+            remaining = remaining.saturating_sub(batch_len);
+            let Some(next_start) = height_after_count(batch_start, batch_len) else {
+                break;
+            };
+            batch_start = next_start;
+            anchor_hash = None;
+        }
     }
 }
 
@@ -183,7 +277,7 @@ impl VctRootRepair {
             range: RangeRequest {
                 start_height: height,
                 count,
-                anchor_hash,
+                anchor_hash: Some(anchor_hash),
                 finalized: false,
                 want_tree_aux_roots: true,
                 priority: RangePriority::Repair,
@@ -479,11 +573,21 @@ pub(super) struct OutstandingRange {
     pub(super) purpose: RangePurpose,
 }
 
+#[derive(Clone, Debug)]
+pub(super) struct BufferedHeaderRange {
+    pub(super) peer: ZakuraPeerId,
+    pub(super) session_id: u64,
+    pub(super) range: RangeRequest,
+    pub(super) headers: Vec<Arc<block::Header>>,
+    pub(super) body_sizes: Vec<u32>,
+    pub(super) tree_aux_roots: Vec<BlockCommitmentRoots>,
+}
+
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub(super) struct RangeRequest {
     pub(super) start_height: block::Height,
     pub(super) count: u32,
-    pub(super) anchor_hash: block::Hash,
+    pub(super) anchor_hash: Option<block::Hash>,
     pub(super) finalized: bool,
     pub(super) want_tree_aux_roots: bool,
     pub(super) priority: RangePriority,
@@ -501,7 +605,7 @@ impl RangeRequest {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(super) enum RangePriority {
     Forward,
     Backward,

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -581,7 +581,7 @@ impl HeaderSyncPeerMeters {
 pub(super) struct OutstandingRange {
     pub(super) request_id: HeaderSyncRequestId,
     pub(super) range: RangeRequest,
-    pub(super) deadline: Instant,
+    pub(super) deadline: Option<Instant>,
     pub(super) expected_max_count: u32,
     pub(super) clear_assignment_on_timeout: bool,
     pub(super) purpose: RangePurpose,

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -140,8 +140,7 @@ impl HeaderSyncCore {
         let mut anchor_hash = (batch_start == start).then_some(self.best_header_hash);
         while remaining > 0 {
             let mut batch_len = remaining.min(batch_count);
-            let batch_end = height_after_count(batch_start, batch_len)
-                .and_then(previous_height)
+            let batch_end = range_end_height(batch_start, batch_len)
                 .expect("bounded header work batch has an end height");
             if let Some(checkpoint) = checkpoints.min_height_in_range(batch_start..=batch_end) {
                 batch_len = count_between(batch_start, checkpoint);
@@ -209,8 +208,7 @@ impl HeaderSyncCore {
         let mut anchor_hash = (batch_start == start).then_some(frontier_hash);
         while remaining > 0 {
             let mut batch_len = remaining.min(batch_count);
-            let batch_end = height_after_count(batch_start, batch_len)
-                .and_then(previous_height)
+            let batch_end = range_end_height(batch_start, batch_len)
                 .expect("bounded backward work batch has an end height");
             if let Some(checkpoint) = checkpoints.min_height_in_range(batch_start..=batch_end) {
                 batch_len = count_between(batch_start, checkpoint);
@@ -585,6 +583,14 @@ pub(super) struct OutstandingRange {
     pub(super) expected_max_count: u32,
     pub(super) clear_assignment_on_timeout: bool,
     pub(super) purpose: RangePurpose,
+    pub(super) phase: OutstandingPhase,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum OutstandingPhase {
+    Registered,
+    Sent,
+    EmptyRetry,
 }
 
 #[derive(Clone, Debug)]
@@ -609,13 +615,30 @@ pub(super) struct RangeRequest {
 
 impl RangeRequest {
     pub(super) fn end_height(self) -> block::Height {
-        height_after_count(self.start_height, self.count)
-            .and_then(previous_height)
-            .expect("range request count is non-zero")
+        range_end_height(self.start_height, self.count)
+            .expect("range request is non-zero and clamped to the remaining height domain")
     }
 
     pub(super) fn is_within(self, start: block::Height, end: block::Height) -> bool {
         self.start_height >= start && self.end_height() <= end
+    }
+
+    pub(super) fn suffix_after(
+        self,
+        covered_through: block::Height,
+        anchor_hash: block::Hash,
+    ) -> Option<Self> {
+        let end_height = self.end_height();
+        if end_height <= covered_through {
+            return None;
+        }
+        let start_height = next_height(covered_through)?;
+        Some(Self {
+            start_height,
+            count: count_between(start_height, end_height),
+            anchor_hash: Some(anchor_hash),
+            ..self
+        })
     }
 }
 

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -1,5 +1,11 @@
 use super::{
-    error::*, events::*, requester::HeaderRequesterHandle, validation::*, wire::*, work_queue::*, *,
+    error::*,
+    events::*,
+    requester::{HeaderRequesterHandle, HeaderRequesterIdentity},
+    validation::*,
+    wire::*,
+    work_queue::*,
+    *,
 };
 use crate::zakura::{
     HeaderSyncServiceSummary, ServicePeerDirection, DEFAULT_LIVE_SERVICE_SUMMARY_TTL,
@@ -424,8 +430,7 @@ pub(super) struct PeerHeaderState {
     /// which the peer's inbound rate limiter would otherwise treat as spam.
     pub(super) last_sent_status: Option<HeaderSyncStatus>,
     pub(super) outstanding: Vec<OutstandingRange>,
-    pub(super) pending_request_sends: usize,
-    pub(super) requester_generation: u64,
+    pub(super) requester_identity: Option<HeaderRequesterIdentity>,
     pub(super) requester: Option<HeaderRequesterHandle>,
     pub(super) meters: HeaderSyncPeerMeters,
     pub(super) served_headers_inflight: u16,
@@ -455,8 +460,7 @@ impl PeerHeaderState {
             last_received_status_at: None,
             last_sent_status: None,
             outstanding: Vec::new(),
-            pending_request_sends: 0,
-            requester_generation: 0,
+            requester_identity: None,
             requester: None,
             meters: HeaderSyncPeerMeters::new(
                 status_refresh_interval,
@@ -470,11 +474,7 @@ impl PeerHeaderState {
     }
 
     pub(super) fn available_slots(&self) -> usize {
-        usize::from(self.max_inflight_requests).saturating_sub(
-            self.outstanding
-                .len()
-                .saturating_add(self.pending_request_sends),
-        )
+        usize::from(self.max_inflight_requests).saturating_sub(self.outstanding.len())
     }
 
     pub(super) fn remove_outstanding_by_request_id(
@@ -579,17 +579,15 @@ impl HeaderSyncPeerMeters {
 pub(super) struct OutstandingRange {
     pub(super) request_id: HeaderSyncRequestId,
     pub(super) range: RangeRequest,
-    pub(super) deadline: Option<Instant>,
-    pub(super) expected_max_count: u32,
-    pub(super) clear_assignment_on_timeout: bool,
+    pub(super) deadline: Instant,
     pub(super) purpose: RangePurpose,
     pub(super) phase: OutstandingPhase,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(super) enum OutstandingPhase {
-    Registered,
-    Sent,
+    Publishing,
+    AwaitingResponse,
     EmptyRetry,
 }
 

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -2352,6 +2352,10 @@ async fn vct_repair_scheduler_requires_an_idle_peer() {
     .await;
     let (requested_peer, _request_id, _, _) = next_outbound_get_headers(&mut fixture.actions).await;
     assert_eq!(requested_peer, busy_peer);
+    while tokio::time::timeout(std::time::Duration::from_millis(25), fixture.actions.recv())
+        .await
+        .is_ok()
+    {}
 
     fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
     advertise_tip(
@@ -2436,7 +2440,7 @@ async fn status_updates_peer_caps_and_scheduler_respects_them() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn scheduler_assigns_only_current_forward_range_before_progress() {
+async fn scheduler_fills_v7_outstanding_request_slots() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
         network.clone(),
@@ -2456,28 +2460,34 @@ async fn scheduler_assigns_only_current_forward_range_before_progress() {
     )
     .await;
 
-    let mut get_headers_count = 0;
+    let mut starts = HashSet::new();
     while let Ok(Some(action)) = tokio::time::timeout(
         std::time::Duration::from_millis(100),
         fixture.actions.recv(),
     )
     .await
     {
-        if matches!(
-            action,
-            HeaderSyncAction::SendMessage {
-                peer,
-                msg: HeaderSyncMessage::GetHeaders { .. },
-                ..
-            } if peer == peer_id
-        ) {
-            get_headers_count += 1;
+        if let HeaderSyncAction::SendMessage {
+            peer,
+            msg:
+                HeaderSyncMessage::GetHeaders {
+                    start_height,
+                    count,
+                    ..
+                },
+            ..
+        } = action
+        {
+            if peer == peer_id {
+                assert_eq!(count, 2);
+                assert!(starts.insert(start_height));
+            }
         }
     }
 
-    // The peer has many inflight slots, but only the current forward range is
-    // queued until committed progress advances the frontier.
-    assert_eq!(get_headers_count, 1);
+    assert_eq!(starts.len(), 10);
+    assert_eq!(starts.iter().copied().min(), Some(block::Height(1)));
+    assert_eq!(starts.iter().copied().max(), Some(block::Height(19)));
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -2570,7 +2580,7 @@ async fn scheduler_uses_inflight_slots_and_matches_reverse_response_ids() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn scheduler_fans_out_same_forward_range_to_three_peers() {
+async fn work_queue_assigns_each_forward_range_to_one_peer() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
         network.clone(),
@@ -2585,7 +2595,7 @@ async fn scheduler_fans_out_same_forward_range_to_three_peers() {
     }
 
     let mut requested = HashSet::new();
-    while requested.len() < HEADER_SYNC_FANOUT {
+    while requested.is_empty() {
         if let HeaderSyncAction::SendMessage {
             peer,
             msg:
@@ -2603,34 +2613,29 @@ async fn scheduler_fans_out_same_forward_range_to_three_peers() {
         }
     }
 
-    assert_eq!(requested.len(), HEADER_SYNC_FANOUT);
+    assert_eq!(requested.len(), 1);
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn covered_hedged_outstanding_ranges_do_not_commit_twice() {
+async fn covered_outstanding_range_does_not_commit_late_response() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
         network.clone(),
         (block::Height(0), network.genesis_hash()),
         None,
     ));
-    let peers = [peer(33), peer(34)];
+    let peer_id = peer(33);
     let start = block::Height(1);
     let tip = block::Height(2);
 
-    for peer_id in peers.clone() {
-        connect_peer(&fixture, peer_id.clone()).await;
-        advertise_tip(&fixture, peer_id, block::Height(0), tip, 2, 1).await;
-    }
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(&fixture, peer_id.clone(), block::Height(0), tip, 2, 1).await;
 
-    let mut requests = HashMap::new();
-    while requests.len() < peers.len() {
-        let (peer, request_id, start_height, count) =
-            next_outbound_get_headers(&mut fixture.actions).await;
-        assert_eq!(start_height, start);
-        assert_eq!(count, 2);
-        requests.insert(peer, request_id);
-    }
+    let (requested_peer, request_id, start_height, count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(requested_peer, peer_id);
+    assert_eq!(start_height, start);
+    assert_eq!(count, 2);
 
     fixture
         .handle
@@ -2642,152 +2647,25 @@ async fn covered_hedged_outstanding_ranges_do_not_commit_twice() {
         .await
         .unwrap();
 
-    for peer_id in peers {
-        send_headers(
-            &fixture,
-            &peer_id,
-            requests[&peer_id],
-            headers_message_from(
-                start,
-                vec![
-                    mainnet_header(&BLOCK_MAINNET_1_BYTES),
-                    mainnet_header(&BLOCK_MAINNET_2_BYTES),
-                ],
-            ),
-        )
-        .await;
-    }
+    send_headers(
+        &fixture,
+        &peer_id,
+        request_id,
+        headers_message_from(
+            start,
+            vec![
+                mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                mainnet_header(&BLOCK_MAINNET_2_BYTES),
+            ],
+        ),
+    )
+    .await;
 
     assert_no_commit_or_misbehavior(&mut fixture.actions).await;
 }
 
-/// Hedged responses can double-commit, and that must stay benign.
-///
-/// The scheduler fans one range out to several peers, and `pending_commits` is keyed per
-/// `(peer, start_height, count)`, so the commit dispatch does not check for an overlapping
-/// pending commit from another peer. Redundant outstanding ranges are only cancelled in
-/// `handle_header_range_committed`, once the state writer confirms. Two responses that land
-/// inside that window therefore each dispatch their own `CommitHeaderRange`.
-///
-/// That is harmless *today*: the state writer treats an identical header at a height as a
-/// non-conflict, so the second commit revalidates and rewrites the same rows and returns
-/// `Ok`; the duplicate committed event is idempotent in the reactor; and the tip only
-/// publishes on a strictly higher height. Neither honest peer is scored.
-///
-/// The property holds only because of those downstream details, so it is tested at both
-/// layers: the state writer's half (re-committing an identical range succeeds) is covered by
-/// `header_range_commit_merges_same_header_advertised_body_size_by_max` in `zakura-state`,
-/// and this test covers the reactor's half. If `commit_header_range` starts rejecting an
-/// already-present range, or a conflict error is reclassified as scoring, honest hedged peers
-/// would be scored for misbehavior; these two tests are what catch that.
 #[tokio::test(flavor = "current_thread")]
-async fn hedged_double_commit_does_not_score_peers_or_publish_the_tip_twice() {
-    // A checkpoint at height 3 with the range starting at 4: above the checkpoint, so the
-    // range is non-finalized and gets hedged, while the mainnet header still validates.
-    let checkpoint_hash = block::Hash::from(mainnet_header(&BLOCK_MAINNET_3_BYTES).as_ref());
-    let (network, _) = checkpoint_testnet_with_hash(block::Height(3), checkpoint_hash);
-    let start = block::Height(4);
-    let header = mainnet_header(&BLOCK_MAINNET_4_BYTES);
-    let tip_hash = block::Hash::from(header.as_ref());
-    let mut fixture = spawn_test_reactor(startup_for(
-        network.clone(),
-        (block::Height(0), network.genesis_hash()),
-        Some((block::Height(3), checkpoint_hash)),
-    ));
-    let peers = [peer(43), peer(44)];
-
-    for peer_id in peers.clone() {
-        connect_peer(&fixture, peer_id.clone()).await;
-        advertise_tip(&fixture, peer_id, block::Height(0), start, 1, 1).await;
-    }
-
-    // The same range is hedged across both peers.
-    let mut requests = HashMap::new();
-    while requests.len() < peers.len() {
-        let (peer, request_id, start_height, count) =
-            next_outbound_get_headers(&mut fixture.actions).await;
-        assert_eq!(start_height, start);
-        assert_eq!(count, 1);
-        requests.insert(peer, request_id);
-    }
-
-    // Both answer before either commit is confirmed, so both outstandings are still live.
-    for peer_id in peers.clone() {
-        send_headers(
-            &fixture,
-            &peer_id,
-            requests[&peer_id],
-            headers_message(vec![header.clone()]),
-        )
-        .await;
-    }
-
-    // Each response dispatches its own commit: the race is real, and neither peer is scored.
-    let mut committed_peers = Vec::new();
-    while committed_peers.len() < peers.len() {
-        match next_non_query_action(&mut fixture.actions).await {
-            HeaderSyncAction::CommitHeaderRange {
-                peer, start_height, ..
-            } => {
-                assert_eq!(start_height, start);
-                committed_peers.push(peer);
-            }
-            HeaderSyncAction::Misbehavior { peer, reason } => {
-                panic!("an honest hedged peer must not be scored: {peer:?} {reason:?}")
-            }
-            _ => {}
-        }
-    }
-    committed_peers.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
-    let mut expected_peers = peers.to_vec();
-    expected_peers.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
-    assert_eq!(
-        committed_peers, expected_peers,
-        "both hedged responses should dispatch their own commit"
-    );
-
-    // The state writer confirms both: rewriting an identical range succeeds.
-    for _ in 0..peers.len() {
-        fixture
-            .handle
-            .send(HeaderSyncEvent::HeaderRangeCommitted {
-                start_height: start,
-                tip_height: start,
-                tip_hash,
-            })
-            .await
-            .unwrap();
-    }
-
-    // The duplicate commit neither scores a peer nor republishes the frontier.
-    let mut advanced = 0;
-    while let Ok(Some(action)) = tokio::time::timeout(
-        std::time::Duration::from_millis(100),
-        fixture.actions.recv(),
-    )
-    .await
-    {
-        match action {
-            HeaderSyncAction::HeaderAdvanced { height, hash } => {
-                assert_eq!(height, start);
-                assert_eq!(hash, tip_hash);
-                advanced += 1;
-            }
-            HeaderSyncAction::Misbehavior { peer, reason } => {
-                panic!("a duplicate commit must not score {peer:?}: {reason:?}")
-            }
-            _ => {}
-        }
-    }
-    assert_eq!(
-        advanced, 1,
-        "a duplicate commit at the same tip must not republish the header frontier"
-    );
-    assert_eq!(fixture.handle.best_header_tip(), (start, tip_hash));
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn scheduler_narrows_large_ranges_before_tracking_fanout() {
+async fn work_queue_splits_large_ranges_without_duplicate_ownership() {
     let network = Network::Mainnet;
     let first_checkpoint = network
         .checkpoint_list()
@@ -2828,7 +2706,7 @@ async fn scheduler_narrows_large_ranges_before_tracking_fanout() {
         .await;
     }
 
-    let mut requested = HashSet::new();
+    let mut requested = HashMap::new();
     while let Ok(Some(action)) = tokio::time::timeout(
         std::time::Duration::from_millis(100),
         fixture.actions.recv(),
@@ -2846,48 +2724,16 @@ async fn scheduler_narrows_large_ranges_before_tracking_fanout() {
             ..
         } = action
         {
-            assert_eq!(start_height, start);
-            assert_eq!(count, clamped_count);
+            assert!(count <= clamped_count);
+            assert!(count > 0);
             assert!(
-                requested.insert(peer),
-                "scheduler must not duplicate a clamped chunk for one peer"
+                requested.insert(start_height, peer).is_none(),
+                "work queue must not assign one clamped chunk to multiple peers"
             );
         }
     }
-    assert_eq!(requested.len(), HEADER_SYNC_FANOUT);
-
-    let chunk_tip = height_after_count(start, clamped_count)
-        .and_then(previous_height)
-        .expect("clamped range has a tip");
-    fixture
-        .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: start,
-            tip_height: chunk_tip,
-            tip_hash: block::Hash([4; 32]),
-        })
-        .await
-        .unwrap();
-
-    loop {
-        if let HeaderSyncAction::SendMessage {
-            msg:
-                HeaderSyncMessage::GetHeaders {
-                    start_height,
-                    count,
-                    want_tree_aux_roots: true,
-                },
-            ..
-        } = next_non_query_action(&mut fixture.actions).await
-        {
-            assert_eq!(
-                start_height,
-                next_height(chunk_tip).expect("committed chunk tip has successor")
-            );
-            assert_eq!(count, clamped_count);
-            break;
-        }
-    }
+    assert_eq!(requested.len(), peers.len());
+    assert_eq!(requested.keys().copied().min(), Some(start));
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -5524,6 +5370,39 @@ async fn empty_headers_for_outstanding_range_retries_without_disconnect() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn one_silent_peer_retries_the_same_missing_range_indefinitely() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_with_timeout(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        std::time::Duration::from_millis(5),
+    ));
+    let peer_id = peer(90);
+
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(1),
+        1,
+        1,
+    )
+    .await;
+
+    for _ in 0..3 {
+        let (request_peer, _request_id, start, count) =
+            next_outbound_get_headers(&mut fixture.actions).await;
+        assert_eq!(request_peer, peer_id);
+        assert_eq!(start, block::Height(1));
+        assert_eq!(count, 1);
+        // Silence: let the request deadline expire. The work queue must return
+        // the claim and make it eligible again after the short peer-local delay.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn committed_range_updates_best_tip_watch_and_does_not_advance_finality() {
     let network = regtest_network();
     let fixture = spawn_test_reactor(startup_for(
@@ -5759,7 +5638,7 @@ async fn forward_genesis_backfill_reaches_checkpoint_before_finalized_commit() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn truncated_finalized_backfill_is_rejected_before_commit() {
+async fn truncated_finalized_backfill_commits_valid_prefix_and_requeues_suffix() {
     let headers = [
         mainnet_header(&BLOCK_MAINNET_1_BYTES),
         mainnet_header(&BLOCK_MAINNET_2_BYTES),
@@ -5795,9 +5674,17 @@ async fn truncated_finalized_backfill_is_rejected_before_commit() {
     .await;
 
     match next_non_query_action(&mut fixture.actions).await {
-        HeaderSyncAction::Misbehavior { peer, reason } => {
+        HeaderSyncAction::CommitHeaderRange {
+            peer,
+            start_height,
+            headers,
+            finalized,
+            ..
+        } => {
             assert_eq!(peer, peer_id);
-            assert_eq!(reason, HeaderSyncMisbehavior::InvalidRange);
+            assert_eq!(start_height, block::Height(1));
+            assert_eq!(headers.len(), 2);
+            assert!(finalized);
         }
         action => panic!("unexpected action: {action:?}"),
     }

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -5113,7 +5113,7 @@ async fn header_sync_jsonl_trace_captures_status_range_dedup_and_violation_recor
         Some((first_checkpoint, checkpoint_hash)),
     );
     startup.trace = ZakuraTrace::new(capture.tracer(), "01");
-    let fixture = spawn_test_reactor(startup);
+    let mut fixture = spawn_test_reactor(startup);
     let peer_id = peer(55);
 
     connect_peer(&fixture, peer_id.clone()).await;
@@ -5126,6 +5126,7 @@ async fn header_sync_jsonl_trace_captures_status_range_dedup_and_violation_recor
         1,
     )
     .await;
+    let _ = next_get_headers_request_id(&mut fixture.actions).await;
     fixture
         .handle
         .send(HeaderSyncEvent::FullBlockCommitted {
@@ -5400,6 +5401,399 @@ async fn one_silent_peer_retries_the_same_missing_range_indefinitely() {
         // the claim and make it eligible again after the short peer-local delay.
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn commit_failure_after_source_disconnect_retries_without_blocking_the_lane() {
+    let checkpoint_hash = block::Hash::from(mainnet_header(&BLOCK_MAINNET_3_BYTES).as_ref());
+    let (network, _) = checkpoint_testnet_with_hash(block::Height(3), checkpoint_hash);
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        Some((block::Height(3), checkpoint_hash)),
+    ));
+    let first_peer = peer(140);
+    let second_peer = peer(141);
+
+    for peer_id in [&first_peer, &second_peer] {
+        connect_peer(&fixture, peer_id.clone()).await;
+        advertise_tip(
+            &fixture,
+            peer_id.clone(),
+            block::Height(0),
+            block::Height(4),
+            1,
+            1,
+        )
+        .await;
+    }
+    let (source, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(source, first_peer);
+    assert_eq!((start, count), (block::Height(4), 1));
+    send_headers(
+        &fixture,
+        &source,
+        request_id,
+        headers_message(vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]),
+    )
+    .await;
+    loop {
+        if matches!(
+            next_non_query_action(&mut fixture.actions).await,
+            HeaderSyncAction::CommitHeaderRange { .. }
+        ) {
+            break;
+        }
+    }
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::PeerDisconnected(first_peer.clone()))
+        .await
+        .unwrap();
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
+            peer: first_peer,
+            session_id: 0,
+            start_height: start,
+            count,
+            kind: HeaderSyncCommitFailureKind::Local,
+        })
+        .await
+        .unwrap();
+
+    let (retry_peer, _, retry_start, retry_count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(retry_peer, second_peer);
+    assert_eq!((retry_start, retry_count), (start, count));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn partial_full_block_coverage_retires_old_request_and_requests_suffix() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(142);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(2),
+        2,
+        1,
+    )
+    .await;
+    let (_, old_request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((start, count), (block::Height(1), 2));
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::FullBlockCommitted {
+            height: block::Height(1),
+            hash: mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+            header: mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        })
+        .await
+        .unwrap();
+
+    let (_, _, retry_start, retry_count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((retry_start, retry_count), (block::Height(2), 1));
+    send_headers(
+        &fixture,
+        &peer_id,
+        old_request_id,
+        headers_message_from(
+            block::Height(1),
+            vec![
+                mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                mainnet_header(&BLOCK_MAINNET_2_BYTES),
+            ],
+        ),
+    )
+    .await;
+    assert_no_commit_or_misbehavior(&mut fixture.actions).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn buffered_successor_drains_after_full_block_covers_its_predecessor() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(143);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(2),
+        1,
+        2,
+    )
+    .await;
+
+    let mut requests = HashMap::new();
+    while requests.len() < 2 {
+        let (_, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+        assert_eq!(count, 1);
+        requests.insert(start, request_id);
+    }
+    send_headers(
+        &fixture,
+        &peer_id,
+        requests[&block::Height(2)],
+        headers_message_from(
+            block::Height(2),
+            vec![mainnet_header(&BLOCK_MAINNET_2_BYTES)],
+        ),
+    )
+    .await;
+    fixture
+        .handle
+        .send(HeaderSyncEvent::FullBlockCommitted {
+            height: block::Height(1),
+            hash: mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+            header: mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        match next_non_query_action(&mut fixture.actions).await {
+            HeaderSyncAction::CommitHeaderRange {
+                start_height,
+                headers,
+                ..
+            } => {
+                assert_eq!(start_height, block::Height(2));
+                assert_eq!(headers.len(), 1);
+                break;
+            }
+            HeaderSyncAction::Misbehavior { peer, reason } => {
+                panic!("unexpected misbehavior from {peer:?}: {reason:?}")
+            }
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
+    let checkpoint_hash = block::Hash::from(mainnet_header(&BLOCK_MAINNET_3_BYTES).as_ref());
+    let (network, _) = checkpoint_testnet_with_hash(block::Height(3), checkpoint_hash);
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        Some((block::Height(3), checkpoint_hash)),
+    ));
+    let source = peer(200);
+    connect_peer(&fixture, source.clone()).await;
+    advertise_tip(
+        &fixture,
+        source.clone(),
+        block::Height(0),
+        block::Height(4),
+        1,
+        1,
+    )
+    .await;
+    let (_, request_id, _, _) = next_outbound_get_headers(&mut fixture.actions).await;
+
+    for id in 0..128 {
+        connect_peer(&fixture, peer(id)).await;
+    }
+    let violations_before = metric_value("sync.header.peer.violation");
+    fixture
+        .handle
+        .send(HeaderSyncEvent::WireDecodeFailed {
+            peer: peer(0),
+            error: Arc::new(HeaderSyncWireError::TrailingBytes),
+        })
+        .await
+        .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while metric_value("sync.header.peer.violation") == violations_before {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the final action fills the remaining queue slot");
+    assert_eq!(
+        fixture.actions.len(),
+        128,
+        "test must saturate action queue"
+    );
+    let responses_before = metric_value("sync.header.response.received");
+    let unknown_before = metric_value("sync.header.response.unknown_request_id");
+    let response_violations_before = metric_value("sync.header.peer.violation");
+    let commit_full_before = metric_value("sync.header.commit.action_queue_full");
+    send_headers(
+        &fixture,
+        &source,
+        request_id,
+        headers_message(vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]),
+    )
+    .await;
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while metric_value("sync.header.commit.action_queue_full") == commit_full_before {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the reactor reaches commit admission while its action queue is full");
+    assert!(metric_value("sync.header.response.received") > responses_before);
+    assert_eq!(
+        metric_value("sync.header.peer.violation"),
+        response_violations_before,
+        "the test response must reach commit admission"
+    );
+    assert_eq!(
+        metric_value("sync.header.response.unknown_request_id"),
+        unknown_before,
+        "the source request must remain outstanding"
+    );
+    assert_eq!(gauge_value("sync.header.work.buffered.count"), 1.0);
+
+    // Freeing one action slot is the only wakeup. The capacity waiter must
+    // admit the preserved buffer without requiring another peer event.
+    let _ = fixture
+        .actions
+        .recv()
+        .await
+        .expect("status action fills queue");
+    tokio::task::yield_now().await;
+    for _ in 0..129 {
+        if let HeaderSyncAction::CommitHeaderRange {
+            peer,
+            start_height,
+            headers,
+            ..
+        } = next_action(&mut fixture.actions).await
+        {
+            assert_eq!(peer, source);
+            assert_eq!(start_height, block::Height(4));
+            assert_eq!(headers.len(), 1);
+            return;
+        }
+    }
+    panic!("preserved header buffer was not committed after action capacity returned");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn peer_requester_waits_for_outbound_capacity_without_reencoding_or_polling() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(201);
+    let (send, mut recv) = crate::zakura::framed_channel(1);
+    let session = HeaderSyncPeerSession::from_parts_with_direction(
+        peer_id.clone(),
+        ServicePeerDirection::Inbound,
+        send,
+        CancellationToken::new(),
+    );
+    fixture
+        .handle
+        .send(HeaderSyncEvent::PeerConnected(session))
+        .await
+        .unwrap();
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(1),
+        1,
+        1,
+    )
+    .await;
+
+    // The initial Status occupies the only real outbound slot. The requester
+    // owns the range descriptor but must not publish a sent request yet.
+    assert!(tokio::time::timeout(
+        std::time::Duration::from_millis(20),
+        next_outbound_get_headers(&mut fixture.actions),
+    )
+    .await
+    .is_err());
+    let _status_frame = recv.recv().await.expect("initial status frame is queued");
+
+    let (request_peer, _, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(request_peer, peer_id);
+    assert_eq!((start, count), (block::Height(1), 1));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn retry_avoidance_does_not_create_a_permanent_idle_tick() {
+    let mut capture =
+        TraceCapture::for_test("retry_avoidance_does_not_create_a_permanent_idle_tick").unwrap();
+    let network = regtest_network();
+    let mut startup = startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    );
+    startup.trace = ZakuraTrace::new(capture.tracer(), "idle-reactor");
+    let _fixture = spawn_test_reactor(startup);
+    tokio::task::yield_now().await;
+    tokio::time::advance(std::time::Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+
+    capture.flush().await;
+    let reader = capture.reader().unwrap();
+    assert_eq!(
+        reader
+            .table(HEADER_SYNC_TABLE.table())
+            .count(hs_trace::HEADER_MAINTENANCE_WAKEUP),
+        0,
+        "an idle reactor should sleep until real work or maintenance is due"
+    );
+    let _ = capture.finish().await.unwrap();
+}
+
+#[test]
+fn work_queue_transitions_have_one_explicit_owner() {
+    use super::state::{RangePriority, RangeRequest};
+    use super::work_queue::{HeaderWorkQueue, HeaderWorkState};
+
+    let owner = peer(144);
+    let range = RangeRequest {
+        start_height: block::Height(1),
+        count: 2,
+        anchor_hash: Some(block::Hash([1; 32])),
+        finalized: false,
+        want_tree_aux_roots: true,
+        priority: RangePriority::Forward,
+    };
+    let mut queue = HeaderWorkQueue::new();
+    queue.ensure_forward(range);
+    let pending = queue.forward.pop_front().expect("range is pending");
+    queue.mark_assigned(owner.clone(), pending);
+    assert!(matches!(
+        queue.state(range),
+        Some(HeaderWorkState::InFlight { peer }) if peer == &owner
+    ));
+    queue.mark_buffered(owner.clone(), range);
+    assert!(matches!(
+        queue.state(range),
+        Some(HeaderWorkState::Buffered { peer }) if peer == &owner
+    ));
+    queue.mark_committing(owner.clone(), 7, range);
+    assert!(matches!(
+        queue.state(range),
+        Some(HeaderWorkState::Committing { peer, session_id: 7 }) if peer == &owner
+    ));
+    queue.complete(range);
+    assert!(queue.state(range).is_none());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -4,7 +4,10 @@ use super::{
     error::*,
     events::*,
     reactor::*,
-    state::{VctRootRepair, VCT_ROOT_REPAIR_BACKOFFS, VCT_ROOT_REPAIR_MAX_WALL_TIME},
+    state::{
+        OutstandingPhase, OutstandingRange, RangePriority, RangePurpose, RangeRequest,
+        VctRootRepair, VCT_ROOT_REPAIR_BACKOFFS, VCT_ROOT_REPAIR_MAX_WALL_TIME,
+    },
     validation::*,
     wire::*,
 };
@@ -3497,6 +3500,56 @@ fn peer_state_suppresses_redundant_status_until_session_reset() {
 }
 
 #[test]
+fn response_before_publication_completion_is_not_reinstalled() {
+    let (send, _recv) = crate::zakura::framed_channel(1);
+    let session = HeaderSyncPeerSession::from_parts_with_direction(
+        peer(81),
+        ServicePeerDirection::Inbound,
+        send,
+        CancellationToken::new(),
+    );
+    let mut peer_state = super::state::PeerHeaderState::new(
+        session,
+        (block::Height(0), block::Hash([0; 32])),
+        DEFAULT_HS_RANGE,
+        DEFAULT_HS_MAX_INFLIGHT,
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_secs(1),
+    );
+    let request_id = HeaderSyncRequestId::new(1).expect("non-zero request ID");
+    let range = RangeRequest {
+        start_height: block::Height(1),
+        count: 1,
+        anchor_hash: None,
+        finalized: false,
+        want_tree_aux_roots: true,
+        priority: RangePriority::Forward,
+    };
+    peer_state.outstanding.push(OutstandingRange {
+        request_id,
+        range,
+        deadline: Instant::now() + std::time::Duration::from_secs(1),
+        purpose: RangePurpose::Sync,
+        phase: OutstandingPhase::Publishing,
+    });
+
+    let _response = peer_state
+        .remove_outstanding_by_request_id(request_id)
+        .expect("response consumes the publishing request");
+    complete_request_publication(
+        &mut peer_state,
+        request_id,
+        Instant::now() + std::time::Duration::from_secs(2),
+    );
+
+    assert!(
+        peer_state.outstanding.is_empty(),
+        "the later successful completion must not recreate a consumed request"
+    );
+}
+
+#[test]
 fn completed_v7_inbound_request_id_cannot_be_reused() {
     let (send, _recv) = crate::zakura::framed_channel(32);
     let session = HeaderSyncPeerSession::from_parts_with_direction(
@@ -6041,6 +6094,11 @@ async fn peer_requester_waits_for_outbound_capacity_without_reencoding_or_pollin
     )
     .await
     .is_err());
+    assert_eq!(
+        gauge_value("sync.header.work.in_flight.count"),
+        1.0,
+        "the reactor assigns the range before transport publication can complete"
+    );
     let _status_frame = recv.recv().await.expect("initial status frame is queued");
 
     let (request_peer, _, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
@@ -6049,7 +6107,8 @@ async fn peer_requester_waits_for_outbound_capacity_without_reencoding_or_pollin
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn registered_request_times_out_while_waiting_for_outbound_capacity() {
+async fn publishing_request_times_out_while_waiting_for_outbound_capacity() {
+    let metrics = metric_snapshot(&["sync.header.request.publication_timeout"]);
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_with_timeout(
         network.clone(),
@@ -6085,9 +6144,70 @@ async fn registered_request_times_out_while_waiting_for_outbound_capacity() {
         blocked_cancel.cancelled(),
     )
     .await
-    .expect("a registered-but-unsent request cancels its blocked session");
+    .expect("a publishing request cancels its blocked session");
+    assert_metric_incremented(&metrics, "sync.header.request.publication_timeout");
 
     let replacement = peer(206);
+    connect_peer(&fixture, replacement.clone()).await;
+    advertise_tip(
+        &fixture,
+        replacement.clone(),
+        block::Height(0),
+        block::Height(1),
+        1,
+        1,
+    )
+    .await;
+    let (retry_peer, _, retry_start, retry_count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(retry_peer, replacement);
+    assert_eq!((retry_start, retry_count), (block::Height(1), 1));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn transport_closure_retries_work_and_disconnects_requester() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let failed_peer = peer(207);
+    let (send, recv) = crate::zakura::framed_channel(1);
+    let failed_session = HeaderSyncPeerSession::from_parts_with_direction(
+        failed_peer.clone(),
+        ServicePeerDirection::Inbound,
+        send,
+        CancellationToken::new(),
+    );
+    drop(recv);
+    fixture
+        .handle
+        .send(HeaderSyncEvent::PeerConnected(failed_session))
+        .await
+        .unwrap();
+    advertise_tip(
+        &fixture,
+        failed_peer.clone(),
+        block::Height(0),
+        block::Height(1),
+        1,
+        1,
+    )
+    .await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while {
+            let snapshot = fixture.handle.peer_snapshot();
+            snapshot.inbound_peers + snapshot.outbound_peers != 0
+        } {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("closed transport stops its requester and removes the peer");
+
+    let replacement = peer(208);
     connect_peer(&fixture, replacement.clone()).await;
     advertise_tip(
         &fixture,

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -6057,6 +6057,7 @@ async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn peer_requester_waits_for_outbound_capacity_without_reencoding_or_polling() {
+    header_sync_metrics_recorder();
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
         network.clone(),

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -3098,6 +3098,75 @@ async fn matching_headers_are_statelessly_validated_before_commit() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn truncated_finalized_suffix_still_checks_its_checkpoint_hash() {
+    let headers = [
+        mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        mainnet_header(&BLOCK_MAINNET_2_BYTES),
+        mainnet_header(&BLOCK_MAINNET_3_BYTES),
+    ];
+    let (network, _) = checkpoint_testnet_with_hash(block::Height(3), block::Hash([9; 32]));
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(207);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(3),
+        DEFAULT_HS_RANGE,
+        1,
+    )
+    .await;
+    let prefix_id = next_get_headers_request_id(&mut fixture.actions).await;
+    send_headers(
+        &fixture,
+        &peer_id,
+        prefix_id,
+        headers_message(headers[..2].to_vec()),
+    )
+    .await;
+    loop {
+        if matches!(
+            next_non_query_action(&mut fixture.actions).await,
+            HeaderSyncAction::CommitHeaderRange { .. }
+        ) {
+            break;
+        }
+    }
+    let (_, suffix_id, suffix_start, suffix_count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((suffix_start, suffix_count), (block::Height(3), 1));
+    send_headers(
+        &fixture,
+        &peer_id,
+        suffix_id,
+        headers_message_from(block::Height(3), vec![headers[2].clone()]),
+    )
+    .await;
+
+    loop {
+        match next_non_query_action(&mut fixture.actions).await {
+            HeaderSyncAction::Misbehavior {
+                peer,
+                reason: HeaderSyncMisbehavior::InvalidRange,
+            } => {
+                assert_eq!(peer, peer_id);
+                break;
+            }
+            HeaderSyncAction::CommitHeaderRange {
+                start_height: block::Height(3),
+                ..
+            } => panic!("a truncated suffix with the wrong checkpoint hash was committed"),
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn invalid_async_header_commit_failure_reports_peer_disconnect() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
@@ -5331,10 +5400,10 @@ async fn header_sync_metrics_record_status_range_new_block_dedup_and_violation()
 /// so there is no reactor-level unsolicited case to exercise here.
 async fn empty_headers_for_outstanding_range_retries_without_disconnect() {
     let network = regtest_network();
-    let mut fixture = spawn_test_reactor(startup_with_timeout(
+    let mut fixture = spawn_test_reactor(startup_for(
         network.clone(),
         (block::Height(0), network.genesis_hash()),
-        std::time::Duration::from_millis(20),
+        None,
     ));
     let peer_id = peer(9);
 
@@ -5350,6 +5419,24 @@ async fn empty_headers_for_outstanding_range_retries_without_disconnect() {
     .await;
     let request_id = next_get_headers_request_id(&mut fixture.actions).await;
     send_headers(&fixture, &peer_id, request_id, headers_message(Vec::new())).await;
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if matches!(
+                    next_non_query_action(&mut fixture.actions).await,
+                    HeaderSyncAction::SendMessage {
+                        msg: HeaderSyncMessage::GetHeaders { .. },
+                        ..
+                    }
+                ) {
+                    break;
+                }
+            }
+        })
+        .await
+        .is_err(),
+        "empty responses use the one-second retry delay rather than the 50ms peer-avoidance delay"
+    );
     // Periodic keepalive Status sends may interleave with the retry; the
     // property under test is that the range retries without a disconnect.
     loop {
@@ -5520,6 +5607,169 @@ async fn partial_full_block_coverage_retires_old_request_and_requests_suffix() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn partial_coverage_recreates_an_interior_hole_before_a_later_batch() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(202);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(&fixture, peer_id, block::Height(0), block::Height(4), 2, 2).await;
+
+    let mut requests = Vec::new();
+    while requests.len() < 2 {
+        let (_, _, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+        requests.push((start, count));
+    }
+    requests.sort_unstable();
+    assert_eq!(requests, vec![(block::Height(1), 2), (block::Height(3), 2)]);
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::FullBlockCommitted {
+            height: block::Height(1),
+            hash: mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+            header: mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        })
+        .await
+        .unwrap();
+
+    let (_, _, retry_start, retry_count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((retry_start, retry_count), (block::Height(2), 1));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn partial_coverage_trims_and_commits_an_already_buffered_suffix() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(203);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(4),
+        2,
+        2,
+    )
+    .await;
+
+    let mut requests = HashMap::new();
+    while requests.len() < 2 {
+        let (_, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+        assert_eq!(count, 2);
+        requests.insert(start, request_id);
+    }
+    send_headers(
+        &fixture,
+        &peer_id,
+        requests[&block::Height(3)],
+        headers_message_from(
+            block::Height(3),
+            vec![
+                mainnet_header(&BLOCK_MAINNET_3_BYTES),
+                mainnet_header(&BLOCK_MAINNET_4_BYTES),
+            ],
+        ),
+    )
+    .await;
+    fixture
+        .handle
+        .send(HeaderSyncEvent::FullBlockCommitted {
+            height: block::Height(3),
+            hash: mainnet_block(&BLOCK_MAINNET_3_BYTES).hash(),
+            header: mainnet_header(&BLOCK_MAINNET_3_BYTES),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        if let HeaderSyncAction::CommitHeaderRange {
+            start_height,
+            headers,
+            ..
+        } = next_non_query_action(&mut fixture.actions).await
+        {
+            assert_eq!(start_height, block::Height(4));
+            assert_eq!(headers, vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
+            break;
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn partially_covered_failed_commit_requeues_its_uncovered_suffix() {
+    let headers = [
+        mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        mainnet_header(&BLOCK_MAINNET_2_BYTES),
+        mainnet_header(&BLOCK_MAINNET_3_BYTES),
+    ];
+    let checkpoint_hash = block::Hash::from(headers[2].as_ref());
+    let (network, _) = checkpoint_testnet_with_hash(block::Height(3), checkpoint_hash);
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(204);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(3),
+        3,
+        1,
+    )
+    .await;
+    let (_, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+    send_headers(
+        &fixture,
+        &peer_id,
+        request_id,
+        finalized_headers_message(headers.to_vec()),
+    )
+    .await;
+    loop {
+        if matches!(
+            next_non_query_action(&mut fixture.actions).await,
+            HeaderSyncAction::CommitHeaderRange { .. }
+        ) {
+            break;
+        }
+    }
+    fixture
+        .handle
+        .send(HeaderSyncEvent::FullBlockCommitted {
+            height: block::Height(1),
+            hash: mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+            header: mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        })
+        .await
+        .unwrap();
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
+            peer: peer_id,
+            session_id: 0,
+            start_height: start,
+            count,
+            kind: HeaderSyncCommitFailureKind::Local,
+        })
+        .await
+        .unwrap();
+
+    let (_, _, retry_start, retry_count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((retry_start, retry_count), (block::Height(2), 2));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn buffered_successor_drains_after_full_block_covers_its_predecessor() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
@@ -5585,6 +5835,94 @@ async fn buffered_successor_drains_after_full_block_covers_its_predecessor() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn ordered_drain_rejects_a_buffered_range_on_the_wrong_fork() {
+    let checkpoint_hash = block::Hash::from(mainnet_header(&BLOCK_MAINNET_3_BYTES).as_ref());
+    let (network, _) = checkpoint_testnet_with_hash(block::Height(3), checkpoint_hash);
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(208);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(3),
+        1,
+        2,
+    )
+    .await;
+    let mut requests = HashMap::new();
+    while requests.len() < 2 {
+        let (_, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+        assert_eq!(count, 1);
+        requests.insert(start, request_id);
+    }
+
+    // Block 3 is internally/statelessly valid and has no wire-time anchor for
+    // the height-2 batch, but it does not follow the eventual height-1 block.
+    send_headers(
+        &fixture,
+        &peer_id,
+        requests[&block::Height(2)],
+        headers_message_from(
+            block::Height(2),
+            vec![mainnet_header(&BLOCK_MAINNET_3_BYTES)],
+        ),
+    )
+    .await;
+    send_headers(
+        &fixture,
+        &peer_id,
+        requests[&block::Height(1)],
+        headers_message_from(
+            block::Height(1),
+            vec![mainnet_header(&BLOCK_MAINNET_1_BYTES)],
+        ),
+    )
+    .await;
+    loop {
+        if matches!(
+            next_non_query_action(&mut fixture.actions).await,
+            HeaderSyncAction::CommitHeaderRange {
+                start_height: block::Height(1),
+                ..
+            }
+        ) {
+            break;
+        }
+    }
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeCommitted {
+            start_height: block::Height(1),
+            tip_height: block::Height(1),
+            tip_hash: block::Hash::from(mainnet_header(&BLOCK_MAINNET_1_BYTES).as_ref()),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        match next_non_query_action(&mut fixture.actions).await {
+            HeaderSyncAction::Misbehavior {
+                peer,
+                reason: HeaderSyncMisbehavior::InvalidRange,
+            } => {
+                assert_eq!(peer, peer_id);
+                break;
+            }
+            HeaderSyncAction::CommitHeaderRange {
+                start_height: block::Height(2),
+                ..
+            } => panic!("ordered drain committed a buffered range on the wrong fork"),
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
     let checkpoint_hash = block::Hash::from(mainnet_header(&BLOCK_MAINNET_3_BYTES).as_ref());
     let (network, _) = checkpoint_testnet_with_hash(block::Height(3), checkpoint_hash);
@@ -5609,31 +5947,18 @@ async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
     for id in 0..128 {
         connect_peer(&fixture, peer(id)).await;
     }
-    let violations_before = metric_value("sync.header.peer.violation");
-    fixture
-        .handle
-        .send(HeaderSyncEvent::WireDecodeFailed {
-            peer: peer(0),
-            error: Arc::new(HeaderSyncWireError::TrailingBytes),
-        })
-        .await
-        .unwrap();
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
-        while metric_value("sync.header.peer.violation") == violations_before {
+        while fixture.actions.len() < 128 {
             tokio::task::yield_now().await;
         }
     })
     .await
-    .expect("the final action fills the remaining queue slot");
+    .expect("peer status actions fill the action queue");
     assert_eq!(
         fixture.actions.len(),
         128,
         "test must saturate action queue"
     );
-    let responses_before = metric_value("sync.header.response.received");
-    let unknown_before = metric_value("sync.header.response.unknown_request_id");
-    let response_violations_before = metric_value("sync.header.peer.violation");
-    let commit_full_before = metric_value("sync.header.commit.action_queue_full");
     send_headers(
         &fixture,
         &source,
@@ -5642,24 +5967,14 @@ async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
     )
     .await;
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
-        while metric_value("sync.header.commit.action_queue_full") == commit_full_before {
+        while gauge_value("sync.header.work.buffered.count") != 1.0 {
             tokio::task::yield_now().await;
         }
     })
     .await
     .expect("the reactor reaches commit admission while its action queue is full");
-    assert!(metric_value("sync.header.response.received") > responses_before);
-    assert_eq!(
-        metric_value("sync.header.peer.violation"),
-        response_violations_before,
-        "the test response must reach commit admission"
-    );
-    assert_eq!(
-        metric_value("sync.header.response.unknown_request_id"),
-        unknown_before,
-        "the source request must remain outstanding"
-    );
     assert_eq!(gauge_value("sync.header.work.buffered.count"), 1.0);
+    assert_eq!(fixture.actions.len(), 128, "commit admission stays blocked");
 
     // Freeing one action slot is the only wakeup. The capacity waiter must
     // admit the preserved buffer without requiring another peer event.
@@ -5680,6 +5995,7 @@ async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
             assert_eq!(peer, source);
             assert_eq!(start_height, block::Height(4));
             assert_eq!(headers.len(), 1);
+            assert_no_commit_or_misbehavior(&mut fixture.actions).await;
             return;
         }
     }
@@ -5732,10 +6048,67 @@ async fn peer_requester_waits_for_outbound_capacity_without_reencoding_or_pollin
     assert_eq!((start, count), (block::Height(1), 1));
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn registered_request_times_out_while_waiting_for_outbound_capacity() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_with_timeout(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        std::time::Duration::from_millis(50),
+    ));
+    let blocked_peer = peer(205);
+    let (send, _recv) = crate::zakura::framed_channel(1);
+    let blocked_cancel = CancellationToken::new();
+    let session = HeaderSyncPeerSession::from_parts_with_direction(
+        blocked_peer.clone(),
+        ServicePeerDirection::Inbound,
+        send,
+        blocked_cancel.clone(),
+    );
+    fixture
+        .handle
+        .send(HeaderSyncEvent::PeerConnected(session))
+        .await
+        .unwrap();
+    advertise_tip(
+        &fixture,
+        blocked_peer,
+        block::Height(0),
+        block::Height(1),
+        1,
+        1,
+    )
+    .await;
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        blocked_cancel.cancelled(),
+    )
+    .await
+    .expect("a registered-but-unsent request cancels its blocked session");
+
+    let replacement = peer(206);
+    connect_peer(&fixture, replacement.clone()).await;
+    advertise_tip(
+        &fixture,
+        replacement.clone(),
+        block::Height(0),
+        block::Height(1),
+        1,
+        1,
+    )
+    .await;
+    let (retry_peer, _, retry_start, retry_count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(retry_peer, replacement);
+    assert_eq!((retry_start, retry_count), (block::Height(1), 1));
+}
+
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn retry_avoidance_does_not_create_a_permanent_idle_tick() {
+async fn idle_reactor_does_not_create_a_permanent_maintenance_tick() {
     let mut capture =
-        TraceCapture::for_test("retry_avoidance_does_not_create_a_permanent_idle_tick").unwrap();
+        TraceCapture::for_test("idle_reactor_does_not_create_a_permanent_maintenance_tick")
+            .unwrap();
     let network = regtest_network();
     let mut startup = startup_for(
         network.clone(),
@@ -6082,6 +6455,10 @@ async fn truncated_finalized_backfill_commits_valid_prefix_and_requeues_suffix()
         }
         action => panic!("unexpected action: {action:?}"),
     }
+    let (suffix_peer, _, suffix_start, suffix_count) =
+        next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(suffix_peer, peer_id);
+    assert_eq!((suffix_start, suffix_count), (block::Height(3), 1));
     assert_no_commit_or_misbehavior(&mut fixture.actions).await;
 }
 

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -3609,9 +3609,11 @@ async fn reconnect_resends_initial_status_after_session_reset() {
     ));
 }
 
-#[tokio::test(flavor = "current_thread")]
-async fn retries_initial_status_after_full_outbound_queue() {
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn failed_status_publication_is_retry_paced() {
+    header_sync_metrics_recorder();
     let send_failed_before = metric_value("sync.header.peer.status.send_failed");
+    let mut capture = TraceCapture::for_test("failed_status_publication_is_retry_paced").unwrap();
     let network = regtest_network();
     let mut startup = startup_for(
         network.clone(),
@@ -3620,7 +3622,8 @@ async fn retries_initial_status_after_full_outbound_queue() {
     );
     startup.range_state_actions_enabled = false;
     startup.request_timeout = std::time::Duration::from_millis(10);
-    startup.status_refresh_interval = std::time::Duration::from_millis(10);
+    startup.status_refresh_interval = std::time::Duration::from_secs(10);
+    startup.trace = ZakuraTrace::new(capture.tracer(), "status-publication-retry");
     let fixture = spawn_test_reactor(startup);
     let peer_id = peer(74);
     let (send, mut recv) = crate::zakura::framed_channel(1);
@@ -3654,7 +3657,22 @@ async fn retries_initial_status_after_full_outbound_queue() {
     .await
     .expect("peer is admitted while outbound queue is full");
 
+    for _ in 0..3 {
+        tokio::task::yield_now().await;
+    }
+    capture.flush().await;
+    assert!(
+        capture
+            .reader()
+            .unwrap()
+            .table(HEADER_SYNC_TABLE.table())
+            .count(hs_trace::HEADER_MAINTENANCE_WAKEUP)
+            <= 1,
+        "a failed status publication must not make maintenance spin"
+    );
+
     let _ = recv.recv().await.expect("filler frame drains");
+    tokio::time::advance(STATUS_PUBLICATION_RETRY_DELAY).await;
     let frame = tokio::time::timeout(std::time::Duration::from_secs(1), recv.recv())
         .await
         .expect("status retry arrives")
@@ -3669,6 +3687,7 @@ async fn retries_initial_status_after_full_outbound_queue() {
         metric_value("sync.header.peer.status.send_failed") > send_failed_before,
         "a full outbound queue must increment the header-sync Status send-failure counter"
     );
+    let _ = capture.finish().await.unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/zakura-network/src/zakura/header_sync/validation.rs
+++ b/zakura-network/src/zakura/header_sync/validation.rs
@@ -19,12 +19,20 @@ pub(super) fn next_height(height: block::Height) -> Option<block::Height> {
     height.0.checked_add(1).map(block::Height)
 }
 
+#[cfg(test)]
 pub(super) fn previous_height(height: block::Height) -> Option<block::Height> {
     height.0.checked_sub(1).map(block::Height)
 }
 
 pub(super) fn height_after_count(start: block::Height, count: u32) -> Option<block::Height> {
     start.0.checked_add(count).map(block::Height)
+}
+
+pub(super) fn range_end_height(start: block::Height, count: u32) -> Option<block::Height> {
+    count
+        .checked_sub(1)
+        .and_then(|offset| start.0.checked_add(offset))
+        .map(block::Height)
 }
 
 pub(super) fn count_between(start: block::Height, end: block::Height) -> u32 {

--- a/zakura-network/src/zakura/header_sync/wire.rs
+++ b/zakura-network/src/zakura/header_sync/wire.rs
@@ -48,6 +48,7 @@ pub(super) const REGTEST_HEADER_BYTES: usize = 177;
 pub(super) const LOCAL_MAX_HS_INFLIGHT_PER_PEER: u16 = 16;
 pub(super) const HEADER_SYNC_MAX_RESIDENT_BATCHES: u32 = 16;
 pub(super) const HEADER_SYNC_RETRY_AVOIDANCE: Duration = Duration::from_millis(50);
+pub(super) const STATUS_PUBLICATION_RETRY_DELAY: Duration = Duration::from_millis(50);
 pub(super) const HEADER_SYNC_SEEN_HASH_CAPACITY: usize = 4096;
 pub(super) const DEFAULT_HS_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 pub(super) const EMPTY_HEADERS_RETRY_DELAY: Duration = Duration::from_secs(1);

--- a/zakura-network/src/zakura/header_sync/wire.rs
+++ b/zakura-network/src/zakura/header_sync/wire.rs
@@ -45,8 +45,9 @@ pub(super) const HEADER_SYNC_BLOCK_COMMITMENT_ROOTS_BYTES: usize =
     4 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
 pub(super) const COMMON_HEADER_BYTES: usize = 1_487;
 pub(super) const REGTEST_HEADER_BYTES: usize = 177;
-pub(super) const HEADER_SYNC_FANOUT: usize = 3;
 pub(super) const LOCAL_MAX_HS_INFLIGHT_PER_PEER: u16 = 16;
+pub(super) const HEADER_SYNC_MAX_RESIDENT_BATCHES: u32 = 16;
+pub(super) const HEADER_SYNC_RETRY_AVOIDANCE: Duration = Duration::from_millis(50);
 pub(super) const HEADER_SYNC_SEEN_HASH_CAPACITY: usize = 4096;
 pub(super) const DEFAULT_HS_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 pub(super) const EMPTY_HEADERS_RETRY_DELAY: Duration = Duration::from_secs(1);

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -28,8 +28,16 @@ impl HeaderHashDedup {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(super) struct PendingCommitKey {
     pub(super) peer: ZakuraPeerId,
+    pub(super) session_id: u64,
     pub(super) start_height: block::Height,
     pub(super) count: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum HeaderWorkState {
+    InFlight { peer: ZakuraPeerId },
+    Buffered { peer: ZakuraPeerId },
+    Committing { peer: ZakuraPeerId, session_id: u64 },
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -42,8 +50,11 @@ pub(super) struct CoveredRange {
 pub(super) struct HeaderWorkQueue {
     pub(super) forward: VecDeque<RangeRequest>,
     pub(super) backward: VecDeque<RangeRequest>,
-    pub(super) assigned: HashMap<RangeRequest, ZakuraPeerId>,
-    pub(super) retry_avoidance: HashMap<(ZakuraPeerId, block::Height, RangePriority), Instant>,
+    pub(super) active: HashMap<RangeRequest, HeaderWorkState>,
+    pending_starts: HashSet<(RangePriority, block::Height)>,
+    active_starts: HashSet<(RangePriority, block::Height)>,
+    pub(super) retry_avoidance:
+        HashMap<ZakuraPeerId, HashMap<(block::Height, RangePriority), Instant>>,
     pub(super) covered: Vec<CoveredRange>,
     pub(super) epoch: u64,
     pub(super) oldest_missing_since: Option<Instant>,
@@ -54,7 +65,9 @@ impl HeaderWorkQueue {
         Self {
             forward: VecDeque::new(),
             backward: VecDeque::new(),
-            assigned: HashMap::new(),
+            active: HashMap::new(),
+            pending_starts: HashSet::new(),
+            active_starts: HashSet::new(),
             retry_avoidance: HashMap::new(),
             covered: Vec::new(),
             epoch: 0,
@@ -72,10 +85,10 @@ impl HeaderWorkQueue {
 
     pub(super) fn ensure(&mut self, range: RangeRequest, priority: RangePriority) {
         if self.is_covered(range)
-            || self.assigned.contains_key(&range)
-            || self.assigned.keys().any(|assigned| {
-                assigned.start_height == range.start_height && assigned.priority == priority
-            })
+            || self.active_starts.contains(&(priority, range.start_height))
+            || self
+                .pending_starts
+                .contains(&(priority, range.start_height))
         {
             return;
         }
@@ -84,15 +97,10 @@ impl HeaderWorkQueue {
             RangePriority::Backward => &mut self.backward,
             RangePriority::Repair => return,
         };
-        if !queue.contains(&range)
-            && !queue.iter().any(|queued| {
-                queued.start_height == range.start_height && queued.priority == priority
-            })
-        {
-            queue.push_back(range);
-            self.oldest_missing_since.get_or_insert_with(Instant::now);
-            metrics::counter!("sync.header.work.added", "lane" => priority.label()).increment(1);
-        }
+        queue.push_back(range);
+        self.pending_starts.insert((priority, range.start_height));
+        self.oldest_missing_since.get_or_insert_with(Instant::now);
+        metrics::counter!("sync.header.work.added", "lane" => priority.label()).increment(1);
     }
 
     pub(super) fn next_for_peer(
@@ -101,23 +109,31 @@ impl HeaderWorkQueue {
         peer: &PeerHeaderState,
     ) -> Option<RangeRequest> {
         let now = Instant::now();
-        self.retry_avoidance.retain(|_, until| *until > now);
-        Self::pop_assignable(&mut self.forward, &self.retry_avoidance, peer_id, peer, now).or_else(
-            || {
-                Self::pop_assignable(
-                    &mut self.backward,
-                    &self.retry_avoidance,
-                    peer_id,
-                    peer,
-                    now,
-                )
-            },
-        )
+        self.retry_avoidance.retain(|_, ranges| {
+            ranges.retain(|_, until| *until > now);
+            !ranges.is_empty()
+        });
+        let range =
+            Self::pop_assignable(&mut self.forward, &self.retry_avoidance, peer_id, peer, now)
+                .or_else(|| {
+                    Self::pop_assignable(
+                        &mut self.backward,
+                        &self.retry_avoidance,
+                        peer_id,
+                        peer,
+                        now,
+                    )
+                });
+        if let Some(range) = range {
+            self.pending_starts
+                .remove(&(range.priority, range.start_height));
+        }
+        range
     }
 
     pub(super) fn pop_assignable(
         queue: &mut VecDeque<RangeRequest>,
-        retry_avoidance: &HashMap<(ZakuraPeerId, block::Height, RangePriority), Instant>,
+        retry_avoidance: &HashMap<ZakuraPeerId, HashMap<(block::Height, RangePriority), Instant>>,
         peer_id: &ZakuraPeerId,
         peer: &PeerHeaderState,
         now: Instant,
@@ -125,15 +141,50 @@ impl HeaderWorkQueue {
         let index = queue.iter().position(|range| {
             range.end_height() <= peer.advertised_tip
                 && retry_avoidance
-                    .get(&(peer_id.clone(), range.start_height, range.priority))
+                    .get(peer_id)
+                    .and_then(|ranges| ranges.get(&(range.start_height, range.priority)))
                     .is_none_or(|until| *until <= now)
         })?;
         queue.remove(index)
     }
 
     pub(super) fn mark_assigned(&mut self, peer: ZakuraPeerId, range: RangeRequest) {
-        self.assigned.insert(range, peer);
+        let previous = self
+            .active
+            .insert(range, HeaderWorkState::InFlight { peer });
+        self.active_starts
+            .insert((range.priority, range.start_height));
+        debug_assert!(previous.is_none(), "pending work has no active owner");
         metrics::counter!("sync.header.work.taken", "lane" => range.priority.label()).increment(1);
+    }
+
+    pub(super) fn mark_buffered(&mut self, peer: ZakuraPeerId, range: RangeRequest) {
+        let previous = self
+            .active
+            .insert(range, HeaderWorkState::Buffered { peer: peer.clone() });
+        debug_assert!(
+            matches!(previous, Some(HeaderWorkState::InFlight { peer: owner }) if owner == peer),
+            "only the wire owner can buffer active header work"
+        );
+    }
+
+    pub(super) fn mark_committing(
+        &mut self,
+        peer: ZakuraPeerId,
+        session_id: u64,
+        range: RangeRequest,
+    ) {
+        let previous = self.active.insert(
+            range,
+            HeaderWorkState::Committing {
+                peer: peer.clone(),
+                session_id,
+            },
+        );
+        debug_assert!(
+            matches!(previous, Some(HeaderWorkState::Buffered { peer: owner }) if owner == peer),
+            "only buffered header work can enter state commit"
+        );
     }
 
     pub(super) fn narrow_queued_range(&mut self, original: RangeRequest, narrowed: RangeRequest) {
@@ -141,13 +192,19 @@ impl HeaderWorkQueue {
             return;
         }
 
-        if let Some(peer) = self.assigned.remove(&original) {
-            self.assigned.insert(narrowed, peer);
+        if let Some(state) = self.active.remove(&original) {
+            self.active_starts
+                .remove(&(original.priority, original.start_height));
+            self.active_starts
+                .insert((narrowed.priority, narrowed.start_height));
+            self.active.insert(narrowed, state);
         }
     }
 
     pub(super) fn retry(&mut self, range: RangeRequest) {
-        self.assigned.remove(&range);
+        self.active.remove(&range);
+        self.active_starts
+            .remove(&(range.priority, range.start_height));
         if self.is_covered(range) {
             return;
         }
@@ -156,9 +213,10 @@ impl HeaderWorkQueue {
             RangePriority::Backward => &mut self.backward,
             RangePriority::Repair => return,
         };
-        if !queue.iter().any(|queued| {
-            queued.start_height == range.start_height && queued.priority == range.priority
-        }) {
+        if self
+            .pending_starts
+            .insert((range.priority, range.start_height))
+        {
             queue.push_front(range);
         }
         metrics::counter!("sync.header.work.returned", "lane" => range.priority.label())
@@ -166,8 +224,8 @@ impl HeaderWorkQueue {
     }
 
     pub(super) fn retry_avoiding(&mut self, peer: ZakuraPeerId, range: RangeRequest) {
-        self.retry_avoidance.insert(
-            (peer, range.start_height, range.priority),
+        self.retry_avoidance.entry(peer).or_default().insert(
+            (range.start_height, range.priority),
             Instant::now() + HEADER_SYNC_RETRY_AVOIDANCE,
         );
         self.retry(range);
@@ -175,26 +233,46 @@ impl HeaderWorkQueue {
 
     pub(super) fn forget_peer(&mut self, peer: &ZakuraPeerId) {
         let ranges: Vec<_> = self
-            .assigned
+            .active
             .iter()
-            .filter_map(|(range, owner)| (owner == peer).then_some(*range))
+            .filter_map(|(range, state)| {
+                matches!(state, HeaderWorkState::InFlight { peer: owner } if owner == peer)
+                    .then_some(*range)
+            })
             .collect();
         for range in ranges {
             self.retry(range);
         }
-        self.retry_avoidance
-            .retain(|(avoided_peer, _, _), _| avoided_peer != peer);
+        self.retry_avoidance.remove(peer);
     }
 
     pub(super) fn clear_assignment(&mut self, range: RangeRequest) {
-        self.assigned.remove(&range);
+        self.active.remove(&range);
+        self.active_starts
+            .remove(&(range.priority, range.start_height));
+    }
+
+    pub(super) fn complete(&mut self, range: RangeRequest) {
+        let previous = self.active.remove(&range);
+        self.active_starts
+            .remove(&(range.priority, range.start_height));
+        debug_assert!(
+            matches!(previous, Some(HeaderWorkState::Committing { .. })) || previous.is_none(),
+            "only committing or externally covered work can complete"
+        );
+    }
+
+    pub(super) fn drop_pending_forward_through(&mut self, height: block::Height) {
+        self.forward.retain(|range| range.start_height > height);
+        self.rebuild_start_indexes();
     }
 
     pub(super) fn clear_forward(&mut self) {
         self.epoch = self.epoch.wrapping_add(1);
         self.forward.clear();
-        self.assigned
+        self.active
             .retain(|range, _| range.priority != RangePriority::Forward);
+        self.rebuild_start_indexes();
         metrics::counter!("sync.header.work.reset").increment(1);
     }
 
@@ -255,8 +333,11 @@ impl HeaderWorkQueue {
         };
         self.forward.retain(|range| !is_covered(range));
         self.backward.retain(|range| !is_covered(range));
-        self.assigned.retain(|range, _| !is_covered(range));
-        if self.forward.is_empty() && self.backward.is_empty() && self.assigned.is_empty() {
+        self.active.retain(|range, state| {
+            matches!(state, HeaderWorkState::Committing { .. }) || !is_covered(range)
+        });
+        self.rebuild_start_indexes();
+        if self.forward.is_empty() && self.backward.is_empty() && self.active.is_empty() {
             self.oldest_missing_since = None;
         }
     }
@@ -269,7 +350,7 @@ impl HeaderWorkQueue {
         self.forward
             .iter()
             .chain(&self.backward)
-            .chain(self.assigned.keys())
+            .chain(self.active.keys())
             .map(|range| u64::from(range.count))
             .sum()
     }
@@ -278,10 +359,79 @@ impl HeaderWorkQueue {
         self.forward
             .iter()
             .chain(&self.backward)
-            .chain(self.assigned.keys())
+            .chain(self.active.keys())
             .filter(|range| range.priority == priority)
             .map(|range| range.end_height())
             .max()
+    }
+
+    pub(super) fn next_retry_deadline(&self) -> Option<Instant> {
+        self.retry_avoidance
+            .values()
+            .flat_map(HashMap::values)
+            .copied()
+            .min()
+    }
+
+    pub(super) fn has_pending(&self) -> bool {
+        !self.forward.is_empty() || !self.backward.is_empty()
+    }
+
+    pub(super) fn peer_retry_avoided(
+        &self,
+        peer: &ZakuraPeerId,
+        advertised_tip: block::Height,
+    ) -> bool {
+        let Some(avoided) = self.retry_avoidance.get(peer) else {
+            return false;
+        };
+        self.forward.iter().chain(&self.backward).any(|range| {
+            range.end_height() <= advertised_tip
+                && avoided
+                    .get(&(range.start_height, range.priority))
+                    .is_some_and(|until| *until > Instant::now())
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn state(&self, range: RangeRequest) -> Option<&HeaderWorkState> {
+        self.active.get(&range)
+    }
+
+    pub(super) fn active_counts(&self) -> (usize, usize, usize) {
+        self.active.values().fold((0, 0, 0), |mut counts, state| {
+            match state {
+                HeaderWorkState::InFlight { .. } => counts.0 += 1,
+                HeaderWorkState::Buffered { .. } => counts.1 += 1,
+                HeaderWorkState::Committing { .. } => counts.2 += 1,
+            }
+            counts
+        })
+    }
+
+    pub(super) fn oldest_missing_height(&self) -> Option<block::Height> {
+        self.forward
+            .iter()
+            .chain(&self.backward)
+            .chain(self.active.keys())
+            .map(|range| range.start_height)
+            .min()
+    }
+
+    fn rebuild_start_indexes(&mut self) {
+        self.pending_starts.clear();
+        self.pending_starts.extend(
+            self.forward
+                .iter()
+                .chain(&self.backward)
+                .map(|range| (range.priority, range.start_height)),
+        );
+        self.active_starts.clear();
+        self.active_starts.extend(
+            self.active
+                .keys()
+                .map(|range| (range.priority, range.start_height)),
+        );
     }
 }
 

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -39,20 +39,26 @@ pub(super) struct CoveredRange {
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct RangeScheduler {
+pub(super) struct HeaderWorkQueue {
     pub(super) forward: VecDeque<RangeRequest>,
     pub(super) backward: VecDeque<RangeRequest>,
-    pub(super) assigned: HashMap<RangeRequest, HashSet<ZakuraPeerId>>,
+    pub(super) assigned: HashMap<RangeRequest, ZakuraPeerId>,
+    pub(super) retry_avoidance: HashMap<(ZakuraPeerId, block::Height, RangePriority), Instant>,
     pub(super) covered: Vec<CoveredRange>,
+    pub(super) epoch: u64,
+    pub(super) oldest_missing_since: Option<Instant>,
 }
 
-impl RangeScheduler {
+impl HeaderWorkQueue {
     pub(super) fn new() -> Self {
         Self {
             forward: VecDeque::new(),
             backward: VecDeque::new(),
             assigned: HashMap::new(),
+            retry_avoidance: HashMap::new(),
             covered: Vec::new(),
+            epoch: 0,
+            oldest_missing_since: None,
         }
     }
 
@@ -84,6 +90,8 @@ impl RangeScheduler {
             })
         {
             queue.push_back(range);
+            self.oldest_missing_since.get_or_insert_with(Instant::now);
+            metrics::counter!("sync.header.work.added", "lane" => priority.label()).increment(1);
         }
     }
 
@@ -92,34 +100,40 @@ impl RangeScheduler {
         peer_id: &ZakuraPeerId,
         peer: &PeerHeaderState,
     ) -> Option<RangeRequest> {
-        Self::pop_assignable(&mut self.forward, &self.assigned, peer_id, peer)
-            .or_else(|| Self::pop_assignable(&mut self.backward, &self.assigned, peer_id, peer))
+        let now = Instant::now();
+        self.retry_avoidance.retain(|_, until| *until > now);
+        Self::pop_assignable(&mut self.forward, &self.retry_avoidance, peer_id, peer, now).or_else(
+            || {
+                Self::pop_assignable(
+                    &mut self.backward,
+                    &self.retry_avoidance,
+                    peer_id,
+                    peer,
+                    now,
+                )
+            },
+        )
     }
 
     pub(super) fn pop_assignable(
         queue: &mut VecDeque<RangeRequest>,
-        assigned: &HashMap<RangeRequest, HashSet<ZakuraPeerId>>,
+        retry_avoidance: &HashMap<(ZakuraPeerId, block::Height, RangePriority), Instant>,
         peer_id: &ZakuraPeerId,
         peer: &PeerHeaderState,
+        now: Instant,
     ) -> Option<RangeRequest> {
         let index = queue.iter().position(|range| {
             range.end_height() <= peer.advertised_tip
-                && assigned.get(range).is_none_or(|peers| {
-                    peers.len() < HEADER_SYNC_FANOUT && !peers.contains(peer_id)
-                })
+                && retry_avoidance
+                    .get(&(peer_id.clone(), range.start_height, range.priority))
+                    .is_none_or(|until| *until <= now)
         })?;
-        let range = queue[index];
-        if assigned
-            .get(&range)
-            .is_some_and(|peers| peers.len() + 1 >= HEADER_SYNC_FANOUT)
-        {
-            queue.remove(index);
-        }
-        Some(range)
+        queue.remove(index)
     }
 
     pub(super) fn mark_assigned(&mut self, peer: ZakuraPeerId, range: RangeRequest) {
-        self.assigned.entry(range).or_default().insert(peer);
+        self.assigned.insert(range, peer);
+        metrics::counter!("sync.header.work.taken", "lane" => range.priority.label()).increment(1);
     }
 
     pub(super) fn narrow_queued_range(&mut self, original: RangeRequest, narrowed: RangeRequest) {
@@ -127,38 +141,49 @@ impl RangeScheduler {
             return;
         }
 
-        let queue = match original.priority {
-            RangePriority::Forward => &mut self.forward,
-            RangePriority::Backward => &mut self.backward,
-            RangePriority::Repair => return,
-        };
-        for queued in queue {
-            if *queued == original {
-                *queued = narrowed;
-                break;
-            }
-        }
-        if let Some(peers) = self.assigned.remove(&original) {
-            self.assigned.entry(narrowed).or_default().extend(peers);
+        if let Some(peer) = self.assigned.remove(&original) {
+            self.assigned.insert(narrowed, peer);
         }
     }
 
     pub(super) fn retry(&mut self, range: RangeRequest) {
+        self.assigned.remove(&range);
         if self.is_covered(range) {
             return;
         }
-        match range.priority {
-            RangePriority::Forward => self.forward.push_front(range),
-            RangePriority::Backward => self.backward.push_front(range),
-            RangePriority::Repair => {}
+        let queue = match range.priority {
+            RangePriority::Forward => &mut self.forward,
+            RangePriority::Backward => &mut self.backward,
+            RangePriority::Repair => return,
+        };
+        if !queue.iter().any(|queued| {
+            queued.start_height == range.start_height && queued.priority == range.priority
+        }) {
+            queue.push_front(range);
         }
+        metrics::counter!("sync.header.work.returned", "lane" => range.priority.label())
+            .increment(1);
+    }
+
+    pub(super) fn retry_avoiding(&mut self, peer: ZakuraPeerId, range: RangeRequest) {
+        self.retry_avoidance.insert(
+            (peer, range.start_height, range.priority),
+            Instant::now() + HEADER_SYNC_RETRY_AVOIDANCE,
+        );
+        self.retry(range);
     }
 
     pub(super) fn forget_peer(&mut self, peer: &ZakuraPeerId) {
-        for peers in self.assigned.values_mut() {
-            peers.remove(peer);
+        let ranges: Vec<_> = self
+            .assigned
+            .iter()
+            .filter_map(|(range, owner)| (owner == peer).then_some(*range))
+            .collect();
+        for range in ranges {
+            self.retry(range);
         }
-        self.assigned.retain(|_, peers| !peers.is_empty());
+        self.retry_avoidance
+            .retain(|(avoided_peer, _, _), _| avoided_peer != peer);
     }
 
     pub(super) fn clear_assignment(&mut self, range: RangeRequest) {
@@ -166,9 +191,11 @@ impl RangeScheduler {
     }
 
     pub(super) fn clear_forward(&mut self) {
+        self.epoch = self.epoch.wrapping_add(1);
         self.forward.clear();
         self.assigned
             .retain(|range, _| range.priority != RangePriority::Forward);
+        metrics::counter!("sync.header.work.reset").increment(1);
     }
 
     pub(super) fn mark_height_covered(&mut self, height: block::Height) {
@@ -229,6 +256,32 @@ impl RangeScheduler {
         self.forward.retain(|range| !is_covered(range));
         self.backward.retain(|range| !is_covered(range));
         self.assigned.retain(|range, _| !is_covered(range));
+        if self.forward.is_empty() && self.backward.is_empty() && self.assigned.is_empty() {
+            self.oldest_missing_since = None;
+        }
+    }
+
+    pub(super) fn pending_len(&self) -> usize {
+        self.forward.len().saturating_add(self.backward.len())
+    }
+
+    pub(super) fn resident_heights(&self) -> u64 {
+        self.forward
+            .iter()
+            .chain(&self.backward)
+            .chain(self.assigned.keys())
+            .map(|range| u64::from(range.count))
+            .sum()
+    }
+
+    pub(super) fn highest_end(&self, priority: RangePriority) -> Option<block::Height> {
+        self.forward
+            .iter()
+            .chain(&self.backward)
+            .chain(self.assigned.keys())
+            .filter(|range| range.priority == priority)
+            .map(|range| range.end_height())
+            .max()
     }
 }
 

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -465,3 +465,212 @@ impl RateMeter {
         self.next_allowed = now + self.interval;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zakura::ServicePeerDirection;
+
+    fn peer(byte: u8) -> ZakuraPeerId {
+        ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
+    }
+
+    fn range(start: u32, count: u32, priority: RangePriority) -> RangeRequest {
+        RangeRequest {
+            start_height: block::Height(start),
+            count,
+            anchor_hash: None,
+            finalized: false,
+            want_tree_aux_roots: true,
+            priority,
+        }
+    }
+
+    fn peer_state(byte: u8, advertised_tip: u32) -> (ZakuraPeerId, PeerHeaderState) {
+        let peer = peer(byte);
+        let (send, _recv) = crate::zakura::framed_channel(1);
+        let session = HeaderSyncPeerSession::from_parts_with_direction(
+            peer.clone(),
+            ServicePeerDirection::Inbound,
+            send,
+            CancellationToken::new(),
+        );
+        let interval = Duration::from_secs(1);
+        let mut state = PeerHeaderState::new(
+            session,
+            (block::Height(0), block::Hash([0; 32])),
+            DEFAULT_HS_RANGE,
+            DEFAULT_HS_MAX_INFLIGHT,
+            interval,
+            interval,
+            interval,
+        );
+        state.advertised_tip = block::Height(advertised_tip);
+        (peer, state)
+    }
+
+    #[test]
+    fn pending_and_active_ranges_are_deduplicated() {
+        let mut queue = HeaderWorkQueue::new();
+        let range = range(1, 2, RangePriority::Forward);
+        let (peer, state) = peer_state(1, 10);
+
+        queue.ensure_forward(range);
+        queue.ensure_forward(range);
+        assert_eq!(queue.pending_len(), 1);
+
+        let claimed = queue
+            .next_for_peer(&peer, &state)
+            .expect("peer can claim the pending range");
+        queue.mark_assigned(peer.clone(), claimed);
+        queue.ensure_forward(RangeRequest { count: 3, ..range });
+        assert_eq!(queue.pending_len(), 0);
+        assert!(matches!(
+            queue.state(range),
+            Some(HeaderWorkState::InFlight { peer: owner }) if owner == &peer
+        ));
+
+        queue.retry(range);
+        queue.retry(range);
+        assert_eq!(queue.pending_len(), 1);
+        assert_eq!(queue.next_for_peer(&peer, &state), Some(range));
+    }
+
+    #[test]
+    fn retry_avoidance_is_local_to_the_failed_peer() {
+        let mut queue = HeaderWorkQueue::new();
+        let range = range(1, 1, RangePriority::Forward);
+        let (failed_peer, failed_state) = peer_state(2, 10);
+        let (other_peer, other_state) = peer_state(3, 10);
+
+        queue.ensure_forward(range);
+        let claimed = queue
+            .next_for_peer(&failed_peer, &failed_state)
+            .expect("failed peer initially claims the range");
+        queue.mark_assigned(failed_peer.clone(), claimed);
+        queue.retry_avoiding(failed_peer.clone(), range);
+
+        assert!(queue.peer_retry_avoided(&failed_peer, failed_state.advertised_tip));
+        assert_eq!(queue.next_for_peer(&failed_peer, &failed_state), None);
+        assert_eq!(queue.next_for_peer(&other_peer, &other_state), Some(range));
+    }
+
+    #[test]
+    fn assignment_prefers_forward_work_but_skips_ranges_above_the_peer_tip() {
+        let mut queue = HeaderWorkQueue::new();
+        let forward = range(10, 2, RangePriority::Forward);
+        let backward = range(1, 2, RangePriority::Backward);
+        let (peer, mut state) = peer_state(4, 2);
+
+        queue.ensure_forward(forward);
+        queue.ensure_backward(backward);
+        assert_eq!(queue.next_for_peer(&peer, &state), Some(backward));
+
+        state.advertised_tip = block::Height(11);
+        assert_eq!(queue.next_for_peer(&peer, &state), Some(forward));
+    }
+
+    #[test]
+    fn covered_ranges_merge_and_prune_owned_work_except_commits() {
+        let mut queue = HeaderWorkQueue::new();
+        let owner = peer(5);
+        let pending = range(1, 1, RangePriority::Forward);
+        let in_flight = range(2, 1, RangePriority::Forward);
+        let committing = range(3, 1, RangePriority::Forward);
+
+        queue.ensure_forward(pending);
+        queue.mark_assigned(owner.clone(), in_flight);
+        queue.mark_assigned(owner.clone(), committing);
+        queue.mark_buffered(owner.clone(), committing);
+        queue.mark_committing(owner, 7, committing);
+
+        queue.mark_range_covered(block::Height(1), block::Height(2));
+        queue.mark_height_covered(block::Height(3));
+
+        assert_eq!(
+            queue.covered,
+            vec![CoveredRange {
+                start: block::Height(1),
+                end: block::Height(3),
+            }]
+        );
+        assert_eq!(queue.pending_len(), 0);
+        assert!(queue.state(in_flight).is_none());
+        assert!(matches!(
+            queue.state(committing),
+            Some(HeaderWorkState::Committing { session_id: 7, .. })
+        ));
+
+        queue.ensure_forward(pending);
+        assert_eq!(queue.pending_len(), 0);
+    }
+
+    #[test]
+    fn forgetting_a_peer_requeues_only_its_in_flight_work() {
+        let mut queue = HeaderWorkQueue::new();
+        let forgotten = peer(6);
+        let other = peer(7);
+        let in_flight = range(1, 1, RangePriority::Forward);
+        let buffered = range(2, 1, RangePriority::Forward);
+        let committing = range(3, 1, RangePriority::Forward);
+        let other_in_flight = range(4, 1, RangePriority::Forward);
+
+        queue.mark_assigned(forgotten.clone(), in_flight);
+        queue.mark_assigned(forgotten.clone(), buffered);
+        queue.mark_buffered(forgotten.clone(), buffered);
+        queue.mark_assigned(forgotten.clone(), committing);
+        queue.mark_buffered(forgotten.clone(), committing);
+        queue.mark_committing(forgotten.clone(), 9, committing);
+        queue.mark_assigned(other.clone(), other_in_flight);
+        queue.retry_avoidance.insert(
+            forgotten.clone(),
+            HashMap::from([(
+                (in_flight.start_height, in_flight.priority),
+                Instant::now() + HEADER_SYNC_RETRY_AVOIDANCE,
+            )]),
+        );
+
+        queue.forget_peer(&forgotten);
+
+        assert_eq!(
+            queue.forward.iter().copied().collect::<Vec<_>>(),
+            vec![in_flight]
+        );
+        assert!(matches!(
+            queue.state(buffered),
+            Some(HeaderWorkState::Buffered { peer }) if peer == &forgotten
+        ));
+        assert!(matches!(
+            queue.state(committing),
+            Some(HeaderWorkState::Committing { peer, session_id: 9 }) if peer == &forgotten
+        ));
+        assert!(matches!(
+            queue.state(other_in_flight),
+            Some(HeaderWorkState::InFlight { peer }) if peer == &other
+        ));
+        assert!(!queue.retry_avoidance.contains_key(&forgotten));
+    }
+
+    #[test]
+    fn narrowing_active_work_updates_start_deduplication() {
+        let mut queue = HeaderWorkQueue::new();
+        let owner = peer(8);
+        let original = range(1, 3, RangePriority::Forward);
+        let narrowed = range(2, 2, RangePriority::Forward);
+
+        queue.mark_assigned(owner.clone(), original);
+        queue.narrow_queued_range(original, narrowed);
+
+        assert!(queue.state(original).is_none());
+        assert!(matches!(
+            queue.state(narrowed),
+            Some(HeaderWorkState::InFlight { peer }) if peer == &owner
+        ));
+        queue.ensure_forward(original);
+        queue.ensure_forward(narrowed);
+        assert_eq!(
+            queue.forward.iter().copied().collect::<Vec<_>>(),
+            vec![original]
+        );
+    }
+}

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -262,9 +262,44 @@ impl HeaderWorkQueue {
         );
     }
 
-    pub(super) fn drop_pending_forward_through(&mut self, height: block::Height) {
-        self.forward.retain(|range| range.start_height > height);
+    pub(super) fn trim_pending_forward_through(
+        &mut self,
+        height: block::Height,
+        anchor_hash: block::Hash,
+    ) {
+        self.forward = self
+            .forward
+            .drain(..)
+            .filter_map(|range| {
+                if range.start_height <= height {
+                    range.suffix_after(height, anchor_hash)
+                } else {
+                    Some(range)
+                }
+            })
+            .collect();
         self.rebuild_start_indexes();
+    }
+
+    pub(super) fn clear_pending_anchor(
+        &mut self,
+        priority: RangePriority,
+        start_height: block::Height,
+        anchor_hash: block::Hash,
+    ) {
+        let queue = match priority {
+            RangePriority::Forward => &mut self.forward,
+            RangePriority::Backward => &mut self.backward,
+            RangePriority::Repair => return,
+        };
+        if let Some(range) = queue
+            .iter_mut()
+            .find(|range| range.start_height == start_height)
+        {
+            if range.anchor_hash == Some(anchor_hash) {
+                range.anchor_hash = None;
+            }
+        }
     }
 
     pub(super) fn clear_forward(&mut self) {
@@ -365,7 +400,12 @@ impl HeaderWorkQueue {
             .max()
     }
 
-    pub(super) fn next_retry_deadline(&self) -> Option<Instant> {
+    pub(super) fn next_retry_deadline(&mut self) -> Option<Instant> {
+        let now = Instant::now();
+        self.retry_avoidance.retain(|_, ranges| {
+            ranges.retain(|_, until| *until > now);
+            !ranges.is_empty()
+        });
         self.retry_avoidance
             .values()
             .flat_map(HashMap::values)
@@ -534,6 +574,127 @@ mod tests {
         queue.retry(range);
         assert_eq!(queue.pending_len(), 1);
         assert_eq!(queue.next_for_peer(&peer, &state), Some(range));
+    }
+
+    #[test]
+    fn partial_forward_coverage_preserves_the_interior_suffix() {
+        let mut queue = HeaderWorkQueue::new();
+        let first = range(1, 2, RangePriority::Forward);
+        let later = range(3, 2, RangePriority::Forward);
+        let anchor = block::Hash([9; 32]);
+        queue.ensure_forward(first);
+        queue.ensure_forward(later);
+
+        queue.trim_pending_forward_through(block::Height(1), anchor);
+
+        assert_eq!(
+            queue.forward.iter().copied().collect::<Vec<_>>(),
+            vec![
+                RangeRequest {
+                    start_height: block::Height(2),
+                    count: 1,
+                    anchor_hash: Some(anchor),
+                    ..first
+                },
+                later,
+            ]
+        );
+    }
+
+    #[test]
+    fn rejected_prefix_clears_its_pending_suffix_anchor() {
+        let mut queue = HeaderWorkQueue::new();
+        let poisoned = block::Hash([7; 32]);
+        let suffix = RangeRequest {
+            anchor_hash: Some(poisoned),
+            ..range(3, 2, RangePriority::Backward)
+        };
+        queue.ensure_backward(suffix);
+
+        queue.clear_pending_anchor(RangePriority::Backward, suffix.start_height, poisoned);
+
+        assert_eq!(
+            queue.backward.front().and_then(|range| range.anchor_hash),
+            None
+        );
+    }
+
+    #[test]
+    fn expired_retry_avoidance_does_not_leave_a_past_deadline() {
+        let mut queue = HeaderWorkQueue::new();
+        queue.retry_avoidance.insert(
+            peer(2),
+            HashMap::from([(
+                (block::Height(1), RangePriority::Forward),
+                Instant::now() - Duration::from_millis(1),
+            )]),
+        );
+
+        assert_eq!(queue.next_retry_deadline(), None);
+        assert!(queue.retry_avoidance.is_empty());
+    }
+
+    #[test]
+    fn maximum_height_range_keeps_valid_queue_ownership() {
+        let mut queue = HeaderWorkQueue::new();
+        let range = range(u32::MAX, 1, RangePriority::Forward);
+        let (peer, state) = peer_state(3, u32::MAX);
+        queue.ensure_forward(range);
+
+        let claimed = queue
+            .next_for_peer(&peer, &state)
+            .expect("maximum-height work is assignable without overflow");
+        queue.mark_assigned(peer.clone(), claimed);
+        assert_eq!(claimed.end_height(), block::Height(u32::MAX));
+        assert!(matches!(
+            queue.state(range),
+            Some(HeaderWorkState::InFlight { peer: owner }) if owner == &peer
+        ));
+    }
+
+    #[test]
+    fn seen_hash_dedup_evicts_the_oldest_entry_at_capacity() {
+        let mut seen = HeaderHashDedup::default();
+        for value in 0..=HEADER_SYNC_SEEN_HASH_CAPACITY {
+            let mut bytes = [0; 32];
+            bytes[..8].copy_from_slice(
+                &u64::try_from(value)
+                    .expect("the test capacity fits in u64")
+                    .to_le_bytes(),
+            );
+            assert!(seen.insert(block::Hash(bytes)));
+        }
+
+        assert_eq!(seen.order.len(), HEADER_SYNC_SEEN_HASH_CAPACITY);
+        assert!(!seen.contains(&block::Hash([0; 32])));
+    }
+
+    #[test]
+    fn clearing_forward_work_preserves_backward_ownership_and_rebuilds_indexes() {
+        let mut queue = HeaderWorkQueue::new();
+        let forward_pending = range(1, 1, RangePriority::Forward);
+        let forward_active = range(2, 1, RangePriority::Forward);
+        let backward_pending = range(3, 1, RangePriority::Backward);
+        let backward_active = range(4, 1, RangePriority::Backward);
+        let owner = peer(4);
+        queue.ensure_forward(forward_pending);
+        queue.ensure_backward(backward_pending);
+        queue.mark_assigned(owner.clone(), forward_active);
+        queue.mark_assigned(owner.clone(), backward_active);
+        let old_epoch = queue.epoch;
+
+        queue.clear_forward();
+
+        assert_eq!(queue.epoch, old_epoch.wrapping_add(1));
+        assert_eq!(queue.forward, VecDeque::new());
+        assert!(queue.state(forward_active).is_none());
+        assert_eq!(queue.backward, VecDeque::from([backward_pending]));
+        assert!(matches!(
+            queue.state(backward_active),
+            Some(HeaderWorkState::InFlight { peer }) if peer == &owner
+        ));
+        queue.ensure_forward(forward_pending);
+        assert_eq!(queue.forward, VecDeque::from([forward_pending]));
     }
 
     #[test]

--- a/zakura-network/src/zakura/trace.rs
+++ b/zakura-network/src/zakura/trace.rs
@@ -446,6 +446,8 @@ pub mod header_sync_trace {
     pub const HEADER_FRONTIER_REANCHORED: &str = "header_frontier_reanchored";
     /// Missing block bodies reported.
     pub const HEADER_MISSING_BODIES_REPORTED: &str = "header_missing_bodies_reported";
+    /// The reactor woke because a real retry, timeout, or status deadline expired.
+    pub const HEADER_MAINTENANCE_WAKEUP: &str = "header_maintenance_wakeup";
 }
 
 /// Shared commit/frontier adapter trace event names and field keys.


### PR DESCRIPTION
## Motivation

Header sync can permanently strand a missing range after peer or local failures. The fixed-fanout scheduler recorded assignment history rather than explicit work ownership, so repeated timeouts, disconnects, partial external coverage, or local commit backpressure could leave useful peers idle while finalized progress stopped.

This draft preserves the requester implementation for continuous-sync testing and design review. Zakura does not currently use issues for this work.

## Solution

- Replace fixed-fanout bookkeeping with a bounded, single-owner header work queue whose explicit states are pending, wire-in-flight, buffered, and committing.
- Retry normal forward and backward work indefinitely, with short peer-local avoidance after timeout, empty/short/invalid responses, send failure, or disconnect.
- Fill bounded per-peer v7 request slots from shared work and retire request IDs before returning timed-out claims.
- Synchronously prepare the frame and response reservation, install a `Publishing` outstanding request, and assign its range before handing blocking transport publication to the generation-gated peer-local requester.
- Roll back the outstanding request, range assignment, and pipe reservation if requester enqueue fails.
- Reduce requester events to publication completion and requester stop notifications. Successful publication transitions `Publishing` to `AwaitingResponse`; an early response remains valid and cannot be recreated by a late completion.
- Preserve publication deadlines for requesters blocked on outbound capacity, while keeping global scheduling and retries reactor-owned.
- Buffer valid out-of-order responses while committing only from the durable contiguous frontier.
- Preserve local buffered/committing ownership across peer disconnects and correlate commit completion with the admitted session generation.
- Trim overlapping pending/in-flight/buffered work when `FullBlockCommitted`/`NewBlock` advances the durable frontier. Already validated buffered suffix vectors are preserved rather than re-downloaded; partially covered failed commits requeue their uncovered suffix.
- Clear a short response's inherited suffix anchor if ordered drain later rejects its parent prefix, including for backward work.
- Reserve action-channel capacity before marking work committing, so a full driver queue cannot orphan a commit.
- Use one-second empty-response pacing, prune expired retry avoidance before calculating maintenance, and replace the permanent 50 ms tick with deadline-driven wakeups.
- Add queue state/byte/stall observability and pin the driver's all-or-nothing commit-completion contract.

### Audit regressions

- Two resident batches plus partial external coverage recreate the interior suffix instead of wedging ordered drain.
- Partial coverage trims and commits an already buffered suffix without re-downloading it.
- A partially covered local commit failure requeues the uncovered suffix.
- A publishing request blocked on outbound capacity expires, cancels its session, and becomes available to another peer.
- A response received before publication completion is accepted, and the later completion does not reinstall it.
- Requester queue failure cancels the prepared pipe reservation and rolls back reactor ownership.
- Closed transport reports publication failure, retries the range, stops the requester, and disconnects the peer.
- Empty-response retry bookkeeping cannot be extended by a late publication-completion event and does not run at 20 Hz.
- Ordered-drain rejection clears a dependent suffix anchor; wrong-fork buffered work is rejected before commit.
- Expired retry avoidance cannot leave a maintenance deadline in the past.
- A saturated 128-entry action queue preserves the buffered range and emits exactly one commit after capacity returns.
- Truncated finalized responses explicitly request their suffix, and that suffix still enforces its checkpoint hash.
- `Height(u32::MAX)` one-header ranges, 4096-entry seen-hash eviction, and forward queue reset/index rebuilding have direct coverage.

### Tests

- `cargo fmt --all -- --check`
- `CXXFLAGS='-include cstdint' cargo clippy --workspace --all-targets -- -D warnings`
- `CXXFLAGS='-include cstdint' cargo test -p zakura-network header_sync::` — 158 passed
- `CXXFLAGS='-include cstdint' cargo test --workspace --exclude zakura` — passed, including 978 `zakura-network` library tests with 4 ignored; the node-launching `zakura` package was excluded
- Real-QUIC `header-faults` coverage for silence, delayed/out-of-order responses, empty/short responses, disconnect, and failover. The clean second-run trace corpus passed the direct oracle before this follow-up; the final post-follow-up rerun remains rollout evidence.

### Specifications & References

- Based on the v7-only protocol merged in #128: mandatory non-zero request IDs and explicit response correlation.
- Requester lifecycle refactor head: `b0e7f5b7a`.
- The ownership and retry invariants follow block sync, but the queue remains header-specific.
- Detailed audit handoff and regression evidence are maintained in the Valar artifact inbox for this work.

### Follow-up Work

- The serving-side bulk-read and concurrency changes are split into #139, stacked on this branch.
- Exercise this requester draft on the continuous-sync canary with preserved state and injected silent peers.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex implemented the requester queue, sequencing, tests, observability, validation, audit fixes, lifecycle refactor, and draft PR description under developer direction.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with a core Zakura developer; no issue is used because issues are not the project's current workflow.
- [x] The solution is tested.
- [x] The documentation and changelog are up to date.
