### PR TITLE
fix(zcashd): restrict pruned diagnostics to protected peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Limit pruned block recovery diagnostics to configured inbound zcashd compat
   peers. Ordinary peers still receive `notfound` without a misleading sidecar
-  error.
+  error
+  ([#304](https://github.com/zakura-core/zakura/pull/304)).
 
 ## [1.0.2-rc1] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   block body that shares its header hash with a later valid block
   ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
 
+### Fixed
+
+- Limit pruned block recovery diagnostics to configured inbound zcashd compat
+  peers. Ordinary peers still receive `notfound` without a misleading sidecar
+  error.
+
 ## [1.0.2-rc1] - 2026-07-19
 
 ### Added

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the hidden `Request::BlocksByHashFromProtectedPeer` variant so the
   inbound handler can distinguish requests from configured protected peers.
-  Downstream exhaustive `Request` matches must handle the new variant.
+  Downstream exhaustive `Request` matches must handle the new variant
+  ([#304](https://github.com/zakura-core/zakura/pull/304)).
 
 ## [3.0.0-rc1] - 2026-07-19
 

--- a/zakura-network/CHANGELOG.md
+++ b/zakura-network/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Added the hidden `Request::BlocksByHashFromProtectedPeer` variant so the
+  inbound handler can distinguish requests from configured protected peers.
+  Downstream exhaustive `Request` matches must handle the new variant.
+
 ## [3.0.0-rc1] - 2026-07-19
 
 ### Breaking Changes

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -1057,7 +1057,12 @@ where
                     .map(|()| Handler::Ping { nonce, ping_sent_at })
             }
 
-            (AwaitingRequest, BlocksByHash(hashes) | BlocksByHashFrom { hashes, .. }) => {
+            (
+                AwaitingRequest,
+                BlocksByHash(hashes)
+                | BlocksByHashFromProtectedPeer(hashes)
+                | BlocksByHashFrom { hashes, .. },
+            ) => {
                 self
                     .peer_tx
                     .send(Message::GetData(
@@ -1345,7 +1350,13 @@ where
                         .iter()
                         .any(|item| matches!(item, InventoryHash::Block(_))) =>
                 {
-                    Request::BlocksByHash(block_hashes(items).collect()).into()
+                    let hashes = block_hashes(items).collect();
+
+                    if self.connection_info.is_protected_peer {
+                        Request::BlocksByHashFromProtectedPeer(hashes).into()
+                    } else {
+                        Request::BlocksByHash(hashes).into()
+                    }
                 }
                 tx_ids if tx_ids.iter().any(|item| item.unmined_tx_id().is_some()) => {
                     Request::TransactionsById(transaction_ids(items).collect()).into()

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -114,6 +114,24 @@ fn new_test_connection_with_protection<A>(
     mpsc::Receiver<Message>,
     ErrorSlot,
 ) {
+    new_test_connection_with_metadata(ConnectedAddr::Isolated, is_protected_peer)
+}
+
+/// Creates a new [`Connection`] instance for testing with explicit connection
+/// metadata.
+fn new_test_connection_with_metadata<A>(
+    connected_addr: ConnectedAddr,
+    is_protected_peer: bool,
+) -> (
+    Connection<
+        MockService<Request, Response, A>,
+        SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, A>,
+    mpsc::Receiver<Message>,
+    ErrorSlot,
+) {
     let mock_inbound_service = MockService::build().finish();
     let (client_tx, client_rx) = mpsc::channel(0);
     let shared_error_slot = ErrorSlot::default();
@@ -148,7 +166,7 @@ fn new_test_connection_with_protection<A>(
     };
 
     let connection_info = ConnectionInfo {
-        connected_addr: ConnectedAddr::Isolated,
+        connected_addr,
         local: remote.clone(),
         remote,
         negotiated_version: fake_version,

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -18,8 +18,10 @@ use futures::{
 use tower::load_shed::error::Overloaded;
 use tracing::Span;
 
-use zakura_chain::serialization::SerializationError;
+use zakura_chain::{block, serialization::SerializationError};
 use zakura_test::mock_service::{MockService, PanicAssertion};
+
+use super::new_test_connection_with_metadata;
 
 use crate::{
     constants::{MAX_OVERLOAD_DROP_PROBABILITY, MIN_OVERLOAD_DROP_PROBABILITY, REQUEST_TIMEOUT},
@@ -30,7 +32,7 @@ use crate::{
     peer_set::ActiveConnectionCounter,
     protocol::external::Message,
     types::Nonce,
-    PeerError, Request, Response,
+    InventoryResponse, PeerError, PeerSocketAddr, Request, Response,
 };
 
 /// Test that the connection run loop works as a future
@@ -236,6 +238,71 @@ async fn connection_run_loop_message_ok() {
     connection_join_handle.abort();
     let outbound_message = peer_outbound_messages.next().await;
     assert_eq!(outbound_message, None);
+}
+
+/// Test that inbound block requests retain the configured protected peer marker.
+#[tokio::test]
+async fn block_getdata_preserves_protected_peer_marker() {
+    let _init_guard = zakura_test::init();
+    let block_hash = block::Hash([0x11; 32]);
+
+    let fake_addr: PeerSocketAddr = "127.0.0.1:8233".parse().expect("valid peer address");
+    let cases = [
+        (
+            crate::peer::ConnectedAddr::OutboundDirect { addr: fake_addr },
+            false,
+        ),
+        (
+            crate::peer::ConnectedAddr::InboundDirect { addr: fake_addr },
+            false,
+        ),
+        (
+            crate::peer::ConnectedAddr::InboundDirect { addr: fake_addr },
+            true,
+        ),
+    ];
+
+    for (connected_addr, is_protected_peer) in cases {
+        let (mut peer_tx, peer_rx) = mpsc::channel(1);
+        let (
+            connection,
+            _client_tx,
+            mut inbound_service,
+            mut peer_outbound_messages,
+            shared_error_slot,
+        ) = new_test_connection_with_metadata::<PanicAssertion>(connected_addr, is_protected_peer);
+
+        let connection_handle = tokio::spawn(connection.run(peer_rx));
+
+        peer_tx
+            .send(Ok(Message::GetData(vec![block_hash.into()])))
+            .await
+            .expect("send to channel always succeeds");
+
+        let expected_request = if is_protected_peer {
+            Request::BlocksByHashFromProtectedPeer(HashSet::from([block_hash]))
+        } else {
+            Request::BlocksByHash(HashSet::from([block_hash]))
+        };
+        inbound_service
+            .expect_request(expected_request)
+            .await
+            .respond(Response::Blocks(vec![InventoryResponse::Missing(
+                block_hash,
+            )]));
+
+        assert_eq!(
+            peer_outbound_messages.next().await,
+            Some(Message::NotFound(vec![block_hash.into()])),
+            "all missing block bodies must remain wire notfound responses"
+        );
+        assert!(
+            shared_error_slot.try_get_error().is_none(),
+            "the request must not terminate the peer connection"
+        );
+
+        connection_handle.abort();
+    }
 }
 
 /// Test that the connection run loop fails correctly when dropped

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -1702,7 +1702,9 @@ where
     fn call(&mut self, req: Request) -> Self::Future {
         let fut = match req {
             // Only do inventory-aware routing on individual items.
-            Request::BlocksByHash(ref hashes) | Request::BlocksByHashFrom { ref hashes, .. }
+            Request::BlocksByHash(ref hashes)
+            | Request::BlocksByHashFromProtectedPeer(ref hashes)
+            | Request::BlocksByHashFrom { ref hashes, .. }
                 if hashes.len() == 1 =>
             {
                 let hash = InventoryHash::from(*hashes.iter().next().unwrap());

--- a/zakura-network/src/protocol/internal/request.rs
+++ b/zakura-network/src/protocol/internal/request.rs
@@ -88,6 +88,17 @@ pub enum Request {
     /// Returns [`Response::Blocks`](super::Response::Blocks).
     BlocksByHash(HashSet<block::Hash>),
 
+    /// Request block data sent to this node by an operator configured protected peer.
+    ///
+    /// This marker preserves the requester class across the peer connection and
+    /// inbound service boundary without exposing the peer's address.
+    ///
+    /// # Returns
+    ///
+    /// Returns [`Response::Blocks`](super::Response::Blocks).
+    #[doc(hidden)]
+    BlocksByHashFromProtectedPeer(HashSet<block::Hash>),
+
     /// Request block data by block hashes from a known advertising peer.
     ///
     /// This is used by authenticated transports that can safely route a
@@ -232,7 +243,8 @@ pub enum Request {
     /// block hash, allowing the remote peer to choose whether to download
     /// it. Remote peers who choose to download the block will generate a
     /// [`Request::BlocksByHash`] against the "inbound" service passed to
-    /// [`init`](crate::init).
+    /// [`init`](crate::init), or [`Request::BlocksByHashFromProtectedPeer`] when
+    /// the connection is configured as a protected peer.
     ///
     /// The peer set routes this request specially, sending it to *a fraction of*
     /// the available peers. See [`number_of_peers_to_broadcast()`](crate::PeerSet::number_of_peers_to_broadcast)
@@ -272,6 +284,9 @@ impl fmt::Display for Request {
             Request::BlocksByHash(hashes) => {
                 format!("BlocksByHash({})", hashes.len())
             }
+            Request::BlocksByHashFromProtectedPeer(hashes) => {
+                format!("BlocksByHashFromProtectedPeer({})", hashes.len())
+            }
             Request::BlocksByHashFrom { hashes, .. } => {
                 format!("BlocksByHashFrom({})", hashes.len())
             }
@@ -310,7 +325,9 @@ impl Request {
             Request::Peers => "Peers",
             Request::Ping(_) => "Ping",
 
-            Request::BlocksByHash(_) | Request::BlocksByHashFrom { .. } => "BlocksByHash",
+            Request::BlocksByHash(_)
+            | Request::BlocksByHashFromProtectedPeer(_)
+            | Request::BlocksByHashFrom { .. } => "BlocksByHash",
             Request::TransactionsById(_) | Request::TransactionsByIdFrom { .. } => {
                 "TransactionsById"
             }
@@ -331,6 +348,7 @@ impl Request {
         matches!(
             self,
             Request::BlocksByHash(_)
+                | Request::BlocksByHashFromProtectedPeer(_)
                 | Request::BlocksByHashFrom { .. }
                 | Request::TransactionsById(_)
                 | Request::TransactionsByIdFrom { .. }
@@ -341,6 +359,7 @@ impl Request {
     pub fn block_hash_inventory(&self) -> HashSet<block::Hash> {
         match self {
             Request::BlocksByHash(block_hashes)
+            | Request::BlocksByHashFromProtectedPeer(block_hashes)
             | Request::BlocksByHashFrom {
                 hashes: block_hashes,
                 ..

--- a/zakura-network/src/zakura/legacy_gossip.rs
+++ b/zakura-network/src/zakura/legacy_gossip.rs
@@ -288,7 +288,9 @@ impl LegacyRequestFrame {
     /// Convert a legacy network request into an inventory request frame.
     pub fn from_request(request: Request) -> Result<Self, LegacyGossipError> {
         match request {
-            Request::BlocksByHash(hashes) | Request::BlocksByHashFrom { hashes, .. } => {
+            Request::BlocksByHash(hashes)
+            | Request::BlocksByHashFromProtectedPeer(hashes)
+            | Request::BlocksByHashFrom { hashes, .. } => {
                 let hashes = truncate_to_inventory_cap(hashes)?;
                 Ok(Self::BlocksByHash(hashes))
             }
@@ -1705,6 +1707,7 @@ where
             | Request::AdvertiseBlockToAll(..)
             | Request::AdvertiseTransactionIds(..) => DualStackRoute::Advertise,
             Request::BlocksByHash(..)
+            | Request::BlocksByHashFromProtectedPeer(..)
             | Request::BlocksByHashFrom { .. }
             | Request::TransactionsById(..)
             | Request::TransactionsByIdFrom { .. }
@@ -5063,6 +5066,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn protected_peer_block_request_uses_ordinary_legacy_frame() {
+        let hash = block_hash(1);
+        let frame = LegacyRequestFrame::from_request(Request::BlocksByHashFromProtectedPeer(
+            HashSet::from([hash]),
+        ))
+        .expect("protected peer block requests use the ordinary wire frame");
+
+        assert_eq!(frame, LegacyRequestFrame::BlocksByHash(vec![hash]));
+    }
+
     #[tokio::test]
     async fn first_seen_cache_is_bounded_and_expires() {
         let cache = FirstSeenCache::new(1, Duration::from_millis(20));
@@ -5587,6 +5601,22 @@ mod tests {
             Response::BlockHashes(hashes) => assert_eq!(hashes, vec![block.hash()]),
             other => panic!("unexpected FindBlocks response: {other:?}"),
         }
+
+        let protected_block = composite
+            .ready()
+            .await?
+            .call(Request::BlocksByHashFromProtectedPeer(HashSet::from([
+                block.hash(),
+            ])))
+            .await?;
+        assert!(
+            matches!(
+                protected_block,
+                Response::Blocks(ref blocks)
+                    if matches!(blocks.as_slice(), [InventoryResponse::Available((received, None))] if received.hash() == block.hash())
+            ),
+            "protected peer block requests should be served over Zakura, got {protected_block:?}",
+        );
 
         let find_headers = composite
             .ready()

--- a/zakurad/src/components/inbound.rs
+++ b/zakurad/src/components/inbound.rs
@@ -506,7 +506,16 @@ impl Service<zn::Request> for Inbound {
                     Ok(response)
                 }.boxed()
             }
-            zn::Request::BlocksByHash(hashes) | zn::Request::BlocksByHashFrom { hashes, .. } => {
+            request @ (zn::Request::BlocksByHash(_)
+            | zn::Request::BlocksByHashFromProtectedPeer(_)
+            | zn::Request::BlocksByHashFrom { .. }) => {
+                let (hashes, is_protected_peer) = match request {
+                    zn::Request::BlocksByHash(hashes)
+                    | zn::Request::BlocksByHashFrom { hashes, .. } => (hashes, false),
+                    zn::Request::BlocksByHashFromProtectedPeer(hashes) => (hashes, true),
+                    _ => unreachable!("request was matched as a block request"),
+                };
+
                 // We return an available or missing response to each inventory request,
                 // unless the request is empty, or it reaches a response limit.
                 if hashes.is_empty() {
@@ -549,7 +558,9 @@ impl Service<zn::Request> for Inbound {
                                 // A retained canonical header with no block body identifies
                                 // history removed by pruning. Unknown hashes remain ordinary
                                 // `notfound` responses without reserving a log interval.
-                                if pruned_block_not_found_logger.is_enabled() {
+                                if is_protected_peer
+                                    && pruned_block_not_found_logger.is_enabled()
+                                {
                                     if let Some(height) =
                                         retained_block_height(state.clone(), hash).await
                                     {

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -2,7 +2,10 @@
 
 #![allow(clippy::unwrap_in_result)]
 
-use std::{iter, net::SocketAddr};
+use std::{
+    iter,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
 
 use futures::FutureExt;
 use indexmap::IndexSet;
@@ -62,7 +65,14 @@ async fn inbound_peers_empty_address_book() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         listen_addr,
-    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral(), None).await;
+    ) = setup(
+        None,
+        P2pStack::Legacy,
+        StateConfig::ephemeral(),
+        None,
+        Vec::new(),
+    )
+    .await;
 
     // yield and sleep until the address book lock is released.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -156,6 +166,7 @@ async fn dual_stack_node_coexists_with_legacy_tcp_peer() -> Result<(), crate::Bo
         P2pStack::Dual,
         StateConfig::ephemeral(),
         None,
+        Vec::new(),
     )
     .await;
 
@@ -221,7 +232,14 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral(), None).await;
+    ) = setup(
+        None,
+        P2pStack::Legacy,
+        StateConfig::ephemeral(),
+        None,
+        Vec::new(),
+    )
+    .await;
 
     let test_block = block::Hash([0x11; 32]);
 
@@ -284,13 +302,12 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
     Ok(())
 }
 
-/// Check that a retained chain-index hash is not advertised when its block body is pruned.
+/// Check that pruned block diagnostics are limited to configured protected peers.
 ///
 /// Uses a real Zebra network stack, with an isolated Zebra inbound TCP connection.
 #[tokio::test(flavor = "multi_thread")]
 #[tracing_test::traced_test]
-async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
-) -> Result<(), crate::BoxError> {
+async fn pruned_block_diagnostic_is_scoped_to_protected_peer() -> Result<(), crate::BoxError> {
     // `setup` configures checkpoint retention against `Height::MAX`, so block 1 is committed
     // to the retained chain indexes without storing its transaction bytes. Genesis is retained.
     let state_config = StateConfig {
@@ -317,6 +334,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         P2pStack::Legacy,
         state_config,
         Some(PruningConfig::default().tx_retention),
+        vec![IpAddr::V4(Ipv4Addr::LOCALHOST)],
     )
     .await;
 
@@ -373,7 +391,9 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
     let unknown_hash = block::Hash([0x11; 32]);
     let unknown_response = inbound_service
         .clone()
-        .oneshot(Request::BlocksByHash(iter::once(unknown_hash).collect()))
+        .oneshot(Request::BlocksByHashFromProtectedPeer(
+            iter::once(unknown_hash).collect(),
+        ))
         .await?;
     assert_eq!(
         unknown_response,
@@ -394,7 +414,10 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         Response::Blocks(vec![Missing(block1.hash())]),
         "inbound maps the unavailable block body to missing inventory"
     );
-    assert!(logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR));
+    assert!(
+        !logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        "ordinary peer requests must not emit a zcashd sidecar diagnostic"
+    );
 
     let wire_response = connected_peer_service
         .clone()
@@ -413,6 +436,10 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
              actual result: {wire_response:?}"
         )
     }
+    assert!(
+        logs_contain(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        "configured protected peers must receive the actionable pruning diagnostic"
+    );
 
     assert!(
         block_gossip_task_handle.now_or_never().is_none(),
@@ -446,7 +473,14 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
         tx_gossip_task_handle,
         // real open socket addresses
         _listen_addr,
-    ) = setup(None, P2pStack::Legacy, StateConfig::ephemeral(), None).await;
+    ) = setup(
+        None,
+        P2pStack::Legacy,
+        StateConfig::ephemeral(),
+        None,
+        Vec::new(),
+    )
+    .await;
 
     let test_tx = UnminedTxId::from_legacy_id(TxHash([0x22; 32]));
     let test_wtx: UnminedTxId = WtxId {
@@ -583,6 +617,7 @@ async fn outbound_tx_unrelated_response_notfound() -> Result<(), crate::BoxError
         P2pStack::Legacy,
         StateConfig::ephemeral(),
         None,
+        Vec::new(),
     )
     .await;
 
@@ -738,6 +773,7 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
         P2pStack::Legacy,
         StateConfig::ephemeral(),
         None,
+        Vec::new(),
     )
     .await;
 
@@ -834,6 +870,7 @@ async fn setup(
     p2p_stack: P2pStack,
     state_config: StateConfig,
     zcashd_compat_pruning_retention: Option<u32>,
+    block_gossip_peer_ips: Vec<IpAddr>,
 ) -> (
     // real services
     // connected peer which responds with isolated_peer_response
@@ -906,12 +943,14 @@ async fn setup(
 
         ..NetworkConfig::default()
     };
-    let (mut peer_set, address_book, _) = zakura_network::init(
+    let (mut peer_set, address_book, _, _) = zakura_network::init_with_zakura_header_sync(
         network_config,
         inbound_service.clone(),
         latest_chain_tip.clone(),
         "Zebra user agent".to_string(),
         PeerServices::NODE_NETWORK,
+        block_gossip_peer_ips,
+        None,
     )
     .await;
 


### PR DESCRIPTION
Alternative implementation to #302.

## Motivation

The pruned block diagnostic was enabled globally for zcashd compatibility, but the shared inbound service did not know which peer requested a missing block body. Ordinary peers could therefore emit a misleading sidecar error and consume its global rate limit even though they correctly received `notfound` and syncing continued.

## Solution

Carry an address-free marker for block `getdata` requests from configured protected peers across the connection and inbound service boundary. Only marked requests perform the retained-header lookup and emit the pruning diagnostic. Ordinary legacy and Zakura v2 requests retain silent `notfound` behavior.

This deliberately keeps protected requester classification separate from the existing source-aware advertiser request. The tradeoff is a new hidden public `Request` variant, which is documented as breaking for downstream exhaustive matches.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p zakura-network -p zakura --lib --tests -- -D warnings`
- `cargo test --locked -p zakura-network block_getdata_preserves_protected_peer_marker`
- `cargo test --locked -p zakura-network protected_peer_block_request_uses_ordinary_legacy_frame`
- `cargo test --locked -p zakura-network dual_stack_zakura_only_routes_chain_sync_and_mempool_requests`
- `cargo test --locked -p zakura pruned_block_diagnostic_is_scoped_to_protected_peer`
- Reproduced the false diagnostic on v1.0.2-rc1 while zcashd continued for 483 blocks.
- Replayed the same height-38,086 request against the patched rc1 binary. The peer received the same `notfound`, the diagnostic remained absent, and zcashd advanced 472 blocks.
