### PR TITLE
fix(mempool): preserve verification errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   SIGTERM.
 - Enable all legacy wallet features by default for supervised zcashd-compat
   processes, while allowing `-allowdeprecated=none` to disable them all.
+- Preserve failed shielded proof/signature verification errors so they receive
+  the existing mempool peer-misbehaviour score.
 
 ## [1.0.2-rc0] - 2026-07-19
 

--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -132,6 +132,12 @@ pub enum TransactionError {
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Script(#[from] zakura_script::Error),
 
+    #[error("Sapling proof or signature verification failed")]
+    SaplingVerificationFailed,
+
+    #[error("Orchard or Ironwood Halo2 proof verification failed")]
+    Halo2VerificationFailed,
+
     #[error("spend description cv and rk MUST NOT be of small order")]
     SmallOrder,
 
@@ -158,8 +164,7 @@ pub enum TransactionError {
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     RedPallas(zakura_chain::primitives::reddsa::Error),
 
-    // temporary error type until #1186 is fixed
-    #[error("Downcast from BoxError to redjubjub::Error failed: {0}")]
+    #[error("could not convert an asynchronous verification error: {0}")]
     InternalDowncastError(String),
 
     #[error("either vpub_old or vpub_new must be zero")]
@@ -332,17 +337,24 @@ impl From<amount::Error> for TransactionError {
     }
 }
 
-// TODO: use a dedicated variant and From impl for each concrete type, and update callers (#5732)
 impl From<BoxError> for TransactionError {
     fn from(mut err: BoxError) -> Self {
-        // TODO: handle redpallas::Error and InvalidSignature
         match err.downcast::<zakura_script::Error>() {
             Ok(e) => return TransactionError::Script(*e),
             Err(e) => err = e,
         }
 
+        match err.downcast::<zakura_chain::primitives::ed25519::Error>() {
+            Ok(e) => return TransactionError::Ed25519(*e),
+            Err(e) => err = e,
+        }
         match err.downcast::<zakura_chain::primitives::redjubjub::Error>() {
             Ok(e) => return TransactionError::RedJubjub(*e),
+            Err(e) => err = e,
+        }
+
+        match err.downcast::<zakura_chain::primitives::reddsa::Error>() {
+            Ok(e) => return TransactionError::RedPallas(*e),
             Err(e) => err = e,
         }
 
@@ -392,6 +404,8 @@ impl TransactionError {
             | NoOutputs
             | BadBalance
             | Script(_)
+            | SaplingVerificationFailed
+            | Halo2VerificationFailed
             | SmallOrder
             | Groth16(_)
             | MalformedGroth16(_)
@@ -413,6 +427,59 @@ impl TransactionError {
             // transactions are consensus-valid, and zcashd relays a reject message
             // without a DoS score for them.
             _other => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boxed_signature_errors_are_preserved() {
+        let script_error: BoxError = Box::new(zakura_script::Error::ScriptInvalid);
+        assert_eq!(
+            TransactionError::from(script_error),
+            TransactionError::Script(zakura_script::Error::ScriptInvalid)
+        );
+
+        let ed25519_error: BoxError =
+            Box::new(zakura_chain::primitives::ed25519::Error::InvalidSignature);
+        assert_eq!(
+            TransactionError::from(ed25519_error),
+            TransactionError::Ed25519(zakura_chain::primitives::ed25519::Error::InvalidSignature)
+        );
+
+        let redjubjub_error: BoxError =
+            Box::new(zakura_chain::primitives::redjubjub::Error::InvalidSignature);
+        assert_eq!(
+            TransactionError::from(redjubjub_error),
+            TransactionError::RedJubjub(
+                zakura_chain::primitives::redjubjub::Error::InvalidSignature
+            )
+        );
+
+        let redpallas_error: BoxError =
+            Box::new(zakura_chain::primitives::reddsa::Error::InvalidSignature);
+        assert_eq!(
+            TransactionError::from(redpallas_error),
+            TransactionError::RedPallas(zakura_chain::primitives::reddsa::Error::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn verification_errors_have_high_misbehavior_score() {
+        for error in [
+            TransactionError::Script(zakura_script::Error::ScriptInvalid),
+            TransactionError::SaplingVerificationFailed,
+            TransactionError::Halo2VerificationFailed,
+            TransactionError::Ed25519(zakura_chain::primitives::ed25519::Error::InvalidSignature),
+            TransactionError::RedJubjub(
+                zakura_chain::primitives::redjubjub::Error::InvalidSignature,
+            ),
+            TransactionError::RedPallas(zakura_chain::primitives::reddsa::Error::InvalidSignature),
+        ] {
+            assert_eq!(error.mempool_misbehavior_score(), 100);
         }
     }
 }

--- a/zakura-consensus/src/primitives/halo2.rs
+++ b/zakura-consensus/src/primitives/halo2.rs
@@ -18,7 +18,7 @@ use rand::thread_rng;
 use zakura_chain::{parameters::NetworkUpgrade, transaction::SigHash};
 use zcash_protocol::value::ZatBalance;
 
-use crate::BoxError;
+use crate::{error::TransactionError, BoxError};
 use thiserror::Error;
 use tokio::sync::watch;
 use tower::Service;
@@ -416,7 +416,7 @@ impl Verifier {
         if spawn_fifo(move || item.verify_single(vk)).await? {
             Ok(())
         } else {
-            Err("could not validate orchard proof".into())
+            Err(TransactionError::Halo2VerificationFailed.into())
         }
     }
 }
@@ -462,7 +462,7 @@ impl Service<BatchControl<Item>> for Verifier {
                             } else {
                                 tracing::trace!(?is_valid, "invalid halo2 proof");
                                 metrics::counter!("proofs.halo2.invalid").increment(1);
-                                Err("could not validate halo2 proofs".into())
+                                Err(TransactionError::Halo2VerificationFailed.into())
                             }
                         }
                         Err(_recv_error) => panic!("verifier was dropped without flushing"),

--- a/zakura-consensus/src/primitives/sapling.rs
+++ b/zakura-consensus/src/primitives/sapling.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use rand::thread_rng;
 use tokio::sync::watch;
@@ -20,6 +20,8 @@ use sapling_crypto::{bundle::Authorized, BatchValidator, Bundle};
 use zakura_chain::transaction::SigHash;
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::value::ZatBalance;
+
+use crate::{error::TransactionError, BoxError};
 
 /// Sapling prover containing spend and output params for the Sapling circuit.
 ///
@@ -115,28 +117,30 @@ impl Service<BatchControl<Item>> for Verifier {
                     .batch
                     .check_bundle(item.bundle, item.sighash.into())
                     .then_some(())
-                    .ok_or("invalid Sapling bundle");
+                    .ok_or(TransactionError::SaplingVerificationFailed);
 
                 async move {
-                    bundle_check?;
+                    bundle_check.map_err(BoxError::from)?;
 
                     rx.changed()
                         .await
-                        .map_err(|_| "verifier was dropped without flushing")
-                        .and_then(|_| {
-                            // We use a new channel for each batch, so we always get the correct
-                            // batch result here.
-                            rx.borrow()
-                                .ok_or("threadpool unexpectedly dropped channel sender")?
-                                .then(|| {
-                                    metrics::counter!("proofs.sapling.verified").increment(1);
-                                })
-                                .ok_or_else(|| {
-                                    metrics::counter!("proofs.sapling.invalid").increment(1);
-                                    "batch verification of Sapling shielded data failed"
-                                })
-                        })
-                        .map_err(Self::Error::from)
+                        .map_err(|_| BoxError::from("verifier was dropped without flushing"))?;
+
+                    // We use a new channel for each batch, so we always get the correct
+                    // batch result here.
+                    let is_valid = *rx.borrow().as_ref().ok_or_else(|| {
+                        Box::<dyn std::error::Error + Send + Sync>::from(
+                            "threadpool unexpectedly dropped channel sender",
+                        )
+                    })?;
+
+                    if is_valid {
+                        metrics::counter!("proofs.sapling.verified").increment(1);
+                        Ok(())
+                    } else {
+                        metrics::counter!("proofs.sapling.invalid").increment(1);
+                        Err(BoxError::from(TransactionError::SaplingVerificationFailed))
+                    }
                 }
                 .boxed()
             }
@@ -187,20 +191,23 @@ pub fn verify_single(
             .batch
             .check_bundle(item.bundle, item.sighash.into())
             .then_some(())
-            .ok_or("invalid Sapling bundle");
-        check?;
+            .ok_or(TransactionError::SaplingVerificationFailed);
+        check.map_err(BoxError::from)?;
 
-        tokio::task::spawn_blocking(move || {
+        let is_valid = tokio::task::spawn_blocking(move || {
             let (spend_vk, output_vk) = SAPLING.verifying_keys();
 
             mem::take(&mut verifier.batch).validate(&spend_vk, &output_vk, thread_rng())
         })
         .await
-        .map_err(|_| "Sapling bundle validation thread panicked")?
-        .then_some(())
-        .ok_or("invalid proof or sig in Sapling bundle")
+        .map_err(|_| BoxError::from("Sapling bundle validation thread panicked"))?;
+
+        if is_valid {
+            Ok(())
+        } else {
+            Err(BoxError::from(TransactionError::SaplingVerificationFailed))
+        }
     }
-    .map_err(Box::from)
     .boxed()
 }
 

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -2865,12 +2865,7 @@ fn v4_with_modified_joinsplit_is_rejected() {
     zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
         v4_with_joinsplit_is_rejected_for_modification(
             JoinSplitModification::CorruptSignature,
-            // TODO: Fix error downcast
-            // Err(TransactionError::Ed25519(ed25519::Error::InvalidSignature))
-            TransactionError::InternalDowncastError(
-                "downcast to known transaction error type failed, original error: InvalidSignature"
-                    .to_string(),
-            ),
+            TransactionError::Ed25519(ed25519::Error::InvalidSignature),
         )
         .await;
 


### PR DESCRIPTION
## Motivation

Several transaction-verification failures crossed asynchronous verifier boundaries as untyped boxed errors. They became `InternalDowncastError`, received a zero mempool misbehaviour score, and obscured the original failure.

## Solution

- Preserve transparent script, JoinSplit Ed25519, RedJubjub, and RedPallas signature errors during `BoxError` conversion.
- Add explicit transaction errors for invalid Sapling proof/signature verification and invalid Orchard or Ironwood Halo2 proof verification.
- Score each preserved verification failure using the existing 100-point mempool score.
- Update end-to-end expectations and add conversion/scoring coverage.

## Impact

Peers sending transactions with these invalid verification results are now attributed the existing high misbehaviour score instead of silently receiving score zero.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-consensus error::tests`
- affected transparent-script, JoinSplit, and mempool transaction tests
- `cargo clippy -p zakura-consensus --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mempool peer punishment and error propagation across async transaction verification; behaviour is intentional but affects DoS/misbehaviour handling for invalid txs from peers.
> 
> **Overview**
> Async Sapling and Halo2 verifiers now return typed `TransactionError` variants (`SaplingVerificationFailed`, `Halo2VerificationFailed`) instead of generic string errors, and `From<BoxError>` for `TransactionError` also downcasts **Ed25519** and **RedPallas** signature errors (along with existing script/RedJubjub paths).
> 
> Those verification failures are included in the **100-point** `mempool_misbehavior_score` path, so peers pushing invalid shielded proofs or signatures are penalized instead of hitting `InternalDowncastError` with score **0**. JoinSplit signature tests now expect `Ed25519::InvalidSignature` directly; unit tests cover boxed-error conversion and scoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5379ed214d30511c782b0731f128d6c1e5eaf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->