### PR TITLE
fix(network): bound peer writer shutdown

### DIFF
--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -1735,16 +1735,15 @@ where
     /// If the connection has errored already, re-use the original error.
     /// Otherwise, fail the connection with `error`.
     async fn shutdown_async(&mut self, error: impl Into<SharedPeerError>) {
-        // Close async channels first, so other tasks can start shutting down.
-        // There's nothing we can do about errors while shutting down, and some errors are expected.
-        //
-        // TODO: close peer_tx and peer_rx in shutdown() and Drop, after:
-        // - using channels instead of streams/sinks?
-        // - exposing the underlying implementation rather than using generics and closures?
-        // - adding peer_rx to the connection struct (optional)
-        let _ = self.peer_tx.close().await;
-
+        // Mark the connection as failed before awaiting a best-effort writer close.
+        // A peer that stops receiving data can block flushing the writer, but
+        // must not keep the client, peer set, or connection tracker alive indefinitely.
         self.shutdown(error);
+
+        // There's nothing we can do about errors while shutting down, and some errors are expected.
+        // `PeerTx::close` has the same timeout as sends, so this cannot delay
+        // dropping the connection indefinitely.
+        let _ = self.peer_tx.close().await;
     }
 
     /// Marks the peer as having failed with `error`, and performs connection cleanup.

--- a/zakura-network/src/peer/connection/peer_tx.rs
+++ b/zakura-network/src/peer/connection/peer_tx.rs
@@ -33,8 +33,13 @@ where
     }
 
     /// Flush any remaining output and close this [`PeerTx`], if necessary.
-    pub async fn close(&mut self) -> Result<(), SerializationError> {
-        self.inner.close().await
+    ///
+    /// Returns a timeout error if flushing takes too long.
+    pub async fn close(&mut self) -> Result<(), PeerError> {
+        tokio::time::timeout(REQUEST_TIMEOUT, self.inner.close())
+            .await
+            .map_err(|_| PeerError::ConnectionSendTimeout)?
+            .map_err(Into::into)
     }
 }
 
@@ -53,6 +58,6 @@ where
 {
     fn drop(&mut self) {
         // Do a last-ditch close attempt on the sink
-        self.close().now_or_never();
+        self.inner.close().now_or_never();
     }
 }

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -5,11 +5,13 @@
 use std::{
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    panic,
     sync::Arc,
+    task::{Context, Poll},
 };
 
 use chrono::Utc;
-use futures::{channel::mpsc, sink::SinkMapErr, SinkExt};
+use futures::{channel::mpsc, sink::SinkMapErr, Sink, SinkExt};
 
 use zakura_chain::{block::Height, serialization::SerializationError};
 use zakura_test::mock_service::MockService;
@@ -27,6 +29,47 @@ use crate::{
 
 mod prop;
 mod vectors;
+
+/// Test that dropping a peer sender does not require a Tokio timer context.
+#[test]
+fn peer_tx_drop_does_not_require_tokio_timer() {
+    let result = panic::catch_unwind(|| drop(super::peer_tx::PeerTx::from(NeverClosingSink)));
+
+    assert!(result.is_ok(), "dropping a peer sender must not panic");
+}
+
+/// A sink that accepts messages but never finishes closing.
+#[derive(Clone, Debug)]
+struct NeverClosingSink;
+
+impl Sink<Message> for NeverClosingSink {
+    type Error = SerializationError;
+
+    fn poll_ready(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: std::pin::Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+}
 
 /// Creates a new [`Connection`] instance for testing.
 fn new_test_connection<A>() -> (
@@ -96,4 +139,50 @@ fn new_test_connection<A>() -> (
         peer_rx,
         shared_error_slot,
     )
+}
+
+/// Creates a connection whose peer writer never finishes closing.
+fn new_never_closing_test_connection<A>(
+    connection_tracker: crate::peer_set::ConnectionTracker,
+) -> (
+    Connection<MockService<Request, Response, A>, NeverClosingSink>,
+    mpsc::Sender<ClientRequest>,
+    ErrorSlot,
+) {
+    let mock_inbound_service = MockService::build().finish();
+    let (client_tx, client_rx) = mpsc::channel(0);
+    let shared_error_slot = ErrorSlot::default();
+
+    let fake_addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4).into();
+    let fake_version = CURRENT_NETWORK_PROTOCOL_VERSION;
+    let fake_services = PeerServices::default();
+    let remote = VersionMessage {
+        version: fake_version,
+        services: fake_services,
+        timestamp: Utc::now(),
+        address_recv: AddrInVersion::new(fake_addr, fake_services),
+        address_from: AddrInVersion::new(fake_addr, fake_services),
+        nonce: Nonce::default(),
+        user_agent: "connection test".to_string(),
+        start_height: Height(0),
+        relay: true,
+    };
+    let connection_info = ConnectionInfo {
+        connected_addr: ConnectedAddr::Isolated,
+        local: remote.clone(),
+        remote,
+        negotiated_version: fake_version,
+    };
+
+    let connection = Connection::new(
+        mock_inbound_service,
+        client_rx,
+        shared_error_slot.clone(),
+        NeverClosingSink,
+        connection_tracker,
+        Arc::new(connection_info),
+        Vec::new(),
+    );
+
+    (connection, client_tx, shared_error_slot)
 }

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -27,6 +27,7 @@ use crate::{
         connection::{overload_drop_connection_probability, Connection, State},
         ClientRequest, ErrorSlot,
     },
+    peer_set::ActiveConnectionCounter,
     protocol::external::Message,
     types::Nonce,
     PeerError, Request, Response,
@@ -108,6 +109,54 @@ async fn connection_run_loop_spawn_ok() {
     connection_join_handle.abort();
     let outbound_message = peer_outbound_messages.next().await;
     assert_eq!(outbound_message, None);
+}
+
+/// Test that a peer writer which never closes cannot retain a failed connection.
+#[tokio::test]
+async fn connection_shutdown_times_out_stalled_peer_tx_close() {
+    let _init_guard = zakura_test::init();
+
+    tokio::time::pause();
+
+    let mut active_connections = ActiveConnectionCounter::new_counter();
+    let connection_tracker = active_connections.track_connection();
+    let (connection, client_tx, shared_error_slot) =
+        super::new_never_closing_test_connection::<crate::BoxError>(connection_tracker);
+
+    // Closing the peer receiver fails the connection immediately.
+    let (peer_tx, peer_rx) = mpsc::channel(1);
+    drop(peer_tx);
+
+    let mut connection_task = tokio::spawn(connection.run(peer_rx));
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        shared_error_slot
+            .try_get_error()
+            .expect("peer stream closure must fail the connection")
+            .inner_debug(),
+        "ConnectionClosed",
+    );
+    assert!(
+        client_tx.is_closed(),
+        "failed connections must close client work before flushing the peer writer"
+    );
+    assert!(
+        matches!(futures::poll!(&mut connection_task), Poll::Pending),
+        "stalled close must wait for its timeout"
+    );
+
+    tokio::time::advance(REQUEST_TIMEOUT).await;
+
+    assert!(
+        connection_task.await.is_ok(),
+        "connection must finish after the peer writer close timeout"
+    );
+    assert_eq!(
+        active_connections.update_count(),
+        0,
+        "finished connections must release their connection tracker"
+    );
 }
 
 /// Test that the connection run loop works as a spawned task with messages in and out


### PR DESCRIPTION
## Motivation

Bound peer-writer shutdown so a peer that stops reading cannot retain a failed
connection and its connection-tracker slot indefinitely.

No linked issue.

## Solution

Mark connections failed before their best-effort peer-writer close, and apply
the existing request timeout to that close. Preserve a non-blocking final sink
close in `Drop`, which does not require a Tokio timer context. Add regression
tests for a sink whose close never completes and dropping a peer sender outside
Tokio.

### Tests

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network peer::connection::tests`
- `cargo clippy -p zakura-network --all-targets -- -D warnings`

### Specifications & References

Related: #134.

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used: Codex for the implementation and regression test.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer connection teardown order and timeouts in core networking; incorrect behavior could affect connection limits or shutdown under bad peers, but scope is localized with regression tests.
> 
> **Overview**
> Prevents a peer that stops reading from holding a failed connection (and its **connection tracker** slot) open while the outbound writer flush never completes.
> 
> **`shutdown_async`** now runs synchronous **`shutdown`** first—closing the client channel, failing the connection, and flushing pending work—then performs a best-effort **`PeerTx::close`** afterward. **`PeerTx::close`** is bounded with the same **`REQUEST_TIMEOUT`** as sends and surfaces **`ConnectionSendTimeout`** instead of hanging indefinitely. **`PeerTx`’s `Drop`** calls **`inner.close()`** directly (non-blocking) so dropping the sender does not require a Tokio timer context.
> 
> Regression tests cover a sink whose **`poll_close`** never completes (connection task finishes after the timeout and releases the tracker) and dropping **`PeerTx`** outside Tokio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d20cf8c2a1e65f59e174f7d5c3b9b7f0c8c9c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->