### PR TITLE
chore(release): prepare v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-### Changed
-
-- Reuse transaction-wide transparent signature hash components across input
-  checks instead of hashing them again for every signature
-  ([#281](https://github.com/zakura-core/zakura/pull/281)).
-
-### Security
-
-- Prevent a peer from stalling chain synchronization by delivering a rejected
-  block body that shares its header hash with a later valid block
-  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
-
-## [1.0.2-rc1] - 2026-07-19
+## [1.0.2] - 2026-07-20
 
 ### Added
 
@@ -34,9 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Diagnose requests for pruned block bodies with the block height, hash, and
   configured retention, rate limited to once per minute
   ([#279](https://github.com/zakura-core/zakura/pull/279)).
+- Add a configurable 250,000-byte default maximum for individual mempool
+  transactions. Larger transactions are rejected before semantic and contextual
+  verification without penalizing peers, and the policy does not affect block
+  validation ([#255](https://github.com/zakura-core/zakura/pull/255)).
+- Add `zakurad validate-vct-sprout-history` to audit repaired historical
+  Sprout anchors in archive or pruned Mainnet state databases
+  ([#247](https://github.com/zakura-core/zakura/pull/247),
+  [#251](https://github.com/zakura-core/zakura/pull/251)).
 
 ### Changed
 
+- Reuse transaction-wide transparent signature hash components across input
+  checks instead of hashing them again for every signature
+  ([#281](https://github.com/zakura-core/zakura/pull/281)).
 - Reject transactions that do not meet ZIP-317 mempool fee policy before
   running script and proof checks. Block validation is unchanged
   ([#263](https://github.com/zakura-core/zakura/pull/263)).
@@ -49,6 +48,17 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   ([#268](https://github.com/zakura-core/zakura/pull/268)).
 - Point snapshot links and benchmark defaults at the Zakura snapshot service
   ([#276](https://github.com/zakura-core/zakura/pull/276)).
+- Source the embedded Mainnet VCT Sprout-history repair artifact from
+  exact-versioned crates.io packages instead of storing its large source
+  bytes in the Zakura repository, and reuse one validated decode throughout
+  startup repair ([#259](https://github.com/zakura-core/zakura/pull/259)).
+- Update the embedded zcashd-compat binary and default split-container image to
+  valargroup/zcashd v1.0.1
+  ([#245](https://github.com/zakura-core/zakura/pull/245)).
+- Header sync now schedules only forward ranges from the durable verified block
+  tip. Startup rejects configured anchors above that base, and no longer
+  backfills headers below a checkpoint anchor
+  ([#227](https://github.com/zakura-core/zakura/pull/227)).
 
 ### Fixed
 
@@ -78,36 +88,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   ([#283](https://github.com/zakura-core/zakura/pull/283)).
 - Ban peers that send mempool transactions with invalid Orchard or Ironwood
   proof sizes ([#285](https://github.com/zakura-core/zakura/pull/285)).
-
-## [1.0.2-rc0] - 2026-07-19
-
-### Added
-
-- Add a configurable 250,000-byte default maximum for individual mempool
-  transactions. Larger transactions are rejected before semantic and contextual
-  verification without penalizing peers, and the policy does not affect block
-  validation ([#255](https://github.com/zakura-core/zakura/pull/255)).
-- Add `zakurad validate-vct-sprout-history` to audit repaired historical
-  Sprout anchors in archive or pruned Mainnet state databases
-  ([#247](https://github.com/zakura-core/zakura/pull/247),
-  [#251](https://github.com/zakura-core/zakura/pull/251)).
-
-### Changed
-
-- Source the embedded Mainnet VCT Sprout-history repair artifact from
-  exact-versioned crates.io packages instead of storing its large source
-  bytes in the Zakura repository, and reuse one validated decode throughout
-  startup repair ([#259](https://github.com/zakura-core/zakura/pull/259)).
-- Update the embedded zcashd-compat binary and default split-container image to
-  valargroup/zcashd v1.0.1
-  ([#245](https://github.com/zakura-core/zakura/pull/245)).
-- Header sync now schedules only forward ranges from the durable verified block
-  tip. Startup rejects configured anchors above that base, and no longer
-  backfills headers below a checkpoint anchor
-  ([#227](https://github.com/zakura-core/zakura/pull/227)).
-
-### Fixed
-
 - Database format upgrades now finish before startup exposes the finalized
   state database; only configured periodic format checks continue in the
   background ([#240](https://github.com/zakura-core/zakura/pull/240)).
@@ -145,6 +125,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   their requests are still shed for backpressure, but the connection is not
   closed. Every other peer's denial-of-service protection is unchanged
   ([#242](https://github.com/zakura-core/zakura/pull/242)).
+
+### Security
+
+- Prevent a peer from stalling chain synchronization by delivering a rejected
+  block body that shares its header hash with a later valid block
+  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
 
 ## [1.0.1] - 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.2-rc1"
+version = "1.0.2"
 dependencies = [
  "abscissa_core",
  "anyhow",
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "1.2.0-rc1"
+version = "1.2.0"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "3.0.0-rc1"
+version = "3.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "3.0.0-rc1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "1.0.1-rc0"
+version = "1.0.1"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "3.0.0-rc1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "1.0.1-rc0"
+version = "1.0.1"
 dependencies = [
  "hex",
  "lazy_static",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "3.0.0-rc1"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "1.0.2-rc0"
+version = "1.0.2"
 dependencies = [
  "color-eyre",
  "hex",

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.0.2-rc1 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.0.2 zakura
 ```
 
 You can start Zakura by running

--- a/zakura-chain/CHANGELOG.md
+++ b/zakura-chain/CHANGELOG.md
@@ -7,24 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Reuse transaction-wide transparent signature hash components across input
-  checks.
-
-## [1.2.0-rc1] - 2026-07-19
-
-### Changed
-
-- Added test coverage for ZIP-317 unpaid-action rejection in
-  `VerifiedUnminedTx::new`; no APIs defined in this crate changed.
-
-## [1.2.0-rc0] - 2026-07-19
+## [1.2.0] - 2026-07-20
 
 ### Added
 
 - Added `NoteCommitmentTrees::update_sprout_tree` for updating the Sprout
   note-commitment tree from a block.
+
+### Changed
+
+- Transparent signature hashes reuse transaction-wide precomputed ZIP 143,
+  ZIP 243, and ZIP 244 components across input checks instead of hashing them
+  again for every signature
+  ([#281](https://github.com/zakura-core/zakura/pull/281)).
 
 ## [1.1.0] - 2026-07-17
 

--- a/zakura-chain/Cargo.toml
+++ b/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "1.2.0-rc1"
+version = "1.2.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-consensus/CHANGELOG.md
+++ b/zakura-consensus/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0-rc1] - 2026-07-19
+## [3.0.0] - 2026-07-20
+
+### Breaking Changes
+
+- `zakura-state` moved to 3.0.0. State service types appear in this crate's
+  public `init` signatures, so the state major version is part of this crate's
+  API; no APIs defined in this crate changed.
 
 ### Added
 
@@ -33,14 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mempool rejections of NU6.2 branch-ID transactions no longer penalize the
   relaying peer during the first 40 heights after NU6.3 activation; consensus
   validation is unchanged.
-
-## [3.0.0-rc0] - 2026-07-19
-
-### Breaking Changes
-
-- `zakura-state` moved to 3.0.0-rc0. State service types appear in this crate's
-  public `init` signatures, so the state major version is part of this crate's
-  API; no APIs defined in this crate changed.
 
 ## [2.0.0] - 2026-07-17
 

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "3.0.0-rc1"
+version = "3.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -68,10 +68,10 @@ zcash_primitives = { workspace = true }
 tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.0.0" }
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.0.0" }
 
-zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc1" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1" }
+zakura-script = { path = "../zakura-script", version = "1.0.1" }
+zakura-state = { path = "../zakura-state", version = "3.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0" }
 
 zcash_protocol.workspace = true
 
@@ -96,8 +96,8 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc1", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "3.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0-rc1] - 2026-07-19
+## [3.0.0] - 2026-07-20
 
 ### Breaking Changes
 
@@ -15,21 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   peer address labels in peer activity logs and metrics. Downstream exhaustive
   `Config` struct literals must initialize the new field
   ([#258](https://github.com/zakura-core/zakura/pull/258)).
-
-### Added
-
-- Added `legacy_peer_request.jsonl` tracing for attributed legacy `FindBlocks`
-  responses and block downloads when `[network.zakura] trace_dir` is set.
-
-### Fixed
-
-- Pruned nodes no longer advertise retained block hashes in legacy `getblocks`
-  responses when their corresponding block bodies are unavailable.
-
-## [3.0.0-rc0] - 2026-07-19
-
-### Breaking Changes
-
 - Added `ConnectionInfo::is_protected_peer`, requiring downstream struct
   literals to specify whether a configured peer is protected from overload
   disconnects.
@@ -38,8 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `legacy_peer_request.jsonl` tracing for attributed legacy `FindBlocks`
+  responses and block downloads when `[network.zakura] trace_dir` is set.
 - Added `ConnectedAddr::is_protected_peer` for identifying configured
   block-gossip and zcashd-compat peers.
+
+### Fixed
+
+- Pruned nodes no longer advertise retained block hashes in legacy `getblocks`
+  responses when their corresponding block bodies are unavailable.
 
 ## [2.0.0] - 2026-07-17
 

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "3.0.0-rc1"
+version = "3.0.0"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -93,7 +93,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = ["async-error"] }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
 
 [dev-dependencies]
@@ -106,7 +106,7 @@ static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]

--- a/zakura-node-services/CHANGELOG.md
+++ b/zakura-node-services/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1-rc0] - 2026-07-19
+## [1.0.1] - 2026-07-20
 
 ### Changed
 
-- Updated the `zakura-chain` dependency to 1.2.0-rc0; no APIs defined in this
+- Updated the `zakura-chain` dependency to 1.2.0; no APIs defined in this
   crate changed.
 
 ## [1.0.0] - 2026-07-15

--- a/zakura-node-services/Cargo.toml
+++ b/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "1.0.1-rc0"
+version = "1.0.1"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "1.2.0-rc0" }
+zakura-chain = { path = "../zakura-chain" , version = "1.2.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zakura-rpc/CHANGELOG.md
+++ b/zakura-rpc/CHANGELOG.md
@@ -7,23 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0-rc1] - 2026-07-19
+## [3.0.0] - 2026-07-20
+
+### Breaking Changes
+
+- `zakura-state`, `zakura-network`, and `zakura-consensus` moved to 3.0.0.
+  Their service types appear in this crate's public server signatures, so
+  their major versions are part of this crate's API; no APIs defined in this
+  crate changed.
 
 ### Changed
 
 - `getblocktemplate` coinbase construction reuses the process-wide Sapling
-  prover from `zakura-consensus` (requiring 3.0.0-rc1 for `sapling_prover`)
+  prover from `zakura-consensus` (requiring 3.0.0 for `sapling_prover`)
   instead of re-parsing the bundled proving parameters on every request; no
   APIs defined in this crate changed.
-
-## [3.0.0-rc0] - 2026-07-19
-
-### Breaking Changes
-
-- `zakura-state`, `zakura-network`, and `zakura-consensus` moved to 3.0.0-rc0.
-  Their service types appear in this crate's public server signatures, so
-  their major versions are part of this crate's API; no APIs defined in this
-  crate changed.
 
 ## [2.0.0] - 2026-07-17
 

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "3.0.0-rc1"
+version = "3.0.0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1" }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc1" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0" }
+zakura-network = { path = "../zakura-network", version = "3.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc1" }
+zakura-script = { path = "../zakura-script", version = "1.0.1" }
+zakura-state = { path = "../zakura-state", version = "3.0.0" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -140,16 +140,16 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = [
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc1", features = [
+zakura-network = { path = "../zakura-network", version = "3.0.0", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc1", features = [
+zakura-state = { path = "../zakura-state", version = "3.0.0", features = [
     "proptest-impl",
 ] }
 

--- a/zakura-script/CHANGELOG.md
+++ b/zakura-script/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1-rc0] - 2026-07-19
+## [1.0.1] - 2026-07-20
 
 ### Changed
 
-- Updated the `zakura-chain` dependency to 1.2.0-rc0; no APIs defined in this
-  crate changed.
+- Transparent input signature hashes are now computed through `zakura-chain`'s
+  shared transaction-wide precomputation context
+  ([#281](https://github.com/zakura-core/zakura/pull/281)); no APIs defined in
+  this crate changed.
+- Updated the `zakura-chain` dependency to 1.2.0.
 
 ## [1.0.0] - 2026-07-15
 

--- a/zakura-script/Cargo.toml
+++ b/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "1.0.1-rc0"
+version = "1.0.1"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,28 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
-
-- The state service now accepts children of a block that was accepted and has the same
-  block header hash (due to [ZIP-244](https://zips.z.cash/zip-0244)) as a block that
-  was previously rejected
-  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
-
-## [3.0.0-rc1] - 2026-07-19
-
-### Changed
-
-- `FindBlockHashes` now returns only the contiguous prefix of block hashes whose
-  full bodies are serveable, while other chain-identity reads continue using
-  retained indexes after pruning.
-
-### Fixed
-
-- Contextual difficulty validation returns the consensus proof-of-work limit
-  for all candidate heights at or below the averaging window, including
-  height 17 with a full difficulty context.
-
-## [3.0.0-rc0] - 2026-07-19
+## [3.0.0] - 2026-07-20
 
 ### Breaking Changes
 
@@ -45,6 +24,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   APIs, plus an offline generator binary and exact-versioned crates.io
   packaging that keeps the embedded repair bytes outside `zakura-state` and
   reuses one validated decode throughout startup repair.
+
+### Changed
+
+- `FindBlockHashes` now returns only the contiguous prefix of block hashes whose
+  full bodies are serveable, while other chain-identity reads continue using
+  retained indexes after pruning.
+
+### Fixed
+
+- Contextual difficulty validation returns the consensus proof-of-work limit
+  for all candidate heights at or below the averaging window, including
+  height 17 with a full difficulty context.
+
+### Security
+
+- The state service now accepts children of a block that was accepted and has the same
+  block header hash (due to [ZIP-244](https://zips.z.cash/zip-0244)) as a block that
+  was previously rejected
+  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
 
 ## [2.0.0] - 2026-07-17
 

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "3.0.0-rc1"
+version = "3.0.0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -87,8 +87,8 @@ zakura-vct-sprout-history = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["async-error"] }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -119,7 +119,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "1.0.0" }
 
 [lints]

--- a/zakura-utils/CHANGELOG.md
+++ b/zakura-utils/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.2-rc0] - 2026-07-19
+## [1.0.2] - 2026-07-20
 
 ### Changed
 
-- Updated the bundled tools to the release-candidate Zakura crate graph; no
-  APIs defined in this crate changed.
+- Updated the bundled tools to the Zakura v1.0.2 crate graph; no APIs defined
+  in this crate changed.
 
 ## [1.0.1] - 2026-07-17
 

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "1.0.2-rc0"
+version = "1.0.2"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -60,11 +60,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zakura-rpc = { path = "../zakura-rpc", version = "3.0.0-rc0" }
+zakura-rpc = { path = "../zakura-rpc", version = "3.0.0" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.0.2-rc1"
+version = "1.0.2"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -158,21 +158,21 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1" }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1" }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.0" }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc1" }
-zakura-node-services = { path = "../zakura-node-services", version = "1.0.1-rc0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "3.0.0-rc1" }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc1" }
+zakura-network = { path = "../zakura-network", version = "3.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "1.0.1", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "3.0.0" }
+zakura-state = { path = "../zakura-state", version = "3.0.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "1.0.1-rc0" }
+zakura-script = { path = "../zakura-script", version = "1.0.1" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "1.0.2-rc0", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "1.0.2", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -312,10 +312,10 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "1.2.0-rc1", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "3.0.0-rc1", features = ["proptest-impl"] }
-zakura-network = { path = "../zakura-network", version = "3.0.0-rc1", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "3.0.0-rc1", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "1.2.0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "3.0.0", features = ["proptest-impl"] }
+zakura-network = { path = "../zakura-network", version = "3.0.0", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "3.0.0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "1.0.0" }
 
@@ -328,7 +328,7 @@ zakura-test = { path = "../zakura-test", version = "1.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "1.0.2-rc0" }
+zakura-utils = { path = "../zakura-utils", version = "1.0.2" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_419_500;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_420_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -24,8 +24,8 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_419_500;
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
 /// - Currently set to 18 days
 ///
-/// Note: v1.0.2-rc1 spans the expected Ironwood activation (height 3,428,143,
-/// ~2026-07-28) and halts about ten days after it (~2026-08-07, height 3,440,236),
+/// Note: v1.0.2 spans the expected Ironwood activation (height 3,428,143,
+/// ~2026-07-28) and halts about eleven days after it (~2026-08-08, height 3,440,736),
 /// forcing migration to the post-Ironwood release.
 pub const EOS_PANIC_AFTER: u32 = 18;
 

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_420_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_419_500;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -25,7 +25,7 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_420_000;
 /// - Currently set to 18 days
 ///
 /// Note: v1.0.2 spans the expected Ironwood activation (height 3,428,143,
-/// ~2026-07-28) and halts about eleven days after it (~2026-08-08, height 3,440,736),
+/// ~2026-07-28) and halts about ten days after it (~2026-08-07, height 3,440,236),
 /// forcing migration to the post-Ironwood release.
 pub const EOS_PANIC_AFTER: u32 = 18;
 

--- a/zakurad/tests/common/configs/v1.0.2.toml
+++ b/zakurad/tests/common/configs/v1.0.2.toml
@@ -1,0 +1,151 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+expose_peer_addresses = false
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"


### PR DESCRIPTION
## Motivation

Prepare `main` for the stable v1.0.2 release, graduating the v1.0.2-rc0/rc1
release candidates. Everything user-visible in this release has already
shipped on `main`, almost all of it exercised in the two rcs; this PR moves
the crate graph and release metadata to their stable versions.

## Solution

**Crate graph** — graduate all 9 crates changed since their last stable
publish (verified against the crates.io index and
`check-crate-version-bumps.sh` with `BASE_TAG=v1.0.1`):

| Crate | Last stable | This release |
| --- | --- | --- |
| `zakura` | 1.0.1 | 1.0.2 |
| `zakura-chain` | 1.1.0 | 1.2.0 |
| `zakura-consensus` | 2.0.0 | 3.0.0 |
| `zakura-network` | 2.0.0 | 3.0.0 |
| `zakura-rpc` | 2.0.0 | 3.0.0 |
| `zakura-state` | 2.0.0 | 3.0.0 |
| `zakura-node-services` | 1.0.0 | 1.0.1 |
| `zakura-script` | 1.0.0 | 1.0.1 |
| `zakura-utils` | 1.0.1 | 1.0.2 |

`zakura-test`, `zakura-tower-batch-control`, `zakura-tower-fallback`, and
`zakura-jsonl-trace` have zero diff since v1.0.0 and are not bumped or
published. Post-rc1 changes are covered by the graduation: #281 touched
`zakura-chain` and `zakura-script`, #296 touched `zakura-network`, and #300
touched `zakura-state` — all four crates were already in the bump set.

**Changelogs** — the rc0/rc1 sections in the root and crate changelogs are
consolidated into single stable sections (entries verbatim, rc-version
cross-references reworded to stable), matching the changelog policy that rcs
are pre-releases *of* a version and don't keep standalone entries.
`zakura-chain`'s rc1 test-only entry was dropped as not consumer-visible.
#300's root and `zakura-state` entries (added on `main` under
`[Unreleased]`) are folded into the stable `[1.0.2]` and `[3.0.0]` sections.

**Release metadata**

- Stored config fixture `zakurad/tests/common/configs/v1.0.2.toml` generated
  from this branch via `zakurad generate` (byte-identical to the rc1 fixture —
  no config surface changed since rc1).
- `ESTIMATED_RELEASE_HEIGHT` stays at the rc1 estimate of 3,419,500 (tip was
  3,418,970 at 2026-07-20 13:54 UTC). v1.0.2 spans Ironwood activation and
  halts ~2026-08-07 at height 3,440,236.
- README install example tag → `v1.0.2`.
- Installer metadata is left pinned to v1.0.2-rc1; the release workflow
  rewrites it and opens the follow-up PR after the release exists.

## Testing

- `BASE_TAG=v1.0.1 ./scripts/check-crate-version-bumps.sh` — 9 changed crates,
  all bumped, no warnings.
- `cargo semver-checks` against last stable baselines: `zakura-chain`
  1.1.0→1.2.0 (minor), `zakura-script` and `zakura-node-services`
  1.0.0→1.0.1 (patch) — all pass; major bumps need no check.
- `cargo public-api diff 1.1.0` for `zakura-chain`: exactly one addition
  (`NoteCommitmentTrees::update_sprout_tree`), nothing removed or changed —
  the changelog matches the full API delta.
- `./scripts/check-release-version.sh v1.0.2` — tag matches package version.
- `cargo metadata --locked`, `cargo fmt --check`, `bash -n
  scripts/install-zakura.sh`, markdownlint (CI config) on all changed
  Markdown — clean.
- `stored_configs_parsed_correctly` passes (includes the new fixture);
  the `last_config_is_stored` comparison was reproduced manually (the fixture
  is the checklist command's exact output). The full `config_tests` sequence
  cannot run on the prep machine — a long-running sync node holds the default
  state-DB lock and port 8233 — so node-starting config tests rely on draft
  CI here.
- `./scripts/check-crate-packaging.sh --verify` on the release commit — all
  13 crates package cleanly at their stable versions and the packaged
  `zakura-1.0.2` archive rebuilds.
- Clippy relies on draft CI (`-D warnings`); the only Rust change is two
  constants and a doc comment in `end_of_support.rs`.

### Specifications & References

- Follows #294 (v1.0.2-rc1 prep) and #295 (rc1 installer metadata).
- Release policy: `docs/release-tag-protection.md`;
  checklist: `.github/PULL_REQUEST_TEMPLATE/release-checklist.md`.

### Follow-up Work

- Checkpoints have not been refreshed since the fork (last checkpoint height
  3,358,006 vs tip ~3,418,970). v1.0.0/v1.0.1/rc0/rc1 all shipped this way —
  refresh or record an explicit waiver before dispatching the release.
- After merge + explicit go-ahead: dispatch `create-release.yml` with
  `v1.0.2`, publish the 9 changed crates in dependency order, then promote to
  Latest and merge the installer-metadata follow-up PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
