### PR TITLE
fix(ci): accept HTTP 202 in the docs link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -54,8 +54,10 @@ exclude_path = [
     "CHANGELOG.md",
 ]
 
-# Accept these HTTP status codes as valid
-accept = ["200", "204", "206", "301", "302", "307", "308", "429"]
+# Accept these HTTP status codes as valid. 202 is included because z.cash and
+# zfnd.org intermittently return "202 Accepted" to automated checkers (CDN bot
+# protection) — the link is not broken, the content just wasn't served.
+accept = ["200", "202", "204", "206", "301", "302", "307", "308", "429"]
 
 # Timeout for requests (seconds)
 timeout = 30


### PR DESCRIPTION
## Motivation

Since #186 enabled external link checking, `Docs Check → link-check` has been flaky on unrelated commits: the same four links (two zfnd.org blog posts, `z.cash/halo2-audit/`, `z.cash/technology/zksnarks/`) intermittently return **202 Accepted** — CDN bot protection acknowledging the request without serving the page — and lychee rejects any status outside its accept list. Tonight's runs alternated pass/fail minutes apart: #183's PR run passed at 01:41 UTC, its merge push to `main` failed at 01:56 ([failing job](https://github.com/zakura-core/zakura/actions/runs/29382845109/job/87249975694)).

## Solution

Add `202` to the existing `accept` list in `.lychee.toml`. A 202 means the URL resolves and the server accepted the request, so this stays a valid-link signal while real 404s/500s are still caught. The alternative — excluding the z.cash/zfnd.org hosts entirely, like the existing eprint.iacr.org rule — would stop catching genuinely dead links on those domains.

## Testing

- `.lychee.toml` parses (checked with Python `tomllib`).
- `.lychee.toml` is in `docs-check.yml`'s path filter, so this PR runs the link check itself; 202-acceptance is deterministic config, unlike a lucky re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)