### PR TITLE
chore(release): add unified pre-release checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -123,7 +123,6 @@ cargo release version --verbose --execute --allow-branch '*' -p zakura patch # [
       about to create, using the previous release tag as the base:
       `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<previous-release-tag>`
       For example: `make pre-release RELEASE_TAG=v1.0.0 BASE_TAG=v1.0.0-rc5`
-      
 
 ## Update Crate Versions and Crate Change Logs
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -119,8 +119,8 @@ version.
 cargo release version --verbose --execute --allow-branch '*' -p zakura patch # [ major | minor ]
 ```
 
-- [ ] On the release commit, check that the version matches the tag you are
-      about to create: `./scripts/check-release-version.sh v<version>`
+- [ ] On the release commit, run the pre-release checks for the tag you are
+      about to create: `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<version>`
 
 ## Update Crate Versions and Crate Change Logs
 
@@ -129,8 +129,10 @@ and make sure you're a member of owners group.
 
 Check that the release will work:
 
-- [ ] Determine which crates require release. Run `git diff --stat <previous_tag>`
-      and enumerate the crates that had changes.
+- [ ] Review the changed-crate version advisory from `make pre-release`. It
+      warns when publishable crates changed since the latest release tag without
+      a package version bump. This warning is local-only and advisory; unchanged
+      crates are not bumped or published.
 - [ ] Update (or install) `semver-checks`: `cargo +stable install cargo-semver-checks --locked`
 - [ ] Update (or install) `public-api`: `cargo +stable install cargo-public-api --locked`
 - [ ] For each crate that requires a release:

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -120,7 +120,10 @@ cargo release version --verbose --execute --allow-branch '*' -p zakura patch # [
 ```
 
 - [ ] On the release commit, run the pre-release checks for the tag you are
-      about to create: `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<version>`
+      about to create, using the previous release tag as the base:
+      `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<previous-release-tag>`
+      For example: `make pre-release RELEASE_TAG=v1.0.0 BASE_TAG=v1.0.0-rc5`
+      
 
 ## Update Crate Versions and Crate Change Logs
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,7 +45,9 @@ jobs:
             exit 1
           fi
 
-          ./scripts/check-release-version.sh "$RELEASE_TAG"
+          make pre-release \
+            RELEASE_TAG="$RELEASE_TAG" \
+            PRE_RELEASE_WARN_CRATE_VERSION_BUMPS=0
 
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,6 +31,10 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
+        with:
+          toolchain: stable
+
       - name: Validate source, tag, and package version
         id: validate
         env:

--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,5 @@ help:
 	@echo "  compat-test-testnet              Run read-only zcashd-compat tests against live testnet"
 	@echo ""
 	@echo "  Release:"
+	@echo "  pre-release RELEASE_TAG=vX.Y.Z BASE_TAG=vX.Y.Z   Run release version, local crate bump, and packaging checks"
 	@echo "  sign-release TAG=vX.Y.Z          Sign a release's SHA256SUMS.txt with the maintainer minisign key (see VERIFY.md)"

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,4 +1,30 @@
-.PHONY: sign-release
+.PHONY: pre-release pre-release-version pre-release-packaging sign-release
+
+PRE_RELEASE_WARN_CRATE_VERSION_BUMPS ?= $(if $(CI),0,1)
+CRATE_PACKAGING_VERIFY ?= 0
+
+pre-release:
+	@test -n "$(RELEASE_TAG)" || { echo "RELEASE_TAG is required, e.g. make pre-release RELEASE_TAG=v1.0.0" >&2; exit 1; }
+	@printf '\n==> [1/2] Checking release version\n\n'
+	$(MAKE) pre-release-version RELEASE_TAG="$(RELEASE_TAG)" BASE_TAG="$(BASE_TAG)" PRE_RELEASE_WARN_CRATE_VERSION_BUMPS="$(PRE_RELEASE_WARN_CRATE_VERSION_BUMPS)"
+	@printf '\n==> [2/2] Checking crate packaging\n\n'
+	$(MAKE) pre-release-packaging CRATE_PACKAGING_VERIFY="$(CRATE_PACKAGING_VERIFY)"
+
+pre-release-version:
+	@test -n "$(RELEASE_TAG)" || { echo "RELEASE_TAG is required, e.g. make pre-release-version RELEASE_TAG=v1.0.0" >&2; exit 1; }
+	./scripts/check-release-version.sh "$(RELEASE_TAG)"
+	@if [ "$(PRE_RELEASE_WARN_CRATE_VERSION_BUMPS)" = "0" ]; then \
+		echo "Skipping changed-crate version advisory."; \
+	else \
+		BASE_TAG="$(BASE_TAG)" bash ./scripts/check-crate-version-bumps.sh; \
+	fi
+
+pre-release-packaging:
+	@if [ "$(CRATE_PACKAGING_VERIFY)" = "1" ]; then \
+		./scripts/check-crate-packaging.sh --verify; \
+	else \
+		./scripts/check-crate-packaging.sh; \
+	fi
 
 sign-release:
 	@test -n "$(TAG)" || { echo "TAG is required, e.g. make sign-release TAG=v1.0.0" >&2; exit 1; }

--- a/scripts/check-crate-packaging.sh
+++ b/scripts/check-crate-packaging.sh
@@ -74,6 +74,8 @@ cargo package --locked $VERIFY_FLAG "${package_args[@]}"
 # crates.io rejects archives over 10 MiB.
 max_bytes=$((10 * 1024 * 1024))
 
+echo
+echo "Package archive sizes:"
 failed=0
 for crate in "${PUBLISH_ORDER[@]}"; do
   version="$(jq -r --arg crate "$crate" '.packages[] | select(.name == $crate) | .version' <<<"$metadata")"
@@ -102,4 +104,5 @@ if [ "$failed" -ne 0 ]; then
   exit 1
 fi
 
+echo
 echo "All ${#PUBLISH_ORDER[@]} crates package cleanly."

--- a/scripts/check-crate-version-bumps.sh
+++ b/scripts/check-crate-version-bumps.sh
@@ -63,6 +63,8 @@ while IFS=$'\t' read -r crate manifest_path current_version; do
   fi
 
   changed_count=$((changed_count + 1))
+# Assumes [package] has a literal version before any other version key;
+  # manifests using version.workspace = true would need different parsing.
   base_version="$(
     git -C "$repo_root" show "${base_tag}:${manifest_rel}" \
       | awk -F ' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }'

--- a/scripts/check-crate-version-bumps.sh
+++ b/scripts/check-crate-version-bumps.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Warn when publishable crates changed since the previous release tag without a
+# package version bump.
+#
+# This check is advisory: documentation-only or test-only crate changes might
+# not require publishing, and crate versions intentionally advance on their own
+# cadence. Run it locally before release dispatch so missed bumps are visible.
+#
+# Usage:
+#   ./scripts/check-crate-version-bumps.sh
+#   BASE_TAG=v1.0.0-rc5 ./scripts/check-crate-version-bumps.sh
+set -euo pipefail
+
+for cmd in cargo git jq; do
+  command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd" >&2; exit 1; }
+done
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+base_tag="${BASE_TAG:-}"
+if [ -z "$base_tag" ]; then
+  base_tag="$(git -C "$repo_root" describe --tags --match 'v*' --abbrev=0 HEAD)"
+fi
+
+if ! git -C "$repo_root" rev-parse --verify --quiet "${base_tag}^{commit}" >/dev/null; then
+  echo "ERROR: base tag '${base_tag}' does not exist or is not a commit." >&2
+  exit 1
+fi
+
+if ! git -C "$repo_root" merge-base --is-ancestor "$base_tag" HEAD; then
+  echo "ERROR: base tag '${base_tag}' is not an ancestor of HEAD." >&2
+  exit 1
+fi
+
+metadata="$(
+  cargo metadata --format-version 1 --no-deps --manifest-path "${repo_root}/Cargo.toml"
+)"
+
+warning_count=0
+changed_count=0
+new_count=0
+
+while IFS=$'\t' read -r crate manifest_path current_version; do
+  [ -n "$crate" ] || continue
+
+  manifest_rel="${manifest_path#"$repo_root"/}"
+  crate_dir="$(dirname "$manifest_rel")"
+
+  if ! git -C "$repo_root" cat-file -e "${base_tag}:${manifest_rel}" 2>/dev/null; then
+    if ! git -C "$repo_root" diff --quiet "$base_tag" -- "$crate_dir"; then
+      printf 'NOTICE: %s is new since %s; choose an initial publish version intentionally.\n' "$crate" "$base_tag" >&2
+      new_count=$((new_count + 1))
+    fi
+    continue
+  fi
+
+  if git -C "$repo_root" diff --quiet "$base_tag" -- "$crate_dir"; then
+    continue
+  fi
+
+  changed_count=$((changed_count + 1))
+  base_version="$(
+    git -C "$repo_root" show "${base_tag}:${manifest_rel}" \
+      | awk -F ' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }'
+  )"
+
+  if [ -z "$base_version" ]; then
+    echo "WARNING: could not read ${crate}'s package version at ${base_tag}." >&2
+    warning_count=$((warning_count + 1))
+    continue
+  fi
+
+  if [ "$current_version" = "$base_version" ]; then
+    cat >&2 <<EOF
+WARNING: ${crate} changed since ${base_tag}, but its package version is still ${current_version}.
+         If this crate should be published, bump ${manifest_rel}; otherwise ignore this advisory.
+EOF
+    warning_count=$((warning_count + 1))
+  fi
+done < <(
+  jq -r '
+    .packages[]
+    | select(.publish == null or (.publish | length) > 0)
+    | [.name, .manifest_path, .version]
+    | @tsv
+  ' <<<"$metadata"
+)
+
+if [ "$warning_count" -gt 0 ]; then
+  printf '\nWARNING: Crate version bump advisory found %d warning(s) across %d changed published crate(s).\n' \
+    "$warning_count" "$changed_count" >&2
+else
+  echo "Crate version bump advisory found no unchanged versions across ${changed_count} changed published crate(s)."
+fi
+
+if [ "$new_count" -gt 0 ]; then
+  printf '\nNOTICE: Crate version bump advisory also found %d new published crate(s).\n' \
+    "$new_count" >&2
+fi
+
+if [ -n "$(git -C "$repo_root" status --porcelain --untracked-files=normal)" ]; then
+  cat >&2 <<EOF
+
+NOTICE: The working tree has local changes.
+        This advisory compared those changes against ${base_tag}.
+EOF
+fi

--- a/scripts/check-crate-version-bumps.sh
+++ b/scripts/check-crate-version-bumps.sh
@@ -48,6 +48,7 @@ while IFS=$'\t' read -r crate manifest_path current_version; do
 
   if ! git -C "$repo_root" cat-file -e "${base_tag}:${manifest_rel}" 2>/dev/null; then
     if ! git -C "$repo_root" diff --quiet "$base_tag" -- "$crate_dir"; then
+      printf 'Changed publishable crate: %s (new -> %s)\n' "$crate" "$current_version"
       printf 'NOTICE: %s is new since %s; choose an initial publish version intentionally.\n' "$crate" "$base_tag" >&2
       new_count=$((new_count + 1))
     fi
@@ -63,6 +64,9 @@ while IFS=$'\t' read -r crate manifest_path current_version; do
     git -C "$repo_root" show "${base_tag}:${manifest_rel}" \
       | awk -F ' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }'
   )"
+
+  printf 'Changed publishable crate: %s (%s -> %s)\n' \
+    "$crate" "${base_version:-unknown}" "$current_version"
 
   if [ -z "$base_version" ]; then
     echo "WARNING: could not read ${crate}'s package version at ${base_tag}." >&2

--- a/scripts/check-crate-version-bumps.sh
+++ b/scripts/check-crate-version-bumps.sh
@@ -19,7 +19,10 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
 base_tag="${BASE_TAG:-}"
 if [ -z "$base_tag" ]; then
-  base_tag="$(git -C "$repo_root" describe --tags --match 'v*' --abbrev=0 HEAD)"
+if ! base_tag="$(git -C "$repo_root" describe --tags --match 'v*' --abbrev=0 HEAD 2>/dev/null)"; then
+    echo "ERROR: no v* release tag found; pass BASE_TAG explicitly." >&2
+    exit 1
+  fi
 fi
 
 if ! git -C "$repo_root" rev-parse --verify --quiet "${base_tag}^{commit}" >/dev/null; then

--- a/scripts/check-crate-version-bumps.sh
+++ b/scripts/check-crate-version-bumps.sh
@@ -5,6 +5,10 @@
 # This check is advisory: documentation-only or test-only crate changes might
 # not require publishing, and crate versions intentionally advance on their own
 # cadence. Run it locally before release dispatch so missed bumps are visible.
+# It does not query the registry, so it cannot detect different content already
+# published under the same name and version. It also only checks changes inside
+# each crate directory, missing workspace-level changes that affect packaging.
+# Publish-time registry content validation remains the hard-error gate.
 #
 # Usage:
 #   ./scripts/check-crate-version-bumps.sh
@@ -19,7 +23,7 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
 base_tag="${BASE_TAG:-}"
 if [ -z "$base_tag" ]; then
-if ! base_tag="$(git -C "$repo_root" describe --tags --match 'v*' --abbrev=0 HEAD 2>/dev/null)"; then
+  if ! base_tag="$(git -C "$repo_root" describe --tags --match 'v*' --abbrev=0 HEAD 2>/dev/null)"; then
     echo "ERROR: no v* release tag found; pass BASE_TAG explicitly." >&2
     exit 1
   fi
@@ -63,7 +67,7 @@ while IFS=$'\t' read -r crate manifest_path current_version; do
   fi
 
   changed_count=$((changed_count + 1))
-# Assumes [package] has a literal version before any other version key;
+  # Assumes [package] has a literal version before any other version key;
   # manifests using version.workspace = true would need different parsing.
   base_version="$(
     git -C "$repo_root" show "${base_tag}:${manifest_rel}" \


### PR DESCRIPTION
## Motivation

Release preparation currently requires separate version, crate-change, and packaging checks, which makes it easier to miss a step or overlook advisory output.

## Solution

- add a `make pre-release` entry point for version and packaging checks
- warn locally when changed publishable crates retain their previous versions
- use the unified preflight in the release workflow while keeping the crate-version advisory local-only
- update the release checklist and improve output grouping and notice visibility

## Testing

- `make pre-release RELEASE_TAG=v1.0.0 BASE_TAG=v1.0.0-rc5`
  - release tag matched the package version
  - all 13 changed publishable crates had version bumps
  - all 13 crates packaged cleanly
- `bash -n scripts/check-crate-version-bumps.sh scripts/check-crate-packaging.sh`
- `make -n pre-release RELEASE_TAG=v1.0.0 BASE_TAG=v1.0.0-rc5`
- `markdownlint .github/PULL_REQUEST_TEMPLATE/release-checklist.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics: no errors in changed files

Risk classification: low. This changes release tooling, CI orchestration, and documentation without modifying validator runtime behavior, so workspace Rust tests and clippy were not run.

## Example

### Success

```bash
roman@Romans-MacBook-Pro-2 zakura % make pre-release RELEASE_TAG=v1.0.0 BASE_TAG=v1.0.0-rc5

==> [1/2] Checking release version

/Applications/Xcode.app/Contents/Developer/usr/bin/make pre-release-version RELEASE_TAG="v1.0.0" BASE_TAG="v1.0.0-rc5" PRE_RELEASE_WARN_CRATE_VERSION_BUMPS="1"
./scripts/check-release-version.sh "v1.0.0"
Release tag v1.0.0 matches the 'zakura' package version (1.0.0).
Crate version bump advisory found no unchanged versions across 13 changed published crate(s).

NOTICE: The working tree has local changes.
        This advisory compared those changes against v1.0.0-rc5.

==> [2/2] Checking crate packaging

/Applications/Xcode.app/Contents/Developer/usr/bin/make pre-release-packaging CRATE_PACKAGING_VERIFY="0"
Packaging 13 crates...
   Packaging zakura-test v1.0.0 (/Users/roman/projects/zakura/zakura-test)
...

Package archive sizes:
  zakura-test-1.0.0.crate: 1718077 bytes
...

All 13 crates package cleanly.
```

### Warn

What I did here: the crate was changed between tags, but I did not bump its version.

```bash
roman@Romans-MacBook-Pro-2 zakura % make pre-release RELEASE_TAG=v1.0.0 BASE_TAG=v1.0.0-rc5

==> [1/2] Checking release version

/Applications/Xcode.app/Contents/Developer/usr/bin/make pre-release-version RELEASE_TAG="v1.0.0" BASE_TAG="v1.0.0-rc5" PRE_RELEASE_WARN_CRATE_VERSION_BUMPS="1"
./scripts/check-release-version.sh "v1.0.0"
Release tag v1.0.0 matches the 'zakura' package version (1.0.0).
WARNING: zakura-state changed since v1.0.0-rc5, but its package version is still 1.0.0-rc5.
         If this crate should be published, bump zakura-state/Cargo.toml; otherwise ignore this advisory.

WARNING: Crate version bump advisory found 1 warning(s) across 13 changed published crate(s).

NOTICE: The working tree has local changes.
        This advisory compared those changes against v1.0.0-rc5.

==> [2/2] Checking crate packaging

/Applications/Xcode.app/Contents/Developer/usr/bin/make pre-release-packaging CRATE_PACKAGING_VERIFY="0"
Packaging 13 crates...
error: failed to select a version for the requirement `zakura-state = "^1.0.0"`
candidate versions found which didn't match: 1.0.0-rc5
location searched: /Users/roman/projects/zakura/zakura-state
required by package `zakura v1.0.0 (/Users/roman/projects/zakura/zakurad)`
help: if you are looking for the prerelease package it needs to be specified explicitly
    zakura-state = { version = "1.0.0-rc5" }
make[1]: *** [pre-release-packaging] Error 101
make: *** [pre-release] Error 2
```

## AI Disclosure

Cursor was used to implement the release preflight scripts and Make targets, improve their output formatting, and draft this PR description. The changes were reviewed and tested by the contributor.