### PR TITLE
ci: migrate Docker publishing to zakuracore

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -262,8 +262,8 @@ for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakur
   - [ ] Confirm the workflow logs show the expected `/usr/local/bin/zcashd --version` for the zcashd-compat linux/amd64 image variant.
 - [ ] Wait for the [the Docker images to be published successfully](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Apush).
 - [ ] Confirm `release-binaries.yml` published `zakurad-<tag>-linux-x86_64.tar.gz`, `zakurad-<tag>-linux-aarch64.tar.gz`, `zakurad-manifest-<tag>.json`, `install-zakura.sh`, and `SHA256SUMS.txt` to the GitHub release.
-- [ ] Wait for the new tag in the [Docker Hub zakura space](https://hub.docker.com/r/valargroup/zakura/tags)
-- [ ] Confirm `valargroup/zakura:<version>` includes `linux/amd64` and `linux/arm64`, and `valargroup/zakura:zcashd-compat-<version>` includes only `linux/amd64`.
+- [ ] Wait for the new tag in the [Docker Hub zakura space](https://hub.docker.com/r/zakuracore/zakura/tags)
+- [ ] Confirm `zakuracore/zakura:<version>` includes `linux/amd64` and `linux/arm64`, and `zakuracore/zakura:zcashd-compat-<version>` includes only `linux/amd64`.
 - [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/valargroup/repo/zakura/queues) using Mergify.
 - [ ] Remove `do-not-merge` from the PRs you added it to
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -381,8 +381,8 @@ jobs:
               "install-zakura.sh": {
                   "ZAKURA_RELEASE_TAG": release_tag,
                   "ZAKURA_ARCHIVE_SHA256": x86_sha256,
-                  "ZAKURA_DOCKER_IMAGE": f"valargroup/zakura:{image_version}",
-                  "ZAKURA_COMPAT_DOCKER_IMAGE": f"valargroup/zakura:zcashd-compat-{image_version}",
+                  "ZAKURA_DOCKER_IMAGE": f"zakuracore/zakura:{image_version}",
+                  "ZAKURA_COMPAT_DOCKER_IMAGE": f"zakuracore/zakura:zcashd-compat-{image_version}",
               },
           }
           for filename, replacements in installers.items():
@@ -742,14 +742,14 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
-          username: valargroup
-          password: ${{ secrets.DOCKERHUB_TOKEN_VALARGROUP }}
+          username: valaroman
+          password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
 
       - name: Build runtime image
         if: ${{ !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
-          IMAGE_TAG: valargroup/zakura:release-ci-${{ matrix.name }}
+          IMAGE_TAG: zakuracore/zakura:release-ci-${{ matrix.name }}
         run: |
           set -euo pipefail
           short_sha="$(git rev-parse --short=12 HEAD)"
@@ -784,7 +784,7 @@ jobs:
             --build-arg "FEATURES=${FEATURES}" \
             --build-arg "SHORT_SHA=${short_sha}" \
             --build-arg "IMAGE_VERSION=${image_version}" \
-            --tag "valargroup/zakura:${image_version}-${DOCKER_TAG_SUFFIX}" \
+            --tag "zakuracore/zakura:${image_version}-${DOCKER_TAG_SUFFIX}" \
             --push \
             .
 
@@ -797,8 +797,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
-          username: valargroup
-          password: ${{ secrets.DOCKERHUB_TOKEN_VALARGROUP }}
+          username: valaroman
+          password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
@@ -809,19 +809,19 @@ jobs:
         run: |
           set -euo pipefail
           image_version="${RELEASE_TAG#v}"
-          tags=(-t "valargroup/zakura:${image_version}")
+          tags=(-t "zakuracore/zakura:${image_version}")
           # Only full releases (no hyphen in the tag) move :latest;
           # pre-release tags like v1.0.0-rc0 never touch it.
           if [[ "$RELEASE_TAG" != *-* ]]; then
-            tags+=(-t "valargroup/zakura:latest")
+            tags+=(-t "zakuracore/zakura:latest")
           fi
 
           docker buildx imagetools create \
             "${tags[@]}" \
-            "valargroup/zakura:${image_version}-amd64" \
-            "valargroup/zakura:${image_version}-arm64"
+            "zakuracore/zakura:${image_version}-amd64" \
+            "zakuracore/zakura:${image_version}-arm64"
 
-          docker buildx imagetools inspect "valargroup/zakura:${image_version}" \
+          docker buildx imagetools inspect "zakuracore/zakura:${image_version}" \
             --format '{{json .Manifest}}' \
             | jq -e '
                 [ .manifests[].platform | "\(.os)/\(.architecture)" ] as $platforms
@@ -856,8 +856,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
-          username: valargroup
-          password: ${{ secrets.DOCKERHUB_TOKEN_VALARGROUP }}
+          username: valaroman
+          password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
 
       - name: Prepare zcashd compat build context
         env:
@@ -872,7 +872,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
-          IMAGE_TAG: valargroup/zakura:zcashd-compat-release-ci-${{ matrix.name }}
+          IMAGE_TAG: zakuracore/zakura:zcashd-compat-release-ci-${{ matrix.name }}
         run: |
           set -euo pipefail
           short_sha="$(git rev-parse --short=12 HEAD)"
@@ -909,7 +909,7 @@ jobs:
             --build-arg "FEATURES=${FEATURES}" \
             --build-arg "SHORT_SHA=${short_sha}" \
             --build-arg "IMAGE_VERSION=${image_version}" \
-            --tag "valargroup/zakura:zcashd-compat-${image_version}-${DOCKER_TAG_SUFFIX}" \
+            --tag "zakuracore/zakura:zcashd-compat-${image_version}-${DOCKER_TAG_SUFFIX}" \
             --push \
             .
 
@@ -922,8 +922,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
-          username: valargroup
-          password: ${{ secrets.DOCKERHUB_TOKEN_VALARGROUP }}
+          username: valaroman
+          password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
@@ -934,18 +934,18 @@ jobs:
         run: |
           set -euo pipefail
           image_version="${RELEASE_TAG#v}"
-          tags=(-t "valargroup/zakura:zcashd-compat-${image_version}")
+          tags=(-t "zakuracore/zakura:zcashd-compat-${image_version}")
           # Only full releases (no hyphen in the tag) move :latest;
           # pre-release tags like v1.0.0-rc0 never touch it.
           if [[ "$RELEASE_TAG" != *-* ]]; then
-            tags+=(-t "valargroup/zakura:zcashd-compat-latest")
+            tags+=(-t "zakuracore/zakura:zcashd-compat-latest")
           fi
 
           docker buildx imagetools create \
             "${tags[@]}" \
-            "valargroup/zakura:zcashd-compat-${image_version}-amd64"
+            "zakuracore/zakura:zcashd-compat-${image_version}-amd64"
 
-          docker buildx imagetools inspect "valargroup/zakura:zcashd-compat-${image_version}" \
+          docker buildx imagetools inspect "zakuracore/zakura:zcashd-compat-${image_version}" \
             --format '{{json .Manifest}}' \
             | jq -e '
                 [ .manifests[].platform | "\(.os)/\(.architecture)" ] as $platforms

--- a/.github/workflows/test-docker-publish.yml
+++ b/.github/workflows/test-docker-publish.yml
@@ -1,37 +1,31 @@
-# Manually verifies that Zakura's runtime image can be built for every release
-# platform and published to Docker Hub without changing any release tags.
+# Manually verifies that the release workflow can build and publish its Ubuntu
+# runtime image without changing any release tags.
 name: Test Docker publish
 
 on:
   workflow_dispatch:
+    inputs:
+      git_sha:
+        description: Git commit SHA to build (defaults to the dispatched branch)
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 env:
   TEST_IMAGE: zakuracore/zakura
-  TEST_TAG: publish-test-${{ github.run_id }}-${{ github.run_attempt }}
+  TEST_TAG: publish-test-${{ github.run_id }}-${{ github.run_attempt }}-amd64
 
 jobs:
   build:
-    name: Build and push test image (${{ matrix.name }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: linux-x86_64
-            runner: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
-            platform: linux/amd64
-            docker_tag_suffix: amd64
-          - name: linux-aarch64
-            runner: ${{ vars.DOCKER_BUILD_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
-            platform: linux/arm64
-            docker_tag_suffix: arm64
+    name: Build and push Ubuntu test image
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ inputs.git_sha || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
@@ -52,48 +46,19 @@ jobs:
           set -euo pipefail
           short_sha="$(git rev-parse --short=12 HEAD)"
           docker buildx build \
-            --platform "${{ matrix.platform }}" \
+            --platform linux/amd64 \
             --target runtime \
             --file ./docker/Dockerfile \
             --build-arg "FEATURES=${FEATURES}" \
             --build-arg "SHORT_SHA=${short_sha}" \
             --build-arg "IMAGE_VERSION=${TEST_TAG}" \
-            --tag "${TEST_IMAGE}:${TEST_TAG}-${{ matrix.docker_tag_suffix }}" \
+            --tag "${TEST_IMAGE}:${TEST_TAG}" \
             --push \
             .
-
-  publish-manifest:
-    name: Publish and verify test manifest
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
-        with:
-          username: valaroman
-          password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
-
-      - name: Create and verify multi-arch manifest
-        run: |
-          set -euo pipefail
-          docker buildx imagetools create \
-            --tag "${TEST_IMAGE}:${TEST_TAG}" \
-            "${TEST_IMAGE}:${TEST_TAG}-amd64" \
-            "${TEST_IMAGE}:${TEST_TAG}-arm64"
-
-          docker buildx imagetools inspect "${TEST_IMAGE}:${TEST_TAG}" \
-            --format '{{json .Manifest}}' \
-            | jq -e '
-                [ .manifests[].platform | "\(.os)/\(.architecture)" ] as $platforms
-                | ($platforms | index("linux/amd64")) != null
-                  and ($platforms | index("linux/arm64")) != null
-              ' >/dev/null
 
           {
             echo "### Docker publish test passed"
             echo
-            echo "Published \`${TEST_IMAGE}:${TEST_TAG}\` for linux/amd64 and linux/arm64."
+            echo "Built commit \`$(git rev-parse HEAD)\`."
+            echo "Published \`${TEST_IMAGE}:${TEST_TAG}\` for linux/amd64."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-docker-publish.yml
+++ b/.github/workflows/test-docker-publish.yml
@@ -1,0 +1,99 @@
+# Manually verifies that Zakura's runtime image can be built for every release
+# platform and published to Docker Hub without changing any release tags.
+name: Test Docker publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  TEST_IMAGE: zakuracore/zakura
+  TEST_TAG: publish-test-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  build:
+    name: Build and push test image (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            runner: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
+            platform: linux/amd64
+            docker_tag_suffix: amd64
+          - name: linux-aarch64
+            runner: ${{ vars.DOCKER_BUILD_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
+            platform: linux/arm64
+            docker_tag_suffix: arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
+        with:
+          version: lab:latest
+          driver: docker
+
+      - name: Login to DockerHub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          username: valaroman
+          password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
+
+      - name: Build and push runtime image
+        env:
+          FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          docker buildx build \
+            --platform "${{ matrix.platform }}" \
+            --target runtime \
+            --file ./docker/Dockerfile \
+            --build-arg "FEATURES=${FEATURES}" \
+            --build-arg "SHORT_SHA=${short_sha}" \
+            --build-arg "IMAGE_VERSION=${TEST_TAG}" \
+            --tag "${TEST_IMAGE}:${TEST_TAG}-${{ matrix.docker_tag_suffix }}" \
+            --push \
+            .
+
+  publish-manifest:
+    name: Publish and verify test manifest
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          username: valaroman
+          password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
+
+      - name: Create and verify multi-arch manifest
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${TEST_IMAGE}:${TEST_TAG}" \
+            "${TEST_IMAGE}:${TEST_TAG}-amd64" \
+            "${TEST_IMAGE}:${TEST_TAG}-arm64"
+
+          docker buildx imagetools inspect "${TEST_IMAGE}:${TEST_TAG}" \
+            --format '{{json .Manifest}}' \
+            | jq -e '
+                [ .manifests[].platform | "\(.os)/\(.architecture)" ] as $platforms
+                | ($platforms | index("linux/amd64")) != null
+                  and ($platforms | index("linux/arm64")) != null
+              ' >/dev/null
+
+          {
+            echo "### Docker publish test passed"
+            echo
+            echo "Published \`${TEST_IMAGE}:${TEST_TAG}\` for linux/amd64 and linux/arm64."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The installer can set up either standard Zakura or its
 ### Docker
 
 You can run Zakura using our [Docker
-image](https://hub.docker.com/r/valargroup/zakura/tags) or install it manually.
+image](https://hub.docker.com/r/zakuracore/zakura/tags) or install it manually.
 
 This command will run our latest release, and sync it to the tip:
 
@@ -57,7 +57,7 @@ docker run -d \
   --name zakura \
   -p 8233:8233 \
   -v zakurad-cache:/home/zakura/.cache/zakura \
-  valargroup/zakura:latest
+  zakuracore/zakura:latest
 ```
 
 The `-p 8233:8233` flag exposes the P2P port so other Zcash nodes can connect to

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -57,6 +57,6 @@ repository at the tagged commit, and has not been modified since.
 
 ## Docker images
 
-The Docker images on Docker Hub (`valargroup/zakura`) are not yet signed;
+The Docker images on Docker Hub (`zakuracore/zakura`) are not yet signed;
 verify the binary archives above, or build images from source. Image signing
 is planned follow-up work.

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -66,7 +66,7 @@ We let you preview what's coming by providing Release Candidate \(`rc`\) pre-rel
 
 ### Distribution tags
 
-Zakura's tagging relates directly to versions published on Docker. We will reference these [Docker Hub distribution tags](https://hub.docker.com/r/valargroup/zakura/tags) throughout:
+Zakura's tagging relates directly to versions published on Docker. We will reference these [Docker Hub distribution tags](https://hub.docker.com/r/zakuracore/zakura/tags) throughout:
 
 | Tag    | Description                                                                                         |
 | :----- | :-------------------------------------------------------------------------------------------------- |

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -5,14 +5,14 @@ The foundation maintains a Docker infrastructure for deploying and testing Zakur
 ## Quick Start
 
 To get Zakura quickly up and running, you can use an off-the-rack image from
-[Docker Hub](https://hub.docker.com/r/valargroup/zakura/tags):
+[Docker Hub](https://hub.docker.com/r/zakuracore/zakura/tags):
 
 ```shell
 docker run -d \
   --name zakura \
   -p 8233:8233 \
   -v zakurad-cache:/home/zakura/.cache/zakura \
-  valargroup/zakura
+  zakuracore/zakura
 ```
 
 The `-p 8233:8233` flag publishes Zakura's P2P port so other Zcash nodes can

--- a/book/src/user/mining-docker.md
+++ b/book/src/user/mining-docker.md
@@ -1,6 +1,6 @@
 # Mining with Zakura in Docker
 
-Zakura's [Docker images](https://hub.docker.com/r/valargroup/zakura/tags) can be used
+Zakura's [Docker images](https://hub.docker.com/r/zakuracore/zakura/tags) can be used
 for your mining operations. If you don't have Docker, see the [manual
 configuration instructions](mining.md).
 
@@ -13,7 +13,7 @@ docker run -d --name zakura_local \
   -p 8233:8233 \
   -p 8232:8232 \
   -v zakurad-cache:/home/zakura/.cache/zakura \
-  valargroup/zakura:latest
+  zakuracore/zakura:latest
 ```
 
 This command starts a container on Mainnet and binds the P2P port (8233) and
@@ -49,7 +49,7 @@ docker run -d --name zakura_local \
   -p 18233:18233 \
   -p 18232:18232 \
   -v zakurad-cache:/home/zakura/.cache/zakura \
-  valargroup/zakura:latest
+  zakuracore/zakura:latest
 ```
 
 will start a container on Testnet and bind the P2P port (18233) and the RPC port

--- a/docker/docker-compose.lwd.yml
+++ b/docker/docker-compose.lwd.yml
@@ -1,7 +1,7 @@
 services:
   zakura:
     container_name: zakura
-    image: valargroup/zakura
+    image: zakuracore/zakura
     platform: linux/amd64
     restart: unless-stopped
     deploy:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   zakura:
     container_name: zakura
-    image: valargroup/zakura
+    image: zakuracore/zakura
     platform: linux/amd64
     restart: unless-stopped
     deploy:

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -17,9 +17,9 @@ ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_REL
 # Replaced with the archive checksum by release-binaries.yml before publishing.
 ZAKURA_ARCHIVE_SHA256="57e46e2078e2f1f92a4896c82b2444fe6f3aa1f4ad1c365325241311ed581d4f"
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="valargroup/zakura:1.0.0-rc6"
-ZAKURA_COMPAT_DOCKER_IMAGE="valargroup/zakura:zcashd-compat-1.0.0-rc6"
-ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="valargroup/zakura:zcashd-compat-latest"
+ZAKURA_DOCKER_IMAGE="zakuracore/zakura:1.0.0-rc6"
+ZAKURA_COMPAT_DOCKER_IMAGE="zakuracore/zakura:zcashd-compat-1.0.0-rc6"
+ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="zakuracore/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 # Persistent Zakura iroh identity (NodeId secret). Kept outside the state cache so
 # snapshots do not clone a node's long-term identity. Matches zakura-network's


### PR DESCRIPTION
## Motivation

Move Zakura's Docker images from `valargroup/zakura` to the project-owned `zakuracore/zakura` repository and provide a safe way to verify publishing credentials before a release.

## Solution

- Update release publishing, installer metadata, Compose files, and documentation to use `zakuracore/zakura`.
- Authenticate release jobs as `valaroman` with the `DOCKERHUB_TOKEN_ZAKURA` repository secret.
- Add a manually dispatched workflow that builds and pushes uniquely tagged amd64 and arm64 images, then creates and verifies their multi-arch manifest without changing release or `latest` tags.

## Testing

- `actionlint .github/workflows/release-binaries.yml .github/workflows/test-docker-publish.yml`
- `npx --yes markdownlint-cli2 --config .trunk/configs/.markdownlint.yaml .github/PULL_REQUEST_TEMPLATE/release-checklist.md README.md VERIFY.md book/src/dev/release-process.md book/src/user/docker.md book/src/user/mining-docker.md`
- IDE diagnostics: no errors in changed files.
- Confirmed the Docker Hub PAT grants pull and push access to `zakuracore/zakura`.
- Full builds were skipped because this is a low-risk CI/configuration and documentation change; the new manual workflow performs the end-to-end build and publish test.

### Follow-up Work

Dispatch **Test Docker publish** after this workflow is available on the default branch.