### PR TITLE
fix(network): update deprecated atomic calls

### DIFF
--- a/zakura-network/src/peer/load_tracked_client.rs
+++ b/zakura-network/src/peer/load_tracked_client.rs
@@ -54,7 +54,7 @@ impl From<Client> for LoadTrackedClient {
             service,
             connection_info,
             trace_id: NEXT_PEER_TRACE_ID
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| {
+                .try_update(Ordering::Relaxed, Ordering::Relaxed, |id| {
                     Some(id.saturating_add(1))
                 })
                 .expect("trace ID update succeeds because its closure always returns Some"),

--- a/zakura-network/src/peer_set/legacy_peer_trace.rs
+++ b/zakura-network/src/peer_set/legacy_peer_trace.rs
@@ -56,7 +56,7 @@ impl LegacyPeerTrace {
 
     pub(super) fn next_request_id(&self) -> u64 {
         self.next_request_id
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |id| {
                 Some(id.saturating_add(1))
             })
             .expect("request ID update succeeds because its closure always returns Some")


### PR DESCRIPTION
## Summary
- replace the deprecated `AtomicU64::fetch_update` calls with `try_update`
- restore nightly documentation builds that deny deprecation warnings

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS=\"-D warnings\" cargo check -p zakura-network --all-features`
- [x] `cargo doc --no-deps -p zakura-network --all-features --document-private-items` with documentation warnings denied