### PR TITLE
fix(deploy): include failure height in sync alerts

### DIFF
--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -605,9 +605,11 @@ def completion_text(config: Config, run_state: dict[str, Any]) -> str:
 def failure_text(config: Config, run_state: dict[str, Any], reason: str) -> str:
     p = config.policy
     duration = format_duration(int(run_state["time_to_failure_seconds"]))
+    height = run_state.get("height")
+    height_text = str(height) if isinstance(height, int) else "unknown"
     return (
         f":rotating_light: Zakura failed: {p.hostname} | {policy_mode(p)} | "
-        f"{ssh_target(p)} | time to failure: {duration}"
+        f"{ssh_target(p)} | time to failure: {duration} | height: {height_text}"
     )
 
 

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -345,16 +345,23 @@ class ContinuousSyncTests(unittest.TestCase):
 
         text = sync.failure_text(
             config,
-            {"sha": "abcdef", "time_to_failure_seconds": 3723},
+            {"sha": "abcdef", "time_to_failure_seconds": 3723, "height": 2584406},
             "boom",
         )
 
         self.assertEqual(
             text,
             ":rotating_light: Zakura failed: temp-zakura-sync-test-3 | legacy | "
-            "root@134.209.49.92 | time to failure: 1h 2m 3s",
+            "root@134.209.49.92 | time to failure: 1h 2m 3s | height: 2584406",
         )
         self.assertNotIn("\n", text)
+
+    def test_controller_failure_slack_text_handles_unknown_height(self):
+        config = make_config(Path("/tmp"))
+
+        text = sync.failure_text(config, {"time_to_failure_seconds": 5}, "boom")
+
+        self.assertIn("time to failure: 5s | height: unknown", text)
 
     def test_completion_slack_text_includes_sync_duration(self):
         config = make_config(


### PR DESCRIPTION
## Motivation

Continuous-sync failure alerts report elapsed time but omit the block height where the run stopped, requiring operators to inspect node state or logs to locate the failure point.

## Solution

- append the last observed finalized or verified height to controller failure alerts
- report `height: unknown` when a run fails before any height is observed
- cover both known-height and unknown-height alert formatting

## Testing

- `python3 -m unittest deploy/continuous-sync/tests/test_continuous_sync.py` — 21 tests passed, including known and unknown failure heights
- IDE diagnostics — no errors
- deployed successfully from this main-based worktree to all seven continuous-sync nodes

Risk classification: low. This is a small alert-formatting change with focused unit coverage.

### Specifications & References

No linked issue.

### Follow-up Work

The separate cluster monitor and scheduled audit alerts still do not expose per-run timing or height data.

### AI Disclosure

Used Cursor to investigate the alert paths, implement the formatting change, and add focused tests. The author reviewed and deployed the result.