### PR TITLE
chore(deploy): expand continuous sync legacy fleet

### DIFF
--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -1,6 +1,6 @@
 # Zakura Continuous Genesis Sync Fleet
 
-This directory codifies the six permanent mainnet sync nodes that repeatedly
+This directory codifies the seven permanent mainnet sync nodes that repeatedly
 test a fresh genesis-to-tip sync from the latest `origin/main` build:
 
 | Node | Address | Mode |
@@ -11,6 +11,7 @@ test a fresh genesis-to-tip sync from the latest `origin/main` build:
 | `temp-zakura-sync-test-4` | `root@134.209.57.146` | Zebra/legacy-only |
 | `temp-zakura-sync-test-5` | `root@142.93.27.189` | Zebra/legacy-only |
 | `temp-zakura-sync-test-6` | `root@138.68.249.46` | Zebra/legacy-only |
+| `temp-zakura-sync-test-7` | `root@134.209.50.231` | dual-stack |
 
 Each node runs a local systemd controller. GitHub Actions installs and audits the
 controller, but it does not hold an SSH session open during the long sync.

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -1,6 +1,6 @@
 # Zakura Continuous Genesis Sync Fleet
 
-This directory codifies the three permanent mainnet sync nodes that repeatedly
+This directory codifies the six permanent mainnet sync nodes that repeatedly
 test a fresh genesis-to-tip sync from the latest `origin/main` build:
 
 | Node | Address | Mode |
@@ -8,6 +8,9 @@ test a fresh genesis-to-tip sync from the latest `origin/main` build:
 | `temp-zakura-sync-test-1` | `root@138.68.43.212` | dual-stack |
 | `temp-zakura-sync-test-2` | `root@138.197.218.91` | Zakura/v2-only |
 | `temp-zakura-sync-test-3` | `root@134.209.49.92` | Zebra/legacy-only |
+| `temp-zakura-sync-test-4` | `root@134.209.57.146` | Zebra/legacy-only |
+| `temp-zakura-sync-test-5` | `root@142.93.27.189` | Zebra/legacy-only |
+| `temp-zakura-sync-test-6` | `root@138.68.249.46` | Zebra/legacy-only |
 
 Each node runs a local systemd controller. GitHub Actions installs and audits the
 controller, but it does not hold an SSH session open during the long sync.

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -220,6 +220,7 @@ set -euo pipefail
 controller_config={controller_config}
 alert_config={alert_config}
 config_template={config_template}
+config_path={config_path}
 chain_state_dir={chain_state_dir}
 wipe_sentinel={wipe_sentinel}
 state_dir={state_dir}
@@ -232,8 +233,9 @@ start_controller={start_controller}
 
 install -d -m 755 /usr/local/sbin
 install -d -m 755 "$(dirname "$controller_config")" "$(dirname "$alert_config")" \
-  "$(dirname "$config_template")" "$chain_state_dir" "$state_dir" "$runs_dir" \
-  "$(dirname "$log_file")" "$(dirname "$monitor_log")" /var/lib/zakura-monitor
+  "$(dirname "$config_template")" "$(dirname "$config_path")" "$chain_state_dir" \
+  "$state_dir" "$runs_dir" "$(dirname "$log_file")" "$(dirname "$monitor_log")" \
+  /var/lib/zakura-monitor
 
 install -m 755 /tmp/zakura-continuous-sync.py /usr/local/sbin/zakura-continuous-sync.py
 install -m 755 /tmp/zakura-monitor.py /usr/local/sbin/zakura-monitor.py
@@ -332,6 +334,7 @@ def deploy_node(node: Node, args: argparse.Namespace) -> tuple[str, bool, str]:
             controller_config=shlex.quote(str(raw["controller_config_path"])),
             alert_config=shlex.quote(str(raw["alert_config_path"])),
             config_template=shlex.quote(str(raw["config_template_path"])),
+            config_path=shlex.quote(str(raw["config_path"])),
             chain_state_dir=shlex.quote(str(raw["chain_state_dir"])),
             wipe_sentinel=shlex.quote(str(raw["wipe_sentinel"])),
             state_dir=shlex.quote(str(raw["state_dir"])),

--- a/deploy/continuous-sync/nodes.toml
+++ b/deploy/continuous-sync/nodes.toml
@@ -77,7 +77,6 @@ alias = "temp-zakura-sync-test-3"
 public_ip = "134.209.49.92"
 mode_label = "Zebra/legacy-only"
 p2p_stack = "legacy"
-branch = "fix/checkpoint-refill-minimal"
 stall_seconds = 1800
 
 [[nodes]]
@@ -88,7 +87,6 @@ alias = "temp-zakura-sync-test-4"
 public_ip = "134.209.57.146"
 mode_label = "Zebra/legacy-only"
 p2p_stack = "legacy"
-branch = "fix/checkpoint-refill-minimal"
 stall_seconds = 1800
 
 [[nodes]]
@@ -99,7 +97,6 @@ alias = "temp-zakura-sync-test-5"
 public_ip = "142.93.27.189"
 mode_label = "Zebra/legacy-only"
 p2p_stack = "legacy"
-branch = "fix/checkpoint-refill-minimal"
 stall_seconds = 1800
 
 [[nodes]]
@@ -110,5 +107,13 @@ alias = "temp-zakura-sync-test-6"
 public_ip = "138.68.249.46"
 mode_label = "Zebra/legacy-only"
 p2p_stack = "legacy"
-branch = "fix/checkpoint-refill-minimal"
 stall_seconds = 1800
+
+[[nodes]]
+name = "temp-zakura-sync-test-7"
+hostname = "temp-zakura-sync-test-7"
+ssh_string = "root@134.209.50.231"
+alias = "temp-zakura-sync-test-7"
+public_ip = "134.209.50.231"
+mode_label = "dual-stack"
+p2p_stack = "dual"

--- a/deploy/continuous-sync/nodes.toml
+++ b/deploy/continuous-sync/nodes.toml
@@ -77,4 +77,38 @@ alias = "temp-zakura-sync-test-3"
 public_ip = "134.209.49.92"
 mode_label = "Zebra/legacy-only"
 p2p_stack = "legacy"
+branch = "fix/checkpoint-refill-minimal"
+stall_seconds = 1800
+
+[[nodes]]
+name = "temp-zakura-sync-test-4"
+hostname = "temp-zakura-sync-test-4"
+ssh_string = "root@134.209.57.146"
+alias = "temp-zakura-sync-test-4"
+public_ip = "134.209.57.146"
+mode_label = "Zebra/legacy-only"
+p2p_stack = "legacy"
+branch = "fix/checkpoint-refill-minimal"
+stall_seconds = 1800
+
+[[nodes]]
+name = "temp-zakura-sync-test-5"
+hostname = "temp-zakura-sync-test-5"
+ssh_string = "root@142.93.27.189"
+alias = "temp-zakura-sync-test-5"
+public_ip = "142.93.27.189"
+mode_label = "Zebra/legacy-only"
+p2p_stack = "legacy"
+branch = "fix/checkpoint-refill-minimal"
+stall_seconds = 1800
+
+[[nodes]]
+name = "temp-zakura-sync-test-6"
+hostname = "temp-zakura-sync-test-6"
+ssh_string = "root@138.68.249.46"
+alias = "temp-zakura-sync-test-6"
+public_ip = "138.68.249.46"
+mode_label = "Zebra/legacy-only"
+p2p_stack = "legacy"
+branch = "fix/checkpoint-refill-minimal"
 stall_seconds = 1800

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -210,8 +210,28 @@ class ContinuousSyncTests(unittest.TestCase):
         self.assertIn("down_confirmation_samples = 2", rendered["alert-monitor.toml"])
         self.assertIn("zakura.service", rendered)
 
+    def test_deploy_renders_expanded_legacy_alert_inventory(self):
+        nodes = deploy.load_nodes(
+            ROOT / "deploy" / "continuous-sync" / "nodes.toml",
+            ["temp-zakura-sync-test-4"],
+        )
+        rendered = deploy.render_files(nodes[0])
+
+        self.assertIn('p2p_stack = "legacy"', rendered["zakurad.toml.template"])
+        self.assertIn('mode_label = "Zebra/legacy-only"', rendered["controller.toml"])
+        self.assertIn('branch = "fix/checkpoint-refill-minimal"', rendered["controller.toml"])
+        self.assertEqual(rendered["alert-monitor.toml"].count("[[nodes]]"), 6)
+        for index in range(1, 7):
+            self.assertIn(
+                f'hostname = "temp-zakura-sync-test-{index}"',
+                rendered["alert-monitor.toml"],
+            )
+
     def test_deploy_does_not_stop_node_before_restarting_controller(self):
         self.assertNotIn('systemctl stop "$node_service"', deploy.INSTALL_SCRIPT)
+
+    def test_deploy_creates_zakurad_config_parent_directory(self):
+        self.assertIn('dirname "$config_path"', deploy.INSTALL_SCRIPT)
 
     def test_forced_ssh_wrapper_uses_current_status_script(self):
         self.assertIn(

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -219,9 +219,9 @@ class ContinuousSyncTests(unittest.TestCase):
 
         self.assertIn('p2p_stack = "legacy"', rendered["zakurad.toml.template"])
         self.assertIn('mode_label = "Zebra/legacy-only"', rendered["controller.toml"])
-        self.assertIn('branch = "fix/checkpoint-refill-minimal"', rendered["controller.toml"])
-        self.assertEqual(rendered["alert-monitor.toml"].count("[[nodes]]"), 6)
-        for index in range(1, 7):
+        self.assertIn('branch = "main"', rendered["controller.toml"])
+        self.assertEqual(rendered["alert-monitor.toml"].count("[[nodes]]"), 7)
+        for index in range(1, 8):
             self.assertIn(
                 f'hostname = "temp-zakura-sync-test-{index}"',
                 rendered["alert-monitor.toml"],

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -266,7 +266,7 @@ journalctl -u zakura-fleet-watchdog -f
 
 ## Continuous genesis sync fleet
 
-The permanent six-node genesis sync canary is managed separately under
+The permanent seven-node genesis sync canary is managed separately under
 `deploy/continuous-sync/`. It repeatedly builds latest `origin/main`, wipes only
 its dedicated disposable state, syncs from genesis to tip, posts Slack
 completion/failure alerts through its codified monitor timer, and retains five

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -266,7 +266,7 @@ journalctl -u zakura-fleet-watchdog -f
 
 ## Continuous genesis sync fleet
 
-The permanent three-node genesis sync canary is managed separately under
+The permanent six-node genesis sync canary is managed separately under
 `deploy/continuous-sync/`. It repeatedly builds latest `origin/main`, wipes only
 its dedicated disposable state, syncs from genesis to tip, posts Slack
 completion/failure alerts through its codified monitor timer, and retains five


### PR DESCRIPTION
## Motivation

Expand the continuous genesis sync canary to cover the additional legacy nodes that are now running in the fleet, and make the deployer safe for fresh hosts that do not already have `/etc/zakura`.

## Solution

- Add `temp-zakura-sync-test-4`, `temp-zakura-sync-test-5`, and `temp-zakura-sync-test-6` to the checked-in continuous-sync inventory.
- Configure the legacy canaries `temp-zakura-sync-test-3` through `temp-zakura-sync-test-6` to use `origin/fix/checkpoint-refill-minimal`.
- Ensure deploys create the parent directory for the rendered `zakurad` config before the controller tries to write it.
- Update continuous-sync documentation and render tests for the six-node fleet.

### Tests

- `python3 -m unittest deploy.continuous-sync.tests.test_continuous_sync`
- `python3 -m py_compile deploy/continuous-sync/*.py`
- `markdownlint deploy/continuous-sync/README.md deploy/deployer/README.md --config .trunk/configs/.markdownlint.yaml`
- `ReadLints` for edited files
- Live dry-run fleet audit: `python3 deploy/continuous-sync/deploy.py audit --dry-run` reported `audit ok: 6 node(s)`

Full Rust workspace checks were skipped: this is a low-risk deploy/inventory/docs change, and the focused deploy checks plus live audit passed.

### Specifications & References

N/A

### Follow-up Work

N/A

### AI Disclosure

- [x] AI tools were used: Cursor agent for infrastructure wiring, tests, verification, and PR description.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was requested by the team/operator in chat.
- [x] The solution is tested.
- [x] The documentation is up to date; no changelog entry is needed for operator-only deploy inventory.