### PR TITLE
docs(network): mark P2P v2 experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This 
 - Performance: Blockchain sync is nearly 5× faster than Zebra. Block execution is notably faster than Zebra on worst case sandblast attacks as well.
 - Pruning and snapshots: Native block pruning with configurable retention cuts disk usage substantially. We also publish snapshots (~11 GB pruned) that let you bootstrap a node 680× faster than syncing over the standard P2P network. See [here](https://zakura.com/snapshots/)
 - zcashd compatibility: A compatibility mode reproduces the legacy zcashd RPC interface, so existing wallets and integrations keep working.
-- Alpha of a v2 p2p layer: We are building a new P2P transport layer for Zakura nodes, currently off by default. The goals: sub-500ms worst-case block propagation, mempool aggregation (used in Tachyon), sync at the speed of your bandwidth, and a future-proofed gossip protocol with strict DoS resistance built in.
+- Experimental P2P v2: We are building a new P2P transport layer for Zakura nodes, currently off by default on Mainnet. The goals are sub-500ms worst-case block propagation, mempool aggregation (used in Tachyon), sync at the speed of your bandwidth, and a future-proofed gossip protocol. The native stack has known DoS risks and is not yet production-hardened; see its [current tradeoffs and exit criteria](book/src/user/p2p.md).
 
 ## Getting Started
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ The Zakura team is committed to working with researchers who submit security vul
 
 Please submit issues privately through GitHub's security advisory reporting for this repository: <https://github.com/zakura-core/zakura/security/advisories/new>.
 
-If an issue also affects upstream [Zebra](https://github.com/ZcashFoundation/zebra), please also report it to the Zcash Foundation by following [upstream's security policy](https://github.com/ZcashFoundation/zebra/blob/main/SECURITY.md). Issues in Zakura's own additions (for example the Zakura P2P v2 stack) should be reported only to us.
+If an issue also affects upstream [Zebra](https://github.com/ZcashFoundation/zebra), please also report it to the Zcash Foundation by following [upstream's security policy](https://github.com/ZcashFoundation/zebra/blob/main/SECURITY.md). Issues in Zakura's own additions (for example the [experimental Zakura P2P v2 stack](book/src/user/p2p.md)) should be reported only to us.
 
 ## Sending Disclosures
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
     - [Platform Tier Policy](user/target-tier-policies.md)
   - [Building and Installing Zakura](user/install.md)
   - [Running Zakura](user/run.md)
+  - [Experimental Zakura P2P v2](user/p2p.md)
   - [Zakura with Docker](user/docker.md)
   - [Tracing Zakura](user/tracing.md)
   - [Zakura Metrics](user/metrics.md)

--- a/book/src/dev/private-zakura-network.md
+++ b/book/src/dev/private-zakura-network.md
@@ -6,6 +6,9 @@ A node bootstraps from a few peers, but discovery and gossip then pull in the
 rest of the network, so two engineers testing different changes at the same time
 would otherwise collide.
 
+The Zakura v2 stack is [experimental](../user/p2p.md). Private cohorts isolate
+experiments from each other; they do not make the stack production-hardened.
+
 A _private Zakura dev network_ (a "cohort") solves this without changing
 consensus. Set a tag in the config and a node only forms Zakura (v2) connections
 with peers that advertise the same tag. Public nodes and other cohorts ignore it,

--- a/book/src/dev/private-zakura-network.md
+++ b/book/src/dev/private-zakura-network.md
@@ -6,8 +6,7 @@ A node bootstraps from a few peers, but discovery and gossip then pull in the
 rest of the network, so two engineers testing different changes at the same time
 would otherwise collide.
 
-The Zakura v2 stack is [experimental](../user/p2p.md). Private cohorts isolate
-experiments from each other; they do not make the stack production-hardened.
+The Zakura v2 stack is [experimental](../user/p2p.md).
 
 A _private Zakura dev network_ (a "cohort") solves this without changing
 consensus. Set a tag in the config and a node only forms Zakura (v2) connections

--- a/book/src/user/p2p.md
+++ b/book/src/user/p2p.md
@@ -1,0 +1,35 @@
+# Experimental Zakura P2P v2
+
+The native Zakura P2P v2 stack is **experimental**. It is off by default on
+Mainnet, where an unset `network.p2p_stack` resolves to the legacy TCP stack.
+Testnet and Regtest currently default to dual-stack operation so the new stack
+gets exercised while legacy peers remain available.
+
+The experimental designation applies to the native Zakura stack used by the
+`"zakura"` and `"dual"` modes. It does not apply to the legacy Zcash TCP stack.
+
+## Current tradeoff
+
+The stack has bounded framing, admission, connection, and queue mechanisms, but
+it intentionally does not yet impose universal limits on a node's total usable
+bandwidth or total number of requests. Avoiding those blunt global limits lets
+different message types use available capacity and supports high-throughput
+sync and gossip. The tradeoff is that there are known denial-of-service vectors
+in which a peer can consume disproportionate bandwidth or request-processing
+capacity.
+
+Treat `p2p_stack = "zakura"` and `p2p_stack = "dual"` as opt-in testing modes,
+especially on Mainnet. Operators should monitor resource use and should not
+rely on the native stack as a hardened trust boundary yet.
+
+## Removing the designation
+
+Zakura P2P v2 will remain experimental until it:
+
+- defines and enforces explicit resource and behavior expectations for every
+  message type; and
+- prioritizes latency-sensitive, consensus-critical streams over bulk or
+  background traffic such as block sync and mempool traffic.
+
+These controls must bound abusive work without imposing a universal ceiling
+that prevents a well-behaved node from using its available bandwidth.

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -211,6 +211,10 @@ legacy Zcash P2P protocol. Every `network.p2p_stack` value runs it except
 `"zakura"`. Do not enable state pruning on the fronting Zakura — a pruned node does
 not advertise `NODE_NETWORK` and zcashd will not sync from it.
 
+The `"zakura"` and `"dual"` modes enable the [experimental Zakura P2P v2
+stack](./p2p.md); zcashd itself continues to use the legacy connection in dual
+mode.
+
 > [!WARNING]
 > When the fronting Zakura runs in Docker with a published P2P port, all
 > connections arriving through `docker-proxy` (including a sidecar zcashd

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -206,14 +206,14 @@ manage_zcashd = false
 block_gossip_peer_ips = ["127.0.0.1"]
 ```
 
-zcashd-compat mode requires the legacy Zcash P2P stack, because zcashd speaks the
-legacy Zcash P2P protocol. Every `network.p2p_stack` value runs it except
-`"zakura"`. Do not enable state pruning on the fronting Zakura — a pruned node does
-not advertise `NODE_NETWORK` and zcashd will not sync from it.
+zcashd only connects to Zakura using the legacy Zcash P2P protocol. The fronting
+Zakura must therefore use `network.p2p_stack = "legacy"` or `"dual"`; Zakura
+refuses to start zcashd-compat mode with the `"zakura"`-only setting. The
+`"dual"` setting also enables the [experimental Zakura P2P v2 stack](./p2p.md),
+but the zcashd sidecar still connects over Zakura's legacy listener.
 
-The `"zakura"` and `"dual"` modes enable the [experimental Zakura P2P v2
-stack](./p2p.md); zcashd itself continues to use the legacy connection in dual
-mode.
+Do not enable state pruning on the fronting Zakura — a pruned node does not
+advertise `NODE_NETWORK` and zcashd will not sync from it.
 
 > [!WARNING]
 > When the fronting Zakura runs in Docker with a published P2P port, all

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -17,8 +17,7 @@ Each node runs a local systemd controller. GitHub Actions installs and audits th
 controller, but it does not hold an SSH session open during the long sync.
 
 The dual-stack and Zakura/v2-only nodes exercise the [experimental Zakura P2P
-v2 stack](../../book/src/user/p2p.md); this fleet is test infrastructure, not an
-assertion that the native stack is production-hardened.
+v2 stack](../../book/src/user/p2p.md).
 
 ## Lifecycle
 

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -16,6 +16,10 @@ test a fresh genesis-to-tip sync from the latest `origin/main` build:
 Each node runs a local systemd controller. GitHub Actions installs and audits the
 controller, but it does not hold an SSH session open during the long sync.
 
+The dual-stack and Zakura/v2-only nodes exercise the [experimental Zakura P2P
+v2 stack](../../book/src/user/p2p.md); this fleet is test infrastructure, not an
+assertion that the native stack is production-hardened.
+
 ## Lifecycle
 
 `zakura-continuous-sync.service` runs

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -106,6 +106,11 @@ volume at `/mnt/data`; legacy `/mnt/<node-name>-data` paths are compatibility
 symlinks only. The compat Zakura process uses the same snapshot layout on its
 host.
 
+The `"dual"` setting enables the [experimental Zakura P2P v2
+stack](../../book/src/user/p2p.md) alongside the legacy stack. Deployments using
+it are intended to exercise and observe the native stack, not treat it as a
+production-hardened trust boundary.
+
 The workflow also refreshes a simple fleet status dashboard on
 `zakura-testnet-1`:
 

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -107,9 +107,7 @@ symlinks only. The compat Zakura process uses the same snapshot layout on its
 host.
 
 The `"dual"` setting enables the [experimental Zakura P2P v2
-stack](../../book/src/user/p2p.md) alongside the legacy stack. Deployments using
-it are intended to exercise and observe the native stack, not treat it as a
-production-hardened trust boundary.
+stack](../../book/src/user/p2p.md) alongside the legacy stack.
 
 The workflow also refreshes a simple fleet status dashboard on
 `zakura-testnet-1`:

--- a/deploy/runner/runbook.md
+++ b/deploy/runner/runbook.md
@@ -7,8 +7,7 @@ feature, PR #262), so other engineers churning the public fleet can't perturb a
 run. Background: `book/src/dev/private-zakura-network.md`.
 
 This benchmark intentionally exercises the [experimental Zakura P2P v2
-stack](../../book/src/user/p2p.md). Its isolation improves measurement
-repeatability but does not remove the native stack's known DoS risks.
+stack](../../book/src/user/p2p.md).
 
 Everything lives in `/root/zakura/deploy/runner/` (untracked local tooling).
 `perf.sh` is the entry point — it wraps the deployer and the run/analyze scripts.

--- a/deploy/runner/runbook.md
+++ b/deploy/runner/runbook.md
@@ -6,6 +6,10 @@ serving nodes we control, over a private Zakura cohort (the `dev_network`
 feature, PR #262), so other engineers churning the public fleet can't perturb a
 run. Background: `book/src/dev/private-zakura-network.md`.
 
+This benchmark intentionally exercises the [experimental Zakura P2P v2
+stack](../../book/src/user/p2p.md). Its isolation improves measurement
+repeatability but does not remove the native stack's known DoS risks.
+
 Everything lives in `/root/zakura/deploy/runner/` (untracked local tooling).
 `perf.sh` is the entry point — it wraps the deployer and the run/analyze scripts.
 Repo-relative paths below are from the repo root `/root/zakura/`.

--- a/docker/mining/README.md
+++ b/docker/mining/README.md
@@ -23,8 +23,9 @@ Docker Compose setup for running a Zcash mining pool with Zebra and S-NOMP.
 - **Redis**: Stores share counts and pool statistics
 
 The included full node explicitly uses the legacy TCP P2P stack. Native Zakura
-QUIC transport is disabled, matching the single TCP peer port published by the
-Compose configuration.
+QUIC transport, which is [experimental](../../book/src/user/p2p.md), is
+disabled, matching the single TCP peer port published by the Compose
+configuration.
 
 All block rewards go to the address configured in `MINER_ADDRESS`.
 

--- a/docs/decisions/zakura/0001-iroh-dependency.md
+++ b/docs/decisions/zakura/0001-iroh-dependency.md
@@ -2,6 +2,10 @@
 
 Plan: `/home/evan/src/valar/art/inbox/zakura_p2p/00.0_iroh_dependency.md`
 
+> **Status:** This decision contributes to the [experimental Zakura P2P v2
+> stack](../../../book/src/user/p2p.md); it does not indicate production
+> hardening.
+
 ## Decision
 
 Zakura pins `iroh = "=0.92.0"` in the workspace with `default-features = false`.

--- a/docs/decisions/zakura/0001-iroh-dependency.md
+++ b/docs/decisions/zakura/0001-iroh-dependency.md
@@ -3,8 +3,7 @@
 Plan: `/home/evan/src/valar/art/inbox/zakura_p2p/00.0_iroh_dependency.md`
 
 > **Status:** This decision contributes to the [experimental Zakura P2P v2
-> stack](../../../book/src/user/p2p.md); it does not indicate production
-> hardening.
+> stack](../../../book/src/user/p2p.md).
 
 ## Decision
 

--- a/docs/decisions/zakura/0002-test-tooling-review-fixes.md
+++ b/docs/decisions/zakura/0002-test-tooling-review-fixes.md
@@ -2,6 +2,10 @@
 
 Plan: `/home/evan/src/valar/art/inbox/zakura_p2p/01.b_test_tooling.md`
 
+> **Status:** This tooling supports the [experimental Zakura P2P v2
+> stack](../../../book/src/user/p2p.md); passing these tests does not indicate
+> production hardening.
+
 ## Applied in This Fix
 
 - Inbound delivery now has one production path: stream workers send frames into

--- a/docs/decisions/zakura/0002-test-tooling-review-fixes.md
+++ b/docs/decisions/zakura/0002-test-tooling-review-fixes.md
@@ -3,8 +3,7 @@
 Plan: `/home/evan/src/valar/art/inbox/zakura_p2p/01.b_test_tooling.md`
 
 > **Status:** This tooling supports the [experimental Zakura P2P v2
-> stack](../../../book/src/user/p2p.md); passing these tests does not indicate
-> production hardening.
+> stack](../../../book/src/user/p2p.md).
 
 ## Applied in This Fix
 

--- a/zakura-network/src/config.rs
+++ b/zakura-network/src/config.rs
@@ -115,11 +115,11 @@ pub enum P2pStack {
     /// The legacy TCP Zcash P2P stack only.
     Legacy,
 
-    /// The native Zakura P2P v2 stack only.
+    /// The experimental native Zakura P2P v2 stack only.
     Zakura,
 
-    /// Both stacks: mutually capable peers are upgraded to Zakura P2P v2, and the legacy
-    /// stack stays available for peers that can't upgrade.
+    /// Both stacks: mutually capable peers are upgraded to the experimental Zakura P2P v2
+    /// stack, and the legacy stack stays available for peers that can't upgrade.
     Dual,
 }
 
@@ -280,8 +280,8 @@ pub struct Config {
     /// |---|---|
     /// | `"default"` | The configured network's binary default |
     /// | `"legacy"` | The legacy TCP Zcash P2P stack only |
-    /// | `"zakura"` | The native Zakura P2P v2 stack only |
-    /// | `"dual"` | Both stacks, with legacy fallback |
+    /// | `"zakura"` | The experimental native Zakura P2P v2 stack only |
+    /// | `"dual"` | Both stacks, enabling experimental v2 with legacy fallback |
     ///
     /// Leave this at `"default"` so Zakura can change the per-network default during upgrades.
     /// See [`P2pStack::resolve`] for the current defaults, and [`legacy_p2p`](Self::legacy_p2p)

--- a/zakura-network/src/zakura/README.md
+++ b/zakura-network/src/zakura/README.md
@@ -4,6 +4,10 @@ Developer notes for the `[network.zakura] dev_network` cohort tag. For the
 operator-facing setup guide, see
 [`book/src/dev/private-zakura-network.md`](../../../book/src/dev/private-zakura-network.md).
 
+The native Zakura P2P v2 stack is
+[experimental](../../../book/src/user/p2p.md). Cohort isolation is a development
+tool and does not address the stack's known DoS risks.
+
 ## What it does
 
 Zakura (v2) dev nodes bootstrap from a few peers, then discovery and gossip pull

--- a/zakura-network/src/zakura/README.md
+++ b/zakura-network/src/zakura/README.md
@@ -5,8 +5,7 @@ operator-facing setup guide, see
 [`book/src/dev/private-zakura-network.md`](../../../book/src/dev/private-zakura-network.md).
 
 The native Zakura P2P v2 stack is
-[experimental](../../../book/src/user/p2p.md). Cohort isolation is a development
-tool and does not address the stack's known DoS risks.
+[experimental](../../../book/src/user/p2p.md).
 
 ## What it does
 

--- a/zakurad/src/commands/generate.rs
+++ b/zakurad/src/commands/generate.rs
@@ -115,8 +115,8 @@ fn document_network_p2p_config(config: &str) -> String {
     let comments = [
         "# The peer-to-peer stack to run:",
         "# - \"legacy\": the legacy TCP Zcash P2P stack only.",
-        "# - \"zakura\": the native Zakura P2P v2 stack only.",
-        "# - \"dual\": both stacks, with legacy fallback.",
+        "# - \"zakura\": the experimental native Zakura P2P v2 stack only.",
+        "# - \"dual\": both stacks, enabling experimental v2 with legacy fallback.",
         "# - \"default\": Zakura's default for this network, which can change between",
         "#   releases. Currently \"legacy\" on Mainnet, and \"dual\" everywhere else.",
     ]

--- a/zakurad/tests/common/configs/v1.0.0-rc5.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc5.toml
@@ -80,8 +80,8 @@ max_connections_per_ip = 1
 network = "Mainnet"
 # The peer-to-peer stack to run:
 # - "legacy": the legacy TCP Zcash P2P stack only.
-# - "zakura": the native Zakura P2P v2 stack only.
-# - "dual": both stacks, with legacy fallback.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
 # - "default": Zakura's default for this network, which can change between
 #   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
 p2p_stack = "default"
@@ -197,4 +197,3 @@ shutdown_grace_period = "5m"
 startup_delay = "1s"
 zcashd_extra_args = []
 zcashd_source = "path"
-


### PR DESCRIPTION
## Motivation

The native Zakura P2P v2 stack is still experimental, but its status and the
reason for that designation were not stated consistently across the repository.
In particular, the top-level README described strict DoS resistance as a goal
without documenting the known resource-exhaustion tradeoff that remains today.

## Solution

- add one operator-facing page that defines the experimental scope, current
  bandwidth/request-limiting tradeoff, and exit criteria;
- mark and cross-link active documentation that describes or enables native
  Zakura P2P v2;
- clarify that the legacy TCP stack is not covered by the designation; and
- document that zcashd only connects over Zakura's legacy listener and that the
  existing startup guard rejects zcashd-compat with Zakura-only P2P; and
- keep generated configuration comments and Rust API documentation consistent
  with the operator docs.

Historical changelog entries and generic legacy-P2P port guidance are left
unchanged.

### Tests

- `cargo fmt --all -- --check`
- `mdbook build book`
- `CXXFLAGS='-include cstdint' cargo test -p zakura zcashd_compat_config_rejects_disabled_legacy_p2p`
- `git diff --check`

`mdbook test book` was also attempted, but the repository currently has
pre-existing failures in unrelated illustrative snippets, including the Regtest
guide, state database guide, and older RFC chapters. The new P2P page contains no
Rust code blocks and produced no doctest failure.

### Specifications & References

The removal criteria are explicit per-message resource and behavior
expectations, plus prioritization of latency-sensitive consensus-critical
streams over bulk/background block-sync and mempool traffic.

### Follow-up Work

- Link a tracking issue if maintainers want this documentation request recorded
  separately before the draft is marked ready for review.
- Implement and validate the per-message controls and stream prioritization
  needed to remove the experimental designation.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed directly with the team requester before opening the draft.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
