### PR TITLE
fix(network): don't drop configured sidecar peers on inbound overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   coincided with a ready service. The latest hash is now queued for an unready
   sidecar and delivered once it is ready again, bounding the stall to one
   readiness cycle.
+- The inbound-overload protection no longer disconnects operator-configured
+  block-gossip / zcashd-compat sidecar peers. When such a peer's own getdata /
+  getheaders overloaded or timed out the inbound service, the random
+  connection-drop (probability 0.05→0.5) could sever the very peer this node
+  feeds, and the one-connection-per-IP reconnect refusal could stretch that into
+  a multi-second blackout. Configured sidecars are now exempt from the drop —
+  their requests are still shed for backpressure, but the connection is not
+  closed. Every other peer's denial-of-service protection is unchanged.
 
 ## [1.0.1] - 2026-07-17
 

--- a/zakura-network/src/peer/client/tests.rs
+++ b/zakura-network/src/peer/client/tests.rs
@@ -338,6 +338,7 @@ where
             local: remote.clone(),
             remote,
             negotiated_version,
+            is_protected_peer: false,
         });
 
         let client = Client {

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -1614,6 +1614,24 @@ where
     /// probability of being disconnected increases.
     async fn handle_inbound_overload(&mut self, req: Request, now: Instant, error: PeerError) {
         let prev = self.last_overload_time.replace(now);
+
+        // # Security / liveness
+        //
+        // Operator-configured sidecar / block-gossip peers are trusted and
+        // depended on: they follow this node and learn the chain tip only from
+        // it. Shedding (ignoring) their request is correct backpressure, but
+        // *severing* the connection just makes the sidecar fall behind, and the
+        // `max_connections_per_ip = 1` reconnect refusal can stretch that into a
+        // multi-second blackout. So we never drop them for an overload/timeout.
+        //
+        // This exemption is scoped strictly to configured IPs; every other
+        // peer's denial-of-service protection below is unchanged.
+        if self.connection_info.is_protected_peer {
+            self.update_state_metrics(format!("In::Req::{}/Rsp::{error}::Ignored", req.command()));
+            metrics::counter!("pool.ignored.protected").increment(1);
+            return;
+        }
+
         let drop_connection_probability = overload_drop_connection_probability(now, prev);
 
         if thread_rng().gen::<f32>() < drop_connection_probability {

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -82,6 +82,38 @@ fn new_test_connection<A>() -> (
     mpsc::Receiver<Message>,
     ErrorSlot,
 ) {
+    new_test_connection_with_protection(false)
+}
+
+/// Creates a new [`Connection`] marked as an operator-configured protected peer
+/// (exempt from the inbound-overload connection drop).
+fn new_protected_test_connection<A>() -> (
+    Connection<
+        MockService<Request, Response, A>,
+        SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, A>,
+    mpsc::Receiver<Message>,
+    ErrorSlot,
+) {
+    new_test_connection_with_protection(true)
+}
+
+/// Creates a new [`Connection`] instance for testing, setting whether it is an
+/// operator-configured protected peer.
+fn new_test_connection_with_protection<A>(
+    is_protected_peer: bool,
+) -> (
+    Connection<
+        MockService<Request, Response, A>,
+        SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, A>,
+    mpsc::Receiver<Message>,
+    ErrorSlot,
+) {
     let mock_inbound_service = MockService::build().finish();
     let (client_tx, client_rx) = mpsc::channel(0);
     let shared_error_slot = ErrorSlot::default();
@@ -120,6 +152,7 @@ fn new_test_connection<A>() -> (
         local: remote.clone(),
         remote,
         negotiated_version: fake_version,
+        is_protected_peer,
     };
 
     let connection = Connection::new(
@@ -172,6 +205,7 @@ fn new_never_closing_test_connection<A>(
         local: remote.clone(),
         remote,
         negotiated_version: fake_version,
+        is_protected_peer: false,
     };
 
     let connection = Connection::new(

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -971,6 +971,69 @@ async fn connection_is_randomly_disconnected_on_overload() {
     );
 }
 
+/// Test that operator-configured protected peers (block-gossip / zcashd-compat
+/// sidecars) are never disconnected in response to `Overloaded` errors: their
+/// requests are still shed, but the connection is never severed, even as
+/// repeated overloads would drive an ordinary peer's drop probability toward
+/// `MAX_OVERLOAD_DROP_PROBABILITY`.
+#[tokio::test(flavor = "multi_thread")]
+async fn protected_connection_is_never_disconnected_on_overload() {
+    let _init_guard = zakura_test::init();
+
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
+    let (mut peer_tx, peer_rx) = mpsc::channel(1);
+
+    let (
+        connection,
+        _client_tx,
+        mut inbound_service,
+        mut peer_outbound_messages,
+        shared_error_slot,
+    ) = new_protected_test_connection();
+
+    // Start the connection run loop future in a spawned task
+    let connection_handle = tokio::spawn(connection.run(peer_rx));
+    tokio::time::sleep(Duration::from_millis(1)).await;
+
+    // Repeatedly overload the inbound service on the same connection. Each
+    // overload refreshes `last_overload_time`, so for an ordinary peer the drop
+    // probability climbs quadratically toward `MAX_OVERLOAD_DROP_PROBABILITY`.
+    // A protected peer must survive every one of them.
+    const OVERLOADS: usize = 50;
+    for i in 0..OVERLOADS {
+        // Simulate an overloaded connection error in response to an inbound request.
+        peer_tx
+            .send(Ok(Message::GetAddr))
+            .await
+            .expect("send to channel always succeeds");
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        inbound_service
+            .expect_request(Request::Peers)
+            .await
+            .respond_error(Overloaded::new().into());
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        // The request is shed: no response is sent to the peer.
+        let outbound_result = peer_outbound_messages.try_recv();
+        assert!(
+            outbound_result.is_err(),
+            "overload {i}: protected peer's request must be shed, not answered:\n{outbound_result:?}"
+        );
+
+        // The connection is never severed for a protected peer.
+        let error = shared_error_slot.try_get_error();
+        assert!(
+            error.is_none(),
+            "overload {i}: protected peer must never be disconnected on overload, but got: {error:?}"
+        );
+    }
+
+    // We need to terminate the spawned task
+    connection_handle.abort();
+}
+
 #[tokio::test]
 async fn connection_ping_pong_round_trip() {
     let _init_guard = zakura_test::init();
@@ -1058,4 +1121,19 @@ fn new_test_connection() -> (
     ErrorSlot,
 ) {
     super::new_test_connection()
+}
+
+/// Creates a new protected-peer [`Connection`] instance for unit tests
+/// (exempt from the inbound-overload connection drop).
+fn new_protected_test_connection() -> (
+    Connection<
+        MockService<Request, Response, PanicAssertion>,
+        SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, PanicAssertion>,
+    mpsc::Receiver<Message>,
+    ErrorSlot,
+) {
+    super::new_protected_test_connection()
 }

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -2,9 +2,10 @@
 
 use std::{
     cmp::min,
+    collections::HashSet,
     fmt,
     future::Future,
-    net::{Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     panic,
     pin::Pin,
     sync::Arc,
@@ -44,7 +45,7 @@ use crate::{
     },
     peer_set::{ConnectionTracker, InventoryChange},
     protocol::{
-        external::{types::*, AddrInVersion, Codec, InventoryHash, Message},
+        external::{canonical_socket_addr, types::*, AddrInVersion, Codec, InventoryHash, Message},
         internal::{Request, Response},
     },
     types::MetaAddr,
@@ -85,6 +86,11 @@ where
     minimum_peer_version: MinimumPeerVersion<C>,
     nonces: Arc<futures::lock::Mutex<IndexSet<Nonce>>>,
     zakura_handshake_connector: Option<ZakuraHandshakeConnector>,
+
+    /// Inbound peer IPs that are exempt from the inbound-overload connection
+    /// drop (operator-configured block-gossip / zcashd-compat sidecars),
+    /// canonicalized for IPv4-mapped matching. Empty when unconfigured.
+    protected_peer_ips: Arc<HashSet<IpAddr>>,
 
     parent_span: Span,
 }
@@ -130,6 +136,7 @@ where
             minimum_peer_version: self.minimum_peer_version.clone(),
             nonces: self.nonces.clone(),
             zakura_handshake_connector: self.zakura_handshake_connector.clone(),
+            protected_peer_ips: self.protected_peer_ips.clone(),
             parent_span: self.parent_span.clone(),
         }
     }
@@ -156,6 +163,21 @@ pub struct ConnectionInfo {
     /// Derived from `remote.version` and the
     /// [current `zakura_network` protocol version](constants::CURRENT_NETWORK_PROTOCOL_VERSION).
     pub negotiated_version: Version,
+
+    /// Whether this is an inbound connection from an operator-configured
+    /// protected peer (a block-gossip / zcashd-compat sidecar).
+    ///
+    /// Protected peers follow this node and learn the chain tip only from it,
+    /// so they are exempt from the inbound-overload connection drop (their
+    /// requests are still shed for backpressure, but the connection is not
+    /// severed). See [`Connection::handle_inbound_overload`].
+    pub is_protected_peer: bool,
+}
+
+/// Canonicalizes `ip` so an IPv4-mapped IPv6 address (`::ffff:A.B.C.D`) compares
+/// equal to its plain IPv4 form, matching how inbound peer accounting keys peers.
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    canonical_socket_addr(SocketAddr::new(ip, 0)).ip()
 }
 
 /// The peer address that we are handshaking with.
@@ -393,6 +415,24 @@ impl ConnectedAddr {
     pub fn is_inbound(&self) -> bool {
         matches!(self, InboundDirect { .. } | InboundProxy { .. })
     }
+
+    /// Returns `true` if this is an inbound connection whose peer IP is in the
+    /// operator-configured `protected_peer_ips` set (block-gossip / zcashd-compat
+    /// sidecars).
+    ///
+    /// The peer's transient inbound IP is canonicalized (IPv4-mapped IPv6 →
+    /// IPv4) before lookup, so a dual-stack `::ffff:` sidecar still matches an
+    /// IPv4 configuration entry. Outbound connections are never protected: the
+    /// set describes inbound sidecars that dial this node.
+    pub fn is_protected_peer(&self, protected_peer_ips: &HashSet<IpAddr>) -> bool {
+        if protected_peer_ips.is_empty() || !self.is_inbound() {
+            return false;
+        }
+
+        self.get_transient_addr()
+            .map(|addr| protected_peer_ips.contains(&canonical_ip(addr.ip())))
+            .unwrap_or(false)
+    }
 }
 
 impl fmt::Debug for ConnectedAddr {
@@ -424,6 +464,7 @@ where
     address_book_updater: Option<tokio::sync::mpsc::Sender<MetaAddrChange>>,
     inv_collector: Option<broadcast::Sender<InventoryChange>>,
     zakura_handshake_connector: Option<ZakuraHandshakeConnector>,
+    protected_peer_ips: Option<Arc<HashSet<IpAddr>>>,
     latest_chain_tip: C,
 }
 
@@ -507,6 +548,7 @@ where
             relay: self.relay,
             inv_collector: self.inv_collector,
             zakura_handshake_connector: self.zakura_handshake_connector,
+            protected_peer_ips: self.protected_peer_ips,
         }
     }
 
@@ -516,6 +558,17 @@ where
         zakura_handshake_connector: ZakuraHandshakeConnector,
     ) -> Self {
         self.zakura_handshake_connector = Some(zakura_handshake_connector);
+        self
+    }
+
+    /// Provide the set of inbound peer IPs that are exempt from the
+    /// inbound-overload connection drop. Optional.
+    ///
+    /// These are operator-configured block-gossip / zcashd-compat sidecar IPs
+    /// (canonicalized for IPv4-mapped matching). If this is unset, no peer is
+    /// exempted and every connection behaves exactly as before.
+    pub fn with_protected_peer_ips(mut self, protected_peer_ips: Arc<HashSet<IpAddr>>) -> Self {
+        self.protected_peer_ips = Some(protected_peer_ips);
         self
     }
 
@@ -566,6 +619,7 @@ where
             minimum_peer_version,
             nonces,
             zakura_handshake_connector: self.zakura_handshake_connector,
+            protected_peer_ips: self.protected_peer_ips.unwrap_or_default(),
             parent_span: Span::current(),
         })
     }
@@ -590,6 +644,7 @@ where
             address_book_updater: None,
             inv_collector: None,
             zakura_handshake_connector: None,
+            protected_peer_ips: None,
             latest_chain_tip: NoChainTip,
         }
     }
@@ -656,6 +711,7 @@ pub async fn negotiate_version<PeerTransport>(
     our_services: PeerServices,
     relay: bool,
     mut minimum_peer_version: MinimumPeerVersion<impl ChainTip>,
+    is_protected_peer: bool,
 ) -> Result<Arc<ConnectionInfo>, HandshakeError>
 where
     PeerTransport: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -871,6 +927,7 @@ where
         remote,
         local: our_version,
         negotiated_version,
+        is_protected_peer,
     });
 
     debug!(
@@ -1369,6 +1426,11 @@ where
         let minimum_peer_version = self.minimum_peer_version.clone();
         let zakura_handshake_connector = self.zakura_handshake_connector.clone();
 
+        // Whether this peer is exempt from the inbound-overload connection drop.
+        // Computed here (not in the future) so only the resulting `bool` is moved
+        // into the handshake task.
+        let is_protected_peer = connected_addr.is_protected_peer(&self.protected_peer_ips);
+
         // # Security
         //
         // `zakura_network::init()` implements a connection timeout on this future.
@@ -1400,6 +1462,7 @@ where
                 our_services,
                 relay,
                 minimum_peer_version,
+                is_protected_peer,
             )
             .await
             {

--- a/zakura-network/src/peer/handshake/tests.rs
+++ b/zakura-network/src/peer/handshake/tests.rs
@@ -3,7 +3,8 @@
 #![allow(clippy::unwrap_in_result)]
 
 use std::{
-    net::{Ipv4Addr, SocketAddr},
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -94,6 +95,7 @@ async fn negotiate_test_pair(
             local_services,
             true,
             local_min_version,
+            false,
         )
         .await
     });
@@ -108,6 +110,7 @@ async fn negotiate_test_pair(
             remote_services,
             true,
             remote_min_version,
+            false,
         )
         .await
     });
@@ -707,6 +710,7 @@ fn p2p_v2_upgrade_uses_main_version_services_only() {
         local: inconsistent_remote.clone(),
         remote: inconsistent_remote,
         negotiated_version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
+        is_protected_peer: false,
     };
 
     assert!(!should_attempt_zakura_upgrade(&config, &connection_info));
@@ -733,6 +737,7 @@ fn p2p_v2_upgrade_requires_local_enable_and_remote_service_bit() {
         local: version(PeerServices::NODE_NETWORK | PeerServices::NODE_P2P_V2),
         remote: version(remote_services),
         negotiated_version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
+        is_protected_peer: false,
     };
 
     assert!(!should_attempt_zakura_upgrade(
@@ -747,6 +752,42 @@ fn p2p_v2_upgrade_requires_local_enable_and_remote_service_bit() {
         &test_config(P2pStack::Dual),
         &connection_info(PeerServices::NODE_NETWORK | PeerServices::NODE_P2P_V2),
     ));
+}
+
+/// A configured inbound peer is recognized as protected, including when it
+/// arrives as an IPv4-mapped IPv6 address; outbound, unconfigured, empty-set,
+/// and isolated cases are not protected.
+#[test]
+fn connected_addr_is_protected_peer_matches_configured_inbound_ips() {
+    let _init_guard = zakura_test::init();
+
+    let configured = Ipv4Addr::new(203, 0, 113, 7);
+    let protected: HashSet<IpAddr> = [IpAddr::V4(configured)].into_iter().collect();
+
+    let inbound = |ip: IpAddr| ConnectedAddr::new_inbound_direct(SocketAddr::new(ip, 8233).into());
+
+    // A configured inbound peer (plain IPv4) is protected.
+    assert!(inbound(IpAddr::V4(configured)).is_protected_peer(&protected));
+
+    // The same peer arriving as an IPv4-mapped IPv6 address is still protected:
+    // its IP is canonicalized before the lookup.
+    let mapped = IpAddr::V6(configured.to_ipv6_mapped());
+    assert!(inbound(mapped).is_protected_peer(&protected));
+
+    // An inbound peer that is not in the configured set is not protected.
+    assert!(!inbound(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9))).is_protected_peer(&protected));
+
+    // Outbound connections are never protected, even to a configured IP.
+    assert!(!ConnectedAddr::new_outbound_direct(
+        SocketAddr::new(IpAddr::V4(configured), 8233).into()
+    )
+    .is_protected_peer(&protected));
+
+    // An empty configured set protects no one.
+    assert!(!inbound(IpAddr::V4(configured)).is_protected_peer(&HashSet::new()));
+
+    // Isolated connections have no peer address and are never protected.
+    assert!(!ConnectedAddr::Isolated.is_protected_peer(&protected));
 }
 
 #[tokio::test]

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -233,6 +233,18 @@ where
     // handshakes. These use the same handshake service internally to detect
     // self-connection attempts. Both are decorated with a tower TimeoutLayer to
     // enforce timeouts as specified in the Config.
+
+    // Inbound peers exempt from the inbound-overload connection drop: the
+    // operator-configured block-gossip / zcashd-compat sidecars. Canonicalized
+    // (IPv4-mapped IPv6 -> IPv4) so an inbound `::ffff:` address still matches,
+    // exactly like the reserved-slot accounting in `accept_inbound_connections`.
+    let protected_peer_ips: Arc<HashSet<IpAddr>> = Arc::new(
+        block_gossip_peer_ips
+            .iter()
+            .map(|&ip| canonical_socket_addr(SocketAddr::new(ip, 0)).ip())
+            .collect(),
+    );
+
     let (listen_handshaker, outbound_connector) = {
         use tower::timeout::TimeoutLayer;
         let hs_timeout = TimeoutLayer::new(constants::HANDSHAKE_TIMEOUT);
@@ -248,6 +260,7 @@ where
             .with_advertised_services(advertised_services)
             .with_user_agent(user_agent)
             .with_latest_chain_tip(latest_chain_tip.clone())
+            .with_protected_peer_ips(protected_peer_ips)
             .want_transactions(true);
 
         if let Some(zakura_handshake_connector) = zakura_handshake_connector {

--- a/zakura-network/tests/acceptance.rs
+++ b/zakura-network/tests/acceptance.rs
@@ -42,5 +42,6 @@ fn connection_info_types_are_public() {
         local: remote.clone(),
         remote,
         negotiated_version,
+        is_protected_peer: false,
     });
 }


### PR DESCRIPTION
## Problem

`Connection::handle_inbound_overload` (`zakura-network/src/peer/connection.rs`)
closes a peer's connection with probability **0.05 → 0.5** when that peer's
inbound requests overload (`Overloaded`) or time out (`Elapsed`) the shared
inbound service. The probability rises quadratically as a peer keeps
overloading within a short window.

Operator-configured **zcashd-compat / block-gossip sidecars** were **not**
exempt. A sidecar follows this node and learns the chain tip *only* from its
block `inv`s, so it fetches aggressively; while zakura's own sync contends for
the shared state buffer, that fetching can overload or slow (>5s) the inbound
service and randomly sever the very peer zakura feeds. The
one-connection-per-IP reconnect refusal (`max_connections_per_ip = 1`) can then
stretch a single drop into a multi-second blackout, during which the sidecar is
blind to new blocks.

This is the single most likely *recurring* sever of a healthy sidecar, and it
compounds with the reconnect refusal.

## Fix

- Plumb an `is_protected_peer` bit into `ConnectionInfo`, computed at handshake
  time from the peer's **canonicalized** inbound IP against the configured
  block-gossip / zcashd-compat set (`ConnectedAddr::is_protected_peer`).
  Canonicalization (IPv4-mapped `::ffff:` → IPv4) mirrors the reserved-slot
  accounting in `accept_inbound_connections`, so a dual-stack sidecar still
  matches.
- Early-return from `handle_inbound_overload` for protected peers **before** the
  random drop. The request is still **shed** (ignored) so backpressure is
  preserved — only the connection *drop* is skipped.

This rests on the same operator-trust basis as the sidecar's existing
carve-outs (reserved inbound slot, always-on gossip inclusion, stall-tracker
exemption). Outbound connections are never protected; the set describes inbound
sidecars that dial this node.

## Security tradeoff (deliberate)

Exempting a peer from the overload drop means that peer can keep sending inbound
requests that overload zakura without being disconnected. This is acceptable
**only because the exemption is scoped strictly to operator-configured IPs** (the
same operator runs both nodes). Every other peer's denial-of-service protection
— the probability curve and the `fail_with` drop path — is **byte-for-byte
unchanged**. The repo has no `C-security` label, so this is filed as `C-bug`
with the tradeoff called out here.

## Tests

- `connected_addr_is_protected_peer_matches_configured_inbound_ips` — the IP
  match, including the IPv4-mapped `::ffff:` form, and that outbound /
  unconfigured / empty-set / isolated cases are **not** protected.
- `protected_connection_is_never_disconnected_on_overload` — drives 50
  overloads at a protected connection and asserts every request is shed and the
  connection is never severed (deterministic: the exemption returns before the
  RNG).
- `connection_is_randomly_disconnected_on_overload` (unchanged) still proves
  ordinary peers can be dropped.

## Scope

Independent of #231/#236 (touches `connection.rs` / `handshake.rs` /
`initialize.rs`, not the gossip queues). Complements them: those keep the tip
flowing *to* the sidecar; this keeps the sidecar *connected* so it can fetch.
Backward compatible — the protected set defaults to empty, so nodes without a
configured sidecar behave exactly as before.
