### PR TITLE
fix(network): deliver committed-tip block gossip to unready zcashd-compat sidecar peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   tip. Startup rejects configured anchors above that base, and no longer
   backfills headers below a checkpoint anchor.
 
+### Fixed
+
+- Deliver committed-tip block gossip to configured zcashd-compat sidecar peers
+  even when they are momentarily unready. The "always include sidecars" carve-out
+  in block broadcasts only covered ready peers, so a sidecar that was unready when
+  a block was gossiped was skipped; because it follows a single upstream and
+  learns the tip only from block `inv`s, it then stalled until a later gossip
+  coincided with a ready service. The latest hash is now queued for an unready
+  sidecar and delivered once it is ready again, bounding the stall to one
+  readiness cycle.
+
 ## [1.0.1] - 2026-07-17
 
 ### Added

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -98,7 +98,7 @@ use std::{
     convert,
     fmt::Debug,
     marker::PhantomData,
-    net::IpAddr,
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -137,7 +137,7 @@ use crate::{
         InventoryChange, InventoryRegistry,
     },
     protocol::{
-        external::InventoryHash,
+        external::{canonical_socket_addr, InventoryHash},
         internal::{Request, Response},
     },
     BoxError, Config, PeerError, PeerSocketAddr, SharedPeerError,
@@ -246,6 +246,21 @@ where
 
     /// Inbound peer IPs that must always receive block inventory broadcasts.
     block_gossip_peer_ips: HashSet<IpAddr>,
+
+    /// The most recent block gossip queued for configured sidecar peers (see
+    /// [`Self::block_gossip_peer_ips`]) that were unready when it fired, paired
+    /// with the unready sidecar peers still awaiting it.
+    ///
+    /// A sidecar follows a single upstream and learns the chain tip only from
+    /// block `inv`s, so a gossip dropped because the peer was momentarily
+    /// unready starves it until a later gossip happens to coincide with a ready
+    /// service — an unbounded stall. Re-delivering the latest hash once the peer
+    /// is ready again (mirroring [`Self::queued_broadcast_all`], on a subsequent
+    /// `poll_ready`) bounds that stall to a single readiness cycle. Only the
+    /// newest hash is kept: a sidecar that missed
+    /// earlier hashes learns them from its `getheaders` locator once it receives
+    /// any newer tip `inv`.
+    queued_sidecar_block_gossip: Option<(Request, HashSet<D::Key>)>,
 
     // Peer Tracking: Busy Peers
     //
@@ -372,6 +387,7 @@ where
             inventory_registry: InventoryRegistry::new(inv_stream),
             queued_broadcast_all: None,
             block_gossip_peer_ips: block_gossip_peer_ips.into_iter().collect(),
+            queued_sidecar_block_gossip: None,
 
             // Busy peers
             unready_services: FuturesUnordered::new(),
@@ -1186,6 +1202,11 @@ where
     /// Broadcasts a block inventory request to sampled peers and configured sidecars.
     fn route_block_broadcast(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
         let selected_peers = self.select_block_broadcast_peers(self.number_of_peers_to_broadcast());
+        // `select_block_broadcast_peers` can only include sidecar peers that are
+        // ready right now. A sidecar that is unready would silently miss this
+        // gossip, and a single-upstream sidecar has no other way to learn the
+        // tip, so queue the gossip for any unready sidecar to receive once ready.
+        self.queue_block_gossip_for_unready_sidecars(&req, &selected_peers);
         self.send_multiple(req, selected_peers)
     }
 
@@ -1256,6 +1277,84 @@ where
 
         if !remaining_peers.is_empty() {
             self.queued_broadcast_all = Some((req, sender, remaining_peers));
+        }
+    }
+
+    /// Queues block gossip `req` for configured sidecar peers that are currently
+    /// unready, so [`PeerSet::deliver_queued_sidecar_block_gossip`] can send it
+    /// once they become ready.
+    ///
+    /// `already_selected` are the peers being served synchronously by the
+    /// caller; a sidecar in that list is already covered and is not queued. Only
+    /// the newest request is retained (see [`Self::queued_sidecar_block_gossip`]).
+    fn queue_block_gossip_for_unready_sidecars(
+        &mut self,
+        req: &Request,
+        already_selected: &[D::Key],
+    ) {
+        if self.block_gossip_peer_ips.is_empty() {
+            return;
+        }
+
+        // Collect keys first so the sidecar-IP check can borrow `self`.
+        let unready_keys: Vec<D::Key> = self.cancel_handles.keys().copied().collect();
+        let unready_sidecars: HashSet<D::Key> = unready_keys
+            .into_iter()
+            .filter(|key| self.is_block_gossip_sidecar_ip(key))
+            .filter(|key| !already_selected.contains(key))
+            .collect();
+
+        // A ready sidecar was just served directly, so a newer gossip supersedes
+        // any stale queue: replace it, or clear it when nothing is left unready.
+        self.queued_sidecar_block_gossip =
+            (!unready_sidecars.is_empty()).then(|| (req.clone(), unready_sidecars));
+    }
+
+    /// Returns true if `key`'s canonical IP is one of the configured sidecar
+    /// block-gossip IPs ([`Self::block_gossip_peer_ips`]).
+    ///
+    /// This identifies a sidecar peer by key alone, for when the peer is unready
+    /// and its service is not available for the stricter
+    /// [`Self::is_zcashd_compat_peer`] check. Canonicalizing both sides matches
+    /// [`LoadTrackedClient::is_inbound_direct_from_ip`], so IPv4-mapped and native
+    /// loopback forms compare equal.
+    fn is_block_gossip_sidecar_ip(&self, key: &D::Key) -> bool {
+        let key_ip = canonical_socket_addr(SocketAddr::new(key.ip(), 0)).ip();
+        self.block_gossip_peer_ips
+            .iter()
+            .any(|ip| canonical_socket_addr(SocketAddr::new(*ip, 0)).ip() == key_ip)
+    }
+
+    /// Sends the queued block gossip to configured sidecar peers that have
+    /// become ready since it was queued, mirroring
+    /// [`PeerSet::broadcast_all_queued`] but scoped to sidecar peers.
+    ///
+    /// Called from `poll_ready`, so delivery happens on the next peer-set poll
+    /// after the sidecar becomes ready — near-immediate on an active node, but
+    /// gated on peer-set traffic rather than truly instantaneous.
+    fn deliver_queued_sidecar_block_gossip(&mut self) {
+        let Some((req, mut remaining)) = self.queued_sidecar_block_gossip.take() else {
+            return;
+        };
+
+        let ready_now: Vec<D::Key> = self
+            .ready_services
+            .keys()
+            .filter(|key| remaining.remove(*key))
+            .copied()
+            .collect();
+
+        if !ready_now.is_empty() {
+            // `send_multiple` enqueues the inventory to each peer synchronously
+            // and marks it unready; the returned future only drains the ignored
+            // broadcast responses, so it is spawned to run to completion.
+            let send_fut = self.send_multiple(req.clone(), ready_now);
+            tokio::spawn(send_fut);
+        }
+
+        // Keep waiting on any sidecar that is still unready.
+        if !remaining.is_empty() {
+            self.queued_sidecar_block_gossip = Some((req, remaining));
         }
     }
 
@@ -1456,6 +1555,7 @@ where
         }
 
         self.broadcast_all_queued();
+        self.deliver_queued_sidecar_block_gossip();
 
         if self.ready_services.is_empty() {
             self.poll_peers(cx)

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -20,7 +20,9 @@ use zakura_chain::{
 
 use crate::{
     constants::{CURRENT_NETWORK_PROTOCOL_VERSION, DEFAULT_MAX_CONNS_PER_IP},
-    peer::{ClientRequest, ClientTestHarness, ConnectedAddr, MinimumPeerVersion},
+    peer::{
+        ClientRequest, ClientTestHarness, ConnectedAddr, LoadTrackedClient, MinimumPeerVersion,
+    },
     peer_set::{inventory_registry::InventoryStatus, stall_tracker::FIND_RESPONSE_STALL_THRESHOLD},
     protocol::external::{types::Version, InventoryHash},
     BoxError, PeerSocketAddr, Request, Response, SharedPeerError,
@@ -1013,6 +1015,208 @@ fn find_blocks_stall_count_preserved_across_tip_transition() {
         assert!(
             !handle.wants_connection_heartbeats(),
             "peer should be disconnected because its syncing stall count was preserved"
+        );
+    });
+}
+
+/// Returns the block hash of the next `AdvertiseBlock` request the mock peer
+/// received, or `None` if it received nothing. Panics on any other request.
+fn recv_advertise_block(handle: &mut ClientTestHarness) -> Option<block::Hash> {
+    match handle.try_to_receive_outbound_client_request().request() {
+        Some(ClientRequest {
+            request: Request::AdvertiseBlock(hash, _),
+            ..
+        }) => Some(hash),
+        Some(other) => panic!("unexpected outbound request: {:?}", other.request),
+        None => None,
+    }
+}
+
+/// Builds a discovery stream of two ready inbound-direct peers: a sidecar at
+/// `127.0.0.1` (a configured block-gossip carve-out IP) and an ordinary peer at
+/// `127.0.0.2`. Returns the stream, the two addresses, and a mock handle for
+/// each peer.
+fn sidecar_and_ordinary_discovery() -> (
+    impl futures::Stream<Item = Result<Change<PeerSocketAddr, LoadTrackedClient>, BoxError>>,
+    PeerSocketAddr,
+    PeerSocketAddr,
+    ClientTestHarness,
+    ClientTestHarness,
+) {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+
+    let sidecar_addr: PeerSocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1).into();
+    let ordinary_addr: PeerSocketAddr =
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 2).into();
+
+    let (sidecar_client, sidecar_handle) = ClientTestHarness::build()
+        .with_version(peer_version)
+        .with_connected_addr(ConnectedAddr::InboundDirect { addr: sidecar_addr })
+        .finish();
+    let (ordinary_client, ordinary_handle) = ClientTestHarness::build()
+        .with_version(peer_version)
+        .with_connected_addr(ConnectedAddr::InboundDirect {
+            addr: ordinary_addr,
+        })
+        .finish();
+
+    let discovered = stream::iter([
+        Ok::<_, BoxError>(Change::Insert(
+            sidecar_addr,
+            LoadTrackedClient::from(sidecar_client),
+        )),
+        Ok::<_, BoxError>(Change::Insert(
+            ordinary_addr,
+            LoadTrackedClient::from(ordinary_client),
+        )),
+    ])
+    .chain(stream::pending());
+
+    (
+        discovered,
+        sidecar_addr,
+        ordinary_addr,
+        sidecar_handle,
+        ordinary_handle,
+    )
+}
+
+/// A block gossip that fires while a configured sidecar peer is unready must be
+/// queued for that peer, not silently dropped.
+///
+/// Regression test: the "always include sidecars" carve-out in
+/// [`PeerSet::select_block_broadcast_peers`] could only cover *ready* sidecars.
+/// A sidecar that was unready when the committed-tip gossip fired was excluded,
+/// and — because it follows a single upstream and learns the tip only from
+/// block `inv`s — it then stalled until a later gossip happened to coincide with
+/// a ready service.
+#[test]
+fn unready_sidecar_block_gossip_is_queued_not_dropped() {
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+    tokio::time::pause();
+
+    let (discovered, sidecar_addr, _ordinary_addr, mut sidecar_handle, mut ordinary_handle) =
+        sidecar_and_ordinary_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered)
+            .with_minimum_peer_version(minimum_peer_version)
+            .max_conns_per_ip(max(2, DEFAULT_MAX_CONNS_PER_IP))
+            .with_block_gossip_peer_ips(vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+            .build();
+
+        {
+            let ready = peer_set.ready().await.expect("peer set is always ready");
+            assert_eq!(ready.ready_services.len(), 2);
+        }
+
+        // Force the sidecar unready, as if a request to it were in flight.
+        let sidecar_svc = peer_set
+            .take_ready_service(&sidecar_addr)
+            .expect("sidecar is ready");
+        peer_set.push_unready(sidecar_addr, sidecar_svc);
+        assert!(peer_set.cancel_handles.contains_key(&sidecar_addr));
+        assert!(!peer_set.ready_services.contains_key(&sidecar_addr));
+
+        // Gossip a block while the sidecar is unready.
+        let hash = block::Hash([7; 32]);
+        let _fut = peer_set.route_block_broadcast(Request::AdvertiseBlock(hash, None));
+
+        // The ordinary ready peer received the gossip immediately.
+        assert_eq!(
+            recv_advertise_block(&mut ordinary_handle),
+            Some(hash),
+            "an ordinary ready peer should receive the block gossip immediately",
+        );
+
+        // The unready sidecar could not receive it synchronously ...
+        assert_eq!(
+            recv_advertise_block(&mut sidecar_handle),
+            None,
+            "an unready sidecar cannot be sent to synchronously",
+        );
+
+        // ... but the fix queued it for redelivery rather than dropping it.
+        let (queued_req, queued_peers) = peer_set
+            .queued_sidecar_block_gossip
+            .as_ref()
+            .expect("block gossip should be queued for the unready sidecar");
+        assert_eq!(*queued_req, Request::AdvertiseBlock(hash, None));
+        assert!(
+            queued_peers.contains(&sidecar_addr),
+            "the unready sidecar should be queued for redelivery"
+        );
+    });
+}
+
+/// A block gossip queued for an unready sidecar is delivered once the sidecar
+/// becomes ready again, through the [`PeerSet`] poll cycle. This exercises the
+/// `poll_ready` wiring, not just the helper in isolation.
+#[test]
+fn queued_sidecar_block_gossip_delivered_once_ready() {
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+    tokio::time::pause();
+
+    let (discovered, sidecar_addr, _ordinary_addr, mut sidecar_handle, _ordinary_handle) =
+        sidecar_and_ordinary_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered)
+            .with_minimum_peer_version(minimum_peer_version)
+            .max_conns_per_ip(max(2, DEFAULT_MAX_CONNS_PER_IP))
+            .with_block_gossip_peer_ips(vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+            .build();
+
+        {
+            let ready = peer_set.ready().await.expect("peer set is always ready");
+            assert_eq!(ready.ready_services.len(), 2);
+        }
+
+        // Sidecar unready, then a block is gossiped: it gets queued (the queuing
+        // itself is asserted by the test above).
+        let sidecar_svc = peer_set
+            .take_ready_service(&sidecar_addr)
+            .expect("sidecar is ready");
+        peer_set.push_unready(sidecar_addr, sidecar_svc);
+
+        let hash = block::Hash([9; 32]);
+        let _fut = peer_set.route_block_broadcast(Request::AdvertiseBlock(hash, None));
+        assert!(peer_set.queued_sidecar_block_gossip.is_some());
+        assert_eq!(recv_advertise_block(&mut sidecar_handle), None);
+
+        // Driving the peer set re-readies the sidecar (via `poll_unready`) and
+        // then delivers the queued gossip (via `deliver_queued_sidecar_block_gossip`),
+        // both inside `poll_ready`.
+        let mut delivered = None;
+        for _ in 0..8 {
+            {
+                let _ = peer_set.ready().await.expect("peer set is always ready");
+            }
+            // Let the spawned send future drain, and allow another poll if the
+            // sidecar needed an extra readiness cycle.
+            tokio::task::yield_now().await;
+            if let Some(received_hash) = recv_advertise_block(&mut sidecar_handle) {
+                delivered = Some(received_hash);
+                break;
+            }
+        }
+
+        assert_eq!(
+            delivered,
+            Some(hash),
+            "the sidecar should receive the queued block gossip once it is ready again",
+        );
+        assert!(
+            peer_set.queued_sidecar_block_gossip.is_none(),
+            "the queue should be cleared after delivery",
         );
     });
 }


### PR DESCRIPTION
## Root cause

A zcashd-compat sidecar peer connects to exactly one Zakura node and, in this
zcashd lineage, has **no `sendheaders`/BIP130** — it learns of a new tip *only*
from block `inv` gossip (`inv` → `getheaders` → `headers` → fetch). It also has no
at-tip timeout that recovers a missed `inv`.

Committed-tip block gossip (a node *following* the network) is sent as
`Request::AdvertiseBlock`, which the peer set routes via
`select_block_broadcast_peers` — and that function's "always include configured
sidecar peers" carve-out **iterates `ready_services` only**. When the sidecar's
outbound peer service is momentarily *unready* (any in-flight/hung request to it,
up to `REQUEST_TIMEOUT` = 20s), it is silently excluded from the broadcast. Unlike
`AdvertiseBlockToAll` (used only for locally-mined blocks), `AdvertiseBlock` has no
unready-queue fallback. Because the sidecar is inv-only and never retries, it then
stalls until it becomes ready *and* a later gossip happens to coincide — then it
burst-catches-up.

This was confirmed on a live testnet node (read-only): during stalls the sidecar
received **zero** block invs while every `getheaders` it sent was answered in <1ms
(13/13), `blocks == headers` stayed frozen with `inflight == []` (ruling out a
block-download timeout), the TCP connection never dropped, and gossip continued
reaching *other* Zakura peers. Recovery was a single inv → one `getheaders` → a
batch of headers → a burst of block requests.

## Fix

Give the sidecar carve-out the same unready-capable delivery that
`AdvertiseBlockToAll` already has, scoped to configured sidecar IPs:

- `route_block_broadcast` now also queues the latest `AdvertiseBlock` for any
  configured sidecar peer that is currently unready (`queue_block_gossip_for_unready_sidecars`).
- `poll_ready` delivers the queued gossip to those peers the moment they are ready
  again (`deliver_queued_sidecar_block_gossip`), mirroring `broadcast_all_queued`.
- Only the newest hash is retained — a sidecar that missed earlier hashes learns
  them from its next `getheaders` locator (exactly the observed burst recovery).
- Sidecar identification for unready peers canonicalizes the key IP, matching
  `LoadTrackedClient::is_inbound_direct_from_ip` so mapped/native loopback compare
  equal.

This bounds the sidecar's stall to one readiness cycle instead of leaving it
unbounded. Ordinary peers are unchanged (still sampled ready-only).

## Tests

`zakura-network/src/peer_set/set/tests/vectors.rs`:
- `unready_sidecar_block_gossip_is_queued_not_dropped` — an unready sidecar's
  gossip is queued (not dropped) while a ready peer still receives it immediately.
- `queued_sidecar_block_gossip_delivered_once_ready` — driving the peer set
  re-readies the sidecar and delivers the queued gossip through the `poll_ready`
  wiring.

The existing `prop::sidecar_peer_always_receives_block_gossip` (ready-sidecar path)
still passes. `cargo test`/`clippy`/`fmt` clean on `zakura-network`; `zakura` builds.

## Notes

- Distinct from the stale `fix/zcashd-compat-sidecar-stalls` branch (mapped-address
  identity canonicalization + reserved inbound slots for reconnect); `main` already
  canonicalizes, and the deployed stall is not a reconnect (constant TCP port).
- The deployed zcashd having no at-tip `getheaders` timeout is a separate,
  lower-priority hardening (would bound damage from any *single* missed inv);
  fixing the gossip is the real fix.

Full investigation + evidence: `art/debug/zcashd-recovers/FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
