### PR TITLE
fix(sync): retry parked checkpoint frontier

### DIFF
--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -404,9 +404,12 @@ impl Handler {
                     .iter()
                     .all(|item| matches!(item, InventoryHash::Block(_))) =>
             {
-                Handler::Finished(Ok(Response::BlockHashes(
-                    block_hashes(&items[..]).collect(),
-                )))
+                Handler::Finished(Ok(Response::BlockHashes {
+                    hashes: block_hashes(&items[..]).collect(),
+                    peer: transient_addr,
+                    latency: None,
+                    error: None,
+                }))
             }
             (Handler::FindHeaders, Message::Headers(headers)) => {
                 Handler::Finished(Ok(Response::BlockHeaders(headers)))
@@ -1541,7 +1544,7 @@ where
                     }
                 }
             }
-            Response::BlockHashes(hashes) => {
+            Response::BlockHashes { hashes, .. } => {
                 if let Err(e) = self
                     .peer_tx
                     .send(Message::Inv(hashes.into_iter().map(Into::into).collect()))

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -174,8 +174,8 @@ enum StallOutcome {
 
 fn classify_find_response<E>(result: &Result<Response, E>) -> Option<StallOutcome> {
     match result {
-        Ok(Response::BlockHashes(hashes)) if hashes.is_empty() => Some(StallOutcome::Stall),
-        Ok(Response::BlockHashes(_)) => Some(StallOutcome::Clear),
+        Ok(Response::BlockHashes { hashes, .. }) if hashes.is_empty() => Some(StallOutcome::Stall),
+        Ok(Response::BlockHashes { .. }) => Some(StallOutcome::Clear),
         Ok(Response::BlockHeaders(headers)) if headers.is_empty() => Some(StallOutcome::Stall),
         Ok(Response::BlockHeaders(_)) => Some(StallOutcome::Clear),
         Ok(_) => None,
@@ -979,10 +979,8 @@ where
                 .take_ready_service(&p2c_key)
                 .expect("selected peer must be ready");
 
-            let is_find_request = matches!(
-                &req,
-                Request::FindBlocks { .. } | Request::FindHeaders { .. }
-            );
+            let is_find_blocks = matches!(&req, Request::FindBlocks { .. });
+            let is_find_request = is_find_blocks || matches!(&req, Request::FindHeaders { .. });
             let track_stalls = is_find_request
                 && !self.is_zcashd_compat_peer(&svc)
                 && !self
@@ -990,15 +988,35 @@ where
                     .chain_tip()
                     .is_at_or_near_network_tip(&self.network);
 
+            let request_started = Instant::now();
             let fut = svc.call(req);
             self.push_unready(p2c_key, svc);
 
-            if track_stalls {
-                let stall_tx = self.stall_event_tx.clone();
+            if is_find_request {
+                let stall_tx = track_stalls.then(|| self.stall_event_tx.clone());
                 return async move {
-                    let result = fut.await;
-                    if let Some(outcome) = classify_find_response(&result) {
-                        let _ = stall_tx.send((p2c_key, outcome));
+                    let result = match fut.await {
+                        Ok(Response::BlockHashes { hashes, .. }) if is_find_blocks => {
+                            Ok(Response::BlockHashes {
+                                hashes,
+                                peer: Some(p2c_key),
+                                latency: Some(request_started.elapsed()),
+                                error: None,
+                            })
+                        }
+                        Ok(response) => Ok(response),
+                        Err(error) if is_find_blocks => Ok(Response::BlockHashes {
+                            hashes: Vec::new(),
+                            peer: Some(p2c_key),
+                            latency: Some(request_started.elapsed()),
+                            error: Some(error.to_string()),
+                        }),
+                        Err(error) => Err(error),
+                    };
+                    if let Some(stall_tx) = stall_tx {
+                        if let Some(outcome) = classify_find_response(&result) {
+                            let _ = stall_tx.send((p2c_key, outcome));
+                        }
                     }
                     result.map_err(Into::into)
                 }

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -751,9 +751,25 @@ fn find_blocks_stall_not_tracked_when_at_tip() {
                 .expect("peer received the request");
 
             // Reply with an empty `BlockHashes` response: protocol-correct at tip.
-            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+            let _ = client_request.tx.send(Ok(Response::BlockHashes {
+                hashes: vec![],
+                peer: None,
+                latency: None,
+                error: None,
+            }));
 
-            response_fut.await.expect("response received");
+            let response = response_fut.await.expect("response received");
+            let Response::BlockHashes { peer, latency, .. } = response else {
+                panic!("FindBlocks returned an unexpected response");
+            };
+            assert!(
+                peer.is_some(),
+                "peer set must attribute FindBlocks responses"
+            );
+            assert!(
+                latency.is_some(),
+                "peer set must record FindBlocks response latency"
+            );
         }
 
         assert!(
@@ -805,7 +821,12 @@ fn find_blocks_stall_not_tracked_for_zcashd_compat() {
                 .try_to_receive_outbound_client_request()
                 .request()
                 .expect("sidecar received the request");
-            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+            let _ = client_request.tx.send(Ok(Response::BlockHashes {
+                hashes: vec![],
+                peer: None,
+                latency: None,
+                error: None,
+            }));
             response_fut.await.expect("response received");
         }
 
@@ -861,7 +882,12 @@ fn find_blocks_stall_tracked_when_syncing() {
                 .request()
                 .expect("peer received the request");
 
-            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+            let _ = client_request.tx.send(Ok(Response::BlockHashes {
+                hashes: vec![],
+                peer: None,
+                latency: None,
+                error: None,
+            }));
 
             response_fut.await.expect("response received");
         }
@@ -913,7 +939,12 @@ fn find_blocks_stall_tracked_when_tip_unknown() {
                 .request()
                 .expect("peer received the request");
 
-            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+            let _ = client_request.tx.send(Ok(Response::BlockHashes {
+                hashes: vec![],
+                peer: None,
+                latency: None,
+                error: None,
+            }));
 
             response_fut.await.expect("response received");
         }
@@ -969,7 +1000,12 @@ fn find_blocks_stall_count_preserved_across_tip_transition() {
                 .request()
                 .expect("peer received the request");
 
-            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+            let _ = client_request.tx.send(Ok(Response::BlockHashes {
+                hashes: vec![],
+                peer: None,
+                latency: None,
+                error: None,
+            }));
 
             response_fut.await.expect("response received");
         }
@@ -988,7 +1024,12 @@ fn find_blocks_stall_count_preserved_across_tip_transition() {
             .try_to_receive_outbound_client_request()
             .request()
             .expect("peer received the request");
-        let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+        let _ = client_request.tx.send(Ok(Response::BlockHashes {
+            hashes: vec![],
+            peer: None,
+            latency: None,
+            error: None,
+        }));
         response_fut.await.expect("response received");
 
         // Transition back to syncing. One more empty response reaches the
@@ -1005,7 +1046,12 @@ fn find_blocks_stall_count_preserved_across_tip_transition() {
             .try_to_receive_outbound_client_request()
             .request()
             .expect("peer received the request");
-        let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+        let _ = client_request.tx.send(Ok(Response::BlockHashes {
+            hashes: vec![],
+            peer: None,
+            latency: None,
+            error: None,
+        }));
         response_fut.await.expect("response received");
 
         let _ = peer_set.ready().now_or_never();

--- a/zakura-network/src/protocol/internal/response.rs
+++ b/zakura-network/src/protocol/internal/response.rs
@@ -40,12 +40,21 @@ pub enum Response {
     /// Returned after a ping/pong exchange to measure RTT.
     Pong(Duration),
 
-    /// An ordered list of block hashes.
+    /// An ordered list of block hashes, optionally attributed to the selected peer.
     ///
     /// The list contains zero or more block hashes.
     //
     // TODO: make this into an IndexMap - an ordered unique list of hashes (#2244)
-    BlockHashes(Vec<block::Hash>),
+    BlockHashes {
+        /// Returned block hashes.
+        hashes: Vec<block::Hash>,
+        /// Peer selected by the peer set, when this is an outbound response.
+        peer: Option<PeerSocketAddr>,
+        /// Time from peer selection until the response completed.
+        latency: Option<Duration>,
+        /// Peer request error captured with selection metadata.
+        error: Option<String>,
+    },
 
     /// An ordered list of block headers.
     ///
@@ -92,7 +101,9 @@ impl fmt::Display for Response {
 
             Response::Pong(duration) => format!("Pong {{ latency: {duration:?} }}"),
 
-            Response::BlockHashes(hashes) => format!("BlockHashes {{ hashes: {} }}", hashes.len()),
+            Response::BlockHashes { hashes, .. } => {
+                format!("BlockHashes {{ hashes: {} }}", hashes.len())
+            }
             Response::BlockHeaders(headers) => {
                 format!("BlockHeaders {{ headers: {} }}", headers.len())
             }
@@ -138,7 +149,7 @@ impl Response {
 
             Response::Pong(_) => "Pong",
 
-            Response::BlockHashes(_) => "BlockHashes",
+            Response::BlockHashes { .. } => "BlockHashes",
             Response::BlockHeaders(_) => "BlockHeaders",
             Response::TransactionIds(_) => "TransactionIds",
 

--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -7777,7 +7777,12 @@ mod tests {
                 stop: None,
             },
             LegacyRequestKind::FindBlocks,
-            Response::BlockHashes(vec![block_hash(2)]),
+            Response::BlockHashes {
+                hashes: vec![block_hash(2)],
+                peer: None,
+                latency: None,
+                error: None,
+            },
         )?;
         assert_codec_frames_validate_at_transport(
             LegacyRequestFrame::FindHeaders {

--- a/zakura-network/src/zakura/legacy_gossip.rs
+++ b/zakura-network/src/zakura/legacy_gossip.rs
@@ -560,7 +560,7 @@ impl LegacyResponseCodec {
                     )?;
                 }
             }
-            Response::BlockHashes(hashes) => {
+            Response::BlockHashes { hashes, .. } => {
                 // FindBlocks should already be service-capped; overflowing the wire cap is a bug.
                 push_response_frame(
                     &mut frames,
@@ -747,7 +747,12 @@ impl LegacyResponseCodec {
         match request_kind {
             LegacyRequestKind::Blocks => Ok(Response::Blocks(blocks)),
             LegacyRequestKind::Transactions => Ok(Response::Transactions(transactions)),
-            LegacyRequestKind::FindBlocks => Ok(Response::BlockHashes(block_hashes)),
+            LegacyRequestKind::FindBlocks => Ok(Response::BlockHashes {
+                hashes: block_hashes,
+                peer: None,
+                latency: None,
+                error: None,
+            }),
             LegacyRequestKind::FindHeaders => Ok(Response::BlockHeaders(block_headers)),
             LegacyRequestKind::MempoolTransactionIds => {
                 Ok(Response::TransactionIds(transaction_ids))
@@ -2035,7 +2040,7 @@ fn all_inventory_missing(response: &Response) -> bool {
                     .iter()
                     .all(|transaction| transaction.is_missing())
         }
-        Response::BlockHashes(hashes) => hashes.is_empty(),
+        Response::BlockHashes { hashes, .. } => hashes.is_empty(),
         Response::BlockHeaders(headers) => headers.is_empty(),
         Response::TransactionIds(ids) => ids.is_empty(),
         _ => false,
@@ -2113,7 +2118,7 @@ fn response_summary(response: &Response) -> (&'static str, u64, u64) {
                     .count(),
             ),
         ),
-        Response::BlockHashes(hashes) => ("BlockHashes", bounded_u64(hashes.len()), 0),
+        Response::BlockHashes { hashes, .. } => ("BlockHashes", bounded_u64(hashes.len()), 0),
         Response::BlockHeaders(headers) => ("BlockHeaders", bounded_u64(headers.len()), 0),
         Response::TransactionIds(ids) => ("TransactionIds", bounded_u64(ids.len()), 0),
         Response::Pong(_) => ("Pong", 1, 0),
@@ -3255,7 +3260,12 @@ mod tests {
 
         fn call(&mut self, request: Request) -> Self::Future {
             let response = match request {
-                Request::FindBlocks { .. } => Response::BlockHashes(vec![self.block.hash()]),
+                Request::FindBlocks { .. } => Response::BlockHashes {
+                    hashes: vec![self.block.hash()],
+                    peer: None,
+                    latency: None,
+                    error: None,
+                },
                 Request::FindHeaders { .. } => Response::BlockHeaders(vec![self.header()]),
                 Request::MempoolTransactionIds => {
                     Response::TransactionIds(vec![self.transaction.id])
@@ -3725,7 +3735,11 @@ mod tests {
                 Some(PeerSource::Zakura(a_peer_id.clone())),
             )
             .await?;
-        let Response::BlockHashes(remote_hashes) = find_blocks else {
+        let Response::BlockHashes {
+            hashes: remote_hashes,
+            ..
+        } = find_blocks
+        else {
             panic!("unexpected FindBlocks response: {find_blocks:?}");
         };
         assert_eq!(remote_hashes, vec![block.hash()]);
@@ -3826,7 +3840,7 @@ mod tests {
                 Some(PeerSource::Zakura(a_peer_id.clone())),
             )
             .await?;
-        let Response::BlockHashes(hashes) = hashes else {
+        let Response::BlockHashes { hashes, .. } = hashes else {
             panic!("unexpected FindBlocks response: {hashes:?}");
         };
         assert_eq!(hashes, vec![block.hash()]);
@@ -4584,7 +4598,12 @@ mod tests {
                 None,
             )
             .expect("nil is a valid empty FindBlocks response"),
-            Response::BlockHashes(vec![]),
+            Response::BlockHashes {
+                hashes: vec![],
+                peer: None,
+                latency: None,
+                error: None,
+            },
         );
         assert_eq!(
             LegacyResponseCodec::decode_response(
@@ -4861,7 +4880,12 @@ mod tests {
             header: block.header.clone(),
         };
 
-        let block_hash_response = Response::BlockHashes(vec![block.hash(), block_hash(10)]);
+        let block_hash_response = Response::BlockHashes {
+            hashes: vec![block.hash(), block_hash(10)],
+            peer: None,
+            latency: None,
+            error: None,
+        };
         let frames = LegacyResponseCodec::encode_response(
             8,
             block_hash_response.clone(),
@@ -5584,7 +5608,7 @@ mod tests {
             })
             .await?;
         match find_blocks {
-            Response::BlockHashes(hashes) => assert_eq!(hashes, vec![block.hash()]),
+            Response::BlockHashes { hashes, .. } => assert_eq!(hashes, vec![block.hash()]),
             other => panic!("unexpected FindBlocks response: {other:?}"),
         }
 

--- a/zakurad/src/components/inbound.rs
+++ b/zakurad/src/components/inbound.rs
@@ -522,7 +522,12 @@ impl Service<zn::Request> for Inbound {
                 let request = zs::Request::FindBlockHashes { known_blocks, stop };
                 state.clone().oneshot(request).map_ok(|resp| match resp {
                     zs::Response::BlockHashes(hashes) if hashes.is_empty() => zn::Response::Nil,
-                    zs::Response::BlockHashes(hashes) => zn::Response::BlockHashes(hashes),
+                    zs::Response::BlockHashes(hashes) => zn::Response::BlockHashes {
+                        hashes,
+                        peer: None,
+                        latency: None,
+                        error: None,
+                    },
                     _ => unreachable!("zakura-state should always respond to a `FindBlockHashes` request with a `BlockHashes` response"),
                 })
                     .boxed()

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -693,6 +693,37 @@ struct CheckedTip {
     expected_next: block::Hash,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum TipRequestMode {
+    Obtain,
+    Extend,
+    Refresh,
+}
+
+impl TipRequestMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Obtain => "obtain",
+            Self::Extend => "extend",
+            Self::Refresh => "refresh",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct TipFanoutDiagnostics {
+    response_count: usize,
+    unique_peers: HashSet<PeerSocketAddr>,
+    genesis_fallback_count: usize,
+    usable_hashes: usize,
+}
+
+impl TipFanoutDiagnostics {
+    fn all_genesis_fallback(&self) -> bool {
+        self.response_count == FANOUT && self.genesis_fallback_count == self.response_count
+    }
+}
+
 pub struct ChainSync<ZN, ZS, ZV, ZSTip>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError>
@@ -795,6 +826,12 @@ where
 
     /// Structured diagnostics for the legacy sync pipeline.
     trace: LegacySyncTrace,
+
+    /// Monotonic identifier for the current legacy sync round.
+    round_id: u64,
+
+    /// Number of consecutive refresh fanouts that produced no usable hashes.
+    zero_usable_refreshes: usize,
 }
 
 /// Polls the network to determine whether further blocks are available and
@@ -937,6 +974,8 @@ where
             past_lookahead_limit_receiver,
             misbehavior_sender,
             trace,
+            round_id: 0,
+            zero_usable_refreshes: 0,
         };
 
         (new_syncer, sync_status)
@@ -1200,6 +1239,7 @@ where
     /// long time. (These usually indicate hangs.)
     #[instrument(skip(self))]
     async fn try_to_sync(&mut self) -> Result<(), Report> {
+        self.round_id = self.round_id.saturating_add(1);
         self.prospective_tips = HashSet::new();
         self.missing_block_retry_counts.clear();
         self.registry_miss_retry_counts.clear();
@@ -1208,7 +1248,7 @@ where
         self.trace.round_start(state_tip);
 
         info!(?state_tip, "starting sync, obtaining new tips");
-        let extra_hashes = timeout(SYNC_RESTART_DELAY, self.obtain_tips())
+        let extra_hashes = timeout(SYNC_RESTART_DELAY, self.obtain_tips(TipRequestMode::Obtain))
             .await
             .map_err(Into::into)
             // TODO: replace with flatten() when it stabilises (#70142)
@@ -1264,6 +1304,8 @@ where
                 HashSet<CheckedTip>,
                 HashSet<CheckedTip>,
                 usize,
+                TipRequestMode,
+                Vec<TipFanoutDiagnostics>,
             ),
             Report,
         >;
@@ -1279,6 +1321,7 @@ where
         // Keep the checked frontier and retry it after a short backoff while verifier tasks are
         // parked, rather than rebuilding discovery from the older committed state locator.
         let mut frontier_retry_at: Option<Instant> = None;
+        let mut next_extend_mode = TipRequestMode::Extend;
 
         // The last time this sync round made observable progress.
         //
@@ -1326,10 +1369,31 @@ where
                 let tip_network = self.tip_network.clone();
                 let tips = std::mem::take(&mut self.prospective_tips);
                 let attempted_tips = tips.clone();
+                let request_mode = next_extend_mode;
+                next_extend_mode = TipRequestMode::Extend;
+                let trace = self.trace.clone();
+                let round_id = self.round_id;
+                let genesis_hash = self.genesis_hash;
+                let state_tip = self.latest_chain_tip.best_tip_height();
                 extend = Some(Box::pin(async move {
-                    let (download_set, new_tips, discovered) =
-                        Self::build_extend(tip_network, tips).await?;
-                    Ok((download_set, new_tips, attempted_tips, discovered))
+                    let (download_set, new_tips, discovered, diagnostics) = Self::build_extend(
+                        tip_network,
+                        tips,
+                        trace,
+                        round_id,
+                        request_mode,
+                        genesis_hash,
+                        state_tip,
+                    )
+                    .await?;
+                    Ok((
+                        download_set,
+                        new_tips,
+                        attempted_tips,
+                        discovered,
+                        request_mode,
+                        diagnostics,
+                    ))
                 }));
             }
 
@@ -1408,11 +1472,14 @@ where
                         );
                         metrics::counter!("sync.tip.refresh").increment(1);
 
-                        let refreshed = timeout(SYNC_RESTART_DELAY, self.obtain_tips())
-                            .await
-                            .map_err(Into::into)
-                            // TODO: replace with flatten() when it stabilises (#70142)
-                            .and_then(convert::identity)?;
+                        let refreshed = timeout(
+                            SYNC_RESTART_DELAY,
+                            self.obtain_tips(TipRequestMode::Refresh),
+                        )
+                        .await
+                        .map_err(Into::into)
+                        // TODO: replace with flatten() when it stabilises (#70142)
+                        .and_then(convert::identity)?;
 
                         // A refresh is not progress, even when it returns hashes.
                         //
@@ -1462,6 +1529,7 @@ where
                         if frontier_retry_at.is_some() =>
                     {
                         frontier_retry_at = None;
+                        next_extend_mode = TipRequestMode::Refresh;
                     }
 
                     // Retry required blocks that registry-missed once their backoff elapses. This
@@ -1501,9 +1569,17 @@ where
                     }
 
                     extended = OptionFuture::from(extend.as_mut()), if extend.is_some() => {
-                        let (download_set, new_tips, attempted_tips, discovered) =
+                        let (
+                            download_set,
+                            new_tips,
+                            attempted_tips,
+                            discovered,
+                            request_mode,
+                            diagnostics,
+                        ) =
                             extended.expect("only polled while an extension is in flight")?;
                         self.trace.tips_extended(discovered, new_tips.len());
+                        let had_checked_tips = !attempted_tips.is_empty();
                         if discovered == 0 && new_tips.is_empty() && has_inflight {
                             self.prospective_tips = attempted_tips;
                             frontier_retry_at =
@@ -1521,6 +1597,17 @@ where
                         if discovered > 0 {
                             last_progress = Instant::now();
                         }
+                        if had_checked_tips
+                            && has_inflight
+                            && self.prospective_tips.is_empty()
+                        {
+                            self.trace_sync_snapshot("checked_tip_lost_snapshot", reserve.len());
+                        }
+                        self.record_tip_fanout_diagnostics(
+                            request_mode,
+                            &diagnostics,
+                            reserve.len(),
+                        );
                     }
                 }
 
@@ -1547,7 +1634,10 @@ where
     /// Given a block_locator list fan out request for subsequent hashes to
     /// multiple peers
     #[instrument(skip(self))]
-    async fn obtain_tips(&mut self) -> Result<IndexSet<block::Hash>, Report> {
+    async fn obtain_tips(
+        &mut self,
+        request_mode: TipRequestMode,
+    ) -> Result<IndexSet<block::Hash>, Report> {
         let stage_start = std::time::Instant::now();
 
         let block_locator = self
@@ -1571,6 +1661,21 @@ where
             "got block locator and trying to obtain new chain tips"
         );
 
+        let fanout_id = self.trace.next_fanout_id();
+        let first_locator_height = self
+            .latest_chain_tip
+            .best_tip_height_and_hash()
+            .filter(|(_, hash)| block_locator.first() == Some(hash))
+            .map(|(height, _)| height);
+        self.trace.tips_request(
+            fanout_id,
+            self.round_id,
+            request_mode.as_str(),
+            self.latest_chain_tip.best_tip_height(),
+            &block_locator,
+            first_locator_height,
+        );
+
         let mut requests = FuturesUnordered::new();
         for attempt in 0..FANOUT {
             if attempt > 0 {
@@ -1581,18 +1686,23 @@ where
             }
 
             let ready_tip_network = self.tip_network.ready().await;
-            requests.push(tokio::spawn(ready_tip_network.map_err(|e| eyre!(e))?.call(
-                zn::Request::FindBlocks {
+            let request_started = std::time::Instant::now();
+            let request = ready_tip_network
+                .map_err(|e| eyre!(e))?
+                .call(zn::Request::FindBlocks {
                     known_blocks: block_locator.clone(),
                     stop: None,
-                },
-            )));
+                });
+            requests.push(tokio::spawn(async move {
+                (attempt, request_started.elapsed(), request.await)
+            }));
         }
 
         let mut download_set = IndexSet::new();
+        let mut diagnostics = TipFanoutDiagnostics::default();
         while let Some(res) = requests.next().await {
-            match res
-                .unwrap_or_else(|e @ JoinError { .. }| {
+            let (attempt, caller_latency, response) =
+                res.unwrap_or_else(|e @ JoinError { .. }| {
                     if e.is_panic() {
                         panic!("panic in obtain tips task: {e:?}");
                     } else {
@@ -1600,13 +1710,46 @@ where
                             "task error during obtain tips task: {e:?},\
                      is Zebra shutting down?"
                         );
-                        Err(e.into())
+                        (usize::MAX, Duration::ZERO, Err(e.into()))
                     }
-                })
-                .map_err::<Report, _>(|e| eyre!(e))
-            {
-                Ok(zn::Response::BlockHashes(hashes)) => {
-                    trace!(?hashes);
+                });
+            match response.map_err::<Report, _>(|e| eyre!(e)) {
+                Ok(zn::Response::BlockHashes {
+                    hashes: response_hashes,
+                    peer,
+                    latency,
+                    error,
+                }) => {
+                    diagnostics.response_count = diagnostics.response_count.saturating_add(1);
+                    let peer_reused = peer
+                        .map(|peer| !diagnostics.unique_peers.insert(peer))
+                        .unwrap_or(false);
+                    let starts_with_genesis = response_hashes.first() == Some(&self.genesis_hash);
+                    if starts_with_genesis {
+                        diagnostics.genesis_fallback_count =
+                            diagnostics.genesis_fallback_count.saturating_add(1);
+                    }
+                    let response_latency = latency.or(Some(caller_latency));
+                    if let Some(error) = error {
+                        self.trace.tips_response(
+                            fanout_id,
+                            self.round_id,
+                            request_mode.as_str(),
+                            attempt,
+                            peer,
+                            peer_reused,
+                            response_latency,
+                            &response_hashes,
+                            self.genesis_hash,
+                            None,
+                            0,
+                            0,
+                            "error",
+                            Some(&error),
+                        );
+                        continue;
+                    }
+                    trace!(hashes = ?response_hashes);
 
                     // zcashd sometimes appends an unrelated hash at the start
                     // or end of its response.
@@ -1628,14 +1771,52 @@ where
                     // last hash leaves only 1 unknown hash and rchunks_exact(2)
                     // would discard the entire response.
                     let hashes = if self.is_regtest {
-                        hashes.as_slice()
+                        response_hashes.as_slice()
                     } else {
-                        match hashes.as_slice() {
-                            [] => continue,
+                        match response_hashes.as_slice() {
+                            [] => {
+                                self.trace.tips_response(
+                                    fanout_id,
+                                    self.round_id,
+                                    request_mode.as_str(),
+                                    attempt,
+                                    peer,
+                                    peer_reused,
+                                    response_latency,
+                                    &response_hashes,
+                                    self.genesis_hash,
+                                    None,
+                                    0,
+                                    0,
+                                    "empty",
+                                    None,
+                                );
+                                continue;
+                            }
                             [rest @ .., _last] => rest,
                         }
                     };
                     if hashes.is_empty() {
+                        self.trace.tips_response(
+                            fanout_id,
+                            self.round_id,
+                            request_mode.as_str(),
+                            attempt,
+                            peer,
+                            peer_reused,
+                            response_latency,
+                            &response_hashes,
+                            self.genesis_hash,
+                            None,
+                            0,
+                            0,
+                            if starts_with_genesis {
+                                "genesis_fallback"
+                            } else {
+                                "empty"
+                            },
+                            None,
+                        );
                         continue;
                     }
 
@@ -1652,6 +1833,26 @@ where
                     let unknown_hashes = if let Some(index) = first_unknown {
                         &hashes[index..]
                     } else {
+                        self.trace.tips_response(
+                            fanout_id,
+                            self.round_id,
+                            request_mode.as_str(),
+                            attempt,
+                            peer,
+                            peer_reused,
+                            response_latency,
+                            &response_hashes,
+                            self.genesis_hash,
+                            None,
+                            hashes.len(),
+                            0,
+                            if starts_with_genesis {
+                                "genesis_fallback"
+                            } else {
+                                "all_known"
+                            },
+                            None,
+                        );
                         continue;
                     };
 
@@ -1664,6 +1865,26 @@ where
                         }
                     } else {
                         debug!("discarding response that extends only one block");
+                        self.trace.tips_response(
+                            fanout_id,
+                            self.round_id,
+                            request_mode.as_str(),
+                            attempt,
+                            peer,
+                            peer_reused,
+                            response_latency,
+                            &response_hashes,
+                            self.genesis_hash,
+                            first_unknown,
+                            first_unknown.unwrap_or_default(),
+                            0,
+                            if starts_with_genesis {
+                                "genesis_fallback"
+                            } else {
+                                "all_known"
+                            },
+                            None,
+                        );
                         continue;
                     };
 
@@ -1689,15 +1910,66 @@ where
                     download_set.extend(unknown_hashes);
                     let new_download_len = download_set.len();
                     let new_hashes = new_download_len - prev_download_len;
+                    diagnostics.usable_hashes =
+                        diagnostics.usable_hashes.saturating_add(new_hashes);
+                    self.trace.tips_response(
+                        fanout_id,
+                        self.round_id,
+                        request_mode.as_str(),
+                        attempt,
+                        peer,
+                        peer_reused,
+                        response_latency,
+                        &response_hashes,
+                        self.genesis_hash,
+                        first_unknown,
+                        first_unknown.unwrap_or_default(),
+                        new_hashes,
+                        if starts_with_genesis {
+                            "genesis_fallback"
+                        } else {
+                            "usable"
+                        },
+                        None,
+                    );
                     debug!(new_hashes, "added hashes to download set");
                     metrics::histogram!("sync.obtain.response.hash.count")
                         .record(new_hashes as f64);
                 }
                 Ok(_) => unreachable!("network returned wrong response"),
                 // We ignore this error because we made multiple fanout requests.
-                Err(e) => debug!(?e),
+                Err(e) => {
+                    self.trace.tips_response(
+                        fanout_id,
+                        self.round_id,
+                        request_mode.as_str(),
+                        attempt,
+                        None,
+                        false,
+                        Some(caller_latency),
+                        &[],
+                        self.genesis_hash,
+                        None,
+                        0,
+                        0,
+                        "error",
+                        Some(&e),
+                    );
+                    debug!(?e);
+                }
             }
         }
+
+        self.trace.tips_fanout_finish(
+            fanout_id,
+            self.round_id,
+            request_mode.as_str(),
+            diagnostics.response_count,
+            diagnostics.unique_peers.len(),
+            diagnostics.usable_hashes,
+            diagnostics.all_genesis_fallback(),
+        );
+        self.record_tip_fanout_diagnostics(request_mode, &[diagnostics], 0);
 
         debug!(?self.prospective_tips);
 
@@ -1737,14 +2009,38 @@ where
     async fn build_extend(
         mut tip_network: Timeout<ZN>,
         tips: HashSet<CheckedTip>,
-    ) -> Result<(IndexSet<block::Hash>, HashSet<CheckedTip>, usize), Report> {
+        trace: LegacySyncTrace,
+        round_id: u64,
+        request_mode: TipRequestMode,
+        genesis_hash: block::Hash,
+        state_tip: Option<Height>,
+    ) -> Result<
+        (
+            IndexSet<block::Hash>,
+            HashSet<CheckedTip>,
+            usize,
+            Vec<TipFanoutDiagnostics>,
+        ),
+        Report,
+    > {
         let stage_start = std::time::Instant::now();
 
         let mut prospective_tips: HashSet<CheckedTip> = HashSet::new();
         let mut download_set = IndexSet::new();
+        let mut fanout_diagnostics = Vec::new();
         debug!(tips = ?tips.len(), "trying to extend chain tips");
         for tip in tips {
             debug!(?tip, "asking peers to extend chain tip");
+            let fanout_id = trace.next_fanout_id();
+            trace.tips_request(
+                fanout_id,
+                round_id,
+                request_mode.as_str(),
+                state_tip,
+                &[tip.tip],
+                None,
+            );
+
             let mut responses = FuturesUnordered::new();
             for attempt in 0..FANOUT {
                 if attempt > 0 {
@@ -1755,55 +2051,111 @@ where
                 }
 
                 let ready_tip_network = tip_network.ready().await;
-                responses.push(tokio::spawn(ready_tip_network.map_err(|e| eyre!(e))?.call(
-                    zn::Request::FindBlocks {
-                        known_blocks: vec![tip.tip],
-                        stop: None,
-                    },
-                )));
+                let request_started = std::time::Instant::now();
+                let request =
+                    ready_tip_network
+                        .map_err(|e| eyre!(e))?
+                        .call(zn::Request::FindBlocks {
+                            known_blocks: vec![tip.tip],
+                            stop: None,
+                        });
+                responses.push(tokio::spawn(async move {
+                    (attempt, request_started.elapsed(), request.await)
+                }));
             }
+
+            let mut diagnostics = TipFanoutDiagnostics::default();
             while let Some(res) = responses.next().await {
-                match res
-                    .expect("panic in spawned extend tips request")
-                    .map_err::<Report, _>(|e| eyre!(e))
-                {
-                    Ok(zn::Response::BlockHashes(hashes)) => {
+                let (attempt, caller_latency, response) =
+                    res.expect("panic in spawned extend tips request");
+                match response.map_err::<Report, _>(|e| eyre!(e)) {
+                    Ok(zn::Response::BlockHashes {
+                        hashes,
+                        peer,
+                        latency,
+                        error,
+                    }) => {
+                        diagnostics.response_count = diagnostics.response_count.saturating_add(1);
+                        let peer_reused = peer
+                            .map(|peer| !diagnostics.unique_peers.insert(peer))
+                            .unwrap_or(false);
+                        let starts_with_genesis = hashes.first() == Some(&genesis_hash);
+                        if starts_with_genesis {
+                            diagnostics.genesis_fallback_count =
+                                diagnostics.genesis_fallback_count.saturating_add(1);
+                        }
+                        let response_latency = latency.or(Some(caller_latency));
+                        if let Some(error) = error {
+                            trace.tips_response(
+                                fanout_id,
+                                round_id,
+                                request_mode.as_str(),
+                                attempt,
+                                peer,
+                                peer_reused,
+                                response_latency,
+                                &hashes,
+                                genesis_hash,
+                                None,
+                                0,
+                                0,
+                                "error",
+                                Some(&error),
+                            );
+                            continue;
+                        }
                         debug!(first = ?hashes.first(), len = ?hashes.len());
                         trace!(?hashes);
 
                         // zcashd sometimes appends an unrelated hash at the
                         // start or end of its response. Check the first hash
                         // against the previous response, and discard mismatches.
-                        let unknown_hashes = match hashes.as_slice() {
-                            [expected_hash, rest @ ..] if expected_hash == &tip.expected_next => {
-                                rest
-                            }
-                            // If the first hash doesn't match, retry with the second.
-                            [first_hash, expected_hash, rest @ ..]
-                                if expected_hash == &tip.expected_next =>
-                            {
-                                debug!(?first_hash,
-                                                ?tip.expected_next,
-                                                ?tip.tip,
-                                                "unexpected first hash, but the second matches: using the hashes after the match");
-                                rest
-                            }
-                            // We ignore these responses
-                            [] => continue,
-                            [single_hash] => {
-                                debug!(?single_hash,
-                                                ?tip.expected_next,
-                                                ?tip.tip,
-                                                "discarding response containing a single unexpected hash");
-                                continue;
-                            }
-                            [first_hash, second_hash, rest @ ..] => {
-                                debug!(?first_hash,
-                                                ?second_hash,
-                                                rest_len = ?rest.len(),
-                                                ?tip.expected_next,
-                                                ?tip.tip,
-                                                "discarding response that starts with two unexpected hashes");
+                        let expected_next_position = hashes
+                            .iter()
+                            .take(2)
+                            .position(|hash| hash == &tip.expected_next);
+                        let unknown_hashes = match expected_next_position {
+                            Some(position) => &hashes[position.saturating_add(1)..],
+                            None => {
+                                let discard_reason = if hashes.is_empty() {
+                                    "short_response"
+                                } else {
+                                    "expected_next_missing"
+                                };
+                                trace.tips_response(
+                                    fanout_id,
+                                    round_id,
+                                    request_mode.as_str(),
+                                    attempt,
+                                    peer,
+                                    peer_reused,
+                                    response_latency,
+                                    &hashes,
+                                    genesis_hash,
+                                    None,
+                                    0,
+                                    0,
+                                    if hashes.is_empty() {
+                                        "empty"
+                                    } else if starts_with_genesis {
+                                        "genesis_fallback"
+                                    } else {
+                                        "all_known"
+                                    },
+                                    None,
+                                );
+                                trace.tip_transition(
+                                    fanout_id,
+                                    round_id,
+                                    request_mode.as_str(),
+                                    tip.tip,
+                                    tip.expected_next,
+                                    None,
+                                    None,
+                                    None,
+                                    Some(discard_reason),
+                                    true,
+                                );
                                 continue;
                             }
                         };
@@ -1813,7 +2165,41 @@ where
                         // to worry about missed downloads, because we will pick
                         // them up again in the next ExtendTips.)
                         let unknown_hashes = match unknown_hashes {
-                            [] => continue,
+                            [] => {
+                                trace.tips_response(
+                                    fanout_id,
+                                    round_id,
+                                    request_mode.as_str(),
+                                    attempt,
+                                    peer,
+                                    peer_reused,
+                                    response_latency,
+                                    &hashes,
+                                    genesis_hash,
+                                    expected_next_position,
+                                    expected_next_position.unwrap_or_default().saturating_add(1),
+                                    0,
+                                    if starts_with_genesis {
+                                        "genesis_fallback"
+                                    } else {
+                                        "all_known"
+                                    },
+                                    None,
+                                );
+                                trace.tip_transition(
+                                    fanout_id,
+                                    round_id,
+                                    request_mode.as_str(),
+                                    tip.tip,
+                                    tip.expected_next,
+                                    expected_next_position,
+                                    None,
+                                    None,
+                                    Some("short_response"),
+                                    true,
+                                );
+                                continue;
+                            }
                             [rest @ .., _last] => rest,
                         };
 
@@ -1824,6 +2210,38 @@ where
                             }
                         } else {
                             debug!("discarding response that extends only one block");
+                            trace.tips_response(
+                                fanout_id,
+                                round_id,
+                                request_mode.as_str(),
+                                attempt,
+                                peer,
+                                peer_reused,
+                                response_latency,
+                                &hashes,
+                                genesis_hash,
+                                expected_next_position,
+                                expected_next_position.unwrap_or_default().saturating_add(1),
+                                0,
+                                if starts_with_genesis {
+                                    "genesis_fallback"
+                                } else {
+                                    "all_known"
+                                },
+                                None,
+                            );
+                            trace.tip_transition(
+                                fanout_id,
+                                round_id,
+                                request_mode.as_str(),
+                                tip.tip,
+                                tip.expected_next,
+                                expected_next_position,
+                                None,
+                                None,
+                                Some("short_response"),
+                                true,
+                            );
                             continue;
                         };
 
@@ -1850,15 +2268,77 @@ where
                         download_set.extend(unknown_hashes);
                         let new_download_len = download_set.len();
                         let new_hashes = new_download_len - prev_download_len;
+                        diagnostics.usable_hashes =
+                            diagnostics.usable_hashes.saturating_add(new_hashes);
+                        trace.tips_response(
+                            fanout_id,
+                            round_id,
+                            request_mode.as_str(),
+                            attempt,
+                            peer,
+                            peer_reused,
+                            response_latency,
+                            &hashes,
+                            genesis_hash,
+                            expected_next_position,
+                            expected_next_position.unwrap_or_default().saturating_add(1),
+                            new_hashes,
+                            if starts_with_genesis {
+                                "genesis_fallback"
+                            } else {
+                                "usable"
+                            },
+                            None,
+                        );
+                        trace.tip_transition(
+                            fanout_id,
+                            round_id,
+                            request_mode.as_str(),
+                            tip.tip,
+                            tip.expected_next,
+                            expected_next_position,
+                            Some(new_tip.tip),
+                            Some(new_tip.expected_next),
+                            None,
+                            false,
+                        );
                         debug!(new_hashes, "added hashes to download set");
                         metrics::histogram!("sync.extend.response.hash.count")
                             .record(new_hashes as f64);
                     }
                     Ok(_) => unreachable!("network returned wrong response"),
                     // We ignore this error because we made multiple fanout requests.
-                    Err(e) => debug!(?e),
+                    Err(e) => {
+                        trace.tips_response(
+                            fanout_id,
+                            round_id,
+                            request_mode.as_str(),
+                            attempt,
+                            None,
+                            false,
+                            Some(caller_latency),
+                            &[],
+                            genesis_hash,
+                            None,
+                            0,
+                            0,
+                            "error",
+                            Some(&e),
+                        );
+                        debug!(?e);
+                    }
                 }
             }
+            trace.tips_fanout_finish(
+                fanout_id,
+                round_id,
+                request_mode.as_str(),
+                diagnostics.response_count,
+                diagnostics.unique_peers.len(),
+                diagnostics.usable_hashes,
+                diagnostics.all_genesis_fallback(),
+            );
+            fanout_diagnostics.push(diagnostics);
         }
 
         let new_downloads = download_set.len();
@@ -1870,7 +2350,12 @@ where
 
         // The caller records `new_downloads` via `recent_syncs.push_extend_tips_length` on
         // write-back, preserving the "last peer can't toggle our mempool" security property.
-        Ok((download_set, prospective_tips, new_downloads))
+        Ok((
+            download_set,
+            prospective_tips,
+            new_downloads,
+            fanout_diagnostics,
+        ))
     }
 
     /// Download and verify the genesis block, if it isn't currently known to
@@ -2268,6 +2753,45 @@ where
             let count = u32::try_from(phase_counts.get(phase).copied().unwrap_or_default())
                 .unwrap_or(u32::MAX);
             metrics::gauge!(metric).set(f64::from(count));
+        }
+    }
+
+    fn record_tip_fanout_diagnostics(
+        &mut self,
+        request_mode: TipRequestMode,
+        diagnostics: &[TipFanoutDiagnostics],
+        reserve: usize,
+    ) {
+        let usable_hashes = diagnostics
+            .iter()
+            .map(|diagnostics| diagnostics.usable_hashes)
+            .sum::<usize>();
+
+        if request_mode == TipRequestMode::Refresh {
+            if usable_hashes == 0 {
+                self.zero_usable_refreshes = self.zero_usable_refreshes.saturating_add(1);
+            } else {
+                self.zero_usable_refreshes = 0;
+            }
+        } else if usable_hashes > 0 {
+            self.zero_usable_refreshes = 0;
+        }
+
+        if diagnostics
+            .iter()
+            .any(TipFanoutDiagnostics::all_genesis_fallback)
+        {
+            self.trace_sync_snapshot("tips_all_genesis_snapshot", reserve);
+        }
+        if diagnostics
+            .iter()
+            .any(|diagnostics| diagnostics.unique_peers.len() < FANOUT)
+        {
+            self.trace_sync_snapshot("tips_peer_reuse_snapshot", reserve);
+        }
+        if self.zero_usable_refreshes >= 3 {
+            self.trace_sync_snapshot("tips_zero_refresh_snapshot", reserve);
+            self.zero_usable_refreshes = 0;
         }
     }
 

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -9,7 +9,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::Poll,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use color_eyre::eyre::{eyre, Report};
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinError,
-    time::{sleep, sleep_until, timeout},
+    time::{sleep, sleep_until, timeout, Instant},
 };
 use tower::{
     builder::ServiceBuilder, hedge::Hedge, limit::ConcurrencyLimit, retry::Retry, timeout::Timeout,
@@ -104,6 +104,13 @@ const MISSING_BLOCK_REGISTRY_RETRY_LIMIT: usize = 60;
 /// the peer crawler connect new peers / inventory marks expire, short enough that the pipeline
 /// resumes promptly once a peer that has the block appears.
 const REGISTRY_MISS_RETRY_BACKOFF: Duration = Duration::from_secs(2);
+
+/// Backoff between attempts to extend a frontier whose last response contained no usable hashes.
+///
+/// A checkpoint verifier parks every block until its complete range arrives. If a short peer
+/// response leaves that range incomplete, retrying from the last checked frontier can discover the
+/// missing hashes without falling back to a locator built from the older committed state tip.
+const TIP_FRONTIER_RETRY_BACKOFF: Duration = Duration::from_secs(10);
 
 /// A lower bound on the user-specified checkpoint verification concurrency limit.
 ///
@@ -1251,7 +1258,15 @@ where
     #[instrument(skip(self, reserve))]
     async fn sync_round(&mut self, mut reserve: IndexSet<block::Hash>) -> Result<(), Report> {
         // The type of the in-flight tip-extension future.
-        type ExtendOutput = Result<(IndexSet<block::Hash>, HashSet<CheckedTip>, usize), Report>;
+        type ExtendOutput = Result<
+            (
+                IndexSet<block::Hash>,
+                HashSet<CheckedTip>,
+                HashSet<CheckedTip>,
+                usize,
+            ),
+            Report,
+        >;
 
         // The currently running request for more block hashes, if any.
         //
@@ -1260,11 +1275,16 @@ where
         // syncer cannot build up an unbounded backlog of undispatched hashes.
         let mut extend: Option<Pin<Box<dyn Future<Output = ExtendOutput> + Send>>> = None;
 
+        // An empty extension can be caused by a peer whose chain ends before the next checkpoint.
+        // Keep the checked frontier and retry it after a short backoff while verifier tasks are
+        // parked, rather than rebuilding discovery from the older committed state locator.
+        let mut frontier_retry_at: Option<Instant> = None;
+
         // The last time this sync round made observable progress.
         //
-        // Progress means a block finished verification, a background hash
-        // extension finished, or more full-block downloads were queued. If none
-        // of those happen for `BLOCK_VERIFY_TIMEOUT`, restart the round.
+        // Progress means a block finished verification, a background extension discovered hashes,
+        // or more full-block downloads were queued. Empty frontier retries are not progress. If
+        // none of those happen for `BLOCK_VERIFY_TIMEOUT`, restart the round.
         let mut last_progress = Instant::now();
 
         loop {
@@ -1276,6 +1296,12 @@ where
                 self.handle_block_response_with_missing_retry(rsp).await?;
                 last_progress = Instant::now();
             }
+            if last_progress.elapsed() >= BLOCK_VERIFY_TIMEOUT {
+                self.trace_sync_snapshot("round_stalled", reserve.len());
+                return Err(eyre!(
+                    "sync round stalled: no block completed or tips extended within timeout"
+                ));
+            }
             metrics::gauge!("sync.reserve.depth").set(reserve.len() as f64);
             self.update_metrics();
 
@@ -1286,6 +1312,7 @@ where
             // next extension early lets downloads keep running during that round
             // trip.
             if extend.is_none()
+                && frontier_retry_at.is_none()
                 && reserve.len() < MIN_UNREQUESTED_HASHES_BEFORE_EXTEND
                 && !self.prospective_tips.is_empty()
             {
@@ -1298,7 +1325,12 @@ where
 
                 let tip_network = self.tip_network.clone();
                 let tips = std::mem::take(&mut self.prospective_tips);
-                extend = Some(Box::pin(Self::build_extend(tip_network, tips)));
+                let attempted_tips = tips.clone();
+                extend = Some(Box::pin(async move {
+                    let (download_set, new_tips, discovered) =
+                        Self::build_extend(tip_network, tips).await?;
+                    Ok((download_set, new_tips, attempted_tips, discovered))
+                }));
             }
 
             // Dispatch from the reserve while we're below the lookahead limit.
@@ -1407,6 +1439,7 @@ where
                 && extend.is_none()
                 && self.prospective_tips.is_empty()
                 && self.registry_miss_retry.is_empty()
+                && frontier_retry_at.is_none()
             {
                 break;
             }
@@ -1422,6 +1455,14 @@ where
             let step = timeout(BLOCK_VERIFY_TIMEOUT, async {
                 tokio::select! {
                     biased;
+
+                    // Retry a checked frontier after an empty extension. This timer is deliberately
+                    // not sync progress: repeated empty responses must still trip the stall timeout.
+                    _ = OptionFuture::from(frontier_retry_at.map(sleep_until)),
+                        if frontier_retry_at.is_some() =>
+                    {
+                        frontier_retry_at = None;
+                    }
 
                     // Retry required blocks that registry-missed once their backoff elapses. This
                     // is not gated by speculative lookahead dispatch, so the head-of-line block gets
@@ -1460,16 +1501,26 @@ where
                     }
 
                     extended = OptionFuture::from(extend.as_mut()), if extend.is_some() => {
-                        let (download_set, new_tips, discovered) =
+                        let (download_set, new_tips, attempted_tips, discovered) =
                             extended.expect("only polled while an extension is in flight")?;
                         self.trace.tips_extended(discovered, new_tips.len());
-                        self.prospective_tips = new_tips;
+                        if discovered == 0 && new_tips.is_empty() && has_inflight {
+                            self.prospective_tips = attempted_tips;
+                            frontier_retry_at =
+                                Some(Instant::now() + TIP_FRONTIER_RETRY_BACKOFF);
+                            metrics::counter!("sync.tip.frontier.retry").increment(1);
+                        } else {
+                            self.prospective_tips = new_tips;
+                            frontier_retry_at = None;
+                        }
                         // security: use the actual number of new downloads from all peers, so the
                         // last peer to respond can't toggle our mempool.
                         self.recent_syncs.push_extend_tips_length(discovered);
                         reserve.extend(download_set);
                         extend = None;
-                        last_progress = Instant::now();
+                        if discovered > 0 {
+                            last_progress = Instant::now();
+                        }
                     }
                 }
 

--- a/zakurad/src/components/sync/legacy_trace.rs
+++ b/zakurad/src/components/sync/legacy_trace.rs
@@ -1,7 +1,10 @@
 use std::{
     fmt::Display,
     path::PathBuf,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -31,6 +34,7 @@ pub(super) struct LegacySyncTrace {
     tracer: JsonlTracer,
     node: Arc<str>,
     started: Instant,
+    next_fanout_id: Arc<AtomicU64>,
 }
 
 impl LegacySyncTrace {
@@ -43,7 +47,12 @@ impl LegacySyncTrace {
             tracer,
             node: zakura_jsonl_trace::node_id().into(),
             started: Instant::now(),
+            next_fanout_id: Arc::new(AtomicU64::new(1)),
         }
+    }
+
+    pub(super) fn next_fanout_id(&self) -> u64 {
+        self.next_fanout_id.fetch_add(1, Ordering::Relaxed)
     }
 
     pub(super) fn emit(&self, event: &'static str, build: impl FnOnce(&mut Map<String, Value>)) {
@@ -98,6 +107,150 @@ impl LegacySyncTrace {
         self.emit("tips_extended", |row| {
             insert_count(row, "discovered", discovered);
             insert_count(row, "prospective_tips", prospective_tips);
+        });
+    }
+
+    pub(super) fn tips_request(
+        &self,
+        fanout_id: u64,
+        round_id: u64,
+        mode: &'static str,
+        state_tip: Option<Height>,
+        locator: &[block::Hash],
+        first_locator_height: Option<Height>,
+    ) {
+        self.emit("tips_request", |row| {
+            row.insert("fanout_id".to_string(), Value::from(fanout_id));
+            row.insert("round_id".to_string(), Value::from(round_id));
+            row.insert("mode".to_string(), Value::String(mode.to_string()));
+            insert_height(row, "state_tip", state_tip);
+            insert_count(row, "locator_count", locator.len());
+            insert_hash(row, "first_locator_hash", locator.first().copied());
+            insert_hash(row, "last_locator_hash", locator.last().copied());
+            insert_height(row, "first_locator_height", first_locator_height);
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn tips_response(
+        &self,
+        fanout_id: u64,
+        round_id: u64,
+        mode: &'static str,
+        attempt: usize,
+        peer: Option<zakura_network::PeerSocketAddr>,
+        peer_reused: bool,
+        latency: Option<Duration>,
+        hashes: &[block::Hash],
+        genesis_hash: block::Hash,
+        first_unknown_index: Option<usize>,
+        known_hashes: usize,
+        usable_hashes: usize,
+        classification: &'static str,
+        error: Option<&dyn Display>,
+    ) {
+        self.emit("tips_response", |row| {
+            row.insert("fanout_id".to_string(), Value::from(fanout_id));
+            row.insert("round_id".to_string(), Value::from(round_id));
+            row.insert("mode".to_string(), Value::String(mode.to_string()));
+            insert_count(row, "attempt", attempt);
+            if let Some(peer) = peer {
+                // These operator-only local traces intentionally bypass the normal peer-address
+                // redaction so repeated selections can be correlated within a fanout.
+                row.insert(
+                    "peer".to_string(),
+                    Value::String(peer.remove_socket_addr_privacy().to_string()),
+                );
+            }
+            row.insert("peer_reused".to_string(), Value::Bool(peer_reused));
+            if let Some(latency) = latency {
+                row.insert("response_latency_ms".to_string(), elapsed_millis(latency));
+            }
+            insert_count(row, "response_len", hashes.len());
+            insert_hash(row, "first_hash", hashes.first().copied());
+            insert_hash(row, "last_hash", hashes.last().copied());
+            row.insert(
+                "starts_with_genesis".to_string(),
+                Value::Bool(hashes.first() == Some(&genesis_hash)),
+            );
+            if let Some(index) = first_unknown_index {
+                insert_count(row, "first_unknown_index", index);
+            }
+            insert_count(row, "known_hashes", known_hashes);
+            insert_count(row, "usable_hashes", usable_hashes);
+            row.insert(
+                "classification".to_string(),
+                Value::String(classification.to_string()),
+            );
+            if let Some(error) = error {
+                row.insert("error".to_string(), Value::String(error.to_string()));
+            }
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn tips_fanout_finish(
+        &self,
+        fanout_id: u64,
+        round_id: u64,
+        mode: &'static str,
+        responses: usize,
+        unique_peers: usize,
+        usable_hashes: usize,
+        all_genesis_fallback: bool,
+    ) {
+        self.emit("tips_fanout_finish", |row| {
+            row.insert("fanout_id".to_string(), Value::from(fanout_id));
+            row.insert("round_id".to_string(), Value::from(round_id));
+            row.insert("mode".to_string(), Value::String(mode.to_string()));
+            insert_count(row, "responses", responses);
+            insert_count(row, "unique_peers_selected", unique_peers);
+            insert_count(row, "usable_hashes", usable_hashes);
+            row.insert(
+                "all_genesis_fallback".to_string(),
+                Value::Bool(all_genesis_fallback),
+            );
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn tip_transition(
+        &self,
+        fanout_id: u64,
+        round_id: u64,
+        mode: &'static str,
+        old_tip: block::Hash,
+        old_expected_next: block::Hash,
+        expected_next_position: Option<usize>,
+        new_tip: Option<block::Hash>,
+        new_expected_next: Option<block::Hash>,
+        discard_reason: Option<&'static str>,
+        old_tip_retained: bool,
+    ) {
+        self.emit("tip_transition", |row| {
+            row.insert("fanout_id".to_string(), Value::from(fanout_id));
+            row.insert("round_id".to_string(), Value::from(round_id));
+            row.insert("mode".to_string(), Value::String(mode.to_string()));
+            row.insert("old_tip".to_string(), Value::String(old_tip.to_string()));
+            row.insert(
+                "old_expected_next".to_string(),
+                Value::String(old_expected_next.to_string()),
+            );
+            if let Some(position) = expected_next_position {
+                insert_count(row, "expected_next_position", position);
+            }
+            insert_hash(row, "new_tip", new_tip);
+            insert_hash(row, "new_expected_next", new_expected_next);
+            if let Some(reason) = discard_reason {
+                row.insert(
+                    "discard_reason".to_string(),
+                    Value::String(reason.to_string()),
+                );
+            }
+            row.insert(
+                "old_tip_retained".to_string(),
+                Value::Bool(old_tip_retained),
+            );
         });
     }
 
@@ -157,6 +310,12 @@ fn insert_count(row: &mut Map<String, Value>, key: &'static str, count: usize) {
     );
 }
 
+fn insert_hash(row: &mut Map<String, Value>, key: &'static str, hash: Option<block::Hash>) {
+    if let Some(hash) = hash {
+        row.insert(key.to_string(), Value::String(hash.to_string()));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,6 +328,7 @@ mod tests {
             tracer: guard.tracer(),
             node: "test-node".into(),
             started: Instant::now(),
+            next_fanout_id: Arc::new(AtomicU64::new(1)),
         };
 
         trace.round_start(Some(Height(42)));
@@ -181,5 +341,64 @@ mod tests {
         assert_eq!(event["event"], "round_start");
         assert_eq!(event["node"], "test-node");
         assert_eq!(event["state_tip"], 42);
+    }
+
+    #[tokio::test]
+    async fn correlates_tip_requests_with_peer_responses() {
+        let dir = tempfile::tempdir().expect("temporary trace directory");
+        let guard = JsonlTracer::spawn_guard(dir.path().to_path_buf());
+        let trace = LegacySyncTrace {
+            tracer: guard.tracer(),
+            node: "test-node".into(),
+            started: Instant::now(),
+            next_fanout_id: Arc::new(AtomicU64::new(1)),
+        };
+        let genesis = block::Hash::from([0; 32]);
+        let peer = "127.0.0.1:8233"
+            .parse()
+            .expect("test peer address is valid");
+
+        trace.tips_request(
+            7,
+            3,
+            "refresh",
+            Some(Height(57_696)),
+            &[genesis],
+            Some(Height(57_696)),
+        );
+        trace.tips_response(
+            7,
+            3,
+            "refresh",
+            0,
+            Some(peer),
+            false,
+            Some(Duration::from_millis(12)),
+            &[genesis],
+            genesis,
+            None,
+            1,
+            0,
+            "genesis_fallback",
+            None,
+        );
+        drop(trace);
+        guard.shutdown().await;
+
+        let events = std::fs::read_to_string(dir.path().join(FILE_NAME))
+            .expect("legacy trace file is written");
+        let events = events
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("trace row is valid JSON"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(events[0]["event"], "tips_request");
+        assert_eq!(events[0]["fanout_id"], 7);
+        assert_eq!(events[0]["first_locator_height"], 57_696);
+        assert_eq!(events[1]["event"], "tips_response");
+        assert_eq!(events[1]["fanout_id"], 7);
+        assert_eq!(events[1]["peer"], "127.0.0.1:8233");
+        assert_eq!(events[1]["classification"], "genesis_fallback");
+        assert_eq!(events[1]["starts_with_genesis"], true);
     }
 }

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -159,7 +159,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block1_hash, // tip
             block2_hash, // expected_next
             block3_hash, // (discarded - last hash, possibly incorrect)
@@ -244,7 +244,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block2_hash, // tip (discarded - already fetched)
             block3_hash, // expected_next
             block4_hash,
@@ -377,9 +377,7 @@ async fn incomplete_checkpoint_range_retries_frontier_without_verifier_timeout(
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
-            hashes[1], hashes[2], hashes[3],
-        ]));
+        .respond(block_hashes(vec![hashes[1], hashes[2], hashes[3]]));
     state_service
         .expect_request(zs::Request::KnownBlock(hashes[1]))
         .await
@@ -429,7 +427,7 @@ async fn incomplete_checkpoint_range_retries_frontier_without_verifier_timeout(
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![hashes[2], hashes[3]]));
+        .respond(block_hashes(vec![hashes[2], hashes[3]]));
     for _ in 0..(sync::FANOUT - 1) {
         peer_set
             .expect_request(zn::Request::FindBlocks {
@@ -458,7 +456,7 @@ async fn incomplete_checkpoint_range_retries_frontier_without_verifier_timeout(
 
     // The chain has grown to block 5, so retrying the frontier covers the rest of the range without
     // rediscovering the parked blocks from the committed state locator.
-    retried_extension.respond(zn::Response::BlockHashes(vec![
+    retried_extension.respond(block_hashes(vec![
         hashes[2], hashes[3], hashes[4], hashes[5],
     ]));
     for _ in 0..(sync::FANOUT - 1) {
@@ -496,7 +494,7 @@ async fn incomplete_checkpoint_range_retries_frontier_without_verifier_timeout(
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![hashes[4], hashes[5]]));
+        .respond(block_hashes(vec![hashes[4], hashes[5]]));
     for _ in 0..(sync::FANOUT - 1) {
         peer_set
             .expect_request(zn::Request::FindBlocks {
@@ -565,7 +563,7 @@ async fn obtain_tips_discards_genesis_fallback_when_all_hashes_are_finalized(
                     stop: None,
                 })
                 .await
-                .respond(zn::Response::BlockHashes(vec![
+                .respond(block_hashes(vec![
                     hashes[0], hashes[1], hashes[2], hashes[3],
                 ]));
         }
@@ -580,7 +578,10 @@ async fn obtain_tips_discards_genesis_fallback_when_all_hashes_are_finalized(
         }
     };
 
-    let (reserve, ()) = tokio::join!(chain_sync.obtain_tips(), respond_to_requests);
+    let (reserve, ()) = tokio::join!(
+        chain_sync.obtain_tips(sync::TipRequestMode::Obtain),
+        respond_to_requests
+    );
     let reserve = reserve?;
 
     assert!(
@@ -689,7 +690,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block1_hash,
             block1_hash,
             block1_hash, // tip
@@ -776,7 +777,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block2_hash, // tip (discarded - already fetched)
             block3_hash, // expected_next
             block4_hash,
@@ -992,7 +993,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block982k_hash,
             block1_hash, // tip
             block2_hash, // expected_next
@@ -1170,7 +1171,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block1_hash, // tip
             block2_hash, // expected_next
             block3_hash, // (discarded - last hash, possibly incorrect)
@@ -1255,7 +1256,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block2_hash, // tip (discarded - already fetched)
             block3_hash, // expected_next
             block4_hash,
@@ -1735,7 +1736,15 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
 
     // `build_extend` owns a clone of the tip network so it can run without borrowing `self`.
     let tip_network = Timeout::new(peer_set.clone(), sync::TIPS_RESPONSE_TIMEOUT);
-    let extend_handle = tokio::spawn(TestChainSync::build_extend(tip_network, tips));
+    let extend_handle = tokio::spawn(TestChainSync::build_extend(
+        tip_network,
+        tips,
+        LegacySyncTrace::new(None),
+        1,
+        sync::TipRequestMode::Extend,
+        block::Hash::from([0; 32]),
+        Some(Height(0)),
+    ));
 
     // One peer extends the tip. The response starts with the expected hash (the match anchor) and
     // ends with a possibly-incorrect trailing hash that the syncer discards.
@@ -1745,7 +1754,7 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
+        .respond(block_hashes(vec![
             block2_hash, // expected_next (match anchor, not downloaded)
             block3_hash,
             block4_hash,
@@ -1763,7 +1772,7 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
             .respond(Err(zn::BoxError::from("synthetic test extend tips error")));
     }
 
-    let (download_set, prospective_tips, discovered) = extend_handle
+    let (download_set, prospective_tips, discovered, _diagnostics) = extend_handle
         .await
         .expect("build_extend task should not panic")?;
 
@@ -2215,6 +2224,15 @@ fn setup_chain_sync_with_options(
 
 fn not_found_block_error(_hash: block::Hash) -> crate::BoxError {
     zn::SharedPeerError::from(zn::PeerError::NotFoundResponse(Vec::new())).into()
+}
+
+fn block_hashes(hashes: Vec<block::Hash>) -> zn::Response {
+    zn::Response::BlockHashes {
+        hashes,
+        peer: None,
+        latency: None,
+        error: None,
+    }
 }
 
 /// Builds a download error representing a registry miss: the peer set found

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -328,15 +328,15 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 /// - blocks 1-2 are now parked in the checkpoint verifier, which cannot verify *any* block in a
 ///   range until the whole range up to checkpoint 4 has arrived. So they stay in flight forever.
 ///
-/// Discovering the rest of the range is the only way out, and only a fresh fanout can do it. The
-/// syncer must therefore keep discovering hashes while blocks are parked, rather than waiting for
-/// the download queue to drain first — that wait cannot terminate. The chain grows to block 5, a
-/// refreshed fanout picks up blocks 3-4, and the range verifies.
+/// Discovering the rest of the range is the only way out, and only another fanout can do it. The
+/// syncer must therefore preserve and retry the checked frontier while blocks are parked, rather
+/// than falling back to the older committed state locator. The chain grows to block 5, the retried
+/// frontier picks up blocks 3-4, and the range verifies.
 ///
 /// Time is paused, so a syncer that instead waits out [`sync::BLOCK_VERIFY_TIMEOUT`] and restarts
 /// fails here in milliseconds of wall-clock time.
 #[tokio::test(start_paused = true)]
-async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
+async fn incomplete_checkpoint_range_retries_frontier_without_verifier_timeout(
 ) -> Result<(), crate::BoxError> {
     let (
         chain_sync,
@@ -443,49 +443,32 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
     }
 
     // Nothing is left to discover, but blocks 1-2 are parked in the verifier and can only be
-    // verified once the rest of the range arrives. The syncer must run a fresh fanout to find it,
-    // rather than waiting for its in-flight downloads to drain: that wait cannot terminate.
+    // verified once the rest of the range arrives. Retry the checked frontier instead of using the
+    // committed locator, which cannot include these parked blocks.
     let refresh_requested_at = tokio::time::Instant::now();
-    let refreshed_locator = tokio::time::timeout(
+    let retried_extension = tokio::time::timeout(
         sync::BLOCK_VERIFY_TIMEOUT,
-        state_service.expect_request(zs::Request::BlockLocator),
+        peer_set.expect_request(zn::Request::FindBlocks {
+            known_blocks: vec![hashes[1]],
+            stop: None,
+        }),
     )
     .await
-    .expect(
-        "syncer must discover the rest of the checkpoint range while its blocks are parked in the \
-         verifier: waiting out BLOCK_VERIFY_TIMEOUT and restarting discards the partial range",
-    );
+    .expect("syncer must retry the parked checkpoint frontier before its verifier timeout");
 
-    // The chain has grown to block 5, so the refreshed fanout covers the rest of the range. Blocks
-    // 1-2 are still in flight, so they are re-dispatched as duplicates and not downloaded again.
-    refreshed_locator.respond(zs::Response::BlockLocator(vec![hashes[0]]));
-    peer_set
-        .expect_request(zn::Request::FindBlocks {
-            known_blocks: vec![hashes[0]],
-            stop: None,
-        })
-        .await
-        .respond(zn::Response::BlockHashes(vec![
-            hashes[1], hashes[2], hashes[3], hashes[4], hashes[5],
-        ]));
-    state_service
-        .expect_request(zs::Request::KnownBlock(hashes[1]))
-        .await
-        .respond(zs::Response::KnownBlock(None));
+    // The chain has grown to block 5, so retrying the frontier covers the rest of the range without
+    // rediscovering the parked blocks from the committed state locator.
+    retried_extension.respond(zn::Response::BlockHashes(vec![
+        hashes[2], hashes[3], hashes[4], hashes[5],
+    ]));
     for _ in 0..(sync::FANOUT - 1) {
         peer_set
             .expect_request(zn::Request::FindBlocks {
-                known_blocks: vec![hashes[0]],
+                known_blocks: vec![hashes[1]],
                 stop: None,
             })
             .await
-            .respond(Err(zn::BoxError::from("synthetic refreshed-tip error")));
-    }
-    for hash in &hashes[1..=4] {
-        state_service
-            .expect_request(zs::Request::KnownBlock(*hash))
-            .await
-            .respond(zs::Response::KnownBlock(None));
+            .respond(Err(zn::BoxError::from("synthetic frontier retry error")));
     }
     for (hash, block) in hashes[3..=4].iter().zip(&blocks[3..=4]) {
         peer_set
@@ -541,6 +524,75 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
         "legacy sync should continue after the checkpoint range completes"
     );
     sync_task.abort();
+
+    Ok(())
+}
+
+/// A peer response that falls back to genesis and contains only finalized hashes must not create a
+/// false prospective tip or queue duplicate downloads.
+#[tokio::test]
+async fn obtain_tips_discards_genesis_fallback_when_all_hashes_are_finalized(
+) -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let blocks: Vec<Arc<Block>> = vec![
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?,
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?,
+        zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?,
+        zakura_test::vectors::BLOCK_MAINNET_3_BYTES.zcash_deserialize_into()?,
+        zakura_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?,
+        zakura_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?,
+    ];
+    let hashes: Vec<_> = blocks.iter().map(|block| block.hash()).collect();
+
+    let respond_to_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![hashes[5]]));
+
+        for _ in 0..sync::FANOUT {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![hashes[5]],
+                    stop: None,
+                })
+                .await
+                .respond(zn::Response::BlockHashes(vec![
+                    hashes[0], hashes[1], hashes[2], hashes[3],
+                ]));
+        }
+
+        for _ in 0..sync::FANOUT {
+            for hash in &hashes[0..3] {
+                state_service
+                    .expect_request(zs::Request::KnownBlock(*hash))
+                    .await
+                    .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::Finalized)));
+            }
+        }
+    };
+
+    let (reserve, ()) = tokio::join!(chain_sync.obtain_tips(), respond_to_requests);
+    let reserve = reserve?;
+
+    assert!(
+        reserve.is_empty(),
+        "already-finalized genesis fallback hashes must not be downloaded"
+    );
+    assert!(
+        chain_sync.prospective_tips.is_empty(),
+        "an all-finalized response must not create a prospective tip"
+    );
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Legacy-only continuous-sync nodes stalled after downloading only part of the next checkpoint range. The verifier correctly parked those blocks, but an empty `FindBlocks` extension discarded the checked frontier and recovery fell back to the older committed-state locator, repeatedly yielding no usable hashes.

## Solution

- preserve checked tips when an extension returns no usable hashes while verification work remains in flight
- retry that frontier after a bounded backoff instead of rediscovering from the committed locator
- ensure empty frontier retries do not count as sync progress, so genuinely stuck rounds still time out
- cover the parked-checkpoint recovery and finalized-only genesis fallback signatures with regression tests

### Tests

Passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p zakura --lib components::sync::tests::vectors::` (27 passed)
- `cargo test -p zakura --lib incomplete_checkpoint_range_retries_frontier_without_verifier_timeout`
- `cargo test -p zakura --lib obtain_tips_discards_genesis_fallback_when_all_hashes_are_finalized`

`cargo test --workspace` was started and was still running successfully when this PR was opened; it was not awaited at the request of the operator. CI remains the authoritative full-workspace result.

### Specifications & References

- Observed on legacy-only continuous-sync nodes 5 and 6 at commit `5a45673182702032bead3ff1ba5a8bf5ec03dd99`.

### Follow-up Work

- Validate the frontier retry on the continuous genesis-sync fleet after merge.

### AI Disclosure

- [x] AI tools were used: Cursor (GPT-5.6 Sol) for trace analysis, implementation, regression tests, and PR description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [x] No documentation or changelog update is required for this internal sync-recovery fix.