### PR TITLE
fix(chain): reserve V6 Orchard cross-address flag with wire coverage

### DIFF
--- a/zakura-chain/src/block/tests/vectors.rs
+++ b/zakura-chain/src/block/tests/vectors.rs
@@ -5,18 +5,20 @@ use std::{
 };
 
 use chrono::{DateTime, Duration, LocalResult, TimeZone, Utc};
+use halo2::pasta::pallas;
 
 use crate::{
     amount::{Amount, NonNegative, MAX_MONEY},
     block::{
         serialize::MAX_BLOCK_BYTES, Block, BlockTimeError, Commitment::*, Hash, Header, Height,
     },
+    ironwood, orchard,
     parameters::{Network, NetworkUpgrade::*},
     sapling,
     serialization::{
         sha256d, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
     },
-    transaction::{LockTime, Transaction},
+    transaction::{arbitrary::v5_transactions, LockTime, Transaction},
     transparent,
 };
 
@@ -111,6 +113,207 @@ fn chain_value_pool_change_propagates_transaction_value_balance_errors() {
         block.chain_value_pool_change(&utxos, None).is_err(),
         "block-level aggregation should propagate transaction value-balance errors"
     );
+}
+
+/// The block-level Orchard and Ironwood accessors must read from their own
+/// pool's shielded data and preserve transaction order.
+///
+/// Each transaction carries *different* Orchard and Ironwood bundles (and the
+/// second transaction swaps them), so an accessor that read from the wrong
+/// pool, or reordered transactions, would produce a different sequence.
+#[test]
+fn ironwood_block_accessors_preserve_pool_and_wire_order() {
+    let _init_guard = zakura_test::init();
+
+    let mut orchard_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    // Ironwood reuses the Orchard bundle encoding, so an Orchard test bundle
+    // can be cloned into the Ironwood slot of a V6 transaction.
+    let mut ironwood_data = orchard_data.clone();
+
+    let mut orchard_actions = orchard_data.actions.as_slice().to_vec();
+    orchard_actions[0].action.nullifier =
+        orchard::Nullifier::try_from([0; 32]).expect("zero is a valid Pallas base field");
+    orchard_actions[0].action.cm_x = pallas::Base::from(0);
+    orchard_data.actions = orchard_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let mut one = [0; 32];
+    one[0] = 1;
+    let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+    ironwood_actions[0].action.nullifier =
+        ironwood::Nullifier::try_from(one).expect("one is a valid Pallas base field");
+    ironwood_actions[0].action.cm_x = pallas::Base::from(1);
+    ironwood_data.actions = ironwood_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let make_transaction =
+        |orchard_shielded_data: orchard::ShieldedData,
+         ironwood_shielded_data: ironwood::ShieldedData| {
+            Arc::new(Transaction::V6 {
+                network_upgrade: Nu6_3,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(1),
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                sapling_shielded_data: None,
+                orchard_shielded_data: Some(orchard_shielded_data),
+                ironwood_shielded_data: Some(ironwood_shielded_data),
+            })
+        };
+
+    let header: Header = zakura_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let block = Block {
+        header: Arc::new(header),
+        transactions: vec![
+            make_transaction(orchard_data.clone(), ironwood_data.clone()),
+            make_transaction(ironwood_data, orchard_data),
+        ],
+    };
+
+    let expected_orchard_nullifiers: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.orchard_nullifiers().copied())
+        .collect();
+    let expected_ironwood_nullifiers: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.ironwood_nullifiers().copied())
+        .collect();
+    assert_ne!(expected_orchard_nullifiers, expected_ironwood_nullifiers);
+    assert_eq!(
+        block.orchard_nullifiers().copied().collect::<Vec<_>>(),
+        expected_orchard_nullifiers
+    );
+    assert_eq!(
+        block.ironwood_nullifiers().copied().collect::<Vec<_>>(),
+        expected_ironwood_nullifiers
+    );
+
+    let expected_orchard_commitments: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.orchard_note_commitments().copied())
+        .collect();
+    let expected_ironwood_commitments: Vec<_> = block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.ironwood_note_commitments().copied())
+        .collect();
+    assert_ne!(expected_orchard_commitments, expected_ironwood_commitments);
+    assert_eq!(
+        block
+            .orchard_note_commitments()
+            .copied()
+            .collect::<Vec<_>>(),
+        expected_orchard_commitments
+    );
+    assert_eq!(
+        block
+            .ironwood_note_commitments()
+            .copied()
+            .collect::<Vec<_>>(),
+        expected_ironwood_commitments
+    );
+}
+
+/// The ZIP-221 history-leaf transaction counts must count transactions with a
+/// bundle in the matching pool: Orchard-only transactions must not count as
+/// Ironwood ones, and a multi-action Ironwood bundle counts as one transaction.
+#[test]
+fn ironwood_transaction_count_is_pool_specific_and_counts_bundles() {
+    let _init_guard = zakura_test::init();
+
+    let orchard_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    let mut ironwood_data = orchard_data.clone();
+    let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+    ironwood_actions.push(ironwood_actions[0].clone());
+    ironwood_data.actions = ironwood_actions
+        .try_into()
+        .expect("duplicating an action keeps the bundle non-empty");
+    let ironwood_action_count = ironwood_data.actions.len();
+
+    let make_transaction =
+        |orchard_shielded_data: Option<orchard::ShieldedData>,
+         ironwood_shielded_data: Option<ironwood::ShieldedData>| {
+            Arc::new(Transaction::V6 {
+                network_upgrade: Nu6_3,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(1),
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                sapling_shielded_data: None,
+                orchard_shielded_data,
+                ironwood_shielded_data,
+            })
+        };
+
+    let header: Header = zakura_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let block = Block {
+        header: Arc::new(header),
+        transactions: vec![
+            make_transaction(Some(orchard_data.clone()), None),
+            make_transaction(Some(orchard_data), None),
+            make_transaction(None, Some(ironwood_data)),
+        ],
+    };
+
+    assert_eq!(block.orchard_transactions_count(), 2);
+    assert_eq!(block.ironwood_transactions_count(), 1);
+    assert!(ironwood_action_count > 1);
+    assert_eq!(
+        block
+            .transactions
+            .iter()
+            .flat_map(|transaction| transaction.ironwood_actions())
+            .count(),
+        ironwood_action_count,
+        "the history field counts a multi-action bundle as one transaction"
+    );
+}
+
+/// NU6.3 introduces the V3 history leaf but must not change how the block
+/// header's `hashBlockCommitments` field is interpreted: at and after NU5 it
+/// is the `ChainHistoryBlockTxAuthCommitment` digest, with no structural
+/// restriction on its bytes.
+#[test]
+fn nu6_3_uses_post_nu5_block_commitment_format() {
+    let _init_guard = zakura_test::init();
+
+    let regtest = Network::new_regtest(
+        crate::parameters::testnet::ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let commitment_bytes = [0x5a; 32];
+
+    for network in [Network::Mainnet, Network::new_default_testnet(), regtest] {
+        let activation_height = Nu6_3
+            .activation_height(&network)
+            .expect("NU6.3 is configured on this test network");
+        let commitment =
+            super::super::Commitment::from_bytes(commitment_bytes, &network, activation_height)
+                .expect("post-NU5 commitment bytes have no structural restriction");
+
+        let ChainHistoryBlockTxAuthCommitment(commitment) = commitment else {
+            panic!("NU6.3 must retain the post-NU5 block commitment format");
+        };
+        assert_eq!(<[u8; 32]>::from(commitment), commitment_bytes);
+    }
 }
 
 #[test]

--- a/zakura-chain/src/history_tree/tests/vectors.rs
+++ b/zakura-chain/src/history_tree/tests/vectors.rs
@@ -6,7 +6,12 @@ use crate::{
         Commitment::{self, ChainHistoryActivationReserved},
     },
     history_tree::{HistoryTree, HistoryTreeBlockParts, NonEmptyHistoryTree},
-    parameters::{Network, NetworkUpgrade},
+    ironwood, orchard,
+    parameters::{
+        testnet::{ConfiguredActivationHeights, RegtestParameters},
+        Network, NetworkUpgrade,
+    },
+    primitives::zcash_history::{Tree as PrimitiveHistoryTree, V1, V2, V3},
     sapling,
     serialization::ZcashDeserializeInto,
 };
@@ -126,6 +131,14 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
         .expect("test networks have Heartwood activation")
         .0;
 
+    let genesis_block = Arc::new(
+        blocks
+            .get(&0)
+            .expect("genesis test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("genesis block is structurally valid"),
+    );
+
     let first_block = Arc::new(
         blocks
             .get(&heartwood_height)
@@ -152,14 +165,39 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
             .expect("test vector exists"),
     )?;
 
-    let mut block_tree = HistoryTree::from_block(
+    let mut block_tree = HistoryTree::default();
+    let mut parts_tree = HistoryTree::default();
+
+    // Pushing a pre-Heartwood block (genesis) must be accepted as a no-op by
+    // both APIs, leaving the trees empty.
+    block_tree.push(
+        &network,
+        genesis_block.clone(),
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )?;
+    parts_tree.push_from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &genesis_block,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+        ),
+    )?;
+
+    assert!(block_tree.is_none());
+    assert!(parts_tree.is_none());
+
+    block_tree.push(
         &network,
         first_block.clone(),
         &first_sapling_root,
         &Default::default(),
         &Default::default(),
     )?;
-    let mut parts_tree = HistoryTree::from_parts(
+    parts_tree.push_from_parts(
         &network,
         HistoryTreeBlockParts::from_block(
             &first_block,
@@ -170,6 +208,17 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
     )?;
 
     assert_eq!(parts_tree.hash(), block_tree.hash());
+    // The real block after Heartwood activation commits to the MMR containing
+    // only the activation block, anchoring both APIs to the network's actual
+    // chain history commitment rather than just to each other.
+    assert_eq!(
+        second_block.commitment(&network)?,
+        Commitment::ChainHistoryRoot(
+            block_tree
+                .hash()
+                .expect("history tree exists after Heartwood activation")
+        )
+    );
 
     block_tree.push(
         &network,
@@ -189,6 +238,960 @@ fn parts_api_matches_block_api_for_network(network: Network) -> Result<()> {
     )?;
 
     assert_eq!(parts_tree.hash(), block_tree.hash());
+
+    Ok(())
+}
+
+/// Cached history entries must retain the V3 Ironwood suffix at and after NU6.3.
+#[test]
+fn from_cache_preserves_ironwood_history_version() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            nu7: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+    assert_ne!(ironwood_root, Default::default());
+
+    for (height, expected_upgrade) in [
+        (crate::block::Height(1), NetworkUpgrade::Nu6_3),
+        (crate::block::Height(2), NetworkUpgrade::Nu7),
+    ] {
+        assert_eq!(NetworkUpgrade::current(&network, height), expected_upgrade);
+
+        let tree = NonEmptyHistoryTree::from_parts(
+            &network,
+            HistoryTreeBlockParts {
+                header: &block.header,
+                height,
+                sapling_root: &Default::default(),
+                orchard_root: &Default::default(),
+                ironwood_root: &ironwood_root,
+                sapling_tx: 0,
+                orchard_tx: 0,
+                ironwood_tx: 1,
+            },
+        )?;
+        // Decoding the same peaks as V2 succeeds, because the serialized V3
+        // entries are just V2 entries with a trailing Ironwood suffix. The
+        // resulting hash silently loses the suffix, which is why `from_cache`
+        // must select the tree version from the network upgrade.
+        let v2_decode = PrimitiveHistoryTree::<V2>::new_from_cache(
+            &network,
+            expected_upgrade,
+            tree.size(),
+            tree.peaks(),
+            &Default::default(),
+        )?;
+        let restored = NonEmptyHistoryTree::from_cache(
+            &network,
+            tree.size(),
+            tree.peaks().clone(),
+            tree.current_height(),
+        )?;
+
+        assert_ne!(
+            v2_decode.hash(),
+            tree.hash(),
+            "{expected_upgrade:?} V2 decoding silently drops the V3 suffix"
+        );
+        assert_eq!(
+            restored.hash(),
+            tree.hash(),
+            "{expected_upgrade:?} cache reconstruction must retain V3 fields"
+        );
+    }
+
+    Ok(())
+}
+
+/// `NonEmptyHistoryTree::from_block` must build the same tree as
+/// `NonEmptyHistoryTree::from_parts` for the V1 (pre-NU5), V2 (NU5+), and
+/// V3 (NU6.3+) history-tree versions.
+#[test]
+fn from_block_delegation_preserves_all_history_versions() -> Result<()> {
+    let v1_network = Network::new_regtest(RegtestParameters::default());
+    let v2_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = Arc::new(
+        blocks
+            .get(&1)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    for network in [v1_network, v2_network, v3_network] {
+        let block_tree = NonEmptyHistoryTree::from_block(
+            &network,
+            block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        )?;
+        let parts_tree = NonEmptyHistoryTree::from_parts(
+            &network,
+            HistoryTreeBlockParts {
+                header: &block.header,
+                height: block.coinbase_height().expect("test block has a height"),
+                sapling_root: &sapling_root,
+                orchard_root: &orchard_root,
+                ironwood_root: &ironwood_root,
+                sapling_tx: block.sapling_transactions_count(),
+                orchard_tx: block.orchard_transactions_count(),
+                ironwood_tx: block.ironwood_transactions_count(),
+            },
+        )?;
+
+        assert_eq!(block_tree.hash(), parts_tree.hash());
+    }
+
+    Ok(())
+}
+
+/// `NonEmptyHistoryTree::from_parts` must select the history-leaf version from
+/// the network upgrade at the block's height: V1 leaves ignore the Orchard and
+/// Ironwood fields, V2 leaves commit to Orchard but ignore Ironwood, and V3
+/// leaves commit to everything. Each tree is also decoded with the matching
+/// raw `zcash_history` version to pin which version was selected.
+#[test]
+fn from_parts_selects_epoch_version_and_ignores_future_fields() -> Result<()> {
+    let v1_network = Network::new_regtest(RegtestParameters::default());
+    let v2_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let sapling_root = sapling::tree::Root::default();
+    let empty_orchard_root = orchard::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let empty_ironwood_root = ironwood::tree::Root::default();
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+    assert_ne!(orchard_root, empty_orchard_root);
+    assert_ne!(ironwood_root, empty_ironwood_root);
+    let height = crate::block::Height(1);
+
+    let parts = |orchard_root, ironwood_root, orchard_tx, ironwood_tx| HistoryTreeBlockParts {
+        header: &block.header,
+        height,
+        sapling_root: &sapling_root,
+        orchard_root,
+        ironwood_root,
+        sapling_tx: 1,
+        orchard_tx,
+        ironwood_tx,
+    };
+
+    assert_eq!(
+        NetworkUpgrade::current(&v1_network, height),
+        NetworkUpgrade::Canopy
+    );
+    let v1_tree =
+        NonEmptyHistoryTree::from_parts(&v1_network, parts(&orchard_root, &ironwood_root, 2, 3))?;
+    let v1_without_future_fields = NonEmptyHistoryTree::from_parts(
+        &v1_network,
+        parts(&empty_orchard_root, &empty_ironwood_root, 0, 0),
+    )?;
+    let v1_decoded = PrimitiveHistoryTree::<V1>::new_from_cache(
+        &v1_network,
+        NetworkUpgrade::Canopy,
+        v1_tree.size(),
+        v1_tree.peaks(),
+        &Default::default(),
+    )?;
+    assert_eq!(v1_tree.hash(), v1_decoded.hash());
+    assert_eq!(v1_tree.hash(), v1_without_future_fields.hash());
+
+    assert_eq!(
+        NetworkUpgrade::current(&v2_network, height),
+        NetworkUpgrade::Nu5
+    );
+    let v2_tree =
+        NonEmptyHistoryTree::from_parts(&v2_network, parts(&orchard_root, &ironwood_root, 2, 3))?;
+    let v2_without_future_fields = NonEmptyHistoryTree::from_parts(
+        &v2_network,
+        parts(&orchard_root, &empty_ironwood_root, 2, 0),
+    )?;
+    let v2_decoded = PrimitiveHistoryTree::<V2>::new_from_cache(
+        &v2_network,
+        NetworkUpgrade::Nu5,
+        v2_tree.size(),
+        v2_tree.peaks(),
+        &Default::default(),
+    )?;
+    assert_eq!(v2_tree.hash(), v2_decoded.hash());
+    assert_eq!(v2_tree.hash(), v2_without_future_fields.hash());
+
+    assert_eq!(
+        NetworkUpgrade::current(&v3_network, height),
+        NetworkUpgrade::Nu6_3
+    );
+    let v3_tree =
+        NonEmptyHistoryTree::from_parts(&v3_network, parts(&orchard_root, &ironwood_root, 2, 3))?;
+    let v3_without_ironwood_fields = NonEmptyHistoryTree::from_parts(
+        &v3_network,
+        parts(&orchard_root, &empty_ironwood_root, 2, 0),
+    )?;
+    let v3_decoded = PrimitiveHistoryTree::<V3>::new_from_cache(
+        &v3_network,
+        NetworkUpgrade::Nu6_3,
+        v3_tree.size(),
+        v3_tree.peaks(),
+        &Default::default(),
+    )?;
+    assert_eq!(v3_tree.hash(), v3_decoded.hash());
+    assert_ne!(v3_tree.hash(), v3_without_ironwood_fields.hash());
+
+    Ok(())
+}
+
+/// Pushing the NU6.3 activation block must reset the MMR to a single V3 leaf
+/// that commits to the Ironwood root, via both the block and parts APIs.
+#[test]
+fn push_wrapper_matches_parts_across_nu6_3_activation() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_2: Some(1),
+            nu6_3: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let first_block = Arc::new(
+        blocks
+            .get(&1)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let activation_block = Arc::new(
+        blocks
+            .get(&2)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    assert_eq!(
+        NetworkUpgrade::current(&network, crate::block::Height(1)),
+        NetworkUpgrade::Nu6_2
+    );
+    assert_eq!(
+        NetworkUpgrade::current(&network, crate::block::Height(2)),
+        NetworkUpgrade::Nu6_3
+    );
+
+    let mut block_tree = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    let mut parts_tree = NonEmptyHistoryTree::from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &first_block,
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        ),
+    )?;
+
+    block_tree.push(
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    parts_tree.push_from_parts(HistoryTreeBlockParts::from_block(
+        &activation_block,
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    ))?;
+    let activation_tree = NonEmptyHistoryTree::from_block(
+        &network,
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    let activation_without_ironwood = NonEmptyHistoryTree::from_block(
+        &network,
+        activation_block,
+        &sapling_root,
+        &orchard_root,
+        &Default::default(),
+    )?;
+
+    assert_eq!(block_tree.hash(), parts_tree.hash());
+    assert_eq!(block_tree.hash(), activation_tree.hash());
+    assert_ne!(block_tree.hash(), activation_without_ironwood.hash());
+    assert_eq!(
+        block_tree.size(),
+        1,
+        "a new consensus branch resets the MMR"
+    );
+    assert_eq!(block_tree.current_height(), crate::block::Height(2));
+
+    Ok(())
+}
+
+/// `push_from_parts` must append leaves using the tree's history version:
+/// V1 leaves ignore the Orchard and Ironwood fields, V2 leaves commit to
+/// Orchard but ignore Ironwood, and V3 leaves commit to Ironwood as well.
+#[test]
+fn push_from_parts_routes_each_history_version() -> Result<()> {
+    let v1_network = Network::new_regtest(RegtestParameters::default());
+    let v2_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let first_block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let second_block = blocks
+        .get(&2)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let sapling_root = sapling::tree::Root::default();
+    let empty_orchard_root = orchard::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let empty_ironwood_root = ironwood::tree::Root::default();
+    let mut first_ironwood_root_bytes = [0; 32];
+    first_ironwood_root_bytes[0] = 1;
+    let first_ironwood_root = ironwood::tree::Root::try_from(first_ironwood_root_bytes)?;
+    let mut second_ironwood_root_bytes = [0; 32];
+    second_ironwood_root_bytes[0] = 2;
+    let second_ironwood_root = ironwood::tree::Root::try_from(second_ironwood_root_bytes)?;
+    assert_ne!(orchard_root, empty_orchard_root);
+    assert_ne!(first_ironwood_root, empty_ironwood_root);
+
+    fn parts<'a>(
+        block: &'a Block,
+        sapling_root: &'a sapling::tree::Root,
+        orchard_root: &'a orchard::tree::Root,
+        ironwood_root: &'a ironwood::tree::Root,
+        orchard_tx: u64,
+        ironwood_tx: u64,
+    ) -> HistoryTreeBlockParts<'a> {
+        HistoryTreeBlockParts {
+            header: &block.header,
+            height: block.coinbase_height().expect("test block has a height"),
+            sapling_root,
+            orchard_root,
+            ironwood_root,
+            sapling_tx: 1,
+            orchard_tx,
+            ironwood_tx,
+        }
+    }
+    let two_leaf_tree = |network: &Network,
+                         second_orchard_root,
+                         second_ironwood_root,
+                         second_orchard_tx,
+                         second_ironwood_tx|
+     -> Result<NonEmptyHistoryTree> {
+        let mut tree = NonEmptyHistoryTree::from_parts(
+            network,
+            parts(
+                &first_block,
+                &sapling_root,
+                &orchard_root,
+                &first_ironwood_root,
+                2,
+                3,
+            ),
+        )?;
+        tree.push_from_parts(parts(
+            &second_block,
+            &sapling_root,
+            second_orchard_root,
+            second_ironwood_root,
+            second_orchard_tx,
+            second_ironwood_tx,
+        ))?;
+        Ok(tree)
+    };
+
+    let v1_tree = two_leaf_tree(&v1_network, &orchard_root, &second_ironwood_root, 5, 7)?;
+    let v1_without_future_fields =
+        two_leaf_tree(&v1_network, &empty_orchard_root, &empty_ironwood_root, 0, 0)?;
+    assert_eq!(v1_tree.hash(), v1_without_future_fields.hash());
+
+    let v2_tree = two_leaf_tree(&v2_network, &orchard_root, &second_ironwood_root, 5, 7)?;
+    let v2_without_ironwood =
+        two_leaf_tree(&v2_network, &orchard_root, &empty_ironwood_root, 5, 0)?;
+    let v2_without_orchard =
+        two_leaf_tree(&v2_network, &empty_orchard_root, &empty_ironwood_root, 0, 0)?;
+    assert_eq!(v2_tree.hash(), v2_without_ironwood.hash());
+    assert_ne!(v2_tree.hash(), v2_without_orchard.hash());
+
+    let v3_tree = two_leaf_tree(&v3_network, &orchard_root, &second_ironwood_root, 5, 7)?;
+    let v3_without_ironwood =
+        two_leaf_tree(&v3_network, &orchard_root, &empty_ironwood_root, 5, 0)?;
+    assert_ne!(v3_tree.hash(), v3_without_ironwood.hash());
+
+    Ok(())
+}
+
+/// `try_extend` must forward each block's Ironwood root to `push` in order:
+/// extending matches a sequence of individual pushes, and changing only the
+/// last block's Ironwood root changes the resulting tree.
+#[test]
+fn try_extend_forwards_ironwood_roots_in_order() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = |height| {
+        Arc::new(
+            blocks
+                .get(&height)
+                .expect("test vector exists")
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid"),
+        )
+    };
+    let first_block = block(1);
+    let second_block = block(2);
+    let third_block = block(3);
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut first_ironwood_root_bytes = [0; 32];
+    first_ironwood_root_bytes[0] = 1;
+    let first_ironwood_root = ironwood::tree::Root::try_from(first_ironwood_root_bytes)?;
+    let mut second_ironwood_root_bytes = [0; 32];
+    second_ironwood_root_bytes[0] = 2;
+    let second_ironwood_root = ironwood::tree::Root::try_from(second_ironwood_root_bytes)?;
+    let mut third_ironwood_root_bytes = [0; 32];
+    third_ironwood_root_bytes[0] = 3;
+    let third_ironwood_root = ironwood::tree::Root::try_from(third_ironwood_root_bytes)?;
+
+    let mut sequential = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    sequential.push(
+        second_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &second_ironwood_root,
+    )?;
+    sequential.push(
+        third_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &third_ironwood_root,
+    )?;
+
+    let mut extended = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    extended.try_extend([
+        (
+            second_block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &second_ironwood_root,
+        ),
+        (
+            third_block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &third_ironwood_root,
+        ),
+    ])?;
+
+    let mut wrong_last_root = NonEmptyHistoryTree::from_block(
+        &network,
+        first_block,
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    wrong_last_root.try_extend([
+        (
+            second_block,
+            &sapling_root,
+            &orchard_root,
+            &second_ironwood_root,
+        ),
+        (
+            third_block,
+            &sapling_root,
+            &orchard_root,
+            &Default::default(),
+        ),
+    ])?;
+
+    assert_eq!(extended.hash(), sequential.hash());
+    assert_ne!(extended.hash(), wrong_last_root.hash());
+
+    Ok(())
+}
+
+/// Pruning a V3 tree to its peaks and rebuilding it from the cache must never
+/// change the root hash, which commits to the Ironwood suffix that a V2 decode
+/// of the same peaks would silently drop.
+#[test]
+fn v3_pruning_and_hash_dispatch_match_unpruned_tree() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = blocks
+        .get(&1)
+        .expect("test vector exists")
+        .zcash_deserialize_into::<Block>()
+        .expect("block is structurally valid");
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+
+    fn ironwood_root(value: u32) -> Result<ironwood::tree::Root> {
+        let mut bytes = [0; 32];
+        bytes[0] = u8::try_from(value).expect("test values fit in a byte");
+        Ok(ironwood::tree::Root::try_from(bytes)?)
+    }
+
+    fn parts<'a>(
+        block: &'a Block,
+        sapling_root: &'a sapling::tree::Root,
+        orchard_root: &'a orchard::tree::Root,
+        ironwood_root: &'a ironwood::tree::Root,
+        height: u32,
+    ) -> HistoryTreeBlockParts<'a> {
+        HistoryTreeBlockParts {
+            header: &block.header,
+            height: crate::block::Height(height),
+            sapling_root,
+            orchard_root,
+            ironwood_root,
+            sapling_tx: u64::from(height),
+            orchard_tx: u64::from(height + 1),
+            ironwood_tx: u64::from(height + 2),
+        }
+    }
+
+    let first_ironwood_root = ironwood_root(1)?;
+    let first_parts = parts(
+        &block,
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+        1,
+    );
+    let mut pruned = NonEmptyHistoryTree::from_parts(&network, first_parts)?;
+    let (mut unpruned, _) = PrimitiveHistoryTree::<V3>::new_from_parts(&network, first_parts)?;
+
+    for height in 2u32..=16 {
+        let next_ironwood_root = ironwood_root(height)?;
+        let next_parts = parts(
+            &block,
+            &sapling_root,
+            &orchard_root,
+            &next_ironwood_root,
+            height,
+        );
+
+        unpruned
+            .append_leaf_parts(next_parts)
+            .expect("valid sequential V3 leaves append to the unpruned reference tree");
+        pruned.push_from_parts(next_parts)?;
+
+        assert_eq!(
+            pruned.hash(),
+            unpruned.hash(),
+            "V3 prune/rebuild changed the root after leaf {height}"
+        );
+        assert_eq!(
+            pruned.peaks().len(),
+            usize::try_from(height.count_ones())
+                .expect("u32 peak counts fit in usize on supported platforms"),
+            "the retained peaks must match the MMR leaf decomposition"
+        );
+
+        let rebuilt = PrimitiveHistoryTree::<V3>::new_from_cache(
+            &network,
+            NetworkUpgrade::Nu6_3,
+            pruned.size(),
+            pruned.peaks(),
+            &Default::default(),
+        )?;
+        assert_eq!(pruned.hash(), rebuilt.hash());
+    }
+
+    let v2_decode = PrimitiveHistoryTree::<V2>::new_from_cache(
+        &network,
+        NetworkUpgrade::Nu6_3,
+        pruned.size(),
+        pruned.peaks(),
+        &Default::default(),
+    )?;
+    assert_ne!(
+        pruned.hash(),
+        v2_decode.hash(),
+        "the public hash must include the V3 Ironwood suffix"
+    );
+
+    Ok(())
+}
+
+/// Cloning a V3 tree (which rebuilds the inner tree from its peaks) must
+/// preserve the root, size, and height, and the clone must stay in sync with
+/// the original when both push the same next block.
+#[test]
+fn v3_clone_preserves_root_and_future_append() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = |height| {
+        Arc::new(
+            blocks
+                .get(&height)
+                .expect("test vector exists")
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid"),
+        )
+    };
+    let ironwood_root = |value| -> Result<ironwood::tree::Root> {
+        let mut bytes = [0; 32];
+        bytes[0] = value;
+        Ok(ironwood::tree::Root::try_from(bytes)?)
+    };
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let first_ironwood_root = ironwood_root(1)?;
+    let second_ironwood_root = ironwood_root(2)?;
+    let third_ironwood_root = ironwood_root(3)?;
+    let fourth_ironwood_root = ironwood_root(4)?;
+
+    let mut original = NonEmptyHistoryTree::from_block(
+        &network,
+        block(1),
+        &sapling_root,
+        &orchard_root,
+        &first_ironwood_root,
+    )?;
+    original.push(
+        block(2),
+        &sapling_root,
+        &orchard_root,
+        &second_ironwood_root,
+    )?;
+    original.push(block(3), &sapling_root, &orchard_root, &third_ironwood_root)?;
+    assert_eq!(original.peaks().len(), 2, "three leaves have two MMR peaks");
+
+    let mut cloned = original.clone();
+    assert_eq!(cloned.hash(), original.hash());
+    assert_eq!(cloned.size(), original.size());
+    assert_eq!(
+        cloned.peaks().keys().collect::<Vec<_>>(),
+        original.peaks().keys().collect::<Vec<_>>()
+    );
+    assert_eq!(cloned.current_height(), original.current_height());
+    assert_eq!(cloned.network(), original.network());
+
+    let fourth_block = block(4);
+    original.push(
+        fourth_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &fourth_ironwood_root,
+    )?;
+    cloned.push(
+        fourth_block,
+        &sapling_root,
+        &orchard_root,
+        &fourth_ironwood_root,
+    )?;
+
+    assert_eq!(cloned.hash(), original.hash());
+    assert_eq!(cloned.size(), original.size());
+    assert_eq!(cloned.current_height(), original.current_height());
+
+    Ok(())
+}
+
+/// The `HistoryTree` wrapper must return an empty tree for pre-Heartwood
+/// blocks and matching block/parts trees for the V1, V2, and V3 history
+/// versions.
+#[test]
+fn history_tree_from_block_matches_parts_across_history_versions() -> Result<()> {
+    let pre_heartwood = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            heartwood: Some(2),
+            canopy: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v1 = Network::new_regtest(RegtestParameters::default());
+    let v2 = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let v3 = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_3: Some(1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = Arc::new(
+        blocks
+            .get(&1)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    for (network, should_exist) in [(pre_heartwood, false), (v1, true), (v2, true), (v3, true)] {
+        let block_tree = HistoryTree::from_block(
+            &network,
+            block.clone(),
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        )?;
+        let parts_tree = HistoryTree::from_parts(
+            &network,
+            HistoryTreeBlockParts::from_block(&block, &sapling_root, &orchard_root, &ironwood_root),
+        )?;
+
+        assert_eq!(block_tree.is_some(), should_exist);
+        assert_eq!(parts_tree.is_some(), should_exist);
+        assert_eq!(block_tree.hash(), parts_tree.hash());
+    }
+
+    Ok(())
+}
+
+/// The `HistoryTree` push wrappers must recreate the tree as a single V3 leaf
+/// at NU6.3 activation, committing to the Ironwood root, via both the block
+/// and parts APIs.
+#[test]
+fn history_tree_push_wrapper_matches_parts_across_nu6_3_activation() -> Result<()> {
+    let network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            nu6_2: Some(1),
+            nu6_3: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let (blocks, _) = Network::Mainnet.block_sapling_roots_map();
+    let block = |height| {
+        Arc::new(
+            blocks
+                .get(&height)
+                .expect("test vector exists")
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid"),
+        )
+    };
+    let first_block = block(1);
+    let activation_block = block(2);
+    let sapling_root = sapling::tree::Root::default();
+    // A nonzero root: `orchard::tree::Root::default()` is the all-zero root, so
+    // an all-zero value would make "commits to the Orchard root" checks vacuous.
+    let mut orchard_root_bytes = [0; 32];
+    orchard_root_bytes[0] = 9;
+    let orchard_root = orchard::tree::Root::try_from(orchard_root_bytes)?;
+    let mut ironwood_root_bytes = [0; 32];
+    ironwood_root_bytes[0] = 1;
+    let ironwood_root = ironwood::tree::Root::try_from(ironwood_root_bytes)?;
+
+    let mut block_tree = HistoryTree::default();
+    let mut parts_tree = HistoryTree::default();
+    block_tree.push(
+        &network,
+        first_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    parts_tree.push_from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &first_block,
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        ),
+    )?;
+    assert_eq!(block_tree.hash(), parts_tree.hash());
+
+    block_tree.push(
+        &network,
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    parts_tree.push_from_parts(
+        &network,
+        HistoryTreeBlockParts::from_block(
+            &activation_block,
+            &sapling_root,
+            &orchard_root,
+            &ironwood_root,
+        ),
+    )?;
+    let activation_tree = HistoryTree::from_block(
+        &network,
+        activation_block.clone(),
+        &sapling_root,
+        &orchard_root,
+        &ironwood_root,
+    )?;
+    let activation_without_ironwood = HistoryTree::from_block(
+        &network,
+        activation_block,
+        &sapling_root,
+        &orchard_root,
+        &Default::default(),
+    )?;
+
+    assert_eq!(block_tree.hash(), parts_tree.hash());
+    assert_eq!(block_tree.hash(), activation_tree.hash());
+    assert_ne!(block_tree.hash(), activation_without_ironwood.hash());
+    assert_eq!(
+        block_tree
+            .as_ref()
+            .expect("history tree exists at NU6.3")
+            .size(),
+        1,
+        "a new consensus branch resets the MMR"
+    );
 
     Ok(())
 }

--- a/zakura-chain/src/orchard/tree.rs
+++ b/zakura-chain/src/orchard/tree.rs
@@ -1076,6 +1076,43 @@ mod tests {
         assert_eq!(tree.root(), original.root());
     }
 
+    /// `append_batch` must match sequential appends when a batch exactly fills
+    /// the last two leaf positions of the tree, completing the final tracked
+    /// subtree (index `u16::MAX`) without reporting a spurious overflow.
+    #[test]
+    fn append_batch_matches_sequential_at_tree_capacity() {
+        let max_position = (1u64 << MERKLE_DEPTH) - 1;
+        let start_position = max_position - 2;
+        let leaf = node(1);
+        // A frontier at position `p` stores one ommer per set bit of `p`;
+        // `max_position - 2` has 31 of its 32 bits set.
+        let ommers: Vec<Node> = (2..=32).map(node).collect();
+        let inner = Frontier::from_parts(Position::from(start_position), leaf, ommers)
+            .expect("frontier two leaves below capacity is valid");
+        let start = NoteCommitmentTree {
+            inner,
+            cached_root: Default::default(),
+        };
+        let note_commitments = [note_commitment(100), note_commitment(200)];
+
+        let mut seq_tree = start.clone();
+        let seq_result = sequential_append_batch(&mut seq_tree, &note_commitments)
+            .expect("two sequential appends reach exact capacity");
+
+        let mut batch_tree = start;
+        let batch_result = batch_tree
+            .append_batch(&note_commitments)
+            .expect("batch append reaches exact capacity");
+
+        assert_eq!(batch_result, seq_result);
+        assert_eq!(
+            batch_result.map(|(index, _)| index),
+            Some(NoteCommitmentSubtreeIndex(u16::MAX)),
+        );
+        batch_tree.assert_frontier_eq(&seq_tree);
+        assert_eq!(batch_tree.root(), seq_tree.root());
+    }
+
     #[test]
     fn append_batch_multiple_subtrees_preserves_tree_and_cached_root() {
         let mut tree = NoteCommitmentTree::default();

--- a/zakura-chain/src/parallel/tree.rs
+++ b/zakura-chain/src/parallel/tree.rs
@@ -275,3 +275,193 @@ impl NoteCommitmentTrees {
         Ok((ironwood, subtree_root))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use halo2::pasta::pallas;
+
+    use crate::{
+        block::{Header, Height},
+        parameters::{Network, NetworkUpgrade::Nu6_3},
+        serialization::ZcashDeserializeInto,
+        transaction::{arbitrary::v5_transactions, LockTime, Transaction},
+        transparent,
+    };
+
+    use super::*;
+
+    /// `update_trees_parallel` must feed each pool's note commitments to its
+    /// own tree, in transaction order, and must not touch unrelated trees.
+    ///
+    /// The block's two transactions carry the commitments `1` and `2` in
+    /// opposite pools, so a pool mix-up or reordering would change the
+    /// resulting Orchard or Ironwood tree root.
+    #[test]
+    fn parallel_block_update_keeps_orchard_and_ironwood_order_and_assignment() {
+        let _init_guard = zakura_test::init();
+
+        let mut orchard_data = Network::iter()
+            .flat_map(|network| v5_transactions(network.block_iter()))
+            .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+            .expect("test vectors include an Orchard transaction");
+        // Ironwood reuses the Orchard bundle encoding, so an Orchard test
+        // bundle can be cloned into the Ironwood slot of a V6 transaction.
+        let mut ironwood_data = orchard_data.clone();
+
+        let mut orchard_actions = orchard_data.actions.as_slice().to_vec();
+        orchard_actions.truncate(1);
+        orchard_actions[0].action.cm_x = pallas::Base::from(1);
+        orchard_data.actions = orchard_actions
+            .try_into()
+            .expect("the test bundle has at least one action");
+
+        let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+        ironwood_actions.truncate(1);
+        ironwood_actions[0].action.cm_x = pallas::Base::from(2);
+        ironwood_data.actions = ironwood_actions
+            .try_into()
+            .expect("the test bundle has at least one action");
+
+        let make_transaction =
+            |orchard_shielded_data: orchard::ShieldedData,
+             ironwood_shielded_data: ironwood::ShieldedData| {
+                Arc::new(Transaction::V6 {
+                    network_upgrade: Nu6_3,
+                    lock_time: LockTime::unlocked(),
+                    expiry_height: Height(1),
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                    sapling_shielded_data: None,
+                    orchard_shielded_data: Some(orchard_shielded_data),
+                    ironwood_shielded_data: Some(ironwood_shielded_data),
+                })
+            };
+
+        let height = Height(123);
+        let coinbase = Arc::new(Transaction::V6 {
+            network_upgrade: Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: height,
+            inputs: vec![transparent::Input::Coinbase {
+                height,
+                data: Vec::new(),
+                sequence: u32::MAX,
+            }],
+            outputs: Vec::new(),
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+            ironwood_shielded_data: None,
+        });
+        let header: Header = zakura_test::vectors::DUMMY_HEADER
+            .zcash_deserialize_into()
+            .expect("dummy header should deserialize");
+        let block = Arc::new(Block {
+            header: Arc::new(header),
+            transactions: vec![
+                coinbase,
+                make_transaction(orchard_data.clone(), ironwood_data.clone()),
+                make_transaction(ironwood_data, orchard_data),
+            ],
+        });
+
+        let orchard_commitments: Vec<_> = block.orchard_note_commitments().copied().collect();
+        let ironwood_commitments: Vec<_> = block.ironwood_note_commitments().copied().collect();
+        assert_eq!(
+            orchard_commitments,
+            [pallas::Base::from(1), pallas::Base::from(2)]
+        );
+        assert_eq!(
+            ironwood_commitments,
+            [pallas::Base::from(2), pallas::Base::from(1)]
+        );
+
+        let mut expected_orchard = orchard::tree::NoteCommitmentTree::default();
+        for commitment in &orchard_commitments {
+            expected_orchard
+                .append(*commitment)
+                .expect("two Orchard commitments fit in an empty tree");
+        }
+        let mut expected_ironwood = ironwood::tree::NoteCommitmentTree::default();
+        for commitment in &ironwood_commitments {
+            expected_ironwood
+                .append(*commitment)
+                .expect("two Ironwood commitments fit in an empty tree");
+        }
+        assert_ne!(expected_orchard.root(), expected_ironwood.root());
+
+        let mut trees = NoteCommitmentTrees::default();
+        let unchanged_sprout = trees.sprout.clone();
+        let unchanged_sapling = trees.sapling.clone();
+        trees
+            .update_trees_parallel(&block)
+            .expect("the mixed-pool block fits in empty trees");
+
+        assert_eq!(trees.sprout, unchanged_sprout);
+        assert_eq!(trees.sapling, unchanged_sapling);
+        assert_eq!(trees.orchard.root(), expected_orchard.root());
+        assert_eq!(trees.ironwood.root(), expected_ironwood.root());
+        assert_eq!(trees.orchard.count(), 2);
+        assert_eq!(trees.ironwood.count(), 2);
+        assert_eq!(trees.orchard_subtree, None);
+        assert_eq!(trees.ironwood_subtree, None);
+        assert!(!Arc::ptr_eq(&trees.orchard, &trees.ironwood));
+    }
+
+    /// Updating one pool's note commitment tree must not affect the other's,
+    /// even though the two pools share the same tree implementation and their
+    /// empty trees have equal roots.
+    #[test]
+    fn orchard_and_ironwood_trees_remain_independent() {
+        let mut trees = NoteCommitmentTrees::default();
+        let empty_orchard_root = trees.orchard.root();
+        let empty_ironwood_root = trees.ironwood.root();
+
+        assert_eq!(empty_orchard_root, empty_ironwood_root);
+        assert!(!Arc::ptr_eq(&trees.orchard, &trees.ironwood));
+
+        let (ironwood, ironwood_subtree) =
+            NoteCommitmentTrees::update_ironwood_note_commitment_tree(
+                trees.ironwood.clone(),
+                vec![pallas::Base::from(1)],
+            )
+            .expect("one Ironwood commitment fits in an empty tree");
+        trees.ironwood = ironwood;
+
+        assert_eq!(ironwood_subtree, None);
+        assert_eq!(trees.orchard.root(), empty_orchard_root);
+        assert_ne!(trees.ironwood.root(), empty_ironwood_root);
+
+        let ironwood_root = trees.ironwood.root();
+        let (orchard, orchard_subtree) = NoteCommitmentTrees::update_orchard_note_commitment_tree(
+            trees.orchard.clone(),
+            vec![pallas::Base::from(2)],
+        )
+        .expect("one Orchard commitment fits in an empty tree");
+        trees.orchard = orchard;
+
+        assert_eq!(orchard_subtree, None);
+        assert_eq!(trees.ironwood.root(), ironwood_root);
+        assert_ne!(trees.orchard.root(), trees.ironwood.root());
+    }
+
+    /// Tree errors must name the pool they came from: the `From` conversion
+    /// maps the shared inner error type to the Orchard variant, so Ironwood
+    /// errors must be constructed explicitly and display as Ironwood.
+    #[test]
+    fn orchard_and_ironwood_tree_errors_keep_their_pool_identity() {
+        let orchard_error =
+            NoteCommitmentTreeError::from(orchard::tree::NoteCommitmentTreeError::FullTree);
+        let ironwood_error =
+            NoteCommitmentTreeError::Ironwood(ironwood::tree::NoteCommitmentTreeError::FullTree);
+
+        assert!(matches!(orchard_error, NoteCommitmentTreeError::Orchard(_)));
+        assert!(matches!(
+            ironwood_error,
+            NoteCommitmentTreeError::Ironwood(_)
+        ));
+        assert_eq!(
+            ironwood_error.to_string(),
+            "ironwood error: The note commitment tree is full"
+        );
+    }
+}

--- a/zakura-chain/src/primitives/zcash_note_encryption.rs
+++ b/zakura-chain/src/primitives/zcash_note_encryption.rs
@@ -7,8 +7,8 @@ use crate::{
     transaction::Transaction,
 };
 
-/// Returns true if all Sapling or Orchard outputs, if any, decrypt successfully with
-/// an all-zeroes outgoing viewing key.
+/// Returns true if all Sapling, Orchard, or Ironwood outputs, if any, decrypt
+/// successfully with an all-zeroes outgoing viewing key.
 pub fn decrypts_successfully(tx: &Transaction, network: &Network, height: Height) -> bool {
     let nu = NetworkUpgrade::current(network, height);
 
@@ -82,7 +82,7 @@ fn ironwood_action_decrypts_successfully<A>(act: &orchard::Action<A>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use group::{prime::PrimeCurveAffine, GroupEncoding};
+    use group::{ff::PrimeField, prime::PrimeCurveAffine, GroupEncoding};
     use halo2::pasta::pallas;
     use orchard::{
         note::{
@@ -95,6 +95,19 @@ mod tests {
     };
     use rand_core::OsRng;
     use zcash_note_encryption::Domain;
+
+    use crate::{
+        at_least_one,
+        block::Height,
+        orchard as chain_orchard,
+        parameters::{
+            testnet::{ConfiguredActivationHeights, RegtestParameters},
+            Network, NetworkUpgrade,
+        },
+        primitives::Halo2Proof,
+        transaction::{arbitrary::v5_transactions, LockTime, Transaction},
+        transparent,
+    };
 
     #[test]
     fn orchard_and_ironwood_domains_accept_only_their_plaintext_versions() {
@@ -121,6 +134,28 @@ mod tests {
                 "{domain_name} domain result for note plaintext {plaintext_lead_byte:#04x}"
             );
         }
+    }
+
+    #[test]
+    fn decrypts_successfully_routes_v6_ironwood_outputs_through_ironwood_domain() {
+        let vector = zakura_test::vectors::ORCHARD_NOTE_ENCRYPTION_ZERO_VECTOR
+            .first()
+            .expect("test vectors are non-empty");
+        let v3_shielded_data = local_shielded_data_from_action(&v3_action_from_test_vector(vector));
+        let network = nu6_3_network();
+        let height = Height(1);
+
+        let ironwood_tx = v6_coinbase(height, None, Some(v3_shielded_data.clone()));
+        assert!(
+            super::decrypts_successfully(&ironwood_tx, &network, height),
+            "V6 Ironwood outputs must use the V3 note plaintext domain"
+        );
+
+        let orchard_tx = v6_coinbase(height, Some(v3_shielded_data), None);
+        assert!(
+            !super::decrypts_successfully(&orchard_tx, &network, height),
+            "the same V3 ciphertext must not be accepted as an Orchard output"
+        );
     }
 
     fn v2_action_from_test_vector(v: &zakura_test::vectors::TestVector) -> Action<()> {
@@ -174,6 +209,66 @@ mod tests {
             (),
         )
         .expect("test vector fields form a valid action")
+    }
+
+    fn local_shielded_data_from_action(action: &Action<()>) -> chain_orchard::ShieldedData {
+        let mut shielded_data = v5_transactions(Network::new_default_testnet().block_iter())
+            .find_map(|tx| tx.orchard_shielded_data().cloned())
+            .expect("test vectors include an Orchard transaction");
+        let mut local_action = shielded_data.actions.first().action.clone();
+
+        local_action.cv = chain_orchard::ValueCommitment::try_from(action.cv_net().to_bytes())
+            .expect("test vector has a valid value commitment");
+        local_action.nullifier =
+            chain_orchard::Nullifier::try_from((*action.nullifier()).to_bytes())
+                .expect("test vector has a valid nullifier");
+        local_action.cm_x = pallas::Base::from_repr((*action.cmx()).to_bytes())
+            .expect("test vector has a valid note commitment");
+        local_action.ephemeral_key =
+            chain_orchard::keys::EphemeralPublicKey::try_from(action.encrypted_note().epk_bytes)
+                .expect("test vector has a valid ephemeral key");
+        local_action.enc_ciphertext = action.encrypted_note().enc_ciphertext.into();
+        local_action.out_ciphertext = action.encrypted_note().out_ciphertext.into();
+
+        let spend_auth_sig = shielded_data.actions.first().spend_auth_sig;
+        shielded_data.flags = chain_orchard::Flags::ENABLE_OUTPUTS;
+        shielded_data.proof = Halo2Proof(vec![0; ::orchard::Proof::expected_proof_size(1)]);
+        shielded_data.actions = at_least_one![chain_orchard::AuthorizedAction::from_parts(
+            local_action,
+            spend_auth_sig,
+        )];
+        shielded_data
+    }
+
+    fn nu6_3_network() -> Network {
+        Network::new_regtest(RegtestParameters {
+            activation_heights: ConfiguredActivationHeights {
+                nu6_3: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    fn v6_coinbase(
+        height: Height,
+        orchard_shielded_data: Option<chain_orchard::ShieldedData>,
+        ironwood_shielded_data: Option<chain_orchard::ShieldedData>,
+    ) -> Transaction {
+        Transaction::V6 {
+            network_upgrade: NetworkUpgrade::Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: height,
+            inputs: vec![transparent::Input::Coinbase {
+                height,
+                data: vec![],
+                sequence: u32::MAX,
+            }],
+            outputs: vec![],
+            sapling_shielded_data: None,
+            orchard_shielded_data,
+            ironwood_shielded_data,
+        }
     }
 
     fn test_vector_address(v: &zakura_test::vectors::TestVector) -> Address {

--- a/zakura-chain/src/primitives/zcash_primitives.rs
+++ b/zakura-chain/src/primitives/zcash_primitives.rs
@@ -540,7 +540,8 @@ pub(crate) fn auth_digest(tx: &Transaction) -> AuthDigest {
 }
 
 /// Compute both the transaction ID (txid) and the ZIP-244 authorizing-data
-/// commitment of a v5+ transaction from a single `librustzcash` conversion.
+/// commitment of a v5+ transaction from a shared native ZIP-244
+/// decomposition, falling back to `librustzcash` for unsupported versions.
 ///
 /// # Panics
 ///

--- a/zakura-chain/src/transaction.rs
+++ b/zakura-chain/src/transaction.rs
@@ -284,7 +284,8 @@ impl Transaction {
     }
 
     /// Compute this transaction's ID (txid) and ZIP-244 authorizing-data digest
-    /// together, sharing the librustzcash conversion used by both computations.
+    /// together, sharing the native ZIP-244 decomposition used by both
+    /// computations.
     ///
     /// Returns `None` for the auth digest of pre-v5 transactions.
     pub fn txid_and_auth_digest(&self) -> (Hash, Option<AuthDigest>) {

--- a/zakura-chain/src/transaction/serialize.rs
+++ b/zakura-chain/src/transaction/serialize.rs
@@ -854,10 +854,11 @@ impl ZcashSerialize for Transaction {
                 // A bundle of fields denoted in the spec as `nActionsOrchard`, `vActionsOrchard`,
                 // `flagsOrchard`,`valueBalanceOrchard`, `anchorOrchard`, `sizeProofsOrchard`,
                 // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`.
+                // V6 Orchard still reserves bit 2; only the Ironwood slot below permits it.
                 serialize_optional_orchard_shielded_data_with_flags(
                     orchard_shielded_data,
                     &mut writer,
-                    ALLOW_CROSS_ADDRESS_BIT,
+                    !ALLOW_CROSS_ADDRESS_BIT,
                 )?;
 
                 // A bundle of fields denoted in the spec as `nActionsIronwood`,
@@ -1204,9 +1205,10 @@ impl ZcashDeserialize for Transaction {
                 // A bundle of fields denoted in the spec as `nActionsOrchard`, `vActionsOrchard`,
                 // `flagsOrchard`,`valueBalanceOrchard`, `anchorOrchard`, `sizeProofsOrchard`,
                 // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`.
+                // V6 Orchard still reserves bit 2; only the Ironwood slot below permits it.
                 let orchard_shielded_data = deserialize_orchard_shielded_data_with_flags(
                     &mut limited_reader,
-                    ALLOW_CROSS_ADDRESS_BIT,
+                    !ALLOW_CROSS_ADDRESS_BIT,
                 )?;
 
                 // A bundle of fields denoted in the spec as `nActionsIronwood`,

--- a/zakura-chain/src/transaction/tests/prop.rs
+++ b/zakura-chain/src/transaction/tests/prop.rs
@@ -160,6 +160,7 @@ fn nu5_or_later_upgrade() -> BoxedStrategy<NetworkUpgrade> {
         Just(NetworkUpgrade::Nu6),
         Just(NetworkUpgrade::Nu6_1),
         Just(NetworkUpgrade::Nu6_2),
+        Just(NetworkUpgrade::Nu6_3),
     ]
     .boxed()
 }
@@ -252,6 +253,15 @@ proptest! {
             crate::transaction::zip244::auth_digest(&tx).expect("v5/v6"),
             native_auth
         );
+
+        // The public wrappers route v5/v6 transactions through the same
+        // native decomposition. Keep that routing pinned to the oracle too,
+        // rather than only testing the internal ZIP-244 helpers.
+        let (public_txid, public_auth) = tx.txid_and_auth_digest();
+        prop_assert_eq!(public_txid, ref_txid);
+        prop_assert_eq!(public_auth, Some(ref_auth));
+        prop_assert_eq!(tx.hash(), ref_txid);
+        prop_assert_eq!(tx.auth_digest(), Some(ref_auth));
     }
 
     #[test]

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -206,104 +206,126 @@ fn v5_orchard_cross_address_flag_fails_deserialization() {
     ));
 }
 
-/// V6 Orchard and Ironwood bundles must round-trip the `ENABLE_CROSS_ADDRESS`
-/// flag bit (which V5 reserves and rejects), while still rejecting the
-/// undefined flag bits 3..7.
-///
-/// The flags byte position is located by serializing the same transaction
-/// with and without the cross-address bit and diffing: exactly one byte may
-/// change.
+/// V6 Orchard keeps the cross-address bit reserved on the wire, even though
+/// V6 Ironwood uses the same internal `Flags` type and permits that bit.
 #[test]
-fn v6_orchard_style_flags_allow_cross_address_but_reject_reserved_bits() {
+fn v6_orchard_cross_address_flag_fails_serialization_and_deserialization() {
     let _init_guard = zakura_test::init();
 
-    let shielded_data = Network::iter()
+    let mut shielded_data = Network::iter()
         .flat_map(|network| v5_transactions(network.block_iter()))
         .find_map(|transaction| transaction.orchard_shielded_data().cloned())
         .expect("test vectors include an Orchard transaction");
 
-    let make_tx = |mut shielded_data: crate::orchard::ShieldedData, ironwood: bool| {
-        shielded_data
-            .flags
-            .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
-
-        Transaction::V6 {
-            network_upgrade: NetworkUpgrade::Nu6_3,
-            lock_time: LockTime::unlocked(),
-            expiry_height: Height(1),
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            sapling_shielded_data: None,
-            orchard_shielded_data: (!ironwood).then_some(shielded_data.clone()),
-            ironwood_shielded_data: ironwood.then_some(shielded_data),
-        }
+    let make_tx = |shielded_data: crate::orchard::ShieldedData| Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: Some(shielded_data),
+        ironwood_shielded_data: None,
     };
 
-    for ironwood in [false, true] {
-        let tx = make_tx(shielded_data.clone(), ironwood);
-        let cross_address_bytes = tx
-            .zcash_serialize_to_vec()
-            .expect("V6 Orchard-style formats allow the cross-address bit on the wire");
-        let parsed = Transaction::zcash_deserialize(&cross_address_bytes[..])
-            .expect("V6 Orchard-style cross-address flag must deserialize");
-        let parsed_flags = if ironwood {
-            parsed
-                .ironwood_shielded_data()
-                .expect("test transaction has Ironwood data")
-                .flags
-        } else {
-            parsed
-                .orchard_shielded_data()
-                .expect("test transaction has Orchard data")
-                .flags
-        };
-        assert!(parsed_flags.contains(crate::orchard::Flags::ENABLE_CROSS_ADDRESS));
+    let valid_bytes = make_tx(shielded_data.clone())
+        .zcash_serialize_to_vec()
+        .expect("V6 Orchard flags without cross-address must serialize");
 
-        let mut without_cross_address = tx;
-        let Transaction::V6 {
-            orchard_shielded_data,
-            ironwood_shielded_data,
-            ..
-        } = &mut without_cross_address
-        else {
-            unreachable!("test transaction is V6");
-        };
-        if ironwood {
-            ironwood_shielded_data
-                .as_mut()
-                .expect("test transaction has Ironwood data")
-                .flags
-                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
-        } else {
-            orchard_shielded_data
-                .as_mut()
-                .expect("test transaction has Orchard data")
-                .flags
-                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
-        }
+    let mut toggled = shielded_data.clone();
+    toggled.flags.toggle(crate::orchard::Flags::ENABLE_SPENDS);
+    let toggled_bytes = make_tx(toggled)
+        .zcash_serialize_to_vec()
+        .expect("V6 Orchard spend flag should serialize");
+    let differing_indices: Vec<_> = valid_bytes
+        .iter()
+        .zip(&toggled_bytes)
+        .enumerate()
+        .filter_map(|(index, (original, toggled))| (original != toggled).then_some(index))
+        .collect();
+    let [flags_index] = differing_indices.as_slice() else {
+        panic!("toggling the V6 Orchard spend flag should change exactly one byte");
+    };
 
-        let without_cross_address_bytes = without_cross_address
-            .zcash_serialize_to_vec()
-            .expect("V6 Orchard-style flags without cross-address must serialize");
-        let differing_indices: Vec<_> = cross_address_bytes
-            .iter()
-            .zip(&without_cross_address_bytes)
-            .enumerate()
-            .filter_map(|(index, (with, without))| (with != without).then_some(index))
-            .collect();
-        let [flags_index] = differing_indices.as_slice() else {
-            panic!("toggling the cross-address flag should change exactly one byte");
-        };
+    shielded_data
+        .flags
+        .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+    let error = make_tx(shielded_data)
+        .zcash_serialize_to_vec()
+        .expect_err("V6 Orchard flags must reject reserved cross-address bit");
+    assert_eq!(error.kind(), ErrorKind::InvalidData);
 
-        let mut reserved_bit_bytes = cross_address_bytes;
-        reserved_bit_bytes[*flags_index] |= 0b0000_1000;
-        let error = Transaction::zcash_deserialize(&reserved_bit_bytes[..])
-            .expect_err("V6 Orchard-style flags must reject reserved bits 3..7");
-        assert!(matches!(
-            error,
-            SerializationError::Parse("invalid reserved orchard flags")
-        ));
-    }
+    let mut malformed_bytes = valid_bytes;
+    malformed_bytes[*flags_index] |= crate::orchard::Flags::ENABLE_CROSS_ADDRESS.bits();
+    let error = Transaction::zcash_deserialize(&malformed_bytes[..])
+        .expect_err("V6 Orchard flags must reject reserved cross-address bit");
+    assert!(matches!(
+        error,
+        SerializationError::Parse("invalid reserved orchard flags")
+    ));
+}
+
+/// V6 Ironwood must round-trip `ENABLE_CROSS_ADDRESS`, while still rejecting
+/// undefined flag bits 3..7.
+#[test]
+fn v6_ironwood_cross_address_flag_round_trips_and_rejects_reserved_bits() {
+    let _init_guard = zakura_test::init();
+
+    let mut shielded_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    shielded_data
+        .flags
+        .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+
+    let make_tx = |shielded_data: crate::ironwood::ShieldedData| Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        ironwood_shielded_data: Some(shielded_data),
+    };
+
+    let tx = make_tx(shielded_data.clone());
+    let cross_address_bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("V6 Ironwood must allow the cross-address bit on the wire");
+    let parsed = Transaction::zcash_deserialize(&cross_address_bytes[..])
+        .expect("V6 Ironwood cross-address flag must deserialize");
+    assert!(parsed
+        .ironwood_shielded_data()
+        .expect("test transaction has Ironwood data")
+        .flags
+        .contains(crate::orchard::Flags::ENABLE_CROSS_ADDRESS));
+
+    shielded_data
+        .flags
+        .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+    let without_cross_address_bytes = make_tx(shielded_data)
+        .zcash_serialize_to_vec()
+        .expect("V6 Ironwood flags without cross-address must serialize");
+    let differing_indices: Vec<_> = cross_address_bytes
+        .iter()
+        .zip(&without_cross_address_bytes)
+        .enumerate()
+        .filter_map(|(index, (with, without))| (with != without).then_some(index))
+        .collect();
+    let [flags_index] = differing_indices.as_slice() else {
+        panic!("toggling the V6 Ironwood cross-address flag should change exactly one byte");
+    };
+
+    let mut reserved_bit_bytes = cross_address_bytes;
+    reserved_bit_bytes[*flags_index] |= 0b0000_1000;
+    let error = Transaction::zcash_deserialize(&reserved_bit_bytes[..])
+        .expect_err("V6 Ironwood flags must reject reserved bits 3..7");
+    assert!(matches!(
+        error,
+        SerializationError::Parse("invalid reserved orchard flags")
+    ));
 }
 
 #[test]
@@ -2200,6 +2222,128 @@ fn sapling_lazy_cv_epk_edge_cases() {
         ValidatingKey::try_from(small_order).is_err(),
         "Sapling rk must still reject a small-order point at deserialization",
     );
+}
+
+/// Native ZIP-244 hashing must stay byte-oriented for lazy Sapling points.
+///
+/// Checkpoint hashing and pre-verification mempool IDs are computed before
+/// semantic point validation. An off-curve Sapling commitment must therefore
+/// still produce a deterministic V5/V6 `UnminedTx` ID, while the later
+/// librustzcash conversion remains fail-closed.
+#[test]
+fn native_zip244_hashes_invalid_lazy_sapling_points_before_semantic_rejection() {
+    use group::Group;
+
+    use crate::{
+        amount::Amount,
+        at_least_one,
+        block::Height,
+        parameters::NetworkUpgrade,
+        primitives::{
+            redjubjub::{Binding, Signature},
+            Groth16Proof,
+        },
+        sapling::{
+            self,
+            keys::EphemeralPublicKey,
+            shielded_data::{ShieldedData, TransferData},
+            EncryptedNote, Output, ValueCommitment, WrappedNoteKey,
+        },
+        serialization::{ZcashDeserializeInto, ZcashSerialize},
+        transaction::{LockTime, Transaction, UnminedTx},
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let off_curve = [0xffu8; 32];
+    let other_off_curve = [0xfeu8; 32];
+    assert!(
+        bool::from(jubjub::AffinePoint::from_bytes(off_curve).is_none()),
+        "0xff..ff must not be a valid Jubjub point encoding",
+    );
+    assert!(
+        bool::from(jubjub::AffinePoint::from_bytes(other_off_curve).is_none()),
+        "0xfe..fe must not be a valid Jubjub point encoding",
+    );
+    let valid_epk = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
+
+    let shielded_data = |cv: [u8; 32]| ShieldedData::<sapling::SharedAnchor> {
+        value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+        transfers: TransferData::JustOutputs {
+            outputs: at_least_one![Output {
+                cv: ValueCommitment(cv),
+                cm_u: sapling_crypto::note::ExtractedNoteCommitment::from_bytes(&[0u8; 32])
+                    .expect("zero bytes encode a valid extracted note commitment"),
+                ephemeral_key: EphemeralPublicKey(valid_epk),
+                enc_ciphertext: EncryptedNote([0u8; 580]),
+                out_ciphertext: WrappedNoteKey([0u8; 80]),
+                zkproof: Groth16Proof([0u8; 192]),
+            }],
+        },
+        binding_sig: Signature::<Binding>::from([0u8; 64]),
+    };
+
+    let make_transactions = |cv: [u8; 32]| {
+        [
+            Transaction::V5 {
+                network_upgrade: NetworkUpgrade::Nu5,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(0),
+                inputs: vec![],
+                outputs: vec![],
+                sapling_shielded_data: Some(shielded_data(cv)),
+                orchard_shielded_data: None,
+            },
+            Transaction::V6 {
+                network_upgrade: NetworkUpgrade::Nu6_3,
+                lock_time: LockTime::unlocked(),
+                expiry_height: Height(0),
+                inputs: vec![],
+                outputs: vec![],
+                sapling_shielded_data: Some(shielded_data(cv)),
+                orchard_shielded_data: None,
+                ironwood_shielded_data: None,
+            },
+        ]
+    };
+
+    for (tx, changed_tx) in make_transactions(off_curve)
+        .into_iter()
+        .zip(make_transactions(other_off_curve))
+    {
+        let network_upgrade = tx
+            .network_upgrade()
+            .expect("V5/V6 transactions carry a network upgrade");
+        let parsed: Transaction = tx
+            .zcash_serialize_to_vec()
+            .expect("crafted transaction must serialize")
+            .zcash_deserialize_into()
+            .expect("lazy Sapling point bytes must deserialize");
+        let changed_parsed: Transaction = changed_tx
+            .zcash_serialize_to_vec()
+            .expect("crafted transaction must serialize")
+            .zcash_deserialize_into()
+            .expect("lazy Sapling point bytes must deserialize");
+
+        assert!(
+            !parsed.sapling_point_encodings_are_valid(),
+            "off-curve Sapling cv must fail deferred semantic validation",
+        );
+        assert!(
+            parsed.to_librustzcash(network_upgrade).is_err(),
+            "off-curve Sapling cv must fail librustzcash conversion",
+        );
+
+        let unmined = UnminedTx::from(parsed.clone());
+        let (txid, auth_digest) = parsed.txid_and_auth_digest();
+        assert_eq!(unmined.id.mined_id(), txid);
+        assert_eq!(unmined.id.auth_digest(), auth_digest);
+        assert_ne!(
+            txid,
+            changed_parsed.hash(),
+            "native txid must commit to the raw lazy Sapling cv bytes",
+        );
+    }
 }
 
 /// The local Sapling binding-key helper stays fail-closed when it sees a lazy

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -206,6 +206,106 @@ fn v5_orchard_cross_address_flag_fails_deserialization() {
     ));
 }
 
+/// V6 Orchard and Ironwood bundles must round-trip the `ENABLE_CROSS_ADDRESS`
+/// flag bit (which V5 reserves and rejects), while still rejecting the
+/// undefined flag bits 3..7.
+///
+/// The flags byte position is located by serializing the same transaction
+/// with and without the cross-address bit and diffing: exactly one byte may
+/// change.
+#[test]
+fn v6_orchard_style_flags_allow_cross_address_but_reject_reserved_bits() {
+    let _init_guard = zakura_test::init();
+
+    let shielded_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+
+    let make_tx = |mut shielded_data: crate::orchard::ShieldedData, ironwood: bool| {
+        shielded_data
+            .flags
+            .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+
+        Transaction::V6 {
+            network_upgrade: NetworkUpgrade::Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(1),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            sapling_shielded_data: None,
+            orchard_shielded_data: (!ironwood).then_some(shielded_data.clone()),
+            ironwood_shielded_data: ironwood.then_some(shielded_data),
+        }
+    };
+
+    for ironwood in [false, true] {
+        let tx = make_tx(shielded_data.clone(), ironwood);
+        let cross_address_bytes = tx
+            .zcash_serialize_to_vec()
+            .expect("V6 Orchard-style formats allow the cross-address bit on the wire");
+        let parsed = Transaction::zcash_deserialize(&cross_address_bytes[..])
+            .expect("V6 Orchard-style cross-address flag must deserialize");
+        let parsed_flags = if ironwood {
+            parsed
+                .ironwood_shielded_data()
+                .expect("test transaction has Ironwood data")
+                .flags
+        } else {
+            parsed
+                .orchard_shielded_data()
+                .expect("test transaction has Orchard data")
+                .flags
+        };
+        assert!(parsed_flags.contains(crate::orchard::Flags::ENABLE_CROSS_ADDRESS));
+
+        let mut without_cross_address = tx;
+        let Transaction::V6 {
+            orchard_shielded_data,
+            ironwood_shielded_data,
+            ..
+        } = &mut without_cross_address
+        else {
+            unreachable!("test transaction is V6");
+        };
+        if ironwood {
+            ironwood_shielded_data
+                .as_mut()
+                .expect("test transaction has Ironwood data")
+                .flags
+                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+        } else {
+            orchard_shielded_data
+                .as_mut()
+                .expect("test transaction has Orchard data")
+                .flags
+                .remove(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
+        }
+
+        let without_cross_address_bytes = without_cross_address
+            .zcash_serialize_to_vec()
+            .expect("V6 Orchard-style flags without cross-address must serialize");
+        let differing_indices: Vec<_> = cross_address_bytes
+            .iter()
+            .zip(&without_cross_address_bytes)
+            .enumerate()
+            .filter_map(|(index, (with, without))| (with != without).then_some(index))
+            .collect();
+        let [flags_index] = differing_indices.as_slice() else {
+            panic!("toggling the cross-address flag should change exactly one byte");
+        };
+
+        let mut reserved_bit_bytes = cross_address_bytes;
+        reserved_bit_bytes[*flags_index] |= 0b0000_1000;
+        let error = Transaction::zcash_deserialize(&reserved_bit_bytes[..])
+            .expect_err("V6 Orchard-style flags must reject reserved bits 3..7");
+        assert!(matches!(
+            error,
+            SerializationError::Parse("invalid reserved orchard flags")
+        ));
+    }
+}
+
 #[test]
 fn doesnt_deserialize_transaction_with_invalid_value_balance() {
     let _init_guard = zakura_test::init();
@@ -599,6 +699,36 @@ fn native_zip244_matches_test_vectors() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// V5 remains valid under the NU6.3 branch ID, even though NU6.3 also
+/// introduces V6 and changes Orchard bundle semantics. Keep the native
+/// ZIP-244 path pinned to the librustzcash oracle at that mixed boundary.
+#[test]
+fn native_zip244_matches_librustzcash_for_v5_nu6_3_orchard() {
+    let _init_guard = zakura_test::init();
+
+    let mut tx = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find(|transaction| transaction.orchard_shielded_data().is_some())
+        .expect("test vectors include a V5 Orchard transaction");
+
+    tx.update_network_upgrade(NetworkUpgrade::Nu6_3)
+        .expect("V5 transactions can carry the NU6.3 branch ID");
+
+    let (native_txid, native_auth_digest) = crate::transaction::zip244::txid_and_auth_digest(&tx)
+        .expect("V5 transactions have native ZIP-244 digests");
+    let (librustzcash_txid, librustzcash_auth_digest) =
+        crate::primitives::zcash_primitives::txid_and_auth_digest_via_librustzcash(&tx);
+
+    assert_eq!(
+        native_txid, librustzcash_txid,
+        "native V5 NU6.3 txid must match librustzcash"
+    );
+    assert_eq!(
+        native_auth_digest, librustzcash_auth_digest,
+        "native V5 NU6.3 auth digest must match librustzcash"
+    );
 }
 
 fn assert_native_zip244_matches_test_vector(
@@ -1261,6 +1391,55 @@ fn test_coinbase_script() -> Result<()> {
     Ok(())
 }
 
+/// The V6 version group ID must match librustzcash's finalized constant, both
+/// as a constant and in the serialized header bytes (fOverwintered | version,
+/// then the group ID, little-endian), and the former `0xffff_ffff`
+/// placeholder value must no longer deserialize.
+#[test]
+fn v6_version_group_id_matches_librustzcash_and_wire_format() {
+    use crate::parameters::TX_V6_VERSION_GROUP_ID;
+
+    let _init_guard = zakura_test::init();
+
+    assert_eq!(
+        TX_V6_VERSION_GROUP_ID,
+        zcash_protocol::constants::V6_VERSION_GROUP_ID,
+    );
+    assert_eq!(
+        TX_V6_VERSION_GROUP_ID,
+        zcash_primitives::transaction::TxVersion::V6.version_group_id(),
+    );
+
+    let tx = Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(0),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        ironwood_shielded_data: None,
+    };
+    let tx_bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("an empty NU6.3 V6 transaction has a valid wire encoding");
+
+    assert_eq!(&tx_bytes[0..4], &[0x06, 0x00, 0x00, 0x80]);
+    assert_eq!(&tx_bytes[4..8], &[0x98, 0xb6, 0x84, 0xd8]);
+    assert_eq!(tx.version_group_id(), Some(TX_V6_VERSION_GROUP_ID));
+    tx.to_librustzcash(NetworkUpgrade::Nu6_3)
+        .expect("librustzcash must accept Zakura's finalized V6 header");
+
+    let mut placeholder_bytes = tx_bytes;
+    placeholder_bytes[4..8].copy_from_slice(&0xffff_ffffu32.to_le_bytes());
+    let error = Transaction::zcash_deserialize(&placeholder_bytes[..])
+        .expect_err("the former placeholder V6 version group ID must be rejected");
+    assert!(matches!(
+        error,
+        SerializationError::Parse("expected TX_V6_VERSION_GROUP_ID")
+    ));
+}
+
 #[test]
 fn v6_transactions_accept_nu6_3_and_later_branch_ids() {
     use crate::parameters::TX_V6_VERSION_GROUP_ID;
@@ -1322,6 +1501,83 @@ fn v6_transactions_accept_nu6_3_and_later_branch_ids() {
             assert_eq!(tx.zcash_serialize_to_vec().unwrap(), tx_bytes);
         }
     }
+}
+
+/// The V6 sighash precomputation path must preserve the separate Orchard and
+/// Ironwood bundle slots after the librustzcash round-trip.
+///
+/// Both fields use the same upstream `orchard::Bundle` concrete type and the
+/// same authorization mapper, so a swapped getter or accidental alias would
+/// otherwise send one pool's proof to the other pool's verifier.
+#[test]
+fn v6_sighasher_preserves_distinct_orchard_and_ironwood_bundle_slots() {
+    use crate::{ironwood, orchard};
+
+    let _init_guard = zakura_test::init();
+
+    let mut orchard_data = Network::iter()
+        .flat_map(|network| v5_transactions(network.block_iter()))
+        .find_map(|transaction| transaction.orchard_shielded_data().cloned())
+        .expect("test vectors include an Orchard transaction");
+    let mut ironwood_data = orchard_data.clone();
+
+    let orchard_nullifier = [0u8; 32];
+    let mut ironwood_nullifier = [0u8; 32];
+    ironwood_nullifier[0] = 1;
+
+    let mut orchard_actions = orchard_data.actions.as_slice().to_vec();
+    orchard_actions[0].action.nullifier =
+        orchard::Nullifier::try_from(orchard_nullifier).expect("zero is a valid nullifier");
+    orchard_data.actions = orchard_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let mut ironwood_actions = ironwood_data.actions.as_slice().to_vec();
+    ironwood_actions[0].action.nullifier =
+        ironwood::Nullifier::try_from(ironwood_nullifier).expect("one is a valid nullifier");
+    ironwood_data.actions = ironwood_actions
+        .try_into()
+        .expect("the test bundle has at least one action");
+
+    let tx = Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(1),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: Some(orchard_data),
+        ironwood_shielded_data: Some(ironwood_data),
+    };
+
+    let sighasher = tx
+        .sighasher(NetworkUpgrade::Nu6_3, Arc::new(Vec::new()))
+        .expect("the mixed-pool V6 transaction converts to librustzcash");
+    let orchard_bundle = sighasher
+        .orchard_bundle()
+        .expect("the V6 transaction keeps its Orchard bundle");
+    let ironwood_bundle = sighasher
+        .ironwood_bundle()
+        .expect("the V6 transaction keeps its Ironwood bundle");
+
+    let parsed_orchard_nullifier = (*orchard_bundle
+        .actions()
+        .iter()
+        .next()
+        .expect("the Orchard bundle has at least one action")
+        .nullifier())
+    .to_bytes();
+    let parsed_ironwood_nullifier = (*ironwood_bundle
+        .actions()
+        .iter()
+        .next()
+        .expect("the Ironwood bundle has at least one action")
+        .nullifier())
+    .to_bytes();
+
+    assert_eq!(parsed_orchard_nullifier, orchard_nullifier);
+    assert_eq!(parsed_ironwood_nullifier, ironwood_nullifier);
+    assert_ne!(parsed_orchard_nullifier, parsed_ironwood_nullifier);
 }
 
 #[test]

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
@@ -743,6 +743,45 @@ fn known_block_reports_finalized_block_after_body_pruned() {
 }
 
 #[test]
+fn best_chain_hash_reads_survive_finalized_body_pruning() {
+    let _init_guard = zakura_test::init();
+    let (state, genesis, block1) = mainnet_state_with_genesis();
+
+    write_full_block_header_and_transactions(&state, block1.clone());
+
+    let tx_by_loc = state.db.cf_handle("tx_by_loc").unwrap();
+    let mut batch = DiskWriteBatch::new();
+    batch.zs_delete_range(
+        &tx_by_loc,
+        TransactionLocation::min_for_height(Height(1)),
+        TransactionLocation::min_for_height(Height(2)),
+    );
+    state.db.write(batch).expect("body prune writes");
+
+    assert!(!state.contains_body_at_height(Height(1)));
+    assert_eq!(state.height(block1.hash()), Some(Height(1)));
+
+    let no_chain = Option::<Arc<crate::service::non_finalized_state::Chain>>::None;
+    assert_eq!(
+        read::depth(no_chain.clone(), &state, block1.hash()),
+        Some(0)
+    );
+    assert_eq!(
+        read::hash_by_height(no_chain.clone(), &state, Height(1)),
+        Some(block1.hash()),
+    );
+    assert!(read::find::chain_contains_hash(
+        no_chain.clone(),
+        &state,
+        block1.hash()
+    ));
+    assert_eq!(
+        read::find_chain_headers(no_chain, &state, vec![genesis.hash()], None, 1),
+        vec![block1.header.clone()],
+    );
+}
+
+#[test]
 fn header_range_commit_rejects_finalized_or_body_conflicts() {
     let _init_guard = zakura_test::init();
     let (state, genesis, block1) = mainnet_state_with_genesis();

--- a/zakura-state/src/service/read/tests/vectors.rs
+++ b/zakura-state/src/service/read/tests/vectors.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tower::ServiceExt;
 use zakura_chain::{
     block::{Block, Height},
-    orchard,
+    ironwood, orchard,
     parameters::Network::*,
     serialization::ZcashDeserializeInto,
     subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
@@ -24,7 +24,7 @@ use crate::{
     service::{
         finalized_state::{DiskWriteBatch, ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
         non_finalized_state::Chain,
-        read::{orchard_subtrees, sapling_subtrees},
+        read::{ironwood_subtrees, orchard_subtrees, sapling_subtrees},
     },
     Config, ReadRequest, ReadResponse,
 };
@@ -332,6 +332,83 @@ async fn test_orchard_subtrees() -> Result<()> {
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     Ok(())
+}
+
+/// Tests if Zebra combines the Ironwood note commitment subtrees from the finalized and
+/// non-finalized states correctly.
+#[tokio::test]
+async fn test_ironwood_subtrees() -> Result<()> {
+    let dummy_subtree_root = ironwood::tree::Node::default();
+
+    // Prepare the finalized state.
+    let db_subtree = NoteCommitmentSubtree::new(0, Height(1), dummy_subtree_root);
+
+    let db = new_ephemeral_db();
+    let mut db_batch = DiskWriteBatch::new();
+    db_batch.insert_ironwood_subtree(&db, &db_subtree);
+    db.write(db_batch)
+        .expect("Writing a batch with an Ironwood subtree should succeed.");
+
+    // Prepare the non-finalized state.
+    let chain_subtree = NoteCommitmentSubtree::new(1, Height(3), dummy_subtree_root);
+    let mut chain = Chain::default();
+    chain.insert_ironwood_subtree(chain_subtree);
+    let chain = Some(Arc::new(chain));
+
+    // At this point, we have one Ironwood subtree in the finalized state and one Ironwood subtree in
+    // the non-finalized state.
+
+    // Retrieve only the first subtree and check its properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
+
+    // Retrieve both subtrees using a limit and check their properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 2);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve both subtrees without using a limit and check their properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..);
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 2);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve only the second subtree and check its properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve only the second subtree, using a limit that would allow for more trees if they were
+    // present, and check its properties.
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into());
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    // Retrieve only the second subtree, without using any limit, and check its properties.
+    let subtrees = ironwood_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..);
+    let mut subtrees = subtrees.iter();
+    assert_eq!(subtrees.len(), 1);
+    assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
+
+    Ok(())
+}
+
+#[test]
+fn excluded_max_subtree_range_is_empty() {
+    use std::ops::Bound::*;
+
+    let db = new_ephemeral_db();
+    let no_chain = Option::<Arc<Chain>>::None;
+    let range = (Excluded(NoteCommitmentSubtreeIndex(u16::MAX)), Unbounded);
+
+    assert!(sapling_subtrees(no_chain, &db, range).is_empty());
 }
 
 /// Returns test cases for the empty state and missing blocks.

--- a/zakura-state/src/service/read/tree.rs
+++ b/zakura-state/src/service/read/tree.rs
@@ -188,10 +188,12 @@ where
 {
     use std::ops::Bound::*;
 
-    let start_index = match range.start_bound().cloned() {
-        Included(start_index) => start_index,
-        Excluded(start_index) => (start_index.0 + 1).into(),
-        Unbounded => 0.into(),
+    let Some(start_index) = (match range.start_bound().cloned() {
+        Included(start_index) => Some(start_index),
+        Excluded(start_index) => start_index.0.checked_add(1).map(Into::into),
+        Unbounded => Some(0.into()),
+    }) else {
+        return BTreeMap::new();
     };
 
     // # Correctness


### PR DESCRIPTION
## Motivation

Extract the V6 wire-format hardening changes and closely related chain/state test coverage from #165 for a smaller review.

## Solution

Cherry-picks these five commits from #165:

- `test(chain): strengthen history and note-commitment tree coverage`
- `test(chain): cover V5/V6 wire format and ZIP-244 digest paths`
- `fix(chain): reserve V6 Orchard cross-address flag`
- `test(state): cover pruned-chain reads across the read service`
- `fix(state): avoid overflow when a subtree range starts at an excluded u16::MAX`

## User impact

The V6 transaction codec rejects the Ironwood-only cross-address flag in the Orchard slot, preserving the V6 wire-format grammar. The state read helper safely handles an excluded `u16::MAX` subtree index by returning an empty result rather than overflowing. The tests add regression coverage for V5/V6 encoding and ZIP-244 digests, history/note-commitment trees, and best-chain reads after finalized body pruning.

## Test evidence

- `cargo fmt --all -- --check` passed.
- `cargo test -p zakura-chain -p zakura-state` passed.

## AI disclosure

Used Codex to identify and cherry-pick the requested existing commits, run validation, and draft this PR description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-adjacent V6 transaction encoding and history/ZIP-244 test surfaces; production logic changes are small but wire-format mistakes would reject valid or accept invalid txs.
> 
> **Overview**
> **V6 wire format:** V6 **Orchard** bundle serialize/deserialize now passes `!ALLOW_CROSS_ADDRESS_BIT`, so the cross-address flag stays reserved in the Orchard slot while the **Ironwood** slot still allows it. New vector tests lock in Orchard reject vs Ironwood round-trip behavior.
> 
> **State reads:** Note-commitment subtree merging treats an **excluded** start index of `u16::MAX` as an empty range (`checked_add` → empty `BTreeMap`) instead of overflowing. Tests cover Ironwood subtree merging and pruned finalized bodies still serving best-chain hash/depth/header reads.
> 
> **Regression tests (bulk of the diff):** Extensive coverage for NU6.3 / Ironwood—block pool accessors and ZIP-221 tx counts, V3 history MMR (cache, NU6.3 reset, prune/clone), parallel Orchard/Ironwood NCT updates, Orchard `append_batch` at full tree capacity, V6 sighash/ZIP-244/V6 version group ID, Ironwood note decryption routing, and native ZIP-244 with lazy invalid Sapling points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a65c91541ddc7f0efb558ff2ed11ffe1e31c692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->