### PR TITLE
fix(chain): validate configured checkpoint invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Reject configured checkpoint lists with gaps larger than the bounded sync
+  pipeline, and reject Regtest checkpoint lists whose height-0 hash does not
+  match the Regtest genesis hash.
 - Database format upgrades now finish before startup exposes the finalized
   state database; only configured periodic format checks continue in the
   background.

--- a/zakura-chain/CHANGELOG.md
+++ b/zakura-chain/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quadratic work over a block's spends
   ([GHSA-4g24-549m-hp75](https://github.com/zakura-core/zakura/security/advisories/GHSA-4g24-549m-hp75)).
 
+### Fixed
+
+- `CheckpointList` now rejects adjacent height gaps above
+  `MAX_CHECKPOINT_HEIGHT_GAP`.
+- Regtest parameter construction now rejects checkpoint lists whose height-0
+  hash does not match the Regtest genesis hash.
+
 ## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zakura-chain/src/parameters/checkpoint/list.rs
+++ b/zakura-chain/src/parameters/checkpoint/list.rs
@@ -12,7 +12,11 @@ use std::{
     sync::Arc,
 };
 
-use crate::{block, parameters::Network, BoxError};
+use crate::{
+    block,
+    parameters::{checkpoint::constants::MAX_CHECKPOINT_HEIGHT_GAP, Network},
+    BoxError,
+};
 
 #[cfg(test)]
 mod tests;
@@ -103,6 +107,7 @@ impl FromStr for CheckpointList {
     /// `block::Hash`, separated by a single space.
     ///
     /// Assumes that the provided genesis checkpoint is correct.
+    /// See [`CheckpointList::from_list`] for the structural requirements.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut checkpoint_list: Vec<(block::Height, block::Hash)> = Vec::new();
 
@@ -120,8 +125,10 @@ impl CheckpointList {
     /// Assumes that the provided genesis checkpoint is correct.
     ///
     /// Checkpoint heights and checkpoint hashes must be unique.
+    /// Adjacent checkpoint heights must be no more than
+    /// [`MAX_CHECKPOINT_HEIGHT_GAP`] apart.
     /// There must be a checkpoint for a genesis block at block::Height 0.
-    /// (All other checkpoints are optional.)
+    /// A list containing only that genesis checkpoint is valid.
     pub fn from_list(
         list: impl IntoIterator<Item = (block::Height, block::Hash)>,
     ) -> Result<Self, BoxError> {
@@ -160,6 +167,23 @@ impl CheckpointList {
         let checkpoints = CheckpointList(checkpoints);
         if checkpoints.max_height() > block::Height::MAX {
             Err("checkpoint list contains invalid checkpoint: checkpoint height is greater than the maximum block height")?;
+        }
+
+        let max_height_gap = block::HeightDiff::try_from(MAX_CHECKPOINT_HEIGHT_GAP)?;
+        let mut heights = checkpoints.0.keys().copied();
+        let mut previous_height = heights
+            .next()
+            .expect("checkpoint lists contain a genesis checkpoint");
+        for height in heights {
+            let height_gap = height - previous_height;
+            if height_gap > max_height_gap {
+                return Err(format!(
+                    "checkpoint height gap exceeds maximum: {height:?} - \
+                     {previous_height:?} = {height_gap}, maximum is {max_height_gap}",
+                )
+                .into());
+            }
+            previous_height = height;
         }
 
         Ok(checkpoints)

--- a/zakura-chain/src/parameters/checkpoint/list/tests.rs
+++ b/zakura-chain/src/parameters/checkpoint/list/tests.rs
@@ -50,8 +50,6 @@ fn checkpoint_list_multiple() -> Result<(), BoxError> {
     for b in &[
         &zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..],
         &zakura_test::vectors::BLOCK_MAINNET_1_BYTES[..],
-        &zakura_test::vectors::BLOCK_MAINNET_415000_BYTES[..],
-        &zakura_test::vectors::BLOCK_MAINNET_434873_BYTES[..],
     ] {
         let block = Arc::<Block>::zcash_deserialize(*b)?;
         let hash = block.hash();
@@ -67,6 +65,40 @@ fn checkpoint_list_multiple() -> Result<(), BoxError> {
     let _ = CheckpointList::from_list(checkpoint_list)?;
 
     Ok(())
+}
+
+/// Checkpoint height gaps must not exceed [`MAX_CHECKPOINT_HEIGHT_GAP`].
+#[test]
+fn checkpoint_list_height_gap_limit() {
+    let _init_guard = zakura_test::init();
+
+    let max_gap = u32::try_from(MAX_CHECKPOINT_HEIGHT_GAP)
+        .expect("maximum checkpoint height gap fits in u32");
+    let second_height = max_gap
+        .checked_mul(2)
+        .expect("test checkpoint height fits in u32");
+    let oversized_second_height = second_height
+        .checked_add(1)
+        .expect("test checkpoint height fits in u32");
+
+    CheckpointList::from_list([
+        (block::Height(0), block::Hash([1; 32])),
+        (block::Height(max_gap), block::Hash([2; 32])),
+        (block::Height(second_height), block::Hash([3; 32])),
+    ])
+    .expect("checkpoint height gaps at the maximum must be valid");
+
+    let error = CheckpointList::from_list([
+        (block::Height(0), block::Hash([1; 32])),
+        (block::Height(max_gap), block::Hash([2; 32])),
+        (block::Height(oversized_second_height), block::Hash([3; 32])),
+    ])
+    .expect_err("checkpoint height gaps above the maximum must fail");
+
+    assert!(
+        error.to_string().contains("checkpoint height gap"),
+        "unexpected checkpoint height gap error: {error}",
+    );
 }
 
 /// Make sure that an empty checkpoint list fails

--- a/zakura-chain/src/parameters/network/testnet.rs
+++ b/zakura-chain/src/parameters/network/testnet.rs
@@ -887,8 +887,18 @@ impl ParametersBuilder {
         Network::new_configured_testnet(self.clone().finish())
     }
 
+    /// Checks that the genesis checkpoint matches this builder's genesis hash.
+    fn validate_checkpoint_genesis(&self) -> Result<(), ParametersBuilderError> {
+        if self.checkpoints.hash(Height(0)) != Some(self.genesis_hash) {
+            return Err(ParametersBuilderError::CheckpointGenesisMismatch);
+        }
+
+        Ok(())
+    }
+
     /// Checks funding streams and converts the builder to a configured [`Network::Testnet`]
     pub fn to_network(self) -> Result<Network, ParametersBuilderError> {
+        self.validate_checkpoint_genesis()?;
         let network = self.to_network_unchecked();
 
         // Final check that the configured funding streams will be valid for these Testnet parameters.
@@ -897,10 +907,7 @@ impl ParametersBuilder {
             check_funding_stream_address_period(fs, &network);
         }
 
-        // Final check that the configured checkpoints are valid for this network.
-        if network.checkpoint_list().hash(Height(0)) != Some(network.genesis_hash()) {
-            return Err(ParametersBuilderError::CheckpointGenesisMismatch);
-        }
+        // Final check that the configured checkpoints cover the mandatory height.
         if network.checkpoint_list().max_height() < network.mandatory_checkpoint_height() {
             return Err(ParametersBuilderError::InsufficientCheckpointCoverage);
         }
@@ -1052,6 +1059,8 @@ impl Parameters {
         if Some(true) == extend_funding_stream_addresses_as_required {
             parameters = parameters.extend_funding_streams();
         }
+
+        parameters.validate_checkpoint_genesis()?;
 
         Ok(Self {
             network_name: "Regtest".to_string(),

--- a/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -1,17 +1,21 @@
 //! Fixed test vectors for the network consensus parameters.
 
+use std::io::Write;
+
 use zcash_protocol::consensus::{self as zp_consensus, NetworkConstants as _, Parameters};
 
 use crate::{
     amount::{Amount, NonNegative},
     block::Height,
     parameters::{
+        checkpoint::constants::MAX_CHECKPOINT_HEIGHT_GAP,
         network::error::ParametersBuilderError,
         subsidy::{self, block_subsidy, funding_stream_values, FundingStreamReceiver},
         testnet::{
-            self, ConfiguredActivationHeights, ConfiguredFundingStreamRecipient,
-            ConfiguredFundingStreams, ConfiguredLockboxDisbursement, RegtestParameters,
-            MAX_NETWORK_NAME_LENGTH, RESERVED_NETWORK_NAMES,
+            self, ConfiguredActivationHeights, ConfiguredCheckpoints,
+            ConfiguredFundingStreamRecipient, ConfiguredFundingStreams,
+            ConfiguredLockboxDisbursement, RegtestParameters, MAX_NETWORK_NAME_LENGTH,
+            RESERVED_NETWORK_NAMES,
         },
         ConsensusBranchId, Network, NetworkKind, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS,
         TESTNET_ACTIVATION_HEIGHTS,
@@ -388,6 +392,78 @@ fn regtest_preserves_optional_nu6_3_activation() {
         Some(&NetworkUpgrade::Nu6_3),
         "the configured NU6.3 height must remain explicit"
     );
+}
+
+#[test]
+fn configured_checkpoints_reject_excessive_height_gaps() {
+    let network = Network::new_default_testnet();
+    let minimum_oversized_height = Height(
+        u32::try_from(MAX_CHECKPOINT_HEIGHT_GAP)
+            .expect("maximum checkpoint height gap fits in u32")
+            .checked_add(1)
+            .expect("test checkpoint height fits in u32"),
+    );
+    let distant_height = network
+        .mandatory_checkpoint_height()
+        .max(minimum_oversized_height);
+    let checkpoints = vec![
+        (Height(0), network.genesis_hash()),
+        (distant_height, crate::block::Hash([0x42; 32])),
+    ];
+
+    let inline_error = testnet::Parameters::build()
+        .with_checkpoints(ConfiguredCheckpoints::HeightsAndHashes(checkpoints.clone()))
+        .and_then(|builder| builder.to_network())
+        .expect_err("inline checkpoints with an oversized height gap must fail");
+    assert_eq!(
+        inline_error,
+        ParametersBuilderError::InvalidCustomCheckpoints,
+    );
+
+    let mut checkpoint_file =
+        tempfile::NamedTempFile::new().expect("temporary checkpoint file should be created");
+    for (height, hash) in checkpoints {
+        writeln!(checkpoint_file, "{} {hash}", height.0)
+            .expect("test checkpoint should be written");
+    }
+    checkpoint_file
+        .flush()
+        .expect("test checkpoints should be flushed");
+    let checkpoint_path = checkpoint_file.path().to_path_buf();
+
+    let file_error = testnet::Parameters::build()
+        .with_checkpoints(ConfiguredCheckpoints::Path(checkpoint_path.clone()))
+        .and_then(|builder| builder.to_network())
+        .expect_err("file checkpoints with an oversized height gap must fail");
+    match file_error {
+        ParametersBuilderError::FailedToParseCheckpointFile { path_buf, err } => {
+            assert_eq!(path_buf, checkpoint_path);
+            assert!(
+                err.contains("checkpoint height gap"),
+                "unexpected checkpoint height gap error: {err}",
+            );
+        }
+        error => panic!("unexpected checkpoint file error: {error}"),
+    }
+}
+
+#[test]
+fn regtest_rejects_checkpoint_genesis_mismatch() {
+    let testnet_genesis = Network::new_default_testnet().genesis_hash();
+    let mismatched_checkpoints = [
+        ConfiguredCheckpoints::Default(true),
+        ConfiguredCheckpoints::HeightsAndHashes(vec![(Height(0), testnet_genesis)]),
+    ];
+
+    for checkpoints in mismatched_checkpoints {
+        let error = testnet::Parameters::new_regtest(RegtestParameters {
+            checkpoints: Some(checkpoints),
+            ..Default::default()
+        })
+        .expect_err("Regtest checkpoints must use the Regtest genesis hash");
+
+        assert_eq!(error, ParametersBuilderError::CheckpointGenesisMismatch,);
+    }
 }
 
 /// Checks that configured testnet names are validated and used correctly.

--- a/zakura-consensus/src/checkpoint/tests.rs
+++ b/zakura-consensus/src/checkpoint/tests.rs
@@ -737,10 +737,31 @@ async fn checkpoint_drop_cancel() -> Result<(), Report> {
     }
 
     // Make a checkpoint list containing all the blocks
-    let checkpoint_list: BTreeMap<block::Height, block::Hash> = checkpoint_data
+    let mut checkpoint_list: BTreeMap<block::Height, block::Hash> = checkpoint_data
         .iter()
         .map(|(_block, height, hash)| (*height, *hash))
         .collect();
+
+    // Preserve the checkpoint height-gap invariant while leaving the two high
+    // blocks incomplete, so their requests remain pending until verifier drop.
+    let max_height = checkpoint_data
+        .iter()
+        .map(|(_block, height, _hash)| *height)
+        .max()
+        .expect("checkpoint test data is not empty");
+    let max_height_gap = u32::try_from(MAX_CHECKPOINT_HEIGHT_GAP)
+        .expect("maximum checkpoint height gap fits in u32");
+    let mut bridge_height = max_height_gap;
+    while bridge_height < max_height.0 {
+        let mut bridge_hash = [0; 32];
+        bridge_hash[..4].copy_from_slice(&bridge_height.to_le_bytes());
+        checkpoint_list
+            .entry(block::Height(bridge_height))
+            .or_insert(block::Hash(bridge_hash));
+        bridge_height = bridge_height
+            .checked_add(max_height_gap)
+            .expect("test checkpoint height fits in u32");
+    }
 
     let state_service = zakura_state::init_test(&Mainnet).await;
     let mut checkpoint_verifier =

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Regtest configuration now reports checkpoint-genesis mismatches as invalid
+  configuration instead of constructing inconsistent network parameters.
+
 ## [2.0.0] - 2026-07-17
 
 ### Breaking Changes

--- a/zakura-network/src/config.rs
+++ b/zakura-network/src/config.rs
@@ -1142,7 +1142,7 @@ impl<'de> Deserialize<'de> for Config {
                 build_configured_testnet::<D>(*params, &initial_testnet_peers)?
             }
             (DNetwork::ConfiguredRegtest { params, .. }, _) => {
-                Network::new_regtest(build_regtest_params(*params))
+                build_configured_regtest::<D>(*params)?
             }
             (DNetwork::DefaultForKind(NetworkKind::Mainnet), _) => Network::Mainnet,
             (DNetwork::DefaultForKind(NetworkKind::Testnet), Some(params)) => {
@@ -1152,7 +1152,7 @@ impl<'de> Deserialize<'de> for Config {
                 Network::new_default_testnet()
             }
             (DNetwork::DefaultForKind(NetworkKind::Regtest), Some(params)) => {
-                Network::new_regtest(build_regtest_params(params))
+                build_configured_regtest::<D>(params)?
             }
             (DNetwork::DefaultForKind(NetworkKind::Regtest), None) => {
                 Network::new_regtest(Default::default())
@@ -1415,6 +1415,16 @@ where
     } else {
         Ok(params_builder.to_network().map_err(de::Error::custom)?)
     }
+}
+
+fn build_configured_regtest<'de, D>(params: DTestnetParameters) -> Result<Network, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let params = testnet::Parameters::new_regtest(build_regtest_params(params))
+        .map_err(de::Error::custom)?;
+
+    Ok(Network::new_configured_testnet(params))
 }
 
 fn build_regtest_params(params: DTestnetParameters) -> RegtestParameters {

--- a/zakura-network/src/config/tests/vectors.rs
+++ b/zakura-network/src/config/tests/vectors.rs
@@ -645,6 +645,21 @@ fn configured_regtest_checkpoints_preserve_regtest_identity() {
 }
 
 #[test]
+fn configured_regtest_rejects_testnet_checkpoints() {
+    let _init_guard = zakura_test::init();
+
+    let error = toml::from_str::<Config>("network = { params = { checkpoints = true } }")
+        .expect_err("Regtest must reject the default Testnet checkpoint list");
+
+    assert!(
+        error
+            .to_string()
+            .contains("first checkpoint hash must match genesis hash"),
+        "unexpected Regtest checkpoint error: {error}",
+    );
+}
+
+#[test]
 fn zakura_bootstrap_peers_parse_in_nested_config() {
     let _init_guard = zakura_test::init();
 

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -2818,6 +2818,7 @@ async fn forward_ranges_below_checkpoint_handoff_request_tree_aux_roots() {
         .with_checkpoints(ConfiguredCheckpoints::HeightsAndHashes(vec![
             (block::Height(0), Network::Mainnet.genesis_hash()),
             (block::Height(400), block::Hash([4; 32])),
+            (block::Height(800), block::Hash([8; 32])),
             (block::Height(1_200), block::Hash([12; 32])),
         ]))
         .expect("custom checkpoints are valid")
@@ -2860,7 +2861,7 @@ async fn forward_ranges_below_checkpoint_handoff_request_tree_aux_roots() {
         } = next_non_query_action(&mut fixture.actions).await
         {
             assert_eq!(start_height, block::Height(401));
-            assert_eq!(count, 600);
+            assert_eq!(count, 400);
             assert!(
                 want_tree_aux_roots,
                 "header ranges below the checkpoint handoff should carry roots"
@@ -2875,7 +2876,7 @@ async fn forward_ranges_below_checkpoint_handoff_request_tree_aux_roots() {
         hs_trace::HEADER_GET_HEADERS_SENT,
         &[
             (hs_trace::RANGE_START, TraceValue::U64(401)),
-            (hs_trace::RANGE_COUNT, TraceValue::U64(600)),
+            (hs_trace::RANGE_COUNT, TraceValue::U64(400)),
             (hs_trace::FINALIZED, TraceValue::Bool(false)),
             (hs_trace::WANT_TREE_AUX_ROOTS, TraceValue::Bool(true)),
             (hs_trace::RANGE_PRIORITY, TraceValue::Str("forward")),


### PR DESCRIPTION
## Motivation

Configured checkpoint lists could violate two invariants that the checkpoint
sync path relies on:

- `CheckpointList::from_list` accepted arbitrarily large adjacent height gaps.
  A custom Testnet list containing only genesis and a distant mandatory
  checkpoint passed final network validation even though checkpoint sync bounds
  its in-flight range and memory assumptions with
  `MAX_CHECKPOINT_HEIGHT_GAP`.
- Regtest construction did not run the checkpoint-genesis consistency check
  used by configured Testnets. `ConfiguredCheckpoints::Default(true)` therefore
  combined the Testnet checkpoint list with the Regtest genesis hash and
  consensus parameters.

The first case can stall checkpoint sync or require resources beyond the
bounded pipeline. The second creates an internally inconsistent network that
targets Testnet's checkpointed genesis while otherwise identifying as Regtest.

## Solution

- Enforce `MAX_CHECKPOINT_HEIGHT_GAP` between every adjacent checkpoint in
  `CheckpointList::from_list`. This single boundary covers inline lists,
  checkpoint files, hard-coded lists, and test-only verifier construction.
- Share the existing checkpoint-genesis validation between configured Testnet
  and Regtest parameter construction.
- Route configured and legacy Regtest TOML through the fallible parameter
  constructor, returning a configuration error instead of panicking.
- Update the verifier cancellation fixture with bounded synthetic checkpoint
  metadata and add regression coverage for both accepted-input boundaries.

No `pub` or `pub(crate)` declaration, signature, variant, or visibility changes
are introduced. This intentionally tightens the accepted inputs of the existing
public `CheckpointList::from_list` and `FromStr` implementations.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-chain -p zakura-consensus -p zakura-network \
  --all-targets -- -D warnings`
- `cargo test -p zakura-chain` — 356 unit tests and 9 doc tests passed
- `cargo test -p zakura-consensus checkpoint::tests` — 10 passed
- `cargo test -p zakura-network config::tests` — 28 passed

The new tests cover an exact 400-block gap, a 401-block adjacent gap, inline and
file-based configured Testnet inputs, default and custom Regtest genesis
mismatches, valid custom Regtest checkpoints, and graceful TOML rejection.

### Specifications & References

- `MAX_CHECKPOINT_HEIGHT_GAP` is the shared checkpoint-sync limit and is
  currently 400 blocks.
- No tracking issue was supplied with these findings; this remains a draft
  until the required maintainer discussion is linked.

AI disclosure: OpenAI Codex was used to trace the checkpoint construction paths,
implement the invariant checks and regression tests, run validation, and draft
this PR description. The contributor reviewed the changes and test results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens accepted startup configuration for checkpoints and Regtest; invalid custom lists that previously loaded may now fail at config time, but runtime behavior for valid networks is unchanged.
> 
> **Overview**
> **Checkpoint lists** now fail construction when any adjacent heights are more than `MAX_CHECKPOINT_HEIGHT_GAP` (400) apart, so custom inline lists, checkpoint files, and `FromStr` parsing cannot feed checkpoint sync a gap the bounded pipeline was never meant to handle.
> 
> **Regtest and network config** apply the same height-0 checkpoint vs genesis hash check that configured Testnet already used: `ParametersBuilder::validate_checkpoint_genesis` runs for both `to_network()` and `new_regtest()`, and Regtest TOML deserialization goes through a fallible `build_configured_regtest` path instead of building inconsistent parameters (e.g. default Testnet checkpoints with Regtest genesis).
> 
> Regression tests cover gap boundaries, file vs inline checkpoints, Regtest genesis mismatch, and TOML rejection; existing fixtures (consensus drop-cancel, header-sync range sizing) were adjusted to satisfy the new gap rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccdc286d795042c4ec0d69a5dfc994961c8e56ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->