### PR TITLE
chore(release): prepare v1.0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -124,10 +124,15 @@ cargo release version --verbose --execute --allow-branch '*' -p zakura patch # [
 ```sh
 cargo build --bin zakurad &&
 ./target/debug/zakurad generate |
-sed 's/cache_dir = ".*"/cache_dir = "cache_dir"/' |
-sed 's/identity_dir = ".*"/identity_dir = "identity_dir"/' \
+sed "s#${XDG_CACHE_HOME:-$HOME/.cache}/zakura#cache_dir#g" |
+sed "s#$HOME/.zakura#identity_dir#g" \
   > zakurad/tests/common/configs/v<version>.toml
 ```
+
+      The replacements are global path-string substitutions, mirroring
+      `last_config_is_stored` — the default cache path also appears in
+      fields other than `cache_dir` (for example `cookie_dir`), so
+      per-field rewrites produce a snapshot the test rejects.
 
 - [ ] On the release commit, run the pre-release checks for the tag you are
       about to create, using the previous release tag as the base:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Zakura are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 Initial release of Zakura.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "abscissa_core",
  "anyhow",
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-jsonl-trace"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "tempfile",
  "tokio",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -9189,7 +9189,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-test"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "color-eyre",
  "futures",
@@ -9216,7 +9216,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-tower-batch-control"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-tower-fallback"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -9250,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "color-eyre",
  "hex",

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0-rc6 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.0 zakura
 ```
 
 You can start Zakura by running

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -11,14 +11,14 @@ fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UNITY_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
 
-ZAKURA_RELEASE_TAG="v1.0.0-rc6"
+ZAKURA_RELEASE_TAG="v1.0.0"
 ZAKURA_ARCHIVE="zakurad-${ZAKURA_RELEASE_TAG}-linux-x86_64.tar.gz"
 ZAKURA_URL="https://github.com/zakura-core/zakura/releases/download/${ZAKURA_RELEASE_TAG}/${ZAKURA_ARCHIVE}"
 # Replaced with the archive checksum by release-binaries.yml before publishing.
-ZAKURA_ARCHIVE_SHA256="57e46e2078e2f1f92a4896c82b2444fe6f3aa1f4ad1c365325241311ed581d4f"
+ZAKURA_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 ZAKURA_MEMBER="./bin/zakurad"
-ZAKURA_DOCKER_IMAGE="zakuracore/zakura:1.0.0-rc6"
-ZAKURA_COMPAT_DOCKER_IMAGE="zakuracore/zakura:zcashd-compat-1.0.0-rc6"
+ZAKURA_DOCKER_IMAGE="zakuracore/zakura:1.0.0"
+ZAKURA_COMPAT_DOCKER_IMAGE="zakuracore/zakura:zcashd-compat-1.0.0"
 ZAKURA_COMPAT_DOCKER_FALLBACK_IMAGE="zakuracore/zakura:zcashd-compat-latest"
 ZAKURA_DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/zakura"
 # Persistent Zakura iroh identity (NodeId secret). Kept outside the state cache so

--- a/tower-batch-control/CHANGELOG.md
+++ b/tower-batch-control/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-tower-batch-control"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Tower middleware for batch request processing. Internal Zakura fork, published to support cargo install zakura"
 # # Legal
@@ -41,10 +41,10 @@ rand = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-test = { workspace = true }
-tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc6" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0" }
 tower-test = { workspace = true }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/tower-fallback/CHANGELOG.md
+++ b/tower-fallback/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-tower-fallback"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors. Internal Zakura fork, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/zakura-chain/CHANGELOG.md
+++ b/zakura-chain/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-chain/Cargo.toml
+++ b/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -133,7 +133,7 @@ proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0", optional = true }
 bounded-vec = { version = "0.9.0", features = ["serde"] }
 
 [dev-dependencies]
@@ -154,7 +154,7 @@ rand_chacha = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
+zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [[bench]]
 name = "block"

--- a/zakura-consensus/CHANGELOG.md
+++ b/zakura-consensus/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -65,13 +65,13 @@ libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
 
-tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0-rc6" }
-tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0-rc6" }
+tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0" }
+tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0" }
 
-zakura-script = { path = "../zakura-script", version = "1.0.0-rc6" }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc6" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
+zakura-script = { path = "../zakura-script", version = "1.0.0" }
+zakura-state = { path = "../zakura-state", version = "1.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
 
 zcash_protocol.workspace = true
 
@@ -96,9 +96,9 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc6", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
+zakura-state = { path = "../zakura-state", version = "1.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/zakura-jsonl-trace/CHANGELOG.md
+++ b/zakura-jsonl-trace/CHANGELOG.md
@@ -7,6 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 Initial stable release.

--- a/zakura-jsonl-trace/Cargo.toml
+++ b/zakura-jsonl-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-jsonl-trace"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -93,8 +93,8 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["async-error"] }
-zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["async-error"] }
+zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -106,8 +106,8 @@ static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/zakura-node-services/CHANGELOG.md
+++ b/zakura-node-services/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-node-services/Cargo.toml
+++ b/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain" , version = "1.0.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zakura-rpc/CHANGELOG.md
+++ b/zakura-rpc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6" }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc6" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0" }
+zakura-network = { path = "../zakura-network", version = "1.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "1.0.0-rc6" }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc6" }
+zakura-script = { path = "../zakura-script", version = "1.0.0" }
+zakura-state = { path = "../zakura-state", version = "1.0.0" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -140,20 +140,20 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc6", features = [
+zakura-network = { path = "../zakura-network", version = "1.0.0", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc6", features = [
+zakura-state = { path = "../zakura-state", version = "1.0.0", features = [
     "proptest-impl",
 ] }
 
-zakura-test = { path = "../zakura-test", version = "1.0.0-rc6" }
+zakura-test = { path = "../zakura-test", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/zakura-script/CHANGELOG.md
+++ b/zakura-script/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-script/Cargo.toml
+++ b/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }
@@ -37,7 +37,7 @@ lazy_static = { workspace = true }
 ripemd = { workspace = true }
 secp256k1 = { workspace = true }
 sha2 = { workspace = true }
-zakura-test = { path = "../zakura-test", version = "1.0.0-rc6" }
+zakura-test = { path = "../zakura-test", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -82,14 +82,14 @@ sapling-crypto = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["async-error"] }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
 
 # test feature proptest-impl
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6", optional = true }
+zakura-test = { path = "../zakura-test/", version = "1.0.0", optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 derive-getters.workspace = true
@@ -114,8 +114,8 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
-zakura-test = { path = "../zakura-test/", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
+zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/zakura-test/CHANGELOG.md
+++ b/zakura-test/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-test/Cargo.toml
+++ b/zakura-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-test"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Test harnesses and test vectors for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-utils/CHANGELOG.md
+++ b/zakura-utils/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-07-14
+## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly
 change so major version bumps can be common.

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -60,11 +60,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc6" }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.0.0-rc6"
+version = "1.0.0"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -158,21 +158,21 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6" }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6" }
-zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0-rc6" }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc6" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0-rc6", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "1.0.0-rc6" }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc6" }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0" }
+zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
+zakura-network = { path = "../zakura-network", version = "1.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "1.0.0" }
+zakura-state = { path = "../zakura-state", version = "1.0.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "1.0.0-rc6" }
+zakura-script = { path = "../zakura-script", version = "1.0.0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc6", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -312,12 +312,12 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0-rc6", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "1.0.0-rc6", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "1.0.0-rc6", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "1.0.0-rc6", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "1.0.0", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "1.0.0", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "1.0.0", features = ["proptest-impl"] }
 
-zakura-test = { path = "../zakura-test", version = "1.0.0-rc6" }
+zakura-test = { path = "../zakura-test", version = "1.0.0" }
 
 # Used by the checkpoint generation tests via the zakura-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -328,7 +328,7 @@ zakura-test = { path = "../zakura-test", version = "1.0.0-rc6" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "1.0.0-rc6" }
+zakura-utils = { path = "../zakura-utils", version = "1.0.0" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_412_800;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_414_300;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_414_300;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_413_500;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.

--- a/zakurad/tests/common/configs/v1.0.0.toml
+++ b/zakurad/tests/common/configs/v1.0.0.toml
@@ -147,3 +147,4 @@ shutdown_grace_period = "5m"
 startup_delay = "1s"
 zcashd_extra_args = []
 zcashd_source = "path"
+


### PR DESCRIPTION
## Motivation

Re-stage the v1.0.0 release. `main` has sat at `1.0.0-rc6` since #183, and the rc6 cut completed the full dress rehearsal: the tag gate passed its fifth exercise, #177's pre-tag packaging ran in CI for the first time, and all 13 crates published to crates.io from the tagged SHA. This PR moves the package graph back to the fork-point `1.0.0` so the real release can be dispatched.

## Solution

- Bump all 13 publishable crates `1.0.0-rc6` → `1.0.0` via `cargo release version` (all internal dependency requirements included) and sync `Cargo.lock`.
- Point the installer at the `v1.0.0` tag with the placeholder-zero checksum (release CI substitutes the real value into the published asset copy; the zeroed pin fails cleanly — the #169 design). Docker pins move to `zakuracore/zakura:1.0.0` / `zcashd-compat-1.0.0` on the new org (#189/#191).
- Update the README `cargo install --tag` line via `cargo release replace` (see the note in `zakurad/Cargo.toml`).
- Regenerate the stored config snapshot `zakurad/tests/common/configs/v1.0.0.toml` from this branch (the `last_config_is_stored` acceptance test derives the filename from the package version). The regenerated file is byte-identical to the rc6 snapshot that passed CI at the rc6 cut; versus the #169-era copy the only change is trailing-newline normalization.
- Fix the release checklist's snapshot-generation command: its per-field `sed`s miss `cookie_dir`, which also embeds the default cache path — the test does global path-string replacement, so the documented command produced a snapshot the test rejects. The command now mirrors the test's semantics (found live while preparing this PR).
- Refresh `ESTIMATED_RELEASE_HEIGHT` 3,412,800 → **3,414,300**: the mainnet tip passed the old estimate this morning (3,413,133 at 11:58 UTC, per Blockchair). The new value assumes a cut within ~1 day; with `EOS_PANIC_AFTER = 7`, end-of-support lands at ≈3,422,364 — still ~5,800 blocks (~5 days) before Ironwood activation at 3,428,143, preserving the follow-up-release forcing function. **Re-run this estimate if dispatch slips past ~July 17.**
- Refresh the frozen "Initial release" changelog entries' date (root + 12 crate changelogs) to the expected tag date, 2026-07-15.

Merging this PR does **not** cut the release: the `create-release` dispatch and the `release`-environment approval remain the controls, and no crates.io publish happens as part of this change.

## Testing

- `make pre-release RELEASE_TAG=v1.0.0 BASE_TAG=v1.0.0-rc6`:
  - release tag matches the `zakura` package version
  - the changed-crate advisory enumerated all 13 publishable crates against the rc6 baseline with no missing bumps
  - all 13 crates package cleanly
- `cargo metadata --locked` resolves, so the lockfile matches the new graph
- freshly generated config matches the committed `v1.0.0.toml` byte-for-byte (the `last_config_is_stored` contract)
- `bash -n scripts/install-zakura.sh`
- Workspace tests/clippy not run locally for a metadata-only version bump; CI provides those checks. `cargo semver-checks` / `cargo public-api diff` skipped: 1.0.0 is the initial release baseline (changelogs frozen per `CHANGELOG_GUIDELINES.md`).

### Specifications & References

- `.github/PULL_REQUEST_TEMPLATE/release-checklist.md`
- `docs/release-tag-protection.md`
- #183 (the rc6 full-graph rehearsal), #169 (the original 1.0.0 prep)

### Follow-up Work

- Dispatch `create-release` for `v1.0.0` after merge (separate decision, per the release checklist).
- Checkpoints: `zakura-chain/src/parameters/checkpoint/main-checkpoints.txt` tops out at height 3,358,006 (last substantive update: upstream v4.5.0, 2026-05-28) — ~55k blocks behind tip. No release in this repo has bumped them; deferring keeps this PR a pure re-bump, but it should be an explicit decision (or a separate PR) before or shortly after 1.0.0.
- The pre-1.0.0 rc sweep, promotion to "Latest", signing, and the manual crates.io publish follow the release checklist after the cut.
- At promotion time, `zakuracore/zakura:zcashd-compat-latest` (the installer's compat fallback image) does not exist yet on the new org — push or re-point it.

## AI Disclosure

Prepared with Claude Code (version bumps via `cargo release`, metadata edits, and preflight runs); human review required before merge and dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
