### PR TITLE
fix(network): bound underestimated block body memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Initial release of Zakura.
 
 ### Fixed
 
+- Block sync now reserves the maximum accepted body size before issuing requests,
+  preventing underestimated size hints from expanding the resident-memory budget.
+  The former `size_deviation_tolerance` setting has been replaced by a fixed 2× policy.
 - Pruned finalized blocks remain visible to chain-identity queries, including peer
   block-hash responses and RPC confirmation lookups, after their bodies are removed.
 

--- a/zakura-network/src/zakura/block_sync/README.md
+++ b/zakura-network/src/zakura/block_sync/README.md
@@ -81,12 +81,12 @@ height is just another gated height.
 
 ### Decision table
 
-| Condition | Outcome | `take_high` | `max_request_bytes` |
-| --- | --- | --- | --- |
-| `start ≤ verified_tip + 401` (in-window) | always `Admit` | `min(servable_high, window_top)` | `min(budget_available, response_byte_cap)`; Floor priority floors it at 1 |
-| `start > window` and gate full (bytes **or** blocks), or wire headroom rounds to 0 | `LookaheadAtCap` | — | — |
-| `start > window`, gate open | `Admit` | `servable_high` | `min(budget_available, remaining_wire, response_byte_cap)` |
-| any admitted sizing that still comes to 0 bytes (in-flight budget spent, non-floor) | `InflightBudgetEmpty` | — | — |
+| Condition | Outcome | `take_high` | Estimate cap | Reservation cap |
+| --- | --- | --- | --- | --- |
+| `start ≤ verified_tip + 401` (in-window) | always `Admit` | `min(servable_high, window_top)` | `min(response_byte_cap, budget_available)` | `budget_available`; Floor priority floors it at 1 |
+| `start > window` and gate full (bytes **or** blocks), or wire headroom rounds to 0 | `LookaheadAtCap` | — | — | — |
+| `start > window`, gate open | `Admit` | `servable_high` | `min(response_byte_cap, budget_available, remaining_wire)` | `min(budget_available, remaining_wire)` |
+| either admitted cap is 0 (non-floor) | `InflightBudgetEmpty` | — | — | — |
 
 where `remaining_wire = (effective_budget − estimated_resident) / DESERIALIZED_MEM_FACTOR`
 — the remaining memory headroom expressed back in wire bytes, so one admitted response
@@ -112,7 +112,13 @@ _eventual_ decoded cost, `wire_bytes × DESERIALIZED_MEM_FACTOR` (= 4):
 | `reorder_buffered_bytes` | wire-retained | the reorder→applying drain decodes the whole contiguous prefix unconditionally the moment a gap fills, with no admission re-gate |
 | `applying_buffered_bytes` | decoded `Arc<Block>` | already resident at the decoded multiple |
 | `sequencer_input_queued_bytes` | decoded | already resident |
-| `reserved_above_floor_bytes` | not received yet | in-flight bodies land and decode the same way; charging them 0× makes the landing wave invisible until it is already resident |
+| `reserved_above_floor_bytes` | not received yet | each height reserves the largest body accepted by the fixed 2× estimate policy, capped at the consensus block maximum |
+
+Request shaping still uses the advertised estimate. Resident accounting instead uses
+the fixed policy `min(estimate × 2, MAX_BLOCK_BYTES)`. Receipt replaces that
+maximum-accepted reservation with actual serialized bytes, so every accepted body can
+only preserve or reduce the aggregate charge. A full wave of underestimated responses
+therefore cannot expand beyond its reservations.
 
 Two gates, checked together in `lookahead_over_budget`:
 
@@ -124,9 +130,9 @@ Two gates, checked together in `lookahead_over_budget`:
   overhead dominates; never needed operator tuning, so it is a constant, not a
   config knob).
 
-This is separate from the **in-flight wire budget** (`max_inflight_block_bytes`,
-default 6 GiB, tracked by `ByteBudget`): that bounds bytes concurrently on the wire;
-the look-ahead gate bounds bytes _retained_ by the pipeline.
+The shared `ByteBudget` (`max_inflight_block_bytes`, default 6 GiB) carries the same
+maximum-accepted reservation until receipt and then the actual retained body charge.
+The look-ahead gate applies the decoded-memory factor and a smaller speculative cap.
 
 ### Config clamps
 
@@ -142,7 +148,7 @@ Resident memory plateaus near
 **`effective budget + one worst-case commit window`** (401 × `MAX_BLOCK_BYTES` × 4
 ≈ 3.2 GB), plus bounded transients:
 
-- the floor's first-item progress margin (≤ one block per request — see liveness below);
+- the commit window's first-item progress margin (≤ one block per request — see liveness below);
 - a single in-window response can exceed the byte gate by up to
   `response_byte_cap × 4` (in-window sizing is by the in-flight budget, for liveness);
 - concurrent peer routines admit against per-iteration snapshots, so a simultaneous
@@ -156,9 +162,10 @@ retained wire 807.7–807.9 MB → ×4 = 3.231 GB, +0.7% over budget.
 
 1. **Commit-window heights are always fundable**, on both lanes, regardless of the
    look-ahead gates — a pinned checkpoint range can always assemble.
-2. **Floor grants never size below one byte**, and `take_in_range_budgeted` always
-   takes its first item regardless of the byte cap — so the floor block is taken even
-   when the in-flight budget is exactly full, reaching the floor funding path…
+2. **Floor grants never size below one byte**, and a commit-window grant lets
+   `take_in_range_budgeted` take its first item past the reservation cap — so the
+   floor block reaches the funding path even when the in-flight budget is exactly
+   full. Above-window work never receives this exemption.
 3. **…which can shed to fund.** `reserve_request_budget`'s Floor path awaits
    `FundFloorReservation`: an above-floor reorder body is shed (returned to pending)
    to free bytes for the floor block. The floor is therefore never starved by

--- a/zakura-network/src/zakura/block_sync/admission.rs
+++ b/zakura-network/src/zakura/block_sync/admission.rs
@@ -87,9 +87,14 @@ pub(super) struct AdmissionGrant {
     /// rides an exempt request; gated (above-window) grants pass the caller's
     /// servable ceiling through.
     pub(super) take_high: block::Height,
-    /// Authoritative summed-estimate byte cap for the take and its reservation.
-    /// Nothing downstream may substitute its own sizing.
-    pub(super) max_request_bytes: u64,
+    /// Summed estimate cap used for response sizing and congestion control.
+    pub(super) max_estimated_bytes: u64,
+    /// Summed maximum-accepted body cap used for resident reservation.
+    pub(super) max_reservation_bytes: u64,
+    /// Whether the first item may exceed the reservation cap.
+    ///
+    /// Only commit-window grants receive this liveness exemption.
+    pub(super) allow_first_reservation_overshoot: bool,
 }
 
 /// Return the highest start height that can be rescued by a floor request.
@@ -278,20 +283,19 @@ pub(super) fn admit(
     let priority = request_priority(snapshot.download_floor, start_height);
     let window_high = commit_window_high(&snapshot);
 
-    let (take_high, max_request_bytes) = if start_height <= window_high {
+    let (take_high, max_estimated_bytes, max_reservation_bytes) = if start_height <= window_high {
         // Exempt: liveness sizing, take clamped at the window top so the resident
         // gate's coverage of above-window heights is total.
         (
             servable_high.min(window_high),
             snapshot.budget_available.min(response_byte_cap),
+            snapshot.budget_available,
         )
     } else {
         if lookahead_over_budget(config, &snapshot) {
             return AdmissionOutcome::LookaheadAtCap;
         }
-        // Remaining memory headroom, expressed back in wire bytes for the response cap so a
-        // single response can't push resident memory past the budget. The next admitted body
-        // will usually become decoded soon, so it is sized as if it costs the decoded multiple.
+        // Remaining resident headroom expressed in serialized-body bytes.
         let remaining_wire_bytes = config
             .effective_max_reorder_lookahead_bytes()
             .saturating_sub(estimated_resident_pipeline_bytes(&snapshot))
@@ -301,25 +305,27 @@ pub(super) fn admit(
         }
         (
             servable_high,
-            snapshot
-                .budget_available
-                .min(remaining_wire_bytes)
-                .min(response_byte_cap),
+            response_byte_cap
+                .min(snapshot.budget_available)
+                .min(remaining_wire_bytes),
+            snapshot.budget_available.min(remaining_wire_bytes),
         )
     };
 
-    let max_request_bytes = if priority == RequestPriority::Floor {
-        max_request_bytes.max(1)
+    let (max_estimated_bytes, max_reservation_bytes) = if priority == RequestPriority::Floor {
+        (max_estimated_bytes.max(1), max_reservation_bytes.max(1))
     } else {
-        max_request_bytes
+        (max_estimated_bytes, max_reservation_bytes)
     };
-    if max_request_bytes == 0 {
+    if max_estimated_bytes == 0 || max_reservation_bytes == 0 {
         return AdmissionOutcome::InflightBudgetEmpty;
     }
     AdmissionOutcome::Admit(AdmissionGrant {
         priority,
         take_high,
-        max_request_bytes,
+        max_estimated_bytes,
+        max_reservation_bytes,
+        allow_first_reservation_overshoot: start_height <= window_high,
     })
 }
 

--- a/zakura-network/src/zakura/block_sync/config.rs
+++ b/zakura-network/src/zakura/block_sync/config.rs
@@ -92,8 +92,6 @@ pub const DEFAULT_BS_NO_PROGRESS_PEER_COOLDOWN: Duration = Duration::from_secs(1
 pub const DEFAULT_BS_FLOOR_PEER_AVOID_COOLDOWN: Duration = DEFAULT_BS_REQUEST_TIMEOUT;
 /// Default block-sync status refresh interval after local frontier changes.
 pub const DEFAULT_BS_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
-/// Default tolerated size-hint deviation percentage before a peer is reported.
-pub const DEFAULT_BS_SIZE_DEVIATION_TOLERANCE: u32 = 200;
 /// Maximum peer-advertised aggregate byte target accepted per requested range.
 ///
 /// A range response is sent as one `Block` frame per body, and each body frame
@@ -264,8 +262,6 @@ pub struct ZakuraBlockSyncConfig {
     /// How often this node sends unsolicited status refreshes after local frontier changes.
     #[serde(with = "humantime_serde")]
     pub status_refresh_interval: Duration,
-    /// Percentage deviation from advertised body-size hints tolerated before soft scoring.
-    pub size_deviation_tolerance: u32,
     /// Steady-state cwnd as a percent of the measured bandwidth-delay product.
     pub bbr_cwnd_gain_percent: u32,
     /// ProbeBW up-probe pacing gain, percent. Reserved: the ProbeBW gain cycle is not
@@ -337,7 +333,6 @@ impl Default for ZakuraBlockSyncConfig {
             initial_block_probe_requests: DEFAULT_BS_INITIAL_BLOCK_PROBE_REQUESTS,
             max_requests_without_block_progress: DEFAULT_BS_MAX_REQUESTS_WITHOUT_BLOCK_PROGRESS,
             status_refresh_interval: DEFAULT_BS_STATUS_REFRESH_INTERVAL,
-            size_deviation_tolerance: DEFAULT_BS_SIZE_DEVIATION_TOLERANCE,
             bbr_cwnd_gain_percent: DEFAULT_BS_BBR_CWND_GAIN_PERCENT,
             bbr_probe_bw_gain_percent: DEFAULT_BS_BBR_PROBE_BW_GAIN_PERCENT,
             bbr_probe_rtt_interval: DEFAULT_BS_BBR_PROBE_RTT_INTERVAL,

--- a/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -39,7 +39,6 @@ use super::{
     pipe::block_sync_guard,
     reactor::{
         block_sync_message_label, bs_insert_height, bs_insert_peer, bs_insert_str, bs_insert_u64,
-        tolerated_bytes,
     },
     reorder::BufferedBlockBody,
     request::{BlockRangeRequest, ExpectedBlock},
@@ -48,7 +47,7 @@ use super::{
         DownloadWindow, LivenessOutcome, OutstandingBlockRange, ReceivedBlockTracker,
         ThroughputMeter,
     },
-    work_queue::{WorkItem, WorkQueue, WorkReturnOutcome},
+    work_queue::{maximum_accepted_body_bytes, WorkItem, WorkQueue, WorkReturnOutcome},
     BlockSyncAction, BlockSyncMessage, BlockSyncMisbehavior, BlockSyncPeerSession, BlockSyncStatus,
     ZakuraBlockSyncConfig, ZakuraPeerId, ZakuraTrace, MSG_BS_BLOCK,
 };
@@ -760,7 +759,9 @@ impl PeerRoutine {
                                 servable_low,
                                 grant.take_high,
                                 max_count,
-                                grant.max_request_bytes.min(floor_cwnd_cap).max(1),
+                                grant.max_estimated_bytes.min(floor_cwnd_cap).max(1),
+                                grant.max_reservation_bytes,
+                                grant.allow_first_reservation_overshoot,
                             );
                         }
                         AdmissionOutcome::LookaheadAtCap => break FillStop::LookaheadCap,
@@ -805,7 +806,9 @@ impl PeerRoutine {
                             servable_low,
                             grant.take_high,
                             max_count,
-                            grant.max_request_bytes.min(above_cwnd_cap),
+                            grant.max_estimated_bytes.min(above_cwnd_cap),
+                            grant.max_reservation_bytes,
+                            grant.allow_first_reservation_overshoot,
                         );
                     }
                     // A floor-priority start while the floor arm deferred to a
@@ -866,8 +869,11 @@ impl PeerRoutine {
             // funded as a floor reservation or given the short floor-rescue leash.
             let request_priority = classify_priority(view.download_floor, items[0].0);
 
-            let reserved_bytes = items.iter().fold(0u64, |acc, (_, item)| {
+            let estimated_bytes = items.iter().fold(0u64, |acc, (_, item)| {
                 acc.saturating_add(item.estimated_bytes)
+            });
+            let reserved_bytes = items.iter().fold(0u64, |acc, (_, item)| {
+                acc.saturating_add(item.maximum_accepted_bytes())
             });
             if !self
                 .reserve_request_budget(request_priority, reserved_bytes)
@@ -901,10 +907,10 @@ impl PeerRoutine {
                 start_height: items[0].0,
                 count,
                 anchor_hash: items[0].1.hash,
-                // The summed size-estimate reservation for this request (released
-                // on a send failure below); equals the sum of the per-height
-                // `expected_blocks` estimates.
-                estimated_bytes: reserved_bytes,
+                // The summed request-shaping estimate; equals the per-height
+                // `expected_blocks` estimates. The WorkQueue ledger separately
+                // owns the maximum-accepted reservation.
+                estimated_bytes,
                 expected_blocks: items
                     .iter()
                     .map(|(height, item)| ExpectedBlock {
@@ -952,7 +958,7 @@ impl PeerRoutine {
                 queued_at,
                 self.config.request_timeout,
                 self.config.effective_floor_rescue_timeout(),
-                reserved_bytes,
+                estimated_bytes,
                 // Filter BtlBw by the request's send time so a stale-high rate from a
                 // now-slow peer cannot tighten the deadline below what it can meet.
                 self.window.bbr_btlbw_bytes_per_sec(queued_at),
@@ -1187,7 +1193,7 @@ impl PeerRoutine {
     /// Drop this routine's outstanding requests whose whole range is at or below
     /// the download floor: their bodies have entered the commit pipeline or have
     /// already been verified, so
-    /// release the size-estimate reservation still held for any unreceived heights
+    /// release the maximum-accepted reservation still held for any unreceived heights
     /// and free the slot. No heights return to the queue (they are committed,
     /// below the floor, GC'd from the WorkQueue). A partially-committed request
     /// (suffix still above the floor) is left so its remaining bodies keep their
@@ -1317,8 +1323,7 @@ impl PeerRoutine {
                 }
             },
         };
-        if serialized_bytes > tolerated_bytes(estimated_bytes, self.config.size_deviation_tolerance)
-        {
+        if serialized_bytes > maximum_accepted_body_bytes(estimated_bytes) {
             self.report_misbehavior(BlockSyncMisbehavior::SizeMismatch)
                 .await;
             self.finish_outstanding_at(index, Disposition::RetryOriginal);
@@ -1327,10 +1332,8 @@ impl PeerRoutine {
 
         metrics::counter!("sync.block.body.received").increment(1);
         self.record_received(serialized_bytes);
-        // The block reserved its size estimate at send time; settle to the actual
-        // size. When the body is no larger than its estimate this frees the
-        // slack; when it is larger (a stale/under-advertised hint) this charges
-        // the overshoot so held bodies are never under-counted.
+        // The block reserved its maximum accepted size at send time; settle to
+        // actual bytes, releasing any slack.
         // `mark_received` then stops `reserved_bytes()` counting this height; the
         // only bytes still held are the `serialized_bytes` carried into the reorder
         // buffer.
@@ -1495,17 +1498,24 @@ impl PeerRoutine {
         };
 
         let reserved_in_flight = self.work.reserved_in_flight_charge(height);
-        let is_pending = self.work.pending_contains(height);
-        if reserved_in_flight.is_none() && !is_pending {
+        let pending_maximum_accepted = self.work.pending_maximum_accepted_bytes(height);
+        if reserved_in_flight.is_none() && pending_maximum_accepted.is_none() {
             return false;
         }
 
-        if is_pending {
+        if let Some(maximum_accepted_bytes) = pending_maximum_accepted {
+            if serialized_bytes > maximum_accepted_bytes {
+                self.report_misbehavior(BlockSyncMisbehavior::SizeMismatch)
+                    .await;
+                return true;
+            }
             let sequencer_view = *self.sequencer_view.borrow();
             let snapshot = self.admission_snapshot(&sequencer_view);
             let admitted_bytes =
                 match admit(&self.config, snapshot, height, height, serialized_bytes) {
-                    AdmissionOutcome::Admit(grant) => grant.max_request_bytes,
+                    AdmissionOutcome::Admit(grant) => {
+                        grant.max_estimated_bytes.min(grant.max_reservation_bytes)
+                    }
                     AdmissionOutcome::LookaheadAtCap | AdmissionOutcome::InflightBudgetEmpty => {
                         tracing::debug!(
                             peer = ?self.peer,
@@ -1530,7 +1540,7 @@ impl PeerRoutine {
             // This queued height owns no prior reservation: reserve its actual size
             // before buffering. If the budget is genuinely full of other legitimate
             // bodies, skip buffering (the height stays queued for retry with its own
-            // size-estimate reservation, so no valid body is lost overall).
+            // maximum-accepted reservation, so no valid body is lost overall).
             if !self.budget.try_reserve(serialized_bytes) {
                 tracing::debug!(
                     peer = ?self.peer,
@@ -1551,6 +1561,14 @@ impl PeerRoutine {
             // peer: convert the active request reservation into held bytes and settle
             // only the delta, instead of discarding a valid body because another peer
             // currently owns the request slot.
+            let Some(maximum_accepted_bytes) = reserved_in_flight else {
+                return false;
+            };
+            if serialized_bytes > maximum_accepted_bytes {
+                self.report_misbehavior(BlockSyncMisbehavior::SizeMismatch)
+                    .await;
+                return true;
+            }
             let Some(delta) = self
                 .work
                 .settle_active_reserved_height(height, serialized_bytes)
@@ -1744,7 +1762,7 @@ impl PeerRoutine {
         }
         let released_heights: Vec<_> = outstanding_unreceived_through(outstanding, tip).collect();
         let _ = outstanding.mark_received_through(tip);
-        // Held-aware: release only the still-reserved estimate for the committed
+        // Held-aware: release only the still-reserved maximum accepted size for the committed
         // prefix; a height a competing peer delivered late is owned by the
         // Sequencer, so it is left in place instead of double-released.
         let released_bytes = self.work.release_reserved_heights(released_heights);
@@ -1777,7 +1795,7 @@ impl PeerRoutine {
                 // Every requested height was received and buffered; nothing
                 // returns to the queue (buffered heights stay in `in_flight`
                 // until the floor commits past them). Release any residual
-                // reserved estimate (normally none once complete).
+                // maximum-accepted reservation (normally none once complete).
                 let released = self
                     .work
                     .release_reserved_heights(unreceived_heights(&outstanding));
@@ -2591,7 +2609,7 @@ mod tests {
         routine.servable_low = block::Height(1);
         routine.servable_high = block::Height(10);
 
-        // One fill pass: the routine reserves height 1's estimate and sends its
+        // One fill pass: the routine reserves height 1's maximum accepted size and sends its
         // request, creating an outstanding claim for a still-reserved height.
         timeout(Duration::from_secs(5), routine.try_fill())
             .await
@@ -2601,16 +2619,16 @@ mod tests {
             "height 1 is reserved and outstanding after the fill"
         );
         assert!(!work.pending_contains(block::Height(1)));
-        assert_eq!(budget_probe.reserved(), 1_000);
+        assert_eq!(budget_probe.reserved(), 2_000);
         assert_eq!(routine.window.outstanding.len(), 1);
 
         // A competing peer delivers height 1 first: settle the shared reservation to
-        // `Held(actual)`. The estimate matches the actual, so the budget is unchanged
-        // and now holds the body's actual bytes.
+        // `Held(actual)`, releasing the maximum-accepted reservation slack.
         let delta = work
             .settle_active_reserved_height(block::Height(1), 1_000)
             .expect("height 1 still owns its active reservation");
-        assert_eq!(delta, 0);
+        assert_eq!(delta, -1_000);
+        routine.apply_budget_delta(delta);
         assert_eq!(budget_probe.reserved(), 1_000);
 
         // Tear the routine down while it still lists height 1 as unreceived. `Drop`

--- a/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/zakura-network/src/zakura/block_sync/reactor.rs
@@ -2462,7 +2462,3 @@ fn set_block_reactor_active_connection_gauge(active_connections: usize) {
     metrics::gauge!("zakura.p2p.reactor.active_connections", "reactor" => "block_sync")
         .set(active_connections as f64);
 }
-
-pub(super) fn tolerated_bytes(reserved_bytes: u64, tolerance_percent: u32) -> u64 {
-    reserved_bytes.saturating_mul(u64::from(tolerance_percent.max(100))) / 100
-}

--- a/zakura-network/src/zakura/block_sync/state.rs
+++ b/zakura-network/src/zakura/block_sync/state.rs
@@ -891,7 +891,7 @@ impl OutstandingBlockRange {
 ///
 /// The shared [`ByteBudget`] is just the atomic sink. This ledger owns the
 /// lifecycle arithmetic for one requested height:
-/// `Reserved(estimate) -> Held(actual) -> Released`.
+/// `Reserved(maximum accepted) -> Held(actual) -> Released`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(super) enum BlockBudgetLedger {
     Reserved(u64),
@@ -900,8 +900,8 @@ pub(super) enum BlockBudgetLedger {
 }
 
 impl BlockBudgetLedger {
-    pub(super) fn reserved(estimate: u64) -> Self {
-        Self::Reserved(estimate)
+    pub(super) fn reserved(maximum_accepted: u64) -> Self {
+        Self::Reserved(maximum_accepted)
     }
 
     pub(super) fn current_charge(self) -> u64 {

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -32,7 +32,9 @@ use zakura_chain::{
     transaction::Transaction,
     transparent,
 };
-use zakura_test::vectors::{BLOCK_MAINNET_1_BYTES, BLOCK_MAINNET_2_BYTES, BLOCK_MAINNET_3_BYTES};
+use zakura_test::vectors::{
+    BLOCK_MAINNET_1_BYTES, BLOCK_MAINNET_2_BYTES, BLOCK_MAINNET_347499_BYTES, BLOCK_MAINNET_3_BYTES,
+};
 
 fn peer(byte: u8) -> ZakuraPeerId {
     ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
@@ -984,6 +986,22 @@ fn block_sync_config_defaults_and_round_trips() {
 }
 
 #[test]
+fn block_sync_config_rejects_removed_size_deviation_tolerance() {
+    let error = toml::from_str::<crate::Config>(
+        r#"
+        [zakura.block_sync]
+        size_deviation_tolerance = 200
+        "#,
+    )
+    .expect_err("the removed tolerance setting must be rejected");
+
+    assert!(
+        error.to_string().contains("size_deviation_tolerance"),
+        "the configuration error should identify the removed key: {error}",
+    );
+}
+
+#[test]
 fn config_validate_rejects_degenerate_values() {
     let mut config = ZakuraBlockSyncConfig {
         max_inflight_block_bytes: 0,
@@ -1431,7 +1449,14 @@ fn work_queue_budgeted_take_respects_count_cap() {
         (1..=4).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
     );
 
-    let taken = queue.take_in_range_budgeted(block::Height(1), block::Height(4), 2, u64::MAX);
+    let taken = queue.take_in_range_budgeted(
+        block::Height(1),
+        block::Height(4),
+        2,
+        u64::MAX,
+        u64::MAX,
+        false,
+    );
 
     assert_eq!(
         taken.iter().map(|(height, _)| height.0).collect::<Vec<_>>(),
@@ -1450,7 +1475,8 @@ fn work_queue_budgeted_take_respects_estimated_byte_cap() {
         ],
     );
 
-    let taken = queue.take_in_range_budgeted(block::Height(1), block::Height(3), 3, 250);
+    let taken =
+        queue.take_in_range_budgeted(block::Height(1), block::Height(3), 3, 250, u64::MAX, false);
 
     assert_eq!(
         taken.iter().map(|(height, _)| height.0).collect::<Vec<_>>(),
@@ -1470,7 +1496,14 @@ fn work_queue_budgeted_take_stops_at_gaps() {
         ],
     );
 
-    let taken = queue.take_in_range_budgeted(block::Height(10), block::Height(13), 3, u64::MAX);
+    let taken = queue.take_in_range_budgeted(
+        block::Height(10),
+        block::Height(13),
+        3,
+        u64::MAX,
+        u64::MAX,
+        false,
+    );
 
     assert_eq!(
         taken.iter().map(|(height, _)| height.0).collect::<Vec<_>>(),
@@ -1489,7 +1522,8 @@ fn work_queue_budgeted_take_takes_one_oversized_first_item_for_progress() {
         ],
     );
 
-    let taken = queue.take_in_range_budgeted(block::Height(1), block::Height(2), 2, 100);
+    let taken =
+        queue.take_in_range_budgeted(block::Height(1), block::Height(2), 2, 100, u64::MAX, false);
 
     assert_eq!(
         taken.iter().map(|(height, _)| height.0).collect::<Vec<_>>(),
@@ -1500,17 +1534,75 @@ fn work_queue_budgeted_take_takes_one_oversized_first_item_for_progress() {
 }
 
 #[test]
+fn work_queue_first_item_respects_reservation_cap_without_exemption() {
+    let queue = super::work_queue::WorkQueue::new(block::Height(0));
+    queue.set_estimate_floor_for_tests(1);
+    queue.extend([needed(1, BlockSizeEstimate::Advertised(100))]);
+
+    let gated =
+        queue.take_in_range_budgeted(block::Height(1), block::Height(1), 1, u64::MAX, 199, false);
+    assert!(gated.is_empty());
+    assert!(queue.pending_contains(block::Height(1)));
+
+    let exempt =
+        queue.take_in_range_budgeted(block::Height(1), block::Height(1), 1, u64::MAX, 199, true);
+    assert_eq!(exempt.len(), 1);
+    assert_eq!(exempt[0].1.maximum_accepted_bytes(), 200);
+}
+
+#[test]
 fn work_queue_budgeted_take_preserves_estimates_through_take_and_return() {
     let queue = work_queue_with(0, [needed(10, BlockSizeEstimate::Advertised(12_345))]);
 
-    let taken = queue.take_in_range_budgeted(block::Height(10), block::Height(10), 1, 1);
+    let taken =
+        queue.take_in_range_budgeted(block::Height(10), block::Height(10), 1, 1, u64::MAX, false);
     assert_eq!(taken.len(), 1);
     assert_eq!(taken[0].1.estimated_bytes, 12_345);
 
     queue.return_items([block::Height(10)]);
-    let retaken = queue.take_in_range_budgeted(block::Height(10), block::Height(10), 1, 1);
+    let retaken =
+        queue.take_in_range_budgeted(block::Height(10), block::Height(10), 1, 1, u64::MAX, false);
     assert_eq!(retaken.len(), 1);
     assert_eq!(retaken[0].1.estimated_bytes, 12_345);
+}
+
+#[test]
+fn work_queue_separates_request_estimates_from_resident_reservations() {
+    let queue = super::work_queue::WorkQueue::new(block::Height(0));
+    queue.set_estimate_floor_for_tests(1);
+    queue.extend([
+        needed(1, BlockSizeEstimate::Advertised(100)),
+        needed(2, BlockSizeEstimate::Advertised(100)),
+    ]);
+
+    let taken =
+        queue.take_in_range_budgeted(block::Height(1), block::Height(2), 2, u64::MAX, 250, false);
+    assert_eq!(taken.len(), 1);
+    assert_eq!(taken[0].1.estimated_bytes, 100);
+    assert_eq!(taken[0].1.maximum_accepted_bytes(), 200);
+    assert_eq!(queue.mark_reserved([block::Height(1)]), 200);
+    assert_eq!(queue.reserved_bytes(), 200);
+
+    let delta = queue
+        .settle_active_reserved_height(block::Height(1), 200)
+        .expect("the maximum-accepted reservation is active");
+    assert_eq!(delta, 0);
+    assert_eq!(queue.reserved_bytes(), 0);
+}
+
+#[test]
+fn maximum_accepted_body_bytes_is_bounded_by_consensus() {
+    use super::work_queue::maximum_accepted_body_bytes;
+
+    assert_eq!(maximum_accepted_body_bytes(1_000), 2_000);
+    assert_eq!(
+        maximum_accepted_body_bytes(block::MAX_BLOCK_BYTES),
+        block::MAX_BLOCK_BYTES,
+    );
+    assert_eq!(
+        maximum_accepted_body_bytes(u64::MAX),
+        block::MAX_BLOCK_BYTES,
+    );
 }
 
 /// Test shorthand: the grant for an admitted take, or `None` on any refusal.
@@ -1557,7 +1649,9 @@ fn admission_blocks_above_floor_at_cap_but_keeps_floor_fundable() {
     )
     .expect("floor rescue remains admitted at the look-ahead cap");
     assert_eq!(floor.priority, super::admission::RequestPriority::Floor);
-    assert_eq!(floor.max_request_bytes, 1_000);
+    assert_eq!(floor.max_estimated_bytes, 1_000);
+    assert_eq!(floor.max_reservation_bytes, 40_000_000);
+    assert!(floor.allow_first_reservation_overshoot);
 
     // Height 412 is the first height above the commit window (verified_tip 10 + 401).
     assert_eq!(
@@ -1590,7 +1684,9 @@ fn admission_blocks_above_floor_at_cap_but_keeps_floor_fundable() {
         super::admission::RequestPriority::AboveFloor
     );
     // Remaining headroom is measured in resident memory: (500 - 100*4) / 4 = 25 wire bytes.
-    assert_eq!(above.max_request_bytes, 25);
+    assert_eq!(above.max_estimated_bytes, 25);
+    assert_eq!(above.max_reservation_bytes, 25);
+    assert!(!above.allow_first_reservation_overshoot);
 }
 
 #[test]
@@ -1767,7 +1863,7 @@ fn outstanding_reservations_are_charged_at_the_resident_multiple() {
         1_000,
     )
     .expect("the commit window is exempt from the reservation charge");
-    assert_eq!(window.max_request_bytes, 1_000);
+    assert_eq!(window.max_estimated_bytes, 1_000);
 }
 
 #[test]
@@ -1828,7 +1924,7 @@ fn floor_backpressures_when_download_floor_escalates_past_commit() {
         1_000,
     )
     .expect("the commit-frontier block is always fundable");
-    assert_eq!(frontier.max_request_bytes, 1_000);
+    assert_eq!(frontier.max_estimated_bytes, 1_000);
     let window_top = admit_grant(
         &config,
         snapshot,
@@ -1837,7 +1933,7 @@ fn floor_backpressures_when_download_floor_escalates_past_commit() {
         1_000,
     )
     .expect("the top of the commit window is still fundable");
-    assert_eq!(window_top.max_request_bytes, 1_000);
+    assert_eq!(window_top.max_estimated_bytes, 1_000);
     assert_eq!(
         admit_grant(
             &config,
@@ -1889,7 +1985,7 @@ fn exempt_take_never_spans_the_commit_window_boundary() {
         block::Height(411),
         "the exempt take is clamped at the commit-window top",
     );
-    assert_eq!(grant.max_request_bytes, 1_000);
+    assert_eq!(grant.max_estimated_bytes, 1_000);
 
     // Same clamp with the gate open: no exempt take ever spans the boundary.
     let open = super::admission::AdmissionSnapshot {
@@ -1918,7 +2014,7 @@ fn exempt_take_never_spans_the_commit_window_boundary() {
     )
     .expect("an above-window start is admitted below the cap");
     assert_eq!(grant.take_high, block::Height(10_000));
-    assert_eq!(grant.max_request_bytes, 250);
+    assert_eq!(grant.max_reservation_bytes, 250);
 }
 
 #[test]
@@ -1974,7 +2070,7 @@ fn commit_window_stays_fundable_at_exact_floor() {
         completing.priority,
         super::admission::RequestPriority::Floor
     );
-    assert_eq!(completing.max_request_bytes, 2_000_000);
+    assert_eq!(completing.max_estimated_bytes, 2_000_000);
 
     // The first height above the window is refused while the gate is full — on both
     // lanes, since `admit` gates every above-window start regardless of priority.
@@ -1996,13 +2092,13 @@ fn work_queue_force_cancel_and_owner_timeout_release_once() {
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(block::Height(1), block::Height(1), 1);
     assert_eq!(taken.len(), 1);
-    assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
-    assert_eq!(budget.reserved(), 100);
+    assert!(budget.try_reserve(200));
+    assert_eq!(queue.mark_reserved([block::Height(1)]), 200);
+    assert_eq!(budget.reserved(), 200);
 
     let watchdog_released = queue.release_and_return_items([block::Height(1)]);
     budget.release(watchdog_released);
-    assert_eq!(watchdog_released, 100);
+    assert_eq!(watchdog_released, 200);
     assert_eq!(budget.reserved(), 0);
     assert!(queue.pending_contains(block::Height(1)));
 
@@ -2035,31 +2131,31 @@ fn work_queue_reserved_bytes_counter_matches_scan_across_transitions() {
     // take + mark_reserved: Released -> Reserved.
     let taken = queue.take_in_range(block::Height(1), block::Height(6), 6);
     assert_eq!(taken.len(), 6);
-    assert_eq!(queue.mark_reserved((1..=6).map(block::Height)), 600);
-    assert_eq!(queue.reserved_bytes(), 600);
+    assert_eq!(queue.mark_reserved((1..=6).map(block::Height)), 1200);
+    assert_eq!(queue.reserved_bytes(), 1200);
     check("mark_reserved");
 
     // settle: Reserved -> Held drops the reservation for height 1.
     queue
         .settle_active_reserved_height(block::Height(1), 80)
         .expect("height 1 is reserved");
-    assert_eq!(queue.reserved_bytes(), 500);
+    assert_eq!(queue.reserved_bytes(), 1000);
     check("settle");
 
     // mark_held_direct: Reserved -> Held drops height 2's reservation.
     queue.mark_held_direct(block::Height(2), 90);
-    assert_eq!(queue.reserved_bytes(), 400);
+    assert_eq!(queue.reserved_bytes(), 800);
     check("mark_held_direct");
 
     // release_heights: Reserved -> Released for height 3.
     queue.release_heights([block::Height(3)]);
-    assert_eq!(queue.reserved_bytes(), 300);
+    assert_eq!(queue.reserved_bytes(), 600);
     check("release_heights");
 
     // release_reserved_and_return_items: only the still-reserved height 4 releases.
     let released = queue.release_reserved_and_return_items([block::Height(4)]);
-    assert_eq!(released, 100);
-    assert_eq!(queue.reserved_bytes(), 200);
+    assert_eq!(released, 200);
+    assert_eq!(queue.reserved_bytes(), 400);
     check("release_reserved_and_return_items");
 
     // advance_floor drops the committed `<= floor` prefix. Heights 1 (Held) and 2
@@ -2069,13 +2165,13 @@ fn work_queue_reserved_bytes_counter_matches_scan_across_transitions() {
     assert_eq!(released, 0, "heights <= 4 owned no live reservation");
     assert!(!queue.pending_contains(block::Height(1)));
     assert!(!queue.in_flight_contains(block::Height(2)));
-    assert_eq!(queue.reserved_bytes(), 200);
+    assert_eq!(queue.reserved_bytes(), 400);
     check("advance_floor");
 
     // reset_above drops the `> floor` suffix (heights 5 and 6), releasing their
     // reservations and zeroing the counter.
     let released = queue.reset_above(block::Height(4));
-    assert_eq!(released, 200);
+    assert_eq!(released, 400);
     assert_eq!(queue.reserved_bytes(), 0);
     assert!(!queue.in_flight_contains(block::Height(5)));
     assert!(!queue.in_flight_contains(block::Height(6)));
@@ -2090,23 +2186,23 @@ fn work_queue_advance_floor_drops_only_committed_prefix() {
     );
     // Reserve a contiguous run so we can see the reservation accounting on GC.
     let _ = queue.take_in_range(block::Height(1), block::Height(10), 10);
-    assert_eq!(queue.mark_reserved((1..=10).map(block::Height)), 1000);
+    assert_eq!(queue.mark_reserved((1..=10).map(block::Height)), 2000);
 
     // advance_floor to 4: drops heights 1..=4 (still reserved -> released), keeps 5..=10.
     let released = queue.advance_floor(block::Height(4));
-    assert_eq!(released, 400, "reserved bytes for the dropped 1..=4 prefix");
+    assert_eq!(released, 800, "reserved bytes for the dropped 1..=4 prefix");
     for h in 1..=4 {
         assert!(!queue.in_flight_contains(block::Height(h)));
     }
     for h in 5..=10 {
         assert!(queue.in_flight_contains(block::Height(h)));
     }
-    assert_eq!(queue.reserved_bytes(), 600);
+    assert_eq!(queue.reserved_bytes(), 1200);
     assert_eq!(queue.reserved_bytes(), queue.reserved_bytes_scanned());
 
     // A lower floor is a no-op (floor only advances).
     assert_eq!(queue.advance_floor(block::Height(2)), 0);
-    assert_eq!(queue.reserved_bytes(), 600);
+    assert_eq!(queue.reserved_bytes(), 1200);
 }
 
 #[test]
@@ -2115,14 +2211,14 @@ fn watchdog_after_held_settle_releases_once() {
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(block::Height(1), block::Height(1), 1);
     assert_eq!(taken.len(), 1);
-    assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
+    assert!(budget.try_reserve(200));
+    assert_eq!(queue.mark_reserved([block::Height(1)]), 200);
 
     let delta = queue
         .settle_active_reserved_height(block::Height(1), 80)
         .expect("active reserved height settles");
-    assert_eq!(delta, -20);
-    budget.release(20);
+    assert_eq!(delta, -120);
+    budget.release(120);
     assert_eq!(budget.reserved(), 80);
 
     let outcome = queue.release_reserved_and_return_items_detailed([block::Height(1)]);
@@ -2149,8 +2245,8 @@ fn late_delivery_after_watchdog_cancellation_does_not_resurrect_released_claim()
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(block::Height(1), block::Height(1), 1);
     assert_eq!(taken.len(), 1);
-    assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
+    assert!(budget.try_reserve(200));
+    assert_eq!(queue.mark_reserved([block::Height(1)]), 200);
 
     let outcome = queue.release_reserved_and_return_items_detailed([block::Height(1)]);
     let watchdog_released = outcome.released_bytes;
@@ -2182,13 +2278,13 @@ fn mark_held_direct_does_not_orphan_a_charge() {
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(block::Height(1), block::Height(1), 1);
     assert_eq!(taken.len(), 1);
-    assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
+    assert!(budget.try_reserve(200));
+    assert_eq!(queue.mark_reserved([block::Height(1)]), 200);
 
     assert!(budget.try_reserve(80));
     let old_charge = queue.mark_held_direct(block::Height(1), 80);
     budget.release(old_charge);
-    assert_eq!(old_charge, 100);
+    assert_eq!(old_charge, 200);
     assert_eq!(budget.reserved(), 80);
 
     let released = queue.release_heights([block::Height(1)]);
@@ -2209,23 +2305,23 @@ fn release_reserved_mixed_reserved_held_conserves_budget() {
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(block::Height(1), block::Height(2), 2);
     assert_eq!(taken.len(), 2);
-    assert!(budget.try_reserve(200));
+    assert!(budget.try_reserve(400));
     assert_eq!(
         queue.mark_reserved([block::Height(1), block::Height(2)]),
-        200
+        400
     );
 
     let delta = queue
         .settle_active_reserved_height(block::Height(1), 80)
         .expect("active height settles");
-    assert_eq!(delta, -20);
-    budget.release(20);
-    assert_eq!(budget.reserved(), 180);
+    assert_eq!(delta, -120);
+    budget.release(120);
+    assert_eq!(budget.reserved(), 280);
 
     let released = queue.advance_floor(block::Height(2));
     budget.release(released);
     assert_eq!(
-        released, 100,
+        released, 200,
         "WorkQueue releases only the still-reserved height; held bytes are released by Sequencer"
     );
     assert_eq!(budget.reserved(), 80);
@@ -2240,7 +2336,7 @@ fn release_reserved_heights_skips_held_body_owned_by_sequencer() {
     // `stale_adjusted_disposition`, `finish_detached`) releases via
     // `release_reserved_heights`. When a competing peer delivered a height late, it
     // settled to `Held(actual)` in the shared queue; the owner must release only
-    // the still-reserved estimate and leave the held body for the Sequencer — never
+    // the still-reserved maximum accepted size and leave the held body for the Sequencer — never
     // double-releasing its bytes. The non-Held-aware `release_heights` would return
     // the held `actual` here and saturate the budget.
     let queue = work_queue_with(
@@ -2253,10 +2349,10 @@ fn release_reserved_heights_skips_held_body_owned_by_sequencer() {
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(block::Height(1), block::Height(2), 2);
     assert_eq!(taken.len(), 2);
-    assert!(budget.try_reserve(200));
+    assert!(budget.try_reserve(400));
     assert_eq!(
         queue.mark_reserved([block::Height(1), block::Height(2)]),
-        200
+        400
     );
 
     // A competing peer's late body settles height 1 to Held(80); height 2 stays
@@ -2264,17 +2360,17 @@ fn release_reserved_heights_skips_held_body_owned_by_sequencer() {
     let delta = queue
         .settle_active_reserved_height(block::Height(1), 80)
         .expect("height 1 is reserved");
-    assert_eq!(delta, -20);
-    budget.release(20);
-    assert_eq!(budget.reserved(), 180);
+    assert_eq!(delta, -120);
+    budget.release(120);
+    assert_eq!(budget.reserved(), 280);
 
     // GC both heights: only the still-reserved height 2 releases. The Held height 1
     // is skipped (owned by the Sequencer) and stays in `in_flight`.
     let released = queue.release_reserved_heights([block::Height(1), block::Height(2)]);
     budget.release(released);
     assert_eq!(
-        released, 100,
-        "release_reserved_heights frees only the still-reserved estimate, never held body bytes"
+        released, 200,
+        "release_reserved_heights frees only the still-reserved reservation, never held body bytes"
     );
     assert!(queue.in_flight_contains(block::Height(1)));
     assert_eq!(budget.reserved(), 80);
@@ -4338,10 +4434,14 @@ proptest::proptest! {
             // A gated request funds min(budget, remaining_wire, response_cap); the next
             // body is sized as decoded, so remaining_wire = (effective - resident) / factor.
             let remaining_wire = (effective - estimated_resident) / factor;
-            let expected = snapshot.budget_available.min(remaining_wire).min(1_000);
+            let expected_reservation = snapshot.budget_available.min(remaining_wire);
             match above {
                 super::admission::AdmissionOutcome::Admit(grant) => {
-                    prop_assert_eq!(grant.max_request_bytes, expected);
+                    prop_assert_eq!(
+                        grant.max_estimated_bytes,
+                        expected_reservation.min(1_000)
+                    );
+                    prop_assert_eq!(grant.max_reservation_bytes, expected_reservation);
                     // Gated grants pass the servable ceiling through unchanged.
                     prop_assert_eq!(grant.take_high, block::Height(100_000));
                     // Single-admission no-breach invariant: whatever the gate admits
@@ -4349,7 +4449,7 @@ proptest::proptest! {
                     // and decodes.
                     prop_assert!(
                         estimated_resident
-                            .saturating_add(grant.max_request_bytes.saturating_mul(factor))
+                            .saturating_add(grant.max_reservation_bytes.saturating_mul(factor))
                             <= effective
                     );
                 }
@@ -4367,7 +4467,7 @@ proptest::proptest! {
             1_000,
         ) {
             super::admission::AdmissionOutcome::Admit(grant) => {
-                prop_assert_eq!(grant.max_request_bytes, 1_000);
+                prop_assert_eq!(grant.max_estimated_bytes, 1_000);
                 prop_assert_eq!(grant.take_high, block::Height(411));
             }
             other => prop_assert!(
@@ -4556,64 +4656,47 @@ fn received_tracker_handles_a_full_range_at_the_bitset_boundary() {
     );
 }
 
-/// A body whose actual serialized size exceeds its advertised size hint is still
-/// accepted and buffered, and the byte budget charges the overshoot so it cannot
-/// issue more work while under-counting held bodies.
+/// A full wave at the accepted 2x estimate limit is reserved before issuance, so
+/// receiving every body never expands the shared byte budget.
 #[test]
-fn underestimated_body_is_buffered_and_charges_budget_delta() {
+fn underestimated_body_wave_is_fully_reserved_before_receipt() {
     let hint = 1_000u64;
-    // Budget holds several hint-sized shares: enough to reserve this body's hint.
-    let mut budget = ByteBudget::new(hint * 4);
+    let accepted = super::work_queue::maximum_accepted_body_bytes(hint);
+    assert_eq!(accepted, hint * 2);
+    let body_count = 4u64;
+    let mut budget = ByteBudget::new(accepted * body_count);
     let mut reorder = ReorderBuffer::new();
 
-    let request = BlockRangeRequest {
-        start_height: block::Height(1),
-        count: 1,
-        anchor_hash: block::Hash([1; 32]),
-        // Size-estimate reservation: the per-height hint, not worst case.
-        estimated_bytes: hint,
-        expected_blocks: vec![ExpectedBlock {
-            height: block::Height(1),
-            hash: block::Hash([1; 32]),
-            estimated_bytes: hint,
-        }],
-    };
-    assert!(budget.try_reserve(request.estimated_bytes));
-    let now = Instant::now();
-    let mut outstanding = OutstandingBlockRange {
-        request,
-        queued_at: now,
-        deadline: now,
-        delivery_snapshot: test_delivery_snapshot(now),
-        delivered_bytes: 0,
-        received: ReceivedBlockTracker::default(),
-    };
-    assert_eq!(budget.reserved(), hint);
-
-    // The body's actual serialized size is far larger than the hint (but still
-    // <= MAX_BLOCK_BYTES).
-    let actual = hint * 50;
-    assert!(actual < BS_PER_BLOCK_WORST_CASE_BYTES);
-    assert!(actual > hint);
-
-    // Receipt: settle toward the actual size. Because actual exceeds the reserved
-    // hint, the budget charges the delta even though the body is already admitted.
-    budget.settle(hint, actual);
-    outstanding.mark_received(block::Height(1));
-    let block = mainnet_block(&BLOCK_MAINNET_1_BYTES);
-    assert_eq!(
-        reorder.insert(block::Height(1), block, actual, peer(0)),
-        ReorderInsertResult::Inserted,
-        "an underestimated body must still buffer; a received body is never dropped"
-    );
-    assert_eq!(reorder.buffered_bytes(), actual);
-    assert_eq!(budget.reserved(), actual);
+    for _ in 0..body_count {
+        assert!(budget.try_reserve(accepted));
+    }
     assert_eq!(budget.available(), 0);
-    assert!(
-        !budget.try_reserve(hint),
-        "charging the underestimated delta closes the budget gate"
-    );
-    budget.release(reorder.drop_through(block::Height(1)));
+
+    for height in 1..=body_count {
+        budget.settle(accepted, accepted);
+        let block = mainnet_block(&BLOCK_MAINNET_1_BYTES);
+        assert_eq!(
+            reorder.insert(
+                block::Height(u32::try_from(height).expect("test height fits u32")),
+                block,
+                accepted,
+                peer(0),
+            ),
+            ReorderInsertResult::Inserted,
+        );
+        assert_eq!(
+            budget.reserved(),
+            accepted * body_count,
+            "receipt at the tolerance limit must not expand aggregate accounting",
+        );
+    }
+
+    assert_eq!(reorder.buffered_bytes(), accepted * body_count);
+    assert_eq!(budget.reserved(), accepted * body_count);
+    assert_eq!(budget.available(), 0);
+    budget.release(reorder.drop_through(block::Height(
+        u32::try_from(body_count).expect("test height fits u32"),
+    )));
     assert_eq!(budget.reserved(), 0);
 }
 
@@ -5176,7 +5259,8 @@ async fn reactor_keeps_submitted_body_budget_until_apply_finishes() {
     let mut config = immediate_body_download_config();
     // One block's size hint of budget: size-based reservation now means one
     // advertised body fills the budget, throttling to one in-flight request.
-    config.max_inflight_block_bytes = u64::from(block1_size);
+    config.max_inflight_block_bytes =
+        super::work_queue::maximum_accepted_body_bytes(u64::from(block1_size));
 
     let (tip_tx, tip_rx) = watch::channel((block::Height(0), block::Hash([0; 32])));
     let startup = BlockSyncStartup::new(
@@ -5481,19 +5565,17 @@ async fn reactor_does_not_requeue_held_height_reported_still_needed() {
 }
 
 /// A real body whose serialized size dwarfs its advertised size hint is still
-/// accepted, buffered, and submitted. Worst case (not the hint) is reserved at
-/// send time, so shrink-on-receipt always has room and never drops the body.
+/// accepted, buffered, and submitted. The maximum size accepted by the hint
+/// tolerance is reserved at send time, so settlement never expands the budget.
 ///
 /// A/B: under the old release-then-reserve scheme the request reserved only the
-/// hint-sized estimate, so a body larger than the hint re-reserved more than was
-/// released and, against a tight budget, hit `BudgetFull` and dropped a valid
-/// body. With worst-case reservation this path is unreachable.
+/// hint-sized estimate, so a larger accepted body expanded the aggregate budget
+/// after admission. With maximum-accepted reservation this path is unreachable.
 #[tokio::test]
 async fn reactor_buffers_body_larger_than_its_size_hint() {
     let blocks = mainnet_blocks_1_to_3();
     let mut config = immediate_body_download_config();
-    // Budget holds exactly one worst-case share, so a hint-sized re-reservation
-    // would have left no headroom for an underestimated body.
+    // Keep enough global room for the maximum accepted reservation.
     config.max_inflight_block_bytes = BS_PER_BLOCK_WORST_CASE_BYTES;
 
     let (tip_tx, tip_rx) = watch::channel((block::Height(0), block::Hash([0; 32])));
@@ -5758,7 +5840,8 @@ async fn reactor_keeps_applying_body_after_non_advancing_duplicate_result() {
     let mut config = immediate_body_download_config();
     // One block's size hint of budget: size-based reservation now means one
     // advertised body fills the budget, throttling to one in-flight request.
-    config.max_inflight_block_bytes = u64::from(block1_size);
+    config.max_inflight_block_bytes =
+        super::work_queue::maximum_accepted_body_bytes(u64::from(block1_size));
 
     let (_tip_tx, tip_rx) = watch::channel((block::Height(2), blocks[1].hash()));
     let startup = BlockSyncStartup::new(
@@ -6185,6 +6268,23 @@ async fn reactor_accepts_unmatched_body_for_queued_height() {
     assert_eq!(submitted, blocks[0].hash());
 
     reactor_task.abort();
+}
+
+#[test]
+fn queued_height_retains_the_fixed_maximum_accepted_size_policy() {
+    let queue = super::work_queue::WorkQueue::new(block::Height(0));
+    queue.set_estimate_floor_for_tests(1);
+    queue.extend([needed(1, BlockSizeEstimate::Advertised(100))]);
+
+    assert_eq!(
+        queue.pending_maximum_accepted_bytes(block::Height(1)),
+        Some(200),
+    );
+    assert!(
+        201 > queue
+            .pending_maximum_accepted_bytes(block::Height(1))
+            .unwrap()
+    );
 }
 
 // Removed by the per-peer routine design: `reactor_accepts_queued_body_from_
@@ -6827,14 +6927,10 @@ async fn routine_disconnect_returns_outstanding_and_releases_budget() {
 }
 
 #[tokio::test]
-async fn reactor_reserves_size_hint_per_block_not_worst_case() {
-    // The issuance path (`try_fill`) reserves the advertised size hint per block,
-    // NOT `BS_PER_BLOCK_WORST_CASE_BYTES`. The global byte budget = 3 worst-case
-    // blocks; the peer advertises a generous slot/response/block-count budget and
-    // tiny 1 KiB size hints. Under the old worst-case reservation the budget would
-    // bound the request to 3 blocks; because the reservation now honors the 1 KiB
-    // hints, the full 16-block range fits under the budget and the request is the
-    // whole 16-block range.
+async fn reactor_reserves_maximum_accepted_size_not_protocol_worst_case() {
+    // The issuance path reserves the maximum size accepted by the fixed 2×
+    // estimate policy, not `BS_PER_BLOCK_WORST_CASE_BYTES`. With 1 KiB hints,
+    // all 16 reservations still fit comfortably.
     let budget_blocks = 3u32;
     let config = ZakuraBlockSyncConfig {
         max_inflight_block_bytes: u64::from(budget_blocks) * BS_PER_BLOCK_WORST_CASE_BYTES,
@@ -6882,8 +6978,8 @@ async fn reactor_reserves_size_hint_per_block_not_worst_case() {
                 .map(|height| BlockSyncBlockMeta {
                     height: block::Height(height),
                     hash: block::Hash([height as u8; 32]),
-                    // Tiny hint: if the reservation honored this instead of the
-                    // worst case, the whole 16-block range would fit under the cap.
+                    // Tiny hint: its 2 KiB maximum-accepted reservation lets the
+                    // whole 16-block range fit under the cap.
                     size: BlockSizeEstimate::Advertised(1_000),
                 })
                 .collect(),
@@ -6894,8 +6990,8 @@ async fn reactor_reserves_size_hint_per_block_not_worst_case() {
     let (_start_height, count) = wait_for_outbound_getblocks(&mut outbound).await;
     assert_eq!(
         count, 16,
-        "the request must cover the full 16-block range: the 1 KiB size hints (not a \
-         worst-case-per-block reservation) drive the budget, so all 16 fit under a \
+        "the request must cover the full 16-block range: the 2 KiB maximum-accepted \
+         reservations (not protocol-worst-case reservations) let all 16 fit under a \
          {budget_blocks}-worst-case-block budget",
     );
 
@@ -11940,19 +12036,30 @@ async fn reactor_publishes_block_sync_candidate_gap() {
 
 #[tokio::test]
 async fn oversize_body_policy_reports_size_mismatch_and_retries_without_buffering() {
-    let mut config = ZakuraBlockSyncConfig {
-        size_deviation_tolerance: 100,
-        ..immediate_body_download_config()
-    };
+    let mut config = immediate_body_download_config();
     config.peer_limits.outbound_queue_depth = 8;
-    let (tip_tx, tip_rx) = watch::channel((block::Height(0), block::Hash([0; 32])));
+    let block = mainnet_block(&BLOCK_MAINNET_347499_BYTES);
+    let height = block
+        .coinbase_height()
+        .expect("test block has a coinbase height");
+    let previous_height = block::Height(height.0 - 1);
+    let previous_hash = block.header.previous_block_hash;
+    let actual_bytes = u64::from(block_size(&block));
+    let underestimated_bytes =
+        u32::try_from(actual_bytes / 3).expect("test block estimate fits u32");
+    assert!(
+        actual_bytes
+            > super::work_queue::maximum_accepted_body_bytes(u64::from(underestimated_bytes))
+    );
+
+    let (tip_tx, tip_rx) = watch::channel((previous_height, previous_hash));
     let startup = BlockSyncStartup::new(
         BlockSyncFrontiers {
-            finalized_height: block::Height(0),
-            verified_block_tip: block::Height(0),
-            verified_block_hash: block::Hash([0; 32]),
+            finalized_height: previous_height,
+            verified_block_tip: previous_height,
+            verified_block_hash: previous_hash,
         },
-        (block::Height(0), block::Hash([0; 32])),
+        (previous_height, previous_hash),
         tip_rx,
         config.clone(),
     );
@@ -11974,9 +12081,9 @@ async fn oversize_body_policy_reports_size_mismatch_and_retries_without_bufferin
     inbound_tx
         .send(
             BlockSyncMessage::Status(BlockSyncStatus {
-                servable_low: block::Height(1),
-                servable_high: block::Height(1),
-                tip_hash: block::Hash([1; 32]),
+                servable_low: height,
+                servable_high: height,
+                tip_hash: block.hash(),
                 max_blocks_per_response: 4,
                 max_inflight_requests: 1,
                 max_response_bytes: MAX_BS_RESPONSE_BYTES,
@@ -11986,9 +12093,8 @@ async fn oversize_body_policy_reports_size_mismatch_and_retries_without_bufferin
         )
         .await
         .expect("status queues");
-    let block = mainnet_block(&BLOCK_MAINNET_1_BYTES);
     tip_tx
-        .send((block::Height(1), block.hash()))
+        .send((height, block.hash()))
         .expect("tip watch is live");
     while !matches!(
         next_action(&mut actions).await,
@@ -11996,9 +12102,9 @@ async fn oversize_body_policy_reports_size_mismatch_and_retries_without_bufferin
     ) {}
     handle
         .send(BlockSyncEvent::NeededBlocks(vec![BlockSyncBlockMeta {
-            height: block::Height(1),
+            height,
             hash: block.hash(),
-            size: BlockSizeEstimate::Advertised(1),
+            size: BlockSizeEstimate::Advertised(underestimated_bytes),
         }]))
         .await
         .expect("needed metadata queues");

--- a/zakura-network/src/zakura/block_sync/work_queue.rs
+++ b/zakura-network/src/zakura/block_sync/work_queue.rs
@@ -17,9 +17,8 @@
 //!
 //! Internals are a brief `std::sync::Mutex` whose critical sections are tiny map
 //! splices held **never across `.await`** (the anti-block rule). `estimated_bytes`
-//! on a [`WorkItem`] is the block's size *estimate* (not its worst-case
-//! reservation); it exists only to carry the `SizeMismatch` tolerance check
-//! through to the reactor's receive path and request budget.
+//! on a [`WorkItem`] keeps the block's request-shaping estimate separate from
+//! its maximum-accepted resident reservation.
 
 use std::sync::Mutex as StdMutex;
 
@@ -36,13 +35,13 @@ pub(super) const DEFAULT_BS_SIZE_FLOOR_BYTES: u64 = 1024;
 pub(super) struct WorkItem {
     /// Expected hash of the block at this height (drives the response match).
     pub(super) hash: block::Hash,
-    /// The block's size estimate. Used for request budget reservation and the
-    /// receive-path `SizeMismatch` tolerance check.
+    /// The block's size estimate. Used for request shaping and the receive-path
+    /// `SizeMismatch` tolerance check.
     pub(super) estimated_bytes: u64,
     /// Current byte-budget charge owned by this height.
     ///
     /// Pending items normally have `Released`; issued-but-unreceived items have
-    /// `Reserved(estimate)`; received bodies held by the commit pipeline have
+    /// `Reserved(maximum accepted)`; received bodies held by the commit pipeline have
     /// `Held(actual)`. All terminal release paths go through this ledger so a
     /// stale local owner cannot release a charge that another path already
     /// returned.
@@ -103,6 +102,27 @@ fn estimate_bytes_with(estimate: BlockSizeEstimate, floor: u64) -> u64 {
         BlockSizeEstimate::Unknown => block::MAX_BLOCK_BYTES,
     };
     hinted.max(floor).min(block::MAX_BLOCK_BYTES)
+}
+
+/// Largest serialized body accepted for an estimated size.
+///
+/// The fixed percentage is a total-size multiplier (200 means 2×). The consensus
+/// block-size limit is the final authority, so reservations never exceed the
+/// largest valid serialized block.
+pub(super) fn maximum_accepted_body_bytes(estimated_bytes: u64) -> u64 {
+    const SIZE_DEVIATION_TOLERANCE_PERCENT: u64 = 200;
+
+    estimated_bytes
+        .saturating_mul(SIZE_DEVIATION_TOLERANCE_PERCENT)
+        .checked_div(100)
+        .unwrap_or(u64::MAX)
+        .min(block::MAX_BLOCK_BYTES)
+}
+
+impl WorkItem {
+    pub(super) fn maximum_accepted_bytes(self) -> u64 {
+        maximum_accepted_body_bytes(self.estimated_bytes)
+    }
 }
 
 /// The shared download work source. See the module docs for the invariants.
@@ -218,17 +238,21 @@ impl WorkQueue {
 
     /// Move up to `max_count` contiguous-ascending `pending` heights within
     /// `low..=high` from `pending` to `in_flight`, also stopping before the
-    /// sum of stored size estimates would exceed `max_estimated_bytes`.
+    /// either the sum of stored size estimates would exceed
+    /// `max_estimated_bytes`, or the sum of maximum accepted body reservations
+    /// would exceed `max_reservation_bytes`.
     ///
-    /// The estimate cap bounds the request's summed byte reservation. To
-    /// guarantee progress, the first eligible item is always taken when
-    /// `max_count > 0`, even if its estimate alone exceeds the cap.
+    /// The two caps independently bound request shaping and resident reservation.
+    /// The first item may exceed the estimate cap for progress, but may exceed the
+    /// reservation cap only for an explicit commit-window exemption.
     pub(super) fn take_in_range_budgeted(
         &self,
         low: block::Height,
         high: block::Height,
         max_count: usize,
         max_estimated_bytes: u64,
+        max_reservation_bytes: u64,
+        allow_first_reservation_overshoot: bool,
     ) -> Vec<(block::Height, WorkItem)> {
         // An empty count or inverted range is a caller bug, not a real "nothing to
         // take": every caller computes `low <= high` and a positive count before
@@ -245,6 +269,7 @@ impl WorkQueue {
         let mut inner = self.lock();
         let mut taken: Vec<(block::Height, WorkItem)> = Vec::new();
         let mut estimated_bytes = 0u64;
+        let mut reservation_bytes = 0u64;
         let mut next_expected: Option<block::Height> = None;
         for (height, item) in inner.pending.range(low..=high) {
             if let Some(expected) = next_expected {
@@ -254,12 +279,20 @@ impl WorkQueue {
             }
 
             let next_estimated_bytes = estimated_bytes.saturating_add(item.estimated_bytes);
-            if !taken.is_empty() && next_estimated_bytes > max_estimated_bytes {
+            let next_reservation_bytes =
+                reservation_bytes.saturating_add(item.maximum_accepted_bytes());
+            let estimate_over_cap = next_estimated_bytes > max_estimated_bytes;
+            let reservation_over_cap = next_reservation_bytes > max_reservation_bytes;
+            if (!taken.is_empty() && estimate_over_cap)
+                || (reservation_over_cap
+                    && (!taken.is_empty() || !allow_first_reservation_overshoot))
+            {
                 break;
             }
 
             taken.push((*height, *item));
             estimated_bytes = next_estimated_bytes;
+            reservation_bytes = next_reservation_bytes;
             if taken.len() >= max_count {
                 break;
             }
@@ -313,7 +346,7 @@ impl WorkQueue {
         }
     }
 
-    /// Mark already-taken heights as owning an estimated byte reservation.
+    /// Mark already-taken heights as owning their maximum accepted byte reservation.
     ///
     /// Returns the sum marked. The caller must have already admitted the same
     /// byte total through [`ByteBudget`](crate::zakura::transport::ByteBudget).
@@ -327,10 +360,11 @@ impl WorkQueue {
             if item.budget.current_charge() != 0 {
                 continue;
             }
-            item.budget = BlockBudgetLedger::reserved(item.estimated_bytes);
-            marked = marked.saturating_add(item.estimated_bytes);
+            let maximum_accepted_bytes = item.maximum_accepted_bytes();
+            item.budget = BlockBudgetLedger::reserved(maximum_accepted_bytes);
+            marked = marked.saturating_add(maximum_accepted_bytes);
         }
-        // Released (0) -> Reserved(estimate): the reserved total grows by exactly
+        // Released (0) -> Reserved(maximum accepted): the total grows by exactly
         // the bytes just marked.
         inner.reserved_bytes = inner.reserved_bytes.saturating_add(marked);
         marked
@@ -362,7 +396,7 @@ impl WorkQueue {
     /// Mark a height as directly held after the caller admitted `actual` bytes.
     ///
     /// Used for unmatched queued bodies, which did not have a prior request
-    /// estimate reservation.
+    /// reservation.
     pub(super) fn mark_held_direct(&self, height: block::Height, actual: u64) -> u64 {
         let mut inner = self.lock();
         if let Some(item) = inner.in_flight.get_mut(&height) {
@@ -384,7 +418,7 @@ impl WorkQueue {
         0
     }
 
-    /// Release *any* live charge (reserved estimate **or** held body bytes) for
+    /// Release *any* live charge (maximum-accepted reservation **or** held body bytes) for
     /// `heights`, exactly once. This is the non-Held-aware release: it hands back
     /// held-body bytes the Sequencer also owns, so production must never call it
     /// (see [`release_reserved_heights`](Self::release_reserved_heights) and
@@ -409,7 +443,7 @@ impl WorkQueue {
         released
     }
 
-    /// Release only the still-reserved size-estimate charges for `heights`,
+    /// Release only the still-reserved maximum-accepted charges for `heights`,
     /// exactly once, leaving each height in place.
     ///
     /// A height that already settled to `Held(actual)` is owned by the body
@@ -648,7 +682,7 @@ impl WorkQueue {
             })
     }
 
-    /// Sum of reserved request-estimate bytes across `pending` + `in_flight`.
+    /// Sum of maximum-accepted request reservations across `pending` + `in_flight`.
     ///
     /// O(1): returns the incrementally-maintained counter (see
     /// [`WorkQueueInner::reserved_bytes`]). This is on the sequencer's hot path via
@@ -738,6 +772,13 @@ impl WorkQueue {
 
     pub(super) fn pending_contains(&self, height: block::Height) -> bool {
         self.lock().pending.contains_key(&height)
+    }
+
+    pub(super) fn pending_maximum_accepted_bytes(&self, height: block::Height) -> Option<u64> {
+        self.lock()
+            .pending
+            .get(&height)
+            .map(|item| item.maximum_accepted_bytes())
     }
 
     pub(super) fn reserved_in_flight_charge(&self, height: block::Height) -> Option<u64> {

--- a/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
+++ b/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
@@ -271,12 +271,11 @@ pub(crate) fn assert_core(
         outstanding_bound,
     );
 
-    // The global byte budget is never over-committed: peak reserved download bytes
-    // (in-flight + reorder + applying) must stay within the configured ceiling. Every
-    // per-peer routine reserves against the same CAS-guarded `ByteBudget`, so this must
-    // hold no matter how many peers race — the memory bound the spec requires. Vacuous
-    // only for scenarios that set an effectively unbounded budget (`u64::MAX`); the
-    // tight-ceiling scenarios make it bite.
+    // The global byte budget is never over-committed: unreceived heights charge their
+    // maximum accepted body size, while received heights charge actual retained bytes.
+    // Every per-peer routine reserves against the same CAS-guarded `ByteBudget`, so this
+    // must hold no matter how many peers race. Vacuous only for scenarios that set an
+    // effectively unbounded budget (`u64::MAX`); the tight-ceiling scenarios make it bite.
     assert!(
         report.peak_budget_reserved <= scenario.config.max_inflight_block_bytes,
         "peak reserved bytes {} exceeded the global in-flight byte budget {}",

--- a/zakurad/tests/common/configs/v1.0.0-rc0.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc0.toml
@@ -133,7 +133,6 @@ max_response_bytes = 33554432
 max_submitted_block_applies = 401
 no_progress_peer_cooldown = "3m"
 request_timeout = "8s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v1.0.0-rc2.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc2.toml
@@ -133,7 +133,6 @@ max_response_bytes = 33554432
 max_submitted_block_applies = 401
 no_progress_peer_cooldown = "3m"
 request_timeout = "8s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v1.0.0-rc3.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc3.toml
@@ -133,7 +133,6 @@ max_response_bytes = 33554432
 max_submitted_block_applies = 401
 no_progress_peer_cooldown = "3m"
 request_timeout = "8s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v1.0.0-rc4.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc4.toml
@@ -133,7 +133,6 @@ max_response_bytes = 33554432
 max_submitted_block_applies = 401
 no_progress_peer_cooldown = "3m"
 request_timeout = "8s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v4.5.0-zakura-blocksync.toml
+++ b/zakurad/tests/common/configs/v4.5.0-zakura-blocksync.toml
@@ -93,7 +93,6 @@ max_inflight_requests = 4
 max_response_bytes = 33554432
 replace_legacy_syncer = false
 request_timeout = "30s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v5.0.0-rc.3.toml
+++ b/zakurad/tests/common/configs/v5.0.0-rc.3.toml
@@ -133,7 +133,6 @@ max_response_bytes = 33554432
 max_submitted_block_applies = 401
 no_progress_peer_cooldown = "3m"
 request_timeout = "8s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v5.0.0-zakura-conservative-rtt.toml
+++ b/zakurad/tests/common/configs/v5.0.0-zakura-conservative-rtt.toml
@@ -124,7 +124,6 @@ max_response_bytes = 33554432
 max_submitted_block_applies = 401
 no_progress_peer_cooldown = "3m"
 request_timeout = "8s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v5.0.0-zakura-p2p.toml
+++ b/zakurad/tests/common/configs/v5.0.0-zakura-p2p.toml
@@ -104,7 +104,6 @@ max_inflight_requests = 2048
 max_response_bytes = 33554432
 max_submitted_block_applies = 400
 request_timeout = "10s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]

--- a/zakurad/tests/common/configs/v5.0.0-zakura-throughput-control.toml
+++ b/zakurad/tests/common/configs/v5.0.0-zakura-throughput-control.toml
@@ -121,7 +121,6 @@ max_response_bytes = 33554432
 max_submitted_block_applies = 401
 no_progress_peer_cooldown = "3m"
 request_timeout = "8s"
-size_deviation_tolerance = 200
 status_refresh_interval = "30s"
 
 [network.zakura.block_sync.peer_limits]


### PR DESCRIPTION
## Motivation

Block-sync admission reserved peer-advertised body-size estimates, but accepted responses up to twice those estimates. A full admitted wave could therefore expand retained memory toward twice the configured resident budget.

No linked issue; this PR is being opened without prior team discussion.

## Solution

- reserve each body at the fixed maximum accepted size (`min(estimate × 2, MAX_BLOCK_BYTES)`) before issuing requests
- keep advertised estimates separate for request shaping, congestion control, deadlines, and mismatch attribution
- settle maximum reservations down to actual body bytes on receipt
- enforce reservation headroom for above-window first items while preserving the commit-window floor-funding exemption
- apply the same size policy to active and timed-out pending responses
- remove the former `size_deviation_tolerance` configuration key and update config fixtures

### Tests

- `cargo test -p zakura-network --lib zakura::block_sync` — 229 passed
- `cargo test -p zakura --test config` — passed
- `cargo clippy -p zakura-network --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `markdownlint CHANGELOG.md zakura-network/src/zakura/block_sync/README.md --config .trunk/configs/.markdownlint.yaml` — passed
- IDE diagnostics — clean

### Specifications & References

- Zcash consensus maximum serialized block size: 2,000,000 bytes

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: GPT-5.6 Sol in Cursor for implementation, tests, documentation, and PR preparation

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.