### PR TITLE
fix(zcashd): verify managed binary cache

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -263,6 +263,7 @@ for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakur
 
 - [ ] Confirm the pinned zcashd compat manifest is ready before publishing:
   - [ ] Update [`zakurad/zcashd-compat-manifest.json`](https://github.com/zakura-core/zakura/blob/main/zakurad/zcashd-compat-manifest.json) to the intended `zcashd` compat release (it is the single source of truth: zakurad embeds it at compile time and CI/Docker builds read it directly).
+  - [ ] Record SHA-256 digests for both the release archive and the extracted `./bin/zcashd` executable in the manifest.
   - [ ] Confirm the manifest contains only the `x86_64-pc-linux-gnu` artifact before publishing zcashd-compat Docker images.
   - [ ] Confirm the workflow logs show the expected `/usr/local/bin/zcashd --version` for the zcashd-compat linux/amd64 image variant.
 - [ ] Wait for the [the Docker images to be published successfully](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Apush).

--- a/make/zcashd-compat.mk
+++ b/make/zcashd-compat.mk
@@ -36,6 +36,7 @@ ZCASHD_COMPAT_TARGET_TRIPLE ?= x86_64-pc-linux-gnu
 ZCASHD_COMPAT_RELEASE_TAG ?= $(shell jq -er '.release_tag' $(ZCASHD_COMPAT_MANIFEST))
 ZCASHD_COMPAT_URL ?= $(shell jq -er --arg target '$(ZCASHD_COMPAT_TARGET_TRIPLE)' '.artifacts[] | select(.target_triple == $$target) | .runtime_archive_url' $(ZCASHD_COMPAT_MANIFEST))
 ZCASHD_COMPAT_SHA256 ?= $(shell jq -er --arg target '$(ZCASHD_COMPAT_TARGET_TRIPLE)' '.artifacts[] | select(.target_triple == $$target) | .runtime_archive_sha256' $(ZCASHD_COMPAT_MANIFEST))
+ZCASHD_COMPAT_BINARY_SHA256 ?= $(shell jq -er --arg target '$(ZCASHD_COMPAT_TARGET_TRIPLE)' '.artifacts[] | select(.target_triple == $$target) | .runtime_binary_sha256' $(ZCASHD_COMPAT_MANIFEST))
 ZCASHD_COMPAT_ARTIFACT_DIR ?= $(CURDIR)/target/zcashd-compat
 ZCASHD_COMPAT_ARCHIVE_PATH ?= $(ZCASHD_COMPAT_ARTIFACT_DIR)/zcashd-compat.tar.gz
 ZCASHD_COMPAT_EXTRACT_DIR ?= $(ZCASHD_COMPAT_ARTIFACT_DIR)/extracted
@@ -59,6 +60,7 @@ compat-zcashd-prepare:
 		mkdir -p "$(ZCASHD_COMPAT_EXTRACT_DIR)"; \
 		tar -xzf "$(ZCASHD_COMPAT_ARCHIVE_PATH)" -C "$(ZCASHD_COMPAT_EXTRACT_DIR)"; \
 		test -x "$(ZCASHD_COMPAT_EXTRACT_DIR)/bin/zcashd"; \
+		echo "$(ZCASHD_COMPAT_BINARY_SHA256)  $(ZCASHD_COMPAT_EXTRACT_DIR)/bin/zcashd" | sha256sum -c -; \
 	fi
 
 compat-docker-build: compat-zcashd-prepare

--- a/scripts/resolve-zcashd-compat-manifest.sh
+++ b/scripts/resolve-zcashd-compat-manifest.sh
@@ -84,6 +84,7 @@ validate_manifest() {
       | select(.target_triple == $target)
       | .runtime_archive_url
       and .runtime_archive_sha256
+      and .runtime_binary_sha256
       and .runtime_archive_member_binary_path
     ' "$manifest" >/dev/null
   done < <(jq -r '.artifacts[].target_triple' "$manifest")
@@ -167,10 +168,11 @@ prepare_build_context() {
   local manifest="$1"
   local target_triple="$2"
   local context_dir="$3"
-  local url sha256 member_path archive_path extract_dir work_dir binary_source binary_dest
+  local url archive_sha256 binary_sha256 member_path archive_path extract_dir work_dir binary_source binary_dest
 
   url="$(artifact_field "$manifest" "$target_triple" "runtime_archive_url")"
-  sha256="$(artifact_field "$manifest" "$target_triple" "runtime_archive_sha256")"
+  archive_sha256="$(artifact_field "$manifest" "$target_triple" "runtime_archive_sha256")"
+  binary_sha256="$(artifact_field "$manifest" "$target_triple" "runtime_binary_sha256")"
   member_path="$(artifact_field "$manifest" "$target_triple" "runtime_archive_member_binary_path")"
 
   work_dir="$(mktemp -d)"
@@ -180,7 +182,7 @@ prepare_build_context() {
   extract_dir="$work_dir/extracted"
 
   curl -fsSL "$url" -o "$archive_path"
-  echo "$sha256  $archive_path" | sha256sum -c -
+  echo "$archive_sha256  $archive_path" | sha256sum -c -
   mkdir -p "$extract_dir"
   tar -xzf "$archive_path" -C "$extract_dir"
 
@@ -189,6 +191,7 @@ prepare_build_context() {
     echo "expected executable missing from zcashd compat archive: $member_path" >&2
     exit 1
   fi
+  echo "$binary_sha256  $binary_source" | sha256sum -c -
 
   rm -rf "$context_dir"
   binary_dest="$context_dir/bin/zcashd"

--- a/zakurad/src/components/zcashd_compat/managed.rs
+++ b/zakurad/src/components/zcashd_compat/managed.rs
@@ -119,12 +119,10 @@ pub(super) fn cached_managed_zcashd_binary_is_current(
         return Ok(None);
     };
 
-    let provenance_path = binary_path.with_file_name("zcashd.sha256");
-
-    Ok(Some(
-        binary_path.is_file()
-            && provenance_matches(&provenance_path, &artifact.runtime_archive_sha256)?,
-    ))
+    Ok(Some(sha256_matches_file(
+        &binary_path,
+        &artifact.runtime_binary_sha256,
+    )?))
 }
 
 fn resolve_managed_zcashd_binary_from_manifest(
@@ -150,10 +148,7 @@ fn resolve_managed_zcashd_binary_from_manifest(
     fs::create_dir_all(&cache_dir)?;
 
     let binary_path = cache_dir.join("zcashd");
-    let provenance_path = cache_dir.join("zcashd.sha256");
-    if binary_path.is_file()
-        && provenance_matches(&provenance_path, &artifact.runtime_archive_sha256)?
-    {
+    if sha256_matches_file(&binary_path, &artifact.runtime_binary_sha256)? {
         return Ok(binary_path);
     }
 
@@ -164,9 +159,7 @@ fn resolve_managed_zcashd_binary_from_manifest(
     )?;
 
     // Re-check after acquiring the lock.
-    if binary_path.is_file()
-        && provenance_matches(&provenance_path, &artifact.runtime_archive_sha256)?
-    {
+    if sha256_matches_file(&binary_path, &artifact.runtime_binary_sha256)? {
         return Ok(binary_path);
     }
 
@@ -188,6 +181,13 @@ fn resolve_managed_zcashd_binary_from_manifest(
         &artifact.runtime_archive_member_binary_path,
         extracted_temp.path(),
     )?;
+    let binary_sha256 = sha256_hex_file(extracted_temp.path())?;
+    if binary_sha256 != artifact.runtime_binary_sha256 {
+        return Err(eyre!(
+            "managed zcashd binary hash mismatch for target {target}: expected {}, got {binary_sha256}",
+            artifact.runtime_binary_sha256
+        ));
+    }
     make_executable(extracted_temp.path())?;
     extracted_temp.persist(&binary_path).map_err(|err| {
         eyre!(
@@ -196,11 +196,6 @@ fn resolve_managed_zcashd_binary_from_manifest(
             err.error
         )
     })?;
-    fs::write(
-        &provenance_path,
-        format!("{}\n", artifact.runtime_archive_sha256),
-    )?;
-
     Ok(binary_path)
 }
 
@@ -318,16 +313,13 @@ fn normalize_member_path(path: &str) -> String {
     path.trim_start_matches("./").to_string()
 }
 
-/// Returns `true` if `path` exists and stores exactly `expected_sha256`.
-fn provenance_matches(path: &Path, expected_sha256: &str) -> Result<bool, Report> {
+/// Returns `true` if `path` exists and its SHA256 is exactly `expected_sha256`.
+fn sha256_matches_file(path: &Path, expected_sha256: &str) -> Result<bool, Report> {
     if !path.is_file() {
         return Ok(false);
     }
 
-    let value = fs::read_to_string(path)
-        .map(|content| content.trim().to_string())
-        .unwrap_or_default();
-    Ok(value == expected_sha256)
+    Ok(sha256_hex_file(path)? == expected_sha256)
 }
 
 /// Computes the lowercase hex SHA256 digest for `path`.
@@ -527,13 +519,14 @@ mod tests {
     };
 
     use flate2::{write::GzEncoder, Compression};
+    use sha2::{Digest, Sha256};
     use tar::Builder;
     use tempfile::tempdir;
 
     use super::{
-        acquire_lock, effective_zcashd_source, normalize_member_path, provenance_matches,
-        resolve_managed_zcashd_binary_from_manifest, sha256_hex_file, zcashd_target_triple, Config,
-        ZcashdBinarySource,
+        acquire_lock, effective_zcashd_source, normalize_member_path,
+        resolve_managed_zcashd_binary_from_manifest, sha256_hex_file, sha256_matches_file,
+        zcashd_target_triple, Config, ZcashdBinarySource,
     };
     use crate::components::zcashd_compat::{
         ConfigZcashdBinarySource, ZcashdReleaseArtifact, ZcashdReleaseManifest,
@@ -589,23 +582,28 @@ mod tests {
     }
 
     #[test]
-    fn provenance_matches_handles_missing_and_present_files() {
+    fn sha256_matches_file_rejects_replaced_cached_binary() {
         let temp = tempdir().expect("tempdir should exist");
-        let path = temp.path().join("sha.txt");
+        let path = temp.path().join("zcashd");
 
         assert!(
-            !provenance_matches(&path, "abc").expect("missing file should not match"),
-            "missing provenance should not match"
+            !sha256_matches_file(&path, "abc").expect("missing file should not match"),
+            "missing binary should not match"
         );
 
-        std::fs::write(&path, "abc\n").expect("provenance file should write");
+        std::fs::write(&path, "expected binary").expect("cached binary should write");
+        let expected_sha256 = sha256_hex_file(&path).expect("binary hash should compute");
         assert!(
-            provenance_matches(&path, "abc").expect("matching provenance should succeed"),
-            "written provenance should match"
+            sha256_matches_file(&path, &expected_sha256)
+                .expect("matching binary hash should succeed"),
+            "cached binary should match its expected hash"
         );
+
+        std::fs::write(&path, "replaced binary").expect("cached binary should replace");
         assert!(
-            !provenance_matches(&path, "def").expect("mismatched provenance should succeed"),
-            "different expected hash should not match"
+            !sha256_matches_file(&path, &expected_sha256)
+                .expect("replaced binary hash should succeed"),
+            "replaced cached binary should not match"
         );
     }
 
@@ -691,6 +689,8 @@ mod tests {
                 runtime_archive_url: "http://example.com/zcashd.tar.gz".to_string(),
                 runtime_archive_sha256:
                     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+                runtime_binary_sha256:
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
                 runtime_archive_member_binary_path: "./bin/zcashd".to_string(),
             }],
         };
@@ -704,7 +704,7 @@ mod tests {
     }
 
     #[test]
-    fn managed_resolver_downloads_and_installs_from_http_archive() {
+    fn managed_resolver_replaces_cached_binary_when_its_hash_mismatches() {
         let Some(target) = zcashd_target_triple() else {
             return;
         };
@@ -738,19 +738,21 @@ mod tests {
             .expect("listener should have local address");
         let payload = archive_bytes.clone();
         let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("one client should connect");
-            let mut request_buf = [0u8; 1024];
-            let _ = stream.read(&mut request_buf);
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                payload.len()
-            );
-            stream
-                .write_all(response.as_bytes())
-                .expect("response headers should write");
-            stream
-                .write_all(&payload)
-                .expect("response body should write");
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().expect("client should connect");
+                let mut request_buf = [0u8; 1024];
+                let _ = stream.read(&mut request_buf);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    payload.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("response headers should write");
+                stream
+                    .write_all(&payload)
+                    .expect("response body should write");
+            }
         });
 
         let local_http_url = format!("http://{address}/zcashd-compat.tar.gz");
@@ -758,6 +760,7 @@ mod tests {
             target_triple: target.to_string(),
             runtime_archive_url: local_http_url,
             runtime_archive_sha256: archive_sha256,
+            runtime_binary_sha256: format!("{:x}", Sha256::digest(binary_contents)),
             runtime_archive_member_binary_path: "./bin/zcashd".to_string(),
         };
         let manifest = ZcashdReleaseManifest {
@@ -769,6 +772,13 @@ mod tests {
             .expect("managed resolver should install zcashd");
         let installed = std::fs::read(&resolved).expect("installed zcashd should be readable");
         assert_eq!(installed, binary_contents);
+
+        std::fs::write(&resolved, "replaced binary").expect("cached binary should replace");
+        let resolved_again = resolve_managed_zcashd_binary_from_manifest(&manifest, temp.path())
+            .expect("managed resolver should replace the cached binary");
+        let reinstalled =
+            std::fs::read(&resolved_again).expect("reinstalled zcashd should be readable");
+        assert_eq!(reinstalled, binary_contents);
 
         server.join().expect("server thread should exit cleanly");
     }

--- a/zakurad/src/components/zcashd_compat/manifest.rs
+++ b/zakurad/src/components/zcashd_compat/manifest.rs
@@ -34,6 +34,8 @@ pub struct ZcashdReleaseArtifact {
     pub runtime_archive_url: String,
     /// SHA256 hex digest of the runtime archive.
     pub runtime_archive_sha256: String,
+    /// SHA256 hex digest of the extracted `zcashd` executable.
+    pub runtime_binary_sha256: String,
     /// Runtime archive member path that points to the `zcashd` executable.
     pub runtime_archive_member_binary_path: String,
 }
@@ -88,20 +90,22 @@ mod tests {
                 "managed zcashd artifact URL must be https: {}",
                 artifact.runtime_archive_url
             );
-            assert_eq!(
-                artifact.runtime_archive_sha256.len(),
-                64,
-                "artifact SHA256 must be 64 hex chars for target {}",
-                artifact.target_triple
-            );
-            assert!(
-                artifact
-                    .runtime_archive_sha256
-                    .chars()
-                    .all(|c| c.is_ascii_hexdigit()),
-                "artifact SHA256 contains non-hex characters for target {}",
-                artifact.target_triple
-            );
+            for digest in [
+                &artifact.runtime_archive_sha256,
+                &artifact.runtime_binary_sha256,
+            ] {
+                assert_eq!(
+                    digest.len(),
+                    64,
+                    "artifact SHA256 must be 64 hex chars for target {}",
+                    artifact.target_triple
+                );
+                assert!(
+                    digest.chars().all(|c| c.is_ascii_hexdigit()),
+                    "artifact SHA256 contains non-hex characters for target {}",
+                    artifact.target_triple
+                );
+            }
         }
     }
 }

--- a/zakurad/zcashd-compat-manifest.json
+++ b/zakurad/zcashd-compat-manifest.json
@@ -6,6 +6,7 @@
       "target_triple": "x86_64-pc-linux-gnu",
       "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz",
       "runtime_archive_sha256": "b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2",
+      "runtime_binary_sha256": "d7dca8bfd44fd872f62bab0b1a7017d3619134712abd4647ead51ece117c6959",
       "runtime_archive_member_binary_path": "./bin/zcashd"
     }
   ]


### PR DESCRIPTION
## Motivation

The managed zcashd resolver previously treated a cache entry as valid when a
sidecar file contained the manifest's archive digest. That did not verify the
cached executable bytes, so a replaced `zcashd` binary could be reused and
spawned.

## Solution

Add the extracted executable's SHA-256 to the embedded release manifest.
The resolver now hashes the cached binary and compares it directly with that
manifest pin before reuse. Installation also verifies the extracted binary
before persisting it. The obsolete archive-digest sidecar is no longer trusted.

Release Docker context preparation and the local compat Docker Make target now
verify the extracted executable too. The release checklist requires recording
both the archive and executable digests for each managed artifact.

The regression test replaces a successfully installed cached executable, then
confirms the next resolution downloads and restores the manifest-pinned binary.

## Test evidence

- `cargo fmt --all -- --check`
- `cargo test -p zakura zcashd_compat::managed --locked`
- `cargo clippy -p zakura --lib -- -D warnings`
- `bash -n scripts/resolve-zcashd-compat-manifest.sh`
- `make -n compat-zcashd-prepare`

`cargo clippy -p zakura --all-targets -- -D warnings` is currently blocked by
an existing unused import in `zakurad/tests/acceptance.rs`.

## Issue

No linked issue.

## AI disclosure

Used OpenAI Codex to implement the cache-integrity verification and regression
test.
