### PR TITLE
chore(release): prepare v1.0.0-rc5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "1.0.0-rc3"
+version = "1.0.0-rc5"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.0-rc4"
+version = "1.0.0-rc5"
 dependencies = [
  "abscissa_core",
  "anyhow",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "1.0.0-rc3"
+version = "1.0.0-rc5"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "1.0.0-rc3"
+version = "1.0.0-rc5"
 dependencies = [
  "bincode",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0-rc4 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0-rc5 zakura
 ```
 
 You can start Zakura by running

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -91,7 +91,7 @@ Both release workflows publish every release with `prerelease: true`, whatever
 the tag looks like — nothing promotes a release automatically. Promotion is a
 deliberate manual step, governed by this convention:
 
-- **Pre-releases are never promoted.** Hyphenated tags (`v1.0.0-rc4`) stay
+- **Pre-releases are never promoted.** Hyphenated tags (`v1.0.0-rc5`) stay
   pre-releases from publication until deletion. `v1.0.0-rc3` is the cautionary
   tale: it was hand-promoted, external instructions adopted
   `releases/latest/download/...` URLs, and deleting the release left those

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -91,7 +91,7 @@ Both release workflows publish every release with `prerelease: true`, whatever
 the tag looks like — nothing promotes a release automatically. Promotion is a
 deliberate manual step, governed by this convention:
 
-- **Pre-releases are never promoted.** Hyphenated tags (`v1.0.0-rc5`) stay
+- **Pre-releases are never promoted.** Hyphenated tags (`v1.0.0-rc4`) stay
   pre-releases from publication until deletion. `v1.0.0-rc3` is the cautionary
   tale: it was hand-promoted, external instructions adopted
   `releases/latest/download/...` URLs, and deleting the release left those

--- a/scripts/check-crate-packaging.sh
+++ b/scripts/check-crate-packaging.sh
@@ -3,9 +3,8 @@
 #
 # Packages every publishable workspace crate and checks each .crate archive
 # against the crates.io size limit. All crates are packaged in one cargo
-# invocation: the zakura-* crates depend on each other at the workspace
-# version, which does not exist on crates.io until the graph is actually
-# published, so per-crate packaging cannot resolve. Workspace-aware
+# invocation: some zakura-* crates depend on unpublished workspace package
+# versions, so per-crate packaging cannot always resolve. Workspace-aware
 # `cargo package` (Rust 1.90+) resolves those dependencies against an
 # in-memory overlay of the packages being packaged instead.
 #
@@ -59,22 +58,16 @@ PUBLISH_ORDER=(
   zakura
 )
 
-# All publishable crates share the workspace release version.
-version="$(
-  cargo metadata --format-version 1 --no-deps --manifest-path "${repo_root}/Cargo.toml" \
-    | jq -r '.packages[] | select(.name == "zakura") | .version'
+metadata="$(
+  cargo metadata --format-version 1 --no-deps --manifest-path "${repo_root}/Cargo.toml"
 )"
-if [ -z "$version" ]; then
-  echo "Could not find the 'zakura' package in the workspace." >&2
-  exit 1
-fi
 
 package_args=()
 for crate in "${PUBLISH_ORDER[@]}"; do
   package_args+=(-p "$crate")
 done
 
-echo "Packaging ${#PUBLISH_ORDER[@]} crates at version ${version}..."
+echo "Packaging ${#PUBLISH_ORDER[@]} crates..."
 # shellcheck disable=SC2086 # VERIFY_FLAG is intentionally empty or one flag
 cargo package --locked $VERIFY_FLAG "${package_args[@]}"
 
@@ -83,6 +76,13 @@ max_bytes=$((10 * 1024 * 1024))
 
 failed=0
 for crate in "${PUBLISH_ORDER[@]}"; do
+  version="$(jq -r --arg crate "$crate" '.packages[] | select(.name == $crate) | .version' <<<"$metadata")"
+  if [ -z "$version" ] || [ "$version" = "null" ]; then
+    echo "ERROR: could not find ${crate} in workspace metadata" >&2
+    failed=1
+    continue
+  fi
+
   archive="${repo_root}/target/package/${crate}-${version}.crate"
   if [ ! -f "$archive" ]; then
     echo "ERROR: expected ${archive} to exist after packaging" >&2
@@ -102,4 +102,4 @@ if [ "$failed" -ne 0 ]; then
   exit 1
 fi
 
-echo "All ${#PUBLISH_ORDER[@]} crates package cleanly at version ${version}."
+echo "All ${#PUBLISH_ORDER[@]} crates package cleanly."

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -15,7 +15,7 @@ ZAKURA_RELEASE_TAG="v1.0.0-rc4"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
 # Replaced with the archive checksum by release-binaries.yml before publishing.
-ZAKURA_ARCHIVE_SHA256="f5c4cd214e226e6ce283fc0021f9975f2ae816e85bb557a72026ecbb46a13c53"
+ZAKURA_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 ZAKURA_MEMBER="./bin/zakurad"
 ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc4"
 ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc4"

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -11,14 +11,14 @@ fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UNITY_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
 
-ZAKURA_RELEASE_TAG="v1.0.0-rc4"
+ZAKURA_RELEASE_TAG="v1.0.0-rc5"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
 # Replaced with the archive checksum by release-binaries.yml before publishing.
 ZAKURA_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc4"
-ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc4"
+ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc5"
+ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc5"
 ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="valargroup/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 # Persistent Zakura iroh identity (NodeId secret). Kept outside the state cache so

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "1.0.0-rc3"
+version = "1.0.0-rc5"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "1.0.0-rc3"
+version = "1.0.0-rc5"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "1.0.0-rc3"
+version = "1.0.0-rc5"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -159,7 +159,7 @@ comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
 zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3" }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3" }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc5" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc3" }
 zakura-network = { path = "../zakura-network", version = "1.0.0-rc5" }
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc3", features = ["rpc-client"] }
@@ -313,7 +313,7 @@ proptest-derive = { workspace = true }
 color-eyre = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc5", features = ["proptest-impl"] }
 zakura-network = { path = "../zakura-network", version = "1.0.0-rc5", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "1.0.0-rc5", features = ["proptest-impl"] }
 

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.0.0-rc4"
+version = "1.0.0-rc5"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -161,10 +161,10 @@ comparison-interpreter = ["zakura-script/comparison-interpreter"]
 zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3" }
 zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc3" }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc3" }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc5" }
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc3", features = ["rpc-client"] }
 zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc3" }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc3" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc5" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -314,8 +314,8 @@ color-eyre = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc3", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc3", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc3", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc3", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc5", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc5", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "1.0.0-rc3" }
 

--- a/zakurad/tests/common/configs/v1.0.0-rc5.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc5.toml
@@ -1,0 +1,200 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the native Zakura P2P v2 stack only.
+# - "dual": both stacks, with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[network.zakura.block_sync]
+bbr_cwnd_gain_percent = 300
+bbr_cwnd_unit = "bytes"
+bbr_delay_gradient_percent = 150
+bbr_delivery_rate_window = "10s"
+bbr_min_cwnd = 4
+bbr_min_cwnd_bytes = 2524288
+bbr_probe_bw_gain_percent = 125
+bbr_probe_rtt_duration = "200ms"
+bbr_probe_rtt_interval = "10s"
+bbr_reliability_weight_percent = 100
+bbr_rtprop_window = "10s"
+bbr_startup_growth_percent = 200
+floor_bypass_slots = 2
+floor_peer_avoid_cooldown = "8s"
+floor_rescue_timeout = "2s"
+initial_block_probe_requests = 1
+initial_inflight_requests = 64
+max_blocks_per_response = 1
+max_inflight_block_bytes = 6442450944
+max_inflight_requests = 32000
+max_reorder_lookahead_bytes = 6408896512
+max_requests_without_block_progress = 64
+max_response_bytes = 33554432
+max_submitted_block_applies = 401
+no_progress_peer_cooldown = "3m"
+request_timeout = "8s"
+size_deviation_tolerance = 200
+status_refresh_interval = "30s"
+
+[network.zakura.block_sync.peer_limits]
+inbound_queue_depth = 128
+max_inbound_peers = 256
+max_outbound_peers = 256
+max_pending_escalations = 32
+outbound_queue_depth = 128
+
+[network.zakura.header_sync]
+accept_new_blocks = true
+max_headers_per_response = 1000
+max_inflight_requests = 10
+status_refresh_interval = "30s"
+
+[network.zakura.header_sync.peer_limits]
+inbound_queue_depth = 128
+max_inbound_peers = 256
+max_outbound_peers = 256
+max_pending_escalations = 32
+outbound_queue_depth = 128
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"
+


### PR DESCRIPTION
## Motivation

Prepare the next Zakura release candidate with package versions and release metadata that match `v1.0.0-rc5`.

## Solution

- Bump `zakura`, `zakura-network`, `zakura-state`, and `zakura-consensus` to `1.0.0-rc5`, including Zakura's direct dependency requirements and the lockfile.
- Update the README for rc5.
- Add the rc5 stored configuration fixture.
- Zero the installer archive checksum so release CI can replace it with the published artifact checksum.

### Tests

- `cargo metadata --no-deps --format-version 1 --locked`
- `./scripts/check-release-version.sh v1.0.0-rc5`
- `markdownlint README.md docs/release-tag-protection.md --config .trunk/configs/.markdownlint.yaml`
- `bash -n scripts/install-zakura.sh`
- IDE diagnostics for changed files: no errors

Risk classification: low risk; this PR changes release metadata and configuration snapshots without changing runtime logic. Full Rust tests and clippy were skipped under the repository's risk-based verification policy.

### Specifications & References

- Release graph preparation: #122
- Previous release bump: #132

### Follow-up Work

- Release CI will replace the zeroed installer checksum with the rc5 archive checksum.

### AI Disclosure

- [x] AI tools were used: Cursor (GPT-5.6 Sol) updated release metadata, identified changed publishable crates, and prepared the PR description.
- [x] Follow-up commit ec7988718 (zakura-consensus bump, docs revert): Claude Code, maintainer-pushed.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested as described above.
- [x] The documentation and changelogs are up to date.
