### PR TITLE
fix(network): avoid deprecated AtomicU64::fetch_update

### DIFF
--- a/zakura-network/src/zakura/block_sync/sequencer_task.rs
+++ b/zakura-network/src/zakura/block_sync/sequencer_task.rs
@@ -1004,11 +1004,19 @@ impl SequencerTask {
 }
 
 fn add_atomic_bytes(counter: &std::sync::atomic::AtomicU64, bytes: u64) {
-    let _ = counter.fetch_update(
-        std::sync::atomic::Ordering::Relaxed,
-        std::sync::atomic::Ordering::Relaxed,
-        |current| Some(current.saturating_add(bytes)),
-    );
+    let mut current = counter.load(std::sync::atomic::Ordering::Relaxed);
+    loop {
+        let next = current.saturating_add(bytes);
+        match counter.compare_exchange_weak(
+            current,
+            next,
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(observed) => current = observed,
+        }
+    }
 }
 
 fn release_atomic_bytes(counter: &std::sync::atomic::AtomicU64, bytes: u64) {


### PR DESCRIPTION
## Motivation

Scheduled Lint and Build Docs runs on `main` fail with `-D warnings`: Rust 1.95 deprecates `AtomicU64::fetch_update` (renamed to `try_update`) and `add_atomic_bytes` in `zakura-network/src/zakura/block_sync/sequencer_task.rs` uses it.

## Solution

Replace the `fetch_update` call with a `compare_exchange_weak` loop, matching the existing `release_atomic_bytes` in the same file. `try_update` was not an option: it is only stable since 1.95 and MSRV is 1.91. Semantics are unchanged (the updater always returned `Some`, so `fetch_update` was already an unconditional CAS loop).

## Testing

`cargo fmt --all -- --check` and `cargo clippy -p zakura-network --all-targets -- -D warnings` pass on rustc 1.95.0 (previously failed with the deprecation error). `cargo test -p zakura-network --release block_sync` passes (238 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)