### PR TITLE
docs(release): document the pre-release → "Latest" promotion convention

### DIFF
--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -81,7 +81,34 @@ The workflow always builds the commit selected when it was dispatched, even if
 `main` advances before approval. It is safe to rerun after a partial failure:
 it reuses an unpublished draft or exits successfully for a release already
 published from the expected commit. It refuses to reuse a tag that points
-elsewhere. Every release is initially a pre-release; promotion remains a manual
-GitHub step after testing and signing. Existing Docker behavior is unchanged:
-a non-hyphenated stable tag moves the Docker `latest` aliases during the
-tag-triggered workflow, before that GitHub promotion.
+elsewhere. Every release is initially a pre-release; see
+[Promotion and the "Latest" release](#promotion-and-the-latest-release) for
+when and how a release is promoted.
+
+## Promotion and the "Latest" Release
+
+Both release workflows publish every release with `prerelease: true`, whatever
+the tag looks like — nothing promotes a release automatically. Promotion is a
+deliberate manual step, governed by this convention:
+
+- **Pre-releases are never promoted.** Hyphenated tags (`v1.0.0-rc4`) stay
+  pre-releases from publication until deletion. `v1.0.0-rc3` is the cautionary
+  tale: it was hand-promoted, external instructions adopted
+  `releases/latest/download/...` URLs, and deleting the release left those
+  links as dangling 404s. Pre-release artifacts are removed before the next
+  stable release as a matter of policy, so a promoted pre-release always
+  becomes a dangling "Latest" eventually.
+- **The first "Latest" release is `v1.0.0`.** Until it exists,
+  `releases/latest` intentionally returns 404. Any published download
+  instructions must use versioned URLs (`releases/download/<tag>/...`) until
+  the first stable release is promoted.
+- **Stable releases are promoted after testing and signing.** Once
+  `make sign-release` has run against the tag, edit the release: clear the
+  pre-release flag _and_ check **Set as the latest release** (`make_latest:
+  true` via the API). Do both explicitly — the "Latest" badge never points at
+  a pre-release, and an unpromoted stable release leaves the repository with
+  no "Latest" release at all.
+- **Expect brief Docker skew.** The tag-triggered workflow moves the Docker
+  `latest` aliases automatically for non-hyphenated tags, before the manual
+  GitHub promotion. A short window where the Docker `latest` alias is ahead
+  of the GitHub "Latest" release is normal.


### PR DESCRIPTION
## Motivation

The repository currently has no "Latest" release, and nothing documents when one should exist. Every release the workflows publish is a pre-release by design; `v1.0.0-rc3` was hand-promoted and later deleted in the rc sweep, which left external `releases/latest/download/...` links dangling, and `v1.0.0-rc4` was deliberately not promoted. `v1.0.0` needs a deliberate, written answer for when and how a release becomes "Latest".

## Solution

Document the promotion convention in `docs/release-tag-protection.md`, as a new "Promotion and the \"Latest\" Release" section:

- **Pre-releases are never promoted.** Promoting an rc points `releases/latest` at an artifact that is deleted later by policy, guaranteeing dangling links — this already happened once with rc3.
- **The first "Latest" release is `v1.0.0`.** Until it exists, `releases/latest` intentionally returns 404, and published download instructions must use versioned URLs.
- **Stable releases are promoted manually after testing and signing**, by clearing the pre-release flag _and_ explicitly setting "Set as the latest release". Nothing in the workflows does this automatically — both hardcode `prerelease: true` for every tag — so an unpromoted stable release would otherwise sit as a pre-release indefinitely.
- **Brief Docker skew is expected**: the tag-triggered workflow moves the Docker `latest` aliases for stable tags before the manual GitHub promotion.

### Tests

Documentation-only change. `markdownlint` with the repo config passes on the changed file.

### Specifications & References

- GitHub release semantics: the "Latest" badge and the `releases/latest` API/URL only ever resolve to a non-draft, non-pre-release release; `make_latest` controls which one.

### Follow-up Work

- External docs that use `releases/latest/download/install-zakura.sh` need to point at versioned download URLs until `v1.0.0` is promoted (they currently 404).
- #157 adds a crates.io Trusted Publishing section to the same file; whichever lands second takes a trivial append conflict on rebase.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code (Claude Fable 5) drafted the documentation and this PR description; the convention itself is a maintainer decision and the text was reviewed by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
