### PR TITLE
test(e2e): serialize legacy reorg replacements

### DIFF
--- a/docker/zakura-regtest-e2e/run.sh
+++ b/docker/zakura-regtest-e2e/run.sh
@@ -1004,14 +1004,21 @@ wait_block_count_equal 18332 "${reorg_base}" node2
 if strict_upgrade; then
   wait_block_count_equal 18532 "${reorg_base}" node4
 fi
-rpc 18232 generate "[2]" | jq -e '.result | length == 2' >/dev/null \
-  || fail "generate RPC failed on node1 after invalidating old tip"
-target=$(block_count 18232)
-wait_block_count_at_least 18332 "${target}" node2
-wait_block_count_at_least 18432 "${target}" node3
-if strict_upgrade; then
-  wait_block_count_at_least 18532 "${target}" node4
-fi
+# Mine each replacement only after the legacy peer commits its parent. If both
+# are mined together, node3 can receive the child inventory while its parent is
+# still downloading. Its next legacy FindBlocks response then has only that one
+# remaining hash, which the legacy syncer deliberately ignores, leaving node3
+# stuck one block behind despite repeated inventories for the child.
+for replacement in 1 2; do
+  rpc 18232 generate "[1]" | jq -e '.result | length == 1' >/dev/null \
+    || fail "generate RPC failed for replacement block ${replacement} after invalidating old tip"
+  target=$(block_count 18232)
+  wait_block_count_at_least 18332 "${target}" "node2 replacement ${replacement}"
+  wait_block_count_at_least 18432 "${target}" "node3 replacement ${replacement}"
+  if strict_upgrade; then
+    wait_block_count_at_least 18532 "${target}" "node4 replacement ${replacement}"
+  fi
+done
 wait_zakura_body_frontiers_at_tip "${target}" "post-reorg"
 wait_metric_at_least 19001 sync_block_reorg_reset 1 node1
 wait_metric_at_least 19002 sync_block_reorg_reset 1 node2


### PR DESCRIPTION
## Motivation

The `pr-gate` dual-stack E2E can time out with legacy-only node3 stuck at height 163 while the other nodes reach height 164.

The failed run's trace artifact showed that node3 received the child replacement block inventory while its parent was still downloading. After committing the parent, its legacy `FindBlocks` response contained only the one remaining hash, which the legacy syncer deliberately ignores. Repeated inventories did not recover the child before the test timeout.

Failed run: https://github.com/zakura-core/zakura/actions/runs/29446234525

## Solution

Mine the two replacement blocks individually during the non-finalized reorg check. After each block, wait for the Zakura peer and legacy-only node3 to commit it before mining the next replacement. Strict-upgrade mode also waits for node4.

This preserves the existing two-block reorg coverage while removing the parent/child inventory race from the test harness.

## Testing

- `CXXFLAGS='-include cstdint' ZAKURA_E2E_MODE=pr-gate ZAKURA_REGTEST_E2E_LABEL=failing-e2e-fixed cargo test -p zakura --test zakura_regtest_e2e zakura_regtest_dual_stack_e2e -- --ignored --nocapture`
  - Passed: 1 test, 0 failures, 150.37s
  - Trace oracle passed
  - Legacy node3 reached replacement heights 163 and 164
- `bash -n docker/zakura-regtest-e2e/run.sh`
- `git diff --check`

## AI Disclosure

Used OpenAI Codex to inspect the failed GitHub Actions logs and trace artifact, implement the focused E2E harness change, run verification, and draft this PR description.
