### PR TITLE
fix(state): keep raw RocksDB access test-only

### DIFF
--- a/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/zakura-state/src/service/finalized_state/disk_db.rs
@@ -43,7 +43,8 @@ use super::zakura_db::transparent::{
 #[allow(unused_imports)]
 use super::{TypedColumnFamily, WriteTypedBatch};
 
-#[cfg(any(test, feature = "proptest-impl"))]
+// These helpers expose the raw RocksDB handle, so they must remain test-only.
+#[cfg(test)]
 mod tests;
 
 /// The [`rocksdb::ThreadMode`] used by the database.


### PR DESCRIPTION
## Motivation

`disk_db::tests` was compiled when either `cfg(test)` or the
`proptest-impl` feature was enabled. That module implements
`Deref<Target = DB>` for `DiskDb`, so a feature-enabled non-test build could
walk from `ZakuraDb` through `DiskDb` to the raw RocksDB handle and bypass the
guarded write APIs.

## Solution

Compile the low-level database test module only under `cfg(test)`. Proptest
support remains available, while the raw RocksDB dereference helper stays
confined to unit-test builds.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura-state --features proptest-impl`
- `cargo test -p zakura-state service::finalized_state::disk_db::tests::zs_iter_opts_increments_key_by_one --lib`
- Confirmed a downstream crate using `proptest-impl` can no longer call raw
  `ZakuraDb::put` (expected `E0599`)

### Specifications & References

None.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single cfg gate change with no production API behavior change; reduces accidental exposure of raw RocksDB access.
> 
> **Overview**
> **`disk_db::tests` is now compiled only under `cfg(test)`**, not when the `proptest-impl` feature is enabled on non-test builds.
> 
> That module provides a **`Deref` to the raw RocksDB `DB`**, so compiling it with `proptest-impl` let downstream crates reach unguarded low-level `put`/similar APIs through `ZakuraDb` → `DiskDb`. Proptest support stays available elsewhere; only the raw-handle test helpers are confined to unit-test builds. A short comment documents why the gate is test-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6814673d5968614b2b94b23dfe7d1183b9634d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->