### PR TITLE
fix(sync): reconcile promoted header forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Prevent initial sync from stalling at checkpoint boundaries by refilling the
   verifier submission window after stale apply completions.
+- Prevent header sync from stalling after a verified-chain fork by atomically
+  persisting the promoted header branch before reanchoring network requests.
 
 ### Changed
 

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -537,9 +537,7 @@ impl HeaderSyncReactor {
 
     async fn handle_frontier_update(&mut self, update: FrontierUpdate) {
         match update.change {
-            FrontierChange::Snapshot
-            | FrontierChange::VerifiedGrow
-            | FrontierChange::VerifiedReset => {
+            FrontierChange::Snapshot | FrontierChange::VerifiedGrow => {
                 let frontier = update.frontier;
                 self.handle_state_frontiers_changed(HeaderSyncFrontiers {
                     finalized_height: frontier.finalized.height,
@@ -547,6 +545,15 @@ impl HeaderSyncReactor {
                     verified_block_hash: frontier.verified_body.hash,
                 })
                 .await;
+            }
+            FrontierChange::VerifiedReset => {
+                let frontier = update.frontier;
+                self.state.finalized_height = frontier.finalized.height;
+                self.state.verified_block_tip = frontier.verified_body.height;
+                self.state.verified_block_hash = frontier.verified_body.hash;
+                metrics::counter!("sync.header.verified_reset.reanchored").increment(1);
+                self.reanchor_to_verified_block_tip_inner().await;
+                self.schedule().await;
             }
             FrontierChange::HeaderAdvanced | FrontierChange::HeaderReanchored => {}
         }
@@ -2059,10 +2066,13 @@ impl HeaderSyncReactor {
     }
 
     async fn reanchor_to_verified_block_tip(&mut self) {
+        metrics::counter!("sync.header.stale_anchor.reanchored").increment(1);
+        self.reanchor_to_verified_block_tip_inner().await;
+    }
+
+    async fn reanchor_to_verified_block_tip_inner(&mut self) {
         let height = self.state.verified_block_tip;
         let hash = self.state.verified_block_hash;
-        metrics::counter!("sync.header.stale_anchor.reanchored").increment(1);
-
         self.state.stale_anchor.reset();
         self.state.schedule.clear_forward();
         self.state

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -14,8 +14,9 @@ use super::{
 use crate::zakura::{
     framed_channel,
     testkit::{TraceCapture, TraceValue},
-    FramedSend, HeaderSyncServiceSummary, Peer, Service, ServicePeerDirection, ServicePeerLimits,
-    ServicePeerSnapshot, ZakuraConnId, ZakuraHeaderSyncCandidateState, ZAKURA_CAP_HEADER_SYNC,
+    ChainFrontier, FramedSend, Frontier, FrontierChange, FrontierUpdate, HeaderSyncServiceSummary,
+    Peer, Service, ServicePeerDirection, ServicePeerLimits, ServicePeerSnapshot, ZakuraConnId,
+    ZakuraHeaderSyncCandidateState, ZAKURA_CAP_HEADER_SYNC,
 };
 use chrono::Duration;
 use metrics::{
@@ -3807,6 +3808,105 @@ async fn full_block_committed_covers_outstanding_height() {
     assert!(!cancel.is_cancelled());
     assert_eq!(fixture.handle.peer_snapshot().inbound_peers, 1);
     assert_no_commit_or_misbehavior(&mut fixture.actions).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn same_height_verified_reset_reanchors_header_tip() {
+    let network = regtest_network();
+    let anchor = (block::Height(0), network.genesis_hash());
+    let old_tip = (block::Height(1), block::Hash([1; 32]));
+    let new_tip = (block::Height(1), block::Hash([2; 32]));
+    let initial = FrontierUpdate {
+        frontier: ChainFrontier {
+            finalized: Frontier::new(anchor.0, anchor.1),
+            verified_body: Frontier::new(old_tip.0, old_tip.1),
+            best_header: Frontier::new(old_tip.0, old_tip.1),
+        },
+        change: FrontierChange::Snapshot,
+    };
+    let (frontier_tx, frontier_rx) = tokio::sync::watch::channel(initial);
+    let mut startup = startup_for(network, anchor, Some(old_tip));
+    startup.frontiers = HeaderSyncFrontiers {
+        finalized_height: anchor.0,
+        verified_block_tip: old_tip.0,
+        verified_block_hash: old_tip.1,
+    };
+    startup.frontier_updates = Some(frontier_rx);
+    let mut fixture = spawn_test_reactor(startup);
+
+    frontier_tx
+        .send(FrontierUpdate {
+            frontier: ChainFrontier {
+                finalized: Frontier::new(anchor.0, anchor.1),
+                verified_body: Frontier::new(new_tip.0, new_tip.1),
+                best_header: Frontier::new(new_tip.0, new_tip.1),
+            },
+            change: FrontierChange::VerifiedReset,
+        })
+        .expect("reactor retains the frontier receiver");
+
+    assert!(matches!(
+        next_non_query_action(&mut fixture.actions).await,
+        HeaderSyncAction::HeaderReanchored { old, new }
+            if old == old_tip && new == new_tip
+    ));
+    assert_eq!(fixture.handle.best_header_tip(), new_tip);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn forward_verified_reset_clears_old_work_and_requests_from_new_tip() {
+    let network = regtest_network();
+    let anchor = (block::Height(0), network.genesis_hash());
+    let old_tip = (block::Height(1), block::Hash([1; 32]));
+    let new_tip = (block::Height(2), block::Hash([2; 32]));
+    let initial = FrontierUpdate {
+        frontier: ChainFrontier {
+            finalized: Frontier::new(anchor.0, anchor.1),
+            verified_body: Frontier::new(old_tip.0, old_tip.1),
+            best_header: Frontier::new(old_tip.0, old_tip.1),
+        },
+        change: FrontierChange::Snapshot,
+    };
+    let (frontier_tx, frontier_rx) = tokio::sync::watch::channel(initial);
+    let mut startup = startup_for(network, anchor, Some(old_tip));
+    startup.frontiers = HeaderSyncFrontiers {
+        finalized_height: anchor.0,
+        verified_block_tip: old_tip.0,
+        verified_block_hash: old_tip.1,
+    };
+    startup.frontier_updates = Some(frontier_rx);
+    let mut fixture = spawn_test_reactor(startup);
+    let peer_id = peer(211);
+
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(&fixture, peer_id, anchor.0, block::Height(3), 2, 1).await;
+    let (_, _, old_start, _) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!(old_start, block::Height(2));
+
+    frontier_tx
+        .send(FrontierUpdate {
+            frontier: ChainFrontier {
+                finalized: Frontier::new(anchor.0, anchor.1),
+                verified_body: Frontier::new(new_tip.0, new_tip.1),
+                best_header: Frontier::new(new_tip.0, new_tip.1),
+            },
+            change: FrontierChange::VerifiedReset,
+        })
+        .expect("reactor retains the frontier receiver");
+
+    loop {
+        match next_non_query_action(&mut fixture.actions).await {
+            HeaderSyncAction::HeaderReanchored { old, new } => {
+                assert_eq!(old, old_tip);
+                assert_eq!(new, new_tip);
+                break;
+            }
+            HeaderSyncAction::SendMessage { .. } => {}
+            action => panic!("unexpected action while reanchoring: {action:?}"),
+        }
+    }
+    let (_, _, new_start, new_count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((new_start, new_count), (block::Height(3), 1));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -1332,6 +1332,20 @@ impl ZakuraDb {
                 error: error.to_string(),
             })
     }
+
+    /// Atomically reconcile the Zakura header store with the non-finalized best chain.
+    pub(crate) fn reconcile_zakura_headers_from_committed_blocks(
+        &self,
+        blocks: &[(block::Height, Arc<block::Block>)],
+    ) -> Result<(), CommitHeaderRangeError> {
+        let mut batch = DiskWriteBatch::new();
+        batch.prepare_zakura_headers_from_committed_blocks(self, blocks)?;
+        self.db
+            .write(batch)
+            .map_err(|error| CommitHeaderRangeError::StorageWriteError {
+                error: error.to_string(),
+            })
+    }
 }
 
 /// Read a spent transparent UTXO and its output location before deleting it from the database.
@@ -1852,6 +1866,113 @@ impl DiskWriteBatch {
         Ok(())
     }
 
+    /// Prepare a database batch that replaces a stale Zakura header suffix with
+    /// the corresponding headers from the non-finalized best chain.
+    #[allow(clippy::unwrap_in_result)]
+    pub(crate) fn prepare_zakura_headers_from_committed_blocks(
+        &mut self,
+        zakura_db: &ZakuraDb,
+        blocks: &[(block::Height, Arc<block::Block>)],
+    ) -> Result<(), CommitHeaderRangeError> {
+        let Some((new_tip_height, _)) = blocks.last() else {
+            return Ok(());
+        };
+
+        let (first_height, first_block) = blocks
+            .first()
+            .expect("a best chain with a tip contains a first block");
+        let expected_parent = first_height
+            .previous()
+            .ok()
+            .and_then(|parent_height| zakura_db.header_hash(parent_height))
+            .ok_or(CommitHeaderRangeError::UnknownAnchor {
+                anchor: first_block.header.previous_block_hash,
+            })?;
+        if first_block.header.previous_block_hash != expected_parent {
+            return Err(CommitHeaderRangeError::UnlinkedRange {
+                height: *first_height,
+                expected_parent,
+                actual_parent: first_block.header.previous_block_hash,
+            });
+        }
+
+        for pair in blocks.windows(2) {
+            let [(parent_height, parent), (child_height, child)] = pair else {
+                unreachable!("a two-item window always contains two best-chain blocks");
+            };
+            if parent_height.next().ok() != Some(*child_height)
+                || child.header.previous_block_hash != parent.hash()
+            {
+                return Err(CommitHeaderRangeError::UnlinkedRange {
+                    height: *child_height,
+                    expected_parent: parent.hash(),
+                    actual_parent: child.header.previous_block_hash,
+                });
+            }
+        }
+
+        let first_divergence = blocks
+            .iter()
+            .position(|(height, block)| zakura_db.header_hash(*height) != Some(block.hash()));
+
+        let zakura_header_by_height = zakura_db.db.cf_handle(ZAKURA_HEADER_BY_HEIGHT).unwrap();
+        let zakura_hash_by_height = zakura_db
+            .db
+            .cf_handle(ZAKURA_HEADER_HASH_BY_HEIGHT)
+            .unwrap();
+        let zakura_height_by_hash = zakura_db
+            .db
+            .cf_handle(ZAKURA_HEADER_HEIGHT_BY_HASH)
+            .unwrap();
+        let zakura_body_size_by_height = zakura_db
+            .db
+            .cf_handle(ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT)
+            .unwrap();
+        let zakura_roots_by_height = zakura_db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
+        let tx_by_loc = zakura_db.db.cf_handle("tx_by_loc").unwrap();
+
+        let delete_from = first_divergence
+            .map(|index| blocks[index].0)
+            .or_else(|| new_tip_height.next().ok());
+        let old_tip = zakura_db.zakura_header_tip().map(|(height, _)| height);
+        if let (Some(delete_from), Some(old_tip)) = (delete_from, old_tip) {
+            if delete_from <= old_tip {
+                for old_height in delete_from.0..=old_tip.0 {
+                    let old_height = block::Height(old_height);
+                    if zakura_db
+                        .db
+                        .zs_contains(&tx_by_loc, &TransactionLocation::min_for_height(old_height))
+                    {
+                        return Err(CommitHeaderRangeError::ConflictingFullBlockHeader {
+                            height: old_height,
+                        });
+                    }
+                    if let Some(old_hash) = zakura_db
+                        .db
+                        .zs_get::<_, _, block::Hash>(&zakura_hash_by_height, &old_height)
+                    {
+                        self.zs_delete(&zakura_height_by_hash, old_hash);
+                    }
+                    self.zs_delete(&zakura_hash_by_height, old_height);
+                    self.zs_delete(&zakura_header_by_height, old_height);
+                    self.zs_delete(&zakura_body_size_by_height, old_height);
+                    self.zs_delete(&zakura_roots_by_height, old_height);
+                }
+            }
+        }
+
+        if let Some(first_divergence) = first_divergence {
+            for (height, block) in &blocks[first_divergence..] {
+                let hash = block.hash();
+                self.zs_insert(&zakura_header_by_height, *height, &block.header);
+                self.zs_insert(&zakura_hash_by_height, *height, hash);
+                self.zs_insert(&zakura_height_by_hash, hash, *height);
+            }
+        }
+
+        Ok(())
+    }
+
     /// Prepare a database batch that seeds the Zakura header store from a
     /// committed full block.
     ///
@@ -1860,10 +1981,8 @@ impl DiskWriteBatch {
     /// block-derived header and drop stale provisional descendants.
     ///
     /// A block whose parent hash does not match the stored header row below
-    /// `height` is skipped without error: writing it would leave a gap or
-    /// broken link in the header store, so the store instead waits for
-    /// header-range sync to deliver the connecting rows (see the linkage
-    /// refusal below).
+    /// `height` is rejected: reporting success would allow the caller to
+    /// publish an anchor that was never made durable.
     #[allow(clippy::unwrap_in_result)]
     pub fn prepare_zakura_header_from_committed_block(
         &mut self,
@@ -1882,28 +2001,29 @@ impl DiskWriteBatch {
         let existing_zakura_header: Option<Arc<block::Header>> =
             db.zs_get(&zakura_header_by_height, &height);
 
-        if existing_zakura_header.as_ref() == Some(&block.header)
-            && db.zs_get::<_, _, block::Hash>(&zakura_hash_by_height, &height) == Some(hash)
-        {
-            return Ok(());
-        }
-
-        // Seeds can jump to a non-finalized best tip whose parent is not the
-        // stored row below it. Refuse those seeds so the header store stays
-        // linked; header-range sync will later deliver the missing rows.
+        // Reject a seed that jumps across missing promoted ancestors so the
+        // caller can reconcile the whole branch before publishing its tip.
         let hash_by_height = db.cf_handle("hash_by_height").unwrap();
         let parent_hash: Option<block::Hash> = height.previous().ok().and_then(|parent_height| {
             db.zs_get(&hash_by_height, &parent_height)
                 .or_else(|| db.zs_get(&zakura_hash_by_height, &parent_height))
         });
-        if parent_hash != Some(block.header.previous_block_hash) {
-            tracing::debug!(
-                ?height,
-                ?hash,
-                parent = ?block.header.previous_block_hash,
-                stored_parent = ?parent_hash,
-                "skipping Zakura header seed that does not link to the stored row below it"
-            );
+        let Some(parent_hash) = parent_hash else {
+            return Err(CommitHeaderRangeError::UnknownAnchor {
+                anchor: block.header.previous_block_hash,
+            });
+        };
+        if parent_hash != block.header.previous_block_hash {
+            return Err(CommitHeaderRangeError::UnlinkedRange {
+                height,
+                expected_parent: parent_hash,
+                actual_parent: block.header.previous_block_hash,
+            });
+        }
+
+        if existing_zakura_header.as_ref() == Some(&block.header)
+            && db.zs_get::<_, _, block::Hash>(&zakura_hash_by_height, &height) == Some(hash)
+        {
             return Ok(());
         }
 

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/ops.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/ops.rs
@@ -307,10 +307,8 @@ impl Harness {
                     }
                     _ => {
                         // A seed whose parent is not the stored row below it is
-                        // refused by the store as a silent no-op (the header
-                        // store briefly lags the non-finalized chain until a
-                        // linkage-checked header range converges it), so the
-                        // call must succeed without mutating anything.
+                        // rejected without mutating the store. Reporting success
+                        // would let the caller publish a missing durable anchor.
                         let parent_linked = self.oracle.seed_is_parent_linked(&fab);
                         let dump_before = (!parent_linked).then(|| dump_store(self.state()));
                         let block = fabricate_body(&fab);
@@ -321,19 +319,25 @@ impl Harness {
                             Ok(()) => {
                                 if parent_linked {
                                     self.oracle.apply_seed(&fab);
-                                } else if dump_store(self.state())
-                                    != dump_before.expect("dumped before an unlinked seed")
-                                {
+                                } else {
                                     mismatches.push(format!(
-                                        "refused unlinked seed mutated the store: {op:?}"
+                                        "unlinked seed unexpectedly succeeded: {op:?}"
                                     ));
                                 }
                                 OpOutcome::Accepted
                             }
                             Err(error) => {
-                                mismatches.push(format!(
-                                    "oracle predicted accept, seed rejected with {error:?}: {op:?}"
-                                ));
+                                if parent_linked {
+                                    mismatches.push(format!(
+                                        "oracle predicted accept, seed rejected with {error:?}: {op:?}"
+                                    ));
+                                } else if dump_store(self.state())
+                                    != dump_before.expect("dumped before an unlinked seed")
+                                {
+                                    mismatches.push(format!(
+                                        "rejected unlinked seed mutated the store: {op:?}"
+                                    ));
+                                }
                                 OpOutcome::Rejected(RejectError::HeaderRange(error))
                             }
                         }

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/oracle.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/oracle.rs
@@ -248,10 +248,9 @@ impl Oracle {
     }
 
     /// Whether a seeded block's parent is the expected canonical row below it.
-    /// The store refuses seeds that are not parent-linked as silent no-ops
-    /// (writing them would strand a row the chain walk cannot reach); the
-    /// harness uses this to decide whether a successful seed call must have
-    /// mutated the store or left it untouched.
+    /// The store rejects seeds that are not parent-linked (writing them would
+    /// strand a row the chain walk cannot reach); the harness uses this to
+    /// decide whether the seed must succeed or fail without mutation.
     pub fn seed_is_parent_linked(&self, fab: &FabHeader) -> bool {
         let parent_height = Height(fab.height.0 - 1);
         if parent_height == Height(0) {

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/scenarios.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/scenarios.rs
@@ -539,14 +539,14 @@ fn s10_seed_interplay() {
     );
 }
 
-/// s11: a refused (unlinked) seed converges through header-range sync. The
+/// s11: a rejected (unlinked) seed converges through header-range sync. The
 /// zakura store follows branch A (seeded at the fork height); the
 /// non-finalized best chain switches to branch B and its new best tip (B's
-/// *second* row) is seeded. The store refuses the unlinked seed as a no-op —
+/// *second* row) is seeded. The store rejects the unlinked seed —
 /// the header store briefly lags the nf chain — and the later linked range
 /// delivery of B converges it onto the new branch.
 #[test]
-fn s11_refused_seed_converges_via_range_delivery() {
+fn s11_rejected_seed_converges_via_range_delivery() {
     let _init_guard = zakura_test::init();
     let mut harness = Harness::new();
 
@@ -567,18 +567,21 @@ fn s11_refused_seed_converges_via_range_delivery() {
     );
 
     // The nf best tip jumps to B[1]; its parent row is not stored, so the
-    // seed is refused without touching the store (checked by the harness).
+    // seed is rejected without touching the store (checked by the harness).
     let outcome = harness
         .run(&Op::Seed {
             source: Source::Branch(BRANCH_B),
             index: 1,
         })
-        .expect("the refused seed leaves the store coherent");
-    assert_accepted(&outcome);
+        .expect("the rejected seed leaves the store coherent");
+    assert!(matches!(
+        outcome.header_range_error(),
+        CommitHeaderRangeError::UnlinkedRange { .. }
+    ));
     assert_eq!(
         harness.state().best_header_tip(),
         Some((a_first.height, a_first.hash)),
-        "the refused seed must not move the header tip",
+        "the rejected seed must not move the header tip",
     );
 
     // Header sync catches up with the nf chain: B arrives as a linked range
@@ -680,7 +683,7 @@ fn seed_above_gap_ops() -> Vec<Op> {
     }]
 }
 
-/// A seed above a gap is refused as a no-op instead of stranding a row.
+/// A seed above a gap is rejected instead of stranding a row.
 #[test]
 fn seed_above_gap_upholds_invariants() {
     let _init_guard = zakura_test::init();
@@ -693,7 +696,7 @@ fn seed_above_gap_upholds_invariants() {
     assert_eq!(
         harness.state().best_header_tip(),
         Some((Height(0), genesis_hash)),
-        "the refused seed must not move the header tip",
+        "the rejected seed must not move the header tip",
     );
 }
 
@@ -702,8 +705,7 @@ fn seed_above_gap_upholds_invariants() {
 /// best tip (B's *second* row) is seeded. Before the parent-linkage refusal,
 /// the seed's non-conflict arm inserted the row directly over A's truncated
 /// parent — broken linkage on disk, the poisoned-DAA-window generator from
-/// the production incident table. (`s11` proves the refused seed converges
-/// later through range delivery.)
+/// the production incident table.
 fn seed_fork_switch_ops() -> Vec<Op> {
     vec![
         commit_trunk(),
@@ -718,7 +720,7 @@ fn seed_fork_switch_ops() -> Vec<Op> {
     ]
 }
 
-/// A fork-switch seed keeps the store linked (the unlinked seed is refused).
+/// A fork-switch seed keeps the store linked (the unlinked seed is rejected).
 #[test]
 fn seed_fork_switch_upholds_invariants() {
     let _init_guard = zakura_test::init();

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -625,6 +625,7 @@ impl WriteBlockWorkerTask {
             let child_height = queued_child.height;
             let child_block = queued_child.block.clone();
             let parent_error = parent_error_map.get(&parent_hash);
+            let previous_best_tip = non_finalized_state.best_tip();
 
             // If the parent block was marked as rejected, also reject all its children.
             //
@@ -680,11 +681,27 @@ impl WriteBlockWorkerTask {
                 child_height,
                 child_hash,
             ) {
-                seed_zakura_header_from_committed_block(
-                    &finalized_state.db,
-                    child_height,
-                    &child_block,
-                );
+                let direct_best_chain_growth =
+                    previous_best_tip.is_none_or(|(previous_height, previous_hash)| {
+                        previous_height.next().ok() == Some(child_height)
+                            && previous_hash == parent_hash
+                    });
+                if direct_best_chain_growth {
+                    seed_zakura_header_from_committed_block(
+                        &finalized_state.db,
+                        child_height,
+                        &child_block,
+                    )
+                    .expect(
+                        "the published best-chain tip must have a durable linked header anchor",
+                    );
+                } else {
+                    reconcile_zakura_headers_from_best_chain(
+                        &finalized_state.db,
+                        non_finalized_state,
+                    )
+                    .expect("a promoted best chain must be durable before its tip is published");
+                }
             }
 
             // Committing blocks to the finalized state keeps the same chain,
@@ -752,20 +769,38 @@ fn seed_zakura_header_from_committed_block(
     finalized_state: &ZakuraDb,
     height: block::Height,
     block: &Arc<block::Block>,
-) {
+) -> Result<(), CommitHeaderRangeError> {
     match finalized_state.seed_zakura_header_from_committed_block(height, block) {
         Ok(()) => {
             tracing::trace!(?height, hash = ?block.hash(), "seeded Zakura header from committed block");
+            Ok(())
         }
         Err(error) => {
-            tracing::warn!(
+            tracing::error!(
                 ?height,
                 hash = ?block.hash(),
                 ?error,
                 "failed to seed Zakura header from committed block"
             );
+            Err(error)
         }
     }
+}
+
+fn reconcile_zakura_headers_from_best_chain(
+    finalized_state: &ZakuraDb,
+    non_finalized_state: &NonFinalizedState,
+) -> Result<(), CommitHeaderRangeError> {
+    let best_chain = non_finalized_state
+        .best_chain()
+        .expect("a successful best-chain commit leaves a non-empty best chain");
+    let blocks: Vec<_> = best_chain
+        .blocks
+        .iter()
+        .map(|(height, block)| (*height, block.block.clone()))
+        .collect();
+
+    finalized_state.reconcile_zakura_headers_from_committed_blocks(&blocks)
 }
 
 fn should_seed_zakura_header_from_non_finalized_commit(
@@ -788,10 +823,10 @@ mod tests {
     use crate::{
         arbitrary::Prepare,
         service::{
-            finalized_state::{DiskWriteBatch, FinalizedState, WriteDisk},
+            finalized_state::{DiskWriteBatch, FinalizedState, ReadDisk, WriteDisk},
             non_finalized_state::NonFinalizedState,
             write::{
-                seed_zakura_header_from_committed_block,
+                reconcile_zakura_headers_from_best_chain, seed_zakura_header_from_committed_block,
                 should_seed_zakura_header_from_non_finalized_commit,
             },
         },
@@ -856,7 +891,8 @@ mod tests {
             best_height,
             best_block.hash(),
         ));
-        seed_zakura_header_from_committed_block(&finalized_state.db, best_height, &best_block);
+        seed_zakura_header_from_committed_block(&finalized_state.db, best_height, &best_block)
+            .expect("best block header seeds");
 
         non_finalized_state
             .commit_new_chain(side_block.clone().prepare(), &finalized_state)
@@ -875,6 +911,145 @@ mod tests {
         assert_eq!(
             finalized_state.db.headers_by_height_range(best_height, 1),
             vec![(best_height, best_block.hash(), best_block.header.clone())],
+        );
+    }
+
+    #[test]
+    fn promoted_side_chain_reconciles_zakura_headers() {
+        let _init_guard = zakura_test::init();
+
+        let network = Network::Mainnet;
+        let mut config = Config::ephemeral();
+        config.enable_zakura_header_seed_from_committed_blocks = true;
+        let finalized_state = FinalizedState::new(
+            &config,
+            &network,
+            #[cfg(feature = "elasticsearch")]
+            false,
+        )
+        .expect("opening an ephemeral database should succeed");
+        finalized_state.set_finalized_value_pool(ValueBalance::fake_populated_pool());
+
+        let parent = zakura_test::vectors::BLOCK_MAINNET_434873_BYTES
+            .zcash_deserialize_into::<Arc<zakura_chain::block::Block>>()
+            .expect("block deserializes");
+        let best_block = parent.make_fake_child().set_work(10);
+        let side_block = parent.make_fake_child().set_work(1);
+        let fork_height = best_block
+            .coinbase_height()
+            .expect("fake child block has a coinbase height");
+
+        let parent_height = parent
+            .coinbase_height()
+            .expect("test vector block has a coinbase height");
+        let zakura_hash_by_height = finalized_state
+            .db
+            .db()
+            .cf_handle("zakura_header_hash_by_height")
+            .unwrap();
+        let mut batch = DiskWriteBatch::new();
+        batch.zs_insert(&zakura_hash_by_height, parent_height, parent.hash());
+        finalized_state
+            .db
+            .db()
+            .write(batch)
+            .expect("parent hash row writes");
+
+        let mut non_finalized_state = NonFinalizedState::new(&network);
+        non_finalized_state
+            .commit_new_chain(best_block.clone().prepare(), &finalized_state)
+            .expect("best block commits to a new chain");
+        seed_zakura_header_from_committed_block(&finalized_state.db, fork_height, &best_block)
+            .expect("best block header seeds");
+
+        non_finalized_state
+            .commit_new_chain(side_block.clone().prepare(), &finalized_state)
+            .expect("side block commits to a losing fork");
+        let mut promoted_blocks = vec![side_block.clone()];
+        let mut promoted_tip = side_block;
+        for _ in 0..10 {
+            promoted_tip = promoted_tip.make_fake_child();
+            non_finalized_state
+                .commit_block(promoted_tip.clone().prepare(), &finalized_state)
+                .expect("side-chain child commits");
+            promoted_blocks.push(promoted_tip.clone());
+        }
+
+        let promoted_tip_height = promoted_tip
+            .coinbase_height()
+            .expect("fake child block has a coinbase height");
+        assert_eq!(
+            non_finalized_state.best_tip(),
+            Some((promoted_tip_height, promoted_tip.hash())),
+        );
+        assert!(should_seed_zakura_header_from_non_finalized_commit(
+            true,
+            &non_finalized_state,
+            promoted_tip_height,
+            promoted_tip.hash(),
+        ));
+
+        // Before reconciliation, production seeded only this newly promoted
+        // tip. The call reported success even though its unseeded parent was
+        // absent, leaving the whole B suffix unusable as a range anchor.
+        reconcile_zakura_headers_from_best_chain(&finalized_state.db, &non_finalized_state)
+            .expect("the promoted best chain reconciles atomically");
+
+        for block in &promoted_blocks {
+            let height = block
+                .coinbase_height()
+                .expect("fake child block has a coinbase height");
+            assert_eq!(finalized_state.db.header_hash(height), Some(block.hash()));
+        }
+        let expected_headers: Vec<_> = promoted_blocks
+            .iter()
+            .map(|block| {
+                (
+                    block
+                        .coinbase_height()
+                        .expect("fake child block has a coinbase height"),
+                    block.hash(),
+                    block.header.clone(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            finalized_state.db.headers_by_height_range(
+                fork_height,
+                u32::try_from(expected_headers.len())
+                    .expect("the bounded non-finalized chain length fits in u32"),
+            ),
+            expected_headers,
+        );
+        assert_eq!(
+            finalized_state.db.best_header_tip(),
+            Some((promoted_tip_height, promoted_tip.hash())),
+        );
+
+        let zakura_height_by_hash = finalized_state
+            .db
+            .db()
+            .cf_handle("zakura_header_height_by_hash")
+            .unwrap();
+        assert_eq!(
+            finalized_state
+                .db
+                .db()
+                .zs_get::<_, _, zakura_chain::block::Height>(
+                    &zakura_height_by_hash,
+                    &promoted_tip.hash(),
+                ),
+            Some(promoted_tip_height),
+        );
+        assert_eq!(
+            finalized_state
+                .db
+                .db()
+                .zs_get::<_, _, zakura_chain::block::Height>(
+                    &zakura_height_by_hash,
+                    &best_block.hash(),
+                ),
+            None,
         );
     }
 }

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -1767,6 +1767,18 @@ mod zakura_header_sync_driver_tests {
     }
 
     #[test]
+    fn unknown_anchor_is_local_header_sync_commit_failure() {
+        let error = zakura_state::CommitHeaderRangeError::UnknownAnchor {
+            anchor: block::Hash([0; 32]),
+        };
+
+        assert_eq!(
+            header_range_commit_failure_kind(&error),
+            HeaderSyncCommitFailureKind::Local
+        );
+    }
+
+    #[test]
     fn header_range_commit_error_labels_preserve_exact_variant() {
         let unknown_anchor = zakura_state::CommitHeaderRangeError::UnknownAnchor {
             anchor: block::Hash([0; 32]),
@@ -2088,7 +2100,7 @@ mod zakura_header_sync_driver_tests {
     }
 
     #[test]
-    fn chain_tip_mirror_classifies_forward_reset_as_verified_grow() {
+    fn chain_tip_mirror_preserves_forward_reset() {
         let tip_block = zakura_state::ChainTipBlock {
             hash: block::Hash([8; 32]),
             height: block::Height(8),
@@ -2098,33 +2110,21 @@ mod zakura_header_sync_driver_tests {
             previous_block_hash: block::Hash([7; 32]),
         };
         assert_eq!(
-            chain_tip_mirror_frontier_change(
-                &zakura_state::TipAction::Grow { block: tip_block },
-                block::Height(7),
-                block::Height(8),
-            ),
+            chain_tip_mirror_frontier_change(&zakura_state::TipAction::Grow { block: tip_block }),
             zakura_network::zakura::FrontierChange::VerifiedGrow
         );
         assert_eq!(
-            chain_tip_mirror_frontier_change(
-                &zakura_state::TipAction::Reset {
-                    height: block::Height(8),
-                    hash: block::Hash([8; 32]),
-                },
-                block::Height(7),
-                block::Height(8),
-            ),
-            zakura_network::zakura::FrontierChange::VerifiedGrow
+            chain_tip_mirror_frontier_change(&zakura_state::TipAction::Reset {
+                height: block::Height(8),
+                hash: block::Hash([8; 32]),
+            }),
+            zakura_network::zakura::FrontierChange::VerifiedReset
         );
         assert_eq!(
-            chain_tip_mirror_frontier_change(
-                &zakura_state::TipAction::Reset {
-                    height: block::Height(7),
-                    hash: block::Hash([77; 32]),
-                },
-                block::Height(8),
-                block::Height(7),
-            ),
+            chain_tip_mirror_frontier_change(&zakura_state::TipAction::Reset {
+                height: block::Height(7),
+                hash: block::Hash([77; 32]),
+            }),
             zakura_network::zakura::FrontierChange::VerifiedReset
         );
     }

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -1413,6 +1413,10 @@ pub(crate) fn header_range_commit_failure_kind(
         // store's own linkage check failing means the local anchor/response pairing
         // went wrong, not that the peer misbehaved.
         | zakura_state::CommitHeaderRangeError::UnlinkedRange { .. }
+        // The reactor chose this anchor from its local best-header frontier.
+        // If state no longer knows it, the local frontier is stale; the peer
+        // did not choose or corrupt the anchor.
+        | zakura_state::CommitHeaderRangeError::UnknownAnchor { .. }
         // Store incoherence is by definition a local storage fault: the range was
         // rejected because our own header rows failed a linkage/bijection check
         // while reading validation context, not because the peer's range was shown
@@ -1427,7 +1431,6 @@ pub(crate) fn header_range_commit_failure_kind(
         | zakura_state::CommitHeaderRangeError::BodySizeCountMismatch { .. }
         | zakura_state::CommitHeaderRangeError::TreeAuxRootCountMismatch { .. }
         | zakura_state::CommitHeaderRangeError::TreeAuxRootHeightMismatch { .. }
-        | zakura_state::CommitHeaderRangeError::UnknownAnchor { .. }
         | zakura_state::CommitHeaderRangeError::HeightOverflow
         | zakura_state::CommitHeaderRangeError::ImmutableConflict { .. }
         | zakura_state::CommitHeaderRangeError::ReorgTooDeep { .. }
@@ -1610,17 +1613,12 @@ pub(crate) async fn mirror_zakura_full_block_commits<ReadState>(
             },
         );
         if let Some(mut update) = endpoint.current_sync_frontier() {
-            let previous_verified_body = update.frontier.verified_body.height;
             if let Some((finalized_height, finalized_hash)) = finalized_tip {
                 update.frontier.finalized = Frontier::new(finalized_height, finalized_hash);
             }
             update.frontier.verified_body =
                 Frontier::new(verified_block_tip.0, verified_block_tip.1);
-            update.change = chain_tip_mirror_frontier_change(
-                &action,
-                previous_verified_body,
-                verified_block_tip.0,
-            );
+            update.change = chain_tip_mirror_frontier_change(&action);
             endpoint.publish_sync_frontier_from(update, "chain_tip_mirror");
             emit_commit_state(
                 &trace,
@@ -1740,16 +1738,9 @@ pub(crate) fn block_sync_chain_tip_event(
     }
 }
 
-pub(crate) fn chain_tip_mirror_frontier_change(
-    action: &zakura_state::TipAction,
-    previous_verified_body: block::Height,
-    verified_block_tip: block::Height,
-) -> FrontierChange {
+pub(crate) fn chain_tip_mirror_frontier_change(action: &zakura_state::TipAction) -> FrontierChange {
     match action {
         zakura_state::TipAction::Grow { .. } => FrontierChange::VerifiedGrow,
-        zakura_state::TipAction::Reset { .. } if verified_block_tip > previous_verified_body => {
-            FrontierChange::VerifiedGrow
-        }
         zakura_state::TipAction::Reset { .. } => FrontierChange::VerifiedReset,
     }
 }


### PR DESCRIPTION
## Motivation

Recent v2 P2P traces showed a terminal header-sync stall after a non-finalized fork reset. Four peers repeatedly returned the requested successor header, but every state commit failed with `UnknownAnchor` for the locally selected tip.

The reset promoted a branch whose intermediate full-block headers had never been seeded. State attempted to seed only the newly promoted tip, silently skipped the write when its parent was missing, and then published that missing tip. The header reactor also treated forward resets as growth and only replaced its in-memory hash when height increased. Finally, the driver classified the resulting local `UnknownAnchor` as peer misbehavior.

## Solution

- Detect when a successful non-finalized commit changes the best branch rather than directly extending it.
- Atomically find the durable divergence, remove the stale provisional suffix and reverse indexes, and write every promoted full-block header through the new tip before publishing the chain update.
- Reject unlinked one-header seeds instead of reporting a successful no-op.
- Preserve `VerifiedReset` for same-height, backward, and forward resets.
- Reanchor the header reactor on every verified reset, clearing forward scheduled, buffered, committing, and outstanding work before requesting from the new durable tip.
- Treat `UnknownAnchor` as a local header-frontier failure so honest peers are not scored.
- Document the operator-visible stall fix in the changelog.

This restores the invariant that any header tip published as a sync anchor already exists as a contiguous durable header chain.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-state side_chain`
  - Reproduces a work-1 side branch overtaking a work-10 branch.
  - Verifies every promoted header, the new forward/reverse indexes, removal of the stale branch index, and the durable best header tip.
- `cargo test -p zakura-state header_store_coherence`
  - 37 scripted, audit, restart, and randomized coherence tests.
- `cargo test -p zakura-network verified_reset`
  - Verifies same-height hash replacement and forward-reset work cancellation/restart.
- `cargo test -p zakura zakura_header_sync_driver_tests`
  - 48 driver tests, including reset identity and local `UnknownAnchor` classification.
- `cargo clippy -p zakura-state -p zakura-network -p zakura --tests -- -D warnings`

Local state builds used the repository-documented `CXXFLAGS="-include cstdint"` workaround for the bundled RocksDB headers.

### Follow-up Work

The independent block-sync token-bucket behavior that cancels a shared connection after message throttling remains out of scope for this PR and should be fixed separately.
