### PR TITLE
fix(state): prevent same-hash rejected blocks from stalling sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   checks instead of hashing them again for every signature
   ([#281](https://github.com/zakura-core/zakura/pull/281)).
 
+### Security
+
+- Prevent a peer from stalling chain synchronization by delivering a rejected
+  block body that shares its header hash with a later valid block
+  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
+
 ## [1.0.2-rc1] - 2026-07-19
 
 ### Added

--- a/zakura-state/CHANGELOG.md
+++ b/zakura-state/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- The state service now accepts children of a block that was accepted and has the same
+  block header hash (due to [ZIP-244](https://zips.z.cash/zip-0244)) as a block that
+  was previously rejected
+  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
+
 ## [3.0.0-rc1] - 2026-07-19
 
 ### Changed

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -674,6 +674,10 @@ impl WriteBlockWorkerTask {
                 continue;
             }
 
+            // A successfully committed block supersedes any contextual error
+            // recorded for a different block body with the same header hash.
+            parent_error_map.shift_remove(&child_hash);
+
             if should_seed_zakura_header_from_non_finalized_commit(
                 *seed_zakura_header_from_best_chain_commits,
                 non_finalized_state,

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -162,7 +162,8 @@ use zakura_chain::{
         Network::{self, *},
         NetworkUpgrade,
     },
-    serialization::BytesInDisplayOrder,
+    serialization::{BytesInDisplayOrder, ZcashSerialize as _},
+    transparent,
 };
 use zakura_node_services::rpc_client::RpcRequestClient;
 use zakura_rpc::{
@@ -171,6 +172,7 @@ use zakura_rpc::{
         GetBlockTemplateRequestMode, GetBlockTemplateResponse, SubmitBlockErrorResponse,
         SubmitBlockResponse, TransactionTemplate,
     },
+    config::mining::ExtraCoinbaseData,
     fetch_chain_info,
     methods::{RpcImpl, RpcServer},
     proposal_block_from_template,
@@ -3044,6 +3046,162 @@ fn external_address() -> Result<()> {
 #[tokio::test]
 async fn regtest_block_templates_are_valid_block_submissions() -> Result<()> {
     common::regtest::submit_blocks_test().await?;
+    Ok(())
+}
+
+/// A rejected block body must not poison the children of a later valid block with the same header
+/// hash.
+///
+/// This is a regression test for [GHSA-8gxx-hc65-vv82][ghsa-8gxx]. Under the transaction digest
+/// scheme defined by [ZIP-244][zip-244], two different block bodies can share the same header hash.
+/// `zakura-state` previously retained the contextual validation error from the poisoned body and
+/// incorrectly propagated it to children of the later valid block, causing them to be incorrectly
+/// rejected.
+///
+/// [ghsa-8gxx]: https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82
+/// [zip-244]: https://zips.z.cash/zip-0244
+#[tokio::test]
+async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()> {
+    const EXTRA_COINBASE_DATA: &str = "zakura-chain-stall-poc";
+
+    let _init_guard = zakura_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let mut config = os_assigned_rpc_port_config(false, &network)?;
+    config.mempool.debug_enable_at_height = Some(0);
+    config.mining.extra_coinbase_data =
+        Some(ExtraCoinbaseData::try_from(EXTRA_COINBASE_DATA.to_owned())?);
+
+    let mut block_builder = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+    let rpc_address = read_listen_addr_from_logs(&mut block_builder, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+    let mut blocks = Vec::new();
+    for expected_height in 1..=4 {
+        let (block, height) = client.block_from_template(&network).await?;
+        assert_eq!(height.0, expected_height);
+        client.submit_block(block.clone()).await?;
+        blocks.push(block);
+    }
+
+    block_builder.kill(false)?;
+    let output = block_builder.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    let mut zakurad = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+    let rpc_address = read_listen_addr_from_logs(&mut zakurad, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+    client.submit_block(blocks[0].clone()).await?;
+    client.submit_block(blocks[1].clone()).await?;
+
+    let valid_block = blocks[2].clone();
+
+    let mut poisoned_block = valid_block.clone();
+    let coinbase = Arc::make_mut(
+        poisoned_block
+            .transactions
+            .first_mut()
+            .expect("block templates contain a coinbase transaction"),
+    );
+    let transparent::Input::Coinbase { data, .. } = coinbase
+        .inputs_mut()
+        .first_mut()
+        .expect("coinbase transactions contain a transparent input")
+    else {
+        panic!("the first coinbase transaction input must be a coinbase input");
+    };
+    assert!(
+        data.ends_with(EXTRA_COINBASE_DATA.as_bytes()),
+        "the coinbase transaction must contain the configured extra data"
+    );
+    let last_data_byte = data
+        .last_mut()
+        .expect("configured extra coinbase data is non-empty");
+    *last_data_byte = b'a';
+
+    assert_eq!(
+        poisoned_block.hash(),
+        valid_block.hash(),
+        "changing a NU5 coinbase scriptSig must not change the block header hash"
+    );
+
+    let poisoned_block_data = hex::encode(poisoned_block.zcash_serialize_to_vec()?);
+    let poisoned_response: SubmitBlockResponse = client
+        .json_result_from_call("submitblock", format!(r#"["{poisoned_block_data}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert!(
+        matches!(poisoned_response, SubmitBlockResponse::ErrorResponse(_)),
+        "the poisoned block body must be rejected"
+    );
+
+    // The rejected hash is still marked as sent until the state service drains the write task's
+    // rejection notification. For now this same-hash block is considered a duplicate.
+    let valid_block_data = hex::encode(valid_block.zcash_serialize_to_vec()?);
+    let first_valid_response: SubmitBlockResponse = client
+        .json_result_from_call("submitblock", format!(r#"["{valid_block_data}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert_eq!(
+        first_valid_response,
+        SubmitBlockResponse::ErrorResponse(SubmitBlockErrorResponse::Duplicate),
+        "the first valid block submission must wait for the rejected hash to be drained"
+    );
+
+    // The child submission below triggers another state request and drains the previous
+    // notification, which means the block can then be resubmitted.
+    let valid_child = blocks[3].clone();
+    let valid_child_data = hex::encode(valid_child.zcash_serialize_to_vec()?);
+    let submit_child = client.json_result_from_call::<SubmitBlockResponse>(
+        "submitblock",
+        format!(r#"["{valid_child_data}"]"#),
+    );
+
+    let resubmit_valid_block = async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        client
+            .json_result_from_call::<SubmitBlockResponse>(
+                "submitblock",
+                format!(r#"["{valid_block_data}"]"#),
+            )
+            .await
+    };
+    let (valid_child_response, valid_block_response) =
+        tokio::join!(submit_child, resubmit_valid_block);
+    let valid_child_response = valid_child_response.map_err(|err| eyre!(err))?;
+    let valid_block_response = valid_block_response.map_err(|err| eyre!(err))?;
+
+    assert_eq!(valid_block_response, SubmitBlockResponse::Accepted);
+    assert_eq!(
+        valid_child_response,
+        SubmitBlockResponse::Accepted,
+        "the valid child must not inherit the rejected block body's contextual error"
+    );
+    assert_eq!(
+        client.blockchain_info().await?.blocks(),
+        Height(4),
+        "the valid child must not inherit the rejected block body error"
+    );
+
+    zakurad.kill(false)?;
+    let output = zakurad.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Motivation

A rejected NU5+ block body can share its header hash with a later canonical block because the header hash does not commit to authorizing data. If contextual verification rejects the poisoned body first, the state write task records its hash in `parent_error_map`.

Even after the canonical same-hash block commits successfully, the stale map entry remains and causes the canonical block's children to inherit the earlier error. A remote peer that wins the propagation race can therefore stall chain synchronization.

This ports the GHSA-specific fix from ZcashFoundation/zebra#10995.

## Solution

Remove a block hash from `parent_error_map` immediately after a block with that hash commits successfully. Contextual verification remains unchanged: the poisoned body is still rejected, while the successful canonical commit supersedes the stale error associated with its hash.

Add an end-to-end Regtest regression test that:

1. Builds a canonical four-block NU5 chain.
2. Mutates the height-3 coinbase scriptSig to create a contextually invalid body with the canonical header hash.
3. Submits the poisoned body and verifies it is rejected.
4. Resubmits the canonical block and its child.
5. Verifies both are accepted and the chain reaches height 4.

## Testing

- `CXX=clang++ CXXFLAGS='-include cstdint' cargo test -p zakura --test acceptance rejected_block_does_not_reject_same_hash_block_children`
- `CXX=clang++ CXXFLAGS='-include cstdint' cargo clippy -p zakura-state --lib -- -D warnings`
- `CXX=clang++ CXXFLAGS='-include cstdint' cargo clippy -p zakura --test acceptance -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The explicit C++ flags work around vendored RocksDB 8.10 missing direct `<cstdint>` includes with this host's current C++ toolchain.

### Specifications & References

- [GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)
- [Upstream combined security fix PR](https://github.com/ZcashFoundation/zebra/pull/10995)
- [ZIP-244](https://zips.z.cash/zip-0244)
