### PR TITLE
fix(rpc): avoid repeated mempool index rebuilds

### DIFF
--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -1686,6 +1686,10 @@ where
                 last_seen_tip_hash: _,
             } => {
                 if verbose {
+                    let transactions_by_id = transactions
+                        .iter()
+                        .map(|unmined_tx| (unmined_tx.transaction.id.mined_id(), unmined_tx))
+                        .collect::<HashMap<_, _>>();
                     let map = transactions
                         .iter()
                         .map(|unmined_tx| {
@@ -1693,7 +1697,7 @@ where
                                 unmined_tx.transaction.id.mined_id().encode_hex(),
                                 get_raw_mempool::MempoolObject::from_verified_unmined_tx(
                                     unmined_tx,
-                                    &transactions,
+                                    &transactions_by_id,
                                     &transaction_dependencies,
                                 ),
                             )

--- a/zakura-rpc/src/methods/tests/prop.rs
+++ b/zakura-rpc/src/methods/tests/prop.rs
@@ -257,6 +257,10 @@ proptest! {
         runtime.block_on(async move {
             if verbose.unwrap_or(false) {
                 let (expected_response, mempool_query) = {
+                    let transactions_by_id = transactions
+                        .iter()
+                        .map(|unmined_tx| (unmined_tx.transaction.id.mined_id(), unmined_tx))
+                        .collect::<HashMap<_, _>>();
                     let transaction_dependencies = Default::default();
                     let txs = transactions
                         .iter()
@@ -265,7 +269,7 @@ proptest! {
                                 unmined_tx.transaction.id.mined_id().encode_hex(),
                                 MempoolObject::from_verified_unmined_tx(
                                     unmined_tx,
-                                    &transactions,
+                                    &transactions_by_id,
                                     &transaction_dependencies,
                                 ),
                             )

--- a/zakura-rpc/src/methods/types/get_raw_mempool.rs
+++ b/zakura-rpc/src/methods/types/get_raw_mempool.rs
@@ -6,7 +6,11 @@ use derive_getters::Getters;
 use derive_new::new;
 use hex::ToHex as _;
 
-use zakura_chain::{amount::NonNegative, block::Height, transaction::VerifiedUnminedTx};
+use zakura_chain::{
+    amount::NonNegative,
+    block::Height,
+    transaction::{Hash, VerifiedUnminedTx},
+};
 use zakura_node_services::mempool::TransactionDependencies;
 
 use super::zec::Zec;
@@ -58,15 +62,9 @@ pub struct MempoolObject {
 impl MempoolObject {
     pub(crate) fn from_verified_unmined_tx(
         unmined_tx: &VerifiedUnminedTx,
-        transactions: &[VerifiedUnminedTx],
+        transactions_by_id: &HashMap<Hash, &VerifiedUnminedTx>,
         transaction_dependencies: &TransactionDependencies,
     ) -> Self {
-        // Map transactions by their txids to make lookups easier
-        let transactions_by_id = transactions
-            .iter()
-            .map(|unmined_tx| (unmined_tx.transaction.id.mined_id(), unmined_tx))
-            .collect::<HashMap<_, _>>();
-
         // Get txids of this transaction's descendants (dependents)
         let empty_set = HashSet::new();
         let deps = transaction_dependencies


### PR DESCRIPTION
## Motivation

Backport Zebra #10599. Verbose `getrawmempool` rebuilt a transaction-ID index once per mempool transaction, causing O(N²) CPU and allocation work.

## Solution

Build the index once per RPC response and reuse it while constructing all verbose mempool objects.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-rpc mempool_transactions_are_sent_to_caller --lib`
- `cargo clippy -p zakura-rpc --all-targets -- -D warnings`

### Specifications & References

Backport of https://github.com/ZcashFoundation/zebra/pull/10599

### AI disclosure

Used Codex to adapt and validate the upstream patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactor of verbose getrawmempool assembly; RPC output shape and logic are unchanged aside from avoiding redundant indexing.
> 
> **Overview**
> Verbose **`getrawmempool`** no longer rebuilds a transaction-ID **`HashMap`** inside **`MempoolObject::from_verified_unmined_tx`** for every mempool entry. That path previously did **O(N²)** work when the mempool was large.
> 
> The RPC handler now builds **`transactions_by_id`** once per **`FullTransactions`** response and passes that map into each verbose object. **`from_verified_unmined_tx`** takes **`&HashMap<Hash, &VerifiedUnminedTx>`** instead of the full slice. Property tests mirror the same single-index pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c4b161cadfcc254061aa14d228b20167084738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->