### PR TITLE
fix(release): finalize v1.0.2 package graph

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -129,10 +129,10 @@ sed "s#$HOME/.zakura#identity_dir#g" \
   > zakurad/tests/common/configs/v<version>.toml
 ```
 
-The replacements are global path-string substitutions, mirroring
-`last_config_is_stored` — the default cache path also appears in fields other
-than `cache_dir` (for example `cookie_dir`), so per-field rewrites produce a
-snapshot the test rejects.
+      The replacements are global path-string substitutions, mirroring
+      `last_config_is_stored` — the default cache path also appears in
+      fields other than `cache_dir` (for example `cookie_dir`), so
+      per-field rewrites produce a snapshot the test rejects.
 
 - [ ] On the release commit, run the pre-release checks for the tag you are
       about to create, using the previous release tag as the base:

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -129,10 +129,10 @@ sed "s#$HOME/.zakura#identity_dir#g" \
   > zakurad/tests/common/configs/v<version>.toml
 ```
 
-      The replacements are global path-string substitutions, mirroring
-      `last_config_is_stored` — the default cache path also appears in
-      fields other than `cache_dir` (for example `cookie_dir`), so
-      per-field rewrites produce a snapshot the test rejects.
+The replacements are global path-string substitutions, mirroring
+`last_config_is_stored` — the default cache path also appears in fields other
+than `cache_dir` (for example `cookie_dir`), so per-field rewrites produce a
+snapshot the test rejects.
 
 - [ ] On the release commit, run the pre-release checks for the tag you are
       about to create, using the previous release tag as the base:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Preserve Sprout note-commitment history during fresh verified-commitment-tree
   fast sync, so later JoinSplit spends can use historical anchors
   ([#239](https://github.com/zakura-core/zakura/pull/239)).
-- Automatically repair affected Mainnet databases that previously ran v2 p2p
-  plus fast mode during writable startup, using the reviewed embedded artifact.
-  Startup fails safely if the artifact or database does not validate, the
-  database is read-only, or format upgrades are disabled; operators can instead
-  restore a trusted snapshot or resync from genesis
+- Official release binaries automatically repair affected Mainnet databases
+  that previously ran v2 p2p plus fast mode during writable startup, using the
+  reviewed embedded artifact. Builds installed from crates.io omit the large
+  artifact and fail safely on affected databases; those operators must use an
+  official release binary, restore a trusted snapshot, or resync from genesis.
+  Startup also fails safely if validation fails, the database is read-only, or
+  format upgrades are disabled
   ([#244](https://github.com/zakura-core/zakura/pull/244),
   [#250](https://github.com/zakura-core/zakura/pull/250)).
 - Deliver mined/submitted block gossip to peers that were momentarily unready

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,6 +139,7 @@ FROM deps AS release
 ARG SHORT_SHA
 ARG FEATURES
 ENV FEATURES=${FEATURES}
+ENV ZAKURA_REQUIRE_VCT_SPROUT_HISTORY=1
 
 # Set the working directory for the build.
 ARG HOME

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -888,11 +888,18 @@ its output.
 
 ### 17.4 Embedding, availability, and replay
 
-The reviewed Mainnet bytes are compiled into `vct/artifact.rs` and loaded only through
-`embedded_mainnet()`. The guard rejects affected read-only databases and writable opens with
-upgrades disabled: operators must reopen writable to repair or discard/resync. Non-Mainnet
-databases never load or replay this Mainnet artifact. Normally synced databases and databases
-already marked at the repair format are unaffected.
+Source-checkout and official release builds compile the reviewed Mainnet bytes into the binary
+and load them only through `embedded_mainnet()`. Official Docker builds require the source
+artifact at build time and fail rather than produce an artifactless release binary. The
+`zakura-state` crates.io package excludes the large artifact to remain within registry package
+limits; builds from that package report the artifact as unavailable and fail closed if an affected
+database requires repair. They never download or substitute bytes.
+
+The startup guard also rejects affected read-only databases and writable opens with upgrades
+disabled. Operators must use an official release binary and reopen writable to repair, or
+discard/restore/resync the database. Non-Mainnet databases never load or replay this Mainnet
+artifact. Normally synced databases and databases already marked at the repair format are
+unaffected.
 
 The initial startup format change now runs synchronously before `ZakuraDb` or `FinalizedState`
 is exposed; only periodic current-format checks remain in the background. Therefore no block

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1] - 2026-07-18
+## [3.0.0] - 2026-07-18
+
+### Breaking Changes
+
+- Added `HeaderSyncStartError::AnchorAboveVerifiedBlockTip` to the exhaustive
+  `HeaderSyncStartError` enum
+  ([#227](https://github.com/zakura-core/zakura/pull/227)).
 
 ### Changed
 

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "2.0.1"
+version = "3.0.0"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal

--- a/zakura-rpc/CHANGELOG.md
+++ b/zakura-rpc/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- `zakura-state` and `zakura-consensus` moved to 3.0.0. Their service types
-  appear in this crate's public server signatures, so their major versions are
-  part of this crate's API; no APIs defined in this crate changed.
+- `zakura-state`, `zakura-network`, and `zakura-consensus` moved to 3.0.0.
+  Their service types appear in this crate's public server signatures, so
+  their major versions are part of this crate's API; no APIs defined in this
+  crate changed.
 
 ## [2.0.0] - 2026-07-17
 

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -113,7 +113,7 @@ zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
     "json-conversion",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "3.0.0" }
-zakura-network = { path = "../zakura-network", version = "2.0.0" }
+zakura-network = { path = "../zakura-network", version = "3.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = [
     "rpc-client",
 ] }
@@ -146,7 +146,7 @@ zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
 zakura-consensus = { path = "../zakura-consensus", version = "3.0.0", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "2.0.0", features = [
+zakura-network = { path = "../zakura-network", version = "3.0.0", features = [
     "proptest-impl",
 ] }
 zakura-state = { path = "../zakura-state", version = "3.0.0", features = [

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `ZakuraDb::spawn_format_change`; database format upgrades now
   complete synchronously during startup
   ([#240](https://github.com/zakura-core/zakura/pull/240)).
+- Changed `ZakuraDb::note_commitment_trees_for_tip`,
+  `ZakuraDb::sprout_tree_for_tip`, and
+  `DiskWriteBatch::prepare_trees_batch` to return errors when required Sprout
+  state is unavailable
+  ([#239](https://github.com/zakura-core/zakura/pull/239)).
 - Added variants to the exhaustive `FinalFrontiersGenerationError` and
   `RollbackFinalizedStateError` enums for missing Sprout state and stable-tip
   validation failures
@@ -28,8 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an offline validation API for auditing repaired Sprout anchors in
   archive or pruned Mainnet state databases
   ([#247](https://github.com/zakura-core/zakura/pull/247)).
-- Embedded the reviewed Mainnet Sprout-history artifact used by startup repair
-  and offline validation
+- Embedded the reviewed Mainnet Sprout-history artifact in source and official
+  release builds for startup repair and offline validation. The crates.io
+  package omits the large artifact and fails safely when an affected database
+  requires it
   ([#250](https://github.com/zakura-core/zakura/pull/250)).
 
 ### Fixed
@@ -40,8 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete database upgrades before exposing the finalized state service
   ([#240](https://github.com/zakura-core/zakura/pull/240)).
 - Automatically repair eligible legacy VCT Sprout history during writable
-  startup using the reviewed embedded Mainnet artifact. Startup fails safely
-  when repair cannot run or its inputs do not validate
+  startup when the build contains the reviewed Mainnet artifact. Startup fails
+  safely when repair cannot run or its inputs do not validate
   ([#244](https://github.com/zakura-core/zakura/pull/244),
   [#250](https://github.com/zakura-core/zakura/pull/250)).
 

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 keywords.workspace = true
 # Must be one of <https://crates.io/category_slugs>
 categories = ["asynchronous", "caching", "cryptography::cryptocurrencies"]
+exclude = ["src/service/finalized_state/vct/mainnet-sprout-history.bin"]
 
 [features]
 

--- a/zakura-state/build.rs
+++ b/zakura-state/build.rs
@@ -6,11 +6,9 @@ use std::{
 };
 
 const ARTIFACT_PATH: &str = "src/service/finalized_state/vct/mainnet-sprout-history.bin";
-const REQUIRE_ARTIFACT_ENV: &str = "ZAKURA_REQUIRE_VCT_SPROUT_HISTORY";
 
 fn main() {
     println!("cargo:rerun-if-changed={ARTIFACT_PATH}");
-    println!("cargo:rerun-if-env-changed={REQUIRE_ARTIFACT_ENV}");
     println!("cargo:rustc-check-cfg=cfg(zakura_vct_sprout_history_embedded)");
 
     let manifest_dir =
@@ -22,9 +20,7 @@ fn main() {
     if source.is_file() {
         embed_artifact(&source, &out_dir, &generated);
     } else {
-        require_artifact_if_configured(&source);
-        fs::write(generated, "const MAINNET_ARTIFACT: Option<&[u8]> = None;\n")
-            .expect("generated artifact source is writable");
+        require_artifact(&source);
     }
 }
 
@@ -39,11 +35,12 @@ fn embed_artifact(source: &Path, out_dir: &Path, generated: &Path) {
     println!("cargo:rustc-cfg=zakura_vct_sprout_history_embedded");
 }
 
-fn require_artifact_if_configured(source: &Path) {
-    if env::var_os(REQUIRE_ARTIFACT_ENV).is_some_and(|value| value == "1") {
-        panic!(
-            "{REQUIRE_ARTIFACT_ENV}=1 but the reviewed Sprout-history artifact is missing at {}",
-            source.display()
-        );
-    }
+fn require_artifact(source: &Path) -> ! {
+    // From the repository root:
+    // curl -fL https://raw.githubusercontent.com/zakura-core/zakura/main/zakura-state/src/service/finalized_state/vct/mainnet-sprout-history.bin -o zakura-state/src/service/finalized_state/vct/mainnet-sprout-history.bin
+    // cargo install --locked --path zakurad
+    panic!(
+        "the Sprout-history artifact is missing at {}. It was not included in the crates.io build due to size limit. Download it from https://github.com/zakura-core/zakura/blob/main/zakura-state/src/service/finalized_state/vct/mainnet-sprout-history.bin. Alternatively, sync from genesis or restore a snapshot from https://zakura.com/snapshots/",
+        source.display()
+    );
 }

--- a/zakura-state/build.rs
+++ b/zakura-state/build.rs
@@ -38,6 +38,7 @@ fn embed_artifact(source: &Path, out_dir: &Path, generated: &Path) {
 fn require_artifact(source: &Path) -> ! {
     // From the repository root:
     // curl -fL https://raw.githubusercontent.com/zakura-core/zakura/main/zakura-state/src/service/finalized_state/vct/mainnet-sprout-history.bin -o zakura-state/src/service/finalized_state/vct/mainnet-sprout-history.bin
+    // echo "abf89ec7b9eacbe7a259be891a17059496f2c7c7c2144d3babb34f85f8098832  zakura-state/src/service/finalized_state/vct/mainnet-sprout-history.bin" | shasum -a 256 --check
     // cargo install --locked --path zakurad
     panic!(
         "the Sprout-history artifact is missing at {}. It was not included in the crates.io build due to size limit. Download it from https://github.com/zakura-core/zakura/blob/main/zakura-state/src/service/finalized_state/vct/mainnet-sprout-history.bin. Alternatively, sync from genesis or restore a snapshot from https://zakura.com/snapshots/",

--- a/zakura-state/build.rs
+++ b/zakura-state/build.rs
@@ -1,0 +1,49 @@
+//! Selects the reviewed VCT Sprout-history artifact for this build.
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+const ARTIFACT_PATH: &str = "src/service/finalized_state/vct/mainnet-sprout-history.bin";
+const REQUIRE_ARTIFACT_ENV: &str = "ZAKURA_REQUIRE_VCT_SPROUT_HISTORY";
+
+fn main() {
+    println!("cargo:rerun-if-changed={ARTIFACT_PATH}");
+    println!("cargo:rerun-if-env-changed={REQUIRE_ARTIFACT_ENV}");
+    println!("cargo:rustc-check-cfg=cfg(zakura_vct_sprout_history_embedded)");
+
+    let manifest_dir =
+        PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("Cargo sets CARGO_MANIFEST_DIR"));
+    let source = manifest_dir.join(ARTIFACT_PATH);
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"));
+    let generated = out_dir.join("vct_sprout_history_artifact.rs");
+
+    if source.is_file() {
+        embed_artifact(&source, &out_dir, &generated);
+    } else {
+        require_artifact_if_configured(&source);
+        fs::write(generated, "const MAINNET_ARTIFACT: Option<&[u8]> = None;\n")
+            .expect("generated artifact source is writable");
+    }
+}
+
+fn embed_artifact(source: &Path, out_dir: &Path, generated: &Path) {
+    let destination = out_dir.join("mainnet-sprout-history.bin");
+    fs::copy(source, destination).expect("reviewed Sprout-history artifact is readable");
+    fs::write(
+        generated,
+        "const MAINNET_ARTIFACT: Option<&[u8]> = Some(include_bytes!(concat!(env!(\"OUT_DIR\"), \"/mainnet-sprout-history.bin\")));\n",
+    )
+    .expect("generated artifact source is writable");
+    println!("cargo:rustc-cfg=zakura_vct_sprout_history_embedded");
+}
+
+fn require_artifact_if_configured(source: &Path) {
+    if env::var_os(REQUIRE_ARTIFACT_ENV).is_some_and(|value| value == "1") {
+        panic!(
+            "{REQUIRE_ARTIFACT_ENV}=1 but the reviewed Sprout-history artifact is missing at {}",
+            source.display()
+        );
+    }
+}

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -109,7 +109,7 @@ pub enum StateInitError {
     /// A Mainnet VCT database written before the Sprout-history repair format is unsafe to use.
     #[error(
         "cannot open {mode} state: this verified-commitment-tree database may be missing historical Sprout anchors. \
-         {reason}. Hint: reopen the database writable with a build containing the reviewed repair artifact, or discard it and resync"
+         {reason}. Hint: reopen the database writable with a build containing the repair artifact, sync from snapshot (https://zakura.com/snapshots/), or resync from genesis"
     )]
     VctSproutHistoryRepairRequired {
         /// Whether this was a writable primary or read-only secondary open.
@@ -121,8 +121,7 @@ pub enum StateInitError {
     /// The embedded repair inputs or the local marker-scoped canonical state did not validate.
     #[error(
         "cannot open state: verified-commitment-tree Sprout-history repair validation failed: {reason}. \
-         Hint: use a build with mutually consistent checkpoint, frontier, and repair artifacts; \
-         if the local canonical marker binding is invalid, discard the database and resync"
+         Hint: reopen the database writable with a build containing the repair artifact, sync from snapshot (https://zakura.com/snapshots/), or resync from genesis"
     )]
     VctSproutHistoryRepairInvalid {
         /// The failed build-level or database-level validation.

--- a/zakura-state/src/service/finalized_state/vct/artifact.rs
+++ b/zakura-state/src/service/finalized_state/vct/artifact.rs
@@ -21,7 +21,8 @@ const MAGIC: &[u8; 8] = b"ZKVCTSP1";
 const MAINNET_NETWORK: u8 = 1;
 const MAX_RECORDS: usize = 1_000_000;
 const MAX_COMMITMENTS_PER_RECORD: usize = 65_535;
-const MAINNET_ARTIFACT: Option<&[u8]> = Some(include_bytes!("mainnet-sprout-history.bin"));
+
+include!(concat!(env!("OUT_DIR"), "/vct_sprout_history_artifact.rs"));
 
 /// One historical block that changed the Sprout commitment tree.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -437,6 +438,7 @@ pub(crate) fn embedded_mainnet() -> Result<Artifact, Error> {
 mod tests {
     use super::*;
 
+    #[cfg(zakura_vct_sprout_history_embedded)]
     #[test]
     fn embedded_mainnet_artifact_matches_handoff() {
         let network = zakura_chain::parameters::Network::Mainnet;
@@ -451,6 +453,12 @@ mod tests {
         artifact
             .validate_last_checkpoint(frontiers.height, handoff_hash, frontiers.sprout.root())
             .expect("the reviewed Mainnet artifact matches the embedded handoff");
+    }
+
+    #[cfg(not(zakura_vct_sprout_history_embedded))]
+    #[test]
+    fn artifactless_build_reports_unavailable_mainnet_artifact() {
+        assert_eq!(embedded_mainnet(), Err(Error::CanonicalArtifactUnavailable));
     }
 
     #[test]

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -161,7 +161,7 @@ comparison-interpreter = ["zakura-script/comparison-interpreter"]
 zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
 zakura-consensus = { path = "../zakura-consensus", version = "3.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
-zakura-network = { path = "../zakura-network", version = "2.0.0" }
+zakura-network = { path = "../zakura-network", version = "3.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = ["rpc-client"] }
 zakura-rpc = { path = "../zakura-rpc", version = "3.0.0" }
 zakura-state = { path = "../zakura-state", version = "3.0.0" }
@@ -314,7 +314,7 @@ color-eyre = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "3.0.0", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "2.0.0", features = ["proptest-impl", "zakura-testkit"] }
+zakura-network = { path = "../zakura-network", version = "3.0.0", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "3.0.0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "1.0.0" }


### PR DESCRIPTION
## Summary

- exclude the large Mainnet Sprout-history artifact from the `zakura-state` crates.io package
- embed and require the reviewed artifact in official Docker/release builds
- make artifactless crates.io builds fail closed on databases that require repair
- bump `zakura-network` to 3.0.0 for its breaking public error-enum change and update dependent requirements
- document the channel-specific behavior, breaking API, and recovery options

## Motivation

The reviewed repair artifact is required by affected legacy VCT databases, but including it makes `zakura-state` exceed crates.io package constraints. Official builds must guarantee that the artifact is present, while crates.io builds must never download or substitute unreviewed bytes.

The release also adds a variant to the exhaustive public `HeaderSyncStartError` enum, which requires a major `zakura-network` version and a coherent dependent package graph.

## Tests

- `make pre-release RELEASE_TAG=v1.0.2 BASE_TAG=v1.0.1 CRATE_PACKAGING_VERIFY=1`
- `cargo semver-checks -p zakura-network --default-features`
- `ZAKURA_REQUIRE_VCT_SPROUT_HISTORY=1 cargo test -p zakura-state`
- `cargo fmt --all -- --check`
- Markdown lint on all changed Markdown files
- IDE diagnostics on changed source files

## Risk

High risk: this changes release packaging and the availability of a database-repair artifact. Source and official Docker builds require the artifact; crates.io builds intentionally omit it and fail closed when repair is needed.

## AI disclosure

Prepared with AI assistance.