### PR TITLE
fix(state): correct comment typo that fails the updated codespell

### DIFF
--- a/zakura-state/src/service/finalized_state/tests/vectors.rs
+++ b/zakura-state/src/service/finalized_state/tests/vectors.rs
@@ -455,7 +455,7 @@ fn sprout_checks(incremental_tree: SproutNoteCommitmentTree, expected_serialized
         deserialized_legacy_tree_as_new.recalculate_root()
     );
 
-    // Check reclaculated and cached roots are the same
+    // Check recalculated and cached roots are the same
     assert_eq!(
         incremental_tree.recalculate_root(),
         deserialized_tree
@@ -509,7 +509,7 @@ fn sapling_checks(
         deserialized_legacy_tree_as_new.recalculate_root()
     );
 
-    // Check reclaculated and cached roots are the same
+    // Check recalculated and cached roots are the same
     assert_eq!(
         incremental_tree.recalculate_root(),
         deserialized_tree
@@ -585,7 +585,7 @@ fn orchard_checks(
         deserialized_legacy_tree_as_new.recalculate_root()
     );
 
-    // Check reclaculated and cached roots are the same
+    // Check recalculated and cached roots are the same
     assert_eq!(
         incremental_tree.recalculate_root(),
         deserialized_tree


### PR DESCRIPTION
## Motivation

Main's `spell-check` job started failing at 10:01 UTC today (previous main runs were green at 06:32 and 03:46) with no change to the flagged file — the job installs unpinned `codespell`, and a new dictionary release added `reclaculated`. Every open PR now fails lint, including the v1.0.0 re-bump (#194).

## Solution

Fix the three comment-only occurrences in `zakura-state/src/service/finalized_state/tests/vectors.rs`. No code changes.

## Testing

`codespell` no longer flags the file; the spell-check job on this PR is the live check.

### Follow-up Work

Consider pinning the codespell version in the lint workflow so dictionary updates land deliberately instead of breaking main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)