### PR TITLE
test(network): prove block-sync retained-memory accounting

### DIFF
--- a/zakura-network/src/zakura/block_sync/accounting_probe.rs
+++ b/zakura-network/src/zakura/block_sync/accounting_probe.rs
@@ -1,0 +1,113 @@
+//! Test-only accounting oracle for block-sync retained memory.
+//!
+//! The fuzz scenarios bound *peaks* sampled from a trace, which can only infer
+//! correct accounting from the absence of a visible plateau breach. This probe reads
+//! the live ledgers directly and states the conservation laws exactly:
+//!
+//! - the wire budget, the work queue's maintained reserved counter, and its scanned
+//!   ground-truth recomputation all agree;
+//! - the active decoded total equals the sum of its per-stage parts;
+//! - at full teardown every ledger is zero, with no slack at all.
+//!
+//! It is built from the same [`RoutineWiring`] handles the production path threads to
+//! each peer routine, so a snapshot observes the real counters rather than a copy.
+//! Nothing here is compiled into release binaries.
+
+use std::sync::{atomic::Ordering, Arc};
+
+use super::{
+    retained_memory::RetainedBodyMemoryTracker, state::RoutineWiring, work_queue::WorkQueue,
+};
+use crate::zakura::transport::ByteBudget;
+
+/// One instantaneous read of every block-sync accounting ledger.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct BlockSyncAccounting {
+    /// Bytes reserved in the shared wire budget.
+    pub(crate) wire_budget_reserved: u64,
+    /// The work queue's incrementally-maintained reserved-bytes counter.
+    pub(crate) work_reserved: u64,
+    /// Ground-truth recomputation of the same sum by scanning the queue.
+    pub(crate) work_reserved_scanned: u64,
+    /// Authoritative retained-memory total (reservations + live body charges).
+    pub(crate) retained_total: u64,
+    /// Bytes still held by unreconciled in-flight request reservations.
+    pub(crate) in_flight_reservation_bytes: u64,
+    /// Number of unreconciled in-flight request reservations.
+    pub(crate) in_flight_reservation_count: u64,
+    /// Wire bytes queued on the sequencer input channel.
+    pub(crate) sequencer_input_bytes: u64,
+    /// Decoded bytes attributed to bodies queued on the sequencer input channel.
+    pub(crate) sequencer_input_decoded: u64,
+    /// Decoded bytes attributed to the reorder buffer.
+    pub(crate) reorder_decoded: u64,
+    /// Decoded bytes attributed to applying bodies, including detached submissions.
+    pub(crate) applying_decoded: u64,
+    /// The aggregate the reactor publishes for the whole active body pipeline.
+    pub(crate) active_pipeline_decoded: u64,
+    /// Submitted bodies awaiting a matching completion.
+    pub(crate) in_flight_submission_count: u64,
+}
+
+/// Reads the live block-sync ledgers.
+///
+/// Holds its own handles, so it stays readable after the reactor, the peer routines,
+/// and the sequencer task have all been dropped — the state in which the zero-slack
+/// teardown assertion is meaningful.
+#[derive(Clone, Debug)]
+pub(crate) struct BlockSyncAccountingProbe {
+    budget: ByteBudget,
+    work: Arc<WorkQueue>,
+    retained_memory: RetainedBodyMemoryTracker,
+    sequencer_input_bytes: Arc<std::sync::atomic::AtomicU64>,
+    sequencer_input_decoded: Arc<std::sync::atomic::AtomicU64>,
+    view: tokio::sync::watch::Receiver<super::sequencer_task::SequencerView>,
+}
+
+impl BlockSyncAccountingProbe {
+    pub(super) fn new(wiring: &RoutineWiring) -> Self {
+        Self {
+            budget: wiring.budget.clone(),
+            work: wiring.work.clone(),
+            retained_memory: wiring.retained_memory.clone(),
+            sequencer_input_bytes: wiring.sequencer_input_bytes.clone(),
+            sequencer_input_decoded: wiring
+                .sequencer_input_decoded_attributed_memory_bytes
+                .clone(),
+            view: wiring.view.clone(),
+        }
+    }
+
+    /// Read every ledger once.
+    ///
+    /// The reads are not one atomic operation, so a snapshot taken while routines are
+    /// running can catch a handoff mid-flight. Assert on it only at a quiescent
+    /// barrier, where no transition is in progress.
+    pub(crate) fn snapshot(&self) -> BlockSyncAccounting {
+        let (in_flight_reservation_bytes, in_flight_reservation_count) =
+            self.work.in_flight_memory_reservations_for_test();
+        // The sequencer task zeroes its view on drop, so post-teardown these read as
+        // zero — which is exactly the teardown expectation, not a masked leak: the
+        // retained total is owned by the tracker and survives the task.
+        let view = *self.view.borrow();
+
+        BlockSyncAccounting {
+            wire_budget_reserved: self.budget.reserved(),
+            work_reserved: self.work.reserved_bytes(),
+            work_reserved_scanned: self.work.reserved_bytes_scanned(),
+            retained_total: self.retained_memory.used(),
+            in_flight_reservation_bytes,
+            in_flight_reservation_count,
+            sequencer_input_bytes: self.sequencer_input_bytes.load(Ordering::Relaxed),
+            sequencer_input_decoded: self.sequencer_input_decoded.load(Ordering::Relaxed),
+            reorder_decoded: view.reorder_decoded_attributed_memory_bytes,
+            applying_decoded: view.applying_decoded_attributed_memory_bytes,
+            active_pipeline_decoded: view.active_pipeline_decoded_attributed_memory_bytes,
+            in_flight_submission_count: view.in_flight_submission_count,
+        }
+    }
+
+    pub(crate) fn retained_total(&self) -> u64 {
+        self.retained_memory.used()
+    }
+}

--- a/zakura-network/src/zakura/block_sync/bench.rs
+++ b/zakura-network/src/zakura/block_sync/bench.rs
@@ -333,12 +333,9 @@ impl BenchCommitter {
             bs_insert_u64(
                 row,
                 "retained_pipeline_wire_bytes",
-                super::admission::RetainedPipelineBytes {
-                    reorder_buffered_bytes: view.reorder_buffered_bytes,
-                    applying_buffered_bytes: view.applying_buffered_bytes,
-                    sequencer_input_queued_bytes: self.body_input_bytes.load(Ordering::Relaxed),
-                }
-                .wire_bytes(),
+                view.reorder_buffered_bytes
+                    .saturating_add(view.applying_buffered_bytes)
+                    .saturating_add(self.body_input_bytes.load(Ordering::Relaxed)),
             );
         });
     }

--- a/zakura-network/src/zakura/block_sync/mod.rs
+++ b/zakura-network/src/zakura/block_sync/mod.rs
@@ -30,6 +30,8 @@ use super::{
     Frame, ServicePeerDirection, ServicePeerLimits, ZakuraPeerId, ZakuraTrace,
 };
 
+#[cfg(test)]
+mod accounting_probe;
 mod admission;
 mod bbr;
 #[cfg(feature = "internal-bench")]
@@ -52,6 +54,11 @@ mod state;
 mod tests;
 mod wire;
 mod work_queue;
+#[cfg(test)]
+mod work_queue_model;
+
+#[cfg(test)]
+pub(crate) use accounting_probe::BlockSyncAccounting;
 
 #[cfg(feature = "internal-bench")]
 pub use bench::{

--- a/zakura-network/src/zakura/block_sync/retained_memory.rs
+++ b/zakura-network/src/zakura/block_sync/retained_memory.rs
@@ -109,6 +109,12 @@ impl InFlightMemoryReservation {
         self.0.resize(exact_bytes);
         self.0
     }
+
+    /// Bytes this reservation currently holds, for the accounting probe.
+    #[cfg(test)]
+    pub(super) fn charged_bytes(&self) -> u64 {
+        self.0.inner.bytes.load(Ordering::Relaxed)
+    }
 }
 
 /// A shareable Resource Acquisition Is Initialization (RAII) charge for one retained body representation.
@@ -283,6 +289,237 @@ mod tests {
 
         drop(charge);
         assert_eq!(memory.used(), 0);
+    }
+
+    /// What a contender thread observed while racing a transition at the limit.
+    struct ContenderResult {
+        /// Bytes the contender managed to charge — headroom the tracker really published.
+        stolen: u64,
+        /// `try_charge` calls made, so a passing "stole nothing" assertion can be shown
+        /// to have actually raced the transition rather than finished before it started.
+        attempts: u64,
+    }
+
+    /// Spin `try_charge(1)` on a background thread until told to stop.
+    ///
+    /// A contender at a saturated limit is a *witness*, not a sampler: every byte it
+    /// acquires is headroom the tracker actually published, so a bound on its take is a
+    /// bound on the headroom the transition exposed. Sampling `used()` in a loop could
+    /// miss a transient dip between reads; a contender that wins cannot miss one.
+    ///
+    /// Returns once `stop` is set. The caller must wait for `started` before running the
+    /// transition under test, otherwise the race never happens and the assertion is vacuous.
+    fn spawn_contender(
+        memory: &RetainedBodyMemoryTracker,
+        started: &Arc<std::sync::atomic::AtomicBool>,
+        stop: &Arc<std::sync::atomic::AtomicBool>,
+    ) -> std::thread::JoinHandle<ContenderResult> {
+        let memory = memory.clone();
+        let started = started.clone();
+        let stop = stop.clone();
+        std::thread::spawn(move || {
+            let mut stolen = Vec::new();
+            let mut attempts = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                if let Some(charge) = memory.try_charge(1) {
+                    stolen.push(charge);
+                }
+                attempts += 1;
+                started.store(true, Ordering::Release);
+                std::hint::spin_loop();
+            }
+            ContenderResult {
+                // Each stolen charge is one byte, so the count is the byte total.
+                stolen: stolen.len() as u64,
+                attempts,
+            }
+        })
+    }
+
+    fn wait_for_contender(started: &Arc<std::sync::atomic::AtomicBool>) {
+        while !started.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+        }
+    }
+
+    #[test]
+    fn growth_at_the_limit_never_exposes_headroom_to_a_contender() {
+        const LIMIT: u64 = 100;
+
+        // Saturate the limit, so *any* headroom the tracker publishes is winnable and a
+        // contender that stays empty-handed proves none was ever published.
+        let memory = RetainedBodyMemoryTracker::new(LIMIT);
+        let _fixed = memory.charge(40);
+        let reservation = try_reserve(&memory, 60).expect("60 bytes fit exactly");
+        assert_eq!(memory.used(), LIMIT);
+
+        let started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let contender = spawn_contender(&memory, &started, &stop);
+        wait_for_contender(&started);
+
+        // Reconcile, then keep growing. Growth is monotone, so the total never returns
+        // below the limit and a correct tracker leaves the contender nothing at any
+        // instant. The step count gives the contender thousands of chances to interleave
+        // with the grow path's add-then-CAS (and with its refund on a lost CAS), which a
+        // single transition would not.
+        let charge = reservation.reconcile_exact(61);
+        for bytes in 62..=4096 {
+            charge.resize(bytes);
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        let observed = contender.join().expect("contender thread does not panic");
+
+        assert!(
+            observed.attempts > 0,
+            "the contender never ran, so it never raced the growth",
+        );
+        assert_eq!(
+            observed.stolen, 0,
+            "growth published headroom to a contender across {} attempts; a \
+             release-then-recharge would briefly free the whole reservation",
+            observed.attempts,
+        );
+        assert_eq!(memory.used(), 4136, "40 fixed + 4096 grown");
+        drop(charge);
+        assert_eq!(memory.used(), 40);
+    }
+
+    #[test]
+    fn racing_resizes_to_one_size_apply_growth_exactly_once() {
+        // The growth path charges globally *before* publishing locally and refunds on a
+        // lost CAS. If a refund were ever skipped, or a retry double-charged, the total
+        // would settle above the agreed size. Racing threads onto one value keeps the
+        // expected result exact while maximising CAS contention.
+        let memory = RetainedBodyMemoryTracker::new(u64::MAX);
+        let charge = memory.charge(1);
+
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let charge = charge.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..2_000 {
+                        charge.resize(4096);
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().expect("resize thread does not panic");
+        }
+
+        assert_eq!(
+            memory.used(),
+            4096,
+            "concurrent resizes to one size must not accumulate",
+        );
+        drop(charge);
+        assert_eq!(memory.used(), 0);
+    }
+
+    #[test]
+    fn clones_share_one_charge_and_the_last_drop_releases_it() {
+        let memory = RetainedBodyMemoryTracker::new(1000);
+        let charge = memory.charge(64);
+        let clones: Vec<_> = (0..16).map(|_| charge.clone()).collect();
+
+        // Cloning an owner never charges again, however many owners exist.
+        assert_eq!(memory.used(), 64, "clones must not duplicate the charge");
+        // Resizing through any clone resizes the one shared charge.
+        clones[3].resize(128);
+        assert_eq!(memory.used(), 128);
+
+        drop(clones);
+        assert_eq!(
+            memory.used(),
+            128,
+            "the original owner still holds the body"
+        );
+        drop(charge);
+        assert_eq!(memory.used(), 0, "the final owner's drop releases it once");
+    }
+
+    #[test]
+    fn concurrent_clone_and_drop_releases_each_charge_exactly_once() {
+        let memory = RetainedBodyMemoryTracker::new(u64::MAX);
+        let bodies: Vec<_> = (0..64).map(|index| memory.charge(index + 1)).collect();
+        let expected: u64 = (1..=64).sum();
+        assert_eq!(memory.used(), expected);
+
+        // Hand every body to several threads that clone and drop it concurrently. Only
+        // the original owners below keep it alive, so the total must not move.
+        let threads: Vec<_> = (0..4)
+            .map(|_| {
+                let bodies = bodies.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..500 {
+                        let clones = bodies.to_vec();
+                        drop(clones);
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().expect("clone thread does not panic");
+        }
+
+        assert_eq!(
+            memory.used(),
+            expected,
+            "transient clones must neither charge nor release",
+        );
+        drop(bodies);
+        assert_eq!(memory.used(), 0);
+    }
+
+    #[test]
+    fn concurrent_reservations_never_oversubscribe_the_limit() {
+        const LIMIT: u64 = 10_000;
+        const RESERVATION: u64 = 300;
+
+        let memory = RetainedBodyMemoryTracker::new(LIMIT);
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let memory = memory.clone();
+                std::thread::spawn(move || {
+                    let mut held = Vec::new();
+                    for _ in 0..200 {
+                        // Two-height requests exercise the all-or-none path.
+                        if let Some(reservations) =
+                            memory.try_reserve_many(&[RESERVATION, RESERVATION])
+                        {
+                            assert!(
+                                memory.used() <= LIMIT,
+                                "a granted reservation pushed the total past the limit",
+                            );
+                            held.push(reservations);
+                        }
+                    }
+                    held
+                })
+            })
+            .collect();
+
+        let held: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("reserving thread does not panic"))
+            .collect();
+
+        let granted: u64 = held.iter().flatten().flatten().count() as u64;
+        assert!(
+            granted > 0,
+            "no reservation was granted; the test is vacuous"
+        );
+        assert_eq!(
+            memory.used(),
+            granted * RESERVATION,
+            "the total must equal exactly the granted reservations",
+        );
+        assert!(memory.used() <= LIMIT);
+
+        drop(held);
+        assert_eq!(memory.used(), 0, "every reservation released exactly once");
     }
 
     #[tokio::test]

--- a/zakura-network/src/zakura/block_sync/state.rs
+++ b/zakura-network/src/zakura/block_sync/state.rs
@@ -221,17 +221,18 @@ impl BlockSyncHandle {
         self.candidates.borrow().clone()
     }
 
-    /// Return a test-only probe that keeps the retained-memory counter alive after
-    /// every reactor, routine, and sequencer owner has been torn down.
-    #[cfg(any(test, feature = "zakura-testkit"))]
-    pub(crate) fn retained_memory_probe(&self) -> impl Fn() -> u64 + Clone + Send + 'static {
-        let retained_memory = self
-            .routine_wiring
-            .as_ref()
-            .expect("spawned block-sync handles have routine wiring")
-            .retained_memory
-            .clone();
-        move || retained_memory.used()
+    /// Return a test-only probe over every block-sync accounting ledger.
+    ///
+    /// It owns its handles, so it stays readable after every reactor, routine, and
+    /// sequencer owner has been torn down — the state in which a zero-slack teardown
+    /// assertion is meaningful.
+    #[cfg(test)]
+    pub(crate) fn accounting_probe(&self) -> super::accounting_probe::BlockSyncAccountingProbe {
+        super::accounting_probe::BlockSyncAccountingProbe::new(
+            self.routine_wiring
+                .as_ref()
+                .expect("spawned block-sync handles have routine wiring"),
+        )
     }
 }
 

--- a/zakura-network/src/zakura/block_sync/work_queue.rs
+++ b/zakura-network/src/zakura/block_sync/work_queue.rs
@@ -802,6 +802,21 @@ impl WorkQueue {
         self.lock().reserved_bytes
     }
 
+    /// Bytes and count still held by unreconciled in-flight memory reservations.
+    #[cfg(test)]
+    pub(super) fn in_flight_memory_reservations_for_test(&self) -> (u64, u64) {
+        let inner = self.lock();
+        inner.in_flight_memory_reservations.values().fold(
+            (0u64, 0u64),
+            |(bytes, count), reservation| {
+                (
+                    bytes.saturating_add(reservation.charged_bytes()),
+                    count.saturating_add(1),
+                )
+            },
+        )
+    }
+
     /// Ground-truth O(pending + in_flight) recomputation of [`reserved_bytes`],
     /// used by tests to assert the maintained counter never drifts.
     #[cfg(test)]

--- a/zakura-network/src/zakura/block_sync/work_queue_model.rs
+++ b/zakura-network/src/zakura/block_sync/work_queue_model.rs
@@ -1,0 +1,480 @@
+//! Model-based transition test over [`WorkQueue`] + [`RetainedBodyMemoryTracker`].
+//!
+//! The fuzz scenarios assert accounting only at teardown, which is structurally blind
+//! to a leak that a later `advance_floor` sweeps up: the end state is clean even though
+//! an intermediate state was not. This test asserts the conservation laws after *every*
+//! generated operation, so a charge that is briefly stranded fails immediately, at the
+//! transition that stranded it.
+//!
+//! The reference model tracks accounting, not scheduling: which heights
+//! [`take_in_range_budgeted`](WorkQueue::take_in_range_budgeted) selects is driven from
+//! the call's own result rather than re-derived here. Its contiguity and byte-cap rules
+//! already have dedicated unit tests (`work_queue_budgeted_take_*`), and reimplementing
+//! them in the model would only test the copy. What the model does own is every byte:
+//! which heights hold a request reservation, which hold a retained-memory reservation,
+//! and what the authoritative tracker total must therefore be.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use proptest::prelude::*;
+use zakura_chain::block;
+
+use super::{
+    request::BlockSizeEstimate,
+    retained_memory::{RetainedBodyMemoryTracker, RetainedCharge},
+    work_queue::{UnmatchedBodyClaimOutcome, WorkQueue},
+};
+
+/// Height universe. Small on purpose: operations must collide on the same heights
+/// often enough to exercise re-issue, late receipt, and reset interleavings.
+const MAX_HEIGHT: u32 = 12;
+
+/// Wide enough that a reservation is never refused, so the test exercises accounting
+/// rather than admission (which `retained_memory`'s own tests cover).
+const MEMORY_LIMIT: u64 = u64::MAX;
+
+/// Where a height sits in the queue. Below-floor heights are absent from the model.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum Location {
+    Pending,
+    InFlight,
+}
+
+#[derive(Copy, Clone, Debug)]
+struct ModelItem {
+    estimated_bytes: u64,
+    location: Location,
+    /// Whether the request-byte ledger is `Reserved(estimated_bytes)`.
+    reserved: bool,
+    /// Bytes of the retained-memory reservation the queue holds for this height.
+    reservation_bytes: Option<u64>,
+}
+
+/// The expected accounting state, maintained independently of the implementation.
+#[derive(Debug, Default)]
+struct Model {
+    floor: u32,
+    items: BTreeMap<u32, ModelItem>,
+    /// Heights exclusively owned by an outstanding unmatched-body claim, and the token
+    /// that owns each. Mirrors the queue's `received_claims`.
+    claims: BTreeMap<u32, u64>,
+    next_token: u64,
+}
+
+impl Model {
+    /// Sum of request-byte reservations across pending + in-flight.
+    fn reserved_bytes(&self) -> u64 {
+        self.items
+            .values()
+            .filter(|item| item.reserved)
+            .fold(0, |acc, item| acc.saturating_add(item.estimated_bytes))
+    }
+
+    /// Bytes and count of retained-memory reservations the queue still holds.
+    fn reservations(&self) -> (u64, u64) {
+        self.items
+            .values()
+            .filter_map(|item| item.reservation_bytes)
+            .fold((0, 0), |(bytes, count), reservation| {
+                (bytes.saturating_add(reservation), count + 1)
+            })
+    }
+
+    fn extend(&mut self, height: u32, estimated_bytes: u64) {
+        if height <= self.floor || self.items.contains_key(&height) {
+            return;
+        }
+        self.items.insert(
+            height,
+            ModelItem {
+                estimated_bytes,
+                location: Location::Pending,
+                reserved: false,
+                reservation_bytes: None,
+            },
+        );
+    }
+
+    fn advance_floor(&mut self, floor: u32) {
+        self.floor = self.floor.max(floor);
+        self.items.retain(|height, _| *height > self.floor);
+        self.claims.retain(|height, _| *height > self.floor);
+    }
+
+    /// A frontier reset pins the floor rather than raising it, and drops above it.
+    fn reset_above(&mut self, floor: u32) {
+        self.floor = floor;
+        self.items.retain(|height, _| *height <= self.floor);
+        self.claims.retain(|height, _| *height <= self.floor);
+    }
+
+    /// Mirror `claim_unmatched_body`, returning the claim token on success.
+    ///
+    /// The generated hash always matches the stored one, so the hash-mismatch arm of
+    /// the implementation is not modelled here; `work_queue` unit tests cover it.
+    fn claim_unmatched(&mut self, height: u32) -> Option<u64> {
+        if self.claims.contains_key(&height) {
+            return None;
+        }
+        let item = self.items.get_mut(&height)?;
+        match item.location {
+            Location::Pending => item.location = Location::InFlight,
+            // An in-flight height whose request reservation is already released is not
+            // claimable: no outstanding request owns it.
+            Location::InFlight if !item.reserved => return None,
+            Location::InFlight => {}
+        }
+        item.reserved = false;
+        // The retained-memory reservation transfers out of the queue to the claimant.
+        item.reservation_bytes = None;
+
+        let token = self.next_token;
+        self.next_token += 1;
+        self.claims.insert(height, token);
+        Some(token)
+    }
+
+    /// Mirror `rollback_unmatched_claim`: an uncommitted claim returns its height.
+    fn rollback_claim(&mut self, height: u32, token: u64) {
+        if self.claims.get(&height) != Some(&token) {
+            return;
+        }
+        self.claims.remove(&height);
+        let Some(item) = self.items.get_mut(&height) else {
+            return;
+        };
+        if item.location != Location::InFlight {
+            return;
+        }
+        // The queue pops the item out of `in_flight` before re-checking the floor, so a
+        // height that slipped below it is dropped rather than returned to `pending`.
+        if height <= self.floor {
+            self.items.remove(&height);
+            return;
+        }
+        item.location = Location::Pending;
+    }
+}
+
+/// One generated operation.
+#[derive(Clone, Debug)]
+enum Op {
+    Extend {
+        height: u32,
+        size: u32,
+    },
+    TakeAndIssue {
+        low: u32,
+        high: u32,
+        max_count: u32,
+    },
+    Receive {
+        height: u32,
+        exact_bytes: u64,
+    },
+    /// A late/unmatched response racing for a height it was not issued.
+    ClaimUnmatched {
+        height: u32,
+        exact_bytes: u64,
+        /// Whether the claimant accepts the body (`commit`) or abandons it, which must
+        /// roll the height back and release the transferred reservation.
+        commit: bool,
+    },
+    Return {
+        heights: Vec<u32>,
+    },
+    AdvanceFloor {
+        height: u32,
+    },
+    ResetAbove {
+        height: u32,
+    },
+    DropBody {
+        height: u32,
+    },
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        // Weighted toward supply + issue so the later ops have state to act on.
+        3 => (1u32..=MAX_HEIGHT, 1024u32..8192).prop_map(|(height, size)| Op::Extend { height, size }),
+        3 => (1u32..=MAX_HEIGHT, 1u32..=MAX_HEIGHT, 1u32..4)
+            .prop_map(|(a, b, max_count)| Op::TakeAndIssue {
+                low: a.min(b),
+                high: a.max(b),
+                max_count,
+            }),
+        3 => (1u32..=MAX_HEIGHT, 512u64..16_384)
+            .prop_map(|(height, exact_bytes)| Op::Receive { height, exact_bytes }),
+        3 => (1u32..=MAX_HEIGHT, 512u64..16_384, any::<bool>())
+            .prop_map(|(height, exact_bytes, commit)| Op::ClaimUnmatched {
+                height,
+                exact_bytes,
+                commit,
+            }),
+        2 => proptest::collection::vec(1u32..=MAX_HEIGHT, 0..4)
+            .prop_map(|heights| Op::Return { heights }),
+        1 => (0u32..=MAX_HEIGHT).prop_map(|height| Op::AdvanceFloor { height }),
+        1 => (0u32..=MAX_HEIGHT).prop_map(|height| Op::ResetAbove { height }),
+        2 => (1u32..=MAX_HEIGHT).prop_map(|height| Op::DropBody { height }),
+    ]
+}
+
+/// Drive one operation against both the implementation and the model.
+///
+/// `bodies` holds each received body's charge alongside the size the model expects it
+/// to hold. The test itself is the downstream pipeline owner, standing in for the
+/// reorder/applying stages.
+///
+/// The expected size is tracked here rather than read back via the charge, so the
+/// conservation assertion compares the tracker against an independently-derived number.
+/// Reading the size out of the charge under test would make the law circular: it would
+/// hold no matter what size was actually charged.
+fn apply_op(
+    op: &Op,
+    queue: &Arc<WorkQueue>,
+    memory: &RetainedBodyMemoryTracker,
+    model: &mut Model,
+    bodies: &mut BTreeMap<u32, (RetainedCharge, u64)>,
+) {
+    match *op {
+        Op::Extend { height, size } => {
+            queue.extend([(
+                block::Height(height),
+                block::Hash([height as u8; 32]),
+                BlockSizeEstimate::Confirmed(size),
+            )]);
+            model.extend(height, u64::from(size));
+        }
+
+        Op::TakeAndIssue {
+            low,
+            high,
+            max_count,
+        } => {
+            let taken = queue.take_in_range_budgeted(
+                block::Height(low),
+                block::Height(high),
+                max_count as usize,
+                u64::MAX,
+            );
+            if taken.is_empty() {
+                return;
+            }
+
+            // Reserve retained memory for the whole request, all or none, exactly as the
+            // peer routine does at issue.
+            let estimates: Vec<u64> = taken.iter().map(|(_, item)| item.estimated_bytes).collect();
+            let reservations = memory
+                .try_reserve_many(&estimates)
+                .expect("an unbounded limit always admits a reservation");
+
+            let issued = queue.mark_issued(
+                taken
+                    .iter()
+                    .zip(reservations)
+                    .map(|((height, _), reservation)| (*height, Some(reservation))),
+            );
+
+            // The take moved these heights `pending -> in_flight` whether or not the
+            // issue was accepted, so mirror that first.
+            for (height, item) in &taken {
+                if let Some(entry) = model.items.get_mut(&height.0) {
+                    entry.location = Location::InFlight;
+                    entry.estimated_bytes = item.estimated_bytes;
+                }
+            }
+            if issued.is_some() {
+                for (height, item) in &taken {
+                    if let Some(entry) = model.items.get_mut(&height.0) {
+                        entry.reserved = true;
+                        entry.reservation_bytes = Some(item.estimated_bytes);
+                    }
+                }
+            }
+        }
+
+        Op::Receive {
+            height,
+            exact_bytes,
+        } => {
+            let settled = queue.claim_received(block::Height(height));
+
+            // A received height is in-flight with its request reservation released; any
+            // retained-memory reservation transfers out to the receiving owner.
+            if let Some(entry) = model.items.get_mut(&height) {
+                entry.location = Location::InFlight;
+                entry.reserved = false;
+                entry.reservation_bytes = None;
+            }
+
+            if let Some(reservation) = settled.in_flight_memory_reservation {
+                // Reconciling to the exact size must move the charge, not recreate it:
+                // the tracker total is asserted against the model right after.
+                let charge = reservation.reconcile_exact(exact_bytes);
+                // A duplicate response for a height whose body we already hold replaces
+                // the old charge; dropping it here is the real owner's drop.
+                bodies.insert(height, (charge, exact_bytes));
+            }
+        }
+
+        Op::ClaimUnmatched {
+            height,
+            exact_bytes,
+            commit,
+        } => {
+            let outcome =
+                queue.claim_unmatched_body(block::Height(height), block::Hash([height as u8; 32]));
+            let expected = model.claim_unmatched(height);
+
+            match outcome {
+                UnmatchedBodyClaimOutcome::Claimed(mut claim) => {
+                    let token = expected.expect("the model must also grant the claim");
+
+                    if commit {
+                        // The accepting path: take the transferred reservation, reconcile
+                        // it to the body's exact size, and keep the height claimed.
+                        if let Some(reservation) = claim.take_memory_reservation() {
+                            bodies.insert(
+                                height,
+                                (reservation.reconcile_exact(exact_bytes), exact_bytes),
+                            );
+                        }
+                        claim.commit();
+                    } else {
+                        // The abandoning path: dropping the claim must roll the height
+                        // back and release the reservation it carried.
+                        drop(claim);
+                        model.rollback_claim(height, token);
+                    }
+                }
+                UnmatchedBodyClaimOutcome::AlreadyClaimed
+                | UnmatchedBodyClaimOutcome::NotWanted => {
+                    assert!(
+                        expected.is_none(),
+                        "the queue refused a claim for height {height} that the model granted",
+                    );
+                }
+            }
+        }
+
+        Op::Return { ref heights } => {
+            let outcome = queue.release_reserved_and_return_items_detailed(
+                heights.iter().copied().map(block::Height),
+            );
+
+            let mut released = 0u64;
+            for height in heights {
+                let Some(entry) = model.items.get_mut(height) else {
+                    continue;
+                };
+                // Only still-reserved in-flight heights are returned; a received height
+                // (ledger already released) stays put.
+                if entry.location != Location::InFlight || !entry.reserved {
+                    continue;
+                }
+                released = released.saturating_add(entry.estimated_bytes);
+                entry.location = Location::Pending;
+                entry.reserved = false;
+                entry.reservation_bytes = None;
+            }
+            assert_eq!(
+                outcome.released_bytes, released,
+                "returned request bytes disagreed with the model",
+            );
+        }
+
+        Op::AdvanceFloor { height } => {
+            queue.advance_floor(block::Height(height));
+            model.advance_floor(height);
+        }
+
+        Op::ResetAbove { height } => {
+            queue.reset_above(block::Height(height));
+            model.reset_above(height);
+        }
+
+        Op::DropBody { height } => {
+            bodies.remove(&height);
+        }
+    }
+}
+
+/// Assert every conservation law that must hold after each operation.
+fn assert_conserved(
+    queue: &Arc<WorkQueue>,
+    memory: &RetainedBodyMemoryTracker,
+    model: &Model,
+    bodies: &BTreeMap<u32, (RetainedCharge, u64)>,
+    step: usize,
+    op: &Op,
+) -> Result<(), TestCaseError> {
+    let context = format!("after step {step} ({op:?})");
+
+    prop_assert_eq!(
+        queue.reserved_bytes(),
+        queue.reserved_bytes_scanned(),
+        "{}: the maintained reserved counter drifted from its scanned ground truth",
+        context
+    );
+    prop_assert_eq!(
+        queue.reserved_bytes(),
+        model.reserved_bytes(),
+        "{}: reserved request bytes disagreed with the model",
+        context
+    );
+
+    let (expected_bytes, expected_count) = model.reservations();
+    prop_assert_eq!(
+        queue.in_flight_memory_reservations_for_test(),
+        (expected_bytes, expected_count),
+        "{}: in-flight memory reservations disagreed with the model",
+        context
+    );
+
+    // The conservation law: the authoritative total is exactly the reservations the
+    // queue still holds plus the live body charges the pipeline owns. A charge stranded
+    // by any transition — released twice, or leaked past its last owner — breaks this
+    // the moment it happens, rather than at teardown where a floor sweep could hide it.
+    let live_bodies: u64 = bodies.values().map(|(_, expected)| *expected).sum();
+    prop_assert_eq!(
+        memory.used(),
+        expected_bytes.saturating_add(live_bodies),
+        "{}: retained total is not reservations ({}) + live bodies ({})",
+        context,
+        expected_bytes,
+        live_bodies
+    );
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(proptest::test_runner::Config::with_cases(256))]
+
+    #[test]
+    fn work_queue_and_retained_memory_conserve_every_transition(
+        ops in proptest::collection::vec(op_strategy(), 1..40),
+    ) {
+        let queue = Arc::new(WorkQueue::new(block::Height(0)));
+        let memory = RetainedBodyMemoryTracker::new(MEMORY_LIMIT);
+        let mut model = Model::default();
+        let mut bodies: BTreeMap<u32, (RetainedCharge, u64)> = BTreeMap::new();
+
+        for (step, op) in ops.iter().enumerate() {
+            apply_op(op, &queue, &memory, &mut model, &mut bodies);
+            assert_conserved(&queue, &memory, &model, &bodies, step, op)?;
+        }
+
+        // Teardown: once the queue and every body owner are gone, nothing may remain
+        // charged. This is the same zero-slack statement the fuzz harness makes, but
+        // reached through an arbitrary generated history rather than one happy path.
+        drop(queue);
+        bodies.clear();
+        prop_assert_eq!(
+            memory.used(),
+            0,
+            "retained memory did not drain to zero after dropping every owner"
+        );
+    }
+}

--- a/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
+++ b/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
@@ -242,6 +242,43 @@ pub(crate) fn assert_retained_memory_drained(report: &InvariantReport) {
     );
 }
 
+/// Assert every accounting ledger drained to exactly zero after teardown.
+///
+/// Unlike the trace-derived bounds this reads the live ledgers and permits no slack:
+/// once every owner is gone there is no handoff left to be mid-flight, so any nonzero
+/// value is a charge some drop path failed to release.
+pub(crate) fn assert_accounting_drained(outcome: &FuzzOutcome) {
+    let accounting = outcome.final_accounting;
+    let leaked: Vec<(&'static str, u64)> = [
+        ("wire_budget_reserved", accounting.wire_budget_reserved),
+        ("work_reserved", accounting.work_reserved),
+        ("work_reserved_scanned", accounting.work_reserved_scanned),
+        ("retained_total", accounting.retained_total),
+        (
+            "in_flight_reservation_bytes",
+            accounting.in_flight_reservation_bytes,
+        ),
+        (
+            "in_flight_reservation_count",
+            accounting.in_flight_reservation_count,
+        ),
+        ("sequencer_input_bytes", accounting.sequencer_input_bytes),
+        (
+            "sequencer_input_decoded",
+            accounting.sequencer_input_decoded,
+        ),
+    ]
+    .into_iter()
+    .filter(|(_, value)| *value != 0)
+    .collect();
+
+    assert!(
+        leaked.is_empty(),
+        "block-sync accounting must drain to zero after teardown; leaked {leaked:?} \
+         (full snapshot: {accounting:?})",
+    );
+}
+
 fn max_unproven_requests_without_block_progress(reader: &TraceReader) -> u64 {
     reader
         .table("block_sync")
@@ -320,6 +357,7 @@ pub(crate) fn assert_core(
         "successful run never observed active decoded pipeline bytes",
     );
     assert_retained_memory_drained(report);
+    assert_accounting_drained(outcome);
 
     // Per-peer windows respect the advertised inflight caps: aggregate in-flight must
     // not exceed the sum of per-peer advertised `max_inflight_requests`.

--- a/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
+++ b/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
@@ -90,7 +90,7 @@ pub(crate) async fn run_scenario(
     startup.shutdown = shutdown.clone();
 
     let (handle, actions, reactor_task) = crate::zakura::spawn_block_sync_reactor(startup);
-    let retained_memory_used = handle.retained_memory_probe();
+    let accounting = handle.accounting_probe();
 
     let (committed_tx, mut committed_rx) = watch::channel(block::Height(0));
 
@@ -164,7 +164,7 @@ pub(crate) async fn run_scenario(
     // sequencer and peer routines can need a few scheduler turns to drop their final
     // queued/detached body owners. Keep only the counter probe alive while they settle.
     let _ = tokio::time::timeout(Duration::from_secs(2), async {
-        while retained_memory_used() != 0 {
+        while accounting.retained_total() != 0 {
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
     })
@@ -173,7 +173,8 @@ pub(crate) async fn run_scenario(
     Ok(FuzzOutcome {
         committed_tip,
         target,
-        final_retained_memory_bytes: retained_memory_used(),
+        final_retained_memory_bytes: accounting.retained_total(),
+        final_accounting: accounting.snapshot(),
     })
 }
 

--- a/zakura-network/src/zakura/testkit/blocksync_fuzz/scenario.rs
+++ b/zakura-network/src/zakura/testkit/blocksync_fuzz/scenario.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use zakura_chain::block;
 
+use crate::zakura::BlockSyncAccounting;
+
 use crate::zakura::{BlockSyncStatus, ZakuraBlockSyncConfig, ZakuraPeerId, MAX_BS_RESPONSE_BYTES};
 
 /// A latency draw, fixed or uniform over `[low, high]`.
@@ -346,6 +348,8 @@ pub(crate) struct FuzzOutcome {
     pub(crate) target: block::Height,
     /// Authoritative retained body memory after full harness teardown.
     pub(crate) final_retained_memory_bytes: u64,
+    /// Every block-sync accounting ledger, read after full harness teardown.
+    pub(crate) final_accounting: BlockSyncAccounting,
 }
 
 impl FuzzOutcome {

--- a/zakura-network/src/zakura/testkit/blocksync_fuzz/tests.rs
+++ b/zakura-network/src/zakura/testkit/blocksync_fuzz/tests.rs
@@ -42,6 +42,63 @@ fn max_retained_body_bytes(blocks: u32, seed: u64, target_block_bytes: usize) ->
         .unwrap_or(0)
 }
 
+/// The most bodies that can be in flight at once across every peer in a scenario.
+///
+/// Each peer is capped at its advertised `max_inflight_requests`, and each request
+/// carries at most the smaller of the peer's and our own `max_blocks_per_response`
+/// bodies. Uses the advertised cap directly, as `assert_core`'s `outstanding_bound`
+/// does; the `MAX_BS_INFLIGHT_REQUESTS` hard clamp sits far above any scenario's.
+fn max_inflight_bodies(scenario: &Scenario) -> u64 {
+    scenario
+        .peers
+        .iter()
+        .map(|peer| {
+            let requests = u64::from(peer.max_inflight_requests);
+            let blocks = u64::from(
+                peer.max_blocks_per_response
+                    .min(scenario.config.max_blocks_per_response),
+            );
+            requests.saturating_mul(blocks)
+        })
+        .fold(0u64, u64::saturating_add)
+}
+
+/// The worst-case peak retained memory a scenario can reach, derived from the
+/// admission gate rather than chosen by hand.
+///
+/// The retained-memory tracker's limit is `max_reorder_lookahead_bytes` (call it `L`),
+/// and above-window requests reserve against it with an atomic `try_reserve_many`, so
+/// the gated lane alone can never exceed `L`. Every byte above `L` comes from one of
+/// exactly two paths that charge without consulting the limit:
+///
+/// 1. **Commit-window bodies.** Heights within `MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES`
+///    of the *verified* tip are exempt from the look-ahead gate and take no reservation
+///    at issue (`peer_routine` filters them out of the reservation), so at receipt they
+///    charge unconditionally. One exempt span can be co-resident: `span x max_body`.
+///
+/// 2. **Reconciliation growth.** An above-window request reserves its *estimated* wire
+///    size and, at receipt, resizes that same charge to the exact retained size (decoded
+///    attributed memory + raw payload). The resize does not re-consult the limit, so
+///    each in-flight body can add up to its full retained size on top of `L`.
+///
+/// In practice term 1 dominates by two orders of magnitude: the commit-window exemption,
+/// not `L`, is what actually sizes block-sync's resident memory.
+///
+/// This is a ceiling, not a prediction. It assumes every in-flight body reconciles from
+/// nothing to the corpus's largest body at the same instant, while a full exempt span is
+/// simultaneously resident.
+fn derived_retained_memory_bound(scenario: &Scenario, max_body_bytes: u64) -> u64 {
+    let commit_window =
+        (MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES as u64).saturating_mul(max_body_bytes);
+    let reconciliation_growth = max_inflight_bodies(scenario).saturating_mul(max_body_bytes);
+
+    scenario
+        .config
+        .max_reorder_lookahead_bytes
+        .saturating_add(commit_window)
+        .saturating_add(reconciliation_growth)
+}
+
 /// Run a scenario, flush its trace, assert the core invariants, and return the outcome
 /// + report. `outstanding_slack` absorbs brief over-counts at request boundaries.
 async fn run_checked(
@@ -909,26 +966,23 @@ async fn fuzz_commit_stall() {
         }),
     };
     scenario.deadline = Duration::from_secs(60);
+    // Derived from the scenario, so compute it before the run consumes it.
+    let max_body_bytes = max_retained_body_bytes(blocks, 0x57ea_000c, body_bytes);
+    let inflight_bodies = max_inflight_bodies(&scenario);
+    let bound = derived_retained_memory_bound(&scenario, max_body_bytes);
     let (_, report) = run_checked("fuzz_commit_stall", scenario, 64).await;
 
-    // Budget plus exact bodies in the commit window and a bounded arrival margin.
-    let max_body_bytes = max_retained_body_bytes(blocks, 0x57ea_000c, body_bytes);
-    let window_slack =
-        (MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES as u64).saturating_mul(max_body_bytes);
-    let margin = max_body_bytes.saturating_mul(128);
     let peak_retained_resident = report.peak_retained_memory_bytes;
-    let bound = resident_budget
-        .saturating_add(window_slack)
-        .saturating_add(margin);
     assert!(
         peak_retained_resident <= bound,
-        "peak retained resident cost {} must stay within the {} B budget \
-         (+{} B bounded-window allowance, +{} B arrival margin); the apply backlog is bounded by \
-         the resident gate, not unbounded by the commit stall",
+        "peak retained resident cost {} exceeded the derived ceiling {} (look-ahead budget \
+         {} B, {} in-flight bodies, max body {} B); the apply backlog is bounded by the \
+         resident gate, not unbounded by the commit stall",
         peak_retained_resident,
+        bound,
         resident_budget,
-        window_slack,
-        margin,
+        inflight_bodies,
+        max_body_bytes,
     );
     // Ensure the bound is exercised.
     assert!(
@@ -981,28 +1035,25 @@ async fn fuzz_commit_stall_resident_plateau() {
         }),
     };
     scenario.deadline = Duration::from_secs(120);
+    let max_body_bytes = max_retained_body_bytes(blocks, 0x57ea_000d, body_bytes);
+    let inflight_bodies = max_inflight_bodies(&scenario);
+    let bound = derived_retained_memory_bound(&scenario, max_body_bytes);
     let (_, report) = run_checked("fuzz_commit_stall_resident_plateau", scenario, 64).await;
 
     // Peak retained memory stays within the budget, plus exact commit/submission
     // window bodies and a bounded in-flight arrival margin. A gate regression (the
     // escalator, or reservations invisible to the byte gate) drives retention toward
     // the full ~150 MB resident chain instead.
-    let max_body_bytes = max_retained_body_bytes(blocks, 0x57ea_000d, body_bytes);
-    let window_slack =
-        (MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES as u64).saturating_mul(max_body_bytes);
-    let margin = max_body_bytes.saturating_mul(128);
     let peak_retained_resident = report.peak_retained_memory_bytes;
-    let bound = resident_budget
-        .saturating_add(window_slack)
-        .saturating_add(margin);
     assert!(
         peak_retained_resident <= bound,
-        "peak retained resident cost {} must stay within the {} B budget \
-         (+{} B bounded-window allowance, +{} B arrival margin)",
+        "peak retained resident cost {} exceeded the derived ceiling {} \
+         (look-ahead budget {} B, {} in-flight bodies, max body {} B)",
         peak_retained_resident,
+        bound,
         resident_budget,
-        window_slack,
-        margin,
+        inflight_bodies,
+        max_body_bytes,
     );
     // Non-vacuous: the stall actually pushed retention past the gated budget alone, so
     // the bound above is doing real work.
@@ -1017,7 +1068,8 @@ async fn fuzz_commit_stall_resident_plateau() {
         peak_retained_pipeline_wire_bytes = report.peak_retained_pipeline_wire_bytes,
         peak_retained_resident,
         resident_budget,
-        window_slack,
+        bound,
+        inflight_bodies,
         "commit_stall resident-plateau observation",
     );
 }
@@ -1061,6 +1113,9 @@ async fn fuzz_commit_stall_resident_plateau_multiblock() {
         }),
     };
     scenario.deadline = Duration::from_secs(120);
+    let max_body_bytes = max_retained_body_bytes(blocks, 0x57ea_000e, body_bytes);
+    let inflight_bodies = max_inflight_bodies(&scenario);
+    let bound = derived_retained_memory_bound(&scenario, max_body_bytes);
     let (_, report) = run_checked(
         "fuzz_commit_stall_resident_plateau_multiblock",
         scenario,
@@ -1072,22 +1127,16 @@ async fn fuzz_commit_stall_resident_plateau_multiblock() {
     // window bodies + a bounded in-flight arrival margin. A take-geometry regression (an exempt
     // multi-block take extending above the window sized by the in-flight budget) drives
     // retention toward the full ~150 MB resident chain instead.
-    let max_body_bytes = max_retained_body_bytes(blocks, 0x57ea_000e, body_bytes);
-    let window_slack =
-        (MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES as u64).saturating_mul(max_body_bytes);
-    let margin = max_body_bytes.saturating_mul(128);
     let peak_retained_resident = report.peak_retained_memory_bytes;
-    let bound = resident_budget
-        .saturating_add(window_slack)
-        .saturating_add(margin);
     assert!(
         peak_retained_resident <= bound,
-        "peak retained resident cost {} must stay within the {} B budget \
-         (+{} B bounded-window allowance, +{} B arrival margin) with multi-block responses",
+        "peak retained resident cost {} exceeded the derived ceiling {} (look-ahead budget \
+         {} B, {} in-flight bodies, max body {} B) with multi-block responses",
         peak_retained_resident,
+        bound,
         resident_budget,
-        window_slack,
-        margin,
+        inflight_bodies,
+        max_body_bytes,
     );
     assert!(
         peak_retained_resident >= resident_budget / 2,
@@ -1100,7 +1149,8 @@ async fn fuzz_commit_stall_resident_plateau_multiblock() {
         peak_retained_pipeline_wire_bytes = report.peak_retained_pipeline_wire_bytes,
         peak_retained_resident,
         resident_budget,
-        window_slack,
+        bound,
+        inflight_bodies,
         "commit_stall multi-block resident-plateau observation",
     );
 }


### PR DESCRIPTION
## Motivation

PR #217 makes block-sync retained-memory accounting exact. Its coverage bounds sampled trace peaks and asserts a final retained total of zero. Both are useful, but neither states the accounting laws:

- the wire-budget final value comes from a sampled trace and permits one request of slack;
- `ByteBudget::audit()` is one-sided (`actual >= expected`), so excess charges pass;
- the plateau tests allow a `max_body_bytes × 128` arrival margin — a hand-chosen heuristic, unlike the sibling `window_slack` term, which is derived from `MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES`;
- `final_retained_memory_bytes == 0` is exact and valuable, but end-state only.

Together these infer correct accounting from the absence of a visible plateau breach. A charge that is transferred incorrectly, released twice, or briefly stranded can still pass every one of them.

## Solution

Three layers that state the laws directly. All test-only; no production logic changes.

**Tracker property tests** (`retained_memory.rs`). A contender spinning `try_charge` at a saturated limit *witnesses* any headroom the tracker publishes — every byte it wins is headroom that really existed, so "growth exposed nothing" is provable rather than sampled. Also pins racing resizes applying growth exactly once, clones sharing one charge, and all-or-none reservations never oversubscribing.

**Accounting probe** (`accounting_probe.rs`, new). Reads the live ledgers via the same `RoutineWiring` handles the production path threads to each peer routine. It owns its handles, so it outlives teardown — the state in which a zero-slack assertion is meaningful. The fuzz harness now asserts every ledger drains to exactly zero, with no slack. It supersedes `retained_memory_probe`, which is removed.

**Model-based transition test** (`work_queue_model.rs`, new). Generated operation sequences over `WorkQueue` + `RetainedBodyMemoryTracker`, asserting conservation after *every* operation, including the unmatched-body claim path and its RAII rollback.

The model exists because teardown assertions are structurally blind to a transient leak: a reservation stranded by `reset_above` is swept by a later `advance_floor`, so the end state is clean. The model fails at the transition that stranded it — see Testing.

The model tracks accounting, not scheduling. Which heights `take_in_range_budgeted` selects is driven from the call's own result rather than re-derived; its contiguity and byte-cap rules already have unit tests, and reimplementing them in the model would only test the copy.

## Testing

- `cargo test -p zakura-network --lib block_sync` — 260 passed
- `cargo test -p zakura-network --lib blocksync_fuzz` — 21 passed
- `cargo clippy -p zakura-network --all-targets` — 0 warnings
- `cargo clippy -p zakura-network --lib --all-features` — 0 warnings (see the bench commit)
- `cargo fmt --all -- --check`

Every assertion was validated by mutation testing rather than trusted because it was green. Each mutation is caught, each by a different assertion:

| Mutation | Caught by |
| --- | --- |
| `reconcile_exact` as release-then-recharge | contender at the limit |
| `reset_above` strands a memory reservation | reservations vs model |
| `claim_received` strands a memory reservation | reservations vs model |
| `reconcile_exact` ignores the exact size | conservation law |
| `mark_issued` over-counts reserved bytes | maintained-vs-scanned drift |
| uncommitted claim never rolls back | claim grant vs model |

The `reset_above` case is the load-bearing one: it **passes** the zero-slack teardown assertion, because `advance_floor` sweeps the stranded reservation before teardown. The model catches it at step 2 and shrinks to a 3-step counterexample. End-state and per-transition assertions cover genuinely different classes of leak.

Two tests were discarded or rewritten because mutation showed they passed under the exact bug they targeted:

- an identity check using `Arc` pointer equality was ABA-unsafe (the allocator reuses the freed address, so release-then-recharge passed) — **deleted**, since the contender covers it soundly;
- the conservation law initially read `live_bodies` back out of the implementation under test, making it circular — the model now tracks the expected size independently.

**No accounting bugs were found in #217.** Every mutation above is artificial. The accounting held under all of them, which is the intended result: this PR converts "we believe it is correct" into "these properties are proven".

**Derived the retained-memory bound.** The plateau tests used a hand-chosen `max_body × 128` arrival margin. Deriving it from the admission gate instead:

```
peak_retained <= L                                  # tracker limit, enforced atomically
              +  MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES × max_body   # commit-window exemption
              +  max_inflight_bodies × max_body                          # reconciliation growth
```

`L` is `max_reorder_lookahead_bytes`. Above-window requests reserve against it with an atomic `try_reserve_many`, so the gated lane alone can never exceed it. Exactly two paths charge without consulting the limit: commit-window bodies (exempt, no reservation at issue, charge unconditionally at receipt) and reconciliation growth (an above-window reservation resizes from estimate to exact retained size without re-consulting the limit).

The old margin turns out to *be* the second term: `Σ peers(max_inflight_requests) × max_blocks_per_response` = 2 × 64 × 1 = **exactly 128** for the single-block scenarios. The derived ceiling reproduces the previous bound identically for two of the three tests, which is a good sign the derivation matches the original reasoning. For the multi-block scenario the same quantity is **2048**, so its margin was 16× too small and passed only because reconciliation growth stays far below worst case.

**The headline finding is what the measurement showed, not the margin.** Peaks against the derived terms:

| Scenario | look-ahead budget `L` | measured peak | commit-window term |
| --- | --- | --- | --- |
| `fuzz_commit_stall` | 2 MiB | 181.7 MB | 227.8 MB |
| `..._resident_plateau` | 8 MiB | 227.7 MB | 227.8 MB |

The peak tracks the commit-window term to within 0.02% and is unrelated to `L`. **`max_reorder_lookahead_bytes` is not what sizes block-sync resident memory in these scenarios — the commit-window exemption is**, and it is not configurable. Nothing amplifies `L` here: the exempt bodies never take a reservation against it, so lowering `L` cannot lower the peak.

Two independent multipliers produce that 227.8 MB, and only the first is structural:

- **401 bodies co-resident**, bypassing the gate (`MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES`).
- **16.3× decoded expansion per body** — but this is an artefact of the synthetic corpus, not a property of Zcash. The corpus packs 242 transactions of ~135 B into each 32 KiB block, and `attributed_memory_size_bytes` charges a fixed `inline_size_bytes::<Transaction>()` per transaction, so tiny transactions make that overhead dominate. Measured against real mainnet vectors, where transactions are ~1.2–1.7 kB:

| Block | wire | txs | bytes/tx | decoded ratio |
| --- | --- | --- | --- | --- |
| `MAINNET_1` | 1,617 | 1 | 1,617 | 2.31× |
| `MAINNET_982681` | 5,244 | 3 | 1,748 | 2.22× |
| `MAINNET_434873` | 13,935 | 12 | 1,161 | 3.12× |
| synthetic (32 KiB) | 32,706 | 242 | **135** | **16.35×** |

So the plateau tests run ~5–7× pessimistic on decoded expansion. That is the safe direction for a ceiling, but the absolute MB figures in these tests should not be read as representative of mainnet.

### Specifications & References

Stacked on `feat/exact-block-sync-retained-memory` (#217); please merge that first.

AI disclosure: authored with Claude Code.

### Follow-up Work

- **The commit-window exemption, not the configured cap, sizes resident memory.** The bound is now derived, and the measurement above shows the exempt span dominating while `L` is irrelevant to it. `BS_CHECKPOINT_RANGE_BYTE_FLOOR` already encodes the wire half of this (`401 × 2 MB` = ~802 MB), so the floor is known and intentional — checkpoint ranges must be co-resident to commit. What the tests add is that it is the *dominant* term, and that lowering `max_reorder_lookahead_bytes` cannot bring resident memory below it. Sizing it with the measured real-block expansion (~2.3–3.1×) rather than the synthetic 16×, a worst-case 2 MB-block range costs roughly `401 × ~8 MB` ≈ **3 GB**, on top of the 1.5 GiB default `L`. Typical mainnet blocks (a few kB) make the same term ~20 MB and irrelevant. So the exposure is real but confined to sustained large-block stretches. Worth a design conversation for the OOM work; not a test gap.
- **The fuzz corpus is not shape-representative.** 242 × 135 B transactions per block, against a real ~1–12 × ~1.2 kB. Since retained memory is charged per transaction, this systematically inflates decoded expansion ~5–7×. Pessimistic (so bounds stay safe), but it means memory figures from these scenarios do not transfer to mainnet, and it is worth knowing before anyone tunes a real limit against them.
- **Conservation is not boundedness.** The accounting tests prove every byte is charged once, transferred correctly, and released exactly once. That is orthogonal to whether the total stays under a ceiling — conservation holds perfectly while the total climbs. The derived bound above is the first half of the boundedness story; the reconciliation-growth term is a worst case no scenario currently provokes.
- Extend the model across the sequencer stages (`prepare_submit` clones the charge, `retain_for_driver_in_place` resizes it, detach/unsubmit/resubmit move it). That is the largest remaining transient-leak surface.
- The model is single-threaded; the fuzz tests are concurrent but assert only peaks and teardown. Loom on the tracker would close the gap, though the contender tests already cover the sharpest race.
- `fuzz_reorg` remains ignored: a faithful mid-sync reset needs the high-fidelity `Committer<MockVerifier>` tier.
