### PR TITLE
fix(network): replace nightly-deprecated fetch_update in trace ID counters

### DIFF
--- a/zakura-network/src/peer/load_tracked_client.rs
+++ b/zakura-network/src/peer/load_tracked_client.rs
@@ -53,11 +53,8 @@ impl From<Client> for LoadTrackedClient {
         LoadTrackedClient {
             service,
             connection_info,
-            trace_id: NEXT_PEER_TRACE_ID
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| {
-                    Some(id.saturating_add(1))
-                })
-                .expect("trace ID update succeeds because its closure always returns Some"),
+            // Wrap-around is unreachable for a process-local u64 counter.
+            trace_id: NEXT_PEER_TRACE_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
 }

--- a/zakura-network/src/peer_set/legacy_peer_trace.rs
+++ b/zakura-network/src/peer_set/legacy_peer_trace.rs
@@ -55,11 +55,8 @@ impl LegacyPeerTrace {
     }
 
     pub(super) fn next_request_id(&self) -> u64 {
-        self.next_request_id
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| {
-                Some(id.saturating_add(1))
-            })
-            .expect("request ID update succeeds because its closure always returns Some")
+        // Wrap-around is unreachable for a process-local u64 counter.
+        self.next_request_id.fetch_add(1, Ordering::Relaxed)
     }
 
     pub(super) fn find_blocks_finish(


### PR DESCRIPTION
## Motivation

The Book workflow is failing on main ([run 29712449076](https://github.com/zakura-core/zakura/actions/runs/29712449076)). Its "Build internal docs" job builds the workspace with the `nightly` toolchain and `RUSTDOCFLAGS: -D warnings`, and current nightly (1.99.0-nightly) deprecates `Atomic*::fetch_update` (renamed to `try_update`). The workspace has two `fetch_update` call sites — the trace ID counters in `zakura-network/src/peer_set/legacy_peer_trace.rs` and `zakura-network/src/peer/load_tracked_client.rs` — so the denied deprecation warning fails the docs build. Stable jobs (Lint, tests) still pass because the deprecation has not reached stable yet.

## Solution

Replace both counters with `fetch_add(1, Ordering::Relaxed)`. Nightly's suggested `try_update` is not usable here: it only stabilized in Rust 1.95, and the MSRV job pins 1.91.

Both `fetch_update` closures unconditionally returned `Some(id.saturating_add(1))`, so they were plain atomic increments; `fetch_add` returns the same previous value. The only semantic difference is at `u64::MAX` (wrap instead of saturate), which is unreachable for process-local counters that start at 1.

## Testing

- `RUSTDOCFLAGS="-D warnings -A rustdoc::private_intra_doc_links" cargo +nightly doc --no-deps -p zakura-network --document-private-items` passes on nightly 1.99.0 (2026-07-19, same generation as CI's), which reproduces the failing job's deny-warnings docs build against the fixed code.
- `cargo clippy -p zakura-network --all-targets -- -D warnings` passes.
- `cargo test -p zakura-network --release --lib -- legacy_peer_trace load_tracked` passes (2 tests), covering the trace events built on the changed request ID counter.

Note: the Book workflow only triggers on pushes to `main`, so it does not run on this PR — the local nightly docs build above is the pre-merge verification; the job itself re-runs on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)