### PR TITLE
chore(zcashd): update compatibility assets to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Update the embedded zcashd-compat binary and default split-container image to
+  valargroup/zcashd v1.0.1.
 - Header sync now schedules only forward ranges from the durable verified block
   tip. Startup rejects configured anchors above that base, and no longer
   backfills headers below a checkpoint anchor.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The installer can set up either standard Zakura or its
 You can run Zakura using our [Docker
 image](https://hub.docker.com/r/zakuracore/zakura/tags) or install it manually.
 The zcashd-compatible split-container mode uses the
-[zakuracore/zcashd:v1.0.0 image](https://hub.docker.com/r/zakuracore/zcashd/tags).
+[zakuracore/zcashd:v1.0.1 image](https://hub.docker.com/r/zakuracore/zcashd/tags).
 
 This command will run our latest release and sync it to the tip:
 

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -93,7 +93,7 @@ Use the sidecar `zcashd` build from
 [valargroup/zcashd](https://github.com/valargroup/zcashd). The installer and
 Zakura's embedded download both pin its release archives by SHA256. The
 split-container mode uses the
-[zakuracore/zcashd v1.0.0 image](https://hub.docker.com/r/zakuracore/zcashd/tags).
+[zakuracore/zcashd v1.0.1 image](https://hub.docker.com/r/zakuracore/zcashd/tags).
 It differs from stock `zcash/zcash` in three ways:
 
 1. **P2P sidecar mode is hard-locked.** The binary refuses to start unless

--- a/scripts/install-zakura.sh
+++ b/scripts/install-zakura.sh
@@ -41,10 +41,10 @@ ZAKURA_DOCKER_IDENTITY_DIR="/home/zebra/.zakura"
 
 MANIFEST_PATH="$REPO_ROOT/zakurad/zcashd-compat-manifest.json"
 TARGET_TRIPLE="x86_64-pc-linux-gnu"
-ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz"
-ZCASHD_RUNTIME_ARCHIVE_SHA256="b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2"
+ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/valargroup/zcashd/releases/download/v1.0.1/zcashd-zebra-compat-v1.0.1-linux-x86_64.tar.gz"
+ZCASHD_RUNTIME_ARCHIVE_SHA256="92bdb38ce3c602ebefda0ba9afb47130f9eb034012c811d0f5d159d10db247e9"
 ZCASHD_RUNTIME_ARCHIVE_MEMBER_BINARY_PATH="./bin/zcashd"
-ZCASHD_DEFAULT_DOCKER_IMAGE="zakuracore/zcashd:v1.0.0"
+ZCASHD_DEFAULT_DOCKER_IMAGE="zakuracore/zcashd:v1.0.1"
 
 INSTALL_PROFILE=""
 MODE=""

--- a/zakurad/zcashd-compat-manifest.json
+++ b/zakurad/zcashd-compat-manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "release_tag": "v1.0.0",
+  "release_tag": "v1.0.1",
   "artifacts": [
     {
       "target_triple": "x86_64-pc-linux-gnu",
-      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz",
-      "runtime_archive_sha256": "b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2",
+      "runtime_archive_url": "https://github.com/valargroup/zcashd/releases/download/v1.0.1/zcashd-zebra-compat-v1.0.1-linux-x86_64.tar.gz",
+      "runtime_archive_sha256": "92bdb38ce3c602ebefda0ba9afb47130f9eb034012c811d0f5d159d10db247e9",
       "runtime_archive_member_binary_path": "./bin/zcashd"
     }
   ]


### PR DESCRIPTION
## Motivation

Zakura's embedded zcashd compatibility manifest, installer fallback values, Docker split-container image, and documentation still referenced valargroup/zcashd v1.0.0 after v1.0.1 was released.

## Solution

- Pin the embedded compatibility manifest and installer to the v1.0.1 runtime archive and its published SHA256.
- Update the Docker split-container installer default to `zakuracore/zcashd:v1.0.1`.
- Update the README, user guide, and changelog to document the new compatibility release.

## Testing

- `markdownlint README.md book/src/user/zcashd-compat.md CHANGELOG.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics for all five changed files: no errors.
- `git diff --check main...HEAD`

Classified as low risk because this only updates release pins and documentation; Rust builds and tests were skipped under the repository's risk-based verification policy.

### Specifications & References

- https://github.com/valargroup/zcashd/releases/tag/v1.0.1