### PR TITLE
ci(release): adopt crates.io Trusted Publishing in create-release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -207,17 +207,17 @@ The end of support height is calculated from the current blockchain height:
 
 ## Publish Crates
 
-- [ ] [Run `cargo login`](https://github.com/zakura-core/zakura/dev/crate-owners.html#logging-in-to-cratesio)
-- [ ] It is recommended that the following step be run from a fresh checkout of
-      the repo, to avoid accidentally publishing files like e.g. logs that might
-      be lingering around
-- [ ] Publish the crates to crates.io; edit the list to only include the crates that
-      have been changed, but keep their overall order:
+Stable releases publish the crate graph automatically: the `Publish crates to
+crates.io` job in the same Create release run uses crates.io Trusted
+Publishing (no `cargo login`, no long-lived token) and publishes from the
+exact tagged commit. It skips crates whose version is already on crates.io,
+so re-running the workflow resumes a partial publish. See
+[`docs/release-tag-protection.md`](https://github.com/zakura-core/zakura/blob/main/docs/release-tag-protection.md#cratesio-trusted-publishing).
 
-```
-for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakura-tower-batch-control zakura-node-services zakura-script zakura-state zakura-consensus zakura-network zakura-rpc zakura-utils zakura; do cargo release publish --verbose --execute -p $c; done
-```
-
+- [ ] After promoting the release, approve the `crates-io` environment
+      deployment on the Create release run.
+- [ ] Check the job log: unchanged crates are skipped as already published,
+      and every selected crate is at the release version.
 - [ ] Check that Zakura can be installed from `crates.io`:
       `cargo install --locked --force --version <version> zakura && ~/.cargo/bin/zakurad`
       and put the output in a comment on the PR.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,8 @@
 # This workflow is the only supported path for creating v* release tags.
 # It builds and verifies every release asset before a protected environment
 # allows the release GitHub App to publish a draft and create the immutable tag.
+# For stable (non-hyphenated) tags it then publishes the crate graph to
+# crates.io from that same commit, behind a second environment approval.
 name: Create release
 
 on:
@@ -311,3 +313,56 @@ jobs:
               --jq '.html_url'
           )"
           echo "Published ${html_url}; tag ${RELEASE_TAG} now points to ${TARGET_SHA}."
+
+  publish-crates:
+    name: Publish crates to crates.io
+    runs-on: ubuntu-latest
+    needs: [validate, publish]
+    # Pre-releases never reach crates.io, so hyphenated tags skip this job
+    # entirely and no crates-io deployment approval is requested for them.
+    if: ${{ !contains(needs.validate.outputs.release_tag, '-') }}
+    # The crates-io environment holds no secrets: it exists so the crates.io
+    # Trusted Publishing configuration can require this environment, and so
+    # its reviewer controls *when* the registry publish happens. Approve it
+    # after the release has been tested, signed, and promoted — registry
+    # publishes cannot be rolled back, only yanked.
+    environment: crates-io
+    permissions:
+      contents: read
+      # Required to mint the temporary crates.io token via OIDC.
+      id-token: write
+    steps:
+      # The same commit the tag points to: the registry artifacts and the
+      # tag must never come from different SHAs.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.target_sha }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
+        with:
+          # Registry artifacts must not be assembled from cached build output.
+          cache: false
+
+      # Skips versions that are already on the index, so re-running the
+      # workflow resumes a partially-published graph instead of failing.
+      - name: Select unpublished crates
+        id: select
+        run: ./scripts/publish-crates.sh plan
+
+      # Package and verify-build before minting the registry token: the
+      # builds take longer than the 30-minute token lifetime.
+      - name: Package and verify selected crates
+        if: ${{ steps.select.outputs.count != '0' }}
+        run: ./scripts/publish-crates.sh verify
+
+      - name: Mint crates.io Trusted Publishing token
+        if: ${{ steps.select.outputs.count != '0' }}
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 #v1.0.5
+
+      - name: Publish selected crates
+        if: ${{ steps.select.outputs.count != '0' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: ./scripts/publish-crates.sh publish

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -40,6 +40,12 @@ variable and secret. Allow deployments from the `main` branch and tags matching
 installer metadata update pull request. It is separate so tag deployment rules
 or approvals cannot block post-release automation.
 
+Configure a third environment named `crates-io` with required reviewers and
+deployments allowed from the `main` branch only. It holds no variables or
+secrets: it exists so the crates.io Trusted Publishing configuration can be
+restricted to it, and so a human controls when the registry publish happens
+(see [crates.io Trusted Publishing](#cratesio-trusted-publishing)).
+
 The app private key is a credential. Store its source copy in the team's secret
 manager and do not commit it or paste it into issues, pull requests, or logs.
 
@@ -76,6 +82,11 @@ ruleset administration must remain limited.
 6. Confirm that `Release binaries` starts from the new tag, skips rebuilding
    the existing assets, publishes the Docker images, and opens the installer
    metadata update pull request.
+7. For stable (non-hyphenated) tags only: after the release has been tested,
+   signed, and promoted, approve the `crates-io` environment deployment on
+   the same run. The workflow publishes the crate graph to crates.io from
+   the tagged commit (see
+   [crates.io Trusted Publishing](#cratesio-trusted-publishing)).
 
 The workflow always builds the commit selected when it was dispatched, even if
 `main` advances before approval. It is safe to rerun after a partial failure:
@@ -85,3 +96,49 @@ elsewhere. Every release is initially a pre-release; promotion remains a manual
 GitHub step after testing and signing. Existing Docker behavior is unchanged:
 a non-hyphenated stable tag moves the Docker `latest` aliases during the
 tag-triggered workflow, before that GitHub promotion.
+
+## crates.io Trusted Publishing
+
+Stable releases publish the crate graph to crates.io from the `Publish crates
+to crates.io` job in the same `Create release` run, so the tag and the
+registry artifacts always come from one commit. (The `v1.0.0-rc3` crates were
+published by hand from a different commit than the one eventually tagged —
+the exact skew this design removes.) Pre-releases never reach crates.io: the
+job only exists on non-hyphenated tags.
+
+Publishing authenticates with [crates.io Trusted
+Publishing](https://crates.io/docs/trusted-publishing): the job exchanges a
+GitHub OIDC token for a temporary (30-minute) registry token, so no
+long-lived `cargo login` token is stored anywhere. A crate owner must
+configure each publishable crate once, under **Settings > Trusted Publishing**
+on crates.io:
+
+- Repository owner `zakura-core`, repository name `zakura`
+- Workflow filename `create-release.yml`
+- Environment `crates-io`
+
+Pinning the environment means a registry token can only be minted by a job
+that passed the `crates-io` reviewer gate. New crates must be reserved on
+crates.io and given this configuration before they can release; the publish
+plan fails with instructions if a publishable workspace crate is missing from
+the registry.
+
+How the job works (`scripts/publish-crates.sh`):
+
+1. **Plan.** Every workspace crate without `publish = false` is checked
+   against the sparse index. Versions already on the index are skipped —
+   this is what makes re-running the workflow resume a partially-published
+   graph — and every crate still to publish must carry the release version.
+2. **Verify.** The selected crates are packaged with their verify builds
+   _before_ any registry token exists; the builds take longer than the
+   30-minute token lifetime. Expect this stage to take a while.
+3. **Publish.** A fresh token is minted and the crates are published in one
+   dependency-ordered `cargo publish` invocation (with `--no-verify`, since
+   verification just happened). The script refuses to publish pre-release
+   versions regardless of how it is invoked.
+
+Approve the `crates-io` deployment only after the release has been tested,
+signed, and promoted: registry publishes cannot be rolled back, only yanked.
+Two operational notes: an unapproved deployment expires after 30 days, and a
+run left waiting on this approval blocks the `create-release` concurrency
+group — reject the deployment if a new release must be cut first.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Publish the Zakura crate graph to crates.io from the create-release workflow.
+#
+# Modes:
+#   plan     Compute which publishable workspace crates still need their
+#            current version published and write the selection to
+#            target/publish-crates-plan.txt. Emits `count=` and `crates=` to
+#            $GITHUB_OUTPUT when running under GitHub Actions. Needs no
+#            registry token, so it is safe to run locally.
+#   verify   Package the selected crates, including their verify builds,
+#            without touching the registry. This runs before the registry
+#            token is minted: the verify builds take longer than the
+#            30-minute Trusted Publishing token lifetime.
+#   publish  Publish the selected crates in one dependency-ordered cargo
+#            invocation with --no-verify (verification already happened in
+#            `verify`). Requires CARGO_REGISTRY_TOKEN.
+#
+# The selection is derived from `cargo metadata` — every workspace crate
+# without `publish = false` — so new crates are picked up automatically. A
+# crate name that does not exist on crates.io fails the plan with setup
+# instructions instead of failing the publish halfway through the graph:
+# every publishable name must already be reserved and have a Trusted
+# Publishing configuration (see docs/release-tag-protection.md).
+#
+# Already-published versions are skipped, so a partially-published graph is
+# resumed by re-running the workflow. Versions are checked against the
+# sparse index, which lists yanked versions too: a yanked version can never
+# be re-published, so it counts as published here.
+set -euo pipefail
+
+MODE="${1:-}"
+case "$MODE" in
+  plan | verify | publish) ;;
+  *)
+    echo "Usage: $0 <plan|verify|publish>" >&2
+    exit 1
+    ;;
+esac
+
+for cmd in cargo curl jq; do
+  command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd" >&2; exit 1; }
+done
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+plan_file="${repo_root}/target/publish-crates-plan.txt"
+
+# The release version is the `zakura` package version: the create-release
+# workflow only runs this script on a tag that check-release-version.sh has
+# matched against that version, and every crate being published at a given
+# release must carry it (unchanged crates stay at their already-published
+# older version and are skipped by the index check).
+release_version() {
+  cargo metadata --format-version 1 --no-deps --manifest-path "${repo_root}/Cargo.toml" \
+    | jq -r '.packages[] | select(.name == "zakura") | .version'
+}
+
+read_plan() {
+  if [ ! -f "$plan_file" ]; then
+    echo "Missing ${plan_file}; run '$0 plan' first." >&2
+    exit 1
+  fi
+  mapfile -t selected < "$plan_file"
+}
+
+plan() {
+  local metadata version index_json http_code index_url selected=()
+  metadata="$(cargo metadata --format-version 1 --no-deps --manifest-path "${repo_root}/Cargo.toml")"
+  version="$(echo "$metadata" | jq -r '.packages[] | select(.name == "zakura") | .version')"
+  if [ -z "$version" ] || [ "$version" = "null" ]; then
+    echo "Could not find the 'zakura' package in the workspace." >&2
+    exit 1
+  fi
+
+  local crate crate_version
+  while IFS=$'\t' read -r crate crate_version; do
+    # Sparse index path for names of four or more characters; every Zakura
+    # crate name is longer.
+    index_url="https://index.crates.io/${crate:0:2}/${crate:2:2}/${crate}"
+    index_json="$(mktemp)"
+    http_code="$(curl -sS --retry 3 -o "$index_json" -w '%{http_code}' "$index_url")"
+    case "$http_code" in
+      200) ;;
+      404)
+        echo "ERROR: ${crate} does not exist on crates.io." >&2
+        echo "Reserve the name and add its Trusted Publishing configuration" >&2
+        echo "before releasing (see docs/release-tag-protection.md)." >&2
+        exit 1
+        ;;
+      *)
+        echo "ERROR: sparse index lookup for ${crate} returned HTTP ${http_code}." >&2
+        exit 1
+        ;;
+    esac
+    if jq -r '.vers' "$index_json" | grep -Fxq "$crate_version"; then
+      echo "  ${crate} ${crate_version}: already published, skipping."
+    else
+      if [ "$crate_version" != "$version" ]; then
+        echo "ERROR: ${crate} is at ${crate_version}, but this release publishes ${version}." >&2
+        echo "Crates published at a release must carry the release version;" >&2
+        echo "unchanged crates keep their already-published older version." >&2
+        exit 1
+      fi
+      echo "  ${crate} ${crate_version}: selected for publish."
+      selected+=("$crate")
+    fi
+    rm -f "$index_json"
+  done < <(
+    echo "$metadata" \
+      | jq -r '.packages[] | select(.publish == null) | [.name, .version] | @tsv' \
+      | sort
+  )
+
+  mkdir -p "$(dirname "$plan_file")"
+  printf '%s\n' "${selected[@]:-}" | sed '/^$/d' > "$plan_file"
+  echo "Planned ${#selected[@]} crate(s) at version ${version}."
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "count=${#selected[@]}"
+      echo "crates=${selected[*]:-}"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+verify() {
+  local selected package_args=()
+  read_plan
+  if [ "${#selected[@]}" -eq 0 ]; then
+    echo "Nothing selected; skipping packaging."
+    return
+  fi
+  local crate
+  for crate in "${selected[@]}"; do
+    package_args+=(-p "$crate")
+  done
+  echo "Packaging and verifying ${#selected[@]} crate(s): ${selected[*]}"
+  cargo package --locked "${package_args[@]}"
+}
+
+publish() {
+  local selected version publish_args=()
+  read_plan
+  if [ "${#selected[@]}" -eq 0 ]; then
+    echo "Nothing selected; skipping publish."
+    return
+  fi
+  version="$(release_version)"
+  case "$version" in
+    *-*)
+      echo "ERROR: refusing to publish pre-release version ${version}:" >&2
+      echo "pre-releases never reach crates.io (docs/release-tag-protection.md)." >&2
+      exit 1
+      ;;
+  esac
+  if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+    echo "ERROR: CARGO_REGISTRY_TOKEN is not set." >&2
+    exit 1
+  fi
+  local crate
+  for crate in "${selected[@]}"; do
+    publish_args+=(-p "$crate")
+  done
+  # cargo publishes the selected packages in dependency order, waiting for
+  # each to be available in the index before publishing its dependents.
+  echo "Publishing ${#selected[@]} crate(s) at version ${version}: ${selected[*]}"
+  cargo publish --locked --no-verify "${publish_args[@]}"
+}
+
+"$MODE"


### PR DESCRIPTION
## Motivation

The release tag and the crates.io artifacts must come from one commit. The rc3 publish demonstrated the failure mode this design removes: the crates were published by hand from a different commit than the one eventually tagged — and after the rc sweep, those registry versions now correspond to no tag at all. Manual publishing also depends on a long-lived `cargo login` token sitting on a maintainer machine.

This PR makes the `Create release` workflow publish the crate graph itself, from the exact SHA it tags, authenticated via [crates.io Trusted Publishing](https://crates.io/docs/trusted-publishing) (short-lived OIDC-minted tokens, no stored registry credential).

**Draft on purpose:** the mechanics work (see Tests), but I want maintainer eyes on the design decisions below before this becomes the release path.

## Solution

New `publish-crates` job in `create-release.yml`:

- Runs only for **stable (non-hyphenated) tags** — pre-releases never reach crates.io, and hyphenated tags skip the job entirely (no approval prompt is even requested for them).
- Runs **after the GitHub release publishes**, and checks out `target_sha` — the same commit the tag points to.
- Gated by a new **`crates-io` environment** with required reviewers. The environment holds no secrets; it exists so the crates.io Trusted Publishing configuration can be restricted to it, and so a human decides *when* the registry publish happens (intended: after the release is tested, signed, and promoted — registry publishes can only be yanked, never rolled back).

The work itself is in `scripts/publish-crates.sh`, with three modes so each step is separately runnable and locally testable:

1. **`plan`** — derives the publish set from `cargo metadata` (every workspace crate without `publish = false`, so there is no hardcoded crate list to drift), then checks each crate against the sparse index. Versions already on the index are skipped, which makes re-running the workflow resume a partially-published graph. Hard errors: a publishable crate that doesn't exist on crates.io (must be reserved + configured first), and a selected crate whose version differs from the release version.
2. **`verify`** — packages the selected crates with their verify builds. This runs *before* any registry token exists, because the builds take longer than the 30-minute Trusted Publishing token lifetime.
3. **`publish`** — mints the token and publishes everything in one dependency-ordered multi-package `cargo publish --no-verify` (cargo ≥ 1.90; CI is on `stable`). The script refuses pre-release versions no matter how it is invoked, as a second layer under the job-level tag condition.

Also updated:

- `docs/release-tag-protection.md` — new "crates.io Trusted Publishing" section covering the environment, the per-crate crates.io configuration, and the operational notes.
- `.github/PULL_REQUEST_TEMPLATE/release-checklist.md` — the manual `cargo login` + `cargo release publish` loop is replaced by "approve the `crates-io` deployment after promoting", plus the existing `cargo install` verification.

### Design decisions I'd like feedback on

1. **Publish timing.** The job waits on the `crates-io` approval, intended to be granted after test/sign/promote. Consequence: a run left waiting blocks the `create-release` concurrency group until approved or rejected, and unapproved deployments expire after 30 days. The alternative — publishing immediately after the tag — removes the human gate on an irreversible action.
2. **`--no-verify` at publish time.** Verification happens in the `verify` stage minutes earlier on the same checkout; re-verifying inside `cargo publish` would blow the 30-minute token TTL. Is that separation acceptable?
3. **Metadata-derived crate set** vs. an explicit list (as in `check-crate-packaging.sh`). Metadata can't drift, and the plan-time "crate not on crates.io" hard error catches new crates before they half-publish; but it means adding a publishable crate implicitly adds it to the release publish.
4. **Version-mix hard error**: every crate selected for publish must carry the release version; unchanged crates simply stay at their older published version. This matches how partial releases should look on the registry, but it's stricter than the old checklist flow.

### Tests

- `shellcheck` (the CI lint gate for `scripts/*.sh`) passes; the workflow YAML parses; `markdownlint` passes on the changed docs.
- `./scripts/publish-crates.sh plan` run live against crates.io from the current tree: correctly skips the 12 crates already published at `1.0.0-rc3` and selects only `zakura` (currently `1.0.0-rc4`), exercising both the index-skip path and the selection path.
- `cargo package --locked --no-verify -p zakura` packages cleanly; full 13-crate workspace packaging was already validated by the #122 preflight.
- **Not tested end-to-end:** the job can only run for real on a stable tag with the console configuration in place (see Follow-up Work). That, plus the design questions above, is why this is a draft.

### Specifications & References

- crates.io Trusted Publishing: <https://crates.io/docs/trusted-publishing> (token minted via `rust-lang/crates-io-auth-action`, SHA-pinned)
- Multi-package publish (dependency-ordered, waits for index availability): stabilized in cargo 1.90

### Follow-up Work

Owner-only console setup, required before the job can ever succeed:

- Create the `crates-io` GitHub environment: required reviewer(s), deployments from `main` only, no variables or secrets.
- Add the Trusted Publishing configuration on each of the 13 publishable crates on crates.io: repository `zakura-core/zakura`, workflow `create-release.yml`, environment `crates-io`.

Note: this PR and #156 both append a section to `docs/release-tag-protection.md`; whichever lands second takes a trivial append conflict on rebase.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code (Claude Fable 5) wrote the workflow job, publish script, documentation, and this PR description; design reviewed by the author, who is seeking further review via this draft.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand — this draft PR is that discussion.
- [x] The solution is tested (see Tests; not yet exercised end-to-end on a real stable release).
- [x] The documentation and changelogs are up to date.
