### PR TITLE
fix(zcashd): scope pruned block logs to sidecar peers

### DIFF
--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -1352,7 +1352,7 @@ where
                             .connection_info
                             .connected_addr
                             .get_transient_addr()
-                            .expect("protected peers are direct inbound connections")
+                            .expect("protected peers have transient inbound addresses")
                             .into();
 
                         Request::BlocksByHashFrom { hashes, source }.into()

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -1345,7 +1345,20 @@ where
                         .iter()
                         .any(|item| matches!(item, InventoryHash::Block(_))) =>
                 {
-                    Request::BlocksByHash(block_hashes(items).collect()).into()
+                    let hashes = block_hashes(items).collect();
+
+                    if self.connection_info.is_protected_peer {
+                        let source = self
+                            .connection_info
+                            .connected_addr
+                            .get_transient_addr()
+                            .expect("protected peers are direct inbound connections")
+                            .into();
+
+                        Request::BlocksByHashFrom { hashes, source }.into()
+                    } else {
+                        Request::BlocksByHash(hashes).into()
+                    }
                 }
                 tx_ids if tx_ids.iter().any(|item| item.unmined_tx_id().is_some()) => {
                     Request::TransactionsById(transaction_ids(items).collect()).into()

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -147,8 +147,13 @@ fn new_test_connection_with_protection<A>(
         relay: true,
     };
 
+    let connected_addr = if is_protected_peer {
+        ConnectedAddr::new_inbound_direct(fake_addr.into())
+    } else {
+        ConnectedAddr::Isolated
+    };
     let connection_info = ConnectionInfo {
-        connected_addr: ConnectedAddr::Isolated,
+        connected_addr,
         local: remote.clone(),
         remote,
         negotiated_version: fake_version,

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -18,7 +18,7 @@ use futures::{
 use tower::load_shed::error::Overloaded;
 use tracing::Span;
 
-use zakura_chain::serialization::SerializationError;
+use zakura_chain::{block, serialization::SerializationError};
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
@@ -30,7 +30,7 @@ use crate::{
     peer_set::ActiveConnectionCounter,
     protocol::external::Message,
     types::Nonce,
-    PeerError, Request, Response,
+    PeerError, PeerSource, Request, Response,
 };
 
 /// Test that the connection run loop works as a future
@@ -1031,6 +1031,37 @@ async fn protected_connection_is_never_disconnected_on_overload() {
     }
 
     // We need to terminate the spawned task
+    connection_handle.abort();
+}
+
+/// A block `getdata` from a configured sidecar carries its classified
+/// connection source into the inbound service.
+#[tokio::test]
+async fn protected_connection_attributes_inbound_block_request() {
+    let _init_guard = zakura_test::init();
+    let (mut peer_tx, peer_rx) = mpsc::channel(1);
+    let (connection, _client_tx, mut inbound_service, _peer_messages, _error_slot) =
+        new_protected_test_connection();
+    let connection_handle = tokio::spawn(connection.run(peer_rx));
+    let hash = block::Hash([0x11; 32]);
+
+    peer_tx
+        .send(Ok(Message::GetData(vec![hash.into()])))
+        .await
+        .expect("test peer channel is open");
+
+    inbound_service
+        .expect_request(Request::BlocksByHashFrom {
+            hashes: HashSet::from([hash]),
+            source: PeerSource::LegacySocket(
+                "127.0.0.1:4"
+                    .parse()
+                    .expect("test peer socket address is valid"),
+            ),
+        })
+        .await
+        .respond_error(Overloaded::new().into());
+
     connection_handle.abort();
 }
 

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -452,6 +452,7 @@ impl StartCmd {
                 config.sync.full_verify_concurrency_limit,
                 config.network.expose_peer_addresses,
                 zcashd_compat_pruning_retention,
+                zcashd_compat_block_gossip_peer_ips.clone(),
                 setup_rx,
             ));
 

--- a/zakurad/src/components/inbound.rs
+++ b/zakurad/src/components/inbound.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::HashSet,
     future::Future,
+    net::IpAddr,
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
@@ -99,19 +100,26 @@ type GossipedBlockDownloads =
 #[derive(Debug)]
 struct PrunedBlockNotFoundLogger {
     tx_retention: Option<u32>,
+    peer_ips: HashSet<IpAddr>,
     last_log: Mutex<Option<Instant>>,
 }
 
 impl PrunedBlockNotFoundLogger {
-    fn new(tx_retention: Option<u32>) -> Self {
+    fn new(tx_retention: Option<u32>, peer_ips: Vec<IpAddr>) -> Self {
         Self {
             tx_retention,
+            peer_ips: peer_ips.into_iter().map(canonical_ip).collect(),
             last_log: Mutex::new(None),
         }
     }
 
-    fn is_enabled(&self) -> bool {
-        self.tx_retention.is_some()
+    fn is_enabled_for(&self, source: Option<&zn::PeerSource>) -> bool {
+        let Some(zn::PeerSource::LegacySocket(addr)) = source else {
+            return false;
+        };
+        let source_ip = canonical_ip(addr.remove_socket_addr_privacy().ip());
+
+        self.tx_retention.is_some() && self.peer_ips.contains(&source_ip)
     }
 
     /// Reserves the current log interval and returns the configured retention.
@@ -134,6 +142,16 @@ impl PrunedBlockNotFoundLogger {
 
         *last_log = Some(now);
         Some(tx_retention)
+    }
+}
+
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(ip) => ip
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(ip)),
+        ip => ip,
     }
 }
 
@@ -308,6 +326,7 @@ impl Inbound {
         full_verify_concurrency_limit: usize,
         expose_peer_addresses: bool,
         zcashd_compat_pruning_retention: Option<u32>,
+        zcashd_compat_peer_ips: Vec<IpAddr>,
         setup: oneshot::Receiver<InboundSetupData>,
     ) -> Inbound {
         Inbound {
@@ -318,6 +337,7 @@ impl Inbound {
             expose_peer_addresses,
             pruned_block_not_found_logger: Arc::new(PrunedBlockNotFoundLogger::new(
                 zcashd_compat_pruning_retention,
+                zcashd_compat_peer_ips,
             )),
         }
     }
@@ -508,15 +528,15 @@ impl Service<zn::Request> for Inbound {
             }
             request @ (zn::Request::BlocksByHash(_)
             | zn::Request::BlocksByHashFrom { .. }) => {
-                let (hashes, is_zcashd_compat_peer) = match request {
-                    zn::Request::BlocksByHash(hashes) => (hashes, false),
-                    zn::Request::BlocksByHashFrom {
-                        hashes,
-                        source: zn::PeerSource::LegacySocket(_),
-                    } => (hashes, true),
-                    zn::Request::BlocksByHashFrom { hashes, .. } => (hashes, false),
+                let (hashes, source) = match request {
+                    zn::Request::BlocksByHash(hashes) => (hashes, None),
+                    zn::Request::BlocksByHashFrom { hashes, source } => {
+                        (hashes, Some(source))
+                    }
                     _ => unreachable!("matched block inventory request"),
                 };
+                let log_pruned_block =
+                    pruned_block_not_found_logger.is_enabled_for(source.as_ref());
 
                 // We return an available or missing response to each inventory request,
                 // unless the request is empty, or it reaches a response limit.
@@ -560,9 +580,7 @@ impl Service<zn::Request> for Inbound {
                                 // A retained canonical header with no block body identifies
                                 // history removed by pruning. Unknown hashes remain ordinary
                                 // `notfound` responses without reserving a log interval.
-                                if is_zcashd_compat_peer
-                                    && pruned_block_not_found_logger.is_enabled()
-                                {
+                                if log_pruned_block {
                                     if let Some(height) =
                                         retained_block_height(state.clone(), hash).await
                                     {

--- a/zakurad/src/components/inbound.rs
+++ b/zakurad/src/components/inbound.rs
@@ -506,7 +506,18 @@ impl Service<zn::Request> for Inbound {
                     Ok(response)
                 }.boxed()
             }
-            zn::Request::BlocksByHash(hashes) | zn::Request::BlocksByHashFrom { hashes, .. } => {
+            request @ (zn::Request::BlocksByHash(_)
+            | zn::Request::BlocksByHashFrom { .. }) => {
+                let (hashes, is_zcashd_compat_peer) = match request {
+                    zn::Request::BlocksByHash(hashes) => (hashes, false),
+                    zn::Request::BlocksByHashFrom {
+                        hashes,
+                        source: zn::PeerSource::LegacySocket(_),
+                    } => (hashes, true),
+                    zn::Request::BlocksByHashFrom { hashes, .. } => (hashes, false),
+                    _ => unreachable!("matched block inventory request"),
+                };
+
                 // We return an available or missing response to each inventory request,
                 // unless the request is empty, or it reaches a response limit.
                 if hashes.is_empty() {
@@ -549,7 +560,9 @@ impl Service<zn::Request> for Inbound {
                                 // A retained canonical header with no block body identifies
                                 // history removed by pruning. Unknown hashes remain ordinary
                                 // `notfound` responses without reserving a log interval.
-                                if pruned_block_not_found_logger.is_enabled() {
+                                if is_zcashd_compat_peer
+                                    && pruned_block_not_found_logger.is_enabled()
+                                {
                                     if let Some(height) =
                                         retained_block_height(state.clone(), hash).await
                                     {

--- a/zakurad/src/components/inbound/tests.rs
+++ b/zakurad/src/components/inbound/tests.rs
@@ -1,15 +1,18 @@
 //! Inbound service tests.
 
-use std::time::{Duration, Instant};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::{Duration, Instant},
+};
 
-use super::{PrunedBlockNotFoundLogger, ZCASHD_COMPAT_PRUNED_BLOCK_LOG_INTERVAL};
+use super::{canonical_ip, PrunedBlockNotFoundLogger, ZCASHD_COMPAT_PRUNED_BLOCK_LOG_INTERVAL};
 
 mod fake_peer_set;
 mod real_peer_set;
 
 #[test]
 fn pruned_block_not_found_log_is_rate_limited() {
-    let logger = PrunedBlockNotFoundLogger::new(Some(10_000));
+    let logger = PrunedBlockNotFoundLogger::new(Some(10_000), Vec::new());
     let start = Instant::now();
 
     assert_eq!(logger.reserve_log_at(start), Some(10_000));
@@ -22,7 +25,17 @@ fn pruned_block_not_found_log_is_rate_limited() {
 
 #[test]
 fn pruned_block_not_found_log_is_disabled_without_compat_pruning() {
-    let logger = PrunedBlockNotFoundLogger::new(None);
+    let logger = PrunedBlockNotFoundLogger::new(None, Vec::new());
 
     assert_eq!(logger.reserve_log_at(Instant::now()), None);
+}
+
+#[test]
+fn pruned_block_not_found_peer_ips_canonicalize_mapped_ipv6() {
+    let ipv4 = Ipv4Addr::new(192, 0, 2, 1);
+
+    assert_eq!(
+        canonical_ip(IpAddr::V6(ipv4.to_ipv6_mapped())),
+        IpAddr::V4(ipv4)
+    );
 }

--- a/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -1064,6 +1064,7 @@ async fn caches_getaddr_response() {
             MAX_INBOUND_CONCURRENCY,
             false,
             None,
+            Vec::new(),
             setup_rx,
         ));
         let inbound_service = BoxService::new(inbound_service);
@@ -1298,6 +1299,7 @@ async fn setup(
         MAX_INBOUND_CONCURRENCY,
         false,
         None,
+        Vec::new(),
         setup_rx,
     ));
     let inbound_service = BoxService::new(inbound_service);

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -394,7 +394,10 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         Response::Blocks(vec![Missing(block1.hash())]),
         "inbound maps the unavailable block body to missing inventory"
     );
-    assert!(logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR));
+    assert!(
+        !logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        "an ordinary peer must not log a zcashd-compat pruning error"
+    );
 
     let wire_response = connected_peer_service
         .clone()
@@ -413,6 +416,10 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
              actual result: {wire_response:?}"
         )
     }
+    assert!(
+        logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        "the configured zcashd-compat peer must log the pruning error"
+    );
 
     assert!(
         block_gossip_task_handle.now_or_never().is_none(),
@@ -906,12 +913,18 @@ async fn setup(
 
         ..NetworkConfig::default()
     };
-    let (mut peer_set, address_book, _) = zakura_network::init(
+    let protected_peer_ips = zcashd_compat_pruning_retention
+        .is_some()
+        .then_some(vec![config_listen_addr.ip()])
+        .unwrap_or_default();
+    let (mut peer_set, address_book, _, _) = zakura_network::init_with_zakura_header_sync(
         network_config,
         inbound_service.clone(),
         latest_chain_tip.clone(),
         "Zebra user agent".to_string(),
         PeerServices::NODE_NETWORK,
+        protected_peer_ips,
+        None,
     )
     .await;
 

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -21,8 +21,8 @@ use zakura_consensus::{error::TransactionError, router::RouterError, transaction
 use zakura_network::{
     canonical_peer_addr, connect_isolated_tcp_direct_with_inbound,
     types::{InventoryHash, PeerServices},
-    CacheDir, Config as NetworkConfig, InventoryResponse, P2pStack, PeerError, Request, Response,
-    SharedPeerError,
+    CacheDir, Config as NetworkConfig, InventoryResponse, P2pStack, PeerError, PeerSource, Request,
+    Response, SharedPeerError,
 };
 use zakura_node_services::mempool;
 use zakura_rpc::SubmitBlockChannel;
@@ -397,6 +397,27 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
     assert!(
         !logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "an ordinary peer must not log a zcashd-compat pruning error"
+    );
+
+    let unconfigured_peer_response = inbound_service
+        .clone()
+        .oneshot(Request::BlocksByHashFrom {
+            hashes: iter::once(block1.hash()).collect(),
+            source: PeerSource::LegacySocket(
+                "192.0.2.1:8233"
+                    .parse()
+                    .expect("test peer socket address is valid"),
+            ),
+        })
+        .await?;
+    assert_eq!(
+        unconfigured_peer_response,
+        Response::Blocks(vec![Missing(block1.hash())]),
+        "an unconfigured legacy peer still receives missing inventory"
+    );
+    assert!(
+        !logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        "an unconfigured legacy peer must not log a zcashd-compat pruning error"
     );
 
     let wire_response = connected_peer_service
@@ -875,7 +896,11 @@ async fn setup(
 
     let network = Network::Mainnet;
     // Open a listener on an unused IPv4 localhost port
-    let config_listen_addr = "127.0.0.1:0".parse().unwrap();
+    let config_listen_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let protected_peer_ips = zcashd_compat_pruning_retention
+        .is_some()
+        .then_some(vec![config_listen_addr.ip()])
+        .unwrap_or_default();
 
     // Inbound
     let (setup_tx, setup_rx) = oneshot::channel();
@@ -883,6 +908,7 @@ async fn setup(
         MAX_INBOUND_CONCURRENCY,
         false,
         zcashd_compat_pruning_retention,
+        protected_peer_ips.clone(),
         setup_rx,
     );
     // TODO: add a timeout just above the service, if needed
@@ -913,10 +939,6 @@ async fn setup(
 
         ..NetworkConfig::default()
     };
-    let protected_peer_ips = zcashd_compat_pruning_retention
-        .is_some()
-        .then_some(vec![config_listen_addr.ip()])
-        .unwrap_or_default();
     let (mut peer_set, address_book, _, _) = zakura_network::init_with_zakura_header_sync(
         network_config,
         inbound_service.clone(),
@@ -1119,7 +1141,8 @@ mod submitblock_test {
 
         // Inbound
         let (_setup_tx, setup_rx) = oneshot::channel();
-        let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, false, None, setup_rx);
+        let inbound_service =
+            Inbound::new(MAX_INBOUND_CONCURRENCY, false, None, Vec::new(), setup_rx);
         let inbound_service = ServiceBuilder::new()
             .load_shed()
             .buffer(10)


### PR DESCRIPTION
## Motivation

PR #279 enabled an actionable diagnostic when a pruned zcashd-compat node cannot serve a requested block body. The diagnostic was configuration-gated, but the shared inbound service did not identify which connected peer sent the request, so any peer could trigger the message and consume its global rate-limit interval.

## Solution

- attribute block `getdata` requests from operator-configured protected legacy peers with their connection source
- independently match that source against the effective `zcashd_compat.block_gossip_peer_ips` allowlist
- emit the pruning diagnostic only for configured legacy sidecar requests
- keep ordinary legacy, unconfigured legacy, and Zakura v2 requests on the existing `notfound` path without logging

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network protected_connection_attributes_inbound_block_request --lib`
- `cargo test -p zakura inbound_pruned_block --lib`
- `cargo test -p zakura pruned_block_not_found --lib`
- `cargo clippy -p zakura-network -p zakura --lib --tests --no-deps -- -D warnings`

The connection test verifies that configured sidecar requests carry their classified source. The inbound integration test verifies that ordinary and unconfigured legacy requests do not log while the configured zcashd-compat peer does, without changing the wire `notfound` response. Unit coverage verifies rate limiting and IPv4-mapped IPv6 canonicalization.

### Specifications & References

- Follow-up to #279