### PR TITLE
fix(state): harden VCT authorizing-data validation

### DIFF
--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -151,7 +151,7 @@ impl CommitBlockError {
     }
 
     /// Returns the height for any retryable VCT root stall (absent/evicted root, or one
-    /// not yet verifiable for lack of a buffered successor). See
+    /// not yet verifiable for lack of a stored successor header). See
     /// [`ValidateContextError::vct_retryable_height`].
     pub fn vct_retryable_height(&self) -> Option<block::Height> {
         match self {
@@ -240,7 +240,7 @@ impl CommitCheckpointVerifiedError {
     }
 
     /// Returns the height for any retryable VCT root stall (absent/evicted root, or one
-    /// not yet verifiable for lack of a buffered successor). See
+    /// not yet verifiable for lack of a stored successor header). See
     /// [`ValidateContextError::vct_retryable_height`].
     pub fn vct_retryable_height(&self) -> Option<block::Height> {
         self.0.vct_retryable_height()
@@ -564,9 +564,9 @@ pub enum ValidateContextError {
 
     #[error(
         "verified-commitment-trees fast path cannot yet verify the supplied root for height \
-         {height:?}: no successor block is buffered to confirm it against the header chain, and \
+         {height:?}: no successor header is stored to confirm it against the header chain, and \
          committing it unverified would persist a root that is only checked one block later \
-         (irreversibly, once on disk). Commit is deferred until the successor arrives (retryable)"
+         (irreversibly, once on disk). Commit is deferred until the successor header arrives (retryable)"
     )]
     #[non_exhaustive]
     VctSuppliedRootAwaitingSuccessor { height: block::Height },
@@ -820,7 +820,7 @@ impl ValidateContextError {
     /// verification. It can only be filled by a later re-delivery of that header range (for
     /// example another fanout peer's response); roots are not individually re-requested. An
     /// await-successor stall ([`Self::vct_retryable_height`] but not this) already has its root
-    /// and only waits for the next block to be downloaded.
+    /// and only waits for the next header to be stored.
     pub fn vct_supplied_root_unavailable_height(&self) -> Option<block::Height> {
         match self {
             ValidateContextError::VctSuppliedRootUnavailable { height } => Some(*height),

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -747,8 +747,8 @@ impl FinalizedState {
                         // different parent tree, so verifying against it would fail and
                         // wrongly evict a good supplied root. Treat a non-linking witness
                         // as absent, so the await-successor deferral below handles it. The
-                        // write worker only buffers direct successors, so this should
-                        // never fire.
+                        // header-store lookup only returns direct successors, so this
+                        // should never fire in production.
                         let next_vct_block = next_vct_block.filter(|next_vct_block| {
                             let links = next_vct_block.header.previous_block_hash == block_hash;
                             if !links {
@@ -1190,7 +1190,7 @@ impl FinalizedState {
         self.vct.clear_prevalidated_next();
     }
 
-    /// `true` when committing `height` on the fast path needs a buffered successor before
+    /// `true` when committing `height` on the fast path needs a stored successor header before
     /// it can safely persist this block's supplied roots.
     ///
     /// Only untrusted peer-supplied roots at or above Heartwood require this. The

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -854,9 +854,18 @@ impl FinalizedState {
                                     verification_items,
                                 )
                             })
-                            .map_err(|(_fail_height, error)| {
+                            .map_err(|failure| {
                                 self.vct.clear_prevalidated_next();
-                                self.vct_reject_supplied_root(height, error)
+                                match failure {
+                                    commitment_aux_verify::CommitmentRootVerificationError::CurrentBlock {
+                                        error,
+                                        ..
+                                    } => error.into(),
+                                    commitment_aux_verify::CommitmentRootVerificationError::SuppliedRoot {
+                                        error,
+                                        ..
+                                    } => self.vct_reject_supplied_root(height, error),
+                                }
                             })?;
 
                         if let Some(next_vct_block) = &next_vct_block {

--- a/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux_verify.rs
@@ -84,6 +84,37 @@ impl CommitmentRootVerification {
     }
 }
 
+/// Identifies whether VCT verification rejected the current block body or a supplied root.
+#[derive(Debug)]
+pub(crate) enum CommitmentRootVerificationError {
+    /// The current block body does not match its parent-history commitment.
+    CurrentBlock {
+        height: Height,
+        error: ValidateContextError,
+    },
+    /// A supplied root failed a direct check or the successor commitment check.
+    SuppliedRoot {
+        height: Height,
+        error: ValidateContextError,
+    },
+}
+
+impl CommitmentRootVerificationError {
+    #[cfg(test)]
+    fn height(&self) -> Height {
+        match self {
+            Self::CurrentBlock { height, .. } | Self::SuppliedRoot { height, .. } => *height,
+        }
+    }
+
+    #[cfg(test)]
+    fn error(&self) -> &ValidateContextError {
+        match self {
+            Self::CurrentBlock { error, .. } | Self::SuppliedRoot { error, .. } => error,
+        }
+    }
+}
+
 /// Verifies a supplied Sapling root for a *pre-Heartwood* block directly against the
 /// block header.
 ///
@@ -196,7 +227,7 @@ pub(crate) fn verify_commitment_roots<I>(
     network: &Network,
     mut history_tree: HistoryTree,
     blocks_to_verify: I,
-) -> Result<HistoryTree, (Height, ValidateContextError)>
+) -> Result<HistoryTree, CommitmentRootVerificationError>
 where
     I: IntoIterator<Item = CommitmentRootVerification>,
 {
@@ -232,7 +263,7 @@ where
                     &history_tree,
                     precomputed_auth_data_root,
                 )
-                .map_err(|error| (height, error))?;
+                .map_err(|error| CommitmentRootVerificationError::CurrentBlock { height, error })?;
             } else {
                 let auth_data_root = precomputed_auth_data_root
                     .expect("header-only VCT witnesses have a stored precomputed auth-data root");
@@ -251,7 +282,7 @@ where
                         ValidateContextError::HistoryTreeError(error)
                     }
                 })
-                .map_err(|error| (height, error))?;
+                .map_err(|error| CommitmentRootVerificationError::SuppliedRoot { height, error })?;
             }
         }
 
@@ -261,11 +292,11 @@ where
 
         let block = block.expect("verification items with supplied roots have a block body");
         verify_supplied_sapling_root_below_heartwood(network, &block, &sapling_root)
-            .map_err(|error| (height, error))?;
+            .map_err(|error| CommitmentRootVerificationError::SuppliedRoot { height, error })?;
         verify_supplied_orchard_root_below_nu5(network, height, &orchard_root)
-            .map_err(|error| (height, error))?;
+            .map_err(|error| CommitmentRootVerificationError::SuppliedRoot { height, error })?;
         verify_supplied_ironwood_root_below_nu6_3(network, height, &ironwood_root)
-            .map_err(|error| (height, error))?;
+            .map_err(|error| CommitmentRootVerificationError::SuppliedRoot { height, error })?;
 
         // Fold this block's supplied roots into the running MMR (builds the leaf
         // from the block body tx-counts + the roots).
@@ -273,7 +304,7 @@ where
             .push(network, block, &sapling_root, &orchard_root, &ironwood_root)
             .map_err(Arc::new)
             .map_err(ValidateContextError::from)
-            .map_err(|error| (height, error))?;
+            .map_err(|error| CommitmentRootVerificationError::SuppliedRoot { height, error })?;
     }
 
     Ok(history_tree)
@@ -656,11 +687,10 @@ mod tests {
                 Some(next_block.auth_data_root()),
             ),
         ];
-        let (fail_height, _error) =
-            verify_commitment_roots(&Mainnet, empty_history_tree(), bad_items)
-                .expect_err("a wrong root must be rejected");
+        let failure = verify_commitment_roots(&Mainnet, empty_history_tree(), bad_items)
+            .expect_err("a wrong root must be rejected");
         assert_eq!(
-            fail_height.0,
+            failure.height().0,
             activation + 1,
             "a wrong root at H is detected at H+1 (the lag)"
         );
@@ -783,16 +813,16 @@ mod tests {
             .as_mut()
             .expect("test verification item has roots")
             .0 = wrong_root;
-        let (fail_height, _error) = verify_commitment_roots(&Mainnet, seed, bad_items)
+        let failure = verify_commitment_roots(&Mainnet, seed, bad_items)
             .expect_err("a wrong NU5 root must be rejected");
         assert_eq!(
-            fail_height.0,
+            failure.height().0,
             bad_height + 1,
             "a wrong root at H is detected at H+1 (the lag)"
         );
         eprintln!(
             "VCT NU5 negative: wrong root at {bad_height} rejected at {}",
-            fail_height.0
+            failure.height().0
         );
     }
 
@@ -996,7 +1026,13 @@ mod tests {
         for &(start, end) in ranges.iter().filter(|(start, _)| *start < heartwood) {
             let items = (start..=end).map(|height| verification_item_at(Height(height)));
             verify_commitment_roots(&Mainnet, empty_history_tree(), items).unwrap_or_else(
-                |(height, error)| panic!("pre-Heartwood roots failed at {height:?}: {error}"),
+                |failure| {
+                    panic!(
+                        "pre-Heartwood roots failed at {:?}: {}",
+                        failure.height(),
+                        failure.error()
+                    )
+                },
             );
             eprintln!("validated direct pre-Heartwood commitments for {start}..={end}");
         }
@@ -1041,14 +1077,14 @@ mod tests {
             let items =
                 (activation + 1..=confirm_end).map(|height| verification_item_at(Height(height)));
 
-            verify_commitment_roots(&Mainnet, history_tree, items).unwrap_or_else(
-                |(height, error)| {
-                    panic!(
-                        "{upgrade:?} MMR linkage failed at {height:?} while validating through \
-                         {confirm_end}: {error}"
-                    )
-                },
-            );
+            verify_commitment_roots(&Mainnet, history_tree, items).unwrap_or_else(|failure| {
+                panic!(
+                    "{upgrade:?} MMR linkage failed at {:?} while validating through \
+                     {confirm_end}: {}",
+                    failure.height(),
+                    failure.error()
+                )
+            });
             eprintln!(
                 "validated {upgrade:?} MMR linkage for {activation}..={end} \
                  (confirmed by {confirm_end})"

--- a/zakura-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/shielded.rs
@@ -90,7 +90,7 @@ impl FromDisk for orchard::tree::Root {
 /// The per-height Sapling and Orchard note-commitment roots, as stored in the
 /// `commitment_roots_by_height` index (keyed by [`Height`]).
 ///
-/// Every node persists this 64-byte value for each committed block — including a
+/// Every node persists this 152-byte value for each committed block — including a
 /// verified-commitment-trees fast-synced node, which folds these roots in but writes no
 /// per-height note-commitment trees. It lets such a node still serve the `tree_aux`
 /// `BlockRoots` read from a compact index rather than from the (absent) trees.
@@ -136,41 +136,21 @@ impl IntoDisk for CommitmentRootsByHeight {
 
 impl FromDisk for CommitmentRootsByHeight {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
-        let bytes = bytes.as_ref();
-        // Backwards compatible with shorter rows written by an earlier pre-release build of
-        // this database version (64 bytes pre-auth-data, 96 bytes pre-ironwood/counts): the
-        // missing fields decode as empty/zero, so the writer falls back to the body-wait path
-        // for those heights until they are re-served with full data. New rows are 152 bytes.
-        let auth_data_root = if bytes.len() >= 96 {
-            let mut auth_data_root = [0u8; 32];
-            auth_data_root.copy_from_slice(&bytes[64..96]);
-            AuthDataRoot::from(auth_data_root)
-        } else {
-            AuthDataRoot::from([0u8; 32])
-        };
-        let (ironwood, sapling_tx, orchard_tx, ironwood_tx) = if bytes.len() >= 152 {
-            (
-                ironwood::tree::Root::from_bytes(&bytes[96..128]),
-                u64::from_be_bytes(bytes[128..136].try_into().expect("8 bytes")),
-                u64::from_be_bytes(bytes[136..144].try_into().expect("8 bytes")),
-                u64::from_be_bytes(bytes[144..152].try_into().expect("8 bytes")),
-            )
-        } else {
-            (
-                ironwood::tree::NoteCommitmentTree::default().root(),
-                0,
-                0,
-                0,
-            )
-        };
+        let bytes: [u8; 152] = bytes
+            .as_ref()
+            .try_into()
+            .expect("commitment root rows must use the current 152-byte format");
+        let mut auth_data_root = [0u8; 32];
+        auth_data_root.copy_from_slice(&bytes[64..96]);
+
         CommitmentRootsByHeight {
             sapling: sapling::tree::Root::from_bytes(&bytes[..32]),
             orchard: orchard::tree::Root::from_bytes(&bytes[32..64]),
-            auth_data_root,
-            ironwood,
-            sapling_tx,
-            orchard_tx,
-            ironwood_tx,
+            auth_data_root: AuthDataRoot::from(auth_data_root),
+            ironwood: ironwood::tree::Root::from_bytes(&bytes[96..128]),
+            sapling_tx: u64::from_be_bytes(bytes[128..136].try_into().expect("8 bytes")),
+            orchard_tx: u64::from_be_bytes(bytes[136..144].try_into().expect("8 bytes")),
+            ironwood_tx: u64::from_be_bytes(bytes[144..152].try_into().expect("8 bytes")),
         }
     }
 }
@@ -299,5 +279,22 @@ impl<Node: FromDisk> FromDisk for NoteCommitmentSubtreeData<Node> {
             Height::from_bytes(height_bytes),
             Node::from_bytes(node_bytes),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commitment_roots_reject_legacy_short_rows() {
+        assert!(
+            std::panic::catch_unwind(|| CommitmentRootsByHeight::from_bytes([0u8; 64])).is_err(),
+            "pre-auth-data rows must not decode"
+        );
+        assert!(
+            std::panic::catch_unwind(|| CommitmentRootsByHeight::from_bytes([0u8; 96])).is_err(),
+            "pre-Ironwood/count rows must not decode"
+        );
     }
 }

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1882,7 +1882,7 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 "the hostile body must have a different auth-data root",
             );
 
-            let mismatched = CheckpointVerifiedBlock::from(hostile_block);
+            let mismatched = CheckpointVerifiedBlock::from(hostile_block.clone());
 
             let error = fast
                 .commit_finalized_direct(
@@ -1912,11 +1912,38 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 "the rejected body must leave finalized state untouched",
             );
 
-            // Rejecting an invalid body must not evict the authenticated VCT
-            // roots. A subsequently downloaded honest body with the same hash
-            // can therefore commit after the write loop's hard-error reset and
-            // let checkpoint sync continue.
+            // A write-loop reset clears the prevalidation cache. The same invalid
+            // body must still be a hard error: replacing the supplied roots cannot
+            // repair a body whose auth data does not match its header commitment.
             fast.clear_vct_prevalidated_next();
+            let mismatched_without_cache = CheckpointVerifiedBlock::from(hostile_block);
+            let error = fast
+                .commit_finalized_direct(
+                    mismatched_without_cache.into(),
+                    None,
+                    None,
+                    "vct mismatched auth-data root without prevalidation",
+                )
+                .expect_err("an invalid body must not become retryable when the cache is empty");
+            prop_assert!(
+                format!("{error:?}").contains("InvalidBlockCommitment"),
+                "the cache-empty mismatch must remain a block error, got: {error:?}",
+            );
+            prop_assert_eq!(
+                error.vct_retryable_height(),
+                None,
+                "the write loop must reset rather than park the invalid body",
+            );
+            prop_assert_eq!(
+                fast.db.finalized_tip_height(),
+                Some(Height((seed + 2) as u32)),
+                "the cache-empty rejected body must leave finalized state untouched",
+            );
+
+            // Rejecting either form of the invalid body must not evict the
+            // authenticated VCT roots. A subsequently downloaded honest body
+            // with the same hash can therefore commit and let checkpoint sync
+            // continue.
             commit(&mut fast, seed + 3);
             prop_assert_eq!(
                 fast.db.finalized_tip_height(),
@@ -1961,8 +1988,13 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 .commit_finalized_direct(forged.into(), None, None, "vct forged wrapper hash")
                 .expect_err("a forged wrapper hash must not skip the bad block's own commitment check");
             prop_assert!(
-                format!("{error:?}").contains("VctSuppliedRootUnavailable"),
+                format!("{error:?}").contains("InvalidBlockCommitment"),
                 "the forged wrapper hash path must reject the bad commitment, got: {error:?}",
+            );
+            prop_assert_eq!(
+                error.vct_retryable_height(),
+                None,
+                "a forged block commitment must not be retried as a supplied-root failure",
             );
             prop_assert_eq!(
                 fast.vct_prevalidated_count(),

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -40,8 +40,18 @@ type SaplingTree = Arc<zakura_chain::sapling::tree::NoteCommitmentTree>;
 type OrchardTree = Arc<zakura_chain::orchard::tree::NoteCommitmentTree>;
 type SproutTree = Arc<zakura_chain::sprout::tree::NoteCommitmentTree>;
 
+fn vct_successor_header(block: Arc<Block>) -> NextVctBlock {
+    NextVctBlock::from_header(
+        block.header.clone(),
+        block
+            .coinbase_height()
+            .expect("prepared successor blocks have a coinbase height"),
+        block.auth_data_root(),
+    )
+}
+
 fn next_vct_block(block: Arc<Block>) -> Option<NextVctBlock> {
-    Some(NextVctBlock::from_block(block, None))
+    Some(vct_successor_header(block))
 }
 
 #[test]
@@ -393,7 +403,7 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
 /// sets + history root) as the legacy recompute path across all upgrade boundaries,
 /// and a wrong fixture root is rejected (verify-before-commit) rather than persisted.
 /// Exercises: a below-Heartwood seed, history-tree creation at Heartwood, the NU5
-/// V1->V2 transition, verify-ahead against the buffered successor, trusted fixture tip
+/// V1->V2 transition, verify-ahead against the successor header, trusted fixture tip
 /// commits without a successor, and rejection of a corrupted root.
 #[test]
 #[allow(clippy::needless_range_loop)] // the loops index blocks[i+1] and the fixture by height
@@ -649,7 +659,7 @@ fn vct_frozen_frontier_hole_refuses_instead_of_recomputing() -> Result<()> {
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                 let next = (i < last)
-                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
+                    .then(|| vct_successor_header(blocks[i + 1].block.clone()));
                 match fast.commit_finalized_direct(cv.into(), None, next, "vct hole fast") {
                     Ok(_) => {}
                     Err(error) => {
@@ -774,7 +784,7 @@ fn vct_retryable_root_miss_keeps_checkpoint_response_pending() -> Result<()> {
 }
 
 /// An *untrusted* (peer) source must never commit a fast block whose own supplied root has
-/// no buffered successor to confirm it against the header chain. A block's roots are only
+/// no successor header to confirm it against the header chain. A block's roots are only
 /// committed by the next block's header (the one-block lag), so committing at the sync tip
 /// would persist a root checked only one block later — irreversibly, once on disk. A wrong
 /// tip root would then wedge the sync with no recovery (the failure surfaces at the next
@@ -867,7 +877,7 @@ fn vct_peer_source_defers_unverifiable_tip_root_until_successor() -> Result<()> 
             }
             prop_assert_eq!(fast.db.finalized_tip_height(), Some(Height((tip_target - 1) as u32)));
 
-            // The tip target with no buffered successor must defer, not commit: its own
+            // The tip target with no successor header must defer, not commit: its own
             // (correct) root is not yet confirmed, and the peer source is untrusted.
             prop_assert!(
                 fast.vct_fast_needs_successor(Height(tip_target as u32)),
@@ -1364,7 +1374,7 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                 let next = (i < last)
-                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
+                    .then(|| vct_successor_header(blocks[i + 1].block.clone()));
                 fast.commit_finalized_direct(cv.into(), None, next, "vct fast handoff")
                     .expect("verified fast commit succeeds");
             }
@@ -1443,7 +1453,7 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                 let next = (i < last)
-                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
+                    .then(|| vct_successor_header(blocks[i + 1].block.clone()));
                 match bad_handoff.commit_finalized_direct(cv.into(), None, next, "vct bad handoff") {
                     Ok(_) => {}
                     Err(error) => {
@@ -1500,7 +1510,7 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             for i in 0..=last {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                 let next = (i < last)
-                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
+                    .then(|| vct_successor_header(blocks[i + 1].block.clone()));
                 match bad_ironwood_handoff.commit_finalized_direct(cv.into(), None, next, "vct bad ironwood handoff") {
                     Ok(_) => {}
                     Err(error) => {
@@ -1628,7 +1638,7 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
                 for i in 0..=handoff_index {
                     let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                     let next = (i < handoff_index)
-                        .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
+                        .then(|| vct_successor_header(blocks[i + 1].block.clone()));
                     fast.commit_finalized_direct(cv.into(), None, next, "vct switch fast prefix")
                         .expect("verified fast prefix commits");
                 }
@@ -1705,7 +1715,7 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
             for i in (seed + 1)..=post_handoff_tip {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                 let next = (i < post_handoff_tip)
-                    .then(|| NextVctBlock::from_block(blocks[i + 1].block.clone(), None));
+                    .then(|| vct_successor_header(blocks[i + 1].block.clone()));
                 fast_suffix
                     .commit_finalized_direct(cv.into(), None, next, "vct switch fast suffix")
                     .expect("fast suffix commits after manual prefix");
@@ -1817,24 +1827,6 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
             commit(&mut fast, seed + 1);
             prop_assert_eq!(fast.vct_prevalidated_count(), 0, "the first fast block runs its own commitment check");
 
-            // Second fast block: its predecessor's look-ahead already validated it,
-            // so the own check is skipped — the dedup engages. Use a header-only
-            // successor, as production does when header sync is ahead of body sync.
-            let cv = CheckpointVerifiedBlock::from(blocks[seed + 2].block.clone());
-            let header_only_successor = NextVctBlock::from_header(
-                blocks[seed + 3].block.header.clone(),
-                Height((seed + 3) as u32),
-                blocks[seed + 3].block.auth_data_root(),
-            );
-            fast.commit_finalized_direct(
-                cv.into(),
-                None,
-                Some(header_only_successor),
-                "vct dedup header-only successor",
-            )
-            .expect("verified fast commit succeeds");
-            prop_assert_eq!(fast.vct_prevalidated_count(), 1, "the second fast block skips its redundant own commitment check");
-
             // ZIP-244 transaction IDs do not commit to authorizing data. Mutate
             // a transparent unlocking script as an untrusted peer can, producing
             // a body with the expected header hash and transaction ID but a
@@ -1881,6 +1873,45 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
                 honest_block.auth_data_root(),
                 "the hostile body must have a different auth-data root",
             );
+
+            // Store the canonical successor header and its precomputed auth-data root,
+            // as header sync does before body sync. The separately constructed malformed
+            // same-hash body must not supply this witness. Using only the stored header
+            // preserves the valid root at `seed + 2` and the prevalidation dedup.
+            let header_heights =
+                Height((seed + 2) as u32)..=Height((seed + 3) as u32);
+            let header_roots =
+                commitment_aux::produce_block_roots(&legacy.db, header_heights);
+            for prepared in &blocks[(seed + 2)..=(seed + 3)] {
+                fast.db
+                    .seed_zakura_header_from_committed_block(
+                        prepared
+                            .block
+                            .coinbase_height()
+                            .expect("prepared successor blocks have a coinbase height"),
+                        &prepared.block,
+                    )
+                    .expect("the canonical successor header is stored");
+            }
+            fast.db
+                .insert_zakura_header_commitment_roots(header_roots)
+                .expect("the canonical successor roots are stored");
+
+            let cv = CheckpointVerifiedBlock::from(blocks[seed + 2].block.clone());
+            let stored_successor = fast
+                .vct_successor_from_header_store(
+                    Height((seed + 2) as u32),
+                    blocks[seed + 2].hash,
+                )
+                .expect("header sync stored the canonical successor witness");
+            fast.commit_finalized_direct(
+                cv.into(),
+                None,
+                Some(stored_successor),
+                "vct header-only successor with malformed body available",
+            )
+            .expect("the stored successor witness preserves the valid current root");
+            prop_assert_eq!(fast.vct_prevalidated_count(), 1, "the second fast block skips its redundant own commitment check");
 
             let mismatched = CheckpointVerifiedBlock::from(hostile_block.clone());
 

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 #[cfg(test)]
 use zakura_chain::parallel::tree::NoteCommitmentTrees;
 use zakura_chain::{
-    block::{self, merkle::AuthDataRoot, Block, Header},
+    block::{self, merkle::AuthDataRoot, Header},
     ironwood, orchard,
     parameters::{Network, NetworkUpgrade},
     sapling, sprout,
@@ -40,22 +40,7 @@ pub struct NextVctBlock {
 }
 
 impl NextVctBlock {
-    /// Build a successor witness from a checkpoint-verified block.
-    pub(crate) fn from_block(block: Arc<Block>, auth_data_root: Option<AuthDataRoot>) -> Self {
-        let height = block
-            .coinbase_height()
-            .expect("checkpoint-verified successor blocks have a coinbase height");
-        let auth_data_root = Some(auth_data_root.unwrap_or_else(|| block.auth_data_root()));
-
-        Self {
-            header: block.header.clone(),
-            height,
-            hash: block.hash(),
-            auth_data_root,
-        }
-    }
-
-    /// Build a successor witness from a contextually validated stored header.
+    /// Build a successor witness from a header and its precomputed auth-data root.
     pub(crate) fn from_header(
         header: Arc<Header>,
         height: block::Height,
@@ -108,7 +93,7 @@ pub(crate) struct VctState {
     /// Where the verified per-block roots and final frontier come from. The
     /// committer reads roots/final frontier through this seam only.
     source: Box<dyn CommitmentRootSource>,
-    /// Whether roots from this VCT state must be confirmed against a buffered successor
+    /// Whether roots from this VCT state must be confirmed against a stored successor header
     /// before they are committed.
     requires_verified_successor: bool,
     /// Count of blocks that took the VCT fast-sync, for the run summary.
@@ -222,7 +207,7 @@ impl VctState {
         self.source.vct_root(height)
     }
 
-    /// `true` when committing `height` on the vct path needs a buffered successor before
+    /// `true` when committing `height` on the vct path needs a stored successor header before
     /// it can safely persist this block's supplied roots.
     ///
     /// Only untrusted peer-supplied roots at or above Heartwood require this. The
@@ -373,7 +358,7 @@ impl VctCommitState {
         self.prevalidated_next
     }
 
-    /// Caches the next block as already validated by this fast commit's look-ahead.
+    /// Caches the next header as already validated by this fast commit's look-ahead.
     pub(super) fn mark_prevalidated(
         &mut self,
         height: block::Height,
@@ -600,7 +585,7 @@ mod tests {
         );
         assert!(
             !trusted.vct_root_needs_successor(height, &network),
-            "trusted fixture roots can commit without a buffered successor"
+            "trusted fixture roots can commit without a stored successor header"
         );
 
         let untrusted = VctState::test_with_source(
@@ -612,7 +597,7 @@ mod tests {
         );
         assert!(
             untrusted.vct_root_needs_successor(height, &network),
-            "untrusted roots defer until a buffered successor verifies them"
+            "untrusted roots defer until a stored successor header verifies them"
         );
     }
 

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -459,22 +459,19 @@ impl WriteBlockWorkerTask {
             // block's supplied roots against the successor's header.
             vct_write_manager.fill_successor(finalized_block_write_receiver, &ordered_block);
 
-            // Prefer a buffered body successor, but fall back to the already-validated
-            // Zakura header store. Requiring the body here creates a circular dependency
-            // at checkpoint boundaries: H waits for H+1 while H+1 cannot be submitted
-            // until its entire checkpoint range is verified.
+            // Fast VCT commits use the already-validated Zakura header store as their
+            // successor witness. A checkpoint-verified body is not sufficient: NU5+
+            // block hashes do not bind authorizing data, so an altered same-hash body
+            // could supply the wrong auth-data root and make a valid current root look
+            // invalid. The buffered body remains in the look-ahead for its own commit.
             let needs_vct_successor =
                 finalized_state.vct_fast_needs_successor(ordered_block.0.height);
-            let next_vct_block = vct_write_manager.next_vct_block().or_else(|| {
-                if needs_vct_successor {
-                    finalized_state.vct_successor_from_header_store(
-                        ordered_block.0.height,
-                        ordered_block.0.hash,
-                    )
-                } else {
-                    None
-                }
-            });
+            let next_vct_block = if needs_vct_successor {
+                finalized_state
+                    .vct_successor_from_header_store(ordered_block.0.height, ordered_block.0.hash)
+            } else {
+                None
+            };
 
             if needs_vct_successor && next_vct_block.is_none() {
                 let height = ordered_block.0.height;
@@ -518,12 +515,11 @@ impl WriteBlockWorkerTask {
                 }
                 Err((ordered_block, error)) => {
                     // Retryable VCT root stalls (an absent/evicted root, or one not yet
-                    // verifiable for lack of a buffered successor) park-and-retry the same
+                    // verifiable for lack of a stored successor header) park-and-retry the same
                     // block in place rather than resetting the queue. An absent root can only
                     // be filled by a re-delivery of its header range (roots are not
                     // individually re-requested), so it polls slowly; an await-successor
-                    // stall just waits for the next block to be downloaded into the
-                    // look-ahead, so it polls faster.
+                    // stall just waits for the next header to be stored, so it polls faster.
                     if let Some(height) = error.vct_retryable_height() {
                         let root_unavailable = error.vct_supplied_root_unavailable_height();
 

--- a/zakura-state/src/service/write/vct_write.rs
+++ b/zakura-state/src/service/write/vct_write.rs
@@ -11,7 +11,7 @@ use tracing::info;
 use zakura_chain::block::Height;
 
 use crate::service::{
-    finalized_state::{FinalizedState, NextVctBlock},
+    finalized_state::FinalizedState,
     queued_blocks::QueuedCheckpointVerified,
     write::{VctRootRepairState, VctRootRepairStatus},
 };
@@ -22,13 +22,13 @@ use crate::service::{
 const VCT_ROOT_RETRY_WAIT: Duration = Duration::from_millis(500);
 
 /// Delay between retryable VCT await-successor commit attempts. Shorter than
-/// [`VCT_ROOT_RETRY_WAIT`]: the root is already cached and only the next block needs to be
-/// downloaded into the look-ahead, so a tighter poll keeps the one-block commit lag small.
+/// [`VCT_ROOT_RETRY_WAIT`]: the root is already cached and only the next header needs to be
+/// stored, so a tighter poll keeps the one-block commit lag small.
 const VCT_AWAIT_SUCCESSOR_WAIT: Duration = Duration::from_millis(20);
 
 /// How long a single checkpoint height may stay stuck on a retryable VCT root stall before
 /// the committer escalates to an error-level log and a `state.vct.root.stalled.height` gauge.
-/// Transient waits (a successor still downloading, a fanout re-delivery still in flight)
+/// Transient waits (a successor header still downloading, a fanout re-delivery still in flight)
 /// clear well within this; staying stuck past it means no verifiable root is available for a
 /// height the frozen frontier requires, and — by design — the committer will not recompute
 /// against the stale frontier, so the node cannot advance. Surfacing that loudly is the
@@ -140,14 +140,6 @@ impl VctWriteManager {
                 },
             }
         }
-    }
-
-    /// The buffered successor block's header data, used to verify the
-    /// current block's supplied vct roots before trusting them.
-    pub(super) fn next_vct_block(&self) -> Option<NextVctBlock> {
-        self.lookahead
-            .front()
-            .map(|next| NextVctBlock::from_block(next.0.block.clone(), next.0.auth_data_root))
     }
 
     /// A successful commit clears any vct root stall: logs recovery and

--- a/zakura-state/src/service/write/vct_write/tests.rs
+++ b/zakura-state/src/service/write/vct_write/tests.rs
@@ -92,9 +92,8 @@ fn fill_successor_only_buffers_one_linking_block_at_a_time() {
 }
 
 /// A buffered block that does not extend the block being committed is discarded:
-/// it can't witness the commit, and — because a parked retry is always taken
-/// before the look-ahead — it would otherwise never be popped, wedging the retry
-/// loop against a bogus witness that spuriously evicts good roots.
+/// because a parked retry is always taken before the look-ahead, leaving it there
+/// would wedge the retry loop ahead of the real successor body.
 #[test]
 fn fill_successor_discards_non_successors_and_keeps_the_linking_block() {
     let mut manager = VctWriteManager::default();
@@ -116,15 +115,20 @@ fn fill_successor_discards_non_successors_and_keeps_the_linking_block() {
         successor_hash,
         "the non-linking block is dropped and the true successor takes its place"
     );
-    let witness = manager
-        .next_vct_block()
-        .expect("successor is buffered")
-        .header;
-    assert_eq!(witness.previous_block_hash, current.0.hash);
+    assert_eq!(
+        manager
+            .lookahead
+            .front()
+            .expect("successor is buffered")
+            .0
+            .block
+            .header
+            .previous_block_hash,
+        current.0.hash,
+    );
 }
 
-/// With no linking block buffered anywhere, the look-ahead ends up empty, so the
-/// write loop's await-successor deferral engages instead of a bogus witness.
+/// With no linking body buffered anywhere, the look-ahead ends up empty.
 #[test]
 fn fill_successor_empties_the_lookahead_when_no_successor_exists() {
     let mut manager = VctWriteManager::default();
@@ -135,29 +139,19 @@ fn fill_successor_empties_the_lookahead_when_no_successor_exists() {
     manager.fill_successor(&mut rx, &current);
 
     assert!(manager.lookahead.is_empty());
-    assert!(manager.next_vct_block().is_none());
 }
 
 #[test]
-fn next_vct_block_reflects_the_lookahead_front() {
+fn buffered_successor_body_remains_queued_for_its_own_commit() {
     let mut manager = VctWriteManager::default();
-    assert!(manager.next_vct_block().is_none());
-
     let block = queued_block(1);
-    let expected_block = block.0.block.clone();
-    let expected_auth_data_root = block.0.auth_data_root;
+    let expected_hash = block.0.hash;
     manager.lookahead.push_back(block);
 
-    let next_vct_block = manager.next_vct_block().expect("look-ahead has a block");
-    assert_eq!(next_vct_block.header, expected_block.header);
-    assert_eq!(next_vct_block.hash, expected_block.hash());
-    assert_eq!(
-        next_vct_block.height,
-        expected_block
-            .coinbase_height()
-            .expect("fake block has a height")
-    );
-    assert_eq!(next_vct_block.auth_data_root, expected_auth_data_root);
+    let ready = manager
+        .take_ready()
+        .expect("the buffered successor body is ready for its own commit");
+    assert_eq!(ready.0.hash, expected_hash);
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

VCT fast commits had two related failure-classification problems around NU5+ authorizing data:

- After a queue reset, a malformed current block body could be misclassified as a retryable supplied-root failure and parked indefinitely.
- A buffered successor body with the canonical header/hash but altered authorizing data could provide a different `auth_data_root`. Its failed look-ahead check was then attributed to the current height, evicting a valid supplied root and stalling the frozen-frontier retry path.

The second case is possible because ZIP-244 transaction IDs, and therefore the block hash, do not bind signatures, proofs, or transparent unlocking scripts.

## Solution

- Preserve whether VCT verification failed on the current block body or on supplied roots, keeping current-body failures non-retryable.
- Source production successor witnesses exclusively from the contextually validated header store and its persisted precomputed `auth_data_root`; buffered bodies remain queued only for their own commits.
- Remove body-derived `NextVctBlock` construction while preserving supplied-root fast commits and successful-look-ahead deduplication.
- Reject obsolete short commitment-root rows so a missing persisted auth-data root cannot silently decode as zero.
- Extend regression coverage for cache-empty malformed bodies, forged wrappers, malformed same-hash successors, header-only prevalidation, and buffered-body behavior.

A malformed successor body can no longer evict the current block's root. It is rejected as a hard auth-data mismatch when it becomes the current block, while an honest same-hash replacement can still commit.

## Testing

- `cargo fmt --all -- --check`
- `CXXFLAGS='-include cstdint' cargo test -p zakura-state --lib`
  - 358 passed; 3 ignored.
  - Exercises malformed current and successor bodies, verifies valid supplied roots remain usable, and covers strict commitment-root row decoding.
- `CXXFLAGS='-include cstdint' cargo clippy -p zakura-state --all-targets -- -D warnings`
- VCT-focused state tests
  - 41 passed; 1 ignored.
- IDE diagnostics for all modified files

### Specifications & References

- Follow-up to #208
- ZIP-244 authorizing-data commitments

### Follow-up Work

None.

## AI disclosure

Cursor GPT-5.6 Sol was used to investigate the VCT failure paths, implement the fixes and regression coverage, run verification, and draft this PR description. The contributor reviewed the changes and test results.