### PR TITLE
docs(changelog): record v1.0.1 security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,24 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   submitted to one blocking task
   ([#150](https://github.com/zakura-core/zakura/pull/150)).
 
+### Security
+
+- Validate transparent spends without cloning the block's spent UTXO set for
+  every transaction, removing quadratic work that let a specially crafted
+  block stall block validation for nearly a minute on fast hardware
+  ([GHSA-4g24-549m-hp75](https://github.com/zakura-core/zakura/security/advisories/GHSA-4g24-549m-hp75)).
+- Attribute transactions pushed directly by a peer to that peer when they fail
+  verification, so peers sending consensus-invalid transactions — including
+  transactions with invalid proofs that poison batched proof verification and
+  force repeated, expensive fallback verification — are now misbehavior-scored
+  and banned instead of degrading block validation unidentified
+  ([GHSA-g7c4-2w6c-cr3r](https://github.com/zakura-core/zakura/security/advisories/GHSA-g7c4-2w6c-cr3r)).
+- Reserve the serialized block header, transaction count, and maximum
+  pool-modified coinbase size when selecting mempool transactions for
+  `getblocktemplate`, so an adversary can no longer provoke templates that
+  violate the consensus block size limit and stall mining on a targeted node
+  ([GHSA-95m2-vx53-v2jw](https://github.com/zakura-core/zakura/security/advisories/GHSA-95m2-vx53-v2jw)).
+
 ## [1.0.0] - 2026-07-15
 
 Initial release of Zakura.

--- a/zakura-chain/CHANGELOG.md
+++ b/zakura-chain/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   memory attribution
   ([#159](https://github.com/zakura-core/zakura/pull/159)).
 
+### Security
+
+- `Transaction::value_balance` now looks up only the transaction's own spent
+  outpoints in the provided UTXO map instead of cloning and converting the
+  whole map on every call, so per-transaction callers no longer perform
+  quadratic work over a block's spends
+  ([GHSA-4g24-549m-hp75](https://github.com/zakura-core/zakura/security/advisories/GHSA-4g24-549m-hp75)).
+
 ## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zakura-rpc/CHANGELOG.md
+++ b/zakura-rpc/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   external repository during a `zakura-rpc` build
   ([#206](https://github.com/zakura-core/zakura/pull/206)).
 
+### Security
+
+- `select_mempool_transactions` now reserves the serialized block header,
+  transaction count, and maximum pool-modified coinbase size before filling
+  the remaining block space, so generated block templates can no longer
+  exceed the consensus block size limit
+  ([GHSA-95m2-vx53-v2jw](https://github.com/zakura-core/zakura/security/advisories/GHSA-95m2-vx53-v2jw)).
+
 ## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for supplying a precomputed authorizing-data root
   ([#208](https://github.com/zakura-core/zakura/pull/208)).
 
+### Security
+
+- `service::check::utxo::remaining_transaction_value` now converts the block's
+  spent UTXO set once per block instead of cloning it for every transaction,
+  removing quadratic work from transparent value-pool validation that a
+  specially crafted block could exploit to stall block verification
+  ([GHSA-4g24-549m-hp75](https://github.com/zakura-core/zakura/security/advisories/GHSA-4g24-549m-hp75)).
+
 ## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly


### PR DESCRIPTION
## Motivation

The three privately disclosed security fixes merged at the end of the v1.0.1 release process shipped in the release but were never recorded in the changelogs, because they landed after the release draft was folded into `CHANGELOG.md`. They are now publicly disclosed ([release announcement](https://zakura.com/announcements/zakura-1-0-1/)), so the changelogs should describe them.

## Solution

Add `### Security` sections to the already-released sections that shipped the fixes — no code changes:

- Root `CHANGELOG.md` under `[1.0.1]`: all three fixes, linked to their advisories ([GHSA-4g24-549m-hp75](https://github.com/zakura-core/zakura/security/advisories/GHSA-4g24-549m-hp75), [GHSA-g7c4-2w6c-cr3r](https://github.com/zakura-core/zakura/security/advisories/GHSA-g7c4-2w6c-cr3r), [GHSA-95m2-vx53-v2jw](https://github.com/zakura-core/zakura/security/advisories/GHSA-95m2-vx53-v2jw)). Advisory links are used instead of PR links because these fixes were merged from private disclosure branches and have no public PRs.
- `zakura-rpc/CHANGELOG.md` under `[2.0.0]`: the `getblocktemplate` size-reservation fix.
- `zakura-state/CHANGELOG.md` under `[2.0.0]` and `zakura-chain/CHANGELOG.md` under `[1.1.0]`: the two halves of the quadratic transparent-spend validation fix, recorded under the crate version that shipped each.

The mempool misbehavior-attribution fix only touched `zakurad`, which has no crate changelog, so it appears in the root changelog only. `CHANGELOG_PARAMS.md` is untouched: the `getblocktemplate` fix adds a fixed consensus-derived byte reservation, not a re-tuning of a tunable parameter.

## Testing

Docs-only change; verified the entries against the actual fix diffs (merge commits `25f2bde04`, `00c6436c4`, `b8ebad252`) and the advisory descriptions.

### Specifications & References

- https://zakura.com/announcements/zakura-1-0-1/

🤖 Generated with [Claude Code](https://claude.com/claude-code)