### PR TITLE
fix: cherry-pick consensus and state fixes from #165

### DIFF
--- a/zakura-chain/src/local_genesis.rs
+++ b/zakura-chain/src/local_genesis.rs
@@ -19,7 +19,8 @@ use crate::{
     fmt::HexDebug,
     parameters::{
         testnet::{
-            ConfiguredActivationHeights, ConfiguredCheckpoints, Parameters as TestnetParams,
+            ConfiguredActivationHeights, ConfiguredCheckpoints, ConfiguredLockboxDisbursement,
+            Parameters as TestnetParams,
         },
         Magic, Network, NetworkKind, NetworkUpgrade,
     },
@@ -66,6 +67,9 @@ impl Default for LocalTestnetGenesisOptions {
 /// Fixed private-network PoW limit used by both generated seed blocks and the
 /// configured custom testnet.
 const LOCAL_TESTNET_TARGET_DIFFICULTY_LIMIT: [u8; 32] = [0x0f; 32];
+
+/// Script hash for the zero-value output that marks the implicit NU6.1 event.
+const LOCAL_TESTNET_LOCKBOX_SCRIPT_HASH: [u8; 20] = [0; 20];
 
 /// A secp256k1 keypair with a transparent Zcash address.
 pub struct FundedKey {
@@ -384,6 +388,7 @@ fn build_network(options: BuildNetworkOptions<'_>) -> Result<Network, crate::Box
 
     let activation_heights =
         configured_activation_heights(latest_network_upgrade, activation_height)?;
+    let lockbox_disbursements = configured_lockbox_disbursements(latest_network_upgrade);
 
     // Order matters: with_halving_interval must come before with_funding_streams
     // because funding_streams locks the halving interval.
@@ -397,7 +402,7 @@ fn build_network(options: BuildNetworkOptions<'_>) -> Result<Network, crate::Box
         .with_activation_heights(activation_heights)?
         .with_halving_interval(144)?
         .with_funding_streams(vec![])
-        .with_lockbox_disbursements(vec![])
+        .with_lockbox_disbursements(lockbox_disbursements)
         .with_checkpoints(ConfiguredCheckpoints::HeightsAndHashes(
             checkpoints.to_vec(),
         ))?;
@@ -416,6 +421,10 @@ fn configured_activation_heights(
         return Err("latest_network_upgrade must be BeforeOverwinter or later".into());
     }
 
+    if latest_network_upgrade >= Overwinter && latest_network_upgrade.branch_id().is_none() {
+        return Err("latest_network_upgrade must have a consensus branch ID".into());
+    }
+
     Ok(ConfiguredActivationHeights {
         before_overwinter: Some(1),
         overwinter: (latest_network_upgrade >= Overwinter).then_some(activation_height),
@@ -425,15 +434,33 @@ fn configured_activation_heights(
         canopy: (latest_network_upgrade >= Canopy).then_some(activation_height),
         nu5: (latest_network_upgrade >= Nu5).then_some(activation_height),
         nu6: (latest_network_upgrade >= Nu6).then_some(activation_height),
-        // Nu6.1 is the one-time ZIP-271 lockbox disbursement event from mainnet; activating it on
-        // a local testnet would require synthesising disbursement outputs in the activation-block
-        // coinbase, which the local genesis builder does not produce. Skipping it lets NU6.3 activate
-        // directly without tripping the lockbox-disbursements consensus rule.
-        nu6_1: None,
+        nu6_1: (latest_network_upgrade >= Nu6_1).then_some(activation_height),
         nu6_2: (latest_network_upgrade >= Nu6_2).then_some(activation_height),
         nu6_3: (latest_network_upgrade >= Nu6_3).then_some(activation_height),
         nu7: (latest_network_upgrade >= Nu7).then_some(activation_height),
     })
+}
+
+fn configured_lockbox_disbursements(
+    latest_network_upgrade: NetworkUpgrade,
+) -> Vec<ConfiguredLockboxDisbursement> {
+    if latest_network_upgrade < NetworkUpgrade::Nu6_1 {
+        return Vec::new();
+    }
+
+    // Later upgrades implicitly activate every earlier consensus rule. In particular,
+    // activating NU6.2 or later still triggers the one-time NU6.1 disbursement rule. A
+    // zero-value P2SH output satisfies that structural rule without creating funds or
+    // drawing from the empty local deferred pool. The mining transaction builder reads
+    // this configured output and includes it in the activation-block coinbase.
+    vec![ConfiguredLockboxDisbursement {
+        address: transparent::Address::from_script_hash(
+            NetworkKind::Testnet,
+            LOCAL_TESTNET_LOCKBOX_SCRIPT_HASH,
+        )
+        .to_string(),
+        amount: Amount::<NonNegative>::zero(),
+    }]
 }
 
 /// RIPEMD-160(SHA-256(data)) - standard Bitcoin/Zcash hash160 for public keys.
@@ -521,12 +548,51 @@ mod tests {
             NetworkUpgrade::Nu6_3.activation_height(network),
             Some(activation_height)
         );
+        assert_eq!(
+            NetworkUpgrade::Nu6_1.activation_height(network),
+            Some(activation_height),
+            "later upgrades implicitly activate the NU6.1 one-time rule"
+        );
+        let lockbox_disbursements = network.lockbox_disbursements(activation_height);
+        let [(lockbox_address, lockbox_amount)] = lockbox_disbursements.as_slice() else {
+            panic!("post-NU6 local networks have one lockbox marker output");
+        };
+        assert!(lockbox_address.is_script_hash());
+        assert!(lockbox_amount.is_zero());
         // NU6.3 inherits the post-Blossom consensus target spacing (75s); this is the
         // protocol block spacing and is independent of the harness `target_spacing_secs`
         // option used to space the generated seeded-block timestamps.
         assert_eq!(
             NetworkUpgrade::target_spacing_for_height(network, activation_height).num_seconds(),
             i64::from(crate::parameters::POST_BLOSSOM_POW_TARGET_SPACING)
+        );
+    }
+
+    /// NU6.1 itself must be usable as the latest upgrade: it has a compiled
+    /// consensus branch ID, and the network still gets the lockbox marker its
+    /// activation block needs.
+    #[test]
+    fn nu6_1_can_be_the_latest_network_upgrade() {
+        let generated = generate_local_testnet_with_funded_keys(
+            vec!["alice".to_string(), "bob".to_string()],
+            LocalTestnetGenesisOptions {
+                latest_network_upgrade: NetworkUpgrade::Nu6_1,
+                ..Default::default()
+            },
+        )
+        .expect("local testnet should generate");
+
+        let activation_height = Height(3);
+        assert_eq!(
+            NetworkUpgrade::current(&generated.network, activation_height),
+            NetworkUpgrade::Nu6_1
+        );
+        assert_eq!(
+            generated
+                .network
+                .lockbox_disbursements(activation_height)
+                .len(),
+            1
         );
     }
 

--- a/zakura-chain/src/work/equihash.rs
+++ b/zakura-chain/src/work/equihash.rs
@@ -94,9 +94,9 @@ impl Solution {
     /// the attacker-controlled solution length. A solution whose variant does
     /// not match the parameters `network` requires is rejected: Mainnet and
     /// Testnet require the memory-hard `(200, 9)` [`Solution::Common`]
-    /// solution, and the toy `(48, 5)` [`Solution::Regtest`] solution is only
-    /// accepted on Regtest. This prevents a peer from downgrading the proof of
-    /// work by choosing the on-wire solution length.
+    /// solution, while Regtest requires the toy `(48, 5)`
+    /// [`Solution::Regtest`] solution. This prevents a peer from changing the
+    /// proof-of-work parameters by choosing the on-wire solution length.
     #[allow(clippy::unwrap_in_result)]
     pub fn check(&self, header: &Header, network: &Network) -> Result<(), Error> {
         // TODO:
@@ -106,15 +106,13 @@ impl Solution {
             // Mainnet and Testnet require the memory-hard (200, 9) parameters,
             // encoded as a 1344-byte `Common` solution.
             (false, Solution::Common(_)) => (200, 9),
-            // Regtest accepts either the toy (48, 5) solution used by its
-            // genesis block or a full (200, 9) solution from a miner.
-            (true, Solution::Common(_)) => (200, 9),
+            // Regtest requires the toy (48, 5) parameters used by zcashd.
             (true, Solution::Regtest(_)) => (REGTEST_N, REGTEST_K),
-            // A 36-byte `Regtest`-shaped solution is not a valid proof of work
-            // on Mainnet or Testnet. Reject it before selecting parameters, so
-            // the attacker-controlled solution length cannot downgrade the PoW
-            // to the trivial (48, 5) parameter set.
-            (false, Solution::Regtest(_)) => {
+            // Reject a solution variant that does not match the active
+            // network before selecting parameters. Otherwise the
+            // attacker-controlled solution length could change the PoW
+            // parameter set.
+            (false, Solution::Regtest(_)) | (true, Solution::Common(_)) => {
                 return Err(Error::InvalidSolutionSize {
                     network: network.clone(),
                 })

--- a/zakura-chain/src/work/tests/vectors.rs
+++ b/zakura-chain/src/work/tests/vectors.rs
@@ -182,3 +182,30 @@ fn real_regtest_solution_is_bound_to_regtest_parameters() {
         );
     }
 }
+
+/// Regression test for the reverse network-parameter mismatch.
+///
+/// A known-valid Mainnet `(200, 9)` proof must not be accepted under Regtest's
+/// `(48, 5)` parameters.
+#[test]
+fn real_common_solution_is_rejected_on_regtest() {
+    let _init_guard = zakura_test::init();
+
+    let block = Block::zcash_deserialize(zakura_test::vectors::BLOCKS[0])
+        .expect("block test vector should deserialize");
+    let header = block.header.as_ref();
+    let regtest = Network::new_regtest(Default::default());
+
+    header
+        .solution
+        .check(header, &Network::Mainnet)
+        .expect("the hard-coded Mainnet solution must verify on Mainnet");
+
+    assert!(
+        matches!(
+            header.solution.check(header, &regtest),
+            Err(Error::InvalidSolutionSize { .. }),
+        ),
+        "a real Common proof must not verify on Regtest",
+    );
+}

--- a/zakura-consensus/src/block/tests.rs
+++ b/zakura-consensus/src/block/tests.rs
@@ -15,6 +15,7 @@ use zakura_chain::{
         },
         Block, Height,
     },
+    local_genesis::generate_local_testnet_with_funded_keys,
     orchard,
     parameters::{
         subsidy::block_subsidy,
@@ -323,6 +324,68 @@ fn subsidy_is_valid_for_network(network: Network) -> Result<(), Report> {
                 .expect("subsidies should pass for this block");
         }
     }
+
+    Ok(())
+}
+
+/// A generated local testnet's NU6.3 activation block must be able to satisfy
+/// the ZIP-271 lockbox-disbursement subsidy rule.
+///
+/// NU6.1's activation height falls through to the shared activation height of
+/// the local network, so `subsidy_is_valid` demands its one-time disbursement
+/// outputs there. The generated network configures a zero-value P2SH marker
+/// for this, so a coinbase that pays that marker must pass with no deferred
+/// pool change.
+#[test]
+fn local_genesis_nu6_3_activation_has_satisfiable_lockbox_rule() -> Result<(), Report> {
+    let generated = generate_local_testnet_with_funded_keys(
+        vec!["alice".to_string(), "bob".to_string()],
+        Default::default(),
+    )
+    .map_err(|error| eyre!(error.to_string()))?;
+    let network = generated.network;
+    let height = NetworkUpgrade::Nu6_3
+        .activation_height(&network)
+        .expect("the default local network activates NU6.3");
+    let lockbox_disbursements = network.lockbox_disbursements(height);
+    let [(lockbox_address, lockbox_amount)] = lockbox_disbursements.as_slice() else {
+        panic!("the local network configures one lockbox marker output");
+    };
+    let coinbase = Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: height,
+        inputs: vec![zakura_chain::transparent::Input::Coinbase {
+            height,
+            data: b"local activation".to_vec(),
+            sequence: 0,
+        }],
+        outputs: vec![zakura_chain::transparent::Output::new(
+            *lockbox_amount,
+            lockbox_address.script(),
+        )],
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+    let block = Block {
+        header: generated
+            .blocks
+            .last()
+            .expect("the generated chain contains genesis")
+            .header
+            .clone(),
+        transactions: vec![Arc::new(coinbase)],
+    };
+    let expected_block_subsidy =
+        block_subsidy(height, &network).expect("the local activation height has a block subsidy");
+
+    // `subsidy_is_valid` skips all checks (including the lockbox rule) for a
+    // zero subsidy, which would make this test vacuous.
+    assert!(!expected_block_subsidy.is_zero());
+    assert_eq!(
+        subsidy_is_valid(&block, &network, expected_block_subsidy)?,
+        DeferredPoolBalanceChange::zero()
+    );
 
     Ok(())
 }

--- a/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -11,6 +11,7 @@ use zakura_chain::parameters::testnet::ConfiguredFundingStreamRecipient;
 
 use zakura_chain::{
     block::Height,
+    local_genesis::generate_local_testnet_with_funded_keys,
     parameters::{
         subsidy::FundingStreamReceiver::{Deferred, Ecc, MajorGrants, ZcashFoundation},
         testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams},
@@ -18,6 +19,7 @@ use zakura_chain::{
     },
     serialization::ZcashDeserializeInto,
     transaction::Transaction,
+    transparent,
 };
 
 use crate::client::TransactionTemplate;
@@ -91,6 +93,43 @@ fn coinbase() -> anyhow::Result<()> {
             }
         }
     }
+
+    Ok(())
+}
+
+/// The coinbase built for a local testnet's activation block must include the
+/// network's configured zero-value lockbox marker output, so a mining node
+/// can produce a block that satisfies the one-time ZIP-271 disbursement rule.
+#[test]
+fn local_genesis_activation_coinbase_includes_lockbox_marker() -> anyhow::Result<()> {
+    let generated = generate_local_testnet_with_funded_keys(
+        vec!["alice".to_string(), "bob".to_string()],
+        Default::default(),
+    )
+    .map_err(|error| anyhow!(error.to_string()))?;
+    let net = generated.network;
+    let height = NetworkUpgrade::Nu6_3
+        .activation_height(&net)
+        .expect("the default local network activates NU6.3");
+    let miner_params = MinerParams::from(
+        Address::decode(
+            &net,
+            default_miner_address(net.kind(), &MinerAddressType::Transparent),
+        )
+        .ok_or(anyhow!("hard-coded address must be valid"))?,
+    );
+    let transaction =
+        TransactionTemplate::new_coinbase(&net, height, &miner_params, Amount::zero())?
+            .data()
+            .as_ref()
+            .zcash_deserialize_into::<Transaction>()?;
+    let lockbox_disbursements = net.lockbox_disbursements(height);
+    let [(lockbox_address, lockbox_amount)] = lockbox_disbursements.as_slice() else {
+        return Err(anyhow!("local network must have one lockbox marker"));
+    };
+    let lockbox_output = transparent::Output::new(*lockbox_amount, lockbox_address.script());
+
+    assert!(transaction.outputs().contains(&lockbox_output));
 
     Ok(())
 }

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -11,7 +11,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    ops::RangeBounds,
+    ops::{Bound, RangeBounds},
     sync::Arc,
 };
 
@@ -220,19 +220,45 @@ impl ZakuraDb {
         &self,
         range: impl RangeBounds<block::Height>,
     ) -> Vec<BlockCommitmentRoots> {
+        let Some(tip_height) = self.finalized_tip_height() else {
+            return Vec::new();
+        };
+        let Some(start_height) = (match range.start_bound() {
+            Bound::Included(height) => Some(*height),
+            Bound::Excluded(height) => height.next().ok(),
+            Bound::Unbounded => Some(block::Height::MIN),
+        }) else {
+            return Vec::new();
+        };
+        let Some(end_height) = (match range.end_bound() {
+            Bound::Included(height) => Some(*height),
+            Bound::Excluded(height) => height.previous().ok(),
+            Bound::Unbounded => Some(tip_height),
+        }) else {
+            return Vec::new();
+        };
+        let end_height = end_height.min(tip_height);
+        if start_height > end_height {
+            return Vec::new();
+        }
+
         let mut roots = Vec::new();
 
-        for (height, sapling) in self.sapling_tree_by_height_range(range) {
+        // The per-height tree column families are sparse: they only store a row
+        // when that pool's tree changes. Resolve each requested finalized height
+        // through the backwards tree lookup instead of iterating those sparse
+        // rows as if they were a contiguous block-height index.
+        for raw_height in start_height.0..=end_height.0 {
+            let height = block::Height(raw_height);
+            let Some(sapling) = self.sapling_tree_by_height(&height) else {
+                break;
+            };
             let Some(orchard) = self.orchard_tree_by_height(&height) else {
                 break;
             };
-            // The `unwrap_or_else` default is never reached in practice: the Sapling/Orchard
-            // lookups above already `break` for any height `ironwood_tree_by_height` would
-            // return `None` for (above the tip, or a fast-synced database's absent band).
-            let ironwood_root = self
-                .ironwood_tree_by_height(&height)
-                .map(|tree| tree.root())
-                .unwrap_or_else(|| ironwood::tree::NoteCommitmentTree::default().root());
+            let Some(ironwood) = self.ironwood_tree_by_height(&height) else {
+                break;
+            };
 
             let (sapling_tx, orchard_tx, ironwood_tx, auth_data_root) = self
                 .block(height.into())
@@ -255,7 +281,7 @@ impl ZakuraDb {
                 height,
                 sapling_root: sapling.root(),
                 orchard_root: orchard.root(),
-                ironwood_root,
+                ironwood_root: ironwood.root(),
                 sapling_tx,
                 orchard_tx,
                 ironwood_tx,

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
@@ -669,6 +669,57 @@ fn header_range_roots_do_not_overwrite_committed_serving_index_rows() {
     );
 }
 
+/// Finalized root reads are indexed by block height, not by sparse tree rows.
+///
+/// Empty-shielded blocks leave the note-commitment trees unchanged, so only the
+/// genesis tree row is stored for this fixture. The range helper must still
+/// return one root payload for every committed height.
+#[test]
+fn finalized_commitment_roots_cover_unchanged_tree_heights() {
+    let _init_guard = zakura_test::init();
+    let genesis = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .expect("genesis block deserializes");
+    let block1 = zakura_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .expect("block 1 deserializes");
+    let mut state = ZakuraDb::new(
+        &Config::ephemeral(),
+        STATE_DATABASE_KIND,
+        &state_database_format_version_in_code(),
+        &Mainnet,
+        true,
+        STATE_COLUMN_FAMILIES_IN_CODE
+            .iter()
+            .map(ToString::to_string),
+        false,
+    )
+    .expect("opening the finalized state database should succeed");
+
+    write_full_block(&mut state, genesis);
+    write_full_block(&mut state, block1.clone());
+
+    assert_eq!(
+        state
+            .sapling_tree_by_height_range(Height(0)..=Height(1))
+            .count(),
+        1,
+        "the fixture must keep the Sapling tree column family sparse"
+    );
+
+    let roots = state.finalized_commitment_roots_by_height_range(Height(0)..=Height(1));
+    assert_eq!(
+        roots.iter().map(|roots| roots.height).collect::<Vec<_>>(),
+        vec![Height(0), Height(1)],
+        "every committed height must have a finalized root payload"
+    );
+    assert_eq!(
+        roots[1].auth_data_root,
+        block1.auth_data_root(),
+        "the unchanged-tree height still carries its own block auth-data root"
+    );
+}
+
 /// Pruning-readiness guard: a committed height whose body is removed (as online
 /// pruning deletes `tx_by_loc` rows) keeps its header readable from the retained
 /// consensus `block_header_by_height`, because the header readers are not gated

--- a/zakura-state/src/service/non_finalized_state.rs
+++ b/zakura-state/src/service/non_finalized_state.rs
@@ -379,9 +379,8 @@ impl NonFinalizedState {
         };
 
         let invalidated_blocks = if chain.non_finalized_root_hash() == block_hash {
-            let chain_tip_hash = chain.non_finalized_tip_hash();
             self.chain_set
-                .retain(|chain| chain.non_finalized_tip_hash() != chain_tip_hash);
+                .retain(|chain| !chain.contains_block_hash(block_hash));
             chain.blocks.values().cloned().collect()
         } else {
             let (new_chain, invalidated_blocks) = chain

--- a/zakura-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zakura-state/src/service/non_finalized_state/tests/vectors.rs
@@ -346,8 +346,8 @@ fn new_invalidate_test_state(network: &Network) -> (NonFinalizedState, Finalized
 /// Invalidating the non-finalized root of a tracked chain previously called
 /// `BTreeSet::remove(&chain)`, which compared the stored chain against
 /// itself via `Chain::cmp` and reached an `unreachable!()` for matching tip
-/// hashes. The root branch now retains by tip hash and the call returns
-/// successfully without panicking.
+/// hashes. The root branch now retains chains that do not contain the root
+/// hash, so the call returns successfully without panicking.
 #[test]
 fn invalidating_non_finalized_root_does_not_panic() {
     let _init_guard = zakura_test::init();
@@ -373,6 +373,43 @@ fn invalidating_non_finalized_root_does_not_panic() {
         state.best_chain().is_none(),
         "invalidating the root should leave no live non-finalized chain"
     );
+}
+
+/// A non-finalized root can be shared by multiple sibling forks. Invalidating
+/// that root must remove every live fork containing it, not only the best fork
+/// selected to populate the invalidation record.
+#[test]
+fn invalidating_shared_non_finalized_root_removes_all_forks() {
+    let _init_guard = zakura_test::init();
+
+    let network = Network::Mainnet;
+    let block1: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+    let block2a = block1.make_fake_child().set_work(10);
+    let block2b = block1.make_fake_child().set_work(11);
+
+    let (mut state, finalized_state) = new_invalidate_test_state(&network);
+
+    state
+        .commit_new_chain(block1.clone().prepare(), &finalized_state)
+        .expect("fake root block should commit to an empty non-finalized state");
+    state
+        .commit_block(block2a.clone().prepare(), &finalized_state)
+        .expect("first fork tip should extend the root chain");
+    state
+        .commit_block(block2b.clone().prepare(), &finalized_state)
+        .expect("second fork tip should fork from the root chain");
+
+    state
+        .invalidate_block(block1.hash())
+        .expect("invalidating a shared root should remove every descendant fork");
+
+    assert!(
+        state.best_chain().is_none(),
+        "invalidating a shared root should leave no live non-finalized chain"
+    );
+    assert!(!state.any_chain_contains(&block1.hash()));
+    assert!(!state.any_chain_contains(&block2a.hash()));
+    assert!(!state.any_chain_contains(&block2b.hash()));
 }
 
 /// Regression test for https://github.com/ZcashFoundation/zebra/issues/10586.


### PR DESCRIPTION
## Motivation

Bring four focused correctness fixes from #165 into a smaller reviewable PR while preserving each fix as its own commit.

The affected behavior had four distinct root causes:

- finalized root-range reads iterated sparse Sapling tree rows as if every height were present;
- generated local networks skipped NU6.1 activation even though later upgrades still trigger its one-time lockbox rule;
- `Solution::check()` allowed Common `(200, 9)` proofs on Regtest despite Regtest using `(48, 5)`;
- invalidating a shared non-finalized root removed only one matching chain instead of every descendant fork.

## Solution

Cherry-pick the four corresponding commits from #165, commit by commit:

- `fix(chain): satisfy the lockbox rule on local-genesis networks activating NU6.1 or later`
- `fix(chain): reject common equihash proofs on regtest`
- `fix(state): remove all forks when invalidating shared root`
- `fix(state): fill finalized root ranges across unchanged trees`

The local-genesis fix configures NU6.1 at the shared activation height and adds a zero-value P2SH marker output. Equihash verification now enforces an exact network/solution-variant mapping. Shared-root invalidation retains only chains that do not contain the invalidated hash. Finalized root reads now walk every requested height and resolve each sparse tree through its backwards lookup.

Changelog changes from #165 are intentionally excluded.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-chain nu6_1_can_be_the_latest_network_upgrade`
- `cargo test -p zakura-chain real_common_solution_is_rejected_on_regtest`
- `cargo test -p zakura-consensus local_genesis_nu6_3_activation_has_satisfiable_lockbox_rule`
- `cargo test -p zakura-rpc local_genesis_activation_coinbase_includes_lockbox_marker`
- `cargo test -p zakura-state finalized_commitment_roots_cover_unchanged_tree_heights`
- `cargo test -p zakura-state invalidating_shared_non_finalized_root_removes_all_forks`

These regressions cover the affected activation configuration and coinbase template, reject a known-valid Common proof on Regtest, remove sibling forks sharing an invalid root, and return roots for finalized heights whose trees did not change.

### Specifications & References

- Source PR: #165
- ZIP 271 lockbox disbursement rule
- Equihash parameters `(200, 9)` and Regtest `(48, 5)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus validation (Equihash, ZIP-271 subsidy), mining coinbase construction, and state fork invalidation plus commitment-root serving—incorrect behavior could reject valid blocks or serve wrong roots, but changes are narrow with targeted regression tests.
> 
> **Overview**
> Cherry-picks four focused correctness fixes from #165 across chain, consensus, RPC, and state.
> 
> **Local genesis / NU6.1:** Generated local testnets now activate **NU6.1** at the shared activation height when the chosen upgrade is NU6.1 or later, and configure a **zero-value P2SH lockbox marker** so activation-block coinbases and mining templates can satisfy the one-time ZIP-271 disbursement rule without skipping NU6.1. Adds validation that upgrades have a consensus branch ID and regression tests for NU6.1-as-latest, subsidy checks, and `get_block_template` coinbase output.
> 
> **Equihash:** `Solution::check` now enforces a strict network↔variant mapping—**Regtest only accepts `(48, 5)` Regtest solutions**; Mainnet/Testnet only accept `(200, 9)` Common—rejecting the reverse mismatch (e.g. valid Mainnet proofs on Regtest).
> 
> **Non-finalized state:** Invalidating a **shared non-finalized root** drops **every** chain that contains that hash, not only the chain selected for the invalidation record (fixes sibling forks surviving).
> 
> **Finalized roots:** `finalized_commitment_roots_by_height_range` walks **each requested block height** and resolves Sapling/Orchard/Ironwood trees via per-height backward lookup instead of iterating sparse tree CF rows, so unchanged-tree heights still get root payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224acea2e6e1927a24d81166dbb5744aae7c74da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->