### PR TITLE
fix(state): complete database upgrades before startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Database format upgrades now finish before startup exposes the finalized
+  state database; only configured periodic format checks continue in the
+  background.
+
 ### Changed
 
 - Header sync now schedules only forward ranges from the durable verified block

--- a/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -6,6 +6,13 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+#[cfg(test)]
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{LazyLock, Mutex},
+};
+
 use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender};
 use semver::Version;
 use tracing::Span;
@@ -208,6 +215,59 @@ pub struct DbFormatChangeThreadHandle {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct CancelFormatChange;
 
+#[cfg(test)]
+type StartupUpgradeHook = Arc<dyn Fn() + Send + Sync>;
+
+#[cfg(test)]
+static STARTUP_UPGRADE_HOOKS: LazyLock<Mutex<HashMap<PathBuf, StartupUpgradeHook>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(test)]
+struct StartupUpgradeHookGuard {
+    db_path: PathBuf,
+}
+
+#[cfg(test)]
+impl Drop for StartupUpgradeHookGuard {
+    fn drop(&mut self) {
+        STARTUP_UPGRADE_HOOKS
+            .lock()
+            .expect("startup upgrade test hook mutex is not poisoned")
+            .remove(&self.db_path);
+    }
+}
+
+#[cfg(test)]
+fn register_startup_upgrade_hook(
+    db_path: impl Into<PathBuf>,
+    hook: StartupUpgradeHook,
+) -> StartupUpgradeHookGuard {
+    let db_path = db_path.into();
+    let replaced = STARTUP_UPGRADE_HOOKS
+        .lock()
+        .expect("startup upgrade test hook mutex is not poisoned")
+        .insert(db_path.clone(), hook);
+    assert!(
+        replaced.is_none(),
+        "database already has an upgrade test hook"
+    );
+
+    StartupUpgradeHookGuard { db_path }
+}
+
+#[cfg(test)]
+fn run_startup_upgrade_hook(db_path: &Path) {
+    let hook = STARTUP_UPGRADE_HOOKS
+        .lock()
+        .expect("startup upgrade test hook mutex is not poisoned")
+        .get(db_path)
+        .cloned();
+
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 impl DbFormatChange {
     /// Returns the format change for `running_version` code loading a `disk_version` database.
     ///
@@ -325,13 +385,13 @@ impl DbFormatChange {
         .cloned()
     }
 
-    /// Launch a `std::thread` that applies this format change to the database,
-    /// then continues running to perform periodic format checks.
+    /// Launch a `std::thread` that performs periodic current-format checks.
+    ///
+    /// The startup format change must already have completed synchronously.
     ///
     /// `initial_tip_height` is the database height when it was opened, and `db` is the
     /// database instance to upgrade or check.
-    pub fn spawn_format_change(
-        self,
+    pub fn spawn_periodic_format_checks(
         db: ZakuraDb,
         initial_tip_height: Option<Height>,
     ) -> DbFormatChangeThreadHandle {
@@ -344,7 +404,7 @@ impl DbFormatChange {
         let span = Span::current();
         let update_task = thread::spawn(move || {
             span.in_scope(move || {
-                self.format_change_run_loop(db, initial_tip_height, cancel_receiver)
+                Self::periodic_format_check_loop(db, initial_tip_height, cancel_receiver)
             })
         });
 
@@ -358,19 +418,12 @@ impl DbFormatChange {
         handle
     }
 
-    /// Run the initial format change or check to the database. Under the default runtime config,
-    /// this method returns after the format change or check.
-    ///
-    /// But if runtime validity checks are enabled, this method periodically checks the format of
-    /// newly added blocks matches the current format. It will run until it is cancelled or panics.
-    fn format_change_run_loop(
-        self,
+    /// Periodically check that newly added blocks match the current format.
+    fn periodic_format_check_loop(
         db: ZakuraDb,
         initial_tip_height: Option<Height>,
         cancel_receiver: Receiver<CancelFormatChange>,
     ) -> Result<(), CancelFormatChange> {
-        self.run_format_change_or_check(&db, initial_tip_height, &cancel_receiver)?;
-
         let Some(debug_validity_check_interval) = db.config().debug_validity_check_interval else {
             return Ok(());
         };
@@ -564,6 +617,9 @@ impl DbFormatChange {
         else {
             unreachable!("already checked for Upgrade")
         };
+
+        #[cfg(test)]
+        run_startup_upgrade_hook(db.path());
 
         // # New Upgrades Sometimes Go Here
         //
@@ -874,6 +930,99 @@ impl Drop for DbFormatChangeThreadHandle {
             self.check_for_panics();
         }
     }
+}
+
+#[test]
+fn database_startup_waits_for_format_upgrade() {
+    use std::time::Duration;
+
+    use crate::{
+        constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
+        service::finalized_state::STATE_COLUMN_FAMILIES_IN_CODE,
+        Config,
+    };
+    use zakura_chain::parameters::Network;
+
+    let tempdir = tempfile::tempdir().expect("temporary cache directory is created");
+    let config = Config {
+        cache_dir: tempdir.path().to_owned(),
+        ephemeral: false,
+        debug_skip_non_finalized_state_backup_task: true,
+        ..Config::default()
+    };
+    let network = Network::Mainnet;
+    let running_version = state_database_format_version_in_code();
+
+    let db = ZakuraDb::new(
+        &config,
+        STATE_DATABASE_KIND,
+        &running_version,
+        &network,
+        false,
+        STATE_COLUMN_FAMILIES_IN_CODE
+            .iter()
+            .map(ToString::to_string),
+        false,
+    )
+    .expect("initial database creation succeeds");
+    db.update_format_version_on_disk(&Version::new(27, 3, 0))
+        .expect("test database version is set to an older format");
+    let db_path = db.path().to_owned();
+    drop(db);
+
+    let (entered_tx, entered_rx) = bounded(1);
+    let (release_tx, release_rx) = bounded(1);
+    let _hook_guard = register_startup_upgrade_hook(
+        db_path,
+        Arc::new(move || {
+            entered_tx
+                .send(())
+                .expect("startup test receiver remains open");
+            release_rx
+                .recv()
+                .expect("startup test releases the format upgrade");
+        }),
+    );
+
+    let (returned_tx, returned_rx) = bounded(1);
+    let open_thread = thread::spawn(move || {
+        let db = ZakuraDb::new(
+            &config,
+            STATE_DATABASE_KIND,
+            &running_version,
+            &network,
+            false,
+            STATE_COLUMN_FAMILIES_IN_CODE
+                .iter()
+                .map(ToString::to_string),
+            false,
+        )
+        .expect("upgraded database startup succeeds");
+        returned_tx
+            .send(
+                db.format_version_on_disk()
+                    .expect("upgraded database version is readable"),
+            )
+            .expect("startup result receiver remains open");
+    });
+
+    entered_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("startup reaches the blocking format upgrade hook");
+    assert_eq!(
+        returned_rx.recv_timeout(Duration::from_millis(100)),
+        Err(RecvTimeoutError::Timeout),
+        "ZakuraDb::new must not return while its format upgrade is incomplete"
+    );
+
+    release_tx.send(()).expect("blocked upgrade is released");
+    assert_eq!(
+        returned_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("startup returns after the format upgrade"),
+        Some(state_database_format_version_in_code()),
+    );
+    open_thread.join().expect("startup thread does not panic");
 }
 
 #[test]

--- a/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -225,30 +225,27 @@ impl ZakuraDb {
                 .expect("startup header-store repair write failed: RocksDB is unavailable");
         }
 
-        db.spawn_format_change(format_change);
+        db.run_startup_format_change(format_change);
 
         Ok(db)
     }
 
-    /// Launch any required format changes or format checks, and store their thread handle.
-    pub fn spawn_format_change(&mut self, format_change: DbFormatChange) {
+    /// Complete the startup format change before exposing the database, then launch only
+    /// configured periodic current-format checks in the background.
+    pub fn run_startup_format_change(&mut self, format_change: DbFormatChange) {
         if self.debug_skip_format_upgrades {
             return;
         }
 
-        // We have to get this height before we spawn the upgrade task, because threads can take
-        // a while to start, and new blocks can be committed as soon as we return from this method.
+        // No state service can commit while this synchronous startup operation is running.
         let initial_tip_height = self.finalized_tip_height();
+        let (_never_cancel_handle, never_cancel_receiver) = bounded(1);
+        format_change
+            .run_format_change_or_check(self, initial_tip_height, &never_cancel_receiver)
+            .expect("startup format change cannot be cancelled");
 
-        // `upgrade_db` is a special clone of this database, which can't be used to shut down
-        // the upgrade task. (Because the task hasn't been launched yet,
-        // its `db.format_change_handle` is always None.)
-        let upgrade_db = self.clone();
-
-        // TODO:
-        // - should debug_stop_at_height wait for the upgrade task to finish?
         let format_change_handle =
-            format_change.spawn_format_change(upgrade_db, initial_tip_height);
+            DbFormatChange::spawn_periodic_format_checks(self.clone(), initial_tip_height);
 
         self.format_change_handle = Some(format_change_handle);
     }


### PR DESCRIPTION
## Motivation

`ZakuraDb::new` previously started the initial database format operation on a background thread and returned immediately. The state service could therefore begin reading the database or committing blocks while an upgrade was still changing its contents.

A database upgrade establishes the on-disk invariants expected by the running code. Exposing the database before it finishes creates a race between normal state access and the migration. This is particularly unsafe for migrations such as the planned Sprout-history repair, which must be complete before any caller observes the repaired state.

## Solution

Startup now has two distinct phases:

1. Run the one-time format operation synchronously. This applies any required upgrade, handles a newly created or downgraded database, and validates the resulting format. `ZakuraDb::new` does not return until this phase finishes.
2. Start the existing background worker only for optional periodic validity checks.

A periodic check is not an upgrade and does not search for a newer database version. When `debug_validity_check_interval` is configured, it periodically audits blocks written by the current process against the current database-format invariants. These checks remain asynchronous because they can repeat for the lifetime of the node. They are disabled by default.

The regression test blocks a generic startup upgrade and proves that `ZakuraDb::new` remains blocked until the upgrade is released and the new on-disk version is visible.

This PR is independently mergeable and has no dependency on the VCT Sprout persistence or repair changes.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-state --all-targets -- -D warnings`
- `cargo test -p zakura-state`
- `npx --yes markdownlint-cli "**/*.md" --ignore node_modules --ignore target --ignore .git --config .trunk/configs/.markdownlint.yaml`

### Follow-up Work

The VCT Sprout-history repair migration will rely on this startup guarantee in a separate PR.