### PR TITLE
fix(docs): allow generated uint semicolon lint

### DIFF
--- a/zakura-chain/src/work/u256.rs
+++ b/zakura-chain/src/work/u256.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::all)]
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::fallible_impl_from)]
+#![allow(semicolon_in_expressions_from_macros)]
 #![allow(missing_docs)]
 
 use uint::construct_uint;


### PR DESCRIPTION
## Motivation

Nightly rustdoc builds fail under `-D warnings` because `uint`'s generated `uint_full_mul_reg` macro triggers `semicolon_in_expressions_from_macros` while expanding Zakura's `U256` type.

## Solution

Allow that compiler lint only in the `u256` module, which already scopes lint allowances for generated `uint` code. This leaves warning-as-error enforcement unchanged elsewhere.

## Testing

- `cargo fmt --all -- --check`
- Re-ran the failing nightly rustdoc configuration for `zakura-chain` with all features, private items, docs.rs flags, and warnings denied; it passes.
- Cursor diagnostics: no errors in the changed file.

### Specifications & References

- Rust issue: https://github.com/rust-lang/rust/issues/79813
- AI disclosure: Cursor GPT-5.6 Sol was used to diagnose the CI failure, implement the scoped lint allowance, and draft this PR description.