### PR TITLE
fix(consensus): grace NU6.2 branch IDs at NU6.3

### DIFF
--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -259,7 +259,9 @@ pub enum TransactionError {
     #[error("transaction uses an incorrect consensus branch id")]
     WrongConsensusBranchId,
 
-    #[error("transaction uses the NU6.2 consensus branch id during the NU6.3 grace period")]
+    #[error(
+        "mempool transaction uses the NU6.2 consensus branch id during the NU6.3 grace period"
+    )]
     WrongConsensusBranchIdNu6_3GracePeriod,
 
     #[error("wrong tx format: tx version is ≥ 5, but `nConsensusBranchId` is missing")]
@@ -407,8 +409,8 @@ impl TransactionError {
             | LockedUntilAfterBlockHeight(_)
             | LockedUntilAfterBlockTime(_) => 100,
 
-            // NU6.2 transactions are invalid under NU6.3 rules, but honest peers
-            // can relay them briefly while their chain tips converge at activation.
+            // NU6.2 mempool transactions are invalid under NU6.3 rules, but
+            // honest peers can relay them briefly while their chain tips converge.
             WrongConsensusBranchIdNu6_3GracePeriod => 0,
 
             // Standardness (policy) rejections must not be punished: non-standard

--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -259,6 +259,9 @@ pub enum TransactionError {
     #[error("transaction uses an incorrect consensus branch id")]
     WrongConsensusBranchId,
 
+    #[error("transaction uses the NU6.2 consensus branch id during the NU6.3 grace period")]
+    WrongConsensusBranchIdNu6_3GracePeriod,
+
     #[error("wrong tx format: tx version is ≥ 5, but `nConsensusBranchId` is missing")]
     MissingConsensusBranchId,
 
@@ -403,6 +406,10 @@ impl TransactionError {
             | MissingConsensusBranchId
             | LockedUntilAfterBlockHeight(_)
             | LockedUntilAfterBlockTime(_) => 100,
+
+            // NU6.2 transactions are invalid under NU6.3 rules, but honest peers
+            // can relay them briefly while their chain tips converge at activation.
+            WrongConsensusBranchIdNu6_3GracePeriod => 0,
 
             // Standardness (policy) rejections must not be punished: non-standard
             // transactions are consensus-valid, and zcashd relays a reject message

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -78,6 +78,27 @@ const MEMPOOL_OUTPUT_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::
 /// response from the transaction verifier.
 const POLL_MEMPOOL_DELAY: std::time::Duration = Duration::from_millis(50);
 
+/// Number of blocks after NU6.3 activation during which a NU6.2 branch ID
+/// does not count as peer misbehavior.
+const NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS: i64 = 40;
+
+/// Returns whether a mempool transaction with a NU6.2 branch ID is within the
+/// NU6.3 peer-misbehavior grace period.
+fn is_nu6_3_branch_id_misbehavior_grace_period(
+    tx: &Transaction,
+    height: block::Height,
+    network: &Network,
+) -> bool {
+    tx.network_upgrade() == Some(NetworkUpgrade::Nu6_2)
+        && NetworkUpgrade::current(network, height) == NetworkUpgrade::Nu6_3
+        && NetworkUpgrade::Nu6_3
+            .activation_height(network)
+            .and_then(|activation_height| {
+                activation_height + NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS
+            })
+            .is_some_and(|grace_period_end| height < grace_period_end)
+}
+
 /// Asynchronous transaction verification.
 ///
 /// # Correctness
@@ -406,7 +427,16 @@ where
             check::has_enough_orchard_flags(&tx)?;
             check::has_enough_ironwood_flags(&tx)?;
             check::orchard_cross_address_disabled(&tx)?;
-            check::consensus_branch_id(&tx, req.height(), &network)?;
+            match check::consensus_branch_id(&tx, req.height(), &network) {
+                Err(TransactionError::WrongConsensusBranchId)
+                    if req.is_mempool()
+                        && is_nu6_3_branch_id_misbehavior_grace_period(&tx, req.height(), &network) =>
+                {
+                    return Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod);
+                }
+                Err(error) => return Err(error),
+                Ok(()) => {}
+            }
             check::sapling_point_encodings_are_valid(&tx)?;
 
             // Soft fork: temporarily require transactions to not contain Orchard actions.

--- a/zakura-consensus/src/transaction/check.rs
+++ b/zakura-consensus/src/transaction/check.rs
@@ -28,6 +28,10 @@ use zcash_script::{
 
 use crate::error::TransactionError;
 
+/// Number of blocks after NU6.3 activation during which a NU6.2 branch ID
+/// does not count as peer misbehavior.
+const NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS: i64 = 40;
+
 /// Checks if the transaction's lock time allows this transaction to be included in a block.
 ///
 /// Arguments:
@@ -909,6 +913,19 @@ pub fn consensus_branch_id(
     };
 
     if tx_nu != current_nu {
+        if tx_nu == NetworkUpgrade::Nu6_2 && current_nu == NetworkUpgrade::Nu6_3 {
+            let is_in_grace_period = NetworkUpgrade::Nu6_3
+                .activation_height(network)
+                .and_then(|activation_height| {
+                    activation_height + NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS
+                })
+                .is_some_and(|grace_period_end| height < grace_period_end);
+
+            if is_in_grace_period {
+                return Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod);
+            }
+        }
+
         return Err(TransactionError::WrongConsensusBranchId);
     }
 

--- a/zakura-consensus/src/transaction/check.rs
+++ b/zakura-consensus/src/transaction/check.rs
@@ -28,10 +28,6 @@ use zcash_script::{
 
 use crate::error::TransactionError;
 
-/// Number of blocks after NU6.3 activation during which a NU6.2 branch ID
-/// does not count as peer misbehavior.
-const NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS: i64 = 40;
-
 /// Checks if the transaction's lock time allows this transaction to be included in a block.
 ///
 /// Arguments:
@@ -913,19 +909,6 @@ pub fn consensus_branch_id(
     };
 
     if tx_nu != current_nu {
-        if tx_nu == NetworkUpgrade::Nu6_2 && current_nu == NetworkUpgrade::Nu6_3 {
-            let is_in_grace_period = NetworkUpgrade::Nu6_3
-                .activation_height(network)
-                .and_then(|activation_height| {
-                    activation_height + NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS
-                })
-                .is_some_and(|grace_period_end| height < grace_period_end);
-
-            if is_in_grace_period {
-                return Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod);
-            }
-        }
-
         return Err(TransactionError::WrongConsensusBranchId);
     }
 

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -3913,7 +3913,38 @@ fn public_nu6_3_consensus_branch_id_boundary() {
         );
         assert_eq!(
             check::consensus_branch_id(&tx, activation_height, &network),
+            Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod),
+        );
+        assert_eq!(
+            check::consensus_branch_id(
+                &tx,
+                (activation_height + 39).expect("NU6.3 grace period should fit in a height"),
+                &network,
+            ),
+            Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod),
+        );
+        assert_eq!(
+            check::consensus_branch_id(
+                &tx,
+                (activation_height + 40).expect("NU6.3 grace period should fit in a height"),
+                &network,
+            ),
             Err(TransactionError::WrongConsensusBranchId),
+        );
+        assert_eq!(
+            TransactionError::WrongConsensusBranchIdNu6_3GracePeriod.mempool_misbehavior_score(),
+            0,
+        );
+
+        tx.update_network_upgrade(NetworkUpgrade::Nu6_1)
+            .expect("V5 transactions support the NU6.1 branch ID");
+        assert_eq!(
+            check::consensus_branch_id(&tx, activation_height, &network),
+            Err(TransactionError::WrongConsensusBranchId),
+        );
+        assert_eq!(
+            TransactionError::WrongConsensusBranchId.mempool_misbehavior_score(),
+            100,
         );
 
         tx.update_network_upgrade(NetworkUpgrade::Nu6_3)

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -3913,23 +3913,23 @@ fn public_nu6_3_consensus_branch_id_boundary() {
         );
         assert_eq!(
             check::consensus_branch_id(&tx, activation_height, &network),
-            Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod),
+            Err(TransactionError::WrongConsensusBranchId),
         );
         assert_eq!(
-            check::consensus_branch_id(
+            super::is_nu6_3_branch_id_misbehavior_grace_period(
                 &tx,
                 (activation_height + 39).expect("NU6.3 grace period should fit in a height"),
                 &network,
             ),
-            Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod),
+            true,
         );
         assert_eq!(
-            check::consensus_branch_id(
+            super::is_nu6_3_branch_id_misbehavior_grace_period(
                 &tx,
                 (activation_height + 40).expect("NU6.3 grace period should fit in a height"),
                 &network,
             ),
-            Err(TransactionError::WrongConsensusBranchId),
+            false,
         );
         assert_eq!(
             TransactionError::WrongConsensusBranchIdNu6_3GracePeriod.mempool_misbehavior_score(),
@@ -4033,7 +4033,13 @@ async fn v5_consensus_branch_ids() {
             let (block_rsp, mempool_rsp) = futures::join!(block_req, mempool_req);
 
             assert_eq!(block_rsp, Err(TransactionError::WrongConsensusBranchId));
-            assert_eq!(mempool_rsp, Err(TransactionError::WrongConsensusBranchId));
+            let mempool_expected_error =
+                if network_upgrade == NetworkUpgrade::Nu6_2 && next_nu == NetworkUpgrade::Nu6_3 {
+                    TransactionError::WrongConsensusBranchIdNu6_3GracePeriod
+                } else {
+                    TransactionError::WrongConsensusBranchId
+                };
+            assert_eq!(mempool_rsp, Err(mempool_expected_error));
 
             // Check the currently supported network upgrade.
             let height = network_upgrade.activation_height(&network).expect("height");

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -3915,22 +3915,16 @@ fn public_nu6_3_consensus_branch_id_boundary() {
             check::consensus_branch_id(&tx, activation_height, &network),
             Err(TransactionError::WrongConsensusBranchId),
         );
-        assert_eq!(
-            super::is_nu6_3_branch_id_misbehavior_grace_period(
-                &tx,
-                (activation_height + 39).expect("NU6.3 grace period should fit in a height"),
-                &network,
-            ),
-            true,
-        );
-        assert_eq!(
-            super::is_nu6_3_branch_id_misbehavior_grace_period(
-                &tx,
-                (activation_height + 40).expect("NU6.3 grace period should fit in a height"),
-                &network,
-            ),
-            false,
-        );
+        assert!(super::is_nu6_3_branch_id_misbehavior_grace_period(
+            &tx,
+            (activation_height + 39).expect("NU6.3 grace period should fit in a height"),
+            &network,
+        ));
+        assert!(!super::is_nu6_3_branch_id_misbehavior_grace_period(
+            &tx,
+            (activation_height + 40).expect("NU6.3 grace period should fit in a height"),
+            &network,
+        ));
         assert_eq!(
             TransactionError::WrongConsensusBranchIdNu6_3GracePeriod.mempool_misbehavior_score(),
             0,

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -4041,6 +4041,38 @@ async fn v5_consensus_branch_ids() {
                 };
             assert_eq!(mempool_rsp, Err(mempool_expected_error));
 
+            if network_upgrade == NetworkUpgrade::Nu6_2 && next_nu == NetworkUpgrade::Nu6_3 {
+                let grace_period_last_height =
+                    (height + 39).expect("NU6.3 grace period should fit in a height");
+                let grace_period_response = verifier
+                    .clone()
+                    .oneshot(Request::Mempool {
+                        transaction: tx.clone().into(),
+                        height: grace_period_last_height,
+                    })
+                    .map_err(|err| *err.downcast().expect("`TransactionError` type"))
+                    .await;
+                assert_eq!(
+                    grace_period_response,
+                    Err(TransactionError::WrongConsensusBranchIdNu6_3GracePeriod),
+                );
+
+                let grace_period_end_height =
+                    (height + 40).expect("NU6.3 grace period should fit in a height");
+                let grace_period_end_response = verifier
+                    .clone()
+                    .oneshot(Request::Mempool {
+                        transaction: tx.clone().into(),
+                        height: grace_period_end_height,
+                    })
+                    .map_err(|err| *err.downcast().expect("`TransactionError` type"))
+                    .await;
+                assert_eq!(
+                    grace_period_end_response,
+                    Err(TransactionError::WrongConsensusBranchId),
+                );
+            }
+
             // Check the currently supported network upgrade.
             let height = network_upgrade.activation_height(&network).expect("height");
 


### PR DESCRIPTION
## Motivation

At the NU6.3 activation boundary, an honest peer can briefly relay a NU6.2-branch-ID transaction while its chain tip converges. Zakura correctly rejects that transaction, but scores the attributed legacy peer 100 points, reaching the ban threshold.

## Solution

Keep branch-ID consensus validation strict. For the 40 heights beginning at NU6.3 activation, classify only a NU6.2 branch ID presented where NU6.3 is expected as a dedicated rejection with a zero misbehavior score. All other branch-ID mismatches, and NU6.2 IDs from height `H + 40`, retain the normal 100-point score.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-consensus public_nu6_3_consensus_branch_id_boundary`

The boundary test covers the start and end of the 40-block grace interval, confirms other mismatches still score 100, and confirms the grace-period rejection scores 0.

### Specifications & References

- ZIP-244 branch-ID requirements

### Follow-up Work

- The dedicated public `TransactionError::WrongConsensusBranchIdNu6_3GracePeriod` variant is an intentional API-surface addition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches P2P misbehavior scoring at a network-upgrade boundary; logic is narrow (mempool-only, NU6.2→NU6.3, 40 blocks) but incorrect grace bounds could under- or over-punish peers.
> 
> **Overview**
> After **NU6.3** activates, mempool verification still rejects transactions with a **NU6.2** consensus branch ID, but for the first **40 block heights** it returns a dedicated `TransactionError::WrongConsensusBranchIdNu6_3GracePeriod` instead of `WrongConsensusBranchId`. That variant carries a **zero** mempool misbehavior score so honest peers relaying stale-branch txs during tip convergence are not ban-scored; other branch-ID mismatches and NU6.2 IDs from height **H + 40** onward still score **100**. **Block** verification is unchanged and still uses the normal wrong-branch-ID error.
> 
> The verifier maps the grace case in the early `consensus_branch_id` check via `is_nu6_3_branch_id_misbehavior_grace_period`; tests cover the grace window boundaries and scoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca296346e52d42a6e9c0d326fd318bc5ce7a4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->