### PR TITLE
fix(tests): bound non-blocking logger shutdown

### DIFF
--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -1756,11 +1756,9 @@ async fn rpc_endpoint_client_content_type() -> Result<()> {
 #[test]
 #[cfg(not(target_os = "macos"))]
 fn non_blocking_logger() -> Result<()> {
-    use futures::FutureExt;
-    use std::{sync::mpsc, time::Duration};
+    use std::time::Duration;
 
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let (done_tx, done_rx) = mpsc::channel();
 
     let test_task_handle: tokio::task::JoinHandle<Result<()>> = rt.spawn(async move {
         let mut config = os_assigned_rpc_port_config(false, &Mainnet)?;
@@ -1797,20 +1795,19 @@ fn non_blocking_logger() -> Result<()> {
             .assert_was_killed()
             .wrap_err("Possible port conflict. Are there other acceptance tests running?")?;
 
-        done_tx.send(())?;
-
         Ok(())
     });
 
-    // Wait until the spawned task finishes up to 45 seconds before shutting down tokio runtime
-    if done_rx.recv_timeout(Duration::from_secs(90)).is_ok() {
-        rt.shutdown_timeout(Duration::from_secs(3));
-    }
+    let test_result = rt.block_on(tokio::time::timeout(
+        Duration::from_secs(90),
+        test_task_handle,
+    ));
+    rt.shutdown_timeout(Duration::from_secs(3));
 
-    match test_task_handle.now_or_never() {
-        Some(Ok(result)) => result,
-        Some(Err(error)) => Err(eyre!("join error: {:?}", error)),
-        None => Err(eyre!("unexpected test task hang")),
+    match test_result {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => Err(eyre!("join error: {:?}", error)),
+        Err(_) => Err(eyre!("unexpected test task hang")),
     }
 }
 


### PR DESCRIPTION
## Motivation

The Linux-only `non_blocking_logger` acceptance test can fail while waiting for the RPC endpoint. Its error path never sends the completion signal, so the Tokio runtime is not explicitly shut down and can keep the test process alive until nextest kills it at 240 seconds.

## Solution

Await the spawned test task with a 90-second Tokio timeout, preserve completed task and join errors, and always shut down the runtime with a bounded three-second grace period. A stalled node task now returns an explicit test error instead of hanging the test process.

## Testing

- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- IDE diagnostics checked; the only warning is a pre-existing macOS-only unused import elsewhere in the acceptance test
- The affected test is excluded on macOS, so execution is delegated to Linux CI

### Specifications & References

- Reproduced in [PR #247's unit-test job](https://github.com/zakura-core/zakura/actions/runs/29623957884/job/88024520949?pr=247)