### PR TITLE
fix(zcashd): honor embedded source selection

### DIFF
--- a/zakurad/src/components/zcashd_compat/config.rs
+++ b/zakurad/src/components/zcashd_compat/config.rs
@@ -32,14 +32,15 @@ pub struct Config {
     /// Set this to `false` if `zcashd` is managed externally.
     pub manage_zcashd: bool,
 
-    /// Preferred source for the `zcashd` binary.
+    /// Source for the `zcashd` binary.
     ///
-    /// If `zcashd_path` is set, that explicit local path overrides this value.
+    /// Set to `embedded` to use the managed release download and cache, or `path`
+    /// to use [`zcashd_path`](Config::zcashd_path).
     pub zcashd_source: ZcashdBinarySource,
 
     /// Optional explicit path to a local `zcashd` binary with zcashd-compat support.
     ///
-    /// When set, Zebra uses this path directly and skips embedded downloads.
+    /// Used when [`zcashd_source`](Config::zcashd_source) is set to `path`.
     pub zcashd_path: Option<PathBuf>,
 
     /// Optional `zcashd` datadir path.

--- a/zakurad/src/components/zcashd_compat/managed.rs
+++ b/zakurad/src/components/zcashd_compat/managed.rs
@@ -47,17 +47,20 @@ pub fn zcashd_target_triple() -> Option<&'static str> {
         .map(|_| target)
 }
 
-/// Resolves the effective source for `zcashd`.
+/// Resolves the `zcashd` source selected by configuration.
 pub fn effective_zcashd_source(config: &Config) -> Result<ZcashdBinarySource, Report> {
-    if let Some(path) = config.zcashd_path.clone() {
-        return Ok(ZcashdBinarySource::Path(path));
-    }
-
     match config.zcashd_source {
         ConfigZcashdBinarySource::Embedded => Ok(ZcashdBinarySource::Embedded),
-        ConfigZcashdBinarySource::Path => Err(eyre!(
-            "zcashd_compat.zcashd_source=path requires zcashd_compat.zcashd_path to be set"
-        )),
+        ConfigZcashdBinarySource::Path => config
+            .zcashd_path
+            .clone()
+            .map(ZcashdBinarySource::Path)
+            .ok_or_else(|| {
+                eyre!(
+                    "zcashd_compat.zcashd_source=path requires \
+                     zcashd_compat.zcashd_path to be set"
+                )
+            }),
     }
 }
 
@@ -541,9 +544,23 @@ mod tests {
     };
 
     #[test]
-    fn explicit_zcashd_path_overrides_embedded_source() {
+    fn embedded_source_ignores_explicit_zcashd_path() {
         let config = Config {
             zcashd_source: ConfigZcashdBinarySource::Embedded,
+            zcashd_path: Some("/usr/local/bin/zcashd".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_zcashd_source(&config).expect("source should resolve"),
+            ZcashdBinarySource::Embedded
+        );
+    }
+
+    #[test]
+    fn path_source_uses_explicit_path() {
+        let config = Config {
+            zcashd_source: ConfigZcashdBinarySource::Path,
             zcashd_path: Some("/usr/local/bin/zcashd".into()),
             ..Default::default()
         };


### PR DESCRIPTION
## Motivation

Selecting `ZAKURA_ZCASHD_COMPAT__ZCASHD_SOURCE=embedded` could still run a
configured local `zcashd_path`. This made an explicit environment selection
ineffective when the config file retained an older path.

## Solution

Make `zcashd_source` authoritative: `embedded` now ignores `zcashd_path`, and
`path` continues to require it. Update the configuration documentation and add
coverage for both source selections.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura zcashd_compat::managed::tests`

## AI disclosure

Used Codex to implement the focused configuration precedence change and its
unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small precedence fix in zcashd-compat config resolution; behavior change only affects operators who set embedded while leaving an old path in config.
> 
> **Overview**
> **`zcashd_source` now decides which binary is used** instead of an optional `zcashd_path` silently overriding `embedded`.
> 
> `effective_zcashd_source` no longer checks `zcashd_path` first. With **`embedded`**, Zebra uses the managed download/cache even if a path is still set in config or env (e.g. a stale file value). With **`path`**, resolution still requires `zcashd_path` and errors if it is missing.
> 
> Config docs for `zcashd_source` and `zcashd_path` were updated to match. Unit tests now cover embedded ignoring a path and path mode using the explicit path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf45c502e5e9af1973af0e0cabb46c29195578c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->