### PR TITLE
feat(state): accelerate VCT artifact generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Accelerate offline VCT Sprout-history artifact generation with parallel
+  sequential RocksDB scans, stronger block-body audits, progress reporting, and
+  resumable shard checkpoints.
 - Update the embedded zcashd-compat binary and default split-container image to
   valargroup/zcashd v1.0.1.
 - Header sync now schedules only forward ranges from the durable verified block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Add `zakurad validate-vct-sprout-history` to audit repaired historical
+  Sprout anchors in archive or pruned Mainnet state databases.
+
 ### Fixed
 
 - Database format upgrades now finish before startup exposes the finalized

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -882,6 +882,29 @@ cargo run -p zakura-state --bin generate-vct-sprout-artifact -- \
   /path/to/zakura-cache /path/to/vct-sprout-history.bin
 ```
 
+The generator scans height-keyed RocksDB column families in contiguous shards instead of
+performing point reads at every height. Transactions are decoded in parallel, but candidate
+records are merged by height and Sprout commitments are replayed by one ordered reducer. It also
+checks transaction locations and stored transaction hashes, and recomputes each block's
+transaction Merkle root against its canonical header.
+
+For maximum throughput, copy a stopped archive database to local NVMe and give the generator
+enough shards and workers to saturate the device and available CPU:
+
+```console
+cargo run --release -p zakura-state --bin generate-vct-sprout-artifact -- \
+  /local-nvme/zakura-cache /output/vct-sprout-history.bin \
+  --shards 16 --workers 32 --readahead-mib 32 \
+  --checkpoint-dir /local-nvme/vct-sprout-progress
+```
+
+Completed height shards are written atomically to the checkpoint directory. After interruption,
+repeat the same command with `--resume`. The manifest binds progress to the source path, database
+format, handoff identity, and exact shard boundaries; incompatible or corrupt progress is
+rejected. Checkpoints are local recovery data, not trusted runtime artifacts. Final output is
+always rebuilt by an ordered merge and passed through the production artifact decoder and
+canonical/handoff validation. The output path retains no-clobber semantics.
+
 Reviewers must reproduce and compare the emitted bytes, SHA-256 digest, terminal root, and
 handoff identity before changing `MAINNET_ARTIFACT`. Running the tool never installs or enables
 its output.

--- a/zakura-state/src/bin/generate-vct-sprout-artifact.rs
+++ b/zakura-state/src/bin/generate-vct-sprout-artifact.rs
@@ -7,12 +7,15 @@ use std::{
     io::{self, Write},
     path::{Path, PathBuf},
     process::ExitCode,
+    sync::Arc,
 };
 
 use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 use thiserror::Error;
-use zakura_state::{generate_mainnet_from_archive, Config};
+use zakura_state::{
+    generate_mainnet_from_archive_with_options, Config, GeneratorOptions, GeneratorProgress,
+};
 
 #[derive(Debug, Error)]
 enum OutputError {
@@ -30,22 +33,15 @@ enum OutputError {
 }
 
 fn main() -> ExitCode {
-    let mut args = env::args_os().skip(1);
-    let Some(cache_dir) = args.next() else {
-        eprintln!("usage: generate-vct-sprout-artifact <mainnet-cache-dir> <output-file>");
-        return ExitCode::FAILURE;
+    let (cache_dir, output_file, mut options) = match parse_args(env::args_os().skip(1)) {
+        Ok(arguments) => arguments,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            return ExitCode::FAILURE;
+        }
     };
-    let Some(output_file) = args.next() else {
-        eprintln!("usage: generate-vct-sprout-artifact <mainnet-cache-dir> <output-file>");
-        return ExitCode::FAILURE;
-    };
-    if args.next().is_some() {
-        eprintln!("usage: generate-vct-sprout-artifact <mainnet-cache-dir> <output-file>");
-        return ExitCode::FAILURE;
-    }
 
-    let cache_dir = PathBuf::from(cache_dir);
-    let output_file = PathBuf::from(output_file);
     let output_file = match validated_output_path(&cache_dir, &output_file) {
         Ok(output_file) => output_file,
         Err(error) => {
@@ -53,11 +49,27 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    if let Some(checkpoint_dir) = options.checkpoint_dir.as_mut() {
+        match validated_checkpoint_path(&cache_dir, checkpoint_dir) {
+            Ok(path) => *checkpoint_dir = path,
+            Err(error) => {
+                eprintln!("invalid checkpoint directory: {error}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
     let config = Config {
         cache_dir,
         ..Config::default()
     };
-    let bytes = match generate_mainnet_from_archive(&config) {
+    options.progress = Some(Arc::new(print_progress));
+    eprintln!(
+        "scanning Mainnet archive with {} shards on {} workers and {} MiB readahead per scan",
+        options.shards,
+        options.workers,
+        options.readahead_size / (1024 * 1024),
+    );
+    let bytes = match generate_mainnet_from_archive_with_options(&config, &options) {
         Ok(bytes) => bytes,
         Err(error) => {
             eprintln!("artifact generation failed: {error}");
@@ -68,6 +80,14 @@ fn main() -> ExitCode {
         eprintln!("could not write artifact to {:?}: {error}", output_file);
         return ExitCode::FAILURE;
     }
+    if let Some(checkpoint_dir) = &options.checkpoint_dir {
+        if let Err(error) = cleanup_checkpoint_dir(checkpoint_dir) {
+            eprintln!(
+                "warning: artifact is complete, but checkpoint cleanup failed for {:?}: {error}",
+                checkpoint_dir
+            );
+        }
+    }
 
     println!(
         "wrote {} bytes to {:?}; sha256={:x}",
@@ -76,6 +96,87 @@ fn main() -> ExitCode {
         Sha256::digest(&bytes)
     );
     ExitCode::SUCCESS
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage: generate-vct-sprout-artifact <mainnet-cache-dir> <output-file> \
+         [--shards N] [--workers N] [--readahead-mib N] \
+         [--checkpoint-dir PATH] [--resume]"
+    );
+}
+
+fn parse_args(
+    args: impl IntoIterator<Item = std::ffi::OsString>,
+) -> Result<(PathBuf, PathBuf, GeneratorOptions), String> {
+    let mut args = args.into_iter();
+    let cache_dir = args
+        .next()
+        .map(PathBuf::from)
+        .ok_or_else(|| "missing Mainnet cache directory".to_string())?;
+    let output_file = args
+        .next()
+        .map(PathBuf::from)
+        .ok_or_else(|| "missing output file".to_string())?;
+    let mut options = GeneratorOptions::default();
+
+    while let Some(argument) = args.next() {
+        match argument.to_str() {
+            Some("--shards") => {
+                options.shards = parse_count(args.next(), "--shards")?;
+            }
+            Some("--workers") => {
+                options.workers = parse_count(args.next(), "--workers")?;
+            }
+            Some("--readahead-mib") => {
+                options.readahead_size = parse_count(args.next(), "--readahead-mib")?
+                    .checked_mul(1024 * 1024)
+                    .ok_or_else(|| "--readahead-mib is too large".to_string())?;
+            }
+            Some("--checkpoint-dir") => {
+                options.checkpoint_dir =
+                    Some(PathBuf::from(args.next().ok_or_else(|| {
+                        "--checkpoint-dir requires a path".to_string()
+                    })?));
+            }
+            Some("--resume") => options.resume = true,
+            _ => return Err(format!("unknown generator argument {argument:?}")),
+        }
+    }
+
+    Ok((cache_dir, output_file, options))
+}
+
+fn parse_count(value: Option<std::ffi::OsString>, option: &str) -> Result<usize, String> {
+    let value = value.ok_or_else(|| format!("{option} requires a positive integer"))?;
+    let count = value
+        .to_str()
+        .ok_or_else(|| format!("{option} is not valid UTF-8"))?
+        .parse::<usize>()
+        .map_err(|_| format!("{option} requires a positive integer"))?;
+    if count == 0 {
+        return Err(format!("{option} requires a positive integer"));
+    }
+    Ok(count)
+}
+
+fn print_progress(progress: GeneratorProgress) {
+    let percent = progress.completed_heights as f64 * 100.0 / progress.total_heights as f64;
+    let heights_per_second =
+        progress.completed_heights as f64 / progress.elapsed.as_secs_f64().max(f64::EPSILON);
+    let remaining = progress
+        .total_heights
+        .saturating_sub(progress.completed_heights);
+    let eta_seconds = remaining as f64 / heights_per_second.max(f64::EPSILON);
+    eprintln!(
+        "scan {:>5.1}% ({}/{}) {:.0} heights/s elapsed {:.0}s ETA {:.0}s",
+        percent,
+        progress.completed_heights,
+        progress.total_heights,
+        heights_per_second,
+        progress.elapsed.as_secs_f64(),
+        eta_seconds,
+    );
 }
 
 fn validated_output_path(cache_dir: &Path, output_file: &Path) -> Result<PathBuf, OutputError> {
@@ -105,6 +206,34 @@ fn validated_output_path(cache_dir: &Path, output_file: &Path) -> Result<PathBuf
     Ok(output)
 }
 
+fn validated_checkpoint_path(
+    cache_dir: &Path,
+    checkpoint_dir: &Path,
+) -> Result<PathBuf, OutputError> {
+    let source = fs::canonicalize(cache_dir)?;
+    let checkpoint = match fs::canonicalize(checkpoint_dir) {
+        Ok(path) => path,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let name = checkpoint_dir
+                .file_name()
+                .ok_or(OutputError::MissingFileName)?;
+            let parent = checkpoint_dir
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            fs::canonicalize(parent)?.join(name)
+        }
+        Err(error) => return Err(OutputError::Io(error)),
+    };
+    if checkpoint.starts_with(&source) {
+        return Err(OutputError::InsideSourceCache {
+            output: checkpoint,
+            source_cache: source,
+        });
+    }
+    Ok(checkpoint)
+}
+
 fn write_atomic_noclobber(output_file: &Path, bytes: &[u8]) -> Result<(), OutputError> {
     let output_parent = output_file.parent().ok_or(OutputError::MissingFileName)?;
     let mut temporary = NamedTempFile::new_in(output_parent)?;
@@ -118,9 +247,63 @@ fn write_atomic_noclobber(output_file: &Path, bytes: &[u8]) -> Result<(), Output
     Ok(())
 }
 
+fn cleanup_checkpoint_dir(checkpoint_dir: &Path) -> io::Result<()> {
+    for entry in fs::read_dir(checkpoint_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name == "manifest"
+            || (name.starts_with("shard-") && name.ends_with(".bin"))
+            || name.starts_with(".tmp")
+        {
+            fs::remove_file(entry.path())?;
+        }
+    }
+    match fs::remove_dir(checkpoint_dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::DirectoryNotEmpty => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn parses_parallel_and_resume_options() {
+        let (_, _, options) = parse_args(
+            [
+                "cache",
+                "artifact.bin",
+                "--shards",
+                "12",
+                "--workers",
+                "24",
+                "--readahead-mib",
+                "32",
+                "--checkpoint-dir",
+                "progress",
+                "--resume",
+            ]
+            .map(OsString::from),
+        )
+        .expect("valid generator options parse");
+
+        assert_eq!(options.shards, 12);
+        assert_eq!(options.workers, 24);
+        assert_eq!(options.readahead_size, 32 * 1024 * 1024);
+        assert_eq!(options.checkpoint_dir, Some(PathBuf::from("progress")));
+        assert!(options.resume);
+    }
+
+    #[test]
+    fn rejects_zero_parallelism() {
+        assert!(
+            parse_args(["cache", "artifact.bin", "--shards", "0"].map(OsString::from)).is_err()
+        );
+    }
 
     #[test]
     fn rejects_output_inside_source_cache() {
@@ -132,6 +315,18 @@ mod tests {
             Err(OutputError::InsideSourceCache { .. })
         ));
         assert!(!output.exists());
+    }
+
+    #[test]
+    fn rejects_checkpoint_inside_source_cache() {
+        let source = tempfile::tempdir().expect("source tempdir is created");
+        let checkpoint = source.path().join("progress");
+
+        assert!(matches!(
+            validated_checkpoint_path(source.path(), &checkpoint),
+            Err(OutputError::InsideSourceCache { .. })
+        ));
+        assert!(!checkpoint.exists());
     }
 
     #[test]
@@ -188,5 +383,21 @@ mod tests {
             fs::read(output).expect("existing output remains readable"),
             b"existing"
         );
+    }
+
+    #[test]
+    fn checkpoint_cleanup_preserves_unrelated_files() {
+        let directory = tempfile::tempdir().expect("checkpoint parent is created");
+        let checkpoint = directory.path().join("progress");
+        fs::create_dir(&checkpoint).expect("checkpoint directory is created");
+        fs::write(checkpoint.join("manifest"), b"manifest").expect("manifest is written");
+        fs::write(checkpoint.join("shard-0000.bin"), b"shard").expect("shard is written");
+        fs::write(checkpoint.join("keep.txt"), b"keep").expect("unrelated file is written");
+
+        cleanup_checkpoint_dir(&checkpoint).expect("known checkpoint files are removed");
+
+        assert!(checkpoint.join("keep.txt").exists());
+        assert!(!checkpoint.join("manifest").exists());
+        assert!(!checkpoint.join("shard-0000.bin").exists());
     }
 }

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -64,7 +64,7 @@ pub use service::{
     finalized_state::FinalizedState,
     init, init_read_only,
     non_finalized_state::NonFinalizedState,
-    spawn_init_read_only,
+    spawn_init_read_only, validate_vct_sprout_history,
     watch_receiver::WatchReceiver,
     OutputLocation, ReadState, State, TransactionIndex, TransactionLocation,
 };
@@ -84,6 +84,9 @@ pub use service::finalized_state::{
 pub use service::finalized_state::{
     preview_rollback_finalized_state, rollback_finalized_state, RollbackBackupSummary,
     RollbackFinalizedStateError, RollbackFinalizedStateOptions, RollbackFinalizedStateSummary,
+};
+pub use service::finalized_state::{
+    VctSproutHistoryValidationError, VctSproutHistoryValidationSummary,
 };
 pub use service::{
     finalized_state::{DiskWriteBatch, FromDisk, IntoDisk, WriteDisk, ZakuraDb},

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -74,8 +74,9 @@ pub use service::{
 pub use service::finalized_state::{ReadDisk, TypedColumnFamily, WriteTypedBatch};
 
 pub use service::finalized_state::{
-    generate_mainnet_from_archive, produce_final_frontiers_bytes, validate_final_frontiers_bytes,
-    FinalFrontiersGenerationError, FinalFrontiersValidationError, GeneratorError,
+    generate_mainnet_from_archive, generate_mainnet_from_archive_with_options,
+    produce_final_frontiers_bytes, validate_final_frontiers_bytes, FinalFrontiersGenerationError,
+    FinalFrontiersValidationError, GeneratorError, GeneratorOptions, GeneratorProgress,
 };
 pub use service::finalized_state::{
     preview_prune_finalized_state, prune_finalized_state, PruneFinalizedStateError,

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -2283,6 +2283,20 @@ pub fn init_read_only(
     ))
 }
 
+/// Opens an existing database read-only and audits its completed VCT Sprout-history repair.
+pub fn validate_vct_sprout_history(
+    config: Config,
+    network: &Network,
+) -> Result<
+    finalized_state::VctSproutHistoryValidationSummary,
+    finalized_state::VctSproutHistoryValidationError,
+> {
+    let (_, db, _) = init_read_only(config, network)
+        .map_err(finalized_state::VctSproutHistoryValidationError::OpenDatabase)?;
+
+    finalized_state::validate_completed_repair(&db)
+}
+
 /// Calls [`init_read_only`] with the provided [`Config`] and [`Network`] from a blocking task.
 ///
 /// Returns a [`tokio::task::JoinHandle`] whose output is a [`Result`]: awaiting it yields a

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -98,6 +98,10 @@ pub(crate) use commitment_aux::serve_block_roots;
 pub use commitment_aux::{produce_final_frontiers_bytes, FinalFrontiersGenerationError};
 #[allow(unused_imports)]
 pub use disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk};
+pub(crate) use disk_format::upgrade::repair_vct_sprout_history::validate_completed_repair;
+pub use disk_format::upgrade::repair_vct_sprout_history::{
+    VctSproutHistoryValidationError, VctSproutHistoryValidationSummary,
+};
 #[allow(unused_imports)]
 pub use disk_format::{
     FromDisk, IntoDisk, OutputLocation, RawBytes, TransactionIndex, TransactionLocation,

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -108,8 +108,9 @@ pub use disk_format::{
     MAX_ON_DISK_HEIGHT,
 };
 pub use vct::{
-    generate_mainnet_from_archive, validate_final_frontiers_bytes, FinalFrontiersValidationError,
-    GeneratorError, NextVctBlock,
+    generate_mainnet_from_archive, generate_mainnet_from_archive_with_options,
+    validate_final_frontiers_bytes, FinalFrontiersValidationError, GeneratorError,
+    GeneratorOptions, GeneratorProgress, NextVctBlock,
 };
 pub use zakura_db::ZakuraDb;
 

--- a/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/zakura-state/src/service/finalized_state/disk_db.rs
@@ -782,7 +782,26 @@ impl DiskDb {
         V: FromDisk,
         R: RangeBounds<K>,
     {
-        self.zs_range_iter_with_direction(cf, range, false)
+        self.zs_range_iter_with_direction(cf, range, false, None)
+    }
+
+    /// Returns a forward iterator configured for a large offline sequential scan.
+    ///
+    /// This profile avoids polluting the shared block cache and gives RocksDB enough
+    /// readahead to keep high-throughput local storage busy.
+    pub(crate) fn zs_forward_range_iter_for_bulk_scan<C, K, V, R>(
+        &self,
+        cf: &C,
+        range: R,
+        readahead_size: usize,
+    ) -> impl Iterator<Item = (K, V)> + '_
+    where
+        C: rocksdb::AsColumnFamilyRef,
+        K: IntoDisk + FromDisk,
+        V: FromDisk,
+        R: RangeBounds<K>,
+    {
+        self.zs_range_iter_with_direction(cf, range, false, Some(readahead_size))
     }
 
     /// Returns a reverse iterator over the items in `cf` in `range`.
@@ -799,7 +818,7 @@ impl DiskDb {
         V: FromDisk,
         R: RangeBounds<K>,
     {
-        self.zs_range_iter_with_direction(cf, range, true)
+        self.zs_range_iter_with_direction(cf, range, true, None)
     }
 
     /// Returns an iterator over the items in `cf` in `range`.
@@ -813,6 +832,7 @@ impl DiskDb {
         cf: &C,
         range: R,
         reverse: bool,
+        bulk_readahead_size: Option<usize>,
     ) -> impl Iterator<Item = (K, V)> + '_
     where
         C: rocksdb::AsColumnFamilyRef,
@@ -837,7 +857,12 @@ impl DiskDb {
         let range = (start_bound, end_bound);
 
         let mode = Self::zs_iter_mode(&range, reverse);
-        let opts = Self::zs_iter_opts(&range);
+        let mut opts = Self::zs_iter_opts(&range);
+        if let Some(readahead_size) = bulk_readahead_size {
+            opts.fill_cache(false);
+            opts.set_readahead_size(readahead_size);
+            opts.set_async_io(true);
+        }
 
         // Reading multiple items from iterators has caused database hangs,
         // in previous RocksDB versions

--- a/zakura-state/src/service/finalized_state/disk_format/upgrade/repair_vct_sprout_history.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/upgrade/repair_vct_sprout_history.rs
@@ -27,6 +27,55 @@ pub(crate) const REPAIR_VERSION: Version = Version::new(28, 0, 1);
 /// Replays the reviewed Mainnet artifact into pre-28.0.1 VCT databases.
 pub struct Upgrade;
 
+/// A successful read-only audit of VCT Sprout history.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VctSproutHistoryValidationSummary {
+    /// The finalized database tip checked by the audit.
+    pub finalized_tip: Height,
+    /// The persisted VCT handoff marker.
+    pub vct_marker: Height,
+    /// The handoff authenticated by the embedded artifact.
+    pub artifact_handoff: Height,
+    /// The empty anchor plus artifact-record anchors checked by the audit.
+    pub checked_anchor_count: usize,
+}
+
+/// Errors returned by the read-only VCT Sprout-history audit.
+#[derive(Debug, Error)]
+pub enum VctSproutHistoryValidationError {
+    /// The state database could not be opened read-only.
+    #[error("could not open the state database read-only")]
+    OpenDatabase(#[source] crate::StateInitError),
+    /// The audit only has canonical inputs for Mainnet.
+    #[error("VCT Sprout-history validation is only supported on Mainnet")]
+    UnsupportedNetwork,
+    /// The database was not created by VCT fast sync.
+    #[error("the database does not have a persisted VCT marker")]
+    NotVctSynced,
+    /// The database has not durably completed the repair format.
+    #[error(
+        "database format {actual} predates required VCT Sprout-history repair format {required}"
+    )]
+    RepairNotCompleted {
+        /// The version stored on disk, or `None` if no version was stored.
+        actual: String,
+        /// The first format version containing the repair.
+        required: Version,
+    },
+    /// The database format version could not be read.
+    #[error("could not read the database format version: {reason}")]
+    FormatVersion {
+        /// The underlying version-file error.
+        reason: String,
+    },
+    /// The artifact, canonical indexes, or repaired records failed validation.
+    #[error("VCT Sprout-history validation failed: {reason}")]
+    Invalid {
+        /// The failed artifact, index, anchor, or frontier check.
+        reason: String,
+    },
+}
+
 #[derive(Debug, Error)]
 pub(crate) enum RepairValidationError {
     #[error("the embedded VCT final frontier is invalid: {0}")]
@@ -77,6 +126,63 @@ pub(crate) fn validate_startup_repair(db: &ZakuraDb) -> Result<(), RepairValidat
         .vct_synced_below()
         .ok_or(RepairValidationError::MissingVctMarker)?;
     validated_repair_input(db, marker).map(|_| ())
+}
+
+/// Audits a completed VCT Sprout-history repair without modifying the database.
+pub(crate) fn validate_completed_repair(
+    db: &ZakuraDb,
+) -> Result<VctSproutHistoryValidationSummary, VctSproutHistoryValidationError> {
+    if db.network() != Network::Mainnet {
+        return Err(VctSproutHistoryValidationError::UnsupportedNetwork);
+    }
+
+    let marker = db
+        .vct_synced_below()
+        .ok_or(VctSproutHistoryValidationError::NotVctSynced)?;
+    let disk_version = db.format_version_on_disk().map_err(|error| {
+        VctSproutHistoryValidationError::FormatVersion {
+            reason: error.to_string(),
+        }
+    })?;
+    if disk_version
+        .as_ref()
+        .is_none_or(|version| version < &REPAIR_VERSION)
+    {
+        return Err(VctSproutHistoryValidationError::RepairNotCompleted {
+            actual: disk_version
+                .map_or_else(|| "unknown".to_string(), |version| version.to_string()),
+            required: REPAIR_VERSION,
+        });
+    }
+
+    let input = validated_repair_input(db, marker).map_err(|error| {
+        VctSproutHistoryValidationError::Invalid {
+            reason: error.to_string(),
+        }
+    })?;
+    let finalized_tip =
+        db.finalized_tip_height()
+            .ok_or_else(|| VctSproutHistoryValidationError::Invalid {
+                reason: RepairValidationError::MissingFinalizedTip.to_string(),
+            })?;
+    let checked_anchor_count = input
+        .artifact
+        .records_through(finalized_tip.min(marker))
+        .count()
+        .saturating_add(1);
+    let (_cancel_sender, cancel_receiver) = crossbeam_channel::bounded(1);
+    validate_repaired_records(db, marker, &input, true, &cancel_receiver)
+        .map_err(|_| VctSproutHistoryValidationError::Invalid {
+            reason: "validation was unexpectedly cancelled".to_string(),
+        })?
+        .map_err(|reason| VctSproutHistoryValidationError::Invalid { reason })?;
+
+    Ok(VctSproutHistoryValidationSummary {
+        finalized_tip,
+        vct_marker: marker,
+        artifact_handoff: input.artifact_last_checkpoint,
+        checked_anchor_count,
+    })
 }
 
 impl DiskFormatUpgrade for Upgrade {
@@ -142,7 +248,7 @@ impl DiskFormatUpgrade for Upgrade {
             Err(error) => return Ok(Err(error.to_string())),
         };
 
-        validate_repaired_records(db, marker, &input, cancel_receiver)
+        validate_repaired_records(db, marker, &input, false, cancel_receiver)
     }
 }
 
@@ -284,6 +390,7 @@ fn validate_repaired_records(
     db: &ZakuraDb,
     marker: Height,
     input: &RepairInput,
+    check_tip_at_marker: bool,
     cancel_receiver: &Receiver<CancelFormatChange>,
 ) -> Result<Result<(), String>, CancelFormatChange> {
     let tip = db
@@ -317,7 +424,7 @@ fn validate_repaired_records(
         }
     }
 
-    if tip < marker {
+    if tip < marker || (check_tip_at_marker && tip == marker) {
         let tip_tree = db.sprout_tree_for_tip().map_err(|error| error.to_string());
         if tip_tree.as_deref() != Ok(&tree) {
             return Ok(Err(format!(
@@ -818,16 +925,23 @@ mod tests {
         let handoff = Height(2);
         let first_hash = block::Hash([1; 32]);
         let handoff_hash = block::Hash([2; 32]);
-        let path = seed_repair_db(
-            &config,
-            &network,
-            handoff,
-            &[(first_height, first_hash), (handoff, handoff_hash)],
-        );
         let (artifact, roots) = fixture_artifact_with_records(
             handoff,
             handoff_hash,
             &[(first_height, first_hash, 11), (handoff, handoff_hash, 12)],
+        );
+        let mut tip_tree = NoteCommitmentTree::default();
+        for value in [11, 12] {
+            tip_tree
+                .append(sprout::commitment::NoteCommitment::from([value; 32]))
+                .expect("fixture tree has capacity");
+        }
+        let path = seed_repair_db_with_tip(
+            &config,
+            &network,
+            handoff,
+            &[(first_height, first_hash), (handoff, handoff_hash)],
+            &tip_tree,
         );
         let _injection = inject_test_repair_input(
             path,
@@ -858,6 +972,76 @@ mod tests {
             db.block(first_height.into()).is_none(),
             "repair uses retained canonical indexes and does not require pruned bodies"
         );
+
+        let summary =
+            validate_completed_repair(&db).expect("the completed pruned repair validates");
+        assert_eq!(
+            summary,
+            VctSproutHistoryValidationSummary {
+                finalized_tip: handoff,
+                vct_marker: handoff,
+                artifact_handoff: handoff,
+                checked_anchor_count: 3,
+            }
+        );
+
+        let mut corrupt_batch = DiskWriteBatch::new();
+        corrupt_batch.delete_sprout_anchor(&db, &roots[0]);
+        db.write_batch(corrupt_batch)
+            .expect("fixture anchor corruption succeeds");
+        assert!(matches!(
+            validate_completed_repair(&db),
+            Err(VctSproutHistoryValidationError::Invalid { reason })
+                if reason.contains("Sprout anchor at")
+        ));
+    }
+
+    #[test]
+    fn completed_repair_audit_detects_canonical_reverse_index_corruption() {
+        let (_cache, config) = persistent_config();
+        let network = Network::Mainnet;
+        let record_height = Height(1);
+        let handoff = Height(2);
+        let record_hash = block::Hash([1; 32]);
+        let handoff_hash = block::Hash([2; 32]);
+        let (artifact, roots) =
+            fixture_artifact(handoff, handoff_hash, record_height, record_hash, 13);
+        let mut tip_tree = NoteCommitmentTree::default();
+        tip_tree
+            .append(sprout::commitment::NoteCommitment::from([13; 32]))
+            .expect("fixture tree has capacity");
+        let path = seed_repair_db_with_tip(
+            &config,
+            &network,
+            handoff,
+            &[(record_height, record_hash), (handoff, handoff_hash)],
+            &tip_tree,
+        );
+        let _injection = inject_test_repair_input(
+            path,
+            TestRepairInput {
+                handoff,
+                handoff_hash,
+                handoff_sprout_root: roots,
+                artifact,
+                marker_hash: None,
+                before_write: None,
+            },
+        );
+        let db = open_normally(&config, &network);
+        validate_completed_repair(&db).expect("the completed repair initially validates");
+
+        let height_by_hash = db.db().cf_handle("height_by_hash").unwrap();
+        let mut corrupt_batch = DiskWriteBatch::new();
+        corrupt_batch.zs_delete(&height_by_hash, record_hash);
+        db.write_batch(corrupt_batch)
+            .expect("fixture reverse-index corruption succeeds");
+
+        assert!(matches!(
+            validate_completed_repair(&db),
+            Err(VctSproutHistoryValidationError::Invalid { reason })
+                if reason.contains("reverse block index")
+        ));
     }
 
     #[test]

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -6,7 +6,10 @@
 //! `consensus.vct_fast_sync = false` selects legacy recompute.
 
 pub(super) mod artifact;
-pub use artifact::{generate_mainnet_from_archive, GeneratorError};
+pub use artifact::{
+    generate_mainnet_from_archive, generate_mainnet_from_archive_with_options, GeneratorError,
+    GeneratorOptions, GeneratorProgress,
+};
 
 use std::sync::{
     atomic::{AtomicU64, Ordering},

--- a/zakura-state/src/service/finalized_state/vct/artifact.rs
+++ b/zakura-state/src/service/finalized_state/vct/artifact.rs
@@ -3,14 +3,34 @@
 //! This format intentionally contains only blocks that change Sprout. It is
 //! independent from peer-delivered VCT roots and is never accepted from peers.
 
+use std::{
+    collections::HashMap,
+    fs,
+    io::Write,
+    ops::RangeInclusive,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
-use zakura_chain::{block, sprout};
+use zakura_chain::{
+    block::{self, merkle},
+    sprout,
+    transaction::{self, Transaction},
+};
 
 use crate::{
     constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
-    request::HashOrHeight,
-    service::finalized_state::{ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
+    service::finalized_state::{
+        disk_format::{FromDisk, TransactionLocation},
+        ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE,
+    },
     Config, StateInitError,
 };
 
@@ -341,9 +361,85 @@ pub enum GeneratorError {
         /// The inconsistent block height.
         height: block::Height,
     },
+    /// A canonical database index has a gap, duplicate, or mismatched row.
+    #[error("Mainnet archive canonical index is inconsistent at {height:?}: {reason}")]
+    CanonicalIndex {
+        /// The affected height.
+        height: block::Height,
+        /// Details about the inconsistency.
+        reason: String,
+    },
+    /// A transaction row or its stored hash is inconsistent.
+    #[error("Mainnet archive transaction data is inconsistent at {height:?}: {reason}")]
+    TransactionData {
+        /// The affected height.
+        height: block::Height,
+        /// Details about the inconsistency.
+        reason: String,
+    },
+    /// A checkpoint could not be read, validated, or written.
+    #[error("VCT generator checkpoint error: {0}")]
+    Checkpoint(String),
     /// Artifact encoding or self-validation failed.
     #[error("could not construct the Sprout repair artifact: {0}")]
     Artifact(String),
+}
+
+/// Tuning and crash-recovery options for offline artifact generation.
+#[derive(Clone)]
+pub struct GeneratorOptions {
+    /// Number of contiguous height shards scanned concurrently.
+    pub shards: usize,
+    /// Rayon worker threads used by shard scans and transaction decoding.
+    pub workers: usize,
+    /// RocksDB iterator readahead per column-family scan.
+    pub readahead_size: usize,
+    /// Optional directory for resumable shard outputs.
+    pub checkpoint_dir: Option<PathBuf>,
+    /// Reuse completed shards from `checkpoint_dir`.
+    pub resume: bool,
+    /// Optional progress callback, invoked after each completed shard.
+    pub progress: Option<Arc<dyn Fn(GeneratorProgress) + Send + Sync>>,
+}
+
+/// Aggregate progress from the parallel archive scan.
+#[derive(Copy, Clone, Debug)]
+pub struct GeneratorProgress {
+    /// Heights scanned or loaded from checkpoints.
+    pub completed_heights: u64,
+    /// Total heights through the handoff.
+    pub total_heights: u64,
+    /// Elapsed wall time.
+    pub elapsed: Duration,
+}
+
+impl Default for GeneratorOptions {
+    fn default() -> Self {
+        let workers = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+        Self {
+            shards: workers.clamp(1, 32),
+            workers,
+            readahead_size: 16 * 1024 * 1024,
+            checkpoint_dir: None,
+            resume: false,
+            progress: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CandidateRecord {
+    height: block::Height,
+    block_hash: block::Hash,
+    commitments: Vec<sprout::commitment::NoteCommitment>,
+}
+
+#[derive(Clone, Debug)]
+struct ScanShard {
+    index: usize,
+    range: RangeInclusive<block::Height>,
 }
 
 /// Generate corrected version-1 artifact bytes from a complete, current-format Mainnet archive.
@@ -351,6 +447,14 @@ pub enum GeneratorError {
 /// The result is deliberately returned to an offline caller and is never installed as the
 /// runtime artifact. Release review must independently approve the bytes and digest first.
 pub fn generate_mainnet_from_archive(config: &Config) -> Result<Vec<u8>, GeneratorError> {
+    generate_mainnet_from_archive_with_options(config, &GeneratorOptions::default())
+}
+
+/// Generate corrected version-1 artifact bytes using ordered, parallel archive scans.
+pub fn generate_mainnet_from_archive_with_options(
+    config: &Config,
+    options: &GeneratorOptions,
+) -> Result<Vec<u8>, GeneratorError> {
     let network = zakura_chain::parameters::Network::Mainnet;
     let db = ZakuraDb::new(
         config,
@@ -373,38 +477,98 @@ pub fn generate_mainnet_from_archive(config: &Config) -> Result<Vec<u8>, Generat
                 height: last_checkpoint,
             })?;
 
-    let mut tree = sprout::tree::NoteCommitmentTree::default();
-    let mut records = Vec::new();
-    for raw_height in 0..=last_checkpoint.0 {
-        let height = block::Height(raw_height);
-        let canonical_hash = db
-            .hash(height)
-            .ok_or(GeneratorError::MissingCanonicalHash { height })?;
-        if db.height(canonical_hash) != Some(height) {
-            return Err(GeneratorError::CanonicalReverseIndexMismatch { height });
-        }
-        let block = db
-            .block(HashOrHeight::Height(height))
-            .ok_or(GeneratorError::MissingBlockBody { height })?;
-        if block.hash() != canonical_hash {
-            return Err(GeneratorError::BlockBodyHashMismatch { height });
-        }
-        let commitments: Vec<_> = block.sprout_note_commitments().cloned().collect();
-        if commitments.is_empty() {
-            continue;
-        }
-        for commitment in &commitments {
-            tree.append(*commitment).map_err(|_| {
-                GeneratorError::Artifact(Error::RecordRootMismatch { height }.to_string())
-            })?;
-        }
-        records.push(Record {
-            height,
-            block_hash: canonical_hash,
-            commitments,
-            resulting_root: tree.root(),
-        });
+    if options.shards == 0 || options.workers == 0 {
+        return Err(GeneratorError::Artifact(
+            "generator shard and worker counts must be non-zero".to_string(),
+        ));
     }
+
+    let reverse_index = Arc::new(load_reverse_index(
+        &db,
+        last_checkpoint,
+        options.readahead_size,
+    )?);
+    let shards = plan_shards(last_checkpoint, options.shards);
+    prepare_checkpoint_dir(
+        config,
+        options,
+        last_checkpoint,
+        last_checkpoint_hash,
+        &shards,
+    )?;
+
+    let started = Instant::now();
+    let completed_heights = AtomicU64::new(0);
+    let total_heights = u64::from(last_checkpoint.0) + 1;
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(options.workers)
+        .thread_name(|index| format!("vct-artifact-{index}"))
+        .build()
+        .map_err(|error| GeneratorError::Artifact(error.to_string()))?;
+
+    let shard_records = pool.install(|| {
+        shards
+            .par_iter()
+            .map(|shard| {
+                let checkpoint = options
+                    .checkpoint_dir
+                    .as_ref()
+                    .map(|directory| shard_path(directory, shard.index));
+                let records = if options.resume {
+                    checkpoint
+                        .as_deref()
+                        .filter(|path| path.exists())
+                        .map(|path| read_shard(path, shard, last_checkpoint, last_checkpoint_hash))
+                        .transpose()?
+                } else {
+                    None
+                };
+
+                let records = match records {
+                    Some(records) => records,
+                    None => {
+                        let records =
+                            scan_shard(&db, shard, &reverse_index, options.readahead_size)?;
+                        if let Some(path) = checkpoint {
+                            write_shard_atomic(
+                                &path,
+                                shard,
+                                last_checkpoint,
+                                last_checkpoint_hash,
+                                &records,
+                            )?;
+                        }
+                        records
+                    }
+                };
+
+                let end = shard.range.end().0;
+                let shard_heights =
+                    u64::from(end.saturating_sub(shard.range.start().0).saturating_add(1));
+                let completed = completed_heights
+                    .fetch_add(shard_heights, Ordering::Relaxed)
+                    .saturating_add(shard_heights);
+                if let Some(progress) = &options.progress {
+                    progress(GeneratorProgress {
+                        completed_heights: completed,
+                        total_heights,
+                        elapsed: started.elapsed(),
+                    });
+                }
+                tracing::info!(
+                    shard = shard.index,
+                    start_height = shard.range.start().0,
+                    end_height = end,
+                    records = records.len(),
+                    elapsed = ?started.elapsed(),
+                    "VCT artifact scan shard complete"
+                );
+                Ok::<_, GeneratorError>(records)
+            })
+            .collect::<Result<Vec<_>, _>>()
+    })?;
+
+    let records = replay_candidates(shard_records.into_iter().flatten())?;
 
     let bytes = Artifact::encode(last_checkpoint, last_checkpoint_hash, records)
         .map_err(|error| GeneratorError::Artifact(error.to_string()))?;
@@ -421,6 +585,451 @@ pub fn generate_mainnet_from_archive(config: &Config) -> Result<Vec<u8>, Generat
         .validate_canonical(|height| db.hash(height), |hash| db.height(hash))
         .map_err(|error| GeneratorError::Artifact(error.to_string()))?;
     Ok(bytes)
+}
+
+fn replay_candidates(
+    candidates: impl IntoIterator<Item = CandidateRecord>,
+) -> Result<Vec<Record>, GeneratorError> {
+    let mut tree = sprout::tree::NoteCommitmentTree::default();
+    let mut records = Vec::new();
+    let mut previous_height = None;
+    for candidate in candidates {
+        if previous_height.is_some_and(|previous| previous >= candidate.height) {
+            return Err(GeneratorError::Artifact(Error::InvalidHeight.to_string()));
+        }
+        for commitment in &candidate.commitments {
+            tree.append(*commitment).map_err(|_| {
+                GeneratorError::Artifact(
+                    Error::RecordRootMismatch {
+                        height: candidate.height,
+                    }
+                    .to_string(),
+                )
+            })?;
+        }
+        records.push(Record {
+            height: candidate.height,
+            block_hash: candidate.block_hash,
+            commitments: candidate.commitments,
+            resulting_root: tree.root(),
+        });
+        previous_height = Some(candidate.height);
+    }
+    Ok(records)
+}
+
+#[allow(clippy::unwrap_in_result)]
+fn load_reverse_index(
+    db: &ZakuraDb,
+    last_checkpoint: block::Height,
+    readahead_size: usize,
+) -> Result<HashMap<block::Hash, block::Height>, GeneratorError> {
+    let mut reverse = HashMap::with_capacity(
+        usize::try_from(last_checkpoint.0)
+            .expect("block heights fit in usize")
+            .saturating_add(1),
+    );
+    for (hash, height) in db.heights_by_hash(readahead_size) {
+        if height > last_checkpoint {
+            continue;
+        }
+        if reverse.insert(hash, height).is_some() {
+            return Err(GeneratorError::CanonicalIndex {
+                height,
+                reason: "duplicate reverse-index block hash".to_string(),
+            });
+        }
+    }
+    Ok(reverse)
+}
+
+fn plan_shards(last_checkpoint: block::Height, requested: usize) -> Vec<ScanShard> {
+    let height_count = u64::from(last_checkpoint.0) + 1;
+    let shard_count =
+        requested.min(usize::try_from(height_count).expect("supported block heights fit in usize"));
+    let shard_count_u64 = u64::try_from(shard_count).expect("shard count fits in u64");
+
+    (0..shard_count)
+        .map(|index| {
+            let index_u64 = u64::try_from(index).expect("shard index fits in u64");
+            let start = height_count * index_u64 / shard_count_u64;
+            let end = height_count * (index_u64 + 1) / shard_count_u64 - 1;
+            ScanShard {
+                index,
+                range: block::Height(
+                    u32::try_from(start).expect("shard start is a supported height"),
+                )
+                    ..=block::Height(u32::try_from(end).expect("shard end is a supported height")),
+            }
+        })
+        .collect()
+}
+
+#[allow(clippy::unwrap_in_result)]
+fn scan_shard(
+    db: &ZakuraDb,
+    shard: &ScanShard,
+    reverse_index: &HashMap<block::Hash, block::Height>,
+    readahead_size: usize,
+) -> Result<Vec<CandidateRecord>, GeneratorError> {
+    let start = *shard.range.start();
+    let end = *shard.range.end();
+    let mut hashes = db.hashes_by_height_range(shard.range.clone(), readahead_size);
+    let mut headers = db.raw_block_headers_by_height_range(shard.range.clone(), readahead_size);
+    let mut metadata = Vec::with_capacity(
+        usize::try_from(end.0 - start.0 + 1).expect("shard height count fits in usize"),
+    );
+
+    for raw_height in start.0..=end.0 {
+        let height = block::Height(raw_height);
+        let (hash_height, canonical_hash) = hashes
+            .next()
+            .ok_or(GeneratorError::MissingCanonicalHash { height })?;
+        if hash_height != height {
+            return Err(GeneratorError::CanonicalIndex {
+                height,
+                reason: format!("forward hash row is keyed by {hash_height:?}"),
+            });
+        }
+        if reverse_index.get(&canonical_hash) != Some(&height) {
+            return Err(GeneratorError::CanonicalReverseIndexMismatch { height });
+        }
+
+        let (header_height, raw_header) = headers
+            .next()
+            .ok_or(GeneratorError::MissingBlockBody { height })?;
+        if header_height != height {
+            return Err(GeneratorError::CanonicalIndex {
+                height,
+                reason: format!("block header row is keyed by {header_height:?}"),
+            });
+        }
+        let header = block::Header::from_bytes(raw_header.raw_bytes());
+        if block::Hash::from(header) != canonical_hash {
+            return Err(GeneratorError::BlockBodyHashMismatch { height });
+        }
+        metadata.push((canonical_hash, header.merkle_root));
+    }
+    if hashes.next().is_some() || headers.next().is_some() {
+        return Err(GeneratorError::CanonicalIndex {
+            height: end,
+            reason: "bounded metadata iterator returned an out-of-range row".to_string(),
+        });
+    }
+
+    let location_range =
+        TransactionLocation::min_for_height(start)..=TransactionLocation::max_for_height(end);
+    let mut transactions = db
+        .raw_transactions_by_location_range_for_bulk_scan(location_range.clone(), readahead_size)
+        .peekable();
+    let mut stored_hashes = db
+        .transaction_hashes_by_location_range(location_range, readahead_size)
+        .peekable();
+    let mut candidates = Vec::new();
+
+    for raw_height in start.0..=end.0 {
+        let height = block::Height(raw_height);
+        let mut expected_index = 0u16;
+        let mut transaction_hashes = Vec::new();
+        let mut commitments = Vec::new();
+
+        while transactions
+            .peek()
+            .is_some_and(|(location, _)| location.height == height)
+        {
+            let (location, raw_transaction) = transactions
+                .next()
+                .expect("the transaction iterator was just inspected");
+            let (hash_location, stored_hash) =
+                stored_hashes
+                    .next()
+                    .ok_or_else(|| GeneratorError::TransactionData {
+                        height,
+                        reason: "missing stored transaction hash".to_string(),
+                    })?;
+            if location != hash_location || location.index.index() != expected_index {
+                return Err(GeneratorError::TransactionData {
+                    height,
+                    reason: format!(
+                        "expected transaction index {expected_index}, found {location:?} and \
+                         hash row {hash_location:?}"
+                    ),
+                });
+            }
+
+            let transaction = Transaction::from_bytes(raw_transaction.raw_bytes());
+            let computed_hash = transaction::Hash::from(&transaction);
+            if computed_hash != stored_hash {
+                return Err(GeneratorError::TransactionData {
+                    height,
+                    reason: format!("stored transaction hash mismatch at {location:?}"),
+                });
+            }
+            transaction_hashes.push(computed_hash);
+            commitments.extend(transaction.sprout_note_commitments().copied());
+            expected_index =
+                expected_index
+                    .checked_add(1)
+                    .ok_or_else(|| GeneratorError::TransactionData {
+                        height,
+                        reason: "transaction index overflow".to_string(),
+                    })?;
+        }
+
+        if transaction_hashes.is_empty() {
+            return Err(GeneratorError::MissingBlockBody { height });
+        }
+        let merkle_root: merkle::Root = transaction_hashes.into_iter().collect();
+        let metadata_index =
+            usize::try_from(raw_height - start.0).expect("metadata index fits in usize");
+        let (canonical_hash, expected_merkle_root) = metadata[metadata_index];
+        if merkle_root != expected_merkle_root {
+            return Err(GeneratorError::TransactionData {
+                height,
+                reason: "transaction Merkle root does not match the canonical header".to_string(),
+            });
+        }
+        if !commitments.is_empty() {
+            candidates.push(CandidateRecord {
+                height,
+                block_hash: canonical_hash,
+                commitments,
+            });
+        }
+    }
+
+    if let Some((location, _)) = transactions.next() {
+        return Err(GeneratorError::TransactionData {
+            height: location.height,
+            reason: "bounded transaction iterator returned an out-of-range row".to_string(),
+        });
+    }
+    if let Some((location, _)) = stored_hashes.next() {
+        return Err(GeneratorError::TransactionData {
+            height: location.height,
+            reason: "stored transaction hash has no transaction row".to_string(),
+        });
+    }
+
+    Ok(candidates)
+}
+
+const SHARD_MAGIC: &[u8; 8] = b"ZKVCTSH1";
+const MANIFEST_NAME: &str = "manifest";
+
+fn shard_path(directory: &Path, index: usize) -> PathBuf {
+    directory.join(format!("shard-{index:04}.bin"))
+}
+
+fn manifest_contents(
+    config: &Config,
+    options: &GeneratorOptions,
+    handoff: block::Height,
+    handoff_hash: block::Hash,
+    shards: &[ScanShard],
+) -> Result<String, GeneratorError> {
+    let source = fs::canonicalize(&config.cache_dir)
+        .map_err(|error| GeneratorError::Checkpoint(error.to_string()))?;
+    let ranges = shards
+        .iter()
+        .map(|shard| format!("{}-{}", shard.range.start().0, shard.range.end().0))
+        .collect::<Vec<_>>()
+        .join(",");
+    Ok(format!(
+        "ZKVCTGEN1\nsource={}\ndb_format={}\nhandoff={}\nhandoff_hash={}\nshards={}\nranges={ranges}\n",
+        source.display(),
+        state_database_format_version_in_code(),
+        handoff.0,
+        hex::encode(handoff_hash.0),
+        options.shards,
+    ))
+}
+
+fn prepare_checkpoint_dir(
+    config: &Config,
+    options: &GeneratorOptions,
+    handoff: block::Height,
+    handoff_hash: block::Hash,
+    shards: &[ScanShard],
+) -> Result<(), GeneratorError> {
+    let Some(directory) = &options.checkpoint_dir else {
+        if options.resume {
+            return Err(GeneratorError::Checkpoint(
+                "--resume requires a checkpoint directory".to_string(),
+            ));
+        }
+        return Ok(());
+    };
+    fs::create_dir_all(directory).map_err(|error| GeneratorError::Checkpoint(error.to_string()))?;
+    let manifest_path = directory.join(MANIFEST_NAME);
+    let expected = manifest_contents(config, options, handoff, handoff_hash, shards)?;
+
+    if options.resume {
+        let actual = fs::read_to_string(&manifest_path)
+            .map_err(|error| GeneratorError::Checkpoint(error.to_string()))?;
+        if actual != expected {
+            return Err(GeneratorError::Checkpoint(
+                "checkpoint manifest does not match this source or invocation".to_string(),
+            ));
+        }
+    } else {
+        if manifest_path.exists()
+            || shards
+                .iter()
+                .any(|shard| shard_path(directory, shard.index).exists())
+        {
+            return Err(GeneratorError::Checkpoint(
+                "checkpoint directory already contains generator state; use --resume or another directory"
+                    .to_string(),
+            ));
+        }
+        write_atomic(&manifest_path, expected.as_bytes())?;
+    }
+    Ok(())
+}
+
+fn write_shard_atomic(
+    path: &Path,
+    shard: &ScanShard,
+    handoff: block::Height,
+    handoff_hash: block::Hash,
+    records: &[CandidateRecord],
+) -> Result<(), GeneratorError> {
+    let mut payload = Vec::new();
+    for record in records {
+        payload.extend_from_slice(&record.height.0.to_le_bytes());
+        payload.extend_from_slice(&record.block_hash.0);
+        let count = u16::try_from(record.commitments.len())
+            .map_err(|_| GeneratorError::Artifact(Error::TooManyCommitments.to_string()))?;
+        payload.extend_from_slice(&count.to_le_bytes());
+        for commitment in &record.commitments {
+            payload.extend_from_slice(&<[u8; 32]>::from(commitment));
+        }
+    }
+
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(SHARD_MAGIC);
+    bytes.extend_from_slice(&shard.range.start().0.to_le_bytes());
+    bytes.extend_from_slice(&shard.range.end().0.to_le_bytes());
+    bytes.extend_from_slice(&handoff.0.to_le_bytes());
+    bytes.extend_from_slice(&handoff_hash.0);
+    bytes.extend_from_slice(
+        &u32::try_from(records.len())
+            .map_err(|_| GeneratorError::Artifact(Error::TooManyRecords.to_string()))?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&Sha256::digest(&payload));
+    bytes.extend_from_slice(&payload);
+    write_atomic(path, &bytes)
+}
+
+#[allow(clippy::unwrap_in_result)]
+fn read_shard(
+    path: &Path,
+    shard: &ScanShard,
+    handoff: block::Height,
+    handoff_hash: block::Hash,
+) -> Result<Vec<CandidateRecord>, GeneratorError> {
+    const HEADER_LEN: usize = 8 + 4 + 4 + 4 + 32 + 4 + 32;
+    let bytes = fs::read(path).map_err(|error| GeneratorError::Checkpoint(error.to_string()))?;
+    if bytes.len() < HEADER_LEN || &bytes[..8] != SHARD_MAGIC {
+        return Err(GeneratorError::Checkpoint(format!(
+            "invalid shard file {}",
+            path.display()
+        )));
+    }
+    let read_u32 = |range: std::ops::Range<usize>| {
+        u32::from_le_bytes(bytes[range].try_into().expect("fixed shard header field"))
+    };
+    if read_u32(8..12) != shard.range.start().0
+        || read_u32(12..16) != shard.range.end().0
+        || read_u32(16..20) != handoff.0
+        || bytes[20..52] != handoff_hash.0
+    {
+        return Err(GeneratorError::Checkpoint(format!(
+            "shard identity mismatch in {}",
+            path.display()
+        )));
+    }
+    let record_count = usize::try_from(read_u32(52..56)).expect("u32 fits in usize");
+    let payload = &bytes[HEADER_LEN..];
+    if Sha256::digest(payload).as_slice() != &bytes[56..88] {
+        return Err(GeneratorError::Checkpoint(format!(
+            "shard digest mismatch in {}",
+            path.display()
+        )));
+    }
+
+    let mut cursor = 0usize;
+    let mut records = Vec::with_capacity(record_count);
+    for _ in 0..record_count {
+        let header = payload
+            .get(cursor..cursor + 38)
+            .ok_or_else(|| GeneratorError::Checkpoint("truncated shard record".to_string()))?;
+        let height = block::Height(u32::from_le_bytes(
+            header[..4].try_into().expect("fixed shard height"),
+        ));
+        if !shard.range.contains(&height) {
+            return Err(GeneratorError::Checkpoint(
+                "shard record is outside its height range".to_string(),
+            ));
+        }
+        let block_hash = block::Hash(header[4..36].try_into().expect("fixed shard hash"));
+        let count = usize::from(u16::from_le_bytes(
+            header[36..38].try_into().expect("fixed shard count"),
+        ));
+        cursor += 38;
+        let byte_count = count
+            .checked_mul(32)
+            .ok_or_else(|| GeneratorError::Checkpoint("invalid shard count".to_string()))?;
+        let commitment_bytes = payload
+            .get(cursor..cursor + byte_count)
+            .ok_or_else(|| GeneratorError::Checkpoint("truncated shard commitments".to_string()))?;
+        let commitments = commitment_bytes
+            .chunks_exact(32)
+            .map(|bytes| {
+                sprout::commitment::NoteCommitment::from(
+                    <[u8; 32]>::try_from(bytes).expect("fixed commitment chunk"),
+                )
+            })
+            .collect();
+        cursor += byte_count;
+        records.push(CandidateRecord {
+            height,
+            block_hash,
+            commitments,
+        });
+    }
+    if cursor != payload.len()
+        || records
+            .windows(2)
+            .any(|records| records[0].height >= records[1].height)
+    {
+        return Err(GeneratorError::Checkpoint(
+            "invalid shard record ordering or trailing bytes".to_string(),
+        ));
+    }
+    Ok(records)
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), GeneratorError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| GeneratorError::Checkpoint("checkpoint path has no parent".to_string()))?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|error| GeneratorError::Checkpoint(error.to_string()))?;
+    temporary
+        .write_all(bytes)
+        .and_then(|()| temporary.as_file_mut().sync_all())
+        .map_err(|error| GeneratorError::Checkpoint(error.to_string()))?;
+    temporary
+        .persist_noclobber(path)
+        .map_err(|error| GeneratorError::Checkpoint(error.error.to_string()))?;
+    #[cfg(unix)]
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| GeneratorError::Checkpoint(error.to_string()))?;
+    Ok(())
 }
 
 /// Loads the canonical artifact once independently reviewed bytes are embedded.
@@ -601,5 +1210,142 @@ mod tests {
         // The first record hash begins after the fixed header and height delta.
         bytes[115 + 4] ^= 1;
         assert_eq!(Artifact::decode(&bytes), Err(Error::DigestMismatch));
+    }
+
+    #[test]
+    fn shard_plan_covers_each_height_exactly_once() {
+        let shards = plan_shards(block::Height(10), 4);
+        let heights: Vec<_> = shards
+            .iter()
+            .flat_map(|shard| shard.range.start().0..=shard.range.end().0)
+            .collect();
+
+        assert_eq!(heights, (0..=10).collect::<Vec<_>>());
+        assert_eq!(shards.len(), 4);
+    }
+
+    #[test]
+    fn resumable_shard_round_trip_preserves_ordered_candidates() {
+        let directory = tempfile::tempdir().expect("temporary checkpoint directory is created");
+        let path = directory.path().join("shard.bin");
+        let shard = ScanShard {
+            index: 0,
+            range: block::Height(0)..=block::Height(10),
+        };
+        let handoff = block::Height(10);
+        let handoff_hash = block::Hash([10; 32]);
+        let records = vec![
+            CandidateRecord {
+                height: block::Height(2),
+                block_hash: block::Hash([2; 32]),
+                commitments: vec![sprout::commitment::NoteCommitment::from([20; 32])],
+            },
+            CandidateRecord {
+                height: block::Height(9),
+                block_hash: block::Hash([9; 32]),
+                commitments: vec![
+                    sprout::commitment::NoteCommitment::from([90; 32]),
+                    sprout::commitment::NoteCommitment::from([91; 32]),
+                ],
+            },
+        ];
+
+        write_shard_atomic(&path, &shard, handoff, handoff_hash, &records)
+            .expect("checkpoint shard is written");
+        let decoded =
+            read_shard(&path, &shard, handoff, handoff_hash).expect("checkpoint shard is read");
+
+        assert_eq!(decoded.len(), records.len());
+        for (decoded, expected) in decoded.iter().zip(&records) {
+            assert_eq!(decoded.height, expected.height);
+            assert_eq!(decoded.block_hash, expected.block_hash);
+            assert_eq!(decoded.commitments, expected.commitments);
+        }
+
+        let uninterrupted = Artifact::encode(
+            handoff,
+            handoff_hash,
+            replay_candidates(records).expect("uninterrupted candidates replay"),
+        )
+        .expect("uninterrupted artifact encodes");
+        let resumed = Artifact::encode(
+            handoff,
+            handoff_hash,
+            replay_candidates(decoded).expect("resumed candidates replay"),
+        )
+        .expect("resumed artifact encodes");
+        assert_eq!(resumed, uninterrupted);
+    }
+
+    #[test]
+    fn resumable_shard_rejects_corruption() {
+        let directory = tempfile::tempdir().expect("temporary checkpoint directory is created");
+        let path = directory.path().join("shard.bin");
+        let shard = ScanShard {
+            index: 0,
+            range: block::Height(0)..=block::Height(1),
+        };
+        write_shard_atomic(
+            &path,
+            &shard,
+            block::Height(1),
+            block::Hash([1; 32]),
+            &[CandidateRecord {
+                height: block::Height(1),
+                block_hash: block::Hash([1; 32]),
+                commitments: vec![sprout::commitment::NoteCommitment::from([1; 32])],
+            }],
+        )
+        .expect("checkpoint shard is written");
+        let mut bytes = fs::read(&path).expect("checkpoint shard is readable");
+        *bytes.last_mut().expect("checkpoint has a payload") ^= 1;
+        fs::write(&path, bytes).expect("checkpoint corruption is written");
+
+        assert!(matches!(
+            read_shard(&path, &shard, block::Height(1), block::Hash([1; 32])),
+            Err(GeneratorError::Checkpoint(_))
+        ));
+    }
+
+    #[test]
+    fn resume_manifest_rejects_changed_shard_plan() {
+        let source = tempfile::tempdir().expect("source directory is created");
+        let checkpoint_parent = tempfile::tempdir().expect("checkpoint parent is created");
+        let checkpoint = checkpoint_parent.path().join("progress");
+        let config = Config {
+            cache_dir: source.path().to_path_buf(),
+            ..Config::default()
+        };
+        let mut options = GeneratorOptions {
+            shards: 2,
+            workers: 2,
+            readahead_size: 16 * 1024 * 1024,
+            checkpoint_dir: Some(checkpoint),
+            resume: false,
+            progress: None,
+        };
+        let handoff = block::Height(10);
+        let handoff_hash = block::Hash([10; 32]);
+        prepare_checkpoint_dir(
+            &config,
+            &options,
+            handoff,
+            handoff_hash,
+            &plan_shards(handoff, options.shards),
+        )
+        .expect("initial manifest is written");
+
+        options.resume = true;
+        options.shards = 3;
+        assert!(matches!(
+            prepare_checkpoint_dir(
+                &config,
+                &options,
+                handoff,
+                handoff_hash,
+                &plan_shards(handoff, options.shards)
+            ),
+            Err(GeneratorError::Checkpoint(_))
+        ));
     }
 }

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -292,6 +292,38 @@ impl ZakuraDb {
         self.db.zs_get(&hash_by_height, &height)
     }
 
+    /// Returns canonical block hashes in ascending height order.
+    pub(crate) fn hashes_by_height_range(
+        &self,
+        range: impl RangeBounds<block::Height>,
+        readahead_size: usize,
+    ) -> impl Iterator<Item = (block::Height, block::Hash)> + '_ {
+        let hash_by_height = self.db.cf_handle("hash_by_height").unwrap();
+        self.db
+            .zs_forward_range_iter_for_bulk_scan(hash_by_height, range, readahead_size)
+    }
+
+    /// Returns raw canonical block headers in ascending height order.
+    pub(crate) fn raw_block_headers_by_height_range(
+        &self,
+        range: impl RangeBounds<block::Height>,
+        readahead_size: usize,
+    ) -> impl Iterator<Item = (block::Height, RawBytes)> + '_ {
+        let block_header_by_height = self.db.cf_handle("block_header_by_height").unwrap();
+        self.db
+            .zs_forward_range_iter_for_bulk_scan(block_header_by_height, range, readahead_size)
+    }
+
+    /// Returns the canonical reverse block index in block-hash order.
+    pub(crate) fn heights_by_hash(
+        &self,
+        readahead_size: usize,
+    ) -> impl Iterator<Item = (block::Hash, block::Height)> + '_ {
+        let height_by_hash = self.db.cf_handle("height_by_hash").unwrap();
+        self.db
+            .zs_forward_range_iter_for_bulk_scan(height_by_hash, .., readahead_size)
+    }
+
     /// Returns the height of the given block if it exists.
     #[allow(clippy::unwrap_in_result)]
     pub fn height(&self, hash: block::Hash) -> Option<block::Height> {
@@ -827,6 +859,34 @@ impl ZakuraDb {
     {
         let tx_by_loc = self.db.cf_handle("tx_by_loc").unwrap();
         self.db.zs_forward_range_iter(tx_by_loc, range)
+    }
+
+    /// Returns raw transactions in chain order using the offline bulk-read profile.
+    pub(crate) fn raw_transactions_by_location_range_for_bulk_scan<R>(
+        &self,
+        range: R,
+        readahead_size: usize,
+    ) -> impl Iterator<Item = (TransactionLocation, RawBytes)> + '_
+    where
+        R: RangeBounds<TransactionLocation>,
+    {
+        let tx_by_loc = self.db.cf_handle("tx_by_loc").unwrap();
+        self.db
+            .zs_forward_range_iter_for_bulk_scan(tx_by_loc, range, readahead_size)
+    }
+
+    /// Returns stored transaction hashes in chain order.
+    pub(crate) fn transaction_hashes_by_location_range<R>(
+        &self,
+        range: R,
+        readahead_size: usize,
+    ) -> impl Iterator<Item = (TransactionLocation, transaction::Hash)> + '_
+    where
+        R: RangeBounds<TransactionLocation>,
+    {
+        let hash_by_tx_loc = self.db.cf_handle("hash_by_tx_loc").unwrap();
+        self.db
+            .zs_forward_range_iter_for_bulk_scan(hash_by_tx_loc, range, readahead_size)
     }
 
     /// Returns `true` if raw transaction bytes exist in the half-open height range

--- a/zakurad/src/commands.rs
+++ b/zakurad/src/commands.rs
@@ -13,6 +13,7 @@ pub use self::{entry_point::EntryPoint, start::StartCmd};
 use self::{
     copy_state::CopyStateCmd, generate::GenerateCmd, prune_state::PruneStateCmd,
     rollback_state::RollbackStateCmd, tip_height::TipHeightCmd,
+    validate_vct_sprout_history::ValidateVctSproutHistoryCmd,
 };
 
 pub mod start;
@@ -23,6 +24,7 @@ mod generate;
 pub mod prune_state;
 pub mod rollback_state;
 mod tip_height;
+mod validate_vct_sprout_history;
 
 #[cfg(test)]
 mod tests;
@@ -56,6 +58,9 @@ pub enum ZakuradCmd {
 
     /// Print the tip block height of Zebra's chain state on disk
     TipHeight(TipHeightCmd),
+
+    /// Validate repaired VCT Sprout history in the state database
+    ValidateVctSproutHistory(ValidateVctSproutHistoryCmd),
 }
 
 impl ZakuradCmd {
@@ -71,7 +76,11 @@ impl ZakuradCmd {
             CopyState(_) | Start(_) => true,
 
             // Utility commands that don't use server components
-            Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => false,
+            Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_)
+            | ValidateVctSproutHistory(_) => false,
         }
     }
 
@@ -85,7 +94,12 @@ impl ZakuradCmd {
             Start(_) => true,
 
             // Utility commands
-            CopyState(_) | Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => false,
+            CopyState(_)
+            | Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_)
+            | ValidateVctSproutHistory(_) => false,
         }
     }
 
@@ -104,7 +118,11 @@ impl ZakuradCmd {
             // This output:
             // - is used by automated tools, or
             // - needs to be read easily.
-            Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => true,
+            Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_)
+            | ValidateVctSproutHistory(_) => true,
 
             // Commands that generate informative logging output by default.
             CopyState(_) | Start(_) => false,
@@ -129,6 +147,7 @@ impl Runnable for ZakuradCmd {
             RollbackState(cmd) => cmd.run(),
             Start(cmd) => cmd.run(),
             TipHeight(cmd) => cmd.run(),
+            ValidateVctSproutHistory(cmd) => cmd.run(),
         }
     }
 }

--- a/zakurad/src/commands/tests.rs
+++ b/zakurad/src/commands/tests.rs
@@ -45,3 +45,22 @@ fn args_with_subcommand_pass_through() {
         assert_eq!(matches!(args.cmd(), ZakuradCmd::Start(_)), should_be_start,);
     }
 }
+
+#[test]
+fn validate_vct_sprout_history_requires_network() {
+    let args = EntryPoint::try_parse_from([
+        "zakurad",
+        "validate-vct-sprout-history",
+        "--network",
+        "mainnet",
+        "--cache-dir",
+        "/tmp/zakura-state",
+    ])
+    .expect("validation command with an explicit network should parse");
+    assert!(matches!(
+        args.cmd(),
+        ZakuradCmd::ValidateVctSproutHistory(_)
+    ));
+
+    assert!(EntryPoint::try_parse_from(["zakurad", "validate-vct-sprout-history"]).is_err());
+}

--- a/zakurad/src/commands/validate_vct_sprout_history.rs
+++ b/zakurad/src/commands/validate_vct_sprout_history.rs
@@ -1,0 +1,63 @@
+//! `validate-vct-sprout-history` subcommand - audits repaired historical Sprout anchors.
+
+use std::path::PathBuf;
+
+use abscissa_core::{Application, Command, Runnable};
+use clap::Parser;
+use color_eyre::eyre::Result;
+
+use zakura_chain::parameters::Network;
+use zakura_state::VctSproutHistoryValidationSummary;
+
+use crate::prelude::APPLICATION;
+
+/// Validate repaired VCT Sprout history in an existing state database
+#[derive(Command, Debug, Default, Parser)]
+pub struct ValidateVctSproutHistoryCmd {
+    /// Path to Zakura's cached state.
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
+    cache_dir: Option<PathBuf>,
+
+    /// The network of the chain to validate.
+    #[clap(
+        long,
+        short,
+        required = true,
+        help = "the network of the chain to load"
+    )]
+    network: Network,
+}
+
+impl Runnable for ValidateVctSproutHistoryCmd {
+    /// `validate-vct-sprout-history` sub-command entrypoint.
+    fn run(&self) {
+        if let Err(error) = self.run_with_config(APPLICATION.config().state.clone()) {
+            tracing::error!("Failed to validate VCT Sprout history: {error}");
+            std::process::exit(1);
+        }
+    }
+}
+
+impl ValidateVctSproutHistoryCmd {
+    /// Runs validation using `state_config` as the base state configuration.
+    #[allow(clippy::print_stdout)]
+    pub fn run_with_config(&self, mut state_config: zakura_state::Config) -> Result<()> {
+        if let Some(cache_dir) = self.cache_dir.clone() {
+            state_config.cache_dir = cache_dir;
+        }
+
+        let summary = zakura_state::validate_vct_sprout_history(state_config, &self.network)?;
+        print_summary(&summary);
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::print_stdout)]
+fn print_summary(summary: &VctSproutHistoryValidationSummary) {
+    println!("VCT Sprout history is valid:");
+    println!("  finalized tip: {}", summary.finalized_tip.0);
+    println!("  VCT marker: {}", summary.vct_marker.0);
+    println!("  artifact handoff: {}", summary.artifact_handoff.0);
+    println!("  checked Sprout anchors: {}", summary.checked_anchor_count);
+}


### PR DESCRIPTION
## Motivation

The offline VCT Sprout-history artifact generator performs millions of per-height RocksDB point reads and creates a transaction iterator for every block. On archive volumes this makes random I/O the bottleneck while CPU and memory remain mostly idle, and an interrupted run must restart from genesis.

## Solution

- replace per-height point reads with configurable height-sharded sequential RocksDB scans using async I/O and readahead
- decode transaction streams concurrently while preserving deterministic height, transaction, and JoinSplit ordering in a single Sprout replay
- strengthen source validation with forward/reverse index, transaction hash, transaction-index continuity, header hash, and transaction Merkle-root checks
- add atomic checksummed shard checkpoints, strict resume identity validation, progress/ETA reporting, and safe cleanup after artifact creation
- preserve the version-1 artifact encoding, final production decode/replay, canonical checks, handoff checks, and no-clobber output behavior

## Testing

- `cargo test -p zakura-state` — exercises the complete state suite, including the new shard planning, checkpoint corruption, resume equivalence, manifest mismatch, CLI parsing, and cleanup tests
- `cargo clippy -p zakura-state --all-targets -- -D warnings`
- `markdownlint CHANGELOG.md docs/design/verified-commitment-trees.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics and `git diff --check`

A real-archive throughput benchmark was not run locally because `VCT_ARCHIVE_DB` was not configured. Final artifact bytes should be reproduced and compared on the target local-NVMe archive before embedding.

### Specifications & References

- `docs/design/verified-commitment-trees.md`

### Follow-up Work

- Benchmark shard, worker, and readahead settings against the production archive and record the resulting artifact SHA-256.