### PR TITLE
fix(state): omit VCT roots when block bodies are missing

### DIFF
--- a/zakura-state/src/service/finalized_state/commitment_aux.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux.rs
@@ -464,32 +464,29 @@ pub(crate) fn produce_block_roots(
         // `ironwood_root_or_empty`'s doc comment).
         let ironwood_root = ironwood_root_or_empty(db.ironwood_tree_by_height(&height));
         // Below the upgrade height the serving index does not exist, so derive the
-        // auth-data root and the shielded tx-counts from the locally stored block (this
-        // archival node holds the body for these heights). Zero only if the body is somehow
-        // absent, in which case the recipient simply re-fetches from a node that has it.
-        let block = db.block(height.into());
-        let (sapling_tx, orchard_tx, ironwood_tx, auth_data_root) =
-            if let Some(block) = block.as_ref() {
-                (
-                    block.sapling_transactions_count(),
-                    block.orchard_transactions_count(),
-                    block.ironwood_transactions_count(),
-                    block.auth_data_root(),
-                )
-            } else {
-                metrics::counter!("state.block_roots.zero_aux_fallback").increment(1);
-                static ZERO_AUX_FALLBACKS: AtomicU64 = AtomicU64::new(0);
-                let occurrences = ZERO_AUX_FALLBACKS.fetch_add(1, Ordering::Relaxed) + 1;
-                if occurrences.is_power_of_two() {
-                    tracing::error!(
-                        ?height,
-                        occurrences,
-                        "serving tree-aux roots with zero transaction counts and auth-data root \
-                         because the finalized block body is unavailable"
-                    );
-                }
-                (0, 0, 0, AuthDataRoot::from([0u8; 32]))
-            };
+        // auth-data root and shielded transaction counts from the locally stored block.
+        // These values are consensus inputs, and zero is a valid value rather than an
+        // "unknown" sentinel. Stop at a missing body so callers receive only a contiguous
+        // prefix and never pair real commitment roots with fabricated auxiliary data.
+        let Some(block) = db.block(height.into()) else {
+            metrics::counter!("state.block_roots.missing_body").increment(1);
+            static MISSING_BODIES: AtomicU64 = AtomicU64::new(0);
+            let occurrences = MISSING_BODIES.fetch_add(1, Ordering::Relaxed) + 1;
+            if occurrences.is_power_of_two() {
+                tracing::error!(
+                    ?height,
+                    occurrences,
+                    "stopping tree-aux root serving because the finalized block body is unavailable"
+                );
+            }
+            break;
+        };
+        let (sapling_tx, orchard_tx, ironwood_tx, auth_data_root) = (
+            block.sapling_transactions_count(),
+            block.orchard_transactions_count(),
+            block.ironwood_transactions_count(),
+            block.auth_data_root(),
+        );
         roots.push(BlockCommitmentRoots {
             height,
             sapling_root: sapling.root(),
@@ -579,10 +576,11 @@ pub fn produce_final_frontiers_bytes(
 
 #[cfg(test)]
 mod tests {
-    use zakura_chain::{ironwood, parameters::Network};
+    use zakura_chain::{ironwood, parameters::Network, serialization::ZcashDeserializeInto};
 
     use crate::{
         constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
+        request::{CheckpointVerifiedBlock, FinalizedBlock, SemanticallyVerifiedBlock, Treestate},
         service::finalized_state::{
             disk_db::WriteDisk, DiskWriteBatch, STATE_COLUMN_FAMILIES_IN_CODE,
         },
@@ -661,6 +659,43 @@ mod tests {
             .expect("seeding finalized tip succeeds");
     }
 
+    fn test_block() -> Arc<block::Block> {
+        Network::Mainnet
+            .blockchain_map()
+            .get(&0)
+            .expect("mainnet genesis block test data is available")
+            .zcash_deserialize_into()
+            .expect("mainnet genesis block test data deserializes")
+    }
+
+    fn seed_block_bodies(db: &ZakuraDb, heights: impl IntoIterator<Item = u32>) {
+        for height in heights {
+            let test_body = test_block();
+            let transaction_hashes: Arc<[_]> =
+                test_body.transactions.iter().map(|tx| tx.hash()).collect();
+            let height_byte =
+                u8::try_from(height).expect("test heights fit in a byte for hash fixtures");
+            let finalized = FinalizedBlock::from_checkpoint_verified(
+                CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
+                    block: test_body,
+                    hash: block::Hash([height_byte; 32]),
+                    height: block::Height(height),
+                    new_outputs: HashMap::new(),
+                    transaction_hashes,
+                    deferred_pool_balance_change: None,
+                    auth_data_root: None,
+                }),
+                Treestate::default(),
+            );
+            let mut batch = DiskWriteBatch::new();
+            batch
+                .prepare_block_header_and_transaction_data_batch(db, &finalized, true, None)
+                .expect("seeding a block body succeeds");
+            db.write_batch(batch)
+                .expect("writing a seeded block body succeeds");
+        }
+    }
+
     fn seed_index_roots(db: &ZakuraDb, heights: impl IntoIterator<Item = u32>) {
         let mut batch = DiskWriteBatch::new();
         for height in heights {
@@ -690,15 +725,16 @@ mod tests {
     }
 
     fn expected_tree_roots(height: u32) -> BlockCommitmentRoots {
+        let block = test_block();
         BlockCommitmentRoots {
             height: block::Height(height),
             sapling_root: sapling_tree(u64::from(height)).root(),
             orchard_root: orchard_tree(u64::from(height)).root(),
             ironwood_root: ironwood::tree::NoteCommitmentTree::default().root(),
-            sapling_tx: 0,
-            orchard_tx: 0,
-            ironwood_tx: 0,
-            auth_data_root: AuthDataRoot::from([0; 32]),
+            sapling_tx: block.sapling_transactions_count(),
+            orchard_tx: block.orchard_transactions_count(),
+            ironwood_tx: block.ironwood_transactions_count(),
+            auth_data_root: block.auth_data_root(),
         }
     }
 
@@ -722,6 +758,7 @@ mod tests {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         seed_trees(&db, [1, 2]);
+        seed_block_bodies(&db, [1, 2]);
         seed_finalized_tip(&db, block::Height(2));
 
         let roots = produce_block_roots(&db, block::Height(1)..=block::Height(4));
@@ -730,6 +767,23 @@ mod tests {
             roots,
             vec![expected_tree_roots(1), expected_tree_roots(2)],
             "tree-derived roots stop at the first missing height"
+        );
+    }
+
+    #[test]
+    fn produce_block_roots_stops_before_missing_body() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+        seed_trees(&db, [1, 2, 3]);
+        seed_block_bodies(&db, [1, 3]);
+        seed_finalized_tip(&db, block::Height(3));
+
+        let roots = produce_block_roots(&db, block::Height(1)..=block::Height(3));
+
+        assert_eq!(
+            roots,
+            vec![expected_tree_roots(1)],
+            "a missing body ends the contiguous prefix instead of fabricating auxiliary data"
         );
     }
 
@@ -775,6 +829,7 @@ mod tests {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         seed_trees(&db, [1]);
+        seed_block_bodies(&db, [1]);
         let non_empty_ironwood = non_empty_ironwood_tree(7);
         let non_empty_root = non_empty_ironwood.root();
         let mut batch = DiskWriteBatch::new();
@@ -800,6 +855,7 @@ mod tests {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         seed_trees(&db, [1, 2]);
+        seed_block_bodies(&db, [1, 2]);
         seed_index_roots(&db, [1, 2]);
         seed_finalized_tip(&db, block::Height(2));
 
@@ -817,6 +873,7 @@ mod tests {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         seed_trees(&db, [1, 2]);
+        seed_block_bodies(&db, [1, 2]);
         seed_index_roots(&db, [3, 4]);
         seed_finalized_tip(&db, block::Height(4));
         set_upgrade_height(&db, block::Height(3));
@@ -840,6 +897,7 @@ mod tests {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         seed_trees(&db, [1]);
+        seed_block_bodies(&db, [1]);
         seed_index_roots(&db, [3, 4]);
         seed_finalized_tip(&db, block::Height(1));
         set_upgrade_height(&db, block::Height(3));


### PR DESCRIPTION
## Summary
- stop tree-derived VCT root serving at the first unavailable block body
- avoid pairing valid commitment roots with fabricated zero transaction counts and auth-data roots
- add regression coverage for missing bodies and update tree-root fixtures to use real body-derived auxiliary data

## Test plan
- [x] `cargo test -p zakura-state commitment_aux::tests --lib`
- [x] `cargo fmt --all -- --check`
- [x] verify no linter errors in the modified file