### PR TITLE
fix(state): use retained hashes for block locators

### DIFF
--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -21,7 +21,11 @@ use crate::{
     constants::{MAX_BLOCK_REORG_HEIGHT, MAX_PRUNE_HEIGHTS_PER_COMMIT, MIN_PRUNING_RETENTION},
     request::{CheckpointVerifiedBlock, FinalizableBlock, FinalizedBlock, Treestate},
     rollback_finalized_state,
-    service::finalized_state::{disk_db::DiskWriteBatch, FinalizedState},
+    service::{
+        finalized_state::{disk_db::DiskWriteBatch, FinalizedState},
+        non_finalized_state::Chain,
+        read::find::{block_locator, chain_contains_hash},
+    },
     Config, ContextuallyVerifiedBlock, PruningConfig, RollbackFinalizedStateError,
     RollbackFinalizedStateOptions, SemanticallyVerifiedBlock,
 };
@@ -604,6 +608,30 @@ fn checkpoint_retention_skips_old_raw_transactions_in_pruned_mode() {
         Some(checkpoint_lowest_retained),
         "skipped checkpoint raw transactions advance the pruning marker atomically"
     );
+}
+
+#[test]
+fn block_locator_uses_retained_hashes_when_checkpoint_bodies_are_skipped() {
+    let _init_guard = zakura_test::init();
+    let network = Mainnet;
+    let config = pruned_config();
+    let checkpoint_lowest_retained = Height(TEST_BLOCKS + 1);
+    let max_checkpoint_height = Height(MIN_PRUNING_RETENTION + checkpoint_lowest_retained.0 - 1);
+
+    let state = new_state_with_checkpoint_retention(&config, &network, max_checkpoint_height);
+    let (tip_height, tip_hash) = state.db.tip().expect("test state has a finalized tip");
+
+    assert_eq!(tip_height, Height(TEST_BLOCKS));
+    assert_eq!(state.db.body_hash(tip_height), None);
+    assert_eq!(state.db.hash(tip_height), Some(tip_hash));
+    assert!(!state.db.contains_hash(tip_hash));
+
+    let no_chain = Option::<Arc<Chain>>::None;
+    let locator = block_locator(no_chain.clone(), &state.db)
+        .expect("a finalized tip produces a block locator");
+
+    assert_eq!(locator.first(), Some(&tip_hash));
+    assert!(chain_contains_hash(no_chain, &state.db, tip_hash));
 }
 
 #[test]

--- a/zakura-state/src/service/read/find.rs
+++ b/zakura-state/src/service/read/find.rs
@@ -239,7 +239,7 @@ where
     chain
         .map(|chain| chain.as_ref().height_by_hash.contains_key(&hash))
         .unwrap_or(false)
-        || db.contains_hash(hash)
+        || db.height(hash).is_some()
 }
 
 /// Create a block locator from `chain` and `db`.
@@ -272,7 +272,11 @@ where
     let mut hashes = Vec::with_capacity(heights.len());
 
     for height in heights {
-        if let Some(hash) = hash_by_height(chain, db, height) {
+        let hash = chain
+            .and_then(|chain| chain.as_ref().hash_by_height(height))
+            .or_else(|| db.hash(height));
+
+        if let Some(hash) = hash {
             hashes.push(hash);
         }
     }


### PR DESCRIPTION
## Motivation

Pruned checkpoint sync can permanently stall after a sync round restarts.

Checkpoint sync intentionally omits old transaction bodies while retaining finalized block height/hash indexes. Block locator construction was using the body-gated hash lookup, so a node whose locator window contained only body-pruned blocks produced an empty locator. Peers then responded from genesis, and the node discarded every returned hash as already finalized.

This behavior was introduced when `hash_by_height()` changed from the retained hash index to `db.body_hash()` in `64f405b4ee`.

No issue is linked yet; this draft captures the prototype while the team discussion is still in progress.

## Solution

Separate chain identity from block-body availability:

- construct block locators from the retained finalized hash index with `db.hash(height)`
- recognize finalized chain intersections through `db.height(hash).is_some()`
- keep the general `hash_by_height()` lookup body-gated for callers that advertise serveable block bodies
- add a regression test whose finalized tip/hash index exists while its transaction body is absent

This lets pruned nodes advertise their actual finalized tip after a round restart without claiming that pruned block bodies are serveable.

### Tests

- `cargo fmt --all -- --check`
- `CXXFLAGS='-include cstdint' cargo clippy -p zakura-state --all-targets -- -D warnings`
- `CXXFLAGS='-include cstdint' cargo test -p zakura-state`
  - 352 passed
  - 3 ignored
  - 0 failed

The `CXXFLAGS` workaround force-includes the standard `<cstdint>` header required by bundled RocksDB under the local host compiler.

### Specifications & References

- Regression introduced in `64f405b4ee`
- Zcash `getblocks` / block locator chain-intersection behavior

### Follow-up Work

Before marking ready for review:

- link the relevant issue or team discussion
- decide whether this bug fix needs an `[Unreleased]` changelog entry
- run any additional full-workspace checks requested by maintainers

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex was used for artifact diagnosis, implementation, regression-test construction, local validation, and drafting this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.
