### PR TITLE
chore(release): prepare v1.0.2-rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [1.0.2-rc0] - 2026-07-19
+
 ### Added
 
 - Add a configurable 250,000-byte default maximum for individual mempool
@@ -15,17 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   validation.
 - Add `zakurad validate-vct-sprout-history` to audit repaired historical
   Sprout anchors in archive or pruned Mainnet state databases.
-
-### Fixed
-
-- Database format upgrades now finish before startup exposes the finalized
-  state database; only configured periodic format checks continue in the
-  background.
-- Preserve Sprout note-commitment history during fresh verified-commitment-tree
-  fast sync, so later JoinSplit spends can use historical anchors. Affected
-  Mainnet databases that previously ran v2 p2p + fast mode require repair at
-  startup from a reviewed trusted artifact, snapshot redownload, or genesis
-  resync.
 
 ### Changed
 
@@ -41,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Database format upgrades now finish before startup exposes the finalized
+  state database; only configured periodic format checks continue in the
+  background.
+- Preserve Sprout note-commitment history during fresh verified-commitment-tree
+  fast sync, so later JoinSplit spends can use historical anchors. Affected
+  Mainnet databases that previously ran v2 p2p + fast mode require repair at
+  startup from a reviewed trusted artifact, snapshot redownload, or genesis
+  resync.
 - Deliver mined/submitted block gossip to peers that were momentarily unready
   when the block was advertised. A block broadcast via `AdvertiseBlockToAll`
   queued a re-send for unready peers, but the queued send future was dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,32 +14,38 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Add a configurable 250,000-byte default maximum for individual mempool
   transactions. Larger transactions are rejected before semantic and contextual
   verification without penalizing peers, and the policy does not affect block
-  validation.
+  validation ([#255](https://github.com/zakura-core/zakura/pull/255)).
 - Add `zakurad validate-vct-sprout-history` to audit repaired historical
-  Sprout anchors in archive or pruned Mainnet state databases.
+  Sprout anchors in archive or pruned Mainnet state databases
+  ([#247](https://github.com/zakura-core/zakura/pull/247),
+  [#251](https://github.com/zakura-core/zakura/pull/251)).
 
 ### Changed
 
 - Source the embedded Mainnet VCT Sprout-history repair artifact from
   exact-versioned crates.io packages instead of storing its large source
   bytes in the Zakura repository, and reuse one validated decode throughout
-  startup repair.
+  startup repair ([#259](https://github.com/zakura-core/zakura/pull/259)).
 - Update the embedded zcashd-compat binary and default split-container image to
-  valargroup/zcashd v1.0.1.
+  valargroup/zcashd v1.0.1
+  ([#245](https://github.com/zakura-core/zakura/pull/245)).
 - Header sync now schedules only forward ranges from the durable verified block
   tip. Startup rejects configured anchors above that base, and no longer
-  backfills headers below a checkpoint anchor.
+  backfills headers below a checkpoint anchor
+  ([#227](https://github.com/zakura-core/zakura/pull/227)).
 
 ### Fixed
 
 - Database format upgrades now finish before startup exposes the finalized
   state database; only configured periodic format checks continue in the
-  background.
+  background ([#240](https://github.com/zakura-core/zakura/pull/240)).
 - Preserve Sprout note-commitment history during fresh verified-commitment-tree
   fast sync, so later JoinSplit spends can use historical anchors. Affected
   Mainnet databases that previously ran v2 p2p + fast mode require repair at
   startup from a reviewed trusted artifact, snapshot redownload, or genesis
-  resync.
+  resync ([#239](https://github.com/zakura-core/zakura/pull/239),
+  [#244](https://github.com/zakura-core/zakura/pull/244),
+  [#259](https://github.com/zakura-core/zakura/pull/259)).
 - Deliver mined/submitted block gossip to peers that were momentarily unready
   when the block was advertised. A block broadcast via `AdvertiseBlockToAll`
   queued a re-send for unready peers, but the queued send future was dropped
@@ -49,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   The queued send now runs to completion. Only local mining paths (regtest, e2e,
   and local-mining deployments) exercise `AdvertiseBlockToAll`; standard
   following nodes advertise network blocks via `AdvertiseBlock` and are
-  unaffected.
+  unaffected ([#236](https://github.com/zakura-core/zakura/pull/236)).
 - Deliver committed-tip block gossip to configured zcashd-compat sidecar peers
   even when they are momentarily unready. The "always include sidecars" carve-out
   in block broadcasts only covered ready peers, so a sidecar that was unready when
@@ -57,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   learns the tip only from block `inv`s, it then stalled until a later gossip
   coincided with a ready service. The latest hash is now queued for an unready
   sidecar and delivered once it is ready again, bounding the stall to one
-  readiness cycle.
+  readiness cycle ([#231](https://github.com/zakura-core/zakura/pull/231)).
 - The inbound-overload protection no longer disconnects operator-configured
   block-gossip / zcashd-compat sidecar peers. When such a peer's own getdata /
   getheaders overloaded or timed out the inbound service, the random
@@ -65,7 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   feeds, and the one-connection-per-IP reconnect refusal could stretch that into
   a multi-second blackout. Configured sidecars are now exempt from the drop —
   their requests are still shed for backpressure, but the connection is not
-  closed. Every other peer's denial-of-service protection is unchanged.
+  closed. Every other peer's denial-of-service protection is unchanged
+  ([#242](https://github.com/zakura-core/zakura/pull/242)).
 
 ## [1.0.1] - 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.1"
+version = "1.0.2-rc0"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "1.1.0"
+version = "1.2.0-rc0"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "2.0.0"
+version = "3.0.0-rc0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "2.0.0"
+version = "3.0.0-rc0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "1.0.0"
+version = "1.0.1-rc0"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "2.0.0"
+version = "3.0.0-rc0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "1.0.0"
+version = "1.0.1-rc0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "2.0.0"
+version = "3.0.0-rc0"
 dependencies = [
  "bincode",
  "chrono",
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "1.0.1"
+version = "1.0.2-rc0"
 dependencies = [
  "color-eyre",
  "hex",

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.0.1 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.2-rc0 zakura
 ```
 
 You can start Zakura by running

--- a/zakura-chain/CHANGELOG.md
+++ b/zakura-chain/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0-rc0] - 2026-07-19
+
+### Added
+
+- Added `NoteCommitmentTrees::update_sprout_tree` for updating the Sprout
+  note-commitment tree from a block.
+
 ## [1.1.0] - 2026-07-17
 
 ### Added

--- a/zakura-chain/Cargo.toml
+++ b/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "1.1.0"
+version = "1.2.0-rc0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-consensus/CHANGELOG.md
+++ b/zakura-consensus/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc0] - 2026-07-19
+
+### Breaking Changes
+
+- `zakura-state` moved to 3.0.0-rc0. State service types appear in this crate's
+  public `init` signatures, so the state major version is part of this crate's
+  API; no APIs defined in this crate changed.
+
 ## [2.0.0] - 2026-07-17
 
 ### Breaking Changes

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "2.0.0"
+version = "3.0.0-rc0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -68,10 +68,10 @@ zcash_primitives = { workspace = true }
 tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0" }
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0" }
 
-zakura-script = { path = "../zakura-script", version = "1.0.0" }
-zakura-state = { path = "../zakura-state", version = "2.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
 
 zcash_protocol.workspace = true
 
@@ -96,8 +96,8 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "2.0.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc0] - 2026-07-19
+
+### Breaking Changes
+
+- Added `ConnectionInfo::is_protected_peer`, requiring downstream struct
+  literals to specify whether a configured peer is protected from overload
+  disconnects.
+- Added `HeaderSyncStartError::AnchorAboveVerifiedBlockTip` for invalid
+  checkpoint anchors.
+
+### Added
+
+- Added `ConnectedAddr::is_protected_peer` for identifying configured
+  block-gossip and zcashd-compat peers.
+
 ## [2.0.0] - 2026-07-17
 
 ### Breaking Changes

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "2.0.0"
+version = "3.0.0-rc0"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -93,7 +93,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["async-error"] }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
 
 [dev-dependencies]
@@ -106,7 +106,7 @@ static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]

--- a/zakura-node-services/CHANGELOG.md
+++ b/zakura-node-services/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1-rc0] - 2026-07-19
+
+### Changed
+
+- Updated the `zakura-chain` dependency to 1.2.0-rc0; no APIs defined in this
+  crate changed.
+
 ## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zakura-node-services/Cargo.toml
+++ b/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "1.0.0"
+version = "1.0.1-rc0"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain" , version = "1.2.0-rc0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zakura-rpc/CHANGELOG.md
+++ b/zakura-rpc/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc0] - 2026-07-19
+
+### Breaking Changes
+
+- `zakura-state`, `zakura-network`, and `zakura-consensus` moved to 3.0.0-rc0.
+  Their service types appear in this crate's public server signatures, so
+  their major versions are part of this crate's API; no APIs defined in this
+  crate changed.
+
 ## [2.0.0] - 2026-07-17
 
 ### Breaking Changes

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "2.0.0"
+version = "3.0.0-rc0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "2.0.0" }
-zakura-network = { path = "../zakura-network", version = "2.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0" }
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "1.0.0" }
-zakura-state = { path = "../zakura-state", version = "2.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc0" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -140,16 +140,16 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "2.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "2.0.0", features = [
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc0", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "2.0.0", features = [
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc0", features = [
     "proptest-impl",
 ] }
 

--- a/zakura-script/CHANGELOG.md
+++ b/zakura-script/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1-rc0] - 2026-07-19
+
+### Changed
+
+- Updated the `zakura-chain` dependency to 1.2.0-rc0; no APIs defined in this
+  crate changed.
+
 ## [1.0.0] - 2026-07-15
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zakura-script/Cargo.toml
+++ b/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "1.0.0"
+version = "1.0.1-rc0"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc0] - 2026-07-19
+
+### Breaking Changes
+
+- Changed Sprout tip-tree lookups to return `Result` when the tree is missing,
+  and made tree-batch preparation report validation errors.
+- Removed `ZakuraDb::spawn_format_change`; database format upgrades now finish
+  during initialization.
+- Added variants to public finalized-state error enums for missing Sprout data,
+  tip changes, and invalid VCT repair state.
+
 ### Added
 
 - Added authenticated VCT Sprout-history artifact generation and validation

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "2.0.0"
+version = "3.0.0-rc0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -87,8 +87,8 @@ zakura-vct-sprout-history = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["async-error"] }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -119,7 +119,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]

--- a/zakura-utils/CHANGELOG.md
+++ b/zakura-utils/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2-rc0] - 2026-07-19
+
+### Changed
+
+- Updated the bundled tools to the release-candidate Zakura crate graph; no
+  APIs defined in this crate changed.
+
 ## [1.0.1] - 2026-07-17
 
 ### Changed

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "1.0.1"
+version = "1.0.2-rc0"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -60,11 +60,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0" }
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zakura-rpc = { path = "../zakura-rpc", version = "2.0.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "3.0.0-rc0" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.0.1"
+version = "1.0.2-rc0"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -158,21 +158,21 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "1.0.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "2.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
-zakura-network = { path = "../zakura-network", version = "2.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "2.0.0" }
-zakura-state = { path = "../zakura-state", version = "2.0.0" }
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "3.0.0-rc0" }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "1.0.0" }
+zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "1.0.0", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "1.0.2-rc0", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -312,10 +312,10 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.0.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "2.0.0", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "2.0.0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "2.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc0", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "1.0.0" }
 
@@ -328,7 +328,7 @@ zakura-test = { path = "../zakura-test", version = "1.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "1.0.0" }
+zakura-utils = { path = "../zakura-utils", version = "1.0.2-rc0" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_415_700;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_417_400;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -24,8 +24,8 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_415_700;
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
 /// - Currently set to 18 days
 ///
-/// Note: v1.0.1 spans the expected Ironwood activation (height 3,428,143,
-/// ~2026-07-28) and halts one week after it (~2026-08-04, height ~3,436,436),
+/// Note: v1.0.2-rc0 spans the expected Ironwood activation (height 3,428,143,
+/// ~2026-07-28) and halts about nine days after it (~2026-08-06, height 3,438,136),
 /// forcing migration to the post-Ironwood release.
 pub const EOS_PANIC_AFTER: u32 = 18;
 

--- a/zakurad/tests/common/configs/v1.0.2-rc0.toml
+++ b/zakurad/tests/common/configs/v1.0.2-rc0.toml
@@ -1,0 +1,151 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"
+


### PR DESCRIPTION
## Motivation

Prepare a crates.io, GitHub-assets, and Docker `v1.0.2-rc0` release candidate from the changes merged since `v1.0.1`. Publishing the complete prerelease crate graph lets us test the same registry resolution and `cargo install` path intended for the stable release.

## Solution

- Bump the `zakura` binary package to `1.0.2-rc0`.
- Version every changed library and dependent package as a prerelease, updating all direct requirements so crates.io selects the RC graph:
  - `zakura-chain` 1.2.0-rc0
  - `zakura-node-services` 1.0.1-rc0
  - `zakura-script` 1.0.1-rc0
  - `zakura-state` 3.0.0-rc0
  - `zakura-consensus` 3.0.0-rc0
  - `zakura-network` 3.0.0-rc0
  - `zakura-rpc` 3.0.0-rc0
  - `zakura-utils` 1.0.2-rc0
  - `zakura` 1.0.2-rc0
- Record the public API changes and required major bumps in crate changelogs.
- Finalize the root release notes, add the generated configuration snapshot, and set the estimated release height to 3,417,400.
- Leave installer metadata pinned coherently to `v1.0.1` until release automation replaces all pins together.

## Testing

- `make pre-release RELEASE_TAG=v1.0.2-rc0 BASE_TAG=v1.0.1`
- `./scripts/check-crate-packaging.sh --verify` rebuilt all 13 packaged archives successfully and confirmed every archive remains below crates.io's 10 MiB limit.
- `cargo semver-checks -p <crate> --default-features` passed for all eight released library crates against their latest crates.io versions. The audit identified and validated the 3.0.0 major bumps for state, consensus, network, and RPC.
- `cargo public-api diff latest -p <crate> -sss` reviewed for each source-changed library crate and reflected in its changelog.
- `cargo test -p zakura --test acceptance config_tests -- --nocapture`
- Markdown lint passed for all changed Markdown files.
- `bash -n scripts/install-zakura.sh`
- IDE diagnostics are clean for all changed files.

Risk classification: low for the PR diff because it changes release metadata, dependency requirements, changelogs, and a generated config snapshot rather than validation logic. The package graph receives dedicated archive rebuild and semver/API verification; underlying code changes were tested before merging to `main`.

### Release Checklist

- [x] Target tag matches the `zakura` package version.
- [x] Every changed crate and prerelease-dependent package has an intentional version bump.
- [x] All direct dependency requirements resolve to the new prerelease graph.
- [x] Stored config generated from this release branch.
- [x] Release notes cover user-visible changes since `v1.0.1`.
- [x] `A-release` label applied so no-git-dependencies and Docker release checks run.
- [ ] Refresh Mainnet checkpoints/frontiers or record an explicit rapid-RC waiver. Current checkpoints end at height 3,358,006; see #261 and #262.
- [ ] Wait for required human approval and all enabled CI checks.
- [ ] After merge, obtain explicit operator confirmation before dispatching `create-release.yml` from `main` with `release_tag=v1.0.2-rc0`.
- [ ] Publish the nine changed crates in dependency order, then install exact `zakura` version `1.0.2-rc0` from crates.io and run `zakurad --version`.

### Specifications & References

- Previous release: `v1.0.1`
- Release policy: `docs/release-tag-protection.md`
- Canonical checklist: `.github/PULL_REQUEST_TEMPLATE/release-checklist.md`

### Follow-up Work

After publication, verify GitHub assets and Docker manifests, publish the changed crates in dependency order, run the exact crates.io install smoke test, review the installer metadata update PR, and replace the boilerplate GitHub release body with these concrete notes. Keep the RC marked as a pre-release.

Prepared with AI assistance using Cursor; all changes and verification results were reviewed locally.