### PR TITLE
fix(network): honor disable_pow in native header sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   processes, while allowing `-allowdeprecated=none` to disable them all.
 - Preserve failed shielded proof/signature verification errors so they receive
   the existing mempool peer-misbehaviour score.
+- Native Zakura header sync now honors `disable_pow = true` on configured
+  Testnets, matching semantic and checkpoint block verification.
 
 ## [1.0.2-rc0] - 2026-07-19
 

--- a/zakura-chain/src/parallel/commitment_aux.rs
+++ b/zakura-chain/src/parallel/commitment_aux.rs
@@ -33,10 +33,10 @@ pub struct BlockCommitmentRoots {
     pub sapling_root: sapling::tree::Root,
     /// The Orchard note-commitment tree root as of the end of this block (empty below NU5).
     pub orchard_root: orchard::tree::Root,
-    /// The Ironwood note-commitment tree root as of the end of this block (empty below Nu7).
+    /// The Ironwood note-commitment tree root as of the end of this block (empty below NU6.3).
     ///
     /// Carried alongside the Sapling/Orchard roots because the ZIP-221 V3 history leaf
-    /// (Nu7+) folds the Ironwood root into the chain-history MMR; a recipient rebuilding
+    /// (NU6.3+) folds the Ironwood root into the chain-history MMR; a recipient rebuilding
     /// the leaf to verify against header commitments (design §6) needs it, without the body.
     pub ironwood_root: ironwood::tree::Root,
     /// Number of this block's transactions carrying Sapling shielded data
@@ -53,7 +53,7 @@ pub struct BlockCommitmentRoots {
     /// (`Block::orchard_transactions_count`); the Orchard V2 leaf count input (NU5+).
     pub orchard_tx: u64,
     /// Number of this block's transactions carrying Ironwood shielded data; the Ironwood
-    /// V3 leaf count input (Nu7+).
+    /// V3 leaf count input (NU6.3+).
     pub ironwood_tx: u64,
     /// The authorizing-data root (ZIP-244 `hashAuthDataRoot`) of *this* block's own
     /// transactions. Serialized last.

--- a/zakura-chain/src/parallel/commitment_aux_verify.rs
+++ b/zakura-chain/src/parallel/commitment_aux_verify.rs
@@ -154,7 +154,7 @@ pub fn header_commitment_is_valid_for_chain_history(
             }
         }
         Commitment::ChainHistoryBlockTxAuthCommitment(actual_hash_block_commitments) => {
-            // NU6_3 onward commits to both the parent history tree root and
+            // NU5 onward commits to both the parent history tree root and
             // this block's auth data root. That still preserves the one-block
             // lag for supplied note commitment roots: `history_tree` is the
             // parent tree, while `auth_data_root` belongs to the current

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pruned nodes no longer advertise retained block hashes in legacy `getblocks`
   responses when their corresponding block bodies are unavailable.
+- Native header sync now skips Equihash and difficulty-filter checks for
+  configured Testnets with `disable_pow = true`, not only Regtest.
 
 ## [3.0.0-rc0] - 2026-07-19
 

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -6797,16 +6797,25 @@ async fn stateless_validation_rejects_wrong_solution_size_for_network() {
 }
 
 #[test]
-fn regtest_header_validation_accepts_common_and_short_solution_sizes() {
+fn pow_disabled_header_validation_accepts_common_and_short_solution_sizes() {
     let regtest = Network::new_regtest(Default::default());
+    let custom_testnet = Parameters::build()
+        .with_network_name("HeaderSyncNoPowSizeTest")
+        .expect("custom testnet name is valid")
+        .with_disable_pow(true)
+        .to_network()
+        .expect("custom testnet parameters are valid");
     let common_sized = mainnet_header(&BLOCK_MAINNET_1_BYTES);
     let mut short_sized = *common_sized;
     short_sized.solution = Solution::Regtest([0; 36]);
 
-    validate_solution_sizes(std::slice::from_ref(&common_sized), &regtest)
-        .expect("regtest accepts Zebra-mined common-size solutions");
-    validate_solution_sizes(&[Arc::new(short_sized)], &regtest)
-        .expect("regtest accepts short regtest solutions");
+    for network in [&regtest, &custom_testnet] {
+        validate_solution_sizes(std::slice::from_ref(&common_sized), network)
+            .expect("PoW-disabled networks accept common-size solutions");
+        validate_solution_sizes(&[Arc::new(short_sized)], network)
+            .expect("PoW-disabled networks accept short solutions");
+    }
+
     assert!(matches!(
         validate_solution_sizes(&[Arc::new(short_sized)], &Network::Mainnet),
         Err(HeaderSyncWireError::WrongEquihashSolutionSize)
@@ -6829,6 +6838,33 @@ async fn regtest_stateless_validation_skips_pow_filter() {
     validate_headers_stateless(vec![Arc::new(header)], context)
         .await
         .expect("regtest header sync leaves PoW enforcement to block verification");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_testnet_disable_pow_skips_header_sync_pow_filter() {
+    let network = Parameters::build()
+        .with_network_name("HeaderSyncNoPowTest")
+        .expect("custom testnet name is valid")
+        .with_disable_pow(true)
+        .to_network()
+        .expect("custom testnet parameters are valid");
+    assert!(network.disable_pow());
+    assert!(!network.is_regtest());
+
+    let mut header = *mainnet_header(&BLOCK_MAINNET_1_BYTES);
+    header.nonce[0] ^= 1;
+    header.difficulty_threshold =
+        CompactDifficulty::from_bytes_in_display_order(&[0x01, 0x01, 0x00, 0x00]).unwrap();
+    let context = HeaderSyncValidationContext {
+        network: &network,
+        now: Utc::now(),
+        start_height: block::Height(1),
+        decode_context: headers_context(1, DEFAULT_HS_RANGE),
+    };
+
+    validate_headers_stateless(vec![Arc::new(header)], context)
+        .await
+        .expect("custom disable_pow networks must skip native header-sync PoW checks");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/zakura-network/src/zakura/header_sync/validation.rs
+++ b/zakura-network/src/zakura/header_sync/validation.rs
@@ -190,15 +190,16 @@ pub(super) fn validate_solution_sizes(
     headers: &[Arc<block::Header>],
     network: &Network,
 ) -> Result<(), HeaderSyncWireError> {
-    let expect_regtest = network
-        .parameters()
-        .is_some_and(|parameters| parameters.is_regtest());
+    // PoW-disabled networks do not assign consensus meaning to either
+    // parseable solution variant. Keep native header sync aligned with block
+    // verification, which skips Equihash checks entirely in this mode.
+    if network.disable_pow() {
+        return Ok(());
+    }
+
     for header in headers {
-        match (expect_regtest, header.solution) {
-            (true, equihash::Solution::Regtest(_))
-            | (true, equihash::Solution::Common(_))
-            | (false, equihash::Solution::Common(_)) => {}
-            _ => return Err(HeaderSyncWireError::WrongEquihashSolutionSize),
+        if !matches!(header.solution, equihash::Solution::Common(_)) {
+            return Err(HeaderSyncWireError::WrongEquihashSolutionSize);
         }
     }
     Ok(())
@@ -216,10 +217,9 @@ pub(super) fn validate_pow_blocking(
     headers: &[Arc<block::Header>],
     network: &Network,
 ) -> Result<(), HeaderSyncWireError> {
-    let skip_pow_filter = network
-        .parameters()
-        .is_some_and(|parameters| parameters.is_regtest());
-    if skip_pow_filter {
+    // Custom testnets can disable PoW without using Regtest parameters. Keep
+    // native header sync aligned with semantic and checkpoint verification.
+    if network.disable_pow() {
         return Ok(());
     }
 

--- a/zakura-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/shielded.rs
@@ -106,7 +106,7 @@ pub struct CommitmentRootsByHeight {
     /// against this block's NU5+ header commitment, without re-reading the body.
     /// Default/zero below NU5.
     pub auth_data_root: AuthDataRoot,
-    /// The Ironwood note-commitment tree root at this height (empty below Nu7). Stored so a
+    /// The Ironwood note-commitment tree root at this height (empty below NU6.3). Stored so a
     /// fast-synced node can serve it as a ZIP-221 V3 history-leaf input.
     pub ironwood: ironwood::tree::Root,
     /// This block's Sapling shielded transaction count — a ZIP-221 history-leaf input the
@@ -114,7 +114,7 @@ pub struct CommitmentRootsByHeight {
     pub sapling_tx: u64,
     /// This block's Orchard shielded transaction count (V2 leaf input, NU5+).
     pub orchard_tx: u64,
-    /// This block's Ironwood shielded transaction count (V3 leaf input, Nu7+).
+    /// This block's Ironwood shielded transaction count (V3 leaf input, NU6.3+).
     pub ironwood_tx: u64,
 }
 


### PR DESCRIPTION
## Summary

- Correct Ironwood history-leaf upgrade terminology in documentation.
- Make native header sync honor `disable_pow = true` for configured Testnets.

## Root cause

Native header sync used Regtest-parameter detection to bypass Equihash and difficulty checks, while semantic and checkpoint verification use `Network::disable_pow()`. Custom Testnets with proof of work disabled could therefore have valid headers rejected by native header sync.

## Solution

Use the existing `Network::disable_pow()` predicate for native header-sync solution-size and proof-of-work validation, and retain focused regression coverage.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network header_sync`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-adjacent header-sync validation; behavior change is scoped to PoW-disabled test networks and matches existing block verification.
> 
> **Overview**
> **Native header sync** now skips Equihash solution-size checks and PoW/difficulty validation whenever `Network::disable_pow()` is true, instead of only when Regtest parameters are used. That aligns header sync with semantic and checkpoint verification so custom Testnets with `disable_pow = true` are not rejected for invalid-looking PoW while blocks would still verify.
> 
> Tests cover PoW-disabled custom testnets (solution sizes and stateless validation). **Docs only:** Ironwood/ZIP-221 comments are retagged from Nu7 to **NU6.3**, and the NU5+ header commitment comment in commitment aux verification is corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9317ea1054eabd624b4f7e95475b3b105d88af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->