### PR TITLE
fix(network): canonicalize IPv4-mapped inbound peer addresses for bans and per-IP limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Make retained peer-ban insertion and eviction O(1) rather than O(N),
   preventing ban-list maintenance from slowing as the 20,000-IP bound fills
   ([#286](https://github.com/zakura-core/zakura/pull/286)).
+- Canonicalize IPv4-mapped IPv6 inbound peer addresses on dual-stack listeners so
+  bans, the recent-inbound rate limiter, and `max_connections_per_ip` can no longer
+  be evaded. On a dual-stack bind (`[::]` with `IPV6_V6ONLY=false`), Linux reports an
+  inbound IPv4 peer as `::ffff:A.B.C.D`, but the ban map and address book are keyed on
+  the canonical `A.B.C.D`. The inbound accept path and the peer set compared the raw
+  mapped address, so a banned or rate-limited peer could bypass enforcement by
+  reconnecting in the other address form. The accept path now canonicalizes at the
+  boundary, and the peer-set ban re-checks and per-IP accounting canonicalize before
+  comparing. Nodes that bind `0.0.0.0` are unaffected.
 
 ## [1.0.2] - 2026-07-20
 

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -43,7 +43,7 @@ use crate::{
     },
     peer_cache_updater::peer_cache_updater,
     peer_set::{set::MorePeers, ActiveConnectionCounter, CandidateSet, ConnectionTracker, PeerSet},
-    protocol::external::{canonical_socket_addr, types::PeerServices},
+    protocol::external::{canonical_peer_addr, canonical_socket_addr, types::PeerServices},
     AddressBook, BannedIps, BoxError, Config, PeerSocketAddr, Request, Response,
 };
 
@@ -775,7 +775,14 @@ where
         };
 
         if let Ok((tcp_stream, addr)) = inbound_result {
-            let addr: PeerSocketAddr = addr.into();
+            // Canonicalize IPv4-mapped IPv6 (`::ffff:A.B.C.D`) from dual-stack sockets so the
+            // ban check, the recent-inbound limiter, and the PeerSet key all match the
+            // canonical form used by the ban map and address book.
+            //
+            // TODO(test): this async accept loop over a real `TcpListener` isn't unit-tested
+            // directly; the equivalence of mapped and canonical forms is covered by the
+            // peer-set tests in `peer_set::set::tests`.
+            let addr: PeerSocketAddr = canonical_peer_addr(addr);
             let addr_label = addr.addr_label(config.expose_peer_addresses);
 
             if bans.contains(addr.ip()) {

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -162,6 +162,16 @@ pub struct CancelClientWork;
 
 type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'static>>;
 
+/// Canonicalizes an [`IpAddr`] so an IPv4-mapped IPv6 address (`::ffff:A.B.C.D`) compares
+/// equal to its canonical IPv4 form.
+///
+/// The ban map and address book are keyed on canonical IPs, but a dual-stack listener reports
+/// inbound IPv4 peers as IPv4-mapped IPv6. Canonicalizing before comparing keeps ban re-checks
+/// and per-IP connection accounting from treating the two forms as different hosts.
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    canonical_socket_addr(SocketAddr::new(ip, 0)).ip()
+}
+
 /// Classification of a `FindBlocks`/`FindHeaders` response, sent from a
 /// response-wrapping future to [`PeerSet::poll_ready`] via an mpsc channel so
 /// the stall tracker can be updated and the peer disconnected if needed.
@@ -593,7 +603,7 @@ where
                         "service became ready"
                     );
 
-                    if self.bans.contains(key.ip()) {
+                    if self.bans.contains(canonical_ip(key.ip())) {
                         warn!(
                             peer = %key.addr_label(self.expose_peer_addresses),
                             "service is banned, dropping service"
@@ -677,7 +687,7 @@ where
             match peer_readiness {
                 // Still ready, add it back to the list.
                 Ok(()) => {
-                    if self.bans.contains(key.ip()) {
+                    if self.bans.contains(canonical_ip(key.ip())) {
                         debug!(
                             peer = %key.addr_label(self.expose_peer_addresses),
                             "service ip is banned, dropping service"
@@ -714,10 +724,11 @@ where
     /// This method is `O(connected peers)`, so it should not be called from a loop
     /// that is already iterating through the peer set.
     fn num_peers_with_ip(&self, ip: IpAddr) -> usize {
+        let ip = canonical_ip(ip);
         self.ready_services
             .keys()
             .chain(self.cancel_handles.keys())
-            .filter(|addr| addr.ip() == ip)
+            .filter(|addr| canonical_ip(addr.ip()) == ip)
             .count()
     }
 
@@ -1391,7 +1402,7 @@ where
             return;
         };
 
-        remaining_peers.retain(|addr| !self.bans.contains(addr.ip()));
+        remaining_peers.retain(|addr| !self.bans.contains(canonical_ip(addr.ip())));
 
         let Ok(reserved_send_slot) = sender.try_reserve() else {
             self.queued_broadcast_all = Some((req, sender, remaining_peers));

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -561,6 +561,127 @@ fn remove_unready_peer_clears_cancel_handle_and_updates_counts() {
     });
 }
 
+/// A dual-stack listener reports an inbound IPv4 peer as an IPv4-mapped IPv6 address
+/// (`::ffff:A.B.C.D`). The per-IP connection accounting must treat that mapped form and
+/// its canonical IPv4 form as the **same host**, so `max_conns_per_ip` can't be evaded by
+/// alternating the two forms.
+#[test]
+fn per_ip_accounting_treats_mapped_and_canonical_as_same_host() {
+    let peer_versions = PeerVersions {
+        peer_versions: vec![Version::min_specified_for_upgrade(
+            &Network::Mainnet,
+            NetworkUpgrade::Nu6_2,
+        )],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, _handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version.clone())
+            .build();
+
+        let canonical_ip: IpAddr = Ipv4Addr::new(203, 0, 113, 7).into();
+        let mapped_ip: IpAddr = Ipv4Addr::new(203, 0, 113, 7).to_ipv6_mapped().into();
+        assert_ne!(
+            canonical_ip, mapped_ip,
+            "the two forms are distinct IpAddrs"
+        );
+
+        // Insert a single connection keyed by the canonical form...
+        let canonical_addr: PeerSocketAddr = SocketAddr::new(canonical_ip, 8233).into();
+        let (tx, _rx) =
+            crate::peer_set::set::oneshot::channel::<crate::peer_set::set::CancelClientWork>();
+        peer_set.cancel_handles.insert(canonical_addr, tx);
+
+        // ...both address forms must see that one connection.
+        assert_eq!(peer_set.num_peers_with_ip(canonical_ip), 1);
+        assert_eq!(
+            peer_set.num_peers_with_ip(mapped_ip),
+            1,
+            "mapped-form query must find the canonically-keyed peer"
+        );
+
+        // Reverse the key/query roles: key the connection by the mapped form instead.
+        peer_set.cancel_handles.clear();
+        let mapped_addr: PeerSocketAddr = SocketAddr::new(mapped_ip, 8233).into();
+        let (tx, _rx) =
+            crate::peer_set::set::oneshot::channel::<crate::peer_set::set::CancelClientWork>();
+        peer_set.cancel_handles.insert(mapped_addr, tx);
+
+        assert_eq!(peer_set.num_peers_with_ip(mapped_ip), 1);
+        assert_eq!(
+            peer_set.num_peers_with_ip(canonical_ip),
+            1,
+            "canonical-form query must find the mapped-keyed peer"
+        );
+    });
+}
+
+/// The peer-set ban re-checks key on the **canonical** IP. A banned peer reconnecting as
+/// its IPv4-mapped IPv6 form (`::ffff:A.B.C.D`, as seen on a dual-stack listener) must
+/// still be treated as banned even though the ban map holds the canonical `A.B.C.D`.
+///
+/// This drives the ban filter in `broadcast_all_queued`; all three peer-set ban re-checks
+/// (`poll_unready`, `poll_ready_peer_errors`, and this filter) share the same `canonical_ip`
+/// canonicalization, so this exercises that shared path.
+#[test]
+fn broadcast_all_queued_bans_mapped_ipv6_against_canonical_ban() {
+    let peer_versions = PeerVersions {
+        peer_versions: vec![Version::min_specified_for_upgrade(
+            &Network::Mainnet,
+            NetworkUpgrade::Nu6_2,
+        )],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, _handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version.clone())
+            .build();
+
+        // The ban map holds the canonical IPv4 address.
+        let canonical_ip: IpAddr = Ipv4Addr::new(203, 0, 113, 7).into();
+        peer_set.bans = BannedIps::with_banned_ip(canonical_ip);
+
+        // The banned peer reconnects in its IPv4-mapped IPv6 form.
+        let mapped_ip: IpAddr = Ipv4Addr::new(203, 0, 113, 7).to_ipv6_mapped().into();
+        let mapped_addr: PeerSocketAddr = SocketAddr::new(mapped_ip, 8233).into();
+        let mut remaining_peers = HashSet::new();
+        remaining_peers.insert(mapped_addr);
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        peer_set.queued_broadcast_all = Some((Request::Peers, sender, remaining_peers));
+
+        peer_set.broadcast_all_queued();
+
+        // The mapped-form peer must be dropped by the (canonical) ban filter, so no peers
+        // remain queued for the re-send. On un-canonicalized code the mapped peer would
+        // survive the filter and this assertion would fail.
+        if let Some((_req, _sender, remaining_peers)) = peer_set.queued_broadcast_all.take() {
+            assert!(
+                remaining_peers.is_empty(),
+                "banned mapped-IPv6 peer must be filtered by the canonical ban"
+            );
+        } else {
+            assert!(receiver.try_recv().is_ok());
+        }
+    });
+}
+
 /// Check that a peer set routes inventory requests to a peer that has advertised that inventory.
 #[test]
 fn peer_set_route_inv_advertised_registry() {


### PR DESCRIPTION
## Motivation

On a **dual-stack** listener (`listen_addr = "[::]:port"` with `IPV6_V6ONLY=false`), Linux reports an inbound IPv4 peer as an **IPv4-mapped IPv6 address** `::ffff:A.B.C.D`. Zakura's ban map and address book are keyed on the **canonical** IPv4 form (`A.B.C.D`), but the inbound accept path and the legacy `PeerSet` compared the **raw** `PeerSocketAddr::ip()`, which keeps the mapped form. Insert-canonical / lookup-raw ⇒ the lookups miss.

**Exploit (dual-stack binds only):** a banned or rate-limited peer evades enforcement by reconnecting in the *other* address form:

- A **banned** peer reconnecting as `::ffff:A.B.C.D` is **not** re-banned (both the accept path and the peer set miss the canonical ban entry).
- The per-IP **recent-inbound rate limiter** and the **`max_conns_per_ip`** cap (default `1`) are **evadable**: the mapped and canonical forms count as two different hosts.

Nodes that bind `0.0.0.0` never see mapped addresses and are unaffected. The bug is invisible in regtest/e2e (those bind `127.0.0.1`).

## Solution

- **Accept boundary (the real fix):** canonicalize the inbound address once with `canonical_peer_addr` in `accept_inbound_connections`. Every later use of `addr` — the ban check, the recent-inbound limiter, and the key forwarded into the handshake / `PeerSet` — is then canonical.
- **Peer set (defense-in-depth + testability):** the `PeerSet` ban re-checks (`poll_unready`, `poll_ready_peer_errors`, and the `broadcast_all_queued` ban filter) and the per-IP accounting (`num_peers_with_ip`) also canonicalize before comparing, via a small shared `canonical_ip` helper. The boundary fix already makes all keys canonical; this enforces the invariant even if some future path inserts a raw key, and lets the equivalence be unit-tested directly by injecting a mapped key.

The zcashd-compat reserved-slot check already canonicalized (`canonical_socket_addr(addr.remove_socket_addr_privacy())`) and is unchanged. Genuine IPv6 peers are left untouched by `canonical_peer_addr`. Outbound keys come from the address book and are already canonical.

## Testing

`cargo fmt --all -- --check`, `cargo clippy -p zakura-network --all-targets -- -D warnings`, and `cargo test -p zakura-network` (**1000 passed, 0 failed**) all green, including the zcashd-compat carve-out tests and `prop::sidecar_peer_always_receives_block_gossip`.

Two new deterministic unit tests in `peer_set::set::tests::vectors`:

- **`per_ip_accounting_treats_mapped_and_canonical_as_same_host`** — inserts a connection keyed by the canonical form and asserts both the canonical *and* the mapped query see it as one host, then reverses the key/query roles. This is what `poll_discover`'s `max_conns_per_ip` gate relies on.
- **`broadcast_all_queued_bans_mapped_ipv6_against_canonical_ban`** — a peer keyed `::ffff:A.B.C.D` against a ban map holding canonical `A.B.C.D` is dropped by the ban filter. All three peer-set ban re-checks share the `canonical_ip` helper, so this exercises that shared path.

Both tests were confirmed to **fail** against the un-canonicalized code (test 1 with `left: 0, right: 1`; test 2 with the banned mapped peer surviving the filter) and pass with the fix.

### Follow-up Work

The async `accept_inbound_connections` loop (over a real `TcpListener`) isn't unit-tested directly — a `TODO(test)` marks the boundary canonicalization, and the equivalence is covered by the peer-set tests above. Extracting the accept decision into a pure `(bans, addr) -> accept/reject` helper for direct testing was left out of scope to keep the diff focused; happy to add it if a reviewer prefers.

Independent of #231 (`fix/sidecar-block-gossip-unready`) and #236 — different functions, no shared lines. Branched off `main` at v1.0.1.