### PR TITLE
chore(release): update zcashd compatibility release to v1

### DIFF
--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -31,10 +31,10 @@ ZAKURA_DOCKER_IDENTITY_DIR="/home/zebra/.zakura"
 
 MANIFEST_PATH="$REPO_ROOT/zakurad/zcashd-compat-manifest.json"
 TARGET_TRIPLE="x86_64-pc-linux-gnu"
-ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc3/zcashd-zebra-compat-v1.0.0-compat-rc3-linux-x86_64.tar.gz"
+ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz"
 ZCASHD_RUNTIME_ARCHIVE_SHA256="b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2"
 ZCASHD_RUNTIME_ARCHIVE_MEMBER_BINARY_PATH="./bin/zcashd"
-ZCASHD_DEFAULT_DOCKER_IMAGE="valargroup/zcashd:v1.0.0-compat-rc3"
+ZCASHD_DEFAULT_DOCKER_IMAGE="valargroup/zcashd:v1.0.0"
 
 INSTALL_PROFILE=""
 MODE=""

--- a/zakurad/zcashd-compat-manifest.json
+++ b/zakurad/zcashd-compat-manifest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "release_tag": "v1.0.0-compat-rc3",
+  "release_tag": "v1.0.0",
   "artifacts": [
     {
       "target_triple": "x86_64-pc-linux-gnu",
-      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0-compat-rc3/zcashd-zebra-compat-v1.0.0-compat-rc3-linux-x86_64.tar.gz",
+      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz",
       "runtime_archive_sha256": "b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2",
       "runtime_archive_member_binary_path": "./bin/zcashd"
     }


### PR DESCRIPTION
## Motivation

Use the final `valargroup/zcashd` v1 compatibility release instead of the RC3 release.

## Solution

- Point the embedded compatibility manifest and installer at the v1.0.0 runtime archive.
- Use `valargroup/zcashd:v1.0.0` as the installer's default zcashd image.
- Retain the runtime checksum, which matches the published v1.0.0 asset metadata.

### Tests

- `git diff --check`
- IDE diagnostics: no errors
- Confirmed release archive name, URL, and SHA-256 against the published GitHub release metadata
- Full Cargo checks skipped: low-risk release metadata change with no Rust code changes

### Specifications & References

- https://github.com/valargroup/zcashd/releases/tag/v1.0.0

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Cursor updated the release references and prepared the PR description.

### PR Checklist

- [x] The PR title follows conventional commits format: `type(scope): description`
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested as described above.
- [x] Documentation and changelogs are up to date; no changelog entry is needed for this metadata-only release pointer update.