### PR TITLE
refactor(network): validate aligned header range payloads

### DIFF
--- a/zakura-network/src/zakura/header_sync/error.rs
+++ b/zakura-network/src/zakura/header_sync/error.rs
@@ -48,6 +48,17 @@ pub enum HeaderSyncWireError {
         max: usize,
     },
 
+    /// A locally constructed non-empty range had a zero count or overflowing endpoint.
+    #[error(
+        "Zakura header-sync range starting at {start:?} has invalid or overflowing count {count}"
+    )]
+    InvalidRangeGeometry {
+        /// First requested or delivered height.
+        start: block::Height,
+        /// Number of heights.
+        count: u32,
+    },
+
     /// A locally constructed `Headers` message had a different number of size hints.
     #[error("Zakura header-sync Headers body-size count {body_sizes} does not match header count {headers}")]
     BodySizeCountMismatch {

--- a/zakura-network/src/zakura/header_sync/events.rs
+++ b/zakura-network/src/zakura/header_sync/events.rs
@@ -395,14 +395,8 @@ pub enum HeaderSyncAction {
         operation: HeaderSyncOperationIdentity,
         /// Parent anchor hash for the first header.
         anchor: block::Hash,
-        /// First header height.
-        start_height: block::Height,
-        /// Headers to commit. This is an output payload, not reactor state.
-        headers: Vec<Arc<block::Header>>,
-        /// Advisory serialized body sizes, parallel to `headers`.
-        body_sizes: Vec<u32>,
-        /// Per-height commitment roots, parallel to `headers`.
-        tree_aux_roots: Vec<BlockCommitmentRoots>,
+        /// Checked headers and aligned per-height data to commit.
+        payload: HeaderRangePayload,
         /// Whether the range is expected to be finalized by checkpoint policy.
         finalized: bool,
     },

--- a/zakura-network/src/zakura/header_sync/mod.rs
+++ b/zakura-network/src/zakura/header_sync/mod.rs
@@ -32,6 +32,7 @@ mod config;
 mod error;
 mod events;
 mod pipe;
+mod range;
 mod reactor;
 mod requester;
 mod service;
@@ -53,6 +54,7 @@ pub use events::{
     HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMisbehavior, HeaderSyncOperationIdentity,
     HeaderSyncOperationKind, HeaderSyncRequestId, HeaderSyncStartup, HeaderSyncWireRequestIdentity,
 };
+pub use range::{CheckedHeaderRange, HeaderRangePayload};
 pub use reactor::spawn_header_sync_reactor;
 pub use service::HeaderSyncPeerSession;
 pub(crate) use service::{

--- a/zakura-network/src/zakura/header_sync/range.rs
+++ b/zakura-network/src/zakura/header_sync/range.rs
@@ -45,11 +45,6 @@ impl CheckedHeaderRange {
             .expect("checked range bounds are ascending")
     }
 
-    /// Return the part of this range through `included_end`.
-    pub fn prefix_through(self, included_end: block::Height) -> Option<Self> {
-        Self::from_bounds(self.start, self.end.min(included_end))
-    }
-
     /// Return the part of this range strictly after `covered_through`.
     pub fn suffix_after(self, covered_through: block::Height) -> Option<Self> {
         if covered_through < self.start {
@@ -137,19 +132,6 @@ impl HeaderRangePayload {
         Some(self)
     }
 
-    /// Keep only the part of this payload through `included_end`.
-    pub fn prefix_through(mut self, included_end: block::Height) -> Option<Self> {
-        let prefix = self.range.prefix_through(included_end)?;
-        let retained_count = usize::try_from(prefix.count()).expect("payload length fits in usize");
-        self.headers.truncate(retained_count);
-        self.body_sizes.truncate(retained_count);
-        if let Some(roots) = self.tree_aux_roots.as_mut() {
-            roots.truncate(retained_count);
-        }
-        self.range = prefix;
-        Some(self)
-    }
-
     /// Consume this payload into state request parts.
     pub fn into_parts(
         self,
@@ -199,10 +181,6 @@ mod tests {
         assert_eq!(suffix.end(), block::Height(u32::MAX));
         assert_eq!(suffix.count(), 1);
         assert_eq!(suffix.suffix_after(block::Height(u32::MAX)), None);
-        assert_eq!(
-            range.prefix_through(block::Height(u32::MAX - 1)),
-            CheckedHeaderRange::from_count(block::Height(u32::MAX - 1), 1)
-        );
     }
 
     #[test]

--- a/zakura-network/src/zakura/header_sync/range.rs
+++ b/zakura-network/src/zakura/header_sync/range.rs
@@ -1,0 +1,221 @@
+use super::{
+    error::HeaderSyncWireError,
+    validation::{
+        validate_body_sizes_len, validate_tree_aux_root_heights, validate_tree_aux_roots_len,
+    },
+    *,
+};
+
+/// A non-empty inclusive header-height range whose endpoint cannot overflow.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct CheckedHeaderRange {
+    start: block::Height,
+    end: block::Height,
+}
+
+impl CheckedHeaderRange {
+    /// Construct a checked range from its first height and non-zero count.
+    pub fn from_count(start: block::Height, count: u32) -> Option<Self> {
+        let offset = count.checked_sub(1)?;
+        let end = start.0.checked_add(offset).map(block::Height)?;
+        Some(Self { start, end })
+    }
+
+    /// Construct a non-empty checked range from inclusive bounds.
+    pub fn from_bounds(start: block::Height, end: block::Height) -> Option<Self> {
+        (start <= end).then_some(Self { start, end })
+    }
+
+    /// Return the first height.
+    pub fn start(self) -> block::Height {
+        self.start
+    }
+
+    /// Return the inclusive final height.
+    pub fn end(self) -> block::Height {
+        self.end
+    }
+
+    /// Return the number of heights.
+    pub fn count(self) -> u32 {
+        self.end
+            .0
+            .checked_sub(self.start.0)
+            .and_then(|difference| difference.checked_add(1))
+            .expect("checked range bounds are ascending")
+    }
+
+    /// Return the part of this range through `included_end`.
+    pub fn prefix_through(self, included_end: block::Height) -> Option<Self> {
+        Self::from_bounds(self.start, self.end.min(included_end))
+    }
+
+    /// Return the part of this range strictly after `covered_through`.
+    pub fn suffix_after(self, covered_through: block::Height) -> Option<Self> {
+        if covered_through < self.start {
+            return Some(self);
+        }
+        let start = covered_through.0.checked_add(1).map(block::Height)?;
+        Self::from_bounds(start, self.end)
+    }
+}
+
+/// A non-empty delivered header range with structurally aligned per-height data.
+#[derive(Clone, Debug)]
+pub struct HeaderRangePayload {
+    range: CheckedHeaderRange,
+    headers: Vec<Arc<block::Header>>,
+    body_sizes: Vec<u32>,
+    tree_aux_roots: Option<Vec<BlockCommitmentRoots>>,
+}
+
+impl HeaderRangePayload {
+    /// Validate and construct an aligned payload.
+    pub fn new(
+        start: block::Height,
+        headers: Vec<Arc<block::Header>>,
+        body_sizes: Vec<u32>,
+        tree_aux_roots: Option<Vec<BlockCommitmentRoots>>,
+    ) -> Result<Self, HeaderSyncWireError> {
+        validate_body_sizes_len(headers.len(), body_sizes.len())?;
+        if let Some(roots) = tree_aux_roots.as_ref() {
+            validate_tree_aux_roots_len(headers.len(), roots.len())?;
+            validate_tree_aux_root_heights(start, roots)?;
+        }
+
+        let count =
+            u32::try_from(headers.len()).map_err(|_| HeaderSyncWireError::HeaderCountLimit {
+                actual: headers.len(),
+                max: usize::try_from(u32::MAX).unwrap_or(usize::MAX),
+            })?;
+        let range = CheckedHeaderRange::from_count(start, count)
+            .ok_or(HeaderSyncWireError::InvalidRangeGeometry { start, count })?;
+
+        Ok(Self {
+            range,
+            headers,
+            body_sizes,
+            tree_aux_roots,
+        })
+    }
+
+    /// Return the delivered height range.
+    pub fn range(&self) -> CheckedHeaderRange {
+        self.range
+    }
+
+    /// Return the delivered headers.
+    pub fn headers(&self) -> &[Arc<block::Header>] {
+        &self.headers
+    }
+
+    /// Return the aligned body-size hints.
+    pub fn body_sizes(&self) -> &[u32] {
+        &self.body_sizes
+    }
+
+    /// Return the aligned roots when the request asked for them.
+    pub fn tree_aux_roots(&self) -> Option<&[BlockCommitmentRoots]> {
+        self.tree_aux_roots.as_deref()
+    }
+
+    /// Keep only the part of this payload strictly after `covered_through`.
+    pub fn suffix_after(mut self, covered_through: block::Height) -> Option<Self> {
+        let suffix = self.range.suffix_after(covered_through)?;
+        if suffix == self.range {
+            return Some(self);
+        }
+
+        let covered_count = usize::try_from(suffix.start().0 - self.range.start().0)
+            .expect("payload length fits in usize");
+        self.headers = self.headers.split_off(covered_count);
+        self.body_sizes = self.body_sizes.split_off(covered_count);
+        if let Some(roots) = self.tree_aux_roots.as_mut() {
+            *roots = roots.split_off(covered_count);
+        }
+        self.range = suffix;
+        Some(self)
+    }
+
+    /// Keep only the part of this payload through `included_end`.
+    pub fn prefix_through(mut self, included_end: block::Height) -> Option<Self> {
+        let prefix = self.range.prefix_through(included_end)?;
+        let retained_count = usize::try_from(prefix.count()).expect("payload length fits in usize");
+        self.headers.truncate(retained_count);
+        self.body_sizes.truncate(retained_count);
+        if let Some(roots) = self.tree_aux_roots.as_mut() {
+            roots.truncate(retained_count);
+        }
+        self.range = prefix;
+        Some(self)
+    }
+
+    /// Consume this payload into state request parts.
+    pub fn into_parts(
+        self,
+    ) -> (
+        CheckedHeaderRange,
+        Vec<Arc<block::Header>>,
+        Vec<u32>,
+        Option<Vec<BlockCommitmentRoots>>,
+    ) {
+        (
+            self.range,
+            self.headers,
+            self.body_sizes,
+            self.tree_aux_roots,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_range_rejects_empty_reversed_and_overflowing_geometry() {
+        assert_eq!(CheckedHeaderRange::from_count(block::Height(1), 0), None);
+        assert_eq!(
+            CheckedHeaderRange::from_count(block::Height(u32::MAX), 2),
+            None
+        );
+        assert_eq!(
+            CheckedHeaderRange::from_bounds(block::Height(2), block::Height(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn checked_range_suffix_preserves_maximum_height() {
+        let range =
+            CheckedHeaderRange::from_bounds(block::Height(u32::MAX - 1), block::Height(u32::MAX))
+                .expect("bounds are ascending");
+
+        let suffix = range
+            .suffix_after(block::Height(u32::MAX - 1))
+            .expect("maximum height remains");
+
+        assert_eq!(suffix.start(), block::Height(u32::MAX));
+        assert_eq!(suffix.end(), block::Height(u32::MAX));
+        assert_eq!(suffix.count(), 1);
+        assert_eq!(suffix.suffix_after(block::Height(u32::MAX)), None);
+        assert_eq!(
+            range.prefix_through(block::Height(u32::MAX - 1)),
+            CheckedHeaderRange::from_count(block::Height(u32::MAX - 1), 1)
+        );
+    }
+
+    #[test]
+    fn payload_rejects_misaligned_body_sizes_before_buffering() {
+        let error = HeaderRangePayload::new(block::Height(1), Vec::new(), vec![1], None)
+            .expect_err("body sizes must align with headers");
+
+        assert!(matches!(
+            error,
+            HeaderSyncWireError::BodySizeCountMismatch {
+                headers: 0,
+                body_sizes: 1,
+            }
+        ));
+    }
+}

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1717,13 +1717,13 @@ impl HeaderSyncReactor {
 
         if header_count < outstanding.range.count() {
             let original = outstanding.range;
-            outstanding.range.geometry = payload.range();
+            outstanding.range.range = payload.range();
             self.state
                 .schedule
                 .narrow_queued_range(original, outstanding.range);
             if let Some(suffix_start) = height_after_count(original.start_height(), header_count) {
                 let suffix = RangeRequest {
-                    geometry: CheckedHeaderRange::from_count(
+                    range: CheckedHeaderRange::from_count(
                         suffix_start,
                         original.count().saturating_sub(header_count),
                     )
@@ -2232,13 +2232,13 @@ impl HeaderSyncReactor {
             self.startup.max_frame_bytes,
             range.want_tree_aux_roots,
         );
-        range.geometry = CheckedHeaderRange::from_count(range.start_height(), count)
+        range.range = CheckedHeaderRange::from_count(range.start_height(), count)
             .expect("clamped request count is non-zero and within the original range");
         if count < original_range.count() {
             if let Some(suffix_start) = height_after_count(range.start_height(), count) {
                 self.state.schedule.ensure(
                     RangeRequest {
-                        geometry: CheckedHeaderRange::from_count(
+                        range: CheckedHeaderRange::from_count(
                             suffix_start,
                             original_range.count().saturating_sub(count),
                         )

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -286,7 +286,7 @@ impl HeaderSyncReactor {
                         if let Some(outstanding) = outstanding {
                             self.retry_failed_publication(
                                 &requester_id.peer,
-                                outstanding.range,
+                                outstanding.range_request,
                                 outstanding.purpose,
                             );
                         }
@@ -1501,7 +1501,7 @@ impl HeaderSyncReactor {
             self.schedule().await;
             return;
         }
-        if !outstanding.range.want_tree_aux_roots && !tree_aux_roots.is_empty() {
+        if !outstanding.range_request.want_tree_aux_roots && !tree_aux_roots.is_empty() {
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::MalformedMessage)
                 .await;
             self.retry_or_finish_outstanding(&peer, outstanding);
@@ -1520,12 +1520,12 @@ impl HeaderSyncReactor {
             let deadline = Instant::now() + self.empty_headers_retry_delay();
             self.trace_headers_received(
                 &peer,
-                outstanding.range.start_height(),
+                outstanding.range_request.start_height(),
                 0,
-                outstanding.range.count(),
+                outstanding.range_request.count(),
                 peer_max_headers_per_response,
                 in_flight_count,
-                outstanding.range.want_tree_aux_roots,
+                outstanding.range_request.want_tree_aux_roots,
                 &tree_aux_roots,
             );
             if let Some(peer_state) = self.state.peers.get_mut(&peer) {
@@ -1542,15 +1542,15 @@ impl HeaderSyncReactor {
             u32::try_from(headers.len()).expect("decoded Headers length is capped by u32");
         self.trace_headers_received(
             &peer,
-            outstanding.range.start_height(),
+            outstanding.range_request.start_height(),
             header_count,
-            outstanding.range.count(),
+            outstanding.range_request.count(),
             peer_max_headers_per_response,
             in_flight_count,
-            outstanding.range.want_tree_aux_roots,
+            outstanding.range_request.want_tree_aux_roots,
             &tree_aux_roots,
         );
-        if header_count > outstanding.range.count() {
+        if header_count > outstanding.range_request.count() {
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::ResponseTooLong)
                 .await;
             self.retry_or_finish_outstanding(&peer, outstanding);
@@ -1564,7 +1564,7 @@ impl HeaderSyncReactor {
             tracing::debug!(
                 ?peer,
                 ?reason,
-                start_height = ?outstanding.range.start_height(),
+                start_height = ?outstanding.range_request.start_height(),
                 count = header_count,
                 "Zakura header-sync rejected VCT root repair response"
             );
@@ -1585,40 +1585,40 @@ impl HeaderSyncReactor {
         let validation_context = HeaderSyncValidationContext {
             network: &self.startup.network,
             now: Utc::now(),
-            start_height: outstanding.range.start_height(),
+            start_height: outstanding.range_request.start_height(),
             decode_context: HeaderSyncDecodeContext::for_headers_response(
                 ExpectedHeadersResponse::new(
                     outstanding.wire_request.request_id,
-                    outstanding.range.start_height(),
-                    outstanding.range.count(),
-                    outstanding.range.want_tree_aux_roots,
+                    outstanding.range_request.start_height(),
+                    outstanding.range_request.count(),
+                    outstanding.range_request.want_tree_aux_roots,
                 )
                 .expect("outstanding range uses a non-zero bounded count"),
-                outstanding.range.count(),
+                outstanding.range_request.count(),
             ),
         };
         let validation_anchor = outstanding
-            .range
+            .range_request
             .anchor_hash
             .unwrap_or(headers[0].previous_block_hash);
         if let Err(error) = validate_header_range_links(validation_anchor, &headers) {
             debug!(
                 ?peer,
                 ?error,
-                anchor_hash = ?outstanding.range.anchor_hash,
-                start_height = ?outstanding.range.start_height(),
+                anchor_hash = ?outstanding.range_request.anchor_hash,
+                start_height = ?outstanding.range_request.start_height(),
                 count = ?header_count,
                 "Zakura header-sync rejected header range links"
             );
             self.trace_range_validation_rejected(
                 &peer,
-                outstanding.range,
+                outstanding.range_request,
                 header_count,
                 "link",
                 header_sync_wire_error_kind(&error),
             );
             if self
-                .handle_possible_stale_anchor_link_failure(&peer, outstanding.range, &error)
+                .handle_possible_stale_anchor_link_failure(&peer, outstanding.range_request, &error)
                 .await
             {
                 self.schedule().await;
@@ -1631,18 +1631,18 @@ impl HeaderSyncReactor {
             return;
         }
         if let Err(error) =
-            validate_tree_aux_root_heights(outstanding.range.start_height(), &tree_aux_roots)
+            validate_tree_aux_root_heights(outstanding.range_request.start_height(), &tree_aux_roots)
         {
             tracing::debug!(
                 ?peer,
                 ?error,
-                start_height = ?outstanding.range.start_height(),
+                start_height = ?outstanding.range_request.start_height(),
                 count = ?header_count,
                 "Zakura header-sync rejected tree-aux root heights"
             );
             self.trace_range_validation_rejected(
                 &peer,
-                outstanding.range,
+                outstanding.range_request,
                 header_count,
                 "tree_aux_heights",
                 header_sync_wire_error_kind(&error),
@@ -1658,13 +1658,13 @@ impl HeaderSyncReactor {
             debug!(
                 ?peer,
                 ?error,
-                start_height = ?outstanding.range.start_height(),
+                start_height = ?outstanding.range_request.start_height(),
                 count = ?header_count,
                 "Zakura header-sync rejected stateless header range"
             );
             self.trace_range_validation_rejected(
                 &peer,
-                outstanding.range,
+                outstanding.range_request,
                 header_count,
                 "stateless",
                 header_sync_wire_error_kind(&error),
@@ -1677,17 +1677,17 @@ impl HeaderSyncReactor {
         }
 
         let payload = HeaderRangePayload::new(
-            outstanding.range.start_height(),
+            outstanding.range_request.start_height(),
             headers,
             body_sizes,
             outstanding
-                .range
+                .range_request
                 .want_tree_aux_roots
                 .then_some(tree_aux_roots),
         )
         .expect("validated non-empty response has checked aligned payload data");
         let end_height = payload.range().end();
-        if outstanding.range.finalized {
+        if outstanding.range_request.finalized {
             let last_hash = payload
                 .headers()
                 .last()
@@ -1702,7 +1702,7 @@ impl HeaderSyncReactor {
             if checkpoint_mismatch {
                 self.trace_range_validation_rejected(
                     &peer,
-                    outstanding.range,
+                    outstanding.range_request,
                     header_count,
                     "checkpoint",
                     "checkpoint_hash_mismatch",
@@ -1715,12 +1715,12 @@ impl HeaderSyncReactor {
             }
         }
 
-        if header_count < outstanding.range.count() {
-            let original = outstanding.range;
-            outstanding.range.range = payload.range();
+        if header_count < outstanding.range_request.count() {
+            let original = outstanding.range_request;
+            outstanding.range_request.range = payload.range();
             self.state
                 .schedule
-                .narrow_queued_range(original, outstanding.range);
+                .narrow_queued_range(original, outstanding.range_request);
             if let Some(suffix_start) = height_after_count(original.start_height(), header_count) {
                 let suffix = RangeRequest {
                     range: CheckedHeaderRange::from_count(
@@ -1740,16 +1740,16 @@ impl HeaderSyncReactor {
             }
         }
 
-        if outstanding.range.priority != RangePriority::Repair {
+        if outstanding.range_request.priority != RangePriority::Repair {
             self.state
                 .schedule
-                .mark_buffered(peer.clone(), outstanding.range);
+                .mark_buffered(peer.clone(), outstanding.range_request);
         }
         self.state.buffered.insert(
-            (outstanding.range.priority, outstanding.range.start_height()),
+            (outstanding.range_request.priority, outstanding.range_request.start_height()),
             BufferedHeaderRange {
                 wire_request: outstanding.wire_request,
-                range: outstanding.range,
+                range: outstanding.range_request,
                 purpose: outstanding.purpose,
                 payload,
             },
@@ -1965,7 +1965,7 @@ impl HeaderSyncReactor {
             RangePurpose::Sync => self
                 .state
                 .schedule
-                .retry_avoiding(peer.clone(), outstanding.range),
+                .retry_avoiding(peer.clone(), outstanding.range_request),
             RangePurpose::VctRepair { generation, .. } => {
                 self.finish_vct_repair_attempt(peer, generation)
             }
@@ -2088,11 +2088,11 @@ impl HeaderSyncReactor {
             match outstanding.purpose {
                 RangePurpose::Sync => {
                     if outstanding.phase == OutstandingPhase::EmptyRetry {
-                        self.state.schedule.clear_assignment(outstanding.range);
+                        self.state.schedule.clear_assignment(outstanding.range_request);
                     }
                     self.state
                         .schedule
-                        .retry_avoiding(peer.clone(), outstanding.range);
+                        .retry_avoiding(peer.clone(), outstanding.range_request);
                 }
                 RangePurpose::VctRepair { generation, .. } => {
                     metrics::counter!("sync.header.vct_repair.timeout").increment(1);
@@ -2298,7 +2298,7 @@ impl HeaderSyncReactor {
         };
         let outstanding = OutstandingRange {
             wire_request: wire_request.clone(),
-            range,
+            range_request: range,
             deadline: Instant::now() + self.startup.request_timeout,
             purpose,
             phase: OutstandingPhase::Publishing,
@@ -2747,7 +2747,7 @@ impl HeaderSyncReactor {
                 if self
                     .state
                     .schedule
-                    .is_covered(peer.outstanding[index].range)
+                    .is_covered(peer.outstanding[index].range_request)
                     && matches!(peer.outstanding[index].purpose, RangePurpose::Sync)
                 {
                     let outstanding = peer.outstanding.remove(index);
@@ -2777,15 +2777,15 @@ impl HeaderSyncReactor {
             while index < peer.outstanding.len() {
                 let outstanding = &peer.outstanding[index];
                 if matches!(outstanding.purpose, RangePurpose::Sync)
-                    && outstanding.range.priority == RangePriority::Forward
-                    && outstanding.range.start_height() <= height
+                    && outstanding.range_request.priority == RangePriority::Forward
+                    && outstanding.range_request.start_height() <= height
                 {
                     let outstanding = peer.outstanding.remove(index);
                     let _ = peer
                         .session
                         .retire_expected_headers(outstanding.wire_request.request_id);
-                    self.state.schedule.clear_assignment(outstanding.range);
-                    if let Some(suffix) = outstanding.range.suffix_after(height, hash) {
+                    self.state.schedule.clear_assignment(outstanding.range_request);
+                    if let Some(suffix) = outstanding.range_request.suffix_after(height, hash) {
                         self.state.schedule.ensure_forward(suffix);
                     }
                     metrics::counter!(
@@ -2846,7 +2846,7 @@ impl HeaderSyncReactor {
         for peer in self.state.peers.values_mut() {
             let mut index = 0;
             while index < peer.outstanding.len() {
-                if peer.outstanding[index].range.priority == RangePriority::Forward {
+                if peer.outstanding[index].range_request.priority == RangePriority::Forward {
                     let outstanding = peer.outstanding.remove(index);
                     let _ = peer
                         .session

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1630,9 +1630,10 @@ impl HeaderSyncReactor {
             self.schedule().await;
             return;
         }
-        if let Err(error) =
-            validate_tree_aux_root_heights(outstanding.range_request.start_height(), &tree_aux_roots)
-        {
+        if let Err(error) = validate_tree_aux_root_heights(
+            outstanding.range_request.start_height(),
+            &tree_aux_roots,
+        ) {
             tracing::debug!(
                 ?peer,
                 ?error,
@@ -1746,7 +1747,10 @@ impl HeaderSyncReactor {
                 .mark_buffered(peer.clone(), outstanding.range_request);
         }
         self.state.buffered.insert(
-            (outstanding.range_request.priority, outstanding.range_request.start_height()),
+            (
+                outstanding.range_request.priority,
+                outstanding.range_request.start_height(),
+            ),
             BufferedHeaderRange {
                 wire_request: outstanding.wire_request,
                 range: outstanding.range_request,
@@ -2088,7 +2092,9 @@ impl HeaderSyncReactor {
             match outstanding.purpose {
                 RangePurpose::Sync => {
                     if outstanding.phase == OutstandingPhase::EmptyRetry {
-                        self.state.schedule.clear_assignment(outstanding.range_request);
+                        self.state
+                            .schedule
+                            .clear_assignment(outstanding.range_request);
                     }
                     self.state
                         .schedule
@@ -2784,7 +2790,9 @@ impl HeaderSyncReactor {
                     let _ = peer
                         .session
                         .retire_expected_headers(outstanding.wire_request.request_id);
-                    self.state.schedule.clear_assignment(outstanding.range_request);
+                    self.state
+                        .schedule
+                        .clear_assignment(outstanding.range_request);
                     if let Some(suffix) = outstanding.range_request.suffix_after(height, hash) {
                         self.state.schedule.ensure_forward(suffix);
                     }

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -257,7 +257,7 @@ impl HeaderSyncReactor {
                         self.trace_get_headers_sent(
                             &requester_id.peer,
                             range,
-                            range.count,
+                            range.count(),
                             peer_cap,
                             GetHeadersTraceMeta {
                                 request_id,
@@ -270,8 +270,8 @@ impl HeaderSyncReactor {
                             peer: requester_id.peer,
                             request_id: Some(request_id),
                             msg: HeaderSyncMessage::GetHeaders {
-                                start_height: range.start_height,
-                                count: range.count,
+                                start_height: range.start_height(),
+                                count: range.count(),
                                 want_tree_aux_roots: range.want_tree_aux_roots,
                             },
                         });
@@ -991,7 +991,7 @@ impl HeaderSyncReactor {
         tracing::warn!(
             ?height,
             generation,
-            count = repair.range.count,
+            count = repair.range.count(),
             "scheduling bounded VCT supplied-root repair"
         );
         metrics::counter!("sync.header.vct_repair.requested").increment(1);
@@ -1042,7 +1042,7 @@ impl HeaderSyncReactor {
             return;
         };
         let range = pending.range;
-        let start_height = range.start_height;
+        let start_height = range.start_height();
         let tip_height = range.end_height();
         metrics::counter!("sync.header.range.committed").increment(1);
         self.trace_range_event(
@@ -1094,8 +1094,8 @@ impl HeaderSyncReactor {
         };
         let range = pending.range;
         let peer = operation.wire_request.peer;
-        let start_height = range.start_height;
-        let count = range.count;
+        let start_height = range.start_height();
+        let count = range.count();
         metrics::counter!("sync.header.range.rejected").increment(1);
         self.trace_range_event(
             hs_trace::HEADER_RANGE_REJECTED,
@@ -1109,7 +1109,7 @@ impl HeaderSyncReactor {
                 .await;
         }
         if range.priority == RangePriority::Forward
-            && range.start_height <= self.state.best_header_tip
+            && range.start_height() <= self.state.best_header_tip
         {
             let suffix =
                 range.suffix_after(self.state.best_header_tip, self.state.best_header_hash);
@@ -1520,9 +1520,9 @@ impl HeaderSyncReactor {
             let deadline = Instant::now() + self.empty_headers_retry_delay();
             self.trace_headers_received(
                 &peer,
-                outstanding.range.start_height,
+                outstanding.range.start_height(),
                 0,
-                outstanding.range.count,
+                outstanding.range.count(),
                 peer_max_headers_per_response,
                 in_flight_count,
                 outstanding.range.want_tree_aux_roots,
@@ -1542,15 +1542,15 @@ impl HeaderSyncReactor {
             u32::try_from(headers.len()).expect("decoded Headers length is capped by u32");
         self.trace_headers_received(
             &peer,
-            outstanding.range.start_height,
+            outstanding.range.start_height(),
             header_count,
-            outstanding.range.count,
+            outstanding.range.count(),
             peer_max_headers_per_response,
             in_flight_count,
             outstanding.range.want_tree_aux_roots,
             &tree_aux_roots,
         );
-        if header_count > outstanding.range.count {
+        if header_count > outstanding.range.count() {
             self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::ResponseTooLong)
                 .await;
             self.retry_or_finish_outstanding(&peer, outstanding);
@@ -1564,7 +1564,7 @@ impl HeaderSyncReactor {
             tracing::debug!(
                 ?peer,
                 ?reason,
-                start_height = ?outstanding.range.start_height,
+                start_height = ?outstanding.range.start_height(),
                 count = header_count,
                 "Zakura header-sync rejected VCT root repair response"
             );
@@ -1585,16 +1585,16 @@ impl HeaderSyncReactor {
         let validation_context = HeaderSyncValidationContext {
             network: &self.startup.network,
             now: Utc::now(),
-            start_height: outstanding.range.start_height,
+            start_height: outstanding.range.start_height(),
             decode_context: HeaderSyncDecodeContext::for_headers_response(
                 ExpectedHeadersResponse::new(
                     outstanding.wire_request.request_id,
-                    outstanding.range.start_height,
-                    outstanding.range.count,
+                    outstanding.range.start_height(),
+                    outstanding.range.count(),
                     outstanding.range.want_tree_aux_roots,
                 )
                 .expect("outstanding range uses a non-zero bounded count"),
-                outstanding.range.count,
+                outstanding.range.count(),
             ),
         };
         let validation_anchor = outstanding
@@ -1606,7 +1606,7 @@ impl HeaderSyncReactor {
                 ?peer,
                 ?error,
                 anchor_hash = ?outstanding.range.anchor_hash,
-                start_height = ?outstanding.range.start_height,
+                start_height = ?outstanding.range.start_height(),
                 count = ?header_count,
                 "Zakura header-sync rejected header range links"
             );
@@ -1631,12 +1631,12 @@ impl HeaderSyncReactor {
             return;
         }
         if let Err(error) =
-            validate_tree_aux_root_heights(outstanding.range.start_height, &tree_aux_roots)
+            validate_tree_aux_root_heights(outstanding.range.start_height(), &tree_aux_roots)
         {
             tracing::debug!(
                 ?peer,
                 ?error,
-                start_height = ?outstanding.range.start_height,
+                start_height = ?outstanding.range.start_height(),
                 count = ?header_count,
                 "Zakura header-sync rejected tree-aux root heights"
             );
@@ -1658,7 +1658,7 @@ impl HeaderSyncReactor {
             debug!(
                 ?peer,
                 ?error,
-                start_height = ?outstanding.range.start_height,
+                start_height = ?outstanding.range.start_height(),
                 count = ?header_count,
                 "Zakura header-sync rejected stateless header range"
             );
@@ -1676,13 +1676,23 @@ impl HeaderSyncReactor {
             return;
         }
 
-        let end_height = range_end_height(outstanding.range.start_height, header_count)
-            .expect("non-empty bounded range has an end height");
+        let payload = HeaderRangePayload::new(
+            outstanding.range.start_height(),
+            headers,
+            body_sizes,
+            outstanding
+                .range
+                .want_tree_aux_roots
+                .then_some(tree_aux_roots),
+        )
+        .expect("validated non-empty response has checked aligned payload data");
+        let end_height = payload.range().end();
         if outstanding.range.finalized {
-            let last_hash = headers
+            let last_hash = payload
+                .headers()
                 .last()
                 .map(|header| block::Hash::from(header.as_ref()))
-                .expect("headers is non-empty");
+                .expect("payload is non-empty");
             let checkpoint_mismatch = self
                 .startup
                 .network
@@ -1705,17 +1715,21 @@ impl HeaderSyncReactor {
             }
         }
 
-        if header_count < outstanding.range.count {
+        if header_count < outstanding.range.count() {
             let original = outstanding.range;
-            outstanding.range.count = header_count;
+            outstanding.range.geometry = payload.range();
             self.state
                 .schedule
                 .narrow_queued_range(original, outstanding.range);
-            if let Some(suffix_start) = height_after_count(original.start_height, header_count) {
+            if let Some(suffix_start) = height_after_count(original.start_height(), header_count) {
                 let suffix = RangeRequest {
-                    start_height: suffix_start,
-                    count: original.count.saturating_sub(header_count),
-                    anchor_hash: headers
+                    geometry: CheckedHeaderRange::from_count(
+                        suffix_start,
+                        original.count().saturating_sub(header_count),
+                    )
+                    .expect("short response leaves a checked non-empty suffix"),
+                    anchor_hash: payload
+                        .headers()
                         .last()
                         .map(|header| block::Hash::from(header.as_ref())),
                     ..original
@@ -1732,14 +1746,12 @@ impl HeaderSyncReactor {
                 .mark_buffered(peer.clone(), outstanding.range);
         }
         self.state.buffered.insert(
-            (outstanding.range.priority, outstanding.range.start_height),
+            (outstanding.range.priority, outstanding.range.start_height()),
             BufferedHeaderRange {
                 wire_request: outstanding.wire_request,
                 range: outstanding.range,
                 purpose: outstanding.purpose,
-                headers,
-                body_sizes,
-                tree_aux_roots,
+                payload,
             },
         );
         metrics::counter!("sync.header.work.buffered").increment(1);
@@ -1758,10 +1770,9 @@ impl HeaderSyncReactor {
                 return;
             };
 
-            let invalid =
-                self.state.buffered.get(&key).and_then(|buffered| {
-                    validate_header_range_links(anchor, &buffered.headers).err()
-                });
+            let invalid = self.state.buffered.get(&key).and_then(|buffered| {
+                validate_header_range_links(anchor, buffered.payload.headers()).err()
+            });
             if let Some(error) = invalid {
                 let buffered = self
                     .state
@@ -1771,7 +1782,8 @@ impl HeaderSyncReactor {
                 if let (Some(suffix_start), Some(suffix_anchor)) = (
                     next_height(buffered.range.end_height()),
                     buffered
-                        .headers
+                        .payload
+                        .headers()
                         .last()
                         .map(|header| block::Hash::from(header.as_ref())),
                 ) {
@@ -1787,7 +1799,7 @@ impl HeaderSyncReactor {
                 self.trace_range_validation_rejected(
                     &buffered.wire_request.peer,
                     buffered.range,
-                    u32::try_from(buffered.headers.len()).unwrap_or(u32::MAX),
+                    buffered.payload.range().count(),
                     "ordered_predecessor",
                     header_sync_wire_error_kind(&error),
                 );
@@ -1855,10 +1867,7 @@ impl HeaderSyncReactor {
             permit.send(HeaderSyncAction::CommitHeaderRange {
                 operation,
                 anchor,
-                start_height: buffered.range.start_height,
-                headers: buffered.headers,
-                body_sizes: buffered.body_sizes,
-                tree_aux_roots: buffered.tree_aux_roots,
+                payload: buffered.payload,
                 finalized: buffered.range.finalized,
             });
             metrics::counter!("sync.header.work.ordered_drain", "lane" => lane).increment(1);
@@ -2217,19 +2226,23 @@ impl HeaderSyncReactor {
         };
         let original_range = range;
         let count = clamp_header_sync_request_count(
-            range.count,
+            range.count(),
             peer.max_headers_per_response,
             &self.startup.network,
             self.startup.max_frame_bytes,
             range.want_tree_aux_roots,
         );
-        range.count = count;
-        if count < original_range.count {
-            if let Some(suffix_start) = height_after_count(range.start_height, count) {
+        range.geometry = CheckedHeaderRange::from_count(range.start_height(), count)
+            .expect("clamped request count is non-zero and within the original range");
+        if count < original_range.count() {
+            if let Some(suffix_start) = height_after_count(range.start_height(), count) {
                 self.state.schedule.ensure(
                     RangeRequest {
-                        start_height: suffix_start,
-                        count: original_range.count.saturating_sub(count),
+                        geometry: CheckedHeaderRange::from_count(
+                            suffix_start,
+                            original_range.count().saturating_sub(count),
+                        )
+                        .expect("clamped request leaves a checked non-empty suffix"),
                         anchor_hash: None,
                         ..original_range
                     },
@@ -2259,8 +2272,8 @@ impl HeaderSyncReactor {
             return false;
         };
         let prepared = match session.prepare_get_headers(
-            range.start_height,
-            range.count,
+            range.start_height(),
+            range.count(),
             range.want_tree_aux_roots,
         ) {
             Ok(prepared) => prepared,
@@ -2344,20 +2357,20 @@ impl HeaderSyncReactor {
             .state
             .buffered
             .values()
-            .map(|range| range.headers.len())
+            .map(|range| range.payload.headers().len())
             .sum::<usize>();
         let buffered_bytes = self
             .state
             .buffered
             .values()
             .map(|range| {
-                let root_bytes = if range.tree_aux_roots.is_empty() {
-                    0
-                } else {
+                let root_bytes = if range.payload.tree_aux_roots().is_some() {
                     HEADER_SYNC_BLOCK_COMMITMENT_ROOTS_BYTES
+                } else {
+                    0
                 };
                 let per_header = header_bytes.saturating_add(root_bytes);
-                range.headers.len().saturating_mul(per_header)
+                range.payload.headers().len().saturating_mul(per_header)
             })
             .sum::<usize>();
         metrics::gauge!("sync.header.work.pending.count")
@@ -2422,7 +2435,7 @@ impl HeaderSyncReactor {
                     && peer.received_status
                     && peer.outstanding.is_empty()
                     && peer.advertised_tip >= repair.range.end_height()
-                    && peer.max_headers_per_response >= repair.range.count
+                    && peer.max_headers_per_response >= repair.range.count()
                     && !repair.tried_peers.contains(*peer_id)
             })
             .map(|(peer_id, _)| peer_id.clone())
@@ -2765,7 +2778,7 @@ impl HeaderSyncReactor {
                 let outstanding = &peer.outstanding[index];
                 if matches!(outstanding.purpose, RangePurpose::Sync)
                     && outstanding.range.priority == RangePriority::Forward
-                    && outstanding.range.start_height <= height
+                    && outstanding.range.start_height() <= height
                 {
                     let outstanding = peer.outstanding.remove(index);
                     let _ = peer
@@ -2792,7 +2805,7 @@ impl HeaderSyncReactor {
             .buffered
             .iter()
             .filter_map(|(key, range)| {
-                (key.0 == RangePriority::Forward && range.range.start_height <= height)
+                (key.0 == RangePriority::Forward && range.range.start_height() <= height)
                     .then_some(*key)
             })
             .collect();
@@ -2800,21 +2813,15 @@ impl HeaderSyncReactor {
             if let Some(mut buffered) = self.state.buffered.remove(&key) {
                 let original = buffered.range;
                 if let Some(suffix) = original.suffix_after(height, hash) {
-                    let covered_count = count_between(original.start_height, height);
-                    let covered_count = usize::try_from(covered_count)
-                        .expect("header range counts fit in usize on supported platforms");
-                    buffered.headers = buffered.headers.split_off(covered_count);
-                    if !buffered.body_sizes.is_empty() {
-                        buffered.body_sizes = buffered.body_sizes.split_off(covered_count);
-                    }
-                    if !buffered.tree_aux_roots.is_empty() {
-                        buffered.tree_aux_roots = buffered.tree_aux_roots.split_off(covered_count);
-                    }
+                    buffered.payload = buffered
+                        .payload
+                        .suffix_after(height)
+                        .expect("buffered payload covers the same suffix as its request");
                     buffered.range = suffix;
                     self.state.schedule.narrow_queued_range(original, suffix);
                     self.state
                         .buffered
-                        .insert((RangePriority::Forward, suffix.start_height), buffered);
+                        .insert((RangePriority::Forward, suffix.start_height()), buffered);
                 } else {
                     self.state.schedule.clear_assignment(original);
                 }

--- a/zakura-network/src/zakura/header_sync/reactor/trace.rs
+++ b/zakura-network/src/zakura/header_sync/reactor/trace.rs
@@ -124,7 +124,7 @@ impl HeaderSyncReactor {
                 u64::from(meta.stream_version),
             );
             insert_u64(row, hs_trace::REQUEST_ID, meta.request_id.get());
-            insert_height(row, hs_trace::RANGE_START, range.start_height);
+            insert_height(row, hs_trace::RANGE_START, range.start_height());
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(count));
             insert_u64(row, hs_trace::ADVERTISED_CAP, u64::from(advertised_cap));
             insert_bool(row, hs_trace::FINALIZED, range.finalized);
@@ -218,7 +218,7 @@ impl HeaderSyncReactor {
     ) {
         self.emit_trace(hs_trace::HEADER_RANGE_REJECTED, |row| {
             insert_peer(row, hs_trace::PEER, peer);
-            insert_height(row, hs_trace::RANGE_START, range.start_height);
+            insert_height(row, hs_trace::RANGE_START, range.start_height());
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(count));
             if let Some(anchor_hash) = range.anchor_hash {
                 insert_hash(row, hs_trace::ANCHOR_HASH, anchor_hash);
@@ -640,10 +640,7 @@ fn trace_action_fields(row: &mut serde_json::Map<String, Value>, action: &Header
             insert_u64(row, hs_trace::RANGE_COUNT, u64::from(*count));
         }
         HeaderSyncAction::CommitHeaderRange {
-            operation,
-            start_height,
-            headers,
-            ..
+            operation, payload, ..
         } => {
             insert_optional_str(row, hs_trace::KIND, Some("commit_header_range"));
             insert_peer(row, hs_trace::PEER, &operation.wire_request.peer);
@@ -658,8 +655,12 @@ fn trace_action_fields(row: &mut serde_json::Map<String, Value>, action: &Header
                 "operation_kind",
                 Some(operation_kind_label(operation.op_kind)),
             );
-            insert_height(row, hs_trace::RANGE_START, *start_height);
-            insert_u64(row, hs_trace::RANGE_COUNT, headers.len() as u64);
+            insert_height(row, hs_trace::RANGE_START, payload.range().start());
+            insert_u64(
+                row,
+                hs_trace::RANGE_COUNT,
+                u64::from(payload.range().count()),
+            );
         }
         HeaderSyncAction::QueryBestHeaderTip => {
             insert_optional_str(row, hs_trace::KIND, Some("query_best_header_tip"));
@@ -813,6 +814,7 @@ pub(super) fn header_sync_wire_error_kind(error: &HeaderSyncWireError) -> &'stat
     match error {
         HeaderSyncWireError::OversizedPayload { .. } => "oversized_payload",
         HeaderSyncWireError::HeaderCountLimit { .. } => "header_count_limit",
+        HeaderSyncWireError::InvalidRangeGeometry { .. } => "invalid_range_geometry",
         HeaderSyncWireError::BodySizeCountMismatch { .. } => "body_size_count_mismatch",
         HeaderSyncWireError::TreeAuxRootCountMismatch { .. } => "tree_aux_root_count_mismatch",
         HeaderSyncWireError::TreeAuxRootHeightMismatch { .. } => "tree_aux_root_height_mismatch",
@@ -937,8 +939,8 @@ mod tests {
         header_sync::{
             events::HeaderSyncFrontiers, service::HeaderSyncPeerSession, state::RangePriority,
         },
-        HeaderSyncOperationIdentity, HeaderSyncOperationKind, HeaderSyncServiceSummary,
-        HeaderSyncWireRequestIdentity,
+        HeaderRangePayload, HeaderSyncOperationIdentity, HeaderSyncOperationKind,
+        HeaderSyncServiceSummary, HeaderSyncWireRequestIdentity,
     };
 
     fn peer(byte: u8) -> ZakuraPeerId {
@@ -1190,10 +1192,8 @@ mod tests {
                 HeaderSyncAction::CommitHeaderRange {
                     operation: operation(peer.clone()),
                     anchor: block::Hash([0; 32]),
-                    start_height: block::Height(1),
-                    headers: vec![header],
-                    body_sizes: vec![1],
-                    tree_aux_roots: Vec::new(),
+                    payload: HeaderRangePayload::new(block::Height(1), vec![header], vec![1], None)
+                        .expect("test payload is aligned"),
                     finalized: false,
                 },
                 "commit_header_range",

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -137,8 +137,8 @@ mod tests {
 
     fn range(start: u32, count: u32) -> RangeRequest {
         RangeRequest {
-            start_height: block::Height(start),
-            count,
+            geometry: CheckedHeaderRange::from_count(block::Height(start), count)
+                .expect("test range is non-empty and bounded"),
             anchor_hash: None,
             finalized: false,
             want_tree_aux_roots: true,
@@ -201,7 +201,11 @@ mod tests {
         let (session, mut frames, _cancel) = session(peer, 1);
         let range = range(5, 2);
         let prepared = session
-            .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
+            .prepare_get_headers(
+                range.start_height(),
+                range.count(),
+                range.want_tree_aux_roots,
+            )
             .expect("valid test request is prepared");
         let request_id = prepared.request_id();
         let wire_request = wire_request(&requester_id, request_id);
@@ -239,8 +243,8 @@ mod tests {
         assert_eq!(
             message,
             HeaderSyncMessage::GetHeaders {
-                start_height: range.start_height,
-                count: range.count,
+                start_height: range.start_height(),
+                count: range.count(),
                 want_tree_aux_roots: range.want_tree_aux_roots,
             }
         );
@@ -262,7 +266,11 @@ mod tests {
         let (session, frames, _cancel) = session(peer, 1);
         let range = range(9, 1);
         let prepared = session
-            .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
+            .prepare_get_headers(
+                range.start_height(),
+                range.count(),
+                range.want_tree_aux_roots,
+            )
             .expect("valid test request is prepared");
         let request_id = prepared.request_id();
         let wire_request = wire_request(&requester_id, request_id);

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -137,7 +137,7 @@ mod tests {
 
     fn range(start: u32, count: u32) -> RangeRequest {
         RangeRequest {
-            geometry: CheckedHeaderRange::from_count(block::Height(start), count)
+            range: CheckedHeaderRange::from_count(block::Height(start), count)
                 .expect("test range is non-empty and bounded"),
             anchor_hash: None,
             finalized: false,

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -819,7 +819,7 @@ mod request_id_tests {
             Some(commands_tx),
         );
         let range = RangeRequest {
-            geometry: CheckedHeaderRange::from_count(block::Height(1), 1)
+            range: CheckedHeaderRange::from_count(block::Height(1), 1)
                 .expect("test range is non-empty"),
             anchor_hash: None,
             finalized: false,

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -404,16 +404,13 @@ pub(crate) async fn drive_header_sync_actions(
                     .await;
             }
             HeaderSyncAction::CommitHeaderRange {
-                operation,
-                start_height,
-                headers,
-                ..
+                operation, payload, ..
             } => {
                 let peer = &operation.wire_request.peer;
                 tracing::debug!(
                     ?peer,
-                    ?start_height,
-                    count = headers.len(),
+                    start_height = ?payload.range().start(),
+                    count = payload.range().count(),
                     "suppressing Zakura header range commit until state driver is wired"
                 );
             }
@@ -822,15 +819,19 @@ mod request_id_tests {
             Some(commands_tx),
         );
         let range = RangeRequest {
-            start_height: block::Height(1),
-            count: 1,
+            geometry: CheckedHeaderRange::from_count(block::Height(1), 1)
+                .expect("test range is non-empty"),
             anchor_hash: None,
             finalized: false,
             want_tree_aux_roots: true,
             priority: RangePriority::Forward,
         };
         let prepared = session
-            .prepare_get_headers(range.start_height, range.count, range.want_tree_aux_roots)
+            .prepare_get_headers(
+                range.start_height(),
+                range.count(),
+                range.want_tree_aux_roots,
+            )
             .expect("valid test request is prepared");
         let reserved = match commands_rx.try_recv().expect("reservation is published") {
             HeaderSyncPeerCommand::Reserve(expected) => expected,

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -534,7 +534,7 @@ impl HeaderSyncPeerMeters {
 #[derive(Clone, Debug)]
 pub(super) struct OutstandingRange {
     pub(super) wire_request: HeaderSyncWireRequestIdentity,
-    pub(super) range: RangeRequest,
+    pub(super) range_request: RangeRequest,
     pub(super) deadline: Instant,
     pub(super) purpose: RangePurpose,
     pub(super) phase: OutstandingPhase,

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -155,8 +155,8 @@ impl HeaderSyncCore {
                 batch_len = count_between(batch_start, checkpoint);
             }
             self.schedule.ensure_forward(RangeRequest {
-                start_height: batch_start,
-                count: batch_len,
+                geometry: CheckedHeaderRange::from_count(batch_start, batch_len)
+                    .expect("bounded non-empty batch has checked geometry"),
                 anchor_hash,
                 finalized,
                 want_tree_aux_roots: true,
@@ -218,8 +218,7 @@ impl VctRootRepair {
             height,
             generation,
             range: RangeRequest {
-                start_height: height,
-                count,
+                geometry: CheckedHeaderRange::from_count(height, count)?,
                 anchor_hash: Some(anchor_hash),
                 finalized: false,
                 want_tree_aux_roots: true,
@@ -553,9 +552,7 @@ pub(super) struct BufferedHeaderRange {
     pub(super) wire_request: HeaderSyncWireRequestIdentity,
     pub(super) range: RangeRequest,
     pub(super) purpose: RangePurpose,
-    pub(super) headers: Vec<Arc<block::Header>>,
-    pub(super) body_sizes: Vec<u32>,
-    pub(super) tree_aux_roots: Vec<BlockCommitmentRoots>,
+    pub(super) payload: HeaderRangePayload,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -566,8 +563,7 @@ pub(super) struct PendingOperation {
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub(super) struct RangeRequest {
-    pub(super) start_height: block::Height,
-    pub(super) count: u32,
+    pub(super) geometry: CheckedHeaderRange,
     pub(super) anchor_hash: Option<block::Hash>,
     pub(super) finalized: bool,
     pub(super) want_tree_aux_roots: bool,
@@ -575,9 +571,16 @@ pub(super) struct RangeRequest {
 }
 
 impl RangeRequest {
+    pub(super) fn start_height(self) -> block::Height {
+        self.geometry.start()
+    }
+
+    pub(super) fn count(self) -> u32 {
+        self.geometry.count()
+    }
+
     pub(super) fn end_height(self) -> block::Height {
-        range_end_height(self.start_height, self.count)
-            .expect("range request is non-zero and clamped to the remaining height domain")
+        self.geometry.end()
     }
 
     pub(super) fn suffix_after(
@@ -591,8 +594,8 @@ impl RangeRequest {
         }
         let start_height = next_height(covered_through)?;
         Some(Self {
-            start_height,
-            count: count_between(start_height, end_height),
+            geometry: CheckedHeaderRange::from_bounds(start_height, end_height)
+                .expect("suffix bounds are ascending"),
             anchor_hash: Some(anchor_hash),
             ..self
         })

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -155,7 +155,7 @@ impl HeaderSyncCore {
                 batch_len = count_between(batch_start, checkpoint);
             }
             self.schedule.ensure_forward(RangeRequest {
-                geometry: CheckedHeaderRange::from_count(batch_start, batch_len)
+                range: CheckedHeaderRange::from_count(batch_start, batch_len)
                     .expect("bounded non-empty batch has checked geometry"),
                 anchor_hash,
                 finalized,
@@ -218,7 +218,7 @@ impl VctRootRepair {
             height,
             generation,
             range: RangeRequest {
-                geometry: CheckedHeaderRange::from_count(height, count)?,
+                range: CheckedHeaderRange::from_count(height, count)?,
                 anchor_hash: Some(anchor_hash),
                 finalized: false,
                 want_tree_aux_roots: true,
@@ -563,7 +563,7 @@ pub(super) struct PendingOperation {
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub(super) struct RangeRequest {
-    pub(super) geometry: CheckedHeaderRange,
+    pub(super) range: CheckedHeaderRange,
     pub(super) anchor_hash: Option<block::Hash>,
     pub(super) finalized: bool,
     pub(super) want_tree_aux_roots: bool,
@@ -572,15 +572,15 @@ pub(super) struct RangeRequest {
 
 impl RangeRequest {
     pub(super) fn start_height(self) -> block::Height {
-        self.geometry.start()
+        self.range.start()
     }
 
     pub(super) fn count(self) -> u32 {
-        self.geometry.count()
+        self.range.count()
     }
 
     pub(super) fn end_height(self) -> block::Height {
-        self.geometry.end()
+        self.range.end()
     }
 
     pub(super) fn suffix_after(
@@ -595,7 +595,7 @@ impl RangeRequest {
         let start_height = next_height(covered_through)?;
         let geometry = CheckedHeaderRange::from_bounds(start_height, end_height)?;
         Some(Self {
-            geometry,
+            range: geometry,
             anchor_hash: Some(anchor_hash),
             ..self
         })

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -593,9 +593,9 @@ impl RangeRequest {
             return None;
         }
         let start_height = next_height(covered_through)?;
+        let geometry = CheckedHeaderRange::from_bounds(start_height, end_height)?;
         Some(Self {
-            geometry: CheckedHeaderRange::from_bounds(start_height, end_height)
-                .expect("suffix bounds are ascending"),
+            geometry,
             anchor_hash: Some(anchor_hash),
             ..self
         })

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -3702,7 +3702,7 @@ fn response_before_publication_completion_is_not_reinstalled() {
             session_id: 0,
             request_id,
         },
-        range,
+        range_request: range,
         deadline: Instant::now() + std::time::Duration::from_secs(1),
         purpose: RangePurpose::Sync,
         phase: OutstandingPhase::Publishing,

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -620,7 +620,7 @@ fn commit_and_authentication_operations_from_one_request_are_distinct() {
         op_kind: HeaderSyncOperationKind::AuthenticateRoots,
     };
     let range = RangeRequest {
-        geometry: CheckedHeaderRange::from_count(block::Height(1), 1)
+        range: CheckedHeaderRange::from_count(block::Height(1), 1)
             .expect("test range is non-empty"),
         anchor_hash: Some(network.genesis_hash()),
         finalized: false,
@@ -3689,7 +3689,7 @@ fn response_before_publication_completion_is_not_reinstalled() {
     );
     let request_id = HeaderSyncRequestId::new(1).expect("non-zero request ID");
     let range = RangeRequest {
-        geometry: CheckedHeaderRange::from_count(block::Height(1), 1)
+        range: CheckedHeaderRange::from_count(block::Height(1), 1)
             .expect("test range is non-empty"),
         anchor_hash: None,
         finalized: false,
@@ -6509,7 +6509,7 @@ fn work_queue_transitions_have_one_explicit_owner() {
 
     let owner = peer(144);
     let range = RangeRequest {
-        geometry: CheckedHeaderRange::from_count(block::Height(1), 2)
+        range: CheckedHeaderRange::from_count(block::Height(1), 2)
             .expect("test range is non-empty"),
         anchor_hash: Some(block::Hash([1; 32])),
         finalized: false,

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -620,8 +620,8 @@ fn commit_and_authentication_operations_from_one_request_are_distinct() {
         op_kind: HeaderSyncOperationKind::AuthenticateRoots,
     };
     let range = RangeRequest {
-        start_height: block::Height(1),
-        count: 1,
+        geometry: CheckedHeaderRange::from_count(block::Height(1), 1)
+            .expect("test range is non-empty"),
         anchor_hash: Some(network.genesis_hash()),
         finalized: false,
         want_tree_aux_roots: true,
@@ -2021,16 +2021,14 @@ async fn vct_repair_bypasses_covered_range_and_commits_exact_h_and_successor() {
         match next_action(&mut fixture.actions).await {
             HeaderSyncAction::CommitHeaderRange {
                 operation,
-                start_height,
-                headers,
-                tree_aux_roots,
+                payload,
                 finalized,
                 ..
             } => {
                 assert_eq!(operation.wire_request.peer, peer_id);
-                assert_eq!(start_height, block::Height(1));
-                assert_eq!(headers.len(), 2);
-                assert_eq!(tree_aux_roots.len(), 2);
+                assert_eq!(payload.range().start(), block::Height(1));
+                assert_eq!(payload.headers().len(), 2);
+                assert_eq!(payload.tree_aux_roots().map(<[_]>::len), Some(2),);
                 assert!(
                     !finalized,
                     "repair ranges are canonical but not checkpoint-terminating"
@@ -2978,7 +2976,7 @@ async fn incoming_headers_match_outstanding_before_commit() {
     match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
             operation,
-            start_height,
+            payload,
             finalized,
             ..
         } => {
@@ -2987,7 +2985,7 @@ async fn incoming_headers_match_outstanding_before_commit() {
                 commit_operation(peer_id, 0, request_id),
                 "the commit action preserves the exact wire request identity"
             );
-            assert_eq!(start_height, start);
+            assert_eq!(payload.range().start(), start);
             assert!(!finalized);
         }
         action => panic!("unexpected action: {action:?}"),
@@ -3315,10 +3313,11 @@ async fn truncated_finalized_suffix_still_checks_its_checkpoint_hash() {
                 assert_eq!(peer, peer_id);
                 break;
             }
-            HeaderSyncAction::CommitHeaderRange {
-                start_height: block::Height(3),
-                ..
-            } => panic!("a truncated suffix with the wrong checkpoint hash was committed"),
+            HeaderSyncAction::CommitHeaderRange { payload, .. }
+                if payload.range().start() == block::Height(3) =>
+            {
+                panic!("a truncated suffix with the wrong checkpoint hash was committed")
+            }
             _ => {}
         }
     }
@@ -3495,14 +3494,11 @@ async fn local_commit_failure_retries_without_peer_misbehavior() {
                 panic!("valid headers must not be scored before local commit failure")
             }
             HeaderSyncAction::CommitHeaderRange {
-                operation,
-                start_height,
-                headers,
-                ..
+                operation, payload, ..
             } => {
                 assert_eq!(operation.wire_request.peer, first_peer);
-                assert_eq!(start_height, start);
-                assert_eq!(headers.len(), 1);
+                assert_eq!(payload.range().start(), start);
+                assert_eq!(payload.headers().len(), 1);
                 break operation;
             }
             _ => {}
@@ -3693,8 +3689,8 @@ fn response_before_publication_completion_is_not_reinstalled() {
     );
     let request_id = HeaderSyncRequestId::new(1).expect("non-zero request ID");
     let range = RangeRequest {
-        start_height: block::Height(1),
-        count: 1,
+        geometry: CheckedHeaderRange::from_count(block::Height(1), 1)
+            .expect("test range is non-empty"),
         anchor_hash: None,
         finalized: false,
         want_tree_aux_roots: true,
@@ -5085,13 +5081,11 @@ async fn replacement_session_ignores_old_wire_response_with_reused_id() {
     loop {
         match next_non_query_action(&mut fixture.actions).await {
             HeaderSyncAction::CommitHeaderRange {
-                operation,
-                start_height,
-                ..
+                operation, payload, ..
             } => {
                 assert_eq!(operation.wire_request.peer, peer_id);
                 assert_eq!(operation.wire_request.session_id, 2);
-                assert_eq!(start_height, block::Height(4));
+                assert_eq!(payload.range().start(), block::Height(4));
                 break;
             }
             HeaderSyncAction::Misbehavior { peer, reason } => {
@@ -5587,18 +5581,15 @@ async fn header_sync_metrics_record_status_range_new_block_dedup_and_violation()
     .await;
     let (operation, committed_hash) = match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
-            operation,
-            start_height,
-            headers,
-            ..
+            operation, payload, ..
         } => {
             assert_eq!(
-                start_height,
+                payload.range().start(),
                 next_height(first_checkpoint).expect("checkpoint has a successor")
             );
             (
                 operation,
-                block::Hash::from(headers.last().expect("one header").as_ref()),
+                block::Hash::from(payload.headers().last().expect("one header").as_ref()),
             )
         }
         action => panic!("unexpected action: {action:?}"),
@@ -5917,12 +5908,12 @@ async fn partial_coverage_trims_and_commits_an_already_buffered_suffix() {
         &fixture,
         &peer_id,
         requests[&block::Height(3)],
-        headers_message_from(
-            block::Height(3),
+        headers_message_with_sizes(
             vec![
                 mainnet_header(&BLOCK_MAINNET_3_BYTES),
                 mainnet_header(&BLOCK_MAINNET_4_BYTES),
             ],
+            vec![33, 44],
         ),
     )
     .await;
@@ -5936,14 +5927,16 @@ async fn partial_coverage_trims_and_commits_an_already_buffered_suffix() {
         .unwrap();
 
     loop {
-        if let HeaderSyncAction::CommitHeaderRange {
-            start_height,
-            headers,
-            ..
-        } = next_non_query_action(&mut fixture.actions).await
+        if let HeaderSyncAction::CommitHeaderRange { payload, .. } =
+            next_non_query_action(&mut fixture.actions).await
         {
-            assert_eq!(start_height, block::Height(4));
-            assert_eq!(headers, vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
+            assert_eq!(payload.range().start(), block::Height(4));
+            assert_eq!(payload.headers(), [mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
+            assert_eq!(payload.body_sizes(), [44]);
+            assert_eq!(
+                payload.tree_aux_roots().map(|roots| roots[0].height),
+                Some(block::Height(4))
+            );
             break;
         }
     }
@@ -6000,14 +5993,11 @@ async fn loaded_best_tip_reconciles_outstanding_and_buffered_work() {
         .unwrap();
 
     loop {
-        if let HeaderSyncAction::CommitHeaderRange {
-            start_height,
-            headers,
-            ..
-        } = next_non_query_action(&mut fixture.actions).await
+        if let HeaderSyncAction::CommitHeaderRange { payload, .. } =
+            next_non_query_action(&mut fixture.actions).await
         {
-            assert_eq!(start_height, block::Height(4));
-            assert_eq!(headers, vec![mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
+            assert_eq!(payload.range().start(), block::Height(4));
+            assert_eq!(payload.headers(), [mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
             break;
         }
     }
@@ -6136,13 +6126,9 @@ async fn buffered_successor_drains_after_full_block_covers_its_predecessor() {
 
     loop {
         match next_non_query_action(&mut fixture.actions).await {
-            HeaderSyncAction::CommitHeaderRange {
-                start_height,
-                headers,
-                ..
-            } => {
-                assert_eq!(start_height, block::Height(2));
-                assert_eq!(headers.len(), 1);
+            HeaderSyncAction::CommitHeaderRange { payload, .. } => {
+                assert_eq!(payload.range().start(), block::Height(2));
+                assert_eq!(payload.headers().len(), 1);
                 break;
             }
             HeaderSyncAction::Misbehavior { peer, reason } => {
@@ -6204,12 +6190,12 @@ async fn ordered_drain_rejects_a_buffered_range_on_the_wrong_fork() {
     .await;
     let operation = loop {
         if let HeaderSyncAction::CommitHeaderRange {
-            operation,
-            start_height: block::Height(1),
-            ..
+            operation, payload, ..
         } = next_non_query_action(&mut fixture.actions).await
         {
-            break operation;
+            if payload.range().start() == block::Height(1) {
+                break operation;
+            }
         }
     };
     fixture
@@ -6230,10 +6216,11 @@ async fn ordered_drain_rejects_a_buffered_range_on_the_wrong_fork() {
                 assert_eq!(peer, peer_id);
                 break;
             }
-            HeaderSyncAction::CommitHeaderRange {
-                start_height: block::Height(2),
-                ..
-            } => panic!("ordered drain committed a buffered range on the wrong fork"),
+            HeaderSyncAction::CommitHeaderRange { payload, .. }
+                if payload.range().start() == block::Height(2) =>
+            {
+                panic!("ordered drain committed a buffered range on the wrong fork")
+            }
             _ => {}
         }
     }
@@ -6303,15 +6290,12 @@ async fn full_action_queue_preserves_buffer_until_commit_capacity_returns() {
     tokio::task::yield_now().await;
     for _ in 0..129 {
         if let HeaderSyncAction::CommitHeaderRange {
-            operation,
-            start_height,
-            headers,
-            ..
+            operation, payload, ..
         } = next_action(&mut fixture.actions).await
         {
             assert_eq!(operation.wire_request.peer, source);
-            assert_eq!(start_height, block::Height(4));
-            assert_eq!(headers.len(), 1);
+            assert_eq!(payload.range().start(), block::Height(4));
+            assert_eq!(payload.headers().len(), 1);
             assert_no_commit_or_misbehavior(&mut fixture.actions).await;
             return;
         }
@@ -6525,8 +6509,8 @@ fn work_queue_transitions_have_one_explicit_owner() {
 
     let owner = peer(144);
     let range = RangeRequest {
-        start_height: block::Height(1),
-        count: 2,
+        geometry: CheckedHeaderRange::from_count(block::Height(1), 2)
+            .expect("test range is non-empty"),
         anchor_hash: Some(block::Hash([1; 32])),
         finalized: false,
         want_tree_aux_roots: true,
@@ -6779,15 +6763,14 @@ async fn forward_genesis_backfill_reaches_checkpoint_before_finalized_commit() {
     match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
             operation,
-            start_height,
-            headers,
+            payload,
             finalized,
             ..
         } => {
             assert_eq!(operation.wire_request.peer, peer_id);
             assert_eq!(operation.wire_request.request_id, request_id);
-            assert_eq!(start_height, block::Height(1));
-            assert_eq!(headers.len(), 3);
+            assert_eq!(payload.range().start(), block::Height(1));
+            assert_eq!(payload.headers().len(), 3);
             assert!(finalized);
         }
         action => panic!("unexpected action: {action:?}"),
@@ -6833,15 +6816,14 @@ async fn truncated_finalized_backfill_commits_valid_prefix_and_requeues_suffix()
     match next_non_query_action(&mut fixture.actions).await {
         HeaderSyncAction::CommitHeaderRange {
             operation,
-            start_height,
-            headers,
+            payload,
             finalized,
             ..
         } => {
             assert_eq!(operation.wire_request.peer, peer_id);
             assert_eq!(operation.wire_request.request_id, request_id);
-            assert_eq!(start_height, block::Height(1));
-            assert_eq!(headers.len(), 2);
+            assert_eq!(payload.range().start(), block::Height(1));
+            assert_eq!(payload.headers().len(), 2);
             assert!(finalized);
         }
         action => panic!("unexpected action: {action:?}"),

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -501,7 +501,7 @@ mod tests {
 
     fn range(start: u32, count: u32, priority: RangePriority) -> RangeRequest {
         RangeRequest {
-            geometry: CheckedHeaderRange::from_count(block::Height(start), count)
+            range: CheckedHeaderRange::from_count(block::Height(start), count)
                 .expect("test range is non-empty and bounded"),
             anchor_hash: None,
             finalized: false,
@@ -548,7 +548,7 @@ mod tests {
             .expect("peer can claim the pending range");
         queue.mark_assigned(peer.clone(), claimed);
         queue.ensure_forward(RangeRequest {
-            geometry: CheckedHeaderRange::from_count(block::Height(1), 3)
+            range: CheckedHeaderRange::from_count(block::Height(1), 3)
                 .expect("test range is non-empty"),
             ..range
         });
@@ -579,7 +579,7 @@ mod tests {
             queue.forward.iter().copied().collect::<Vec<_>>(),
             vec![
                 RangeRequest {
-                    geometry: CheckedHeaderRange::from_count(block::Height(2), 1)
+                    range: CheckedHeaderRange::from_count(block::Height(2), 1)
                         .expect("test suffix is non-empty"),
                     anchor_hash: Some(anchor),
                     ..first

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -77,10 +77,12 @@ impl HeaderWorkQueue {
 
     pub(super) fn ensure(&mut self, range: RangeRequest, priority: RangePriority) {
         if self.is_covered(range)
-            || self.active_starts.contains(&(priority, range.start_height))
+            || self
+                .active_starts
+                .contains(&(priority, range.start_height()))
             || self
                 .pending_starts
-                .contains(&(priority, range.start_height))
+                .contains(&(priority, range.start_height()))
         {
             return;
         }
@@ -89,7 +91,7 @@ impl HeaderWorkQueue {
             RangePriority::Repair => return,
         };
         queue.push_back(range);
-        self.pending_starts.insert((priority, range.start_height));
+        self.pending_starts.insert((priority, range.start_height()));
         self.oldest_missing_since.get_or_insert_with(Instant::now);
         metrics::counter!("sync.header.work.added", "lane" => priority.label()).increment(1);
     }
@@ -108,7 +110,7 @@ impl HeaderWorkQueue {
             Self::pop_assignable(&mut self.forward, &self.retry_avoidance, peer_id, peer, now);
         if let Some(range) = range {
             self.pending_starts
-                .remove(&(range.priority, range.start_height));
+                .remove(&(range.priority, range.start_height()));
         }
         range
     }
@@ -124,7 +126,7 @@ impl HeaderWorkQueue {
             range.end_height() <= peer.advertised_tip
                 && retry_avoidance
                     .get(peer_id)
-                    .and_then(|ranges| ranges.get(&(range.start_height, range.priority)))
+                    .and_then(|ranges| ranges.get(&(range.start_height(), range.priority)))
                     .is_none_or(|until| *until <= now)
         })?;
         queue.remove(index)
@@ -135,7 +137,7 @@ impl HeaderWorkQueue {
             .active
             .insert(range, HeaderWorkState::InFlight { peer });
         self.active_starts
-            .insert((range.priority, range.start_height));
+            .insert((range.priority, range.start_height()));
         debug_assert!(previous.is_none(), "pending work has no active owner");
         metrics::counter!("sync.header.work.taken", "lane" => range.priority.label()).increment(1);
     }
@@ -172,9 +174,9 @@ impl HeaderWorkQueue {
 
         if let Some(state) = self.active.remove(&original) {
             self.active_starts
-                .remove(&(original.priority, original.start_height));
+                .remove(&(original.priority, original.start_height()));
             self.active_starts
-                .insert((narrowed.priority, narrowed.start_height));
+                .insert((narrowed.priority, narrowed.start_height()));
             self.active.insert(narrowed, state);
         }
     }
@@ -182,7 +184,7 @@ impl HeaderWorkQueue {
     pub(super) fn retry(&mut self, range: RangeRequest) {
         self.active.remove(&range);
         self.active_starts
-            .remove(&(range.priority, range.start_height));
+            .remove(&(range.priority, range.start_height()));
         if self.is_covered(range) {
             return;
         }
@@ -192,7 +194,7 @@ impl HeaderWorkQueue {
         };
         if self
             .pending_starts
-            .insert((range.priority, range.start_height))
+            .insert((range.priority, range.start_height()))
         {
             queue.push_front(range);
         }
@@ -202,7 +204,7 @@ impl HeaderWorkQueue {
 
     pub(super) fn retry_avoiding(&mut self, peer: ZakuraPeerId, range: RangeRequest) {
         self.retry_avoidance.entry(peer).or_default().insert(
-            (range.start_height, range.priority),
+            (range.start_height(), range.priority),
             Instant::now() + HEADER_SYNC_RETRY_AVOIDANCE,
         );
         self.retry(range);
@@ -226,13 +228,13 @@ impl HeaderWorkQueue {
     pub(super) fn clear_assignment(&mut self, range: RangeRequest) {
         self.active.remove(&range);
         self.active_starts
-            .remove(&(range.priority, range.start_height));
+            .remove(&(range.priority, range.start_height()));
     }
 
     pub(super) fn complete(&mut self, range: RangeRequest) {
         let previous = self.active.remove(&range);
         self.active_starts
-            .remove(&(range.priority, range.start_height));
+            .remove(&(range.priority, range.start_height()));
         debug_assert!(
             matches!(previous, Some(HeaderWorkState::Committing { .. })) || previous.is_none(),
             "only committing or externally covered work can complete"
@@ -248,7 +250,7 @@ impl HeaderWorkQueue {
             .forward
             .drain(..)
             .filter_map(|range| {
-                if range.start_height <= height {
+                if range.start_height() <= height {
                     range.suffix_after(height, anchor_hash)
                 } else {
                     Some(range)
@@ -270,7 +272,7 @@ impl HeaderWorkQueue {
         };
         if let Some(range) = queue
             .iter_mut()
-            .find(|range| range.start_height == start_height)
+            .find(|range| range.start_height() == start_height)
         {
             if range.anchor_hash == Some(anchor_hash) {
                 range.anchor_hash = None;
@@ -304,7 +306,7 @@ impl HeaderWorkQueue {
         let end = range.end_height();
         self.covered
             .iter()
-            .any(|covered| covered.start <= range.start_height && covered.end >= end)
+            .any(|covered| covered.start <= range.start_height() && covered.end >= end)
     }
 
     pub(super) fn mark_covered_interval(&mut self, mut interval: CoveredRange) {
@@ -340,7 +342,7 @@ impl HeaderWorkQueue {
             let end = range.end_height();
             covered
                 .iter()
-                .any(|covered| covered.start <= range.start_height && covered.end >= end)
+                .any(|covered| covered.start <= range.start_height() && covered.end >= end)
         };
         self.forward.retain(|range| !is_covered(range));
         self.active.retain(|range, state| {
@@ -360,7 +362,7 @@ impl HeaderWorkQueue {
         self.forward
             .iter()
             .chain(self.active.keys())
-            .map(|range| u64::from(range.count))
+            .map(|range| u64::from(range.count()))
             .sum()
     }
 
@@ -401,7 +403,7 @@ impl HeaderWorkQueue {
         self.forward.iter().any(|range| {
             range.end_height() <= advertised_tip
                 && avoided
-                    .get(&(range.start_height, range.priority))
+                    .get(&(range.start_height(), range.priority))
                     .is_some_and(|until| *until > Instant::now())
         })
     }
@@ -426,7 +428,7 @@ impl HeaderWorkQueue {
         self.forward
             .iter()
             .chain(self.active.keys())
-            .map(|range| range.start_height)
+            .map(|range| range.start_height())
             .min()
     }
 
@@ -435,13 +437,13 @@ impl HeaderWorkQueue {
         self.pending_starts.extend(
             self.forward
                 .iter()
-                .map(|range| (range.priority, range.start_height)),
+                .map(|range| (range.priority, range.start_height())),
         );
         self.active_starts.clear();
         self.active_starts.extend(
             self.active
                 .keys()
-                .map(|range| (range.priority, range.start_height)),
+                .map(|range| (range.priority, range.start_height())),
         );
     }
 }
@@ -499,8 +501,8 @@ mod tests {
 
     fn range(start: u32, count: u32, priority: RangePriority) -> RangeRequest {
         RangeRequest {
-            start_height: block::Height(start),
-            count,
+            geometry: CheckedHeaderRange::from_count(block::Height(start), count)
+                .expect("test range is non-empty and bounded"),
             anchor_hash: None,
             finalized: false,
             want_tree_aux_roots: true,
@@ -545,7 +547,11 @@ mod tests {
             .next_for_peer(&peer, &state)
             .expect("peer can claim the pending range");
         queue.mark_assigned(peer.clone(), claimed);
-        queue.ensure_forward(RangeRequest { count: 3, ..range });
+        queue.ensure_forward(RangeRequest {
+            geometry: CheckedHeaderRange::from_count(block::Height(1), 3)
+                .expect("test range is non-empty"),
+            ..range
+        });
         assert_eq!(queue.pending_len(), 0);
         assert!(matches!(
             queue.state(range),
@@ -573,8 +579,8 @@ mod tests {
             queue.forward.iter().copied().collect::<Vec<_>>(),
             vec![
                 RangeRequest {
-                    start_height: block::Height(2),
-                    count: 1,
+                    geometry: CheckedHeaderRange::from_count(block::Height(2), 1)
+                        .expect("test suffix is non-empty"),
                     anchor_hash: Some(anchor),
                     ..first
                 },
@@ -593,7 +599,7 @@ mod tests {
         };
         queue.ensure_forward(suffix);
 
-        queue.clear_pending_anchor(RangePriority::Forward, suffix.start_height, poisoned);
+        queue.clear_pending_anchor(RangePriority::Forward, suffix.start_height(), poisoned);
 
         assert_eq!(
             queue.forward.front().and_then(|range| range.anchor_hash),
@@ -727,7 +733,7 @@ mod tests {
         queue.retry_avoidance.insert(
             forgotten.clone(),
             HashMap::from([(
-                (in_flight.start_height, in_flight.priority),
+                (in_flight.start_height(), in_flight.priority),
                 Instant::now() + HEADER_SYNC_RETRY_AVOIDANCE,
             )]),
         );

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -1024,11 +1024,12 @@ mod tests {
                 HeaderSyncAction::CommitHeaderRange {
                     operation,
                     anchor,
-                    start_height,
-                    headers,
+                    payload,
                     finalized,
                     ..
                 } => {
+                    let start_height = payload.range().start();
+                    let (_range, headers, _body_sizes, _tree_aux_roots) = payload.into_parts();
                     let result = local
                         .store
                         .lock()
@@ -1399,10 +1400,11 @@ mod tests {
                     Some(HeaderSyncAction::CommitHeaderRange {
                         operation,
                         anchor,
-                        start_height,
-                        headers,
+                        payload,
                         ..
                     }) => {
+                        let start_height = payload.range().start();
+                        let (_range, headers, _body_sizes, _tree_aux_roots) = payload.into_parts();
                         return Ok(ControlledHeaderCommit {
                             operation,
                             anchor,

--- a/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -915,15 +915,18 @@ pub(crate) async fn drive_zakura_header_sync_actions<State, ReadState, BlockVeri
             HeaderSyncAction::CommitHeaderRange {
                 operation,
                 anchor,
-                start_height,
-                headers,
-                body_sizes,
-                tree_aux_roots,
+                payload,
                 finalized: _finalized,
             } => {
                 let peer = operation.wire_request.peer.clone();
-                let count = u32::try_from(headers.len()).unwrap_or(u32::MAX);
-                let tree_aux_roots_len = u32::try_from(tree_aux_roots.len()).unwrap_or(u32::MAX);
+                let range = payload.range();
+                let start_height = range.start();
+                let count = range.count();
+                let tree_aux_roots_len = payload
+                    .tree_aux_roots()
+                    .map_or(0, |roots| u32::try_from(roots.len()).unwrap_or(u32::MAX));
+                let (_range, headers, body_sizes, tree_aux_roots) = payload.into_parts();
+                let tree_aux_roots = tree_aux_roots.unwrap_or_default();
                 emit_commit_state(
                     &trace,
                     cs_trace::COMMIT_START,
@@ -1805,15 +1808,16 @@ fn trace_header_driver_action(trace: &ZakuraTrace, action: &HeaderSyncAction) {
         "header_sync_driver",
         |row| match action {
             HeaderSyncAction::CommitHeaderRange {
-                operation,
-                start_height,
-                headers,
-                ..
+                operation, payload, ..
             } => {
                 insert_cs_str(row, cs_trace::ACTION, "commit_header_range");
                 insert_cs_peer(row, cs_trace::PEER, &operation.wire_request.peer);
-                insert_cs_height(row, cs_trace::RANGE_START, *start_height);
-                insert_cs_u64(row, cs_trace::RANGE_COUNT, headers.len() as u64);
+                insert_cs_height(row, cs_trace::RANGE_START, payload.range().start());
+                insert_cs_u64(
+                    row,
+                    cs_trace::RANGE_COUNT,
+                    u64::from(payload.range().count()),
+                );
             }
             HeaderSyncAction::QueryBestHeaderTip => {
                 insert_cs_str(row, cs_trace::ACTION, "query_best_header_tip");


### PR DESCRIPTION
## Motivation

Header-sync range geometry is currently represented by loose `start_height` and `count` fields, while headers, body-size hints, and tree-aux roots cross asynchronous boundaries as independent vectors. The upcoming root-authentication lane will reuse one response for operations with different prefixes, making unchecked arithmetic and independent slicing unsafe.

PR #246 answered: “Which request and operation produced this completion?”

This PR answers: “Exactly which heights and per-height data belong to that operation?”

Why this matters:

- Root authentication requests `[F+1 … E+1]` but authenticates only `[F+1 … E]`; the last header is a successor witness.
- Short peer responses change the actual endpoint.
- Existing block progress can trim a buffered range.
- One response will eventually feed both header commit and root authentication.
- CheckedHeaderRange prevents zero-length, reversed, or overflowing range geometry and supplies checked prefix/suffix operations.

HeaderRangePayload binds headers, body-size hints, and optional roots together. Trimming a prefix now slices all three atomically, preventing roots or counts from becoming associated with the wrong header.

This is prerequisite scaffolding only. It does not yet:

- authenticate roots;
- change the wire protocol;
- change persistence;
- add the authentication frontier;
- add overlapping root scheduling.


The next design step can therefore implement state-owned root persistence knowing that network responses have exact identities, checked heights, and structurally aligned data.

## Solution

- add `CheckedHeaderRange` for non-empty, overflow-safe inclusive geometry and checked prefix/suffix operations
- add `HeaderRangePayload` to validate and atomically slice headers, body sizes, and optional all-or-nothing roots
- carry the aligned payload through buffering, commit actions, tracing, the testkit, and the node state driver
- keep the wire encoding, protocol version, state request, and scheduling behavior unchanged

### Specifications & References

- https://github.com/zakura-core/zakura/pull/230
- Builds on #246