### PR TITLE
revert(zcashd): remove pruned block request diagnostics

### DIFF
--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -438,12 +438,6 @@ impl StartCmd {
         //
         // See `zakura_network::Connection::drive_peer_request()` for details.
         let (setup_tx, setup_rx) = oneshot::channel();
-        let zcashd_compat_pruning_retention = config
-            .zcashd_compat
-            .enabled
-            .then(|| config.state.pruning_config())
-            .flatten()
-            .map(|pruning| pruning.tx_retention);
         let inbound = ServiceBuilder::new()
             .load_shed()
             .buffer(inbound::downloads::MAX_INBOUND_CONCURRENCY)
@@ -451,7 +445,6 @@ impl StartCmd {
             .service(Inbound::new(
                 config.sync.full_verify_concurrency_limit,
                 config.network.expose_peer_addresses,
-                zcashd_compat_pruning_retention,
                 setup_rx,
             ));
 

--- a/zakurad/src/components/inbound.rs
+++ b/zakurad/src/components/inbound.rs
@@ -9,9 +9,9 @@ use std::{
     collections::HashSet,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use futures::{
@@ -75,15 +75,6 @@ pub const GETDATA_SENT_BYTES_LIMIT: usize = 1_000_000;
 /// many peers instead of just a few peers.)
 pub const GETDATA_MAX_BLOCK_COUNT: usize = 16;
 
-/// Minimum interval between zcashd-compat errors for requested pruned block bodies.
-const ZCASHD_COMPAT_PRUNED_BLOCK_LOG_INTERVAL: Duration = Duration::from_secs(60);
-
-/// Actionable error emitted when a zcashd sidecar requests a pruned block body.
-pub(crate) const ZCASHD_COMPAT_PRUNED_BLOCK_ERROR: &str =
-    "zcashd_compat: cannot serve block because its body has been pruned; a zcashd sidecar \
-     requiring this block cannot continue syncing. Restore zcashd from a newer snapshot, or use \
-     archive storage on Zakura side https://zakura.com/snapshots/ .";
-
 type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
@@ -94,67 +85,6 @@ type SemanticBlockVerifier = Buffer<
 >;
 type GossipedBlockDownloads =
     BlockDownloads<Timeout<BlockDownloadPeerSet>, Timeout<SemanticBlockVerifier>, State>;
-
-/// Rate-limits diagnostics for missing block bodies in pruned zcashd-compat mode.
-#[derive(Debug)]
-struct PrunedBlockNotFoundLogger {
-    tx_retention: Option<u32>,
-    last_log: Mutex<Option<Instant>>,
-}
-
-impl PrunedBlockNotFoundLogger {
-    fn new(tx_retention: Option<u32>) -> Self {
-        Self {
-            tx_retention,
-            last_log: Mutex::new(None),
-        }
-    }
-
-    fn is_enabled(&self) -> bool {
-        self.tx_retention.is_some()
-    }
-
-    /// Reserves the current log interval and returns the configured retention.
-    fn reserve_log(&self) -> Option<u32> {
-        self.reserve_log_at(Instant::now())
-    }
-
-    fn reserve_log_at(&self, now: Instant) -> Option<u32> {
-        let tx_retention = self.tx_retention?;
-        let mut last_log = self
-            .last_log
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-        if last_log.is_some_and(|last| {
-            now.saturating_duration_since(last) < ZCASHD_COMPAT_PRUNED_BLOCK_LOG_INTERVAL
-        }) {
-            return None;
-        }
-
-        *last_log = Some(now);
-        Some(tx_retention)
-    }
-}
-
-/// Returns the height when `hash` is a known canonical block with a retained header.
-///
-/// Diagnostic lookup errors are intentionally ignored so they never change the
-/// peer's ordinary `notfound` response.
-async fn retained_block_height(mut state: State, hash: block::Hash) -> Option<block::Height> {
-    let response = state
-        .ready()
-        .await
-        .ok()?
-        .call(zs::Request::BlockHeader(hash.into()))
-        .await
-        .ok()?;
-
-    match response {
-        zs::Response::BlockHeader { height, .. } => Some(height),
-        _ => None,
-    }
-}
 
 fn mempool_queue_source(source: zn::PeerSource) -> mempool::QueueSource {
     match source {
@@ -295,9 +225,6 @@ pub struct Inbound {
 
     /// Whether legacy peer address labels in logs are unredacted.
     expose_peer_addresses: bool,
-
-    /// Diagnostics for zcashd-compat requests that need pruned block bodies.
-    pruned_block_not_found_logger: Arc<PrunedBlockNotFoundLogger>,
 }
 
 impl Inbound {
@@ -307,7 +234,6 @@ impl Inbound {
     pub fn new(
         full_verify_concurrency_limit: usize,
         expose_peer_addresses: bool,
-        zcashd_compat_pruning_retention: Option<u32>,
         setup: oneshot::Receiver<InboundSetupData>,
     ) -> Inbound {
         Inbound {
@@ -316,9 +242,6 @@ impl Inbound {
                 setup,
             },
             expose_peer_addresses,
-            pruned_block_not_found_logger: Arc::new(PrunedBlockNotFoundLogger::new(
-                zcashd_compat_pruning_retention,
-            )),
         }
     }
 
@@ -472,7 +395,6 @@ impl Service<zn::Request> for Inbound {
     /// and will cause callers to disconnect from the remote peer.
     #[instrument(name = "inbound", skip(self, req))]
     fn call(&mut self, req: zn::Request) -> Self::Future {
-        let pruned_block_not_found_logger = self.pruned_block_not_found_logger.clone();
         let (cached_peer_addr_response, block_downloads, mempool, state) = match &mut self.setup {
             Setup::Initialized {
                 cached_peer_addr_response,
@@ -545,29 +467,7 @@ impl Service<zn::Request> for Inbound {
                             // We don't need to limit the size of the missing block IDs list,
                             // because it is already limited to the size of the getdata request
                             // sent by the peer. (Their content and encodings are the same.)
-                            zs::Response::Block(None) => {
-                                // A retained canonical header with no block body identifies
-                                // history removed by pruning. Unknown hashes remain ordinary
-                                // `notfound` responses without reserving a log interval.
-                                if pruned_block_not_found_logger.is_enabled() {
-                                    if let Some(height) =
-                                        retained_block_height(state.clone(), hash).await
-                                    {
-                                        if let Some(tx_retention) =
-                                            pruned_block_not_found_logger.reserve_log()
-                                        {
-                                            error!(
-                                                ?hash,
-                                                ?height,
-                                                tx_retention,
-                                                "{ZCASHD_COMPAT_PRUNED_BLOCK_ERROR}"
-                                            );
-                                        }
-                                    }
-                                }
-
-                                blocks.push(Missing(hash))
-                            },
+                            zs::Response::Block(None) => blocks.push(Missing(hash)),
                             _ => unreachable!("wrong response from state"),
                         }
 

--- a/zakurad/src/components/inbound/tests.rs
+++ b/zakurad/src/components/inbound/tests.rs
@@ -1,28 +1,4 @@
 //! Inbound service tests.
 
-use std::time::{Duration, Instant};
-
-use super::{PrunedBlockNotFoundLogger, ZCASHD_COMPAT_PRUNED_BLOCK_LOG_INTERVAL};
-
 mod fake_peer_set;
 mod real_peer_set;
-
-#[test]
-fn pruned_block_not_found_log_is_rate_limited() {
-    let logger = PrunedBlockNotFoundLogger::new(Some(10_000));
-    let start = Instant::now();
-
-    assert_eq!(logger.reserve_log_at(start), Some(10_000));
-    assert_eq!(logger.reserve_log_at(start + Duration::from_secs(1)), None);
-    assert_eq!(
-        logger.reserve_log_at(start + ZCASHD_COMPAT_PRUNED_BLOCK_LOG_INTERVAL),
-        Some(10_000)
-    );
-}
-
-#[test]
-fn pruned_block_not_found_log_is_disabled_without_compat_pruning() {
-    let logger = PrunedBlockNotFoundLogger::new(None);
-
-    assert_eq!(logger.reserve_log_at(Instant::now()), None);
-}

--- a/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -1063,7 +1063,6 @@ async fn caches_getaddr_response() {
         let inbound_service = ServiceBuilder::new().load_shed().service(Inbound::new(
             MAX_INBOUND_CONCURRENCY,
             false,
-            None,
             setup_rx,
         ));
         let inbound_service = BoxService::new(inbound_service);
@@ -1297,7 +1296,6 @@ async fn setup(
     let inbound_service = ServiceBuilder::new().load_shed().service(Inbound::new(
         MAX_INBOUND_CONCURRENCY,
         false,
-        None,
         setup_rx,
     ));
     let inbound_service = BoxService::new(inbound_service);

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -62,7 +62,7 @@ async fn inbound_peers_empty_address_book() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         listen_addr,
-    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral(), None).await;
+    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral()).await;
 
     // yield and sleep until the address book lock is released.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -155,7 +155,6 @@ async fn dual_stack_node_coexists_with_legacy_tcp_peer() -> Result<(), crate::Bo
         Some(Response::Peers(Vec::new())),
         P2pStack::Dual,
         StateConfig::ephemeral(),
-        None,
     )
     .await;
 
@@ -221,7 +220,7 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral(), None).await;
+    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral()).await;
 
     let test_block = block::Hash([0x11; 32]);
 
@@ -288,9 +287,7 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
 ///
 /// Uses a real Zebra network stack, with an isolated Zebra inbound TCP connection.
 #[tokio::test(flavor = "multi_thread")]
-#[tracing_test::traced_test]
-async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
-) -> Result<(), crate::BoxError> {
+async fn inbound_pruned_block_is_not_advertised() -> Result<(), crate::BoxError> {
     // `setup` configures checkpoint retention against `Height::MAX`, so block 1 is committed
     // to the retained chain indexes without storing its transaction bytes. Genesis is retained.
     let state_config = StateConfig {
@@ -312,13 +309,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(
-        None,
-        P2pStack::Legacy,
-        state_config,
-        Some(PruningConfig::default().tx_retention),
-    )
-    .await;
+    ) = setup(None, P2pStack::Legacy, state_config).await;
 
     let genesis: std::sync::Arc<block::Block> =
         zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
@@ -370,21 +361,6 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         "the pruned block body is unavailable"
     );
 
-    let unknown_hash = block::Hash([0x11; 32]);
-    let unknown_response = inbound_service
-        .clone()
-        .oneshot(Request::BlocksByHash(iter::once(unknown_hash).collect()))
-        .await?;
-    assert_eq!(
-        unknown_response,
-        Response::Blocks(vec![Missing(unknown_hash)]),
-        "an unknown hash maps to missing inventory"
-    );
-    assert!(
-        !logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
-        "an unknown hash must not log a pruning error"
-    );
-
     let inbound_response = inbound_service
         .clone()
         .oneshot(Request::BlocksByHash(iter::once(block1.hash()).collect()))
@@ -394,7 +370,6 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         Response::Blocks(vec![Missing(block1.hash())]),
         "inbound maps the unavailable block body to missing inventory"
     );
-    assert!(logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR));
 
     let wire_response = connected_peer_service
         .clone()
@@ -446,7 +421,7 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral(), None).await;
+    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral()).await;
 
     let test_tx = UnminedTxId::from_legacy_id(TxHash([0x22; 32]));
     let test_wtx: UnminedTxId = WtxId {
@@ -582,7 +557,6 @@ async fn outbound_tx_unrelated_response_notfound() -> Result<(), crate::BoxError
         Some(unrelated_response),
         P2pStack::Legacy,
         StateConfig::ephemeral(),
-        None,
     )
     .await;
 
@@ -737,7 +711,6 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
         Some(repeated_response),
         P2pStack::Legacy,
         StateConfig::ephemeral(),
-        None,
     )
     .await;
 
@@ -833,7 +806,6 @@ async fn setup(
     isolated_peer_response: Option<Response>,
     p2p_stack: P2pStack,
     state_config: StateConfig,
-    zcashd_compat_pruning_retention: Option<u32>,
 ) -> (
     // real services
     // connected peer which responds with isolated_peer_response
@@ -872,12 +844,7 @@ async fn setup(
 
     // Inbound
     let (setup_tx, setup_rx) = oneshot::channel();
-    let inbound_service = Inbound::new(
-        MAX_INBOUND_CONCURRENCY,
-        false,
-        zcashd_compat_pruning_retention,
-        setup_rx,
-    );
+    let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, false, setup_rx);
     // TODO: add a timeout just above the service, if needed
     let inbound_service = ServiceBuilder::new()
         .load_shed()
@@ -1106,7 +1073,7 @@ mod submitblock_test {
 
         // Inbound
         let (_setup_tx, setup_rx) = oneshot::channel();
-        let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, false, None, setup_rx);
+        let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, false, setup_rx);
         let inbound_service = ServiceBuilder::new()
             .load_shed()
             .buffer(10)


### PR DESCRIPTION
## Motivation

Revert ac7d8c04ca85a4051ea7282ab3bd18f29f25a381 (`fix(zcashd): diagnose requests for pruned blocks (#279)`).

## Solution

Remove the zcashd-compat pruning-retention wiring, canonical-header diagnostic lookup, rate-limited error logging, and their dedicated tests. Requests for unavailable block bodies return the existing `notfound` response without the additional diagnostic state query.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura components::inbound::tests` (17 passed)
- `cargo clippy -p zakura --all-targets -- -D warnings`
- IDE diagnostics: no errors in changed files

### Specifications & References

- Reverts #279