### PR TITLE
test(sync): make checkpoint coverage network-independent

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -114,9 +114,11 @@ failure-output = "immediate"
 default-filter = 'package(zakura-network) and test(~zakura::testkit::blocksync_fuzz)'
 
 
-[profile.sync-large-checkpoints-empty]
-slow-timeout = { period = "60m", terminate-after = 2 }
-default-filter = 'package(zakura) and test(=sync_large_checkpoints_empty)'
+[profile.sync-large-checkpoints-local]
+test-threads = 1
+slow-timeout = { period = "15m", terminate-after = 1 }
+failure-output = "immediate"
+default-filter = 'package(zakura) and test(=sync_large_checkpoints_local)'
 
 [profile.sync-full-mainnet]
 slow-timeout = { period = "30000m", terminate-after = 1 }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,7 +70,6 @@ jobs:
           # TODO: Do we need --locked --release --features "default-release-binaries" here?
           cargo llvm-cov report --lcov --output-path lcov.info
         env:
-          TEST_LARGE_CHECKPOINTS: 1
           # We set cases to 1, because some tests already run 1 case by default.
           # We set maximum shrink iterations to 0, because we don't expect failures in coverage tests.
           # Coverage tests are much slower than other tests, particularly in hot loops.

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Run unit tests
         run: |
           if [[ "${FULL_COVERAGE}" == "true" ]]; then
-            export TEST_LARGE_CHECKPOINTS=1
             cargo nextest run --profile full-tests --locked --release --features "${{ matrix.features }}" --run-ignored=all --partition "hash:${{ matrix.partition }}/3"
           else
             cargo nextest run --profile all-tests --locked --features "${{ matrix.features }}" --partition "hash:${{ matrix.partition }}/3"

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -38,7 +38,7 @@
 //! Here are some examples on how to run each of the tests using nextest profiles:
 //!
 //! ```console
-//! $ cargo nextest run --profile sync-large-checkpoints-empty
+//! $ cargo nextest run --profile sync-large-checkpoints-local --run-ignored=only
 //!
 //! $ ZAKURA_STATE__CACHE_DIR="/zakurad-cache" cargo nextest run --profile sync-full-mainnet
 //!
@@ -196,8 +196,7 @@ use common::{
     check::{is_zakurad_version, EphemeralCheck, EphemeralConfig},
     config::{
         config_file_full_path, configs_dir, default_test_config, external_address_test_config,
-        os_assigned_rpc_port_config, persistent_test_config, random_known_rpc_port_config,
-        read_listen_addr_from_logs, testdir,
+        os_assigned_rpc_port_config, persistent_test_config, read_listen_addr_from_logs, testdir,
     },
     launch::{
         spawn_zakurad_for_rpc, spawn_zakurad_without_rpc, ZakuradTestDirExt, BETWEEN_NODES_DELAY,
@@ -205,10 +204,10 @@ use common::{
     },
     lightwalletd::{can_spawn_lightwalletd_for_rpc, spawn_lightwalletd_for_rpc},
     sync::{
-        create_cached_database_height, sync_until, MempoolBehavior, LARGE_CHECKPOINT_TEST_HEIGHT,
-        LARGE_CHECKPOINT_TIMEOUT, MEDIUM_CHECKPOINT_TEST_HEIGHT, STOP_AT_HEIGHT_REGEX,
-        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX, TINY_CHECKPOINT_TEST_HEIGHT,
-        TINY_CHECKPOINT_TIMEOUT,
+        create_cached_database_height, sync_until, sync_until_with_config, MempoolBehavior,
+        LARGE_CHECKPOINT_TEST_HEIGHT, LARGE_CHECKPOINT_TIMEOUT, MEDIUM_CHECKPOINT_TEST_HEIGHT,
+        STOP_AT_HEIGHT_REGEX, STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX,
+        TINY_CHECKPOINT_TEST_HEIGHT, TINY_CHECKPOINT_TIMEOUT,
     },
     test_type::TestType::{self, *},
 };
@@ -1171,45 +1170,91 @@ fn activate_mempool_mainnet() -> Result<()> {
     .map(|_tempdir| ())
 }
 
-/// Test if `zakurad` can sync some larger checkpoints on mainnet.
+/// Test a fresh checkpoint sync and restart against a local Regtest peer.
 ///
-/// This test might fail or timeout on slow or unreliable networks,
-/// so we don't run it by default. It also takes a lot longer than
-/// our 10 second target time for default tests.
-#[test]
-#[ignore]
-fn sync_large_checkpoints_empty() -> Result<()> {
-    // Skip unless explicitly enabled
-    if std::env::var("TEST_LARGE_CHECKPOINTS").is_err() {
-        tracing::warn!(
-            "Skipped sync_large_checkpoints_empty, set the TEST_LARGE_CHECKPOINTS environmental variable to run the test"
-        );
-        return Ok(());
-    }
+/// The producer and consumer use the same Regtest network identity, but only
+/// the consumer configures checkpoints derived from the producer's chain.
+/// This exercises two maximum-size checkpoint ranges without public peers.
+#[tokio::test]
+#[ignore = "slow local multi-node checkpoint sync"]
+async fn sync_large_checkpoints_local() -> Result<()> {
+    let producer_network = Network::new_regtest(RegtestParameters::default());
+    let producer_p2p_addr = format!("127.0.0.1:{}", random_known_port()).parse()?;
+    let mut producer_config = os_assigned_rpc_port_config(false, &producer_network)?;
+    producer_config.network.listen_addr = producer_p2p_addr;
+    producer_config.network.initial_testnet_peers = [].into();
+    producer_config.network.cache_dir = false.into();
 
-    let reuse_tempdir = sync_until(
+    let mut producer = testdir()?
+        .with_config(&mut producer_config)?
+        .spawn_child(args!["start"])?
+        .with_timeout(LARGE_CHECKPOINT_TIMEOUT);
+    let producer_rpc_addr = read_listen_addr_from_logs(&mut producer, OPENED_RPC_ENDPOINT_MSG)?;
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let producer_rpc =
+        RpcRequestClient::new_with_timeout(producer_rpc_addr, Duration::from_secs(15 * 60));
+    let mut generated_hashes = Vec::new();
+    let mut remaining_blocks = LARGE_CHECKPOINT_TEST_HEIGHT.0;
+    while remaining_blocks > 0 {
+        let batch_size = remaining_blocks.min(250);
+        generated_hashes.extend(producer_rpc.generate(batch_size).await?);
+        remaining_blocks -= batch_size;
+    }
+    let generated_block_count = usize::try_from(LARGE_CHECKPOINT_TEST_HEIGHT.0)
+        .expect("checkpoint test height fits in usize");
+    assert_eq!(generated_hashes.len(), generated_block_count);
+    assert_eq!(
+        producer_rpc.blockchain_info().await?.blocks(),
+        LARGE_CHECKPOINT_TEST_HEIGHT
+    );
+
+    let checkpoint_interval = u32::try_from(zakura_consensus::MAX_CHECKPOINT_HEIGHT_GAP)
+        .expect("maximum checkpoint gap fits in u32");
+    let first_checkpoint_index =
+        usize::try_from(checkpoint_interval - 1).expect("checkpoint height fits in usize");
+    let checkpoints = vec![
+        (Height(0), regtest_genesis_block().hash()),
+        (
+            Height(checkpoint_interval),
+            generated_hashes[first_checkpoint_index],
+        ),
+        (
+            LARGE_CHECKPOINT_TEST_HEIGHT,
+            generated_hashes[generated_block_count - 1],
+        ),
+    ];
+    let consumer_network = Network::new_regtest(RegtestParameters {
+        checkpoints: Some(ConfiguredCheckpoints::HeightsAndHashes(checkpoints)),
+        ..Default::default()
+    });
+    let mut consumer_config = persistent_test_config(&consumer_network)?;
+    consumer_config.network.initial_testnet_peers = [producer_p2p_addr.to_string()].into();
+    consumer_config.network.cache_dir = false.into();
+    consumer_config.consensus.checkpoint_sync = true;
+
+    let reuse_tempdir = sync_until_with_config(
         LARGE_CHECKPOINT_TEST_HEIGHT,
-        &Mainnet,
+        &consumer_network,
         STOP_AT_HEIGHT_REGEX,
         LARGE_CHECKPOINT_TIMEOUT,
         None,
-        MempoolBehavior::ShouldNotActivate,
-        // checkpoint sync is irrelevant here - all tested checkpoints are mandatory
+        MempoolBehavior::ShouldAutomaticallyActivate,
         true,
-        true,
+        consumer_config.clone(),
     )?;
-    // if this sync fails, see the failure notes in `restart_stop_at_height`
-    sync_until(
+    sync_until_with_config(
         (LARGE_CHECKPOINT_TEST_HEIGHT - 1).unwrap(),
-        &Mainnet,
+        &consumer_network,
         "previous state height is greater than the stop height",
         STOP_ON_LOAD_TIMEOUT,
         reuse_tempdir,
         MempoolBehavior::ShouldNotActivate,
-        // checkpoint sync is irrelevant here - all tested checkpoints are mandatory
-        true,
         false,
+        consumer_config,
     )?;
+
+    producer.kill(true)?;
 
     Ok(())
 }
@@ -2313,7 +2358,7 @@ fn zakura_rpc_conflict() -> Result<()> {
     // [Note on port conflict](#Note on port conflict)
     //
     // This is the required setting to detect port conflicts.
-    let mut config = random_known_rpc_port_config(false, &Mainnet)?;
+    let mut config = common::config::random_known_rpc_port_config(false, &Mainnet)?;
 
     let dir1 = testdir()?.with_config(&mut config)?;
     let regex1 = regex::escape(&format!(

--- a/zakurad/tests/common/sync.rs
+++ b/zakurad/tests/common/sync.rs
@@ -206,6 +206,38 @@ pub fn sync_until(
     config.mempool.debug_enable_at_height = mempool_behavior.enable_at_height();
     config.consensus.checkpoint_sync = checkpoint_sync;
 
+    sync_until_with_config(
+        height,
+        network,
+        stop_regex,
+        timeout,
+        reuse_tempdir,
+        mempool_behavior,
+        check_legacy_chain,
+        config,
+    )
+}
+
+/// Sync using `config` until `zakurad` reaches `height`, or logs `stop_regex`.
+///
+/// This variant lets tests supply deterministic local peers while preserving
+/// the same state, shutdown, and log checks as [`sync_until`].
+#[allow(clippy::too_many_arguments)]
+#[tracing::instrument(skip(reuse_tempdir, config))]
+pub fn sync_until_with_config(
+    height: Height,
+    network: &Network,
+    stop_regex: &str,
+    timeout: Duration,
+    reuse_tempdir: impl Into<Option<TempDir>>,
+    mempool_behavior: MempoolBehavior,
+    check_legacy_chain: bool,
+    mut config: ZakuradConfig,
+) -> Result<TempDir> {
+    let reuse_tempdir = reuse_tempdir.into();
+    config.state.debug_stop_at_height = Some(height.0);
+    config.mempool.debug_enable_at_height = mempool_behavior.enable_at_height();
+
     // Use the default lookahead limit if we're syncing lots of blocks.
     // (Most tests use a smaller limit to minimise redundant block downloads.)
     if height > MIN_HEIGHT_FOR_DEFAULT_LOOKAHEAD {
@@ -221,7 +253,7 @@ pub fn sync_until(
 
     let child = tempdir.spawn_child(args!["start"])?.with_timeout(timeout);
 
-    let network_log = format!("network: {network},");
+    let network_log = format!("Zcash network: {network}");
 
     if mempool_behavior.require_activation() {
         // require that the mempool activated,
@@ -307,7 +339,7 @@ pub fn check_sync_logs_until(
     mempool_behavior: MempoolBehavior,
     check_legacy_chain: bool,
 ) -> Result<TestChild<TempDir>> {
-    zakurad.expect_stdout_line_matches(format!("network: {network},"))?;
+    zakurad.expect_stdout_line_matches(format!("Zcash network: {network}"))?;
 
     if check_legacy_chain {
         zakurad.expect_stdout_line_matches("starting legacy chain check")?;


### PR DESCRIPTION
## Motivation

The ignored large-checkpoint acceptance test downloaded blocks from public Mainnet peers. On CI runners, sparse or unreliable peer connectivity could leave the node at genesis until the four-minute command timeout, failing otherwise healthy post-merge unit-test runs.

## Solution

- replace the public-network test with a local Regtest producer that mines 800 blocks without seed peers or a peer cache
- derive checkpoints at heights 0, 400, and 800, then sync a persistent consumer exclusively from the loopback producer
- preserve the restart-at-lower-height assertion after the consumer checkpoint-verifies both maximum-size ranges
- allow the sync harness to accept custom configurations and use stable network metadata in log assertions
- rename and tighten the dedicated nextest profile, removing the obsolete `TEST_LARGE_CHECKPOINTS` CI switch

## Testing

- `cargo test -p zakura --test acceptance sync_large_checkpoints_local --release --features default-release-binaries -- --ignored --nocapture`
  - verifies local P2P catch-up, checkpoint ranges 0–400 and 400–800, persistence, and restart behavior
- `cargo clippy -p zakura --test acceptance --features default-release-binaries -- -D warnings`
- `cargo fmt --all -- --check`
- `actionlint .github/workflows/tests-unit.yml .github/workflows/coverage.yml`

### Specifications & References

The generated checkpoints use `MAX_CHECKPOINT_HEIGHT_GAP`, preserving the original two-range checkpoint coverage without depending on external peers.