### PR TITLE
fix(consensus): classify wrapped commit errors as duplicate requests

### DIFF
--- a/zakura-consensus/src/block.rs
+++ b/zakura-consensus/src/block.rs
@@ -127,6 +127,25 @@ impl VerifyBlockError {
     }
 }
 
+/// Converts an error from a `CommitSemanticallyVerifiedBlock` state request
+/// into a [`VerifyBlockError`].
+///
+/// The state boxes commit errors as [`zs::CommitSemanticallyVerifiedError`], a
+/// newtype around [`zs::CommitBlockError`], so the wrapper must be unwrapped
+/// here for `is_duplicate_request()` and `misbehavior_score()` to classify
+/// duplicate blocks as benign.
+fn map_commit_error(source: BoxError, hash: block::Hash) -> VerifyBlockError {
+    if let Some(commit_err) = source
+        .downcast_ref::<zs::CommitSemanticallyVerifiedError>()
+        .map(zs::CommitSemanticallyVerifiedError::inner)
+        .or_else(|| source.downcast_ref::<zs::CommitBlockError>())
+    {
+        return VerifyBlockError::Commit(commit_err.clone());
+    }
+
+    VerifyBlockError::StateService { source, hash }
+}
+
 /// The maximum number of transparent signature operations allowed in a block.
 ///
 /// # Consensus
@@ -390,13 +409,7 @@ where
                     Ok(hash)
                 }
 
-                Err(source) => {
-                    if let Some(commit_err) = source.downcast_ref::<zs::CommitBlockError>() {
-                        return Err(VerifyBlockError::Commit(commit_err.clone()));
-                    }
-
-                    Err(VerifyBlockError::StateService { source, hash })
-                }
+                Err(source) => Err(map_commit_error(source, hash)),
 
                 _ => unreachable!("wrong response for CommitSemanticallyVerifiedBlock"),
             }

--- a/zakura-consensus/src/block/tests.rs
+++ b/zakura-consensus/src/block/tests.rs
@@ -1112,3 +1112,34 @@ fn verify_block_error_misbehavior_scores() {
     };
     assert_eq!(VerifyBlockError::Commit(dup_err).misbehavior_score(), 0);
 }
+
+/// Duplicate block errors must stay classified as duplicate requests after the
+/// state wraps them, so they don't restart the syncer or turn `submitblock`
+/// duplicates into rejections.
+#[test]
+fn state_commit_duplicate_errors_are_duplicate_requests() {
+    let duplicate = zakura_state::CommitBlockError::Duplicate {
+        hash_or_height: None,
+        location: zakura_state::KnownBlock::BestChain,
+    };
+
+    // Box the error the same way the state's `CommitSemanticallyVerifiedBlock`
+    // handler does. This mirrors the wrapping manually, so it won't fail
+    // automatically if the state changes its error type — keep it in sync by hand.
+    let source: BoxError = Box::new(zakura_state::CommitSemanticallyVerifiedError::from(
+        duplicate,
+    ));
+
+    let err = map_commit_error(source, zakura_chain::block::Hash([0; 32]));
+
+    assert!(
+        matches!(err, VerifyBlockError::Commit(_)),
+        "state commit errors must be unwrapped into VerifyBlockError::Commit, got: {err:?}"
+    );
+    assert!(err.is_duplicate_request());
+    assert_eq!(
+        err.duplicate_location(),
+        Some(&zakura_state::KnownBlock::BestChain)
+    );
+    assert_eq!(err.misbehavior_score(), 0);
+}

--- a/zakura-consensus/src/checkpoint.rs
+++ b/zakura-consensus/src/checkpoint.rs
@@ -1039,6 +1039,12 @@ impl VerifyCheckpointError {
             // TODO: make this duplicate-incomplete
             VerifyCheckpointError::NewerRequest { .. } => true,
             VerifyCheckpointError::VerifyBlock(block_error) => block_error.is_duplicate_request(),
+            // The state boxes commit errors as `zs::CommitCheckpointVerifiedError`,
+            // a newtype around `zs::CommitBlockError`, so the wrapper must be
+            // unwrapped to classify duplicate blocks as benign.
+            VerifyCheckpointError::CommitCheckpointVerified(source) => source
+                .downcast_ref::<zs::CommitCheckpointVerifiedError>()
+                .is_some_and(|commit_err| commit_err.inner().is_duplicate_request()),
             _ => false,
         }
     }

--- a/zakura-consensus/src/checkpoint/tests.rs
+++ b/zakura-consensus/src/checkpoint/tests.rs
@@ -814,3 +814,23 @@ async fn hard_coded_mainnet() -> Result<(), Report> {
 
     Ok(())
 }
+
+/// Duplicate block errors must stay classified as duplicate requests after the
+/// state wraps them, so they don't restart the syncer during checkpoint sync.
+#[test]
+fn state_commit_duplicate_errors_are_duplicate_requests() {
+    let duplicate = zs::CommitBlockError::Duplicate {
+        hash_or_height: None,
+        location: zs::KnownBlock::Finalized,
+    };
+
+    // Box the error the same way the state's `CommitCheckpointVerifiedBlock`
+    // handler does. This mirrors the wrapping manually, so it won't fail
+    // automatically if the state changes its error type — keep it in sync by hand.
+    let source: BoxError = Box::new(zs::CommitCheckpointVerifiedError::from(duplicate));
+
+    let err = VerifyCheckpointError::CommitCheckpointVerified(source);
+
+    assert!(err.is_duplicate_request());
+    assert_eq!(err.misbehavior_score(), 0);
+}

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -178,6 +178,11 @@ impl From<CommitHeaderRangeError> for CommitBlockError {
 pub struct CommitSemanticallyVerifiedError(#[from] CommitBlockError);
 
 impl CommitSemanticallyVerifiedError {
+    /// Returns the [`CommitBlockError`] describing why the commit failed.
+    pub fn inner(&self) -> &CommitBlockError {
+        &self.0
+    }
+
     /// Returns the state location for duplicate commit requests.
     pub fn duplicate_location(&self) -> Option<&KnownBlock> {
         self.0.duplicate_location()
@@ -219,6 +224,11 @@ impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
 pub struct CommitCheckpointVerifiedError(#[from] CommitBlockError);
 
 impl CommitCheckpointVerifiedError {
+    /// Returns the [`CommitBlockError`] describing why the commit failed.
+    pub fn inner(&self) -> &CommitBlockError {
+        &self.0
+    }
+
     /// Returns the state location for duplicate commit requests.
     pub fn duplicate_location(&self) -> Option<&KnownBlock> {
         self.0.duplicate_location()


### PR DESCRIPTION
## Motivation

Duplicate-block commit errors from the state were losing their classification on the semantic verification path. The state returns `CommitSemanticallyVerifiedBlock` failures boxed as `CommitSemanticallyVerifiedError` — a newtype around `CommitBlockError` — but the semantic block verifier only tried a direct `downcast_ref::<CommitBlockError>()`, which can never match the wrapper. Every commit error, including `CommitBlockError::Duplicate`, fell through to the generic `VerifyBlockError::StateService` variant, where `is_duplicate_request()` returns `false` and `duplicate_location()` returns `None`.

Downstream, this makes benign duplicate commits (e.g. an inbound-gossip/syncer race on the same block near tip) look like real verification failures: `should_restart_sync` restarts the syncer instead of continuing, and the Zakura block-apply path reports `Rejected` instead of `Duplicate`.

The checkpoint verifier had the same gap in `is_duplicate_request()`: its `duplicate_location()` already unwrapped `CommitCheckpointVerifiedError`, but `is_duplicate_request()` did not handle the `CommitCheckpointVerified` variant at all.

This is an availability fix only — no block-acceptance rule changes.

## Solution

- Add an `inner()` accessor to the state's `CommitSemanticallyVerifiedError` and `CommitCheckpointVerifiedError` newtypes.
- Route semantic commit failures through a new `map_commit_error` helper that unwraps `CommitSemanticallyVerifiedError` (with a fallback to a bare `CommitBlockError`) before classifying the error as `VerifyBlockError::StateService`.
- Teach `VerifyCheckpointError::is_duplicate_request()` to unwrap `CommitCheckpointVerifiedError`, matching its existing `duplicate_location()`.

### Tests

- New regression test on the semantic path (`block::tests::state_commit_duplicate_errors_are_duplicate_requests`): boxes a duplicate commit error exactly the way the state's request handler does and asserts it maps to `VerifyBlockError::Commit` with `is_duplicate_request() == true`, the correct `duplicate_location()`, and a zero misbehavior score.
- New regression test on the checkpoint path (`checkpoint::tests::state_commit_duplicate_errors_are_duplicate_requests`); verified it fails without the `is_duplicate_request()` fix and passes with it.
- `cargo test --release -p zakura-consensus --lib` (140 passed), `cargo test --release -p zakura-state --lib` (350 passed, 3 ignored), `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings` all pass locally.

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used: Claude Code — root-cause investigation, the fix, regression tests, and this PR description (maintainer-directed and reviewed).

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date (changelog intentionally untouched pre-1.0.0).
