### PR TITLE
chore(release): prepare v1.0.0-rc6

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -119,6 +119,18 @@ version.
 cargo release version --verbose --execute --allow-branch '*' -p zakura patch # [ major | minor ]
 ```
 
+- [ ] Generate and commit the stored config for the new version — the
+      `last_config_is_stored` acceptance test derives the expected filename
+      from the package version and fails without it:
+
+```sh
+cargo build --bin zakurad &&
+./target/debug/zakurad generate |
+sed 's/cache_dir = ".*"/cache_dir = "cache_dir"/' |
+sed 's/identity_dir = ".*"/identity_dir = "identity_dir"/' \
+  > zakurad/tests/common/configs/v<version>.toml
+```
+
 - [ ] On the release commit, run the pre-release checks for the tag you are
       about to create, using the previous release tag as the base:
       `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<previous-release-tag>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "abscissa_core",
  "anyhow",
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-jsonl-trace"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "tempfile",
  "tokio",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "hex",
  "lazy_static",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "bincode",
  "chrono",
@@ -9189,7 +9189,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-test"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "color-eyre",
  "futures",
@@ -9216,7 +9216,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-tower-batch-control"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-tower-fallback"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -9250,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "1.0.0"
+version = "1.0.0-rc6"
 dependencies = [
  "color-eyre",
  "hex",

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0-rc6 zakura
 ```
 
 You can start Zakura by running

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -11,14 +11,14 @@ fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UNITY_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
 
-ZAKURA_RELEASE_TAG="v1.0.0"
+ZAKURA_RELEASE_TAG="v1.0.0-rc6"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
 # Replaced with the archive checksum by release-binaries.yml before publishing.
 ZAKURA_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0"
-ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0"
+ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc6"
+ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc6"
 ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="valargroup/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 # Persistent Zakura iroh identity (NodeId secret). Kept outside the state cache so

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-tower-batch-control"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Tower middleware for batch request processing. Internal Zakura fork, published to support cargo install zakura"
 # # Legal
@@ -41,10 +41,10 @@ rand = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-test = { workspace = true }
-tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc6" }
 tower-test = { workspace = true }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
 
 [lints]
 workspace = true

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-tower-fallback"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors. Internal Zakura fork, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
 
 [lints]
 workspace = true

--- a/zakura-chain/Cargo.toml
+++ b/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -133,7 +133,7 @@ proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6", optional = true }
 bounded-vec = { version = "0.9.0", features = ["serde"] }
 
 [dev-dependencies]
@@ -154,7 +154,7 @@ rand_chacha = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
 
 [[bench]]
 name = "block"

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -65,13 +65,13 @@ libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
 
-tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0" }
-tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc6" }
+tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0-rc6" }
 
-zakura-script = { path = "../zakura-script", version = "1.0.0" }
-zakura-state = { path = "../zakura-state", version = "1.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc6" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc6" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
 
 zcash_protocol.workspace = true
 
@@ -96,9 +96,9 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "1.0.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc6", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
 
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/zakura-jsonl-trace/Cargo.toml
+++ b/zakura-jsonl-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-jsonl-trace"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -93,8 +93,8 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["async-error"] }
-zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["async-error"] }
+zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc6" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -106,8 +106,8 @@ static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
 
 [lints]
 workspace = true

--- a/zakura-node-services/Cargo.toml
+++ b/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain" , version = "1.0.0-rc6" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0" }
-zakura-network = { path = "../zakura-network", version = "1.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6" }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc6" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "1.0.0" }
-zakura-state = { path = "../zakura-state", version = "1.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc6" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc6" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -140,20 +140,20 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "1.0.0", features = [
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc6", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "1.0.0", features = [
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc6", features = [
     "proptest-impl",
 ] }
 
-zakura-test = { path = "../zakura-test", version = "1.0.0" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc6" }
 
 [lints]
 workspace = true

--- a/zakura-script/Cargo.toml
+++ b/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }
@@ -37,7 +37,7 @@ lazy_static = { workspace = true }
 ripemd = { workspace = true }
 secp256k1 = { workspace = true }
 sha2 = { workspace = true }
-zakura-test = { path = "../zakura-test", version = "1.0.0" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc6" }
 
 [lints]
 workspace = true

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -82,14 +82,14 @@ sapling-crypto = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["async-error"] }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
 
 # test feature proptest-impl
-zakura-test = { path = "../zakura-test/", version = "1.0.0", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6", optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 derive-getters.workspace = true
@@ -114,8 +114,8 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
 
 [lints]
 workspace = true

--- a/zakura-test/Cargo.toml
+++ b/zakura-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-test"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Test harnesses and test vectors for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -60,11 +60,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
 
 # These crates are needed for the block-template-to-proposal binary
-zakura-rpc = { path = "../zakura-rpc", version = "1.0.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc6" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.0.0"
+version = "1.0.0-rc6"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -158,21 +158,21 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0" }
-zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
-zakura-network = { path = "../zakura-network", version = "1.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "1.0.0" }
-zakura-state = { path = "../zakura-state", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6" }
+zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc6" }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc6" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc6" }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc6" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "1.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.0-rc6" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "1.0.0", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc6", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -312,12 +312,12 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "1.0.0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "1.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "1.0.0-rc6", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "1.0.0-rc6", features = ["proptest-impl"] }
 
-zakura-test = { path = "../zakura-test", version = "1.0.0" }
+zakura-test = { path = "../zakura-test", version = "1.0.0-rc6" }
 
 # Used by the checkpoint generation tests via the zakura-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -328,7 +328,7 @@ zakura-test = { path = "../zakura-test", version = "1.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "1.0.0" }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc6" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zakurad/tests/common/configs/v1.0.0-rc6.toml
+++ b/zakurad/tests/common/configs/v1.0.0-rc6.toml
@@ -1,0 +1,150 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"
+


### PR DESCRIPTION
## Motivation

Stage a v1.0.0-rc6 release candidate. Fourteen PRs have merged since the rc5 cut — including consensus-relevant hardening (#168, #171), the release-metadata finalization (#169, #173, #179), and the release-tooling changes (#175, #177) — so the next cut rehearses the full 13-crate graph exactly as the 1.0.0 fork-point publish will ship it.

## Solution

- Bump all 13 publishable crates to `1.0.0-rc6` — the full-graph rehearsal of the 1.0.0 fork-point exception — including every internal dependency requirement, and sync `Cargo.lock`.
- Point the installer at the `v1.0.0-rc6` tag (checksum stays the placeholder that release CI replaces in the published asset copy) and move the Docker image pins to `1.0.0-rc6`.
- Update the README's `cargo install --tag` line, which `cargo release version` does not rewrite (see the note in `zakurad/Cargo.toml`).

Merging this PR does **not** cut the release: the `create-release` dispatch and the `release` environment approval remain the controls, and no crates.io publish happens as part of this change.

## Testing

- `make pre-release RELEASE_TAG=v1.0.0-rc6 BASE_TAG=v1.0.0-rc5` (the #177 preflight, first release exercise):
  - release tag matches the `zakura` package version
  - the changed-crate advisory enumerated all 13 publishable crates with the expected mixed baselines (`1.0.0-rc5 →` for zakura/network/state/consensus, `1.0.0-rc3 →` for the other nine) and found no missing bumps
  - all 13 crates package cleanly
- `cargo metadata --locked` (resolving) passes, so the lockfile matches the new graph
- `bash -n scripts/install-zakura.sh`
- Workspace tests/clippy not run locally for a metadata-only version bump; CI provides those checks.

### Specifications & References

- `.github/PULL_REQUEST_TEMPLATE/release-checklist.md`
- `docs/release-tag-protection.md`

### Follow-up Work

- Dispatch `create-release` for `v1.0.0-rc6` after merge (separate decision).
- When cut, rc6's artifacts join the pre-1.0.0 sweep; any crates.io publish of rc6 is a separate, explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)