### PR TITLE
refactor(consensus): streamline mempool script errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Reject transactions that do not meet ZIP-317 mempool fee policy before
   running script and proof checks. Block validation is unchanged.
+- Streamline mempool script error handling so invalid scripts are reported as
+  script verification errors.
 
 ## [1.0.2-rc0] - 2026-07-19
 

--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -335,7 +335,12 @@ impl From<amount::Error> for TransactionError {
 // TODO: use a dedicated variant and From impl for each concrete type, and update callers (#5732)
 impl From<BoxError> for TransactionError {
     fn from(mut err: BoxError) -> Self {
-        // TODO: handle redpallas::Error, ScriptInvalid, InvalidSignature
+        // TODO: handle redpallas::Error and InvalidSignature
+        match err.downcast::<zakura_script::Error>() {
+            Ok(e) => return TransactionError::Script(*e),
+            Err(e) => err = e,
+        }
+
         match err.downcast::<zakura_chain::primitives::redjubjub::Error>() {
             Ok(e) => return TransactionError::RedJubjub(*e),
             Err(e) => err = e,

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -2086,9 +2086,8 @@ async fn v4_transaction_with_transparent_transfer_is_rejected_by_the_script() {
 
     assert_eq!(
         result,
-        Err(TransactionError::InternalDowncastError(
-            "downcast to known transaction error type failed, original error: ScriptInvalid"
-                .to_string()
+        Err(TransactionError::Script(
+            zakura_script::Error::ScriptInvalid
         ))
     );
 }
@@ -2757,9 +2756,8 @@ async fn v5_transaction_with_transparent_transfer_is_rejected_by_the_script() {
 
     assert_eq!(
         result,
-        Err(TransactionError::InternalDowncastError(
-            "downcast to known transaction error type failed, original error: ScriptInvalid"
-                .to_string()
+        Err(TransactionError::Script(
+            zakura_script::Error::ScriptInvalid
         ))
     );
 }
@@ -4934,9 +4932,8 @@ async fn mempool_transaction_with_sufficient_fee_is_rejected_by_script() {
 
     assert_eq!(
         verifier_response,
-        Err(TransactionError::InternalDowncastError(
-            "downcast to known transaction error type failed, original error: ScriptInvalid"
-                .to_string()
+        Err(TransactionError::Script(
+            zakura_script::Error::ScriptInvalid
         ))
     );
 }


### PR DESCRIPTION
## Motivation

Asynchronous script checks return boxed errors, but transaction error conversion did not recognize `zakura_script::Error`. Script failures therefore surfaced as generic internal downcast errors instead of the existing script transaction error variant.

## Solution

- Downcast boxed `zakura_script::Error` values into `TransactionError::Script`.
- Update V4, V5, and mempool script-rejection expectations to use the specific error variant.
- Document the streamlined error handling in the changelog.

## Testing

- `cargo test -p zakura-consensus` — all 148 tests pass; the V4, V5, and mempool rejection tests exercise boxed script failures and verify their specific classification.
- `cargo clippy -p zakura-consensus --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `markdownlint CHANGELOG.md --config .trunk/configs/.markdownlint.yaml`
- IDE diagnostics and `git diff --check`