### PR TITLE
feat(mempool): add configurable transaction size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Add a configurable 250,000-byte default maximum for individual mempool
+  transactions. Larger transactions are rejected before semantic and contextual
+  verification without penalizing peers, and the policy does not affect block
+  validation.
 - Add `zakurad validate-vct-sprout-history` to audit repaired historical
   Sprout anchors in archive or pruned Mainnet state databases.
 

--- a/book/src/dev/diagrams/mempool-architecture.md
+++ b/book/src/dev/diagrams/mempool-architecture.md
@@ -14,6 +14,7 @@ graph TD
     Mempool{{Mempool Service}}
     Storage{{Storage}}
     Downloads{{Transaction Downloads}}
+    SizePolicy{Within configured size limit?}
     Crawler{{Crawler}}
     QueueChecker{{Queue Checker}}
 
@@ -27,8 +28,10 @@ graph TD
     Downloads -->|4a- Download request| Net
     Net -->|4b- Transaction data| Downloads
 
-    Downloads -->|5a- Verify request| TxVerifier
-    TxVerifier -->|5b- Verification result| Downloads
+    Downloads -->|5a- Check serialized size| SizePolicy
+    SizePolicy -->|5b- Within limit| TxVerifier
+    SizePolicy -->|Over limit: policy result| Downloads
+    TxVerifier -->|5c- Verification result| Downloads
 
     Downloads -->|6a- Check UTXO| State
     State -->|6b- UTXO data| Downloads
@@ -54,7 +57,7 @@ graph TD
     classDef component fill:#333,stroke:#888,stroke-width:1px,color:white;
 
     class Net,State,TxVerifier,RPC external;
-    class Mempool,Storage,Downloads,Crawler,QueueChecker component;
+    class Mempool,Storage,Downloads,SizePolicy,Crawler,QueueChecker component;
 ```
 
 ## Component Descriptions
@@ -79,12 +82,14 @@ graph TD
 
 3. The download service retrieves transaction data from peers.
 
-4. Transactions are verified against consensus rules using the transaction verifier.
+4. The download service rejects transactions larger than `max_transaction_bytes` before semantic and contextual verification. This local mempool policy does not penalize peers or affect transaction validity in blocks.
 
-5. Verified transactions are stored in memory and gossiped to peers via the Gossip task.
+5. Transactions within the configured size limit are verified against consensus rules using the transaction verifier.
 
-6. The queue checker triggers the mempool to process newly verified transactions from the Downloads stream.
+6. Verified transactions are stored in memory and gossiped to peers via the Gossip task.
 
-7. Transactions remain in the mempool until they are mined or evicted due to size limits.
+7. The queue checker triggers the mempool to process newly verified transactions from the Downloads stream.
 
-8. When the chain tip changes, the mempool updates its verification context and potentially evicts invalid transactions.
+8. Transactions remain in the mempool until they are mined or evicted due to total mempool size limits.
+
+9. When the chain tip changes, the mempool updates its verification context and potentially evicts invalid transactions.

--- a/book/src/dev/mempool-specification.md
+++ b/book/src/dev/mempool-specification.md
@@ -56,6 +56,8 @@ The mempool has the following configurable parameters:
 
 4. **Max Data Carrier Bytes** (`max_datacarrier_bytes`): Optional maximum size of an `OP_RETURN` output script in bytes. If omitted, defaults to 83 (80-byte payload plus opcode overhead).
 
+5. **Maximum Transaction Bytes** (`max_transaction_bytes`): The maximum serialized size of an individual transaction accepted into the mempool, defaulting to 250,000 bytes. Transactions exactly at the limit are accepted; larger transactions are rejected before semantic and contextual verification. This is local mempool policy, not a consensus rule, so it does not affect transaction validity in blocks. Setting the limit to at least 2,000,000 bytes effectively disables this additional restriction because transactions are already bounded by the consensus block size limit.
+
 ## State Management
 
 The mempool maintains an `ActiveState` which can be either:
@@ -83,17 +85,22 @@ The mempool responds to chain tip changes:
    - Queues transaction for download if needed
    - Downloads transaction data from peers
 
-3. **Transaction Verification**:
+3. **Transaction Size Policy**:
+   - Compares the transaction's serialized size with `max_transaction_bytes`
+   - Rejects transactions larger than the configured limit before semantic and contextual verification
+   - Does not treat the transaction or its peer as consensus-invalid
+
+4. **Transaction Verification**:
    - Checks transaction against consensus rules
    - Verifies transaction against the current chain state
    - Manages dependencies between transactions
 
-4. **Transaction Storage**:
+5. **Transaction Storage**:
    - Stores verified transactions in memory
    - Tracks transaction dependencies
    - Enforces size limits and eviction policies
 
-5. **Transaction Gossip**:
+6. **Transaction Gossip**:
    - Broadcasts newly verified transactions to peers
 
 ## Transaction Rejection
@@ -117,6 +124,8 @@ Transactions can be rejected for multiple reasons, categorized into:
    - Applies until a rollback or network upgrade
 
 Rejection reasons are stored alongside rejected transaction IDs to prevent repeated verification of invalid transactions.
+
+Transactions larger than `max_transaction_bytes` are local policy rejections. They are not consensus failures, do not contribute to peer misbehavior scores, and remain eligible for validation when included in a block.
 
 ## Memory Management
 

--- a/book/src/dev/private-testnet.md
+++ b/book/src/dev/private-testnet.md
@@ -113,6 +113,7 @@ checkpoint_sync = true
 eviction_memory_time = "1h"
 tx_cost_limit = 80000000
 max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
 
 [metrics]
 

--- a/zakurad/src/components/mempool.rs
+++ b/zakurad/src/components/mempool.rs
@@ -86,6 +86,21 @@ type TxVerifier = Buffer<
 >;
 type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, State>;
 
+fn transaction_misbehavior(
+    error: &TransactionDownloadVerifyError,
+) -> Option<(PeerSocketAddr, u32)> {
+    let TransactionDownloadVerifyError::Invalid {
+        error,
+        advertiser_addr: Some(advertiser_addr),
+    } = error
+    else {
+        return None;
+    };
+
+    let score = error.mempool_misbehavior_score();
+    (score != 0).then_some((*advertiser_addr, score))
+}
+
 /// The state of the mempool.
 ///
 /// Indicates whether it is enabled or disabled and, if enabled, contains
@@ -364,6 +379,7 @@ impl Mempool {
             Timeout::new(self.outbound.clone(), TRANSACTION_DOWNLOAD_TIMEOUT),
             Timeout::new(self.tx_verifier.clone(), TRANSACTION_VERIFY_TIMEOUT),
             self.state.clone(),
+            self.config.max_transaction_bytes,
         ));
         self.active_state = ActiveState::Enabled {
             storage: storage::Storage::new(&self.config),
@@ -674,22 +690,28 @@ impl Service<Request> for Mempool {
                     }
                     Ok(Err(boxed_err)) => {
                         let (tx_id, error) = *boxed_err;
-                        if let TransactionDownloadVerifyError::Invalid {
-                            error,
-                            advertiser_addr: Some(advertiser_addr),
-                        } = &error
-                        {
-                            if error.mempool_misbehavior_score() != 0 {
-                                let _ = self.misbehavior_sender.try_send((
-                                    *advertiser_addr,
-                                    error.mempool_misbehavior_score(),
-                                ));
-                            }
-                        };
+                        if let Some((advertiser_addr, score)) = transaction_misbehavior(&error) {
+                            let _ = self.misbehavior_sender.try_send((advertiser_addr, score));
+                        }
 
-                        tracing::debug!(?tx_id, ?error, "mempool transaction failed to verify");
+                        tracing::debug!(?tx_id, ?error, "mempool transaction was not accepted");
 
-                        metrics::counter!("mempool.failed.verify.tasks.total", "reason" => error.to_string()).increment(1);
+                        match &error {
+                            TransactionDownloadVerifyError::PolicyRejected(
+                                storage::NonStandardTransactionError::TransactionTooLarge {
+                                    ..
+                                },
+                            ) => metrics::counter!(
+                                "mempool.rejected.transactions.total",
+                                "reason" => "transaction_too_large"
+                            )
+                            .increment(1),
+                            _ => metrics::counter!(
+                                "mempool.failed.verify.tasks.total",
+                                "reason" => error.to_string()
+                            )
+                            .increment(1),
+                        }
 
                         invalidated_ids.insert(tx_id);
                         storage.reject_if_needed(tx_id, error);
@@ -905,7 +927,24 @@ impl Service<Request> for Mempool {
                                     MempoolError,
                                 > {
                                     let (rsp_tx, rsp_rx) = oneshot::channel();
-                                    storage.should_download_or_verify(gossiped_tx.id())?;
+                                    match storage.should_download_or_verify(gossiped_tx.id()) {
+                                        Ok(()) => {}
+                                        Err(
+                                            error @ MempoolError::StorageExactTip(
+                                                ExactTipRejectionError::FailedStandard(
+                                                    storage::NonStandardTransactionError::TransactionTooLarge {
+                                                        ..
+                                                    },
+                                                ),
+                                            ),
+                                        ) => {
+                                            // A cached policy rejection is a completed admission
+                                            // result, not a failure to queue the request.
+                                            let _ = rsp_tx.send(Err(error.into()));
+                                            return Ok(rsp_rx);
+                                        }
+                                        Err(error) => return Err(error),
+                                    }
                                     tx_downloads.download_if_needed_and_verify(
                                         gossiped_tx,
                                         None,

--- a/zakurad/src/components/mempool/config.rs
+++ b/zakurad/src/components/mempool/config.rs
@@ -18,6 +18,12 @@ pub struct Config {
     /// This corresponds to `mempooltxcostlimit` from [ZIP-401](https://zips.z.cash/zip-0401#specification).
     pub tx_cost_limit: u64,
 
+    /// Maximum serialized size of an individual transaction accepted into the mempool.
+    ///
+    /// Transactions exactly at this limit are accepted. Larger transactions are rejected before
+    /// semantic and contextual verification. This local policy does not affect block validation.
+    pub max_transaction_bytes: u64,
+
     /// The mempool transaction eviction age limit.
     ///
     /// This limits the maximum amount of time evicted transaction IDs stay in
@@ -62,6 +68,7 @@ impl Default for Config {
             //
             // [ZIP-401]: https://zips.z.cash/zip-0401#specification
             tx_cost_limit: 80_000_000,
+            max_transaction_bytes: DEFAULT_MAX_TRANSACTION_BYTES,
             eviction_memory_time: Duration::from_secs(60 * 60),
 
             debug_enable_at_height: None,
@@ -70,6 +77,9 @@ impl Default for Config {
         }
     }
 }
+
+/// Default maximum serialized size of an individual mempool transaction, in bytes.
+pub const DEFAULT_MAX_TRANSACTION_BYTES: u64 = 250_000;
 
 /// Default maximum size of data carrier scripts (OP_RETURN), in bytes.
 ///

--- a/zakurad/src/components/mempool/downloads.rs
+++ b/zakurad/src/components/mempool/downloads.rs
@@ -59,7 +59,7 @@ use crate::components::{
     sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT},
 };
 
-use super::MempoolError;
+use super::{storage::NonStandardTransactionError, MempoolError};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -157,6 +157,9 @@ pub enum TransactionDownloadVerifyError {
     #[error("transaction download / verification was cancelled")]
     Cancelled,
 
+    #[error("transaction did not pass mempool policy: {0}")]
+    PolicyRejected(#[source] NonStandardTransactionError),
+
     #[error("transaction did not pass consensus validation: {error}")]
     Invalid {
         error: zakura_consensus::error::TransactionError,
@@ -186,6 +189,9 @@ where
 
     /// A service that manages cached blockchain state.
     state: ZS,
+
+    /// The maximum serialized size of a transaction accepted into the mempool.
+    max_transaction_bytes: u64,
 
     // Internal downloads state
     /// A list of pending transaction download and verify tasks.
@@ -324,11 +330,12 @@ where
     /// The [`Downloads`] stream is agnostic to the network policy, so retry and
     /// timeout limits should be applied to the `network` service passed into
     /// this constructor.
-    pub fn new(network: ZN, verifier: ZV, state: ZS) -> Self {
+    pub fn new(network: ZN, verifier: ZV, state: ZS, max_transaction_bytes: u64) -> Self {
         Self {
             network,
             verifier,
             state,
+            max_transaction_bytes,
             pending: FuturesUnordered::new(),
             cancel_handles: HashMap::new(),
             pending_per_peer: HashMap::new(),
@@ -402,10 +409,15 @@ where
         let mut state = self.state.clone();
         let download_source = source.as_ref().and_then(peer_source_from_queue_source);
         let pushed_advertiser_addr = source.as_ref().and_then(misbehavior_addr_from_queue_source);
+        let max_transaction_bytes = self.max_transaction_bytes;
 
         let gossiped_tx_req = gossiped_tx.clone();
 
         let fut = async move {
+            if let Gossip::Tx(tx) = &gossiped_tx {
+                Self::check_transaction_size(tx, max_transaction_bytes)?;
+            }
+
             // Don't download/verify if the transaction is already in the best chain.
             Self::transaction_in_best_chain(&mut state, txid).await?;
 
@@ -462,6 +474,7 @@ where
                         "mempool.downloaded.transactions.total",
                         "version" => format!("{}",tx.transaction.version()),
                     ).increment(1);
+                    Self::check_transaction_size(&tx, max_transaction_bytes)?;
                     (tx, advertiser_addr)
                 }
                 Gossip::Tx(tx) => {
@@ -644,6 +657,25 @@ where
             .map(|(_tx_id, (_handle, tx, _source))| tx)
     }
 
+    /// Reject transactions that exceed the configured serialized size limit.
+    fn check_transaction_size(
+        transaction: &transaction::UnminedTx,
+        max_transaction_bytes: u64,
+    ) -> Result<(), TransactionDownloadVerifyError> {
+        if usize::try_from(max_transaction_bytes)
+            .is_ok_and(|max_transaction_bytes| transaction.size > max_transaction_bytes)
+        {
+            return Err(TransactionDownloadVerifyError::PolicyRejected(
+                NonStandardTransactionError::TransactionTooLarge {
+                    actual_bytes: transaction.size,
+                    max_bytes: max_transaction_bytes,
+                },
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Check if transaction is already in the best chain.
     async fn transaction_in_best_chain(
         state: &mut ZS,
@@ -688,7 +720,13 @@ where
 mod tests {
     use super::*;
     use futures::StreamExt as _;
-    use std::future;
+    use std::{
+        future,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
     use tower::{service_fn, util::BoxCloneService};
 
     type PendingNetwork = BoxCloneService<zn::Request, zn::Response, BoxError>;
@@ -730,6 +768,7 @@ mod tests {
             BoxCloneService::new(service_fn(|_request| {
                 future::pending::<Result<zs::Response, BoxError>>()
             })),
+            u64::MAX,
         )
     }
 
@@ -797,6 +836,7 @@ mod tests {
                     request => Err(format!("unexpected state request: {request:?}").into()),
                 }
             })),
+            u64::MAX,
         );
 
         downloads
@@ -845,6 +885,7 @@ mod tests {
                     request => Err(format!("unexpected state request: {request:?}").into()),
                 }
             })),
+            u64::MAX,
         );
 
         downloads
@@ -863,6 +904,205 @@ mod tests {
                 if error.0 == txid
                     && matches!(error.1, TransactionDownloadVerifyError::DownloadFailed(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn pushed_transaction_at_size_limit_is_verified() {
+        let transaction = empty_v5_transaction(1);
+        let max_transaction_bytes = u64::try_from(transaction.size)
+            .expect("serialized transaction sizes fit in u64 on supported platforms");
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls_for_service = verifier_calls.clone();
+
+        let mut downloads = Downloads::new(
+            BoxCloneService::new(service_fn(|_request| async move {
+                panic!("pushed transactions must not be downloaded");
+            })),
+            BoxCloneService::new(service_fn(move |request| {
+                let verifier_calls = verifier_calls_for_service.clone();
+                async move {
+                    verifier_calls.fetch_add(1, Ordering::SeqCst);
+                    let tx::Request::Mempool { transaction, .. } = request else {
+                        panic!("unexpected transaction verifier request: {request:?}");
+                    };
+                    let miner_fee = transaction.conventional_fee;
+                    let transaction =
+                        VerifiedUnminedTx::new(transaction, miner_fee, 0, 0, Arc::new(Vec::new()))
+                            .expect("test transaction pays its conventional fee");
+
+                    Ok::<_, BoxError>(tx::Response::Mempool {
+                        transaction,
+                        spent_mempool_outpoints: Vec::new(),
+                    })
+                }
+            })),
+            BoxCloneService::new(service_fn(|request| async move {
+                match request {
+                    zs::Request::Transaction(_) => Ok(zs::Response::Transaction(None)),
+                    zs::Request::Tip => Ok(zs::Response::Tip(None)),
+                    request => Err(format!("unexpected state request: {request:?}").into()),
+                }
+            })),
+            max_transaction_bytes,
+        );
+
+        downloads
+            .download_if_needed_and_verify(Gossip::Tx(transaction), None, None)
+            .expect("transaction at the configured limit is queued");
+
+        let result = tokio::time::timeout(Duration::from_secs(1), downloads.next())
+            .await
+            .expect("pushed transaction should complete")
+            .expect("download stream should yield an item")
+            .expect("pushed transaction should not time out");
+
+        assert!(result.is_ok(), "transaction at the limit should verify");
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn pushed_transaction_over_size_limit_skips_state_and_verifier() {
+        let transaction = empty_v5_transaction(1);
+        let actual_bytes = transaction.size;
+        let max_bytes = u64::try_from(
+            actual_bytes
+                .checked_sub(1)
+                .expect("test transaction is not empty"),
+        )
+        .expect("serialized transaction sizes fit in u64 on supported platforms");
+        let state_calls = Arc::new(AtomicUsize::new(0));
+        let state_calls_for_service = state_calls.clone();
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls_for_service = verifier_calls.clone();
+        let peer_addr = PeerSocketAddr::from(([203, 0, 113, 7], 8233));
+        let (rsp_tx, rsp_rx) = oneshot::channel();
+
+        let mut downloads = Downloads::new(
+            BoxCloneService::new(service_fn(|_request| async move {
+                panic!("pushed transactions must not be downloaded");
+            })),
+            BoxCloneService::new(service_fn(move |_request| {
+                let verifier_calls = verifier_calls_for_service.clone();
+                async move {
+                    verifier_calls.fetch_add(1, Ordering::SeqCst);
+                    panic!("oversized pushed transactions must not be verified");
+                }
+            })),
+            BoxCloneService::new(service_fn(move |_request| {
+                let state_calls = state_calls_for_service.clone();
+                async move {
+                    state_calls.fetch_add(1, Ordering::SeqCst);
+                    panic!("oversized pushed transactions must not query state");
+                }
+            })),
+            max_bytes,
+        );
+
+        downloads
+            .download_if_needed_and_verify(
+                Gossip::Tx(transaction),
+                Some(QueueSource::LegacySocket(
+                    peer_addr.remove_socket_addr_privacy(),
+                )),
+                Some(rsp_tx),
+            )
+            .expect("oversized transaction policy check is queued");
+
+        let result = tokio::time::timeout(Duration::from_secs(1), downloads.next())
+            .await
+            .expect("pushed transaction should complete")
+            .expect("download stream should yield an item")
+            .expect("pushed transaction should not time out");
+        let error = result
+            .expect_err("oversized pushed transaction should be rejected")
+            .1;
+
+        assert!(matches!(
+            error,
+            TransactionDownloadVerifyError::PolicyRejected(
+                NonStandardTransactionError::TransactionTooLarge {
+                    actual_bytes: error_actual_bytes,
+                    max_bytes: error_max_bytes,
+                }
+            ) if error_actual_bytes == actual_bytes && error_max_bytes == max_bytes
+        ));
+        assert_eq!(state_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+
+        let responder_error = rsp_rx
+            .await
+            .expect("responder should receive the policy result")
+            .expect_err("responder should receive a policy rejection")
+            .to_string();
+        assert!(responder_error.contains(&format!(
+            "transaction is {actual_bytes} bytes, exceeding the configured mempool maximum of {max_bytes} bytes"
+        )));
+    }
+
+    #[tokio::test]
+    async fn downloaded_transaction_over_size_limit_skips_verifier() {
+        let transaction = empty_v5_transaction(1);
+        let txid = transaction.id;
+        let actual_bytes = transaction.size;
+        let max_bytes = u64::try_from(
+            actual_bytes
+                .checked_sub(1)
+                .expect("test transaction is not empty"),
+        )
+        .expect("serialized transaction sizes fit in u64 on supported platforms");
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls_for_service = verifier_calls.clone();
+
+        let mut downloads = Downloads::new(
+            BoxCloneService::new(service_fn(move |request| {
+                let transaction = transaction.clone();
+                async move {
+                    assert!(matches!(request, zn::Request::TransactionsById(_)));
+                    Ok::<_, BoxError>(zn::Response::Transactions(vec![
+                        zn::InventoryResponse::Available((transaction, None)),
+                    ]))
+                }
+            })),
+            BoxCloneService::new(service_fn(move |_request| {
+                let verifier_calls = verifier_calls_for_service.clone();
+                async move {
+                    verifier_calls.fetch_add(1, Ordering::SeqCst);
+                    panic!("oversized downloaded transactions must not be verified");
+                }
+            })),
+            BoxCloneService::new(service_fn(|request| async move {
+                match request {
+                    zs::Request::Transaction(_) => Ok(zs::Response::Transaction(None)),
+                    zs::Request::Tip => Ok(zs::Response::Tip(None)),
+                    request => Err(format!("unexpected state request: {request:?}").into()),
+                }
+            })),
+            max_bytes,
+        );
+
+        downloads
+            .download_if_needed_and_verify(Gossip::Id(txid), None, None)
+            .expect("oversized advertised transaction is queued");
+
+        let result = tokio::time::timeout(Duration::from_secs(1), downloads.next())
+            .await
+            .expect("downloaded transaction should complete")
+            .expect("download stream should yield an item")
+            .expect("downloaded transaction should not time out");
+        let error = result
+            .expect_err("oversized downloaded transaction should be rejected")
+            .1;
+
+        assert!(matches!(
+            error,
+            TransactionDownloadVerifyError::PolicyRejected(
+                NonStandardTransactionError::TransactionTooLarge {
+                    actual_bytes: error_actual_bytes,
+                    max_bytes: error_max_bytes,
+                }
+            ) if error_actual_bytes == actual_bytes && error_max_bytes == max_bytes
+        ));
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
     }
 
     /// A directly pushed transaction from a legacy-socket peer must keep that
@@ -892,6 +1132,7 @@ mod tests {
                     request => Err(format!("unexpected state request: {request:?}").into()),
                 }
             })),
+            u64::MAX,
         );
 
         downloads

--- a/zakurad/src/components/mempool/storage.rs
+++ b/zakurad/src/components/mempool/storage.rs
@@ -136,6 +136,10 @@ pub enum RejectionError {
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NonStandardTransactionError {
+    #[error(
+        "transaction is {actual_bytes} bytes, exceeding the configured mempool maximum of {max_bytes} bytes"
+    )]
+    TransactionTooLarge { actual_bytes: usize, max_bytes: u64 },
     #[error("transaction is dust")]
     IsDust,
     #[error("transaction scriptSig is too large")]
@@ -871,6 +875,11 @@ impl Storage {
             // If it was cancelled then a block was mined, or there was a network
             // upgrade, etc. No reason to reject it.
             TransactionDownloadVerifyError::Cancelled => {}
+
+            TransactionDownloadVerifyError::PolicyRejected(error) => self.reject(
+                tx_id,
+                ExactTipRejectionError::FailedStandard(error).into(),
+            ),
 
             // Consensus verification failed. Reject transaction to avoid
             // having to download and verify it again just for it to fail again.

--- a/zakurad/src/components/mempool/storage/tests/vectors.rs
+++ b/zakurad/src/components/mempool/storage/tests/vectors.rs
@@ -89,6 +89,40 @@ fn verified_ironwood_v6_tx(
 }
 
 #[test]
+fn oversized_policy_rejection_is_cached_by_exact_id() {
+    let mut storage = Storage::new(&config::Config::default());
+    let transaction = Network::Mainnet
+        .unmined_transactions_in_blocks(..)
+        .find(|transaction| transaction.transaction.id.auth_digest().is_some())
+        .expect("mainnet test vectors contain a witnessed transaction");
+    let tx_id = transaction.transaction.id;
+    let rejection = NonStandardTransactionError::TransactionTooLarge {
+        actual_bytes: 250_001,
+        max_bytes: 250_000,
+    };
+
+    storage.reject_if_needed(
+        tx_id,
+        TransactionDownloadVerifyError::PolicyRejected(rejection.clone()),
+    );
+
+    assert_eq!(
+        storage.rejection_error(&tx_id),
+        Some(MempoolError::StorageExactTip(
+            ExactTipRejectionError::FailedStandard(rejection)
+        ))
+    );
+
+    let mut different_authorizing_data = tx_id;
+    let different_auth_digest = different_authorizing_data
+        .auth_digest_mut()
+        .expect("test selected a witnessed transaction");
+    different_auth_digest.0[0] ^= 1;
+    assert_eq!(different_authorizing_data.mined_id(), tx_id.mined_id());
+    assert!(!storage.contains_rejected(&different_authorizing_data));
+}
+
+#[test]
 fn mempool_storage_crud_exact_mainnet() {
     let _init_guard = zakura_test::init();
 

--- a/zakurad/src/components/mempool/tests/vector.rs
+++ b/zakurad/src/components/mempool/tests/vector.rs
@@ -36,6 +36,107 @@ type StateService = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, 
 /// A [`MockService`] representing the Zebra transaction verifier service.
 type MockTxVerifier = MockService<tx::Request, tx::Response, PanicAssertion, TransactionError>;
 
+#[test]
+fn policy_rejection_has_no_misbehavior_score() {
+    let policy_error = TransactionDownloadVerifyError::PolicyRejected(
+        storage::NonStandardTransactionError::TransactionTooLarge {
+            actual_bytes: 250_001,
+            max_bytes: 250_000,
+        },
+    );
+    assert_eq!(transaction_misbehavior(&policy_error), None);
+
+    let advertiser_addr = PeerSocketAddr::from(([203, 0, 113, 7], 8233));
+    let consensus_error = zakura_consensus::error::TransactionError::WrongVersion;
+    let expected_score = consensus_error.mempool_misbehavior_score();
+    assert_ne!(expected_score, 0, "control error must have a score");
+    let invalid_error = TransactionDownloadVerifyError::Invalid {
+        error: consensus_error,
+        advertiser_addr: Some(advertiser_addr),
+    };
+    assert_eq!(
+        transaction_misbehavior(&invalid_error),
+        Some((advertiser_addr, expected_score))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cached_size_policy_rejection_is_a_transaction_result() -> Result<(), Report> {
+    let network = Network::Mainnet;
+    let transaction = network
+        .unmined_transactions_in_blocks(1..=1)
+        .next()
+        .expect("mainnet test vectors contain an unmined transaction")
+        .transaction
+        .clone();
+    let transaction_id = transaction.id;
+    let mempool_config = mempool::Config {
+        max_transaction_bytes: 1,
+        ..Default::default()
+    };
+
+    let (
+        mut mempool,
+        _peer_set,
+        _state_service,
+        _chain_tip_change,
+        _tx_verifier,
+        mut recent_syncs,
+        _mempool_transaction_receiver,
+    ) = setup_with_mempool_config(&network, mempool_config, true).await;
+    mempool.enable(&mut recent_syncs).await;
+
+    let response = mempool
+        .ready()
+        .await
+        .expect("mempool service becomes ready")
+        .call(Request::Queue(vec![transaction.clone().into()]))
+        .await
+        .expect("mempool service returns a queue response");
+    let Response::Queued(mut queue_results) = response else {
+        panic!("unexpected response to transaction queue request");
+    };
+    let first_result = queue_results
+        .pop()
+        .expect("one transaction has one queue result")
+        .expect("the policy check was queued")
+        .await
+        .expect("the policy result channel remains open")
+        .expect_err("the oversized transaction is rejected");
+    assert!(first_result
+        .to_string()
+        .contains("exceeding the configured mempool maximum"));
+
+    for _ in 0..2 {
+        mempool.dummy_call().await;
+        time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(mempool.storage().contains_rejected(&transaction_id));
+
+    let response = mempool
+        .ready()
+        .await
+        .expect("mempool service becomes ready")
+        .call(Request::Queue(vec![transaction.into()]))
+        .await
+        .expect("mempool service returns a queue response");
+    let Response::Queued(mut queue_results) = response else {
+        panic!("unexpected response to transaction queue request");
+    };
+    let cached_result = queue_results
+        .pop()
+        .expect("one transaction has one queue result")
+        .expect("a cached policy rejection is returned as a transaction result")
+        .await
+        .expect("the cached policy result channel remains open")
+        .expect_err("the cached oversized transaction is rejected");
+    assert!(cached_result
+        .to_string()
+        .contains("exceeding the configured mempool maximum"));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn mempool_service_basic() -> Result<(), Report> {
     // Test multiple times to catch intermittent bugs since eviction is randomized
@@ -2158,6 +2259,7 @@ async fn cancel_handles_drained_after_verification_timeout() {
         Timeout::new(peer_set, TRANSACTION_DOWNLOAD_TIMEOUT),
         Timeout::new(tx_verifier, TRANSACTION_VERIFY_TIMEOUT),
         state,
+        u64::MAX,
     ));
 
     let mut iter = Network::Mainnet.unmined_transactions_in_blocks(1..=10);

--- a/zakurad/src/components/mempool/tests/vector.rs
+++ b/zakurad/src/components/mempool/tests/vector.rs
@@ -19,6 +19,7 @@ use zakura_chain::{
     transparent::{self, OutPoint},
 };
 use zakura_consensus::transaction as tx;
+use zakura_node_services::mempool::QueueSource;
 use zakura_state::{Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
@@ -58,6 +59,154 @@ fn policy_rejection_has_no_misbehavior_score() {
         transaction_misbehavior(&invalid_error),
         Some((advertiser_addr, expected_score))
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<(), Report> {
+    let network = Network::Mainnet;
+    let mut transactions = network
+        .unmined_transactions_in_blocks(2..)
+        .map(|transaction| transaction.transaction.clone())
+        .collect::<Vec<_>>();
+    transactions.sort_by_key(|transaction| transaction.size);
+
+    let at_limit_transaction = transactions
+        .first()
+        .expect("mainnet test vectors contain an unmined transaction")
+        .clone();
+    let oversized_transaction = transactions
+        .last()
+        .expect("mainnet test vectors contain an unmined transaction")
+        .clone();
+    assert!(
+        at_limit_transaction.size < oversized_transaction.size,
+        "test transactions must have different serialized sizes"
+    );
+
+    let max_transaction_bytes = u64::try_from(at_limit_transaction.size)
+        .expect("serialized transaction sizes fit in u64 on supported platforms");
+    let mempool_config = mempool::Config {
+        max_transaction_bytes,
+        ..Default::default()
+    };
+    let peer_addr = PeerSocketAddr::from(([203, 0, 113, 7], 8233));
+    let queue_source = QueueSource::LegacySocket(peer_addr.remove_socket_addr_privacy());
+    let (misbehavior_tx, mut misbehavior_rx) = tokio::sync::mpsc::channel(1);
+
+    let (
+        mut mempool,
+        mut peer_set,
+        _state_service,
+        _chain_tip_change,
+        mut tx_verifier,
+        mut recent_syncs,
+        _mempool_transaction_receiver,
+    ) = setup_with_mempool_config_and_misbehavior_sender(
+        &network,
+        mempool_config,
+        true,
+        misbehavior_tx,
+    )
+    .await;
+    mempool.enable(&mut recent_syncs).await;
+
+    let oversized_id = oversized_transaction.id;
+    let response = mempool
+        .ready()
+        .await
+        .expect("mempool service becomes ready")
+        .call(Request::QueueFromPeer {
+            transactions: vec![oversized_id.into()],
+            source: queue_source.clone(),
+        })
+        .await
+        .expect("mempool service queues the peer transaction");
+    assert!(matches!(response, Response::Queued(results) if results.is_empty()));
+
+    peer_set
+        .expect_request_that(|request| {
+            matches!(request, zn::Request::TransactionsById(ids) if ids.contains(&oversized_id))
+        })
+        .await
+        .respond(zn::Response::Transactions(vec![
+            zn::InventoryResponse::Available((oversized_transaction.clone(), Some(peer_addr))),
+        ]));
+
+    timeout(Duration::from_secs(3), async {
+        while !mempool.storage().contains_rejected(&oversized_id) {
+            mempool.dummy_call().await;
+            time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("oversized transaction should reach the rejection cache");
+
+    assert!(matches!(
+        mempool.storage().rejection_error(&oversized_id),
+        Some(MempoolError::StorageExactTip(
+            ExactTipRejectionError::FailedStandard(
+                storage::NonStandardTransactionError::TransactionTooLarge {
+                    actual_bytes,
+                    max_bytes,
+                }
+            )
+        )) if actual_bytes == oversized_transaction.size && max_bytes == max_transaction_bytes
+    ));
+    assert_eq!(mempool.storage().transaction_count(), 0);
+    tx_verifier.expect_no_requests().await;
+    assert!(matches!(
+        misbehavior_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
+
+    let at_limit_id = at_limit_transaction.id;
+    let response = mempool
+        .ready()
+        .await
+        .expect("mempool service becomes ready")
+        .call(Request::QueueFromPeer {
+            transactions: vec![at_limit_id.into()],
+            source: queue_source,
+        })
+        .await
+        .expect("mempool service queues the peer transaction");
+    assert!(matches!(response, Response::Queued(results) if results.is_empty()));
+
+    peer_set
+        .expect_request_that(|request| {
+            matches!(request, zn::Request::TransactionsById(ids) if ids.contains(&at_limit_id))
+        })
+        .await
+        .respond(zn::Response::Transactions(vec![
+            zn::InventoryResponse::Available((at_limit_transaction, Some(peer_addr))),
+        ]));
+    tx_verifier
+        .expect_request_that(|request| {
+            matches!(
+                request,
+                tx::Request::Mempool { transaction, .. } if transaction.id == at_limit_id
+            )
+        })
+        .await
+        .respond(Err(TransactionError::WrongVersion));
+
+    timeout(Duration::from_secs(3), async {
+        while !mempool.storage().contains_rejected(&at_limit_id) {
+            mempool.dummy_call().await;
+            time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("invalid transaction should reach the rejection cache");
+
+    let expected_score = TransactionError::WrongVersion.mempool_misbehavior_score();
+    assert_eq!(misbehavior_rx.try_recv(), Ok((peer_addr, expected_score)));
+    assert!(matches!(
+        misbehavior_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2169,6 +2318,30 @@ async fn setup_with_mempool_config(
     RecentSyncLengths,
     tokio::sync::broadcast::Receiver<MempoolChange>,
 ) {
+    let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
+    setup_with_mempool_config_and_misbehavior_sender(
+        network,
+        mempool_config,
+        should_commit_genesis_block,
+        misbehavior_tx,
+    )
+    .await
+}
+
+async fn setup_with_mempool_config_and_misbehavior_sender(
+    network: &Network,
+    mempool_config: mempool::Config,
+    should_commit_genesis_block: bool,
+    misbehavior_tx: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
+) -> (
+    Mempool,
+    MockPeerSet,
+    StateService,
+    ChainTipChange,
+    MockTxVerifier,
+    RecentSyncLengths,
+    tokio::sync::broadcast::Receiver<MempoolChange>,
+) {
     let peer_set = MockService::build().for_unit_tests();
 
     // UTXO verification doesn't matter here.
@@ -2180,7 +2353,6 @@ async fn setup_with_mempool_config(
     let tx_verifier = MockService::build().for_unit_tests();
 
     let (sync_status, recent_syncs) = SyncStatus::new();
-    let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mempool, mempool_transaction_subscriber) = Mempool::new(
         &mempool_config,
         Buffer::new(BoxService::new(peer_set.clone()), 1),

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -4575,6 +4575,15 @@ async fn zcashd_compat_transparent_tx_in_mempool() -> Result<()> {
     common::zcashd_compat::tx_flow::transparent_tx_in_mempool().await
 }
 
+/// Rejects a transaction above Zakura's mempool size limit, then accepts it in a block.
+///
+/// See [`common::zcashd_compat::tx_flow::oversized_transparent_tx_rejected`] for details.
+#[tokio::test]
+#[ignore]
+async fn zcashd_compat_oversized_transparent_tx_rejected() -> Result<()> {
+    common::zcashd_compat::tx_flow::oversized_transparent_tx_rejected().await
+}
+
 /// Sends a transparent transaction via zcashd, mines a block, and confirms it via zakurad.
 ///
 /// See [`common::zcashd_compat::tx_flow::transparent_tx_confirms`] for details.

--- a/zakurad/tests/common/configs/v1.0.1.toml
+++ b/zakurad/tests/common/configs/v1.0.1.toml
@@ -54,6 +54,7 @@ ready_max_tip_age = "5m"
 [mempool]
 eviction_memory_time = "1h"
 max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
 tx_cost_limit = 80000000
 
 [metrics]
@@ -147,4 +148,3 @@ shutdown_grace_period = "5m"
 startup_delay = "1s"
 zcashd_extra_args = []
 zcashd_source = "path"
-

--- a/zakurad/tests/common/zcashd_compat/launch.rs
+++ b/zakurad/tests/common/zcashd_compat/launch.rs
@@ -127,6 +127,13 @@ pub fn send_signal(pid: u32, signal: &str) -> Result<()> {
 /// Spawns a fresh regtest zakurad that supervises a zcashd-compat zcashd process,
 /// waits for both to be ready, and returns the test setup.
 pub async fn spawn_zakurad_with_zcashd_compat() -> Result<ZcashdCompatSetup> {
+    spawn_zakurad_with_zcashd_compat_config(|_| {}).await
+}
+
+/// Spawns a managed regtest setup after applying `configure` to zakurad's config.
+pub async fn spawn_zakurad_with_zcashd_compat_config(
+    configure: impl FnOnce(&mut zakurad::config::ZakuradConfig),
+) -> Result<ZcashdCompatSetup> {
     let _init_guard = zakura_test::init();
 
     let dir = testdir()?;
@@ -134,6 +141,7 @@ pub async fn spawn_zakurad_with_zcashd_compat() -> Result<ZcashdCompatSetup> {
 
     let compat_cfg: ZcashdCompatConfig = build_zcashd_compat_config(work_dir)?;
     let mut zakurad_config = compat_cfg.zakurad_config;
+    configure(&mut zakurad_config);
 
     let zakura_rpc_addr = compat_cfg.zakura_rpc_addr;
     let zcashd_own_rpc_addr = compat_cfg.zcashd_own_rpc_addr;

--- a/zakurad/tests/common/zcashd_compat/tx_flow.rs
+++ b/zakurad/tests/common/zcashd_compat/tx_flow.rs
@@ -1,14 +1,40 @@
 //! Transaction flow test bodies for the zcashd-compat integration test suite.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use color_eyre::eyre::{eyre, Result};
+use serde::Deserialize;
 use tokio::time::sleep;
+use zakura_chain::{
+    block::ChainHistoryBlockTxAuthCommitmentHash,
+    parameters::NetworkKind,
+    serialization::{BytesInDisplayOrder, ZcashDeserializeInto},
+    transaction::Transaction,
+};
+use zakura_rpc::{
+    client::{BlockTemplateResponse, BlockTemplateTimeSource},
+    proposal_block_from_template,
+};
 
 use super::{
-    config::MINER_PRIV_WIF, launch::ZcashdCompatSetup, setup_zcashd_compat, wait_for_zcashd_height,
+    config::{read_test_network_kind, MINER_PRIV_WIF},
+    launch::{spawn_zakurad_with_zcashd_compat_config, ZcashdCompatSetup},
+    setup_zcashd_compat, wait_for_zcashd_height, zakura_skip_zcashd_compat_tests,
 };
 use crate::common::regtest::MiningRpcMethods;
+
+const OVERSIZED_TRANSACTION_LIMIT: u64 = 1;
+
+#[derive(Deserialize)]
+struct FundRawTransactionResponse {
+    hex: String,
+}
+
+#[derive(Deserialize)]
+struct SignRawTransactionResponse {
+    hex: String,
+    complete: bool,
+}
 
 /// Imports the deterministic miner private key into zcashd's wallet (with a
 /// rescan), making the mined coinbase outputs spendable via `sendtoaddress`.
@@ -22,6 +48,193 @@ async fn import_miner_key(setup: &ZcashdCompatSetup) -> Result<()> {
         .await
         .map_err(|e| eyre!("importprivkey: {e}"))?;
     Ok(())
+}
+
+/// Builds and signs a transparent wallet transaction without broadcasting it.
+async fn signed_transparent_transaction(setup: &ZcashdCompatSetup) -> Result<(String, String)> {
+    let addr: String = setup
+        .zcashd_client
+        .json_result_from_call("getnewaddress", "[]")
+        .await
+        .map_err(|e| eyre!("getnewaddress: {e}"))?;
+
+    let mut outputs = serde_json::Map::new();
+    outputs.insert(addr, serde_json::json!(0.001));
+    let create_params = serde_json::json!([[], outputs]).to_string();
+    let raw: String = setup
+        .zcashd_client
+        .json_result_from_call("createrawtransaction", create_params)
+        .await
+        .map_err(|e| eyre!("createrawtransaction: {e}"))?;
+
+    let fund_params = serde_json::json!([raw]).to_string();
+    let funded: FundRawTransactionResponse = setup
+        .zcashd_client
+        .json_result_from_call("fundrawtransaction", fund_params)
+        .await
+        .map_err(|e| eyre!("fundrawtransaction: {e}"))?;
+
+    let sign_params = serde_json::json!([funded.hex]).to_string();
+    let signed: SignRawTransactionResponse = match setup
+        .zcashd_client
+        .json_result_from_call("signrawtransactionwithwallet", &sign_params)
+        .await
+    {
+        Ok(signed) => signed,
+        Err(with_wallet_error) => setup
+            .zcashd_client
+            .json_result_from_call("signrawtransaction", sign_params)
+            .await
+            .map_err(|legacy_error| {
+                eyre!(
+                    "signrawtransactionwithwallet: {with_wallet_error}; signrawtransaction: {legacy_error}"
+                )
+            })?,
+    };
+
+    if !signed.complete {
+        return Err(eyre!("zcashd did not completely sign the transaction"));
+    }
+
+    let decode_params = serde_json::json!([&signed.hex]).to_string();
+    let decoded: serde_json::Value = setup
+        .zcashd_client
+        .json_result_from_call("decoderawtransaction", decode_params)
+        .await
+        .map_err(|e| eyre!("decoderawtransaction: {e}"))?;
+    let txid = decoded
+        .get("txid")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| eyre!("decoderawtransaction response is missing `txid`: {decoded}"))?
+        .to_string();
+
+    Ok((signed.hex, txid))
+}
+
+/// Submits a valid transparent transaction larger than Zakura's configured
+/// mempool limit, then proves the same transaction is accepted inside a block.
+pub async fn oversized_transparent_tx_rejected() -> Result<()> {
+    if zakura_skip_zcashd_compat_tests() {
+        return Ok(());
+    }
+
+    if read_test_network_kind()? != NetworkKind::Regtest {
+        return Ok(());
+    }
+
+    let setup = spawn_zakurad_with_zcashd_compat_config(|config| {
+        config.mempool.max_transaction_bytes = OVERSIZED_TRANSACTION_LIMIT;
+    })
+    .await?;
+
+    setup.zakura_client.generate(110).await?;
+    wait_for_zcashd_height(&setup.zcashd_client, 110).await?;
+    import_miner_key(&setup).await?;
+
+    let (raw, txid) = signed_transparent_transaction(&setup).await?;
+    let raw_bytes = hex::decode(&raw)
+        .map_err(|error| eyre!("zcashd returned invalid transaction hex: {error}"))?;
+    let transaction_bytes = raw_bytes.len();
+    let transaction_bytes_u64 = u64::try_from(transaction_bytes)
+        .expect("transaction length fits in u64 on supported platforms");
+    assert!(
+        transaction_bytes_u64 > OVERSIZED_TRANSACTION_LIMIT,
+        "test transaction must exceed the configured limit"
+    );
+
+    for attempt in 1..=2 {
+        let response_text = setup
+            .zakura_client
+            .text_from_call("sendrawtransaction", serde_json::json!([&raw]).to_string())
+            .await?;
+        let response: serde_json::Value = serde_json::from_str(&response_text)?;
+        let error = response
+            .get("error")
+            .filter(|error| !error.is_null())
+            .ok_or_else(|| {
+                eyre!("sendrawtransaction attempt {attempt} unexpectedly succeeded: {response}")
+            })?;
+
+        assert_eq!(
+            error.get("code").and_then(serde_json::Value::as_i64),
+            Some(-25),
+            "unexpected sendrawtransaction error on attempt {attempt}: {error}"
+        );
+        let message = error
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| eyre!("sendrawtransaction error is missing `message`: {error}"))?;
+        assert!(
+            message.contains(&format!("transaction is {transaction_bytes} bytes")),
+            "error must include the actual serialized size: {message}"
+        );
+        assert!(
+            message.contains("exceeding the configured mempool maximum of 1 bytes"),
+            "error must include the configured limit: {message}"
+        );
+    }
+
+    let mempool: Vec<String> = setup
+        .zakura_client
+        .json_result_from_call("getrawmempool", "[]")
+        .await
+        .map_err(|e| eyre!("getrawmempool: {e}"))?;
+    assert!(
+        !mempool.iter().any(|entry| entry == &txid),
+        "oversized transaction must not enter Zakura's mempool"
+    );
+
+    let block_template: BlockTemplateResponse = setup
+        .zakura_client
+        .json_result_from_call("getblocktemplate", "[]")
+        .await
+        .map_err(|error| eyre!("getblocktemplate: {error}"))?;
+    let mut block = proposal_block_from_template(
+        &block_template,
+        BlockTemplateTimeSource::CurTime,
+        &setup.network,
+    )?;
+    let transaction: Arc<Transaction> = raw_bytes.zcash_deserialize_into()?;
+    block.transactions.push(transaction);
+
+    let merkle_root = block.transactions.iter().map(|tx| tx.hash()).collect();
+    let auth_data_root = block.auth_data_root();
+    let chain_history_root = block_template.default_roots().chain_history_root();
+    let header = Arc::make_mut(&mut block.header);
+    header.merkle_root = merkle_root;
+    header.commitment_bytes = ChainHistoryBlockTxAuthCommitmentHash::from_commitments(
+        &chain_history_root,
+        &auth_data_root,
+    )
+    .bytes_in_serialized_order()
+    .into();
+
+    setup.zakura_client.submit_block(block).await?;
+    wait_for_zcashd_height(&setup.zcashd_client, 111).await?;
+    let block_count: u64 = setup
+        .zakura_client
+        .json_result_from_call("getblockcount", "[]")
+        .await
+        .map_err(|e| eyre!("getblockcount: {e}"))?;
+    assert_eq!(block_count, 111, "Zakura must accept the submitted block");
+
+    let tx_info: serde_json::Value = setup
+        .zakura_client
+        .json_result_from_call(
+            "getrawtransaction",
+            serde_json::json!([txid, 1]).to_string(),
+        )
+        .await
+        .map_err(|error| eyre!("getrawtransaction: {error}"))?;
+    assert!(
+        tx_info
+            .get("confirmations")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|confirmations| confirmations >= 1),
+        "the oversized transaction must be accepted through block validation: {tx_info}"
+    );
+
+    setup.teardown()
 }
 
 /// Sends a transparent transaction via zcashd and confirms it appears in

--- a/zakurad/tests/common/zcashd_compat/tx_flow.rs
+++ b/zakurad/tests/common/zcashd_compat/tx_flow.rs
@@ -1,6 +1,6 @@
 //! Transaction flow test bodies for the zcashd-compat integration test suite.
 
-use std::{sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use color_eyre::eyre::{eyre, Result};
 use serde::Deserialize;
@@ -15,6 +15,7 @@ use zakura_rpc::{
     client::{BlockTemplateResponse, BlockTemplateTimeSource},
     proposal_block_from_template,
 };
+use zakura_test::net::random_known_port;
 
 use super::{
     config::{read_test_network_kind, MINER_PRIV_WIF},
@@ -24,6 +25,8 @@ use super::{
 use crate::common::regtest::MiningRpcMethods;
 
 const OVERSIZED_TRANSACTION_LIMIT: u64 = 1;
+const OVERSIZED_REJECTION_METRIC: &str = "mempool_rejected_transactions_total";
+const PEER_MISBEHAVIOR_FLUSH_WAIT: Duration = Duration::from_secs(40);
 
 #[derive(Deserialize)]
 struct FundRawTransactionResponse {
@@ -111,8 +114,125 @@ async fn signed_transparent_transaction(setup: &ZcashdCompatSetup) -> Result<(St
     Ok((signed.hex, txid))
 }
 
+async fn single_zcashd_peer(setup: &ZcashdCompatSetup) -> Result<serde_json::Value> {
+    let mut peers: Vec<serde_json::Value> = setup
+        .zcashd_client
+        .json_result_from_call("getpeerinfo", "[]")
+        .await
+        .map_err(|error| eyre!("zcashd getpeerinfo: {error}"))?;
+
+    if peers.len() != 1 {
+        return Err(eyre!(
+            "the sidecar must have exactly one Zakura peer, got: {peers:?}"
+        ));
+    }
+
+    Ok(peers.pop().expect("peer count was checked"))
+}
+
+fn peer_connection_identity(peer: &serde_json::Value) -> Result<(u64, u64, String)> {
+    if peer.get("inbound").and_then(serde_json::Value::as_bool) != Some(false) {
+        return Err(eyre!(
+            "the sidecar connection to Zakura must be outbound: {peer}"
+        ));
+    }
+
+    let id = peer
+        .get("id")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| eyre!("zcashd peer is missing its connection id: {peer}"))?;
+    let connected_at = peer
+        .get("conntime")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| eyre!("zcashd peer is missing its connection time: {peer}"))?;
+    let addr = peer
+        .get("addr")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| eyre!("zcashd peer is missing its address: {peer}"))?
+        .to_string();
+
+    Ok((id, connected_at, addr))
+}
+
+async fn single_zakura_peer_addr(setup: &ZcashdCompatSetup) -> Result<String> {
+    let mut peers: Vec<serde_json::Value> = setup
+        .zakura_client
+        .json_result_from_call("getpeerinfo", "[]")
+        .await
+        .map_err(|error| eyre!("Zakura getpeerinfo: {error}"))?;
+
+    if peers.len() != 1 {
+        return Err(eyre!(
+            "Zakura must have exactly one sidecar peer, got: {peers:?}"
+        ));
+    }
+
+    let peer = peers.pop().expect("peer count was checked");
+    if peer.get("inbound").and_then(serde_json::Value::as_bool) != Some(true) {
+        return Err(eyre!("the sidecar must be inbound to Zakura: {peer}"));
+    }
+
+    peer.get("addr")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| eyre!("Zakura peer is missing its address: {peer}"))
+}
+
+async fn oversized_rejection_count(
+    client: &reqwest::Client,
+    metrics_addr: SocketAddr,
+) -> Result<f64> {
+    let body = client
+        .get(format!("http://{metrics_addr}"))
+        .send()
+        .await
+        .map_err(|error| eyre!("fetching Zakura metrics: {error}"))?
+        .error_for_status()
+        .map_err(|error| eyre!("Zakura metrics response: {error}"))?
+        .text()
+        .await
+        .map_err(|error| eyre!("reading Zakura metrics: {error}"))?;
+
+    Ok(body
+        .lines()
+        .find_map(|line| {
+            if line.starts_with(OVERSIZED_REJECTION_METRIC)
+                && line.contains("reason=\"transaction_too_large\"")
+            {
+                line.split_whitespace().last()?.parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0.0))
+}
+
+async fn wait_for_oversized_rejection(
+    client: &reqwest::Client,
+    metrics_addr: SocketAddr,
+    previous_count: f64,
+) -> Result<()> {
+    let mut last_seen = previous_count;
+
+    for attempt in 1..=60u32 {
+        last_seen = oversized_rejection_count(client, metrics_addr).await?;
+        if last_seen >= previous_count + 1.0 {
+            return Ok(());
+        }
+
+        if attempt < 60 {
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    Err(eyre!(
+        "Zakura did not record an oversized peer transaction within 60 s (before: {previous_count}, last seen: {last_seen})"
+    ))
+}
+
 /// Submits a valid transparent transaction larger than Zakura's configured
-/// mempool limit, then proves the same transaction is accepted inside a block.
+/// mempool limit over P2P, keeps the peer connected, then proves the same
+/// transaction is accepted inside a block.
 pub async fn oversized_transparent_tx_rejected() -> Result<()> {
     if zakura_skip_zcashd_compat_tests() {
         return Ok(());
@@ -122,8 +242,10 @@ pub async fn oversized_transparent_tx_rejected() -> Result<()> {
         return Ok(());
     }
 
+    let metrics_addr = SocketAddr::from(([127, 0, 0, 1], random_known_port()));
     let setup = spawn_zakurad_with_zcashd_compat_config(|config| {
         config.mempool.max_transaction_bytes = OVERSIZED_TRANSACTION_LIMIT;
+        config.metrics.endpoint_addr = Some(metrics_addr);
     })
     .await?;
 
@@ -131,21 +253,89 @@ pub async fn oversized_transparent_tx_rejected() -> Result<()> {
     wait_for_zcashd_height(&setup.zcashd_client, 110).await?;
     import_miner_key(&setup).await?;
 
-    let (raw, txid) = signed_transparent_transaction(&setup).await?;
-    let raw_bytes = hex::decode(&raw)
+    let (p2p_raw, p2p_txid) = signed_transparent_transaction(&setup).await?;
+    let p2p_raw_bytes = hex::decode(&p2p_raw)
         .map_err(|error| eyre!("zcashd returned invalid transaction hex: {error}"))?;
-    let transaction_bytes = raw_bytes.len();
-    let transaction_bytes_u64 = u64::try_from(transaction_bytes)
+    let p2p_transaction_bytes = p2p_raw_bytes.len();
+    let p2p_transaction_bytes_u64 = u64::try_from(p2p_transaction_bytes)
         .expect("transaction length fits in u64 on supported platforms");
     assert!(
-        transaction_bytes_u64 > OVERSIZED_TRANSACTION_LIMIT,
+        p2p_transaction_bytes_u64 > OVERSIZED_TRANSACTION_LIMIT,
         "test transaction must exceed the configured limit"
+    );
+
+    let peer_identity = peer_connection_identity(&single_zcashd_peer(&setup).await?)?;
+    let zakura_peer_addr = single_zakura_peer_addr(&setup).await?;
+    let metrics_client = reqwest::Client::new();
+    let rejection_count = oversized_rejection_count(&metrics_client, metrics_addr).await?;
+    let relayed_txid: String = setup
+        .zcashd_client
+        .json_result_from_call(
+            "sendrawtransaction",
+            serde_json::json!([&p2p_raw]).to_string(),
+        )
+        .await
+        .map_err(|error| eyre!("zcashd sendrawtransaction: {error}"))?;
+    assert_eq!(relayed_txid, p2p_txid, "zcashd returned an unexpected txid");
+
+    let zcashd_mempool: Vec<String> = setup
+        .zcashd_client
+        .json_result_from_call("getrawmempool", "[]")
+        .await
+        .map_err(|error| eyre!("zcashd getrawmempool: {error}"))?;
+    assert!(
+        zcashd_mempool.iter().any(|entry| entry == &p2p_txid),
+        "zcashd must accept the transaction before relaying it"
+    );
+
+    wait_for_oversized_rejection(&metrics_client, metrics_addr, rejection_count).await?;
+    assert_eq!(
+        peer_connection_identity(&single_zcashd_peer(&setup).await?)?,
+        peer_identity,
+        "Zakura must not disconnect the peer that relayed the oversized transaction"
+    );
+
+    let mempool: Vec<String> = setup
+        .zakura_client
+        .json_result_from_call("getrawmempool", "[]")
+        .await
+        .map_err(|error| eyre!("Zakura getrawmempool: {error}"))?;
+    assert!(
+        !mempool.iter().any(|entry| entry == &p2p_txid),
+        "oversized peer transaction must not enter Zakura's mempool"
+    );
+
+    // Mempool misbehavior updates are applied to the address book in 30-second batches.
+    sleep(PEER_MISBEHAVIOR_FLUSH_WAIT).await;
+    assert_eq!(
+        peer_connection_identity(&single_zcashd_peer(&setup).await?)?,
+        peer_identity,
+        "Zakura must not ban or reconnect the peer after the misbehavior flush"
+    );
+    assert_eq!(
+        single_zakura_peer_addr(&setup).await?,
+        zakura_peer_addr,
+        "Zakura must retain the same sidecar connection after the policy rejection"
+    );
+
+    let (rpc_raw, _rpc_txid) = signed_transparent_transaction(&setup).await?;
+    let rpc_transaction_bytes = hex::decode(&rpc_raw)
+        .map_err(|error| eyre!("zcashd returned invalid transaction hex: {error}"))?
+        .len();
+    assert!(
+        u64::try_from(rpc_transaction_bytes)
+            .expect("transaction length fits in u64 on supported platforms")
+            > OVERSIZED_TRANSACTION_LIMIT,
+        "RPC test transaction must exceed the configured limit"
     );
 
     for attempt in 1..=2 {
         let response_text = setup
             .zakura_client
-            .text_from_call("sendrawtransaction", serde_json::json!([&raw]).to_string())
+            .text_from_call(
+                "sendrawtransaction",
+                serde_json::json!([&rpc_raw]).to_string(),
+            )
             .await?;
         let response: serde_json::Value = serde_json::from_str(&response_text)?;
         let error = response
@@ -165,7 +355,7 @@ pub async fn oversized_transparent_tx_rejected() -> Result<()> {
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| eyre!("sendrawtransaction error is missing `message`: {error}"))?;
         assert!(
-            message.contains(&format!("transaction is {transaction_bytes} bytes")),
+            message.contains(&format!("transaction is {rpc_transaction_bytes} bytes")),
             "error must include the actual serialized size: {message}"
         );
         assert!(
@@ -173,16 +363,6 @@ pub async fn oversized_transparent_tx_rejected() -> Result<()> {
             "error must include the configured limit: {message}"
         );
     }
-
-    let mempool: Vec<String> = setup
-        .zakura_client
-        .json_result_from_call("getrawmempool", "[]")
-        .await
-        .map_err(|e| eyre!("getrawmempool: {e}"))?;
-    assert!(
-        !mempool.iter().any(|entry| entry == &txid),
-        "oversized transaction must not enter Zakura's mempool"
-    );
 
     let block_template: BlockTemplateResponse = setup
         .zakura_client
@@ -194,7 +374,7 @@ pub async fn oversized_transparent_tx_rejected() -> Result<()> {
         BlockTemplateTimeSource::CurTime,
         &setup.network,
     )?;
-    let transaction: Arc<Transaction> = raw_bytes.zcash_deserialize_into()?;
+    let transaction: Arc<Transaction> = p2p_raw_bytes.zcash_deserialize_into()?;
     block.transactions.push(transaction);
 
     let merkle_root = block.transactions.iter().map(|tx| tx.hash()).collect();
@@ -211,6 +391,11 @@ pub async fn oversized_transparent_tx_rejected() -> Result<()> {
 
     setup.zakura_client.submit_block(block).await?;
     wait_for_zcashd_height(&setup.zcashd_client, 111).await?;
+    assert_eq!(
+        peer_connection_identity(&single_zcashd_peer(&setup).await?)?,
+        peer_identity,
+        "the same peer connection must remain live after the policy rejection"
+    );
     let block_count: u64 = setup
         .zakura_client
         .json_result_from_call("getblockcount", "[]")
@@ -222,7 +407,7 @@ pub async fn oversized_transparent_tx_rejected() -> Result<()> {
         .zakura_client
         .json_result_from_call(
             "getrawtransaction",
-            serde_json::json!([txid, 1]).to_string(),
+            serde_json::json!([p2p_txid, 1]).to_string(),
         )
         .await
         .map_err(|error| eyre!("getrawtransaction: {error}"))?;


### PR DESCRIPTION
## Summary

Adds `mempool.max_transaction_bytes`, defaulting to 250,000 bytes, and enforces it before semantic or contextual verification for both submitted and downloaded transactions. Over-limit transactions return RPC `-25`, are cached as policy rejections, and do not penalize peers. Block validation is unchanged.

[Live Ubuntu x86_64 regtest proof](https://github.com/zakura-core/zakura/actions/runs/29654892167) at `626461933b41`: all 27 compatibility tests passed. The new case rejected the same transaction twice with `-25`, kept it out of the mempool, then confirmed that exact transaction in an accepted block at height 111.

Context: [Slack discussion](https://zcashzcaloors.slack.com/archives/C0BF63UF7KP/p1784388018472029) · [Protocol specification §7.1.2](https://github.com/zcash/zips/blob/c55edc7c5b1b4c660505be32b17b9bd4c880077b/protocol/protocol.tex#L13548-L13566)

## AI Disclosure

Codex assisted with implementation, tests, documentation, review, and this description. The contributor reviewed the resulting diff and validation output.
