### PR TITLE
fix(network): ignore inbound source ports for address book identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,7 +2093,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2218,7 +2218,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -3704,7 +3704,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6854,18 +6854,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2134,11 +2134,11 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
-version = "0.9.8"
+version = "0.9.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
-version = "0.10.0"
+version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.spki]]

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -280,10 +280,10 @@ impl ConnectedAddr {
     /// TODO: remove the `get_` from these methods (Rust style avoids `get` prefixes)
     pub fn get_address_book_addr(&self) -> Option<PeerSocketAddr> {
         match self {
-            OutboundDirect { addr } | InboundDirect { addr } => Some(*addr),
+            OutboundDirect { addr } => Some(*addr),
             // TODO: consider using the canonical address of the peer to track
             //       outbound proxy connections
-            OutboundProxy { .. } | InboundProxy { .. } | Isolated => None,
+            InboundDirect { .. } | OutboundProxy { .. } | InboundProxy { .. } | Isolated => None,
         }
     }
 

--- a/zakura-network/src/peer/handshake/tests.rs
+++ b/zakura-network/src/peer/handshake/tests.rs
@@ -42,6 +42,58 @@ fn peer_addr(port: u16) -> PeerSocketAddr {
     SocketAddr::from((Ipv4Addr::LOCALHOST, port)).into()
 }
 
+#[test]
+fn connected_addr_address_book_addr_only_uses_outbound_direct() {
+    let outbound_addr = peer_addr(18233);
+    let inbound_addr = peer_addr(28233);
+    let proxy_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 38233));
+    let transient_local_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 48233));
+
+    assert_eq!(
+        ConnectedAddr::new_outbound_direct(outbound_addr).get_address_book_addr(),
+        Some(outbound_addr)
+    );
+    assert_eq!(
+        ConnectedAddr::new_inbound_direct(inbound_addr).get_address_book_addr(),
+        None
+    );
+    assert_eq!(
+        ConnectedAddr::new_outbound_proxy(proxy_addr, transient_local_addr).get_address_book_addr(),
+        None
+    );
+    assert_eq!(
+        ConnectedAddr::new_inbound_proxy(proxy_addr).get_address_book_addr(),
+        None
+    );
+    assert_eq!(ConnectedAddr::new_isolated().get_address_book_addr(), None);
+}
+
+#[test]
+fn connected_addr_transient_addr_identifies_open_non_isolated_connections() {
+    let outbound_addr = peer_addr(18233);
+    let inbound_addr = peer_addr(28233);
+    let proxy_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 38233));
+    let transient_local_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 48233));
+
+    assert_eq!(
+        ConnectedAddr::new_outbound_direct(outbound_addr).get_transient_addr(),
+        Some(outbound_addr)
+    );
+    assert_eq!(
+        ConnectedAddr::new_inbound_direct(inbound_addr).get_transient_addr(),
+        Some(inbound_addr)
+    );
+    assert_eq!(
+        ConnectedAddr::new_outbound_proxy(proxy_addr, transient_local_addr).get_transient_addr(),
+        Some(transient_local_addr.into())
+    );
+    assert_eq!(
+        ConnectedAddr::new_inbound_proxy(proxy_addr).get_transient_addr(),
+        Some(proxy_addr.into())
+    );
+    assert_eq!(ConnectedAddr::new_isolated().get_transient_addr(), None);
+}
+
 fn test_config(p2p_stack: P2pStack) -> Config {
     Config::for_test(p2p_stack)
 }


### PR DESCRIPTION
## Summary
- Stop treating inbound direct TCP source endpoints as durable address-book identities.
- Keep transient connection identity behavior intact and add regression coverage for every `ConnectedAddr` variant.

## Test plan
- `cargo test -p zakura-network connected_addr_`
- `cargo test -p zakura-network peer::handshake`
- `cargo test -p zakura-network`