### PR TITLE
chore(release): prepare v1.0.2-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-- Ban peers that send mempool transactions with invalid Orchard or Ironwood
-  proof sizes.
-- Parse the bundled Sapling proving parameters once per process and reuse the
-  shared prover, instead of re-parsing the parameters on every
-  `getblocktemplate` refresh.
-- Stop pruned nodes from returning retained chain-index hashes through legacy
-  `getblocks` when the corresponding block bodies are no longer serveable.
-- Add structured legacy peer request traces that attribute `FindBlocks` hash
-  announcements and block download outcomes to privacy-preserving peer IDs,
-  including exact-inventory versus speculative routing and the peer's
-  self-reported handshake height.
-- Reject transactions that do not meet ZIP-317 mempool fee policy before
-  running script and proof checks. Block validation is unchanged.
-- Streamline mempool script error handling so invalid scripts are reported as
-  script verification errors.
+## [1.0.2-rc1] - 2026-07-19
+
+### Added
+
 - Add an opt-in `network.expose_peer_addresses` setting for unredacted legacy
   peer address labels in peer activity logs and metrics
   ([#258](https://github.com/zakura-core/zakura/pull/258)).
+- Add structured legacy peer request traces that attribute `FindBlocks` hash
+  announcements and block download outcomes to privacy-preserving peer IDs,
+  including exact-inventory versus speculative routing and the peer's
+  self-reported handshake height
+  ([#275](https://github.com/zakura-core/zakura/pull/275)).
+- Diagnose requests for pruned block bodies with the block height, hash, and
+  configured retention, rate limited to once per minute
+  ([#279](https://github.com/zakura-core/zakura/pull/279)).
+
+### Changed
+
+- Reject transactions that do not meet ZIP-317 mempool fee policy before
+  running script and proof checks. Block validation is unchanged
+  ([#263](https://github.com/zakura-core/zakura/pull/263)).
+- Parse the bundled Sapling proving parameters once per process and reuse the
+  shared prover, instead of re-parsing the parameters on every
+  `getblocktemplate` refresh
+  ([#291](https://github.com/zakura-core/zakura/pull/291)).
+- Maintain mempool metric totals incrementally instead of rescanning the full
+  mempool after every insertion or removal
+  ([#268](https://github.com/zakura-core/zakura/pull/268)).
+- Point snapshot links and benchmark defaults at the Zakura snapshot service
+  ([#276](https://github.com/zakura-core/zakura/pull/276)).
+
+### Fixed
+
+- Use the consensus proof-of-work limit for early-chain header validation at
+  height 17 ([#220](https://github.com/zakura-core/zakura/pull/220)).
+- Advertise `NODE_NETWORK` to a supervised zcashd-compat sidecar even when
+  Zakura uses pruned storage
+  ([#270](https://github.com/zakura-core/zakura/pull/270)).
+- Report invalid mempool scripts as script verification errors
+  ([#265](https://github.com/zakura-core/zakura/pull/265)).
+- Honor an explicit embedded zcashd-compat source selection even when a stale
+  local binary path remains configured
+  ([#271](https://github.com/zakura-core/zakura/pull/271)).
 - Shut down a managed zcashd-compat process before Zakura exits on SIGINT or
-  SIGTERM.
-- Point snapshot links and benchmark defaults at the Zakura snapshot service.
+  SIGTERM ([#274](https://github.com/zakura-core/zakura/pull/274)).
+- Stop pruned nodes from returning retained chain-index hashes through legacy
+  `getblocks` when the corresponding block bodies are no longer serveable
+  ([#275](https://github.com/zakura-core/zakura/pull/275)).
 - Enable all legacy wallet features by default for supervised zcashd-compat
-  processes, while allowing `-allowdeprecated=none` to disable them all.
-- Preserve failed shielded proof/signature verification errors so they receive
-  the existing mempool peer-misbehaviour score.
+  processes, while allowing `-allowdeprecated=none` to disable them all
+  ([#278](https://github.com/zakura-core/zakura/pull/278)).
+- Avoid penalizing peers that relay NU6.2 branch-ID transactions during the
+  first 40 heights after NU6.3 activation, while keeping consensus validation
+  strict ([#273](https://github.com/zakura-core/zakura/pull/273)).
+- Preserve failed shielded proof and signature verification errors so invalid
+  transactions receive the existing mempool peer misbehavior score
+  ([#283](https://github.com/zakura-core/zakura/pull/283)).
+- Ban peers that send mempool transactions with invalid Orchard or Ironwood
+  proof sizes ([#285](https://github.com/zakura-core/zakura/pull/285)).
 
 ## [1.0.2-rc0] - 2026-07-19
 
@@ -99,8 +133,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   their requests are still shed for backpressure, but the connection is not
   closed. Every other peer's denial-of-service protection is unchanged
   ([#242](https://github.com/zakura-core/zakura/pull/242)).
-- Fixed early-chain header validation to use the consensus proof-of-work limit
-  at height 17.
 
 ## [1.0.1] - 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "1.2.0-rc0"
+version = "1.2.0-rc1"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.2-rc0"
+version = "1.0.2-rc1"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.0.2-rc0 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.2-rc1 zakura
 ```
 
 You can start Zakura by running

--- a/zakura-chain/CHANGELOG.md
+++ b/zakura-chain/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0-rc1] - 2026-07-19
+
+### Changed
+
+- Added test coverage for ZIP-317 unpaid-action rejection in
+  `VerifiedUnminedTx::new`; no APIs defined in this crate changed.
+
 ## [1.2.0-rc0] - 2026-07-19
 
 ### Added

--- a/zakura-chain/Cargo.toml
+++ b/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "1.2.0-rc0"
+version = "1.2.0-rc1"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-consensus/CHANGELOG.md
+++ b/zakura-consensus/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc1] - 2026-07-19
+
+### Added
+
+- Added `sapling_prover()`, re-exported at the crate root, returning the
+  process-wide bundled Sapling prover so callers reuse one parsed copy of the
+  proving parameters.
+- Added `TransactionError::SaplingVerificationFailed` and
+  `TransactionError::Halo2VerificationFailed` variants so failed shielded
+  proof verifications keep their concrete error and mempool misbehavior
+  score.
+
+### Changed
+
+- Mempool transactions must satisfy the ZIP-317 fee policy before script and
+  proof verification runs; block validation is unchanged.
+- Mempool transactions with invalid Orchard or Ironwood proof sizes are
+  rejected before proof verification and the sending peer is banned.
+- Duplicate transparent-spend and duplicate-nullifier mempool errors no
+  longer carry a peer misbehavior penalty.
+- Boxed script and signature verification errors are downcast back to their
+  concrete `TransactionError` variants instead of being reported as internal
+  conversion failures.
+- Mempool rejections of NU6.2 branch-ID transactions no longer penalize the
+  relaying peer during the first 40 heights after NU6.3 activation; consensus
+  validation is unchanged.
+
 ## [3.0.0-rc0] - 2026-07-19
 
 ### Breaking Changes

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -69,9 +69,9 @@ tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0" }
 
 zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc0" }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc1" }
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1" }
 
 zcash_protocol.workspace = true
 
@@ -96,8 +96,8 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc1", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc1] - 2026-07-19
+
 ### Breaking Changes
 
 - Add an opt-in `Config::expose_peer_addresses` field for unredacted legacy

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -93,7 +93,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["async-error"] }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
 
 [dev-dependencies]
@@ -106,7 +106,7 @@ static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]

--- a/zakura-rpc/CHANGELOG.md
+++ b/zakura-rpc/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc1] - 2026-07-19
+
+### Changed
+
+- `getblocktemplate` coinbase construction reuses the process-wide Sapling
+  prover from `zakura-consensus` (requiring 3.0.0-rc1 for `sapling_prover`)
+  instead of re-parsing the bundled proving parameters on every request; no
+  APIs defined in this crate changed.
+
 ## [3.0.0-rc0] - 2026-07-19
 
 ### Breaking Changes

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0" }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc0" }
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1" }
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc1" }
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0", features = [
     "rpc-client",
 ] }
 zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc0" }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc1" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -140,16 +140,16 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc0", features = [
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc1", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc0", features = [
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc1", features = [
     "proptest-impl",
 ] }
 

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc1] - 2026-07-19
+
 ### Changed
 
 - `FindBlockHashes` now returns only the contiguous prefix of block hashes whose
   full bodies are serveable, while other chain-identity reads continue using
   retained indexes after pruning.
+
+### Fixed
+
+- Contextual difficulty validation returns the consensus proof-of-work limit
+  for all candidate heights at or below the averaging window, including
+  height 17 with a full difficulty context.
 
 ## [3.0.0-rc0] - 2026-07-19
 

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "3.0.0-rc0"
+version = "3.0.0-rc1"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -88,7 +88,7 @@ elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -119,7 +119,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.0.2-rc0"
+version = "1.0.2-rc1"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -158,13 +158,13 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1" }
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc0" }
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc1" }
 zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "3.0.0-rc0" }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc0" }
+zakura-rpc = { path = "../zakura-rpc", version = "3.0.0-rc1" }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc1" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -312,10 +312,10 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc0", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "3.0.0-rc1", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "3.0.0-rc1", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "1.0.0" }
 

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_417_400;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_419_500;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -24,8 +24,8 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_417_400;
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
 /// - Currently set to 18 days
 ///
-/// Note: v1.0.2-rc0 spans the expected Ironwood activation (height 3,428,143,
-/// ~2026-07-28) and halts about nine days after it (~2026-08-06, height 3,438,136),
+/// Note: v1.0.2-rc1 spans the expected Ironwood activation (height 3,428,143,
+/// ~2026-07-28) and halts about ten days after it (~2026-08-07, height 3,440,236),
 /// forcing migration to the post-Ironwood release.
 pub const EOS_PANIC_AFTER: u32 = 18;
 

--- a/zakurad/tests/common/configs/v1.0.2-rc1.toml
+++ b/zakurad/tests/common/configs/v1.0.2-rc1.toml
@@ -1,0 +1,151 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+expose_peer_addresses = false
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"


### PR DESCRIPTION
## Motivation

Prepare a GitHub-assets and Docker `v1.0.2-rc1` release candidate from the changes merged since `v1.0.2-rc0`. This rapid RC intentionally does not publish crates.io packages, so existing library crate versions remain unchanged.

## Solution

- Bump only the `zakura` binary package to `1.0.2-rc1`.
- Finalize the root release notes, update the README GitHub install tag, add the generated configuration snapshot, and set the estimated release height to 3,419,500.
- Keep source installer metadata coherently pinned to stable `v1.0.1`; the protected release workflow generates the RC-specific installer asset.
- Use the same rapid-RC checkpoint/frontier waiver as the preceding RC. Mainnet checkpoints remain at height 3,358,006 and the checkpoint/frontier refresh stays in follow up work.

## Testing

- `cargo metadata --no-deps --format-version 1 --locked`
- `CRATE_PACKAGING_VERIFY=1 make pre-release RELEASE_TAG=v1.0.2-rc1 BASE_TAG=v1.0.2-rc0`
  - All 13 crates packaged and compiled successfully.
  - Changed-library version advisories are expected because this RC deliberately skips crates.io publishing.
- `cargo test -p zakura --test acceptance config_tests -- --nocapture`
- `cargo fmt --all -- --check`
- `bash -n scripts/install-zakura.sh`
- `npx --yes markdownlint-cli --disable MD013 MD024 MD033 MD041 -- CHANGELOG.md README.md`
- `git diff --check`

Risk classification: low for this PR because it changes release metadata, release notes, the support height, and a generated config snapshot rather than validation behavior. The underlying code changes were tested before merging to `main`.

### Release Checklist

- [x] Target tag matches the `zakura` package version.
- [x] GitHub-only RC selected; no library crate versions are bumped and no crates.io publication is planned.
- [x] Stored config generated from this release branch and covered by the acceptance test.
- [x] Release notes cover user-visible changes since `v1.0.2-rc0`.
- [x] Source installer assignments remain coherent at stable `v1.0.1`.
- [x] Rapid-RC checkpoint/frontier waiver recorded explicitly.
- [x] `A-release` label applied so no-git-dependencies and Docker release checks run.
- [ ] Wait for required human approval and all enabled CI checks.
- [ ] After merge, obtain explicit operator confirmation before dispatching `create-release.yml` from `main` with `release_tag=v1.0.2-rc1`.

### Specifications & References

- Previous release: `v1.0.2-rc0`
- Release policy: `docs/release-tag-protection.md`
- Canonical checklist: `.github/PULL_REQUEST_TEMPLATE/release-checklist.md`

### Follow-up Work

After merge and explicit operator confirmation, dispatch the protected release workflow, verify the GitHub assets and Docker manifests, handle the generated installer update according to the stable-default policy, replace the boilerplate GitHub release body with these concrete notes, and keep the RC marked as a pre-release. No crate publication is planned.

### AI Disclosure

Prepared with OpenAI Codex for release metadata, generated config, validation, and PR description. All changes were reviewed locally.