### PR TITLE
fix(state): guard pruning for zcashd compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+- Prevent pruned zcashd-compat nodes from deleting block data ahead of the
+  configured sidecar's observed block-serving watermark.
 - Reject transactions that do not meet ZIP-317 mempool fee policy before
   running script and proof checks. Block validation is unchanged.
 - Streamline mempool script error handling so invalid scripts are reported as

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Track the highest block served to a configured compatibility peer, seeded by
+  its handshake height and reset when its connection closes.
+
 ### Breaking Changes
 
 - Add an opt-in `Config::expose_peer_addresses` field for unredacted legacy

--- a/zakura-network/src/lib.rs
+++ b/zakura-network/src/lib.rs
@@ -191,7 +191,10 @@ pub use crate::{
         Client, ConnectedAddr, ConnectionInfo, HandshakeError, NotFoundClass, PeerError,
         SharedPeerError,
     },
-    peer_set::{init, init_with_zakura_header_sync},
+    peer_set::{
+        init, init_with_zakura_header_sync,
+        init_with_zakura_header_sync_and_compatibility_pruning_height,
+    },
     policies::RetryLimit,
     protocol::{
         external::{Version, VersionMessage, MAX_TX_INV_IN_SENT_MESSAGE},

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -7,7 +7,14 @@
 //! And it's unclear if these assumptions match the `zcashd` implementation.
 //! It should be refactored into a cleaner set of request/response pairs (#1515).
 
-use std::{borrow::Cow, collections::HashSet, fmt, pin::Pin, sync::Arc, time::Instant};
+use std::{
+    borrow::Cow,
+    collections::HashSet,
+    fmt,
+    pin::Pin,
+    sync::{atomic::AtomicU32, Arc},
+    time::Instant,
+};
 
 use futures::{future::Either, prelude::*};
 use rand::{seq::SliceRandom, thread_rng, Rng};
@@ -614,6 +621,9 @@ where
     /// service to a request from this connection,
     /// or None if this connection hasn't yet received an overload error.
     last_overload_time: Option<Instant>,
+
+    /// Highest block height served to this compatibility peer.
+    compatibility_pruning_height: Option<Arc<AtomicU32>>,
 }
 
 impl<S, Tx> fmt::Debug for Connection<S, Tx>
@@ -650,6 +660,7 @@ where
         connection_info: Arc<ConnectionInfo>,
         addr_label: String,
         initial_cached_addrs: Vec<MetaAddr>,
+        compatibility_pruning_height: Option<Arc<AtomicU32>>,
     ) -> Self {
         Connection {
             connection_info,
@@ -664,6 +675,7 @@ where
             addr_label,
             last_metrics_state: None,
             last_overload_time: None,
+            compatibility_pruning_height,
         }
     }
 }
@@ -1525,9 +1537,16 @@ where
                 for block in blocks.into_iter() {
                     match block {
                         Available((block, _)) => {
+                            let height = block.coinbase_height();
                             if let Err(e) = self.peer_tx.send(Message::Block(block)).await {
                                 self.fail_with(e).await;
                                 return;
+                            }
+                            if let Some(height) = height {
+                                update_compatibility_pruning_height(
+                                    &self.compatibility_pruning_height,
+                                    height,
+                                );
                             }
                         }
                         Missing(hash) => missing_hashes.push(hash.into()),
@@ -1844,6 +1863,10 @@ where
     Tx: Sink<Message, Error = SerializationError> + Unpin,
 {
     fn drop(&mut self) {
+        if let Some(watermark) = &self.compatibility_pruning_height {
+            watermark.store(0, std::sync::atomic::Ordering::Relaxed);
+        }
+
         self.shutdown(PeerError::ConnectionDropped);
 
         self.erase_state_metrics();
@@ -1863,4 +1886,11 @@ fn transaction_ids(items: &'_ [InventoryHash]) -> impl Iterator<Item = UnminedTx
 /// Non-block inventory hashes are skipped.
 fn block_hashes(items: &'_ [InventoryHash]) -> impl Iterator<Item = block::Hash> + '_ {
     items.iter().filter_map(InventoryHash::block_hash)
+}
+
+/// Advance the compatibility pruning watermark after serving a block.
+fn update_compatibility_pruning_height(watermark: &Option<Arc<AtomicU32>>, height: block::Height) {
+    if let Some(watermark) = watermark {
+        watermark.fetch_max(height.0, std::sync::atomic::Ordering::Relaxed);
+    }
 }

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -6,7 +6,10 @@ use std::{
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     panic,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
 };
 
@@ -29,6 +32,18 @@ use crate::{
 
 mod prop;
 mod vectors;
+
+#[test]
+fn compatibility_pruning_watermark_only_advances() {
+    let watermark = Arc::new(AtomicU32::new(10));
+    let configured = Some(watermark.clone());
+
+    super::update_compatibility_pruning_height(&configured, Height(9));
+    assert_eq!(watermark.load(Ordering::Relaxed), 10);
+
+    super::update_compatibility_pruning_height(&configured, Height(11));
+    assert_eq!(watermark.load(Ordering::Relaxed), 11);
+}
 
 /// Test that dropping a peer sender does not require a Tokio timer context.
 #[test]
@@ -165,6 +180,7 @@ fn new_test_connection_with_protection<A>(
         Arc::new(connection_info),
         addr_label,
         Vec::new(),
+        None,
     );
 
     (
@@ -220,6 +236,7 @@ fn new_never_closing_test_connection<A>(
         Arc::new(connection_info),
         addr_label,
         Vec::new(),
+        None,
     );
 
     (connection, client_tx, shared_error_slot)

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -8,7 +8,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     panic,
     pin::Pin,
-    sync::Arc,
+    sync::{atomic::AtomicU32, Arc},
     task::{Context, Poll},
     time::Duration,
 };
@@ -92,6 +92,9 @@ where
     /// canonicalized for IPv4-mapped matching. Empty when unconfigured.
     protected_peer_ips: Arc<HashSet<IpAddr>>,
 
+    /// Highest block height observed by the configured compatibility peer.
+    compatibility_pruning_height: Option<Arc<AtomicU32>>,
+
     parent_span: Span,
 }
 
@@ -137,6 +140,7 @@ where
             nonces: self.nonces.clone(),
             zakura_handshake_connector: self.zakura_handshake_connector.clone(),
             protected_peer_ips: self.protected_peer_ips.clone(),
+            compatibility_pruning_height: self.compatibility_pruning_height.clone(),
             parent_span: self.parent_span.clone(),
         }
     }
@@ -485,6 +489,7 @@ where
     inv_collector: Option<broadcast::Sender<InventoryChange>>,
     zakura_handshake_connector: Option<ZakuraHandshakeConnector>,
     protected_peer_ips: Option<Arc<HashSet<IpAddr>>>,
+    compatibility_pruning_height: Option<Arc<AtomicU32>>,
     latest_chain_tip: C,
 }
 
@@ -569,6 +574,7 @@ where
             inv_collector: self.inv_collector,
             zakura_handshake_connector: self.zakura_handshake_connector,
             protected_peer_ips: self.protected_peer_ips,
+            compatibility_pruning_height: self.compatibility_pruning_height,
         }
     }
 
@@ -589,6 +595,15 @@ where
     /// exempted and every connection behaves exactly as before.
     pub fn with_protected_peer_ips(mut self, protected_peer_ips: Arc<HashSet<IpAddr>>) -> Self {
         self.protected_peer_ips = Some(protected_peer_ips);
+        self
+    }
+
+    /// Provide a compatibility-peer pruning watermark. Optional.
+    pub fn with_compatibility_pruning_height(
+        mut self,
+        compatibility_pruning_height: Option<Arc<AtomicU32>>,
+    ) -> Self {
+        self.compatibility_pruning_height = compatibility_pruning_height;
         self
     }
 
@@ -640,6 +655,7 @@ where
             nonces,
             zakura_handshake_connector: self.zakura_handshake_connector,
             protected_peer_ips: self.protected_peer_ips.unwrap_or_default(),
+            compatibility_pruning_height: self.compatibility_pruning_height,
             parent_span: Span::current(),
         })
     }
@@ -665,6 +681,7 @@ where
             inv_collector: None,
             zakura_handshake_connector: None,
             protected_peer_ips: None,
+            compatibility_pruning_height: None,
             latest_chain_tip: NoChainTip,
         }
     }
@@ -1470,6 +1487,7 @@ where
         let relay = self.relay;
         let minimum_peer_version = self.minimum_peer_version.clone();
         let zakura_handshake_connector = self.zakura_handshake_connector.clone();
+        let compatibility_pruning_height = self.compatibility_pruning_height.clone();
 
         // Whether this peer is exempt from the inbound-overload connection drop.
         // Computed here (not in the future) so only the resulting `bool` is moved
@@ -1553,6 +1571,16 @@ where
                     return Err(err);
                 }
             };
+
+            let compatibility_pruning_height = is_protected_peer
+                .then_some(compatibility_pruning_height)
+                .flatten();
+            if let Some(height) = &compatibility_pruning_height {
+                height.store(
+                    connection_info.remote.start_height.0,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+            }
 
             let remote_services = connection_info.remote.services;
 
@@ -1755,6 +1783,7 @@ where
                 connection_info.clone(),
                 addr_label,
                 alternate_addrs.collect(),
+                compatibility_pruning_height,
             );
 
             let connection_task = tokio::spawn(

--- a/zakura-network/src/peer_set.rs
+++ b/zakura-network/src/peer_set.rs
@@ -13,4 +13,7 @@ pub(crate) use limit::{ActiveConnectionCounter, ConnectionTracker};
 use inventory_registry::InventoryRegistry;
 pub(crate) use set::PeerSet;
 
-pub use initialize::{init, init_with_zakura_header_sync};
+pub use initialize::{
+    init, init_with_zakura_header_sync,
+    init_with_zakura_header_sync_and_compatibility_pruning_height,
+};

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -145,6 +145,41 @@ where
     S::Future: Send + 'static,
     C: ChainTip + Clone + Send + Sync + 'static,
 {
+    init_with_zakura_header_sync_and_compatibility_pruning_height(
+        config,
+        inbound_service,
+        latest_chain_tip,
+        user_agent,
+        advertised_services,
+        block_gossip_peer_ips,
+        header_sync_driver_startup,
+        None,
+    )
+    .await
+}
+
+/// Initialize a peer set with a compatibility-peer block-serving watermark.
+#[allow(clippy::too_many_arguments)]
+pub async fn init_with_zakura_header_sync_and_compatibility_pruning_height<S, C>(
+    config: Config,
+    inbound_service: S,
+    latest_chain_tip: C,
+    user_agent: String,
+    advertised_services: PeerServices,
+    block_gossip_peer_ips: Vec<IpAddr>,
+    header_sync_driver_startup: Option<crate::zakura::ZakuraHeaderSyncDriverStartup>,
+    compatibility_pruning_height: Option<Arc<std::sync::atomic::AtomicU32>>,
+) -> (
+    Buffer<BoxService<Request, Response, BoxError>, Request>,
+    Arc<std::sync::Mutex<AddressBook>>,
+    mpsc::Sender<(PeerSocketAddr, u32)>,
+    Option<crate::zakura::ZakuraEndpoint>,
+)
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + Sync + 'static,
+    S::Future: Send + 'static,
+    C: ChainTip + Clone + Send + Sync + 'static,
+{
     let (tcp_listener, listen_addr) = if config.legacy_p2p() {
         let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
         (Some(tcp_listener), listen_addr)
@@ -261,6 +296,7 @@ where
             .with_user_agent(user_agent)
             .with_latest_chain_tip(latest_chain_tip.clone())
             .with_protected_peer_ips(protected_peer_ips)
+            .with_compatibility_pruning_height(compatibility_pruning_height)
             .want_transactions(true);
 
         if let Some(zakura_handshake_connector) = zakura_handshake_connector {

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an optional dynamic compatibility-peer height limit for checkpoint and
+  online raw-transaction pruning.
+
 ## [3.0.0-rc0] - 2026-07-19
 
 ### Breaking Changes

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -62,7 +62,7 @@ pub use service::{
     chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip, TipAction},
     check,
     finalized_state::FinalizedState,
-    init, init_read_only,
+    init, init_read_only, init_with_compatibility_pruning_height,
     non_finalized_state::NonFinalizedState,
     spawn_init_read_only, validate_vct_sprout_history,
     watch_receiver::WatchReceiver,

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -330,6 +330,24 @@ impl StateService {
         max_checkpoint_height: block::Height,
         checkpoint_verify_concurrency_limit: usize,
     ) -> (Self, ReadStateService, LatestChainTip, ChainTipChange) {
+        Self::new_with_compatibility_pruning_height(
+            config,
+            network,
+            max_checkpoint_height,
+            checkpoint_verify_concurrency_limit,
+            None,
+        )
+        .await
+    }
+
+    /// Creates a state service with an optional compatibility-peer pruning limit.
+    pub async fn new_with_compatibility_pruning_height(
+        config: Config,
+        network: &Network,
+        max_checkpoint_height: block::Height,
+        checkpoint_verify_concurrency_limit: usize,
+        compatibility_pruning_height: Option<Arc<std::sync::atomic::AtomicU32>>,
+    ) -> (Self, ReadStateService, LatestChainTip, ChainTipChange) {
         let (finalized_state, finalized_tip, timer) = {
             let config = config.clone();
             let network = network.clone();
@@ -346,7 +364,8 @@ impl StateService {
                      state cache directory is writable and not locked by another Zakura instance, \
                      and that there is free disk space",
                 )
-                .with_checkpoint_raw_tx_retention(max_checkpoint_height, &config);
+                .with_checkpoint_raw_tx_retention(max_checkpoint_height, &config)
+                .with_compatibility_pruning_height(compatibility_pruning_height);
                 timer.finish_desc("opening finalized state database");
 
                 let timer = CodeTimer::start();
@@ -2231,6 +2250,37 @@ pub async fn init(
             network,
             max_checkpoint_height,
             checkpoint_verify_concurrency_limit,
+        )
+        .await;
+
+    (
+        BoxService::new(state_service),
+        read_only_state_service,
+        latest_chain_tip,
+        chain_tip_change,
+    )
+}
+
+/// Initialize state with a dynamic compatibility-peer pruning limit.
+pub async fn init_with_compatibility_pruning_height(
+    config: Config,
+    network: &Network,
+    max_checkpoint_height: block::Height,
+    checkpoint_verify_concurrency_limit: usize,
+    compatibility_pruning_height: Arc<std::sync::atomic::AtomicU32>,
+) -> (
+    BoxService<Request, Response, BoxError>,
+    ReadStateService,
+    LatestChainTip,
+    ChainTipChange,
+) {
+    let (state_service, read_only_state_service, latest_chain_tip, chain_tip_change) =
+        StateService::new_with_compatibility_pruning_height(
+            config,
+            network,
+            max_checkpoint_height,
+            checkpoint_verify_concurrency_limit,
+            Some(compatibility_pruning_height),
         )
         .await;
 

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -17,7 +17,7 @@
 use std::{
     io::{stderr, stdout, Write},
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
         Arc, LazyLock,
     },
 };
@@ -240,6 +240,10 @@ pub struct FinalizedState {
     /// clones rather than an owned `bool`.
     checkpoint_raw_tx_archive_backlog: Arc<AtomicBool>,
 
+    /// The highest block height observed in requests served to the configured
+    /// compatibility peer. Genesis is the conservative initial watermark.
+    compatibility_pruning_height: Option<Arc<AtomicU32>>,
+
     // Owned State
     //
     // Everything contained in this state must be shared by all clones, or read-only.
@@ -428,6 +432,7 @@ impl FinalizedState {
             debug_stop_at_height: config.debug_stop_at_height.map(block::Height),
             checkpoint_raw_tx_retention_start: None,
             checkpoint_raw_tx_archive_backlog: Arc::new(AtomicBool::new(false)),
+            compatibility_pruning_height: None,
             db,
             elastic_db,
             elastic_blocks: vec![],
@@ -439,6 +444,7 @@ impl FinalizedState {
             debug_stop_at_height: config.debug_stop_at_height.map(block::Height),
             checkpoint_raw_tx_retention_start: None,
             checkpoint_raw_tx_archive_backlog: Arc::new(AtomicBool::new(false)),
+            compatibility_pruning_height: None,
             db,
             vct: VctCommitState::new(vct, is_vct_sync_below_last_checkpoint),
         };
@@ -537,6 +543,20 @@ impl FinalizedState {
         self
     }
 
+    /// Limit pruning to heights observed by the configured compatibility peer.
+    pub(crate) fn with_compatibility_pruning_height(
+        mut self,
+        compatibility_pruning_height: Option<Arc<AtomicU32>>,
+    ) -> Self {
+        self.compatibility_pruning_height = compatibility_pruning_height;
+        self
+    }
+
+    /// Returns the exclusive pruning limit allowed by the compatibility peer.
+    fn compatibility_prune_until(&self) -> block::Height {
+        compatibility_prune_until(self.compatibility_pruning_height.as_deref())
+    }
+
     /// Returns `true` when raw transaction bytes should be stored for a
     /// checkpoint-verified block at `height`.
     fn store_checkpoint_raw_transactions(&self, height: block::Height) -> bool {
@@ -564,11 +584,33 @@ impl FinalizedState {
         };
 
         let lowest_retained = self.db.lowest_retained_height();
+        let compatibility_prune_until = self.compatibility_prune_until();
 
         // Checkpoint blocks before the retention start: skip raw transactions,
         // draining any pre-existing archive backlog in bounded chunks first.
         if is_checkpoint && !self.store_checkpoint_raw_transactions(height) {
             let skipped_until = (height + 1).expect("checkpoint block height plus one is valid");
+
+            // A compatibility peer can only request this block after it is
+            // committed, so its watermark normally trails `height`. Store the
+            // current block while still pruning older served blocks.
+            if self.compatibility_pruning_height.is_some() {
+                if let Some((from, until)) = self
+                    .db
+                    .checkpoint_raw_transaction_prune_range(skipped_until)
+                    .and_then(|range| cap_prune_range(range, compatibility_prune_until))
+                {
+                    return RetentionPlan::DrainBacklog {
+                        from,
+                        until,
+                        final_chunk: until == skipped_until,
+                    };
+                }
+
+                if skipped_until > compatibility_prune_until {
+                    return RetentionPlan::Store;
+                }
+            }
 
             if self
                 .checkpoint_raw_tx_archive_backlog
@@ -577,6 +619,7 @@ impl FinalizedState {
                 if let Some((from, until)) = self
                     .db
                     .checkpoint_raw_transaction_prune_range(skipped_until)
+                    .and_then(|range| cap_prune_range(range, compatibility_prune_until))
                 {
                     // The marker can only advance past this block once the
                     // backlog below it is fully drained, so the last chunk (which
@@ -593,6 +636,10 @@ impl FinalizedState {
                 }
             }
 
+            if skipped_until > compatibility_prune_until {
+                return RetentionPlan::Store;
+            }
+
             // No archive backlog left to drain: skip this block's raw
             // transactions and advance the pruning marker so readers know raw
             // data below it may be unavailable.
@@ -605,7 +652,9 @@ impl FinalizedState {
         // Archive-equivalent path for this block (contextual blocks, or
         // checkpoint blocks within the retention window): keep raw transactions
         // and run ordinary online pruning.
-        match ZakuraDb::prune_height_range(height, pruning.tx_retention, lowest_retained) {
+        match ZakuraDb::prune_height_range(height, pruning.tx_retention, lowest_retained)
+            .and_then(|range| cap_prune_range(range, compatibility_prune_until))
+        {
             Some((from, until)) => RetentionPlan::Prune { from, until },
             None => RetentionPlan::Store,
         }
@@ -1538,4 +1587,24 @@ fn compute_checkpoint_raw_tx_retention_start(
     let max_skipped_height = max_checkpoint_height.0.checked_sub(tx_retention)?;
 
     max_skipped_height.checked_add(1).map(block::Height)
+}
+
+/// Returns the exclusive pruning limit for a compatibility watermark.
+fn compatibility_prune_until(watermark: Option<&AtomicU32>) -> block::Height {
+    let Some(watermark) = watermark else {
+        return block::Height(u32::MAX);
+    };
+
+    block::Height(watermark.load(Ordering::Relaxed))
+        .next()
+        .unwrap_or(block::Height(u32::MAX))
+}
+
+/// Caps a half-open pruning range at `prune_until`.
+fn cap_prune_range(
+    (from, until): (block::Height, block::Height),
+    prune_until: block::Height,
+) -> Option<(block::Height, block::Height)> {
+    let until = until.min(prune_until);
+    (from < until).then_some((from, until))
 }

--- a/zakura-state/src/service/finalized_state/tests.rs
+++ b/zakura-state/src/service/finalized_state/tests.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+use std::sync::atomic::AtomicU32;
+
 use zakura_chain::block::Height;
 
 mod prop;
@@ -32,5 +34,42 @@ fn checkpoint_prune_range_retains_current_height_when_range_ends_before_it() {
     assert!(
         !super::checkpoint_prune_range_retains_current_height(current_height, None),
         "no checkpoint prune range means there is no archive backlog to drain"
+    );
+}
+
+#[test]
+fn compatibility_watermark_is_an_exclusive_pruning_limit() {
+    assert_eq!(
+        super::compatibility_prune_until(None),
+        Height(u32::MAX),
+        "unconfigured compatibility mode must not change pruning"
+    );
+
+    let watermark = AtomicU32::new(0);
+    assert_eq!(
+        super::compatibility_prune_until(Some(&watermark)),
+        Height(1)
+    );
+
+    watermark.store(42, std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(
+        super::compatibility_prune_until(Some(&watermark)),
+        Height(43)
+    );
+}
+
+#[test]
+fn compatibility_watermark_caps_pruning_ranges() {
+    assert_eq!(
+        super::cap_prune_range((Height(10), Height(20)), Height(15)),
+        Some((Height(10), Height(15)))
+    );
+    assert_eq!(
+        super::cap_prune_range((Height(10), Height(20)), Height(20)),
+        Some((Height(10), Height(20)))
+    );
+    assert_eq!(
+        super::cap_prune_range((Height(10), Height(20)), Height(10)),
+        None
     );
 }

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -78,7 +78,7 @@ pub(crate) mod zakura;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::Path,
-    sync::Arc,
+    sync::{atomic::AtomicU32, Arc},
 };
 
 use abscissa_core::{config, Command, FrameworkError};
@@ -322,6 +322,10 @@ impl StartCmd {
         } else {
             Vec::new()
         };
+        let compatibility_pruning_height = config
+            .zcashd_compat
+            .enabled
+            .then(|| Arc::new(AtomicU32::new(0)));
 
         Self::validate_consensus_config(&config)?;
         Self::validate_debug_blocksync_throughput_config(&config)?;
@@ -373,14 +377,26 @@ impl StartCmd {
         state_config.vct_fast_sync = config.consensus.vct_fast_sync_enabled();
 
         let (state_service, read_only_state_service, latest_chain_tip, chain_tip_change) =
-            zakura_state::init(
-                state_config,
-                &config.network.network,
-                max_checkpoint_height,
-                config.sync.checkpoint_verify_concurrency_limit
-                    * (VERIFICATION_PIPELINE_SCALING_MULTIPLIER + 1),
-            )
-            .await;
+            if let Some(compatibility_pruning_height) = compatibility_pruning_height.clone() {
+                zakura_state::init_with_compatibility_pruning_height(
+                    state_config,
+                    &config.network.network,
+                    max_checkpoint_height,
+                    config.sync.checkpoint_verify_concurrency_limit
+                        * (VERIFICATION_PIPELINE_SCALING_MULTIPLIER + 1),
+                    compatibility_pruning_height,
+                )
+                .await
+            } else {
+                zakura_state::init(
+                    state_config,
+                    &config.network.network,
+                    max_checkpoint_height,
+                    config.sync.checkpoint_verify_concurrency_limit
+                        * (VERIFICATION_PIPELINE_SCALING_MULTIPLIER + 1),
+                )
+                .await
+            };
 
         info!("logging database metrics on startup");
         read_only_state_service.log_db_metrics();
@@ -451,7 +467,7 @@ impl StartCmd {
         let advertised_services = Self::advertised_services(&config);
 
         let (peer_set, address_book, misbehavior_sender, zakura_endpoint) =
-            zakura_network::init_with_zakura_header_sync(
+            zakura_network::init_with_zakura_header_sync_and_compatibility_pruning_height(
                 config.network.clone(),
                 inbound,
                 latest_chain_tip.clone(),
@@ -459,6 +475,7 @@ impl StartCmd {
                 advertised_services,
                 zcashd_compat_block_gossip_peer_ips,
                 zakura_header_sync_driver_startup,
+                compatibility_pruning_height,
             )
             .await;
 


### PR DESCRIPTION
> **Status:** This is an experimental implementation kept for future reference. We are not pursuing this approach now, and this PR will be closed after creation.

## Motivation

A pruned Zakura node can delete raw block transaction data before its configured zcashd compatibility sidecar has downloaded it. Once deleted, Zakura can no longer satisfy the sidecar's block requests, so zcashd can remain permanently behind.

This PR documents one small implementation approach in executable form.

## Solution

- Create an in-memory height watermark when zcashd compatibility mode is enabled.
- Seed it from the protected sidecar's `version.start_height`.
- Advance it after Zakura successfully serves blocks requested through the existing P2P connection.
- Reset it conservatively when the sidecar disconnects.
- Cap checkpoint and online raw-transaction pruning at the exclusive `watermark + 1` boundary.
- Preserve existing pruning behavior when compatibility mode is disabled.

The implementation assumes one configured sidecar. It adds no new P2P messages or active probing.

## Testing

- `cargo fmt --all -- --check`
- `CXXFLAGS='-include cstdint' cargo check -p zakura-state --all-targets`
- `CXXFLAGS='-include cstdint' cargo check -p zakura --all-targets`
- `cargo check -p zakura-network --all-targets`
- `CXXFLAGS='-include cstdint' cargo clippy -p zakura-network -p zakura-state -p zakura --all-targets -- -D warnings`
- Focused network test verifies the served-block watermark only advances.
- Focused state tests verify the exclusive boundary and pruning-range cap.

The `CXXFLAGS` setting works around missing `<cstdint>` includes in the locally bundled RocksDB build and is not part of this change.

### Follow-up Work

If this design is revisited, decide whether a served-block watermark is sufficiently strong evidence of zcashd's validated active-chain height, or whether an explicit active P2P probe is required.
