### PR TITLE
perf(rpc): reuse process-wide Sapling prover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Ban peers that send mempool transactions with invalid Orchard or Ironwood
   proof sizes.
+- Parse the bundled Sapling proving parameters once per process and reuse the
+  shared prover, instead of re-parsing the parameters on every
+  `getblocktemplate` refresh.
 - Stop pruned nodes from returning retained chain-index hashes through legacy
   `getblocks` when the corresponding block bodies are no longer serveable.
 - Add structured legacy peer request traces that attribute `FindBlocks` hash

--- a/zakura-consensus/src/lib.rs
+++ b/zakura-consensus/src/lib.rs
@@ -53,7 +53,7 @@ pub use block::{subsidy::funding_stream_address, Request, VerifyBlockError, MAX_
 pub use checkpoint::{VerifyCheckpointError, MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
 pub use config::Config;
 pub use error::BlockError;
-pub use primitives::{ed25519, groth16, halo2, redjubjub, redpallas};
+pub use primitives::{ed25519, groth16, halo2, redjubjub, redpallas, sapling::sapling_prover};
 pub use router::RouterError;
 
 /// A boxed [`std::error::Error`].

--- a/zakura-consensus/src/primitives/sapling.rs
+++ b/zakura-consensus/src/primitives/sapling.rs
@@ -31,6 +31,15 @@ use crate::{error::TransactionError, BoxError};
 /// - verify Sapling shielded data in the tx verifier.
 static SAPLING: Lazy<LocalTxProver> = Lazy::new(LocalTxProver::bundled);
 
+/// Returns the process-wide Sapling prover for constructing Sapling proofs, initializing it on
+/// first use.
+///
+/// The bundled Sapling spend and output proving parameters are parsed once, then the same prover is
+/// reused for proof construction and verification for the lifetime of the process.
+pub fn sapling_prover() -> &'static LocalTxProver {
+    Lazy::force(&SAPLING)
+}
+
 #[derive(Clone)]
 pub struct Item {
     /// The bundle containing the Sapling shielded data to verify.
@@ -230,3 +239,13 @@ pub static VERIFIER: Lazy<
         tower::service_fn(verify_single),
     )
 });
+
+#[cfg(test)]
+mod tests {
+    use super::sapling_prover;
+
+    #[test]
+    fn sapling_prover_is_reused() {
+        assert!(std::ptr::eq(sapling_prover(), sapling_prover()));
+    }
+}

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -2562,16 +2562,23 @@ where
                     // Respond instantly with an empty block upon a chain tip change so that
                     // the miner doesn't waste their effort trying to extend a shorter
                     // chain.
-                    return Ok(BlockTemplateResponse::new_internal(
-                        &self.network,
-                        precomputed_coinbase,
-                        miner_params,
-                        &chain_info,
-                        server_long_poll_id,
-                        vec![],
-                        submit_old,
-                    )
-                    .into())
+                    let network = self.network.clone();
+                    let miner_params = miner_params.clone();
+                    let response = tokio::task::spawn_blocking(move || {
+                        BlockTemplateResponse::new_internal(
+                            &network,
+                            precomputed_coinbase,
+                            &miner_params,
+                            &chain_info,
+                            server_long_poll_id,
+                            vec![],
+                            submit_old,
+                        )
+                    })
+                    .await
+                    .expect("block template construction task must complete");
+
+                    return Ok(response.into())
                 }
 
                 // The max time does not elapse during normal operation on mainnet,
@@ -2626,16 +2633,23 @@ where
 
         // - After this point, the template only depends on the previously fetched data.
 
-        Ok(BlockTemplateResponse::new_internal(
-            &self.network,
-            None,
-            miner_params,
-            &chain_info,
-            server_long_poll_id,
-            mempool_txs,
-            submit_old,
-        )
-        .into())
+        let network = self.network.clone();
+        let miner_params = miner_params.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            BlockTemplateResponse::new_internal(
+                &network,
+                None,
+                &miner_params,
+                &chain_info,
+                server_long_poll_id,
+                mempool_txs,
+                submit_old,
+            )
+        })
+        .await
+        .expect("block template construction task must complete");
+
+        Ok(response.into())
     }
 
     async fn submit_block(

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -2562,23 +2562,16 @@ where
                     // Respond instantly with an empty block upon a chain tip change so that
                     // the miner doesn't waste their effort trying to extend a shorter
                     // chain.
-                    let network = self.network.clone();
-                    let miner_params = miner_params.clone();
-                    let response = tokio::task::spawn_blocking(move || {
-                        BlockTemplateResponse::new_internal(
-                            &network,
-                            precomputed_coinbase,
-                            &miner_params,
-                            &chain_info,
-                            server_long_poll_id,
-                            vec![],
-                            submit_old,
-                        )
-                    })
-                    .await
-                    .expect("block template construction task must complete");
-
-                    return Ok(response.into())
+                    return Ok(BlockTemplateResponse::new_internal(
+                        &self.network,
+                        precomputed_coinbase,
+                        miner_params,
+                        &chain_info,
+                        server_long_poll_id,
+                        vec![],
+                        submit_old,
+                    )
+                    .into())
                 }
 
                 // The max time does not elapse during normal operation on mainnet,
@@ -2633,23 +2626,16 @@ where
 
         // - After this point, the template only depends on the previously fetched data.
 
-        let network = self.network.clone();
-        let miner_params = miner_params.clone();
-        let response = tokio::task::spawn_blocking(move || {
-            BlockTemplateResponse::new_internal(
-                &network,
-                None,
-                &miner_params,
-                &chain_info,
-                server_long_poll_id,
-                mempool_txs,
-                submit_old,
-            )
-        })
-        .await
-        .expect("block template construction task must complete");
-
-        Ok(response.into())
+        Ok(BlockTemplateResponse::new_internal(
+            &self.network,
+            None,
+            miner_params,
+            &chain_info,
+            server_long_poll_id,
+            mempool_txs,
+            submit_old,
+        )
+        .into())
     }
 
     async fn submit_block(

--- a/zakura-rpc/src/methods/types/transaction.rs
+++ b/zakura-rpc/src/methods/types/transaction.rs
@@ -32,7 +32,6 @@ use zcash_primitives::transaction::{
     builder::{BuildConfig, Builder},
     fees::fixed::FeeRule,
 };
-use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{consensus::BlockHeight, memo::MemoBytes, value::Zatoshis};
 
 use super::zec::Zec;
@@ -248,14 +247,16 @@ impl TransactionTemplate<NegativeOrZero> {
             builder.add_transparent_output(&fs_addr, fs_amount)?;
         }
 
-        let sapling_prover = LocalTxProver::bundled();
+        // Reuse the process-wide Sapling prover instead of re-parsing the bundled parameters on
+        // every coinbase build.
+        let sapling_prover = zakura_consensus::sapling_prover();
         let build_result = builder.build(
             &Default::default(),
             Default::default(),
             Default::default(),
             OsRng,
-            &sapling_prover,
-            &sapling_prover,
+            sapling_prover,
+            sapling_prover,
             &FeeRule::non_standard(Zatoshis::ZERO),
         )?;
 


### PR DESCRIPTION
## Summary
- parse bundled Sapling proving parameters once per process and share the prover between verification and coinbase construction
- remove per-template prover construction without adding an on-disk parameter cache or new direct dependency

Supersedes #277 with the simplified design from review. Blocking-pool isolation is separately scoped in #292.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zakura-consensus --lib primitives::sapling::tests::sapling_prover_is_reused`
- [x] `cargo test -p zakura-rpc --lib methods::types::get_block_template`
- [x] `cargo clippy -p zakura-consensus -p zakura-rpc --all-targets -- -D warnings`
- [x] `cargo build -p zakura-consensus -p zakura-rpc`