### PR TITLE
fix(network): mutate peer ban list in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Honor `disable_pow = true` during native header sync on configured Testnets,
   matching semantic and checkpoint block verification
   ([#289](https://github.com/zakura-core/zakura/pull/289)).
+- Make retained peer-ban insertion and eviction O(1) rather than O(N),
+  preventing ban-list maintenance from slowing as the 20,000-IP bound fills
+  ([#286](https://github.com/zakura-core/zakura/pull/286)).
 
 ## [1.0.2] - 2026-07-20
 

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Replace `AddressBook::bans`'s `Arc<IndexMap<IpAddr, Instant>>` return value
+  with the read-only `BannedIps` handle, which is re-exported and provides
+  membership checks through `BannedIps::contains`
+  ([#286](https://github.com/zakura-core/zakura/pull/286)).
+
 ### Fixed
 
 - Skip Equihash and difficulty-filter checks during native header sync for

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -3,14 +3,13 @@
 
 use std::{
     cmp::Reverse,
-    collections::HashMap,
+    collections::{HashMap, HashSet, VecDeque},
     net::{IpAddr, SocketAddr},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
     time::Instant,
 };
 
 use chrono::Utc;
-use indexmap::IndexMap;
 use ordered_map::OrderedMap;
 use tokio::sync::watch;
 use tracing::Span;
@@ -27,6 +26,63 @@ use crate::{
 
 #[cfg(test)]
 mod tests;
+
+/// Read-only access to currently banned peer IP addresses.
+#[derive(Clone, Debug, Default)]
+pub struct BannedIps {
+    inner: Arc<RwLock<BanList>>,
+}
+
+/// A bounded FIFO list of banned peer IP addresses.
+#[derive(Debug, Default)]
+struct BanList {
+    /// Banned IP addresses for fast membership checks.
+    ips: HashSet<IpAddr>,
+
+    /// Banned IP addresses in insertion order for FIFO eviction.
+    insertion_order: VecDeque<IpAddr>,
+}
+
+impl BanList {
+    /// Inserts `ip`, evicting the oldest IP when the list exceeds its bound.
+    fn insert(&mut self, ip: IpAddr) {
+        if !self.ips.insert(ip) {
+            return;
+        }
+
+        self.insertion_order.push_back(ip);
+
+        if self.ips.len() > constants::MAX_BANNED_IPS {
+            let oldest = self
+                .insertion_order
+                .pop_front()
+                .expect("ban order has an entry for every banned IP");
+
+            self.ips.remove(&oldest);
+        }
+    }
+}
+
+impl BannedIps {
+    /// Returns whether `ip` is currently banned.
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        self.inner
+            .read()
+            .expect("ban list lock should not be poisoned")
+            .ips
+            .contains(&ip)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_banned_ip(ip: IpAddr) -> Self {
+        let bans = Self::default();
+        bans.inner
+            .write()
+            .expect("ban list lock should not be poisoned")
+            .insert(ip);
+        bans
+    }
+}
 
 /// A database of peer listener addresses, their advertised services, and
 /// information on when they were last seen.
@@ -82,7 +138,7 @@ pub struct AddressBook {
     most_recent_by_ip: Option<HashMap<IpAddr, MetaAddr>>,
 
     /// A list of banned addresses, with the time they were banned.
-    bans_by_ip: Arc<IndexMap<IpAddr, Instant>>,
+    bans_by_ip: BannedIps,
 
     /// The local listener address.
     local_listener: SocketAddr,
@@ -447,7 +503,7 @@ impl AddressBook {
     pub fn update(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         let addr_label = change.addr().addr_label(self.expose_peer_addresses);
 
-        if self.bans_by_ip.contains_key(&change.addr().ip()) {
+        if self.bans_by_ip.contains(change.addr().ip()) {
             tracing::warn!(
                 peer = %addr_label,
                 ?change,
@@ -479,13 +535,13 @@ impl AddressBook {
             if updated.misbehavior() >= constants::MAX_PEER_MISBEHAVIOR_SCORE {
                 // Ban and skip outbound connections with excessively misbehaving peers.
                 let banned_ip = updated.addr.ip();
-                let bans_by_ip = Arc::make_mut(&mut self.bans_by_ip);
+                let mut bans_by_ip = self
+                    .bans_by_ip
+                    .inner
+                    .write()
+                    .expect("ban list lock should not be poisoned");
 
-                bans_by_ip.insert(banned_ip, Instant::now());
-                if bans_by_ip.len() > constants::MAX_BANNED_IPS {
-                    // Remove the oldest banned IP from the address book.
-                    bans_by_ip.shift_remove_index(0);
-                }
+                bans_by_ip.insert(banned_ip);
 
                 // `most_recent_by_ip` is only populated when
                 // `max_connections_per_ip == 1`. The ban path runs for any
@@ -726,7 +782,7 @@ impl AddressBook {
     }
 
     /// Returns banned IP addresses.
-    pub fn bans(&self) -> Arc<IndexMap<IpAddr, Instant>> {
+    pub fn bans(&self) -> BannedIps {
         self.bans_by_ip.clone()
     }
 

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -535,13 +535,15 @@ impl AddressBook {
             if updated.misbehavior() >= constants::MAX_PEER_MISBEHAVIOR_SCORE {
                 // Ban and skip outbound connections with excessively misbehaving peers.
                 let banned_ip = updated.addr.ip();
-                let mut bans_by_ip = self
-                    .bans_by_ip
-                    .inner
-                    .write()
-                    .expect("ban list lock should not be poisoned");
+                {
+                    let mut bans_by_ip = self
+                        .bans_by_ip
+                        .inner
+                        .write()
+                        .expect("ban list lock should not be poisoned");
 
-                bans_by_ip.insert(banned_ip);
+                    bans_by_ip.insert(banned_ip);
+                }
 
                 // `most_recent_by_ip` is only populated when
                 // `max_connections_per_ip == 1`. The ban path runs for any

--- a/zakura-network/src/address_book/tests.rs
+++ b/zakura-network/src/address_book/tests.rs
@@ -2,5 +2,29 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+use std::net::{IpAddr, Ipv4Addr};
+
+use crate::constants::MAX_BANNED_IPS;
+
+use super::BanList;
+
 mod prop;
 mod vectors;
+
+#[test]
+fn ban_list_evicts_the_oldest_ip_at_capacity() {
+    let mut bans = BanList::default();
+    let oldest = IpAddr::V4(Ipv4Addr::from(1));
+
+    for ip in 1..=MAX_BANNED_IPS {
+        bans.insert(IpAddr::V4(Ipv4Addr::from(u32::try_from(ip).unwrap())));
+    }
+
+    let newest = IpAddr::V4(Ipv4Addr::from(u32::try_from(MAX_BANNED_IPS + 1).unwrap()));
+    bans.insert(newest);
+
+    assert!(!bans.ips.contains(&oldest));
+    assert!(bans.ips.contains(&newest));
+    assert_eq!(bans.ips.len(), MAX_BANNED_IPS);
+    assert_eq!(bans.insertion_order.len(), MAX_BANNED_IPS);
+}

--- a/zakura-network/src/address_book/tests/vectors.rs
+++ b/zakura-network/src/address_book/tests/vectors.rs
@@ -102,13 +102,15 @@ fn misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one() {
     assert!(address_book.get(banned_addr).is_some());
     assert!(address_book.get(other_port_same_ip).is_some());
 
+    let bans = address_book.bans();
+
     address_book.update(MetaAddrChange::UpdateMisbehavior {
         addr: banned_addr,
         score_increment: MAX_PEER_MISBEHAVIOR_SCORE,
     });
 
     assert!(
-        address_book.bans().contains_key(&banned_addr.ip()),
+        bans.contains(banned_addr.ip()),
         "ban-threshold misbehavior should ban the peer IP"
     );
     assert!(

--- a/zakura-network/src/address_book_updater.rs
+++ b/zakura-network/src/address_book_updater.rs
@@ -1,13 +1,7 @@
 //! The timestamp collector collects liveness information from peers.
 
-use std::{
-    cmp::max,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-    time::Instant,
-};
+use std::{cmp::max, net::SocketAddr, sync::Arc};
 
-use indexmap::IndexMap;
 use thiserror::Error;
 use tokio::{
     sync::{mpsc, watch},
@@ -17,7 +11,7 @@ use tracing::{Level, Span};
 
 use crate::{
     address_book::AddressMetrics, meta_addr::MetaAddrChange, types::PeerServices, AddressBook,
-    BoxError, Config,
+    BannedIps, BoxError, Config,
 };
 
 /// The minimum size of the address book updater channel.
@@ -40,6 +34,7 @@ impl AddressBookUpdater {
     ///
     /// Returns handles for:
     /// - the address book,
+    /// - the shared list of banned peer IP addresses,
     /// - the transmission channel for address book update events,
     /// - a watch channel for address book metrics, and
     /// - the address book updater task join handle.
@@ -51,7 +46,7 @@ impl AddressBookUpdater {
         advertised_services: PeerServices,
     ) -> (
         Arc<std::sync::Mutex<AddressBook>>,
-        watch::Receiver<Arc<IndexMap<IpAddr, Instant>>>,
+        BannedIps,
         mpsc::Sender<MetaAddrChange>,
         watch::Receiver<AddressMetrics>,
         JoinHandle<Result<(), BoxError>>,
@@ -72,6 +67,10 @@ impl AddressBookUpdater {
         .with_local_listener_services(advertised_services)
         .with_expose_peer_addresses(config.expose_peer_addresses);
         let address_metrics = address_book.address_metrics_watcher();
+
+        // The updater needs mutable address-book access, while peer networking
+        // only needs read-only ban checks. Both handles share the ban list lock.
+        let bans = address_book.bans();
         let address_book = Arc::new(std::sync::Mutex::new(address_book));
 
         #[cfg(feature = "progress-bar")]
@@ -86,12 +85,6 @@ impl AddressBookUpdater {
 
         let worker_address_book = address_book.clone();
         let expose_peer_addresses = config.expose_peer_addresses;
-        let (bans_sender, bans_receiver) = tokio::sync::watch::channel(
-            worker_address_book
-                .lock()
-                .expect("mutex should be unpoisoned")
-                .bans(),
-        );
 
         let worker = move || {
             info!("starting the address book updater");
@@ -107,23 +100,10 @@ impl AddressBookUpdater {
                 //
                 // Briefly hold the address book threaded mutex, to update the
                 // state for a single address.
-                let updated = worker_address_book
+                worker_address_book
                     .lock()
                     .expect("mutex should be unpoisoned")
                     .update(event);
-
-                // `UpdateMisbehavior` events should only be passed to `update()` here,
-                // so that this channel is always updated when new addresses are banned.
-                if updated.is_none() {
-                    let bans = worker_address_book
-                        .lock()
-                        .expect("mutex should be unpoisoned")
-                        .bans();
-
-                    if bans.contains_key(&event.addr().ip()) {
-                        let _ = bans_sender.send(bans);
-                    }
-                }
 
                 #[cfg(feature = "progress-bar")]
                 if matches!(howudoin::cancelled(), Some(true)) {
@@ -172,7 +152,7 @@ impl AddressBookUpdater {
 
         (
             address_book,
-            bans_receiver,
+            bans,
             worker_tx,
             address_metrics,
             address_book_updater_task_handle,

--- a/zakura-network/src/lib.rs
+++ b/zakura-network/src/lib.rs
@@ -182,7 +182,7 @@ pub use crate::{
 };
 
 pub use crate::{
-    address_book::AddressBook,
+    address_book::{AddressBook, BannedIps},
     address_book_peers::AddressBookPeers,
     config::{CacheDir, Config, P2pStack},
     isolated::{connect_isolated, connect_isolated_tcp_direct},

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -19,11 +19,10 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     Future, TryFutureExt,
 };
-use indexmap::IndexMap;
 use rand::seq::SliceRandom;
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::{broadcast, mpsc, watch},
+    sync::{broadcast, mpsc},
     time::{sleep, Instant},
 };
 use tokio_stream::wrappers::IntervalStream;
@@ -45,7 +44,7 @@ use crate::{
     peer_cache_updater::peer_cache_updater,
     peer_set::{set::MorePeers, ActiveConnectionCounter, CandidateSet, ConnectionTracker, PeerSet},
     protocol::external::{canonical_socket_addr, types::PeerServices},
-    AddressBook, BoxError, Config, PeerSocketAddr, Request, Response,
+    AddressBook, BannedIps, BoxError, Config, PeerSocketAddr, Request, Response,
 };
 
 #[cfg(test)]
@@ -170,13 +169,8 @@ where
     .await
     .expect("Zakura endpoint should start when P2P v2 is enabled");
 
-    let (
-        address_book,
-        bans_receiver,
-        address_book_updater,
-        address_metrics,
-        address_book_updater_guard,
-    ) = AddressBookUpdater::spawn(&config, listen_addr, advertised_services);
+    let (address_book, bans, address_book_updater, address_metrics, address_book_updater_guard) =
+        AddressBookUpdater::spawn(&config, listen_addr, advertised_services);
 
     let (misbehavior_tx, mut misbehavior_rx) = mpsc::channel(
         // Leave enough room for a misbehaviour update on every peer connection
@@ -304,7 +298,7 @@ where
         demand_tx.clone(),
         handle_rx,
         inv_receiver,
-        bans_receiver.clone(),
+        bans.clone(),
         address_metrics,
         MinimumPeerVersion::new(latest_chain_tip, &config.network),
         None,
@@ -327,7 +321,7 @@ where
             constants::MIN_INBOUND_PEER_CONNECTION_INTERVAL,
             listen_handshaker,
             peerset_tx.clone(),
-            bans_receiver,
+            bans,
             block_gossip_peer_ips,
         );
         task_handles.push(tokio::spawn(listen_fut.in_current_span()));
@@ -733,7 +727,7 @@ async fn accept_inbound_connections<S>(
     min_inbound_peer_connection_interval: Duration,
     handshaker: S,
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
-    bans_receiver: watch::Receiver<Arc<IndexMap<IpAddr, std::time::Instant>>>,
+    bans: BannedIps,
     zcashd_compat_peer_ips: Vec<IpAddr>,
 ) -> Result<(), BoxError>
 where
@@ -784,7 +778,7 @@ where
             let addr: PeerSocketAddr = addr.into();
             let addr_label = addr.addr_label(config.expose_peer_addresses);
 
-            if bans_receiver.borrow().clone().contains_key(&addr.ip()) {
+            if bans.contains(addr.ip()) {
                 debug!(peer = %addr_label, "banned inbound connection attempt");
                 std::mem::drop(tcp_stream);
                 continue;

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -21,7 +21,7 @@ use std::{
 
 use chrono::Utc;
 use futures::{channel::mpsc, FutureExt, StreamExt};
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexSet;
 use tokio::{
     io::AsyncWriteExt,
     net::{TcpSocket, TcpStream},
@@ -46,7 +46,7 @@ use crate::{
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
     },
     protocol::types::PeerServices,
-    AddressBook, BoxError, Config, PeerSocketAddr, Request, Response,
+    AddressBook, BannedIps, BoxError, Config, PeerSocketAddr, Request, Response,
 };
 
 use Network::*;
@@ -1030,7 +1030,7 @@ async fn listener_reserves_one_zcashd_compat_inbound_slot() {
     config.listen_addr = listen_addr;
 
     let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(4);
-    let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
+    let bans = BannedIps::default();
 
     let listen_fut = accept_inbound_connections(
         config.clone(),
@@ -1038,7 +1038,7 @@ async fn listener_reserves_one_zcashd_compat_inbound_slot() {
         MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
         success_stay_open_inbound_handshaker,
         peerset_tx,
-        bans_rx,
+        bans,
         vec![IpAddr::V6(zcashd_compat_ip.to_ipv6_mapped())],
     );
     let listen_task_handle = tokio::spawn(listen_fut);
@@ -1122,7 +1122,7 @@ async fn listener_zcashd_compat_reconnect_bypasses_recent_ip_limit() {
     config.listen_addr = listen_addr;
 
     let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(2);
-    let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
+    let bans = BannedIps::default();
 
     let listen_fut = accept_inbound_connections(
         config,
@@ -1130,7 +1130,7 @@ async fn listener_zcashd_compat_reconnect_bypasses_recent_ip_limit() {
         MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
         success_disconnect_inbound_handshaker,
         peerset_tx,
-        bans_rx,
+        bans,
         vec![zcashd_compat_ip.into()],
     );
     let listen_task_handle = tokio::spawn(listen_fut);
@@ -1179,12 +1179,7 @@ async fn listener_bans_zcashd_compat_peer_before_reserved_slot() {
     config.listen_addr = listen_addr;
 
     let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(1);
-    let (bans_tx, bans_rx) = tokio::sync::watch::channel(
-        [(zcashd_compat_ip.into(), std::time::Instant::now())]
-            .into_iter()
-            .collect::<IndexMap<_, _>>()
-            .into(),
-    );
+    let bans = BannedIps::with_banned_ip(zcashd_compat_ip.into());
 
     let listen_fut = accept_inbound_connections(
         config,
@@ -1192,7 +1187,7 @@ async fn listener_bans_zcashd_compat_peer_before_reserved_slot() {
         MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
         unreachable_inbound_handshaker,
         peerset_tx,
-        bans_rx,
+        bans,
         vec![zcashd_compat_ip.into()],
     );
     let listen_task_handle = tokio::spawn(listen_fut);
@@ -1211,7 +1206,6 @@ async fn listener_bans_zcashd_compat_peer_before_reserved_slot() {
         "banned zcashd-compat peers must not be admitted"
     );
 
-    std::mem::drop(bans_tx);
     std::mem::drop(banned_connection);
 }
 
@@ -2007,7 +2001,7 @@ where
     let over_limit_connections = config.peerset_inbound_connection_limit() * 2 + 1;
     let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_connections);
 
-    let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
+    let bans = BannedIps::default();
 
     // Start listening for connections.
     let listen_fut = accept_inbound_connections(
@@ -2016,7 +2010,7 @@ where
         MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
         listen_handshaker,
         peerset_tx.clone(),
-        bans_rx,
+        bans,
         Vec::new(),
     );
     let listen_task_handle = tokio::spawn(listen_fut);

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -100,7 +100,6 @@ use std::{
     marker::PhantomData,
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -112,7 +111,6 @@ use futures::{
     stream::FuturesUnordered,
     task::noop_waker,
 };
-use indexmap::IndexMap;
 use itertools::Itertools;
 use num_integer::div_ceil;
 use tokio::{
@@ -141,7 +139,7 @@ use crate::{
         external::{canonical_socket_addr, InventoryHash},
         internal::{Request, Response},
     },
-    BoxError, Config, PeerError, PeerSocketAddr, SharedPeerError,
+    BannedIps, BoxError, Config, PeerError, PeerSocketAddr, SharedPeerError,
 };
 
 #[cfg(test)]
@@ -209,8 +207,8 @@ where
     /// A channel that asks the peer crawler task to connect to more peers.
     demand_signal: mpsc::Sender<MorePeers>,
 
-    /// A watch channel receiver with a copy of banned IP addresses.
-    bans_receiver: watch::Receiver<Arc<IndexMap<IpAddr, std::time::Instant>>>,
+    /// A shared list of banned IP addresses.
+    bans: BannedIps,
 
     /// Tracks peers returning empty `FindBlocks`/`FindHeaders` responses.
     /// Mutated only from [`Self::poll_ready`] via [`Self::stall_event_rx`].
@@ -357,7 +355,7 @@ where
     ///   and shuts down all the tasks as soon as one task exits;
     /// - `inv_stream`: receives inventory changes from peers,
     ///   allowing the peer set to direct inventory requests;
-    /// - `bans_receiver`: receives a map of banned IP addresses that should be dropped;
+    /// - `bans`: a map of banned IP addresses that should be dropped;
     /// - `address_book`: when peer set is busy, it logs address book diagnostics.
     /// - `minimum_peer_version`: endpoint to see the minimum peer protocol version in real time.
     /// - `max_conns_per_ip`: configured maximum number of peers that can be in the
@@ -370,7 +368,7 @@ where
         demand_signal: mpsc::Sender<MorePeers>,
         handle_rx: tokio::sync::oneshot::Receiver<Vec<JoinHandle<Result<(), BoxError>>>>,
         inv_stream: broadcast::Receiver<InventoryChange>,
-        bans_receiver: watch::Receiver<Arc<IndexMap<IpAddr, std::time::Instant>>>,
+        bans: BannedIps,
         address_metrics: watch::Receiver<AddressMetrics>,
         minimum_peer_version: MinimumPeerVersion<C>,
         max_conns_per_ip: Option<usize>,
@@ -381,7 +379,7 @@ where
             discover,
             demand_signal,
             // Banned peers
-            bans_receiver,
+            bans,
 
             // Stall tracking
             find_response_stalls: FindResponseStallTracker::new(),
@@ -595,7 +593,7 @@ where
                         "service became ready"
                     );
 
-                    if self.bans_receiver.borrow().contains_key(&key.ip()) {
+                    if self.bans.contains(key.ip()) {
                         warn!(
                             peer = %key.addr_label(self.expose_peer_addresses),
                             "service is banned, dropping service"
@@ -679,7 +677,7 @@ where
             match peer_readiness {
                 // Still ready, add it back to the list.
                 Ok(()) => {
-                    if self.bans_receiver.borrow().contains_key(&key.ip()) {
+                    if self.bans.contains(key.ip()) {
                         debug!(
                             peer = %key.addr_label(self.expose_peer_addresses),
                             "service ip is banned, dropping service"
@@ -1393,8 +1391,7 @@ where
             return;
         };
 
-        let bans = self.bans_receiver.borrow().clone();
-        remaining_peers.retain(|addr| !bans.contains_key(&addr.ip()));
+        remaining_peers.retain(|addr| !self.bans.contains(addr.ip()));
 
         let Ok(reserved_send_slot) = sender.try_reserve() else {
             self.queued_broadcast_all = Some((req, sender, remaining_peers));

--- a/zakura-network/src/peer_set/set/tests.rs
+++ b/zakura-network/src/peer_set/set/tests.rs
@@ -32,7 +32,7 @@ use crate::{
     peer::{ClientTestHarness, LoadTrackedClient, MinimumPeerVersion},
     peer_set::{set::MorePeers, InventoryChange, PeerSet},
     protocol::external::types::Version,
-    AddressBook, Config, PeerSocketAddr,
+    AddressBook, BannedIps, Config, PeerSocketAddr,
 };
 
 #[cfg(test)]
@@ -253,7 +253,7 @@ where
             .unwrap_or_else(|| guard.create_inventory_receiver());
 
         let address_metrics = guard.prepare_address_book(self.address_book);
-        let (_bans_sender, bans_receiver) = tokio::sync::watch::channel(Default::default());
+        let bans = BannedIps::default();
 
         let peer_set = PeerSet::new(
             &config,
@@ -262,7 +262,7 @@ where
             demand_signal,
             handle_rx,
             inv_stream,
-            bans_receiver,
+            bans,
             address_metrics,
             minimum_peer_version,
             max_conns_per_ip,

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -5,7 +5,6 @@ use std::{
     collections::HashSet,
     iter,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
     time::Duration,
 };
 
@@ -25,10 +24,8 @@ use crate::{
     },
     peer_set::{inventory_registry::InventoryStatus, stall_tracker::FIND_RESPONSE_STALL_THRESHOLD},
     protocol::external::{types::Version, InventoryHash},
-    BoxError, PeerSocketAddr, Request, Response, SharedPeerError,
+    BannedIps, BoxError, PeerSocketAddr, Request, Response, SharedPeerError,
 };
-use indexmap::IndexMap;
-use tokio::sync::watch;
 
 use super::{PeerSetBuilder, PeerVersions};
 
@@ -326,12 +323,7 @@ fn broadcast_all_queued_removes_banned_peers() {
             .build();
 
         let banned_ip: std::net::IpAddr = "127.0.0.1".parse().unwrap();
-        let mut bans_map: IndexMap<std::net::IpAddr, std::time::Instant> = IndexMap::new();
-        bans_map.insert(banned_ip, std::time::Instant::now());
-
-        let (bans_tx, bans_rx) = watch::channel(Arc::new(bans_map));
-        let _ = bans_tx;
-        peer_set.bans_receiver = bans_rx;
+        peer_set.bans = BannedIps::with_banned_ip(banned_ip);
 
         let banned_addr: PeerSocketAddr = SocketAddr::new(banned_ip, 1).into();
         let mut remaining_peers = HashSet::new();
@@ -549,10 +541,7 @@ fn remove_unready_peer_clears_cancel_handle_and_updates_counts() {
         // Prepare a banned IP map (not strictly required for remove(), but keeps
         // the test's setup similar to real-world conditions).
         let banned_ip: std::net::IpAddr = "127.0.0.1".parse().unwrap();
-        let mut bans_map: IndexMap<std::net::IpAddr, std::time::Instant> = IndexMap::new();
-        bans_map.insert(banned_ip, std::time::Instant::now());
-        let (_bans_tx, bans_rx) = watch::channel(Arc::new(bans_map));
-        peer_set.bans_receiver = bans_rx;
+        peer_set.bans = BannedIps::with_banned_ip(banned_ip);
 
         // Create a cancel handle as if a request was in-flight to `banned_addr`.
         let banned_addr: PeerSocketAddr = SocketAddr::new(banned_ip, 1).into();


### PR DESCRIPTION
## Motivation

The ban list was shared through immutable `Arc<IndexMap<...>>` snapshots in a
watch channel. Each new ban therefore cloned the complete retained list while
the peer-set and inbound listener retained their snapshots. This made filling
the ban list increasingly expensive.

## Solution

Share one `RwLock`-protected bounded FIFO ban list and mutate it in place.
The list uses `HashSet<IpAddr>` for membership checks and `VecDeque<IpAddr>`
for O(1) FIFO eviction. Peer-set and inbound-listener checks use a read-only
`BannedIps` handle. This removes snapshot cloning and linear eviction from the
ban path while preserving the existing 20,000-IP bound.
The ban-list write lock is held only for insertion and eviction, so peer checks
remain unblocked during address-book cleanup.

## API changes

`AddressBook::bans` and `AddressBookUpdater::spawn` now return `BannedIps`
rather than a watch receiver/snapshot. The handle exposes membership checks
only; it does not expose mutation of the shared ban map.

## Testing

- `npx --yes markdownlint-cli CHANGELOG.md zakura-network/CHANGELOG.md --config .trunk/configs/.markdownlint.yaml`
- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-network --lib -- -D warnings`
- `cargo test -p zakura-network ban_list_evicts_the_oldest_ip_at_capacity --lib`
- `cargo test -p zakura-network misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one --lib`
- `cargo test -p zakura-network broadcast_all_queued_removes_banned_peers --lib`

## AI disclosure

Used Codex for the implementation, test updates, and PR description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking `zakura-network` API and a shared `RwLock` on the ban-check path in peer networking; behavior (FIFO bound, IP-level bans) is intended to stay the same.
> 
> **Overview**
> Fixes ban-list cost as the 20,000-IP cap fills by **mutating one shared list in place** instead of cloning full `Arc<IndexMap<…>>` snapshots on every ban and pushing updates through a watch channel.
> 
> **`BannedIps`** (re-exported) wraps `Arc<RwLock<BanList>>` with **`contains` only** for peer-set and inbound checks. **`BanList`** uses a **`HashSet`** for membership and a **`VecDeque`** for FIFO eviction at **`MAX_BANNED_IPS`**, replacing **`shift_remove_index(0)`** on an ordered map.
> 
> **Breaking:** `AddressBook::bans()` and **`AddressBookUpdater::spawn`** now return **`BannedIps`** instead of `watch::Receiver<Arc<IndexMap<IpAddr, Instant>>>`. Ban timestamps are no longer exposed on the public API. The address-book updater no longer republishes ban snapshots after misbehavior updates—callers share the same handle from spawn.
> 
> **`PeerSet`** and **`accept_inbound_connections`** take **`BannedIps`** and call **`contains`** on the live list rather than borrowing cloned maps from a watch receiver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468e6ebea0439a5cd06221ec6ae75dfc33734dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->