### PR TITLE
fix(state): separate chain identity from body availability

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -63,7 +63,7 @@ retries = 2
 # no-fail-fast without hiding fast unit failures.
 [profile.full-tests]
 failure-output = "immediate"
-default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(~generate_checkpoints_) and not test(=sync_one_checkpoint_mainnet) and not test(=sync_one_checkpoint_testnet) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet) and not test(=restart_stop_at_height) and not test(=sync_large_checkpoints_mempool_mainnet) and not test(=config_tests) and not test(~zakura::testkit::cluster) and not test(~zakura::testkit::blocksync_fuzz)"
+default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(~generate_checkpoints_) and not test(=sync_one_checkpoint_mainnet) and not test(=sync_one_checkpoint_testnet) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet) and not test(=restart_stop_at_height) and not test(=sync_large_checkpoints_mempool_mainnet) and not test(=pruned_storage_mode_prunes_during_regtest_sync) and not test(=config_tests) and not test(~zakura::testkit::cluster) and not test(~zakura::testkit::blocksync_fuzz)"
 
 # Retry the real-time Zakura block-sync scenario tests under load (see the note on the
 # `all-tests` override above).
@@ -93,6 +93,11 @@ retries = 2
 slow-timeout = { period = "5m", terminate-after = 1 }
 failure-output = "immediate"
 default-filter = 'package(zakura) and test(=restart_stop_at_height)'
+
+[profile.zakura-pruned-storage]
+slow-timeout = { period = "15m", terminate-after = 1 }
+failure-output = "immediate"
+default-filter = 'package(zakura) and test(=pruned_storage_mode_prunes_during_regtest_sync)'
 
 [profile.zakura-integration]
 fail-fast = false

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -142,6 +142,31 @@ jobs:
       - name: Run network-dependent acceptance tests
         run: cargo nextest run --profile zakura-network-dependent --locked --features default-release-binaries --no-fail-fast
 
+  pruned-storage:
+    name: pruned storage acceptance test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
+        with:
+          toolchain: stable
+          cache-key: pruned-storage
+          cache-on-failure: true
+      - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 #v2.79.3
+        with:
+          tool: cargo-nextest
+      - uses: ./.github/actions/setup-zakura-build
+      - name: Run pruned storage acceptance test
+        run: cargo nextest run --profile zakura-pruned-storage --locked --features default-release-binaries --no-fail-fast
+
   check-no-git-dependencies:
     name: Check no git dependencies
     permissions:
@@ -178,6 +203,7 @@ jobs:
       - unit-tests
       - zakura-config
       - network-dependent
+      - pruned-storage
       - check-no-git-dependencies
     timeout-minutes: 30
     steps:
@@ -187,4 +213,4 @@ jobs:
           jobs: ${{ toJSON(needs) }}
           # The release-only dependency check is skipped outside its event scope.
           # Failed, non-skipped jobs still fail this aggregate status.
-          allowed-skips: check-no-git-dependencies
+          allowed-skips: check-no-git-dependencies, pruned-storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 Initial release of Zakura.
 
+### Fixed
+
+- Pruned finalized blocks remain visible to chain-identity queries, including peer
+  block-hash responses and RPC confirmation lookups, after their bodies are removed.
+
 Zakura is a fork of the Zcash Foundation's
 [Zebra](https://github.com/ZcashFoundation/zebra), forked at Zebra v5.0.0. For
 the history of this codebase before the fork, see

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,7 +2093,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2218,7 +2218,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -3704,7 +3704,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6854,18 +6854,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/deny.toml
+++ b/deny.toml
@@ -196,7 +196,7 @@ skip-tree = [
     { name = "netdev", version = "=0.36.0" },
     { name = "netwatch", version = "=0.9.0" },
     { name = "socket2", version = "=0.5.10" },
-    { name = "spin", version = "=0.10.0" },
+    { name = "spin", version = "=0.10.1" },
     { name = "webpki-roots", version = "=0.26.11" },
 ]
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2134,11 +2134,11 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
-version = "0.9.8"
+version = "0.9.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
-version = "0.10.0"
+version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.spki]]

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Finalized chain-identity lookups now use retained height/hash indexes after block
+  bodies are pruned.
 - VCT checkpoint writes now use the validated header store for the H+1 root witness,
   avoiding a circular wait for the next checkpoint range's block bodies.
 - `read::history_tree` now returns the finalized history tree only when the
@@ -24,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the body-gated `ZakuraDb::body_hash` and `ZakuraDb::contains_hash`
+  helpers. Use the retained `hash` / `height` indexes for chain identity and the
+  explicit `contains_body_at_height` predicate for body availability.
 - Bumped the state database format to 28 during upgrade, backfilling empty
   Ironwood tree, value pool, and index data, then rebuilding stored history tree
   entries so they use the Ironwood-capable entry size.

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -824,7 +824,7 @@ impl StateService {
         if self
             .read_service
             .db
-            .contains_body_at_height(semantically_verified.height)
+            .contains_height(semantically_verified.height)
         {
             let (rsp_tx, rsp_rx) = oneshot::channel();
             let _ = rsp_tx.send(Err(CommitBlockError::new_duplicate(

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -273,20 +273,6 @@ impl ZakuraDb {
         self.db.zs_get(&hash_by_height, &height)
     }
 
-    /// Returns the hash for `height` only if a full block body is present.
-    pub fn body_hash(&self, height: block::Height) -> Option<block::Hash> {
-        self.contains_body_at_height(height)
-            .then(|| self.hash(height))
-            .flatten()
-    }
-
-    /// Returns `true` if `hash` is present in the finalized state.
-    #[allow(clippy::unwrap_in_result)]
-    pub fn contains_hash(&self, hash: block::Hash) -> bool {
-        self.height(hash)
-            .is_some_and(|height| self.contains_body_at_height(height))
-    }
-
     /// Returns the height of the given block if it exists.
     #[allow(clippy::unwrap_in_result)]
     pub fn height(&self, hash: block::Hash) -> Option<block::Height> {

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -24,7 +24,9 @@ use crate::{
     service::{
         finalized_state::{disk_db::DiskWriteBatch, FinalizedState},
         non_finalized_state::Chain,
-        read::find::{block_locator, chain_contains_hash},
+        read::find::{
+            block_locator, chain_contains_hash, depth, find_chain_hashes, hash_by_height,
+        },
     },
     Config, ContextuallyVerifiedBlock, PruningConfig, RollbackFinalizedStateError,
     RollbackFinalizedStateOptions, SemanticallyVerifiedBlock,
@@ -611,7 +613,7 @@ fn checkpoint_retention_skips_old_raw_transactions_in_pruned_mode() {
 }
 
 #[test]
-fn block_locator_uses_retained_hashes_when_checkpoint_bodies_are_skipped() {
+fn chain_identity_uses_retained_hashes_when_checkpoint_bodies_are_skipped() {
     let _init_guard = zakura_test::init();
     let network = Mainnet;
     let config = pruned_config();
@@ -622,16 +624,32 @@ fn block_locator_uses_retained_hashes_when_checkpoint_bodies_are_skipped() {
     let (tip_height, tip_hash) = state.db.tip().expect("test state has a finalized tip");
 
     assert_eq!(tip_height, Height(TEST_BLOCKS));
-    assert_eq!(state.db.body_hash(tip_height), None);
+    assert!(!state.db.contains_body_at_height(tip_height));
     assert_eq!(state.db.hash(tip_height), Some(tip_hash));
-    assert!(!state.db.contains_hash(tip_hash));
+    assert_eq!(state.db.height(tip_hash), Some(tip_height));
 
     let no_chain = Option::<Arc<Chain>>::None;
+    assert_eq!(
+        hash_by_height(no_chain.clone(), &state.db, tip_height),
+        Some(tip_hash)
+    );
+    assert_eq!(depth(no_chain.clone(), &state.db, tip_hash), Some(0));
+    assert!(chain_contains_hash(no_chain.clone(), &state.db, tip_hash));
+
     let locator = block_locator(no_chain.clone(), &state.db)
         .expect("a finalized tip produces a block locator");
-
     assert_eq!(locator.first(), Some(&tip_hash));
-    assert!(chain_contains_hash(no_chain, &state.db, tip_hash));
+
+    let genesis_hash = state
+        .db
+        .hash(Height::MIN)
+        .expect("test state has a finalized genesis block");
+    let hashes = find_chain_hashes(no_chain, &state.db, vec![genesis_hash], None, 500);
+    assert_eq!(
+        hashes.len(),
+        usize::try_from(TEST_BLOCKS).expect("test block count fits in usize")
+    );
+    assert_eq!(hashes.last(), Some(&tip_hash));
 }
 
 #[test]

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
@@ -132,7 +132,7 @@ fn header_range_commit_keeps_body_availability_separate() {
         vec![Height(1)],
     );
 
-    assert!(!state.contains_hash(block1.hash()));
+    assert_eq!(state.height(block1.hash()), None);
     assert!(!state.contains_body_at_height(Height(1)));
     assert!(state.block(Height(1).into()).is_none());
     assert!(state
@@ -732,12 +732,10 @@ fn known_block_reports_finalized_block_after_body_pruned() {
     );
     state.db.write(batch).expect("body prune writes");
 
-    // The body-availability predicate (what KnownBlock used before the fix) now
-    // reports the block as absent...
+    // Body availability and finalized chain identity remain distinct after pruning.
     assert!(!state.contains_body_at_height(Height(1)));
-    assert!(!state.contains_hash(block1.hash()));
+    assert_eq!(state.height(block1.hash()), Some(Height(1)));
 
-    // ...but KnownBlock still reports it as a known finalized block.
     assert_eq!(
         read::finalized_state_contains_block_hash(&state, block1.hash()),
         Some(crate::KnownBlock::Finalized),
@@ -1108,20 +1106,19 @@ fn header_range_rows_and_tip_survive_reopen_without_body_availability() {
             (Height(2), block2.hash(), block2.header.clone()),
         ],
     );
-    assert!(!reopened.contains_hash(block2.hash()));
-    assert_eq!(reopened.body_hash(Height(2)), None);
+    assert_eq!(reopened.height(block2.hash()), None);
     assert!(reopened.block(Height(2).into()).is_none());
 }
 
 #[test]
-fn block_facing_hash_by_height_requires_body_availability() {
+fn verified_hash_by_height_excludes_provisional_headers() {
     let _init_guard = zakura_test::init();
     let (state, genesis, block1) = mainnet_state_with_genesis();
 
     commit_header_range(&state, genesis.hash(), std::slice::from_ref(&block1.header));
 
     assert_eq!(state.hash(Height(1)), None);
-    assert_eq!(state.body_hash(Height(1)), None);
+    assert_eq!(state.height(block1.hash()), None);
     assert_eq!(
         read::hash_by_height(
             Option::<Arc<crate::service::non_finalized_state::Chain>>::None,
@@ -1145,7 +1142,6 @@ fn full_block_commit_over_identical_header_only_row_is_noop_for_header_indexes()
 
     assert_eq!(state.hash(Height(1)), None);
     assert_eq!(state.height(block1.hash()), None);
-    assert!(!state.contains_hash(block1.hash()));
     assert_eq!(
         state.headers_by_height_range(Height(1), 2),
         vec![(Height(1), block1.hash(), block1.header.clone())],
@@ -1155,7 +1151,6 @@ fn full_block_commit_over_identical_header_only_row_is_noop_for_header_indexes()
 
     assert_eq!(state.hash(Height(1)), Some(block1.hash()));
     assert_eq!(state.height(block1.hash()), Some(Height(1)));
-    assert!(state.contains_hash(block1.hash()));
     assert_eq!(
         state.headers_by_height_range(Height(1), 2),
         vec![(Height(1), block1.hash(), block1.header.clone())],
@@ -1183,7 +1178,7 @@ fn full_block_commit_overwrites_conflicting_header_only_rows() {
     assert_eq!(state.height(alternate_block2_hash), None);
     assert_eq!(state.height(alternate_block3_hash), None);
     assert_eq!(state.best_header_tip(), Some((Height(2), block2.hash())));
-    assert!(state.contains_hash(block2.hash()));
+    assert_eq!(state.height(block2.hash()), Some(Height(2)));
     assert!(state.block(block2.hash().into()).is_some());
     assert!(state.block(alternate_block2_hash.into()).is_none());
 }

--- a/zakura-state/src/service/non_finalized_state/backup.rs
+++ b/zakura-state/src/service/non_finalized_state/backup.rs
@@ -252,7 +252,7 @@ fn read_non_finalized_blocks_from_backup<'a>(
     list_backup_dir_entries(backup_dir_path)
         // It's okay to leave the file here, the backup task will delete it as long as
         // the block is not added to the non-finalized state.
-        .filter(|&(block_hash, _)| !finalized_state.contains_hash(block_hash))
+        .filter(|&(block_hash, _)| finalized_state.height(block_hash).is_none())
         .filter_map(|(block_hash, file_path)| match std::fs::read(file_path) {
             Ok(block_bytes) => Some((block_hash, block_bytes)),
             Err(err) => {

--- a/zakura-state/src/service/read/find.rs
+++ b/zakura-state/src/service/read/find.rs
@@ -151,7 +151,7 @@ where
     let tip = tip_height(chain, db)?;
     let height = chain
         .and_then(|chain| chain.as_ref().height_by_hash(hash))
-        .or_else(|| db.contains_hash(hash).then(|| db.height(hash)).flatten())?;
+        .or_else(|| db.height(hash))?;
 
     tip.0.checked_sub(height.0)
 }
@@ -180,10 +180,10 @@ pub fn non_finalized_state_contains_block_hash(
 ///
 /// Membership is decided by the retained hash index, not by body availability: a
 /// finalized block whose body was pruned (pruning removes `tx_by_loc` rows but keeps
-/// `height_by_hash`) is still a known finalized block. Using `contains_hash` here —
-/// which also requires the body — would report pruned historical blocks as unknown,
-/// so `Request::KnownBlock` callers (sync, inbound gossip) would re-download a full
-/// body we already finalized only to reject it as behind the finalized tip.
+/// `height_by_hash`) is still a known finalized block. Requiring body availability
+/// here would report pruned historical blocks as unknown, so `Request::KnownBlock`
+/// callers (sync, inbound gossip) would re-download a full body we already finalized
+/// only to reject it as behind the finalized tip.
 pub fn finalized_state_contains_block_hash(db: &ZakuraDb, hash: block::Hash) -> Option<KnownBlock> {
     db.height(hash).map(|_| KnownBlock::Finalized)
 }
@@ -219,7 +219,7 @@ where
 
     chain
         .and_then(|chain| chain.as_ref().hash_by_height(height))
-        .or_else(|| db.body_hash(height))
+        .or_else(|| db.hash(height))
 }
 
 /// Return true if `hash` is in `chain` or `db`.
@@ -272,11 +272,7 @@ where
     let mut hashes = Vec::with_capacity(heights.len());
 
     for height in heights {
-        let hash = chain
-            .and_then(|chain| chain.as_ref().hash_by_height(height))
-            .or_else(|| db.hash(height));
-
-        if let Some(hash) = hash {
+        if let Some(hash) = hash_by_height(chain, db, height) {
             hashes.push(hash);
         }
     }

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -26,7 +26,7 @@ use zakura_network::{
 };
 use zakura_node_services::mempool;
 use zakura_rpc::SubmitBlockChannel;
-use zakura_state::Config as StateConfig;
+use zakura_state::{Config as StateConfig, PruningConfig, StorageMode};
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
@@ -62,7 +62,7 @@ async fn inbound_peers_empty_address_book() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         listen_addr,
-    ) = setup(None, P2pStack::Legacy).await;
+    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral()).await;
 
     // yield and sleep until the address book lock is released.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -151,7 +151,12 @@ async fn dual_stack_node_coexists_with_legacy_tcp_peer() -> Result<(), crate::Bo
         tx_gossip_task_handle,
         // real open socket addresses
         listen_addr,
-    ) = setup(Some(Response::Peers(Vec::new())), P2pStack::Dual).await;
+    ) = setup(
+        Some(Response::Peers(Vec::new())),
+        P2pStack::Dual,
+        StateConfig::ephemeral(),
+    )
+    .await;
 
     // yield and sleep until the address book lock is released.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -215,7 +220,7 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, P2pStack::Legacy).await;
+    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral()).await;
 
     let test_block = block::Hash([0x11; 32]);
 
@@ -278,6 +283,112 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
     Ok(())
 }
 
+/// Check that a block advertised from the retained chain index returns `notfound`
+/// when its pruned body is requested.
+///
+/// Uses a real Zebra network stack, with an isolated Zebra inbound TCP connection.
+#[tokio::test(flavor = "multi_thread")]
+async fn inbound_pruned_advertised_block_notfound() -> Result<(), crate::BoxError> {
+    // `setup` configures checkpoint retention against `Height::MAX`, so block 1 is committed
+    // to the retained chain indexes without storing its transaction bytes. Genesis is retained.
+    let state_config = StateConfig {
+        storage_mode: StorageMode::Pruned(PruningConfig::default()),
+        ..StateConfig::ephemeral()
+    };
+    let (
+        // real services
+        connected_peer_service,
+        inbound_service,
+        _peer_set,
+        _mempool_service,
+        state_service,
+        // mocked services
+        _mock_block_verifier,
+        _mock_tx_verifier,
+        // real tasks
+        block_gossip_task_handle,
+        tx_gossip_task_handle,
+        // real open socket addresses
+        _listen_addr,
+    ) = setup(None, P2pStack::Legacy, state_config).await;
+
+    let genesis: std::sync::Arc<block::Block> =
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block1: std::sync::Arc<block::Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+
+    for block in [&genesis, &block1] {
+        state_service
+            .clone()
+            .oneshot(zakura_state::Request::CommitCheckpointVerifiedBlock(
+                (*block).clone().into(),
+            ))
+            .await?;
+    }
+
+    let advertised_hashes = state_service
+        .clone()
+        .oneshot(zakura_state::Request::FindBlockHashes {
+            known_blocks: vec![genesis.hash()],
+            stop: None,
+        })
+        .await?;
+    assert_eq!(
+        advertised_hashes,
+        zakura_state::Response::BlockHashes(vec![block1.hash()]),
+        "the retained chain index advertises the pruned block"
+    );
+
+    let block_response = state_service
+        .clone()
+        .oneshot(zakura_state::Request::Block(block1.hash().into()))
+        .await?;
+    assert_eq!(
+        block_response,
+        zakura_state::Response::Block(None),
+        "the pruned block body is unavailable"
+    );
+
+    let inbound_response = inbound_service
+        .clone()
+        .oneshot(Request::BlocksByHash(iter::once(block1.hash()).collect()))
+        .await?;
+    assert_eq!(
+        inbound_response,
+        Response::Blocks(vec![Missing(block1.hash())]),
+        "inbound maps the unavailable block body to missing inventory"
+    );
+
+    let wire_response = connected_peer_service
+        .clone()
+        .oneshot(Request::BlocksByHash(iter::once(block1.hash()).collect()))
+        .await;
+    if let Err(missing_error) = wire_response.as_ref() {
+        let missing_error = missing_error
+            .downcast_ref::<SharedPeerError>()
+            .expect("unexpected inner error type, expected SharedPeerError");
+        let expected = PeerError::NotFoundResponse(vec![InventoryHash::Block(block1.hash())]);
+        let expected = SharedPeerError::from(expected);
+        assert_eq!(missing_error.inner_debug(), expected.inner_debug());
+    } else {
+        unreachable!(
+            "the wire response should be `notfound` for an advertised block with a pruned body, \
+             actual result: {wire_response:?}"
+        )
+    }
+
+    assert!(
+        block_gossip_task_handle.now_or_never().is_none(),
+        "block gossip task should still be running",
+    );
+    assert!(
+        tx_gossip_task_handle.now_or_never().is_none(),
+        "transaction gossip task should still be running",
+    );
+
+    Ok(())
+}
+
 /// Check that a network stack with an empty state responds to single transaction requests with `notfound`.
 ///
 /// Uses a real Zebra network stack, with an isolated Zebra inbound TCP connection.
@@ -298,7 +409,7 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, P2pStack::Legacy).await;
+    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral()).await;
 
     let test_tx = UnminedTxId::from_legacy_id(TxHash([0x22; 32]));
     let test_wtx: UnminedTxId = WtxId {
@@ -430,7 +541,12 @@ async fn outbound_tx_unrelated_response_notfound() -> Result<(), crate::BoxError
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(Some(unrelated_response), P2pStack::Legacy).await;
+    ) = setup(
+        Some(unrelated_response),
+        P2pStack::Legacy,
+        StateConfig::ephemeral(),
+    )
+    .await;
 
     let test_tx5 = UnminedTxId::from_legacy_id(TxHash([0x55; 32]));
     let test_wtx67: UnminedTxId = WtxId {
@@ -579,7 +695,12 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(Some(repeated_response), P2pStack::Legacy).await;
+    ) = setup(
+        Some(repeated_response),
+        P2pStack::Legacy,
+        StateConfig::ephemeral(),
+    )
+    .await;
 
     let missing_tx_id = UnminedTxId::from_legacy_id(TxHash([0x22; 32]));
 
@@ -672,6 +793,7 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
 async fn setup(
     isolated_peer_response: Option<Response>,
     p2p_stack: P2pStack,
+    state_config: StateConfig,
 ) -> (
     // real services
     // connected peer which responds with isolated_peer_response
@@ -719,7 +841,6 @@ async fn setup(
 
     // State
     // UTXO verification doesn't matter for these tests.
-    let state_config = StateConfig::ephemeral();
     let (state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
         zakura_state::init(state_config, &network, Height::MAX, 0).await;
     let state_service = ServiceBuilder::new().buffer(10).service(state_service);


### PR DESCRIPTION
## Motivation

PR #142 fixed the urgent empty-block-locator stall, but it routed around a broader state-layer semantic bug: identity-named helpers still treat a finalized block as absent when its transaction body has been pruned.

Pruned storage deliberately retains the finalized height/hash indexes and headers. Chain-identity queries must use those indexes; body availability must remain an explicit, separate question. Otherwise pruned nodes truncate `getblocks` responses, report canonical historical blocks with incorrect depth/confirmations, retry stale backup blocks, and fail to reject semantic commits at already-finalized heights through the intended duplicate path.

This PR builds on merged PR #142 by extending its pruned checkpoint fixture and routing block locator construction back through the corrected shared helper, replacing the temporary inline workaround.

## Solution

- make `read::find::hash_by_height` use the retained finalized hash index
- make `read::find::depth` use the retained hash-to-height index
- restore the semantic-commit duplicate guard to finalized-height membership
- ignore backup blocks whose hashes are already in the finalized index
- delete `ZakuraDb::body_hash` and `ZakuraDb::contains_hash`, whose identity-like names encoded body-availability gates
- route block locator construction through the now-correct shared `hash_by_height` helper
- preserve the separate semantics of provisional header-only rows
- extend the pruned checkpoint regression to cover hash lookup, depth, block locators, and peer `getblocks` hash collection while the body remains absent
- add a real-peer reverse-risk characterization proving that an advertised pruned block returns `Block(None)`, maps to missing inventory, and produces a wire `notfound`
- update the two yanked `spin` versions (`0.9.8` and `0.10.0`) to compatible patch releases (`0.9.9` and `0.10.1`), including their matching deny/vet policy entries; this unrelated `main`-baseline CI unblock is kept in a separate commit

The actual block-serving path is unchanged: it still checks body availability and returns `notfound` for a pruned body.

### Tests

- `cargo fmt --all -- --check` — passed after rebasing onto current `main`
- `CXXFLAGS='-include cstdint' cargo clippy --workspace --all-targets -- -D warnings` — passed after rebasing onto current `main`
- `CXXFLAGS='-include cstdint' cargo clippy -p zakura --all-targets -- -D warnings` — passed after adding the reverse-risk characterization
- `CXXFLAGS='-include cstdint' cargo test -p zakura-state` — passed after rebasing onto current `main` (352 passed, 3 ignored)
- `CXXFLAGS='-include cstdint' cargo test -p zakura components::inbound::tests::real_peer_set` — passed (8 passed), including the pruned-body wire `notfound` characterization
- `CXXFLAGS='-include cstdint' cargo check --workspace --locked` — passed with `spin 0.9.9` and `0.10.1`
- `cargo deny --workspace check bans --allow unmatched-skip-root` — passed with the updated `spin 0.10.1` duplicate-version exception
- `cargo vet check --locked` — passed after reviewing both `spin` patch deltas and advancing their existing `safe-to-deploy` exemptions
- `CXXFLAGS='-include cstdint' cargo test --workspace` — state, unit, pruned-regtest, and 48/49 default acceptance tests passed before the rebase; `activate_mempool_mainnet` timed out after four minutes because the live mainnet peer set did not advance past genesis. This network-dependent failure is unrelated to the state changes.
- `pruned_storage_mode_prunes_during_regtest_sync` exceeded 210 seconds locally before the timing run was stopped. It now has a dedicated post-merge CI profile and runs only on pushes to `main`, so it guards pruned sync end-to-end without blocking pull requests or the merge queue.

The `CXXFLAGS` workaround force-includes the standard `<cstdint>` header required by bundled RocksDB under the local host compiler.

### Specifications & References

- Builds on merged PR #142
- Root regression introduced in `64f405b4ee`
- Phase 1 of the pruned body-gate audit

### Follow-up Work

- keep the retained-transaction-hash RPC policy and VCT historical-tree error classification in separate follow-ups

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex was used for audit interpretation, implementation, regression-test updates, rebase/conflict resolution, local validation, and drafting this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
