### PR TITLE
fix(network): bind block-sync cleanup to reservation owner

### DIFF
--- a/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -48,7 +48,7 @@ use super::{
     request::{BlockRangeRequest, ExpectedBlock},
     sequencer_task::{SequencedBody, SequencerControlInput, SequencerView},
     state::{DownloadWindow, LivenessOutcome, ThroughputMeter},
-    work_queue::{LateBodyClaim, WorkItem, WorkQueue, WorkReturnOutcome},
+    work_queue::{LateBodyClaim, ReservationOwner, WorkItem, WorkQueue, WorkReturnOutcome},
     BlockSyncAction, BlockSyncMessage, BlockSyncMisbehavior, BlockSyncPeerSession, BlockSyncStatus,
     ZakuraBlockSyncConfig, ZakuraPeerId, ZakuraTrace, MSG_BS_BLOCK,
 };
@@ -604,9 +604,10 @@ impl PeerRoutine {
                 continue;
             }
             let unreceived: Vec<_> = unreceived_heights(&outstanding).collect();
-            let outcome = self
-                .work
-                .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+            let outcome = self.work.release_reserved_and_return_items_detailed(
+                unreceived.iter().copied(),
+                reservation_owner(self.generation, &outstanding),
+            );
             self.budget.release(outcome.released_bytes);
             self.trace_work_returned("view_reset", &outstanding, unreceived.len(), outcome);
         }
@@ -911,9 +912,14 @@ impl PeerRoutine {
                 self.return_taken_items(&items);
                 break FillStop::Budget;
             }
+            let request_token = self.window.next_request_token();
+            let reservation_owner = ReservationOwner {
+                generation: self.generation,
+                request_token,
+            };
             let marked = self
                 .work
-                .mark_reserved(items.iter().map(|(height, _)| *height));
+                .mark_reserved(items.iter().map(|(height, _)| *height), reservation_owner);
             if marked != reserved_bytes {
                 // Release only what is still reserved, mirroring the sibling unwinds
                 // below. A competing peer's late body may have settled one of these
@@ -921,9 +927,10 @@ impl PeerRoutine {
                 // height's estimate now belongs to the held body (the Sequencer
                 // releases it on commit), so releasing the fixed `reserved_bytes`
                 // here would double-release it and under-count the byte budget.
-                let released = self
-                    .work
-                    .release_reserved_and_return_items(items.iter().map(|(height, _)| *height));
+                let released = self.work.release_reserved_and_return_items(
+                    items.iter().map(|(height, _)| *height),
+                    reservation_owner,
+                );
                 self.budget.release(released);
                 break FillStop::Internal;
             }
@@ -931,9 +938,10 @@ impl PeerRoutine {
             let count = match u32::try_from(kept_count) {
                 Ok(count) => count,
                 Err(_) => {
-                    let released = self
-                        .work
-                        .release_reserved_and_return_items(items.iter().map(|(height, _)| *height));
+                    let released = self.work.release_reserved_and_return_items(
+                        items.iter().map(|(height, _)| *height),
+                        reservation_owner,
+                    );
                     self.budget.release(released);
                     break FillStop::Internal;
                 }
@@ -977,9 +985,10 @@ impl PeerRoutine {
                 // Held-aware: a competing peer's late body may have converted a taken
                 // height during the reserve await; that body is owned by the Sequencer,
                 // so skip it here rather than re-queue and double-release it.
-                let released = self
-                    .work
-                    .release_reserved_and_return_items(items.iter().map(|(height, _)| *height));
+                let released = self.work.release_reserved_and_return_items(
+                    items.iter().map(|(height, _)| *height),
+                    reservation_owner,
+                );
                 self.budget.release(released);
                 if matches!(error, OrderedSendError::Full) {
                     break FillStop::OutboundFull;
@@ -1006,7 +1015,6 @@ impl PeerRoutine {
             let request_start_height = request.start_height;
             let request_count = request.count;
             let request_estimated_bytes = request.estimated_bytes;
-            let request_token = self.window.next_request_token();
             self.window.outstanding.insert(OutstandingBlockRange {
                 token: request_token,
                 state: OutstandingRequestState::Active,
@@ -1234,9 +1242,10 @@ impl PeerRoutine {
             // `in_flight` until committed); re-queuing them would re-fetch a body
             // we already hold (the WorkQueue single-owner invariant forbids it).
             let unreceived: Vec<_> = unreceived_heights(&outstanding).collect();
-            let outcome = self
-                .work
-                .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+            let outcome = self.work.release_reserved_and_return_items_detailed(
+                unreceived.iter().copied(),
+                reservation_owner(self.generation, &outstanding),
+            );
             self.budget.release(outcome.released_bytes);
             self.trace_work_returned("request_timeout", &outstanding, unreceived.len(), outcome);
             timed_out_heights.extend(unreceived);
@@ -1308,6 +1317,7 @@ impl PeerRoutine {
         let now = Instant::now();
         let correlation_deadline = self.retirement_deadline(now);
         let work = Arc::clone(&self.work);
+        let generation = self.generation;
         let retired = self.window.outstanding.retire_covered(
             floor,
             now,
@@ -1317,8 +1327,10 @@ impl PeerRoutine {
                 // heights. A height a competing peer delivered late is `Held`: its
                 // body is in the commit pipeline and the Sequencer releases those
                 // bytes on commit, so it must not be released a second time here.
-                released = released
-                    .saturating_add(work.release_reserved_heights(unreceived_heights(outstanding)));
+                released = released.saturating_add(work.release_reserved_heights(
+                    unreceived_heights(outstanding),
+                    reservation_owner(generation, outstanding),
+                ));
             },
         );
         if released > 0 {
@@ -1974,12 +1986,13 @@ impl PeerRoutine {
         if outstanding.request.start_height > tip {
             return current;
         }
+        let owner = reservation_owner(self.generation, outstanding);
         let released_heights: Vec<_> = outstanding_unreceived_through(outstanding, tip).collect();
         self.window.outstanding.mark_received_through(index, tip);
         // Held-aware: release only the still-reserved estimate for the committed
         // prefix; a height a competing peer delivered late is owned by the
         // Sequencer, so it is left in place instead of double-released.
-        let released_bytes = self.work.release_reserved_heights(released_heights);
+        let released_bytes = self.work.release_reserved_heights(released_heights, owner);
         self.budget.release(released_bytes);
         if self.window.outstanding.is_complete(index) {
             Disposition::Satisfied
@@ -2014,9 +2027,10 @@ impl PeerRoutine {
                 // returns to the queue (buffered heights stay in `in_flight`
                 // until the floor commits past them). Release any residual
                 // reserved estimate (normally none once complete).
-                let released = self
-                    .work
-                    .release_reserved_heights(unreceived_heights(&outstanding));
+                let released = self.work.release_reserved_heights(
+                    unreceived_heights(&outstanding),
+                    reservation_owner(self.generation, &outstanding),
+                );
                 self.budget.release(released);
             }
             // With fanout = 1 a received height is already buffered and must never
@@ -2024,9 +2038,10 @@ impl PeerRoutine {
             // unreceived heights to `pending`. `return_items` is idempotent.
             Disposition::RetryOriginal | Disposition::RetryMissing => {
                 let unreceived: Vec<_> = unreceived_heights(&outstanding).collect();
-                let outcome = self
-                    .work
-                    .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+                let outcome = self.work.release_reserved_and_return_items_detailed(
+                    unreceived.iter().copied(),
+                    reservation_owner(self.generation, &outstanding),
+                );
                 self.budget.release(outcome.released_bytes);
                 self.trace_work_returned(
                     disposition.trace_label(),
@@ -2262,6 +2277,7 @@ impl PeerRoutine {
         if outcome.missing_count == 0
             && outcome.held_count == 0
             && outcome.released_count == 0
+            && outcome.owner_mismatch_count == 0
             && outcome.returned_count == unreceived_count
         {
             return;
@@ -2572,12 +2588,20 @@ fn insert_work_return_outcome(
     bs_insert_u64(row, "already_pending_count", outcome.already_pending_count);
     bs_insert_u64(row, "held_count", outcome.held_count);
     bs_insert_u64(row, "released_count", outcome.released_count);
+    bs_insert_u64(row, "owner_mismatch_count", outcome.owner_mismatch_count);
     bs_insert_u64(row, "missing_count", outcome.missing_count);
     if let Some(height) = outcome.min_height {
         bs_insert_height(row, "return_min_height", height);
     }
     if let Some(height) = outcome.max_height {
         bs_insert_height(row, "return_max_height", height);
+    }
+}
+
+fn reservation_owner(generation: u64, outstanding: &OutstandingBlockRange) -> ReservationOwner {
+    ReservationOwner {
+        generation,
+        request_token: outstanding.token,
     }
 }
 
@@ -2638,9 +2662,10 @@ impl Drop for PeerRoutine {
                 .filter(|expected| !outstanding.has_received(expected.height))
                 .map(|expected| expected.height)
                 .collect();
-            let outcome = self
-                .work
-                .release_reserved_and_return_items_detailed(unreceived.iter().copied());
+            let outcome = self.work.release_reserved_and_return_items_detailed(
+                unreceived.iter().copied(),
+                reservation_owner(self.generation, &outstanding),
+            );
             self.budget.release(outcome.released_bytes);
             self.trace_work_returned("peer_routine_drop", &outstanding, unreceived.len(), outcome);
         }

--- a/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/zakura-network/src/zakura/block_sync/reactor.rs
@@ -403,10 +403,14 @@ impl BlockSyncReactor {
                 );
             }
             let retired_heights: Vec<_> = retired.iter().map(|(height, _)| *height).collect();
+            let owner = super::work_queue::ReservationOwner {
+                generation: claim.generation,
+                request_token: claim.meta.request_token,
+            };
             let released = self
                 .state
                 .work_queue
-                .release_reserved_and_return_items_detailed(retired_heights);
+                .release_reserved_and_return_items_detailed(retired_heights, owner);
             self.state.budget.release(released.released_bytes);
             self.emit_trace(bs_trace::BLOCK_FLOOR_WATCHDOG_CANCELLED, |row| {
                 bs_insert_peer(row, bs_trace::PEER, &claim.peer);
@@ -423,6 +427,7 @@ impl BlockSyncReactor {
                 bs_insert_u64(row, "already_pending_count", released.already_pending_count);
                 bs_insert_u64(row, "held_count", released.held_count);
                 bs_insert_u64(row, "released_count", released.released_count);
+                bs_insert_u64(row, "owner_mismatch_count", released.owner_mismatch_count);
                 bs_insert_u64(row, "missing_count", released.missing_count);
                 bs_insert_u64(
                     row,

--- a/zakura-network/src/zakura/block_sync/sequencer_task.rs
+++ b/zakura-network/src/zakura/block_sync/sequencer_task.rs
@@ -25,6 +25,9 @@ use super::{
     *,
 };
 
+#[cfg(test)]
+use super::work_queue::ReservationOwner;
+
 /// Favor the lowest needed height over the speculative high tail.
 ///
 /// While the byte budget cannot fund even one worst-case request yet the lowest
@@ -995,7 +998,16 @@ mod tests {
             1
         );
         assert_eq!(work.take_in_range(height, height, 1).len(), 1);
-        assert_eq!(work.mark_reserved([height]), 64);
+        assert_eq!(
+            work.mark_reserved(
+                [height],
+                ReservationOwner {
+                    generation: 1,
+                    request_token: 1,
+                },
+            ),
+            64
+        );
         assert!(budget.try_reserve(64));
         assert_eq!(work.settle_active_reserved_height(height, 64), Some(0));
         let budget_view = budget.clone();
@@ -1079,7 +1091,16 @@ mod tests {
             1
         );
         assert_eq!(work.take_in_range(successor, successor, 1).len(), 1);
-        assert_eq!(work.mark_reserved([successor]), 64);
+        assert_eq!(
+            work.mark_reserved(
+                [successor],
+                ReservationOwner {
+                    generation: 1,
+                    request_token: 1,
+                },
+            ),
+            64
+        );
         assert!(budget.try_reserve(64));
         assert_eq!(work.settle_active_reserved_height(successor, 64), Some(0));
         let work_view = Arc::clone(&work);

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -20,7 +20,7 @@ use super::{
     request::*,
     sequencer::*,
     state::*,
-    work_queue::{LateBodyClaim, WorkQueue},
+    work_queue::{LateBodyClaim, ReservationOwner, WorkQueue},
 };
 use crate::zakura::{
     framed_channel,
@@ -39,6 +39,13 @@ use zakura_test::vectors::{BLOCK_MAINNET_1_BYTES, BLOCK_MAINNET_2_BYTES, BLOCK_M
 
 fn peer(byte: u8) -> ZakuraPeerId {
     ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
+}
+
+fn reservation_owner(generation: u64, request_token: BlockRequestToken) -> ReservationOwner {
+    ReservationOwner {
+        generation,
+        request_token,
+    }
 }
 
 fn mainnet_block(bytes: &[u8]) -> Arc<block::Block> {
@@ -2227,10 +2234,11 @@ fn commit_window_stays_fundable_at_exact_floor() {
 fn work_queue_force_cancel_and_owner_timeout_release_once() {
     let queue = work_queue_with(0, [needed(1, BlockSizeEstimate::Advertised(100))]);
     let mut budget = ByteBudget::new(1_000);
+    let owner = reservation_owner(1, 1);
     let taken = queue.take_in_range(block::Height(1), block::Height(1), 1);
     assert_eq!(taken.len(), 1);
     assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
+    assert_eq!(queue.mark_reserved([block::Height(1)], owner), 100);
     assert_eq!(budget.reserved(), 100);
 
     let watchdog_released = queue.release_and_return_items([block::Height(1)]);
@@ -2254,6 +2262,7 @@ fn work_queue_reserved_bytes_counter_matches_scan_across_transitions() {
         0,
         (1..=6).map(|h| needed(h, BlockSizeEstimate::Advertised(100))),
     );
+    let owner = reservation_owner(1, 1);
     let check = |label: &str| {
         assert_eq!(
             queue.reserved_bytes(),
@@ -2268,7 +2277,7 @@ fn work_queue_reserved_bytes_counter_matches_scan_across_transitions() {
     // take + mark_reserved: Released -> Reserved.
     let taken = queue.take_in_range(block::Height(1), block::Height(6), 6);
     assert_eq!(taken.len(), 6);
-    assert_eq!(queue.mark_reserved((1..=6).map(block::Height)), 600);
+    assert_eq!(queue.mark_reserved((1..=6).map(block::Height), owner), 600);
     assert_eq!(queue.reserved_bytes(), 600);
     check("mark_reserved");
 
@@ -2290,7 +2299,7 @@ fn work_queue_reserved_bytes_counter_matches_scan_across_transitions() {
     check("release_heights");
 
     // release_reserved_and_return_items: only the still-reserved height 4 releases.
-    let released = queue.release_reserved_and_return_items([block::Height(4)]);
+    let released = queue.release_reserved_and_return_items([block::Height(4)], owner);
     assert_eq!(released, 100);
     assert_eq!(queue.reserved_bytes(), 200);
     check("release_reserved_and_return_items");
@@ -2323,7 +2332,10 @@ fn work_queue_advance_floor_drops_only_committed_prefix() {
     );
     // Reserve a contiguous run so we can see the reservation accounting on GC.
     let _ = queue.take_in_range(block::Height(1), block::Height(10), 10);
-    assert_eq!(queue.mark_reserved((1..=10).map(block::Height)), 1000);
+    assert_eq!(
+        queue.mark_reserved((1..=10).map(block::Height), reservation_owner(1, 1)),
+        1000
+    );
 
     // advance_floor to 4: drops heights 1..=4 (still reserved -> released), keeps 5..=10.
     let released = queue.advance_floor(block::Height(4));
@@ -2346,10 +2358,11 @@ fn work_queue_advance_floor_drops_only_committed_prefix() {
 fn watchdog_after_held_settle_releases_once() {
     let queue = work_queue_with(0, [needed(1, BlockSizeEstimate::Advertised(100))]);
     let mut budget = ByteBudget::new(1_000);
+    let owner = reservation_owner(1, 1);
     let taken = queue.take_in_range(block::Height(1), block::Height(1), 1);
     assert_eq!(taken.len(), 1);
     assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
+    assert_eq!(queue.mark_reserved([block::Height(1)], owner), 100);
 
     let delta = queue
         .settle_active_reserved_height(block::Height(1), 80)
@@ -2358,7 +2371,7 @@ fn watchdog_after_held_settle_releases_once() {
     budget.release(20);
     assert_eq!(budget.reserved(), 80);
 
-    let outcome = queue.release_reserved_and_return_items_detailed([block::Height(1)]);
+    let outcome = queue.release_reserved_and_return_items_detailed([block::Height(1)], owner);
     let watchdog_released = outcome.released_bytes;
     budget.release(watchdog_released);
     assert_eq!(
@@ -2380,17 +2393,17 @@ fn watchdog_after_held_settle_releases_once() {
 fn watchdog_between_registry_check_and_settlement_preserves_late_body() {
     let height = block::Height(1);
     let hash = block::Hash([1; 32]);
+    let registry = PeerRegistry::new();
+    let peer = peer(0x41);
+    let config = ZakuraBlockSyncConfig::default();
+    let generation = registry.admit(&peer, ServicePeerDirection::Outbound, &config);
+    let owner = reservation_owner(generation, 7);
     let queue = work_queue_with(0, [needed(1, BlockSizeEstimate::Advertised(100))]);
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(height, height, 1);
     assert_eq!(taken.len(), 1);
     assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([height]), 100);
-
-    let registry = PeerRegistry::new();
-    let peer = peer(0x41);
-    let config = ZakuraBlockSyncConfig::default();
-    let generation = registry.admit(&peer, ServicePeerDirection::Outbound, &config);
+    assert_eq!(queue.mark_reserved([height], owner), 100);
     let now = Instant::now();
     registry.set_outstanding(
         &peer,
@@ -2417,7 +2430,7 @@ fn watchdog_between_registry_check_and_settlement_preserves_late_body() {
     let retired = registry.retire_outstanding_claim(&claim);
     assert_eq!(retired.len(), 1);
 
-    let outcome = queue.release_reserved_and_return_items_detailed([height]);
+    let outcome = queue.release_reserved_and_return_items_detailed([height], owner);
     let watchdog_released = outcome.released_bytes;
     budget.release(watchdog_released);
     assert_eq!(outcome.returned_count, 1);
@@ -2444,13 +2457,85 @@ fn watchdog_between_registry_check_and_settlement_preserves_late_body() {
 }
 
 #[test]
+fn stale_watchdog_cleanup_cannot_release_replacement_reservation() {
+    let height = block::Height(1);
+    let hash = block::Hash([1; 32]);
+    let queue = work_queue_with(0, [needed(1, BlockSizeEstimate::Advertised(100))]);
+    let mut budget = ByteBudget::new(1_000);
+    let registry = PeerRegistry::new();
+    let config = ZakuraBlockSyncConfig::default();
+    let old_peer = peer(0x41);
+    let old_generation = registry.admit(&old_peer, ServicePeerDirection::Outbound, &config);
+    let old_owner = reservation_owner(old_generation, 7);
+    let now = Instant::now();
+    registry.set_outstanding(
+        &old_peer,
+        old_generation,
+        std::collections::BTreeMap::from([(
+            height,
+            super::peer_registry::OutstandingMeta {
+                request_token: old_owner.request_token,
+                hash,
+                estimated_bytes: 100,
+                queued_at: now,
+                deadline: now,
+            },
+        )]),
+    );
+
+    assert_eq!(queue.take_in_range(height, height, 1).len(), 1);
+    assert!(budget.try_reserve(100));
+    assert_eq!(queue.mark_reserved([height], old_owner), 100);
+
+    // Local timeout returns the old reservation before its registry publication
+    // catches up, exposing the height to another peer.
+    let local = queue.release_reserved_and_return_items_detailed([height], old_owner);
+    budget.release(local.released_bytes);
+    assert_eq!(local.returned_count, 1);
+
+    let replacement_peer = peer(0x42);
+    let replacement_generation =
+        registry.admit(&replacement_peer, ServicePeerDirection::Outbound, &config);
+    let replacement_owner = reservation_owner(replacement_generation, 1);
+    assert_eq!(queue.take_in_range(height, height, 1).len(), 1);
+    assert!(budget.try_reserve(100));
+    assert_eq!(queue.mark_reserved([height], replacement_owner), 100);
+
+    // The watchdog can still retire the old registry claim, but its owner-tagged
+    // cleanup must not return or uncharge the replacement peer's request.
+    let stale_claim = registry
+        .outstanding_claims_at(height)
+        .into_iter()
+        .find(|claim| claim.peer == old_peer)
+        .expect("the old peer claim remains visible");
+    let retired = registry.retire_outstanding_claim(&stale_claim);
+    assert_eq!(retired.len(), 1);
+    let watchdog = queue.release_reserved_and_return_items_detailed(
+        retired.iter().map(|(height, _)| *height),
+        old_owner,
+    );
+    budget.release(watchdog.released_bytes);
+
+    assert_eq!(watchdog.released_bytes, 0);
+    assert_eq!(watchdog.returned_count, 0);
+    assert_eq!(watchdog.owner_mismatch_count, 1);
+    assert!(queue.in_flight_contains(height));
+    assert!(!queue.pending_contains(height));
+    assert_eq!(queue.reserved_bytes(), 100);
+    assert_eq!(budget.reserved(), 100);
+}
+
+#[test]
 fn mark_held_direct_does_not_orphan_a_charge() {
     let queue = work_queue_with(0, [needed(1, BlockSizeEstimate::Advertised(100))]);
     let mut budget = ByteBudget::new(1_000);
     let taken = queue.take_in_range(block::Height(1), block::Height(1), 1);
     assert_eq!(taken.len(), 1);
     assert!(budget.try_reserve(100));
-    assert_eq!(queue.mark_reserved([block::Height(1)]), 100);
+    assert_eq!(
+        queue.mark_reserved([block::Height(1)], reservation_owner(1, 1)),
+        100
+    );
 
     assert!(budget.try_reserve(80));
     let old_charge = queue.mark_held_direct(block::Height(1), 80);
@@ -2478,7 +2563,10 @@ fn release_reserved_mixed_reserved_held_conserves_budget() {
     assert_eq!(taken.len(), 2);
     assert!(budget.try_reserve(200));
     assert_eq!(
-        queue.mark_reserved([block::Height(1), block::Height(2)]),
+        queue.mark_reserved(
+            [block::Height(1), block::Height(2)],
+            reservation_owner(1, 1),
+        ),
         200
     );
 
@@ -2518,11 +2606,12 @@ fn release_reserved_heights_skips_held_body_owned_by_sequencer() {
         ],
     );
     let mut budget = ByteBudget::new(1_000);
+    let owner = reservation_owner(1, 1);
     let taken = queue.take_in_range(block::Height(1), block::Height(2), 2);
     assert_eq!(taken.len(), 2);
     assert!(budget.try_reserve(200));
     assert_eq!(
-        queue.mark_reserved([block::Height(1), block::Height(2)]),
+        queue.mark_reserved([block::Height(1), block::Height(2)], owner),
         200
     );
 
@@ -2537,7 +2626,7 @@ fn release_reserved_heights_skips_held_body_owned_by_sequencer() {
 
     // GC both heights: only the still-reserved height 2 releases. The Held height 1
     // is skipped (owned by the Sequencer) and stays in `in_flight`.
-    let released = queue.release_reserved_heights([block::Height(1), block::Height(2)]);
+    let released = queue.release_reserved_heights([block::Height(1), block::Height(2)], owner);
     budget.release(released);
     assert_eq!(
         released, 100,

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -2496,7 +2496,8 @@ fn stale_watchdog_cleanup_cannot_release_replacement_reservation() {
     let replacement_peer = peer(0x42);
     let replacement_generation =
         registry.admit(&replacement_peer, ServicePeerDirection::Outbound, &config);
-    let replacement_owner = reservation_owner(replacement_generation, 1);
+    assert_ne!(replacement_generation, old_generation);
+    let replacement_owner = reservation_owner(replacement_generation, old_owner.request_token);
     assert_eq!(queue.take_in_range(height, height, 1).len(), 1);
     assert!(budget.try_reserve(100));
     assert_eq!(queue.mark_reserved([height], replacement_owner), 100);
@@ -2622,6 +2623,14 @@ fn release_reserved_heights_skips_held_body_owned_by_sequencer() {
         .expect("height 1 is reserved");
     assert_eq!(delta, -20);
     budget.release(20);
+    assert_eq!(budget.reserved(), 180);
+
+    let stale_owner = reservation_owner(2, owner.request_token);
+    assert_eq!(
+        queue.release_reserved_heights([block::Height(1), block::Height(2)], stale_owner),
+        0,
+        "a stale request generation must not release replacement reservations"
+    );
     assert_eq!(budget.reserved(), 180);
 
     // GC both heights: only the still-reserved height 2 releases. The Held height 1

--- a/zakura-network/src/zakura/block_sync/work_queue.rs
+++ b/zakura-network/src/zakura/block_sync/work_queue.rs
@@ -27,12 +27,23 @@ use tokio::sync::Notify;
 use zakura_chain::block;
 
 use super::{
+    outstanding::BlockRequestToken,
     request::BlockSizeEstimate,
     state::{BlockBudgetLedger, ByteBudget},
 };
 
 /// Lower clamp on a body-size estimate.
 pub(super) const DEFAULT_BS_SIZE_FLOOR_BYTES: u64 = 1024;
+
+/// Identity of the request that owns a reserved work item.
+///
+/// Routine generations are allocated globally, so the pair is unique across
+/// peers and routine replacements without retaining a peer ID in every item.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) struct ReservationOwner {
+    pub(super) generation: u64,
+    pub(super) request_token: BlockRequestToken,
+}
 
 /// Per-height download metadata held in the [`WorkQueue`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -50,6 +61,10 @@ pub(super) struct WorkItem {
     /// stale local owner cannot release a charge that another path already
     /// returned.
     pub(super) budget: BlockBudgetLedger,
+    /// Request allowed to release a `Reserved` charge.
+    ///
+    /// Cleared whenever the item becomes pending, held, or otherwise released.
+    pub(super) reservation_owner: Option<ReservationOwner>,
 }
 
 /// Diagnostics for an attempted `in_flight -> pending` retry transition.
@@ -69,6 +84,8 @@ pub(super) struct WorkReturnOutcome {
     pub(super) held_count: u64,
     /// Items present in `in_flight` with an unexpected `Released` ledger.
     pub(super) released_count: u64,
+    /// Reserved items now owned by a replacement request.
+    pub(super) owner_mismatch_count: u64,
     /// Requested heights absent from both `pending` and `in_flight`.
     pub(super) missing_count: u64,
     /// Lowest height considered by the cleanup.
@@ -177,6 +194,7 @@ impl WorkQueue {
                         hash,
                         estimated_bytes,
                         budget: BlockBudgetLedger::Released,
+                        reservation_owner: None,
                     },
                 );
                 inserted += 1;
@@ -332,7 +350,11 @@ impl WorkQueue {
     ///
     /// Returns the sum marked. The caller must have already admitted the same
     /// byte total through [`ByteBudget`](crate::zakura::transport::ByteBudget).
-    pub(super) fn mark_reserved(&self, heights: impl IntoIterator<Item = block::Height>) -> u64 {
+    pub(super) fn mark_reserved(
+        &self,
+        heights: impl IntoIterator<Item = block::Height>,
+        owner: ReservationOwner,
+    ) -> u64 {
         let mut marked = 0u64;
         let mut inner = self.lock();
         for height in heights {
@@ -343,6 +365,7 @@ impl WorkQueue {
                 continue;
             }
             item.budget = BlockBudgetLedger::reserved(item.estimated_bytes);
+            item.reservation_owner = Some(owner);
             marked = marked.saturating_add(item.estimated_bytes);
         }
         // Released (0) -> Reserved(estimate): the reserved total grows by exactly
@@ -369,7 +392,9 @@ impl WorkQueue {
                 return None;
             }
             // Reserved(reserved) -> Held(actual): the reserved charge drops to 0.
-            (item.budget.reserved_charge(), item.budget.settle(actual))
+            let result = (item.budget.reserved_charge(), item.budget.settle(actual));
+            item.reservation_owner = None;
+            result
         };
         inner.reserved_bytes = inner.reserved_bytes.saturating_sub(reserved_before);
         Some(delta)
@@ -396,6 +421,7 @@ impl WorkQueue {
             if item.budget.is_reserved() {
                 let reserved_before = item.budget.reserved_charge();
                 let delta = item.budget.settle(actual);
+                item.reservation_owner = None;
                 inner.reserved_bytes = inner.reserved_bytes.saturating_sub(reserved_before);
                 return LateBodyClaim::SettledReserved(delta);
             }
@@ -423,6 +449,7 @@ impl WorkQueue {
         let reserved_before = item.budget.reserved_charge();
         let previous_charge = item.budget.release();
         item.budget = BlockBudgetLedger::Held(actual);
+        item.reservation_owner = None;
         inner.reserved_bytes = inner.reserved_bytes.saturating_sub(reserved_before);
         inner.in_flight.insert(height, item);
         budget.release(previous_charge);
@@ -441,6 +468,7 @@ impl WorkQueue {
             let reserved_before = item.budget.reserved_charge();
             let previous_charge = item.budget.release();
             item.budget = BlockBudgetLedger::Held(actual);
+            item.reservation_owner = None;
             inner.reserved_bytes = inner.reserved_bytes.saturating_sub(reserved_before);
             return previous_charge;
         }
@@ -448,6 +476,7 @@ impl WorkQueue {
             let reserved_before = item.budget.reserved_charge();
             let previous_charge = item.budget.release();
             item.budget = BlockBudgetLedger::Held(actual);
+            item.reservation_owner = None;
             inner.in_flight.insert(height, item);
             inner.reserved_bytes = inner.reserved_bytes.saturating_sub(reserved_before);
             return previous_charge;
@@ -471,9 +500,11 @@ impl WorkQueue {
             if let Some(item) = inner.in_flight.get_mut(&height) {
                 reserved_removed = reserved_removed.saturating_add(item.budget.reserved_charge());
                 released = released.saturating_add(item.budget.release());
+                item.reservation_owner = None;
             } else if let Some(item) = inner.pending.get_mut(&height) {
                 reserved_removed = reserved_removed.saturating_add(item.budget.reserved_charge());
                 released = released.saturating_add(item.budget.release());
+                item.reservation_owner = None;
             }
         }
         inner.reserved_bytes = inner.reserved_bytes.saturating_sub(reserved_removed);
@@ -493,17 +524,20 @@ impl WorkQueue {
     pub(super) fn release_reserved_heights(
         &self,
         heights: impl IntoIterator<Item = block::Height>,
+        owner: ReservationOwner,
     ) -> u64 {
         let mut released = 0u64;
         let mut inner = self.lock();
         for height in heights {
             if let Some(item) = inner.in_flight.get_mut(&height) {
-                if item.budget.is_reserved() {
+                if item.budget.is_reserved() && item.reservation_owner == Some(owner) {
                     released = released.saturating_add(item.budget.release_reserved());
+                    item.reservation_owner = None;
                 }
             } else if let Some(item) = inner.pending.get_mut(&height) {
-                if item.budget.is_reserved() {
+                if item.budget.is_reserved() && item.reservation_owner == Some(owner) {
                     released = released.saturating_add(item.budget.release_reserved());
+                    item.reservation_owner = None;
                 }
             }
         }
@@ -526,6 +560,7 @@ impl WorkQueue {
                     reserved_removed =
                         reserved_removed.saturating_add(item.budget.reserved_charge());
                     released = released.saturating_add(item.budget.release());
+                    item.reservation_owner = None;
                     inner.pending.insert(height, item);
                     moved = true;
                 }
@@ -546,8 +581,9 @@ impl WorkQueue {
     pub(super) fn release_reserved_and_return_items(
         &self,
         heights: impl IntoIterator<Item = block::Height>,
+        owner: ReservationOwner,
     ) -> u64 {
-        self.release_reserved_and_return_items_detailed(heights)
+        self.release_reserved_and_return_items_detailed(heights, owner)
             .released_bytes
     }
 
@@ -556,6 +592,7 @@ impl WorkQueue {
     pub(super) fn release_reserved_and_return_items_detailed(
         &self,
         heights: impl IntoIterator<Item = block::Height>,
+        owner: ReservationOwner,
     ) -> WorkReturnOutcome {
         let mut moved = false;
         let mut outcome = WorkReturnOutcome::default();
@@ -592,6 +629,10 @@ impl WorkQueue {
                     }
                     BlockBudgetLedger::Reserved(_) => {}
                 }
+                if item.reservation_owner != Some(owner) {
+                    outcome.owner_mismatch_count = outcome.owner_mismatch_count.saturating_add(1);
+                    continue;
+                }
                 let mut item = inner
                     .in_flight
                     .remove(&height)
@@ -600,6 +641,7 @@ impl WorkQueue {
                 // the reserved charge leaving the queue.
                 outcome.released_bytes =
                     outcome.released_bytes.saturating_add(item.budget.release());
+                item.reservation_owner = None;
                 outcome.returned_count = outcome.returned_count.saturating_add(1);
                 inner.pending.insert(height, item);
                 moved = true;


### PR DESCRIPTION
## Motivation

Local timeout and routine-drop cleanup returned a height to the shared work queue before removing the old peer-registry claim. A replacement peer could reserve that height, after which the floor watchdog could retire the stale claim and release the replacement reservation by height. This allowed duplicate request ownership and under-counted the shared byte budget.

## Solution

- Tag each reserved work item with its owning routine generation and request token.
- Require timeout, drop, retry, reset, and watchdog cleanup to present that owner before releasing reserved work or budget.
- Leave replacement reservations intact when stale cleanup observes an owner mismatch, and expose the mismatch in lifecycle traces.
- Add a deterministic regression test reproducing local return, replacement reservation, and delayed stale-watchdog cleanup.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network zakura::block_sync` — 241 block-sync tests passed, including the new stale-watchdog regression.
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `cargo test -p zakura-network` — 998 passed; 3 unrelated listener tests failed because this macOS host could not bind their requested loopback source addresses (`AddrNotAvailable`).

The regression test verifies that stale watchdog cleanup releases zero bytes, reports an owner mismatch, leaves the replacement height in flight, and preserves its byte-budget charge.

### Specifications & References

No external specification changes.

### Follow-up Work

None.