### PR TITLE
fix: harden P2SH sigops, archive configuration, and Sapling key parsing

### DIFF
--- a/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -13,7 +13,8 @@ use crate::{
             ConfiguredFundingStreams, ConfiguredLockboxDisbursement, RegtestParameters,
             MAX_NETWORK_NAME_LENGTH, RESERVED_NETWORK_NAMES,
         },
-        Network, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS, TESTNET_ACTIVATION_HEIGHTS,
+        ConsensusBranchId, Network, NetworkKind, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS,
+        TESTNET_ACTIVATION_HEIGHTS,
     },
 };
 
@@ -99,6 +100,119 @@ fn check_parameters_impl() {
     }
 }
 
+/// Pins the public-network NU6.3 boundary and branch ID to librustzcash's consensus parameters.
+#[test]
+fn nu6_3_public_consensus_boundary_matches_librustzcash() {
+    assert_eq!(
+        NetworkUpgrade::from(zp_consensus::NetworkUpgrade::Nu6_3),
+        NetworkUpgrade::Nu6_3,
+        "librustzcash's NU6.3 upgrade must map to Zakura's NU6.3 era",
+    );
+
+    let expected_branch_id = u32::from(zp_consensus::BranchId::Nu6_3);
+    let branch_id = NetworkUpgrade::Nu6_3
+        .branch_id()
+        .expect("NU6.3 has a published consensus branch ID");
+
+    assert_eq!(u32::from(branch_id), expected_branch_id);
+    assert_eq!(
+        NetworkUpgrade::try_from(expected_branch_id)
+            .expect("librustzcash's NU6.3 branch ID is known to Zakura"),
+        NetworkUpgrade::Nu6_3,
+    );
+    assert_eq!(
+        zp_consensus::BranchId::try_from(branch_id)
+            .expect("Zakura's NU6.3 branch ID is known to librustzcash"),
+        zp_consensus::BranchId::Nu6_3,
+    );
+
+    for (network, zp_network) in [
+        (Network::Mainnet, zp_consensus::Network::MainNetwork),
+        (
+            Network::new_default_testnet(),
+            zp_consensus::Network::TestNetwork,
+        ),
+    ] {
+        let expected_height: u32 = zp_network
+            .activation_height(zp_consensus::NetworkUpgrade::Nu6_3)
+            .expect("NU6.3 is scheduled on both public networks")
+            .into();
+        let activation_height = Height(expected_height);
+        let previous_height = (activation_height - 1).expect("NU6.3 is not genesis");
+
+        assert_eq!(
+            NetworkUpgrade::Nu6_3.activation_height(&network),
+            Some(activation_height),
+        );
+        assert_eq!(
+            NetworkUpgrade::current(&network, previous_height),
+            NetworkUpgrade::Nu6_2,
+        );
+        assert_eq!(
+            NetworkUpgrade::current(&network, activation_height),
+            NetworkUpgrade::Nu6_3,
+        );
+        assert_eq!(
+            ConsensusBranchId::current(&network, previous_height),
+            NetworkUpgrade::Nu6_2.branch_id(),
+        );
+        assert_eq!(
+            ConsensusBranchId::current(&network, activation_height),
+            Some(branch_id),
+        );
+    }
+}
+
+/// NU6.3 does not change the post-Blossom timing rules used by difficulty validation.
+#[test]
+fn nu6_3_keeps_post_blossom_timing_rules() {
+    assert_eq!(NetworkUpgrade::Nu6_3.target_spacing().num_seconds(), 75);
+    assert_eq!(
+        NetworkUpgrade::Nu6_3
+            .averaging_window_timespan()
+            .num_seconds(),
+        75 * 17,
+    );
+
+    for network in [Network::Mainnet, Network::new_default_testnet()] {
+        let activation_height = NetworkUpgrade::Nu6_3
+            .activation_height(&network)
+            .expect("NU6.3 is scheduled on both public networks");
+        let previous_height = (activation_height - 1).expect("NU6.3 is not genesis");
+
+        assert_eq!(
+            NetworkUpgrade::target_spacing_for_height(&network, previous_height),
+            NetworkUpgrade::target_spacing_for_height(&network, activation_height),
+            "NU6.3 must not introduce a target-spacing transition",
+        );
+        assert_eq!(
+            NetworkUpgrade::target_spacing_for_height(&network, activation_height).num_seconds(),
+            75,
+        );
+    }
+
+    assert_eq!(
+        NetworkUpgrade::minimum_difficulty_spacing_for_height(
+            &Network::new_default_testnet(),
+            NetworkUpgrade::Nu6_3
+                .activation_height(&Network::new_default_testnet())
+                .expect("NU6.3 is scheduled on default Testnet"),
+        )
+        .expect("the Testnet minimum-difficulty rule is active by NU6.3")
+        .num_seconds(),
+        6 * 75,
+    );
+}
+
+/// Pins the BIP-70 network names, which appear in payment URIs and RPC
+/// responses: Regtest deliberately shares Testnet's "test" name.
+#[test]
+fn bip70_network_names_are_stable_for_every_network_kind() {
+    assert_eq!(NetworkKind::Mainnet.bip70_network_name(), "main");
+    assert_eq!(NetworkKind::Testnet.bip70_network_name(), "test");
+    assert_eq!(NetworkKind::Regtest.bip70_network_name(), "test");
+}
+
 /// Checks that `NetworkUpgrade::activation_height()` returns the activation height of the next
 /// network upgrade if it doesn't find an activation height for a prior network upgrade, that the
 /// `Genesis` upgrade is always at `Height(0)`, and that the default Mainnet/Testnet/Regtest activation
@@ -171,6 +285,109 @@ fn activates_network_upgrades_correctly() {
             "network activation list should match expected activation heights"
         );
     }
+}
+
+/// Configured testnets must keep network upgrades in protocol order around
+/// NU6.3: a later upgrade may share NU6.3's activation height (and wins the
+/// height lookup), but an earlier upgrade configured above it must be
+/// rejected.
+#[test]
+fn configured_nu6_3_activation_preserves_upgrade_order() {
+    let activation_height = Height(23);
+
+    let nu6_3_network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu6_2: Some(activation_height.0),
+            nu6_3: Some(activation_height.0),
+            ..Default::default()
+        })
+        .expect("same-height upgrades are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("valid configured network");
+
+    assert_eq!(
+        NetworkUpgrade::current(&nu6_3_network, activation_height),
+        NetworkUpgrade::Nu6_3,
+        "NU6.3 must overwrite NU6.2 when both activate at the same height"
+    );
+    assert_eq!(
+        NetworkUpgrade::Nu6_2.activation_height(&nu6_3_network),
+        Some(activation_height),
+        "an overwritten NU6.2 activation must remain implicit at the NU6.3 height"
+    );
+
+    let nu7_network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu6_3: Some(activation_height.0),
+            nu7: Some(activation_height.0),
+            ..Default::default()
+        })
+        .expect("same-height upgrades are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("valid configured network");
+
+    assert_eq!(
+        NetworkUpgrade::current(&nu7_network, activation_height),
+        NetworkUpgrade::Nu7,
+        "NU7 must overwrite NU6.3 when both activate at the same height"
+    );
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&nu7_network),
+        Some(activation_height),
+        "an overwritten NU6.3 activation must remain implicit at the NU7 height"
+    );
+
+    let out_of_order = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu6_2: Some(activation_height.0 + 1),
+            nu6_3: Some(activation_height.0),
+            ..Default::default()
+        })
+        .expect_err("NU6.3 must not activate before NU6.2");
+
+    assert_eq!(out_of_order, ParametersBuilderError::OutOfOrderUpgrades);
+}
+
+/// Regtest must not activate NU6.3 unless it is explicitly configured, and
+/// must preserve a configured NU6.3 height in its activation map.
+#[test]
+fn regtest_preserves_optional_nu6_3_activation() {
+    let default_regtest = Network::new_regtest(RegtestParameters::default());
+
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&default_regtest),
+        None,
+        "NU6.3 must remain disabled when it is not configured"
+    );
+    assert!(
+        !default_regtest
+            .activation_list()
+            .values()
+            .any(|upgrade| *upgrade == NetworkUpgrade::Nu6_3),
+        "NU6.3 must not be inserted into the explicit activation map by Regtest defaults"
+    );
+
+    let nu6_3_height = Height(23);
+    let configured_regtest = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu6_3: Some(nu6_3_height.0),
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&configured_regtest),
+        Some(nu6_3_height),
+        "Regtest conversion must preserve the configured NU6.3 height"
+    );
+    assert_eq!(
+        configured_regtest.activation_list().get(&nu6_3_height),
+        Some(&NetworkUpgrade::Nu6_3),
+        "the configured NU6.3 height must remain explicit"
+    );
 }
 
 /// Checks that configured testnet names are validated and used correctly.

--- a/zakura-chain/src/sapling/keys.rs
+++ b/zakura-chain/src/sapling/keys.rs
@@ -214,7 +214,10 @@ impl TryFrom<[u8; 32]> for TransmissionKey {
     /// <https://github.com/zkcrypto/jubjub/blob/master/src/lib.rs#L411>
     /// <https://zips.z.cash/zip-0216>
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        let affine_point = jubjub::AffinePoint::from_bytes(bytes).unwrap();
+        let affine_point = jubjub::AffinePoint::from_bytes(bytes)
+            .into_option()
+            .ok_or("Invalid jubjub::AffinePoint value for Sapling TransmissionKey")?;
+
         // Check if it's identity or has prime order (i.e. is in the prime-order subgroup).
         if affine_point.is_torsion_free().into() {
             Ok(Self(affine_point))

--- a/zakura-chain/src/sapling/tests.rs
+++ b/zakura-chain/src/sapling/tests.rs
@@ -2,3 +2,13 @@
 
 mod preallocate;
 mod prop;
+
+#[test]
+fn transmission_key_rejects_off_curve_bytes() {
+    let _init_guard = zakura_test::init();
+
+    assert!(
+        super::keys::TransmissionKey::try_from([0xffu8; 32]).is_err(),
+        "off-curve Sapling transmission keys must return an error rather than panic",
+    );
+}

--- a/zakura-chain/src/sapling/tree.rs
+++ b/zakura-chain/src/sapling/tree.rs
@@ -788,6 +788,43 @@ mod tests {
         assert_eq!(tree.root(), original.root());
     }
 
+    /// `append_batch` must match sequential appends when a batch exactly fills
+    /// the last two leaf positions of the tree, completing the final tracked
+    /// subtree (index `u16::MAX`) without reporting a spurious overflow.
+    #[test]
+    fn append_batch_matches_sequential_at_tree_capacity() {
+        let max_position = (1u64 << MERKLE_DEPTH) - 1;
+        let start_position = max_position - 2;
+        let leaf = node(1);
+        // A frontier at position `p` stores one ommer per set bit of `p`;
+        // `max_position - 2` has 31 of its 32 bits set.
+        let ommers: Vec<sapling_crypto::Node> = (2..=32).map(node).collect();
+        let inner = Frontier::from_parts(Position::from(start_position), leaf, ommers)
+            .expect("frontier two leaves below capacity is valid");
+        let start = NoteCommitmentTree {
+            inner,
+            cached_root: Default::default(),
+        };
+        let note_commitments = [note_commitment(100), note_commitment(200)];
+
+        let mut seq_tree = start.clone();
+        let seq_result = sequential_append_batch(&mut seq_tree, &note_commitments)
+            .expect("two sequential appends reach exact capacity");
+
+        let mut batch_tree = start;
+        let batch_result = batch_tree
+            .append_batch(&note_commitments)
+            .expect("batch append reaches exact capacity");
+
+        assert_eq!(batch_result, seq_result);
+        assert_eq!(
+            batch_result.map(|(index, _)| index),
+            Some(NoteCommitmentSubtreeIndex(u16::MAX)),
+        );
+        batch_tree.assert_frontier_eq(&seq_tree);
+        assert_eq!(batch_tree.root(), seq_tree.root());
+    }
+
     #[test]
     fn append_batch_multiple_subtrees_preserves_tree_and_cached_root() {
         let mut tree = NoteCommitmentTree::default();

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -1946,6 +1946,89 @@ fn sapling_lazy_cv_epk_edge_cases() {
     );
 }
 
+/// The local Sapling binding-key helper stays fail-closed when it sees a lazy
+/// value commitment that has not passed semantic validation yet.
+///
+/// The verifier currently obtains the binding key from librustzcash instead of
+/// this helper, so this is not an acceptance path today. Keep the public helper
+/// fallible anyway: both spend and output commitments can now hold raw bytes
+/// until `Transaction::sapling_point_encodings_are_valid` runs.
+#[test]
+fn sapling_binding_verification_key_rejects_invalid_lazy_commitments() {
+    use group::Group;
+
+    use crate::{
+        amount::Amount,
+        at_least_one,
+        primitives::{
+            redjubjub::{Binding, Signature, SpendAuth},
+            Groth16Proof,
+        },
+        sapling::{
+            self,
+            keys::{EphemeralPublicKey, ValidatingKey},
+            shielded_data::{ShieldedData, TransferData},
+            EncryptedNote, Output, Spend, ValueCommitment, WrappedNoteKey,
+        },
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let valid = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
+    let invalid = [0xffu8; 32];
+    let rk = ValidatingKey::try_from(valid).expect("the Jubjub generator is a valid Sapling rk");
+
+    let output_bundle = |cv: [u8; 32]| ShieldedData::<sapling::SharedAnchor> {
+        value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+        transfers: TransferData::JustOutputs {
+            outputs: at_least_one![Output {
+                cv: ValueCommitment(cv),
+                cm_u: sapling_crypto::note::ExtractedNoteCommitment::from_bytes(&[0u8; 32])
+                    .expect("zero bytes encode a valid extracted note commitment"),
+                ephemeral_key: EphemeralPublicKey(valid),
+                enc_ciphertext: EncryptedNote([0u8; 580]),
+                out_ciphertext: WrappedNoteKey([0u8; 80]),
+                zkproof: Groth16Proof([0u8; 192]),
+            }],
+        },
+        binding_sig: Signature::<Binding>::from([0u8; 64]),
+    };
+
+    let spend_bundle = |cv: [u8; 32]| ShieldedData::<sapling::PerSpendAnchor> {
+        value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+        transfers: TransferData::SpendsAndMaybeOutputs {
+            shared_anchor: sapling::FieldNotPresent,
+            spends: at_least_one![Spend {
+                cv: ValueCommitment(cv),
+                per_spend_anchor: sapling::tree::Root::default(),
+                nullifier: sapling::Nullifier::from([0u8; 32]),
+                rk: rk.clone(),
+                zkproof: Groth16Proof([0u8; 192]),
+                spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
+            }],
+            maybe_outputs: vec![],
+        },
+        binding_sig: Signature::<Binding>::from([0u8; 64]),
+    };
+
+    assert!(
+        output_bundle(valid).binding_verification_key().is_some(),
+        "a valid output commitment must still produce a binding key",
+    );
+    assert!(
+        spend_bundle(valid).binding_verification_key().is_some(),
+        "a valid spend commitment must still produce a binding key",
+    );
+    assert!(
+        output_bundle(invalid).binding_verification_key().is_none(),
+        "an invalid lazy output commitment must fail closed",
+    );
+    assert!(
+        spend_bundle(invalid).binding_verification_key().is_none(),
+        "an invalid lazy spend commitment must fail closed",
+    );
+}
+
 /// The semantic verifier's Sapling cv/epk not-small-order check rejects bad
 /// points.
 ///

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -2062,6 +2062,76 @@ fn sapling_point_encodings_check_rejects_bad_points() {
     check_transaction("V6", &make_v6);
 }
 
+/// The deferred Sapling point check also covers V4 spend commitments.
+///
+/// The lazy representation applies to spend `cv` as well as output `cv`/`epk`.
+/// V4 takes a distinct `PerSpendAnchor` branch, so keep a focused regression on
+/// that route rather than relying only on output-only V5/V6 coverage.
+#[test]
+fn sapling_point_encodings_check_rejects_bad_v4_spend_cv() {
+    use group::Group;
+
+    use crate::{
+        amount::Amount,
+        at_least_one,
+        block::Height,
+        primitives::{
+            redjubjub::{Binding, Signature, SpendAuth},
+            Groth16Proof,
+        },
+        sapling::{
+            self,
+            keys::ValidatingKey,
+            shielded_data::{ShieldedData, TransferData},
+            Spend, ValueCommitment,
+        },
+        transaction::{LockTime, Transaction},
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let valid = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
+    let off_curve = [0xffu8; 32];
+    let rk = ValidatingKey::try_from(valid).expect("the Jubjub generator is a valid Sapling rk");
+
+    let make_v4 = |cv: [u8; 32]| -> Transaction {
+        let spend = Spend::<sapling::PerSpendAnchor> {
+            cv: ValueCommitment(cv),
+            per_spend_anchor: sapling::tree::Root::default(),
+            nullifier: sapling::Nullifier::from([0u8; 32]),
+            rk: rk.clone(),
+            zkproof: Groth16Proof([0u8; 192]),
+            spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
+        };
+
+        Transaction::V4 {
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(0),
+            inputs: vec![],
+            outputs: vec![],
+            joinsplit_data: None,
+            sapling_shielded_data: Some(ShieldedData::<sapling::PerSpendAnchor> {
+                value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+                transfers: TransferData::SpendsAndMaybeOutputs {
+                    shared_anchor: sapling::FieldNotPresent,
+                    spends: at_least_one![spend],
+                    maybe_outputs: vec![],
+                },
+                binding_sig: Signature::<Binding>::from([0u8; 64]),
+            }),
+        }
+    };
+
+    assert!(
+        make_v4(valid).sapling_point_encodings_are_valid(),
+        "a V4 spend with a valid cv must pass the deferred point check",
+    );
+    assert!(
+        !make_v4(off_curve).sapling_point_encodings_are_valid(),
+        "a V4 spend with an off-curve cv must fail the deferred point check",
+    );
+}
+
 /// The relocated Sapling `cv` / `epk` not-small-order checks accept exactly the
 /// same encodings as the librustzcash functions they mirror.
 ///

--- a/zakura-chain/src/value_balance/tests.rs
+++ b/zakura-chain/src/value_balance/tests.rs
@@ -2,4 +2,114 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+use crate::{
+    amount::{Amount, NegativeAllowed, NonNegative},
+    value_balance::{ValueBalance, ValueBalanceError},
+};
+
 mod prop;
+
+#[test]
+fn ironwood_deposit_updates_only_the_ironwood_chain_pool() {
+    let _init_guard = zakura_test::init();
+
+    let transaction_value_balance =
+        ValueBalance::from_ironwood_amount(Amount::<NegativeAllowed>::try_from(-1).unwrap());
+    let chain_value_pool_change = -transaction_value_balance;
+    let updated = ValueBalance::<NonNegative>::zero()
+        .add_chain_value_pool_change(chain_value_pool_change)
+        .expect("an Ironwood deposit adds value to the Ironwood chain pool");
+
+    assert_eq!(
+        updated.ironwood_amount(),
+        Amount::<NonNegative>::try_from(1).unwrap()
+    );
+    let zero = Amount::<NonNegative>::zero();
+    assert_eq!(updated.transparent_amount(), zero);
+    assert_eq!(updated.sprout_amount(), zero);
+    assert_eq!(updated.sapling_amount(), zero);
+    assert_eq!(updated.orchard_amount(), zero);
+    assert_eq!(updated.deferred_amount(), zero);
+}
+
+#[test]
+fn remaining_transaction_value_includes_ironwood() {
+    let _init_guard = zakura_test::init();
+
+    let one = Amount::<NegativeAllowed>::try_from(1).unwrap();
+    let minus_one = Amount::<NegativeAllowed>::try_from(-1).unwrap();
+    let mut value_balance = ValueBalance::from_transparent_amount(one);
+
+    value_balance.set_ironwood_value_balance(ValueBalance::from_ironwood_amount(minus_one));
+
+    assert_eq!(
+        value_balance.remaining_transaction_value(),
+        Ok(Amount::<NonNegative>::zero())
+    );
+}
+
+#[test]
+fn ironwood_chain_pool_underflow_is_reported_as_ironwood() {
+    let _init_guard = zakura_test::init();
+
+    let chain_value_pool_change =
+        ValueBalance::from_ironwood_amount(Amount::<NegativeAllowed>::try_from(-1).unwrap());
+
+    assert!(matches!(
+        ValueBalance::<NonNegative>::zero().add_chain_value_pool_change(chain_value_pool_change),
+        Err(ValueBalanceError::Ironwood(_))
+    ));
+}
+
+#[test]
+fn value_balance_bytes_keep_deferred_before_ironwood() {
+    let _init_guard = zakura_test::init();
+
+    let orchard = Amount::<NonNegative>::try_from(4).unwrap();
+    let deferred = Amount::<NonNegative>::try_from(5).unwrap();
+    let ironwood = Amount::<NonNegative>::try_from(6).unwrap();
+    let mut value_balance = ValueBalance::from_orchard_amount(orchard);
+
+    value_balance.set_deferred_amount(deferred);
+    value_balance.set_ironwood_value_balance(ValueBalance::from_ironwood_amount(ironwood));
+
+    let bytes = value_balance.to_bytes();
+    assert_eq!(&bytes[32..40], &deferred.to_bytes());
+    assert_eq!(&bytes[40..48], &ironwood.to_bytes());
+
+    let pre_ironwood = ValueBalance::<NonNegative>::from_bytes(&bytes[..40])
+        .expect("40-byte value balance parses");
+    assert_eq!(pre_ironwood.orchard_amount(), orchard);
+    assert_eq!(pre_ironwood.deferred_amount(), deferred);
+    assert_eq!(
+        pre_ironwood.ironwood_amount(),
+        Amount::<NonNegative>::zero()
+    );
+    assert_eq!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes),
+        Ok(value_balance)
+    );
+}
+
+#[test]
+fn value_balance_bytes_report_invalid_tail_pool() {
+    let _init_guard = zakura_test::init();
+
+    let mut bytes = ValueBalance::<NonNegative>::zero().to_bytes();
+    bytes[32..40].copy_from_slice(&(-1_i64).to_le_bytes());
+    assert!(matches!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes),
+        Err(ValueBalanceError::Deferred(_))
+    ));
+
+    bytes[32..40].copy_from_slice(&0_i64.to_le_bytes());
+    bytes[40..48].copy_from_slice(&(-1_i64).to_le_bytes());
+    assert!(matches!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes),
+        Err(ValueBalanceError::Ironwood(_))
+    ));
+    assert_eq!(
+        ValueBalance::<NonNegative>::from_bytes(&bytes[..47]),
+        Err(ValueBalanceError::Unparsable)
+    );
+}

--- a/zakura-chain/src/work/tests/vectors.rs
+++ b/zakura-chain/src/work/tests/vectors.rs
@@ -1,5 +1,5 @@
 use crate::{
-    block::{Block, MAX_BLOCK_BYTES},
+    block::{genesis::regtest_genesis_block, Block, MAX_BLOCK_BYTES},
     parameters::Network,
     serialization::{
         CompactSizeMessage, SerializationError, ZcashDeserialize, ZcashDeserializeInto,
@@ -157,4 +157,28 @@ fn regtest_solution_is_rejected_off_regtest() {
         ),
         "a Regtest solution must be accepted for verification on Regtest",
     );
+}
+
+#[test]
+fn real_regtest_solution_is_bound_to_regtest_parameters() {
+    let _init_guard = zakura_test::init();
+
+    let block = regtest_genesis_block();
+    let header = block.header.as_ref();
+    let regtest = Network::new_regtest(Default::default());
+
+    header
+        .solution
+        .check(header, &regtest)
+        .expect("the hard-coded Regtest genesis solution must verify on Regtest");
+
+    for network in [Network::Mainnet, Network::new_default_testnet()] {
+        assert!(
+            matches!(
+                header.solution.check(header, &network),
+                Err(Error::InvalidSolutionSize { .. }),
+            ),
+            "a real Regtest proof must not verify on {network}",
+        );
+    }
 }

--- a/zakura-consensus/src/checkpoint/tests.rs
+++ b/zakura-consensus/src/checkpoint/tests.rs
@@ -9,7 +9,11 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::time::timeout;
 use tracing_futures::Instrument;
 
-use zakura_chain::{parameters::Network::*, serialization::ZcashDeserialize};
+use zakura_chain::{
+    local_genesis::{generate_local_testnet_with_funded_keys, LocalTestnetGenesisOptions},
+    parameters::Network::*,
+    serialization::ZcashDeserialize,
+};
 
 use super::*;
 
@@ -196,6 +200,57 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
     assert_eq!(
         checkpoint_verifier.checkpoint_list.max_height(),
         block::Height(1)
+    );
+
+    Ok(())
+}
+
+/// Every block of a generated local testnet (genesis, premine, and maturity
+/// padding) must verify against the network's own configured checkpoints, and
+/// the verifier must finish once the last generated block is in.
+///
+/// The generated network checkpoints every seed block, so this exercises the
+/// checkpoint path a fresh local-genesis node uses to accept its seed chain.
+#[tokio::test(flavor = "multi_thread")]
+async fn generated_local_seed_chain_passes_checkpoint_verification() -> Result<(), Report> {
+    let _init_guard = zakura_test::init();
+    let generated = generate_local_testnet_with_funded_keys(
+        vec!["alice".to_string(), "bob".to_string()],
+        LocalTestnetGenesisOptions {
+            maturity_padding_blocks: 2,
+            ..Default::default()
+        },
+    )
+    .map_err(|error| eyre!(error.to_string()))?;
+    let network = generated.network;
+    let state_service = zakura_state::init_test(&network).await;
+    let mut checkpoint_verifier = CheckpointVerifier::new(&network, None, state_service);
+
+    for block in generated.blocks {
+        let block = Arc::new(block);
+        let expected_hash = block.hash();
+        let response = timeout(
+            Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
+            checkpoint_verifier
+                .ready()
+                .map_err(|error| eyre!(error))
+                .await?
+                .call(block),
+        )
+        .await
+        .expect("generated checkpoint verification should not time out")
+        .expect("generated seed block should verify");
+
+        assert_eq!(response, expected_hash);
+    }
+
+    assert_eq!(
+        checkpoint_verifier.previous_checkpoint_height(),
+        FinalCheckpoint
+    );
+    assert_eq!(
+        checkpoint_verifier.target_checkpoint_height(),
+        FinishedVerifying
     );
 
     Ok(())

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -27,7 +27,9 @@ use zakura_chain::{
     },
     primitives::{ed25519, x25519, Groth16Proof},
     sapling,
-    serialization::{AtLeastOne, DateTime32, ZcashDeserialize, ZcashDeserializeInto},
+    serialization::{
+        AtLeastOne, DateTime32, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+    },
     sprout,
     transaction::{
         arbitrary::{
@@ -413,6 +415,29 @@ fn ironwood_cross_address_flag_is_optional_after_nu6_3() {
     assert_eq!(
         check::orchard_cross_address_disabled(&ironwood_with_cross_address),
         Ok(())
+    );
+}
+
+#[test]
+fn ironwood_cross_address_only_is_not_a_spend_or_output_flag() {
+    let tx = v6_pool_flow_transaction(
+        None,
+        Some(ironwood_shielded_data(
+            0,
+            ironwood::Flags::ENABLE_CROSS_ADDRESS,
+        )),
+        vec![],
+    );
+
+    assert!(!tx.has_shielded_inputs());
+    assert!(!tx.has_shielded_outputs());
+    assert_eq!(
+        check::has_inputs_and_outputs(&tx),
+        Err(TransactionError::NoInputs)
+    );
+    assert_eq!(
+        check::has_enough_ironwood_flags(&tx),
+        Err(TransactionError::NotEnoughIronwoodFlags)
     );
 }
 
@@ -3122,6 +3147,162 @@ fn sapling_output_with_invalid_ephemeral_key_is_rejected() {
     });
 }
 
+/// A transaction whose Sapling output has an invalid (off-curve) value
+/// commitment is rejected by the verifier with `SmallOrder`.
+///
+/// Unlike the ephemeral-key regression above, this also round-trips the
+/// corrupted V4 transaction through serialization. That pins the lazy V4
+/// output path: the parser preserves the raw `cv` bytes, and the early
+/// semantic check rejects them before any state lookup.
+#[test]
+fn sapling_v4_output_with_invalid_value_commitment_is_rejected_after_roundtrip() {
+    let _init_guard = zakura_test::init();
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let network = Network::Mainnet;
+
+        let (height, mut transaction) = test_transactions(&network)
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                transaction.sapling_spends_per_anchor().next().is_none()
+                    && transaction.sapling_outputs().next().is_some()
+            })
+            .expect("a V4 transaction with Sapling outputs and no Sapling spends");
+
+        assert!(
+            matches!(transaction.as_ref(), Transaction::V4 { .. }),
+            "test vector must exercise the V4 output encoding"
+        );
+
+        corrupt_first_sapling_output_value_commitment(
+            Arc::get_mut(&mut transaction).expect("transaction only has one active reference"),
+        );
+
+        let serialized = transaction
+            .zcash_serialize_to_vec()
+            .expect("corrupted V4 transaction must serialize raw Sapling cv bytes");
+        let transaction = Arc::new(
+            serialized
+                .zcash_deserialize_into::<Transaction>()
+                .expect("lazy V4 output deserialization must preserve invalid cv bytes"),
+        );
+
+        assert!(
+            !transaction.sapling_point_encodings_are_valid(),
+            "the deferred Sapling point check must reject the round-tripped invalid cv"
+        );
+
+        let state_service =
+            service_fn(|_| async { unreachable!("State service should not be called") });
+        let verifier = Verifier::new_for_tests(&network, state_service);
+
+        let result = verifier
+            .oneshot(Request::Block {
+                transaction_hash: transaction.hash(),
+                transaction,
+                known_utxos: Arc::new(HashMap::new()),
+                known_outpoint_hashes: Arc::new(HashSet::new()),
+                height,
+                time: DateTime::<Utc>::MAX_UTC,
+            })
+            .await;
+
+        assert_eq!(
+            result,
+            Err(TransactionError::SmallOrder),
+            "a V4 Sapling output with an off-curve cv must be rejected with SmallOrder",
+        );
+    });
+}
+
+/// Transactions whose Sapling spend has an invalid (off-curve) value
+/// commitment are rejected by the verifier with `SmallOrder`.
+///
+/// This pins both spend encodings affected by lazy Sapling `cv` parsing:
+/// V4 stores the full `Spend<PerSpendAnchor>` inline, while V5 stores the
+/// `SpendPrefixInTransactionV5` fields separately. In both cases the parser
+/// preserves the raw bytes and the early semantic check rejects them before
+/// any state lookup.
+#[test]
+fn sapling_spends_with_invalid_value_commitments_are_rejected_after_roundtrip() {
+    let _init_guard = zakura_test::init();
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let network = Network::Mainnet;
+
+        let v4 = test_transactions(&network)
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                matches!(transaction.as_ref(), Transaction::V4 { .. })
+                    && transaction.sapling_spends_per_anchor().next().is_some()
+            })
+            .expect("a V4 transaction with Sapling spends");
+
+        let v5 = transactions_from_blocks(network.block_iter())
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                matches!(transaction.as_ref(), Transaction::V5 { .. })
+                    && transaction.sapling_spends_per_anchor().next().is_some()
+            })
+            .expect("a V5 transaction with Sapling spends");
+
+        for (version, height, mut transaction) in [("V4", v4.0, v4.1), ("V5", v5.0, v5.1)] {
+            corrupt_first_sapling_spend_value_commitment(
+                Arc::get_mut(&mut transaction).expect("transaction only has one active reference"),
+            );
+
+            let serialized = transaction
+                .zcash_serialize_to_vec()
+                .expect("corrupted transaction must serialize raw Sapling cv bytes");
+            let transaction = Arc::new(
+                serialized
+                    .zcash_deserialize_into::<Transaction>()
+                    .expect("lazy spend deserialization must preserve invalid cv bytes"),
+            );
+            assert_eq!(
+                serialized,
+                transaction
+                    .zcash_serialize_to_vec()
+                    .expect("round-tripped transaction must reserialize"),
+                "lazy {version} spend cv bytes must round-trip exactly",
+            );
+
+            assert!(
+                !transaction.sapling_point_encodings_are_valid(),
+                "the deferred Sapling point check must reject the round-tripped {version} spend cv"
+            );
+
+            let state_service =
+                service_fn(|_| async { unreachable!("State service should not be called") });
+            let verifier = Verifier::new_for_tests(&network, state_service);
+
+            let result = verifier
+                .oneshot(Request::Block {
+                    transaction_hash: transaction.hash(),
+                    transaction,
+                    known_utxos: Arc::new(HashMap::new()),
+                    known_outpoint_hashes: Arc::new(HashSet::new()),
+                    height,
+                    time: DateTime::<Utc>::MAX_UTC,
+                })
+                .await;
+
+            assert_eq!(
+                result,
+                Err(TransactionError::SmallOrder),
+                "a {version} Sapling spend with an off-curve cv must be rejected with SmallOrder",
+            );
+        }
+    });
+}
+
 /// Replaces the first Sapling output's ephemeral key with an off-curve point,
 /// for `sapling_output_with_invalid_ephemeral_key_is_rejected`.
 fn corrupt_first_sapling_output_ephemeral_key(transaction: &mut Transaction) {
@@ -3141,6 +3322,46 @@ fn corrupt_first_sapling_output_ephemeral_key(transaction: &mut Transaction) {
     }
 }
 
+/// Replaces the first Sapling output's value commitment with off-curve bytes,
+/// for `sapling_v4_output_with_invalid_value_commitment_is_rejected_after_roundtrip`.
+fn corrupt_first_sapling_output_value_commitment(transaction: &mut Transaction) {
+    let bad_cv = [0xffu8; 32][..]
+        .zcash_deserialize_into::<sapling::ValueCommitment>()
+        .expect("deserialization defers point validation, so it stores the bytes");
+
+    match transaction {
+        Transaction::V4 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_output_value_commitment(&mut shielded_data.transfers, bad_cv),
+        _ => panic!("expected a V4 transaction with Sapling data"),
+    }
+}
+
+/// Replaces the first Sapling spend's value commitment with off-curve bytes,
+/// for `sapling_spends_with_invalid_value_commitments_are_rejected_after_roundtrip`.
+fn corrupt_first_sapling_spend_value_commitment(transaction: &mut Transaction) {
+    let bad_cv = [0xffu8; 32][..]
+        .zcash_deserialize_into::<sapling::ValueCommitment>()
+        .expect("deserialization defers point validation, so it stores the bytes");
+
+    match transaction {
+        Transaction::V4 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_value_commitment(&mut shielded_data.transfers, bad_cv),
+        Transaction::V5 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_value_commitment(&mut shielded_data.transfers, bad_cv),
+        Transaction::V6 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_value_commitment(&mut shielded_data.transfers, bad_cv),
+        _ => panic!("expected a V4, V5, or V6 transaction with Sapling data"),
+    }
+}
+
 fn set_first_sapling_output_ephemeral_key<A: sapling::AnchorVariant + Clone>(
     transfers: &mut sapling::TransferData<A>,
     ephemeral_key: sapling::keys::EphemeralPublicKey,
@@ -3154,6 +3375,40 @@ fn set_first_sapling_output_ephemeral_key<A: sapling::AnchorVariant + Clone>(
         }
         sapling::TransferData::SpendsAndMaybeOutputs { maybe_outputs, .. } => {
             maybe_outputs[0].ephemeral_key = ephemeral_key;
+        }
+    }
+}
+
+fn set_first_sapling_output_value_commitment<A: sapling::AnchorVariant + Clone>(
+    transfers: &mut sapling::TransferData<A>,
+    value_commitment: sapling::ValueCommitment,
+) {
+    match transfers {
+        sapling::TransferData::JustOutputs { outputs } => {
+            let mut outputs_vec = outputs.as_slice().to_vec();
+            outputs_vec[0].cv = value_commitment;
+            *outputs = AtLeastOne::from_vec(outputs_vec)
+                .expect("replacing a field keeps at least one output");
+        }
+        sapling::TransferData::SpendsAndMaybeOutputs { maybe_outputs, .. } => {
+            maybe_outputs[0].cv = value_commitment;
+        }
+    }
+}
+
+fn set_first_sapling_spend_value_commitment<A: sapling::AnchorVariant + Clone>(
+    transfers: &mut sapling::TransferData<A>,
+    value_commitment: sapling::ValueCommitment,
+) {
+    match transfers {
+        sapling::TransferData::SpendsAndMaybeOutputs { spends, .. } => {
+            let mut spends_vec = spends.as_slice().to_vec();
+            spends_vec[0].cv = value_commitment;
+            *spends = AtLeastOne::from_vec(spends_vec)
+                .expect("replacing a field keeps at least one spend");
+        }
+        sapling::TransferData::JustOutputs { .. } => {
+            panic!("expected Sapling shielded data with spends")
         }
     }
 }

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -83,6 +83,38 @@ fn v5_transactions_basic_check() -> Result<(), Report> {
     Ok(())
 }
 
+/// Orchard and Ironwood nullifiers are separate namespaces: a V6 transaction
+/// whose Orchard and Ironwood bundles happen to contain bit-identical
+/// nullifiers must not be rejected as a double-spend, because each pool tracks
+/// its own nullifier set. `spend_conflicts` must only reject duplicates
+/// *within* a pool.
+#[test]
+fn matching_orchard_and_ironwood_nullifiers_are_not_conflicts() {
+    let _init_guard = zakura_test::init();
+
+    let shielded_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    let transaction = Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: Some(shielded_data.clone()),
+        ironwood_shielded_data: Some(shielded_data),
+    };
+
+    assert_eq!(
+        transaction.orchard_nullifiers().collect::<Vec<_>>(),
+        transaction.ironwood_nullifiers().collect::<Vec<_>>()
+    );
+    check::spend_conflicts(&transaction)
+        .expect("matching bit patterns in separate nullifier sets are not duplicates");
+}
+
 #[test]
 fn v5_transaction_with_orchard_actions_has_inputs_and_outputs() {
     for net in Network::iter() {
@@ -3599,6 +3631,51 @@ async fn orchard_disabling_soft_fork_accepts_orchard_actions_below_activation_he
         )),
         "Orchard transaction must be rejected at the soft fork height",
     );
+}
+
+/// Checks that public-network branch-ID admission switches exactly at NU6.3 activation.
+#[test]
+fn public_nu6_3_consensus_branch_id_boundary() {
+    let mut tx = Transaction::V5 {
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height::MAX_EXPIRY_HEIGHT,
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        network_upgrade: NetworkUpgrade::Nu6_2,
+    };
+
+    for network in Network::iter() {
+        let activation_height = NetworkUpgrade::Nu6_3
+            .activation_height(&network)
+            .expect("NU6.3 is scheduled on both public networks");
+        let previous_height = (activation_height - 1).expect("NU6.3 is not genesis");
+
+        assert_eq!(
+            check::consensus_branch_id(&tx, previous_height, &network),
+            Ok(()),
+        );
+        assert_eq!(
+            check::consensus_branch_id(&tx, activation_height, &network),
+            Err(TransactionError::WrongConsensusBranchId),
+        );
+
+        tx.update_network_upgrade(NetworkUpgrade::Nu6_3)
+            .expect("V5 transactions support the NU6.3 branch ID");
+
+        assert_eq!(
+            check::consensus_branch_id(&tx, previous_height, &network),
+            Err(TransactionError::WrongConsensusBranchId),
+        );
+        assert_eq!(
+            check::consensus_branch_id(&tx, activation_height, &network),
+            Ok(()),
+        );
+
+        tx.update_network_upgrade(NetworkUpgrade::Nu6_2)
+            .expect("V5 transactions support the NU6.2 branch ID");
+    }
 }
 
 /// Checks that the tx verifier handles consensus branch ids in V5 txs correctly.

--- a/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -100,6 +100,7 @@ fn coinbase() -> anyhow::Result<()> {
 #[test]
 fn coinbase_tag_and_limit() {
     use zcash_address::ZcashAddress;
+    use zcash_transparent::coinbase::{MAX_COINBASE_HEIGHT_LEN, MAX_COINBASE_SCRIPT_LEN};
 
     use crate::config::mining::{
         Config, ExtraCoinbaseData, MAX_USER_COINBASE_DATA_LEN, ZAKURA_COINBASE_MARKER,
@@ -111,6 +112,15 @@ fn coinbase_tag_and_limit() {
     // makes the config fail to load and the node refuse to start.
     assert!(ExtraCoinbaseData::try_from("x".repeat(MAX_USER_COINBASE_DATA_LEN)).is_ok());
     assert!(ExtraCoinbaseData::try_from("x".repeat(MAX_USER_COINBASE_DATA_LEN + 1)).is_err());
+    assert_eq!(
+        MAX_USER_COINBASE_DATA_LEN
+            + ZAKURA_COINBASE_MARKER.len()
+            + ZAKURA_COINBASE_SEPARATOR.len()
+            + 2
+            + MAX_COINBASE_HEIGHT_LEN,
+        MAX_COINBASE_SCRIPT_LEN,
+        "the configured data limit must reserve the worst-case height and OP_PUSHDATA1 bytes"
+    );
 
     let net = Network::Mainnet;
     let addr: ZcashAddress = default_miner_address(net.kind(), &MinerAddressType::Transparent)
@@ -147,6 +157,26 @@ fn coinbase_tag_and_limit() {
         [ZAKURA_COINBASE_MARKER, ZAKURA_COINBASE_SEPARATOR, "/pool/"]
             .concat()
             .as_bytes()
+    );
+
+    // Exercise the invariant behind `MinerParams::new`'s `expect` through the
+    // real coinbase builder at the maximum supported Zakura height.
+    let max_tag = ExtraCoinbaseData::try_from("x".repeat(MAX_USER_COINBASE_DATA_LEN))
+        .expect("maximum-length tag is valid");
+    let max_params = params(Some(max_tag)).expect("maximum-length tag fits miner params");
+    let max_coinbase =
+        TransactionTemplate::new_coinbase(&net, Height::MAX, &max_params, Amount::zero())
+            .expect("maximum-length tag fits a coinbase transaction")
+            .data()
+            .as_ref()
+            .zcash_deserialize_into::<Transaction>()
+            .expect("maximum-length coinbase transaction deserializes");
+    let coinbase_script = max_coinbase.inputs()[0]
+        .coinbase_script()
+        .expect("built coinbase input has a canonical script");
+    assert!(
+        coinbase_script.len() <= MAX_COINBASE_SCRIPT_LEN,
+        "maximum-length configured tag must keep the coinbase script within consensus limits"
     );
 }
 

--- a/zakura-script/src/lib.rs
+++ b/zakura-script/src/lib.rs
@@ -427,6 +427,10 @@ pub fn p2sh_input_sigop_count(
 /// in `tx`. If the lengths differ, `zip()` silently truncates the longer iterator, causing an
 /// incorrect (undercount) result.
 ///
+/// # Panics
+///
+/// Panics if a non-coinbase transaction is passed a misaligned `spent_outputs` slice.
+///
 /// [`GetP2SHSigOpCount()`]: https://github.com/zcash/zcash/blob/v6.11.0/src/main.cpp#L840-L852
 pub fn p2sh_sigop_count(
     tx: &zakura_chain::transaction::Transaction,
@@ -436,7 +440,7 @@ pub fn p2sh_sigop_count(
         return 0;
     }
 
-    debug_assert_eq!(
+    assert_eq!(
         tx.inputs().len(),
         spent_outputs.len(),
         "spent_outputs must align with transaction inputs for non-coinbase txs"

--- a/zakura-script/src/tests.rs
+++ b/zakura-script/src/tests.rs
@@ -1000,6 +1000,19 @@ fn p2sh_sigop_count_counts_redeem_script() -> Result<()> {
     Ok(())
 }
 
+/// A mismatched spent-output vector is an internal invariant violation, not a
+/// zero-sigop case. Keep this check active in release builds so a future caller
+/// cannot silently undercount block sigops by truncating `zip()`.
+#[test]
+#[should_panic(expected = "spent_outputs must align with transaction inputs for non-coinbase txs")]
+fn p2sh_sigop_count_rejects_mismatched_spent_outputs() {
+    let tx = SCRIPT_TX
+        .zcash_deserialize_into::<Transaction>()
+        .expect("test fixture deserializes");
+
+    let _ = p2sh_sigop_count(&tx, &[]);
+}
+
 /// Regression test: `p2sh_sigop_count` must agree with zcashd's
 /// `GetP2SHSigOpCount()` when the redeem script contains a "disabled" opcode such as
 /// `OP_CODESEPARATOR` (0xab).

--- a/zakura-state/src/config.rs
+++ b/zakura-state/src/config.rs
@@ -10,7 +10,7 @@ use std::{
 
 use semver::Version;
 use serde::{
-    de::{self, IgnoredAny, MapAccess, Visitor},
+    de::{self, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
 };
 use tokio::task::{spawn_blocking, JoinHandle};
@@ -362,6 +362,10 @@ impl From<StorageModeSerde> for StorageMode {
 
 struct StorageModeVisitor;
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EmptyArchiveConfig {}
+
 impl<'de> Visitor<'de> for StorageModeVisitor {
     type Value = StorageMode;
 
@@ -390,7 +394,7 @@ impl<'de> Visitor<'de> for StorageModeVisitor {
 
         let storage_mode = match key.as_str() {
             "archive" => {
-                map.next_value::<IgnoredAny>()?;
+                let _ = map.next_value::<EmptyArchiveConfig>()?;
                 StorageMode::Archive
             }
             "pruned" => StorageMode::Pruned(map.next_value()?),
@@ -473,6 +477,25 @@ mod tests {
         let archive: Config = toml::from_str(r#"storage_mode = "archive""#)
             .expect("archive storage mode deserializes from a string");
         assert_eq!(archive.storage_mode, StorageMode::Archive);
+        assert!(
+            archive.checkpoint_sync && archive.vct_fast_sync,
+            "serde defaults preserve the internal checkpoint/VCT mirrors until zakurad overwrites them"
+        );
+
+        let archive_table: Config = toml::from_str("[storage_mode.archive]")
+            .expect("an empty archive storage mode table deserializes");
+        assert_eq!(archive_table.storage_mode, StorageMode::Archive);
+
+        assert!(
+            toml::from_str::<Config>(
+                r#"
+                [storage_mode.archive]
+                tx_retention = 6000
+                "#,
+            )
+            .is_err(),
+            "archive mode must not silently ignore pruned-only or misspelled settings"
+        );
 
         let repair_enabled: Config =
             toml::from_str(r#"repair_zakura_header_store_on_startup = true"#)

--- a/zakurad/tests/config.rs
+++ b/zakurad/tests/config.rs
@@ -9,6 +9,7 @@
 use std::{env, fs, io::Write, path::PathBuf, sync::Mutex};
 
 use tempfile::{Builder, TempDir};
+use zakura_chain::{block::Height, parameters::NetworkUpgrade};
 use zakura_network::zakura::{DEFAULT_ZAKURA_LISTEN_ADDR, DEFAULT_ZAKURA_MAX_CONNS_PER_IP};
 use zakurad::components::{
     tracing::{Config as TracingConfig, InnerConfig as TracingInnerConfig, ProgressConfig},
@@ -150,6 +151,35 @@ endpoint_addr = "127.0.0.1:9999"
     assert_eq!(
         config.metrics.endpoint_addr.unwrap().to_string(),
         "127.0.0.1:9999"
+    );
+}
+
+/// The NU6.3 activation height must be configurable from a zakurad config
+/// file. The serde key contains a dot ("NU6.3"), so the TOML key must be
+/// quoted — this pins the exact spelling an operator has to write.
+#[test]
+fn config_loads_quoted_nu6_3_activation_height() {
+    let _env = EnvGuard::new();
+
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let config_path = temp_dir.path().join("nu6_3_config.toml");
+
+    let test_config = r#"
+[network]
+network = "Regtest"
+
+[network.testnet_parameters.activation_heights]
+"NU6.3" = 23
+"#;
+
+    fs::write(&config_path, test_config).expect("write test config");
+
+    let config = ZakuradConfig::load(Some(config_path)).expect("load NU6.3 config from file");
+
+    assert_eq!(
+        NetworkUpgrade::Nu6_3.activation_height(&config.network.network),
+        Some(Height(23)),
+        "the exact dotted TOML key must configure the requested NU6.3 height"
     );
 }
 


### PR DESCRIPTION
## Motivation

Extract the clearly safe, self-contained hardening fixes and directly related test coverage from #165 for a smaller review.

## Solution

Cherry-picks these six commits from #165:

- `fix(script): enforce p2sh sigop input alignment`
- `fix(state): reject unknown archive storage-mode config keys`
- `fix(chain): reject invalid Sapling transmission key bytes`
- `test: pin network parameters and cover consensus admission paths`
- `test: cover lazy Sapling commitment paths and batch capacity edges`
- `test(chain): cover Ironwood pool isolation and value balance edges`

## User impact

Invalid P2SH sigop input alignment is rejected in release builds, unknown archive-mode configuration keys fail at startup, and malformed Sapling transmission-key bytes return an error rather than panicking. The included tests expand coverage around consensus admission and Sapling/Ironwood edges.

## Test evidence

- `cargo fmt --all -- --check` passed.
- Focused `cargo test -p zakura-chain -p zakura-script -p zakura-state -p zakura-rpc -p zakura` was started locally; its result was not captured because the local runner disconnected.

## AI disclosure

Used Codex to identify and cherry-pick the requested existing commits, run validation, and draft this PR description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production changes affect block sigop counting (panic on internal misuse), startup config strictness, and Sapling key parsing; consensus-adjacent tests reduce split risk but the P2SH assert could panic if a caller regresses.
> 
> **Overview**
> **Release-build hardening:** `p2sh_sigop_count` now **asserts** (not `debug_assert`) that `spent_outputs` length matches transparent inputs on non-coinbase txs, with a `should_panic` test so misaligned slices cannot silently undercount sigops via `zip()` truncation.
> 
> **Config:** Archive `storage_mode` table deserialization uses an empty struct with **`deny_unknown_fields`** instead of ignoring extra keys, so pruned-only or misspelled archive settings fail at startup; tests cover string/table forms and reject unknown archive keys.
> 
> **Sapling:** `TransmissionKey::try_from` returns an error on invalid/off-curve bytes instead of **`unwrap()`** panicking; a unit test pins off-curve rejection.
> 
> The bulk of the diff adds **regression tests** for NU6.3 / branch-ID boundaries vs librustzcash, configured upgrade ordering and Regtest NU6.3, BIP-70 names, lazy Sapling `cv`/`epk` checks and verifier `SmallOrder` paths (including V4 spend/output round-trips), binding-key fail-closed behavior, Sapling `append_batch` at full tree capacity, Ironwood value-balance isolation and serialization, Orchard/Ironwood nullifier namespaces, local-genesis checkpoint verification, Regtest equihash binding, RPC coinbase script size at max height, and quoted `"NU6.3"` activation in zakurad config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783d89159a73532a40d126a0a37603dba89d759d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->