### PR TITLE
feat(state): add authenticated VCT Sprout repair artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9175,6 +9175,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
+ "sha2 0.10.9",
  "spandoc",
  "tempfile",
  "thiserror 2.0.18",

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -822,3 +822,66 @@ cargo test -p zakura-state final_frontier
 cargo test -p zakura-utils --features zakura-checkpoints
 cargo test -p zakura --features zakura-checkpoints checkpoints
 ```
+
+## 17. VCT Sprout-history repair artifact
+
+### 17.1 Purpose and trust boundary
+
+The original VCT fast path advanced Sprout locally but omitted the historical
+`Sprout root → frontier` anchor entries. A later JoinSplit can spend one of those roots, so an
+affected database must be repaired before it is used for validation. The repair artifact is a
+canonical, Mainnet-only history of **only the blocks that change Sprout**; it is unrelated to
+peer-delivered VCT roots and is never accepted from peers.
+
+The SHA-256 digest in the artifact detects accidental or malicious byte changes, but does not
+establish provenance. Provenance comes from release review and embedding the approved bytes in
+the binary. The loader must never substitute downloaded, locally generated, or guessed bytes.
+Each record is bound to its canonical block hash, and the header is bound to the canonical
+handoff block hash. The terminal root is independently pinned to the separately embedded VCT
+handoff frontier, so both artifacts must agree before replay.
+
+### 17.2 Binary format (version 1)
+
+All integers are little-endian. The fixed 115-byte header is:
+
+| Bytes | Field |
+| --- | --- |
+| 0–7 | ASCII magic `ZKVCTSP1` |
+| 8–9 | `u16` format version (`1`) |
+| 10 | network tag (`1`, Mainnet) |
+| 11–14 | `u32` handoff height |
+| 15–46 | canonical handoff block hash |
+| 47–50 | `u32` record count |
+| 51–82 | 32-byte terminal Sprout root |
+| 83–114 | SHA-256 digest of the remaining payload |
+
+The payload contains exactly `record_count` records. Each record is `height_delta: u32`,
+the canonical 32-byte block hash, `commitment_count: u16`, `commitment_count` 32-byte Sprout
+commitments, and one 32-byte resulting Sprout root. The digest covers these canonical hashes.
+Heights are delta-coded from an initial height of zero. The current implementation permits at
+most 1M records and 65,535 commitments per record. Because no bytes using the earlier
+unshipped layout were published, this corrected layout remains version 1 and has no compatibility
+decoder.
+
+### 17.3 Validation and generation
+
+The decoder rejects a wrong magic, version, or network; truncation; digest mismatches; excess
+counts; zero or overflowing/non-increasing height deltas; heights above the handoff; empty
+records; record-root mismatches while replaying commitments from an empty Sprout tree; a
+terminal-root mismatch; and trailing bytes. The generated artifact is authenticated against the
+current build's own identity: its handoff must equal the embedded final frontier's height and its
+terminal Sprout root must equal the embedded final frontier's Sprout root.
+
+The offline generator opens a complete current-format Mainnet archive read-only, scans canonical
+block bodies from genesis through the embedded handoff, emits only Sprout-changing blocks with
+their canonical hashes, and then decodes, replays, canonical-index-validates, and handoff-validates
+its own output:
+
+```console
+cargo run -p zakura-state --bin generate-vct-sprout-artifact -- \
+  /path/to/zakura-cache /path/to/vct-sprout-history.bin
+```
+
+Reviewers must reproduce and compare the emitted bytes, SHA-256 digest, terminal root, and
+handoff identity before changing `MAINNET_ARTIFACT`. Running the tool never installs or enables
+its output.

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added authenticated VCT Sprout-history artifact generation and validation
+  APIs, plus an offline generator binary.
+
 ## [2.0.0] - 2026-07-17
 
 ### Breaking Changes

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -74,6 +74,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 rayon = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "tracing", "macros", "time"] }
 tower = { workspace = true, features = ["buffer", "util"] }
 tracing = { workspace = true }

--- a/zakura-state/src/bin/generate-vct-sprout-artifact.rs
+++ b/zakura-state/src/bin/generate-vct-sprout-artifact.rs
@@ -1,0 +1,192 @@
+//! Offline generator for the reviewed Mainnet VCT Sprout-history repair artifact.
+
+#![allow(clippy::print_stderr, clippy::print_stdout)]
+
+use std::{
+    env, fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
+
+use sha2::{Digest, Sha256};
+use tempfile::NamedTempFile;
+use thiserror::Error;
+use zakura_state::{generate_mainnet_from_archive, Config};
+
+#[derive(Debug, Error)]
+enum OutputError {
+    #[error("output path must name a file")]
+    MissingFileName,
+    #[error("could not resolve artifact path: {0}")]
+    Io(#[from] io::Error),
+    #[error("output path {output:?} is inside the source cache/database {source_cache:?}")]
+    InsideSourceCache {
+        output: PathBuf,
+        source_cache: PathBuf,
+    },
+    #[error("output path already exists: {0:?}")]
+    AlreadyExists(PathBuf),
+}
+
+fn main() -> ExitCode {
+    let mut args = env::args_os().skip(1);
+    let Some(cache_dir) = args.next() else {
+        eprintln!("usage: generate-vct-sprout-artifact <mainnet-cache-dir> <output-file>");
+        return ExitCode::FAILURE;
+    };
+    let Some(output_file) = args.next() else {
+        eprintln!("usage: generate-vct-sprout-artifact <mainnet-cache-dir> <output-file>");
+        return ExitCode::FAILURE;
+    };
+    if args.next().is_some() {
+        eprintln!("usage: generate-vct-sprout-artifact <mainnet-cache-dir> <output-file>");
+        return ExitCode::FAILURE;
+    }
+
+    let cache_dir = PathBuf::from(cache_dir);
+    let output_file = PathBuf::from(output_file);
+    let output_file = match validated_output_path(&cache_dir, &output_file) {
+        Ok(output_file) => output_file,
+        Err(error) => {
+            eprintln!("invalid artifact output: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let config = Config {
+        cache_dir,
+        ..Config::default()
+    };
+    let bytes = match generate_mainnet_from_archive(&config) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            eprintln!("artifact generation failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(error) = write_atomic_noclobber(&output_file, &bytes) {
+        eprintln!("could not write artifact to {:?}: {error}", output_file);
+        return ExitCode::FAILURE;
+    }
+
+    println!(
+        "wrote {} bytes to {:?}; sha256={:x}",
+        bytes.len(),
+        output_file,
+        Sha256::digest(&bytes)
+    );
+    ExitCode::SUCCESS
+}
+
+fn validated_output_path(cache_dir: &Path, output_file: &Path) -> Result<PathBuf, OutputError> {
+    let source = fs::canonicalize(cache_dir)?;
+    let file_name = output_file
+        .file_name()
+        .ok_or(OutputError::MissingFileName)?;
+    let output_parent = output_file
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let output = fs::canonicalize(output_parent)?.join(file_name);
+
+    if output.starts_with(&source) {
+        return Err(OutputError::InsideSourceCache {
+            output,
+            source_cache: source,
+        });
+    }
+
+    match fs::symlink_metadata(&output) {
+        Ok(_) => return Err(OutputError::AlreadyExists(output)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(OutputError::Io(error)),
+    }
+
+    Ok(output)
+}
+
+fn write_atomic_noclobber(output_file: &Path, bytes: &[u8]) -> Result<(), OutputError> {
+    let output_parent = output_file.parent().ok_or(OutputError::MissingFileName)?;
+    let mut temporary = NamedTempFile::new_in(output_parent)?;
+    temporary.write_all(bytes)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .persist_noclobber(output_file)
+        .map_err(|error| OutputError::Io(error.error))?;
+    #[cfg(unix)]
+    fs::File::open(output_parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_output_inside_source_cache() {
+        let source = tempfile::tempdir().expect("source tempdir is created");
+        let output = source.path().join("artifact.bin");
+
+        assert!(matches!(
+            validated_output_path(source.path(), &output),
+            Err(OutputError::InsideSourceCache { .. })
+        ));
+        assert!(!output.exists());
+    }
+
+    #[test]
+    fn rejects_existing_output_without_modifying_it() {
+        let source = tempfile::tempdir().expect("source tempdir is created");
+        let destination = tempfile::tempdir().expect("destination tempdir is created");
+        let output = destination.path().join("artifact.bin");
+        fs::write(&output, b"existing").expect("fixture output is written");
+
+        assert!(matches!(
+            validated_output_path(source.path(), &output),
+            Err(OutputError::AlreadyExists(_))
+        ));
+        assert_eq!(
+            fs::read(output).expect("fixture output remains readable"),
+            b"existing"
+        );
+    }
+
+    #[test]
+    fn atomically_creates_new_output_without_clobbering() {
+        let source = tempfile::tempdir().expect("source tempdir is created");
+        let destination = tempfile::tempdir().expect("destination tempdir is created");
+        let output = validated_output_path(source.path(), &destination.path().join("artifact.bin"))
+            .expect("safe output validates");
+
+        write_atomic_noclobber(&output, b"artifact").expect("artifact is persisted");
+
+        assert_eq!(
+            fs::read(output).expect("artifact remains readable"),
+            b"artifact"
+        );
+    }
+
+    #[test]
+    fn failed_noclobber_cleans_temporary_file() {
+        let destination = tempfile::tempdir().expect("destination tempdir is created");
+        let output = destination.path().join("artifact.bin");
+        fs::write(&output, b"existing").expect("fixture output is written");
+
+        assert!(matches!(
+            write_atomic_noclobber(&output, b"replacement"),
+            Err(OutputError::Io(_))
+        ));
+        let entries: Vec<_> = fs::read_dir(destination.path())
+            .expect("destination directory remains readable")
+            .map(|entry| entry.expect("directory entry is readable").file_name())
+            .collect();
+        assert_eq!(
+            entries,
+            [output.file_name().expect("output has a file name")]
+        );
+        assert_eq!(
+            fs::read(output).expect("existing output remains readable"),
+            b"existing"
+        );
+    }
+}

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -74,16 +74,16 @@ pub use service::{
 pub use service::finalized_state::{ReadDisk, TypedColumnFamily, WriteTypedBatch};
 
 pub use service::finalized_state::{
+    generate_mainnet_from_archive, produce_final_frontiers_bytes, validate_final_frontiers_bytes,
+    FinalFrontiersGenerationError, FinalFrontiersValidationError, GeneratorError,
+};
+pub use service::finalized_state::{
     preview_prune_finalized_state, prune_finalized_state, PruneFinalizedStateError,
     PruneFinalizedStateOptions, PruneFinalizedStateSummary,
 };
 pub use service::finalized_state::{
     preview_rollback_finalized_state, rollback_finalized_state, RollbackBackupSummary,
     RollbackFinalizedStateError, RollbackFinalizedStateOptions, RollbackFinalizedStateSummary,
-};
-pub use service::finalized_state::{
-    produce_final_frontiers_bytes, validate_final_frontiers_bytes, FinalFrontiersGenerationError,
-    FinalFrontiersValidationError,
 };
 pub use service::{
     finalized_state::{DiskWriteBatch, FromDisk, IntoDisk, WriteDisk, ZakuraDb},

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -103,7 +103,10 @@ pub use disk_format::{
     FromDisk, IntoDisk, OutputLocation, RawBytes, TransactionIndex, TransactionLocation,
     MAX_ON_DISK_HEIGHT,
 };
-pub use vct::{validate_final_frontiers_bytes, FinalFrontiersValidationError, NextVctBlock};
+pub use vct::{
+    generate_mainnet_from_archive, validate_final_frontiers_bytes, FinalFrontiersValidationError,
+    GeneratorError, NextVctBlock,
+};
 pub use zakura_db::ZakuraDb;
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zakura-state/src/service/finalized_state/commitment_aux.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux.rs
@@ -45,6 +45,13 @@ pub(super) struct FinalFrontiers {
 /// Errors producing [`FinalFrontiers`] from a finalized database.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum FinalFrontiersGenerationError {
+    /// The database has no finalized tip identity to bind the generated frontier.
+    #[error("cannot produce final frontiers at height {height:?}: finalized database is empty")]
+    MissingFinalizedTip {
+        /// The requested final frontier height.
+        height: block::Height,
+    },
+
     /// The finalized tip has no persisted Sprout tree.
     #[error("missing Sprout final frontier tree at height {height:?}")]
     MissingSproutTree {
@@ -71,6 +78,28 @@ pub enum FinalFrontiersGenerationError {
     MissingIronwoodTree {
         /// The requested final frontier height.
         height: block::Height,
+    },
+
+    /// The requested height is not the finalized tip, so its Sprout frontier is unavailable.
+    #[error(
+        "cannot produce final frontiers at height {height:?}: Sprout is only stored at finalized tip {tip:?}"
+    )]
+    RequestedHeightIsNotTip {
+        /// The requested final frontier height.
+        height: block::Height,
+        /// The finalized database tip height.
+        tip: block::Height,
+    },
+
+    /// The finalized tip changed while the four frontiers were being read.
+    #[error(
+        "finalized tip changed while producing final frontiers: before {before:?}, after {after:?}; retry generation"
+    )]
+    FinalizedTipChanged {
+        /// The full tip identity captured before reading any frontier.
+        before: Option<(block::Height, block::Hash)>,
+        /// The full tip identity captured after reading all frontiers.
+        after: Option<(block::Height, block::Hash)>,
     },
 }
 
@@ -543,14 +572,30 @@ pub(crate) fn serve_block_roots(
     roots
 }
 
-/// Produce the final frontiers at `height` from `db`'s per-height trees.
+/// Produce the final frontiers at the finalized database tip `height`.
 ///
-/// Sprout is frozen far below any modern checkpoint, so the tip Sprout tree is the frontier at
-/// `height`.
+/// Sprout stores only its current tip frontier, so producing a frontier at any other height would
+/// combine the requested Sapling/Orchard/Ironwood trees with a later Sprout tree.
 pub(super) fn produce_final_frontiers(
     db: &ZakuraDb,
     height: block::Height,
 ) -> Result<FinalFrontiers, FinalFrontiersGenerationError> {
+    produce_final_frontiers_with_post_read(db, height, || {})
+}
+
+fn produce_final_frontiers_with_post_read(
+    db: &ZakuraDb,
+    height: block::Height,
+    post_read: impl FnOnce(),
+) -> Result<FinalFrontiers, FinalFrontiersGenerationError> {
+    let before = db
+        .tip()
+        .ok_or(FinalFrontiersGenerationError::MissingFinalizedTip { height })?;
+    if before.0 != height {
+        let tip = before.0;
+        return Err(FinalFrontiersGenerationError::RequestedHeightIsNotTip { height, tip });
+    }
+
     let sapling = db
         .sapling_tree_by_height(&height)
         .ok_or(FinalFrontiersGenerationError::MissingSaplingTree { height })?;
@@ -563,6 +608,15 @@ pub(super) fn produce_final_frontiers(
     let sprout = db
         .sprout_tree_for_tip()
         .map_err(|error| FinalFrontiersGenerationError::MissingSproutTree { height: error.tip })?;
+
+    post_read();
+    let after = db.tip();
+    if after != Some(before) {
+        return Err(FinalFrontiersGenerationError::FinalizedTipChanged {
+            before: Some(before),
+            after,
+        });
+    }
 
     Ok(FinalFrontiers {
         height,
@@ -677,6 +731,13 @@ mod tests {
         let mut batch = DiskWriteBatch::new();
         batch.update_sprout_tree(db, tree);
         db.write_batch(batch).expect("seeding Sprout tree succeeds");
+    }
+
+    fn sprout_tree_with_note(value: u8) -> sprout::tree::NoteCommitmentTree {
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        tree.append(sprout::commitment::NoteCommitment::from([value; 32]))
+            .expect("single-note Sprout tree is not full");
+        tree
     }
 
     fn seed_finalized_tip(db: &ZakuraDb, height: block::Height) {
@@ -911,7 +972,7 @@ mod tests {
     }
 
     #[test]
-    fn produce_final_frontiers_reads_requested_trees_and_tip_sprout() {
+    fn produce_final_frontiers_reads_tip_trees_and_sprout() {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         let height = block::Height(2);
@@ -935,14 +996,63 @@ mod tests {
     }
 
     #[test]
+    fn produce_final_frontiers_rejects_height_below_tip_after_sprout_change() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+        let height = block::Height(2);
+        let tip = block::Height(3);
+        let later_sprout = sprout_tree_with_note(1);
+
+        seed_trees(&db, [2, 3]);
+        seed_sprout_tree(&db, &later_sprout);
+        seed_finalized_tip(&db, tip);
+
+        assert_ne!(
+            later_sprout.root(),
+            sprout::tree::NoteCommitmentTree::default().root(),
+            "the later block must change the Sprout frontier"
+        );
+        assert_eq!(
+            produce_final_frontiers(&db, height).expect_err(
+                "a historical request must not mix height 2 trees with the tip Sprout tree"
+            ),
+            FinalFrontiersGenerationError::RequestedHeightIsNotTip { height, tip },
+            "a historical request must not combine height 2 trees with the changed tip Sprout tree"
+        );
+    }
+
+    #[test]
+    fn produce_final_frontiers_retries_when_tip_identity_changes_during_read() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+        let height = block::Height(2);
+        let advanced_height = block::Height(3);
+
+        seed_trees(&db, [2, 3]);
+        seed_sprout_tree(&db, &sprout::tree::NoteCommitmentTree::default());
+        seed_finalized_tip(&db, height);
+
+        assert_eq!(
+            produce_final_frontiers_with_post_read(&db, height, || {
+                seed_finalized_tip(&db, advanced_height);
+            })
+            .expect_err("tip advancement during frontier reads must request a retry"),
+            FinalFrontiersGenerationError::FinalizedTipChanged {
+                before: Some((height, block::Hash([2; 32]))),
+                after: Some((advanced_height, block::Hash([3; 32]))),
+            }
+        );
+    }
+
+    #[test]
     fn produce_final_frontiers_reports_missing_trees() {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         let height = block::Height(2);
 
         assert_eq!(
-            produce_final_frontiers(&db, height).expect_err("Sapling absence is reported first"),
-            FinalFrontiersGenerationError::MissingSaplingTree { height },
+            produce_final_frontiers(&db, height).expect_err("empty database is reported first"),
+            FinalFrontiersGenerationError::MissingFinalizedTip { height },
         );
     }
 

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -5,6 +5,9 @@
 //! the default source is the peer `tree_aux` source. `checkpoint_sync = false` or
 //! `consensus.vct_fast_sync = false` selects legacy recompute.
 
+pub(super) mod artifact;
+pub use artifact::{generate_mainnet_from_archive, GeneratorError};
+
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,

--- a/zakura-state/src/service/finalized_state/vct/artifact.rs
+++ b/zakura-state/src/service/finalized_state/vct/artifact.rs
@@ -1,0 +1,611 @@
+//! Validated canonical Sprout-history artifacts for VCT database repair.
+//!
+//! This format intentionally contains only blocks that change Sprout. It is
+//! independent from peer-delivered VCT roots and is never accepted from peers.
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use zakura_chain::{block, sprout};
+
+use crate::{
+    constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
+    request::HashOrHeight,
+    service::finalized_state::{ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
+    Config, StateInitError,
+};
+
+use super::embedded_final_frontiers;
+
+const VERSION: u16 = 1;
+const MAGIC: &[u8; 8] = b"ZKVCTSP1";
+const MAINNET_NETWORK: u8 = 1;
+const MAX_RECORDS: usize = 1_000_000;
+const MAX_COMMITMENTS_PER_RECORD: usize = 65_535;
+// Consumed by the follow-up repair migration once reviewed bytes are embedded.
+#[allow(dead_code)]
+const MAINNET_ARTIFACT: Option<&[u8]> = None;
+
+/// One historical block that changed the Sprout commitment tree.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Record {
+    pub(crate) height: block::Height,
+    pub(crate) block_hash: block::Hash,
+    pub(crate) commitments: Vec<sprout::commitment::NoteCommitment>,
+    pub(crate) resulting_root: sprout::tree::Root,
+}
+
+/// Errors parsing or replaying a canonical Sprout-history artifact.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub(crate) enum Error {
+    // Consumed by the follow-up repair migration's artifact loader.
+    #[allow(dead_code)]
+    #[error("Sprout history artifact is unavailable: canonical Mainnet bytes have not been verified and embedded")]
+    CanonicalArtifactUnavailable,
+    #[error("invalid Sprout history artifact magic")]
+    InvalidMagic,
+    #[error("unsupported Sprout history artifact version {actual}")]
+    UnsupportedVersion { actual: u16 },
+    #[error("Sprout history artifact is not for Mainnet")]
+    WrongNetwork,
+    #[error("Sprout history artifact is truncated")]
+    Truncated,
+    #[error("Sprout history artifact has too many records")]
+    TooManyRecords,
+    #[error("Sprout history artifact record has too many commitments")]
+    TooManyCommitments,
+    #[error(
+        "Sprout history artifact record heights are not strictly increasing and within its handoff"
+    )]
+    InvalidHeight,
+    #[error("Sprout history artifact payload digest does not match")]
+    DigestMismatch,
+    #[error("Sprout history artifact replay root does not match record {height:?}")]
+    RecordRootMismatch { height: block::Height },
+    #[error("Sprout history artifact terminal root does not match its header")]
+    TerminalRootMismatch,
+    #[error("Sprout history artifact has trailing bytes")]
+    TrailingBytes,
+    #[error("Sprout history artifact handoff {actual:?} does not match expected {expected:?}")]
+    HandoffMismatch {
+        actual: block::Height,
+        expected: block::Height,
+    },
+    #[error("Sprout history artifact handoff block hash does not match the canonical database")]
+    HandoffHashMismatch,
+    #[error("Sprout history artifact terminal root does not match the embedded handoff frontier")]
+    HandoffRootMismatch,
+    #[error("canonical database is missing Sprout history artifact record {height:?}")]
+    MissingCanonicalRecord { height: block::Height },
+    #[error("Sprout history artifact block hash does not match canonical record {height:?}")]
+    CanonicalHashMismatch { height: block::Height },
+    #[error(
+        "canonical reverse block index does not match Sprout history artifact record {height:?}"
+    )]
+    CanonicalReverseIndexMismatch { height: block::Height },
+}
+
+/// A decoded, independently replay-validated artifact.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Artifact {
+    last_checkpoint: block::Height,
+    last_checkpoint_hash: block::Hash,
+    terminal_root: sprout::tree::Root,
+    records: Vec<Record>,
+}
+
+impl Artifact {
+    pub(crate) fn encode(
+        last_checkpoint: block::Height,
+        last_checkpoint_hash: block::Hash,
+        records: impl IntoIterator<Item = Record>,
+    ) -> Result<Vec<u8>, Error> {
+        let records: Vec<_> = records.into_iter().collect();
+        if records.len() > MAX_RECORDS {
+            return Err(Error::TooManyRecords);
+        }
+
+        let mut payload = Vec::new();
+        let mut previous = 0u32;
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        for record in &records {
+            if record.height.0 <= previous || record.height > last_checkpoint {
+                return Err(Error::InvalidHeight);
+            }
+            if record.commitments.is_empty()
+                || record.commitments.len() > MAX_COMMITMENTS_PER_RECORD
+            {
+                return Err(Error::TooManyCommitments);
+            }
+            payload.extend_from_slice(&(record.height.0 - previous).to_le_bytes());
+            payload.extend_from_slice(&record.block_hash.0);
+            let count =
+                u16::try_from(record.commitments.len()).map_err(|_| Error::TooManyCommitments)?;
+            payload.extend_from_slice(&count.to_le_bytes());
+            for commitment in &record.commitments {
+                payload.extend_from_slice(&<[u8; 32]>::from(commitment));
+                tree.append(*commitment)
+                    .map_err(|_| Error::RecordRootMismatch {
+                        height: record.height,
+                    })?;
+            }
+            if tree.root() != record.resulting_root {
+                return Err(Error::RecordRootMismatch {
+                    height: record.height,
+                });
+            }
+            payload.extend_from_slice(&<[u8; 32]>::from(record.resulting_root));
+            previous = record.height.0;
+        }
+
+        let mut out = Vec::new();
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&VERSION.to_le_bytes());
+        out.push(MAINNET_NETWORK);
+        out.extend_from_slice(&last_checkpoint.0.to_le_bytes());
+        out.extend_from_slice(&last_checkpoint_hash.0);
+        let record_count = u32::try_from(records.len()).map_err(|_| Error::TooManyRecords)?;
+        out.extend_from_slice(&record_count.to_le_bytes());
+        out.extend_from_slice(&<[u8; 32]>::from(tree.root()));
+        out.extend_from_slice(&Sha256::digest(&payload));
+        out.extend_from_slice(&payload);
+        Ok(out)
+    }
+
+    #[allow(clippy::unwrap_in_result)]
+    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, Error> {
+        const HEADER_LEN: usize = 8 + 2 + 1 + 4 + 32 + 4 + 32 + 32;
+        if bytes.len() < HEADER_LEN {
+            return Err(Error::Truncated);
+        }
+        if &bytes[..8] != MAGIC {
+            return Err(Error::InvalidMagic);
+        }
+        let version = u16::from_le_bytes(bytes[8..10].try_into().expect("fixed slice length"));
+        if version != VERSION {
+            return Err(Error::UnsupportedVersion { actual: version });
+        }
+        if bytes[10] != MAINNET_NETWORK {
+            return Err(Error::WrongNetwork);
+        }
+        let checkpoint = block::Height(u32::from_le_bytes(
+            bytes[11..15].try_into().expect("fixed slice length"),
+        ));
+        let handoff_hash = block::Hash(bytes[15..47].try_into().expect("fixed slice length"));
+        let record_count = usize::try_from(u32::from_le_bytes(
+            bytes[47..51].try_into().expect("fixed slice length"),
+        ))
+        .expect("u32 fits in usize on supported platforms");
+        if record_count > MAX_RECORDS {
+            return Err(Error::TooManyRecords);
+        }
+        let terminal_root = <[u8; 32]>::try_from(&bytes[51..83])
+            .expect("fixed slice length")
+            .into();
+        let expected_digest: [u8; 32] = bytes[83..115].try_into().expect("fixed slice length");
+        let payload = &bytes[HEADER_LEN..];
+        if Sha256::digest(payload).as_slice() != expected_digest {
+            return Err(Error::DigestMismatch);
+        }
+
+        let mut cursor = 0usize;
+        let mut previous = 0u32;
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        let mut records = Vec::with_capacity(record_count);
+        for _ in 0..record_count {
+            let header = payload.get(cursor..cursor + 38).ok_or(Error::Truncated)?;
+            let delta = u32::from_le_bytes(header[..4].try_into().expect("fixed slice length"));
+            let block_hash = block::Hash(header[4..36].try_into().expect("fixed slice length"));
+            let count = usize::from(u16::from_le_bytes(
+                header[36..].try_into().expect("fixed slice length"),
+            ));
+            cursor += 38;
+            let height = previous
+                .checked_add(delta)
+                .map(block::Height)
+                .ok_or(Error::InvalidHeight)?;
+            if delta == 0 || height > checkpoint {
+                return Err(Error::InvalidHeight);
+            }
+            if count == 0 || count > MAX_COMMITMENTS_PER_RECORD {
+                return Err(Error::TooManyCommitments);
+            }
+            let length = count.checked_mul(32).ok_or(Error::Truncated)?;
+            let commitment_bytes = payload
+                .get(cursor..cursor + length)
+                .ok_or(Error::Truncated)?;
+            let mut commitments = Vec::with_capacity(count);
+            for bytes in commitment_bytes.chunks_exact(32) {
+                let commitment = sprout::commitment::NoteCommitment::from(
+                    <[u8; 32]>::try_from(bytes).expect("chunks have fixed length"),
+                );
+                tree.append(commitment)
+                    .map_err(|_| Error::RecordRootMismatch { height })?;
+                commitments.push(commitment);
+            }
+            cursor += length;
+            let root: sprout::tree::Root =
+                <[u8; 32]>::try_from(payload.get(cursor..cursor + 32).ok_or(Error::Truncated)?)
+                    .expect("fixed slice length")
+                    .into();
+            cursor += 32;
+            if tree.root() != root {
+                return Err(Error::RecordRootMismatch { height });
+            }
+            records.push(Record {
+                height,
+                block_hash,
+                commitments,
+                resulting_root: root,
+            });
+            previous = height.0;
+        }
+        if cursor != payload.len() {
+            return Err(Error::TrailingBytes);
+        }
+        if tree.root() != terminal_root {
+            return Err(Error::TerminalRootMismatch);
+        }
+        Ok(Self {
+            last_checkpoint: checkpoint,
+            last_checkpoint_hash: handoff_hash,
+            terminal_root,
+            records,
+        })
+    }
+
+    pub(crate) fn validate_last_checkpoint(
+        &self,
+        last_checkpoint: block::Height,
+        last_checkpoint_hash: block::Hash,
+        sprout_root: sprout::tree::Root,
+    ) -> Result<(), Error> {
+        if self.last_checkpoint != last_checkpoint {
+            return Err(Error::HandoffMismatch {
+                actual: self.last_checkpoint,
+                expected: last_checkpoint,
+            });
+        }
+        if self.last_checkpoint_hash != last_checkpoint_hash {
+            return Err(Error::HandoffHashMismatch);
+        }
+        if self.terminal_root != sprout_root {
+            return Err(Error::HandoffRootMismatch);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_canonical(
+        &self,
+        hash_by_height: impl Fn(block::Height) -> Option<block::Hash>,
+        height_by_hash: impl Fn(block::Hash) -> Option<block::Height>,
+    ) -> Result<(), Error> {
+        self.validate_canonical_through(self.last_checkpoint, hash_by_height, height_by_hash)
+    }
+
+    pub(crate) fn validate_canonical_through(
+        &self,
+        height: block::Height,
+        hash_by_height: impl Fn(block::Height) -> Option<block::Hash>,
+        height_by_hash: impl Fn(block::Hash) -> Option<block::Height>,
+    ) -> Result<(), Error> {
+        for record in self.records_through(height) {
+            let Some(canonical_hash) = hash_by_height(record.height) else {
+                return Err(Error::MissingCanonicalRecord {
+                    height: record.height,
+                });
+            };
+            if canonical_hash != record.block_hash {
+                return Err(Error::CanonicalHashMismatch {
+                    height: record.height,
+                });
+            }
+            if height_by_hash(record.block_hash) != Some(record.height) {
+                return Err(Error::CanonicalReverseIndexMismatch {
+                    height: record.height,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn records_through(&self, height: block::Height) -> impl Iterator<Item = &Record> {
+        self.records
+            .iter()
+            .take_while(move |record| record.height <= height)
+    }
+}
+
+/// Errors produced by the offline canonical Mainnet artifact generator.
+#[derive(Debug, Error)]
+pub enum GeneratorError {
+    /// The source archive could not be opened.
+    #[error("could not open the Mainnet archive database read-only")]
+    OpenDatabase(#[source] StateInitError),
+    /// A canonical height has no retained forward hash index.
+    #[error("Mainnet archive is missing canonical block {height:?}")]
+    MissingCanonicalHash {
+        /// The missing block height.
+        height: block::Height,
+    },
+    /// A canonical hash does not map back to its height.
+    #[error("Mainnet archive reverse index does not match block {height:?}")]
+    CanonicalReverseIndexMismatch {
+        /// The inconsistent block height.
+        height: block::Height,
+    },
+    /// The archive is missing a required historical block body.
+    #[error("Mainnet archive is missing the body for block {height:?}")]
+    MissingBlockBody {
+        /// The missing block height.
+        height: block::Height,
+    },
+    /// A retained body does not hash to its canonical index entry.
+    #[error("Mainnet archive block body hash does not match its canonical index at {height:?}")]
+    BlockBodyHashMismatch {
+        /// The inconsistent block height.
+        height: block::Height,
+    },
+    /// Artifact encoding or self-validation failed.
+    #[error("could not construct the Sprout repair artifact: {0}")]
+    Artifact(String),
+}
+
+/// Generate corrected version-1 artifact bytes from a complete, current-format Mainnet archive.
+///
+/// The result is deliberately returned to an offline caller and is never installed as the
+/// runtime artifact. Release review must independently approve the bytes and digest first.
+pub fn generate_mainnet_from_archive(config: &Config) -> Result<Vec<u8>, GeneratorError> {
+    let network = zakura_chain::parameters::Network::Mainnet;
+    let db = ZakuraDb::new(
+        config,
+        STATE_DATABASE_KIND,
+        &state_database_format_version_in_code(),
+        &network,
+        true,
+        STATE_COLUMN_FAMILIES_IN_CODE
+            .iter()
+            .map(ToString::to_string),
+        true,
+    )
+    .map_err(GeneratorError::OpenDatabase)?;
+    let frontiers = embedded_final_frontiers(&network)
+        .expect("Mainnet always has an embedded VCT handoff frontier");
+    let last_checkpoint = frontiers.height;
+    let last_checkpoint_hash =
+        db.hash(last_checkpoint)
+            .ok_or(GeneratorError::MissingCanonicalHash {
+                height: last_checkpoint,
+            })?;
+
+    let mut tree = sprout::tree::NoteCommitmentTree::default();
+    let mut records = Vec::new();
+    for raw_height in 0..=last_checkpoint.0 {
+        let height = block::Height(raw_height);
+        let canonical_hash = db
+            .hash(height)
+            .ok_or(GeneratorError::MissingCanonicalHash { height })?;
+        if db.height(canonical_hash) != Some(height) {
+            return Err(GeneratorError::CanonicalReverseIndexMismatch { height });
+        }
+        let block = db
+            .block(HashOrHeight::Height(height))
+            .ok_or(GeneratorError::MissingBlockBody { height })?;
+        if block.hash() != canonical_hash {
+            return Err(GeneratorError::BlockBodyHashMismatch { height });
+        }
+        let commitments: Vec<_> = block.sprout_note_commitments().cloned().collect();
+        if commitments.is_empty() {
+            continue;
+        }
+        for commitment in &commitments {
+            tree.append(*commitment).map_err(|_| {
+                GeneratorError::Artifact(Error::RecordRootMismatch { height }.to_string())
+            })?;
+        }
+        records.push(Record {
+            height,
+            block_hash: canonical_hash,
+            commitments,
+            resulting_root: tree.root(),
+        });
+    }
+
+    let bytes = Artifact::encode(last_checkpoint, last_checkpoint_hash, records)
+        .map_err(|error| GeneratorError::Artifact(error.to_string()))?;
+    let decoded =
+        Artifact::decode(&bytes).map_err(|error| GeneratorError::Artifact(error.to_string()))?;
+    decoded
+        .validate_last_checkpoint(
+            last_checkpoint,
+            last_checkpoint_hash,
+            frontiers.sprout.root(),
+        )
+        .map_err(|error| GeneratorError::Artifact(error.to_string()))?;
+    decoded
+        .validate_canonical(|height| db.hash(height), |hash| db.height(hash))
+        .map_err(|error| GeneratorError::Artifact(error.to_string()))?;
+    Ok(bytes)
+}
+
+/// Loads the canonical artifact once independently reviewed bytes are embedded.
+///
+/// This must never be replaced with downloaded or guessed bytes.
+// Consumed by the follow-up repair migration.
+#[allow(dead_code)]
+pub(crate) fn embedded_mainnet() -> Result<Artifact, Error> {
+    MAINNET_ARTIFACT
+        .map(Artifact::decode)
+        .transpose()?
+        .ok_or(Error::CanonicalArtifactUnavailable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_round_trip_replays_each_record() {
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        let first = sprout::commitment::NoteCommitment::from([1; 32]);
+        tree.append(first).expect("test tree has capacity");
+        let bytes = Artifact::encode(
+            block::Height(20),
+            block::Hash([20; 32]),
+            [Record {
+                height: block::Height(10),
+                block_hash: block::Hash([10; 32]),
+                commitments: vec![first],
+                resulting_root: tree.root(),
+            }],
+        )
+        .expect("valid fixture encodes");
+
+        let artifact = Artifact::decode(&bytes).expect("fixture decodes");
+        artifact
+            .validate_last_checkpoint(block::Height(20), block::Hash([20; 32]), tree.root())
+            .expect("matching handoff validates");
+        assert_eq!(artifact.records_through(block::Height(9)).count(), 0);
+        assert_eq!(artifact.records_through(block::Height(10)).count(), 1);
+    }
+
+    #[test]
+    fn artifact_rejects_digest_tampering() {
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        let commitment = sprout::commitment::NoteCommitment::from([2; 32]);
+        tree.append(commitment).expect("test tree has capacity");
+        let mut bytes = Artifact::encode(
+            block::Height(1),
+            block::Hash([1; 32]),
+            [Record {
+                height: block::Height(1),
+                block_hash: block::Hash([1; 32]),
+                commitments: vec![commitment],
+                resulting_root: tree.root(),
+            }],
+        )
+        .expect("valid fixture encodes");
+        *bytes.last_mut().expect("encoded artifact has payload") ^= 1;
+
+        assert_eq!(Artifact::decode(&bytes), Err(Error::DigestMismatch));
+    }
+
+    #[test]
+    fn artifact_authenticates_handoff_and_record_hashes() {
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        let commitment = sprout::commitment::NoteCommitment::from([3; 32]);
+        tree.append(commitment).expect("test tree has capacity");
+        let height = block::Height(10);
+        let block_hash = block::Hash([10; 32]);
+        let handoff = block::Height(20);
+        let handoff_hash = block::Hash([20; 32]);
+        let artifact = Artifact::decode(
+            &Artifact::encode(
+                handoff,
+                handoff_hash,
+                [Record {
+                    height,
+                    block_hash,
+                    commitments: vec![commitment],
+                    resulting_root: tree.root(),
+                }],
+            )
+            .expect("valid fixture encodes"),
+        )
+        .expect("valid fixture decodes");
+
+        artifact
+            .validate_last_checkpoint(handoff, handoff_hash, tree.root())
+            .expect("matching handoff identity validates");
+        artifact
+            .validate_canonical(
+                |candidate| (candidate == height).then_some(block_hash),
+                |candidate| (candidate == block_hash).then_some(height),
+            )
+            .expect("matching canonical indexes validate");
+
+        assert_eq!(
+            artifact.validate_last_checkpoint(handoff, block::Hash([21; 32]), tree.root()),
+            Err(Error::HandoffHashMismatch)
+        );
+        assert_eq!(
+            artifact.validate_canonical(|_| None, |_| Some(height)),
+            Err(Error::MissingCanonicalRecord { height })
+        );
+        assert_eq!(
+            artifact.validate_canonical(|_| Some(block::Hash([11; 32])), |_| Some(height)),
+            Err(Error::CanonicalHashMismatch { height })
+        );
+        assert_eq!(
+            artifact.validate_canonical(|_| Some(block_hash), |_| Some(block::Height(11))),
+            Err(Error::CanonicalReverseIndexMismatch { height })
+        );
+    }
+
+    #[test]
+    fn prefix_validation_never_queries_records_above_the_tip() {
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        let first_height = block::Height(10);
+        let first_hash = block::Hash([10; 32]);
+        let later_height = block::Height(20);
+        let later_hash = block::Hash([99; 32]);
+        let records = [(first_height, first_hash, 5), (later_height, later_hash, 6)].map(
+            |(height, block_hash, value)| {
+                let commitment = sprout::commitment::NoteCommitment::from([value; 32]);
+                tree.append(commitment).expect("test tree has capacity");
+                Record {
+                    height,
+                    block_hash,
+                    commitments: vec![commitment],
+                    resulting_root: tree.root(),
+                }
+            },
+        );
+        let artifact = Artifact::decode(
+            &Artifact::encode(block::Height(30), block::Hash([30; 32]), records)
+                .expect("valid fixture encodes"),
+        )
+        .expect("valid fixture globally replays");
+
+        artifact
+            .validate_canonical_through(
+                first_height,
+                |height| {
+                    assert_eq!(
+                        height, first_height,
+                        "records above the finalized tip must not be queried"
+                    );
+                    Some(first_hash)
+                },
+                |hash| {
+                    assert_eq!(
+                        hash, first_hash,
+                        "records above the finalized tip must not be reverse-queried"
+                    );
+                    Some(first_height)
+                },
+            )
+            .expect("a mismatch above the finalized tip is deferred");
+    }
+
+    #[test]
+    fn artifact_digest_covers_canonical_block_hashes() {
+        let mut tree = sprout::tree::NoteCommitmentTree::default();
+        let commitment = sprout::commitment::NoteCommitment::from([4; 32]);
+        tree.append(commitment).expect("test tree has capacity");
+        let mut bytes = Artifact::encode(
+            block::Height(1),
+            block::Hash([1; 32]),
+            [Record {
+                height: block::Height(1),
+                block_hash: block::Hash([1; 32]),
+                commitments: vec![commitment],
+                resulting_root: tree.root(),
+            }],
+        )
+        .expect("valid fixture encodes");
+
+        // The first record hash begins after the fixed header and height delta.
+        bytes[115 + 4] ^= 1;
+        assert_eq!(Artifact::decode(&bytes), Err(Error::DigestMismatch));
+    }
+}


### PR DESCRIPTION
## Motivation

Repairing historical Sprout anchors requires a reviewable, deterministic source of canonical Mainnet history. Peer-delivered VCT roots are not sufficient because they do not contain Sprout frontiers, and repair data must not be accepted from an unauthenticated runtime source.

## Solution

- Define a bounded binary artifact containing only canonical blocks that change Sprout.
- Authenticate its payload with SHA-256 and bind every record to canonical block indexes.
- Bind the terminal Sprout root and handoff identity to the separately embedded VCT frontier.
- Add an offline generator that opens a complete Mainnet archive read-only, generates the artifact, and validates its own output.
- Harden finalized-frontier generation so all four trees come from one stable finalized tip identity.
- Document the artifact format, trust boundary, validation, and independent reproduction procedure.

`MAINNET_ARTIFACT` remains `None`: this PR does not enable repair or change node startup behavior.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-state --all-targets -- -D warnings`
- `cargo test -p zakura-state`
- Focused artifact codec, canonical-prefix, handoff, generator, and finalized-tip race tests.
- `npx --yes markdownlint-cli "**/*.md" --ignore node_modules --ignore target --ignore .git --config .trunk/configs/.markdownlint.yaml`

The tests reject malformed or oversized artifacts, digest and replay-root mismatches, canonical index mismatches, incorrect handoffs, historical frontier requests, and finalized-tip changes during generation.

### Follow-up Work

- Add the startup repair migration using the merged Sprout persistence and synchronous startup guarantees.
- Independently reproduce and review the canonical Mainnet artifact.
- Embed the reviewed bytes in a final activation PR.