### PR TITLE
Use dismad's suggested better RPC error

### DIFF
--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -1918,7 +1918,7 @@ where
             }),
 
             zakura_state::ReadResponse::AnyChainTransaction(None) => {
-                Err("No such mempool or main chain transaction")
+                Err("Transaction not found in mempool or best chain")
                     .map_error(server::error::LegacyCode::InvalidAddressOrKey)
             }
 

--- a/zakura-rpc/src/methods/tests/snapshots/getrawtransaction_unknown_txid@mainnet_10.snap
+++ b/zakura-rpc/src/methods/tests/snapshots/getrawtransaction_unknown_txid@mainnet_10.snap
@@ -6,6 +6,6 @@ snapshot_kind: text
 {
   "Err": {
     "code": -5,
-    "message": "No such mempool or main chain transaction"
+    "message": "Transaction not found in mempool or best chain"
   }
 }

--- a/zakura-rpc/src/methods/tests/snapshots/getrawtransaction_unknown_txid@testnet_10.snap
+++ b/zakura-rpc/src/methods/tests/snapshots/getrawtransaction_unknown_txid@testnet_10.snap
@@ -6,6 +6,6 @@ snapshot_kind: text
 {
   "Err": {
     "code": -5,
-    "message": "No such mempool or main chain transaction"
+    "message": "Transaction not found in mempool or best chain"
   }
 }


### PR DESCRIPTION
Bring in Dismad's error message improvement from upstream

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Message-only change for an existing error path; no logic, codes, or API shape changes.
> 
> **Overview**
> Updates the **`getrawtransaction`** RPC error when a txid is missing from both the mempool and chain state.
> 
> The user-facing message changes from *"No such mempool or main chain transaction"* to **"Transaction not found in mempool or best chain"**, aligning with an upstream wording improvement. The legacy error code (**-5**, `InvalidAddressOrKey`) is unchanged.
> 
> Snapshot tests for unknown txids on mainnet and testnet are updated to expect the new message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c019787e4c4435a1cf0707abf256a4dd21eeadc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->