### PR TITLE
fix(network): preserve late block-sync response correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Zakura are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Fixed
+
+- Preserved exact Zakura block-sync request correlation after another sync path
+  commits the requested block, so a matching late response proves peer
+  liveness instead of being discarded before the peer is disconnected.
+
 ## [1.0.0] - 2026-07-15
 
 Initial release of Zakura.

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved exact block-sync request correlation after another path commits the
+  requested block, so a matching late response proves peer liveness instead of
+  being discarded before the peer is disconnected.
+
 ## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -21,7 +21,7 @@
 //! task's own `FramedRecv`: a want-work fill loop, the matched-body tail, and the
 //! unmatched-body fallthroughs all run in this one task.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use tokio::sync::{futures::Notified, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
@@ -35,6 +35,7 @@ use super::{
         admit, floor_rescue_high, request_deadline, request_priority as classify_priority,
         AdmissionOutcome, AdmissionSnapshot, RequestPriority,
     },
+    config::DEFAULT_BS_MAX_REQUESTS_WITHOUT_BLOCK_PROGRESS,
     peer_registry::{hard_outbound_capacity, PeerRegistry},
     pipe::block_sync_guard,
     reactor::{
@@ -50,7 +51,7 @@ use super::{
     },
     work_queue::{WorkItem, WorkQueue, WorkReturnOutcome},
     BlockSyncAction, BlockSyncMessage, BlockSyncMisbehavior, BlockSyncPeerSession, BlockSyncStatus,
-    ZakuraBlockSyncConfig, ZakuraPeerId, ZakuraTrace, MSG_BS_BLOCK,
+    ZakuraBlockSyncConfig, ZakuraPeerId, ZakuraTrace, MAX_BS_BLOCKS_PER_REQUEST, MSG_BS_BLOCK,
 };
 use crate::zakura::{
     trace::{block_sync_trace as bs_trace, BLOCK_SYNC_TABLE},
@@ -75,6 +76,15 @@ const OUTBOUND_FULL_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// emits controller state on a fixed interval so a trace can spot oscillation even while
 /// the peer is idle between deliveries.
 const BBR_TRACE_INTERVAL: Duration = Duration::from_secs(10);
+/// Maximum exact request correlations retained after local commit GC.
+///
+/// This covers one default no-progress window when every request has the
+/// protocol-maximum range, while bounding memory if another path keeps committing
+/// work that this peer never delivers.
+// Both factors are small `u32` protocol constants (64 and 128), so their product
+// fits in `usize` on every supported target.
+const MAX_STALE_REQUEST_CORRELATIONS: usize =
+    DEFAULT_BS_MAX_REQUESTS_WITHOUT_BLOCK_PROGRESS as usize * MAX_BS_BLOCKS_PER_REQUEST as usize;
 
 /// Why a fill pass stopped issuing requests. Typed so every admission refusal is
 /// attributed exhaustively; the `as_str` labels feed the `sync.block.fill_stop`
@@ -171,6 +181,13 @@ enum Disposition {
     RetryMissing,
 }
 
+/// One unreceived block from a request removed by local commit GC.
+#[derive(Copy, Clone, Debug)]
+struct StaleRequestCorrelation {
+    expected: ExpectedBlock,
+    expires_at: Instant,
+}
+
 impl Disposition {
     fn trace_label(self) -> &'static str {
         match self {
@@ -224,6 +241,9 @@ pub(super) struct PeerRoutine {
     /// itself — the peer-local retry bias (see [`RETRY_AVOID_BACKOFF`]). Pruned on
     /// expiry each fill pass.
     retry_avoid: BTreeMap<block::Height, Instant>,
+    /// Exact, unreceived request metadata retained after local commit GC removes
+    /// the scheduling request. Entries are one-shot, expiring, and bounded.
+    stale_request_correlations: BTreeMap<block::Height, StaleRequestCorrelation>,
 
     // ---- shared primitives (clones) ----
     /// Generation this routine was spawned with; gates its registry writes (and
@@ -305,6 +325,7 @@ impl PeerRoutine {
             status_reply_meter,
             inbound_status_meter,
             retry_avoid: BTreeMap::new(),
+            stale_request_correlations: BTreeMap::new(),
             generation,
             budget,
             work,
@@ -594,6 +615,7 @@ impl PeerRoutine {
             self.trace_work_returned("view_reset", &outstanding, unreceived.len(), outcome);
         }
         self.retry_avoid.clear();
+        self.stale_request_correlations.clear();
         // Clear our (now-empty) registry outstanding and refresh slot diagnostics.
         self.publish_outstanding();
         // A destructive reset pulled this peer's outstanding on our initiative, so its
@@ -665,10 +687,10 @@ impl PeerRoutine {
         // requests; it is never a fetch throttle and never churns other peers (a
         // partially-received request whose suffix is still above the floor is left
         // in place).
-        self.gc_committed_outstanding();
+        let now = Instant::now();
+        self.gc_committed_outstanding(now);
         // Drop expired retry-avoid entries: those heights are contestable by this
         // routine again.
-        let now = Instant::now();
         self.retry_avoid.retain(|_, until| *until > now);
         // Count requests issued this pass and capture *why* the fill loop stops, so a
         // trace can attribute carrier idle ("bubble") time to a cause. The loop yields a
@@ -1192,7 +1214,9 @@ impl PeerRoutine {
     /// below the floor, GC'd from the WorkQueue). A partially-committed request
     /// (suffix still above the floor) is left so its remaining bodies keep their
     /// reservation and arrive on the same request.
-    fn gc_committed_outstanding(&mut self) {
+    fn gc_committed_outstanding(&mut self, now: Instant) {
+        self.stale_request_correlations
+            .retain(|_, correlation| correlation.expires_at > now);
         let floor = self.download_floor();
         let mut released = 0u64;
         let mut removed = false;
@@ -1200,6 +1224,7 @@ impl PeerRoutine {
         while index < self.window.outstanding.len() {
             if self.window.outstanding[index].request.end_height() <= floor {
                 let outstanding = self.window.outstanding.remove(index);
+                self.remember_stale_request_correlations(&outstanding, now);
                 // Release only the size-estimate still reserved for unreceived
                 // heights. A height a competing peer delivered late is `Held`: its
                 // body is in the commit pipeline and the Sequencer releases those
@@ -1219,6 +1244,32 @@ impl PeerRoutine {
         if removed {
             self.publish_outstanding();
             self.window.disarm_liveness_after_progress_if_idle();
+        }
+    }
+
+    /// Retain exact metadata for bodies that can arrive after local commit GC
+    /// removes their request. Oldest heights are evicted first at the hard cap;
+    /// body download normally advances monotonically, so they are also the least
+    /// useful correlations.
+    fn remember_stale_request_correlations(
+        &mut self,
+        outstanding: &OutstandingBlockRange,
+        now: Instant,
+    ) {
+        let expires_at = now + self.config.effective_liveness_timeout();
+        for expected in &outstanding.request.expected_blocks {
+            if !outstanding.has_received(expected.height) {
+                self.stale_request_correlations.insert(
+                    expected.height,
+                    StaleRequestCorrelation {
+                        expected: *expected,
+                        expires_at,
+                    },
+                );
+            }
+        }
+        while self.stale_request_correlations.len() > MAX_STALE_REQUEST_CORRELATIONS {
+            self.stale_request_correlations.pop_first();
         }
     }
 
@@ -1249,6 +1300,12 @@ impl PeerRoutine {
                     body_permit,
                     raw_block_payload.clone(),
                 )
+                .await
+            {
+                return;
+            }
+            if self
+                .accept_correlated_stale_body(height, hash, block, body_wire_bytes)
                 .await
             {
                 return;
@@ -1409,6 +1466,104 @@ impl PeerRoutine {
     /// passes it). Reads `download_floor` from the view.
     fn is_stale_response_height(&self, height: block::Height) -> bool {
         height <= self.download_floor() || self.work.in_flight_contains(height)
+    }
+
+    /// Credit a response to a request removed by local commit GC. The response
+    /// must match the exact height, header hash, size envelope, and
+    /// transaction-effects Merkle root. It is consumed once and never buffered
+    /// or sampled by BBR.
+    async fn accept_correlated_stale_body(
+        &mut self,
+        height: block::Height,
+        hash: block::Hash,
+        block: Arc<block::Block>,
+        body_wire_bytes: Option<u64>,
+    ) -> bool {
+        if !self.is_stale_response_height(height) {
+            return false;
+        }
+        let Some(correlation) = self.stale_request_correlations.get(&height).copied() else {
+            return false;
+        };
+        let now = Instant::now();
+        if correlation.expires_at <= now {
+            self.stale_request_correlations.remove(&height);
+            return false;
+        }
+        if correlation.expected.hash != hash {
+            return false;
+        }
+
+        let serialized_bytes = match body_wire_bytes {
+            Some(bytes) => bytes,
+            None => match block.zcash_serialize_to_vec() {
+                Ok(bytes) => u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+                Err(error) => {
+                    self.stale_request_correlations.remove(&height);
+                    tracing::debug!(
+                        peer = ?self.peer,
+                        ?height,
+                        ?error,
+                        "failed to serialize correlated stale block-sync body"
+                    );
+                    self.report_misbehavior(BlockSyncMisbehavior::InvalidBlock)
+                        .await;
+                    return true;
+                }
+            },
+        };
+        if serialized_bytes
+            > tolerated_bytes(
+                correlation.expected.estimated_bytes,
+                self.config.size_deviation_tolerance,
+            )
+        {
+            self.stale_request_correlations.remove(&height);
+            self.report_misbehavior(BlockSyncMisbehavior::SizeMismatch)
+                .await;
+            return true;
+        }
+
+        // This stale body will not reach consensus, so perform the content checks
+        // that bind transaction effects to its already-verified header here.
+        let content_check = tokio::task::spawn_blocking(move || {
+            let transaction_hashes: Vec<_> =
+                block.transactions.iter().map(|tx| tx.hash()).collect();
+            let merkle_root: block::merkle::Root = transaction_hashes.iter().cloned().collect();
+            let unique_transactions = transaction_hashes.iter().collect::<HashSet<_>>().len();
+            merkle_root == block.header.merkle_root
+                && unique_transactions == transaction_hashes.len()
+        })
+        .await;
+        let content_matches_header = match content_check {
+            Ok(matches) => matches,
+            Err(error) => {
+                tracing::debug!(
+                    peer = ?self.peer,
+                    ?height,
+                    ?error,
+                    "correlated stale block content check did not complete"
+                );
+                return true;
+            }
+        };
+        if !content_matches_header {
+            self.stale_request_correlations.remove(&height);
+            self.report_misbehavior(BlockSyncMisbehavior::InvalidBlock)
+                .await;
+            return true;
+        }
+
+        self.stale_request_correlations.remove(&height);
+        metrics::counter!("sync.block.response.correlated_stale_accepted").increment(1);
+        tracing::debug!(
+            peer = ?self.peer,
+            ?height,
+            "crediting a correlated stale block-sync body as peer progress"
+        );
+        self.window
+            .note_block_progress(Instant::now(), self.config.effective_liveness_timeout());
+        true
     }
 
     async fn ignore_stale_response(&mut self, height: block::Height, response_kind: &str) -> bool {

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -339,6 +339,41 @@ async fn wait_for_outbound_getblocks(outbound: &mut FramedRecv) -> (block::Heigh
     }
 }
 
+async fn wait_for_peer_outstanding_state(
+    registry: &super::peer_registry::PeerRegistry,
+    peer: &ZakuraPeerId,
+    height: block::Height,
+    expected: bool,
+) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if registry.peer_has_outstanding_height(peer, height) == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("peer outstanding state reaches the expected value");
+}
+
+async fn assert_no_outbound_getblocks(outbound: &mut FramedRecv, context: &str) {
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                match next_outbound_message(outbound).await {
+                    BlockSyncMessage::Status(_) => {}
+                    BlockSyncMessage::GetBlocks { .. } => return,
+                    message => panic!("unexpected outbound message {context}: {message:?}"),
+                }
+            }
+        })
+        .await
+        .is_err(),
+        "unexpected outbound GetBlocks {context}",
+    );
+}
+
 /// Wait for the node's `Status` advertisement on this peer's real outbound — the
 /// connect status the reactor sends on `PeerConnected`, and later refreshes.
 /// Replaces the mirror-based `wait_for_connect_status`; the peer is implicit in
@@ -3152,6 +3187,214 @@ async fn block_liveness_credits_late_unmatched_body_and_keeps_peer() {
             .is_err(),
         "a peer that delivered an accepted (late) body must not be parked as silent",
     );
+
+    reactor_task.abort();
+}
+
+#[tokio::test]
+async fn block_liveness_credits_requested_body_after_local_commit_gc() {
+    // Regression: another path can commit a requested height before this peer's
+    // response arrives. GC must free the obsolete scheduling request without
+    // losing the exact height/hash correlation needed to prove peer liveness.
+    let config = ZakuraBlockSyncConfig {
+        request_timeout: Duration::from_secs(5),
+        ..ZakuraBlockSyncConfig::default()
+    };
+
+    let blocks = mainnet_blocks_1_to_3();
+    let genesis = Frontier::new(block::Height(0), block::Hash([0; 32]));
+    let initial = FrontierUpdate {
+        frontier: ChainFrontier {
+            finalized: genesis,
+            verified_body: genesis,
+            best_header: Frontier::new(block::Height(2), blocks[1].hash()),
+        },
+        change: FrontierChange::Snapshot,
+    };
+    let (exchange, startup) = exchange_block_sync_startup(initial, config.clone());
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let registry = handle
+        .routine_wiring
+        .as_ref()
+        .expect("reactor handle has routine wiring")
+        .registry
+        .clone();
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+    let (peer_id, inbound_tx, mut outbound_rx) = connect_peer_with_status(
+        &service,
+        &mut actions,
+        0x54,
+        block::Height(2),
+        blocks[1].hash(),
+        1,
+        MAX_BS_RESPONSE_BYTES,
+    )
+    .await;
+
+    handle
+        .send(BlockSyncEvent::NeededBlocks(vec![
+            block_meta(&blocks[0]),
+            block_meta(&blocks[1]),
+        ]))
+        .await
+        .expect("needed metadata queues");
+    assert_eq!(
+        wait_for_outbound_getblocks(&mut outbound_rx).await,
+        (block::Height(1), 1),
+    );
+    wait_for_peer_outstanding_state(&registry, &peer_id, block::Height(1), true).await;
+
+    // Simulate gossip or another sync path committing height 1 while the peer's
+    // requested body is already in flight.
+    exchange.publish_frontier(
+        FrontierUpdate {
+            frontier: ChainFrontier {
+                finalized: genesis,
+                verified_body: Frontier::new(block::Height(1), blocks[0].hash()),
+                best_header: Frontier::new(block::Height(2), blocks[1].hash()),
+            },
+            change: FrontierChange::VerifiedGrow,
+        },
+        "block_liveness_local_commit_gc",
+    );
+    wait_for_peer_outstanding_state(&registry, &peer_id, block::Height(1), false).await;
+    assert_no_outbound_getblocks(
+        &mut outbound_rx,
+        "before the correlated stale body proved progress",
+    )
+    .await;
+
+    // This body is stale locally but exactly matches what we asked this peer for.
+    // It must prove liveness without being submitted again, and unlock the next
+    // cold-start request.
+    send_inbound(&inbound_tx, BlockSyncMessage::Block(blocks[0].clone())).await;
+    assert_eq!(
+        wait_for_outbound_getblocks(&mut outbound_rx).await,
+        (block::Height(2), 1),
+    );
+
+    send_inbound(&inbound_tx, BlockSyncMessage::Block(blocks[1].clone())).await;
+    loop {
+        match next_action(&mut actions).await {
+            BlockSyncAction::SubmitBlock { block, .. } => {
+                assert_eq!(
+                    block.coinbase_height(),
+                    Some(block::Height(2)),
+                    "the already-committed correlated body must not be resubmitted",
+                );
+                break;
+            }
+            BlockSyncAction::QueryNeededBlocks { .. } => {}
+            action => panic!("unexpected action while waiting for height 2: {action:?}"),
+        }
+    }
+
+    reactor_task.abort();
+}
+
+#[tokio::test]
+async fn block_liveness_rejects_invalid_stale_bodies_after_local_commit_gc() {
+    // A stale body must match the request and the header's transaction-effects
+    // Merkle root before it can prove peer progress.
+    let config = ZakuraBlockSyncConfig {
+        request_timeout: Duration::from_secs(5),
+        ..ZakuraBlockSyncConfig::default()
+    };
+
+    let blocks = mainnet_blocks_1_to_3();
+    let unrelated_block = forked_block(&blocks[0], 0x55);
+    let bad_body = block_with_bad_merkle_root(&blocks[0], &blocks[1]);
+    assert!(
+        u64::from(block_size(&bad_body))
+            <= super::reactor::tolerated_bytes(
+                u64::from(block_size(&blocks[0])),
+                config.size_deviation_tolerance,
+            ),
+        "the malformed body must reach the transaction-Merkle check",
+    );
+    let genesis = Frontier::new(block::Height(0), block::Hash([0; 32]));
+    let initial = FrontierUpdate {
+        frontier: ChainFrontier {
+            finalized: genesis,
+            verified_body: genesis,
+            best_header: Frontier::new(block::Height(2), blocks[1].hash()),
+        },
+        change: FrontierChange::Snapshot,
+    };
+    let (exchange, startup) = exchange_block_sync_startup(initial, config.clone());
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let registry = handle
+        .routine_wiring
+        .as_ref()
+        .expect("reactor handle has routine wiring")
+        .registry
+        .clone();
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+    let (peer_id, inbound_tx, mut outbound_rx) = connect_peer_with_status(
+        &service,
+        &mut actions,
+        0x55,
+        block::Height(2),
+        blocks[1].hash(),
+        1,
+        MAX_BS_RESPONSE_BYTES,
+    )
+    .await;
+
+    handle
+        .send(BlockSyncEvent::NeededBlocks(vec![
+            block_meta(&blocks[0]),
+            block_meta(&blocks[1]),
+        ]))
+        .await
+        .expect("needed metadata queues");
+    assert_eq!(
+        wait_for_outbound_getblocks(&mut outbound_rx).await,
+        (block::Height(1), 1),
+    );
+    wait_for_peer_outstanding_state(&registry, &peer_id, block::Height(1), true).await;
+
+    exchange.publish_frontier(
+        FrontierUpdate {
+            frontier: ChainFrontier {
+                finalized: genesis,
+                verified_body: Frontier::new(block::Height(1), blocks[0].hash()),
+                best_header: Frontier::new(block::Height(2), blocks[1].hash()),
+            },
+            change: FrontierChange::VerifiedGrow,
+        },
+        "block_liveness_invalid_stale_body",
+    );
+    wait_for_peer_outstanding_state(&registry, &peer_id, block::Height(1), false).await;
+
+    assert_eq!(unrelated_block.coinbase_height(), Some(block::Height(1)));
+    assert_ne!(unrelated_block.hash(), blocks[0].hash());
+    send_inbound(&inbound_tx, BlockSyncMessage::Block(unrelated_block)).await;
+    assert_no_outbound_getblocks(
+        &mut outbound_rx,
+        "after an unrelated stale body failed exact request correlation",
+    )
+    .await;
+
+    assert_eq!(bad_body.coinbase_height(), Some(block::Height(1)));
+    assert_eq!(bad_body.hash(), blocks[0].hash());
+    send_inbound(&inbound_tx, BlockSyncMessage::Block(bad_body)).await;
+    loop {
+        match next_action(&mut actions).await {
+            BlockSyncAction::Misbehavior { peer, reason } => {
+                assert_eq!(peer, peer_id);
+                assert_eq!(reason, BlockSyncMisbehavior::InvalidBlock);
+                break;
+            }
+            BlockSyncAction::QueryNeededBlocks { .. } => {}
+            action => panic!("unexpected action before stale body rejection: {action:?}"),
+        }
+    }
+    assert_no_outbound_getblocks(
+        &mut outbound_rx,
+        "after a correlated body failed its transaction-effects Merkle root",
+    )
+    .await;
 
     reactor_task.abort();
 }


### PR DESCRIPTION
## Motivation

Sending `GetBlocks` arms the peer's no-progress accounting. If another delivery
path commits that height first, floor GC removes the obsolete scheduling request
and its response correlation. The requested body can then arrive on the wire,
be discarded as an unmatched stale response, and leave the healthy peer capped
until it is parked or disconnected.

This is the Covered/floor-GC late-response case discussed in #192 and #209.

## Solution

- Retain private correlation metadata for unreceived blocks removed by local
  commit GC. Entries are one-shot, expire with the peer liveness window, are
  cleared on destructive reset, and have a hard per-peer bound.
- Before ordinary stale-response handling, accept a matching height and header
  hash only after checking its size envelope, transaction-effects Merkle root,
  and transaction uniqueness.
- Credit that exact response as peer progress without resubmitting the
  already-committed block or sampling it for BBR.
- Reject unrelated or malformed stale bodies without unlocking the next
  cold-start request.
- Add regression coverage for both the valid late-response path and invalid
  response variants, and document the user-visible fix in both changelogs.

The implementation changes only private block-sync internals; it introduces no
`pub` or `pub(crate)` API changes.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `cargo test -p zakura-network --lib local_commit_gc` — 2 passed
- `cargo test -p zakura-network --lib zakura::block_sync::tests` — 181 passed

The positive regression test forces floor GC, proves height 2 is not requested
before the late height-1 response, then verifies the response unlocks height 2
without resubmitting height 1. The negative test verifies that a different block
and a same-header body with a bad transaction Merkle root do not unlock the
peer.

### Specifications & References

Related to #192 and #209. This is a focused alternative for the Covered/floor-GC
race; it does not supersede #209's broader retired-request, ownership, reset,
timeout, and terminator-correlation work.

### Follow-up Work

This patch deliberately counts an already-committed correlated body as peer
progress. #209 instead distinguishes correlation from useful block progress.
Maintainers should choose that policy before this draft is marked ready: a peer
that consistently answers only after another path commits could otherwise reset
its no-progress accounting.

Because the stale body is never submitted, this path performs local structural
checks rather than full consensus authorization-data verification. Full NU5+
body authentication would require retaining the relevant authenticated metadata
or routing the body through consensus without committing it.

AI disclosure: OpenAI Codex was used to diagnose the CI failure, implement the
private block-sync correlation state and regression tests, run validation, and
draft this PR description. The contributor reviewed the changes and test
results.
