### PR TITLE
fix(installer): fall back when mnt is absent

### DIFF
--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -40,16 +40,11 @@ INSTALL_PROFILE=""
 MODE=""
 NETWORK="Mainnet"
 ZCASHD_DEFAULT_DATADIR="${HOME}/.zcash"
-if [[ -d /mnt ]]; then
-  ZAKURA_STANDALONE_STATE_DIR="/mnt/data/zakura-state"
-else
-  ZAKURA_STANDALONE_STATE_DIR="$ZAKURA_DEFAULT_CACHE_DIR"
-fi
 ZAKURA_STANDALONE_INSTALL_DIR="${HOME}/.local/zakura"
 ZAKURA_STANDALONE_CACHE_DIR="${HOME}/.cache/zakura"
 ZAKURA_COMPAT_INSTALL_DIR="${HOME}/.local/zcashd-compat"
 ZAKURA_COMPAT_CACHE_DIR="${HOME}/.cache/zcashd-compat"
-ZAKURA_STATE_DIR="$ZAKURA_STANDALONE_STATE_DIR"
+ZAKURA_STATE_DIR="$ZAKURA_DEFAULT_CACHE_DIR"
 ZAKURA_IDENTITY_DIR="$ZAKURA_DEFAULT_IDENTITY_DIR"
 ZCASHD_DATADIR="$ZCASHD_DEFAULT_DATADIR"
 INSTALL_DIR="$ZAKURA_STANDALONE_INSTALL_DIR"
@@ -2236,9 +2231,9 @@ default_p2p_port() {
   esac
 }
 
-# Run the same capacity- and permission-aware search the zcashd-compat profile
-# uses. A large writable volume still wins; otherwise keep the initial default:
-# /mnt/data/zakura-state when /mnt exists, or Zakura's platform cache directory.
+# Use the same default and capacity- and permission-aware search as the
+# zcashd-compat profile. An existing state directory wins; if ~/.cache/zakura
+# is unsuitable, select a writable volume with enough capacity.
 default_recommend_datadir_defaults() {
   if ((ZAKURA_STATE_DIR_SET)); then
     return
@@ -2248,7 +2243,7 @@ default_recommend_datadir_defaults() {
   min_bytes="$(disk_standalone_min_bytes)"
 
   SYNTHETIC_INSTALL_MIN_BYTES="$min_bytes"
-  ZAKURA_STATE_DIR="$(compat_recommend_zakura_state_dir "$ZAKURA_STANDALONE_STATE_DIR" "$min_bytes")"
+  ZAKURA_STATE_DIR="$(compat_recommend_zakura_state_dir "$ZAKURA_DEFAULT_CACHE_DIR" "$min_bytes")"
   unset SYNTHETIC_INSTALL_MIN_BYTES
 }
 

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -40,7 +40,11 @@ INSTALL_PROFILE=""
 MODE=""
 NETWORK="Mainnet"
 ZCASHD_DEFAULT_DATADIR="${HOME}/.zcash"
-ZAKURA_STANDALONE_STATE_DIR="/mnt/data/zakura-state"
+if [[ -d /mnt ]]; then
+  ZAKURA_STANDALONE_STATE_DIR="/mnt/data/zakura-state"
+else
+  ZAKURA_STANDALONE_STATE_DIR="$ZAKURA_DEFAULT_CACHE_DIR"
+fi
 ZAKURA_STANDALONE_INSTALL_DIR="${HOME}/.local/zakura"
 ZAKURA_STANDALONE_CACHE_DIR="${HOME}/.cache/zakura"
 ZAKURA_COMPAT_INSTALL_DIR="${HOME}/.local/zcashd-compat"
@@ -2232,10 +2236,9 @@ default_p2p_port() {
   esac
 }
 
-# The standalone default (/mnt/data/zakura-state) is only usable by root on a
-# stock cloud image, so run the same capacity- and permission-aware search the
-# zcashd-compat profile uses. A large writable volume still wins; otherwise this
-# lands on ~/.cache/zakura instead of a path the user cannot create.
+# Run the same capacity- and permission-aware search the zcashd-compat profile
+# uses. A large writable volume still wins; otherwise keep the initial default:
+# /mnt/data/zakura-state when /mnt exists, or Zakura's platform cache directory.
 default_recommend_datadir_defaults() {
   if ((ZAKURA_STATE_DIR_SET)); then
     return


### PR DESCRIPTION
## Motivation

The standalone installer assumes `/mnt` exists and initially recommends
`/mnt/data/zakura-state`. Hosts without `/mnt` therefore receive an unusable
default instead of a path under the current user.

## Solution

- Keep `/mnt/data/zakura-state` as the standalone default when `/mnt` exists.
- Otherwise use Zakura's existing user cache default,
  `$XDG_CACHE_HOME/zakura` or `$HOME/.cache/zakura`.
- Preserve the existing capacity- and permission-aware large-volume discovery.

### Tests

- `bash -n scripts/install-zakura.sh`
- `bash scripts/install-zakura.sh --self-test-disk-limits`
- Traced initialization on a host without `/mnt` and confirmed it selected
  `/Users/valar/.cache/zakura`.
- `git diff --check`

### Specifications & References

Zakura's state configuration uses its platform cache directory by default.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex inspected Zakura's default cache
  behavior, implemented the installer fallback, ran validation, and drafted
  this PR description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was requested directly by the project owner.
- [x] The solution is tested as described above.
- [x] Per maintainer direction, no changelog entry is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional default-path change in the install script only; no runtime node or auth logic touched.
> 
> **Overview**
> The standalone Zakura installer no longer always seeds state at `/mnt/data/zakura-state`. **`ZAKURA_STANDALONE_STATE_DIR`** is set to that path only when **`/mnt` exists**; otherwise it uses **`ZAKURA_DEFAULT_CACHE_DIR`** (`$XDG_CACHE_HOME/zakura` or `$HOME/.cache/zakura`).
> 
> Comments around **`default_recommend_datadir_defaults`** are updated to match: capacity- and permission-aware discovery is unchanged, but the documented fallback is “`/mnt` path when present, else platform cache,” not “always rewrite toward `~/.cache/zakura` because `/mnt` is unusable.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3729fab6b81af820362bd0557a6253b970c92de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->