### PR TITLE
fix(config): hide experimental sync tuning from generated configs

### DIFF
--- a/zakurad/src/commands/generate.rs
+++ b/zakurad/src/commands/generate.rs
@@ -72,7 +72,8 @@ impl Runnable for GenerateCmd {
 
         // this avoids a ValueAfterTable error
         // https://github.com/alexcrichton/toml-rs/issues/145
-        let conf = toml::Value::try_from(default_config).unwrap();
+        let mut conf = toml::Value::try_from(default_config).unwrap();
+        remove_experimental_sync_config(&mut conf);
         let conf = toml::to_string_pretty(&conf).expect("default config should be serializable");
         output += &document_network_p2p_config(&conf);
         match self.output_file {
@@ -88,6 +89,24 @@ impl Runnable for GenerateCmd {
             }
         }
     }
+}
+
+/// Omit unstable native sync tuning knobs from the generated config skeleton.
+///
+/// The fields remain deserializable for advanced overrides, while absent
+/// sections use their defaults from code.
+fn remove_experimental_sync_config(config: &mut toml::Value) {
+    let Some(zakura) = config
+        .get_mut("network")
+        .and_then(toml::Value::as_table_mut)
+        .and_then(|network| network.get_mut("zakura"))
+        .and_then(toml::Value::as_table_mut)
+    else {
+        return;
+    };
+
+    zakura.remove("block_sync");
+    zakura.remove("header_sync");
 }
 
 fn document_network_p2p_config(config: &str) -> String {
@@ -129,4 +148,36 @@ fn document_network_p2p_config(config: &str) -> String {
         output.push('\n');
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_config_omits_experimental_sync_config_and_uses_defaults() {
+        let default_config = ZakuradConfig::default();
+        let mut config = toml::Value::try_from(&default_config).unwrap();
+
+        remove_experimental_sync_config(&mut config);
+
+        let zakura = config
+            .get("network")
+            .and_then(|network| network.get("zakura"))
+            .expect("default config contains the native Zakura section");
+        assert!(zakura.get("block_sync").is_none());
+        assert!(zakura.get("header_sync").is_none());
+        assert!(zakura.get("bootstrap_peers").is_some());
+
+        let config = toml::to_string_pretty(&config).unwrap();
+        let parsed: ZakuradConfig = toml::from_str(&config).unwrap();
+        assert_eq!(
+            parsed.network.zakura.block_sync,
+            default_config.network.zakura.block_sync
+        );
+        assert_eq!(
+            parsed.network.zakura.header_sync,
+            default_config.network.zakura.header_sync
+        );
+    }
 }

--- a/zakurad/tests/common/configs/v1.0.0.toml
+++ b/zakurad/tests/common/configs/v1.0.0.toml
@@ -106,56 +106,6 @@ max_pending_handshakes = 32
 message_rate_per_second = 2048
 stream_open_rate_per_second = 32
 
-[network.zakura.block_sync]
-bbr_cwnd_gain_percent = 300
-bbr_cwnd_unit = "bytes"
-bbr_delay_gradient_percent = 150
-bbr_delivery_rate_window = "10s"
-bbr_min_cwnd = 4
-bbr_min_cwnd_bytes = 2524288
-bbr_probe_bw_gain_percent = 125
-bbr_probe_rtt_duration = "200ms"
-bbr_probe_rtt_interval = "10s"
-bbr_reliability_weight_percent = 100
-bbr_rtprop_window = "10s"
-bbr_startup_growth_percent = 200
-floor_bypass_slots = 2
-floor_peer_avoid_cooldown = "8s"
-floor_rescue_timeout = "2s"
-initial_block_probe_requests = 1
-initial_inflight_requests = 64
-max_blocks_per_response = 1
-max_inflight_block_bytes = 6442450944
-max_inflight_requests = 32000
-max_reorder_lookahead_bytes = 6408896512
-max_requests_without_block_progress = 64
-max_response_bytes = 33554432
-max_submitted_block_applies = 401
-no_progress_peer_cooldown = "3m"
-request_timeout = "8s"
-size_deviation_tolerance = 200
-status_refresh_interval = "30s"
-
-[network.zakura.block_sync.peer_limits]
-inbound_queue_depth = 128
-max_inbound_peers = 256
-max_outbound_peers = 256
-max_pending_escalations = 32
-outbound_queue_depth = 128
-
-[network.zakura.header_sync]
-accept_new_blocks = true
-max_headers_per_response = 1000
-max_inflight_requests = 10
-status_refresh_interval = "30s"
-
-[network.zakura.header_sync.peer_limits]
-inbound_queue_depth = 128
-max_inbound_peers = 256
-max_outbound_peers = 256
-max_pending_escalations = 32
-outbound_queue_depth = 128
-
 [rpc]
 cookie_dir = "cache_dir"
 cookie_file_name = ".cookie"


### PR DESCRIPTION
## Motivation

The native Zakura header-sync and block-sync settings are experimental and likely to change. Emitting every tuning value from `zakurad generate` pins users to a generated snapshot instead of allowing new code defaults to take effect.

## Solution

- Remove `network.zakura.header_sync` and `network.zakura.block_sync` from generated configuration skeletons.
- Keep both sections deserializable so advanced users can still override them manually.
- Verify omitted sections resolve to the defaults in code and update the current generated-config fixture.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura generated_config_omits_experimental_sync_config_and_uses_defaults` — verifies both sections are omitted, other Zakura settings remain, and parsing restores code defaults.
- Generated `zakura.toml` with the rebuilt binary and confirmed neither section was present.
- IDE diagnostics and `git diff --check` passed.

Full workspace tests were skipped because this is a low-risk generated-output change with focused coverage.

## AI Disclosure

Used Cursor to implement the generated-config filtering, add the focused test, and prepare this PR description.