### PR TITLE
fix(mempool): further restrict invalid shielded proof sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+- Ban peers that send mempool transactions with invalid Orchard or Ironwood
+  proof sizes.
 - Stop pruned nodes from returning retained chain-index hashes through legacy
   `getblocks` when the corresponding block bodies are no longer serveable.
 - Add structured legacy peer request traces that attribute `FindBlocks` hash

--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -423,6 +423,8 @@ impl TransactionError {
             | NotEnoughFlags
             | NotEnoughIronwoodFlags
             | OrchardHasEnableCrossAddress
+            | OrchardProofSize
+            | IronwoodProofSize
             | WrongConsensusBranchId
             | MissingConsensusBranchId
             | LockedUntilAfterBlockHeight(_)

--- a/zakurad/src/components/mempool/tests/vector.rs
+++ b/zakurad/src/components/mempool/tests/vector.rs
@@ -61,6 +61,26 @@ fn policy_rejection_has_no_misbehavior_score() {
     );
 }
 
+#[test]
+fn invalid_shielded_proof_sizes_ban_mempool_peers() {
+    let advertiser_addr = PeerSocketAddr::from(([203, 0, 113, 7], 8233));
+
+    for consensus_error in [
+        TransactionError::OrchardProofSize,
+        TransactionError::IronwoodProofSize,
+    ] {
+        let invalid_error = TransactionDownloadVerifyError::Invalid {
+            error: consensus_error,
+            advertiser_addr: Some(advertiser_addr),
+        };
+
+        assert_eq!(
+            transaction_misbehavior(&invalid_error),
+            Some((advertiser_addr, zn::constants::MAX_PEER_MISBEHAVIOR_SCORE)),
+        );
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<(), Report> {
     let network = Network::Mainnet;


### PR DESCRIPTION
## Motivation

Mempool verification already rejects transactions with non-canonical Orchard or Ironwood proof sizes, but those errors had no peer-misbehavior score. A legacy peer could therefore send malformed proof sizes without being banned.

## Solution

Classify `OrchardProofSize` and `IronwoodProofSize` as 100-point mempool misbehavior. This reaches the existing peer-ban threshold. Add a regression test that confirms either verification error is attributed to the advertising peer at that threshold, and document the operator-visible behavior.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura --lib invalid_shielded_proof_sizes_ban_mempool_peers`
- `cargo test -p zakura-consensus --lib`
- `cargo clippy -p zakura-consensus -p zakura --lib -- -D warnings`

### Specifications & References

- Canonical shielded proof-size enforcement is already performed by the transaction verifier after activation of the relevant network rule.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Peer policy only; block validation is unchanged and the change aligns two existing error variants with other high-score mempool rejections.
> 
> **Overview**
> Peers that advertise mempool transactions with **non-canonical Orchard or Ironwood proof sizes** are now treated like other consensus-invalid relay traffic: those verification errors score **100** misbehavior points, which triggers the existing peer ban threshold.
> 
> A mempool regression test asserts `OrchardProofSize` and `IronwoodProofSize` map to the maximum misbehavior score when attributed to the advertising peer. The unreleased changelog notes the operator-visible ban behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe41b5e1a495a3a1f124852d3f66c5adb3ed52d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->