### PR TITLE
refactor(network): correlate header operations by exact identity

### DIFF
--- a/zakura-network/src/zakura/header_sync/events.rs
+++ b/zakura-network/src/zakura/header_sync/events.rs
@@ -286,25 +286,24 @@ pub enum HeaderSyncEvent {
         /// State repair generation that was resolved.
         generation: u64,
     },
-    /// State successfully committed a header range.
-    HeaderRangeCommitted {
-        /// First committed height.
-        start_height: block::Height,
-        /// New best header tip height.
+    /// State returned the durable best header tip during startup or refresh.
+    BestHeaderTipLoaded {
+        /// Durable best header tip height.
         tip_height: block::Height,
+        /// Durable best header tip hash.
+        tip_hash: block::Hash,
+    },
+    /// State successfully committed a header range.
+    HeaderRangeOperationCompleted {
+        /// Exact header-commit operation that completed.
+        operation: HeaderSyncOperationIdentity,
         /// New best header tip hash.
         tip_hash: block::Hash,
     },
     /// State rejected a previously requested range.
-    HeaderRangeCommitFailed {
-        /// Peer that supplied the failed range.
-        peer: ZakuraPeerId,
-        /// Ordered-stream generation that supplied the range.
-        session_id: u64,
-        /// First failed range height.
-        start_height: block::Height,
-        /// Failed range count.
-        count: u32,
+    HeaderRangeOperationFailed {
+        /// Exact header-commit operation that failed.
+        operation: HeaderSyncOperationIdentity,
         /// Whether state rejected peer data or hit a local resource/channel failure.
         kind: HeaderSyncCommitFailureKind,
     },
@@ -368,8 +367,9 @@ impl HeaderSyncEvent {
             Self::StateFrontiersChanged(_) => "state_frontiers_changed",
             Self::VctRootRepairRequested { .. } => "vct_root_repair_requested",
             Self::VctRootRepairResolved { .. } => "vct_root_repair_resolved",
-            Self::HeaderRangeCommitted { .. } => "header_range_committed",
-            Self::HeaderRangeCommitFailed { .. } => "header_range_commit_failed",
+            Self::BestHeaderTipLoaded { .. } => "best_header_tip_loaded",
+            Self::HeaderRangeOperationCompleted { .. } => "header_range_operation_completed",
+            Self::HeaderRangeOperationFailed { .. } => "header_range_operation_failed",
             Self::HeaderRangeResponseFinished { .. } => "header_range_response_finished",
             Self::HeaderRangeResponseReady { .. } => "header_range_response_ready",
         }
@@ -391,10 +391,8 @@ pub enum HeaderSyncAction {
     },
     /// Ask state to commit a contiguous header range.
     CommitHeaderRange {
-        /// Peer that supplied the range.
-        peer: ZakuraPeerId,
-        /// Ordered-stream generation that supplied the range.
-        session_id: u64,
+        /// Exact header-commit operation represented by this action.
+        operation: HeaderSyncOperationIdentity,
         /// Parent anchor hash for the first header.
         anchor: block::Hash,
         /// First header height.
@@ -539,6 +537,35 @@ impl HeaderSyncRequestId {
     pub fn get(self) -> u64 {
         self.0
     }
+}
+
+/// Exact identity of one outbound header-sync request.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct HeaderSyncWireRequestIdentity {
+    /// Peer that served the request.
+    pub peer: ZakuraPeerId,
+    /// Ordered-stream generation that issued the request.
+    pub session_id: u64,
+    /// Request ID allocated within that stream session.
+    pub request_id: HeaderSyncRequestId,
+}
+
+/// Kind of state operation started from a header-sync response.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum HeaderSyncOperationKind {
+    /// Commit canonical headers to state.
+    CommitHeaders,
+    /// Authenticate supplied commitment roots against canonical headers.
+    AuthenticateRoots,
+}
+
+/// Exact identity of one state operation started from a header-sync request.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct HeaderSyncOperationIdentity {
+    /// Wire request that supplied the operation payload.
+    pub wire_request: HeaderSyncWireRequestIdentity,
+    /// Operation performed on that payload.
+    pub op_kind: HeaderSyncOperationKind,
 }
 
 /// A single outbound `GetHeaders` range expected by a peer session.

--- a/zakura-network/src/zakura/header_sync/mod.rs
+++ b/zakura-network/src/zakura/header_sync/mod.rs
@@ -50,8 +50,8 @@ pub use config::{
 pub use error::{HeaderSyncStartError, HeaderSyncWireError};
 pub use events::{
     ExpectedHeadersResponse, HeaderSyncAction, HeaderSyncCommitFailureKind, HeaderSyncEvent,
-    HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMisbehavior, HeaderSyncRequestId,
-    HeaderSyncStartup,
+    HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMisbehavior, HeaderSyncOperationIdentity,
+    HeaderSyncOperationKind, HeaderSyncRequestId, HeaderSyncStartup, HeaderSyncWireRequestIdentity,
 };
 pub use reactor::spawn_header_sync_reactor;
 pub use service::HeaderSyncPeerSession;

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1,10 +1,7 @@
 use super::super::trace::{
     header_sync_trace as hs_trace, ordered_send_error_label, queue_send_trace as qs_trace,
 };
-use super::{
-    config::*, error::*, events::*, requester::*, state::*, validation::*, wire::*, work_queue::*,
-    *,
-};
+use super::{config::*, error::*, events::*, requester::*, state::*, validation::*, wire::*, *};
 use crate::zakura::{
     FrontierChange, FrontierUpdate, HeaderSyncServiceSummary, OrderedSendError,
     ServiceAdmissionDecision, ServicePeerDirection, ServicePeerSnapshot,
@@ -112,7 +109,7 @@ pub(super) fn complete_request_publication(
     if let Some(outstanding) = peer
         .outstanding
         .iter_mut()
-        .find(|outstanding| outstanding.request_id == request_id)
+        .find(|outstanding| outstanding.wire_request.request_id == request_id)
     {
         if outstanding.phase == OutstandingPhase::Publishing {
             outstanding.deadline = deadline;
@@ -225,12 +222,12 @@ impl HeaderSyncReactor {
     fn handle_requester_event(&mut self, event: HeaderRequesterEvent) -> RequesterEventOutcome {
         match event {
             HeaderRequesterEvent::Completed {
-                identity,
+                requester_id,
+                wire_request,
                 range,
-                request_id,
                 result,
             } => {
-                if !self.is_current_requester(&identity) {
+                if !self.is_current_requester(&requester_id) {
                     let metric = if result.is_ok() {
                         "sync.header.request.late_send"
                     } else {
@@ -239,9 +236,12 @@ impl HeaderSyncReactor {
                     metrics::counter!(metric).increment(1);
                     return RequesterEventOutcome::None;
                 }
+                debug_assert_eq!(wire_request.peer, requester_id.peer);
+                debug_assert_eq!(wire_request.session_id, requester_id.session_id);
+                let request_id = wire_request.request_id;
                 match result {
                     Ok(()) => {
-                        let Some(peer_state) = self.state.peers.get_mut(&identity.peer) else {
+                        let Some(peer_state) = self.state.peers.get_mut(&requester_id.peer) else {
                             return RequesterEventOutcome::None;
                         };
                         complete_request_publication(
@@ -255,19 +255,19 @@ impl HeaderSyncReactor {
                             metrics::counter!("sync.header.vct_repair.request.sent").increment(1);
                         }
                         self.trace_get_headers_sent(
-                            &identity.peer,
+                            &requester_id.peer,
                             range,
                             range.count,
                             peer_cap,
                             GetHeadersTraceMeta {
                                 request_id,
-                                session_id: identity.session_id,
+                                session_id: requester_id.session_id,
                                 stream_version: ZAKURA_HEADER_SYNC_STREAM_VERSION,
                             },
                         );
                         #[cfg(test)]
                         let _ = self.actions.try_send(HeaderSyncAction::SendMessage {
-                            peer: identity.peer,
+                            peer: requester_id.peer,
                             request_id: Some(request_id),
                             msg: HeaderSyncMessage::GetHeaders {
                                 start_height: range.start_height,
@@ -281,11 +281,11 @@ impl HeaderSyncReactor {
                         let outstanding = self
                             .state
                             .peers
-                            .get_mut(&identity.peer)
+                            .get_mut(&requester_id.peer)
                             .and_then(|peer| peer.remove_outstanding_by_request_id(request_id));
                         if let Some(outstanding) = outstanding {
                             self.retry_failed_publication(
-                                &identity.peer,
+                                &requester_id.peer,
                                 outstanding.range,
                                 outstanding.purpose,
                             );
@@ -299,10 +299,10 @@ impl HeaderSyncReactor {
                     }
                 }
             }
-            HeaderRequesterEvent::Stopped { identity } => {
-                if self.is_current_requester(&identity) {
+            HeaderRequesterEvent::Stopped { requester_id } => {
+                if self.is_current_requester(&requester_id) {
                     metrics::counter!("sync.header.requester.stopped").increment(1);
-                    self.handle_peer_disconnected(identity.peer);
+                    self.handle_peer_disconnected(requester_id.peer);
                 } else {
                     metrics::counter!("sync.header.requester.stale_stop").increment(1);
                 }
@@ -420,40 +420,23 @@ impl HeaderSyncReactor {
             HeaderSyncEvent::VctRootRepairResolved { generation } => {
                 self.handle_vct_root_repair_resolved(generation).await;
             }
-            HeaderSyncEvent::HeaderRangeCommitted {
-                start_height,
+            HeaderSyncEvent::BestHeaderTipLoaded {
                 tip_height,
                 tip_hash,
             } => {
-                self.handle_header_range_committed(start_height, tip_height, tip_hash)
+                self.handle_best_header_tip_loaded(tip_height, tip_hash)
+                    .await;
+            }
+            HeaderSyncEvent::HeaderRangeOperationCompleted {
+                operation,
+                tip_hash,
+            } => {
+                self.handle_header_range_op_completed(operation, tip_hash)
                     .await
             }
-            HeaderSyncEvent::HeaderRangeCommitFailed {
-                peer,
-                session_id,
-                start_height,
-                count,
-                kind,
-            } => {
-                if self.state.pending_commits.contains_key(&PendingCommitKey {
-                    peer: peer.clone(),
-                    session_id,
-                    start_height,
-                    count,
-                }) || (kind == HeaderSyncCommitFailureKind::InvalidPeerRange
-                    && self.is_current_session(&peer, session_id))
-                {
-                    self.handle_header_range_commit_failed(
-                        peer,
-                        session_id,
-                        start_height,
-                        count,
-                        kind,
-                    )
+            HeaderSyncEvent::HeaderRangeOperationFailed { operation, kind } => {
+                self.handle_header_range_commit_failed(operation, kind)
                     .await;
-                } else {
-                    metrics::counter!("sync.header.session.stale_completion").increment(1);
-                }
             }
             HeaderSyncEvent::HeaderRangeResponseFinished {
                 peer,
@@ -534,11 +517,11 @@ impl HeaderSyncReactor {
             .is_some_and(|state| state.session.session_id() == session_id)
     }
 
-    fn is_current_requester(&self, identity: &HeaderRequesterIdentity) -> bool {
+    fn is_current_requester(&self, requester_id: &HeaderRequesterId) -> bool {
         self.state
             .peers
-            .get(&identity.peer)
-            .is_some_and(|state| state.requester_identity.as_ref() == Some(identity))
+            .get(&requester_id.peer)
+            .is_some_and(|state| state.requester_id.as_ref() == Some(requester_id))
     }
 
     async fn handle_frontier_update(&mut self, update: FrontierUpdate) {
@@ -738,7 +721,7 @@ impl HeaderSyncReactor {
                 peer_state.last_received_status_at = None;
                 peer_state.reset_sent_status();
                 peer_state.outstanding.clear();
-                peer_state.requester_identity = None;
+                peer_state.requester_id = None;
                 peer_state.requester = None;
                 peer_state.served_headers_inflight = 0;
                 peer_state.served_header_request_ids.clear();
@@ -762,19 +745,19 @@ impl HeaderSyncReactor {
             });
         let requester_generation = self.next_requester_generation;
         self.next_requester_generation = self.next_requester_generation.wrapping_add(1).max(1);
-        let requester_identity = HeaderRequesterIdentity {
+        let requester_id = HeaderRequesterId {
             peer: peer.clone(),
             session_id: requester_session.session_id(),
             generation: requester_generation,
         };
         let requester = spawn_header_requester(
             requester_session,
-            requester_identity.clone(),
+            requester_id.clone(),
             self.requester_events_tx.clone(),
             self.startup.shutdown.clone(),
         );
         if let Some(peer_state) = self.state.peers.get_mut(&peer) {
-            peer_state.requester_identity = Some(requester_identity);
+            peer_state.requester_id = Some(requester_id);
             peer_state.requester = Some(requester);
         }
         self.publish_connectivity_metrics();
@@ -790,7 +773,7 @@ impl HeaderSyncReactor {
         self.state.parked_peers.remove(&peer);
         self.state.advisory.remove(&peer);
         self.state.schedule.forget_peer(&peer);
-        self.finish_vct_repair_attempt(&peer);
+        self.finish_current_vct_repair_attempt(&peer);
         if was_connected {
             self.publish_connectivity_metrics();
             self.trace_peer_disconnected(&peer, self.state.peers.len());
@@ -1030,12 +1013,37 @@ impl HeaderSyncReactor {
         self.schedule().await;
     }
 
-    async fn handle_header_range_committed(
+    async fn handle_best_header_tip_loaded(
         &mut self,
-        start_height: block::Height,
         tip_height: block::Height,
         tip_hash: block::Hash,
     ) {
+        if tip_height > self.state.best_header_tip {
+            self.reconcile_forward_coverage(tip_height, tip_hash);
+            self.publish_best_tip(tip_height, tip_hash, BestTipPublication::Advanced)
+                .await;
+        }
+        self.drain_buffered_with_permit(None).await;
+        self.notify_body_gaps().await;
+        self.schedule().await;
+    }
+
+    async fn handle_header_range_op_completed(
+        &mut self,
+        operation: HeaderSyncOperationIdentity,
+        tip_hash: block::Hash,
+    ) {
+        if operation.op_kind != HeaderSyncOperationKind::CommitHeaders {
+            metrics::counter!("sync.header.session.stale_completion").increment(1);
+            return;
+        }
+        let Some(pending) = self.state.pending_operations.remove(&operation) else {
+            metrics::counter!("sync.header.session.stale_completion").increment(1);
+            return;
+        };
+        let range = pending.range;
+        let start_height = range.start_height;
+        let tip_height = range.end_height();
         metrics::counter!("sync.header.range.committed").increment(1);
         self.trace_range_event(
             hs_trace::HEADER_RANGE_COMMITTED,
@@ -1044,43 +1052,13 @@ impl HeaderSyncReactor {
             None,
             None,
         );
-        let completed_repair_peer = self
-            .state
-            .repair
-            .as_ref()
-            .and_then(|repair| repair.in_flight.as_ref())
-            .filter(|repair_peer| {
-                self.state.pending_commits.iter().any(|(key, range)| {
-                    &key.peer == *repair_peer
-                        && range.priority == RangePriority::Repair
-                        && range.is_within(start_height, tip_height)
-                })
-            })
-            .cloned();
-        let completed_ranges: Vec<_> = self
-            .state
-            .pending_commits
-            .values()
-            .filter(|range| range.is_within(start_height, tip_height))
-            .copied()
-            .collect();
-        debug_assert!(
-            self.state.pending_commits.values().all(|range| {
-                range.end_height() < start_height
-                    || range.start_height > tip_height
-                    || range.is_within(start_height, tip_height)
-            }),
-            "a state commit completion covers every overlapping submitted header range in full"
-        );
-        self.state
-            .pending_commits
-            .retain(|_, range| !range.is_within(start_height, tip_height));
-        for range in completed_ranges {
-            self.state.schedule.complete(range);
-        }
-        if let Some(repair_peer) = completed_repair_peer {
+        self.state.schedule.complete(range);
+        if let RangePurpose::VctRepair { generation, .. } = pending.purpose {
+            let repair_peer = operation.wire_request.peer.clone();
             if let Some(repair) = self.state.repair.as_mut() {
-                if repair.in_flight.as_ref() == Some(&repair_peer) {
+                if repair.generation == generation
+                    && repair.in_flight.as_ref() == Some(&repair_peer)
+                {
                     // Committing the repair range finishes this peer's attempt, but does
                     // not prove the VCT root issue is fixed. Keep the repair active until
                     // the state writer reports it resolved, and free this peer slot.
@@ -1091,8 +1069,6 @@ impl HeaderSyncReactor {
         self.state
             .schedule
             .mark_range_covered(start_height, tip_height);
-        // The zakurad driver also uses this event to reload the durable best header tip at
-        // startup. In that path start==tip, so covered-range side effects are bounded.
         self.cancel_covered_outstanding();
         if tip_height > self.state.best_header_tip {
             self.publish_best_tip(tip_height, tip_hash, BestTipPublication::Advanced)
@@ -1105,12 +1081,21 @@ impl HeaderSyncReactor {
 
     async fn handle_header_range_commit_failed(
         &mut self,
-        peer: ZakuraPeerId,
-        session_id: u64,
-        start_height: block::Height,
-        count: u32,
+        operation: HeaderSyncOperationIdentity,
         kind: HeaderSyncCommitFailureKind,
     ) {
+        if operation.op_kind != HeaderSyncOperationKind::CommitHeaders {
+            metrics::counter!("sync.header.session.stale_completion").increment(1);
+            return;
+        }
+        let Some(pending) = self.state.pending_operations.remove(&operation) else {
+            metrics::counter!("sync.header.session.stale_completion").increment(1);
+            return;
+        };
+        let range = pending.range;
+        let peer = operation.wire_request.peer;
+        let start_height = range.start_height;
+        let count = range.count;
         metrics::counter!("sync.header.range.rejected").increment(1);
         self.trace_range_event(
             hs_trace::HEADER_RANGE_REJECTED,
@@ -1123,48 +1108,40 @@ impl HeaderSyncReactor {
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
                 .await;
         }
-        let key = PendingCommitKey {
-            peer: peer.clone(),
-            session_id,
-            start_height,
-            count,
-        };
-        if let Some(range) = self.state.pending_commits.remove(&key) {
-            if range.priority == RangePriority::Forward
-                && range.start_height <= self.state.best_header_tip
-            {
-                let suffix =
-                    range.suffix_after(self.state.best_header_tip, self.state.best_header_hash);
-                self.state.schedule.complete(range);
-                metrics::counter!(
-                    "sync.header.work.covered",
-                    "state" => "committing",
-                    "lane" => "forward"
-                )
-                .increment(1);
-                if let Some(suffix) = suffix {
-                    if kind == HeaderSyncCommitFailureKind::InvalidPeerRange {
-                        self.state.schedule.retry_avoiding(peer.clone(), suffix);
-                    } else {
-                        self.state.schedule.retry(suffix);
-                    }
+        if range.priority == RangePriority::Forward
+            && range.start_height <= self.state.best_header_tip
+        {
+            let suffix =
+                range.suffix_after(self.state.best_header_tip, self.state.best_header_hash);
+            self.state.schedule.complete(range);
+            metrics::counter!(
+                "sync.header.work.covered",
+                "state" => "committing",
+                "lane" => "forward"
+            )
+            .increment(1);
+            if let Some(suffix) = suffix {
+                if kind == HeaderSyncCommitFailureKind::InvalidPeerRange {
+                    self.state.schedule.retry_avoiding(peer.clone(), suffix);
+                } else {
+                    self.state.schedule.retry(suffix);
                 }
-                self.schedule().await;
-                return;
             }
-            if range.priority == RangePriority::Repair {
-                self.finish_vct_repair_attempt(&peer);
-                self.schedule().await;
-                return;
-            }
-            if kind == HeaderSyncCommitFailureKind::Local {
-                self.state.schedule.clear_assignment(range);
-            }
-            if kind == HeaderSyncCommitFailureKind::InvalidPeerRange {
-                self.state.schedule.retry_avoiding(peer.clone(), range);
-            } else {
-                self.state.schedule.retry(range);
-            }
+            self.schedule().await;
+            return;
+        }
+        if let RangePurpose::VctRepair { generation, .. } = pending.purpose {
+            self.finish_vct_repair_attempt(&peer, generation);
+            self.schedule().await;
+            return;
+        }
+        if kind == HeaderSyncCommitFailureKind::Local {
+            self.state.schedule.clear_assignment(range);
+        }
+        if kind == HeaderSyncCommitFailureKind::InvalidPeerRange {
+            self.state.schedule.retry_avoiding(peer, range);
+        } else {
+            self.state.schedule.retry(range);
         }
         self.schedule().await;
     }
@@ -1533,9 +1510,9 @@ impl HeaderSyncReactor {
         }
 
         if headers.is_empty() {
-            if matches!(outstanding.purpose, RangePurpose::VctRepair { .. }) {
+            if let RangePurpose::VctRepair { generation, .. } = outstanding.purpose {
                 self.record_advisory_unconfirmed(&peer);
-                self.finish_vct_repair_attempt(&peer);
+                self.finish_vct_repair_attempt(&peer, generation);
                 self.schedule().await;
                 return;
             }
@@ -1597,7 +1574,10 @@ impl HeaderSyncReactor {
             }
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::InvalidRange)
                 .await;
-            self.finish_vct_repair_attempt(&peer);
+            let RangePurpose::VctRepair { generation, .. } = outstanding.purpose else {
+                unreachable!("only VCT repair responses have repair validation errors");
+            };
+            self.finish_vct_repair_attempt(&peer, generation);
             self.schedule().await;
             return;
         }
@@ -1608,7 +1588,7 @@ impl HeaderSyncReactor {
             start_height: outstanding.range.start_height,
             decode_context: HeaderSyncDecodeContext::for_headers_response(
                 ExpectedHeadersResponse::new(
-                    outstanding.request_id,
+                    outstanding.wire_request.request_id,
                     outstanding.range.start_height,
                     outstanding.range.count,
                     outstanding.range.want_tree_aux_roots,
@@ -1746,12 +1726,6 @@ impl HeaderSyncReactor {
             }
         }
 
-        let session_id = self
-            .state
-            .peers
-            .get(&peer)
-            .map(|state| state.session.session_id())
-            .expect("peer exists because its response is being buffered");
         if outstanding.range.priority != RangePriority::Repair {
             self.state
                 .schedule
@@ -1760,9 +1734,9 @@ impl HeaderSyncReactor {
         self.state.buffered.insert(
             (outstanding.range.priority, outstanding.range.start_height),
             BufferedHeaderRange {
-                peer,
-                session_id,
+                wire_request: outstanding.wire_request,
                 range: outstanding.range,
+                purpose: outstanding.purpose,
                 headers,
                 body_sizes,
                 tree_aux_roots,
@@ -1809,16 +1783,19 @@ impl HeaderSyncReactor {
                 }
                 self.state
                     .schedule
-                    .retry_avoiding(buffered.peer.clone(), buffered.range);
+                    .retry_avoiding(buffered.wire_request.peer.clone(), buffered.range);
                 self.trace_range_validation_rejected(
-                    &buffered.peer,
+                    &buffered.wire_request.peer,
                     buffered.range,
                     u32::try_from(buffered.headers.len()).unwrap_or(u32::MAX),
                     "ordered_predecessor",
                     header_sync_wire_error_kind(&error),
                 );
-                self.report_misbehavior(buffered.peer, HeaderSyncMisbehavior::InvalidRange)
-                    .await;
+                self.report_misbehavior(
+                    buffered.wire_request.peer,
+                    HeaderSyncMisbehavior::InvalidRange,
+                )
+                .await;
                 continue;
             }
 
@@ -1858,28 +1835,25 @@ impl HeaderSyncReactor {
             self.state
                 .schedule
                 .narrow_queued_range(original, buffered.range);
-            let count = u32::try_from(buffered.headers.len())
-                .expect("decoded Headers length is capped by u32");
-            let commit_key = PendingCommitKey {
-                peer: buffered.peer.clone(),
-                session_id: buffered.session_id,
-                start_height: buffered.range.start_height,
-                count,
+            let operation = HeaderSyncOperationIdentity {
+                wire_request: buffered.wire_request,
+                op_kind: HeaderSyncOperationKind::CommitHeaders,
             };
             if buffered.range.priority != RangePriority::Repair {
-                self.state.schedule.mark_committing(
-                    buffered.peer.clone(),
-                    buffered.session_id,
-                    buffered.range,
-                );
+                self.state
+                    .schedule
+                    .mark_committing(operation.clone(), buffered.range);
             }
-            self.state
-                .pending_commits
-                .insert(commit_key, buffered.range);
+            self.state.pending_operations.insert(
+                operation.clone(),
+                PendingOperation {
+                    range: buffered.range,
+                    purpose: buffered.purpose,
+                },
+            );
             let lane = buffered.range.priority.label();
             permit.send(HeaderSyncAction::CommitHeaderRange {
-                peer: buffered.peer,
-                session_id: buffered.session_id,
+                operation,
                 anchor,
                 start_height: buffered.range.start_height,
                 headers: buffered.headers,
@@ -1905,9 +1879,9 @@ impl HeaderSyncReactor {
 
         if !self
             .state
-            .pending_commits
+            .pending_operations
             .values()
-            .any(|range| range.priority == RangePriority::Forward)
+            .any(|pending| pending.range.priority == RangePriority::Forward)
         {
             let start = next_height(self.state.best_header_tip)?;
             let key = (RangePriority::Forward, start);
@@ -1983,21 +1957,36 @@ impl HeaderSyncReactor {
                 .state
                 .schedule
                 .retry_avoiding(peer.clone(), outstanding.range),
-            RangePurpose::VctRepair { .. } => self.finish_vct_repair_attempt(peer),
+            RangePurpose::VctRepair { generation, .. } => {
+                self.finish_vct_repair_attempt(peer, generation)
+            }
         }
     }
 
-    fn finish_vct_repair_attempt(&mut self, peer: &ZakuraPeerId) {
+    fn finish_vct_repair_attempt(&mut self, peer: &ZakuraPeerId, generation: u64) {
         let Some(repair) = self.state.repair.as_mut() else {
             return;
         };
         let was_exhausted = repair.exhausted;
-        if !repair.finish_attempt(peer, Instant::now()) {
+        if !repair.finish_attempt(peer, generation, Instant::now()) {
             return;
         }
         if !was_exhausted && repair.exhausted {
             Self::report_vct_repair_exhausted(repair);
         }
+    }
+
+    fn finish_current_vct_repair_attempt(&mut self, peer: &ZakuraPeerId) {
+        let Some(generation) = self
+            .state
+            .repair
+            .as_ref()
+            .filter(|repair| repair.in_flight.as_ref() == Some(peer))
+            .map(|repair| repair.generation)
+        else {
+            return;
+        };
+        self.finish_vct_repair_attempt(peer, generation);
     }
 
     fn report_vct_repair_exhausted(repair: &VctRootRepair) {
@@ -2050,8 +2039,8 @@ impl HeaderSyncReactor {
             .buffered
             .retain(|(priority, _), _| *priority != RangePriority::Forward);
         self.state
-            .pending_commits
-            .retain(|_, range| range.priority != RangePriority::Forward);
+            .pending_operations
+            .retain(|_, pending| pending.range.priority != RangePriority::Forward);
         self.cancel_forward_outstanding();
         self.publish_best_tip(
             height,
@@ -2073,7 +2062,9 @@ impl HeaderSyncReactor {
                 if peer.outstanding[index].deadline <= now {
                     let outstanding = peer.outstanding.remove(index);
                     let peer_id = peer.session.peer_id().clone();
-                    let _ = peer.session.retire_expected_headers(outstanding.request_id);
+                    let _ = peer
+                        .session
+                        .retire_expected_headers(outstanding.wire_request.request_id);
                     if outstanding.phase == OutstandingPhase::Publishing {
                         peer.session.cancel_token().cancel();
                         blocked_sessions.insert(peer_id.clone());
@@ -2094,9 +2085,9 @@ impl HeaderSyncReactor {
                         .schedule
                         .retry_avoiding(peer.clone(), outstanding.range);
                 }
-                RangePurpose::VctRepair { .. } => {
+                RangePurpose::VctRepair { generation, .. } => {
                     metrics::counter!("sync.header.vct_repair.timeout").increment(1);
-                    self.finish_vct_repair_attempt(&peer);
+                    self.finish_vct_repair_attempt(&peer, generation);
                 }
             }
         }
@@ -2287,8 +2278,13 @@ impl HeaderSyncReactor {
             }
         };
         let request_id = prepared.request_id();
-        let outstanding = OutstandingRange {
+        let wire_request = HeaderSyncWireRequestIdentity {
+            peer: peer_id.clone(),
+            session_id: session.session_id(),
             request_id,
+        };
+        let outstanding = OutstandingRange {
+            wire_request: wire_request.clone(),
             range,
             deadline: Instant::now() + self.startup.request_timeout,
             purpose,
@@ -2305,7 +2301,11 @@ impl HeaderSyncReactor {
             self.state.schedule.mark_assigned(peer_id.clone(), range);
         }
 
-        let command = HeaderRequesterCommand { range, prepared };
+        let command = HeaderRequesterCommand {
+            range,
+            wire_request,
+            prepared,
+        };
         if let Err(error) = requester.try_send(command) {
             let (reason, command) = match error {
                 mpsc::error::TrySendError::Full(command) => ("requester_full", command),
@@ -2330,7 +2330,9 @@ impl HeaderSyncReactor {
     ) {
         match purpose {
             RangePurpose::Sync => self.state.schedule.retry(range),
-            RangePurpose::VctRepair { .. } => self.finish_vct_repair_attempt(peer),
+            RangePurpose::VctRepair { generation, .. } => {
+                self.finish_vct_repair_attempt(peer, generation)
+            }
         }
     }
 
@@ -2736,7 +2738,9 @@ impl HeaderSyncReactor {
                     && matches!(peer.outstanding[index].purpose, RangePurpose::Sync)
                 {
                     let outstanding = peer.outstanding.remove(index);
-                    let _ = peer.session.retire_expected_headers(outstanding.request_id);
+                    let _ = peer
+                        .session
+                        .retire_expected_headers(outstanding.wire_request.request_id);
                 } else {
                     index += 1;
                 }
@@ -2758,13 +2762,15 @@ impl HeaderSyncReactor {
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
             while index < peer.outstanding.len() {
-                let outstanding = peer.outstanding[index];
+                let outstanding = &peer.outstanding[index];
                 if matches!(outstanding.purpose, RangePurpose::Sync)
                     && outstanding.range.priority == RangePriority::Forward
                     && outstanding.range.start_height <= height
                 {
                     let outstanding = peer.outstanding.remove(index);
-                    let _ = peer.session.retire_expected_headers(outstanding.request_id);
+                    let _ = peer
+                        .session
+                        .retire_expected_headers(outstanding.wire_request.request_id);
                     self.state.schedule.clear_assignment(outstanding.range);
                     if let Some(suffix) = outstanding.range.suffix_after(height, hash) {
                         self.state.schedule.ensure_forward(suffix);
@@ -2835,7 +2841,9 @@ impl HeaderSyncReactor {
             while index < peer.outstanding.len() {
                 if peer.outstanding[index].range.priority == RangePriority::Forward {
                     let outstanding = peer.outstanding.remove(index);
-                    let _ = peer.session.retire_expected_headers(outstanding.request_id);
+                    let _ = peer
+                        .session
+                        .retire_expected_headers(outstanding.wire_request.request_id);
                 } else {
                     index += 1;
                 }

--- a/zakura-network/src/zakura/header_sync/reactor/trace.rs
+++ b/zakura-network/src/zakura/header_sync/reactor/trace.rs
@@ -6,7 +6,7 @@ use super::super::{
     error::HeaderSyncWireError,
     events::{
         HeaderSyncAction, HeaderSyncCommitFailureKind, HeaderSyncEvent, HeaderSyncMisbehavior,
-        HeaderSyncRequestId,
+        HeaderSyncOperationKind, HeaderSyncRequestId,
     },
     state::RangeRequest,
     validation::count_between,
@@ -509,32 +509,51 @@ fn trace_event_fields(row: &mut serde_json::Map<String, Value>, event: &HeaderSy
             insert_optional_str(row, hs_trace::KIND, Some("vct_root_repair_resolved"));
             insert_u64(row, "generation", *generation);
         }
-        HeaderSyncEvent::HeaderRangeCommitted {
-            start_height,
+        HeaderSyncEvent::BestHeaderTipLoaded {
             tip_height,
             tip_hash,
         } => {
-            insert_optional_str(row, hs_trace::KIND, Some("header_range_committed"));
-            insert_height(row, hs_trace::RANGE_START, *start_height);
-            insert_u64(
-                row,
-                hs_trace::RANGE_COUNT,
-                u64::from(count_between(*start_height, *tip_height)),
-            );
+            insert_optional_str(row, hs_trace::KIND, Some("best_header_tip_loaded"));
             insert_height(row, hs_trace::HEIGHT, *tip_height);
             insert_hash(row, hs_trace::HASH, *tip_hash);
         }
-        HeaderSyncEvent::HeaderRangeCommitFailed {
-            peer,
-            start_height,
-            count,
-            kind,
-            ..
+        HeaderSyncEvent::HeaderRangeOperationCompleted {
+            operation,
+            tip_hash,
         } => {
-            insert_optional_str(row, hs_trace::KIND, Some("header_range_commit_failed"));
-            insert_peer(row, hs_trace::PEER, peer);
-            insert_height(row, hs_trace::RANGE_START, *start_height);
-            insert_u64(row, hs_trace::RANGE_COUNT, u64::from(*count));
+            insert_optional_str(
+                row,
+                hs_trace::KIND,
+                Some("header_range_operation_completed"),
+            );
+            insert_peer(row, hs_trace::PEER, &operation.wire_request.peer);
+            insert_u64(row, hs_trace::SESSION_ID, operation.wire_request.session_id);
+            insert_u64(
+                row,
+                hs_trace::REQUEST_ID,
+                operation.wire_request.request_id.get(),
+            );
+            insert_optional_str(
+                row,
+                "operation_kind",
+                Some(operation_kind_label(operation.op_kind)),
+            );
+            insert_hash(row, hs_trace::HASH, *tip_hash);
+        }
+        HeaderSyncEvent::HeaderRangeOperationFailed { operation, kind } => {
+            insert_optional_str(row, hs_trace::KIND, Some("header_range_operation_failed"));
+            insert_peer(row, hs_trace::PEER, &operation.wire_request.peer);
+            insert_u64(row, hs_trace::SESSION_ID, operation.wire_request.session_id);
+            insert_u64(
+                row,
+                hs_trace::REQUEST_ID,
+                operation.wire_request.request_id.get(),
+            );
+            insert_optional_str(
+                row,
+                "operation_kind",
+                Some(operation_kind_label(operation.op_kind)),
+            );
             insert_optional_str(
                 row,
                 hs_trace::REASON,
@@ -621,13 +640,24 @@ fn trace_action_fields(row: &mut serde_json::Map<String, Value>, action: &Header
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(*count));
         }
         HeaderSyncAction::CommitHeaderRange {
-            peer,
+            operation,
             start_height,
             headers,
             ..
         } => {
             insert_optional_str(row, hs_trace::KIND, Some("commit_header_range"));
-            insert_peer(row, hs_trace::PEER, peer);
+            insert_peer(row, hs_trace::PEER, &operation.wire_request.peer);
+            insert_u64(row, hs_trace::SESSION_ID, operation.wire_request.session_id);
+            insert_u64(
+                row,
+                hs_trace::REQUEST_ID,
+                operation.wire_request.request_id.get(),
+            );
+            insert_optional_str(
+                row,
+                "operation_kind",
+                Some(operation_kind_label(operation.op_kind)),
+            );
             insert_height(row, hs_trace::RANGE_START, *start_height);
             insert_u64(row, hs_trace::RANGE_COUNT, headers.len() as u64);
         }
@@ -878,6 +908,13 @@ pub(super) fn commit_failure_reason_label(kind: HeaderSyncCommitFailureKind) -> 
     }
 }
 
+fn operation_kind_label(kind: HeaderSyncOperationKind) -> &'static str {
+    match kind {
+        HeaderSyncOperationKind::CommitHeaders => "commit_headers",
+        HeaderSyncOperationKind::AuthenticateRoots => "authenticate_roots",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -900,7 +937,8 @@ mod tests {
         header_sync::{
             events::HeaderSyncFrontiers, service::HeaderSyncPeerSession, state::RangePriority,
         },
-        HeaderSyncServiceSummary,
+        HeaderSyncOperationIdentity, HeaderSyncOperationKind, HeaderSyncServiceSummary,
+        HeaderSyncWireRequestIdentity,
     };
 
     fn peer(byte: u8) -> ZakuraPeerId {
@@ -916,6 +954,17 @@ mod tests {
 
     fn request_id() -> HeaderSyncRequestId {
         HeaderSyncRequestId::new(1).expect("test request id is non-zero")
+    }
+
+    fn operation(peer: ZakuraPeerId) -> HeaderSyncOperationIdentity {
+        HeaderSyncOperationIdentity {
+            wire_request: HeaderSyncWireRequestIdentity {
+                peer,
+                session_id: 7,
+                request_id: request_id(),
+            },
+            op_kind: HeaderSyncOperationKind::CommitHeaders,
+        }
     }
 
     fn root(height: block::Height) -> BlockCommitmentRoots {
@@ -1066,16 +1115,16 @@ mod tests {
                 expected_hashes: vec![(block::Height(5), block::Hash([5; 32]))],
             },
             HeaderSyncEvent::VctRootRepairResolved { generation: 8 },
-            HeaderSyncEvent::HeaderRangeCommitted {
-                start_height: block::Height(5),
+            HeaderSyncEvent::BestHeaderTipLoaded {
                 tip_height: block::Height(7),
                 tip_hash: block::Hash([7; 32]),
             },
-            HeaderSyncEvent::HeaderRangeCommitFailed {
-                peer: peer.clone(),
-                session_id: 7,
-                start_height: block::Height(5),
-                count: 3,
+            HeaderSyncEvent::HeaderRangeOperationCompleted {
+                operation: operation(peer.clone()),
+                tip_hash: block::Hash([7; 32]),
+            },
+            HeaderSyncEvent::HeaderRangeOperationFailed {
+                operation: operation(peer.clone()),
                 kind: HeaderSyncCommitFailureKind::InvalidPeerRange,
             },
             HeaderSyncEvent::HeaderRangeResponseFinished {
@@ -1139,8 +1188,7 @@ mod tests {
             ),
             (
                 HeaderSyncAction::CommitHeaderRange {
-                    peer: peer.clone(),
-                    session_id: 7,
+                    operation: operation(peer.clone()),
                     anchor: block::Hash([0; 32]),
                     start_height: block::Height(1),
                     headers: vec![header],
@@ -1501,12 +1549,11 @@ mod tests {
 
         assert_eq!(count_between(block::Height(3), block::Height(5)), 3);
         assert_eq!(count_between(block::Height(5), block::Height(3)), 0);
-        let committed = event_row(&HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: block::Height(3),
-            tip_height: block::Height(5),
+        let committed = event_row(&HeaderSyncEvent::HeaderRangeOperationCompleted {
+            operation: operation(peer(3)),
             tip_hash: block::Hash([5; 32]),
         });
-        assert_eq!(committed[hs_trace::RANGE_COUNT], Value::from(3));
+        assert_eq!(committed[hs_trace::REQUEST_ID], Value::from(1));
         let gaps = action_row(&HeaderSyncAction::BodyGaps {
             from: block::Height(3),
             to: block::Height(5),

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -17,11 +17,12 @@ impl HeaderRequesterHandle {
 
 pub(super) struct HeaderRequesterCommand {
     pub(super) range: RangeRequest,
+    pub(super) wire_request: HeaderSyncWireRequestIdentity,
     pub(super) prepared: PreparedGetHeaders,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) struct HeaderRequesterIdentity {
+pub(super) struct HeaderRequesterId {
     pub(super) peer: ZakuraPeerId,
     pub(super) session_id: u64,
     pub(super) generation: u64,
@@ -30,39 +31,43 @@ pub(super) struct HeaderRequesterIdentity {
 #[derive(Debug)]
 pub(super) enum HeaderRequesterEvent {
     Completed {
-        identity: HeaderRequesterIdentity,
+        requester_id: HeaderRequesterId,
+        wire_request: HeaderSyncWireRequestIdentity,
         range: RangeRequest,
-        request_id: HeaderSyncRequestId,
         result: Result<(), OrderedSendError>,
     },
     Stopped {
-        identity: HeaderRequesterIdentity,
+        requester_id: HeaderRequesterId,
     },
 }
 
 pub(super) fn spawn_header_requester(
     session: HeaderSyncPeerSession,
-    identity: HeaderRequesterIdentity,
+    requester_id: HeaderRequesterId,
     events: mpsc::UnboundedSender<HeaderRequesterEvent>,
     shutdown: CancellationToken,
 ) -> HeaderRequesterHandle {
     let (commands, receiver) = mpsc::channel(usize::from(LOCAL_MAX_HS_INFLIGHT_PER_PEER));
     tokio::spawn(run_header_requester(
-        session, identity, receiver, events, shutdown,
+        session,
+        requester_id,
+        receiver,
+        events,
+        shutdown,
     ));
     HeaderRequesterHandle { commands }
 }
 
 async fn run_header_requester(
     session: HeaderSyncPeerSession,
-    identity: HeaderRequesterIdentity,
+    requester_id: HeaderRequesterId,
     mut commands: mpsc::Receiver<HeaderRequesterCommand>,
     events: mpsc::UnboundedSender<HeaderRequesterEvent>,
     shutdown: CancellationToken,
 ) {
     let cancel = session.cancel_token();
     let _exit = HeaderRequesterExit {
-        identity: identity.clone(),
+        requester_id: requester_id.clone(),
         events: events.clone(),
     };
 
@@ -78,8 +83,12 @@ async fn run_header_requester(
                 command
             }
         };
-        let HeaderRequesterCommand { range, prepared } = command;
-        let request_id = prepared.request_id();
+        let HeaderRequesterCommand {
+            range,
+            wire_request,
+            prepared,
+        } = command;
+        debug_assert_eq!(wire_request.request_id, prepared.request_id());
         let result = tokio::select! {
             biased;
             _ = shutdown.cancelled() => return,
@@ -89,9 +98,9 @@ async fn run_header_requester(
         let transport_closed = matches!(result, Err(OrderedSendError::Closed));
         if events
             .send(HeaderRequesterEvent::Completed {
-                identity: identity.clone(),
+                requester_id: requester_id.clone(),
+                wire_request,
                 range,
-                request_id,
                 result,
             })
             .is_err()
@@ -103,14 +112,14 @@ async fn run_header_requester(
 }
 
 struct HeaderRequesterExit {
-    identity: HeaderRequesterIdentity,
+    requester_id: HeaderRequesterId,
     events: mpsc::UnboundedSender<HeaderRequesterEvent>,
 }
 
 impl Drop for HeaderRequesterExit {
     fn drop(&mut self) {
         let _ = self.events.send(HeaderRequesterEvent::Stopped {
-            identity: self.identity.clone(),
+            requester_id: self.requester_id.clone(),
         });
     }
 }
@@ -137,11 +146,22 @@ mod tests {
         }
     }
 
-    fn identity(peer: ZakuraPeerId) -> HeaderRequesterIdentity {
-        HeaderRequesterIdentity {
+    fn requester_id(peer: ZakuraPeerId) -> HeaderRequesterId {
+        HeaderRequesterId {
             peer,
             session_id: TEST_SESSION_ID,
             generation: TEST_GENERATION,
+        }
+    }
+
+    fn wire_request(
+        requester_id: &HeaderRequesterId,
+        request_id: HeaderSyncRequestId,
+    ) -> HeaderSyncWireRequestIdentity {
+        HeaderSyncWireRequestIdentity {
+            peer: requester_id.peer.clone(),
+            session_id: requester_id.session_id,
+            request_id,
         }
     }
 
@@ -177,36 +197,37 @@ mod tests {
     #[tokio::test]
     async fn prepared_request_is_published_and_completed() {
         let peer = peer(1);
-        let requester_identity = identity(peer.clone());
+        let requester_id = requester_id(peer.clone());
         let (session, mut frames, _cancel) = session(peer, 1);
         let range = range(5, 2);
         let prepared = session
             .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
             .expect("valid test request is prepared");
         let request_id = prepared.request_id();
+        let wire_request = wire_request(&requester_id, request_id);
         let (events_tx, mut events_rx) = mpsc::unbounded_channel();
         let shutdown = CancellationToken::new();
-        let requester = spawn_header_requester(
-            session,
-            requester_identity.clone(),
-            events_tx,
-            shutdown.clone(),
-        );
+        let requester =
+            spawn_header_requester(session, requester_id.clone(), events_tx, shutdown.clone());
 
         requester
-            .try_send(HeaderRequesterCommand { range, prepared })
+            .try_send(HeaderRequesterCommand {
+                range,
+                wire_request: wire_request.clone(),
+                prepared,
+            })
             .expect("requester command queue has capacity");
 
         match next_event(&mut events_rx).await {
             HeaderRequesterEvent::Completed {
-                identity,
+                requester_id: completed_requester_id,
+                wire_request: completed_wire_request,
                 range: completed_range,
-                request_id: completed_id,
                 result,
             } => {
-                assert_eq!(identity, requester_identity);
+                assert_eq!(completed_requester_id, requester_id);
                 assert_eq!(completed_range, range);
-                assert_eq!(completed_id, request_id);
+                assert_eq!(completed_wire_request, wire_request);
                 result.expect("prepared request is published");
             }
             event => panic!("unexpected requester event: {event:?}"),
@@ -228,49 +249,58 @@ mod tests {
         shutdown.cancel();
         assert!(matches!(
             next_event(&mut events_rx).await,
-            HeaderRequesterEvent::Stopped { identity } if identity == requester_identity
+            HeaderRequesterEvent::Stopped {
+                requester_id: stopped_requester_id
+            } if stopped_requester_id == requester_id
         ));
     }
 
     #[tokio::test]
     async fn closed_transport_reports_completion_failure_then_stops() {
         let peer = peer(2);
-        let requester_identity = identity(peer.clone());
+        let requester_id = requester_id(peer.clone());
         let (session, frames, _cancel) = session(peer, 1);
         let range = range(9, 1);
         let prepared = session
             .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
             .expect("valid test request is prepared");
         let request_id = prepared.request_id();
+        let wire_request = wire_request(&requester_id, request_id);
         drop(frames);
         let (events_tx, mut events_rx) = mpsc::unbounded_channel();
         let requester = spawn_header_requester(
             session,
-            requester_identity.clone(),
+            requester_id.clone(),
             events_tx,
             CancellationToken::new(),
         );
 
         requester
-            .try_send(HeaderRequesterCommand { range, prepared })
+            .try_send(HeaderRequesterCommand {
+                range,
+                wire_request: wire_request.clone(),
+                prepared,
+            })
             .expect("requester command queue has capacity");
 
         match next_event(&mut events_rx).await {
             HeaderRequesterEvent::Completed {
-                identity,
+                requester_id: completed_requester_id,
+                wire_request: completed_wire_request,
                 range: completed_range,
-                request_id: completed_id,
                 result: Err(OrderedSendError::Closed),
             } => {
-                assert_eq!(identity, requester_identity);
+                assert_eq!(completed_requester_id, requester_id);
                 assert_eq!(completed_range, range);
-                assert_eq!(completed_id, request_id);
+                assert_eq!(completed_wire_request, wire_request);
             }
             event => panic!("unexpected requester event: {event:?}"),
         }
         assert!(matches!(
             next_event(&mut events_rx).await,
-            HeaderRequesterEvent::Stopped { identity } if identity == requester_identity
+            HeaderRequesterEvent::Stopped {
+                requester_id: stopped_requester_id
+            } if stopped_requester_id == requester_id
         ));
     }
 }

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -404,11 +404,12 @@ pub(crate) async fn drive_header_sync_actions(
                     .await;
             }
             HeaderSyncAction::CommitHeaderRange {
-                peer,
+                operation,
                 start_height,
                 headers,
                 ..
             } => {
+                let peer = &operation.wire_request.peer;
                 tracing::debug!(
                     ?peer,
                     ?start_height,
@@ -813,7 +814,7 @@ mod request_id_tests {
         let (commands_tx, mut commands_rx) = mpsc::unbounded_channel();
         let peer_id = ZakuraPeerId::new(vec![5; 32]).expect("test peer id is valid");
         let session = HeaderSyncPeerSession::from_parts_with_direction_and_commands(
-            peer_id,
+            peer_id.clone(),
             1,
             ServicePeerDirection::Outbound,
             send,
@@ -838,7 +839,16 @@ mod request_id_tests {
         let (requester_tx, requester_rx) = mpsc::channel(1);
         drop(requester_rx);
 
-        let rejected = match requester_tx.try_send(HeaderRequesterCommand { range, prepared }) {
+        let wire_request = HeaderSyncWireRequestIdentity {
+            peer: peer_id,
+            session_id: 1,
+            request_id: prepared.request_id(),
+        };
+        let rejected = match requester_tx.try_send(HeaderRequesterCommand {
+            range,
+            wire_request,
+            prepared,
+        }) {
             Err(mpsc::error::TrySendError::Closed(command)) => command,
             _ => panic!("closed requester queue rejects the prepared command"),
         };

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -1,7 +1,7 @@
 use super::{
     error::*,
     events::*,
-    requester::{HeaderRequesterHandle, HeaderRequesterIdentity},
+    requester::{HeaderRequesterHandle, HeaderRequesterId},
     validation::*,
     wire::*,
     work_queue::*,
@@ -42,7 +42,7 @@ pub(super) struct HeaderSyncCore {
     pub(super) pending_new_blocks: HashSet<block::Hash>,
     pub(super) schedule: HeaderWorkQueue,
     pub(super) buffered: BTreeMap<(RangePriority, block::Height), BufferedHeaderRange>,
-    pub(super) pending_commits: HashMap<PendingCommitKey, RangeRequest>,
+    pub(super) pending_operations: HashMap<HeaderSyncOperationIdentity, PendingOperation>,
     pub(super) repair: Option<VctRootRepair>,
     pub(super) advisory: HashMap<ZakuraPeerId, HeaderSyncAdvisoryPeerState>,
     pub(super) stale_anchor: StaleAnchorFailures,
@@ -83,7 +83,7 @@ impl HeaderSyncCore {
             pending_new_blocks: HashSet::new(),
             schedule: HeaderWorkQueue::new(),
             buffered: BTreeMap::new(),
-            pending_commits: HashMap::new(),
+            pending_operations: HashMap::new(),
             repair: None,
             advisory: HashMap::new(),
             stale_anchor: StaleAnchorFailures::default(),
@@ -258,8 +258,13 @@ impl VctRootRepair {
         self.in_flight = Some(peer);
     }
 
-    pub(super) fn finish_attempt(&mut self, peer: &ZakuraPeerId, now: Instant) -> bool {
-        if self.in_flight.as_ref() != Some(peer) {
+    pub(super) fn finish_attempt(
+        &mut self,
+        peer: &ZakuraPeerId,
+        generation: u64,
+        now: Instant,
+    ) -> bool {
+        if self.generation != generation || self.in_flight.as_ref() != Some(peer) {
             return false;
         }
         self.in_flight = None;
@@ -376,7 +381,7 @@ pub(super) struct PeerHeaderState {
     /// which the peer's inbound rate limiter would otherwise treat as spam.
     pub(super) last_sent_status: Option<HeaderSyncStatus>,
     pub(super) outstanding: Vec<OutstandingRange>,
-    pub(super) requester_identity: Option<HeaderRequesterIdentity>,
+    pub(super) requester_id: Option<HeaderRequesterId>,
     pub(super) requester: Option<HeaderRequesterHandle>,
     pub(super) meters: HeaderSyncPeerMeters,
     pub(super) served_headers_inflight: u16,
@@ -406,7 +411,7 @@ impl PeerHeaderState {
             last_received_status_at: None,
             last_sent_status: None,
             outstanding: Vec::new(),
-            requester_identity: None,
+            requester_id: None,
             requester: None,
             meters: HeaderSyncPeerMeters::new(
                 status_refresh_interval,
@@ -429,7 +434,7 @@ impl PeerHeaderState {
     ) -> Option<OutstandingRange> {
         self.outstanding
             .iter()
-            .position(|outstanding| outstanding.request_id == request_id)
+            .position(|outstanding| outstanding.wire_request.request_id == request_id)
             .map(|index| self.outstanding.remove(index))
     }
 
@@ -527,9 +532,9 @@ impl HeaderSyncPeerMeters {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(super) struct OutstandingRange {
-    pub(super) request_id: HeaderSyncRequestId,
+    pub(super) wire_request: HeaderSyncWireRequestIdentity,
     pub(super) range: RangeRequest,
     pub(super) deadline: Instant,
     pub(super) purpose: RangePurpose,
@@ -545,12 +550,18 @@ pub(super) enum OutstandingPhase {
 
 #[derive(Clone, Debug)]
 pub(super) struct BufferedHeaderRange {
-    pub(super) peer: ZakuraPeerId,
-    pub(super) session_id: u64,
+    pub(super) wire_request: HeaderSyncWireRequestIdentity,
     pub(super) range: RangeRequest,
+    pub(super) purpose: RangePurpose,
     pub(super) headers: Vec<Arc<block::Header>>,
     pub(super) body_sizes: Vec<u32>,
     pub(super) tree_aux_roots: Vec<BlockCommitmentRoots>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) struct PendingOperation {
+    pub(super) range: RangeRequest,
+    pub(super) purpose: RangePurpose,
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -567,10 +578,6 @@ impl RangeRequest {
     pub(super) fn end_height(self) -> block::Height {
         range_end_height(self.start_height, self.count)
             .expect("range request is non-zero and clamped to the remaining height domain")
-    }
-
-    pub(super) fn is_within(self, start: block::Height, end: block::Height) -> bool {
-        self.start_height >= start && self.end_height() <= end
     }
 
     pub(super) fn suffix_after(

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -5,8 +5,9 @@ use super::{
     events::*,
     reactor::*,
     state::{
-        HeaderSyncCore, OutstandingPhase, OutstandingRange, RangePriority, RangePurpose,
-        RangeRequest, VctRootRepair, VCT_ROOT_REPAIR_BACKOFFS, VCT_ROOT_REPAIR_MAX_WALL_TIME,
+        HeaderSyncCore, OutstandingPhase, OutstandingRange, PendingOperation, RangePriority,
+        RangePurpose, RangeRequest, VctRootRepair, VCT_ROOT_REPAIR_BACKOFFS,
+        VCT_ROOT_REPAIR_MAX_WALL_TIME,
     },
     validation::*,
     wire::*,
@@ -384,6 +385,21 @@ fn peer(byte: u8) -> ZakuraPeerId {
     ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
 }
 
+fn commit_operation(
+    peer: ZakuraPeerId,
+    session_id: u64,
+    request_id: HeaderSyncRequestId,
+) -> HeaderSyncOperationIdentity {
+    HeaderSyncOperationIdentity {
+        wire_request: HeaderSyncWireRequestIdentity {
+            peer,
+            session_id,
+            request_id,
+        },
+        op_kind: HeaderSyncOperationKind::CommitHeaders,
+    }
+}
+
 fn node_peer() -> (ZakuraPeerId, iroh::NodeId) {
     let node_id = iroh::SecretKey::generate(OsRng).public();
     (
@@ -579,6 +595,50 @@ fn startup_uses_verified_block_tip_when_stored_header_tip_is_stale() {
         (state.best_header_tip, state.best_header_hash),
         (verified_tip, verified_hash)
     );
+}
+
+#[test]
+fn commit_and_authentication_operations_from_one_request_are_distinct() {
+    let network = regtest_network();
+    let startup = startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    );
+    let mut state = HeaderSyncCore::new(&startup).expect("test startup is coherent");
+    let wire_request = HeaderSyncWireRequestIdentity {
+        peer: peer(211),
+        session_id: 7,
+        request_id: HeaderSyncRequestId::new(9).expect("test request ID is non-zero"),
+    };
+    let commit = HeaderSyncOperationIdentity {
+        wire_request: wire_request.clone(),
+        op_kind: HeaderSyncOperationKind::CommitHeaders,
+    };
+    let authenticate = HeaderSyncOperationIdentity {
+        wire_request,
+        op_kind: HeaderSyncOperationKind::AuthenticateRoots,
+    };
+    let range = RangeRequest {
+        start_height: block::Height(1),
+        count: 1,
+        anchor_hash: Some(network.genesis_hash()),
+        finalized: false,
+        want_tree_aux_roots: true,
+        priority: RangePriority::Forward,
+    };
+
+    let pending = PendingOperation {
+        range,
+        purpose: RangePurpose::Sync,
+    };
+    state.pending_operations.insert(commit.clone(), pending);
+    state
+        .pending_operations
+        .insert(authenticate.clone(), pending);
+
+    assert_eq!(state.pending_operations.remove(&commit), Some(pending));
+    assert_eq!(state.pending_operations.get(&authenticate), Some(&pending));
 }
 
 #[tokio::test]
@@ -1793,7 +1853,7 @@ fn vct_repair_episode_enforces_attempt_and_time_bounds() {
         let peer_id = peer(120 + u8::try_from(attempt).expect("attempt fits in u8"));
         repair.mark_attempt(peer_id.clone());
         let finished_at = repair.next_attempt_at;
-        assert!(repair.finish_attempt(&peer_id, finished_at));
+        assert!(repair.finish_attempt(&peer_id, repair.generation, finished_at));
         assert_eq!(
             repair.next_attempt_at,
             finished_at + backoff,
@@ -1845,7 +1905,7 @@ fn vct_repair_maintenance_ignores_retry_deadline_during_attempt() {
 }
 
 #[test]
-fn vct_repair_ignores_unrelated_peer_disconnects() {
+fn vct_repair_ignores_unrelated_peer_and_stale_generation_completions() {
     let mut repair = VctRootRepair::new(
         block::Height(1),
         1,
@@ -1862,6 +1922,12 @@ fn vct_repair_ignores_unrelated_peer_disconnects() {
 
     assert!(!repair.finish_attempt(
         &peer(131),
+        repair.generation,
+        repair.started_at + VCT_ROOT_REPAIR_MAX_WALL_TIME
+    ));
+    assert!(!repair.finish_attempt(
+        &repair_peer,
+        repair.generation.saturating_add(1),
         repair.started_at + VCT_ROOT_REPAIR_MAX_WALL_TIME
     ));
     assert_eq!(repair.in_flight.as_ref(), Some(&repair_peer));
@@ -1919,15 +1985,16 @@ async fn vct_repair_bypasses_covered_range_and_commits_exact_h_and_successor() {
         1,
     )
     .await;
-    fixture
-        .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: block::Height(1),
-            tip_height: block::Height(4),
-            tip_hash: best.1,
-        })
-        .await
-        .unwrap();
+    for height in 1..=4 {
+        fixture
+            .handle
+            .send(HeaderSyncEvent::FullBlockCommitted {
+                height: block::Height(height),
+                hash: block::Hash([u8::try_from(height).expect("test height fits in u8"); 32]),
+            })
+            .await
+            .unwrap();
+    }
     fixture.handle.send(mainnet_repair_event(1)).await.unwrap();
 
     let (requested_peer, request_id, start_height, count) =
@@ -1953,14 +2020,14 @@ async fn vct_repair_bypasses_covered_range_and_commits_exact_h_and_successor() {
     loop {
         match next_action(&mut fixture.actions).await {
             HeaderSyncAction::CommitHeaderRange {
-                peer,
+                operation,
                 start_height,
                 headers,
                 tree_aux_roots,
                 finalized,
                 ..
             } => {
-                assert_eq!(peer, peer_id);
+                assert_eq!(operation.wire_request.peer, peer_id);
                 assert_eq!(start_height, block::Height(1));
                 assert_eq!(headers.len(), 2);
                 assert_eq!(tree_aux_roots.len(), 2);
@@ -2112,21 +2179,17 @@ async fn vct_repair_commit_failure_retries_another_peer() {
     )
     .await;
 
-    loop {
-        if matches!(
-            next_action(&mut fixture.actions).await,
-            HeaderSyncAction::CommitHeaderRange { .. }
-        ) {
-            break;
+    let operation = loop {
+        if let HeaderSyncAction::CommitHeaderRange { operation, .. } =
+            next_action(&mut fixture.actions).await
+        {
+            break operation;
         }
-    }
+    };
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-            peer: first_peer,
-            session_id: 0,
-            start_height: block::Height(1),
-            count: 2,
+        .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+            operation: operation.clone(),
             kind: HeaderSyncCommitFailureKind::Local,
         })
         .await
@@ -2327,8 +2390,8 @@ async fn stale_vct_repair_response_is_dropped_without_peer_misbehavior() {
 
     loop {
         match next_action(&mut fixture.actions).await {
-            HeaderSyncAction::CommitHeaderRange { peer, .. } => {
-                assert_eq!(peer, current_peer);
+            HeaderSyncAction::CommitHeaderRange { operation, .. } => {
+                assert_eq!(operation.wire_request.peer, current_peer);
                 break;
             }
             HeaderSyncAction::Misbehavior { peer, reason } => {
@@ -2376,19 +2439,17 @@ async fn vct_repair_generation_change_keeps_tried_peers_at_same_height() {
     )
     .await;
 
-    loop {
-        if matches!(
-            next_action(&mut fixture.actions).await,
-            HeaderSyncAction::CommitHeaderRange { .. }
-        ) {
-            break;
+    let operation = loop {
+        if let HeaderSyncAction::CommitHeaderRange { operation, .. } =
+            next_action(&mut fixture.actions).await
+        {
+            break operation;
         }
-    }
+    };
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: block::Height(1),
-            tip_height: block::Height(2),
+        .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+            operation,
             tip_hash: mainnet_block(&BLOCK_MAINNET_2_BYTES).hash(),
         })
         .await
@@ -2621,15 +2682,16 @@ async fn covered_outstanding_range_does_not_commit_late_response() {
     assert_eq!(start_height, start);
     assert_eq!(count, 2);
 
-    fixture
-        .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: start,
-            tip_height: tip,
-            tip_hash: block::Hash([2; 32]),
-        })
-        .await
-        .unwrap();
+    for height in start.0..=tip.0 {
+        fixture
+            .handle
+            .send(HeaderSyncEvent::FullBlockCommitted {
+                height: block::Height(height),
+                hash: block::Hash([u8::try_from(height).expect("test height fits in u8"); 32]),
+            })
+            .await
+            .unwrap();
+    }
 
     send_headers(
         &fixture,
@@ -2915,17 +2977,129 @@ async fn incoming_headers_match_outstanding_before_commit() {
 
     match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
-            peer,
+            operation,
             start_height,
             finalized,
             ..
         } => {
-            assert_eq!(peer, peer_id);
+            assert_eq!(
+                operation,
+                commit_operation(peer_id, 0, request_id),
+                "the commit action preserves the exact wire request identity"
+            );
             assert_eq!(start_height, start);
             assert!(!finalized);
         }
         action => panic!("unexpected action: {action:?}"),
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn only_exact_commit_operation_completion_has_side_effects() {
+    let checkpoint_hash = block::Hash::from(mainnet_header(&BLOCK_MAINNET_3_BYTES).as_ref());
+    let (network, _) = checkpoint_testnet_with_hash(block::Height(3), checkpoint_hash);
+    let start = block::Height(4);
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        Some((block::Height(3), checkpoint_hash)),
+    ));
+    let peer_id = peer(209);
+    let mut tip = fixture.handle.subscribe_tip();
+
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(&fixture, peer_id.clone(), block::Height(0), start, 1, 1).await;
+    let request_id = next_get_headers_request_id(&mut fixture.actions).await;
+    send_headers(
+        &fixture,
+        &peer_id,
+        request_id,
+        headers_message(vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]),
+    )
+    .await;
+    let exact = loop {
+        if let HeaderSyncAction::CommitHeaderRange { operation, .. } =
+            next_non_query_action(&mut fixture.actions).await
+        {
+            break operation;
+        }
+    };
+
+    let wrong_request = HeaderSyncOperationIdentity {
+        wire_request: HeaderSyncWireRequestIdentity {
+            request_id: HeaderSyncRequestId::new(
+                request_id
+                    .get()
+                    .checked_add(1)
+                    .expect("test request ID has room"),
+            )
+            .expect("incremented request ID is non-zero"),
+            ..exact.wire_request.clone()
+        },
+        op_kind: HeaderSyncOperationKind::CommitHeaders,
+    };
+    let wrong_session = HeaderSyncOperationIdentity {
+        wire_request: HeaderSyncWireRequestIdentity {
+            session_id: exact.wire_request.session_id + 1,
+            ..exact.wire_request.clone()
+        },
+        op_kind: HeaderSyncOperationKind::CommitHeaders,
+    };
+    let wrong_peer = HeaderSyncOperationIdentity {
+        wire_request: HeaderSyncWireRequestIdentity {
+            peer: peer(210),
+            ..exact.wire_request.clone()
+        },
+        op_kind: HeaderSyncOperationKind::CommitHeaders,
+    };
+    let wrong_kind = HeaderSyncOperationIdentity {
+        wire_request: exact.wire_request.clone(),
+        op_kind: HeaderSyncOperationKind::AuthenticateRoots,
+    };
+
+    for operation in [wrong_request, wrong_session, wrong_peer, wrong_kind] {
+        fixture
+            .handle
+            .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+                operation,
+                tip_hash: block::Hash([99; 32]),
+            })
+            .await
+            .unwrap();
+    }
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), tip.changed())
+            .await
+            .is_err(),
+        "wrong operation identities must not advance the tip"
+    );
+
+    let committed_hash = mainnet_block(&BLOCK_MAINNET_4_BYTES).hash();
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+            operation: exact.clone(),
+            tip_hash: committed_hash,
+        })
+        .await
+        .unwrap();
+    tip.changed().await.unwrap();
+    assert_eq!(*tip.borrow(), (start, committed_hash));
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+            operation: exact,
+            tip_hash: block::Hash([100; 32]),
+        })
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+    assert_eq!(
+        *tip.borrow(),
+        (start, committed_hash),
+        "a duplicate completion is stale and side-effect free"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -3151,7 +3325,7 @@ async fn truncated_finalized_suffix_still_checks_its_checkpoint_hash() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn invalid_async_header_commit_failure_reports_peer_disconnect() {
+async fn unmatched_async_header_commit_failure_is_ignored() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
         network.clone(),
@@ -3163,24 +3337,24 @@ async fn invalid_async_header_commit_failure_reports_peer_disconnect() {
     connect_peer(&fixture, peer_id.clone()).await;
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-            peer: peer_id.clone(),
-            session_id: 0,
-            start_height: block::Height(1),
-            count: 1,
+        .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+            operation: commit_operation(
+                peer_id.clone(),
+                0,
+                HeaderSyncRequestId::new(1).expect("test request ID is non-zero"),
+            ),
             kind: HeaderSyncCommitFailureKind::InvalidPeerRange,
         })
         .await
         .unwrap();
 
-    loop {
-        if let HeaderSyncAction::Misbehavior { peer, reason } =
-            next_non_query_action(&mut fixture.actions).await
-        {
-            assert_eq!(peer, peer_id);
-            assert_eq!(reason, HeaderSyncMisbehavior::InvalidRange);
-            break;
-        }
+    while let Ok(Some(action)) =
+        tokio::time::timeout(std::time::Duration::from_millis(50), fixture.actions.recv()).await
+    {
+        assert!(
+            !matches!(action, HeaderSyncAction::Misbehavior { .. }),
+            "an unmatched completion must not score a peer"
+        );
     }
 }
 
@@ -3315,33 +3489,30 @@ async fn local_commit_failure_retries_without_peer_misbehavior() {
         headers_message(vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]),
     )
     .await;
-    loop {
+    let operation = loop {
         match next_non_query_action(&mut fixture.actions).await {
             HeaderSyncAction::Misbehavior { .. } => {
                 panic!("valid headers must not be scored before local commit failure")
             }
             HeaderSyncAction::CommitHeaderRange {
-                peer,
+                operation,
                 start_height,
                 headers,
                 ..
             } => {
-                assert_eq!(peer, first_peer);
+                assert_eq!(operation.wire_request.peer, first_peer);
                 assert_eq!(start_height, start);
                 assert_eq!(headers.len(), 1);
-                break;
+                break operation;
             }
             _ => {}
         }
-    }
+    };
 
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-            peer: first_peer.clone(),
-            session_id: 0,
-            start_height: start,
-            count: 1,
+        .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+            operation: operation.clone(),
             kind: HeaderSyncCommitFailureKind::Local,
         })
         .await
@@ -3368,6 +3539,29 @@ async fn local_commit_failure_retries_without_peer_misbehavior() {
             }
             _ => {}
         }
+    }
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+            operation,
+            kind: HeaderSyncCommitFailureKind::Local,
+        })
+        .await
+        .unwrap();
+    while let Ok(Some(action)) =
+        tokio::time::timeout(std::time::Duration::from_millis(50), fixture.actions.recv()).await
+    {
+        assert!(
+            !matches!(
+                action,
+                HeaderSyncAction::SendMessage {
+                    msg: HeaderSyncMessage::GetHeaders { .. },
+                    ..
+                } | HeaderSyncAction::Misbehavior { .. }
+            ),
+            "a duplicate failure must not retry or score twice"
+        );
     }
 }
 
@@ -3399,8 +3593,7 @@ async fn material_tip_advance_sends_rate_limited_unsolicited_status() {
     for height in [block::Height(1), block::Height(2)] {
         fixture
             .handle
-            .send(HeaderSyncEvent::HeaderRangeCommitted {
-                start_height: height,
+            .send(HeaderSyncEvent::BestHeaderTipLoaded {
                 tip_height: height,
                 tip_hash: block::Hash(
                     [u8::try_from(height.0).expect("test heights fit in u8"); 32],
@@ -3508,7 +3701,11 @@ fn response_before_publication_completion_is_not_reinstalled() {
         priority: RangePriority::Forward,
     };
     peer_state.outstanding.push(OutstandingRange {
-        request_id,
+        wire_request: HeaderSyncWireRequestIdentity {
+            peer: peer(82),
+            session_id: 0,
+            request_id,
+        },
         range,
         deadline: Instant::now() + std::time::Duration::from_secs(1),
         purpose: RangePurpose::Sync,
@@ -4888,13 +5085,12 @@ async fn replacement_session_ignores_old_wire_response_with_reused_id() {
     loop {
         match next_non_query_action(&mut fixture.actions).await {
             HeaderSyncAction::CommitHeaderRange {
-                peer,
-                session_id,
+                operation,
                 start_height,
                 ..
             } => {
-                assert_eq!(peer, peer_id);
-                assert_eq!(session_id, 2);
+                assert_eq!(operation.wire_request.peer, peer_id);
+                assert_eq!(operation.wire_request.session_id, 2);
                 assert_eq!(start_height, block::Height(4));
                 break;
             }
@@ -5389,8 +5585,9 @@ async fn header_sync_metrics_record_status_range_new_block_dedup_and_violation()
         headers_message(vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]),
     )
     .await;
-    let committed_hash = match next_non_query_action(&mut fixture.actions).await {
+    let (operation, committed_hash) = match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
+            operation,
             start_height,
             headers,
             ..
@@ -5399,16 +5596,18 @@ async fn header_sync_metrics_record_status_range_new_block_dedup_and_violation()
                 start_height,
                 next_height(first_checkpoint).expect("checkpoint has a successor")
             );
-            block::Hash::from(headers.last().expect("one header").as_ref())
+            (
+                operation,
+                block::Hash::from(headers.last().expect("one header").as_ref()),
+            )
         }
         action => panic!("unexpected action: {action:?}"),
     };
 
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: next_height(first_checkpoint).expect("checkpoint has a successor"),
-            tip_height: next_height(first_checkpoint).expect("checkpoint has a successor"),
+        .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+            operation,
             tip_hash: committed_hash,
         })
         .await
@@ -5578,14 +5777,13 @@ async fn commit_failure_after_source_disconnect_retries_without_blocking_the_lan
         headers_message(vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]),
     )
     .await;
-    loop {
-        if matches!(
-            next_non_query_action(&mut fixture.actions).await,
-            HeaderSyncAction::CommitHeaderRange { .. }
-        ) {
-            break;
+    let operation = loop {
+        if let HeaderSyncAction::CommitHeaderRange { operation, .. } =
+            next_non_query_action(&mut fixture.actions).await
+        {
+            break operation;
         }
-    }
+    };
 
     fixture
         .handle
@@ -5594,11 +5792,8 @@ async fn commit_failure_after_source_disconnect_retries_without_blocking_the_lan
         .unwrap();
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-            peer: first_peer,
-            session_id: 0,
-            start_height: start,
-            count,
+        .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+            operation,
             kind: HeaderSyncCommitFailureKind::Local,
         })
         .await
@@ -5755,6 +5950,85 @@ async fn partial_coverage_trims_and_commits_an_already_buffered_suffix() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn loaded_best_tip_reconciles_outstanding_and_buffered_work() {
+    let network = regtest_network();
+    let mut fixture = spawn_test_reactor(startup_for(
+        network.clone(),
+        (block::Height(0), network.genesis_hash()),
+        None,
+    ));
+    let peer_id = peer(214);
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(
+        &fixture,
+        peer_id.clone(),
+        block::Height(0),
+        block::Height(4),
+        2,
+        2,
+    )
+    .await;
+
+    let mut requests = HashMap::new();
+    while requests.len() < 2 {
+        let (_, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+        assert_eq!(count, 2);
+        requests.insert(start, request_id);
+    }
+    let covered_request_id = requests[&block::Height(1)];
+    send_headers(
+        &fixture,
+        &peer_id,
+        requests[&block::Height(3)],
+        headers_message_from(
+            block::Height(3),
+            vec![
+                mainnet_header(&BLOCK_MAINNET_3_BYTES),
+                mainnet_header(&BLOCK_MAINNET_4_BYTES),
+            ],
+        ),
+    )
+    .await;
+
+    fixture
+        .handle
+        .send(HeaderSyncEvent::BestHeaderTipLoaded {
+            tip_height: block::Height(3),
+            tip_hash: mainnet_block(&BLOCK_MAINNET_3_BYTES).hash(),
+        })
+        .await
+        .unwrap();
+
+    loop {
+        if let HeaderSyncAction::CommitHeaderRange {
+            start_height,
+            headers,
+            ..
+        } = next_non_query_action(&mut fixture.actions).await
+        {
+            assert_eq!(start_height, block::Height(4));
+            assert_eq!(headers, vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
+            break;
+        }
+    }
+
+    send_headers(
+        &fixture,
+        &peer_id,
+        covered_request_id,
+        headers_message_from(
+            block::Height(1),
+            vec![
+                mainnet_header(&BLOCK_MAINNET_1_BYTES),
+                mainnet_header(&BLOCK_MAINNET_2_BYTES),
+            ],
+        ),
+    )
+    .await;
+    assert_no_commit_or_misbehavior(&mut fixture.actions).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn partially_covered_failed_commit_requeues_its_uncovered_suffix() {
     let headers = [
         mainnet_header(&BLOCK_MAINNET_1_BYTES),
@@ -5779,7 +6053,7 @@ async fn partially_covered_failed_commit_requeues_its_uncovered_suffix() {
         1,
     )
     .await;
-    let (_, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+    let (_, request_id, _start, _count) = next_outbound_get_headers(&mut fixture.actions).await;
     send_headers(
         &fixture,
         &peer_id,
@@ -5787,14 +6061,13 @@ async fn partially_covered_failed_commit_requeues_its_uncovered_suffix() {
         finalized_headers_message(headers.to_vec()),
     )
     .await;
-    loop {
-        if matches!(
-            next_non_query_action(&mut fixture.actions).await,
-            HeaderSyncAction::CommitHeaderRange { .. }
-        ) {
-            break;
+    let operation = loop {
+        if let HeaderSyncAction::CommitHeaderRange { operation, .. } =
+            next_non_query_action(&mut fixture.actions).await
+        {
+            break operation;
         }
-    }
+    };
     fixture
         .handle
         .send(HeaderSyncEvent::FullBlockCommitted {
@@ -5805,11 +6078,8 @@ async fn partially_covered_failed_commit_requeues_its_uncovered_suffix() {
         .unwrap();
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-            peer: peer_id,
-            session_id: 0,
-            start_height: start,
-            count,
+        .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+            operation,
             kind: HeaderSyncCommitFailureKind::Local,
         })
         .await
@@ -5932,22 +6202,20 @@ async fn ordered_drain_rejects_a_buffered_range_on_the_wrong_fork() {
         ),
     )
     .await;
-    loop {
-        if matches!(
-            next_non_query_action(&mut fixture.actions).await,
-            HeaderSyncAction::CommitHeaderRange {
-                start_height: block::Height(1),
-                ..
-            }
-        ) {
-            break;
+    let operation = loop {
+        if let HeaderSyncAction::CommitHeaderRange {
+            operation,
+            start_height: block::Height(1),
+            ..
+        } = next_non_query_action(&mut fixture.actions).await
+        {
+            break operation;
         }
-    }
+    };
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: block::Height(1),
-            tip_height: block::Height(1),
+        .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+            operation,
             tip_hash: block::Hash::from(mainnet_header(&BLOCK_MAINNET_1_BYTES).as_ref()),
         })
         .await
@@ -6035,13 +6303,13 @@ async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
     tokio::task::yield_now().await;
     for _ in 0..129 {
         if let HeaderSyncAction::CommitHeaderRange {
-            peer,
+            operation,
             start_height,
             headers,
             ..
         } = next_action(&mut fixture.actions).await
         {
-            assert_eq!(peer, source);
+            assert_eq!(operation.wire_request.peer, source);
             assert_eq!(start_height, block::Height(4));
             assert_eq!(headers.len(), 1);
             assert_no_commit_or_misbehavior(&mut fixture.actions).await;
@@ -6277,17 +6545,22 @@ fn work_queue_transitions_have_one_explicit_owner() {
         queue.state(range),
         Some(HeaderWorkState::Buffered { peer }) if peer == &owner
     ));
-    queue.mark_committing(owner.clone(), 7, range);
+    let operation = commit_operation(
+        owner.clone(),
+        7,
+        HeaderSyncRequestId::new(1).expect("test request ID is non-zero"),
+    );
+    queue.mark_committing(operation.clone(), range);
     assert!(matches!(
         queue.state(range),
-        Some(HeaderWorkState::Committing { peer, session_id: 7 }) if peer == &owner
+        Some(HeaderWorkState::Committing { operation: active }) if active == &operation
     ));
     queue.complete(range);
     assert!(queue.state(range).is_none());
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn committed_range_updates_best_tip_watch_and_does_not_advance_finality() {
+async fn loaded_best_tip_updates_tip_watch_and_does_not_advance_finality() {
     let network = regtest_network();
     let fixture = spawn_test_reactor(startup_for(
         network.clone(),
@@ -6299,8 +6572,7 @@ async fn committed_range_updates_best_tip_watch_and_does_not_advance_finality() 
 
     fixture
         .handle
-        .send(HeaderSyncEvent::HeaderRangeCommitted {
-            start_height: block::Height(1),
+        .send(HeaderSyncEvent::BestHeaderTipLoaded {
             tip_height: block::Height(1),
             tip_hash,
         })
@@ -6506,13 +6778,14 @@ async fn forward_genesis_backfill_reaches_checkpoint_before_finalized_commit() {
 
     match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
-            peer,
+            operation,
             start_height,
             headers,
             finalized,
             ..
         } => {
-            assert_eq!(peer, peer_id);
+            assert_eq!(operation.wire_request.peer, peer_id);
+            assert_eq!(operation.wire_request.request_id, request_id);
             assert_eq!(start_height, block::Height(1));
             assert_eq!(headers.len(), 3);
             assert!(finalized);
@@ -6559,13 +6832,14 @@ async fn truncated_finalized_backfill_commits_valid_prefix_and_requeues_suffix()
 
     match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
-            peer,
+            operation,
             start_height,
             headers,
             finalized,
             ..
         } => {
-            assert_eq!(peer, peer_id);
+            assert_eq!(operation.wire_request.peer, peer_id);
+            assert_eq!(operation.wire_request.request_id, request_id);
             assert_eq!(start_height, block::Height(1));
             assert_eq!(headers.len(), 2);
             assert!(finalized);

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -25,19 +25,17 @@ impl HeaderHashDedup {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(super) struct PendingCommitKey {
-    pub(super) peer: ZakuraPeerId,
-    pub(super) session_id: u64,
-    pub(super) start_height: block::Height,
-    pub(super) count: u32,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) enum HeaderWorkState {
-    InFlight { peer: ZakuraPeerId },
-    Buffered { peer: ZakuraPeerId },
-    Committing { peer: ZakuraPeerId, session_id: u64 },
+    InFlight {
+        peer: ZakuraPeerId,
+    },
+    Buffered {
+        peer: ZakuraPeerId,
+    },
+    Committing {
+        operation: HeaderSyncOperationIdentity,
+    },
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -154,17 +152,13 @@ impl HeaderWorkQueue {
 
     pub(super) fn mark_committing(
         &mut self,
-        peer: ZakuraPeerId,
-        session_id: u64,
+        operation: HeaderSyncOperationIdentity,
         range: RangeRequest,
     ) {
-        let previous = self.active.insert(
-            range,
-            HeaderWorkState::Committing {
-                peer: peer.clone(),
-                session_id,
-            },
-        );
+        let peer = operation.wire_request.peer.clone();
+        let previous = self
+            .active
+            .insert(range, HeaderWorkState::Committing { operation });
         debug_assert!(
             matches!(previous, Some(HeaderWorkState::Buffered { peer: owner }) if owner == peer),
             "only buffered header work can enter state commit"
@@ -492,6 +486,17 @@ mod tests {
         ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
     }
 
+    fn operation(peer: ZakuraPeerId, session_id: u64) -> HeaderSyncOperationIdentity {
+        HeaderSyncOperationIdentity {
+            wire_request: HeaderSyncWireRequestIdentity {
+                peer,
+                session_id,
+                request_id: HeaderSyncRequestId::new(1).expect("test request ID is non-zero"),
+            },
+            op_kind: HeaderSyncOperationKind::CommitHeaders,
+        }
+    }
+
     fn range(start: u32, count: u32, priority: RangePriority) -> RangeRequest {
         RangeRequest {
             start_height: block::Height(start),
@@ -677,7 +682,8 @@ mod tests {
         queue.mark_assigned(owner.clone(), in_flight);
         queue.mark_assigned(owner.clone(), committing);
         queue.mark_buffered(owner.clone(), committing);
-        queue.mark_committing(owner, 7, committing);
+        let operation = operation(owner, 7);
+        queue.mark_committing(operation.clone(), committing);
 
         queue.mark_range_covered(block::Height(1), block::Height(2));
         queue.mark_height_covered(block::Height(3));
@@ -693,7 +699,7 @@ mod tests {
         assert!(queue.state(in_flight).is_none());
         assert!(matches!(
             queue.state(committing),
-            Some(HeaderWorkState::Committing { session_id: 7, .. })
+            Some(HeaderWorkState::Committing { operation: active }) if active == &operation
         ));
 
         queue.ensure_forward(pending);
@@ -715,7 +721,8 @@ mod tests {
         queue.mark_buffered(forgotten.clone(), buffered);
         queue.mark_assigned(forgotten.clone(), committing);
         queue.mark_buffered(forgotten.clone(), committing);
-        queue.mark_committing(forgotten.clone(), 9, committing);
+        let committing_operation = operation(forgotten.clone(), 9);
+        queue.mark_committing(committing_operation.clone(), committing);
         queue.mark_assigned(other.clone(), other_in_flight);
         queue.retry_avoidance.insert(
             forgotten.clone(),
@@ -737,7 +744,7 @@ mod tests {
         ));
         assert!(matches!(
             queue.state(committing),
-            Some(HeaderWorkState::Committing { peer, session_id: 9 }) if peer == &forgotten
+            Some(HeaderWorkState::Committing { operation }) if operation == &committing_operation
         ));
         assert!(matches!(
             queue.state(other_in_flight),

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -155,12 +155,12 @@ mod tests {
             BlockSyncStatus, DiscoveryMessage, Frame, FramedRecv, FramedSend, HeaderSyncAction,
             HeaderSyncCommitFailureKind, HeaderSyncDecodeContext, HeaderSyncEvent,
             HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMessage, HeaderSyncMisbehavior,
-            HeaderSyncPeerSession, HeaderSyncRequestId, HeaderSyncStartup, HeaderSyncStatus, Peer,
-            Service, ServicePeerLimits, Stream, ZakuraBlockSyncConfig, ZakuraConnId,
-            ZakuraHeaderSyncConfig, ZakuraLocalLimits, ZakuraTrace, MAX_BS_RESPONSE_BYTES,
-            ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC, ZAKURA_CAP_LEGACY_GOSSIP,
-            ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_STREAM_DISCOVERY, ZAKURA_STREAM_GOSSIP,
-            ZAKURA_STREAM_HEADER_SYNC,
+            HeaderSyncOperationIdentity, HeaderSyncPeerSession, HeaderSyncRequestId,
+            HeaderSyncStartup, HeaderSyncStatus, Peer, Service, ServicePeerLimits, Stream,
+            ZakuraBlockSyncConfig, ZakuraConnId, ZakuraHeaderSyncConfig, ZakuraLocalLimits,
+            ZakuraTrace, MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
+            ZAKURA_CAP_LEGACY_GOSSIP, ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_STREAM_DISCOVERY,
+            ZAKURA_STREAM_GOSSIP, ZAKURA_STREAM_HEADER_SYNC,
         },
         Config,
     };
@@ -1022,22 +1022,20 @@ mod tests {
                     }
                 }
                 HeaderSyncAction::CommitHeaderRange {
-                    peer,
-                    session_id,
+                    operation,
                     anchor,
                     start_height,
                     headers,
                     finalized,
                     ..
                 } => {
-                    let count = u32::try_from(headers.len()).unwrap_or(u32::MAX);
                     let result = local
                         .store
                         .lock()
                         .expect("test store mutex is not poisoned")
                         .commit_headers(anchor, start_height, headers, finalized);
                     match result {
-                        Ok((tip_height, tip_hash)) => {
+                        Ok((_tip_height, tip_hash)) => {
                             let frontiers = local
                                 .store
                                 .lock()
@@ -1045,9 +1043,8 @@ mod tests {
                                 .frontiers();
                             let _ = local
                                 .handle
-                                .send(HeaderSyncEvent::HeaderRangeCommitted {
-                                    start_height,
-                                    tip_height,
+                                .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+                                    operation,
                                     tip_hash,
                                 })
                                 .await;
@@ -1059,13 +1056,7 @@ mod tests {
                         Err(kind) => {
                             let _ = local
                                 .handle
-                                .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-                                    peer,
-                                    session_id,
-                                    start_height,
-                                    count,
-                                    kind,
-                                })
+                                .send(HeaderSyncEvent::HeaderRangeOperationFailed { operation, kind })
                                 .await;
                         }
                     }
@@ -1078,8 +1069,7 @@ mod tests {
                         .best_header_tip();
                     let _ = local
                         .handle
-                        .send(HeaderSyncEvent::HeaderRangeCommitted {
-                            start_height: tip_height,
+                        .send(HeaderSyncEvent::BestHeaderTipLoaded {
                             tip_height,
                             tip_hash,
                         })
@@ -1348,8 +1338,7 @@ mod tests {
 
     #[derive(Debug)]
     struct ControlledHeaderCommit {
-        peer: ZakuraPeerId,
-        session_id: u64,
+        operation: HeaderSyncOperationIdentity,
         anchor: block::Hash,
         start_height: block::Height,
         headers: Vec<Arc<block::Header>>,
@@ -1405,16 +1394,14 @@ mod tests {
             loop {
                 match actions.recv().await {
                     Some(HeaderSyncAction::CommitHeaderRange {
-                        peer,
-                        session_id,
+                        operation,
                         anchor,
                         start_height,
                         headers,
                         ..
                     }) => {
                         return Ok(ControlledHeaderCommit {
-                            peer,
-                            session_id,
+                            operation,
                             anchor,
                             start_height,
                             headers,
@@ -1550,23 +1537,13 @@ mod tests {
                             })
                             .await;
                     }
-                    HeaderSyncAction::CommitHeaderRange {
-                        peer,
-                        session_id,
-                        start_height,
-                        headers,
-                        ..
-                    } => {
+                    HeaderSyncAction::CommitHeaderRange { operation, .. } => {
                         let Some(handle) = endpoint.header_sync() else {
                             continue;
                         };
-                        let count = u32::try_from(headers.len()).unwrap_or(u32::MAX);
                         let _ = handle
-                            .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-                                peer,
-                                session_id,
-                                start_height,
-                                count,
+                            .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+                                operation,
                                 kind: HeaderSyncCommitFailureKind::Local,
                             })
                             .await;
@@ -2859,8 +2836,8 @@ mod tests {
 
         for expected_start in [block::Height(1), block::Height(3)] {
             let commit = next_controlled_header_commit(&mut actions).await?;
-            assert_eq!(commit.peer, hostile_id);
-            assert_ne!(commit.session_id, 0);
+            assert_eq!(commit.operation.wire_request.peer, hostile_id);
+            assert_ne!(commit.operation.wire_request.session_id, 0);
             assert_eq!(commit.start_height, expected_start);
             let expected_anchor = if commit.start_height == block::Height(1) {
                 mainnet_genesis_hash()
@@ -2877,11 +2854,6 @@ mod tests {
                 ),
                 commit.start_height
             );
-            let tip_height = block::Height(
-                commit.start_height.0
-                    + u32::try_from(commit.headers.len()).expect("test header count fits u32")
-                    - 1,
-            );
             let tip_hash = commit
                 .headers
                 .last()
@@ -2890,9 +2862,8 @@ mod tests {
             victim
                 .header_sync()
                 .expect("header-sync handle is enabled")
-                .send(HeaderSyncEvent::HeaderRangeCommitted {
-                    start_height: commit.start_height,
-                    tip_height,
+                .send(HeaderSyncEvent::HeaderRangeOperationCompleted {
+                    operation: commit.operation,
                     tip_hash,
                 })
                 .await?;

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -1056,7 +1056,10 @@ mod tests {
                         Err(kind) => {
                             let _ = local
                                 .handle
-                                .send(HeaderSyncEvent::HeaderRangeOperationFailed { operation, kind })
+                                .send(HeaderSyncEvent::HeaderRangeOperationFailed {
+                                    operation,
+                                    kind,
+                                })
                                 .await;
                         }
                     }

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -16,8 +16,8 @@ use zakura_chain::{
 };
 use zakura_network::zakura::{
     commit_state_trace as cs_trace, BlockSyncFrontiers, Frontier, FrontierChange, HeaderSyncAction,
-    HeaderSyncCommitFailureKind, HeaderSyncEvent, HeaderSyncFrontiers, ZakuraEndpoint,
-    ZakuraHeaderSyncDriverStartup, ZakuraTrace, DEFAULT_HS_RANGE,
+    HeaderSyncCommitFailureKind, HeaderSyncEvent, HeaderSyncFrontiers, HeaderSyncOperationIdentity,
+    ZakuraEndpoint, ZakuraHeaderSyncDriverStartup, ZakuraTrace, DEFAULT_HS_RANGE,
 };
 
 #[cfg(test)]
@@ -176,6 +176,68 @@ pub(crate) fn block_roots_cover_range(
             .checked_add(offset)
             .is_some_and(|height| roots.height == block::Height(height))
     })
+}
+
+fn header_range_committed(
+    operation: HeaderSyncOperationIdentity,
+    tip_hash: block::Hash,
+) -> HeaderSyncEvent {
+    HeaderSyncEvent::HeaderRangeOperationCompleted {
+        operation,
+        tip_hash,
+    }
+}
+
+fn header_range_commit_failed(
+    operation: HeaderSyncOperationIdentity,
+    kind: HeaderSyncCommitFailureKind,
+) -> HeaderSyncEvent {
+    HeaderSyncEvent::HeaderRangeOperationFailed { operation, kind }
+}
+
+#[cfg(test)]
+mod operation_identity_tests {
+    use super::*;
+    use zakura_network::zakura::{
+        HeaderSyncOperationKind, HeaderSyncRequestId, HeaderSyncWireRequestIdentity, ZakuraPeerId,
+    };
+
+    fn operation() -> HeaderSyncOperationIdentity {
+        HeaderSyncOperationIdentity {
+            wire_request: HeaderSyncWireRequestIdentity {
+                peer: ZakuraPeerId::new(vec![1; 32]).expect("test peer ID is valid"),
+                session_id: 7,
+                request_id: HeaderSyncRequestId::new(9).expect("test request ID is non-zero"),
+            },
+            op_kind: HeaderSyncOperationKind::CommitHeaders,
+        }
+    }
+
+    #[test]
+    fn commit_completion_events_echo_exact_operation_identity() {
+        let operation = operation();
+        let tip_hash = block::Hash([3; 32]);
+        assert!(matches!(
+            header_range_committed(operation.clone(), tip_hash),
+            HeaderSyncEvent::HeaderRangeOperationCompleted {
+                operation: echoed,
+                tip_hash: echoed_hash,
+            } if echoed == operation && echoed_hash == tip_hash
+        ));
+
+        for kind in [
+            HeaderSyncCommitFailureKind::InvalidPeerRange,
+            HeaderSyncCommitFailureKind::Local,
+        ] {
+            assert!(matches!(
+                header_range_commit_failed(operation.clone(), kind),
+                HeaderSyncEvent::HeaderRangeOperationFailed {
+                    operation: echoed,
+                    kind: echoed_kind,
+                } if echoed == operation && echoed_kind == kind
+            ));
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -851,8 +913,7 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
                 }
             }
             HeaderSyncAction::CommitHeaderRange {
-                peer,
-                session_id,
+                operation,
                 anchor,
                 start_height,
                 headers,
@@ -860,6 +921,7 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
                 tree_aux_roots,
                 finalized: _finalized,
             } => {
+                let peer = operation.wire_request.peer.clone();
                 let count = u32::try_from(headers.len()).unwrap_or(u32::MAX);
                 let tree_aux_roots_len = u32::try_from(tree_aux_roots.len()).unwrap_or(u32::MAX);
                 emit_commit_state(
@@ -913,11 +975,7 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
                             block::Height(start_height.0.saturating_add(count.saturating_sub(1)));
                         let _ = handles
                             .header_sync
-                            .send(HeaderSyncEvent::HeaderRangeCommitted {
-                                start_height,
-                                tip_height,
-                                tip_hash,
-                            })
+                            .send(header_range_committed(operation, tip_hash))
                             .await;
                         trace_header_reactor_event(
                             &trace,
@@ -960,13 +1018,10 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
                         );
                         let _ = handles
                             .header_sync
-                            .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-                                peer,
-                                session_id,
-                                start_height,
-                                count,
-                                kind: HeaderSyncCommitFailureKind::Local,
-                            })
+                            .send(header_range_commit_failed(
+                                operation,
+                                HeaderSyncCommitFailureKind::Local,
+                            ))
                             .await;
                     }
                     Err(error) => {
@@ -1017,13 +1072,7 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
                         );
                         let _ = handles
                             .header_sync
-                            .send(HeaderSyncEvent::HeaderRangeCommitFailed {
-                                peer,
-                                session_id,
-                                start_height,
-                                count,
-                                kind,
-                            })
+                            .send(header_range_commit_failed(operation, kind))
                             .await;
                     }
                 }
@@ -1080,8 +1129,7 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
                         );
                         let _ = handles
                             .header_sync
-                            .send(HeaderSyncEvent::HeaderRangeCommitted {
-                                start_height: tip_height,
+                            .send(HeaderSyncEvent::BestHeaderTipLoaded {
                                 tip_height,
                                 tip_hash,
                             })
@@ -1757,13 +1805,13 @@ fn trace_header_driver_action(trace: &ZakuraTrace, action: &HeaderSyncAction) {
         "header_sync_driver",
         |row| match action {
             HeaderSyncAction::CommitHeaderRange {
-                peer,
+                operation,
                 start_height,
                 headers,
                 ..
             } => {
                 insert_cs_str(row, cs_trace::ACTION, "commit_header_range");
-                insert_cs_peer(row, cs_trace::PEER, peer);
+                insert_cs_peer(row, cs_trace::PEER, &operation.wire_request.peer);
                 insert_cs_height(row, cs_trace::RANGE_START, *start_height);
                 insert_cs_u64(row, cs_trace::RANGE_COUNT, headers.len() as u64);
             }


### PR DESCRIPTION
## Motivation

Header-sync state completions were correlated using peer/session/range geometry. That relies on implicit serialization and cannot safely distinguish retries from the separate header-commit and root-authentication operations that can originate in a single wire response.

This sets up work for further integration of the vct auth roots: https://github.com/zakura-core/zakura/pull/230

## Solution

### 1. Split HeaderRangeCommitted

Split the old `HeaderRangeCommitted` path because it represented two semantically different events:

- `BestHeaderTipLoaded`: state reports its durable tip during startup/refresh. No reactor-owned operation completed.
- `HeaderRangeOperationCompleted`: a specific submitted commit completed, identified by peer, session, request ID, and operation kind.

### 2. Add `operation` field to `CommitHeaderRange`

In a future PR, we will utilize the same path for root auth and committing.

### 3. Introduced exact end-to-end identities for wire requests and state operation

This will allow detailed peer attribution with peers in the future.

Makes commit success/failure affect only the exact matching pending operation, preventing stale or overlapping events from corrupting scheduling.


### Specifications & References

https://github.com/zakura-core/zakura/pull/230
