### PR TITLE
fix(network): correct header-sync maintenance timing

### DIFF
--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -2998,7 +2998,6 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
         config.zakura.header_sync.clone(),
         limits.max_frame_bytes,
     );
-    startup.status_refresh_interval = config.zakura.header_sync.status_refresh_interval;
     startup.trace = trace.clone();
     startup.frontier_updates = sync_frontier
         .as_ref()

--- a/zakura-network/src/zakura/header_sync/events.rs
+++ b/zakura-network/src/zakura/header_sync/events.rs
@@ -56,6 +56,7 @@ impl HeaderSyncStartup {
         config: ZakuraHeaderSyncConfig,
         max_frame_bytes: u32,
     ) -> Self {
+        let status_refresh_interval = config.status_refresh_interval;
         Self {
             network,
             anchor,
@@ -65,7 +66,7 @@ impl HeaderSyncStartup {
             config,
             max_frame_bytes,
             request_timeout: DEFAULT_HS_REQUEST_TIMEOUT,
-            status_refresh_interval: DEFAULT_HS_STATUS_REFRESH_INTERVAL,
+            status_refresh_interval,
             trace: ZakuraTrace::noop(),
             shutdown: CancellationToken::new(),
             range_state_actions_enabled: false,

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -2154,8 +2154,7 @@ impl HeaderSyncReactor {
             deadline = deadline.min(status_deadline);
         }
         if let Some(repair) = self.state.repair.as_ref() {
-            deadline = deadline.min(repair.next_attempt_at);
-            deadline = deadline.min(repair.started_at + VCT_ROOT_REPAIR_MAX_WALL_TIME);
+            deadline = deadline.min(repair.next_maintenance_deadline());
         }
 
         deadline.max(now)

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -307,6 +307,17 @@ impl VctRootRepair {
             && now >= self.next_attempt_at
     }
 
+    pub(super) fn next_maintenance_deadline(&self) -> Instant {
+        let repair_deadline = self.started_at + VCT_ROOT_REPAIR_MAX_WALL_TIME;
+        // An in-flight attempt has its own request timeout, so ignore its stale
+        // retry timestamp while retaining the overall repair deadline.
+        if self.in_flight.is_none() {
+            repair_deadline.min(self.next_attempt_at)
+        } else {
+            repair_deadline
+        }
+    }
+
     pub(super) fn mark_attempt(&mut self, peer: ZakuraPeerId) {
         self.tried_peers.insert(peer.clone());
         self.in_flight = Some(peer);

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -506,6 +506,30 @@ fn startup_new_is_passive_until_local_hooks_are_wired() {
     assert!(!startup.inbound_new_block_acceptance_enabled);
 }
 
+#[test]
+fn startup_new_uses_configured_status_refresh_interval() {
+    let network = Network::Mainnet;
+    let anchor = (block::Height(0), network.genesis_hash());
+    let status_refresh_interval = std::time::Duration::from_secs(17);
+    let startup = HeaderSyncStartup::new(
+        network,
+        anchor,
+        HeaderSyncFrontiers {
+            finalized_height: anchor.0,
+            verified_block_tip: anchor.0,
+            verified_block_hash: anchor.1,
+        },
+        Some(anchor),
+        ZakuraHeaderSyncConfig {
+            status_refresh_interval,
+            ..ZakuraHeaderSyncConfig::default()
+        },
+        LOCAL_MAX_MESSAGE_BYTES,
+    );
+
+    assert_eq!(startup.status_refresh_interval, status_refresh_interval);
+}
+
 fn startup_with_timeout(
     network: Network,
     anchor: (block::Height, block::Hash),
@@ -1772,6 +1796,28 @@ fn vct_repair_episode_enforces_attempt_and_time_bounds() {
     assert!(timed.exhausted);
     assert!(!timed.refresh_exhausted(now));
     assert!(!timed.can_attempt(now));
+}
+
+#[test]
+fn vct_repair_maintenance_ignores_retry_deadline_during_attempt() {
+    let mut repair = VctRootRepair::new(
+        block::Height(1),
+        1,
+        Network::Mainnet.genesis_hash(),
+        vec![(
+            block::Height(1),
+            mainnet_block(&BLOCK_MAINNET_1_BYTES).hash(),
+        )],
+    )
+    .expect("single-header handoff repair is valid");
+    let retry_deadline = repair.next_attempt_at;
+    let repair_deadline = repair.started_at + VCT_ROOT_REPAIR_MAX_WALL_TIME;
+
+    assert_eq!(repair.next_maintenance_deadline(), retry_deadline);
+
+    repair.mark_attempt(peer(129));
+
+    assert_eq!(repair.next_maintenance_deadline(), repair_deadline);
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Header sync could repeatedly wake on a stale VCT repair retry timestamp while the repair request was still in flight. Separately, `HeaderSyncStartup::new` ignored the configured status refresh interval, requiring production wiring to correct it after construction.

## Solution

- Exclude `next_attempt_at` from the VCT repair maintenance deadline while an attempt is in flight, while retaining request and overall repair deadlines.
- Initialize the startup status refresh interval from `ZakuraHeaderSyncConfig` and remove the production-only override.
- Add focused regression coverage for both timing behaviors.

## Testing

- `cargo fmt --all -- --check` — passed.
- `cargo clippy -p zakura-network --all-targets -- -D warnings` — passed.
- Both new focused regression tests passed. They verify that active repairs ignore stale retry deadlines and constructors preserve custom refresh intervals.
- `cargo test -p zakura-network` — 992 passed; 3 unrelated listener tests failed because this macOS host could not bind their requested loopback source addresses (`AddrNotAvailable`).