### PR TITLE
fix(state): harden VCT checkpoint validation

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -27,6 +27,8 @@ exclude = [
     "^https://eprint\\.iacr\\.org/",
     # Tor's GitLab returns 403 to automated link checkers
     "^https://gitlab\\.torproject\\.org/",
+    # The ZIP site returns 521 to GitHub-hosted automated link checkers
+    "^https://zips\\.z\\.cash/",
 
     # These routes will become available when the Zakura website launches.
     "^https://zakura\\.com/",

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -393,9 +393,11 @@ The ZIP-221 MMR does not authenticate everything, so three gaps are closed by di
 
 A block's own commitment check `C(X, T_{X-1})` is the _identical_ computation the previous
 fast block already ran as its look-ahead one commit earlier. The committer caches the
-look-ahead result as `(next_height, next_hash)` and skips a block's own check when the prior
-look-ahead validated exactly it. The guard is hash identity and heights are monotonic, so a
-stale or cloned cache entry can never cause a false skip. Steady state drops from two
+look-ahead result as `(next_height, next_hash, next_auth_data_root)` and skips a block's own
+check when the prior look-ahead validated exactly it. Below NU5 the auth-data-root component is
+unused because it is not an input to the header commitment. At NU5 and later it binds a
+header-only successor witness to the later body, so a same-header body with different
+authorizing data cannot reuse the earlier prevalidation. Steady state drops from two
 commitment checks per block to one (legacy parity) while still attesting every root before it
 is persisted. A non-last checkpoint height fast block with no buffered successor is deferred by the write
 worker until the successor arrives; the checkpoint last checkpoint height is the only no-successor fast commit
@@ -412,10 +414,9 @@ construction_ — but the public API previously let it be desynced after constru
 (`pub auth_data_root`, `DerefMut`, both re-exported). A holder could swap the block while
 keeping a stale root, and a header matching the stale root would finalize a block without
 proving the header binds the block's actual authorizing data. The (block, auth-data-root) pair
-is now locked together: `auth_data_root` is `pub(crate)`, `CheckpointVerifiedBlock` drops
-`DerefMut`, the one legitimately-post-set field goes through
-`set_deferred_pool_balance_change`, and the semantic verifier builds blocks through
-`from_semantic_data` (auth-data root left unset). Compile-time enforced (fix in commit #192).
+is locked together: `CheckpointVerifiedBlock` drops `DerefMut`, and the checkpoint verifier
+can only fill the optional cache through `with_precomputed_auth_data_root`, which computes the
+value from that same wrapped block rather than accepting arbitrary bytes.
 
 ## 7. The fast commit path and checkpoint last checkpoint height
 
@@ -430,7 +431,8 @@ logic. For a checkpoint-verified block at `height`:
    - apply the direct below-Heartwood/below-NU5/below-Nu6_3 checks (§6.1);
    - build a candidate history tree with the roots folded in (`HistoryTree::push`);
    - **verify-before-commit:** either check the buffered successor's commitment against the
-     candidate (the one-block-lag confirmation) and cache `(height+1, next_hash)` as
+     candidate (the one-block-lag confirmation) and cache
+     `(height+1, next_hash, next_auth_data_root)` as
      pre-validated, or, at the checkpoint last checkpoint height only, verify the embedded final
      frontiers — including Ironwood — against this height's roots; a failure means _this_
      height's root is bad → reject and evict (§8);

--- a/zakura-consensus/src/checkpoint.rs
+++ b/zakura-consensus/src/checkpoint.rs
@@ -1152,11 +1152,12 @@ where
             if req_block.block.auth_data_root.is_none()
                 && NetworkUpgrade::current(&network, req_block.block.height) >= NetworkUpgrade::Nu5
             {
-                let block = req_block.block.block.clone();
-                if let Ok(auth_data_root) =
-                    tokio::task::spawn_blocking(move || block.auth_data_root()).await
+                let block = req_block.block.clone();
+                if let Ok(block) =
+                    tokio::task::spawn_blocking(move || block.with_precomputed_auth_data_root())
+                        .await
                 {
-                    req_block.block.auth_data_root = Some(auth_data_root);
+                    req_block.block = block;
                 }
             }
 

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -571,6 +571,17 @@ pub enum ValidateContextError {
     #[non_exhaustive]
     VctSuppliedRootAwaitingSuccessor { height: block::Height },
 
+    #[error(
+        "checkpoint block at {height:?} has authorizing-data root {actual:?}, but its cached \
+         header prevalidation requires {expected:?}"
+    )]
+    #[non_exhaustive]
+    VctBlockAuthDataRootMismatch {
+        height: block::Height,
+        expected: block::merkle::AuthDataRoot,
+        actual: block::merkle::AuthDataRoot,
+    },
+
     #[error("block height {candidate_height:?} is lower than the current finalized height {finalized_tip_height:?}")]
     #[non_exhaustive]
     OrphanedBlock {

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    ops::{Add, Deref, DerefMut, RangeInclusive},
+    ops::{Add, Deref, RangeInclusive},
     pin::Pin,
     sync::Arc,
 };
@@ -552,7 +552,7 @@ impl CheckpointVerifiedBlock {
         deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
     ) -> Self {
         let mut block = Self::with_hash(block.clone(), hash.unwrap_or(block.hash()));
-        block.deferred_pool_balance_change = deferred_pool_balance_change;
+        block.0.deferred_pool_balance_change = deferred_pool_balance_change;
         block
     }
     /// Creates a block that's ready to be committed to the finalized state,
@@ -576,6 +576,15 @@ impl CheckpointVerifiedBlock {
             deferred_pool_balance_change: None,
             auth_data_root: None,
         })
+    }
+
+    /// Returns this checkpoint block with an auth-data root computed from its wrapped block.
+    ///
+    /// Computing the root internally prevents callers from pairing a cached root with a
+    /// different block.
+    pub fn with_precomputed_auth_data_root(mut self) -> Self {
+        self.0.auth_data_root = Some(self.0.block.auth_data_root());
+        self
     }
 }
 
@@ -680,6 +689,24 @@ mod tests {
         assert_eq!(transaction_hashes.as_ref(), expected_transaction_hashes);
         assert_eq!(auth_data_root, block.auth_data_root());
     }
+
+    #[test]
+    fn checkpoint_precomputed_auth_data_root_matches_its_block() {
+        let _init_guard = zakura_test::init();
+
+        let block = Arc::new(
+            zakura_test::vectors::BLOCK_MAINNET_1687107_BYTES
+                .zcash_deserialize_into::<Block>()
+                .expect("NU5 mainnet block deserializes"),
+        );
+        let checkpoint = CheckpointVerifiedBlock::with_hash(block.clone(), block.hash());
+
+        assert!(checkpoint.auth_data_root.is_none());
+
+        let checkpoint = checkpoint.with_precomputed_auth_data_root();
+
+        assert_eq!(checkpoint.auth_data_root, Some(block.auth_data_root()));
+    }
 }
 
 impl From<ContextuallyVerifiedBlock> for SemanticallyVerifiedBlock {
@@ -723,11 +750,6 @@ impl Deref for CheckpointVerifiedBlock {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-impl DerefMut for CheckpointVerifiedBlock {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -282,6 +282,17 @@ pub struct SemanticallyVerifiedBlock {
 /// Note: The difference between a `CheckpointVerifiedBlock` and a `ContextuallyVerifiedBlock` is
 /// that the `CheckpointVerifier` doesn't bind the transaction authorizing data to the
 /// `ChainHistoryBlockTxAuthCommitmentHash`, but the `NonFinalizedState` and `FinalizedState` do.
+///
+/// The wrapped block and any cached authorizing-data root must not be changed independently:
+///
+/// ```compile_fail
+/// use zakura_chain::block::merkle::AuthDataRoot;
+/// use zakura_state::CheckpointVerifiedBlock;
+///
+/// fn replace_cached_root(mut block: CheckpointVerifiedBlock, root: AuthDataRoot) {
+///     block.auth_data_root = Some(root);
+/// }
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CheckpointVerifiedBlock(pub(crate) SemanticallyVerifiedBlock);
 

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -770,6 +770,44 @@ impl FinalizedState {
                             .then(|| {
                                 precomputed_auth_data_root.unwrap_or_else(|| block.auth_data_root())
                             });
+
+                        // A successful look-ahead check authenticates both this header and
+                        // its NU5+ auth-data root. A same-header body with a different root
+                        // can never become valid by replacing the supplied note-commitment
+                        // roots, so reject the body without evicting those roots or entering
+                        // the write loop's retry path.
+                        if let (
+                            Some((
+                                prevalidated_height,
+                                prevalidated_hash,
+                                Some(expected_auth_data_root),
+                            )),
+                            Some(actual_auth_data_root),
+                        ) = (self.vct.prevalidated_next(), block_auth_data_root)
+                        {
+                            if prevalidated_height == height
+                                && prevalidated_hash == block_hash
+                                && expected_auth_data_root != actual_auth_data_root
+                            {
+                                metrics::counter!("state.vct.block.auth_data_root_mismatch.count")
+                                    .increment(1);
+                                tracing::warn!(
+                                    ?height,
+                                    ?block_hash,
+                                    ?expected_auth_data_root,
+                                    ?actual_auth_data_root,
+                                    "VCT: checkpoint body auth-data root differs from its \
+                                     authenticated header prevalidation"
+                                );
+                                return Err(ValidateContextError::VctBlockAuthDataRootMismatch {
+                                    height,
+                                    expected: expected_auth_data_root,
+                                    actual: actual_auth_data_root,
+                                }
+                                .into());
+                            }
+                        }
+
                         let is_prevalidated = self.vct.prevalidated_next()
                             == Some((height, block_hash, block_auth_data_root));
                         if is_prevalidated {

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -23,7 +23,10 @@ use std::{
 };
 
 use zakura_chain::{
-    block, ironwood, orchard, parallel::tree::NoteCommitmentTrees, parameters::Network, sapling,
+    block, ironwood, orchard,
+    parallel::tree::NoteCommitmentTrees,
+    parameters::{Network, NetworkUpgrade},
+    sapling,
 };
 use zakura_db::{
     block::{RetentionPlan, ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT},
@@ -760,8 +763,15 @@ impl FinalizedState {
                             links
                         });
 
-                        let is_prevalidated =
-                            self.vct.prevalidated_next() == Some((height, block_hash));
+                        // NU5+ block hashes do not commit to authorizing data. Include the
+                        // body's auth-data root when matching a header-only prevalidation.
+                        let block_auth_data_root = (NetworkUpgrade::current(&network, height)
+                            >= NetworkUpgrade::Nu5)
+                            .then(|| {
+                                precomputed_auth_data_root.unwrap_or_else(|| block.auth_data_root())
+                            });
+                        let is_prevalidated = self.vct.prevalidated_next()
+                            == Some((height, block_hash, block_auth_data_root));
                         if is_prevalidated {
                             if let Some(v) = self.vct.source() {
                                 v.record_prevalidated();
@@ -812,8 +822,16 @@ impl FinalizedState {
                             })?;
 
                         if let Some(next_vct_block) = &next_vct_block {
-                            self.vct
-                                .mark_prevalidated(next_vct_block.height, next_vct_block.hash);
+                            let next_auth_data_root =
+                                (NetworkUpgrade::current(&network, next_vct_block.height)
+                                    >= NetworkUpgrade::Nu5)
+                                    .then_some(next_vct_block.auth_data_root)
+                                    .flatten();
+                            self.vct.mark_prevalidated(
+                                next_vct_block.height,
+                                next_vct_block.hash,
+                                next_auth_data_root,
+                            );
                         } else if self
                             .vct
                             .source()

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1876,7 +1876,11 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             let stale_hash = blocks[seed + 1].hash;
             prop_assert_ne!(stale_hash, blocks[seed + 3].hash, "stale hash must differ from the real block");
             fast.vct
-                .set_prevalidated_next(Some((Height((seed + 3) as u32), stale_hash)));
+                .set_prevalidated_next(Some((
+                    Height((seed + 3) as u32),
+                    stale_hash,
+                    Some(blocks[seed + 3].block.auth_data_root()),
+                )));
             commit(&mut fast, seed + 3);
             prop_assert_eq!(fast.vct_prevalidated_count(), 1, "a stale cache entry (wrong hash) must not cause a false skip");
 
@@ -1894,7 +1898,11 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 "the forged wrapper hash must differ from the bad block's real hash",
             );
             fast.vct
-                .set_prevalidated_next(Some((Height((seed + 4) as u32), forged_wrapper_hash)));
+                .set_prevalidated_next(Some((
+                    Height((seed + 4) as u32),
+                    forged_wrapper_hash,
+                    Some(blocks[seed + 4].block.auth_data_root()),
+                )));
             let forged = CheckpointVerifiedBlock::with_hash(bad_block, forged_wrapper_hash);
             let error = fast
                 .commit_finalized_direct(forged.into(), None, None, "vct forged wrapper hash")

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1817,9 +1817,59 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             prop_assert_eq!(fast.vct_prevalidated_count(), 0, "the first fast block runs its own commitment check");
 
             // Second fast block: its predecessor's look-ahead already validated it,
-            // so the own check is skipped — the dedup engages.
-            commit(&mut fast, seed + 2);
+            // so the own check is skipped — the dedup engages. Use a header-only
+            // successor, as production does when header sync is ahead of body sync.
+            let cv = CheckpointVerifiedBlock::from(blocks[seed + 2].block.clone());
+            let header_only_successor = NextVctBlock::from_header(
+                blocks[seed + 3].block.header.clone(),
+                Height((seed + 3) as u32),
+                blocks[seed + 3].block.auth_data_root(),
+            );
+            fast.commit_finalized_direct(
+                cv.into(),
+                None,
+                Some(header_only_successor),
+                "vct dedup header-only successor",
+            )
+            .expect("verified fast commit succeeds");
             prop_assert_eq!(fast.vct_prevalidated_count(), 1, "the second fast block skips its redundant own commitment check");
+
+            // ZIP-244 transaction IDs do not commit to authorizing data, so this
+            // later body has the same header hash as the witness but a different
+            // cached auth-data root. It must run its own commitment check rather
+            // than reuse the header-only witness's prevalidation.
+            let mut mismatched = CheckpointVerifiedBlock::from(blocks[seed + 3].block.clone());
+            let mismatched_auth_data_root =
+                zakura_chain::block::merkle::AuthDataRoot::from([0x42; 32]);
+            prop_assert_ne!(
+                mismatched.auth_data_root,
+                Some(mismatched_auth_data_root),
+                "the test needs a different auth-data root",
+            );
+            mismatched.0.auth_data_root = Some(mismatched_auth_data_root);
+
+            let error = fast
+                .commit_finalized_direct(
+                    mismatched.into(),
+                    None,
+                    None,
+                    "vct mismatched auth-data root",
+                )
+                .expect_err("a mismatched body must not reuse header-only prevalidation");
+            prop_assert!(
+                format!("{error:?}").contains("VctSuppliedRootUnavailable"),
+                "the mismatched body must fail its own commitment check, got: {error:?}",
+            );
+            prop_assert_eq!(
+                fast.vct_prevalidated_count(),
+                1,
+                "a mismatched auth-data root must not increment the prevalidated count",
+            );
+            prop_assert_eq!(
+                fast.db.finalized_tip_height(),
+                Some(Height((seed + 2) as u32)),
+                "the rejected body must leave finalized state untouched",
+            );
 
             // Stale-cache guard: overwrite the cache with the correct height but the
             // hash of a *different* block. The next commit must NOT skip.

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1768,10 +1768,11 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             let blocks: Vec<_> = chain.iter().collect();
             let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0 as usize;
 
-            // Seed just before NU5, then operate on four consecutive fast blocks so
-            // the forged-wrapper regression exercises `hashBlockCommitments`.
+            // Seed just before NU5, then operate on five consecutive fast blocks so
+            // the auth-data and forged-wrapper regressions exercise
+            // `hashBlockCommitments`.
             let seed = nu5 - 2;
-            let last = seed + 4;
+            let last = seed + 5;
             prop_assert!(blocks.len() > last + 1, "generated chain unexpectedly short");
 
             // Legacy pass to record the correct per-block roots as the fixture.
@@ -1834,19 +1835,54 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             .expect("verified fast commit succeeds");
             prop_assert_eq!(fast.vct_prevalidated_count(), 1, "the second fast block skips its redundant own commitment check");
 
-            // ZIP-244 transaction IDs do not commit to authorizing data, so this
-            // later body has the same header hash as the witness but a different
-            // cached auth-data root. It must run its own commitment check rather
-            // than reuse the header-only witness's prevalidation.
-            let mut mismatched = CheckpointVerifiedBlock::from(blocks[seed + 3].block.clone());
-            let mismatched_auth_data_root =
-                zakura_chain::block::merkle::AuthDataRoot::from([0x42; 32]);
-            prop_assert_ne!(
-                mismatched.auth_data_root,
-                Some(mismatched_auth_data_root),
-                "the test needs a different auth-data root",
+            // ZIP-244 transaction IDs do not commit to authorizing data. Mutate
+            // a transparent unlocking script as an untrusted peer can, producing
+            // a body with the expected header hash and transaction ID but a
+            // different auth-data root. (Coinbase scripts are a special case:
+            // they are bound by the mined transaction ID.)
+            let honest_block = blocks[seed + 3].block.clone();
+            let mut hostile_block = (*honest_block).clone();
+            let (transaction_index, input_index) = honest_block
+                .transactions
+                .iter()
+                .enumerate()
+                .find_map(|(transaction_index, transaction)| {
+                    transaction
+                        .inputs()
+                        .iter()
+                        .position(|input| {
+                            matches!(input, zakura_chain::transparent::Input::PrevOut { .. })
+                        })
+                        .map(|input_index| (transaction_index, input_index))
+                })
+                .expect("the generated NU5 block must contain a transparent spend");
+            let hostile_transaction =
+                Arc::make_mut(&mut hostile_block.transactions[transaction_index]);
+            let zakura_chain::transparent::Input::PrevOut { unlock_script, .. } =
+                &mut hostile_transaction.inputs_mut()[input_index]
+            else {
+                unreachable!("the selected input is a transparent spend");
+            };
+            *unlock_script = zakura_chain::transparent::Script::new(&[0x42]);
+            let hostile_block = Arc::new(hostile_block);
+
+            prop_assert_eq!(
+                hostile_block.hash(),
+                honest_block.hash(),
+                "authorizing-data malleation must preserve the block hash",
             );
-            mismatched.0.auth_data_root = Some(mismatched_auth_data_root);
+            prop_assert_eq!(
+                hostile_block.transactions[transaction_index].hash(),
+                honest_block.transactions[transaction_index].hash(),
+                "ZIP-244 transaction IDs must not bind transparent unlocking scripts",
+            );
+            prop_assert_ne!(
+                hostile_block.auth_data_root(),
+                honest_block.auth_data_root(),
+                "the hostile body must have a different auth-data root",
+            );
+
+            let mismatched = CheckpointVerifiedBlock::from(hostile_block);
 
             let error = fast
                 .commit_finalized_direct(
@@ -1857,8 +1893,13 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 )
                 .expect_err("a mismatched body must not reuse header-only prevalidation");
             prop_assert!(
-                format!("{error:?}").contains("VctSuppliedRootUnavailable"),
-                "the mismatched body must fail its own commitment check, got: {error:?}",
+                format!("{error:?}").contains("VctBlockAuthDataRootMismatch"),
+                "the mismatched body must be classified as invalid, got: {error:?}",
+            );
+            prop_assert_eq!(
+                error.vct_retryable_height(),
+                None,
+                "the write loop must not park and retry an irreparably invalid body",
             );
             prop_assert_eq!(
                 fast.vct_prevalidated_count(),
@@ -1871,17 +1912,29 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 "the rejected body must leave finalized state untouched",
             );
 
+            // Rejecting an invalid body must not evict the authenticated VCT
+            // roots. A subsequently downloaded honest body with the same hash
+            // can therefore commit after the write loop's hard-error reset and
+            // let checkpoint sync continue.
+            fast.clear_vct_prevalidated_next();
+            commit(&mut fast, seed + 3);
+            prop_assert_eq!(
+                fast.db.finalized_tip_height(),
+                Some(Height((seed + 3) as u32)),
+                "the honest same-hash body must commit after the hostile body is rejected",
+            );
+
             // Stale-cache guard: overwrite the cache with the correct height but the
             // hash of a *different* block. The next commit must NOT skip.
             let stale_hash = blocks[seed + 1].hash;
-            prop_assert_ne!(stale_hash, blocks[seed + 3].hash, "stale hash must differ from the real block");
+            prop_assert_ne!(stale_hash, blocks[seed + 4].hash, "stale hash must differ from the real block");
             fast.vct
                 .set_prevalidated_next(Some((
-                    Height((seed + 3) as u32),
+                    Height((seed + 4) as u32),
                     stale_hash,
-                    Some(blocks[seed + 3].block.auth_data_root()),
+                    Some(blocks[seed + 4].block.auth_data_root()),
                 )));
-            commit(&mut fast, seed + 3);
+            commit(&mut fast, seed + 4);
             prop_assert_eq!(fast.vct_prevalidated_count(), 1, "a stale cache entry (wrong hash) must not cause a false skip");
 
             // Public wrapper-hash guard: the stale cache records a real look-ahead
@@ -1890,7 +1943,7 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             // The skip must compare the cache against the wrapped block's real hash,
             // not the wrapper hash, so the bad commitment is checked and rejected.
             let forged_wrapper_hash = blocks[seed + 2].hash;
-            let bad_block = blocks[seed + 4].block.clone().set_block_commitment([0x42; 32]);
+            let bad_block = blocks[seed + 5].block.clone().set_block_commitment([0x42; 32]);
             let bad_block_hash = bad_block.hash();
             prop_assert_ne!(
                 forged_wrapper_hash,
@@ -1899,9 +1952,9 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             );
             fast.vct
                 .set_prevalidated_next(Some((
-                    Height((seed + 4) as u32),
+                    Height((seed + 5) as u32),
                     forged_wrapper_hash,
-                    Some(blocks[seed + 4].block.auth_data_root()),
+                    Some(blocks[seed + 5].block.auth_data_root()),
                 )));
             let forged = CheckpointVerifiedBlock::with_hash(bad_block, forged_wrapper_hash);
             let error = fast
@@ -1918,7 +1971,7 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             );
             prop_assert_eq!(
                 fast.db.finalized_tip_height(),
-                Some(Height((seed + 3) as u32)),
+                Some(Height((seed + 4) as u32)),
                 "the rejected forged block must leave finalized state untouched",
             );
     });

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -326,10 +326,15 @@ pub(crate) struct VctCommitState {
     /// - legacy Zebra checkpoint sync
     source: Option<Arc<VctState>>,
 
-    /// `(height, hash)` of the next block already validated by the previous fast
-    /// commit's look-ahead, so its own commitment check can be skipped. Guarded by
-    /// hash identity, so a stale or cloned value can't cause an incorrect skip.
-    prevalidated_next: Option<(block::Height, block::Hash)>,
+    /// `(height, hash, auth_data_root)` of the next block already validated by
+    /// the previous fast commit's look-ahead, so its own commitment check can
+    /// be skipped.
+    ///
+    /// The auth-data root is `None` below NU5, where it is not an input to the
+    /// block commitment. At NU5 and later it stays paired with the header hash,
+    /// so a same-header body with different authorizing data cannot reuse the
+    /// earlier prevalidation.
+    prevalidated_next: Option<(block::Height, block::Hash, Option<AuthDataRoot>)>,
 
     /// `true` while a vct sync is in-progress below the last checkpoint height.
     /// During this time, we do not reconstruct per-height note-commitment trees.
@@ -362,14 +367,20 @@ impl VctCommitState {
     }
 
     /// The cached successor prevalidation, if any.
-    pub(super) fn prevalidated_next(&self) -> Option<(block::Height, block::Hash)> {
+    pub(super) fn prevalidated_next(
+        &self,
+    ) -> Option<(block::Height, block::Hash, Option<AuthDataRoot>)> {
         self.prevalidated_next
     }
 
-    /// Caches the next block's `(height, hash)` as already validated by this
-    /// fast commit's look-ahead.
-    pub(super) fn mark_prevalidated(&mut self, height: block::Height, hash: block::Hash) {
-        self.prevalidated_next = Some((height, hash));
+    /// Caches the next block as already validated by this fast commit's look-ahead.
+    pub(super) fn mark_prevalidated(
+        &mut self,
+        height: block::Height,
+        hash: block::Hash,
+        auth_data_root: Option<AuthDataRoot>,
+    ) {
+        self.prevalidated_next = Some((height, hash, auth_data_root));
     }
 
     /// Clears any cached successor prevalidation.
@@ -380,7 +391,10 @@ impl VctCommitState {
     /// Test-only: overwrites the cached successor prevalidation, so tests can
     /// install a stale or forged entry to exercise the dedup's guard checks.
     #[cfg(test)]
-    pub(super) fn set_prevalidated_next(&mut self, next: Option<(block::Height, block::Hash)>) {
+    pub(super) fn set_prevalidated_next(
+        &mut self,
+        next: Option<(block::Height, block::Hash, Option<AuthDataRoot>)>,
+    ) {
         self.prevalidated_next = next;
     }
 


### PR DESCRIPTION
## Motivation

VCT fast sync used a weaker identity for prevalidation reuse than for commitment validation. That could reuse a successful check for a checkpoint body whose authorizing-data commitment had not been validated. An initial correction also exposed a liveness failure by classifying a permanently invalid body as a retryable missing-root condition.

This draft isolates packets 14 and 22 from #165 and fixes both the validation invariant and the retry classification.

## Solution

- Bind VCT prevalidation reuse to the height, canonical block hash, and normalized NU5+ authorizing-data root.
- Keep the cached checkpoint root tied to the wrapped block by computing it through a consuming API and removing mutable dereference access.
- Reject a cached same-block/different-root body with a dedicated non-retryable error, without invalidating authenticated VCT roots.
- Add end-to-end regressions showing the invalid body is not parked and a valid replacement for the same block identity can subsequently commit.
- Update the VCT design documentation with the cache and error-handling invariants.

### Review tradeoffs and risk

- Removing `DerefMut` from `CheckpointVerifiedBlock` is source-breaking for public `zakura-state` consumers. It makes the cached-root invariant structural and preserves parallel root computation. Alternatives are to retain mutable access while clearing a private trusted-root field, or to recompute the body root during serialized commit.
- Residual risk is low to medium because this remains a consensus-sensitive checkpoint path. The regression covers both safety and recovery/liveness behavior.
- Security disclosure and release timing must be coordinated under `SECURITY.md` before merge or public release. This PR intentionally avoids operational reproduction details.

## Testing

- `cargo fmt --all -- --check`
- `CXXFLAGS='-include cstdint' cargo test --workspace --locked`
- `CXXFLAGS='-include cstdint' cargo clippy --workspace --all-targets --locked -- -D warnings`

The workspace run included 356 passing `zakura-state` tests, the hostile-body write-loop regression, and the compile-fail test for mutable checkpoint access.

### Specifications & References

- Related review and source decomposition: #165 (packets 14 and 22)
- `SECURITY.md`
- `docs/design/verified-commitment-trees.md`

### Follow-up Work

- Confirm coordinated disclosure/advisory handling before merge.
- Confirm the public API compatibility choice for `DerefMut`.
- Changelog text is omitted while the repository's v1.0 changelog freeze applies; coordinate any security release-note treatment with maintainers.

## AI disclosure

OpenAI Codex was used to analyze #165, draft the regression tests, implement the fixes, run verification, and prepare this PR description. The contributor reviewed the changes and test results.
