### PR TITLE
fix(sync): cap FindBlocks response hashes after trailing strip

### DIFF
--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -156,6 +156,15 @@ pub const MIN_CONCURRENCY_LIMIT: usize = 1;
 /// See [`MIN_CHECKPOINT_CONCURRENCY_LIMIT`] for details.
 pub const MAX_TIPS_RESPONSE_HASH_COUNT: usize = 500;
 
+/// Returns true if a `FindBlocks` response has the protocol maximum number of
+/// block hashes or fewer.
+///
+/// This rejects oversized generic `inv` messages before they can inflate the
+/// syncer's discovered-hash reserve.
+fn has_valid_tips_response_hash_count(hashes: &[block::Hash]) -> bool {
+    hashes.len() <= MAX_TIPS_RESPONSE_HASH_COUNT
+}
+
 /// Start asking peers for more block hashes before we run out of hashes to download.
 ///
 /// The syncer keeps a list of block hashes it has learned from `FindBlocks`
@@ -1555,6 +1564,15 @@ where
                 .map_err::<Report, _>(|e| eyre!(e))
             {
                 Ok(zn::Response::BlockHashes(hashes)) => {
+                    if !has_valid_tips_response_hash_count(&hashes) {
+                        debug!(
+                            hashes.len = hashes.len(),
+                            max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
+                            "discarding oversized FindBlocks response"
+                        );
+                        continue;
+                    }
+
                     trace!(?hashes);
 
                     // zcashd sometimes appends an unrelated hash at the start
@@ -1717,6 +1735,15 @@ where
                     .map_err::<Report, _>(|e| eyre!(e))
                 {
                     Ok(zn::Response::BlockHashes(hashes)) => {
+                        if !has_valid_tips_response_hash_count(&hashes) {
+                            debug!(
+                                hashes.len = hashes.len(),
+                                max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
+                                "discarding oversized FindBlocks response"
+                            );
+                            continue;
+                        }
+
                         debug!(first = ?hashes.first(), len = ?hashes.len());
                         trace!(?hashes);
 

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -156,10 +156,13 @@ pub const MIN_CONCURRENCY_LIMIT: usize = 1;
 /// See [`MIN_CHECKPOINT_CONCURRENCY_LIMIT`] for details.
 pub const MAX_TIPS_RESPONSE_HASH_COUNT: usize = 500;
 
-/// Returns true if a `FindBlocks` response has the protocol maximum number of
+/// Returns true if a `FindBlocks` hash list has the protocol maximum number of
 /// block hashes or fewer.
 ///
-/// This rejects oversized generic `inv` messages before they can inflate the
+/// Callers that discard zcashd's extra trailing hash must apply this check to
+/// the hashes that remain after stripping. That way a 501-hash zcashd response
+/// (500 chain hashes plus one appended hash) is accepted as 500 usable hashes,
+/// while larger responses are still rejected before they can inflate the
 /// syncer's discovered-hash reserve.
 fn has_valid_tips_response_hash_count(hashes: &[block::Hash]) -> bool {
     hashes.len() <= MAX_TIPS_RESPONSE_HASH_COUNT
@@ -1564,15 +1567,6 @@ where
                 .map_err::<Report, _>(|e| eyre!(e))
             {
                 Ok(zn::Response::BlockHashes(hashes)) => {
-                    if !has_valid_tips_response_hash_count(&hashes) {
-                        debug!(
-                            hashes.len = hashes.len(),
-                            max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
-                            "discarding oversized FindBlocks response"
-                        );
-                        continue;
-                    }
-
                     trace!(?hashes);
 
                     // zcashd sometimes appends an unrelated hash at the start
@@ -1603,6 +1597,18 @@ where
                         }
                     };
                     if hashes.is_empty() {
+                        continue;
+                    }
+
+                    // Apply the count guard after stripping zcashd's trailing
+                    // hash so a full 500-hash chain plus one appended hash is
+                    // still usable.
+                    if !has_valid_tips_response_hash_count(hashes) {
+                        debug!(
+                            hashes.len = hashes.len(),
+                            max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
+                            "discarding oversized FindBlocks response"
+                        );
                         continue;
                     }
 
@@ -1735,15 +1741,6 @@ where
                     .map_err::<Report, _>(|e| eyre!(e))
                 {
                     Ok(zn::Response::BlockHashes(hashes)) => {
-                        if !has_valid_tips_response_hash_count(&hashes) {
-                            debug!(
-                                hashes.len = hashes.len(),
-                                max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
-                                "discarding oversized FindBlocks response"
-                            );
-                            continue;
-                        }
-
                         debug!(first = ?hashes.first(), len = ?hashes.len());
                         trace!(?hashes);
 
@@ -1792,6 +1789,18 @@ where
                             [] => continue,
                             [rest @ .., _last] => rest,
                         };
+
+                        // Apply the count guard after stripping the trailing
+                        // hash so a full 500-hash chain plus one appended hash
+                        // is still usable.
+                        if !has_valid_tips_response_hash_count(unknown_hashes) {
+                            debug!(
+                                hashes.len = unknown_hashes.len(),
+                                max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
+                                "discarding oversized FindBlocks response"
+                            );
+                            continue;
+                        }
 
                         let new_tip = if let Some(end) = unknown_hashes.rchunks_exact(2).next() {
                             CheckedTip {

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -72,6 +72,8 @@ const STALLED_SERVICE_REQUEST_DELAY: Duration = Duration::from_secs(30 * 60);
 fn oversized_find_blocks_response_is_rejected() {
     let hash = block::Hash([0; 32]);
 
+    // The guard is applied after ObtainTips/ExtendTips strip zcashd's extra
+    // trailing hash, so 500 remaining hashes are accepted and 501 are not.
     assert!(sync::has_valid_tips_response_hash_count(&vec![
         hash;
         sync::MAX_TIPS_RESPONSE_HASH_COUNT
@@ -81,6 +83,13 @@ fn oversized_find_blocks_response_is_rejected() {
         sync::MAX_TIPS_RESPONSE_HASH_COUNT
             + 1
     ]));
+
+    // A zcashd response with 500 chain hashes plus one appended hash must remain
+    // usable after the trailing hash is discarded.
+    let raw = vec![hash; sync::MAX_TIPS_RESPONSE_HASH_COUNT + 1];
+    let stripped = &raw[..raw.len() - 1];
+    assert_eq!(stripped.len(), sync::MAX_TIPS_RESPONSE_HASH_COUNT);
+    assert!(sync::has_valid_tips_response_hash_count(stripped));
 }
 
 /// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips.

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -68,6 +68,21 @@ const MAX_SERVICE_REQUEST_DELAY: Duration = Duration::from_millis(1000);
 /// unrelated failure. These tests pause time, so a long delay costs no wall-clock time.
 const STALLED_SERVICE_REQUEST_DELAY: Duration = Duration::from_secs(30 * 60);
 
+#[test]
+fn oversized_find_blocks_response_is_rejected() {
+    let hash = block::Hash([0; 32]);
+
+    assert!(sync::has_valid_tips_response_hash_count(&vec![
+        hash;
+        sync::MAX_TIPS_RESPONSE_HASH_COUNT
+    ]));
+    assert!(!sync::has_valid_tips_response_hash_count(&vec![
+        hash;
+        sync::MAX_TIPS_RESPONSE_HASH_COUNT
+            + 1
+    ]));
+}
+
 /// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips.
 ///
 /// This test also makes sure that the syncer downloads blocks in order.


### PR DESCRIPTION
## Motivation

Legacy peers can send generic `inv` responses containing up to 50,000 entries, but `getblocks` pagination is limited to 500 hashes. The syncer accepted the full response into its discovered-hash reserve.

## Solution

Reject `FindBlocks` responses with more than `MAX_TIPS_RESPONSE_HASH_COUNT` hashes before state lookups, reserve insertion, or lookahead calculations. Apply the check to both ObtainTips and ExtendTips.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura oversized_find_blocks_response_is_rejected --lib`
- `cargo clippy -p zakura --lib -- -D warnings`

### Specifications & References

- `MAX_FIND_BLOCK_HASHES_RESULTS` is 500 for `getblocks` responses.

### AI Disclosure

Used Codex to implement the response-bound check and its focused unit test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches initial sync’s tip discovery path and peer-response handling; the change is narrow and defensive but incorrect bounds could reject valid peers or still admit bad data.
> 
> **Overview**
> Caps how many block hashes legacy **`FindBlocks`** responses can contribute to the syncer’s discovered-hash reserve, so oversized peer replies (e.g. huge generic `inv` payloads) no longer flood the pipeline before state lookups or lookahead logic run.
> 
> Adds **`has_valid_tips_response_hash_count`** (≤ **`MAX_TIPS_RESPONSE_HASH_COUNT`**, 500) and applies it in **ObtainTips** and **ExtendTips** *after* stripping zcashd’s extra trailing hash, so a normal 501-hash reply (500 chain hashes + one append) still counts as 500 usable hashes while anything larger is logged and dropped. A focused unit test covers the accept/reject boundary and the strip-then-check behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e9a8f5f14cd577675308bf69c4df726e9fc438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->