### PR TITLE
fix(mempool): exempt duplicate errors from peer penalties

### DIFF
--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -434,6 +434,13 @@ impl TransactionError {
             // honest peers can relay them briefly while their chain tips converge.
             WrongConsensusBranchIdNu6_3GracePeriod => 0,
 
+            // TODO: Consider add peer penalty 1 if these are very old
+            DuplicateTransparentSpend(_)
+            | DuplicateSproutNullifier(_)
+            | DuplicateSaplingNullifier(_)
+            | DuplicateOrchardNullifier(_)
+            | DuplicateIronwoodNullifier(_) => 0,
+
             // Standardness (policy) rejections must not be punished: non-standard
             // transactions are consensus-valid, and zcashd relays a reject message
             // without a DoS score for them.
@@ -491,6 +498,25 @@ mod tests {
             TransactionError::RedPallas(zakura_chain::primitives::reddsa::Error::InvalidSignature),
         ] {
             assert_eq!(error.mempool_misbehavior_score(), 100);
+        }
+    }
+
+    #[test]
+    fn duplicate_spend_errors_have_no_misbehavior_score() {
+        let orchard_nullifier = orchard::Nullifier::try_from([0; 32])
+            .expect("zero is a valid Pallas base-field encoding");
+
+        for error in [
+            TransactionError::DuplicateTransparentSpend(transparent::OutPoint {
+                hash: [0; 32].into(),
+                index: 0,
+            }),
+            TransactionError::DuplicateSproutNullifier([0; 32].into()),
+            TransactionError::DuplicateSaplingNullifier([0; 32].into()),
+            TransactionError::DuplicateOrchardNullifier(orchard_nullifier),
+            TransactionError::DuplicateIronwoodNullifier(orchard_nullifier),
+        ] {
+            assert_eq!(error.mempool_misbehavior_score(), 0);
         }
     }
 }


### PR DESCRIPTION
## Motivation

Duplicate nullifier and duplicate transparent-output errors deliberately receive no mempool peer penalty, but this policy was only implicit through the catch-all score. That makes the intended treatment easy to change accidentally when the error classifier evolves.

## Solution

Explicitly classify duplicate transparent spends and duplicate Sprout, Sapling, Orchard, and Ironwood nullifiers with score zero. Add the requested follow-up comment:

`TODO: Consider add peer penalty 1 if these are very old`

Add a regression test covering every explicitly exempt error.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-consensus --lib duplicate_spend_errors_have_no_misbehavior_score`
- `cargo test -p zakura-consensus --lib`
- `cargo clippy -p zakura-consensus --lib -- -D warnings`

### Specifications & References

None.

### Follow-up Work

Consider a small peer penalty for very old duplicate errors, as captured in the source TODO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy-only clarification in mempool DoS scoring with no behavior change intended; low blast radius in error classification.
> 
> **Overview**
> Mempool peer misbehavior scoring now **explicitly** assigns score **0** to duplicate transparent spends and duplicate Sprout, Sapling, Orchard, and Ironwood nullifiers in `TransactionError::mempool_misbehavior_score`, instead of relying on the catch-all branch. A **TODO** notes possibly using penalty **1** for very old duplicates.
> 
> A new unit test **`duplicate_spend_errors_have_no_misbehavior_score`** asserts score 0 for all five duplicate-spend variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074a0bbf2d45c6ae1e1e4b2a8f3a5aa61177f809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->