### PR TITLE
docs: highlight installer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,20 @@
 
 Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This first release brings major improvements over existing Zcash node software:
 
-- Performance: Blockchain sync is nearly 5× faster than Zebra. Block execution is notably faster than Zebra on worst case sandblast attacks as well.
+- Performance: Blockchain sync is nearly 5× faster than Zebra. Block execution is notably faster than Zebra, especially on worst case sandblast attacks.
 - Pruning and snapshots: Native block pruning with configurable retention cuts disk usage substantially. We also publish snapshots (~11 GB pruned) that let you bootstrap a node 680× faster than syncing over the standard P2P network. See [here](https://zakura.com/snapshots/)
 - [zcashd compatibility](book/src/user/zcashd-compat.md): A compatibility mode
   reproduces the legacy zcashd RPC interface, so existing wallets and
   integrations keep working.
-- Experimental P2P v2: We are building a new P2P transport layer for Zakura nodes, currently off by default on Mainnet. The goals are sub-500ms worst-case block propagation, mempool aggregation (used in Tachyon), sync at the speed of your bandwidth, and a future-proofed gossip protocol. The native stack has known DoS risks and is not yet production-hardened; see its [current tradeoffs and exit criteria](book/src/user/p2p.md).
+- Experimental P2P v2: We are building a new P2P transport layer for Zakura nodes, currently off by default on Mainnet. The goals are sub-500ms worst-case block propagation, mempool aggregation (used in Tachyon), sync at the speed of your bandwidth, and a future-proofed gossip protocol. The v2 stack has known DoS risks and is not yet production-hardened; see its [current tradeoffs and production readyness criteria](book/src/user/p2p.md).
 
 ## Getting Started
 
+There are several ways to install the node software. Install from an interactive installer, crates.io, source or Docker.
+
 ### Installer
 
-The recommended way to install Zakura is with the interactive installer:
+The simplest way to install Zakura on a new machine, is using the interactive installer:
 
 ```console
 curl -fsSL https://raw.githubusercontent.com/zakura-core/zakura/main/scripts/install-zakura.sh | bash
@@ -43,10 +45,17 @@ curl -fsSL https://raw.githubusercontent.com/zakura-core/zakura/main/scripts/ins
 The installer can set up either standard Zakura or its
 [zcashd-compatible variant](book/src/user/zcashd-compat.md).
 
-You can also run Zakura using our [Docker
-image](https://hub.docker.com/r/valargroup/zakura/tags) or install it manually.
+### Crates.io
+
+Install from [crates.io](https://crates.io/crates/zakura) with
+```console
+cargo install zakura
+```
 
 ### Docker
+
+You can run Zakura using our [Docker
+image](https://hub.docker.com/r/valargroup/zakura/tags) or install it manually.
 
 This command will run our latest release, and sync it to the tip:
 
@@ -150,7 +159,7 @@ triage new issues and we will respond. We maintain a list of known issues in the
 [Troubleshooting](book/src/user/troubleshooting.md) section of
 the book.
 
-If you want to chat with us, use the project discussion channels linked from the Zakura repository.
+If you want to chat with us, use the github issues for now.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The installer can set up either standard Zakura or its
 ### Crates.io
 
 Install from [crates.io](https://crates.io/crates/zakura) with
+
 ```console
 cargo install zakura
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This 
 
 ## Getting Started
 
-There are several ways to install the node software. Install from an interactive installer, crates.io, source or Docker.
+There are several ways to install the node software. Install from an interactive installer which downloads the binary, Docker, source or crates.
 
 ### Installer
 
@@ -44,14 +44,6 @@ curl -fsSL https://raw.githubusercontent.com/zakura-core/zakura/main/scripts/ins
 
 The installer can set up either standard Zakura or its
 [zcashd-compatible variant](book/src/user/zcashd-compat.md).
-
-### Crates.io
-
-Install from [crates.io](https://crates.io/crates/zakura) with
-
-```console
-cargo install zakura
-```
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This 
 - [zcashd compatibility](book/src/user/zcashd-compat.md): A compatibility mode
   reproduces the legacy zcashd RPC interface, so existing wallets and
   integrations keep working.
-- Experimental P2P v2: We are building a new P2P transport layer for Zakura nodes, currently off by default on Mainnet. The goals are sub-500ms worst-case block propagation, mempool aggregation (used in Tachyon), sync at the speed of your bandwidth, and a future-proofed gossip protocol. The v2 stack has known DoS risks and is not yet production-hardened; see its [current tradeoffs and production readyness criteria](book/src/user/p2p.md).
+- Experimental P2P v2: We are building a new P2P transport layer for Zakura nodes, currently off by default on Mainnet. The goals are sub-500ms worst-case block propagation, mempool aggregation (used in Tachyon), sync at the speed of your bandwidth, and a future-proofed gossip protocol. The v2 stack has known DoS risks and is not yet production-hardened; see its [current tradeoffs and production readiness criteria](book/src/user/p2p.md).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This 
 
 - Performance: Blockchain sync is nearly 5× faster than Zebra. Block execution is notably faster than Zebra on worst case sandblast attacks as well.
 - Pruning and snapshots: Native block pruning with configurable retention cuts disk usage substantially. We also publish snapshots (~11 GB pruned) that let you bootstrap a node 680× faster than syncing over the standard P2P network. See [here](https://zakura.com/snapshots/)
-- zcashd compatibility: A compatibility mode reproduces the legacy zcashd RPC interface, so existing wallets and integrations keep working.
+- [zcashd compatibility](book/src/user/zcashd-compat.md): A compatibility mode
+  reproduces the legacy zcashd RPC interface, so existing wallets and
+  integrations keep working.
 - Experimental P2P v2: We are building a new P2P transport layer for Zakura nodes, currently off by default on Mainnet. The goals are sub-500ms worst-case block propagation, mempool aggregation (used in Tachyon), sync at the speed of your bandwidth, and a future-proofed gossip protocol. The native stack has known DoS risks and is not yet production-hardened; see its [current tradeoffs and exit criteria](book/src/user/p2p.md).
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)
 
 - [Getting Started](#getting-started)
+  - [Installer](#installer)
   - [Docker](#docker)
   - [Manual Install](#manual-install)
 - [Documentation](#documentation)
@@ -29,8 +30,19 @@ Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This 
 
 ## Getting Started
 
-You can run Zakura using our [Docker
-image](https://hub.docker.com/r/valargroup/zakura/tags) or you can install it manually.
+### Installer
+
+The recommended way to install Zakura is with the interactive installer:
+
+```console
+curl -fsSL https://raw.githubusercontent.com/zakura-core/zakura/main/scripts/install-zakura.sh | bash
+```
+
+The installer can set up either standard Zakura or its
+[zcashd-compatible variant](book/src/user/zcashd-compat.md).
+
+You can also run Zakura using our [Docker
+image](https://hub.docker.com/r/valargroup/zakura/tags) or install it manually.
 
 ### Docker
 


### PR DESCRIPTION
## Motivation

Make the recommended interactive installer easy to find from the repository's main README.

## Solution

- Add the installer as the first Getting Started option, including the copyable install command.
- Link to the zcashd-compatible variant documentation.
- Keep Docker and manual installation as alternative paths.

AI disclosure: Cursor was used to update the README and prepare this PR description.

## Testing

- `markdownlint README.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics: no errors

This is a low-risk, documentation-only change, so Rust tests and linters were not run.

### Specifications & References

- [`book/src/user/zcashd-compat.md`](book/src/user/zcashd-compat.md)