### PR TITLE
ci: limit per-PR git history growth to 2 MiB

### DIFF
--- a/.github/workflows/history-growth.yml
+++ b/.github/workflows/history-growth.yml
@@ -1,0 +1,52 @@
+# Rejects changes that grow the git history by more than 2 MiB of packed
+# objects. Added after a 68 MB embedded artifact had to be removed from
+# history with a force push: large artifacts belong in release assets or
+# external storage with a pinned hash, never in git history.
+name: History growth
+
+on:
+  pull_request:
+    branches: [main, "feat/**", "release/**"]
+
+  # Run when a PR is queued so the merge queue validates the merged result
+  # against the latest `main`.
+  merge_group:
+
+# Ensures that only one workflow task will run at a time. Previous builds, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Limit history growth to 2 MiB
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Select revision range
+        id: range
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          if [ "${EVENT_NAME}" = "merge_group" ]; then
+            echo "base=${MG_BASE_SHA}" >> "${GITHUB_OUTPUT}"
+            echo "head=${MG_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "base=${PR_BASE_SHA}" >> "${GITHUB_OUTPUT}"
+            echo "head=${PR_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Check history growth
+        run: ./scripts/check-history-growth.sh "${{ steps.range.outputs.base }}" "${{ steps.range.outputs.head }}"

--- a/scripts/check-history-growth.sh
+++ b/scripts/check-history-growth.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Enforce a limit on how much a change grows the repository's git history.
+#
+# Sums the packed on-disk size of every object reachable from <head-rev> but
+# not from <base-rev>. The repository is repacked first so new objects are
+# delta-compressed against existing history, approximating the real growth
+# once the change is merged and the server repacks.
+#
+# Added after a 68 MB embedded artifact had to be removed from history with a
+# force push: large artifacts belong in release assets or external storage
+# with a pinned hash, never in git history.
+#
+# Usage:
+#   ./scripts/check-history-growth.sh <base-rev> [head-rev]
+#
+# Environment:
+#   HISTORY_GROWTH_LIMIT_BYTES   Growth limit in bytes (default: 2097152, 2 MiB).
+#   HISTORY_GROWTH_SKIP_REPACK   Set to 1 to skip the repack. Faster, but new
+#                                objects may not be delta-compressed, which
+#                                overestimates growth.
+
+set -euo pipefail
+
+BASE_REV="${1:?usage: check-history-growth.sh <base-rev> [head-rev]}"
+HEAD_REV="${2:-HEAD}"
+LIMIT_BYTES="${HISTORY_GROWTH_LIMIT_BYTES:-2097152}"
+
+git rev-parse --verify --quiet "${BASE_REV}^{commit}" >/dev/null \
+  || { echo "ERROR: base revision '${BASE_REV}' not found" >&2; exit 2; }
+git rev-parse --verify --quiet "${HEAD_REV}^{commit}" >/dev/null \
+  || { echo "ERROR: head revision '${HEAD_REV}' not found" >&2; exit 2; }
+
+if [ "${HISTORY_GROWTH_SKIP_REPACK:-0}" != "1" ]; then
+  git repack -adq
+fi
+
+# One line per new object: "<sha>" for commits, "<sha> <path>" for trees and blobs.
+objects="$(git rev-list --objects "${HEAD_REV}" --not "${BASE_REV}")"
+
+human() {
+  numfmt --to=iec-i --suffix=B "$1" 2>/dev/null || echo "$1 B"
+}
+
+if [ -z "${objects}" ]; then
+  echo "OK: no new objects; history growth is 0 B (limit $(human "${LIMIT_BYTES}"))."
+  exit 0
+fi
+
+# "<sha> <type> <size>" per new object.
+sizes="$(cut -d' ' -f1 <<<"${objects}" \
+  | git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize:disk)')"
+
+total="$(awk '{ sum += $3 } END { print sum }' <<<"${sizes}")"
+count="$(wc -l <<<"${sizes}")"
+
+echo "New objects: ${count}; history growth: $(human "${total}") (limit $(human "${LIMIT_BYTES}"))."
+
+if [ "${total}" -le "${LIMIT_BYTES}" ]; then
+  exit 0
+fi
+
+echo
+echo "ERROR: this change grows the git history by $(human "${total}"), over the $(human "${LIMIT_BYTES}") limit."
+echo
+echo "Largest new blobs (packed size in bytes):"
+awk 'NR == FNR { type[$1] = $2; size[$1] = $3; next }
+     type[$1] == "blob" {
+       path = $0
+       sub(/^[0-9a-f]+ ?/, "", path)
+       printf "%12d  %s\n", size[$1], (path == "" ? $1 : path)
+     }' <(printf '%s\n' "${sizes}") <(printf '%s\n' "${objects}") \
+  | sort -rn | head -10
+echo
+echo "Large files must not be committed to git history: distribute them as"
+echo "release assets or external downloads pinned by hash, or shrink the data."
+echo "If the growth is intentional, get maintainer sign-off and adjust"
+echo "HISTORY_GROWTH_LIMIT_BYTES for this check."
+exit 1


### PR DESCRIPTION
## Motivation

A 68 MB embedded artifact was merged to `main` in #250 and had to be removed with an emergency history rewrite on 2026-07-18 (old tip `089a0baa0` → `b9d0ebd0c`): the single blob was 62% of every clone. Nothing in CI measured how much a PR grows the git history, so the only guard was review attention.

## Solution

- `scripts/check-history-growth.sh`: sums the packed on-disk size of every object reachable from the PR head but not from its base, after a full repack so new objects delta-compress against existing history — approximating real repository growth post-merge. Fails over 2 MiB (configurable via `HISTORY_GROWTH_LIMIT_BYTES`), printing the largest new blobs with paths and remediation guidance. Runnable locally: `./scripts/check-history-growth.sh origin/main HEAD`.
- `.github/workflows/history-growth.yml`: runs the script on `pull_request` and `merge_group`, resolving the base/head SHAs per event. No path filter, so it cannot be skipped by construction of the diff.

Measuring new-object pack size rather than per-file thresholds catches cumulative growth (many medium files) and ignores compressible or delta-friendly changes (checkpoint list refreshes), so routine PRs stay well under the limit.

## Testing

- Synthetic: a 3 MB random blob fails (reported 2.9 MiB with the file named); a small text change passes at 877 B; an empty range passes at 0 B
- Regression: the pre-rewrite `44e8f447e..089a0baa0` range from the backup mirror fails at 68 MiB with `mainnet-sprout-history.bin` at the top of the offender report
- Self-test: this PR passes its own check at 6.7 KiB

### Specifications & References

Follows the 2026-07-18 history rewrite removing the #250 artifact.

### Follow-up Work

- Mark the `Limit history growth to 2 MiB` check as required in the branch ruleset once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)