### PR TITLE
refactor: move mempool check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+- Reject transactions that do not meet ZIP-317 mempool fee policy before
+  running script and proof checks. Block validation is unchanged.
+
 ## [1.0.2-rc0] - 2026-07-19
 
 ### Added

--- a/zakura-chain/src/transaction/unmined.rs
+++ b/zakura-chain/src/transaction/unmined.rs
@@ -493,3 +493,36 @@ impl VerifiedUnminedTx {
         cost
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        block::Height,
+        parameters::NetworkUpgrade,
+        transaction::{LockTime, Transaction},
+    };
+
+    #[test]
+    fn verified_unmined_tx_rejects_insufficient_zip317_fee() {
+        let transaction = UnminedTx::from(Transaction::V5 {
+            network_upgrade: NetworkUpgrade::Nu5,
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(1),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+        });
+
+        let result = VerifiedUnminedTx::new(
+            transaction,
+            Amount::try_from(1).expect("valid amount"),
+            0,
+            0,
+            Arc::new(Vec::new()),
+        );
+
+        assert_eq!(result, Err(zip317::Error::UnpaidActions));
+    }
+}

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -521,13 +521,14 @@ where
                 check::mempool_standard_input_scripts(tx.as_ref(), &spent_outputs)?;
             }
 
+            let mempool_transaction = req.mempool_transaction();
             let mut miner_fee = None;
-            if let Some(unmined_tx) = req.mempool_transaction() {
+            if let Some(unmined_tx) = mempool_transaction.as_ref() {
                 // Apply ZIP-317 policy before expensive cryptographic verification.
                 // VerifiedUnminedTx::new() repeats this check to preserve its constructor
                 // invariant.
                 let fee = Self::miner_fee(tx.as_ref(), &spent_utxos)?;
-                let unpaid_actions = transaction::zip317::unpaid_actions(&unmined_tx, fee);
+                let unpaid_actions = transaction::zip317::unpaid_actions(unmined_tx, fee);
 
                 transaction::zip317::mempool_checks(unpaid_actions, fee, unmined_tx.size)?;
                 miner_fee = Some(fee);
@@ -572,7 +573,7 @@ where
                 )?,
             };
 
-            if let Some(unmined_tx) = req.mempool_transaction() {
+            if let Some(unmined_tx) = mempool_transaction {
                 let check_anchors_and_revealed_nullifiers_query = state
                     .clone()
                     .oneshot(zs::Request::CheckBestChainTipNullifiersAndAnchors(

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -521,6 +521,18 @@ where
                 check::mempool_standard_input_scripts(tx.as_ref(), &spent_outputs)?;
             }
 
+            let mut miner_fee = None;
+            if let Some(unmined_tx) = req.mempool_transaction() {
+                // Apply ZIP-317 policy before expensive cryptographic verification.
+                // VerifiedUnminedTx::new() repeats this check to preserve its constructor
+                // invariant.
+                let fee = Self::miner_fee(tx.as_ref(), &spent_utxos)?;
+                let unpaid_actions = transaction::zip317::unpaid_actions(&unmined_tx, fee);
+
+                transaction::zip317::mempool_checks(unpaid_actions, fee, unmined_tx.size)?;
+                miner_fee = Some(fee);
+            }
+
             let nu = req.upgrade(&network);
             let cached_ffi_transaction =
                 Arc::new(CachedFfiTransaction::new(tx.clone(), Arc::new(spent_outputs), nu).map_err(|_| TransactionError::UnsupportedByNetworkUpgrade(tx.version(), nu))?);
@@ -584,20 +596,10 @@ where
 
             tracing::trace!(?tx_id, "finished async checks");
 
-            // Get the `value_balance` to calculate the transaction fee.
-            let value_balance = tx.value_balance(&spent_utxos);
-
-            // Calculate the fee only for non-coinbase transactions.
-            let mut miner_fee = None;
-            if !tx.is_coinbase() {
-                // TODO: deduplicate this code with remaining_transaction_value()?
-                miner_fee = match value_balance {
-                    Ok(vb) => match vb.remaining_transaction_value() {
-                        Ok(fee) => Some(fee),
-                        Err(_) => return Err(TransactionError::IncorrectFee),
-                    },
-                    Err(_) => return Err(TransactionError::IncorrectFee),
-                };
+            // Mempool fees were calculated before the expensive async checks.
+            // Calculate the fee here only for non-coinbase block transactions.
+            if miner_fee.is_none() && !tx.is_coinbase() {
+                miner_fee = Some(Self::miner_fee(tx.as_ref(), &spent_utxos)?);
             }
 
             let sigops = tx.sigops().map_err(zakura_script::Error::from)?;
@@ -687,6 +689,19 @@ where
             Ok(median_time_past)
         } else {
             unreachable!("Request::BestChainNextMedianTimePast always responds with BestChainNextMedianTimePast")
+        }
+    }
+
+    /// Calculate the miner fee from the transaction's value balance.
+    fn miner_fee(
+        tx: &Transaction,
+        spent_utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
+    ) -> Result<Amount<NonNegative>, TransactionError> {
+        match tx.value_balance(spent_utxos) {
+            Ok(value_balance) => value_balance
+                .remaining_transaction_value()
+                .map_err(|_| TransactionError::IncorrectFee),
+            Err(_) => Err(TransactionError::IncorrectFee),
         }
     }
 

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -4130,16 +4130,14 @@ fn mock_transparent_transfer(
     transparent::Output,
     HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
 ) {
-    // A standard, signature-free P2SH input that the script interpreter accepts. The redeem
-    // script is OP_TRUE, so the spend is valid without a signature, while the spent output is a
-    // standard P2SH `scriptPubKey`. This lets the input pass the mempool `AreInputsStandard`
-    // gate (`check::mempool_standard_input_scripts`) that now runs before script verification,
-    // as well as the interpreter itself.
+    // Standard, signature-free P2SH inputs that either pass or fail in the script interpreter.
+    // Both variants pass the mempool `AreInputsStandard` gate.
+    const OP_FALSE: u8 = 0x00;
     const OP_TRUE: u8 = 0x51;
-    // `scriptSig`: a single push of the OP_TRUE redeem script (push-only, one stack item).
     let accepting_unlock_script = transparent::Script::new(&[0x01, OP_TRUE]);
-    // `scriptPubKey`: OP_HASH160 <HASH160(OP_TRUE)> OP_EQUAL. The 20-byte hash is precomputed
-    // (RIPEMD160(SHA256([OP_TRUE]))) so the P2SH hash check passes during verification.
+    let rejecting_unlock_script = transparent::Script::new(&[0x01, OP_FALSE]);
+
+    // `scriptPubKey`: OP_HASH160 <HASH160(redeem script)> OP_EQUAL.
     let mut p2sh_lock_bytes = vec![0xa9, 0x14];
     p2sh_lock_bytes.extend_from_slice(&[
         0xda, 0x17, 0x45, 0xe9, 0xb5, 0x49, 0xbd, 0x0b, 0xfa, 0x1a, 0x56, 0x99, 0x71, 0xc7, 0x7e,
@@ -4147,9 +4145,14 @@ fn mock_transparent_transfer(
     ]);
     p2sh_lock_bytes.push(0x87);
     let accepting_lock_script = transparent::Script::new(&p2sh_lock_bytes);
-    // A script with a single opcode that rejects the transaction (OP_FALSE). Only used for block
-    // requests (the standardness gate is mempool-only), so it need not be a standard type.
-    let rejecting_script = transparent::Script::new(&[0]);
+
+    let mut p2sh_lock_bytes = vec![0xa9, 0x14];
+    p2sh_lock_bytes.extend_from_slice(&[
+        0x9f, 0x7f, 0xd0, 0x96, 0xd3, 0x7e, 0xd2, 0xc0, 0xe3, 0xf7, 0xf0, 0xcf, 0xc9, 0x24, 0xbe,
+        0xef, 0x4f, 0xfc, 0xeb, 0x68,
+    ]);
+    p2sh_lock_bytes.push(0x87);
+    let rejecting_lock_script = transparent::Script::new(&p2sh_lock_bytes);
 
     // Mock an unspent transaction output
     let previous_outpoint = transparent::OutPoint {
@@ -4160,9 +4163,7 @@ fn mock_transparent_transfer(
     let (lock_script, unlock_script) = if script_should_succeed {
         (accepting_lock_script, accepting_unlock_script)
     } else {
-        // The spent output's OP_FALSE `scriptPubKey` makes verification fail regardless of the
-        // `scriptSig`, so the `scriptSig` value is irrelevant here.
-        (rejecting_script.clone(), accepting_unlock_script)
+        (rejecting_lock_script, rejecting_unlock_script)
     };
 
     let previous_output = transparent::Output {
@@ -4183,7 +4184,7 @@ fn mock_transparent_transfer(
     // Using the rejecting script pretends the amount is burned because it can't be spent again
     let output = transparent::Output {
         value: Amount::try_from(1).expect("1 is an invalid amount"),
-        lock_script: rejecting_script,
+        lock_script: transparent::Script::new(&[OP_FALSE]),
     };
 
     // Cache the source of the fund so that it can be used during verification
@@ -4746,10 +4747,11 @@ async fn mempool_zip317_error() {
         .expect("Nu5 activation height is specified");
     let fund_height = (height - 1).expect("fake source fund block height is too small");
 
-    // Will produce a small enough miner fee to fail the check.
+    // This transaction has both an insufficient fee and a standard P2SH input whose redeem
+    // script fails. ZIP-317 must reject it before the script interpreter is invoked.
     let (input, output, known_utxos) = mock_transparent_transfer(
         fund_height,
-        true,
+        false,
         0,
         Amount::try_from(10).expect("valid amount"),
     );
@@ -4780,17 +4782,6 @@ async fn mempool_zip317_error() {
                     .get(&input_outpoint)
                     .map(|utxo| utxo.utxo.clone()),
             ));
-
-        state
-            .expect_request_that(|req| {
-                matches!(
-                    req,
-                    zakura_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
-                )
-            })
-            .await
-            .expect("verifier should call mock state service with correct request")
-            .respond(zakura_state::Response::ValidBestChainTipNullifiersAndAnchors);
     });
 
     let verifier_response = verifier

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -4869,6 +4869,78 @@ async fn mempool_zip317_ok() {
     );
 }
 
+#[tokio::test]
+async fn mempool_transaction_with_sufficient_fee_is_rejected_by_script() {
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let verifier = Verifier::new_for_tests(&Network::Mainnet, state.clone());
+
+    let height = NetworkUpgrade::Nu5
+        .activation_height(&Network::Mainnet)
+        .expect("Nu5 activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+
+    // The fee passes ZIP-317, but the standard P2SH input's redeem script fails.
+    let (input, output, known_utxos) = mock_transparent_transfer(
+        fund_height,
+        false,
+        0,
+        Amount::try_from(10_001).expect("valid amount"),
+    );
+
+    let tx = Transaction::V5 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::unlocked(),
+        network_upgrade: NetworkUpgrade::Nu5,
+        expiry_height: height,
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    let input_outpoint = match tx.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zakura_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zakura_state::Response::UnspentBestChainUtxo(
+                known_utxos
+                    .get(&input_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zakura_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zakura_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await;
+
+    assert_eq!(
+        verifier_response,
+        Err(TransactionError::InternalDowncastError(
+            "downcast to known transaction error type failed, original error: ScriptInvalid"
+                .to_string()
+        ))
+    );
+}
+
 /// Test for CVE-2026-34377 https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-3vmh-33xr-9cqh
 ///
 /// Ensure a block with a transaction with garbage Orchard proofs is rejected, even if the mempool has a valid version of the same transaction.


### PR DESCRIPTION
## Motivation

ZIP-317 mempool fee policy was evaluated only when constructing `VerifiedUnminedTx`, after script and proof checks had completed. This made the policy ordering later than other mempool admission checks.

## Solution

- Calculate and validate mempool transaction fees after spent UTXOs are loaded and before script and proof checks.
- Reuse the calculated fee when constructing the verified transaction while retaining the constructor check as an invariant.
- Keep block transaction fee calculation and block validation behavior unchanged.
- Add coverage for early ZIP-317 rejection, constructor validation, and sufficiently funded mempool script rejection.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-chain -p zakura-consensus --all-targets -- -D warnings`
- `cargo test -p zakura-chain -p zakura-consensus`
- `markdownlint CHANGELOG.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics for changed files