### PR TITLE
fix(zcashd): preserve deprecated wallet RPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   ([#258](https://github.com/zakura-core/zakura/pull/258)).
 - Shut down a managed zcashd-compat process before Zakura exits on SIGINT or
   SIGTERM.
+- Enable all legacy wallet features by default for supervised zcashd-compat
+  processes, while allowing `-allowdeprecated=none` to disable them all.
 
 ## [1.0.2-rc0] - 2026-07-19
 

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -177,7 +177,10 @@ On start, Zakura:
 
    The network-selection flags follow Zakura's own configured network, and
    `-printtoconsole` is always included so zcashd's output lands in Zakura's
-   logs.
+   logs. Zakura also passes each legacy wallet `-allowdeprecated` feature once,
+   preserving the full compatibility RPC surface by default. An
+   operator-supplied `-allowdeprecated=none` overrides that behavior; Zakura
+   then passes only `-allowdeprecated=none`.
 
 4. supervises it: restarts on unexpected exit with capped exponential
    backoff, and shuts it down gracefully (SIGTERM, then a configurable grace

--- a/zakurad/src/components/zcashd_compat/config.rs
+++ b/zakurad/src/components/zcashd_compat/config.rs
@@ -55,10 +55,13 @@ pub struct Config {
     /// - a JSON array string (useful for environment variable overrides):
     ///   `ZAKURA_ZCASHD_COMPAT__ZCASHD_EXTRA_ARGS='["-conf=/path/to/zcash.conf","-debug=1"]'`
     ///
-    /// Zebra passes these arguments through unchanged. For first-start bootstrap,
-    /// Zebra only infers path overrides from the first valid `-conf=/path` or
-    /// `-datadir=/path` form, and logs warnings for paired, empty, or duplicate
-    /// path options.
+    /// Zakura passes these arguments through unchanged, except that supervised
+    /// compatibility mode normalizes and deduplicates `-allowdeprecated`
+    /// arguments while enabling all legacy wallet features by default. An
+    /// explicit `-allowdeprecated=none` overrides those defaults. For first-start
+    /// bootstrap, Zakura only infers path overrides from the first valid
+    /// `-conf=/path` or `-datadir=/path` form, and logs warnings for paired,
+    /// empty, or duplicate path options.
     ///
     /// Supervised zcashd runs always include `-printtoconsole` automatically.
     #[serde(default, deserialize_with = "deserialize_zcashd_extra_args")]

--- a/zakurad/src/components/zcashd_compat/supervisor.rs
+++ b/zakurad/src/components/zcashd_compat/supervisor.rs
@@ -24,6 +24,21 @@ const SUPERVISOR_ACTIVE_METRIC: &str = "zcashd_compat.supervisor.active";
 const SUPERVISOR_DISABLED_METRIC: &str = "zcashd_compat.supervisor.disabled";
 const SUPERVISOR_EXHAUSTED_METRIC: &str = "zcashd_compat.supervisor.exhausted";
 
+/// All deprecated wallet features supported by the embedded compatibility zcashd.
+const WALLET_DEPRECATED_FEATURES: &[&str] = &[
+    "z_gettotalbalance",
+    "fundrawtransaction",
+    "keypoolrefill",
+    "settxfee",
+    "getnewaddress",
+    "getrawchangeaddress",
+    "z_getnewaddress",
+    "z_getbalance",
+    "z_listaddresses",
+    "legacy_privacy",
+    "wallettxvjoinsplit",
+];
+
 /// The full configuration used by the zcashd-compat supervisor task.
 #[derive(Clone, Debug)]
 pub struct SupervisorConfig {
@@ -98,14 +113,46 @@ impl SupervisorConfig {
             }
         }
 
-        // Always include -printtoconsole and filter it out from extra_args
+        // Always include -printtoconsole and normalize the multi-valued
+        // -allowdeprecated arguments below.
         args.push("-printtoconsole".to_string());
         args.extend(
             self.extra_args
                 .iter()
                 .filter(|arg| arg.as_str() != "-printtoconsole")
+                .filter(|arg| allowdeprecated_value(arg).is_none())
                 .cloned(),
         );
+
+        let disable_deprecated_features = self
+            .extra_args
+            .iter()
+            .filter_map(|arg| allowdeprecated_value(arg))
+            .any(|feature| feature.eq_ignore_ascii_case("none"));
+
+        if disable_deprecated_features {
+            // `none` is an explicit operator override. zcashd rejects it when
+            // combined with any named feature, so emit it by itself.
+            args.push("-allowdeprecated=none".to_string());
+        } else {
+            let mut allowed_features = Vec::new();
+            for feature in self
+                .extra_args
+                .iter()
+                .filter_map(|arg| allowdeprecated_value(arg))
+                .chain(WALLET_DEPRECATED_FEATURES.iter().copied())
+            {
+                if !allowed_features.contains(&feature) {
+                    allowed_features.push(feature);
+                }
+            }
+
+            args.extend(
+                allowed_features
+                    .into_iter()
+                    .map(|feature| format!("-allowdeprecated={feature}")),
+            );
+        }
 
         // zcashd peers only with the local Zebra node: `-connect` pins the
         // single outbound peer, and zcashd itself then soft-disables DNS
@@ -123,6 +170,12 @@ impl SupervisorConfig {
 
         args
     }
+}
+
+fn allowdeprecated_value(arg: &str) -> Option<&str> {
+    let (name, value) = arg.trim_start_matches('-').split_once('=')?;
+    name.eq_ignore_ascii_case("allowdeprecated")
+        .then_some(value)
 }
 
 /// zcashd options that add P2P peers and accumulate across the command line,
@@ -644,7 +697,7 @@ mod tests {
 
     use super::{
         reject_peer_selection_extra_args, restart_backoff_delay, should_reset_restart_count,
-        wait_for_delay_or_shutdown, SupervisorConfig,
+        wait_for_delay_or_shutdown, SupervisorConfig, WALLET_DEPRECATED_FEATURES,
     };
 
     fn test_supervisor_config(extra_args: Vec<String>) -> SupervisorConfig {
@@ -664,7 +717,10 @@ mod tests {
 
     #[test]
     fn command_args_pin_zcashd_to_zakura_p2p() {
-        let config = test_supervisor_config(vec!["-debug=1".to_string()]);
+        let config = test_supervisor_config(vec![
+            "-debug=1".to_string(),
+            "-allowdeprecated=getnewaddress".to_string(),
+        ]);
 
         let args = config.command_args();
 
@@ -678,6 +734,19 @@ mod tests {
         assert!(args.contains(&"-discover=0".to_string()));
         assert!(args.contains(&"-printtoconsole".to_string()));
         assert!(args.contains(&"-debug=1".to_string()));
+        for feature in WALLET_DEPRECATED_FEATURES {
+            assert!(
+                args.contains(&format!("-allowdeprecated={feature}")),
+                "wallet compatibility feature {feature} must be enabled"
+            );
+            assert_eq!(
+                args.iter()
+                    .filter(|arg| *arg == &format!("-allowdeprecated={feature}"))
+                    .count(),
+                1,
+                "wallet compatibility feature {feature} must not be duplicated"
+            );
+        }
         assert!(
             !args.iter().any(|arg| arg.starts_with("-zebra-compat")),
             "P2P sidecar must not pass RPC-ingest flags: {args:?}"
@@ -699,6 +768,23 @@ mod tests {
                 "{forced} must come after extra_args"
             );
         }
+    }
+
+    #[test]
+    fn allowdeprecated_none_overrides_wallet_compatibility_defaults() {
+        let config = test_supervisor_config(vec![
+            "-allowdeprecated=getnewaddress".to_string(),
+            "-allowdeprecated=none".to_string(),
+            "-allowdeprecated=none".to_string(),
+        ]);
+
+        let allowdeprecated_args: Vec<_> = config
+            .command_args()
+            .into_iter()
+            .filter(|arg| arg.starts_with("-allowdeprecated="))
+            .collect();
+
+        assert_eq!(allowdeprecated_args, ["-allowdeprecated=none"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- enable every legacy wallet feature by default for supervised zcashd-compat processes
- normalize and deduplicate `-allowdeprecated` arguments while making explicit `-allowdeprecated=none` override all defaults
- document the behavior and add an Unreleased changelog entry

## Test plan
- [x] `cargo test -p zakura components::zcashd_compat::supervisor::tests::`
- [x] `cargo fmt`
- [x] `git diff --check`