### PR TITLE
fix(mempool): score ZIP-317 fee violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Reject transactions that do not meet ZIP-317 mempool fee policy before
   running script and proof checks. Block validation is unchanged.
+- Assign a low peer misbehaviour score to transactions that fail ZIP-317
+  mempool fee policy.
 
 ## [1.0.2-rc0] - 2026-07-19
 

--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -27,6 +27,10 @@ use proptest_derive::Arbitrary;
 /// Workaround for format string identifier rules.
 const MAX_EXPIRY_HEIGHT: block::Height = block::Height::MAX_EXPIRY_HEIGHT;
 
+/// The misbehaviour score assigned to a peer that sends a transaction which
+/// fails ZIP-317 mempool fee policy.
+const ZIP317_MEMPOOL_MISBEHAVIOR_SCORE: u32 = 10;
+
 /// Errors for semantic transaction validation.
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
@@ -404,10 +408,36 @@ impl TransactionError {
             | LockedUntilAfterBlockHeight(_)
             | LockedUntilAfterBlockTime(_) => 100,
 
-            // Standardness (policy) rejections must not be punished: non-standard
-            // transactions are consensus-valid, and zcashd relays a reject message
-            // without a DoS score for them.
+            // ZIP-317 fee policy rejections get a low score, because locally
+            // generated and relayed transactions must meet this policy.
+            Zip317(_) => ZIP317_MEMPOOL_MISBEHAVIOR_SCORE,
+
+            // Other standardness (policy) rejections must not be punished:
+            // non-standard transactions are consensus-valid, and zcashd relays a
+            // reject message without a DoS score for them.
             _other => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zakura_chain::transaction::zip317;
+
+    #[test]
+    fn zip317_mempool_errors_have_low_misbehavior_score() {
+        for zip317_error in [
+            zip317::Error::UnpaidActions,
+            zip317::Error::FeeBelowMinimumRate,
+            zip317::Error::InvalidMinFee,
+        ] {
+            let error = TransactionError::Zip317(zip317_error);
+
+            assert_eq!(
+                error.mempool_misbehavior_score(),
+                ZIP317_MEMPOOL_MISBEHAVIOR_SCORE
+            );
         }
     }
 }


### PR DESCRIPTION
## Motivation

Transactions that fail ZIP-317 mempool fee policy are rejected before expensive verification, but their sending peer currently receives no misbehaviour score.

## Solution

- Assign a score of 10 to all ZIP-317 mempool fee-policy failures.
- Keep other standardness-policy failures unscored.
- Add coverage for every ZIP-317 error variant.
- Document the peer-policy change under Unreleased.

## Impact

A peer that sends ten transactions rejected by ZIP-317 fee policy reaches the existing misbehaviour threshold. The transactions remain rejected from the mempool.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-consensus error::tests`
- `cargo clippy -p zakura-consensus --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small peer-DoS policy tweak in mempool scoring only; block validation and non-ZIP-317 standardness handling are unchanged.
> 
> **Overview**
> Peers that push transactions rejected for **ZIP-317 mempool fee policy** now get a **low misbehaviour score (10)** instead of no penalty, while other mempool standardness failures stay at score 0.
> 
> `TransactionError::mempool_misbehavior_score` maps `Zip317(_)` to the new constant; consensus-invalid failures remain at 100. Tests cover all `zip317::Error` variants, and the Unreleased changelog notes the peer-policy change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ce01246dcbd880481111479b6931d2b495e7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->