### PR TITLE
docs(readme): fix typos and polish intro prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@
 - [Security](#security)
 - [License](#license)
 
-[Zakura](https://github.com/zakura-core/zakura/) is a fully consensus compatible Zcash full node written in Rust, built for scale. We dream of the future where Zcash can power the worlds payments. Mastercard and Visa give a lower bound, we have to first hit 50k TPS of capacity. With ongoing cryptographic optimizations to the Zcash protocol, from [Project Tachyon](https://tachyon.z.cash/) and [Valargroup](https://valargroup.dev), this implies consensus must be capable of at least 100MB/s of block data. The starting point today is 28 KB/s. Zakura builds for this future.
+[Zakura](https://github.com/zakura-core/zakura/) is a consensus-compatible Zcash full node written in Rust, built for scale. Supporting payments at global scale requires on the order of 50k TPS, which translates to consensus processing at least 100 MB/s of block data — today's chain produces roughly 28 KB/s. With cryptographic optimizations to the Zcash protocol underway in [Project Tachyon](https://tachyon.z.cash/) and at [Valargroup](https://valargroup.dev), Zakura is the node implementation built to close that gap.
 
-Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This first release brings major improvements over existing Zcash node software:
+Zakura is forked from [Zebra](https://github.com/ZcashFoundation/zebra). This first release brings major improvements over existing Zcash node software:
 
-- Performance: Blockchain sync is nearly 5× faster than Zebra. Block execution is notably faster than Zebra, especially on worst case sandblast attacks.
-- Pruning and snapshots: Native block pruning with configurable retention cuts disk usage substantially. We also publish snapshots (~11 GB pruned) that let you bootstrap a node 680× faster than syncing over the standard P2P network. See [here](https://zakura.com/snapshots/)
+- Performance: Blockchain sync is nearly 5× faster than Zebra. Block execution is notably faster than Zebra, especially on worst-case sandblast attacks.
+- Pruning and snapshots: Native block pruning with configurable retention lets you operate a full node with substantially less disk space. We also publish snapshots (~11 GB pruned) that let you bootstrap a node 680× faster than syncing over the standard P2P network. See the [snapshots page](https://zakura.com/snapshots/).
 - [zcashd compatibility](book/src/user/zcashd-compat.md): A compatibility mode
   reproduces the legacy zcashd RPC interface, so existing wallets and
   integrations keep working.
@@ -32,11 +32,11 @@ Zakura is forked off of [Zebra](https://github.com/ZcashFoundation/zebra). This 
 
 ## Getting Started
 
-There are several ways to install the node software. Install from an interactive installer which downloads the binary, Docker, source or crates.
+There are several ways to install the node software: an interactive installer that downloads the binary, Docker, or building from source or crates.io.
 
 ### Installer
 
-The simplest way to install Zakura on a new machine, is using the interactive installer:
+The simplest way to install Zakura on a new machine is using the interactive installer:
 
 ```console
 curl -fsSL https://raw.githubusercontent.com/zakura-core/zakura/main/scripts/install-zakura.sh | bash
@@ -52,7 +52,7 @@ image](https://hub.docker.com/r/zakuracore/zakura/tags) or install it manually.
 The zcashd-compatible split-container mode uses the
 [zakuracore/zcashd:v1.0.0 image](https://hub.docker.com/r/zakuracore/zcashd/tags).
 
-This command will run our latest release, and sync it to the tip:
+This command will run our latest release and sync it to the tip:
 
 ```sh
 docker run -d \
@@ -85,7 +85,7 @@ compiler. Below are quick summaries for installing these dependencies.
 2. Install Zakura's build dependencies:
    - **libclang**, which is a library that comes under various names, typically
      `libclang`, `libclang-dev`, `llvm`, or `llvm-dev`;
-   - **clang** or another C++ compiler (`g++,` which is for all platforms or
+   - **clang** or another C++ compiler (`g++`, which is for all platforms, or
      `Xcode`, which is for macOS);
    - **[`protoc`](https://grpc.io/docs/protoc-installation/)** (optional).
 
@@ -133,7 +133,7 @@ zakurad start
 Refer to the [Building and Installing
 Zakura](book/src/user/install.md) and [Running
 Zakura](book/src/user/run.md) sections in the book for enabling
-optional features, detailed configuration and further details.
+optional features, detailed configuration, and further details.
 
 ## Documentation
 
@@ -154,7 +154,7 @@ triage new issues and we will respond. We maintain a list of known issues in the
 [Troubleshooting](book/src/user/troubleshooting.md) section of
 the book.
 
-If you want to chat with us, use the github issues for now.
+If you want to chat with us, use the GitHub issues for now.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - [Security](#security)
 - [License](#license)
 
-[Zakura](https://github.com/zakura-core/zakura/) is a consensus-compatible Zcash full node written in Rust, built for scale. Supporting payments at global scale requires on the order of 50k TPS, which translates to consensus processing at least 100 MB/s of block data — today's chain produces roughly 28 KB/s. With cryptographic optimizations to the Zcash protocol underway in [Project Tachyon](https://tachyon.z.cash/) and at [Valargroup](https://valargroup.dev), Zakura is the node implementation built to close that gap.
+[Zakura](https://github.com/zakura-core/zakura/) is a consensus-compatible Zcash full node written in Rust, built for scale. Supporting payments at global scale requires on the order of 50k TPS, which translates to consensus processing at least 100 MB/s of block data. Today's chain peaks at 28 KB/s. With cryptographic optimizations to the Zcash protocol underway in [Project Tachyon](https://tachyon.z.cash/) and at [Valargroup](https://valargroup.dev), Zakura is the node implementation built to close that gap.
 
 Zakura is forked from [Zebra](https://github.com/ZcashFoundation/zebra). This first release brings major improvements over existing Zcash node software:
 


### PR DESCRIPTION
## Motivation

The README had several typos and grammar errors (missing apostrophe in "worlds payments", comma splice in the TPS sentence, `g++,` with the comma inside the code span, lowercase "github", a garbled install-methods sentence, a dangling "See here" without a period). The intro paragraph also leaned on marketing framing (Mastercard/Visa) that suits the website better than a technical README.

## Solution

- Fixed the typos and grammar throughout.
- Reworked the intro to lead with the technical framing: the 50k TPS → 100 MB/s consensus throughput target vs. today's ~28 KB/s, with the payments motivation compressed to a single clause and the brand names dropped.
- Small wording alignment in the pruning bullet and a proper link ("snapshots page") in place of "See here".

## Testing

Prose-only README change; no code affected. Links touched are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)