### PR TITLE
ci(docs): enable link checking

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -31,39 +31,38 @@ permissions:
   pull-requests: read
 
 jobs:
-  # TODO: this always ends up failing due to random issues. Possibly move to a weekly job
-  # link-check:
-  #   name: link-check
-  #   permissions:
-  #     contents: read
-  #     pull-requests: read
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-  #       with:
-  #         persist-credentials: false
+  link-check:
+    name: link-check
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
 
-  #     - name: Restore lychee cache
-  #       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
-  #       with:
-  #         path: .lycheecache
-  #         key: cache-lychee-${{ github.sha }}
-  #         restore-keys: cache-lychee-
+      - name: Restore lychee cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
 
-  #     - name: Link Checker
-  #       uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 #v2.8.0
-  #       with:
-  #         args: >-
-  #           --verbose
-  #           --no-progress
-  #           --cache
-  #           --max-cache-age 1d
-  #           --config .lychee.toml
-  #           "**/*.md"
-  #         fail: true
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 #v2.8.0
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --config .lychee.toml
+            "**/*.md"
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   spell-check:
     name: spell-check
@@ -114,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      # - link-check
+      - link-check
       - spell-check
       - markdown-lint
     timeout-minutes: 5

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,4 +1,4 @@
-# Lychee link checker configuration for Zebra
+# Lychee link checker configuration for Zakura
 # https://github.com/lycheeverse/lychee
 
 # Exclude patterns
@@ -9,8 +9,6 @@ exclude = [
     "^https?://localhost",
     "^https?://127\\.0\\.0\\.1",
     "^https?://0\\.0\\.0\\.0",
-    # Local file references
-    "^file://",
     # Placeholder URLs
     "^https?://example\\.com",
     # Rate-limited or auth-required
@@ -27,6 +25,15 @@ exclude = [
     "^https://dashboard.mergify.com/",
     # IACR eprint server returns 403 to automated link checkers
     "^https://eprint\\.iacr\\.org/",
+    # Tor's GitLab returns 403 to automated link checkers
+    "^https://gitlab\\.torproject\\.org/",
+
+    # These routes will become available when the Zakura website launches.
+    "^https://zakura\\.com/",
+    "^https://zakura-core\\.github\\.io/zakura/",
+
+    # Remove after the stable Zakura crates have been published to docs.rs.
+    "^https://docs\\.rs/zakura(?:-[a-z0-9-]+)?/latest/",
 
     # Dead upstream links in historical audit document (zebra-dependencies-for-audit.md)
     "^https://github.com/iqlusioninc/abscissa/tree/develop",
@@ -41,6 +48,8 @@ exclude_path = [
     "book/mermaid.min.js",
     "zakura-rpc/qa/rpc-tests",
     "supply-chain",
+    # Contains intentionally unresolved ADR filename placeholders.
+    "docs/decisions/template.md",
     # CHANGELOG contains historical references to deprecated URLs
     "CHANGELOG.md",
 ]
@@ -65,7 +74,7 @@ max_cache_age = "7d"
 max_concurrency = 8
 
 # User agent string
-user_agent = "lychee/0.14 (Zakura link checker; https://github.com/zakura-core/zakura)"
+user_agent = "lychee/0.24 (Zakura link checker; https://github.com/zakura-core/zakura)"
 
 # Skip checking mail addresses
 include_mail = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ## Running and Debugging
 
-See the [user documentation](https://github.com/zakura-core/zakura/user.html) for details on
+See the [user documentation](book/src/user.md) for details on
 how to build, run, and instrument Zakura.
 
 ## Bug Reports

--- a/book/src/dev/audit.md
+++ b/book/src/dev/audit.md
@@ -4,7 +4,7 @@ In addition to our normal [release process](https://github.com/zakura-core/zakur
 
 1. [Tag a release candidate](https://github.com/zakura-core/zakura/blob/main/book/src/dev/release-process.md#preview-releases) with the code to be audited
 2. Declare a feature and fix freeze: non-essential changes must wait until after the audit, new features must be behind a [Rust feature flag](https://doc.rust-lang.org/cargo/reference/features.html)
-3. Prepare a list of dependencies that are [in scope, partially in scope, and out of scope](https://github.com/zakura-core/zakura/issues/5214). Audits focus on:
+3. Prepare a list of dependencies that are in scope, partially in scope, and out of scope. The inherited [Zebra issue #5214](https://github.com/ZcashFoundation/zebra/issues/5214) is an example. Audits focus on:
    - production Rust code that the Zcash Foundation has written, or is responsible for
    - consensus-critical and security-critical code
    - code that hasn't already been audited

--- a/book/src/dev/continuous-delivery.md
+++ b/book/src/dev/continuous-delivery.md
@@ -38,4 +38,4 @@ The workflow runs on:
 
 Pull requests run only the Docker-configuration tests; they do not deploy.
 
-For implementation details, see the [deploy workflow](https://github.com/zakura-core/zakura/blob/main/.github/workflows/zfnd-deploy-nodes-gcp.yml).
+For implementation details, see the [mainnet deploy workflow](https://github.com/zakura-core/zakura/blob/main/.github/workflows/zakura-mainnet-deploy.yml).

--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -11,12 +11,12 @@ see the [CI/CD Architecture documentation](https://github.com/zakura-core/zakura
 
 ## Integration Tests
 
-On every PR change, Zakura runs [these Docker tests](https://github.com/zakura-core/zakura/blob/main/.github/workflows/zfnd-ci-integration-tests-gcp.yml):
+On relevant PR changes, Zakura runs [its end-to-end test workflow](https://github.com/zakura-core/zakura/blob/main/.github/workflows/zakura-e2e.yml), including:
 
-- Zakura update syncs from a cached state Google Cloud tip image
-- lightwalletd full syncs from a cached state Google Cloud tip image
-- lightwalletd update syncs from a cached state Google Cloud tip image
-- lightwalletd integration with Zakura JSON-RPC and Light Wallet gRPC calls
+- a Zakura regtest end-to-end gate
+- a multi-node testkit integration test
+- block-sync fuzz scenarios after merges to `main`
+- longer multi-node modes on a schedule or on demand
 
 When a PR is merged to the `main` branch, we also run a Zakura full sync test from genesis.
 Some of our builds and tests are repeated on the `main` branch, due to:
@@ -129,7 +129,7 @@ Admin:
 GitHub doesn't allow PRs from forked repositories to have access to our repository secret keys, even after we approve their CI.
 This means that Google Cloud CI fails on these PRs.
 
-Until we [fix this CI bug](https://github.com/zakura-core/zakura/issues/4529), we can merge external PRs by:
+Until the inherited [Zebra CI bug](https://github.com/ZcashFoundation/zebra/issues/4529) is resolved, we can merge external PRs by:
 
 1. Reviewing the code to make sure it won't give our secret keys to anyone
 2. Pushing a copy of the branch to the Zakura repository
@@ -210,7 +210,7 @@ To fix a CI sync timeout, follow these steps until the timeouts are fixed:
 2. [Update Zakura's checkpoints](https://github.com/zakura-core/zakura/blob/main/zakura-utils/README.md#zakura-checkpoints)
 3. If a Rust test fails with "command did not log any matches for the given regex, within the ... timeout":
 
-   a. If it's the full sync test, [increase the full sync timeout](https://github.com/zakura-core/zakura/pull/5129/files)
+   a. If it's the full sync test, use [Zebra PR #5129](https://github.com/ZcashFoundation/zebra/pull/5129/files) as an example of increasing the timeout.
 
    b. If it's an update sync test, [increase the update sync timeouts](https://github.com/zakura-core/zakura/commit/9fb87425b76ba3747985ea2f22043ff0276a03bd#diff-92f93c26e696014d82c3dc1dbf385c669aa61aa292f44848f52167ab747cb6f6R51)
 
@@ -224,7 +224,7 @@ You can view Zakura's entire dependency tree using `cargo tree`. It can also sho
 To fix duplicate dependencies, follow these steps until the duplicate dependencies are fixed:
 
 1. Check for updates to the crates mentioned in the `Check deny.toml bans` logs, and try doing them in the same PR.
-   For an example, see [PR #5009](https://github.com/zakura-core/zakura/pull/5009#issuecomment-1232488943).
+   For an example, see [Zebra PR #5009](https://github.com/ZcashFoundation/zebra/pull/5009#issuecomment-1232488943).
 
    a. Check for open dependabot PRs, and
 
@@ -234,7 +234,7 @@ To fix duplicate dependencies, follow these steps until the duplicate dependenci
 
    a. Check for features that Zakura activates in its `Cargo.toml` files, and try turning them off, then
 
-   b. Try adding `default-features = false` to Zakura's dependencies (see [PR #4082](https://github.com/zakura-core/zakura/pull/4082/files)).
+   b. Try adding `default-features = false` to Zakura's dependencies (see [Zebra PR #4082](https://github.com/ZcashFoundation/zebra/pull/4082/files)).
 
 3. If there are still duplicate dependencies, add or update `skip-tree` in [`deny.toml`](https://github.com/zakura-core/zakura/blob/main/deny.toml):
 
@@ -244,7 +244,7 @@ To fix duplicate dependencies, follow these steps until the duplicate dependenci
 
    c. Add a comment about why the dependency exception is needed: what was the direct Zakura dependency that caused it?
 
-   d. For an example, see [PR #4890](https://github.com/zakura-core/zakura/pull/4890/files).
+   d. For an example, see [Zebra PR #4890](https://github.com/ZcashFoundation/zebra/pull/4890/files).
 
 4. Repeat step 3 until the dependency warnings are fixed. Adding a single `skip-tree` exception can resolve multiple warnings.
 
@@ -256,10 +256,9 @@ To fix duplicate dependencies, follow these steps until the duplicate dependenci
 
 ### Fixing Disk Full Errors
 
-If the Docker cached state disks are full, increase the disk sizes in:
-
-- [zfnd-deploy-integration-tests-gcp.yml](https://github.com/zakura-core/zakura/blob/main/.github/workflows/zfnd-deploy-integration-tests-gcp.yml)
-- [zfnd-deploy-nodes-gcp.yml](https://github.com/zakura-core/zakura/blob/main/.github/workflows/zfnd-deploy-nodes-gcp.yml)
+If a PR test node's state volume is full, increase the volume size in the
+[PR-node bake workflow](https://github.com/zakura-core/zakura/blob/main/.github/workflows/zakura-pr-node-bake.yml)
+and create a new snapshot.
 
 If the GitHub Actions disks are full, follow these steps until the errors are fixed:
 
@@ -297,7 +296,7 @@ If it looks like a failure might be temporary, try re-running all the jobs on th
 Here are some of the rare and temporary errors that should be retried:
 
 - Docker: "buildx failed with ... cannot reuse body, request must be retried"
-- Failure in `local_listener_fixed_port_localhost_addr_v4` Rust test, mention [ticket #4999](https://github.com/zakura-core/zakura/issues/4999) on the PR
+- Failure in `local_listener_fixed_port_localhost_addr_v4` Rust test; the inherited [Zebra issue #4999](https://github.com/ZcashFoundation/zebra/issues/4999) has additional context.
 - any network connection or download failures
 
 We track some rare errors using tickets, so we know if they are becoming more common and we need to fix them.

--- a/book/src/dev/ecc-updates.md
+++ b/book/src/dev/ecc-updates.md
@@ -10,7 +10,7 @@ Let's dive into the details of each step required to perform an upgrade:
 
 ### Before starting
 
-- Zakura developers often dismiss ECC dependency upgrade suggestions from dependabot. For instance, see [this closed PR](https://github.com/zakura-core/zakura/pull/7745) in favor of the [5.7.0 zcashd upgrade PR](https://github.com/zakura-core/zakura/pull/7784), which followed this guide.
+- Zebra developers often dismiss ECC dependency upgrade suggestions from dependabot. For instance, see [this closed PR](https://github.com/ZcashFoundation/zebra/pull/7745) in favor of the [5.7.0 zcashd upgrade PR](https://github.com/ZcashFoundation/zebra/pull/7784), which followed this guide.
 
 - Determine the version of `zcashd` to use. This version will determine which versions of other crates to use. Typically, this should be a [tag](https://github.com/zcash/zcash/tags), but in some cases, it might be a reference to a branch (e.g., nu5-consensus) for testing unreleased developments.
 
@@ -20,7 +20,7 @@ Let's dive into the details of each step required to perform an upgrade:
 
 ### Upgrade versions
 
-- Use the `cargo upgrade` command to upgrade all the ECC dependency versions in Zakura. For example, in [this PR](https://github.com/zakura-core/zakura/pull/7784), the following command was used:
+- Use the `cargo upgrade` command to upgrade all the ECC dependency versions in Zakura. For example, in [this Zebra PR](https://github.com/ZcashFoundation/zebra/pull/7784), the following command was used:
 
 ```sh
 cargo upgrade --incompatible -p bridgetree -p incrementalmerkletree -p orchard -p zcash_primitives -p zcash_proofs -p zcash_address -p zcash_encoding -p zcash_note_encryption -p zcash_script

--- a/book/src/dev/profiling-and-benchmarking.md
+++ b/book/src/dev/profiling-and-benchmarking.md
@@ -110,4 +110,4 @@ Note that:
   To speed the build process up, you can link RocksDB dynamically, as described
   in the section on [building Zakura][building-zakura].
 
-[building-zakura]: install.md#building-zakura
+[building-zakura]: ../user/install.md#building-zakura

--- a/book/src/dev/proptests.md
+++ b/book/src/dev/proptests.md
@@ -23,4 +23,4 @@ If we need to add another dependency as part of the `proptest-impl` feature:
 2. Add the crate as an optional `dependencies` entry
 3. Add the crate as a required `dev-dependencies` entry
 
-For an example of these changes, see [PR 2070](https://github.com/zakura-core/zakura/pull/2070/files).
+For an example of these changes, see [Zebra PR 2070](https://github.com/ZcashFoundation/zebra/pull/2070/files).

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -50,7 +50,8 @@ You can update to any version of Zakura, provided that the following criteria ar
 - The version you want to update _to_ is supported.
 - The version you want to update _from_ is within one major version of the version you want to upgrade to.
 
-See [Keeping Up-to-Date](guide/updating "Updating your projects") for more information about updating your Zakura projects to the most recent version.
+See [Building and Installing Zakura](../user/install.md) for instructions on
+installing the most recent version.
 
 <a id="previews"></a>
 
@@ -65,7 +66,7 @@ We let you preview what's coming by providing Release Candidate \(`rc`\) pre-rel
 
 ### Distribution tags
 
-Zakura's tagging relates directly to versions published on Docker. We will reference these [Docker Hub distribution tags](https://hub.docker.com/r/valaroman/zakura/tags) throughout:
+Zakura's tagging relates directly to versions published on Docker. We will reference these [Docker Hub distribution tags](https://hub.docker.com/r/valargroup/zakura/tags) throughout:
 
 | Tag    | Description                                                                                         |
 | :----- | :-------------------------------------------------------------------------------------------------- |

--- a/book/src/dev/rfcs/drafts/xxxx-basic-integration-testing.md
+++ b/book/src/dev/rfcs/drafts/xxxx-basic-integration-testing.md
@@ -25,7 +25,7 @@ On `main` branch merge:
 
 For an up-to-date list, see:
 
-- <https://github.com/ZcashFoundation/zebra/blob/main/zebrad/tests/acceptance.rs>
+- <https://github.com/ZcashFoundation/zebra/blob/audit-v1.0.0-rc.0/zebrad/tests/acceptance.rs>
 - <https://github.com/ZcashFoundation/zebra/tree/main/.github/workflows>
 
 Design strategies:

--- a/book/src/dev/state-db-upgrades.md
+++ b/book/src/dev/state-db-upgrades.md
@@ -112,13 +112,13 @@ To write to a legacy batch, then write it to the database, you can use
 `take_batch_for_writing(batch).write_batch()`.
 
 During database upgrades, you might need to access the same column family using different types.
-[Define a type](https://github.com/zakura-core/zakura/pull/8115/files#diff-ba689ca6516946a903da62153652d91dc1bb3d0100bcf08698cb3f38ead57734R36-R53)
-and [convenience method](https://github.com/zakura-core/zakura/pull/8115/files#diff-ba689ca6516946a903da62153652d91dc1bb3d0100bcf08698cb3f38ead57734R69-R87)
+[Define a type](https://github.com/ZcashFoundation/zebra/pull/8115/files#diff-ba689ca6516946a903da62153652d91dc1bb3d0100bcf08698cb3f38ead57734R36-R53)
+and [convenience method](https://github.com/ZcashFoundation/zebra/pull/8115/files#diff-ba689ca6516946a903da62153652d91dc1bb3d0100bcf08698cb3f38ead57734R69-R87)
 for each legacy type, and use them during the upgrade.
 
 Some full examples of legacy code conversions, and the typed column family implementation itself
-are in [PR #8112](https://github.com/zakura-core/zakura/pull/8112/files) and
-[PR #8115](https://github.com/zakura-core/zakura/pull/8115/files).
+are in [Zebra PR #8112](https://github.com/ZcashFoundation/zebra/pull/8112/files) and
+[Zebra PR #8115](https://github.com/ZcashFoundation/zebra/pull/8115/files).
 
 ## Current Implementation
 

--- a/book/src/dev/zakura-dependencies-for-audit.md
+++ b/book/src/dev/zakura-dependencies-for-audit.md
@@ -1,6 +1,7 @@
-# Zakura dependencies
+# Historical Zebra audit dependencies
 
-This is a list of production Rust code that is in scope and out of scope for Zakura's first audit.
+This inherited document records the scope of Zebra's first audit. It is not a
+security audit of Zakura or its subsequent changes.
 
 Test code, deployment configurations, and other configuration files in the `zakura` repository are out of scope. Due to the way we've created the `audit-v1.0.0-rc.0` tag, tests might not compile, run, or pass.
 
@@ -12,16 +13,16 @@ Test code, deployment configurations, and other configuration files in the `zaku
 
 | Name | Version | Notes
 |------| ------- | -----
-| tower-batch | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/tower-batch/src) |
-| tower-fallback | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/tower-fallback/src) |
-| zakura-chain | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-chain/src) |
-| zakura-consensus | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-consensus/src) |
-| zakura-network | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-network/src) |
-| zakura-node-services | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-node-services/src) |
-| zakura-rpc | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-rpc/src) |
-| zakura-script | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-script/src) |
-| zakura-state | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-state/src) |
-| zakurad | [audit-v1.0.0-rc.0](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakurad/src) |
+| tower-batch | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/tower-batch/src) |
+| tower-fallback | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/tower-fallback/src) |
+| zebra-chain | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-chain/src) |
+| zebra-consensus | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-consensus/src) |
+| zebra-network | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-network/src) |
+| zebra-node-services | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-node-services/src) |
+| zebra-rpc | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-rpc/src) |
+| zebra-script | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-script/src) |
+| zebra-state | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-state/src) |
+| zebrad | [audit-v1.0.0-rc.0](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebrad/src) |
 
 ### Zcash/ZF dependencies
 
@@ -37,7 +38,7 @@ Test code, deployment configurations, and other configuration files in the `zaku
 
 | Name | Version | Notes
 |------| ------- | -----
-| zakura-utils | audit-v1.0.0-rc.0 | <i>Only the [zakura-checkpoints](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/zakura-utils/src/bin/zakura-checkpoints) utility needs to be audited.</i>
+| zebra-utils | audit-v1.0.0-rc.0 | <i>Only the [zebra-checkpoints](https://github.com/ZcashFoundation/zebra/tree/audit-v1.0.0-rc.0/zebra-utils/src/bin/zebra-checkpoints) utility needs to be audited.</i>
 
 ### Zcash/ZF dependencies
 
@@ -48,19 +49,23 @@ Test code, deployment configurations, and other configuration files in the `zaku
 | redjubjub | [0.5.0](https://github.com/ZcashFoundation/redjubjub/tree/0.5.0/src) | [jp](https://github.com/ZcashFoundation/redjubjub/raw/main/zcash-frost-audit-report-20210323.pdf) <i>(FROST only)</i> | <b><i>Optional</i></b><br><i>All files should be audited EXCEPT:<br />- the [signing code](https://github.com/ZcashFoundation/redjubjub/blob/0.5.0/src/signing_key.rs)<br /> - the [FROST code](https://github.com/ZcashFoundation/redjubjub/blob/0.5.0/src/frost.rs), and<br />- the FROST messages [module](https://github.com/ZcashFoundation/redjubjub/blob/0.5.0/src/messages.rs) and [directory](https://github.com/ZcashFoundation/redjubjub/blob/0.5.0/src/messages)</i>
 | reddsa | [0.4.0](https://github.com/ZcashFoundation/reddsa/tree/0.4.0/src) | [jp](https://github.com/ZcashFoundation/redjubjub/raw/main/zcash-frost-audit-report-20210323.pdf) <i>(FROST only)</i> | <b><i>Optional</i></b><br><i>This code was moved from `zakura/zakura-chain/src/primitives/redpallas` into a separate crate after the Zakura `v1.0.0-rc.0` release. A previous version of this code was audited as the `redjubjub` crate.<br />All files should be audited EXCEPT:<br />- the [signing code](https://github.com/ZcashFoundation/reddsa/blob/0.4.0/src/signing_key.rs), and<br />- the [Sapling code](https://github.com/ZcashFoundation/reddsa/blob/0.4.0/src/sapling.rs)</i>
 
-Note: there are duplicate `zcash_primitives`, `zcash_proofs`, and `reddsa` dependencies in Zakura's audit and development branches, [this will get fixed](https://github.com/zakura-core/zakura/issues/6107) after the `zcashd` 5.4.0 release.
+Note: there were duplicate `zcash_primitives`, `zcash_proofs`, and `reddsa`
+dependencies in Zebra's audit and development branches. See
+[Zebra issue #6107](https://github.com/ZcashFoundation/zebra/issues/6107).
 
 ---
 
 ## Not Included
 
-The changes in these PRs are out of scope for the audit. When the Zakura team checks for bugs that have already been fixed, we can check these PRs, and any changes after commit [c4032e2b](https://github.com/zakura-core/zakura/commit/c4032e2b7f6dbee8a9480d3c978c70a3cfc3332c).
+The changes in these PRs were out of scope for the audit. When checking for bugs
+that have already been fixed, consult these PRs and changes after
+[Zebra commit c4032e2b](https://github.com/ZcashFoundation/zebra/commit/c4032e2b7f6dbee8a9480d3c978c70a3cfc3332c).
 
 The following consensus, security, and functional changes are in Zakura's development branch, but they are not included in the `audit-v1.0.0-rc.0` tag, because they caused too many merge conflicts:
 
-- [fix(sync): Pause new downloads when Zakura reaches the lookahead limit #5561](https://github.com/zakura-core/zakura/pull/5561)
-- [fix(rpc): Shut down the RPC server properly when Zakura shuts down #5591](https://github.com/zakura-core/zakura/pull/5591)
-- [refactor(state): Make implementation of block consensus rules clearer #5915](https://github.com/zakura-core/zakura/pull/5915)
+- [fix(sync): Pause new downloads when Zebra reaches the lookahead limit #5561](https://github.com/ZcashFoundation/zebra/pull/5561)
+- [fix(rpc): Shut down the RPC server properly when Zebra shuts down #5591](https://github.com/ZcashFoundation/zebra/pull/5591)
+- [refactor(state): Make implementation of block consensus rules clearer #5915](https://github.com/ZcashFoundation/zebra/pull/5915)
 
 ---
 
@@ -70,7 +75,9 @@ The following list of dependencies is out of scope for the audit.
 
 Please ignore the dependency versions in these tables, some of them are outdated. All versions of these dependencies are out of scope.
 
-The latest versions of Zakura's dependencies are in [`Cargo.lock`](https://github.com/zakura-core/zakura/tree/audit-v1.0.0-rc.0/Cargo.lock), including transitive dependencies. They can be viewed using `cargo tree`.
+The audited versions of Zebra's dependencies are in
+[`Cargo.lock`](https://github.com/ZcashFoundation/zebra/blob/audit-v1.0.0-rc.0/Cargo.lock),
+including transitive dependencies. They can be viewed using `cargo tree`.
 
 Click the triangle for details:
 <details>

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -5,14 +5,14 @@ The foundation maintains a Docker infrastructure for deploying and testing Zakur
 ## Quick Start
 
 To get Zakura quickly up and running, you can use an off-the-rack image from
-[Docker Hub](https://hub.docker.com/r/zakura-core/zakura/tags):
+[Docker Hub](https://hub.docker.com/r/valargroup/zakura/tags):
 
 ```shell
 docker run -d \
   --name zakura \
   -p 8233:8233 \
   -v zakurad-cache:/home/zakura/.cache/zakura \
-  zakura-core/zakura
+  valargroup/zakura
 ```
 
 The `-p 8233:8233` flag publishes Zakura's P2P port so other Zcash nodes can

--- a/book/src/user/elasticsearch.md
+++ b/book/src/user/elasticsearch.md
@@ -4,7 +4,7 @@ The goal here is to export block data from Zakura into an [elasticsearch](https:
 
 **Attention:** This is an experimental feature tested only in the Zcash Testnet.
 
-Elasticsearch support was introduced to Zakura in [pull request #6274](https://github.com/zakura-core/zakura/pull/6274).
+Elasticsearch support was introduced upstream in [Zebra pull request #6274](https://github.com/ZcashFoundation/zebra/pull/6274).
 
 ## Download, build and run Elasticsearch
 

--- a/book/src/user/fork-zakura-testnet.md
+++ b/book/src/user/fork-zakura-testnet.md
@@ -83,7 +83,7 @@ Here we are making changes to create an isolated network version of Zakura. In a
 - Make fixes needed to compile.
 - Ignore how far we are from the tip in get block template: `zakura-rpc/src/methods/get_block_template_rpcs/get_block_template.rs`
 
-Unclean test commit for Zakura: [Zakura commit](https://github.com/zakura-core/zakura/commit/d05af154c897d4820999fcb968b7b62d10b26aa8)
+Unclean test commit from upstream: [Zebra commit](https://github.com/ZcashFoundation/zebra/commit/d05af154c897d4820999fcb968b7b62d10b26aa8)
 
 Make sure you can build the `zakurad` binary after the changes with `cargo build --release`
 

--- a/book/src/user/tracing.md
+++ b/book/src/user/tracing.md
@@ -59,6 +59,6 @@ configuration.
 [filter]: https://docs.rs/zakura/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.filter
 [flamegraph]: https://docs.rs/zakura/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.flamegraph
 [flamegraphs]: http://www.brendangregg.com/flamegraphs.html
-[systemd_journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
+[systemd_journald]: https://man7.org/linux/man-pages/man8/systemd-journald.service.8.html
 [use_journald]: https://docs.rs/zakura/latest/zakurad/components/tracing/struct.InnerConfig.html#structfield.use_journald
 [sentry]: https://sentry.io/welcome/

--- a/book/src/user/troubleshooting.md
+++ b/book/src/user/troubleshooting.md
@@ -6,11 +6,11 @@ There are a few bugs in Zakura that we're still working on fixing:
 
 - [Progress bar estimates can become extremely large](https://github.com/console-rs/indicatif/issues/556). This may be improved in recent versions of the progress bar library.
 
-- Zakura currently gossips and connects to [private IP addresses](https://en.wikipedia.org/wiki/IP_address#Private_addresses), we want to [disable private IPs but provide a config (#3117)](https://github.com/zakura-core/zakura/issues/3117) in an upcoming release
+- Zakura currently gossips and connects to [private IP addresses](https://en.wikipedia.org/wiki/IP_address#Private_addresses). See the inherited [Zebra issue #3117](https://github.com/ZcashFoundation/zebra/issues/3117) for background.
 
-- Block download and verification sometimes times out during Zakura's initial sync [#5709](https://github.com/zakura-core/zakura/issues/5709). The full sync still finishes reasonably quickly.
+- Block download and verification sometimes times out during Zakura's initial sync. See the inherited [Zebra issue #5709](https://github.com/ZcashFoundation/zebra/issues/5709) for background. The full sync still finishes reasonably quickly.
 
-- Experimental Tor support is disabled until Zakura upgrades to the latest `arti-client`. [#8328](https://github.com/zakura-core/zakura/issues/8328#issuecomment-1969989648)
+- Experimental Tor support is disabled until Zakura upgrades to the latest `arti-client`. See the inherited [Zebra issue #8328](https://github.com/ZcashFoundation/zebra/issues/8328#issuecomment-1969989648) for background.
 
 ## Memory Issues
 


### PR DESCRIPTION
## Motivation

The documentation link-check job was commented out, so stale external links
and broken local references could merge unnoticed. A full Lychee run found 69
external failures, largely inherited Zebra references that had been renamed to
the Zakura repository even though the target issue, PR, commit, or audit tag
still lives upstream.

## Solution

- enable the Lychee job and make `docs check success` depend on it
- repair stale Docker Hub, CI workflow, local documentation, and inherited
  Zebra links
- validate local file links instead of excluding every `file://` URL
- label the inherited Zebra audit-scope document as historical and restore its
  upstream references
- narrowly exclude launch-pending Zakura website and docs.rs routes, the ADR
  filename template, and hosts that reject automated checks

## Testing

- Lychee 0.24.2 over `**/*.md` with the cache disabled
- `markdownlint-cli` using `.trunk/configs/.markdownlint.yaml`
- `codespell --config .codespellrc`
- Ruby YAML parser on `.github/workflows/docs-check.yml`
- `git diff --check`

The final Lychee run checks 943 link occurrences (731 unique URLs) with no
broken-link errors.

### Follow-up Work

- remove the Zakura website exclusions after the launch routes are live
- remove the Zakura docs.rs exclusion after the stable crates are published
- replace the historical Zebra audit-scope document with a current Zakura
  threat model and audit record

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI docs workflows, Lychee configuration, and markdown link text with no runtime or consensus impact.
> 
> **Overview**
> Re-enables the **Lychee** `link-check` job in `docs-check.yml` and wires it into **`docs check success`**, so markdown PRs must pass external and local link validation again.
> 
> **`.lychee.toml`** is tuned for Zakura: drops the blanket `file://` exclude so local references are checked, adds narrow skips for not-yet-live `zakura.com` / GitHub Pages / `docs.rs` routes, Tor GitLab 403s, and `docs/decisions/template.md`, and bumps the user-agent string.
> 
> Across **CONTRIBUTING** and the **book**, broken or misleading URLs are corrected—Docker Hub (`valargroup/zakura`), deploy/E2E workflow names, in-repo paths instead of invalid GitHub `user.html` links, and **inherited Zebra** issue/PR/commit targets where Zakura renamed links but upstream still owns the artifact. The audit dependency page is reframed as a **historical Zebra audit** record with restored upstream crate/tag links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d788bdbed838599ec2bf90af6b955f6da3ed42b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->