### PR TITLE
fix: consensus, state-integrity, and sync-liveness fixes with expanded test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Initial release of Zakura.
 
 ### Fixed
 
+- Native Zakura header sync now honors `disable_pow = true` on configured
+  Testnets, matching semantic and checkpoint block verification.
 - Pruned finalized blocks remain visible to chain-identity queries, including peer
   block-hash responses and RPC confirmation lookups, after their bodies are removed.
 

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -412,10 +412,9 @@ construction_ — but the public API previously let it be desynced after constru
 (`pub auth_data_root`, `DerefMut`, both re-exported). A holder could swap the block while
 keeping a stale root, and a header matching the stale root would finalize a block without
 proving the header binds the block's actual authorizing data. The (block, auth-data-root) pair
-is now locked together: `auth_data_root` is `pub(crate)`, `CheckpointVerifiedBlock` drops
-`DerefMut`, the one legitimately-post-set field goes through
-`set_deferred_pool_balance_change`, and the semantic verifier builds blocks through
-`from_semantic_data` (auth-data root left unset). Compile-time enforced (fix in commit #192).
+is now locked together: `CheckpointVerifiedBlock` drops `DerefMut`, and the checkpoint
+verifier can only fill the optional cache through `with_precomputed_auth_data_root`, which
+computes the value from that same wrapped block rather than accepting arbitrary bytes.
 
 ## 7. The fast commit path and checkpoint last checkpoint height
 

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -393,9 +393,12 @@ The ZIP-221 MMR does not authenticate everything, so three gaps are closed by di
 
 A block's own commitment check `C(X, T_{X-1})` is the _identical_ computation the previous
 fast block already ran as its look-ahead one commit earlier. The committer caches the
-look-ahead result as `(next_height, next_hash)` and skips a block's own check when the prior
-look-ahead validated exactly it. The guard is hash identity and heights are monotonic, so a
-stale or cloned cache entry can never cause a false skip. Steady state drops from two
+look-ahead result as `(next_height, next_hash, next_auth_data_root)` and skips a block's own
+check when the prior look-ahead validated exactly it. Below NU5 the auth-data-root component is
+unused because it is not an input to the header commitment; at NU5 and later it binds a
+header-only successor witness to the later body, so a same-header body with different
+authorizing data cannot reuse the earlier prevalidation. Heights are monotonic, so a stale or
+cloned cache entry can never cause a false skip. Steady state drops from two
 commitment checks per block to one (legacy parity) while still attesting every root before it
 is persisted. A non-last checkpoint height fast block with no buffered successor is deferred by the write
 worker until the successor arrives; the checkpoint last checkpoint height is the only no-successor fast commit
@@ -429,7 +432,8 @@ logic. For a checkpoint-verified block at `height`:
    - apply the direct below-Heartwood/below-NU5/below-Nu6_3 checks (§6.1);
    - build a candidate history tree with the roots folded in (`HistoryTree::push`);
    - **verify-before-commit:** either check the buffered successor's commitment against the
-     candidate (the one-block-lag confirmation) and cache `(height+1, next_hash)` as
+     candidate (the one-block-lag confirmation) and cache
+     `(height+1, next_hash, next_auth_data_root)` as
      pre-validated, or, at the checkpoint last checkpoint height only, verify the embedded final
      frontiers — including Ironwood — against this height's roots; a failure means _this_
      height's root is bad → reject and evict (§8);

--- a/zakura-chain/CHANGELOG.md
+++ b/zakura-chain/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   serialize and deserialize successfully, while unsupported later placeholders
   are rejected.
 
+### Fixed
+
+- Local-genesis networks that activate NU6.1 or later now configure the
+  required zero-value lockbox marker output, so their first semantic
+  activation block can pass subsidy validation. Requests for an upgrade with
+  no compiled consensus branch ID now fail during generation.
+
 ## [9.0.0] - 2026-06-02
 
 ### Added

--- a/zakura-chain/src/block/tests/vectors.rs
+++ b/zakura-chain/src/block/tests/vectors.rs
@@ -5,18 +5,20 @@ use std::{
 };
 
 use chrono::{DateTime, Duration, LocalResult, TimeZone, Utc};
+use halo2::pasta::pallas;
 
 use crate::{
     amount::{Amount, NonNegative, MAX_MONEY},
     block::{
         serialize::MAX_BLOCK_BYTES, Block, BlockTimeError, Commitment::*, Hash, Header, Height,
     },
+    ironwood, orchard,
     parameters::{Network, NetworkUpgrade::*},
     sapling,
     serialization::{
         sha256d, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
     },
-    transaction::{LockTime, Transaction},
+    transaction::{arbitrary::v5_transactions, LockTime, Transaction},
     transparent,
 };
 
@@ -111,6 +113,207 @@ fn chain_value_pool_change_propagates_transaction_value_balance_errors() {
         block.chain_value_pool_change(&utxos, None).is_err(),
         "block-level aggregation should propagate transaction value-balance errors"
     );
+}
+
+/// The block-level Orchard and Ironwood accessors must read from their own
+/// pool's shielded data and preserve transaction order.
+///
+/// Each transaction carries *different* Orchard and Ironwood bundles (and the
+/// second transaction swaps them), so an accessor that read from the wrong
+/// pool, or reordered transactions, would produce a different sequence.
+#[test]
+fn ironwood_block_accessors_preserve_pool_and_wire_order() {
+    let _init_guard = zakura_test::init();
+
+    let mut orchard_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    // Ironwood reuses the Orchard bundle encoding, so an Orchard test bundle
+    // can be cloned into the Ironwood slot of a V6 transaction.
+    let mut ironwood_data = orchard_data.clone();
+
+    let mut orchard_actions = orchard_data.actions.as_slice().to_vec();
+    orchard_actions[0].action.nullifier =
+        orchard::Nullifier::try_from([0; 32]).expect("zero is a valid Pallas base field");
+    orchard_actions[0].action.cm_x = pallas::Base::from(0);
+    orchard_data.actions = orchard_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let mut one = [0; 32];
+    one[0] = 1;
+    let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+    ironwood_actions[0].action.nullifier =
+        ironwood::Nullifier::try_from(one).expect("one is a valid Pallas base field");
+    ironwood_actions[0].action.cm_x = pallas::Base::from(1);
+    ironwood_data.actions = ironwood_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let make_transaction =
+        |orchard_shielded_data: orchard::ShieldedData,
+         ironwood_shielded_data: ironwood::ShieldedData| {
+            Arc::new(Transaction::V6 {
+                network_upgrade: Nu6_3,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(1),
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                sapling_shielded_data: None,
+                orchard_shielded_data: Some(orchard_shielded_data),
+                ironwood_shielded_data: Some(ironwood_shielded_data),
+            })
+        };
+
+    let header: Header = zakura_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let block = Block {
+        header: Arc::new(header),
+        transactions: vec![
+            make_transaction(orchard_data.clone(), ironwood_data.clone()),
+            make_transaction(ironwood_data, orchard_data),
+        ],
+    };
+
+    let expected_orchard_nullifiers: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.orchard_nullifiers().copied())
+        .collect();
+    let expected_ironwood_nullifiers: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.ironwood_nullifiers().copied())
+        .collect();
+    assert_ne!(expected_orchard_nullifiers, expected_ironwood_nullifiers);
+    assert_eq!(
+        block.orchard_nullifiers().copied().collect::<Vec<_>>(),
+        expected_orchard_nullifiers
+    );
+    assert_eq!(
+        block.ironwood_nullifiers().copied().collect::<Vec<_>>(),
+        expected_ironwood_nullifiers
+    );
+
+    let expected_orchard_commitments: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.orchard_note_commitments().copied())
+        .collect();
+    let expected_ironwood_commitments: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.ironwood_note_commitments().copied())
+        .collect();
+    assert_ne!(expected_orchard_commitments, expected_ironwood_commitments);
+    assert_eq!(
+        block
+            .orchard_note_commitments()
+            .copied()
+            .collect::<Vec<_>>(),
+        expected_orchard_commitments
+    );
+    assert_eq!(
+        block
+            .ironwood_note_commitments()
+            .copied()
+            .collect::<Vec<_>>(),
+        expected_ironwood_commitments
+    );
+}
+
+/// The ZIP-221 history-leaf transaction counts must count transactions with a
+/// bundle in the matching pool: Orchard-only transactions must not count as
+/// Ironwood ones, and a multi-action Ironwood bundle counts as one transaction.
+#[test]
+fn ironwood_transaction_count_is_pool_specific_and_counts_bundles() {
+    let _init_guard = zakura_test::init();
+
+    let orchard_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    let mut ironwood_data = orchard_data.clone();
+    let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+    ironwood_actions.push(ironwood_actions[0].clone());
+    ironwood_data.actions = ironwood_actions
+        .try_into()
+        .expect("duplicating an action keeps the bundle non-empty");
+    let ironwood_action_count = ironwood_data.actions.len();
+
+    let make_transaction =
+        |orchard_shielded_data: Option<orchard::ShieldedData>,
+         ironwood_shielded_data: Option<ironwood::ShieldedData>| {
+            Arc::new(Transaction::V6 {
+                network_upgrade: Nu6_3,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(1),
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                sapling_shielded_data: None,
+                orchard_shielded_data,
+                ironwood_shielded_data,
+            })
+        };
+
+    let header: Header = zakura_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let block = Block {
+        header: Arc::new(header),
+        transactions: vec![
+            make_transaction(Some(orchard_data.clone()), None),
+            make_transaction(Some(orchard_data), None),
+            make_transaction(None, Some(ironwood_data)),
+        ],
+    };
+
+    assert_eq!(block.orchard_transactions_count(), 2);
+    assert_eq!(block.ironwood_transactions_count(), 1);
+    assert!(ironwood_action_count > 1);
+    assert_eq!(
+        block
+            .transactions
+            .iter()
+            .flat_map(|transaction| transaction.ironwood_actions())
+            .count(),
+        ironwood_action_count,
+        "the history field counts a multi-action bundle as one transaction"
+    );
+}
+
+/// NU6.3 introduces the V3 history leaf but must not change how the block
+/// header's `hashBlockCommitments` field is interpreted: at and after NU5 it
+/// is the `ChainHistoryBlockTxAuthCommitment` digest, with no structural
+/// restriction on its bytes.
+#[test]
+fn nu6_3_uses_post_nu5_block_commitment_format() {
+    let _init_guard = zakura_test::init();
+
+    let regtest = Network::new_regtest(
+        crate::parameters::testnet::ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let commitment_bytes = [0x5a; 32];
+
+    for network in [Network::Mainnet, Network::new_default_testnet(), regtest] {
+        let activation_height = Nu6_3
+            .activation_height(&network)
+            .expect("NU6.3 is configured on this test network");
+        let commitment =
+            super::super::Commitment::from_bytes(commitment_bytes, &network, activation_height)
+                .expect("post-NU5 commitment bytes have no structural restriction");
+
+        let ChainHistoryBlockTxAuthCommitment(commitment) = commitment else {
+            panic!("NU6.3 must retain the post-NU5 block commitment format");
+        };
+        assert_eq!(<[u8; 32]>::from(commitment), commitment_bytes);
+    }
 }
 
 #[test]

--- a/zakura-chain/src/history_tree/tests/vectors.rs
+++ b/zakura-chain/src/history_tree/tests/vectors.rs
@@ -6,7 +6,12 @@ use crate::{
         Commitment::{self, ChainHistoryActivationReserved},
     },
     history_tree::{HistoryTree, HistoryTreeBlockParts, NonEmptyHistoryTree},
-    parameters::{Network, NetworkUpgrade},
+    ironwood, orchard,
+    parameters::{
+        testnet::{ConfiguredActivationHeights, RegtestParameters},
+        Network, NetworkUpgrade,
+    },
+    primitives::zcash_history::{Tree as PrimitiveHistoryTree, V1, V2, V3},
     sapling,
     serialization::ZcashDeserializeInto,
 };
@@ -126,6 +131,14 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
         .expect("test networks have Heartwood activation")
         .0;
 
+    let genesis_block = Arc::new(
+        blocks
+            .get(&0)
+            .expect("genesis test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("genesis block is structurally valid"),
+    );
+
     let first_block = Arc::new(
         blocks
             .get(&heartwood_height)
@@ -152,14 +165,39 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
             .expect("test vector exists"),
     )?;
 
-    let mut block_tree = HistoryTree::from_block(
+    let mut block_tree = HistoryTree::default();
+    let mut parts_tree = HistoryTree::default();
+
+    // Pushing a pre-Heartwood block (genesis) must be accepted as a no-op by
+    // both APIs, leaving the trees empty.
+    block_tree.push(
+        &network,
+        genesis_block.clone(),
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )?;
+    parts_tree.push_from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &genesis_block,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+        ),
+    )?;
+
+    assert!(block_tree.is_none());
+    assert!(parts_tree.is_none());
+
+    block_tree.push(
         &network,
         first_block.clone(),
         &first_sapling_root,
         &Default::default(),
         &Default::default(),
     )?;
-    let mut parts_tree = HistoryTree::from_parts(
+    parts_tree.push_from_parts(
         &network,
         HistoryTreeBlockParts::from_block(
             &first_block,
@@ -170,6 +208,17 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
     )?;
 
     assert_eq!(parts_tree.hash(), block_tree.hash());
+    // The real block after Heartwood activation commits to the MMR containing
+    // only the activation block, anchoring both APIs to the network's actual
+    // chain history commitment rather than just to each other.
+    assert_eq!(
+        second_block.commitment(&network)?,
+        Commitment::ChainHistoryRoot(
+            block_tree
+                .hash()
+                .expect("history tree exists after Heartwood activation")
+        )
+    );
 
     block_tree.push(
         &network,
@@ -189,6 +238,960 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
     )?;
 
     assert_eq!(parts_tree.hash(), block_tree.hash());
+
+    Ok(())
+}
+
+/// Cached history entries must retain the V3 Ironwood suffix at and after NU6.3.
+#[test]
+fn from_cache_preserves_ironwood_history_version() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            nu7: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+    assert_ne!(ironwood_root, Default::default());
+
+    for (height, expected_upgrade) in [
+        (crate::block::Height(1), NetworkUpgrade::Nu6_3),
+        (crate::block::Height(2), NetworkUpgrade::Nu7),
+    ] {
+        assert_eq!(NetworkUpgrade::current(&network, height), expected_upgrade);
+
+        let tree = NonEmptyHistoryTree::from_parts(
+            &network,
+            HistoryTreeBlockParts {
+                header: &block.header,
+                height,
+                sapling_root: &Default::default(),
+                orchard_root: &Default::default(),
+                ironwood_root: &ironwood_root,
+                sapling_tx: 0,
+                orchard_tx: 0,
+                ironwood_tx: 1,
+            },
+        )?;
+        // Decoding the same peaks as V2 succeeds, because the serialized V3
+        // entries are just V2 entries with a trailing Ironwood suffix. The
+        // resulting hash silently loses the suffix, which is why `from_cache`
+        // must select the tree version from the network upgrade.
+        let v2_decode = PrimitiveHistoryTree::<V2>::new_from_cache(
+            &network,
+            expected_upgrade,
+            tree.size(),
+            tree.peaks(),
+            &Default::default(),
+        )?;
+        let restored = NonEmptyHistoryTree::from_cache(
+            &network,
+            tree.size(),
+            tree.peaks().clone(),
+            tree.current_height(),
+        )?;
+
+        assert_ne!(
+            v2_decode.hash(),
+            tree.hash(),
+            "{expected_upgrade:?} V2 decoding silently drops the V3 suffix"
+        );
+        assert_eq!(
+            restored.hash(),
+            tree.hash(),
+            "{expected_upgrade:?} cache reconstruction must retain V3 fields"
+        );
+    }
+
+    Ok(())
+}
+
+/// `NonEmptyHistoryTree::from_block` must build the same tree as
+/// `NonEmptyHistoryTree::from_parts` for the V1 (pre-NU5), V2 (NU5+), and
+/// V3 (NU6.3+) history-tree versions.
+#[test]
+fn from_block_delegation_preserves_all_history_versions() -> Result<()> {
+    let v1_network = Network::new_regtest(RegtestParameters::default());
+    let v2_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = Arc::new(
+        blocks
+            .get(&1)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    for network in [v1_network, v2_network, v3_network] {
+        let block_tree = NonEmptyHistoryTree::from_block(
+            &network,
+            block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        )?;
+        let parts_tree = NonEmptyHistoryTree::from_parts(
+            &network,
+            HistoryTreeBlockParts {
+                header: &block.header,
+                height: block.coinbase_height().expect("test block has a height"),
+                sapling_root: &sapling_root,
+                orchard_root: &orchard_root,
+                ironwood_root: &ironwood_root,
+                sapling_tx: block.sapling_transactions_count(),
+                orchard_tx: block.orchard_transactions_count(),
+                ironwood_tx: block.ironwood_transactions_count(),
+            },
+        )?;
+
+        assert_eq!(block_tree.hash(), parts_tree.hash());
+    }
+
+    Ok(())
+}
+
+/// `NonEmptyHistoryTree::from_parts` must select the history-leaf version from
+/// the network upgrade at the block's height: V1 leaves ignore the Orchard and
+/// Ironwood fields, V2 leaves commit to Orchard but ignore Ironwood, and V3
+/// leaves commit to everything. Each tree is also decoded with the matching
+/// raw `zcash_history` version to pin which version was selected.
+#[test]
+fn from_parts_selects_epoch_version_and_ignores_future_fields() -> Result<()> {
+    let v1_network = Network::new_regtest(RegtestParameters::default());
+    let v2_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let sapling_root = sapling::tree::Root::default();
+    let empty_orchard_root = orchard::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let empty_ironwood_root = ironwood::tree::Root::default();
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+    assert_ne!(orchard_root, empty_orchard_root);
+    assert_ne!(ironwood_root, empty_ironwood_root);
+    let height = crate::block::Height(1);
+
+    let parts = |orchard_root, ironwood_root, orchard_tx, ironwood_tx| HistoryTreeBlockParts {
+        header: &block.header,
+        height,
+        sapling_root: &sapling_root,
+        orchard_root,
+        ironwood_root,
+        sapling_tx: 1,
+        orchard_tx,
+        ironwood_tx,
+    };
+
+    assert_eq!(
+        NetworkUpgrade::current(&v1_network, height),
+        NetworkUpgrade::Canopy
+    );
+    let v1_tree =
+        NonEmptyHistoryTree::from_parts(&v1_network, parts(&orchard_root, &ironwood_root, 2, 3))?;
+    let v1_without_future_fields = NonEmptyHistoryTree::from_parts(
+        &v1_network,
+        parts(&empty_orchard_root, &empty_ironwood_root, 0, 0),
+    )?;
+    let v1_decoded = PrimitiveHistoryTree::<V1>::new_from_cache(
+        &v1_network,
+        NetworkUpgrade::Canopy,
+        v1_tree.size(),
+        v1_tree.peaks(),
+        &Default::default(),
+    )?;
+    assert_eq!(v1_tree.hash(), v1_decoded.hash());
+    assert_eq!(v1_tree.hash(), v1_without_future_fields.hash());
+
+    assert_eq!(
+        NetworkUpgrade::current(&v2_network, height),
+        NetworkUpgrade::Nu5
+    );
+    let v2_tree =
+        NonEmptyHistoryTree::from_parts(&v2_network, parts(&orchard_root, &ironwood_root, 2, 3))?;
+    let v2_without_future_fields = NonEmptyHistoryTree::from_parts(
+        &v2_network,
+        parts(&orchard_root, &empty_ironwood_root, 2, 0),
+    )?;
+    let v2_decoded = PrimitiveHistoryTree::<V2>::new_from_cache(
+        &v2_network,
+        NetworkUpgrade::Nu5,
+        v2_tree.size(),
+        v2_tree.peaks(),
+        &Default::default(),
+    )?;
+    assert_eq!(v2_tree.hash(), v2_decoded.hash());
+    assert_eq!(v2_tree.hash(), v2_without_future_fields.hash());
+
+    assert_eq!(
+        NetworkUpgrade::current(&v3_network, height),
+        NetworkUpgrade::Nu6_3
+    );
+    let v3_tree =
+        NonEmptyHistoryTree::from_parts(&v3_network, parts(&orchard_root, &ironwood_root, 2, 3))?;
+    let v3_without_ironwood_fields = NonEmptyHistoryTree::from_parts(
+        &v3_network,
+        parts(&orchard_root, &empty_ironwood_root, 2, 0),
+    )?;
+    let v3_decoded = PrimitiveHistoryTree::<V3>::new_from_cache(
+        &v3_network,
+        NetworkUpgrade::Nu6_3,
+        v3_tree.size(),
+        v3_tree.peaks(),
+        &Default::default(),
+    )?;
+    assert_eq!(v3_tree.hash(), v3_decoded.hash());
+    assert_ne!(v3_tree.hash(), v3_without_ironwood_fields.hash());
+
+    Ok(())
+}
+
+/// Pushing the NU6.3 activation block must reset the MMR to a single V3 leaf
+/// that commits to the Ironwood root, via both the block and parts APIs.
+#[test]
+fn push_wrapper_matches_parts_across_nu6_3_activation() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_2: Some(1),
+            nu6_3: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let first_block = Arc::new(
+        blocks
+            .get(&1)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let activation_block = Arc::new(
+        blocks
+            .get(&2)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    assert_eq!(
+        NetworkUpgrade::current(&network, crate::block::Height(1)),
+        NetworkUpgrade::Nu6_2
+    );
+    assert_eq!(
+        NetworkUpgrade::current(&network, crate::block::Height(2)),
+        NetworkUpgrade::Nu6_3
+    );
+
+    let mut block_tree = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    let mut parts_tree = NonEmptyHistoryTree::from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &first_block,
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        ),
+    )?;
+
+    block_tree.push(
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    parts_tree.push_from_parts(HistoryTreeBlockParts::from_block(
+        &activation_block,
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    ))?;
+    let activation_tree = NonEmptyHistoryTree::from_block(
+        &network,
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    let activation_without_ironwood = NonEmptyHistoryTree::from_block(
+        &network,
+        activation_block,
+        &sapling_root,
+        &orchard_root,
+        &Default::default(),
+    )?;
+
+    assert_eq!(block_tree.hash(), parts_tree.hash());
+    assert_eq!(block_tree.hash(), activation_tree.hash());
+    assert_ne!(block_tree.hash(), activation_without_ironwood.hash());
+    assert_eq!(
+        block_tree.size(),
+        1,
+        "a new consensus branch resets the MMR"
+    );
+    assert_eq!(block_tree.current_height(), crate::block::Height(2));
+
+    Ok(())
+}
+
+/// `push_from_parts` must append leaves using the tree's history version:
+/// V1 leaves ignore the Orchard and Ironwood fields, V2 leaves commit to
+/// Orchard but ignore Ironwood, and V3 leaves commit to Ironwood as well.
+#[test]
+fn push_from_parts_routes_each_history_version() -> Result<()> {
+    let v1_network = Network::new_regtest(RegtestParameters::default());
+    let v2_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let first_block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let second_block = blocks
+        .get(&2)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let sapling_root = sapling::tree::Root::default();
+    let empty_orchard_root = orchard::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let empty_ironwood_root = ironwood::tree::Root::default();
+    let mut first_ironwood_root_bytes = [0; 32];
+    first_ironwood_root_bytes[0] = 1;
+    let first_ironwood_root = ironwood::tree::Root::try_from(first_ironwood_root_bytes)?;
+    let mut second_ironwood_root_bytes = [0; 32];
+    second_ironwood_root_bytes[0] = 2;
+    let second_ironwood_root = ironwood::tree::Root::try_from(second_ironwood_root_bytes)?;
+    assert_ne!(orchard_root, empty_orchard_root);
+    assert_ne!(first_ironwood_root, empty_ironwood_root);
+
+    fn parts<'a>(
+        block: &'a Block,
+        sapling_root: &'a sapling::tree::Root,
+        orchard_root: &'a orchard::tree::Root,
+        ironwood_root: &'a ironwood::tree::Root,
+        orchard_tx: u64,
+        ironwood_tx: u64,
+    ) -> HistoryTreeBlockParts<'a> {
+        HistoryTreeBlockParts {
+            header: &block.header,
+            height: block.coinbase_height().expect("test block has a height"),
+            sapling_root,
+            orchard_root,
+            ironwood_root,
+            sapling_tx: 1,
+            orchard_tx,
+            ironwood_tx,
+        }
+    }
+    let two_leaf_tree = |network: &Network,
+                         second_orchard_root,
+                         second_ironwood_root,
+                         second_orchard_tx,
+                         second_ironwood_tx|
+     -> Result<NonEmptyHistoryTree> {
+        let mut tree = NonEmptyHistoryTree::from_parts(
+            network,
+            parts(
+                &first_block,
+                &sapling_root,
+                &orchard_root,
+                &first_ironwood_root,
+                2,
+                3,
+            ),
+        )?;
+        tree.push_from_parts(parts(
+            &second_block,
+            &sapling_root,
+            second_orchard_root,
+            second_ironwood_root,
+            second_orchard_tx,
+            second_ironwood_tx,
+        ))?;
+        Ok(tree)
+    };
+
+    let v1_tree = two_leaf_tree(&v1_network, &orchard_root, &second_ironwood_root, 5, 7)?;
+    let v1_without_future_fields =
+        two_leaf_tree(&v1_network, &empty_orchard_root, &empty_ironwood_root, 0, 0)?;
+    assert_eq!(v1_tree.hash(), v1_without_future_fields.hash());
+
+    let v2_tree = two_leaf_tree(&v2_network, &orchard_root, &second_ironwood_root, 5, 7)?;
+    let v2_without_ironwood =
+        two_leaf_tree(&v2_network, &orchard_root, &empty_ironwood_root, 5, 0)?;
+    let v2_without_orchard =
+        two_leaf_tree(&v2_network, &empty_orchard_root, &empty_ironwood_root, 0, 0)?;
+    assert_eq!(v2_tree.hash(), v2_without_ironwood.hash());
+    assert_ne!(v2_tree.hash(), v2_without_orchard.hash());
+
+    let v3_tree = two_leaf_tree(&v3_network, &orchard_root, &second_ironwood_root, 5, 7)?;
+    let v3_without_ironwood =
+        two_leaf_tree(&v3_network, &orchard_root, &empty_ironwood_root, 5, 0)?;
+    assert_ne!(v3_tree.hash(), v3_without_ironwood.hash());
+
+    Ok(())
+}
+
+/// `try_extend` must forward each block's Ironwood root to `push` in order:
+/// extending matches a sequence of individual pushes, and changing only the
+/// last block's Ironwood root changes the resulting tree.
+#[test]
+fn try_extend_forwards_ironwood_roots_in_order() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = |height| {
+        Arc::new(
+            blocks
+                .get(&height)
+                .expect("test vector exists")
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid"),
+        )
+    };
+    let first_block = block(1);
+    let second_block = block(2);
+    let third_block = block(3);
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut first_ironwood_root_bytes = [0; 32];
+    first_ironwood_root_bytes[0] = 1;
+    let first_ironwood_root = ironwood::tree::Root::try_from(first_ironwood_root_bytes)?;
+    let mut second_ironwood_root_bytes = [0; 32];
+    second_ironwood_root_bytes[0] = 2;
+    let second_ironwood_root = ironwood::tree::Root::try_from(second_ironwood_root_bytes)?;
+    let mut third_ironwood_root_bytes = [0; 32];
+    third_ironwood_root_bytes[0] = 3;
+    let third_ironwood_root = ironwood::tree::Root::try_from(third_ironwood_root_bytes)?;
+
+    let mut sequential = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    sequential.push(
+        second_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &second_ironwood_root,
+    )?;
+    sequential.push(
+        third_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &third_ironwood_root,
+    )?;
+
+    let mut extended = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    extended.try_extend([
+        (
+            second_block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &second_ironwood_root,
+        ),
+        (
+            third_block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &third_ironwood_root,
+        ),
+    ])?;
+
+    let mut wrong_last_root = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block,
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    wrong_last_root.try_extend([
+        (
+            second_block,
+            &sapling_root,
+            &orchard_root,
+            &second_ironwood_root,
+        ),
+        (
+            third_block,
+            &sapling_root,
+            &orchard_root,
+            &Default::default(),
+        ),
+    ])?;
+
+    assert_eq!(extended.hash(), sequential.hash());
+    assert_ne!(extended.hash(), wrong_last_root.hash());
+
+    Ok(())
+}
+
+/// Pruning a V3 tree to its peaks and rebuilding it from the cache must never
+/// change the root hash, which commits to the Ironwood suffix that a V2 decode
+/// of the same peaks would silently drop.
+#[test]
+fn v3_pruning_and_hash_dispatch_match_unpruned_tree() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+
+    fn ironwood_root(value: u32) -> Result<ironwood::tree::Root> {
+        let mut bytes = [0; 32];
+        bytes[0] = u8::try_from(value).expect("test values fit in a byte");
+        Ok(ironwood::tree::Root::try_from(bytes)?)
+    }
+
+    fn parts<'a>(
+        block: &'a Block,
+        sapling_root: &'a sapling::tree::Root,
+        orchard_root: &'a orchard::tree::Root,
+        ironwood_root: &'a ironwood::tree::Root,
+        height: u32,
+    ) -> HistoryTreeBlockParts<'a> {
+        HistoryTreeBlockParts {
+            header: &block.header,
+            height: crate::block::Height(height),
+            sapling_root,
+            orchard_root,
+            ironwood_root,
+            sapling_tx: u64::from(height),
+            orchard_tx: u64::from(height + 1),
+            ironwood_tx: u64::from(height + 2),
+        }
+    }
+
+    let first_ironwood_root = ironwood_root(1)?;
+    let first_parts = parts(
+        &block,
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+        1,
+    );
+    let mut pruned = NonEmptyHistoryTree::from_parts(&network, first_parts)?;
+    let (mut unpruned, _) = PrimitiveHistoryTree::<V3>::new_from_parts(&network, first_parts)?;
+
+    for height in 2u32..=16 {
+        let next_ironwood_root = ironwood_root(height)?;
+        let next_parts = parts(
+            &block,
+            &sapling_root,
+            &orchard_root,
+            &next_ironwood_root,
+            height,
+        );
+
+        unpruned
+            .append_leaf_parts(next_parts)
+            .expect("valid sequential V3 leaves append to the unpruned reference tree");
+        pruned.push_from_parts(next_parts)?;
+
+        assert_eq!(
+            pruned.hash(),
+            unpruned.hash(),
+            "V3 prune/rebuild changed the root after leaf {height}"
+        );
+        assert_eq!(
+            pruned.peaks().len(),
+            usize::try_from(height.count_ones())
+                .expect("u32 peak counts fit in usize on supported platforms"),
+            "the retained peaks must match the MMR leaf decomposition"
+        );
+
+        let rebuilt = PrimitiveHistoryTree::<V3>::new_from_cache(
+            &network,
+            NetworkUpgrade::Nu6_3,
+            pruned.size(),
+            pruned.peaks(),
+            &Default::default(),
+        )?;
+        assert_eq!(pruned.hash(), rebuilt.hash());
+    }
+
+    let v2_decode = PrimitiveHistoryTree::<V2>::new_from_cache(
+        &network,
+        NetworkUpgrade::Nu6_3,
+        pruned.size(),
+        pruned.peaks(),
+        &Default::default(),
+    )?;
+    assert_ne!(
+        pruned.hash(),
+        v2_decode.hash(),
+        "the public hash must include the V3 Ironwood suffix"
+    );
+
+    Ok(())
+}
+
+/// Cloning a V3 tree (which rebuilds the inner tree from its peaks) must
+/// preserve the root, size, and height, and the clone must stay in sync with
+/// the original when both push the same next block.
+#[test]
+fn v3_clone_preserves_root_and_future_append() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = |height| {
+        Arc::new(
+            blocks
+                .get(&height)
+                .expect("test vector exists")
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid"),
+        )
+    };
+    let ironwood_root = |value| -> Result<ironwood::tree::Root> {
+        let mut bytes = [0; 32];
+        bytes[0] = value;
+        Ok(ironwood::tree::Root::try_from(bytes)?)
+    };
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let first_ironwood_root = ironwood_root(1)?;
+    let second_ironwood_root = ironwood_root(2)?;
+    let third_ironwood_root = ironwood_root(3)?;
+    let fourth_ironwood_root = ironwood_root(4)?;
+
+    let mut original = NonEmptyHistoryTree::from_block(
+        &network,
+        block(1),
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    original.push(
+        block(2),
+        &sapling_root,
+        &orchard_root,
+        &second_ironwood_root,
+    )?;
+    original.push(block(3), &sapling_root, &orchard_root, &third_ironwood_root)?;
+    assert_eq!(original.peaks().len(), 2, "three leaves have two MMR peaks");
+
+    let mut cloned = original.clone();
+    assert_eq!(cloned.hash(), original.hash());
+    assert_eq!(cloned.size(), original.size());
+    assert_eq!(
+        cloned.peaks().keys().collect::<Vec<_>>(),
+        original.peaks().keys().collect::<Vec<_>>()
+    );
+    assert_eq!(cloned.current_height(), original.current_height());
+    assert_eq!(cloned.network(), original.network());
+
+    let fourth_block = block(4);
+    original.push(
+        fourth_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &fourth_ironwood_root,
+    )?;
+    cloned.push(
+        fourth_block,
+        &sapling_root,
+        &orchard_root,
+        &fourth_ironwood_root,
+    )?;
+
+    assert_eq!(cloned.hash(), original.hash());
+    assert_eq!(cloned.size(), original.size());
+    assert_eq!(cloned.current_height(), original.current_height());
+
+    Ok(())
+}
+
+/// The `HistoryTree` wrapper must return an empty tree for pre-Heartwood
+/// blocks and matching block/parts trees for the V1, V2, and V3 history
+/// versions.
+#[test]
+fn history_tree_from_block_matches_parts_across_history_versions() -> Result<()> {
+    let pre_heartwood = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            heartwood: Some(2),
+            canopy: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v1 = Network::new_regtest(RegtestParameters::default());
+    let v2 = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3 = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = Arc::new(
+        blocks
+            .get(&1)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    for (network, should_exist) in [(pre_heartwood, false), (v1, true), (v2, true), (v3, true)] {
+        let block_tree = HistoryTree::from_block(
+            &network,
+            block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        )?;
+        let parts_tree = HistoryTree::from_parts(
+            &network,
+            HistoryTreeBlockParts::from_block(&block, &sapling_root, &orchard_root, &ironwood_root),
+        )?;
+
+        assert_eq!(block_tree.is_some(), should_exist);
+        assert_eq!(parts_tree.is_some(), should_exist);
+        assert_eq!(block_tree.hash(), parts_tree.hash());
+    }
+
+    Ok(())
+}
+
+/// The `HistoryTree` push wrappers must recreate the tree as a single V3 leaf
+/// at NU6.3 activation, committing to the Ironwood root, via both the block
+/// and parts APIs.
+#[test]
+fn history_tree_push_wrapper_matches_parts_across_nu6_3_activation() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_2: Some(1),
+            nu6_3: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = |height| {
+        Arc::new(
+            blocks
+                .get(&height)
+                .expect("test vector exists")
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid"),
+        )
+    };
+    let first_block = block(1);
+    let activation_block = block(2);
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    let mut block_tree = HistoryTree::default();
+    let mut parts_tree = HistoryTree::default();
+    block_tree.push(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    parts_tree.push_from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &first_block,
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        ),
+    )?;
+    assert_eq!(block_tree.hash(), parts_tree.hash());
+
+    block_tree.push(
+        &network,
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    parts_tree.push_from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &activation_block,
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        ),
+    )?;
+    let activation_tree = HistoryTree::from_block(
+        &network,
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    let activation_without_ironwood = HistoryTree::from_block(
+        &network,
+        activation_block,
+        &sapling_root,
+        &orchard_root,
+        &Default::default(),
+    )?;
+
+    assert_eq!(block_tree.hash(), parts_tree.hash());
+    assert_eq!(block_tree.hash(), activation_tree.hash());
+    assert_ne!(block_tree.hash(), activation_without_ironwood.hash());
+    assert_eq!(
+        block_tree
+            .as_ref()
+            .expect("history tree exists at NU6.3")
+            .size(),
+        1,
+        "a new consensus branch resets the MMR"
+    );
 
     Ok(())
 }

--- a/zakura-chain/src/local_genesis.rs
+++ b/zakura-chain/src/local_genesis.rs
@@ -19,7 +19,8 @@ use crate::{
     fmt::HexDebug,
     parameters::{
         testnet::{
-            ConfiguredActivationHeights, ConfiguredCheckpoints, Parameters as TestnetParams,
+            ConfiguredActivationHeights, ConfiguredCheckpoints, ConfiguredLockboxDisbursement,
+            Parameters as TestnetParams,
         },
         Magic, Network, NetworkKind, NetworkUpgrade,
     },
@@ -66,6 +67,9 @@ impl Default for LocalTestnetGenesisOptions {
 /// Fixed private-network PoW limit used by both generated seed blocks and the
 /// configured custom testnet.
 const LOCAL_TESTNET_TARGET_DIFFICULTY_LIMIT: [u8; 32] = [0x0f; 32];
+
+/// Script hash for the zero-value output that marks the implicit NU6.1 event.
+const LOCAL_TESTNET_LOCKBOX_SCRIPT_HASH: [u8; 20] = [0; 20];
 
 /// A secp256k1 keypair with a transparent Zcash address.
 pub struct FundedKey {
@@ -384,6 +388,7 @@ fn build_network(options: BuildNetworkOptions<'_>) -> Result<Network, crate::Box
 
     let activation_heights =
         configured_activation_heights(latest_network_upgrade, activation_height)?;
+    let lockbox_disbursements = configured_lockbox_disbursements(latest_network_upgrade);
 
     // Order matters: with_halving_interval must come before with_funding_streams
     // because funding_streams locks the halving interval.
@@ -397,7 +402,7 @@ fn build_network(options: BuildNetworkOptions<'_>) -> Result<Network, crate::Box
         .with_activation_heights(activation_heights)?
         .with_halving_interval(144)?
         .with_funding_streams(vec![])
-        .with_lockbox_disbursements(vec![])
+        .with_lockbox_disbursements(lockbox_disbursements)
         .with_checkpoints(ConfiguredCheckpoints::HeightsAndHashes(
             checkpoints.to_vec(),
         ))?;
@@ -416,6 +421,10 @@ fn configured_activation_heights(
         return Err("latest_network_upgrade must be BeforeOverwinter or later".into());
     }
 
+    if latest_network_upgrade >= Overwinter && latest_network_upgrade.branch_id().is_none() {
+        return Err("latest_network_upgrade must have a consensus branch ID".into());
+    }
+
     Ok(ConfiguredActivationHeights {
         before_overwinter: Some(1),
         overwinter: (latest_network_upgrade >= Overwinter).then_some(activation_height),
@@ -425,15 +434,33 @@ fn configured_activation_heights(
         canopy: (latest_network_upgrade >= Canopy).then_some(activation_height),
         nu5: (latest_network_upgrade >= Nu5).then_some(activation_height),
         nu6: (latest_network_upgrade >= Nu6).then_some(activation_height),
-        // Nu6.1 is the one-time ZIP-271 lockbox disbursement event from mainnet; activating it on
-        // a local testnet would require synthesising disbursement outputs in the activation-block
-        // coinbase, which the local genesis builder does not produce. Skipping it lets NU6.3 activate
-        // directly without tripping the lockbox-disbursements consensus rule.
-        nu6_1: None,
+        nu6_1: (latest_network_upgrade >= Nu6_1).then_some(activation_height),
         nu6_2: (latest_network_upgrade >= Nu6_2).then_some(activation_height),
         nu6_3: (latest_network_upgrade >= Nu6_3).then_some(activation_height),
         nu7: (latest_network_upgrade >= Nu7).then_some(activation_height),
     })
+}
+
+fn configured_lockbox_disbursements(
+    latest_network_upgrade: NetworkUpgrade,
+) -> Vec<ConfiguredLockboxDisbursement> {
+    if latest_network_upgrade < NetworkUpgrade::Nu6_1 {
+        return Vec::new();
+    }
+
+    // Later upgrades implicitly activate every earlier consensus rule. In particular,
+    // activating NU6.2 or later still triggers the one-time NU6.1 disbursement rule. A
+    // zero-value P2SH output satisfies that structural rule without creating funds or
+    // drawing from the empty local deferred pool. The mining transaction builder reads
+    // this configured output and includes it in the activation-block coinbase.
+    vec![ConfiguredLockboxDisbursement {
+        address: transparent::Address::from_script_hash(
+            NetworkKind::Testnet,
+            LOCAL_TESTNET_LOCKBOX_SCRIPT_HASH,
+        )
+        .to_string(),
+        amount: Amount::<NonNegative>::zero(),
+    }]
 }
 
 /// RIPEMD-160(SHA-256(data)) - standard Bitcoin/Zcash hash160 for public keys.
@@ -521,12 +548,51 @@ mod tests {
             NetworkUpgrade::Nu6_3.activation_height(network),
             Some(activation_height)
         );
+        assert_eq!(
+            NetworkUpgrade::Nu6_1.activation_height(network),
+            Some(activation_height),
+            "later upgrades implicitly activate the NU6.1 one-time rule"
+        );
+        let lockbox_disbursements = network.lockbox_disbursements(activation_height);
+        let [(lockbox_address, lockbox_amount)] = lockbox_disbursements.as_slice() else {
+            panic!("post-NU6 local networks have one lockbox marker output");
+        };
+        assert!(lockbox_address.is_script_hash());
+        assert!(lockbox_amount.is_zero());
         // NU6.3 inherits the post-Blossom consensus target spacing (75s); this is the
         // protocol block spacing and is independent of the harness `target_spacing_secs`
         // option used to space the generated seeded-block timestamps.
         assert_eq!(
             NetworkUpgrade::target_spacing_for_height(network, activation_height).num_seconds(),
             i64::from(crate::parameters::POST_BLOSSOM_POW_TARGET_SPACING)
+        );
+    }
+
+    /// NU6.1 itself must be usable as the latest upgrade: it has a compiled
+    /// consensus branch ID, and the network still gets the lockbox marker its
+    /// activation block needs.
+    #[test]
+    fn nu6_1_can_be_the_latest_network_upgrade() {
+        let generated = generate_local_testnet_with_funded_keys(
+            vec!["alice".to_string(), "bob".to_string()],
+            LocalTestnetGenesisOptions {
+                latest_network_upgrade: NetworkUpgrade::Nu6_1,
+                ..Default::default()
+            },
+        )
+        .expect("local testnet should generate");
+
+        let activation_height = Height(3);
+        assert_eq!(
+            NetworkUpgrade::current(&generated.network, activation_height),
+            NetworkUpgrade::Nu6_1
+        );
+        assert_eq!(
+            generated
+                .network
+                .lockbox_disbursements(activation_height)
+                .len(),
+            1
         );
     }
 

--- a/zakura-chain/src/orchard/tree.rs
+++ b/zakura-chain/src/orchard/tree.rs
@@ -1076,6 +1076,43 @@ mod tests {
         assert_eq!(tree.root(), original.root());
     }
 
+    /// `append_batch` must match sequential appends when a batch exactly fills
+    /// the last two leaf positions of the tree, completing the final tracked
+    /// subtree (index `u16::MAX`) without reporting a spurious overflow.
+    #[test]
+    fn append_batch_matches_sequential_at_tree_capacity() {
+        let max_position = (1u64 << MERKLE_DEPTH) - 1;
+        let start_position = max_position - 2;
+        let leaf = node(1);
+        // A frontier at position `p` stores one ommer per set bit of `p`;
+        // `max_position - 2` has 31 of its 32 bits set.
+        let ommers: Vec<Node> = (2..=32).map(node).collect();
+        let inner = Frontier::from_parts(Position::from(start_position), leaf, ommers)
+            .expect("frontier two leaves below capacity is valid");
+        let start = NoteCommitmentTree {
+            inner,
+            cached_root: Default::default(),
+        };
+        let note_commitments = [note_commitment(100), note_commitment(200)];
+
+        let mut seq_tree = start.clone();
+        let seq_result = sequential_append_batch(&mut seq_tree, &note_commitments)
+            .expect("two sequential appends reach exact capacity");
+
+        let mut batch_tree = start;
+        let batch_result = batch_tree
+            .append_batch(&note_commitments)
+            .expect("batch append reaches exact capacity");
+
+        assert_eq!(batch_result, seq_result);
+        assert_eq!(
+            batch_result.map(|(index, _)| index),
+            Some(NoteCommitmentSubtreeIndex(u16::MAX)),
+        );
+        batch_tree.assert_frontier_eq(&seq_tree);
+        assert_eq!(batch_tree.root(), seq_tree.root());
+    }
+
     #[test]
     fn append_batch_multiple_subtrees_preserves_tree_and_cached_root() {
         let mut tree = NoteCommitmentTree::default();

--- a/zakura-chain/src/parallel/commitment_aux.rs
+++ b/zakura-chain/src/parallel/commitment_aux.rs
@@ -33,10 +33,10 @@ pub struct BlockCommitmentRoots {
     pub sapling_root: sapling::tree::Root,
     /// The Orchard note-commitment tree root as of the end of this block (empty below NU5).
     pub orchard_root: orchard::tree::Root,
-    /// The Ironwood note-commitment tree root as of the end of this block (empty below Nu7).
+    /// The Ironwood note-commitment tree root as of the end of this block (empty below NU6.3).
     ///
     /// Carried alongside the Sapling/Orchard roots because the ZIP-221 V3 history leaf
-    /// (Nu7+) folds the Ironwood root into the chain-history MMR; a recipient rebuilding
+    /// (NU6.3+) folds the Ironwood root into the chain-history MMR; a recipient rebuilding
     /// the leaf to verify against header commitments (design §6) needs it, without the body.
     pub ironwood_root: ironwood::tree::Root,
     /// Number of this block's transactions carrying Sapling shielded data
@@ -53,7 +53,7 @@ pub struct BlockCommitmentRoots {
     /// (`Block::orchard_transactions_count`); the Orchard V2 leaf count input (NU5+).
     pub orchard_tx: u64,
     /// Number of this block's transactions carrying Ironwood shielded data; the Ironwood
-    /// V3 leaf count input (Nu7+).
+    /// V3 leaf count input (NU6.3+).
     pub ironwood_tx: u64,
     /// The authorizing-data root (ZIP-244 `hashAuthDataRoot`) of *this* block's own
     /// transactions. Serialized last.

--- a/zakura-chain/src/parallel/commitment_aux_verify.rs
+++ b/zakura-chain/src/parallel/commitment_aux_verify.rs
@@ -154,7 +154,7 @@ pub fn header_commitment_is_valid_for_chain_history(
             }
         }
         Commitment::ChainHistoryBlockTxAuthCommitment(actual_hash_block_commitments) => {
-            // NU6_3 onward commits to both the parent history tree root and
+            // NU5 onward commits to both the parent history tree root and
             // this block's auth data root. That still preserves the one-block
             // lag for supplied note commitment roots: `history_tree` is the
             // parent tree, while `auth_data_root` belongs to the current

--- a/zakura-chain/src/parallel/tree.rs
+++ b/zakura-chain/src/parallel/tree.rs
@@ -275,3 +275,193 @@ impl NoteCommitmentTrees {
         Ok((ironwood, subtree_root))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use halo2::pasta::pallas;
+
+    use crate::{
+        block::{Header, Height},
+        parameters::{Network, NetworkUpgrade::Nu6_3},
+        serialization::ZcashDeserializeInto,
+        transaction::{arbitrary::v5_transactions, LockTime, Transaction},
+        transparent,
+    };
+
+    use super::*;
+
+    /// `update_trees_parallel` must feed each pool's note commitments to its
+    /// own tree, in transaction order, and must not touch unrelated trees.
+    ///
+    /// The block's two transactions carry the commitments `1` and `2` in
+    /// opposite pools, so a pool mix-up or reordering would change the
+    /// resulting Orchard or Ironwood tree root.
+    #[test]
+    fn parallel_block_update_keeps_orchard_and_ironwood_order_and_assignment() {
+        let _init_guard = zakura_test::init();
+
+        let mut orchard_data = Network::iter()
+            .flat_map(|network| v5_transactions(network.block_iter()))
+            .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+            .expect("test vectors include an Orchard transaction");
+        // Ironwood reuses the Orchard bundle encoding, so an Orchard test
+        // bundle can be cloned into the Ironwood slot of a V6 transaction.
+        let mut ironwood_data = orchard_data.clone();
+
+        let mut orchard_actions = orchard_data.actions.as_slice().to_vec();
+        orchard_actions.truncate(1);
+        orchard_actions[0].action.cm_x = pallas::Base::from(1);
+        orchard_data.actions = orchard_actions
+            .try_into()
+            .expect("the test bundle has at least one action");
+
+        let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+        ironwood_actions.truncate(1);
+        ironwood_actions[0].action.cm_x = pallas::Base::from(2);
+        ironwood_data.actions = ironwood_actions
+            .try_into()
+            .expect("the test bundle has at least one action");
+
+        let make_transaction =
+            |orchard_shielded_data: orchard::ShieldedData,
+             ironwood_shielded_data: ironwood::ShieldedData| {
+                Arc::new(Transaction::V6 {
+                    network_upgrade: Nu6_3,
+                    lock_time: LockTime::unlocked(),
+                    expiry_height: Height(1),
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                    sapling_shielded_data: None,
+                    orchard_shielded_data: Some(orchard_shielded_data),
+                    ironwood_shielded_data: Some(ironwood_shielded_data),
+                })
+            };
+
+        let height = Height(123);
+        let coinbase = Arc::new(Transaction::V6 {
+            network_upgrade: Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: height,
+            inputs: vec![transparent::Input::Coinbase {
+                height,
+                data: Vec::new(),
+                sequence: u32::MAX,
+            }],
+            outputs: Vec::new(),
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+            ironwood_shielded_data: None,
+        });
+        let header: Header = zakura_test::vectors::DUMMY_HEADER
+            .zcash_deserialize_into()
+            .expect("dummy header should deserialize");
+        let block = Arc::new(Block {
+            header: Arc::new(header),
+            transactions: vec![
+                coinbase,
+                make_transaction(orchard_data.clone(), ironwood_data.clone()),
+                make_transaction(ironwood_data, orchard_data),
+            ],
+        });
+
+        let orchard_commitments: Vec<_> = block.orchard_note_commitments().copied().collect();
+        let ironwood_commitments: Vec<_> = block.ironwood_note_commitments().copied().collect();
+        assert_eq!(
+            orchard_commitments,
+            [pallas::Base::from(1), pallas::Base::from(2)]
+        );
+        assert_eq!(
+            ironwood_commitments,
+            [pallas::Base::from(2), pallas::Base::from(1)]
+        );
+
+        let mut expected_orchard = orchard::tree::NoteCommitmentTree::default();
+        for commitment in &orchard_commitments {
+            expected_orchard
+                .append(*commitment)
+                .expect("two Orchard commitments fit in an empty tree");
+        }
+        let mut expected_ironwood = ironwood::tree::NoteCommitmentTree::default();
+        for commitment in &ironwood_commitments {
+            expected_ironwood
+                .append(*commitment)
+                .expect("two Ironwood commitments fit in an empty tree");
+        }
+        assert_ne!(expected_orchard.root(), expected_ironwood.root());
+
+        let mut trees = NoteCommitmentTrees::default();
+        let unchanged_sprout = trees.sprout.clone();
+        let unchanged_sapling = trees.sapling.clone();
+        trees
+            .update_trees_parallel(&block)
+            .expect("the mixed-pool block fits in empty trees");
+
+        assert_eq!(trees.sprout, unchanged_sprout);
+        assert_eq!(trees.sapling, unchanged_sapling);
+        assert_eq!(trees.orchard.root(), expected_orchard.root());
+        assert_eq!(trees.ironwood.root(), expected_ironwood.root());
+        assert_eq!(trees.orchard.count(), 2);
+        assert_eq!(trees.ironwood.count(), 2);
+        assert_eq!(trees.orchard_subtree, None);
+        assert_eq!(trees.ironwood_subtree, None);
+        assert!(!Arc::ptr_eq(&trees.orchard, &trees.ironwood));
+    }
+
+    /// Updating one pool's note commitment tree must not affect the other's,
+    /// even though the two pools share the same tree implementation and their
+    /// empty trees have equal roots.
+    #[test]
+    fn orchard_and_ironwood_trees_remain_independent() {
+        let mut trees = NoteCommitmentTrees::default();
+        let empty_orchard_root = trees.orchard.root();
+        let empty_ironwood_root = trees.ironwood.root();
+
+        assert_eq!(empty_orchard_root, empty_ironwood_root);
+        assert!(!Arc::ptr_eq(&trees.orchard, &trees.ironwood));
+
+        let (ironwood, ironwood_subtree) =
+            NoteCommitmentTrees::update_ironwood_note_commitment_tree(
+                trees.ironwood.clone(),
+                vec![pallas::Base::from(1)],
+            )
+            .expect("one Ironwood commitment fits in an empty tree");
+        trees.ironwood = ironwood;
+
+        assert_eq!(ironwood_subtree, None);
+        assert_eq!(trees.orchard.root(), empty_orchard_root);
+        assert_ne!(trees.ironwood.root(), empty_ironwood_root);
+
+        let ironwood_root = trees.ironwood.root();
+        let (orchard, orchard_subtree) = NoteCommitmentTrees::update_orchard_note_commitment_tree(
+            trees.orchard.clone(),
+            vec![pallas::Base::from(2)],
+        )
+        .expect("one Orchard commitment fits in an empty tree");
+        trees.orchard = orchard;
+
+        assert_eq!(orchard_subtree, None);
+        assert_eq!(trees.ironwood.root(), ironwood_root);
+        assert_ne!(trees.orchard.root(), trees.ironwood.root());
+    }
+
+    /// Tree errors must name the pool they came from: the `From` conversion
+    /// maps the shared inner error type to the Orchard variant, so Ironwood
+    /// errors must be constructed explicitly and display as Ironwood.
+    #[test]
+    fn orchard_and_ironwood_tree_errors_keep_their_pool_identity() {
+        let orchard_error =
+            NoteCommitmentTreeError::from(orchard::tree::NoteCommitmentTreeError::FullTree);
+        let ironwood_error =
+            NoteCommitmentTreeError::Ironwood(ironwood::tree::NoteCommitmentTreeError::FullTree);
+
+        assert!(matches!(orchard_error, NoteCommitmentTreeError::Orchard(_)));
+        assert!(matches!(
+            ironwood_error,
+            NoteCommitmentTreeError::Ironwood(_)
+        ));
+        assert_eq!(
+            ironwood_error.to_string(),
+            "ironwood error: The note commitment tree is full"
+        );
+    }
+}

--- a/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -13,7 +13,8 @@ use crate::{
             ConfiguredFundingStreams, ConfiguredLockboxDisbursement, RegtestParameters,
             MAX_NETWORK_NAME_LENGTH, RESERVED_NETWORK_NAMES,
         },
-        Network, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS, TESTNET_ACTIVATION_HEIGHTS,
+        ConsensusBranchId, Network, NetworkKind, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS,
+        TESTNET_ACTIVATION_HEIGHTS,
     },
 };
 
@@ -99,6 +100,119 @@ fn check_parameters_impl() {
     }
 }
 
+/// Pins the public-network NU6.3 boundary and branch ID to librustzcash's consensus parameters.
+#[test]
+fn nu6_3_public_consensus_boundary_matches_librustzcash() {
+    assert_eq!(
+        NetworkUpgrade::from(zp_consensus::NetworkUpgrade::Nu6_3),
+        NetworkUpgrade::Nu6_3,
+        "librustzcash's NU6.3 upgrade must map to Zakura's NU6.3 era",
+    );
+
+    let expected_branch_id = u32::from(zp_consensus::BranchId::Nu6_3);
+    let branch_id = NetworkUpgrade::Nu6_3
+        .branch_id()
+        .expect("NU6.3 has a published consensus branch ID");
+
+    assert_eq!(u32::from(branch_id), expected_branch_id);
+    assert_eq!(
+        NetworkUpgrade::try_from(expected_branch_id)
+            .expect("librustzcash's NU6.3 branch ID is known to Zakura"),
+        NetworkUpgrade::Nu6_3,
+    );
+    assert_eq!(
+        zp_consensus::BranchId::try_from(branch_id)
+            .expect("Zakura's NU6.3 branch ID is known to librustzcash"),
+        zp_consensus::BranchId::Nu6_3,
+    );
+
+    for (network, zp_network) in [
+        (Network::Mainnet, zp_consensus::Network::MainNetwork),
+        (
+            Network::new_default_testnet(),
+            zp_consensus::Network::TestNetwork,
+        ),
+    ] {
+        let expected_height: u32 = zp_network
+            .activation_height(zp_consensus::NetworkUpgrade::Nu6_3)
+            .expect("NU6.3 is scheduled on both public networks")
+            .into();
+        let activation_height = Height(expected_height);
+        let previous_height = (activation_height - 1).expect("NU6.3 is not genesis");
+
+        assert_eq!(
+            NetworkUpgrade::Nu6_3.activation_height(&network),
+            Some(activation_height),
+        );
+        assert_eq!(
+            NetworkUpgrade::current(&network, previous_height),
+            NetworkUpgrade::Nu6_2,
+        );
+        assert_eq!(
+            NetworkUpgrade::current(&network, activation_height),
+            NetworkUpgrade::Nu6_3,
+        );
+        assert_eq!(
+            ConsensusBranchId::current(&network, previous_height),
+            NetworkUpgrade::Nu6_2.branch_id(),
+        );
+        assert_eq!(
+            ConsensusBranchId::current(&network, activation_height),
+            Some(branch_id),
+        );
+    }
+}
+
+/// NU6.3 does not change the post-Blossom timing rules used by difficulty validation.
+#[test]
+fn nu6_3_keeps_post_blossom_timing_rules() {
+    assert_eq!(NetworkUpgrade::Nu6_3.target_spacing().num_seconds(), 75);
+    assert_eq!(
+        NetworkUpgrade::Nu6_3
+            .averaging_window_timespan()
+            .num_seconds(),
+        75 * 17,
+    );
+
+    for network in [Network::Mainnet, Network::new_default_testnet()] {
+        let activation_height = NetworkUpgrade::Nu6_3
+            .activation_height(&network)
+            .expect("NU6.3 is scheduled on both public networks");
+        let previous_height = (activation_height - 1).expect("NU6.3 is not genesis");
+
+        assert_eq!(
+            NetworkUpgrade::target_spacing_for_height(&network, previous_height),
+            NetworkUpgrade::target_spacing_for_height(&network, activation_height),
+            "NU6.3 must not introduce a target-spacing transition",
+        );
+        assert_eq!(
+            NetworkUpgrade::target_spacing_for_height(&network, activation_height).num_seconds(),
+            75,
+        );
+    }
+
+    assert_eq!(
+        NetworkUpgrade::minimum_difficulty_spacing_for_height(
+            &Network::new_default_testnet(),
+            NetworkUpgrade::Nu6_3
+                .activation_height(&Network::new_default_testnet())
+                .expect("NU6.3 is scheduled on default Testnet"),
+        )
+        .expect("the Testnet minimum-difficulty rule is active by NU6.3")
+        .num_seconds(),
+        6 * 75,
+    );
+}
+
+/// Pins the BIP-70 network names, which appear in payment URIs and RPC
+/// responses: Regtest deliberately shares Testnet's "test" name.
+#[test]
+fn bip70_network_names_are_stable_for_every_network_kind() {
+    assert_eq!(NetworkKind::Mainnet.bip70_network_name(), "main");
+    assert_eq!(NetworkKind::Testnet.bip70_network_name(), "test");
+    assert_eq!(NetworkKind::Regtest.bip70_network_name(), "test");
+}
+
 /// Checks that `NetworkUpgrade::activation_height()` returns the activation height of the next
 /// network upgrade if it doesn't find an activation height for a prior network upgrade, that the
 /// `Genesis` upgrade is always at `Height(0)`, and that the default Mainnet/Testnet/Regtest activation
@@ -171,6 +285,109 @@ fn activates_network_upgrades_correctly() {
             "network activation list should match expected activation heights"
         );
     }
+}
+
+/// Configured testnets must keep network upgrades in protocol order around
+/// NU6.3: a later upgrade may share NU6.3's activation height (and wins the
+/// height lookup), but an earlier upgrade configured above it must be
+/// rejected.
+#[test]
+fn configured_nu6_3_activation_preserves_upgrade_order() {
+    let activation_height = Height(23);
+
+    let nu6_3_network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu6_2: Some(activation_height.0),
+            nu6_3: Some(activation_height.0),
+            ..Default::default()
+        })
+        .expect("same-height upgrades are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("valid configured network");
+
+    assert_eq!(
+        NetworkUpgrade::current(&nu6_3_network, activation_height),
+        NetworkUpgrade::Nu6_3,
+        "NU6.3 must overwrite NU6.2 when both activate at the same height"
+    );
+    assert_eq!(
+        NetworkUpgrade::Nu6_2.activation_height(&nu6_3_network),
+        Some(activation_height),
+        "an overwritten NU6.2 activation must remain implicit at the NU6.3 height"
+    );
+
+    let nu7_network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu6_3: Some(activation_height.0),
+            nu7: Some(activation_height.0),
+            ..Default::default()
+        })
+        .expect("same-height upgrades are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("valid configured network");
+
+    assert_eq!(
+        NetworkUpgrade::current(&nu7_network, activation_height),
+        NetworkUpgrade::Nu7,
+        "NU7 must overwrite NU6.3 when both activate at the same height"
+    );
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&nu7_network),
+        Some(activation_height),
+        "an overwritten NU6.3 activation must remain implicit at the NU7 height"
+    );
+
+    let out_of_order = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu6_2: Some(activation_height.0 + 1),
+            nu6_3: Some(activation_height.0),
+            ..Default::default()
+        })
+        .expect_err("NU6.3 must not activate before NU6.2");
+
+    assert_eq!(out_of_order, ParametersBuilderError::OutOfOrderUpgrades);
+}
+
+/// Regtest must not activate NU6.3 unless it is explicitly configured, and
+/// must preserve a configured NU6.3 height in its activation map.
+#[test]
+fn regtest_preserves_optional_nu6_3_activation() {
+    let default_regtest = Network::new_regtest(RegtestParameters::default());
+
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&default_regtest),
+        None,
+        "NU6.3 must remain disabled when it is not configured"
+    );
+    assert!(
+        !default_regtest
+            .activation_list()
+            .values()
+            .any(|upgrade| *upgrade == NetworkUpgrade::Nu6_3),
+        "NU6.3 must not be inserted into the explicit activation map by Regtest defaults"
+    );
+
+    let nu6_3_height = Height(23);
+    let configured_regtest = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu6_3: Some(nu6_3_height.0),
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&configured_regtest),
+        Some(nu6_3_height),
+        "Regtest conversion must preserve the configured NU6.3 height"
+    );
+    assert_eq!(
+        configured_regtest.activation_list().get(&nu6_3_height),
+        Some(&NetworkUpgrade::Nu6_3),
+        "the configured NU6.3 height must remain explicit"
+    );
 }
 
 /// Checks that configured testnet names are validated and used correctly.

--- a/zakura-chain/src/primitives/zcash_note_encryption.rs
+++ b/zakura-chain/src/primitives/zcash_note_encryption.rs
@@ -7,8 +7,8 @@ use crate::{
     transaction::Transaction,
 };
 
-/// Returns true if all Sapling or Orchard outputs, if any, decrypt successfully with
-/// an all-zeroes outgoing viewing key.
+/// Returns true if all Sapling, Orchard, or Ironwood outputs, if any, decrypt
+/// successfully with an all-zeroes outgoing viewing key.
 pub fn decrypts_successfully(tx: &Transaction, network: &Network, height: Height) -> bool {
     let nu = NetworkUpgrade::current(network, height);
 
@@ -82,7 +82,7 @@ fn ironwood_action_decrypts_successfully<A>(act: &orchard::Action<A>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use group::{prime::PrimeCurveAffine, GroupEncoding};
+    use group::{ff::PrimeField, prime::PrimeCurveAffine, GroupEncoding};
     use halo2::pasta::pallas;
     use orchard::{
         note::{
@@ -95,6 +95,19 @@ mod tests {
     };
     use rand_core::OsRng;
     use zcash_note_encryption::Domain;
+
+    use crate::{
+        at_least_one,
+        block::Height,
+        orchard as chain_orchard,
+        parameters::{
+            testnet::{ConfiguredActivationHeights, RegtestParameters},
+            Network, NetworkUpgrade,
+        },
+        primitives::Halo2Proof,
+        transaction::{arbitrary::v5_transactions, LockTime, Transaction},
+        transparent,
+    };
 
     #[test]
     fn orchard_and_ironwood_domains_accept_only_their_plaintext_versions() {
@@ -121,6 +134,28 @@ mod tests {
                 "{domain_name} domain result for note plaintext {plaintext_lead_byte:#04x}"
             );
         }
+    }
+
+    #[test]
+    fn decrypts_successfully_routes_v6_ironwood_outputs_through_ironwood_domain() {
+        let vector = zakura_test::vectors::ORCHARD_NOTE_ENCRYPTION_ZERO_VECTOR
+            .first()
+            .expect("test vectors are non-empty");
+        let v3_shielded_data = local_shielded_data_from_action(&v3_action_from_test_vector(vector));
+        let network = nu6_3_network();
+        let height = Height(1);
+
+        let ironwood_tx = v6_coinbase(height, None, Some(v3_shielded_data.clone()));
+        assert!(
+            super::decrypts_successfully(&ironwood_tx, &network, height),
+            "V6 Ironwood outputs must use the V3 note plaintext domain"
+        );
+
+        let orchard_tx = v6_coinbase(height, Some(v3_shielded_data), None);
+        assert!(
+            !super::decrypts_successfully(&orchard_tx, &network, height),
+            "the same V3 ciphertext must not be accepted as an Orchard output"
+        );
     }
 
     fn v2_action_from_test_vector(v: &zakura_test::vectors::TestVector) -> Action<()> {
@@ -174,6 +209,66 @@ mod tests {
             (),
         )
         .expect("test vector fields form a valid action")
+    }
+
+    fn local_shielded_data_from_action(action: &Action<()>) -> chain_orchard::ShieldedData {
+        let mut shielded_data = v5_transactions(Network::new_default_testnet().block_iter())
+            .find_map(|tx| tx.orchard_shielded_data().cloned())
+            .expect("test vectors include an Orchard transaction");
+        let mut local_action = shielded_data.actions.first().action.clone();
+
+        local_action.cv = chain_orchard::ValueCommitment::try_from(action.cv_net().to_bytes())
+            .expect("test vector has a valid value commitment");
+        local_action.nullifier =
+            chain_orchard::Nullifier::try_from((*action.nullifier()).to_bytes())
+                .expect("test vector has a valid nullifier");
+        local_action.cm_x = pallas::Base::from_repr((*action.cmx()).to_bytes())
+            .expect("test vector has a valid note commitment");
+        local_action.ephemeral_key =
+            chain_orchard::keys::EphemeralPublicKey::try_from(action.encrypted_note().epk_bytes)
+                .expect("test vector has a valid ephemeral key");
+        local_action.enc_ciphertext = action.encrypted_note().enc_ciphertext.into();
+        local_action.out_ciphertext = action.encrypted_note().out_ciphertext.into();
+
+        let spend_auth_sig = shielded_data.actions.first().spend_auth_sig;
+        shielded_data.flags = chain_orchard::Flags::ENABLE_OUTPUTS;
+        shielded_data.proof = Halo2Proof(vec![0; ::orchard::Proof::expected_proof_size(1)]);
+        shielded_data.actions = at_least_one![chain_orchard::AuthorizedAction::from_parts(
+            local_action,
+            spend_auth_sig,
+        )];
+        shielded_data
+    }
+
+    fn nu6_3_network() -> Network {
+        Network::new_regtest(RegtestParameters {
+            activation_heights: ConfiguredActivationHeights {
+                nu6_3: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    fn v6_coinbase(
+        height: Height,
+        orchard_shielded_data: Option<chain_orchard::ShieldedData>,
+        ironwood_shielded_data: Option<chain_orchard::ShieldedData>,
+    ) -> Transaction {
+        Transaction::V6 {
+            network_upgrade: NetworkUpgrade::Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: height,
+            inputs: vec![transparent::Input::Coinbase {
+                height,
+                data: vec![],
+                sequence: u32::MAX,
+            }],
+            outputs: vec![],
+            sapling_shielded_data: None,
+            orchard_shielded_data,
+            ironwood_shielded_data,
+        }
     }
 
     fn test_vector_address(v: &zakura_test::vectors::TestVector) -> Address {

--- a/zakura-chain/src/primitives/zcash_note_encryption.rs
+++ b/zakura-chain/src/primitives/zcash_note_encryption.rs
@@ -158,6 +158,48 @@ mod tests {
         );
     }
 
+    #[test]
+    fn decrypts_successfully_checks_v6_orchard_and_ironwood_slots_independently() {
+        let mut vectors = zakura_test::vectors::ORCHARD_NOTE_ENCRYPTION_ZERO_VECTOR.iter();
+        let orchard_vector = vectors.next().expect("test vectors are non-empty");
+        let ironwood_vector = vectors.next().expect("test vectors have multiple entries");
+        let orchard_v2 =
+            local_shielded_data_from_action(&v2_action_from_test_vector(orchard_vector));
+        let orchard_v3 =
+            local_shielded_data_from_action(&v3_action_from_test_vector(orchard_vector));
+        let ironwood_v2 =
+            local_shielded_data_from_action(&v2_action_from_test_vector(ironwood_vector));
+        let ironwood_v3 =
+            local_shielded_data_from_action(&v3_action_from_test_vector(ironwood_vector));
+        let network = nu6_3_network();
+        let height = Height(1);
+
+        assert!(
+            super::decrypts_successfully(
+                &v6_coinbase(height, Some(orchard_v2.clone()), Some(ironwood_v3.clone())),
+                &network,
+                height,
+            ),
+            "V6 recovery must accept an Orchard V2 output and an Ironwood V3 output together",
+        );
+        assert!(
+            !super::decrypts_successfully(
+                &v6_coinbase(height, Some(orchard_v3), Some(ironwood_v3)),
+                &network,
+                height,
+            ),
+            "a valid Ironwood output must not hide an Orchard slot using the V3 domain",
+        );
+        assert!(
+            !super::decrypts_successfully(
+                &v6_coinbase(height, Some(orchard_v2), Some(ironwood_v2)),
+                &network,
+                height,
+            ),
+            "a valid Orchard output must not hide an Ironwood slot using the V2 domain",
+        );
+    }
+
     fn v2_action_from_test_vector(v: &zakura_test::vectors::TestVector) -> Action<()> {
         Action::from_parts(
             Nullifier::from_bytes(&v.rho).expect("test vector has a valid nullifier"),

--- a/zakura-chain/src/primitives/zcash_primitives.rs
+++ b/zakura-chain/src/primitives/zcash_primitives.rs
@@ -540,7 +540,8 @@ pub(crate) fn auth_digest(tx: &Transaction) -> AuthDigest {
 }
 
 /// Compute both the transaction ID (txid) and the ZIP-244 authorizing-data
-/// commitment of a v5+ transaction from a single `librustzcash` conversion.
+/// commitment of a v5+ transaction from a shared native ZIP-244
+/// decomposition, falling back to `librustzcash` for unsupported versions.
 ///
 /// # Panics
 ///

--- a/zakura-chain/src/sapling/commitment.rs
+++ b/zakura-chain/src/sapling/commitment.rs
@@ -105,8 +105,14 @@ impl FromHex for ValueCommitment {
         // Convert from big-endian (display) to little-endian (internal)
         bytes.reverse();
 
-        Self::zcash_deserialize(io::Cursor::new(&bytes))
-            .map_err(|_| FromHexError::InvalidStringLength)
+        let commitment = Self::zcash_deserialize(io::Cursor::new(&bytes))
+            .map_err(|_| FromHexError::InvalidStringLength)?;
+
+        if commitment.is_valid_not_small_order() {
+            Ok(commitment)
+        } else {
+            Err(FromHexError::InvalidStringLength)
+        }
     }
 }
 
@@ -118,7 +124,17 @@ impl From<jubjub::ExtendedPoint> for ValueCommitment {
     ///
     /// Panics if the given point does not correspond to a valid ValueCommitment.
     fn from(extended_point: jubjub::ExtendedPoint) -> Self {
-        ValueCommitment(jubjub::AffinePoint::from(extended_point).to_bytes())
+        let bytes = jubjub::AffinePoint::from(extended_point).to_bytes();
+
+        assert!(
+            bool::from(
+                sapling_crypto::value::ValueCommitment::from_bytes_not_small_order(&bytes)
+                    .is_some(),
+            ),
+            "ValueCommitment::from requires a canonical non-small-order point",
+        );
+
+        ValueCommitment(bytes)
     }
 }
 

--- a/zakura-chain/src/sapling/keys.rs
+++ b/zakura-chain/src/sapling/keys.rs
@@ -214,7 +214,10 @@ impl TryFrom<[u8; 32]> for TransmissionKey {
     /// <https://github.com/zkcrypto/jubjub/blob/master/src/lib.rs#L411>
     /// <https://zips.z.cash/zip-0216>
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        let affine_point = jubjub::AffinePoint::from_bytes(bytes).unwrap();
+        let affine_point = jubjub::AffinePoint::from_bytes(bytes)
+            .into_option()
+            .ok_or("Invalid jubjub::AffinePoint value for Sapling TransmissionKey")?;
+
         // Check if it's identity or has prime order (i.e. is in the prime-order subgroup).
         if affine_point.is_torsion_free().into() {
             Ok(Self(affine_point))

--- a/zakura-chain/src/sapling/tests.rs
+++ b/zakura-chain/src/sapling/tests.rs
@@ -2,3 +2,13 @@
 
 mod preallocate;
 mod prop;
+
+#[test]
+fn transmission_key_rejects_off_curve_bytes() {
+    let _init_guard = zakura_test::init();
+
+    assert!(
+        super::keys::TransmissionKey::try_from([0xffu8; 32]).is_err(),
+        "off-curve Sapling transmission keys must return an error rather than panic",
+    );
+}

--- a/zakura-chain/src/sapling/tests.rs
+++ b/zakura-chain/src/sapling/tests.rs
@@ -1,5 +1,10 @@
 #![allow(clippy::unwrap_in_result)]
 
+use group::Group;
+use hex::{FromHex, ToHex};
+
+use crate::serialization::ZcashDeserialize;
+
 mod preallocate;
 mod prop;
 
@@ -11,4 +16,35 @@ fn transmission_key_rejects_off_curve_bytes() {
         super::keys::TransmissionKey::try_from([0xffu8; 32]).is_err(),
         "off-curve Sapling transmission keys must return an error rather than panic",
     );
+}
+
+#[test]
+fn value_commitment_hex_parse_stays_strict_while_wire_decode_is_lazy() {
+    let _init_guard = zakura_test::init();
+
+    let invalid_bytes = [0xff; 32];
+    let parsed_wire = super::ValueCommitment::zcash_deserialize(invalid_bytes.as_slice())
+        .expect("wire parsing intentionally preserves raw Sapling commitment bytes");
+
+    assert!(
+        !parsed_wire.is_valid_not_small_order(),
+        "the chosen bytes must remain invalid under the deferred semantic predicate",
+    );
+    assert!(
+        super::ValueCommitment::from_hex(hex::encode(invalid_bytes)).is_err(),
+        "the display-oriented hex constructor must not silently create an invalid commitment",
+    );
+
+    let valid = super::ValueCommitment::from(jubjub::ExtendedPoint::generator());
+    let display_hex = (&valid).encode_hex::<String>();
+    assert_eq!(
+        super::ValueCommitment::from_hex(display_hex).expect("valid commitment hex should parse"),
+        valid,
+    );
+}
+
+#[test]
+#[should_panic(expected = "ValueCommitment::from requires a canonical non-small-order point")]
+fn value_commitment_test_helper_rejects_small_order_points() {
+    let _ = super::ValueCommitment::from(jubjub::ExtendedPoint::identity());
 }

--- a/zakura-chain/src/sapling/tree.rs
+++ b/zakura-chain/src/sapling/tree.rs
@@ -788,6 +788,43 @@ mod tests {
         assert_eq!(tree.root(), original.root());
     }
 
+    /// `append_batch` must match sequential appends when a batch exactly fills
+    /// the last two leaf positions of the tree, completing the final tracked
+    /// subtree (index `u16::MAX`) without reporting a spurious overflow.
+    #[test]
+    fn append_batch_matches_sequential_at_tree_capacity() {
+        let max_position = (1u64 << MERKLE_DEPTH) - 1;
+        let start_position = max_position - 2;
+        let leaf = node(1);
+        // A frontier at position `p` stores one ommer per set bit of `p`;
+        // `max_position - 2` has 31 of its 32 bits set.
+        let ommers: Vec<sapling_crypto::Node> = (2..=32).map(node).collect();
+        let inner = Frontier::from_parts(Position::from(start_position), leaf, ommers)
+            .expect("frontier two leaves below capacity is valid");
+        let start = NoteCommitmentTree {
+            inner,
+            cached_root: Default::default(),
+        };
+        let note_commitments = [note_commitment(100), note_commitment(200)];
+
+        let mut seq_tree = start.clone();
+        let seq_result = sequential_append_batch(&mut seq_tree, &note_commitments)
+            .expect("two sequential appends reach exact capacity");
+
+        let mut batch_tree = start;
+        let batch_result = batch_tree
+            .append_batch(&note_commitments)
+            .expect("batch append reaches exact capacity");
+
+        assert_eq!(batch_result, seq_result);
+        assert_eq!(
+            batch_result.map(|(index, _)| index),
+            Some(NoteCommitmentSubtreeIndex(u16::MAX)),
+        );
+        batch_tree.assert_frontier_eq(&seq_tree);
+        assert_eq!(batch_tree.root(), seq_tree.root());
+    }
+
     #[test]
     fn append_batch_multiple_subtrees_preserves_tree_and_cached_root() {
         let mut tree = NoteCommitmentTree::default();

--- a/zakura-chain/src/transaction.rs
+++ b/zakura-chain/src/transaction.rs
@@ -284,7 +284,8 @@ impl Transaction {
     }
 
     /// Compute this transaction's ID (txid) and ZIP-244 authorizing-data digest
-    /// together, sharing the librustzcash conversion used by both computations.
+    /// together, sharing the native ZIP-244 decomposition used by both
+    /// computations.
     ///
     /// Returns `None` for the auth digest of pre-v5 transactions.
     pub fn txid_and_auth_digest(&self) -> (Hash, Option<AuthDigest>) {

--- a/zakura-chain/src/transaction/serialize.rs
+++ b/zakura-chain/src/transaction/serialize.rs
@@ -854,10 +854,11 @@ impl ZcashSerialize for Transaction {
                 // A bundle of fields denoted in the spec as `nActionsOrchard`, `vActionsOrchard`,
                 // `flagsOrchard`,`valueBalanceOrchard`, `anchorOrchard`, `sizeProofsOrchard`,
                 // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`.
+                // V6 Orchard still reserves bit 2; only the Ironwood slot below permits it.
                 serialize_optional_orchard_shielded_data_with_flags(
                     orchard_shielded_data,
                     &mut writer,
-                    ALLOW_CROSS_ADDRESS_BIT,
+                    !ALLOW_CROSS_ADDRESS_BIT,
                 )?;
 
                 // A bundle of fields denoted in the spec as `nActionsIronwood`,
@@ -1204,9 +1205,10 @@ impl ZcashDeserialize for Transaction {
                 // A bundle of fields denoted in the spec as `nActionsOrchard`, `vActionsOrchard`,
                 // `flagsOrchard`,`valueBalanceOrchard`, `anchorOrchard`, `sizeProofsOrchard`,
                 // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`.
+                // V6 Orchard still reserves bit 2; only the Ironwood slot below permits it.
                 let orchard_shielded_data = deserialize_orchard_shielded_data_with_flags(
                     &mut limited_reader,
-                    ALLOW_CROSS_ADDRESS_BIT,
+                    !ALLOW_CROSS_ADDRESS_BIT,
                 )?;
 
                 // A bundle of fields denoted in the spec as `nActionsIronwood`,

--- a/zakura-chain/src/transaction/tests/prop.rs
+++ b/zakura-chain/src/transaction/tests/prop.rs
@@ -160,6 +160,7 @@ fn nu5_or_later_upgrade() -> BoxedStrategy<NetworkUpgrade> {
         Just(NetworkUpgrade::Nu6),
         Just(NetworkUpgrade::Nu6_1),
         Just(NetworkUpgrade::Nu6_2),
+        Just(NetworkUpgrade::Nu6_3),
     ]
     .boxed()
 }
@@ -252,6 +253,15 @@ proptest! {
             crate::transaction::zip244::auth_digest(&tx).expect("v5/v6"),
             native_auth
         );
+
+        // The public wrappers route v5/v6 transactions through the same
+        // native decomposition. Keep that routing pinned to the oracle too,
+        // rather than only testing the internal ZIP-244 helpers.
+        let (public_txid, public_auth) = tx.txid_and_auth_digest();
+        prop_assert_eq!(public_txid, ref_txid);
+        prop_assert_eq!(public_auth, Some(ref_auth));
+        prop_assert_eq!(tx.hash(), ref_txid);
+        prop_assert_eq!(tx.auth_digest(), Some(ref_auth));
     }
 
     #[test]

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -2318,6 +2318,76 @@ fn sapling_point_encodings_check_rejects_bad_points() {
     check_transaction("V6", &make_v6);
 }
 
+/// The deferred Sapling point check also covers V4 spend commitments.
+///
+/// The lazy representation applies to spend `cv` as well as output `cv`/`epk`.
+/// V4 takes a distinct `PerSpendAnchor` branch, so keep a focused regression on
+/// that route rather than relying only on output-only V5/V6 coverage.
+#[test]
+fn sapling_point_encodings_check_rejects_bad_v4_spend_cv() {
+    use group::Group;
+
+    use crate::{
+        amount::Amount,
+        at_least_one,
+        block::Height,
+        primitives::{
+            redjubjub::{Binding, Signature, SpendAuth},
+            Groth16Proof,
+        },
+        sapling::{
+            self,
+            keys::ValidatingKey,
+            shielded_data::{ShieldedData, TransferData},
+            Spend, ValueCommitment,
+        },
+        transaction::{LockTime, Transaction},
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let valid = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
+    let off_curve = [0xffu8; 32];
+    let rk = ValidatingKey::try_from(valid).expect("the Jubjub generator is a valid Sapling rk");
+
+    let make_v4 = |cv: [u8; 32]| -> Transaction {
+        let spend = Spend::<sapling::PerSpendAnchor> {
+            cv: ValueCommitment(cv),
+            per_spend_anchor: sapling::tree::Root::default(),
+            nullifier: sapling::Nullifier::from([0u8; 32]),
+            rk: rk.clone(),
+            zkproof: Groth16Proof([0u8; 192]),
+            spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
+        };
+
+        Transaction::V4 {
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(0),
+            inputs: vec![],
+            outputs: vec![],
+            joinsplit_data: None,
+            sapling_shielded_data: Some(ShieldedData::<sapling::PerSpendAnchor> {
+                value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+                transfers: TransferData::SpendsAndMaybeOutputs {
+                    shared_anchor: sapling::FieldNotPresent,
+                    spends: at_least_one![spend],
+                    maybe_outputs: vec![],
+                },
+                binding_sig: Signature::<Binding>::from([0u8; 64]),
+            }),
+        }
+    };
+
+    assert!(
+        make_v4(valid).sapling_point_encodings_are_valid(),
+        "a V4 spend with a valid cv must pass the deferred point check",
+    );
+    assert!(
+        !make_v4(off_curve).sapling_point_encodings_are_valid(),
+        "a V4 spend with an off-curve cv must fail the deferred point check",
+    );
+}
+
 /// The relocated Sapling `cv` / `epk` not-small-order checks accept exactly the
 /// same encodings as the librustzcash functions they mirror.
 ///

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -2202,6 +2202,89 @@ fn sapling_lazy_cv_epk_edge_cases() {
     );
 }
 
+/// The local Sapling binding-key helper stays fail-closed when it sees a lazy
+/// value commitment that has not passed semantic validation yet.
+///
+/// The verifier currently obtains the binding key from librustzcash instead of
+/// this helper, so this is not an acceptance path today. Keep the public helper
+/// fallible anyway: both spend and output commitments can now hold raw bytes
+/// until `Transaction::sapling_point_encodings_are_valid` runs.
+#[test]
+fn sapling_binding_verification_key_rejects_invalid_lazy_commitments() {
+    use group::Group;
+
+    use crate::{
+        amount::Amount,
+        at_least_one,
+        primitives::{
+            redjubjub::{Binding, Signature, SpendAuth},
+            Groth16Proof,
+        },
+        sapling::{
+            self,
+            keys::{EphemeralPublicKey, ValidatingKey},
+            shielded_data::{ShieldedData, TransferData},
+            EncryptedNote, Output, Spend, ValueCommitment, WrappedNoteKey,
+        },
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let valid = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
+    let invalid = [0xffu8; 32];
+    let rk = ValidatingKey::try_from(valid).expect("the Jubjub generator is a valid Sapling rk");
+
+    let output_bundle = |cv: [u8; 32]| ShieldedData::<sapling::SharedAnchor> {
+        value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+        transfers: TransferData::JustOutputs {
+            outputs: at_least_one![Output {
+                cv: ValueCommitment(cv),
+                cm_u: sapling_crypto::note::ExtractedNoteCommitment::from_bytes(&[0u8; 32])
+                    .expect("zero bytes encode a valid extracted note commitment"),
+                ephemeral_key: EphemeralPublicKey(valid),
+                enc_ciphertext: EncryptedNote([0u8; 580]),
+                out_ciphertext: WrappedNoteKey([0u8; 80]),
+                zkproof: Groth16Proof([0u8; 192]),
+            }],
+        },
+        binding_sig: Signature::<Binding>::from([0u8; 64]),
+    };
+
+    let spend_bundle = |cv: [u8; 32]| ShieldedData::<sapling::PerSpendAnchor> {
+        value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+        transfers: TransferData::SpendsAndMaybeOutputs {
+            shared_anchor: sapling::FieldNotPresent,
+            spends: at_least_one![Spend {
+                cv: ValueCommitment(cv),
+                per_spend_anchor: sapling::tree::Root::default(),
+                nullifier: sapling::Nullifier::from([0u8; 32]),
+                rk: rk.clone(),
+                zkproof: Groth16Proof([0u8; 192]),
+                spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
+            }],
+            maybe_outputs: vec![],
+        },
+        binding_sig: Signature::<Binding>::from([0u8; 64]),
+    };
+
+    assert!(
+        output_bundle(valid).binding_verification_key().is_some(),
+        "a valid output commitment must still produce a binding key",
+    );
+    assert!(
+        spend_bundle(valid).binding_verification_key().is_some(),
+        "a valid spend commitment must still produce a binding key",
+    );
+    assert!(
+        output_bundle(invalid).binding_verification_key().is_none(),
+        "an invalid lazy output commitment must fail closed",
+    );
+    assert!(
+        spend_bundle(invalid).binding_verification_key().is_none(),
+        "an invalid lazy spend commitment must fail closed",
+    );
+}
+
 /// The semantic verifier's Sapling cv/epk not-small-order check rejects bad
 /// points.
 ///

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -206,104 +206,126 @@ fn v5_orchard_cross_address_flag_fails_deserialization() {
     ));
 }
 
-/// V6 Orchard and Ironwood bundles must round-trip the `ENABLE_CROSS_ADDRESS`
-/// flag bit (which V5 reserves and rejects), while still rejecting the
-/// undefined flag bits 3..7.
-///
-/// The flags byte position is located by serializing the same transaction
-/// with and without the cross-address bit and diffing: exactly one byte may
-/// change.
+/// V6 Orchard keeps the cross-address bit reserved on the wire, even though
+/// V6 Ironwood uses the same internal `Flags` type and permits that bit.
 #[test]
-fn v6_orchard_style_flags_allow_cross_address_but_reject_reserved_bits() {
+fn v6_orchard_cross_address_flag_fails_serialization_and_deserialization() {
     let _init_guard = zakura_test::init();
 
-    let shielded_data = Network::iter()
+    let mut shielded_data = Network::iter()
         .flat_map(|network| v5_transactions(network.block_iter()))
         .find_map(|transaction| transaction.orchard_shielded_data().cloned())
         .expect("test vectors include an Orchard transaction");
 
-    let make_tx = |mut shielded_data: crate::orchard::ShieldedData, ironwood: bool| {
-        shielded_data
-            .flags
-            .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
-
-        Transaction::V6 {
-            network_upgrade: NetworkUpgrade::Nu6_3,
-            lock_time: LockTime::unlocked(),
-            expiry_height: Height(1),
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            sapling_shielded_data: None,
-            orchard_shielded_data: (!ironwood).then_some(shielded_data.clone()),
-            ironwood_shielded_data: ironwood.then_some(shielded_data),
-        }
+    let make_tx = |shielded_data: crate::orchard::ShieldedData| Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: Some(shielded_data),
+        ironwood_shielded_data: None,
     };
 
-    for ironwood in [false, true] {
-        let tx = make_tx(shielded_data.clone(), ironwood);
-        let cross_address_bytes = tx
-            .zcash_serialize_to_vec()
-            .expect("V6 Orchard-style formats allow the cross-address bit on the wire");
-        let parsed = Transaction::zcash_deserialize(&cross_address_bytes[..])
-            .expect("V6 Orchard-style cross-address flag must deserialize");
-        let parsed_flags = if ironwood {
-            parsed
-                .ironwood_shielded_data()
-                .expect("test transaction has Ironwood data")
-                .flags
-        } else {
-            parsed
-                .orchard_shielded_data()
-                .expect("test transaction has Orchard data")
-                .flags
-        };
-        assert!(parsed_flags.contains(crate::orchard::Flags::ENABLE_CROSS_ADDRESS));
+    let valid_bytes = make_tx(shielded_data.clone())
+        .zcash_serialize_to_vec()
+        .expect("V6 Orchard flags without cross-address must serialize");
 
-        let mut without_cross_address = tx;
-        let Transaction::V6 {
-            orchard_shielded_data,
-            ironwood_shielded_data,
-            ..
-        } = &mut without_cross_address
-        else {
-            unreachable!("test transaction is V6");
-        };
-        if ironwood {
-            ironwood_shielded_data
-                .as_mut()
-                .expect("test transaction has Ironwood data")
-                .flags
-                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
-        } else {
-            orchard_shielded_data
-                .as_mut()
-                .expect("test transaction has Orchard data")
-                .flags
-                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
-        }
+    let mut toggled = shielded_data.clone();
+    toggled.flags.toggle(crate::orchard::Flags::ENABLE_SPENDS);
+    let toggled_bytes = make_tx(toggled)
+        .zcash_serialize_to_vec()
+        .expect("V6 Orchard spend flag should serialize");
+    let differing_indices: Vec<_> = valid_bytes
+        .iter()
+        .zip(&toggled_bytes)
+        .enumerate()
+        .filter_map(|(index, (original, toggled))| (original != toggled).then_some(index))
+        .collect();
+    let [flags_index] = differing_indices.as_slice() else {
+        panic!("toggling the V6 Orchard spend flag should change exactly one byte");
+    };
 
-        let without_cross_address_bytes = without_cross_address
-            .zcash_serialize_to_vec()
-            .expect("V6 Orchard-style flags without cross-address must serialize");
-        let differing_indices: Vec<_> = cross_address_bytes
-            .iter()
-            .zip(&without_cross_address_bytes)
-            .enumerate()
-            .filter_map(|(index, (with, without))| (with != without).then_some(index))
-            .collect();
-        let [flags_index] = differing_indices.as_slice() else {
-            panic!("toggling the cross-address flag should change exactly one byte");
-        };
+    shielded_data
+        .flags
+        .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+    let error = make_tx(shielded_data)
+        .zcash_serialize_to_vec()
+        .expect_err("V6 Orchard flags must reject reserved cross-address bit");
+    assert_eq!(error.kind(), ErrorKind::InvalidData);
 
-        let mut reserved_bit_bytes = cross_address_bytes;
-        reserved_bit_bytes[*flags_index] |= 0b0000_1000;
-        let error = Transaction::zcash_deserialize(&reserved_bit_bytes[..])
-            .expect_err("V6 Orchard-style flags must reject reserved bits 3..7");
-        assert!(matches!(
-            error,
-            SerializationError::Parse("invalid reserved orchard flags")
-        ));
-    }
+    let mut malformed_bytes = valid_bytes;
+    malformed_bytes[*flags_index] |= crate::orchard::Flags::ENABLE_CROSS_ADDRESS.bits();
+    let error = Transaction::zcash_deserialize(&malformed_bytes[..])
+        .expect_err("V6 Orchard flags must reject reserved cross-address bit");
+    assert!(matches!(
+        error,
+        SerializationError::Parse("invalid reserved orchard flags")
+    ));
+}
+
+/// V6 Ironwood must round-trip `ENABLE_CROSS_ADDRESS`, while still rejecting
+/// undefined flag bits 3..7.
+#[test]
+fn v6_ironwood_cross_address_flag_round_trips_and_rejects_reserved_bits() {
+    let _init_guard = zakura_test::init();
+
+    let mut shielded_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    shielded_data
+        .flags
+        .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+
+    let make_tx = |shielded_data: crate::ironwood::ShieldedData| Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        ironwood_shielded_data: Some(shielded_data),
+    };
+
+    let tx = make_tx(shielded_data.clone());
+    let cross_address_bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("V6 Ironwood must allow the cross-address bit on the wire");
+    let parsed = Transaction::zcash_deserialize(&cross_address_bytes[..])
+        .expect("V6 Ironwood cross-address flag must deserialize");
+    assert!(parsed
+        .ironwood_shielded_data()
+        .expect("test transaction has Ironwood data")
+        .flags
+        .contains(crate::orchard::Flags::ENABLE_CROSS_ADDRESS));
+
+    shielded_data
+        .flags
+        .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+    let without_cross_address_bytes = make_tx(shielded_data)
+        .zcash_serialize_to_vec()
+        .expect("V6 Ironwood flags without cross-address must serialize");
+    let differing_indices: Vec<_> = cross_address_bytes
+        .iter()
+        .zip(&without_cross_address_bytes)
+        .enumerate()
+        .filter_map(|(index, (with, without))| (with != without).then_some(index))
+        .collect();
+    let [flags_index] = differing_indices.as_slice() else {
+        panic!("toggling the V6 Ironwood cross-address flag should change exactly one byte");
+    };
+
+    let mut reserved_bit_bytes = cross_address_bytes;
+    reserved_bit_bytes[*flags_index] |= 0b0000_1000;
+    let error = Transaction::zcash_deserialize(&reserved_bit_bytes[..])
+        .expect_err("V6 Ironwood flags must reject reserved bits 3..7");
+    assert!(matches!(
+        error,
+        SerializationError::Parse("invalid reserved orchard flags")
+    ));
 }
 
 #[test]
@@ -2200,6 +2222,128 @@ fn sapling_lazy_cv_epk_edge_cases() {
         ValidatingKey::try_from(small_order).is_err(),
         "Sapling rk must still reject a small-order point at deserialization",
     );
+}
+
+/// Native ZIP-244 hashing must stay byte-oriented for lazy Sapling points.
+///
+/// Checkpoint hashing and pre-verification mempool IDs are computed before
+/// semantic point validation. An off-curve Sapling commitment must therefore
+/// still produce a deterministic V5/V6 `UnminedTx` ID, while the later
+/// librustzcash conversion remains fail-closed.
+#[test]
+fn native_zip244_hashes_invalid_lazy_sapling_points_before_semantic_rejection() {
+    use group::Group;
+
+    use crate::{
+        amount::Amount,
+        at_least_one,
+        block::Height,
+        parameters::NetworkUpgrade,
+        primitives::{
+            redjubjub::{Binding, Signature},
+            Groth16Proof,
+        },
+        sapling::{
+            self,
+            keys::EphemeralPublicKey,
+            shielded_data::{ShieldedData, TransferData},
+            EncryptedNote, Output, ValueCommitment, WrappedNoteKey,
+        },
+        serialization::{ZcashDeserializeInto, ZcashSerialize},
+        transaction::{LockTime, Transaction, UnminedTx},
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let off_curve = [0xffu8; 32];
+    let other_off_curve = [0xfeu8; 32];
+    assert!(
+        bool::from(jubjub::AffinePoint::from_bytes(off_curve).is_none()),
+        "0xff..ff must not be a valid Jubjub point encoding",
+    );
+    assert!(
+        bool::from(jubjub::AffinePoint::from_bytes(other_off_curve).is_none()),
+        "0xfe..fe must not be a valid Jubjub point encoding",
+    );
+    let valid_epk = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
+
+    let shielded_data = |cv: [u8; 32]| ShieldedData::<sapling::SharedAnchor> {
+        value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+        transfers: TransferData::JustOutputs {
+            outputs: at_least_one![Output {
+                cv: ValueCommitment(cv),
+                cm_u: sapling_crypto::note::ExtractedNoteCommitment::from_bytes(&[0u8; 32])
+                    .expect("zero bytes encode a valid extracted note commitment"),
+                ephemeral_key: EphemeralPublicKey(valid_epk),
+                enc_ciphertext: EncryptedNote([0u8; 580]),
+                out_ciphertext: WrappedNoteKey([0u8; 80]),
+                zkproof: Groth16Proof([0u8; 192]),
+            }],
+        },
+        binding_sig: Signature::<Binding>::from([0u8; 64]),
+    };
+
+    let make_transactions = |cv: [u8; 32]| {
+        [
+            Transaction::V5 {
+                network_upgrade: NetworkUpgrade::Nu5,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(0),
+                inputs: vec![],
+                outputs: vec![],
+                sapling_shielded_data: Some(shielded_data(cv)),
+                orchard_shielded_data: None,
+            },
+            Transaction::V6 {
+                network_upgrade: NetworkUpgrade::Nu6_3,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(0),
+                inputs: vec![],
+                outputs: vec![],
+                sapling_shielded_data: Some(shielded_data(cv)),
+                orchard_shielded_data: None,
+                ironwood_shielded_data: None,
+            },
+        ]
+    };
+
+    for (tx, changed_tx) in make_transactions(off_curve)
+        .into_iter()
+        .zip(make_transactions(other_off_curve))
+    {
+        let network_upgrade = tx
+            .network_upgrade()
+            .expect("V5/V6 transactions carry a network upgrade");
+        let parsed: Transaction = tx
+            .zcash_serialize_to_vec()
+            .expect("crafted transaction must serialize")
+            .zcash_deserialize_into()
+            .expect("lazy Sapling point bytes must deserialize");
+        let changed_parsed: Transaction = changed_tx
+            .zcash_serialize_to_vec()
+            .expect("crafted transaction must serialize")
+            .zcash_deserialize_into()
+            .expect("lazy Sapling point bytes must deserialize");
+
+        assert!(
+            !parsed.sapling_point_encodings_are_valid(),
+            "off-curve Sapling cv must fail deferred semantic validation",
+        );
+        assert!(
+            parsed.to_librustzcash(network_upgrade).is_err(),
+            "off-curve Sapling cv must fail librustzcash conversion",
+        );
+
+        let unmined = UnminedTx::from(parsed.clone());
+        let (txid, auth_digest) = parsed.txid_and_auth_digest();
+        assert_eq!(unmined.id.mined_id(), txid);
+        assert_eq!(unmined.id.auth_digest(), auth_digest);
+        assert_ne!(
+            txid,
+            changed_parsed.hash(),
+            "native txid must commit to the raw lazy Sapling cv bytes",
+        );
+    }
 }
 
 /// The local Sapling binding-key helper stays fail-closed when it sees a lazy

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -206,6 +206,106 @@ fn v5_orchard_cross_address_flag_fails_deserialization() {
     ));
 }
 
+/// V6 Orchard and Ironwood bundles must round-trip the `ENABLE_CROSS_ADDRESS`
+/// flag bit (which V5 reserves and rejects), while still rejecting the
+/// undefined flag bits 3..7.
+///
+/// The flags byte position is located by serializing the same transaction
+/// with and without the cross-address bit and diffing: exactly one byte may
+/// change.
+#[test]
+fn v6_orchard_style_flags_allow_cross_address_but_reject_reserved_bits() {
+    let _init_guard = zakura_test::init();
+
+    let shielded_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+
+    let make_tx = |mut shielded_data: crate::orchard::ShieldedData, ironwood: bool| {
+        shielded_data
+            .flags
+            .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+
+        Transaction::V6 {
+            network_upgrade: NetworkUpgrade::Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(1),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            sapling_shielded_data: None,
+            orchard_shielded_data: (!ironwood).then_some(shielded_data.clone()),
+            ironwood_shielded_data: ironwood.then_some(shielded_data),
+        }
+    };
+
+    for ironwood in [false, true] {
+        let tx = make_tx(shielded_data.clone(), ironwood);
+        let cross_address_bytes = tx
+            .zcash_serialize_to_vec()
+            .expect("V6 Orchard-style formats allow the cross-address bit on the wire");
+        let parsed = Transaction::zcash_deserialize(&cross_address_bytes[..])
+            .expect("V6 Orchard-style cross-address flag must deserialize");
+        let parsed_flags = if ironwood {
+            parsed
+                .ironwood_shielded_data()
+                .expect("test transaction has Ironwood data")
+                .flags
+        } else {
+            parsed
+                .orchard_shielded_data()
+                .expect("test transaction has Orchard data")
+                .flags
+        };
+        assert!(parsed_flags.contains(crate::orchard::Flags::ENABLE_CROSS_ADDRESS));
+
+        let mut without_cross_address = tx;
+        let Transaction::V6 {
+            orchard_shielded_data,
+            ironwood_shielded_data,
+            ..
+        } = &mut without_cross_address
+        else {
+            unreachable!("test transaction is V6");
+        };
+        if ironwood {
+            ironwood_shielded_data
+                .as_mut()
+                .expect("test transaction has Ironwood data")
+                .flags
+                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+        } else {
+            orchard_shielded_data
+                .as_mut()
+                .expect("test transaction has Orchard data")
+                .flags
+                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+        }
+
+        let without_cross_address_bytes = without_cross_address
+            .zcash_serialize_to_vec()
+            .expect("V6 Orchard-style flags without cross-address must serialize");
+        let differing_indices: Vec<_> = cross_address_bytes
+            .iter()
+            .zip(&without_cross_address_bytes)
+            .enumerate()
+            .filter_map(|(index, (with, without))| (with != without).then_some(index))
+            .collect();
+        let [flags_index] = differing_indices.as_slice() else {
+            panic!("toggling the cross-address flag should change exactly one byte");
+        };
+
+        let mut reserved_bit_bytes = cross_address_bytes;
+        reserved_bit_bytes[*flags_index] |= 0b0000_1000;
+        let error = Transaction::zcash_deserialize(&reserved_bit_bytes[..])
+            .expect_err("V6 Orchard-style flags must reject reserved bits 3..7");
+        assert!(matches!(
+            error,
+            SerializationError::Parse("invalid reserved orchard flags")
+        ));
+    }
+}
+
 #[test]
 fn doesnt_deserialize_transaction_with_invalid_value_balance() {
     let _init_guard = zakura_test::init();
@@ -599,6 +699,36 @@ fn native_zip244_matches_test_vectors() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// V5 remains valid under the NU6.3 branch ID, even though NU6.3 also
+/// introduces V6 and changes Orchard bundle semantics. Keep the native
+/// ZIP-244 path pinned to the librustzcash oracle at that mixed boundary.
+#[test]
+fn native_zip244_matches_librustzcash_for_v5_nu6_3_orchard() {
+    let _init_guard = zakura_test::init();
+
+    let mut tx = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find(|transaction| transaction.orchard_shielded_data().is_some())
+        .expect("test vectors include a V5 Orchard transaction");
+
+    tx.update_network_upgrade(NetworkUpgrade::Nu6_3)
+        .expect("V5 transactions can carry the NU6.3 branch ID");
+
+    let (native_txid, native_auth_digest) = crate::transaction::zip244::txid_and_auth_digest(&tx)
+        .expect("V5 transactions have native ZIP-244 digests");
+    let (librustzcash_txid, librustzcash_auth_digest) =
+        crate::primitives::zcash_primitives::txid_and_auth_digest_via_librustzcash(&tx);
+
+    assert_eq!(
+        native_txid, librustzcash_txid,
+        "native V5 NU6.3 txid must match librustzcash"
+    );
+    assert_eq!(
+        native_auth_digest, librustzcash_auth_digest,
+        "native V5 NU6.3 auth digest must match librustzcash"
+    );
 }
 
 fn assert_native_zip244_matches_test_vector(
@@ -1261,6 +1391,55 @@ fn test_coinbase_script() -> Result<()> {
     Ok(())
 }
 
+/// The V6 version group ID must match librustzcash's finalized constant, both
+/// as a constant and in the serialized header bytes (fOverwintered | version,
+/// then the group ID, little-endian), and the former `0xffff_ffff`
+/// placeholder value must no longer deserialize.
+#[test]
+fn v6_version_group_id_matches_librustzcash_and_wire_format() {
+    use crate::parameters::TX_V6_VERSION_GROUP_ID;
+
+    let _init_guard = zakura_test::init();
+
+    assert_eq!(
+        TX_V6_VERSION_GROUP_ID,
+        zcash_protocol::constants::V6_VERSION_GROUP_ID,
+    );
+    assert_eq!(
+        TX_V6_VERSION_GROUP_ID,
+        zcash_primitives::transaction::TxVersion::V6.version_group_id(),
+    );
+
+    let tx = Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(0),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        ironwood_shielded_data: None,
+    };
+    let tx_bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("an empty NU6.3 V6 transaction has a valid wire encoding");
+
+    assert_eq!(&tx_bytes[0..4], &[0x06, 0x00, 0x00, 0x80]);
+    assert_eq!(&tx_bytes[4..8], &[0x98, 0xb6, 0x84, 0xd8]);
+    assert_eq!(tx.version_group_id(), Some(TX_V6_VERSION_GROUP_ID));
+    tx.to_librustzcash(NetworkUpgrade::Nu6_3)
+        .expect("librustzcash must accept Zakura's finalized V6 header");
+
+    let mut placeholder_bytes = tx_bytes;
+    placeholder_bytes[4..8].copy_from_slice(&0xffff_ffffu32.to_le_bytes());
+    let error = Transaction::zcash_deserialize(&placeholder_bytes[..])
+        .expect_err("the former placeholder V6 version group ID must be rejected");
+    assert!(matches!(
+        error,
+        SerializationError::Parse("expected TX_V6_VERSION_GROUP_ID")
+    ));
+}
+
 #[test]
 fn v6_transactions_accept_nu6_3_and_later_branch_ids() {
     use crate::parameters::TX_V6_VERSION_GROUP_ID;
@@ -1322,6 +1501,83 @@ fn v6_transactions_accept_nu6_3_and_later_branch_ids() {
             assert_eq!(tx.zcash_serialize_to_vec().unwrap(), tx_bytes);
         }
     }
+}
+
+/// The V6 sighash precomputation path must preserve the separate Orchard and
+/// Ironwood bundle slots after the librustzcash round-trip.
+///
+/// Both fields use the same upstream `orchard::Bundle` concrete type and the
+/// same authorization mapper, so a swapped getter or accidental alias would
+/// otherwise send one pool's proof to the other pool's verifier.
+#[test]
+fn v6_sighasher_preserves_distinct_orchard_and_ironwood_bundle_slots() {
+    use crate::{ironwood, orchard};
+
+    let _init_guard = zakura_test::init();
+
+    let mut orchard_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    let mut ironwood_data = orchard_data.clone();
+
+    let orchard_nullifier = [0u8; 32];
+    let mut ironwood_nullifier = [0u8; 32];
+    ironwood_nullifier[0] = 1;
+
+    let mut orchard_actions = orchard_data.actions.as_slice().to_vec();
+    orchard_actions[0].action.nullifier =
+        orchard::Nullifier::try_from(orchard_nullifier).expect("zero is a valid nullifier");
+    orchard_data.actions = orchard_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+    ironwood_actions[0].action.nullifier =
+        ironwood::Nullifier::try_from(ironwood_nullifier).expect("one is a valid nullifier");
+    ironwood_data.actions = ironwood_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let tx = Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: Some(orchard_data),
+        ironwood_shielded_data: Some(ironwood_data),
+    };
+
+    let sighasher = tx
+        .sighasher(NetworkUpgrade::Nu6_3, Arc::new(Vec::new()))
+        .expect("the mixed-pool V6 transaction converts to librustzcash");
+    let orchard_bundle = sighasher
+        .orchard_bundle()
+        .expect("the V6 transaction keeps its Orchard bundle");
+    let ironwood_bundle = sighasher
+        .ironwood_bundle()
+        .expect("the V6 transaction keeps its Ironwood bundle");
+
+    let parsed_orchard_nullifier = (*orchard_bundle
+        .actions()
+        .iter()
+        .next()
+        .expect("the Orchard bundle has at least one action")
+        .nullifier())
+    .to_bytes();
+    let parsed_ironwood_nullifier = (*ironwood_bundle
+        .actions()
+        .iter()
+        .next()
+        .expect("the Ironwood bundle has at least one action")
+        .nullifier())
+    .to_bytes();
+
+    assert_eq!(parsed_orchard_nullifier, orchard_nullifier);
+    assert_eq!(parsed_ironwood_nullifier, ironwood_nullifier);
+    assert_ne!(parsed_orchard_nullifier, parsed_ironwood_nullifier);
 }
 
 #[test]

--- a/zakura-chain/src/value_balance/tests.rs
+++ b/zakura-chain/src/value_balance/tests.rs
@@ -2,4 +2,114 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+use crate::{
+    amount::{Amount, NegativeAllowed, NonNegative},
+    value_balance::{ValueBalance, ValueBalanceError},
+};
+
 mod prop;
+
+#[test]
+fn ironwood_deposit_updates_only_the_ironwood_chain_pool() {
+    let _init_guard = zakura_test::init();
+
+    let transaction_value_balance =
+        ValueBalance::from_ironwood_amount(Amount::<NegativeAllowed>::try_from(-1).unwrap());
+    let chain_value_pool_change = -transaction_value_balance;
+    let updated = ValueBalance::<NonNegative>::zero()
+        .add_chain_value_pool_change(chain_value_pool_change)
+        .expect("an Ironwood deposit adds value to the Ironwood chain pool");
+
+    assert_eq!(
+        updated.ironwood_amount(),
+        Amount::<NonNegative>::try_from(1).unwrap()
+    );
+    let zero = Amount::<NonNegative>::zero();
+    assert_eq!(updated.transparent_amount(), zero);
+    assert_eq!(updated.sprout_amount(), zero);
+    assert_eq!(updated.sapling_amount(), zero);
+    assert_eq!(updated.orchard_amount(), zero);
+    assert_eq!(updated.deferred_amount(), zero);
+}
+
+#[test]
+fn remaining_transaction_value_includes_ironwood() {
+    let _init_guard = zakura_test::init();
+
+    let one = Amount::<NegativeAllowed>::try_from(1).unwrap();
+    let minus_one = Amount::<NegativeAllowed>::try_from(-1).unwrap();
+    let mut value_balance = ValueBalance::from_transparent_amount(one);
+
+    value_balance.set_ironwood_value_balance(ValueBalance::from_ironwood_amount(minus_one));
+
+    assert_eq!(
+        value_balance.remaining_transaction_value(),
+        Ok(Amount::<NonNegative>::zero())
+    );
+}
+
+#[test]
+fn ironwood_chain_pool_underflow_is_reported_as_ironwood() {
+    let _init_guard = zakura_test::init();
+
+    let chain_value_pool_change =
+        ValueBalance::from_ironwood_amount(Amount::<NegativeAllowed>::try_from(-1).unwrap());
+
+    assert!(matches!(
+        ValueBalance::<NonNegative>::zero().add_chain_value_pool_change(chain_value_pool_change),
+        Err(ValueBalanceError::Ironwood(_))
+    ));
+}
+
+#[test]
+fn value_balance_bytes_keep_deferred_before_ironwood() {
+    let _init_guard = zakura_test::init();
+
+    let orchard = Amount::<NonNegative>::try_from(4).unwrap();
+    let deferred = Amount::<NonNegative>::try_from(5).unwrap();
+    let ironwood = Amount::<NonNegative>::try_from(6).unwrap();
+    let mut value_balance = ValueBalance::from_orchard_amount(orchard);
+
+    value_balance.set_deferred_amount(deferred);
+    value_balance.set_ironwood_value_balance(ValueBalance::from_ironwood_amount(ironwood));
+
+    let bytes = value_balance.to_bytes();
+    assert_eq!(&bytes[32..40], &deferred.to_bytes());
+    assert_eq!(&bytes[40..48], &ironwood.to_bytes());
+
+    let pre_ironwood = ValueBalance::<NonNegative>::from_bytes(&bytes[..40])
+        .expect("40-byte value balance parses");
+    assert_eq!(pre_ironwood.orchard_amount(), orchard);
+    assert_eq!(pre_ironwood.deferred_amount(), deferred);
+    assert_eq!(
+        pre_ironwood.ironwood_amount(),
+        Amount::<NonNegative>::zero()
+    );
+    assert_eq!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes),
+        Ok(value_balance)
+    );
+}
+
+#[test]
+fn value_balance_bytes_report_invalid_tail_pool() {
+    let _init_guard = zakura_test::init();
+
+    let mut bytes = ValueBalance::<NonNegative>::zero().to_bytes();
+    bytes[32..40].copy_from_slice(&(-1_i64).to_le_bytes());
+    assert!(matches!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes),
+        Err(ValueBalanceError::Deferred(_))
+    ));
+
+    bytes[32..40].copy_from_slice(&0_i64.to_le_bytes());
+    bytes[40..48].copy_from_slice(&(-1_i64).to_le_bytes());
+    assert!(matches!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes),
+        Err(ValueBalanceError::Ironwood(_))
+    ));
+    assert_eq!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes[..47]),
+        Err(ValueBalanceError::Unparsable)
+    );
+}

--- a/zakura-chain/src/work/equihash.rs
+++ b/zakura-chain/src/work/equihash.rs
@@ -94,9 +94,9 @@ impl Solution {
     /// the attacker-controlled solution length. A solution whose variant does
     /// not match the parameters `network` requires is rejected: Mainnet and
     /// Testnet require the memory-hard `(200, 9)` [`Solution::Common`]
-    /// solution, and the toy `(48, 5)` [`Solution::Regtest`] solution is only
-    /// accepted on Regtest. This prevents a peer from downgrading the proof of
-    /// work by choosing the on-wire solution length.
+    /// solution, while Regtest requires the toy `(48, 5)`
+    /// [`Solution::Regtest`] solution. This prevents a peer from changing the
+    /// proof-of-work parameters by choosing the on-wire solution length.
     #[allow(clippy::unwrap_in_result)]
     pub fn check(&self, header: &Header, network: &Network) -> Result<(), Error> {
         // TODO:
@@ -106,15 +106,13 @@ impl Solution {
             // Mainnet and Testnet require the memory-hard (200, 9) parameters,
             // encoded as a 1344-byte `Common` solution.
             (false, Solution::Common(_)) => (200, 9),
-            // Regtest accepts either the toy (48, 5) solution used by its
-            // genesis block or a full (200, 9) solution from a miner.
-            (true, Solution::Common(_)) => (200, 9),
+            // Regtest requires the toy (48, 5) parameters used by zcashd.
             (true, Solution::Regtest(_)) => (REGTEST_N, REGTEST_K),
-            // A 36-byte `Regtest`-shaped solution is not a valid proof of work
-            // on Mainnet or Testnet. Reject it before selecting parameters, so
-            // the attacker-controlled solution length cannot downgrade the PoW
-            // to the trivial (48, 5) parameter set.
-            (false, Solution::Regtest(_)) => {
+            // Reject a solution variant that does not match the active
+            // network before selecting parameters. Otherwise the
+            // attacker-controlled solution length could change the PoW
+            // parameter set.
+            (false, Solution::Regtest(_)) | (true, Solution::Common(_)) => {
                 return Err(Error::InvalidSolutionSize {
                     network: network.clone(),
                 })

--- a/zakura-chain/src/work/tests/vectors.rs
+++ b/zakura-chain/src/work/tests/vectors.rs
@@ -1,5 +1,5 @@
 use crate::{
-    block::{Block, MAX_BLOCK_BYTES},
+    block::{genesis::regtest_genesis_block, Block, MAX_BLOCK_BYTES},
     parameters::Network,
     serialization::{
         CompactSizeMessage, SerializationError, ZcashDeserialize, ZcashDeserializeInto,
@@ -176,4 +176,28 @@ fn regtest_solution_is_rejected_off_regtest() {
         ),
         "a Regtest solution must be accepted for verification on Regtest",
     );
+}
+
+#[test]
+fn real_regtest_solution_is_bound_to_regtest_parameters() {
+    let _init_guard = zakura_test::init();
+
+    let block = regtest_genesis_block();
+    let header = block.header.as_ref();
+    let regtest = Network::new_regtest(Default::default());
+
+    header
+        .solution
+        .check(header, &regtest)
+        .expect("the hard-coded Regtest genesis solution must verify on Regtest");
+
+    for network in [Network::Mainnet, Network::new_default_testnet()] {
+        assert!(
+            matches!(
+                header.solution.check(header, &network),
+                Err(Error::InvalidSolutionSize { .. }),
+            ),
+            "a real Regtest proof must not verify on {network}",
+        );
+    }
 }

--- a/zakura-chain/src/work/tests/vectors.rs
+++ b/zakura-chain/src/work/tests/vectors.rs
@@ -57,6 +57,9 @@ fn equihash_solution_test_vectors_are_valid() -> color_eyre::eyre::Result<()> {
 static EQUIHASH_SIZE_TESTS: &[usize] = &[
     0,
     1,
+    REGTEST_SOLUTION_SIZE - 1,
+    REGTEST_SOLUTION_SIZE,
+    REGTEST_SOLUTION_SIZE + 1,
     SOLUTION_SIZE - 1,
     SOLUTION_SIZE,
     SOLUTION_SIZE + 1,
@@ -71,18 +74,34 @@ fn equihash_solution_size_field() {
     for size in EQUIHASH_SIZE_TESTS.iter().copied() {
         let mut data = Vec::new();
 
-        let size: CompactSizeMessage = size
+        let compact_size: CompactSizeMessage = size
             .try_into()
             .expect("test size fits in MAX_PROTOCOL_MESSAGE_LEN");
-        size.zcash_serialize(&mut data)
+        compact_size
+            .zcash_serialize(&mut data)
             .expect("CompactSize should serialize");
         data.resize(data.len() + SOLUTION_SIZE, 0);
 
         let result = Solution::zcash_deserialize(data.as_slice());
-        if size == SOLUTION_SIZE.try_into().unwrap() {
-            result.expect("Correct size field in EquihashSolution should deserialize");
-        } else {
-            result.expect_err("Wrong size field in EquihashSolution should fail on deserialize");
+        match size {
+            REGTEST_SOLUTION_SIZE => assert!(
+                matches!(
+                    result.expect("Regtest size field in EquihashSolution should deserialize"),
+                    Solution::Regtest(_),
+                ),
+                "Regtest size field should deserialize as a Regtest solution",
+            ),
+            SOLUTION_SIZE => assert!(
+                matches!(
+                    result.expect("Common size field in EquihashSolution should deserialize"),
+                    Solution::Common(_),
+                ),
+                "Common size field should deserialize as a Common solution",
+            ),
+            _ => {
+                result
+                    .expect_err("Wrong size field in EquihashSolution should fail on deserialize");
+            }
         }
     }
 }

--- a/zakura-chain/src/work/tests/vectors.rs
+++ b/zakura-chain/src/work/tests/vectors.rs
@@ -201,3 +201,30 @@ fn real_regtest_solution_is_bound_to_regtest_parameters() {
         );
     }
 }
+
+/// Regression test for the reverse network-parameter mismatch.
+///
+/// A known-valid Mainnet `(200, 9)` proof must not be accepted under Regtest's
+/// `(48, 5)` parameters.
+#[test]
+fn real_common_solution_is_rejected_on_regtest() {
+    let _init_guard = zakura_test::init();
+
+    let block = Block::zcash_deserialize(zakura_test::vectors::BLOCKS[0])
+        .expect("block test vector should deserialize");
+    let header = block.header.as_ref();
+    let regtest = Network::new_regtest(Default::default());
+
+    header
+        .solution
+        .check(header, &Network::Mainnet)
+        .expect("the hard-coded Mainnet solution must verify on Mainnet");
+
+    assert!(
+        matches!(
+            header.solution.check(header, &regtest),
+            Err(Error::InvalidSolutionSize { .. }),
+        ),
+        "a real Common proof must not verify on Regtest",
+    );
+}

--- a/zakura-consensus/src/block/check.rs
+++ b/zakura-consensus/src/block/check.rs
@@ -165,10 +165,7 @@ pub fn subsidy_is_valid(
     net: &Network,
     expected_block_subsidy: Amount<NonNegative>,
 ) -> Result<DeferredPoolBalanceChange, BlockError> {
-    if expected_block_subsidy.is_zero() {
-        return Ok(DeferredPoolBalanceChange::zero());
-    }
-
+    // Zero subsidy does not disable NU6.1's one-time lockbox disbursement rule.
     let height = block.coinbase_height().ok_or(SubsidyError::NoCoinbase)?;
 
     let mut coinbase_outputs: MultiSet<Output> = block

--- a/zakura-consensus/src/block/tests.rs
+++ b/zakura-consensus/src/block/tests.rs
@@ -19,7 +19,7 @@ use zakura_chain::{
     orchard,
     parameters::{
         subsidy::block_subsidy,
-        testnet::{ConfiguredActivationHeights, Parameters},
+        testnet::{ConfiguredActivationHeights, ConfiguredLockboxDisbursement, Parameters},
         NetworkUpgrade,
     },
     primitives::Halo2Proof,
@@ -379,12 +379,92 @@ fn local_genesis_nu6_3_activation_has_satisfiable_lockbox_rule() -> Result<(), R
     let expected_block_subsidy =
         block_subsidy(height, &network).expect("the local activation height has a block subsidy");
 
-    // `subsidy_is_valid` skips all checks (including the lockbox rule) for a
-    // zero subsidy, which would make this test vacuous.
+    // Keep this fixture representative of a funded activation block; the
+    // zero-subsidy lockbox edge is covered separately below.
     assert!(!expected_block_subsidy.is_zero());
     assert_eq!(
         subsidy_is_valid(&block, &network, expected_block_subsidy)?,
         DeferredPoolBalanceChange::zero()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn zero_subsidy_does_not_skip_nu6_1_lockbox_outputs() -> Result<(), Report> {
+    let height = Height(100_000_000);
+    let network = Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            blossom: Some(1),
+            canopy: Some(1),
+            nu5: Some(1),
+            nu6: Some(1),
+            nu6_1: Some(height.0),
+            ..Default::default()
+        })
+        .expect("failed to set activation heights")
+        .clear_funding_streams()
+        .with_lockbox_disbursements(vec![ConfiguredLockboxDisbursement {
+            address: "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz".to_string(),
+            amount: Amount::try_from(1).expect("valid test amount"),
+        }])
+        .to_network()
+        .expect("failed to build configured network");
+    let expected_block_subsidy =
+        block_subsidy(height, &network).expect("valid block subsidy at test height");
+    assert!(expected_block_subsidy.is_zero());
+    let lockbox_disbursements = network.lockbox_disbursements(height);
+    let [(lockbox_address, lockbox_amount)] = lockbox_disbursements.as_slice() else {
+        panic!("the test network configures one lockbox disbursement output");
+    };
+
+    let genesis = Block::zcash_deserialize(&zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])
+        .expect("genesis block should deserialize");
+    let block = |outputs| Block {
+        header: genesis.header.clone(),
+        transactions: vec![Arc::new(Transaction::V5 {
+            network_upgrade: NetworkUpgrade::Nu6_1,
+            lock_time: LockTime::unlocked(),
+            expiry_height: height,
+            inputs: vec![transparent::Input::Coinbase {
+                height,
+                data: vec![],
+                sequence: u32::MAX,
+            }],
+            outputs,
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+        })],
+    };
+
+    assert_eq!(
+        subsidy_is_valid(&block(vec![]), &network, expected_block_subsidy),
+        Err(BlockError::Transaction(TransactionError::Subsidy(
+            SubsidyError::OneTimeLockboxDisbursementNotFound,
+        )))
+    );
+    let block_with_disbursement = block(vec![transparent::Output::new(
+        *lockbox_amount,
+        lockbox_address.script(),
+    )]);
+    let deferred_pool_balance_change =
+        subsidy_is_valid(&block_with_disbursement, &network, expected_block_subsidy)?;
+    assert_eq!(
+        deferred_pool_balance_change,
+        DeferredPoolBalanceChange::new(
+            Amount::<NegativeAllowed>::try_from(-1).expect("valid test amount"),
+        )
+    );
+    assert_eq!(
+        check::miner_fees_are_valid(
+            check::coinbase_is_first(&block_with_disbursement)?.as_ref(),
+            height,
+            Amount::zero(),
+            expected_block_subsidy,
+            deferred_pool_balance_change,
+            &network,
+        ),
+        Ok(())
     );
 
     Ok(())
@@ -852,7 +932,7 @@ fn miner_fees_validation_includes_ironwood_balance() {
         .expect("failed to build configured network");
     let height = Height(1);
     let output_value = Amount::try_from(10).expect("valid test amount");
-    let coinbase_tx = Transaction::V6 {
+    let coinbase_tx = |ironwood_value_balance| Transaction::V6 {
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::Height(Height(0)),
         expiry_height: height,
@@ -867,12 +947,13 @@ fn miner_fees_validation_includes_ironwood_balance() {
         }],
         sapling_shielded_data: None,
         orchard_shielded_data: None,
-        ironwood_shielded_data: Some(ironwood_shielded_data(1)),
+        ironwood_shielded_data: Some(ironwood_shielded_data(ironwood_value_balance)),
     };
+    let coinbase_with_withdrawal = coinbase_tx(1);
 
     assert_eq!(
         check::miner_fees_are_valid(
-            &coinbase_tx,
+            &coinbase_with_withdrawal,
             height,
             Amount::zero(),
             output_value,
@@ -886,10 +967,38 @@ fn miner_fees_validation_includes_ironwood_balance() {
 
     assert_eq!(
         check::miner_fees_are_valid(
-            &coinbase_tx,
+            &coinbase_with_withdrawal,
             height,
             Amount::zero(),
             Amount::try_from(9).expect("valid test amount"),
+            DeferredPoolBalanceChange::zero(),
+            &network,
+        ),
+        Ok(())
+    );
+
+    let coinbase_with_deposit = coinbase_tx(-1);
+
+    assert_eq!(
+        check::miner_fees_are_valid(
+            &coinbase_with_deposit,
+            height,
+            Amount::zero(),
+            output_value,
+            DeferredPoolBalanceChange::zero(),
+            &network,
+        ),
+        Err(BlockError::Transaction(TransactionError::Subsidy(
+            SubsidyError::InvalidMinerFees,
+        )))
+    );
+
+    assert_eq!(
+        check::miner_fees_are_valid(
+            &coinbase_with_deposit,
+            height,
+            Amount::zero(),
+            Amount::try_from(11).expect("valid test amount"),
             DeferredPoolBalanceChange::zero(),
             &network,
         ),

--- a/zakura-consensus/src/block/tests.rs
+++ b/zakura-consensus/src/block/tests.rs
@@ -15,6 +15,7 @@ use zakura_chain::{
         },
         Block, Height,
     },
+    local_genesis::generate_local_testnet_with_funded_keys,
     orchard,
     parameters::{
         subsidy::block_subsidy,
@@ -323,6 +324,68 @@ fn subsidy_is_valid_for_network(network: Network) -> Result<(), Report> {
                 .expect("subsidies should pass for this block");
         }
     }
+
+    Ok(())
+}
+
+/// A generated local testnet's NU6.3 activation block must be able to satisfy
+/// the ZIP-271 lockbox-disbursement subsidy rule.
+///
+/// NU6.1's activation height falls through to the shared activation height of
+/// the local network, so `subsidy_is_valid` demands its one-time disbursement
+/// outputs there. The generated network configures a zero-value P2SH marker
+/// for this, so a coinbase that pays that marker must pass with no deferred
+/// pool change.
+#[test]
+fn local_genesis_nu6_3_activation_has_satisfiable_lockbox_rule() -> Result<(), Report> {
+    let generated = generate_local_testnet_with_funded_keys(
+        vec!["alice".to_string(), "bob".to_string()],
+        Default::default(),
+    )
+    .map_err(|error| eyre!(error.to_string()))?;
+    let network = generated.network;
+    let height = NetworkUpgrade::Nu6_3
+        .activation_height(&network)
+        .expect("the default local network activates NU6.3");
+    let lockbox_disbursements = network.lockbox_disbursements(height);
+    let [(lockbox_address, lockbox_amount)] = lockbox_disbursements.as_slice() else {
+        panic!("the local network configures one lockbox marker output");
+    };
+    let coinbase = Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: height,
+        inputs: vec![zakura_chain::transparent::Input::Coinbase {
+            height,
+            data: b"local activation".to_vec(),
+            sequence: 0,
+        }],
+        outputs: vec![zakura_chain::transparent::Output::new(
+            *lockbox_amount,
+            lockbox_address.script(),
+        )],
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+    let block = Block {
+        header: generated
+            .blocks
+            .last()
+            .expect("the generated chain contains genesis")
+            .header
+            .clone(),
+        transactions: vec![Arc::new(coinbase)],
+    };
+    let expected_block_subsidy =
+        block_subsidy(height, &network).expect("the local activation height has a block subsidy");
+
+    // `subsidy_is_valid` skips all checks (including the lockbox rule) for a
+    // zero subsidy, which would make this test vacuous.
+    assert!(!expected_block_subsidy.is_zero());
+    assert_eq!(
+        subsidy_is_valid(&block, &network, expected_block_subsidy)?,
+        DeferredPoolBalanceChange::zero()
+    );
 
     Ok(())
 }

--- a/zakura-consensus/src/checkpoint.rs
+++ b/zakura-consensus/src/checkpoint.rs
@@ -1152,11 +1152,12 @@ where
             if req_block.block.auth_data_root.is_none()
                 && NetworkUpgrade::current(&network, req_block.block.height) >= NetworkUpgrade::Nu5
             {
-                let block = req_block.block.block.clone();
-                if let Ok(auth_data_root) =
-                    tokio::task::spawn_blocking(move || block.auth_data_root()).await
+                let block = req_block.block.clone();
+                if let Ok(block) =
+                    tokio::task::spawn_blocking(move || block.with_precomputed_auth_data_root())
+                        .await
                 {
-                    req_block.block.auth_data_root = Some(auth_data_root);
+                    req_block.block = block;
                 }
             }
 

--- a/zakura-consensus/src/checkpoint/tests.rs
+++ b/zakura-consensus/src/checkpoint/tests.rs
@@ -9,7 +9,11 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::time::timeout;
 use tracing_futures::Instrument;
 
-use zakura_chain::{parameters::Network::*, serialization::ZcashDeserialize};
+use zakura_chain::{
+    local_genesis::{generate_local_testnet_with_funded_keys, LocalTestnetGenesisOptions},
+    parameters::Network::*,
+    serialization::ZcashDeserialize,
+};
 
 use super::*;
 
@@ -196,6 +200,57 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
     assert_eq!(
         checkpoint_verifier.checkpoint_list.max_height(),
         block::Height(1)
+    );
+
+    Ok(())
+}
+
+/// Every block of a generated local testnet (genesis, premine, and maturity
+/// padding) must verify against the network's own configured checkpoints, and
+/// the verifier must finish once the last generated block is in.
+///
+/// The generated network checkpoints every seed block, so this exercises the
+/// checkpoint path a fresh local-genesis node uses to accept its seed chain.
+#[tokio::test(flavor = "multi_thread")]
+async fn generated_local_seed_chain_passes_checkpoint_verification() -> Result<(), Report> {
+    let _init_guard = zakura_test::init();
+    let generated = generate_local_testnet_with_funded_keys(
+        vec!["alice".to_string(), "bob".to_string()],
+        LocalTestnetGenesisOptions {
+            maturity_padding_blocks: 2,
+            ..Default::default()
+        },
+    )
+    .map_err(|error| eyre!(error.to_string()))?;
+    let network = generated.network;
+    let state_service = zakura_state::init_test(&network).await;
+    let mut checkpoint_verifier = CheckpointVerifier::new(&network, None, state_service);
+
+    for block in generated.blocks {
+        let block = Arc::new(block);
+        let expected_hash = block.hash();
+        let response = timeout(
+            Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
+            checkpoint_verifier
+                .ready()
+                .map_err(|error| eyre!(error))
+                .await?
+                .call(block),
+        )
+        .await
+        .expect("generated checkpoint verification should not time out")
+        .expect("generated seed block should verify");
+
+        assert_eq!(response, expected_hash);
+    }
+
+    assert_eq!(
+        checkpoint_verifier.previous_checkpoint_height(),
+        FinalCheckpoint
+    );
+    assert_eq!(
+        checkpoint_verifier.target_checkpoint_height(),
+        FinishedVerifying
     );
 
     Ok(())

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -615,11 +615,6 @@ where
                     sigops: sigops.saturating_add(cached_ffi_transaction.p2sh_sigops()),
                 },
                 Request::Mempool { transaction: tx, .. } => {
-                    // TODO: `spent_outputs` may not align with `tx.inputs()` when a transaction
-                    // spends both chain and mempool UTXOs (mempool outputs are appended last by
-                    // `spent_utxos()`), causing policy checks to pair the wrong input with
-                    // the wrong spent output.
-                    // https://github.com/ZcashFoundation/zebra/issues/10346
                     let spent_outputs = cached_ffi_transaction.all_previous_outputs().clone();
                     let transaction = VerifiedUnminedTx::new(
                         tx,

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -1106,6 +1106,140 @@ async fn mempool_request_with_unmined_output_spends_is_accepted() {
     );
 }
 
+#[tokio::test]
+async fn mempool_mixed_chain_and_unmined_spends_preserve_input_order() {
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let mempool: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let (mempool_setup_tx, mempool_setup_rx) = tokio::sync::oneshot::channel();
+    let verifier = Verifier::new(&Network::Mainnet, state.clone(), mempool_setup_rx);
+    mempool_setup_tx
+        .send(mempool.clone())
+        .ok()
+        .expect("send should succeed");
+
+    let height = NetworkUpgrade::Canopy
+        .activation_height(&Network::Mainnet)
+        .expect("Canopy activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+
+    const OP_TRUE: u8 = 0x51;
+    const OP_2: u8 = 0x52;
+    const OP_TRUE_HASH160: [u8; 20] = [
+        0xda, 0x17, 0x45, 0xe9, 0xb5, 0x49, 0xbd, 0x0b, 0xfa, 0x1a, 0x56, 0x99, 0x71, 0xc7, 0x7e,
+        0xba, 0x30, 0xcd, 0x5a, 0x4b,
+    ];
+    const OP_2_HASH160: [u8; 20] = [
+        0x69, 0xd7, 0xef, 0x8f, 0x42, 0xa2, 0x5e, 0x87, 0x91, 0xbb, 0x37, 0xd5, 0xfb, 0x48, 0x45,
+        0x6f, 0x10, 0x2a, 0x3c, 0xb9,
+    ];
+
+    let (mempool_input, mempool_output, mempool_known_utxos) =
+        mock_transparent_transfer_with_p2sh_redeem_script(
+            fund_height,
+            true,
+            0,
+            Amount::try_from(10_001).expect("valid amount"),
+            OP_TRUE,
+            OP_TRUE_HASH160,
+        );
+    let (chain_input, chain_output, chain_known_utxos) =
+        mock_transparent_transfer_with_p2sh_redeem_script(
+            fund_height,
+            true,
+            1,
+            Amount::try_from(10_001).expect("valid amount"),
+            OP_2,
+            OP_2_HASH160,
+        );
+
+    let tx = Transaction::V4 {
+        inputs: vec![mempool_input, chain_input],
+        outputs: vec![mempool_output, chain_output],
+        lock_time: LockTime::min_lock_time_timestamp(),
+        expiry_height: height,
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let mempool_outpoint = tx.inputs()[0].outpoint().expect("first input is a prevout");
+    let chain_outpoint = tx.inputs()[1]
+        .outpoint()
+        .expect("second input is a prevout");
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zakura_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zakura_state::Response::BestChainNextMedianTimePast(
+                DateTime32::MAX,
+            ));
+
+        state
+            .expect_request(zakura_state::Request::UnspentBestChainUtxo(
+                mempool_outpoint,
+            ))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zakura_state::Response::UnspentBestChainUtxo(None));
+
+        state
+            .expect_request(zakura_state::Request::UnspentBestChainUtxo(chain_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zakura_state::Response::UnspentBestChainUtxo(
+                chain_known_utxos
+                    .get(&chain_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zakura_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zakura_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let mut mempool_clone = mempool.clone();
+    tokio::spawn(async move {
+        mempool_clone
+            .expect_request(mempool::Request::AwaitOutput(mempool_outpoint))
+            .await
+            .expect("verifier should call mock mempool service with correct request")
+            .respond(mempool::Response::UnspentOutput(
+                mempool_known_utxos
+                    .get(&mempool_outpoint)
+                    .expect("mempool outpoint should exist in known_utxos")
+                    .utxo
+                    .output
+                    .clone(),
+            ));
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await
+        .expect("mixed state and mempool spends should verify");
+
+    let crate::transaction::Response::Mempool {
+        transaction: _,
+        spent_mempool_outpoints,
+    } = verifier_response
+    else {
+        panic!("unexpected response variant from transaction verifier for Mempool request")
+    };
+
+    assert_eq!(spent_mempool_outpoints, vec![mempool_outpoint]);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn dont_skip_verification_of_block_transactions_in_mempool() {
     let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
@@ -4130,21 +4264,44 @@ fn mock_transparent_transfer(
     transparent::Output,
     HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
 ) {
-    // A standard, signature-free P2SH input that the script interpreter accepts. The redeem
-    // script is OP_TRUE, so the spend is valid without a signature, while the spent output is a
-    // standard P2SH `scriptPubKey`. This lets the input pass the mempool `AreInputsStandard`
-    // gate (`check::mempool_standard_input_scripts`) that now runs before script verification,
-    // as well as the interpreter itself.
     const OP_TRUE: u8 = 0x51;
-    // `scriptSig`: a single push of the OP_TRUE redeem script (push-only, one stack item).
-    let accepting_unlock_script = transparent::Script::new(&[0x01, OP_TRUE]);
-    // `scriptPubKey`: OP_HASH160 <HASH160(OP_TRUE)> OP_EQUAL. The 20-byte hash is precomputed
-    // (RIPEMD160(SHA256([OP_TRUE]))) so the P2SH hash check passes during verification.
-    let mut p2sh_lock_bytes = vec![0xa9, 0x14];
-    p2sh_lock_bytes.extend_from_slice(&[
+    const OP_TRUE_HASH160: [u8; 20] = [
         0xda, 0x17, 0x45, 0xe9, 0xb5, 0x49, 0xbd, 0x0b, 0xfa, 0x1a, 0x56, 0x99, 0x71, 0xc7, 0x7e,
         0xba, 0x30, 0xcd, 0x5a, 0x4b,
-    ]);
+    ];
+
+    mock_transparent_transfer_with_p2sh_redeem_script(
+        previous_utxo_height,
+        script_should_succeed,
+        outpoint_index,
+        previous_output_value,
+        OP_TRUE,
+        OP_TRUE_HASH160,
+    )
+}
+
+fn mock_transparent_transfer_with_p2sh_redeem_script(
+    previous_utxo_height: block::Height,
+    script_should_succeed: bool,
+    outpoint_index: u32,
+    previous_output_value: Amount<NonNegative>,
+    redeem_script_opcode: u8,
+    redeem_script_hash160: [u8; 20],
+) -> (
+    transparent::Input,
+    transparent::Output,
+    HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+) {
+    // A standard, signature-free P2SH input that the script interpreter accepts. The redeem
+    // script is a true-valued opcode, so the spend is valid without a signature, while the spent
+    // output is a standard P2SH `scriptPubKey`. This lets the input pass the mempool `AreInputsStandard`
+    // gate (`check::mempool_standard_input_scripts`) that now runs before script verification,
+    // as well as the interpreter itself.
+    // `scriptSig`: a single push of the redeem script (push-only, one stack item).
+    let accepting_unlock_script = transparent::Script::new(&[0x01, redeem_script_opcode]);
+    // `scriptPubKey`: OP_HASH160 <HASH160(redeem script)> OP_EQUAL.
+    let mut p2sh_lock_bytes = vec![0xa9, 0x14];
+    p2sh_lock_bytes.extend_from_slice(&redeem_script_hash160);
     p2sh_lock_bytes.push(0x87);
     let accepting_lock_script = transparent::Script::new(&p2sh_lock_bytes);
     // A script with a single opcode that rejects the transaction (OP_FALSE). Only used for block

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -27,7 +27,9 @@ use zakura_chain::{
     },
     primitives::{ed25519, x25519, Groth16Proof},
     sapling,
-    serialization::{AtLeastOne, DateTime32, ZcashDeserialize, ZcashDeserializeInto},
+    serialization::{
+        AtLeastOne, DateTime32, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+    },
     sprout,
     transaction::{
         arbitrary::{
@@ -413,6 +415,29 @@ fn ironwood_cross_address_flag_is_optional_after_nu6_3() {
     assert_eq!(
         check::orchard_cross_address_disabled(&ironwood_with_cross_address),
         Ok(())
+    );
+}
+
+#[test]
+fn ironwood_cross_address_only_is_not_a_spend_or_output_flag() {
+    let tx = v6_pool_flow_transaction(
+        None,
+        Some(ironwood_shielded_data(
+            0,
+            ironwood::Flags::ENABLE_CROSS_ADDRESS,
+        )),
+        vec![],
+    );
+
+    assert!(!tx.has_shielded_inputs());
+    assert!(!tx.has_shielded_outputs());
+    assert_eq!(
+        check::has_inputs_and_outputs(&tx),
+        Err(TransactionError::NoInputs)
+    );
+    assert_eq!(
+        check::has_enough_ironwood_flags(&tx),
+        Err(TransactionError::NotEnoughIronwoodFlags)
     );
 }
 
@@ -3122,6 +3147,162 @@ fn sapling_output_with_invalid_ephemeral_key_is_rejected() {
     });
 }
 
+/// A transaction whose Sapling output has an invalid (off-curve) value
+/// commitment is rejected by the verifier with `SmallOrder`.
+///
+/// Unlike the ephemeral-key regression above, this also round-trips the
+/// corrupted V4 transaction through serialization. That pins the lazy V4
+/// output path: the parser preserves the raw `cv` bytes, and the early
+/// semantic check rejects them before any state lookup.
+#[test]
+fn sapling_v4_output_with_invalid_value_commitment_is_rejected_after_roundtrip() {
+    let _init_guard = zakura_test::init();
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let network = Network::Mainnet;
+
+        let (height, mut transaction) = test_transactions(&network)
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                transaction.sapling_spends_per_anchor().next().is_none()
+                    && transaction.sapling_outputs().next().is_some()
+            })
+            .expect("a V4 transaction with Sapling outputs and no Sapling spends");
+
+        assert!(
+            matches!(transaction.as_ref(), Transaction::V4 { .. }),
+            "test vector must exercise the V4 output encoding"
+        );
+
+        corrupt_first_sapling_output_value_commitment(
+            Arc::get_mut(&mut transaction).expect("transaction only has one active reference"),
+        );
+
+        let serialized = transaction
+            .zcash_serialize_to_vec()
+            .expect("corrupted V4 transaction must serialize raw Sapling cv bytes");
+        let transaction = Arc::new(
+            serialized
+                .zcash_deserialize_into::<Transaction>()
+                .expect("lazy V4 output deserialization must preserve invalid cv bytes"),
+        );
+
+        assert!(
+            !transaction.sapling_point_encodings_are_valid(),
+            "the deferred Sapling point check must reject the round-tripped invalid cv"
+        );
+
+        let state_service =
+            service_fn(|_| async { unreachable!("State service should not be called") });
+        let verifier = Verifier::new_for_tests(&network, state_service);
+
+        let result = verifier
+            .oneshot(Request::Block {
+                transaction_hash: transaction.hash(),
+                transaction,
+                known_utxos: Arc::new(HashMap::new()),
+                known_outpoint_hashes: Arc::new(HashSet::new()),
+                height,
+                time: DateTime::<Utc>::MAX_UTC,
+            })
+            .await;
+
+        assert_eq!(
+            result,
+            Err(TransactionError::SmallOrder),
+            "a V4 Sapling output with an off-curve cv must be rejected with SmallOrder",
+        );
+    });
+}
+
+/// Transactions whose Sapling spend has an invalid (off-curve) value
+/// commitment are rejected by the verifier with `SmallOrder`.
+///
+/// This pins both spend encodings affected by lazy Sapling `cv` parsing:
+/// V4 stores the full `Spend<PerSpendAnchor>` inline, while V5 stores the
+/// `SpendPrefixInTransactionV5` fields separately. In both cases the parser
+/// preserves the raw bytes and the early semantic check rejects them before
+/// any state lookup.
+#[test]
+fn sapling_spends_with_invalid_value_commitments_are_rejected_after_roundtrip() {
+    let _init_guard = zakura_test::init();
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let network = Network::Mainnet;
+
+        let v4 = test_transactions(&network)
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                matches!(transaction.as_ref(), Transaction::V4 { .. })
+                    && transaction.sapling_spends_per_anchor().next().is_some()
+            })
+            .expect("a V4 transaction with Sapling spends");
+
+        let v5 = transactions_from_blocks(network.block_iter())
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                matches!(transaction.as_ref(), Transaction::V5 { .. })
+                    && transaction.sapling_spends_per_anchor().next().is_some()
+            })
+            .expect("a V5 transaction with Sapling spends");
+
+        for (version, height, mut transaction) in [("V4", v4.0, v4.1), ("V5", v5.0, v5.1)] {
+            corrupt_first_sapling_spend_value_commitment(
+                Arc::get_mut(&mut transaction).expect("transaction only has one active reference"),
+            );
+
+            let serialized = transaction
+                .zcash_serialize_to_vec()
+                .expect("corrupted transaction must serialize raw Sapling cv bytes");
+            let transaction = Arc::new(
+                serialized
+                    .zcash_deserialize_into::<Transaction>()
+                    .expect("lazy spend deserialization must preserve invalid cv bytes"),
+            );
+            assert_eq!(
+                serialized,
+                transaction
+                    .zcash_serialize_to_vec()
+                    .expect("round-tripped transaction must reserialize"),
+                "lazy {version} spend cv bytes must round-trip exactly",
+            );
+
+            assert!(
+                !transaction.sapling_point_encodings_are_valid(),
+                "the deferred Sapling point check must reject the round-tripped {version} spend cv"
+            );
+
+            let state_service =
+                service_fn(|_| async { unreachable!("State service should not be called") });
+            let verifier = Verifier::new_for_tests(&network, state_service);
+
+            let result = verifier
+                .oneshot(Request::Block {
+                    transaction_hash: transaction.hash(),
+                    transaction,
+                    known_utxos: Arc::new(HashMap::new()),
+                    known_outpoint_hashes: Arc::new(HashSet::new()),
+                    height,
+                    time: DateTime::<Utc>::MAX_UTC,
+                })
+                .await;
+
+            assert_eq!(
+                result,
+                Err(TransactionError::SmallOrder),
+                "a {version} Sapling spend with an off-curve cv must be rejected with SmallOrder",
+            );
+        }
+    });
+}
+
 /// Replaces the first Sapling output's ephemeral key with an off-curve point,
 /// for `sapling_output_with_invalid_ephemeral_key_is_rejected`.
 fn corrupt_first_sapling_output_ephemeral_key(transaction: &mut Transaction) {
@@ -3141,6 +3322,46 @@ fn corrupt_first_sapling_output_ephemeral_key(transaction: &mut Transaction) {
     }
 }
 
+/// Replaces the first Sapling output's value commitment with off-curve bytes,
+/// for `sapling_v4_output_with_invalid_value_commitment_is_rejected_after_roundtrip`.
+fn corrupt_first_sapling_output_value_commitment(transaction: &mut Transaction) {
+    let bad_cv = [0xffu8; 32][..]
+        .zcash_deserialize_into::<sapling::ValueCommitment>()
+        .expect("deserialization defers point validation, so it stores the bytes");
+
+    match transaction {
+        Transaction::V4 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_output_value_commitment(&mut shielded_data.transfers, bad_cv),
+        _ => panic!("expected a V4 transaction with Sapling data"),
+    }
+}
+
+/// Replaces the first Sapling spend's value commitment with off-curve bytes,
+/// for `sapling_spends_with_invalid_value_commitments_are_rejected_after_roundtrip`.
+fn corrupt_first_sapling_spend_value_commitment(transaction: &mut Transaction) {
+    let bad_cv = [0xffu8; 32][..]
+        .zcash_deserialize_into::<sapling::ValueCommitment>()
+        .expect("deserialization defers point validation, so it stores the bytes");
+
+    match transaction {
+        Transaction::V4 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_value_commitment(&mut shielded_data.transfers, bad_cv),
+        Transaction::V5 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_value_commitment(&mut shielded_data.transfers, bad_cv),
+        Transaction::V6 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_value_commitment(&mut shielded_data.transfers, bad_cv),
+        _ => panic!("expected a V4, V5, or V6 transaction with Sapling data"),
+    }
+}
+
 fn set_first_sapling_output_ephemeral_key<A: sapling::AnchorVariant + Clone>(
     transfers: &mut sapling::TransferData<A>,
     ephemeral_key: sapling::keys::EphemeralPublicKey,
@@ -3154,6 +3375,40 @@ fn set_first_sapling_output_ephemeral_key<A: sapling::AnchorVariant + Clone>(
         }
         sapling::TransferData::SpendsAndMaybeOutputs { maybe_outputs, .. } => {
             maybe_outputs[0].ephemeral_key = ephemeral_key;
+        }
+    }
+}
+
+fn set_first_sapling_output_value_commitment<A: sapling::AnchorVariant + Clone>(
+    transfers: &mut sapling::TransferData<A>,
+    value_commitment: sapling::ValueCommitment,
+) {
+    match transfers {
+        sapling::TransferData::JustOutputs { outputs } => {
+            let mut outputs_vec = outputs.as_slice().to_vec();
+            outputs_vec[0].cv = value_commitment;
+            *outputs = AtLeastOne::from_vec(outputs_vec)
+                .expect("replacing a field keeps at least one output");
+        }
+        sapling::TransferData::SpendsAndMaybeOutputs { maybe_outputs, .. } => {
+            maybe_outputs[0].cv = value_commitment;
+        }
+    }
+}
+
+fn set_first_sapling_spend_value_commitment<A: sapling::AnchorVariant + Clone>(
+    transfers: &mut sapling::TransferData<A>,
+    value_commitment: sapling::ValueCommitment,
+) {
+    match transfers {
+        sapling::TransferData::SpendsAndMaybeOutputs { spends, .. } => {
+            let mut spends_vec = spends.as_slice().to_vec();
+            spends_vec[0].cv = value_commitment;
+            *spends = AtLeastOne::from_vec(spends_vec)
+                .expect("replacing a field keeps at least one spend");
+        }
+        sapling::TransferData::JustOutputs { .. } => {
+            panic!("expected Sapling shielded data with spends")
         }
     }
 }

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -83,6 +83,38 @@ fn v5_transactions_basic_check() -> Result<(), Report> {
     Ok(())
 }
 
+/// Orchard and Ironwood nullifiers are separate namespaces: a V6 transaction
+/// whose Orchard and Ironwood bundles happen to contain bit-identical
+/// nullifiers must not be rejected as a double-spend, because each pool tracks
+/// its own nullifier set. `spend_conflicts` must only reject duplicates
+/// *within* a pool.
+#[test]
+fn matching_orchard_and_ironwood_nullifiers_are_not_conflicts() {
+    let _init_guard = zakura_test::init();
+
+    let shielded_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    let transaction = Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: Some(shielded_data.clone()),
+        ironwood_shielded_data: Some(shielded_data),
+    };
+
+    assert_eq!(
+        transaction.orchard_nullifiers().collect::<Vec<_>>(),
+        transaction.ironwood_nullifiers().collect::<Vec<_>>()
+    );
+    check::spend_conflicts(&transaction)
+        .expect("matching bit patterns in separate nullifier sets are not duplicates");
+}
+
 #[test]
 fn v5_transaction_with_orchard_actions_has_inputs_and_outputs() {
     for net in Network::iter() {
@@ -3599,6 +3631,51 @@ async fn orchard_disabling_soft_fork_accepts_orchard_actions_below_activation_he
         )),
         "Orchard transaction must be rejected at the soft fork height",
     );
+}
+
+/// Checks that public-network branch-ID admission switches exactly at NU6.3 activation.
+#[test]
+fn public_nu6_3_consensus_branch_id_boundary() {
+    let mut tx = Transaction::V5 {
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height::MAX_EXPIRY_HEIGHT,
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        network_upgrade: NetworkUpgrade::Nu6_2,
+    };
+
+    for network in Network::iter() {
+        let activation_height = NetworkUpgrade::Nu6_3
+            .activation_height(&network)
+            .expect("NU6.3 is scheduled on both public networks");
+        let previous_height = (activation_height - 1).expect("NU6.3 is not genesis");
+
+        assert_eq!(
+            check::consensus_branch_id(&tx, previous_height, &network),
+            Ok(()),
+        );
+        assert_eq!(
+            check::consensus_branch_id(&tx, activation_height, &network),
+            Err(TransactionError::WrongConsensusBranchId),
+        );
+
+        tx.update_network_upgrade(NetworkUpgrade::Nu6_3)
+            .expect("V5 transactions support the NU6.3 branch ID");
+
+        assert_eq!(
+            check::consensus_branch_id(&tx, previous_height, &network),
+            Err(TransactionError::WrongConsensusBranchId),
+        );
+        assert_eq!(
+            check::consensus_branch_id(&tx, activation_height, &network),
+            Ok(()),
+        );
+
+        tx.update_network_upgrade(NetworkUpgrade::Nu6_2)
+            .expect("V5 transactions support the NU6.2 branch ID");
+    }
 }
 
 /// Checks that the tx verifier handles consensus branch ids in V5 txs correctly.

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -165,6 +165,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Native header sync now skips Equihash and difficulty-filter checks for
+  configured Testnets with `disable_pow = true`, not only Regtest.
 - Legacy peer-set stall tracking no longer disconnects peers for empty
   `FindBlocks` or `FindHeaders` responses when Zebra is at or near the network
   tip.

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -6167,16 +6167,25 @@ async fn stateless_validation_rejects_wrong_solution_size_for_network() {
 }
 
 #[test]
-fn regtest_header_validation_accepts_common_and_short_solution_sizes() {
+fn pow_disabled_header_validation_accepts_common_and_short_solution_sizes() {
     let regtest = Network::new_regtest(Default::default());
+    let custom_testnet = Parameters::build()
+        .with_network_name("HeaderSyncNoPowSizeTest")
+        .expect("custom testnet name is valid")
+        .with_disable_pow(true)
+        .to_network()
+        .expect("custom testnet parameters are valid");
     let common_sized = mainnet_header(&BLOCK_MAINNET_1_BYTES);
     let mut short_sized = *common_sized;
     short_sized.solution = Solution::Regtest([0; 36]);
 
-    validate_solution_sizes(std::slice::from_ref(&common_sized), &regtest)
-        .expect("regtest accepts Zebra-mined common-size solutions");
-    validate_solution_sizes(&[Arc::new(short_sized)], &regtest)
-        .expect("regtest accepts short regtest solutions");
+    for network in [&regtest, &custom_testnet] {
+        validate_solution_sizes(std::slice::from_ref(&common_sized), network)
+            .expect("PoW-disabled networks accept common-size solutions");
+        validate_solution_sizes(&[Arc::new(short_sized)], network)
+            .expect("PoW-disabled networks accept short solutions");
+    }
+
     assert!(matches!(
         validate_solution_sizes(&[Arc::new(short_sized)], &Network::Mainnet),
         Err(HeaderSyncWireError::WrongEquihashSolutionSize)
@@ -6199,6 +6208,33 @@ async fn regtest_stateless_validation_skips_pow_filter() {
     validate_headers_stateless(vec![Arc::new(header)], context)
         .await
         .expect("regtest header sync leaves PoW enforcement to block verification");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_testnet_disable_pow_skips_header_sync_pow_filter() {
+    let network = Parameters::build()
+        .with_network_name("HeaderSyncNoPowTest")
+        .expect("custom testnet name is valid")
+        .with_disable_pow(true)
+        .to_network()
+        .expect("custom testnet parameters are valid");
+    assert!(network.disable_pow());
+    assert!(!network.is_regtest());
+
+    let mut header = *mainnet_header(&BLOCK_MAINNET_1_BYTES);
+    header.nonce[0] ^= 1;
+    header.difficulty_threshold =
+        CompactDifficulty::from_bytes_in_display_order(&[0x01, 0x01, 0x00, 0x00]).unwrap();
+    let context = HeaderSyncValidationContext {
+        network: &network,
+        now: Utc::now(),
+        start_height: block::Height(1),
+        decode_context: headers_context(1, DEFAULT_HS_RANGE),
+    };
+
+    validate_headers_stateless(vec![Arc::new(header)], context)
+        .await
+        .expect("custom disable_pow networks must skip native header-sync PoW checks");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/zakura-network/src/zakura/header_sync/validation.rs
+++ b/zakura-network/src/zakura/header_sync/validation.rs
@@ -253,15 +253,16 @@ pub(super) fn validate_solution_sizes(
     headers: &[Arc<block::Header>],
     network: &Network,
 ) -> Result<(), HeaderSyncWireError> {
-    let expect_regtest = network
-        .parameters()
-        .is_some_and(|parameters| parameters.is_regtest());
+    // PoW-disabled networks do not assign consensus meaning to either
+    // parseable solution variant. Keep native header sync aligned with block
+    // verification, which skips Equihash checks entirely in this mode.
+    if network.disable_pow() {
+        return Ok(());
+    }
+
     for header in headers {
-        match (expect_regtest, header.solution) {
-            (true, equihash::Solution::Regtest(_))
-            | (true, equihash::Solution::Common(_))
-            | (false, equihash::Solution::Common(_)) => {}
-            _ => return Err(HeaderSyncWireError::WrongEquihashSolutionSize),
+        if !matches!(header.solution, equihash::Solution::Common(_)) {
+            return Err(HeaderSyncWireError::WrongEquihashSolutionSize);
         }
     }
     Ok(())
@@ -279,10 +280,9 @@ pub(super) fn validate_pow_blocking(
     headers: &[Arc<block::Header>],
     network: &Network,
 ) -> Result<(), HeaderSyncWireError> {
-    let skip_pow_filter = network
-        .parameters()
-        .is_some_and(|parameters| parameters.is_regtest());
-    if skip_pow_filter {
+    // Custom testnets can disable PoW without using Regtest parameters. Keep
+    // native header sync aligned with semantic and checkpoint verification.
+    if network.disable_pow() {
         return Ok(());
     }
 

--- a/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -11,6 +11,7 @@ use zakura_chain::parameters::testnet::ConfiguredFundingStreamRecipient;
 
 use zakura_chain::{
     block::Height,
+    local_genesis::generate_local_testnet_with_funded_keys,
     parameters::{
         subsidy::FundingStreamReceiver::{Deferred, Ecc, MajorGrants, ZcashFoundation},
         testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams},
@@ -18,6 +19,7 @@ use zakura_chain::{
     },
     serialization::ZcashDeserializeInto,
     transaction::Transaction,
+    transparent,
 };
 
 use crate::client::TransactionTemplate;
@@ -91,6 +93,43 @@ fn coinbase() -> anyhow::Result<()> {
             }
         }
     }
+
+    Ok(())
+}
+
+/// The coinbase built for a local testnet's activation block must include the
+/// network's configured zero-value lockbox marker output, so a mining node
+/// can produce a block that satisfies the one-time ZIP-271 disbursement rule.
+#[test]
+fn local_genesis_activation_coinbase_includes_lockbox_marker() -> anyhow::Result<()> {
+    let generated = generate_local_testnet_with_funded_keys(
+        vec!["alice".to_string(), "bob".to_string()],
+        Default::default(),
+    )
+    .map_err(|error| anyhow!(error.to_string()))?;
+    let net = generated.network;
+    let height = NetworkUpgrade::Nu6_3
+        .activation_height(&net)
+        .expect("the default local network activates NU6.3");
+    let miner_params = MinerParams::from(
+        Address::decode(
+            &net,
+            default_miner_address(net.kind(), &MinerAddressType::Transparent),
+        )
+        .ok_or(anyhow!("hard-coded address must be valid"))?,
+    );
+    let transaction =
+        TransactionTemplate::new_coinbase(&net, height, &miner_params, Amount::zero())?
+            .data()
+            .as_ref()
+            .zcash_deserialize_into::<Transaction>()?;
+    let lockbox_disbursements = net.lockbox_disbursements(height);
+    let [(lockbox_address, lockbox_amount)] = lockbox_disbursements.as_slice() else {
+        return Err(anyhow!("local network must have one lockbox marker"));
+    };
+    let lockbox_output = transparent::Output::new(*lockbox_amount, lockbox_address.script());
+
+    assert!(transaction.outputs().contains(&lockbox_output));
 
     Ok(())
 }

--- a/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -139,6 +139,7 @@ fn local_genesis_activation_coinbase_includes_lockbox_marker() -> anyhow::Result
 #[test]
 fn coinbase_tag_and_limit() {
     use zcash_address::ZcashAddress;
+    use zcash_transparent::coinbase::{MAX_COINBASE_HEIGHT_LEN, MAX_COINBASE_SCRIPT_LEN};
 
     use crate::config::mining::{
         Config, ExtraCoinbaseData, MAX_USER_COINBASE_DATA_LEN, ZAKURA_COINBASE_MARKER,
@@ -150,6 +151,15 @@ fn coinbase_tag_and_limit() {
     // makes the config fail to load and the node refuse to start.
     assert!(ExtraCoinbaseData::try_from("x".repeat(MAX_USER_COINBASE_DATA_LEN)).is_ok());
     assert!(ExtraCoinbaseData::try_from("x".repeat(MAX_USER_COINBASE_DATA_LEN + 1)).is_err());
+    assert_eq!(
+        MAX_USER_COINBASE_DATA_LEN
+            + ZAKURA_COINBASE_MARKER.len()
+            + ZAKURA_COINBASE_SEPARATOR.len()
+            + 2
+            + MAX_COINBASE_HEIGHT_LEN,
+        MAX_COINBASE_SCRIPT_LEN,
+        "the configured data limit must reserve the worst-case height and OP_PUSHDATA1 bytes"
+    );
 
     let net = Network::Mainnet;
     let addr: ZcashAddress = default_miner_address(net.kind(), &MinerAddressType::Transparent)
@@ -186,6 +196,26 @@ fn coinbase_tag_and_limit() {
         [ZAKURA_COINBASE_MARKER, ZAKURA_COINBASE_SEPARATOR, "/pool/"]
             .concat()
             .as_bytes()
+    );
+
+    // Exercise the invariant behind `MinerParams::new`'s `expect` through the
+    // real coinbase builder at the maximum supported Zakura height.
+    let max_tag = ExtraCoinbaseData::try_from("x".repeat(MAX_USER_COINBASE_DATA_LEN))
+        .expect("maximum-length tag is valid");
+    let max_params = params(Some(max_tag)).expect("maximum-length tag fits miner params");
+    let max_coinbase =
+        TransactionTemplate::new_coinbase(&net, Height::MAX, &max_params, Amount::zero())
+            .expect("maximum-length tag fits a coinbase transaction")
+            .data()
+            .as_ref()
+            .zcash_deserialize_into::<Transaction>()
+            .expect("maximum-length coinbase transaction deserializes");
+    let coinbase_script = max_coinbase.inputs()[0]
+        .coinbase_script()
+        .expect("built coinbase input has a canonical script");
+    assert!(
+        coinbase_script.len() <= MAX_COINBASE_SCRIPT_LEN,
+        "maximum-length configured tag must keep the coinbase script within consensus limits"
     );
 }
 

--- a/zakura-script/src/lib.rs
+++ b/zakura-script/src/lib.rs
@@ -427,6 +427,10 @@ pub fn p2sh_input_sigop_count(
 /// in `tx`. If the lengths differ, `zip()` silently truncates the longer iterator, causing an
 /// incorrect (undercount) result.
 ///
+/// # Panics
+///
+/// Panics if a non-coinbase transaction is passed a misaligned `spent_outputs` slice.
+///
 /// [`GetP2SHSigOpCount()`]: https://github.com/zcash/zcash/blob/v6.11.0/src/main.cpp#L840-L852
 pub fn p2sh_sigop_count(
     tx: &zakura_chain::transaction::Transaction,
@@ -436,7 +440,7 @@ pub fn p2sh_sigop_count(
         return 0;
     }
 
-    debug_assert_eq!(
+    assert_eq!(
         tx.inputs().len(),
         spent_outputs.len(),
         "spent_outputs must align with transaction inputs for non-coinbase txs"

--- a/zakura-script/src/tests.rs
+++ b/zakura-script/src/tests.rs
@@ -1000,6 +1000,19 @@ fn p2sh_sigop_count_counts_redeem_script() -> Result<()> {
     Ok(())
 }
 
+/// A mismatched spent-output vector is an internal invariant violation, not a
+/// zero-sigop case. Keep this check active in release builds so a future caller
+/// cannot silently undercount block sigops by truncating `zip()`.
+#[test]
+#[should_panic(expected = "spent_outputs must align with transaction inputs for non-coinbase txs")]
+fn p2sh_sigop_count_rejects_mismatched_spent_outputs() {
+    let tx = SCRIPT_TX
+        .zcash_deserialize_into::<Transaction>()
+        .expect("test fixture deserializes");
+
+    let _ = p2sh_sigop_count(&tx, &[]);
+}
+
 /// Regression test: `p2sh_sigop_count` must agree with zcashd's
 /// `GetP2SHSigOpCount()` when the redeem script contains a "disabled" opcode such as
 /// `OP_CODESEPARATOR` (0xab).

--- a/zakura-state/src/config.rs
+++ b/zakura-state/src/config.rs
@@ -10,7 +10,7 @@ use std::{
 
 use semver::Version;
 use serde::{
-    de::{self, IgnoredAny, MapAccess, Visitor},
+    de::{self, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
 };
 use tokio::task::{spawn_blocking, JoinHandle};
@@ -362,6 +362,10 @@ impl From<StorageModeSerde> for StorageMode {
 
 struct StorageModeVisitor;
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EmptyArchiveConfig {}
+
 impl<'de> Visitor<'de> for StorageModeVisitor {
     type Value = StorageMode;
 
@@ -390,7 +394,7 @@ impl<'de> Visitor<'de> for StorageModeVisitor {
 
         let storage_mode = match key.as_str() {
             "archive" => {
-                map.next_value::<IgnoredAny>()?;
+                let _ = map.next_value::<EmptyArchiveConfig>()?;
                 StorageMode::Archive
             }
             "pruned" => StorageMode::Pruned(map.next_value()?),
@@ -473,6 +477,25 @@ mod tests {
         let archive: Config = toml::from_str(r#"storage_mode = "archive""#)
             .expect("archive storage mode deserializes from a string");
         assert_eq!(archive.storage_mode, StorageMode::Archive);
+        assert!(
+            archive.checkpoint_sync && archive.vct_fast_sync,
+            "serde defaults preserve the internal checkpoint/VCT mirrors until zakurad overwrites them"
+        );
+
+        let archive_table: Config = toml::from_str("[storage_mode.archive]")
+            .expect("an empty archive storage mode table deserializes");
+        assert_eq!(archive_table.storage_mode, StorageMode::Archive);
+
+        assert!(
+            toml::from_str::<Config>(
+                r#"
+                [storage_mode.archive]
+                tx_retention = 6000
+                "#,
+            )
+            .is_err(),
+            "archive mode must not silently ignore pruned-only or misspelled settings"
+        );
 
         let repair_enabled: Config =
             toml::from_str(r#"repair_zakura_header_store_on_startup = true"#)

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    ops::{Add, Deref, DerefMut, RangeInclusive},
+    ops::{Add, Deref, RangeInclusive},
     pin::Pin,
     sync::Arc,
 };
@@ -541,7 +541,7 @@ impl CheckpointVerifiedBlock {
         deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
     ) -> Self {
         let mut block = Self::with_hash(block.clone(), hash.unwrap_or(block.hash()));
-        block.deferred_pool_balance_change = deferred_pool_balance_change;
+        block.0.deferred_pool_balance_change = deferred_pool_balance_change;
         block
     }
     /// Creates a block that's ready to be committed to the finalized state,
@@ -565,6 +565,16 @@ impl CheckpointVerifiedBlock {
             deferred_pool_balance_change: None,
             auth_data_root: None,
         })
+    }
+
+    /// Returns this checkpoint block with an auth-data root computed from its current block.
+    ///
+    /// This method intentionally computes the root internally rather than accepting a caller
+    /// supplied value, so the cached root cannot be paired with a different block after
+    /// construction.
+    pub fn with_precomputed_auth_data_root(mut self) -> Self {
+        self.0.auth_data_root = Some(self.0.block.auth_data_root());
+        self
     }
 }
 
@@ -669,6 +679,24 @@ mod tests {
         assert_eq!(transaction_hashes.as_ref(), expected_transaction_hashes);
         assert_eq!(auth_data_root, block.auth_data_root());
     }
+
+    #[test]
+    fn checkpoint_precomputed_auth_data_root_matches_its_block() {
+        let _init_guard = zakura_test::init();
+
+        let block = Arc::new(
+            zakura_test::vectors::BLOCK_MAINNET_1687107_BYTES
+                .zcash_deserialize_into::<Block>()
+                .expect("NU5 mainnet block deserializes"),
+        );
+        let checkpoint = CheckpointVerifiedBlock::with_hash(block.clone(), block.hash());
+
+        assert!(checkpoint.auth_data_root.is_none());
+
+        let checkpoint = checkpoint.with_precomputed_auth_data_root();
+
+        assert_eq!(checkpoint.auth_data_root, Some(block.auth_data_root()));
+    }
 }
 
 impl From<ContextuallyVerifiedBlock> for SemanticallyVerifiedBlock {
@@ -712,11 +740,6 @@ impl Deref for CheckpointVerifiedBlock {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-impl DerefMut for CheckpointVerifiedBlock {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -1424,6 +1424,8 @@ pub enum ReadRequest {
     /// Returns [`ReadResponse::BlockRoots(Vec<BlockCommitmentRoots>)`](ReadResponse::BlockRoots)
     /// with the per-block commitment roots for the requested heights, in ascending height
     /// order. May return fewer than `count` roots if the node does not hold the whole range.
+    /// The response is capped by
+    /// [`MAX_HEADER_SYNC_HEIGHT_RANGE`](crate::constants::MAX_HEADER_SYNC_HEIGHT_RANGE).
     BlockRoots {
         /// First requested height.
         start_height: block::Height,
@@ -1463,7 +1465,8 @@ pub enum ReadRequest {
 
     /// Returns contiguous committed blocks by height, in ascending order.
     ///
-    /// The response stops before the first height without a committed body.
+    /// The response stops before the first height without a committed body and is
+    /// capped by [`MAX_HEADER_SYNC_HEIGHT_RANGE`](crate::constants::MAX_HEADER_SYNC_HEIGHT_RANGE).
     BlocksByHeightRange {
         /// First height to read.
         start: block::Height,

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -1640,6 +1640,11 @@ where
     roots
 }
 
+fn capped_height_range(start: block::Height, count: u32) -> impl Iterator<Item = block::Height> {
+    (0..count.min(MAX_HEADER_SYNC_HEIGHT_RANGE))
+        .map_while(move |offset| start.0.checked_add(offset).map(block::Height))
+}
+
 impl Service<ReadRequest> for ReadStateService {
     type Response = ReadResponse;
     type Error = BoxError;
@@ -1933,16 +1938,10 @@ impl Service<ReadRequest> for ReadStateService {
 
             ReadRequest::BlocksByHeightRange { start, count } => {
                 let best_chain = state.latest_best_chain();
-                let blocks = (0..count)
-                    .map_while(|offset| {
-                        start
-                            .0
-                            .checked_add(offset)
-                            .map(block::Height)
-                            .and_then(|height| {
-                                read::block_and_size(best_chain.clone(), &state.db, height.into())
-                                    .map(|(block, size)| (height, block, size))
-                            })
+                let blocks = capped_height_range(start, count)
+                    .map_while(|height| {
+                        read::block_and_size(best_chain.clone(), &state.db, height.into())
+                            .map(|(block, size)| (height, block, size))
                     })
                     .collect();
 

--- a/zakura-state/src/service/check/tests/anchors.rs
+++ b/zakura-state/src/service/check/tests/anchors.rs
@@ -5,11 +5,12 @@ use std::{ops::Deref, sync::Arc};
 use zakura_chain::{
     amount::Amount,
     block::{Block, Height},
+    parameters::{Network, NetworkUpgrade},
     primitives::Groth16Proof,
     sapling,
     serialization::ZcashDeserializeInto,
     sprout::{self, JoinSplit},
-    transaction::{JoinSplitData, LockTime, Transaction, UnminedTx},
+    transaction::{arbitrary::v5_transactions, JoinSplitData, LockTime, Transaction, UnminedTx},
 };
 
 use crate::{
@@ -340,4 +341,66 @@ fn check_sapling_anchors() {
     );
 }
 
-// TODO: create tests for orchard and ironwood anchors
+#[test]
+fn ironwood_anchors_do_not_use_orchard_anchor_namespace() {
+    let _init_guard = zakura_test::init();
+
+    let (finalized_state, non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
+    let ironwood_shielded_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .filter_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .find(|shielded_data| {
+            !finalized_state
+                .db
+                .contains_ironwood_anchor(&shielded_data.shared_anchor)
+        })
+        .expect("test vectors include an Orchard anchor not present at genesis");
+    let shared_anchor = ironwood_shielded_data.shared_anchor;
+    let transaction = Arc::new(Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        ironwood_shielded_data: Some(ironwood_shielded_data),
+    });
+    let unmined_tx = UnminedTx::from(&transaction);
+
+    let mut batch = DiskWriteBatch::new();
+    batch.insert_orchard_anchor(&finalized_state.db, &shared_anchor);
+    finalized_state
+        .write_batch(batch)
+        .expect("unexpected I/O error");
+
+    let result = tx_anchors_refer_to_final_treestates(
+        &finalized_state.db,
+        non_finalized_state.best_chain(),
+        &unmined_tx,
+    );
+
+    assert!(
+        matches!(
+            result,
+            Err(ValidateContextError::UnknownIronwoodAnchor { anchor, .. })
+                if anchor == shared_anchor
+        ),
+        "an Orchard anchor must not satisfy an Ironwood spend: {result:?}",
+    );
+
+    let mut batch = DiskWriteBatch::new();
+    batch.insert_ironwood_anchor(&finalized_state.db, &shared_anchor);
+    finalized_state
+        .write_batch(batch)
+        .expect("unexpected I/O error");
+
+    assert_eq!(
+        tx_anchors_refer_to_final_treestates(
+            &finalized_state.db,
+            non_finalized_state.best_chain(),
+            &unmined_tx,
+        ),
+        Ok(())
+    );
+}

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -23,7 +23,10 @@ use std::{
 };
 
 use zakura_chain::{
-    block, ironwood, orchard, parallel::tree::NoteCommitmentTrees, parameters::Network, sapling,
+    block, ironwood, orchard,
+    parallel::tree::NoteCommitmentTrees,
+    parameters::{Network, NetworkUpgrade},
+    sapling,
 };
 use zakura_db::{
     block::{RetentionPlan, ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT},
@@ -760,8 +763,18 @@ impl FinalizedState {
                             links
                         });
 
-                        let is_prevalidated =
-                            self.vct.prevalidated_next() == Some((height, block_hash));
+                        // A header-only successor witness carries its auth-data root
+                        // separately from the later body. At NU5 and later that root is
+                        // an input to the header commitment, so a same-header body with
+                        // different authorizing data must run its own check rather than
+                        // reusing the witness's prevalidation.
+                        let block_auth_data_root = (NetworkUpgrade::current(&network, height)
+                            >= NetworkUpgrade::Nu5)
+                            .then(|| {
+                                precomputed_auth_data_root.unwrap_or_else(|| block.auth_data_root())
+                            });
+                        let is_prevalidated = self.vct.prevalidated_next()
+                            == Some((height, block_hash, block_auth_data_root));
                         if is_prevalidated {
                             if let Some(v) = self.vct.source() {
                                 v.record_prevalidated();
@@ -812,8 +825,16 @@ impl FinalizedState {
                             })?;
 
                         if let Some(next_vct_block) = &next_vct_block {
-                            self.vct
-                                .mark_prevalidated(next_vct_block.height, next_vct_block.hash);
+                            let next_auth_data_root =
+                                (NetworkUpgrade::current(&network, next_vct_block.height)
+                                    >= NetworkUpgrade::Nu5)
+                                    .then_some(next_vct_block.auth_data_root)
+                                    .flatten();
+                            self.vct.mark_prevalidated(
+                                next_vct_block.height,
+                                next_vct_block.hash,
+                                next_auth_data_root,
+                            );
                         } else if self
                             .vct
                             .source()

--- a/zakura-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/chain.rs
@@ -175,8 +175,11 @@ impl FromDisk for BlockInfo {
 
         let bytes = bytes.as_ref();
 
-        // We want to be forward-compatible, so this must work even if the
-        // size of the buffer is larger than expected.
+        // We want to be forward-compatible with extensions of the current format,
+        // so this must work even if the size of the buffer is larger than expected.
+        // Lengths between the legacy and current formats are incomplete rows, not
+        // forward-compatible extensions: accepting them as legacy would interpret
+        // the first Ironwood amount bytes as the block size.
         match bytes.len() {
             IRONWOOD_BLOCK_INFO_LEN.. => {
                 let value_pools =
@@ -189,7 +192,7 @@ impl FromDisk for BlockInfo {
                 );
                 BlockInfo::new(value_pools, size)
             }
-            NU6_1_BLOCK_INFO_LEN.. => {
+            NU6_1_BLOCK_INFO_LEN => {
                 let value_pools =
                     ValueBalance::<NonNegative>::from_bytes(&bytes[..NU6_1_VALUE_BALANCE_LEN])
                         .expect("must work for 40 bytes");
@@ -200,7 +203,7 @@ impl FromDisk for BlockInfo {
                 );
                 BlockInfo::new(value_pools, size)
             }
-            _ => panic!("invalid format"),
+            _ => panic!("invalid block info format length: {}", bytes.len()),
         }
     }
 }

--- a/zakura-state/src/service/finalized_state/disk_format/chain/tests.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/chain/tests.rs
@@ -118,3 +118,18 @@ fn history_tree_parts_round_trips_current_width() {
     assert_eq!(parsed.current_height, Height(9));
     assert_eq!(parsed.as_bytes(), bytes);
 }
+
+/// A truncated current-width row must not be reinterpreted as a complete legacy row.
+///
+/// The first four bytes of the Ironwood amount sit where the legacy layout stored the block size,
+/// so accepting this length would silently lose the Ironwood pool and manufacture a size.
+#[test]
+#[should_panic(expected = "invalid block info format length")]
+fn block_info_rejects_truncated_ironwood_value_pools() {
+    let ironwood_amount =
+        zakura_chain::amount::Amount::<NonNegative>::try_from(7).expect("7 zatoshi is valid");
+    let block_info = BlockInfo::new(ValueBalance::from_ironwood_amount(ironwood_amount), 123);
+    let bytes = block_info.as_bytes();
+
+    BlockInfo::from_bytes(&bytes[..48]);
+}

--- a/zakura-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/shielded.rs
@@ -106,7 +106,7 @@ pub struct CommitmentRootsByHeight {
     /// against this block's NU5+ header commitment, without re-reading the body.
     /// Default/zero below NU5.
     pub auth_data_root: AuthDataRoot,
-    /// The Ironwood note-commitment tree root at this height (empty below Nu7). Stored so a
+    /// The Ironwood note-commitment tree root at this height (empty below NU6.3). Stored so a
     /// fast-synced node can serve it as a ZIP-221 V3 history-leaf input.
     pub ironwood: ironwood::tree::Root,
     /// This block's Sapling shielded transaction count — a ZIP-221 history-leaf input the
@@ -114,7 +114,7 @@ pub struct CommitmentRootsByHeight {
     pub sapling_tx: u64,
     /// This block's Orchard shielded transaction count (V2 leaf input, NU5+).
     pub orchard_tx: u64,
-    /// This block's Ironwood shielded transaction count (V3 leaf input, Nu7+).
+    /// This block's Ironwood shielded transaction count (V3 leaf input, NU6.3+).
     pub ironwood_tx: u64,
 }
 

--- a/zakura-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/shielded.rs
@@ -90,7 +90,7 @@ impl FromDisk for orchard::tree::Root {
 /// The per-height Sapling and Orchard note-commitment roots, as stored in the
 /// `commitment_roots_by_height` index (keyed by [`Height`]).
 ///
-/// Every node persists this 64-byte value for each committed block — including a
+/// Every node persists this value for each committed block — including a
 /// verified-commitment-trees fast-synced node, which folds these roots in but writes no
 /// per-height note-commitment trees. It lets such a node still serve the `tree_aux`
 /// `BlockRoots` read from a compact index rather than from the (absent) trees.
@@ -118,11 +118,18 @@ pub struct CommitmentRootsByHeight {
     pub ironwood_tx: u64,
 }
 
+/// Rows written before the auth-data root was added.
+const PRE_AUTH_DATA_ROOTS_DISK_BYTES: usize = 64;
+/// Rows written before Ironwood roots and shielded transaction counts were added.
+const PRE_IRONWOOD_ROOTS_DISK_BYTES: usize = 96;
+/// Rows written by the current format.
+const CURRENT_ROOTS_DISK_BYTES: usize = 152;
+
 impl IntoDisk for CommitmentRootsByHeight {
-    type Bytes = [u8; 152];
+    type Bytes = [u8; CURRENT_ROOTS_DISK_BYTES];
 
     fn as_bytes(&self) -> Self::Bytes {
-        let mut out = [0u8; 152];
+        let mut out = [0u8; CURRENT_ROOTS_DISK_BYTES];
         out[..32].copy_from_slice(&IntoDisk::as_bytes(&self.sapling));
         out[32..64].copy_from_slice(&IntoDisk::as_bytes(&self.orchard));
         out[64..96].copy_from_slice(&<[u8; 32]>::from(self.auth_data_root));
@@ -141,28 +148,39 @@ impl FromDisk for CommitmentRootsByHeight {
         // this database version (64 bytes pre-auth-data, 96 bytes pre-ironwood/counts): the
         // missing fields decode as empty/zero, so the writer falls back to the body-wait path
         // for those heights until they are re-served with full data. New rows are 152 bytes.
-        let auth_data_root = if bytes.len() >= 96 {
+        //
+        // Partial rows between those complete layouts are corruption, not a compatible older
+        // format. Reject them before a truncated current row can be silently interpreted as an
+        // older row with defaulted Ironwood roots/counts.
+        match bytes.len() {
+            PRE_AUTH_DATA_ROOTS_DISK_BYTES | PRE_IRONWOOD_ROOTS_DISK_BYTES => {}
+            CURRENT_ROOTS_DISK_BYTES.. => {}
+            len => panic!("invalid commitment roots format length: {len}"),
+        }
+
+        let auth_data_root = if bytes.len() >= PRE_IRONWOOD_ROOTS_DISK_BYTES {
             let mut auth_data_root = [0u8; 32];
             auth_data_root.copy_from_slice(&bytes[64..96]);
             AuthDataRoot::from(auth_data_root)
         } else {
             AuthDataRoot::from([0u8; 32])
         };
-        let (ironwood, sapling_tx, orchard_tx, ironwood_tx) = if bytes.len() >= 152 {
-            (
-                ironwood::tree::Root::from_bytes(&bytes[96..128]),
-                u64::from_be_bytes(bytes[128..136].try_into().expect("8 bytes")),
-                u64::from_be_bytes(bytes[136..144].try_into().expect("8 bytes")),
-                u64::from_be_bytes(bytes[144..152].try_into().expect("8 bytes")),
-            )
-        } else {
-            (
-                ironwood::tree::NoteCommitmentTree::default().root(),
-                0,
-                0,
-                0,
-            )
-        };
+        let (ironwood, sapling_tx, orchard_tx, ironwood_tx) =
+            if bytes.len() >= CURRENT_ROOTS_DISK_BYTES {
+                (
+                    ironwood::tree::Root::from_bytes(&bytes[96..128]),
+                    u64::from_be_bytes(bytes[128..136].try_into().expect("8 bytes")),
+                    u64::from_be_bytes(bytes[136..144].try_into().expect("8 bytes")),
+                    u64::from_be_bytes(bytes[144..152].try_into().expect("8 bytes")),
+                )
+            } else {
+                (
+                    ironwood::tree::NoteCommitmentTree::default().root(),
+                    0,
+                    0,
+                    0,
+                )
+            };
         CommitmentRootsByHeight {
             sapling: sapling::tree::Root::from_bytes(&bytes[..32]),
             orchard: orchard::tree::Root::from_bytes(&bytes[32..64]),
@@ -174,6 +192,9 @@ impl FromDisk for CommitmentRootsByHeight {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;
 
 impl IntoDisk for NoteCommitmentSubtreeIndex {
     type Bytes = [u8; 2];

--- a/zakura-state/src/service/finalized_state/disk_format/shielded/tests.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/shielded/tests.rs
@@ -1,0 +1,55 @@
+//! Shielded-format serialization tests.
+
+use super::*;
+
+fn sample_roots() -> CommitmentRootsByHeight {
+    CommitmentRootsByHeight {
+        sapling: sapling::tree::NoteCommitmentTree::default().root(),
+        orchard: orchard::tree::NoteCommitmentTree::default().root(),
+        auth_data_root: AuthDataRoot::from([7u8; 32]),
+        ironwood: ironwood::tree::NoteCommitmentTree::default().root(),
+        sapling_tx: 11,
+        orchard_tx: 13,
+        ironwood_tx: 17,
+    }
+}
+
+#[test]
+fn commitment_roots_reads_complete_legacy_layouts() {
+    let roots = sample_roots();
+    let bytes = roots.as_bytes();
+
+    let pre_auth = CommitmentRootsByHeight::from_bytes(&bytes[..PRE_AUTH_DATA_ROOTS_DISK_BYTES]);
+    assert_eq!(pre_auth.sapling, roots.sapling);
+    assert_eq!(pre_auth.orchard, roots.orchard);
+    assert_eq!(pre_auth.auth_data_root, AuthDataRoot::from([0u8; 32]));
+    assert_eq!(
+        pre_auth.ironwood,
+        ironwood::tree::NoteCommitmentTree::default().root()
+    );
+    assert_eq!(pre_auth.sapling_tx, 0);
+    assert_eq!(pre_auth.orchard_tx, 0);
+    assert_eq!(pre_auth.ironwood_tx, 0);
+
+    let pre_ironwood = CommitmentRootsByHeight::from_bytes(&bytes[..PRE_IRONWOOD_ROOTS_DISK_BYTES]);
+    assert_eq!(pre_ironwood.sapling, roots.sapling);
+    assert_eq!(pre_ironwood.orchard, roots.orchard);
+    assert_eq!(pre_ironwood.auth_data_root, roots.auth_data_root);
+    assert_eq!(
+        pre_ironwood.ironwood,
+        ironwood::tree::NoteCommitmentTree::default().root()
+    );
+    assert_eq!(pre_ironwood.sapling_tx, 0);
+    assert_eq!(pre_ironwood.orchard_tx, 0);
+    assert_eq!(pre_ironwood.ironwood_tx, 0);
+
+    assert_eq!(CommitmentRootsByHeight::from_bytes(bytes), roots);
+}
+
+#[test]
+#[should_panic(expected = "invalid commitment roots format length")]
+fn commitment_roots_rejects_partial_current_layout() {
+    let bytes = sample_roots().as_bytes();
+
+    CommitmentRootsByHeight::from_bytes(&bytes[..128]);
+}

--- a/zakura-state/src/service/finalized_state/disk_format/upgrade/cache_genesis_roots.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/upgrade/cache_genesis_roots.rs
@@ -84,19 +84,20 @@ pub fn quick_check(db: &ZakuraDb) -> Result<(), String> {
     // A fast-sync commit can set the VCT marker after the `is_vct_synced()`
     // check above but before these tree reads. In that case the readers return
     // `None` for the absent per-height trees, and this genesis-root check no
-    // longer applies. Non-VCT databases still panic on genuinely missing genesis
-    // trees inside the readers.
+    // longer applies. Recheck the marker on each `None`: Sprout anchor lookup
+    // also returns `None` for a genuinely missing non-VCT anchor, which must not
+    // be mistaken for the race.
     let sprout_genesis_tree = sprout::tree::NoteCommitmentTree::default();
     let Some(sprout_genesis_tree) = db.sprout_tree_by_anchor(&sprout_genesis_tree.root()) else {
-        return Ok(());
+        return missing_genesis_tree_or_vct_race(db, "sprout");
     };
     let sprout_tip_tree = db.sprout_tree_for_tip();
 
     let Some(sapling_genesis_tree) = db.sapling_tree_by_height(&Height(0)) else {
-        return Ok(());
+        return missing_genesis_tree_or_vct_race(db, "sapling");
     };
     let Some(orchard_genesis_tree) = db.orchard_tree_by_height(&Height(0)) else {
-        return Ok(());
+        return missing_genesis_tree_or_vct_race(db, "orchard");
     };
 
     // Check the entire format before returning any errors.
@@ -128,6 +129,14 @@ pub fn quick_check(db: &ZakuraDb) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn missing_genesis_tree_or_vct_race(db: &ZakuraDb, pool: &'static str) -> Result<(), String> {
+    if db.is_vct_synced() {
+        Ok(())
+    } else {
+        Err(format!("missing {pool} genesis tree in non-VCT database"))
+    }
 }
 
 /// Detailed check that all trees have cached roots.
@@ -196,4 +205,78 @@ pub fn detailed_check(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zakura_chain::{
+        block::Block, orchard, parameters::Network, sapling, serialization::ZcashDeserializeInto,
+    };
+
+    use crate::{
+        constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
+        request::{FinalizedBlock, Treestate},
+        service::finalized_state::STATE_COLUMN_FAMILIES_IN_CODE,
+        CheckpointVerifiedBlock, Config,
+    };
+
+    use super::*;
+
+    fn db_with_genesis_trees() -> ZakuraDb {
+        let db = ZakuraDb::new(
+            &Config::ephemeral(),
+            STATE_DATABASE_KIND,
+            &state_database_format_version_in_code(),
+            &Network::Mainnet,
+            true,
+            STATE_COLUMN_FAMILIES_IN_CODE
+                .iter()
+                .map(ToString::to_string),
+            false,
+        )
+        .expect("opening an ephemeral finalized state database should succeed");
+        let genesis = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+            .zcash_deserialize_into::<Arc<Block>>()
+            .expect("mainnet genesis block deserializes");
+        let finalized = FinalizedBlock::from_checkpoint_verified(
+            CheckpointVerifiedBlock::from(genesis),
+            Treestate::default(),
+        );
+
+        let mut batch = DiskWriteBatch::new();
+        batch
+            .prepare_block_header_and_transaction_data_batch(&db, &finalized, true, None)
+            .expect("genesis header and transaction rows are valid");
+        batch.update_sprout_tree(&db, &sprout::tree::NoteCommitmentTree::default());
+        batch.create_sapling_tree(
+            &db,
+            &Height::MIN,
+            &sapling::tree::NoteCommitmentTree::default(),
+        );
+        batch.create_orchard_tree(
+            &db,
+            &Height::MIN,
+            &orchard::tree::NoteCommitmentTree::default(),
+        );
+        db.write_batch(batch)
+            .expect("genesis-format rows write successfully");
+
+        db
+    }
+
+    #[test]
+    fn quick_check_rejects_missing_sprout_genesis_anchor_without_vct_marker() {
+        let db = db_with_genesis_trees();
+        assert!(quick_check(&db).is_ok());
+
+        let mut batch = DiskWriteBatch::new();
+        batch.delete_sprout_anchor(&db, &sprout::tree::NoteCommitmentTree::default().root());
+        db.write_batch(batch)
+            .expect("deleting the test Sprout anchor succeeds");
+
+        let error = quick_check(&db).expect_err("missing non-VCT Sprout anchor must fail");
+        assert_eq!(error, "missing sprout genesis tree in non-VCT database");
+    }
 }

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1826,7 +1826,11 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             let stale_hash = blocks[seed + 1].hash;
             prop_assert_ne!(stale_hash, blocks[seed + 3].hash, "stale hash must differ from the real block");
             fast.vct
-                .set_prevalidated_next(Some((Height((seed + 3) as u32), stale_hash)));
+                .set_prevalidated_next(Some((
+                    Height((seed + 3) as u32),
+                    stale_hash,
+                    Some(blocks[seed + 3].block.auth_data_root()),
+                )));
             commit(&mut fast, seed + 3);
             prop_assert_eq!(fast.vct_prevalidated_count(), 1, "a stale cache entry (wrong hash) must not cause a false skip");
 
@@ -1844,7 +1848,11 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 "the forged wrapper hash must differ from the bad block's real hash",
             );
             fast.vct
-                .set_prevalidated_next(Some((Height((seed + 4) as u32), forged_wrapper_hash)));
+                .set_prevalidated_next(Some((
+                    Height((seed + 4) as u32),
+                    forged_wrapper_hash,
+                    Some(blocks[seed + 4].block.auth_data_root()),
+                )));
             let forged = CheckpointVerifiedBlock::with_hash(bad_block, forged_wrapper_hash);
             let error = fast
                 .commit_finalized_direct(forged.into(), None, None, "vct forged wrapper hash")
@@ -1862,6 +1870,135 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 fast.db.finalized_tip_height(),
                 Some(Height((seed + 3) as u32)),
                 "the rejected forged block must leave finalized state untouched",
+            );
+    });
+
+    Ok(())
+}
+
+/// A header-only successor witness can only prevalidate a later body when the
+/// body uses the same NU5+ auth-data root that the witness supplied. The block
+/// hash alone is insufficient because ZIP-244 excludes authorizing data from
+/// transaction IDs: a same-header body can carry different authorizing data,
+/// and the checkpoint verifier deliberately leaves the header/auth-root binding
+/// to finalized commit.
+#[test]
+fn vct_header_only_prevalidation_binds_nu5_auth_data_root() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    let network = ParametersBuilder::default()
+        .with_activation_heights(ConfiguredActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(10),
+            sapling: Some(15),
+            blossom: Some(20),
+            heartwood: Some(25),
+            canopy: Some(30),
+            nu5: Some(35),
+            nu6: Some(40),
+            nu6_1: Some(45),
+            nu6_2: Some(47),
+            nu6_3: Some(48),
+            nu7: Some(50),
+        })
+        .expect("failed to set activation heights")
+        .extend_funding_streams()
+        .to_network()
+        .expect("failed to build configured network");
+    let ledger_strategy =
+        LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
+
+    proptest!(ProptestConfig::with_cases(1),
+        |((chain, _count, network, _history_tree) in PreparedChain::default().with_ledger_strategy(ledger_strategy.clone()).with_valid_commitments().no_shrink())| {
+            let blocks: Vec<_> = chain.iter().collect();
+            let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0 as usize;
+            let seed = nu5 - 2;
+            let first_fast = seed + 1;
+            let target = seed + 2;
+            prop_assert!(blocks.len() > target + 1, "generated chain unexpectedly short");
+
+            let mut legacy = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false).expect("opening an ephemeral database should succeed");
+            let mut fixture = std::collections::HashMap::new();
+            for (i, prepared) in blocks.iter().take(target + 1).enumerate() {
+                let cv = CheckpointVerifiedBlock::from(prepared.block.clone());
+                let (_h, trees) = legacy
+                    .commit_finalized_direct(cv.into(), None, None, "vct auth-root legacy")
+                    .unwrap();
+                if i > seed {
+                    fixture.insert(
+                        i as u32,
+                        (
+                            trees.sapling.root(),
+                            trees.orchard.root(),
+                            zakura_chain::ironwood::tree::NoteCommitmentTree::default().root(),
+                        ),
+                    );
+                }
+            }
+
+            let mut fast = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false).expect("opening an ephemeral database should succeed");
+            enable_vct_test_fixture_source(&mut fast, fixture);
+
+            for i in 0..=seed {
+                let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
+                let next = next_vct_block(blocks[i + 1].block.clone());
+                fast.commit_finalized_direct(cv.into(), None, next, "vct auth-root seed")
+                    .expect("legacy-prefix commits succeed");
+            }
+
+            // Use a header-only witness for `target`, as production does when
+            // header sync is ahead of body sync. It carries the real auth root,
+            // so the previous fast block may safely authenticate its roots.
+            let cv = CheckpointVerifiedBlock::from(blocks[first_fast].block.clone());
+            let header_only_successor = NextVctBlock::from_header(
+                blocks[target].block.header.clone(),
+                Height(target as u32),
+                blocks[target].block.auth_data_root(),
+            );
+            fast.commit_finalized_direct(
+                cv.into(),
+                None,
+                Some(header_only_successor),
+                "vct auth-root header-only prevalidation",
+            )
+            .expect("the first fast block commits with a header-only successor");
+            prop_assert_eq!(fast.vct_prevalidated_count(), 0, "the first fast block runs its own check");
+
+            // This private-field mutation models the later checkpoint wrapper
+            // for a same-header body whose authorizing data differs from the
+            // header-only witness. If the dedup key were only (height, hash),
+            // finalized commit would skip the only check that rejects it.
+            let mut mismatched = CheckpointVerifiedBlock::from(blocks[target].block.clone());
+            let mismatched_auth_data_root =
+                zakura_chain::block::merkle::AuthDataRoot::from([0x42; 32]);
+            prop_assert_ne!(
+                mismatched.auth_data_root,
+                Some(mismatched_auth_data_root),
+                "the test needs a different auth-data root",
+            );
+            mismatched.0.auth_data_root = Some(mismatched_auth_data_root);
+
+            let error = fast
+                .commit_finalized_direct(
+                    mismatched.into(),
+                    None,
+                    None,
+                    "vct auth-root mismatched body",
+                )
+                .expect_err("a body with a different auth-data root must not reuse header-only prevalidation");
+            prop_assert!(
+                format!("{error:?}").contains("VctSuppliedRootUnavailable"),
+                "the mismatched body must fail its own commitment check, got: {error:?}",
+            );
+            prop_assert_eq!(
+                fast.vct_prevalidated_count(),
+                0,
+                "the mismatched auth-data root must not increment the prevalidated count",
+            );
+            prop_assert_eq!(
+                fast.db.finalized_tip_height(),
+                Some(Height(first_fast as u32)),
+                "the rejected body must leave finalized state untouched",
             );
     });
 

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -6,8 +6,8 @@
 //! `consensus.vct_fast_sync = false` selects legacy recompute.
 
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc, Mutex,
 };
 
 use thiserror::Error;
@@ -335,12 +335,21 @@ pub(crate) struct VctCommitState {
     /// hash: a header-only successor witness carries this root separately from
     /// the later body, and a same-header body with different authorizing data
     /// must not reuse the earlier prevalidation.
-    prevalidated_next: Option<(block::Height, block::Hash, Option<AuthDataRoot>)>,
+    ///
+    /// This cache is shared across [`super::FinalizedState`] clones. The
+    /// production node has one finalized writer, but the public state type is
+    /// cloneable and its clone contract requires mutable commit safety state to
+    /// remain coherent across clones.
+    prevalidated_next: Arc<Mutex<Option<(block::Height, block::Hash, Option<AuthDataRoot>)>>>,
 
     /// `true` while a vct sync is in-progress below the last checkpoint height.
     /// During this time, we do not reconstruct per-height note-commitment trees.
     /// As a result, the frontier is unknown.
-    is_vct_sync_below_last_checkpoint: bool,
+    ///
+    /// This flag is shared across [`super::FinalizedState`] clones so a clone
+    /// cannot miss that another clone has frozen the frontier and then
+    /// incorrectly fall back to legacy recomputation.
+    is_vct_sync_below_last_checkpoint: Arc<AtomicBool>,
 }
 
 impl VctCommitState {
@@ -352,8 +361,10 @@ impl VctCommitState {
     ) -> Self {
         VctCommitState {
             source,
-            prevalidated_next: None,
-            is_vct_sync_below_last_checkpoint,
+            prevalidated_next: Arc::new(Mutex::new(None)),
+            is_vct_sync_below_last_checkpoint: Arc::new(AtomicBool::new(
+                is_vct_sync_below_last_checkpoint,
+            )),
         }
     }
 
@@ -365,50 +376,68 @@ impl VctCommitState {
     /// `true` while the note-commitment frontier is below the last checkpoint height.
     pub(super) fn is_below_last_checkpoint(&self) -> bool {
         self.is_vct_sync_below_last_checkpoint
+            .load(Ordering::Acquire)
     }
 
     /// The cached successor prevalidation, if any.
     pub(super) fn prevalidated_next(
         &self,
     ) -> Option<(block::Height, block::Hash, Option<AuthDataRoot>)> {
-        self.prevalidated_next
+        *self
+            .prevalidated_next
+            .lock()
+            .expect("VCT prevalidation lock is not poisoned because commit panics are fatal")
     }
 
     /// Caches the next block as already validated by this fast commit's look-ahead.
     pub(super) fn mark_prevalidated(
-        &mut self,
+        &self,
         height: block::Height,
         hash: block::Hash,
         auth_data_root: Option<AuthDataRoot>,
     ) {
-        self.prevalidated_next = Some((height, hash, auth_data_root));
+        *self
+            .prevalidated_next
+            .lock()
+            .expect("VCT prevalidation lock is not poisoned because commit panics are fatal") =
+            Some((height, hash, auth_data_root));
     }
 
     /// Clears any cached successor prevalidation.
-    pub(super) fn clear_prevalidated_next(&mut self) {
-        self.prevalidated_next = None;
+    pub(super) fn clear_prevalidated_next(&self) {
+        *self
+            .prevalidated_next
+            .lock()
+            .expect("VCT prevalidation lock is not poisoned because commit panics are fatal") =
+            None;
     }
 
     /// Test-only: overwrites the cached successor prevalidation, so tests can
     /// install a stale or forged entry to exercise the dedup's guard checks.
     #[cfg(test)]
     pub(super) fn set_prevalidated_next(
-        &mut self,
+        &self,
         next: Option<(block::Height, block::Hash, Option<AuthDataRoot>)>,
     ) {
-        self.prevalidated_next = next;
+        *self
+            .prevalidated_next
+            .lock()
+            .expect("VCT prevalidation lock is not poisoned because commit panics are fatal") =
+            next;
     }
 
     /// Starts a VCT sync below the last checkpoint height: below the last checkpoint height,
     /// the frontier is unknown as we are not reconstructing the trees every height.
-    pub(super) fn start_vct_sync_below_last_checkpoint(&mut self) {
-        self.is_vct_sync_below_last_checkpoint = true;
+    pub(super) fn start_vct_sync_below_last_checkpoint(&self) {
+        self.is_vct_sync_below_last_checkpoint
+            .store(true, Ordering::Release);
     }
 
     /// Stops a VCT sync at the last checkpoint height: the last checkpoint wrote the
     /// real final frontier as the tip treestate.
-    pub(super) fn stop_vct_sync_at_last_checkpoint(&mut self) {
-        self.is_vct_sync_below_last_checkpoint = false;
+    pub(super) fn stop_vct_sync_at_last_checkpoint(&self) {
+        self.is_vct_sync_below_last_checkpoint
+            .store(false, Ordering::Release);
     }
 
     /// Test-only: installs an arbitrary [`CommitmentRootSource`] as fast-mode
@@ -652,6 +681,43 @@ mod tests {
         assert!(
             bounded.vct_roots_at_height(after_handoff).is_none(),
             "roots above the handoff are ignored even when the source has them"
+        );
+    }
+
+    #[test]
+    fn cloned_commit_state_shares_frozen_frontier_and_prevalidation() {
+        let state = VctCommitState::new(None, false);
+        let clone = state.clone();
+        let prevalidated = (
+            block::Height(7),
+            block::Hash([7; 32]),
+            Some(AuthDataRoot::from([7; 32])),
+        );
+
+        state.start_vct_sync_below_last_checkpoint();
+        state.mark_prevalidated(prevalidated.0, prevalidated.1, prevalidated.2);
+
+        assert!(
+            clone.is_below_last_checkpoint(),
+            "a clone must observe that another clone froze the frontier"
+        );
+        assert_eq!(
+            clone.prevalidated_next(),
+            Some(prevalidated),
+            "a clone must observe the shared successor prevalidation cache"
+        );
+
+        clone.stop_vct_sync_at_last_checkpoint();
+        clone.clear_prevalidated_next();
+
+        assert!(
+            !state.is_below_last_checkpoint(),
+            "unfreezing through one clone must update every clone"
+        );
+        assert_eq!(
+            state.prevalidated_next(),
+            None,
+            "clearing prevalidation through one clone must update every clone"
         );
     }
 

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -326,10 +326,16 @@ pub(crate) struct VctCommitState {
     /// - legacy Zebra checkpoint sync
     source: Option<Arc<VctState>>,
 
-    /// `(height, hash)` of the next block already validated by the previous fast
-    /// commit's look-ahead, so its own commitment check can be skipped. Guarded by
-    /// hash identity, so a stale or cloned value can't cause an incorrect skip.
-    prevalidated_next: Option<(block::Height, block::Hash)>,
+    /// `(height, hash, auth_data_root)` of the next block already validated by
+    /// the previous fast commit's look-ahead, so its own commitment check can
+    /// be skipped.
+    ///
+    /// The auth-data root is `None` below NU5, where it is not an input to the
+    /// block commitment. At NU5 and later it must stay paired with the header
+    /// hash: a header-only successor witness carries this root separately from
+    /// the later body, and a same-header body with different authorizing data
+    /// must not reuse the earlier prevalidation.
+    prevalidated_next: Option<(block::Height, block::Hash, Option<AuthDataRoot>)>,
 
     /// `true` while a vct sync is in-progress below the last checkpoint height.
     /// During this time, we do not reconstruct per-height note-commitment trees.
@@ -362,14 +368,20 @@ impl VctCommitState {
     }
 
     /// The cached successor prevalidation, if any.
-    pub(super) fn prevalidated_next(&self) -> Option<(block::Height, block::Hash)> {
+    pub(super) fn prevalidated_next(
+        &self,
+    ) -> Option<(block::Height, block::Hash, Option<AuthDataRoot>)> {
         self.prevalidated_next
     }
 
-    /// Caches the next block's `(height, hash)` as already validated by this
-    /// fast commit's look-ahead.
-    pub(super) fn mark_prevalidated(&mut self, height: block::Height, hash: block::Hash) {
-        self.prevalidated_next = Some((height, hash));
+    /// Caches the next block as already validated by this fast commit's look-ahead.
+    pub(super) fn mark_prevalidated(
+        &mut self,
+        height: block::Height,
+        hash: block::Hash,
+        auth_data_root: Option<AuthDataRoot>,
+    ) {
+        self.prevalidated_next = Some((height, hash, auth_data_root));
     }
 
     /// Clears any cached successor prevalidation.
@@ -380,7 +392,10 @@ impl VctCommitState {
     /// Test-only: overwrites the cached successor prevalidation, so tests can
     /// install a stale or forged entry to exercise the dedup's guard checks.
     #[cfg(test)]
-    pub(super) fn set_prevalidated_next(&mut self, next: Option<(block::Height, block::Hash)>) {
+    pub(super) fn set_prevalidated_next(
+        &mut self,
+        next: Option<(block::Height, block::Hash, Option<AuthDataRoot>)>,
+    ) {
         self.prevalidated_next = next;
     }
 

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -11,7 +11,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    ops::RangeBounds,
+    ops::{Bound, RangeBounds},
     sync::Arc,
 };
 
@@ -220,19 +220,45 @@ impl ZakuraDb {
         &self,
         range: impl RangeBounds<block::Height>,
     ) -> Vec<BlockCommitmentRoots> {
+        let Some(tip_height) = self.finalized_tip_height() else {
+            return Vec::new();
+        };
+        let Some(start_height) = (match range.start_bound() {
+            Bound::Included(height) => Some(*height),
+            Bound::Excluded(height) => height.next().ok(),
+            Bound::Unbounded => Some(block::Height::MIN),
+        }) else {
+            return Vec::new();
+        };
+        let Some(end_height) = (match range.end_bound() {
+            Bound::Included(height) => Some(*height),
+            Bound::Excluded(height) => height.previous().ok(),
+            Bound::Unbounded => Some(tip_height),
+        }) else {
+            return Vec::new();
+        };
+        let end_height = end_height.min(tip_height);
+        if start_height > end_height {
+            return Vec::new();
+        }
+
         let mut roots = Vec::new();
 
-        for (height, sapling) in self.sapling_tree_by_height_range(range) {
+        // The per-height tree column families are sparse: they only store a row
+        // when that pool's tree changes. Resolve each requested finalized height
+        // through the backwards tree lookup instead of iterating those sparse
+        // rows as if they were a contiguous block-height index.
+        for raw_height in start_height.0..=end_height.0 {
+            let height = block::Height(raw_height);
+            let Some(sapling) = self.sapling_tree_by_height(&height) else {
+                break;
+            };
             let Some(orchard) = self.orchard_tree_by_height(&height) else {
                 break;
             };
-            // The `unwrap_or_else` default is never reached in practice: the Sapling/Orchard
-            // lookups above already `break` for any height `ironwood_tree_by_height` would
-            // return `None` for (above the tip, or a fast-synced database's absent band).
-            let ironwood_root = self
-                .ironwood_tree_by_height(&height)
-                .map(|tree| tree.root())
-                .unwrap_or_else(|| ironwood::tree::NoteCommitmentTree::default().root());
+            let Some(ironwood) = self.ironwood_tree_by_height(&height) else {
+                break;
+            };
 
             let (sapling_tx, orchard_tx, ironwood_tx, auth_data_root) = self
                 .block(height.into())
@@ -255,7 +281,7 @@ impl ZakuraDb {
                 height,
                 sapling_root: sapling.root(),
                 orchard_root: orchard.root(),
-                ironwood_root,
+                ironwood_root: ironwood.root(),
                 sapling_tx,
                 orchard_tx,
                 ironwood_tx,

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
@@ -743,6 +743,45 @@ fn known_block_reports_finalized_block_after_body_pruned() {
 }
 
 #[test]
+fn best_chain_hash_reads_survive_finalized_body_pruning() {
+    let _init_guard = zakura_test::init();
+    let (state, genesis, block1) = mainnet_state_with_genesis();
+
+    write_full_block_header_and_transactions(&state, block1.clone());
+
+    let tx_by_loc = state.db.cf_handle("tx_by_loc").unwrap();
+    let mut batch = DiskWriteBatch::new();
+    batch.zs_delete_range(
+        &tx_by_loc,
+        TransactionLocation::min_for_height(Height(1)),
+        TransactionLocation::min_for_height(Height(2)),
+    );
+    state.db.write(batch).expect("body prune writes");
+
+    assert!(!state.contains_body_at_height(Height(1)));
+    assert_eq!(state.height(block1.hash()), Some(Height(1)));
+
+    let no_chain = Option::<Arc<crate::service::non_finalized_state::Chain>>::None;
+    assert_eq!(
+        read::depth(no_chain.clone(), &state, block1.hash()),
+        Some(0)
+    );
+    assert_eq!(
+        read::hash_by_height(no_chain.clone(), &state, Height(1)),
+        Some(block1.hash()),
+    );
+    assert!(read::find::chain_contains_hash(
+        no_chain.clone(),
+        &state,
+        block1.hash()
+    ));
+    assert_eq!(
+        read::find_chain_headers(no_chain, &state, vec![genesis.hash()], None, 1),
+        vec![block1.header.clone()],
+    );
+}
+
+#[test]
 fn header_range_commit_rejects_finalized_or_body_conflicts() {
     let _init_guard = zakura_test::init();
     let (state, genesis, block1) = mainnet_state_with_genesis();

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
@@ -669,6 +669,57 @@ fn header_range_roots_do_not_overwrite_committed_serving_index_rows() {
     );
 }
 
+/// Finalized root reads are indexed by block height, not by sparse tree rows.
+///
+/// Empty-shielded blocks leave the note-commitment trees unchanged, so only the
+/// genesis tree row is stored for this fixture. The range helper must still
+/// return one root payload for every committed height.
+#[test]
+fn finalized_commitment_roots_cover_unchanged_tree_heights() {
+    let _init_guard = zakura_test::init();
+    let genesis = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .expect("genesis block deserializes");
+    let block1 = zakura_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .expect("block 1 deserializes");
+    let mut state = ZakuraDb::new(
+        &Config::ephemeral(),
+        STATE_DATABASE_KIND,
+        &state_database_format_version_in_code(),
+        &Mainnet,
+        true,
+        STATE_COLUMN_FAMILIES_IN_CODE
+            .iter()
+            .map(ToString::to_string),
+        false,
+    )
+    .expect("opening the finalized state database should succeed");
+
+    write_full_block(&mut state, genesis);
+    write_full_block(&mut state, block1.clone());
+
+    assert_eq!(
+        state
+            .sapling_tree_by_height_range(Height(0)..=Height(1))
+            .count(),
+        1,
+        "the fixture must keep the Sapling tree column family sparse"
+    );
+
+    let roots = state.finalized_commitment_roots_by_height_range(Height(0)..=Height(1));
+    assert_eq!(
+        roots.iter().map(|roots| roots.height).collect::<Vec<_>>(),
+        vec![Height(0), Height(1)],
+        "every committed height must have a finalized root payload"
+    );
+    assert_eq!(
+        roots[1].auth_data_root,
+        block1.auth_data_root(),
+        "the unchanged-tree height still carries its own block auth-data root"
+    );
+}
+
 /// Pruning-readiness guard: a committed height whose body is removed (as online
 /// pruning deletes `tx_by_loc` rows) keeps its header readable from the retained
 /// consensus `block_header_by_height`, because the header readers are not gated

--- a/zakura-state/src/service/finalized_state/zakura_db/chain.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/chain.rs
@@ -18,7 +18,7 @@ use std::{
 
 use zakura_chain::{
     amount::NonNegative,
-    block::Height,
+    block::{Block, Height},
     block_info::BlockInfo,
     history_tree::HistoryTree,
     serialization::{CompactSizeMessage, ZcashSerialize as _},
@@ -36,6 +36,31 @@ use crate::{
     },
     HashOrHeight, ValidateContextError,
 };
+
+/// Returns the serialized wire size of `block`.
+///
+/// This is equivalent to [`Block::zcash_serialized_size`], but sums independent
+/// transaction sizes in parallel for large blocks.
+fn serialized_block_size(block: &Block) -> usize {
+    let transactions = &block.transactions;
+    let transactions_size: usize = if transactions.len() >= super::PARALLEL_BLOCK_TX_THRESHOLD {
+        use rayon::prelude::*;
+        transactions
+            .par_iter()
+            .map(|transaction| transaction.zcash_serialized_size())
+            .sum()
+    } else {
+        transactions
+            .iter()
+            .map(|transaction| transaction.zcash_serialized_size())
+            .sum()
+    };
+    let tx_count_size = CompactSizeMessage::try_from(transactions.len())
+        .expect("block must have a valid transaction count")
+        .zcash_serialized_size();
+
+    block.header.zcash_serialized_size() + tx_count_size + transactions_size
+}
 
 /// The name of the History Tree column family.
 ///
@@ -306,33 +331,51 @@ impl DiskWriteBatch {
         // Only fan out to rayon once the block has enough transactions to
         // amortize the fork-join cost; small blocks sum sequentially (see
         // PARALLEL_BLOCK_TX_THRESHOLD).
-        let block_size = {
-            let transactions = &finalized.block.transactions;
-            let transactions_size: usize =
-                if transactions.len() >= super::PARALLEL_BLOCK_TX_THRESHOLD {
-                    use rayon::prelude::*;
-                    transactions
-                        .par_iter()
-                        .map(|transaction| transaction.zcash_serialized_size())
-                        .sum()
-                } else {
-                    transactions
-                        .iter()
-                        .map(|transaction| transaction.zcash_serialized_size())
-                        .sum()
-                };
-            let tx_count_size = CompactSizeMessage::try_from(transactions.len())
-                .expect("block must have a valid transaction count")
-                .zcash_serialized_size();
-
-            finalized.block.header.zcash_serialized_size() + tx_count_size + transactions_size
-        };
+        let block_size = u32::try_from(serialized_block_size(&finalized.block))
+            .expect("verified blocks are bounded by MAX_BLOCK_BYTES, which fits in u32");
 
         let _ = db.block_info_cf().with_batch_for_writing(self).zs_insert(
             &finalized.height,
-            &BlockInfo::new(new_value_pool, block_size as u32),
+            &BlockInfo::new(new_value_pool, block_size),
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use zakura_chain::serialization::ZcashDeserializeInto;
+
+    fn block_with_transaction_count(transaction_count: usize) -> Block {
+        let mut block = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("mainnet genesis test vector deserializes");
+        let coinbase = block.transactions[0].clone();
+        block.transactions = vec![coinbase; transaction_count];
+        block
+    }
+
+    #[test]
+    fn serialized_block_size_matches_wire_size_across_parallel_and_compact_size_boundaries() {
+        let _init_guard = zakura_test::init();
+
+        for transaction_count in [
+            1,
+            super::super::PARALLEL_BLOCK_TX_THRESHOLD - 1,
+            super::super::PARALLEL_BLOCK_TX_THRESHOLD,
+            252,
+            253,
+        ] {
+            let block = block_with_transaction_count(transaction_count);
+
+            assert_eq!(
+                serialized_block_size(&block),
+                block.zcash_serialized_size(),
+                "serialized block size must match at transaction count {transaction_count}"
+            );
+        }
     }
 }

--- a/zakura-state/src/service/finalized_state/zakura_db/prune.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/prune.rs
@@ -276,10 +276,14 @@ fn raw_transaction_data_available(
     from: block::Height,
     until: block::Height,
 ) -> bool {
-    matches!(
-        raw_transaction_height_ranges(db, from, until).as_slice(),
-        [range] if *range == (from, until)
-    )
+    // This is only called when the current pruning marker is above `until`, so
+    // `ZakuraDb::block()` treats each height as potentially pruned and verifies
+    // that its raw transaction count matches the retained hash index. Requiring
+    // full block reconstruction prevents a partially missing body from being
+    // reclassified as retained history when the marker is moved backwards.
+    (from.0..until.0)
+        .map(block::Height)
+        .all(|height| db.block(height.into()).is_some())
 }
 
 fn raw_transaction_height_ranges(
@@ -334,9 +338,10 @@ mod tests {
 
     use zakura_chain::{
         block::Block, parameters::Network::Mainnet, serialization::ZcashDeserializeInto,
+        transaction,
     };
 
-    use crate::service::finalized_state::FinalizedState;
+    use crate::service::finalized_state::{disk_db::WriteDisk, FinalizedState};
 
     /// The number of leading blocks committed by the database-backed prune tests.
     const TEST_BLOCKS: u32 = 9;
@@ -548,6 +553,48 @@ mod tests {
 
         let error = pruning_summary(&state.db, &PruneFinalizedStateOptions { tx_retention: 6 })
             .expect_err("missing transaction data cannot be restored");
+
+        assert!(matches!(
+            error,
+            PruneFinalizedStateError::AlreadyPrunedBeyondRetention {
+                current: block::Height(5),
+                requested: Some(block::Height(4)),
+            }
+        ));
+    }
+
+    #[test]
+    fn pruning_summary_refuses_marker_correction_for_partial_raw_body() {
+        let _init_guard = zakura_test::init();
+        let state = new_state_with_blocks();
+
+        // Simulate a stale marker plus a partially missing retained body. Height 4
+        // still has its coinbase raw row, but its retained hash index claims a
+        // second transaction body that is absent from `tx_by_loc`.
+        let hash_by_tx_loc = state.db.db().cf_handle("hash_by_tx_loc").unwrap();
+        let mut batch = DiskWriteBatch::new();
+        batch.zs_insert(
+            &hash_by_tx_loc,
+            TransactionLocation::from_index(block::Height(4), 1),
+            transaction::Hash([0x42; 32]),
+        );
+        batch.prepare_pruning_marker_batch(&state.db, block::Height(5));
+        state
+            .db
+            .write_batch(batch)
+            .expect("synthetic partial body writes");
+
+        assert!(
+            state.db.contains_body_at_height(block::Height(4)),
+            "the first raw row still makes the partial body look present"
+        );
+        assert!(
+            state.db.block(block::Height(4).into()).is_none(),
+            "the marker-aware block read rejects the incomplete transaction set"
+        );
+
+        let error = pruning_summary(&state.db, &PruneFinalizedStateOptions { tx_retention: 6 })
+            .expect_err("a partial body cannot justify moving the marker backwards");
 
         assert!(matches!(
             error,

--- a/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
@@ -17,9 +17,7 @@ use zakura_chain::{
         subsidy::{block_subsidy, funding_stream_values, FundingStreamReceiver, SubsidyError},
         Network, NetworkUpgrade,
     },
-    sapling,
-    subtree::NoteCommitmentSubtreeIndex,
-    transaction,
+    sapling, transaction,
     transparent::{self, Input},
     value_balance::ValueBalance,
 };
@@ -661,10 +659,6 @@ fn deferred_pool_balance_change(
     height: Height,
     network: &Network,
 ) -> Result<Option<DeferredPoolBalanceChange>, RollbackFinalizedStateError> {
-    if height <= network.slow_start_interval() {
-        return Ok(None);
-    }
-
     let deferred_amount = funding_stream_values(height, network, block_subsidy(height, network)?)?
         .remove(&FundingStreamReceiver::Deferred)
         .unwrap_or_default()
@@ -1038,15 +1032,15 @@ fn prune_tree_indexes(
     // database does not serve roots for heights it no longer holds.
     batch.delete_range_commitment_roots_by_height(db, &Height(target_height.0 + 1), &Height::MAX);
 
-    // Delete every sapling/orchard/ironwood subtree whose notes extend past the target height. Subtree
-    // indexes are read back from the database and number far fewer than `u16::MAX`, so `index.0 + 1`
-    // (the exclusive end of the single-index delete range) cannot overflow.
+    // Delete every sapling/orchard/ironwood subtree whose notes extend past the target height.
+    // Delete exact keys rather than constructing a one-key half-open range: `u16::MAX` is a
+    // supported subtree index, so `index + 1` would wrap in release builds.
     for (index, _) in db
         .sapling_subtree_list_by_index_range(..)
         .into_iter()
         .filter(|(_, subtree)| subtree.end_height > target_height)
     {
-        batch.delete_range_sapling_subtree(db, index, NoteCommitmentSubtreeIndex(index.0 + 1));
+        batch.delete_sapling_subtree(db, index);
     }
 
     for (index, _) in db
@@ -1054,7 +1048,7 @@ fn prune_tree_indexes(
         .into_iter()
         .filter(|(_, subtree)| subtree.end_height > target_height)
     {
-        batch.delete_range_orchard_subtree(db, index, NoteCommitmentSubtreeIndex(index.0 + 1));
+        batch.delete_orchard_subtree(db, index);
     }
 
     for (index, _) in db
@@ -1062,7 +1056,7 @@ fn prune_tree_indexes(
         .into_iter()
         .filter(|(_, subtree)| subtree.end_height > target_height)
     {
-        batch.delete_range_ironwood_subtree(db, index, NoteCommitmentSubtreeIndex(index.0 + 1));
+        batch.delete_ironwood_subtree(db, index);
     }
 
     // Sprout has no by-height anchor index, so enumerate every anchor and drop the ones not seen
@@ -1162,7 +1156,11 @@ fn clear_backup_dir(path: &PathBuf) -> Result<(), std::io::Error> {
 
 #[cfg(test)]
 mod tests {
+    use zakura_chain::parameters::testnet::{
+        ConfiguredActivationHeights, ConfiguredLockboxDisbursement, Parameters as TestnetParameters,
+    };
     use zakura_chain::serialization::ZcashDeserializeInto;
+    use zakura_chain::subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeIndex};
 
     use crate::service::finalized_state::disk_format::RawBytes;
 
@@ -1325,6 +1323,105 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![Height(1), Height(2)],
             "rollback truncates the serving index above the target"
+        );
+    }
+
+    #[test]
+    fn prune_tree_indexes_deletes_max_subtree_index() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+
+        let sapling_node = sapling_crypto::Node::from_bytes([0; 32]).expect("dummy sapling node");
+        let orchard_node = orchard::tree::Node::default();
+        let ironwood_node = ironwood::tree::Node::default();
+        let max_index = NoteCommitmentSubtreeIndex(u16::MAX);
+
+        let mut batch = DiskWriteBatch::new();
+        batch.insert_sapling_subtree(
+            &db,
+            &NoteCommitmentSubtree::new(0u16, Height(2), sapling_node),
+        );
+        batch.insert_sapling_subtree(
+            &db,
+            &NoteCommitmentSubtree::new(max_index, Height(3), sapling_node),
+        );
+        batch.insert_orchard_subtree(
+            &db,
+            &NoteCommitmentSubtree::new(0u16, Height(2), orchard_node),
+        );
+        batch.insert_orchard_subtree(
+            &db,
+            &NoteCommitmentSubtree::new(max_index, Height(3), orchard_node),
+        );
+        batch.insert_ironwood_subtree(
+            &db,
+            &NoteCommitmentSubtree::new(0u16, Height(2), ironwood_node),
+        );
+        batch.insert_ironwood_subtree(
+            &db,
+            &NoteCommitmentSubtree::new(max_index, Height(3), ironwood_node),
+        );
+        db.write_batch(batch)
+            .expect("seeding synthetic max-index subtrees succeeds");
+
+        let mut batch = DiskWriteBatch::new();
+        prune_tree_indexes(&db, &mut batch, Height(2), &None);
+        db.write_batch(batch)
+            .expect("pruning synthetic max-index subtrees succeeds");
+
+        assert_eq!(
+            db.sapling_subtree_list_by_index_range(..)
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![NoteCommitmentSubtreeIndex(0)]
+        );
+        assert_eq!(
+            db.orchard_subtree_list_by_index_range(..)
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![NoteCommitmentSubtreeIndex(0)]
+        );
+        assert_eq!(
+            db.ironwood_subtree_list_by_index_range(..)
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![NoteCommitmentSubtreeIndex(0)]
+        );
+    }
+
+    #[test]
+    fn deferred_pool_balance_change_keeps_lockbox_disbursement_during_slow_start() {
+        let height = Height(10);
+        let network = TestnetParameters::build()
+            .with_activation_heights(ConfiguredActivationHeights {
+                blossom: Some(1),
+                canopy: Some(1),
+                nu5: Some(1),
+                nu6: Some(1),
+                nu6_1: Some(height.0),
+                ..Default::default()
+            })
+            .expect("configured activation heights are valid")
+            .clear_funding_streams()
+            .with_slow_start_interval(Height(11))
+            .with_lockbox_disbursements(vec![ConfiguredLockboxDisbursement {
+                address: "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz".to_string(),
+                amount: Amount::try_from(1).expect("valid test amount"),
+            }])
+            .to_network()
+            .expect("configured network is valid");
+
+        assert_eq!(
+            deferred_pool_balance_change(height, &network)
+                .expect("configured lockbox amount fits in the deferred pool"),
+            Some(DeferredPoolBalanceChange::new(
+                Amount::<zakura_chain::amount::NegativeAllowed>::try_from(-1)
+                    .expect("valid negative test amount"),
+            )),
+            "rollback backup metadata must match consensus even when NU6.1 activates during slow start"
         );
     }
 

--- a/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
@@ -1123,6 +1123,19 @@ impl DiskWriteBatch {
         self.zs_delete(&sapling_anchors, anchor);
     }
 
+    /// Deletes the Sapling subtree at the given [`NoteCommitmentSubtreeIndex`].
+    pub fn delete_sapling_subtree(
+        &mut self,
+        zakura_db: &ZakuraDb,
+        index: NoteCommitmentSubtreeIndex,
+    ) {
+        let sapling_subtree_cf = zakura_db
+            .db
+            .cf_handle("sapling_note_commitment_subtree")
+            .unwrap();
+        self.zs_delete(&sapling_subtree_cf, index);
+    }
+
     /// Deletes the range of Sapling subtrees at the given [`NoteCommitmentSubtreeIndex`]es.
     /// Doesn't delete the upper bound.
     pub fn delete_range_sapling_subtree(
@@ -1247,6 +1260,19 @@ impl DiskWriteBatch {
         self.zs_delete(&orchard_anchors, anchor);
     }
 
+    /// Deletes the Orchard subtree at the given [`NoteCommitmentSubtreeIndex`].
+    pub fn delete_orchard_subtree(
+        &mut self,
+        zakura_db: &ZakuraDb,
+        index: NoteCommitmentSubtreeIndex,
+    ) {
+        let orchard_subtree_cf = zakura_db
+            .db
+            .cf_handle("orchard_note_commitment_subtree")
+            .unwrap();
+        self.zs_delete(&orchard_subtree_cf, index);
+    }
+
     /// Deletes the range of Orchard subtrees at the given [`NoteCommitmentSubtreeIndex`]es.
     /// Doesn't delete the upper bound.
     pub fn delete_range_orchard_subtree(
@@ -1277,6 +1303,19 @@ impl DiskWriteBatch {
     pub fn delete_ironwood_anchor(&mut self, zakura_db: &ZakuraDb, anchor: &ironwood::tree::Root) {
         let ironwood_anchors = zakura_db.db.cf_handle("ironwood_anchors").unwrap();
         self.zs_delete(&ironwood_anchors, anchor);
+    }
+
+    /// Deletes the Ironwood subtree at the given [`NoteCommitmentSubtreeIndex`].
+    pub fn delete_ironwood_subtree(
+        &mut self,
+        zakura_db: &ZakuraDb,
+        index: NoteCommitmentSubtreeIndex,
+    ) {
+        let ironwood_subtree_cf = zakura_db
+            .db
+            .cf_handle("ironwood_note_commitment_subtree")
+            .unwrap();
+        self.zs_delete(&ironwood_subtree_cf, index);
     }
 
     /// Deletes the range of Ironwood subtrees at the given [`NoteCommitmentSubtreeIndex`]es.

--- a/zakura-state/src/service/non_finalized_state.rs
+++ b/zakura-state/src/service/non_finalized_state.rs
@@ -379,9 +379,8 @@ impl NonFinalizedState {
         };
 
         let invalidated_blocks = if chain.non_finalized_root_hash() == block_hash {
-            let chain_tip_hash = chain.non_finalized_tip_hash();
             self.chain_set
-                .retain(|chain| chain.non_finalized_tip_hash() != chain_tip_hash);
+                .retain(|chain| !chain.contains_block_hash(block_hash));
             chain.blocks.values().cloned().collect()
         } else {
             let (new_chain, invalidated_blocks) = chain

--- a/zakura-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zakura-state/src/service/non_finalized_state/tests/vectors.rs
@@ -346,8 +346,8 @@ fn new_invalidate_test_state(network: &Network) -> (NonFinalizedState, Finalized
 /// Invalidating the non-finalized root of a tracked chain previously called
 /// `BTreeSet::remove(&chain)`, which compared the stored chain against
 /// itself via `Chain::cmp` and reached an `unreachable!()` for matching tip
-/// hashes. The root branch now retains by tip hash and the call returns
-/// successfully without panicking.
+/// hashes. The root branch now retains chains that do not contain the root
+/// hash, so the call returns successfully without panicking.
 #[test]
 fn invalidating_non_finalized_root_does_not_panic() {
     let _init_guard = zakura_test::init();
@@ -373,6 +373,43 @@ fn invalidating_non_finalized_root_does_not_panic() {
         state.best_chain().is_none(),
         "invalidating the root should leave no live non-finalized chain"
     );
+}
+
+/// A non-finalized root can be shared by multiple sibling forks. Invalidating
+/// that root must remove every live fork containing it, not only the best fork
+/// selected to populate the invalidation record.
+#[test]
+fn invalidating_shared_non_finalized_root_removes_all_forks() {
+    let _init_guard = zakura_test::init();
+
+    let network = Network::Mainnet;
+    let block1: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+    let block2a = block1.make_fake_child().set_work(10);
+    let block2b = block1.make_fake_child().set_work(11);
+
+    let (mut state, finalized_state) = new_invalidate_test_state(&network);
+
+    state
+        .commit_new_chain(block1.clone().prepare(), &finalized_state)
+        .expect("fake root block should commit to an empty non-finalized state");
+    state
+        .commit_block(block2a.clone().prepare(), &finalized_state)
+        .expect("first fork tip should extend the root chain");
+    state
+        .commit_block(block2b.clone().prepare(), &finalized_state)
+        .expect("second fork tip should fork from the root chain");
+
+    state
+        .invalidate_block(block1.hash())
+        .expect("invalidating a shared root should remove every descendant fork");
+
+    assert!(
+        state.best_chain().is_none(),
+        "invalidating a shared root should leave no live non-finalized chain"
+    );
+    assert!(!state.any_chain_contains(&block1.hash()));
+    assert!(!state.any_chain_contains(&block2a.hash()));
+    assert!(!state.any_chain_contains(&block2b.hash()));
 }
 
 /// Regression test for https://github.com/ZcashFoundation/zebra/issues/10586.

--- a/zakura-state/src/service/read/tests/vectors.rs
+++ b/zakura-state/src/service/read/tests/vectors.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tower::ServiceExt;
 use zakura_chain::{
     block::{Block, Height},
-    orchard,
+    ironwood, orchard,
     parameters::Network::*,
     serialization::ZcashDeserializeInto,
     subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
@@ -24,7 +24,7 @@ use crate::{
     service::{
         finalized_state::{DiskWriteBatch, ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
         non_finalized_state::Chain,
-        read::{orchard_subtrees, sapling_subtrees},
+        read::{ironwood_subtrees, orchard_subtrees, sapling_subtrees},
     },
     Config, ReadRequest, ReadResponse,
 };
@@ -332,6 +332,83 @@ async fn test_orchard_subtrees() -> Result<()> {
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     Ok(())
+}
+
+/// Tests if Zebra combines the Ironwood note commitment subtrees from the finalized and
+/// non-finalized states correctly.
+#[tokio::test]
+async fn test_ironwood_subtrees() -> Result<()> {
+    let dummy_subtree_root = ironwood::tree::Node::default();
+
+    // Prepare the finalized state.
+    let db_subtree = NoteCommitmentSubtree::new(0, Height(1), dummy_subtree_root);
+
+    let db = new_ephemeral_db();
+    let mut db_batch = DiskWriteBatch::new();
+    db_batch.insert_ironwood_subtree(&db, &db_subtree);
+    db.write(db_batch)
+        .expect("Writing a batch with an Ironwood subtree should succeed.");
+
+    // Prepare the non-finalized state.
+    let chain_subtree = NoteCommitmentSubtree::new(1, Height(3), dummy_subtree_root);
+    let mut chain = Chain::default();
+    chain.insert_ironwood_subtree(chain_subtree);
+    let chain = Some(Arc::new(chain));
+
+    // At this point, we have one Ironwood subtree in the finalized state and one Ironwood subtree in
+    // the non-finalized state.
+
+    // Retrieve only the first subtree and check its properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
+
+    // Retrieve both subtrees using a limit and check their properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 2);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve both subtrees without using a limit and check their properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..);
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 2);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve only the second subtree and check its properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve only the second subtree, using a limit that would allow for more trees if they were
+    // present, and check its properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve only the second subtree, without using any limit, and check its properties.
+    let subtrees = ironwood_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..);
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    Ok(())
+}
+
+#[test]
+fn excluded_max_subtree_range_is_empty() {
+    use std::ops::Bound::*;
+
+    let db = new_ephemeral_db();
+    let no_chain = Option::<Arc<Chain>>::None;
+    let range = (Excluded(NoteCommitmentSubtreeIndex(u16::MAX)), Unbounded);
+
+    assert!(sapling_subtrees(no_chain, &db, range).is_empty());
 }
 
 /// Returns test cases for the empty state and missing blocks.

--- a/zakura-state/src/service/read/tree.rs
+++ b/zakura-state/src/service/read/tree.rs
@@ -188,10 +188,12 @@ where
 {
     use std::ops::Bound::*;
 
-    let start_index = match range.start_bound().cloned() {
-        Included(start_index) => start_index,
-        Excluded(start_index) => (start_index.0 + 1).into(),
-        Unbounded => 0.into(),
+    let Some(start_index) = (match range.start_bound().cloned() {
+        Included(start_index) => Some(start_index),
+        Excluded(start_index) => start_index.0.checked_add(1).map(Into::into),
+        Unbounded => Some(0.into()),
+    }) else {
+        return BTreeMap::new();
     };
 
     // # Correctness

--- a/zakura-state/src/service/tests.rs
+++ b/zakura-state/src/service/tests.rs
@@ -26,10 +26,11 @@ use zakura_test::{prelude::*, transcript::Transcript};
 
 use crate::{
     arbitrary::Prepare,
+    constants::MAX_HEADER_SYNC_HEIGHT_RANGE,
     init_test,
     service::{
-        arbitrary::populated_state, chain_tip::TipAction, headers_by_height_range,
-        non_finalized_state::Chain, read, StateService,
+        arbitrary::populated_state, capped_height_range, chain_tip::TipAction,
+        headers_by_height_range, non_finalized_state::Chain, read, StateService,
     },
     tests::{
         setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
@@ -859,6 +860,22 @@ async fn header_range_reads_include_non_finalized_best_chain_blocks() -> Result<
     );
 
     Ok(())
+}
+
+#[test]
+fn capped_height_range_enforces_max_native_range() {
+    let heights: Vec<_> = capped_height_range(Height(1), u32::MAX).collect();
+
+    assert_eq!(
+        heights.len(),
+        usize::try_from(MAX_HEADER_SYNC_HEIGHT_RANGE).expect("range cap fits in usize"),
+    );
+    assert_eq!(heights.first(), Some(&Height(1)));
+    assert_eq!(heights.last(), Some(&Height(MAX_HEADER_SYNC_HEIGHT_RANGE)));
+    assert_eq!(
+        capped_height_range(Height(u32::MAX), u32::MAX).collect::<Vec<_>>(),
+        vec![Height(u32::MAX)],
+    );
 }
 
 #[test]

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -1911,6 +1911,69 @@ mod zakura_header_sync_driver_tests {
         );
     }
 
+    #[tokio::test]
+    async fn query_best_header_tip_chunks_root_coverage_reads() {
+        let verified_tip = (block::Height(0), block::Hash([0; 32]));
+        let count = zakura_state::constants::MAX_HEADER_SYNC_HEIGHT_RANGE + 2;
+        let durable_header_tip = (block::Height(count), block::Hash([2; 32]));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let read_state = {
+            let requests = Arc::clone(&requests);
+            service_fn(move |request: zakura_state::ReadRequest| {
+                let requests = Arc::clone(&requests);
+                async move {
+                    match request {
+                        zakura_state::ReadRequest::Tip => Ok::<_, zakura_state::BoxError>(
+                            zakura_state::ReadResponse::Tip(Some(verified_tip)),
+                        ),
+                        zakura_state::ReadRequest::BlockRoots {
+                            start_height,
+                            count,
+                        } => {
+                            requests
+                                .lock()
+                                .expect("request capture mutex is not poisoned")
+                                .push((start_height, count));
+                            let roots = (0..count)
+                                .filter_map(|offset| {
+                                    start_height
+                                        .0
+                                        .checked_add(offset)
+                                        .map(|height| root_at(block::Height(height)))
+                                })
+                                .collect();
+                            Ok(zakura_state::ReadResponse::BlockRoots(roots))
+                        }
+                        request => panic!("unexpected read request: {request:?}"),
+                    }
+                }
+            })
+        };
+
+        assert_eq!(
+            root_covered_query_best_header_tip(read_state, durable_header_tip)
+                .await
+                .expect("chunked root coverage query succeeds"),
+            durable_header_tip
+        );
+        assert_eq!(
+            requests
+                .lock()
+                .expect("request capture mutex is not poisoned")
+                .as_slice(),
+            &[
+                (
+                    block::Height(1),
+                    zakura_state::constants::MAX_HEADER_SYNC_HEIGHT_RANGE,
+                ),
+                (
+                    block::Height(zakura_state::constants::MAX_HEADER_SYNC_HEIGHT_RANGE + 1),
+                    2,
+                ),
+            ]
+        );
+    }
+
     #[test]
     fn block_verify_error_duplicate_classifier_detects_router_and_block_errors() {
         let hash = block::Hash([1; 32]);

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -94,7 +94,8 @@ where
             zakura_state::ReadRequest,
             Response = zakura_state::ReadResponse,
             Error = zakura_state::BoxError,
-        > + Send
+        > + Clone
+        + Send
         + 'static,
     ReadState::Future: Send + 'static,
 {
@@ -102,32 +103,49 @@ where
         return Ok(best_header_tip);
     }
 
-    let Ok(start_height) = verified_block_tip.0.next() else {
+    let Ok(mut start_height) = verified_block_tip.0.next() else {
         return Ok(verified_block_tip);
     };
     let best_header_height = best_header_tip.0;
     let verified_block_height = verified_block_tip.0;
-    let count = best_header_height
+    let mut remaining = best_header_height
         .0
         .checked_sub(verified_block_height.0)
         .ok_or_else(|| eyre!("best header tip is unexpectedly below verified block tip"))?;
-    let roots = match read_state
-        .oneshot(zakura_state::ReadRequest::BlockRoots {
-            start_height,
-            count,
-        })
-        .await
-        .map_err(|error| eyre!("{error}"))?
-    {
-        zakura_state::ReadResponse::BlockRoots(roots) => roots,
-        response => Err(eyre!("unexpected BlockRoots response: {response:?}"))?,
-    };
 
-    if block_roots_cover_range(start_height, count, &roots) {
-        Ok(best_header_tip)
-    } else {
-        Ok(verified_block_tip)
+    while remaining > 0 {
+        let count = remaining.min(zakura_state::constants::MAX_HEADER_SYNC_HEIGHT_RANGE);
+        let roots = match read_state
+            .clone()
+            .oneshot(zakura_state::ReadRequest::BlockRoots {
+                start_height,
+                count,
+            })
+            .await
+            .map_err(|error| eyre!("{error}"))?
+        {
+            zakura_state::ReadResponse::BlockRoots(roots) => roots,
+            response => Err(eyre!("unexpected BlockRoots response: {response:?}"))?,
+        };
+
+        if !block_roots_cover_range(start_height, count, &roots) {
+            return Ok(verified_block_tip);
+        }
+
+        remaining = remaining
+            .checked_sub(count)
+            .expect("root coverage chunk count is bounded by the remaining range");
+        if remaining == 0 {
+            break;
+        }
+
+        let Some(next_start_height) = start_height.0.checked_add(count).map(block::Height) else {
+            return Ok(verified_block_tip);
+        };
+        start_height = next_start_height;
     }
+
+    Ok(best_header_tip)
 }
 
 pub(crate) async fn root_covered_query_best_header_tip<ReadState>(

--- a/zakurad/tests/config.rs
+++ b/zakurad/tests/config.rs
@@ -9,6 +9,7 @@
 use std::{env, fs, io::Write, path::PathBuf, sync::Mutex};
 
 use tempfile::{Builder, TempDir};
+use zakura_chain::{block::Height, parameters::NetworkUpgrade};
 use zakura_network::zakura::{DEFAULT_ZAKURA_LISTEN_ADDR, DEFAULT_ZAKURA_MAX_CONNS_PER_IP};
 use zakurad::components::{
     tracing::{Config as TracingConfig, InnerConfig as TracingInnerConfig, ProgressConfig},
@@ -150,6 +151,35 @@ endpoint_addr = "127.0.0.1:9999"
     assert_eq!(
         config.metrics.endpoint_addr.unwrap().to_string(),
         "127.0.0.1:9999"
+    );
+}
+
+/// The NU6.3 activation height must be configurable from a zakurad config
+/// file. The serde key contains a dot ("NU6.3"), so the TOML key must be
+/// quoted — this pins the exact spelling an operator has to write.
+#[test]
+fn config_loads_quoted_nu6_3_activation_height() {
+    let _env = EnvGuard::new();
+
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let config_path = temp_dir.path().join("nu6_3_config.toml");
+
+    let test_config = r#"
+[network]
+network = "Regtest"
+
+[network.testnet_parameters.activation_heights]
+"NU6.3" = 23
+"#;
+
+    fs::write(&config_path, test_config).expect("write test config");
+
+    let config = ZakuradConfig::load(Some(config_path)).expect("load NU6.3 config from file");
+
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&config.network.network),
+        Some(Height(23)),
+        "the exact dotted TOML key must configure the requested NU6.3 height"
     );
 }
 


### PR DESCRIPTION
## Motivation

This branch collects a batch of correctness fixes found while writing
adversarial test coverage for the newer Zakura-specific paths (V6/Ironwood,
NU6.1–NU6.3, verified-commitment-trees fast sync, and the offline
prune/rollback tooling). The history is organized so the two kinds of change
are easy to review separately: a small number of **test-only** commits that
add coverage without touching logic, and **one commit per behavioral change**,
each self-contained.

Nothing here is believed to be remotely exploitable on Mainnet or Testnet as
shipped — see the classification on each fix below for why. The changes are a
mix of genuine bugs on configured/local networks, consensus-code hardening
that is currently fail-closed elsewhere, and robustness/liveness fixes.

## Behavioral changes and bugfixes

Each fix is one commit. Tagged **🔒 consensus/security-relevant** when the code
it touches is consensus- or security-critical (with a note on why it is not
currently exploitable), or **robustness/liveness** otherwise.

### Consensus- and security-relevant

**🔒 `fix(consensus): validate zero-subsidy lockbox outputs`** — `subsidy_is_valid`
returned early with a zero deferred-pool change whenever the expected block
subsidy was zero, which skips the founders-reward, funding-stream, and NU6.1
one-time ZIP-271 lockbox-disbursement checks entirely. The lockbox disbursement
is a fixed amount that does not scale with the subsidy, so a network activating
NU6.1 at a zero-subsidy height would accept an activation block missing its
mandatory disbursement outputs, and even a compliant block had its deferred-pool
debit reported as zero, corrupting value-pool accounting. The early return is
removed so every subsidy-output rule runs regardless of the amount. *Not
exploitable on Mainnet/Testnet:* both activate NU6.1 at funded (non-zero-subsidy)
heights, so only custom-configured networks are affected — but it is a real
consensus-rule skip, hence the tag.

✅ **🔒 `fix(state): bind vct prevalidation to auth roots`** — the verified-commitment-trees
fast-commit look-ahead cached its prevalidated successor as `(height, hash)`, but
at NU5 and later the block hash does not commit to authorizing data — the header
commitment does, via the auth-data root. A header-only successor witness carries
that root separately from the later body, so a body with the same header hash but
different authorizing data could reuse the witness's prevalidation and skip the
one commitment check that binds its authorizing data to the validated header
chain. The cache is now keyed on `(height, hash, auth_data_root)` and the
committed block's own root must match before the check is skipped (below NU5 the
root is not a commitment input and stays `None`). *Not independently exploitable:*
the fast-sync path is checkpoint-gated, so an attacker cannot substitute an
arbitrary body — but this closes the binding gap directly.

✅ **🔒 `fix: lock checkpoint auth roots to wrapped blocks`** — `CheckpointVerifiedBlock`
exposed `DerefMut` alongside its cached `auth_data_root`, so a holder could swap
the block or the cached root after construction and pair a stale auth-data root
with a different block; a header matching the stale root could then finalize a
block without proving the header binds that block's actual authorizing data.
`DerefMut` is removed and the only legitimate use now goes through
`with_precomputed_auth_data_root()`, which computes the root from the wrapped
block itself. *Not a live bug:* no current caller desynced the pair, so this is
compile-time enforcement of a consensus invariant. (Also drops a since-obsolete
TODO about mempool spent-output ordering, which can no longer occur.)

✅ **🔒 `fix(script): enforce p2sh sigop input alignment`** — `p2sh_sigop_count` pairs
inputs with spent outputs via `zip()`, which silently truncates on a length
mismatch and undercounts P2SH sigops; the block sigop limit is a consensus rule,
so a silent undercount could admit an over-limit block. The alignment invariant
was guarded only by a `debug_assert`, which release builds skip — it is now a hard
`assert` with a documented panic contract. *Not a live bug:* all current callers
build `spent_outputs` positionally per input, so this is release-build hardening
of a consensus check.

✅ **🔒 `fix(chain): reserve V6 Orchard cross-address flag`** — the V6 transaction codec
applied the Ironwood-permissive flag grammar to both shielded slots, so a V6
Orchard bundle carrying the cross-address bit (bit 2) round-tripped through the
wire layer even though only the Ironwood slot defines that bit. The codec now
keeps bit 2 reserved in the V6 Orchard slot on both serialization and
deserialization. *Not an acceptance bypass:* the semantic verifier and the
librustzcash conversion already reject such bundles, and V6/NU6.3 is a future
upgrade — this is wire-format spec conformance, fail-closed downstream.

✅ **🔒 `fix(chain): reject common equihash proofs on regtest`** — `Solution::check()`
accepted a 1344-byte `Common` solution on Regtest and verified it under the
`(200, 9)` parameters, even though Regtest's active Equihash parameters are
`(48, 5)`; a Mainnet-shaped proof must not become valid merely because the caller
supplies a Regtest network. The checker now uses an exact network/variant mapping
so any mismatch is rejected before Equihash verification. *Not a live bypass:*
canonical Regtest disables PoW, so this is conformance with zcashd and safety for
direct callers or a future PoW-enabled Regtest.

### Robustness and liveness

**`fix(state): preserve chunked header root coverage`** — the native header-sync
driver issued a single `BlockRoots` read spanning the whole gap between the
verified-block tip and the best header tip, but the state caps each `BlockRoots`
response at `MAX_HEADER_SYNC_HEIGHT_RANGE`. Once the tip lag exceeded the cap, the
coverage check could never observe a full response and the driver kept restarting
from the verified-block tip. The driver now walks the span in cap-sized chunks,
and `BlocksByHeightRange` is bounded by the same constant at the state boundary so
one request cannot ask the database for an unbounded range.

✅ **`fix(state): fill finalized root ranges across unchanged trees`** —
`block_roots_by_height_range` iterated the per-height Sapling tree column family,
which is sparse (a row exists only where that pool's tree changed). Heights whose
blocks added no Sapling commitments were silently omitted from `BlockRoots`
responses, so the header-sync coverage check saw gaps and could stall. It now
resolves every requested finalized height through the backwards tree lookup, and
resolves Ironwood the same way instead of defaulting an absent tree to the empty
root.

✅ **`fix(network): honor disable_pow in native header sync`** — native header sync's
wire-level PoW gating keyed on Regtest parameters rather than the effective PoW
mode, so a configured Testnet with `disable_pow = true` had its headers rejected
and could never sync, even though semantic and checkpoint verification
intentionally skip Equihash and difficulty checks in that mode. Both helpers now
return early when `disable_pow()` is set; canonical Regtest (which always sets it)
keeps its prior behavior, and PoW-enabled networks are unaffected.

✅ **`fix(chain): satisfy the lockbox rule on local-genesis networks activating NU6.1 or later`**
— `NetworkUpgrade::activation_height()` falls through to the next configured
upgrade, so skipping NU6.1 on generated local testnets did not actually skip the
one-time lockbox-disbursement rule: subsidy validation still fired at the shared
activation height, found no configured disbursements, and rejected every possible
activation block. The generator now activates NU6.1 alongside the other upgrades
with a zero-value P2SH lockbox marker output (satisfying the structural rule
without creating funds), and rejects a requested upgrade that has no compiled
consensus branch ID instead of building a network that panics downstream. Affects
the local-testnet generation tool only.

**`fix(state): harden offline prune and rollback integrity`** — three integrity
fixes in the operator-run offline prune/rollback commands: (1) moving the pruning
marker backwards now requires each affected height to fully reconstruct through
the marker-aware block reader, so a partially missing body cannot be reclassified
as retained history; (2) rollback's deferred-pool recomputation no longer skips
heights inside the slow-start interval, where the fixed NU6.1 lockbox disbursement
still debits the deferred pool (skipping it corrupted value-pool accounting on
networks activating NU6.1 during slow start); (3) tree-index pruning deletes
subtrees by exact key instead of an `index..index + 1` range, which wrapped in
release builds for the supported `u16::MAX` subtree index and left that subtree in
place. Also replaces a block-size `as u32` cast with a checked conversion.

**`fix(state): harden finalized disk format checks`** — truncated finalized-state
rows could be misread as complete rows of an older format: a `BlockInfo` row
between the NU6.1 and Ironwood widths was parsed as legacy (reinterpreting the
first Ironwood amount bytes as the block size), and a partial
`CommitmentRootsByHeight` row was parsed as a pre-Ironwood layout with defaulted
roots and counts. Both readers now accept only the exact legacy widths (plus
forward-compatible extensions of the current width) and panic with the offending
length otherwise, surfacing local database corruption instead of silently
mangling value pools or serving zeroed commitment roots. The genesis-roots
upgrade check also now distinguishes the benign VCT fast-sync race from a
genuinely missing genesis tree.

✅ **`fix(state): remove all forks when invalidating shared root`** — invalidating a
block at a chain's non-finalized root removed only the chain whose tip matched, so
sibling forks that also contained the invalidated block survived and the node
could keep extending a chain built on it. Invalidation now retains only chains
that do not contain the invalidated hash, removing every fork rooted in that block
together. Reachable via the operator-facing invalidate request, not remotely.

✅ **`fix(state): reject unknown archive storage-mode config keys`** —
`[storage_mode.archive]` deserialized its table value as `IgnoredAny`, so a
pruned-only or misspelled setting placed under the archive table was silently
ignored rather than failing config parsing. It now deserializes as an empty
`deny_unknown_fields` struct, so such configs are rejected at startup.

**`fix(chain): keep sapling commitment constructors strict`** — Sapling
`ValueCommitment` had two constructors that accepted points its own deserializer
rejects: `FromHex` accepted any decodable byte string, and
`From<jubjub::ExtendedPoint>` encoded whatever point it was handed. Both now
enforce the canonical, not-small-order requirement (the hex path returns an error;
the `From` conversion documents and asserts its contract), so internal callers
cannot build commitments that wire deserialization would reject. Neither path
parses untrusted input.

✅ **`fix(chain): reject invalid Sapling transmission key bytes`** —
`TransmissionKey::try_from` is a fallible parse but called
`AffinePoint::from_bytes(bytes).unwrap()`, panicking on an off-curve `pk_d`
encoding instead of returning `Err`, contradicting the `TryFrom` contract. It now
returns an error. No production path reaches this conversion with untrusted bytes,
so this is API hardening rather than a crash fix.

✅**`fix(state): share vct safety state across clones`** — `VctCommitState`'s
prevalidation cache and frozen-frontier flag were plain fields, so each
`FinalizedState` clone received an independent snapshot: a clone could miss that
another froze the frontier and fall back to legacy recomputation, or miss a
prevalidation update. The production node has a single finalized writer, so this
was a latent hazard rather than a live bug; both fields are now shared across
clones so the clone contract holds regardless of caller topology.

✅ **`fix(state): avoid overflow when a subtree range starts at an excluded u16::MAX`**
— the shared subtree-range read helper computed an excluded start bound as
`start_index.0 + 1`, which panics in debug builds (and wraps in release) when the
excluded bound is `u16::MAX`. It now uses checked arithmetic and returns an empty
subtree map for such a range.

## Tests

<details>
<summary>The remaining commits are test-only and can be skipped by most reviewers — expand for the coverage summary.</summary>

These commits add coverage without touching runtime logic. Where a test lives in
a non-test file, the only non-test changes are doc-comment corrections (noted
below); everything else is inside `#[cfg(test)]` / test modules or test-vector
data.

- ✅ **`test(chain): strengthen history and note-commitment tree coverage`** — history
  tree version selection across upgrade epochs, the reset at NU6.3 activation, V3
  extension/pruning/cloning, and parts-API parity with genesis and header
  commitments; block-level Orchard/Ironwood accessor pool assignment; parallel
  per-pool tree update independence and ordering; and batched Orchard appends at
  exact tree capacity.

- ✅ **`test: pin network parameters and cover consensus admission paths`** — pins
  NU6.3 activation parameters and its consensus branch ID against librustzcash and
  BIP-70 network names per network kind; covers cross-pool nullifier collisions in
  spend-conflict checks, the public NU6.3 branch-ID admission boundary, checkpoint
  verification of generated local seed chains, and the quoted NU6.3
  activation-height config key in `zakurad`.

- ✅ **`test(chain): cover V5/V6 wire format and ZIP-244 digest paths`** — V6
  Orchard-style flag rules on the wire and the finalized V6 version group ID; V6
  Ironwood note-recovery routing; and V5 NU6.3 native ZIP-244 txid/auth digests
  pinned against the librustzcash oracle, plus the native digest wrappers and V6
  bundle slots. *(Non-test change: corrects stale doc comments on the
  txid/auth-digest helpers.)*

- ✅ **`test: cover lazy Sapling commitment paths and batch capacity edges`** — lazy V4
  Sapling output and spend commitment verification paths in the transaction
  verifier, the fallible Sapling binding-key helper, and Sapling incremental-tree
  batch capacity plus the Ironwood flag edge case.

- ✅ **`test(chain): cover Ironwood pool isolation and value balance edges`** — Ironwood
  value balances stay isolated from the Orchard pool, including add/subtract edge
  cases, plus Regtest Equihash proof-binding coverage.

- ✅ **`test(state): cover pruned-chain reads across the read service`** — best-chain
  depth, hash, and header reads (and the read-service request vectors) keep serving
  finalized blocks whose bodies were pruned, since pruning removes body rows but
  keeps the verified chain-identity indexes.

</details>

## Test evidence

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test --workspace` all pass locally (release profile).

## AI disclosure

Used Claude Code to rebase and reorganize the branch history, to review the
changes, and to draft this PR description. All code and tests are authored by the
contributor, who is the sole responsible author.

