### PR TITLE
fix(zakurad): reap managed zcashd on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   running script and proof checks. Block validation is unchanged.
 - Streamline mempool script error handling so invalid scripts are reported as
   script verification errors.
+- Shut down a managed zcashd-compat process before Zakura exits on SIGINT or
+  SIGTERM.
 
 ## [1.0.2-rc0] - 2026-07-19
 

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -88,6 +88,7 @@ use tokio::{
     pin, select,
     sync::{oneshot, watch},
 };
+use tokio_util::sync::CancellationToken;
 use tower::{builder::ServiceBuilder, util::BoxService, ServiceExt};
 use tracing_futures::Instrument;
 
@@ -284,7 +285,11 @@ impl StartCmd {
         )
     }
 
-    async fn start(&self) -> Result<(), Report> {
+    async fn start(
+        &self,
+        shutdown: CancellationToken,
+        cleanup_ready: CancellationToken,
+    ) -> Result<(), Report> {
         check_tcp_slow_start_after_idle();
 
         let config = APPLICATION.config();
@@ -629,38 +634,34 @@ impl StartCmd {
 
         let zcashd_compat_shutdown_timeout =
             Self::zcashd_compat_supervisor_shutdown_timeout(&config);
-        let (zcashd_compat_shutdown_tx, zcashd_compat_shutdown_rx) = watch::channel(false);
-        let mut zcashd_compat_task_handle = if let Some(resolved_zcashd_path) = resolved_zcashd_path
-        {
-            let local_listener = address_book
-                .lock()
-                .expect("unexpected panic in address book mutex guard")
-                .local_listener_socket_addr();
-            let supervisor_config = zcashd_compat::SupervisorConfig::new(
-                &config.zcashd_compat,
-                resolved_zcashd_path,
-                &config.state.cache_dir,
-                config.network.network.kind(),
-                Self::zcashd_compat_p2p_connect_addr(&config, local_listener),
-            );
+        let zcashd_compat_supervisor_config =
+            if let Some(resolved_zcashd_path) = resolved_zcashd_path {
+                let local_listener = address_book
+                    .lock()
+                    .expect("unexpected panic in address book mutex guard")
+                    .local_listener_socket_addr();
+                let supervisor_config = zcashd_compat::SupervisorConfig::new(
+                    &config.zcashd_compat,
+                    resolved_zcashd_path,
+                    &config.state.cache_dir,
+                    config.network.network.kind(),
+                    Self::zcashd_compat_p2p_connect_addr(&config, local_listener),
+                );
 
-            info!(
-                connect = %supervisor_config.zakura_p2p_addr,
-                "zcashd-compat source enabled"
-            );
+                info!(
+                    connect = %supervisor_config.zakura_p2p_addr,
+                    "zcashd-compat source enabled"
+                );
 
-            tokio::spawn(
-                zcashd_compat::run_supervisor(supervisor_config, zcashd_compat_shutdown_rx)
-                    .in_current_span(),
-            )
-        } else {
-            if config.zcashd_compat.enabled {
-                zcashd_compat::set_supervision_config_disabled_metrics();
-                info!("zcashd-compat source enabled: zcashd supervision disabled");
-            }
+                Some(supervisor_config)
+            } else {
+                if config.zcashd_compat.enabled {
+                    zcashd_compat::set_supervision_config_disabled_metrics();
+                    info!("zcashd-compat source enabled: zcashd supervision disabled");
+                }
 
-            tokio::spawn(std::future::pending().in_current_span())
-        };
+                None
+            };
 
         // TODO: Add a shutdown signal and start the server with `serve_with_incoming_shutdown()` if
         //       any related unit tests sometimes crash with memory errors
@@ -825,6 +826,20 @@ impl StartCmd {
 
         info!("spawned initial Zakura tasks");
 
+        let (zcashd_compat_shutdown_tx, zcashd_compat_shutdown_rx) = watch::channel(false);
+        let mut zcashd_compat_task_handle =
+            if let Some(supervisor_config) = zcashd_compat_supervisor_config {
+                tokio::spawn(
+                    zcashd_compat::run_supervisor(supervisor_config, zcashd_compat_shutdown_rx)
+                        .in_current_span(),
+                )
+            } else {
+                tokio::spawn(std::future::pending().in_current_span())
+            };
+        // The supervisor may own a child after this point, so shutdown must
+        // await cleanup. Do not add a yield between the spawn and this marker.
+        cleanup_ready.cancel();
+
         // TODO: put tasks into an ongoing FuturesUnordered and a startup FuturesUnordered?
 
         // ongoing tasks
@@ -860,6 +875,8 @@ impl StartCmd {
                 let mut exit_when_task_finishes = true;
 
                 let result = select! {
+                _ = shutdown.cancelled() => Ok(()),
+
                 rpc_join_result = &mut rpc_task_handle => {
                     let rpc_server_result = rpc_join_result
                         .expect("unexpected panic in the rpc task");
@@ -973,7 +990,7 @@ impl StartCmd {
             }
         };
 
-        info!("exiting Zebra because an ongoing task exited: asking other tasks to stop");
+        info!("exiting Zebra: asking other tasks to stop");
 
         // ongoing tasks
         rpc_task_handle.abort();
@@ -1093,7 +1110,9 @@ impl Runnable for StartCmd {
             .take();
 
         rt.expect("runtime should not already be taken")
-            .run(self.start());
+            .run_with_graceful_shutdown(|shutdown, cleanup_ready| {
+                self.start(shutdown, cleanup_ready)
+            });
 
         info!("stopping zakurad");
     }

--- a/zakurad/src/components/tokio.rs
+++ b/zakurad/src/components/tokio.rs
@@ -14,6 +14,7 @@ use std::{future::Future, time::Duration};
 use abscissa_core::{Component, FrameworkError, Shutdown};
 use color_eyre::Report;
 use tokio::runtime::Runtime;
+use tokio_util::sync::CancellationToken;
 
 use crate::prelude::*;
 
@@ -56,6 +57,12 @@ async fn shutdown() {
 /// depend on tokio
 pub(crate) trait RuntimeRun {
     fn run(self, fut: impl Future<Output = Result<(), Report>>);
+
+    fn run_with_graceful_shutdown<F>(
+        self,
+        run: impl FnOnce(CancellationToken, CancellationToken) -> F,
+    ) where
+        F: Future<Output = Result<(), Report>>;
 }
 
 impl RuntimeRun for Runtime {
@@ -72,22 +79,114 @@ impl RuntimeRun for Runtime {
             }
         });
 
-        // Don't wait for long blocking tasks before shutting down
-        info!(
-            ?TOKIO_SHUTDOWN_TIMEOUT,
-            "waiting for async tokio tasks to shut down"
-        );
-        self.shutdown_timeout(TOKIO_SHUTDOWN_TIMEOUT);
+        finish_runtime(self, result);
+    }
 
-        match result {
-            Ok(()) => {
-                info!("shutting down Zebra");
-            }
-            Err(error) => {
-                warn!(?error, "shutting down Zebra due to an error");
-                APPLICATION.shutdown(Shutdown::Forced);
+    fn run_with_graceful_shutdown<F>(
+        self,
+        run: impl FnOnce(CancellationToken, CancellationToken) -> F,
+    ) where
+        F: Future<Output = Result<(), Report>>,
+    {
+        let shutdown_token = CancellationToken::new();
+        let cleanup_ready = CancellationToken::new();
+        let fut = run(shutdown_token.clone(), cleanup_ready.clone());
+        let result = self.block_on(run_until_shutdown(
+            fut,
+            shutdown(),
+            shutdown_token,
+            cleanup_ready,
+        ));
+
+        finish_runtime(self, result);
+    }
+}
+
+async fn run_until_shutdown(
+    fut: impl Future<Output = Result<(), Report>>,
+    shutdown_signal: impl Future<Output = ()>,
+    shutdown_token: CancellationToken,
+    cleanup_ready: CancellationToken,
+) -> Result<(), Report> {
+    tokio::pin!(fut);
+    tokio::pin!(shutdown_signal);
+
+    tokio::select! {
+        biased;
+        _ = &mut shutdown_signal => {
+            shutdown_token.cancel();
+            if cleanup_ready.is_cancelled() {
+                fut.await
+            } else {
+                Ok(())
             }
         }
+        result = &mut fut => result,
+    }
+}
+
+fn finish_runtime(runtime: Runtime, result: Result<(), Report>) {
+    // Don't wait for long blocking tasks before shutting down
+    info!(
+        ?TOKIO_SHUTDOWN_TIMEOUT,
+        "waiting for async tokio tasks to shut down"
+    );
+    runtime.shutdown_timeout(TOKIO_SHUTDOWN_TIMEOUT);
+
+    match result {
+        Ok(()) => {
+            info!("shutting down Zebra");
+        }
+        Err(error) => {
+            warn!(?error, "shutting down Zebra due to an error");
+            APPLICATION.shutdown(Shutdown::Forced);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn graceful_shutdown_waits_for_root_future_cleanup() {
+        let shutdown = CancellationToken::new();
+        let future_shutdown = shutdown.clone();
+        let cleanup_ready = CancellationToken::new();
+        cleanup_ready.cancel();
+        let (cleanup_tx, cleanup_rx) = oneshot::channel();
+
+        let fut = async move {
+            future_shutdown.cancelled().await;
+            cleanup_tx.send(()).expect("cleanup receiver is open");
+            Ok(())
+        };
+
+        run_until_shutdown(fut, future::ready(()), shutdown, cleanup_ready)
+            .await
+            .expect("shutdown should succeed");
+        cleanup_rx.await.expect("root future ran cleanup");
+    }
+
+    #[tokio::test]
+    async fn shutdown_during_startup_does_not_wait_for_root_future() {
+        let shutdown = CancellationToken::new();
+        let cleanup_ready = CancellationToken::new();
+
+        run_until_shutdown(
+            future::pending(),
+            future::ready(()),
+            shutdown.clone(),
+            cleanup_ready,
+        )
+        .await
+        .expect("shutdown should succeed");
+
+        assert!(shutdown.is_cancelled());
     }
 }
 

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -4598,6 +4598,7 @@ async fn zcashd_compat_transparent_tx_confirms() -> Result<()> {
 /// See [`common::zcashd_compat::resilience::zakurad_clean_shutdown`] for details.
 #[tokio::test]
 #[ignore]
+#[cfg(target_os = "linux")]
 async fn zcashd_compat_zakurad_clean_shutdown() -> Result<()> {
     common::zcashd_compat::resilience::zakurad_clean_shutdown().await
 }

--- a/zakurad/tests/common/zcashd_compat/resilience.rs
+++ b/zakurad/tests/common/zcashd_compat/resilience.rs
@@ -1,37 +1,176 @@
 //! Process-lifecycle test bodies for the zcashd-compat integration test suite.
 
 use std::time::Duration;
+#[cfg(target_os = "linux")]
+use std::{
+    ffi::OsString,
+    os::unix::ffi::OsStringExt,
+    process::{Command, Stdio},
+};
 
 use color_eyre::eyre::{eyre, Result};
 use tokio::time::sleep;
+#[cfg(target_os = "linux")]
+use zakura_test::command::CommandExt;
 
 use super::setup_zcashd_compat;
+
+#[cfg(target_os = "linux")]
+use super::launch::{send_signal, spawn_zakurad_with_zcashd_compat_config};
+#[cfg(target_os = "linux")]
+use super::{config::read_test_network_kind, zakura_skip_zcashd_compat_tests};
+#[cfg(target_os = "linux")]
+use zakura_chain::parameters::NetworkKind;
+
+#[cfg(target_os = "linux")]
+struct PidKillGuard(Option<u32>);
+
+#[cfg(target_os = "linux")]
+impl PidKillGuard {
+    fn new(pid: u32) -> Self {
+        Self(Some(pid))
+    }
+
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for PidKillGuard {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0 {
+            let _ = send_signal(pid, "-KILL");
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn process_exists(pid: u32) -> bool {
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_process_to_stop(pid: u32) -> Result<()> {
+    for _ in 0..100 {
+        let status = std::fs::read_to_string(format!("/proc/{pid}/status"))?;
+        let is_stopped = status
+            .lines()
+            .find_map(|line| line.strip_prefix("State:"))
+            .is_some_and(|state| state.trim_start().starts_with('T'));
+        if is_stopped {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+
+    Err(eyre!(
+        "zcashd process {pid} did not enter the stopped state"
+    ))
+}
 
 /// Verifies that zakurad shuts down cleanly while supervising a running zcashd.
 ///
 /// Only runs in managed (regtest) mode; skipped on external networks where we
 /// do not own the zakurad process.
+#[cfg(target_os = "linux")]
 pub async fn zakurad_clean_shutdown() -> Result<()> {
-    let Some(mut setup) = setup_zcashd_compat().await? else {
+    if zakura_skip_zcashd_compat_tests() || read_test_network_kind()? != NetworkKind::Regtest {
         return Ok(());
-    };
-
-    if !setup.can_mutate() {
-        return setup.teardown();
     }
 
-    let mut zakurad = setup
+    let mut setup = spawn_zakurad_with_zcashd_compat_config(|config| {
+        config.zcashd_compat.shutdown_grace_period = Duration::from_secs(5);
+    })
+    .await?;
+
+    let zakurad = setup
         .managed
         .take()
         .expect("managed process is present in regtest mode");
+    let zakurad_pid = zakurad
+        .child
+        .as_ref()
+        .expect("managed zakurad child is still running")
+        .id();
+    let zcashd_pid = setup.zcashd_pid()?;
+    let mut zcashd_guard = PidKillGuard::new(zcashd_pid);
+    let zcashd_executable = std::fs::read_link(format!("/proc/{zcashd_pid}/exe"))?;
+    let zcashd_args = std::fs::read(format!("/proc/{zcashd_pid}/cmdline"))?
+        .split(|byte| *byte == 0)
+        .filter(|arg| !arg.is_empty())
+        .skip(1)
+        .map(|arg| OsString::from_vec(arg.to_vec()))
+        .collect::<Vec<_>>();
 
-    zakurad.kill(false)?;
-    zakurad
-        .wait_with_output()?
-        .assert_failure()?
-        .assert_was_killed()?;
+    // A stopped child cannot handle SIGTERM, so Zakura must use its bounded
+    // supervisor fallback and reap the child before exiting.
+    send_signal(zcashd_pid, "-STOP")?;
+    wait_for_process_to_stop(zcashd_pid).await?;
+    send_signal(zakurad_pid, "-TERM")?;
+    let output = zakurad
+        .wait_with_output_or_timeout(Duration::from_secs(40))?
+        .assert_success()?;
 
-    Ok(())
+    if !process_exists(zcashd_pid) {
+        zcashd_guard.disarm();
+    }
+
+    let mut restart_command = Command::new(&zcashd_executable);
+    restart_command
+        .args(zcashd_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut restarted_zcashd = restart_command.spawn2((), zcashd_executable.to_string_lossy())?;
+
+    let restart_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let restart_status = restarted_zcashd
+            .child
+            .as_mut()
+            .expect("restarted zcashd child is present")
+            .try_wait()?;
+        if let Some(status) = restart_status {
+            let restart_output = restarted_zcashd.wait_with_output()?;
+            drop(output);
+            return Err(eyre!(
+                "zcashd restart exited with {status}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&restart_output.output.stdout),
+                String::from_utf8_lossy(&restart_output.output.stderr),
+            ));
+        }
+
+        let original_zcashd_exited = !process_exists(zcashd_pid);
+        if original_zcashd_exited {
+            zcashd_guard.disarm();
+        }
+        let rpc_ready = if original_zcashd_exited {
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                setup
+                    .zcashd_client
+                    .json_result_from_call::<serde_json::Value>("getblockchaininfo", "[]"),
+            )
+            .await
+            .is_ok_and(|result| result.is_ok())
+        } else {
+            false
+        };
+        if rpc_ready {
+            zcashd_guard.disarm();
+            restarted_zcashd.kill(false)?;
+            restarted_zcashd.wait_with_output()?;
+            drop(output);
+            return Ok(());
+        }
+
+        if tokio::time::Instant::now() >= restart_deadline {
+            drop(output);
+            return Err(eyre!("restarted zcashd did not become RPC-ready"));
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    }
 }
 
 /// Verifies that zcashd restarts automatically after an unexpected exit while


### PR DESCRIPTION
## Motivation

On SIGINT or SIGTERM, Zakura could drop `StartCmd::start` before its cleanup block ran, leaving the managed zcashd alive and holding its data directory lock.

## Solution

Route shutdown through `StartCmd` and await the existing supervisor cleanup once zcashd can have been spawned, while preserving prompt exit during earlier startup. The Linux acceptance test now exercises the real child process and restarts its exact command against the same data directory.

## Testing

On unpatched `f4d51970f`, the test stopped zcashd, terminated Zakura, and reproduced `Cannot obtain a lock ... Zcash is probably already running` on direct restart. With this change, Zakura terminated and reaped the stopped child, and the same restart became authenticated-RPC ready. Clippy, shutdown unit tests, formatting, and diff checks also passed.

AI disclosure: OpenAI Codex was used to investigate the shutdown path, implement the fix, and write the regression test.