### PR TITLE
fix(network): close discovery-only connections

### DIFF
--- a/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/zakura-network/src/zakura/block_sync/reactor.rs
@@ -85,6 +85,7 @@ pub fn spawn_block_sync_reactor(
     let (peers_tx, peers_rx) = watch::channel(state.peer_snapshot(startup.config.peer_limits));
     let (status_tx, status_rx) = watch::channel(state.last_advertised_status);
     let (candidates_tx, candidates_rx) = watch::channel(ZakuraBlockSyncCandidateState::default());
+    let (admitted_tx, admitted_rx) = watch::channel(HashSet::new());
 
     // The Sequencer (commit pipeline) and the committed-throughput meter move out
     // of the reactor onto their own serial task (Sequencer task). Downloaded
@@ -157,6 +158,7 @@ pub fn spawn_block_sync_reactor(
         peers: peers_rx,
         status: status_rx,
         candidates: candidates_rx,
+        admitted: admitted_rx,
         routine_wiring: Some(routine_wiring),
     };
     let reactor = BlockSyncReactor {
@@ -178,6 +180,7 @@ pub fn spawn_block_sync_reactor(
         peers: peers_tx,
         status: status_tx,
         candidates: candidates_tx,
+        admitted: admitted_tx,
         sequencer_input: sequencer_input_tx,
         sequencer_input_bytes,
         sequencer_input_decoded_attributed_memory_bytes,
@@ -218,6 +221,7 @@ pub(super) struct BlockSyncReactor {
     peers: watch::Sender<ServicePeerSnapshot>,
     status: watch::Sender<BlockSyncStatus>,
     candidates: watch::Sender<ZakuraBlockSyncCandidateState>,
+    admitted: watch::Sender<HashSet<ZakuraPeerId>>,
     /// Bounded body channel to the Sequencer task. Only per-peer routines send
     /// downloaded bodies here; the reactor keeps a sender clone for diagnostics.
     sequencer_input: mpsc::Sender<SequencedBody>,
@@ -534,6 +538,9 @@ impl BlockSyncReactor {
         let _ = self
             .peers
             .send(self.state.peer_snapshot(self.startup.config.peer_limits));
+        let _ = self
+            .admitted
+            .send(self.state.peers.keys().cloned().collect());
     }
 
     fn publish_candidate_state(&self) {

--- a/zakura-network/src/zakura/block_sync/state.rs
+++ b/zakura-network/src/zakura/block_sync/state.rs
@@ -135,6 +135,7 @@ pub struct BlockSyncHandle {
     pub(super) peers: watch::Receiver<ServicePeerSnapshot>,
     pub(super) status: watch::Receiver<BlockSyncStatus>,
     pub(super) candidates: watch::Receiver<ZakuraBlockSyncCandidateState>,
+    pub(super) admitted: watch::Receiver<HashSet<ZakuraPeerId>>,
     /// Shared primitives every per-peer pipe-routine is wired with at spawn
     /// (`service::add_peer`). `None` for the inert/handle-less test constructors
     /// that never spawn routines.
@@ -218,6 +219,11 @@ impl BlockSyncHandle {
     /// Return the currently cached block-sync candidate-selection hints.
     pub fn candidate_state(&self) -> ZakuraBlockSyncCandidateState {
         self.candidates.borrow().clone()
+    }
+
+    /// Returns whether block sync has admitted `peer`.
+    pub(crate) fn has_admitted_peer(&self, peer: &ZakuraPeerId) -> bool {
+        self.admitted.borrow().contains(peer)
     }
 }
 

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -5143,12 +5143,14 @@ async fn lifecycle_events_bypass_full_bounded_wire_queue() {
     let (_peers_tx, peers) = watch::channel(ServicePeerSnapshot::new(0, 0, config.peer_limits));
     let (_status_tx, status) = watch::channel(config.initial_status());
     let (_candidates_tx, candidates) = watch::channel(ZakuraBlockSyncCandidateState::default());
+    let (_admitted_tx, admitted) = watch::channel(HashSet::new());
     let handle = BlockSyncHandle {
         events,
         lifecycle,
         peers,
         status,
         candidates,
+        admitted,
         // No reactor wiring: `add_peer` drains inbound (no routine), and this test
         // only checks the lifecycle-bypass plumbing.
         routine_wiring: None,

--- a/zakura-network/src/zakura/discovery/service.rs
+++ b/zakura-network/src/zakura/discovery/service.rs
@@ -25,7 +25,7 @@ use crate::zakura::{
     CloseCause, Flow, Frame, FramedRecv, FramedSend, HeaderSyncEvent, HeaderSyncHandle,
     OrderedSendError, Peer, PeerStreamSession, Pipe, Service, ServiceAdmissionDecision,
     ServicePeerDirection, SinkReject, Stream, StreamMode, ZakuraConnId, ZakuraPeerId,
-    LOCAL_MAX_CONTROL_FRAME_BYTES, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
+    LOCAL_MAX_CONTROL_FRAME_BYTES, ZAKURA_CAP_DISCOVERY,
 };
 
 #[cfg(test)]
@@ -231,7 +231,6 @@ impl Service for DiscoveryService {
         let service_cancel = discovery_session.cancel_token();
         let connection_cancel = peer.cancel_token();
         let close_cause = peer.close_cause();
-        let other_service_negotiated = has_other_negotiated_service(peer.negotiated);
         let (_peer_id, _stream_kind, recv, _send, _session_cancel) = session.into_parts();
 
         let handle = self.handle.clone();
@@ -285,7 +284,6 @@ impl Service for DiscoveryService {
                     service_cancel,
                     connection_cancel,
                     close_cause,
-                    other_service_negotiated,
                 });
             },
         );
@@ -311,7 +309,6 @@ struct DiscoveryExchangeStart {
     service_cancel: CancellationToken,
     connection_cancel: CancellationToken,
     close_cause: CloseCause,
-    other_service_negotiated: bool,
 }
 
 fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
@@ -326,11 +323,11 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
         service_cancel,
         connection_cancel,
         close_cause,
-        other_service_negotiated,
     } = start;
     let peer_id = discovery_session.peer_id().clone();
     let progress = Arc::new(DiscoveryExchangeProgress::default());
     let source_header_sync = header_sync.clone();
+    let source_block_sync = block_sync.clone();
     let sink = DiscoverySink {
         handle: handle.clone(),
         header_sync,
@@ -399,8 +396,9 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
             if exchanged
                 && !peer_has_other_service_owner(
                     source_header_sync.as_ref(),
+                    source_block_sync.as_ref(),
                     peer_node_id,
-                    other_service_negotiated,
+                    &peer_id,
                 )
             {
                 source_close_cause.record("discovery_exchange_complete");
@@ -714,23 +712,16 @@ impl DiscoveryExchangeProgress {
 
 fn peer_has_other_service_owner(
     header_sync: Option<&HeaderSyncHandle>,
+    block_sync: Option<&BlockSyncHandle>,
     peer_node_id: NodeId,
-    other_service_negotiated: bool,
+    peer_id: &ZakuraPeerId,
 ) -> bool {
-    if other_service_negotiated {
-        return true;
-    }
-
     header_sync.is_some_and(|header_sync| {
         header_sync
             .candidate_state()
             .admitted_node_ids
             .contains(&peer_node_id)
-    })
-}
-
-fn has_other_negotiated_service(negotiated: u64) -> bool {
-    negotiated & !(ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_HEADER_SYNC) != 0
+    }) || block_sync.is_some_and(|block_sync| block_sync.has_admitted_peer(peer_id))
 }
 
 /// Returns the iroh node id encoded by a discovery peer id, if it is a 32-byte
@@ -779,17 +770,6 @@ mod tests {
         MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_BLOCK_SYNC, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
     };
     use zakura_chain::{block, parameters::Network};
-
-    #[test]
-    fn discovery_and_header_sync_do_not_count_as_another_service_owner() {
-        assert!(!has_other_negotiated_service(ZAKURA_CAP_DISCOVERY));
-        assert!(!has_other_negotiated_service(
-            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_HEADER_SYNC
-        ));
-        assert!(has_other_negotiated_service(
-            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_HEADER_SYNC | ZAKURA_CAP_BLOCK_SYNC
-        ));
-    }
 
     struct HeaderAdvisoryFixture {
         discovery_handle: ZakuraDiscoveryHandle,
@@ -1526,7 +1506,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discovery_only_short_lived_exchange_closes_connection_and_backs_off(
+    async fn discovery_exchange_closes_connection_when_block_sync_is_not_admitted(
     ) -> Result<(), crate::BoxError> {
         let (connected_tx, connected_rx) = watch::channel(Vec::new());
         let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
@@ -1559,7 +1539,7 @@ mod tests {
         service.add_peer(Peer::new(
             peer_id,
             None,
-            ZAKURA_CAP_DISCOVERY,
+            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_BLOCK_SYNC,
             streams,
             connection_cancel.clone(),
         ));
@@ -1569,7 +1549,7 @@ mod tests {
             .await?;
         tokio::time::timeout(Duration::from_secs(2), connection_cancel.cancelled())
             .await
-            .expect("discovery-only exchange closes the shared connection");
+            .expect("unadmitted block sync does not keep the shared connection alive");
         wait_for_discovery_inbound_peers(&handle, 0).await;
 
         connected_tx.send_replace(Vec::new());


### PR DESCRIPTION
## Motivation

Discovery treated negotiating any non-discovery capability as proof that another
service owned the shared connection. A peer could negotiate block sync without
being admitted to it, complete a short-lived discovery exchange, and retain an
idle authenticated connection.

## Solution

Use actual service admission to decide whether discovery should keep the shared
connection alive. Header-sync continues to use its admitted-peer state, while
block-sync now publishes a separate admitted-peer snapshot. Discovery no longer
uses the negotiated capability mask for ownership.

### Tests

- `cargo test -p zakura-network discovery_exchange_closes_connection_when_block_sync_is_not_admitted --locked`
- `cargo test -p zakura-network discovery_short_lived_exchange_keeps_header_sync_connection --locked`

`cargo fmt --all -- --check` and clippy with `-D warnings` are currently
blocked by pre-existing unrelated changes in the working tree.

### Specifications & References

No external specification applies.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Codex for investigation, implementation, and test coverage.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.
