### PR TITLE
remove(rpc): delete obsolete Zallet build path

### DIFF
--- a/zakura-rpc/build.rs
+++ b/zakura-rpc/build.rs
@@ -2,20 +2,10 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
-    process::Command,
 };
-
-// 0.1.0-alpha.2 - https://github.com/zcash/wallet/commit/027e5e2139b2ca8f0317edb9d802b03a46e9aa4c
-const ZALLET_COMMIT: Option<&str> = Some("027e5e2139b2ca8f0317edb9d802b03a46e9aa4c");
-
-// Zaino last tested commit - https://github.com/zingolabs/zaino/commit/559510ffcc62a5a6e7bb20db5e3329654542c8b1
-// TODO: Zaino is not currently built by this build script.
-#[allow(dead_code)]
-const ZAINO_COMMIT: Option<&str> = Some("559510ffcc62a5a6e7bb20db5e3329654542c8b1");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_or_copy_proto()?;
-    build_zallet_for_qa_tests();
     build_rpc_schema()?;
 
     Ok(())
@@ -57,64 +47,6 @@ fn build_or_copy_proto() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-}
-
-fn build_zallet_for_qa_tests() {
-    if env::var_os("ZALLET").is_some() {
-        // The following code will clone the zallet repo and build the binary,
-        // then copy the binary to the project target directory.
-        //
-        // Code below is fragile and will just build the main branch of the wallet repository
-        // so we can have it available for `qa` regtests.
-
-        let build_dir = env::var("OUT_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_default()
-            .join("zallet_build");
-
-        let profile = "debug".to_string();
-
-        let target_dir = env::var("CARGO_TARGET_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| std::env::current_dir().expect("failed to get current dir"))
-            .join("../target")
-            .join(&profile);
-
-        let _ = Command::new("git")
-            .args([
-                "clone",
-                "https://github.com/zcash/wallet.git",
-                build_dir.to_str().unwrap(),
-            ])
-            .status()
-            .expect("failed to clone external binary");
-
-        if let Some(zallet_commit) = ZALLET_COMMIT {
-            let _ = Command::new("git")
-                .args(["checkout", zallet_commit])
-                .current_dir(&build_dir)
-                .status()
-                .expect("failed to build external binary");
-        }
-
-        let _ = Command::new("cargo")
-            .args(["build"])
-            .current_dir(&build_dir)
-            .status()
-            .expect("failed to build external binary");
-
-        fs::copy(
-            build_dir.join(format!("target/{profile}/zallet")),
-            target_dir.join("zallet"),
-        )
-        .unwrap_or_else(|_| {
-            panic!(
-                "failed to copy zallet binary from {} to {}",
-                build_dir.display(),
-                target_dir.display()
-            )
-        });
-    }
 }
 
 fn build_rpc_schema() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Motivation

The `ZALLET`-gated build path was left behind when the Python QA RPC test
framework was removed in favor of the external integration-test project. It
has no remaining caller, but setting the environment variable still makes an
ordinary `zakura-rpc` build clone and compile an external wallet repository.

The path also ignores unsuccessful clone, checkout, and build exit statuses,
so it does not reliably enforce its pinned external commit before copying the
resulting binary.

## Solution

Remove the obsolete Zallet build function and invocation, along with the
unused Zallet and Zaino commit constants and `Command` import.

This keeps external QA dependency setup out of the Cargo build script and
eliminates the stale non-hermetic build path.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura-rpc`
- Confirmed the repository has no remaining `ZALLET`, `ZAINO`,
  `zallet_build`, or `build_zallet_for_qa_tests` references

### Specifications & References

- The old QA framework was removed upstream in commit `cee966b2d`.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only cleanup with no runtime or RPC behavior changes; reduces non-hermetic build side effects.
> 
> **Overview**
> **Removes** the legacy `ZALLET` environment-variable path from `zakura-rpc/build.rs` that cloned and built the external `zcash/wallet` repo during Cargo builds.
> 
> The deleted `build_zallet_for_qa_tests` logic, pinned Zallet/Zaino commit constants, and `std::process::Command` import are gone; `main` now only runs proto generation and OpenRPC schema generation. This stops accidental network/git side effects on build and drops a QA workflow that no longer has callers after the old Python RPC QA framework was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678bdeb4da75ce9480da3215d37698ccda2828ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->