### PR TITLE
feat(state): embed Mainnet VCT Sprout history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Add `zakurad validate-vct-sprout-history` to audit repaired historical
+  Sprout anchors in archive or pruned Mainnet state databases.
+
 ### Fixed
 
 - Database format upgrades now finish before startup exposes the finalized

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -888,13 +888,11 @@ its output.
 
 ### 17.4 Embedding, availability, and replay
 
-`vct/artifact.rs` currently has no embedded Mainnet bytes (`MAINNET_ARTIFACT` is `None`).
-When reviewed bytes are available, they are compiled into that module and loaded only through
-`embedded_mainnet()`. Until then, opening a pre-28.0.1 Mainnet VCT-synced database is rejected.
-The guard also rejects affected read-only databases and writable opens with upgrades disabled,
-even after artifact bytes become available: operators must reopen writable to repair or
-discard/resync. Non-Mainnet databases never load or replay this Mainnet artifact. Normally synced
-databases and databases already marked at the repair format are unaffected.
+The reviewed Mainnet bytes are compiled into `vct/artifact.rs` and loaded only through
+`embedded_mainnet()`. The guard rejects affected read-only databases and writable opens with
+upgrades disabled: operators must reopen writable to repair or discard/resync. Non-Mainnet
+databases never load or replay this Mainnet artifact. Normally synced databases and databases
+already marked at the repair format are unaffected.
 
 The initial startup format change now runs synchronously before `ZakuraDb` or `FinalizedState`
 is exposed; only periodic current-format checks remain in the background. Therefore no block

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -64,7 +64,7 @@ pub use service::{
     finalized_state::FinalizedState,
     init, init_read_only,
     non_finalized_state::NonFinalizedState,
-    spawn_init_read_only,
+    spawn_init_read_only, validate_vct_sprout_history,
     watch_receiver::WatchReceiver,
     OutputLocation, ReadState, State, TransactionIndex, TransactionLocation,
 };
@@ -84,6 +84,9 @@ pub use service::finalized_state::{
 pub use service::finalized_state::{
     preview_rollback_finalized_state, rollback_finalized_state, RollbackBackupSummary,
     RollbackFinalizedStateError, RollbackFinalizedStateOptions, RollbackFinalizedStateSummary,
+};
+pub use service::finalized_state::{
+    VctSproutHistoryValidationError, VctSproutHistoryValidationSummary,
 };
 pub use service::{
     finalized_state::{DiskWriteBatch, FromDisk, IntoDisk, WriteDisk, ZakuraDb},

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -2283,6 +2283,20 @@ pub fn init_read_only(
     ))
 }
 
+/// Opens an existing database read-only and audits its completed VCT Sprout-history repair.
+pub fn validate_vct_sprout_history(
+    config: Config,
+    network: &Network,
+) -> Result<
+    finalized_state::VctSproutHistoryValidationSummary,
+    finalized_state::VctSproutHistoryValidationError,
+> {
+    let (_, db, _) = init_read_only(config, network)
+        .map_err(finalized_state::VctSproutHistoryValidationError::OpenDatabase)?;
+
+    finalized_state::validate_completed_repair(&db)
+}
+
 /// Calls [`init_read_only`] with the provided [`Config`] and [`Network`] from a blocking task.
 ///
 /// Returns a [`tokio::task::JoinHandle`] whose output is a [`Result`]: awaiting it yields a

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -98,6 +98,10 @@ pub(crate) use commitment_aux::serve_block_roots;
 pub use commitment_aux::{produce_final_frontiers_bytes, FinalFrontiersGenerationError};
 #[allow(unused_imports)]
 pub use disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk};
+pub(crate) use disk_format::upgrade::repair_vct_sprout_history::validate_completed_repair;
+pub use disk_format::upgrade::repair_vct_sprout_history::{
+    VctSproutHistoryValidationError, VctSproutHistoryValidationSummary,
+};
 #[allow(unused_imports)]
 pub use disk_format::{
     FromDisk, IntoDisk, OutputLocation, RawBytes, TransactionIndex, TransactionLocation,

--- a/zakura-state/src/service/finalized_state/disk_format/upgrade/repair_vct_sprout_history.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/upgrade/repair_vct_sprout_history.rs
@@ -27,6 +27,55 @@ pub(crate) const REPAIR_VERSION: Version = Version::new(28, 0, 1);
 /// Replays the reviewed Mainnet artifact into pre-28.0.1 VCT databases.
 pub struct Upgrade;
 
+/// A successful read-only audit of VCT Sprout history.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VctSproutHistoryValidationSummary {
+    /// The finalized database tip checked by the audit.
+    pub finalized_tip: Height,
+    /// The persisted VCT handoff marker.
+    pub vct_marker: Height,
+    /// The handoff authenticated by the embedded artifact.
+    pub artifact_handoff: Height,
+    /// The empty anchor plus artifact-record anchors checked by the audit.
+    pub checked_anchor_count: usize,
+}
+
+/// Errors returned by the read-only VCT Sprout-history audit.
+#[derive(Debug, Error)]
+pub enum VctSproutHistoryValidationError {
+    /// The state database could not be opened read-only.
+    #[error("could not open the state database read-only")]
+    OpenDatabase(#[source] crate::StateInitError),
+    /// The audit only has canonical inputs for Mainnet.
+    #[error("VCT Sprout-history validation is only supported on Mainnet")]
+    UnsupportedNetwork,
+    /// The database was not created by VCT fast sync.
+    #[error("the database does not have a persisted VCT marker")]
+    NotVctSynced,
+    /// The database has not durably completed the repair format.
+    #[error(
+        "database format {actual} predates required VCT Sprout-history repair format {required}"
+    )]
+    RepairNotCompleted {
+        /// The version stored on disk, or `None` if no version was stored.
+        actual: String,
+        /// The first format version containing the repair.
+        required: Version,
+    },
+    /// The database format version could not be read.
+    #[error("could not read the database format version: {reason}")]
+    FormatVersion {
+        /// The underlying version-file error.
+        reason: String,
+    },
+    /// The artifact, canonical indexes, or repaired records failed validation.
+    #[error("VCT Sprout-history validation failed: {reason}")]
+    Invalid {
+        /// The failed artifact, index, anchor, or frontier check.
+        reason: String,
+    },
+}
+
 #[derive(Debug, Error)]
 pub(crate) enum RepairValidationError {
     #[error("the embedded VCT final frontier is invalid: {0}")]
@@ -77,6 +126,63 @@ pub(crate) fn validate_startup_repair(db: &ZakuraDb) -> Result<(), RepairValidat
         .vct_synced_below()
         .ok_or(RepairValidationError::MissingVctMarker)?;
     validated_repair_input(db, marker).map(|_| ())
+}
+
+/// Audits a completed VCT Sprout-history repair without modifying the database.
+pub(crate) fn validate_completed_repair(
+    db: &ZakuraDb,
+) -> Result<VctSproutHistoryValidationSummary, VctSproutHistoryValidationError> {
+    if db.network() != Network::Mainnet {
+        return Err(VctSproutHistoryValidationError::UnsupportedNetwork);
+    }
+
+    let marker = db
+        .vct_synced_below()
+        .ok_or(VctSproutHistoryValidationError::NotVctSynced)?;
+    let disk_version = db.format_version_on_disk().map_err(|error| {
+        VctSproutHistoryValidationError::FormatVersion {
+            reason: error.to_string(),
+        }
+    })?;
+    if disk_version
+        .as_ref()
+        .is_none_or(|version| version < &REPAIR_VERSION)
+    {
+        return Err(VctSproutHistoryValidationError::RepairNotCompleted {
+            actual: disk_version
+                .map_or_else(|| "unknown".to_string(), |version| version.to_string()),
+            required: REPAIR_VERSION,
+        });
+    }
+
+    let input = validated_repair_input(db, marker).map_err(|error| {
+        VctSproutHistoryValidationError::Invalid {
+            reason: error.to_string(),
+        }
+    })?;
+    let finalized_tip =
+        db.finalized_tip_height()
+            .ok_or_else(|| VctSproutHistoryValidationError::Invalid {
+                reason: RepairValidationError::MissingFinalizedTip.to_string(),
+            })?;
+    let checked_anchor_count = input
+        .artifact
+        .records_through(finalized_tip.min(marker))
+        .count()
+        .saturating_add(1);
+    let (_cancel_sender, cancel_receiver) = crossbeam_channel::bounded(1);
+    validate_repaired_records(db, marker, &input, true, &cancel_receiver)
+        .map_err(|_| VctSproutHistoryValidationError::Invalid {
+            reason: "validation was unexpectedly cancelled".to_string(),
+        })?
+        .map_err(|reason| VctSproutHistoryValidationError::Invalid { reason })?;
+
+    Ok(VctSproutHistoryValidationSummary {
+        finalized_tip,
+        vct_marker: marker,
+        artifact_handoff: input.artifact_last_checkpoint,
+        checked_anchor_count,
+    })
 }
 
 impl DiskFormatUpgrade for Upgrade {
@@ -142,7 +248,7 @@ impl DiskFormatUpgrade for Upgrade {
             Err(error) => return Ok(Err(error.to_string())),
         };
 
-        validate_repaired_records(db, marker, &input, cancel_receiver)
+        validate_repaired_records(db, marker, &input, false, cancel_receiver)
     }
 }
 
@@ -284,6 +390,7 @@ fn validate_repaired_records(
     db: &ZakuraDb,
     marker: Height,
     input: &RepairInput,
+    check_tip_at_marker: bool,
     cancel_receiver: &Receiver<CancelFormatChange>,
 ) -> Result<Result<(), String>, CancelFormatChange> {
     let tip = db
@@ -317,7 +424,7 @@ fn validate_repaired_records(
         }
     }
 
-    if tip < marker {
+    if tip < marker || (check_tip_at_marker && tip == marker) {
         let tip_tree = db.sprout_tree_for_tip().map_err(|error| error.to_string());
         if tip_tree.as_deref() != Ok(&tree) {
             return Ok(Err(format!(
@@ -818,16 +925,23 @@ mod tests {
         let handoff = Height(2);
         let first_hash = block::Hash([1; 32]);
         let handoff_hash = block::Hash([2; 32]);
-        let path = seed_repair_db(
-            &config,
-            &network,
-            handoff,
-            &[(first_height, first_hash), (handoff, handoff_hash)],
-        );
         let (artifact, roots) = fixture_artifact_with_records(
             handoff,
             handoff_hash,
             &[(first_height, first_hash, 11), (handoff, handoff_hash, 12)],
+        );
+        let mut tip_tree = NoteCommitmentTree::default();
+        for value in [11, 12] {
+            tip_tree
+                .append(sprout::commitment::NoteCommitment::from([value; 32]))
+                .expect("fixture tree has capacity");
+        }
+        let path = seed_repair_db_with_tip(
+            &config,
+            &network,
+            handoff,
+            &[(first_height, first_hash), (handoff, handoff_hash)],
+            &tip_tree,
         );
         let _injection = inject_test_repair_input(
             path,
@@ -858,6 +972,76 @@ mod tests {
             db.block(first_height.into()).is_none(),
             "repair uses retained canonical indexes and does not require pruned bodies"
         );
+
+        let summary =
+            validate_completed_repair(&db).expect("the completed pruned repair validates");
+        assert_eq!(
+            summary,
+            VctSproutHistoryValidationSummary {
+                finalized_tip: handoff,
+                vct_marker: handoff,
+                artifact_handoff: handoff,
+                checked_anchor_count: 3,
+            }
+        );
+
+        let mut corrupt_batch = DiskWriteBatch::new();
+        corrupt_batch.delete_sprout_anchor(&db, &roots[0]);
+        db.write_batch(corrupt_batch)
+            .expect("fixture anchor corruption succeeds");
+        assert!(matches!(
+            validate_completed_repair(&db),
+            Err(VctSproutHistoryValidationError::Invalid { reason })
+                if reason.contains("Sprout anchor at")
+        ));
+    }
+
+    #[test]
+    fn completed_repair_audit_detects_canonical_reverse_index_corruption() {
+        let (_cache, config) = persistent_config();
+        let network = Network::Mainnet;
+        let record_height = Height(1);
+        let handoff = Height(2);
+        let record_hash = block::Hash([1; 32]);
+        let handoff_hash = block::Hash([2; 32]);
+        let (artifact, roots) =
+            fixture_artifact(handoff, handoff_hash, record_height, record_hash, 13);
+        let mut tip_tree = NoteCommitmentTree::default();
+        tip_tree
+            .append(sprout::commitment::NoteCommitment::from([13; 32]))
+            .expect("fixture tree has capacity");
+        let path = seed_repair_db_with_tip(
+            &config,
+            &network,
+            handoff,
+            &[(record_height, record_hash), (handoff, handoff_hash)],
+            &tip_tree,
+        );
+        let _injection = inject_test_repair_input(
+            path,
+            TestRepairInput {
+                handoff,
+                handoff_hash,
+                handoff_sprout_root: roots,
+                artifact,
+                marker_hash: None,
+                before_write: None,
+            },
+        );
+        let db = open_normally(&config, &network);
+        validate_completed_repair(&db).expect("the completed repair initially validates");
+
+        let height_by_hash = db.db().cf_handle("height_by_hash").unwrap();
+        let mut corrupt_batch = DiskWriteBatch::new();
+        corrupt_batch.zs_delete(&height_by_hash, record_hash);
+        db.write_batch(corrupt_batch)
+            .expect("fixture reverse-index corruption succeeds");
+
+        assert!(matches!(
+            validate_completed_repair(&db),
+            Err(VctSproutHistoryValidationError::Invalid { reason })
+                if reason.contains("reverse block index")
+        ));
     }
 
     #[test]

--- a/zakura-state/src/service/finalized_state/vct/artifact.rs
+++ b/zakura-state/src/service/finalized_state/vct/artifact.rs
@@ -21,7 +21,7 @@ const MAGIC: &[u8; 8] = b"ZKVCTSP1";
 const MAINNET_NETWORK: u8 = 1;
 const MAX_RECORDS: usize = 1_000_000;
 const MAX_COMMITMENTS_PER_RECORD: usize = 65_535;
-const MAINNET_ARTIFACT: Option<&[u8]> = None;
+const MAINNET_ARTIFACT: Option<&[u8]> = Some(include_bytes!("mainnet-sprout-history.bin"));
 
 /// One historical block that changed the Sprout commitment tree.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -436,6 +436,22 @@ pub(crate) fn embedded_mainnet() -> Result<Artifact, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn embedded_mainnet_artifact_matches_handoff() {
+        let network = zakura_chain::parameters::Network::Mainnet;
+        let frontiers =
+            embedded_final_frontiers(&network).expect("Mainnet has embedded final frontiers");
+        let handoff_hash = network
+            .checkpoint_list()
+            .hash(frontiers.height)
+            .expect("the embedded frontier height has a Mainnet checkpoint");
+        let artifact = embedded_mainnet().expect("the reviewed Mainnet artifact decodes");
+
+        artifact
+            .validate_last_checkpoint(frontiers.height, handoff_hash, frontiers.sprout.root())
+            .expect("the reviewed Mainnet artifact matches the embedded handoff");
+    }
 
     #[test]
     fn artifact_round_trip_replays_each_record() {

--- a/zakurad/src/commands.rs
+++ b/zakurad/src/commands.rs
@@ -13,6 +13,7 @@ pub use self::{entry_point::EntryPoint, start::StartCmd};
 use self::{
     copy_state::CopyStateCmd, generate::GenerateCmd, prune_state::PruneStateCmd,
     rollback_state::RollbackStateCmd, tip_height::TipHeightCmd,
+    validate_vct_sprout_history::ValidateVctSproutHistoryCmd,
 };
 
 pub mod start;
@@ -23,6 +24,7 @@ mod generate;
 pub mod prune_state;
 pub mod rollback_state;
 mod tip_height;
+mod validate_vct_sprout_history;
 
 #[cfg(test)]
 mod tests;
@@ -56,6 +58,9 @@ pub enum ZakuradCmd {
 
     /// Print the tip block height of Zebra's chain state on disk
     TipHeight(TipHeightCmd),
+
+    /// Validate repaired VCT Sprout history in the state database
+    ValidateVctSproutHistory(ValidateVctSproutHistoryCmd),
 }
 
 impl ZakuradCmd {
@@ -71,7 +76,11 @@ impl ZakuradCmd {
             CopyState(_) | Start(_) => true,
 
             // Utility commands that don't use server components
-            Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => false,
+            Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_)
+            | ValidateVctSproutHistory(_) => false,
         }
     }
 
@@ -85,7 +94,12 @@ impl ZakuradCmd {
             Start(_) => true,
 
             // Utility commands
-            CopyState(_) | Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => false,
+            CopyState(_)
+            | Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_)
+            | ValidateVctSproutHistory(_) => false,
         }
     }
 
@@ -104,7 +118,11 @@ impl ZakuradCmd {
             // This output:
             // - is used by automated tools, or
             // - needs to be read easily.
-            Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => true,
+            Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_)
+            | ValidateVctSproutHistory(_) => true,
 
             // Commands that generate informative logging output by default.
             CopyState(_) | Start(_) => false,
@@ -129,6 +147,7 @@ impl Runnable for ZakuradCmd {
             RollbackState(cmd) => cmd.run(),
             Start(cmd) => cmd.run(),
             TipHeight(cmd) => cmd.run(),
+            ValidateVctSproutHistory(cmd) => cmd.run(),
         }
     }
 }

--- a/zakurad/src/commands/tests.rs
+++ b/zakurad/src/commands/tests.rs
@@ -45,3 +45,22 @@ fn args_with_subcommand_pass_through() {
         assert_eq!(matches!(args.cmd(), ZakuradCmd::Start(_)), should_be_start,);
     }
 }
+
+#[test]
+fn validate_vct_sprout_history_requires_network() {
+    let args = EntryPoint::try_parse_from([
+        "zakurad",
+        "validate-vct-sprout-history",
+        "--network",
+        "mainnet",
+        "--cache-dir",
+        "/tmp/zakura-state",
+    ])
+    .expect("validation command with an explicit network should parse");
+    assert!(matches!(
+        args.cmd(),
+        ZakuradCmd::ValidateVctSproutHistory(_)
+    ));
+
+    assert!(EntryPoint::try_parse_from(["zakurad", "validate-vct-sprout-history"]).is_err());
+}

--- a/zakurad/src/commands/validate_vct_sprout_history.rs
+++ b/zakurad/src/commands/validate_vct_sprout_history.rs
@@ -1,0 +1,63 @@
+//! `validate-vct-sprout-history` subcommand - audits repaired historical Sprout anchors.
+
+use std::path::PathBuf;
+
+use abscissa_core::{Application, Command, Runnable};
+use clap::Parser;
+use color_eyre::eyre::Result;
+
+use zakura_chain::parameters::Network;
+use zakura_state::VctSproutHistoryValidationSummary;
+
+use crate::prelude::APPLICATION;
+
+/// Validate repaired VCT Sprout history in an existing state database
+#[derive(Command, Debug, Default, Parser)]
+pub struct ValidateVctSproutHistoryCmd {
+    /// Path to Zakura's cached state.
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
+    cache_dir: Option<PathBuf>,
+
+    /// The network of the chain to validate.
+    #[clap(
+        long,
+        short,
+        required = true,
+        help = "the network of the chain to load"
+    )]
+    network: Network,
+}
+
+impl Runnable for ValidateVctSproutHistoryCmd {
+    /// `validate-vct-sprout-history` sub-command entrypoint.
+    fn run(&self) {
+        if let Err(error) = self.run_with_config(APPLICATION.config().state.clone()) {
+            tracing::error!("Failed to validate VCT Sprout history: {error}");
+            std::process::exit(1);
+        }
+    }
+}
+
+impl ValidateVctSproutHistoryCmd {
+    /// Runs validation using `state_config` as the base state configuration.
+    #[allow(clippy::print_stdout)]
+    pub fn run_with_config(&self, mut state_config: zakura_state::Config) -> Result<()> {
+        if let Some(cache_dir) = self.cache_dir.clone() {
+            state_config.cache_dir = cache_dir;
+        }
+
+        let summary = zakura_state::validate_vct_sprout_history(state_config, &self.network)?;
+        print_summary(&summary);
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::print_stdout)]
+fn print_summary(summary: &VctSproutHistoryValidationSummary) {
+    println!("VCT Sprout history is valid:");
+    println!("  finalized tip: {}", summary.finalized_tip.0);
+    println!("  VCT marker: {}", summary.vct_marker.0);
+    println!("  artifact handoff: {}", summary.artifact_handoff.0);
+    println!("  checked Sprout anchors: {}", summary.checked_anchor_count);
+}


### PR DESCRIPTION
## Motivation

The VCT Sprout repair and validation paths require authenticated Mainnet history bytes. Without an embedded artifact, validation fails before repaired historical anchors can be audited.

## Solution

- embed the generated Mainnet Sprout-history artifact in `zakura-state`
- verify in a focused test that it decodes and matches the checkpoint handoff hash and independently embedded Sprout frontier
- update the VCT design documentation to describe artifact availability

Artifact SHA-256: `abf89ec7b9eacbe7a259be891a17059496f2c7c7c2144d3babb34f85f8098832`

## Testing

- `cargo fmt --all -- --check`
- `npx --yes markdownlint-cli docs/design/verified-commitment-trees.md --config .trunk/configs/.markdownlint.yaml`
- `cargo test -p zakura-state embedded_mainnet_artifact_matches_handoff`
- `cargo build --release --bin zakurad`
- manually ran `validate-vct-sprout-history` against the pruned Mainnet dev database; it validated tip 3,414,993 and 317,191 Sprout anchors
- IDE diagnostics: no errors

The broader `cargo test -p zakura-state -p zakura` run was stopped at the request to open the PR without waiting; CI will provide full-suite coverage.