### PR TITLE
ci: add golden zcashd compatibility PR nodes

### DIFF
--- a/.agents/skills/test-zakura-pr-node/SKILL.md
+++ b/.agents/skills/test-zakura-pr-node/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: test-zakura-pr-node
+description: Dispatch and validate Zakura real node tests with the repository's Golden DigitalOcean image and state fixtures. Use for fresh server or Droplet tests, real node tests of a Zakura PR or ref, managed zcashd wrapper or zcashd-compat tests, reproducing node or sync issues, and requests to use a Golden image or Golden assets instead of downloading chain state.
+---
+
+# Test a Zakura PR Node
+
+Use `.github/workflows/zakura-pr-node.yml` for DigitalOcean tests. Let the
+workflow create the Droplet and clone the maintained Golden assets. Never
+provision an ad hoc test Droplet or manually download or unpack chain state.
+Route provisioning and asset refreshes through `gh workflow run`; do not call
+`doctl` or the DigitalOcean API directly.
+
+Read `docs/pr-node-do-setup.md` before changing workflow inputs or refreshing
+assets.
+
+## Choose a profile
+
+- Use `zakura` for normal Zakura sync, validation, performance, or regression
+  tests. Choose `tip`, `sandblast`, or `genesis` according to the test.
+- Use `zcashd-compat` when testing the managed zcashd wrapper, sidecar lifecycle,
+  block serving, or the pruned state compatibility path. This profile requires
+  `network=mainnet` and `snapshot_mode=tip`.
+- Use `genesis` only when the user explicitly wants a checkpoint sync from
+  genesis. Do not use it as a fallback for a missing Golden fixture.
+
+## Dispatch
+
+Resolve exactly one target as a PR number or a branch, tag, or SHA. Dispatch the
+workflow and record the resulting run ID.
+
+```bash
+# Ordinary Zakura test
+gh workflow run zakura-pr-node.yml \
+  -f pr_number=123 \
+  -f test_profile=zakura
+
+# Managed zcashd compatibility test
+gh workflow run zakura-pr-node.yml \
+  -f pr_number=123 \
+  -f test_profile=zcashd-compat \
+  -f network=mainnet \
+  -f snapshot_mode=tip
+```
+
+Set `teardown_after_run=true` when no SSH inspection is needed. Otherwise leave
+the Droplet and its cloned volumes for the reaper. Do not remove or alter the
+workflow's resource tags or bypass its cleanup path.
+
+## Validate the run
+
+Watch the dispatched run through completion:
+
+```bash
+gh run list --workflow=zakura-pr-node.yml --limit=5
+gh run watch RUN_ID --exit-status
+gh run view RUN_ID --log-failed
+```
+
+Check the job summary and artifact for the requested target SHA, selected
+profile, selected Golden image and state snapshots, node health, and increasing
+heights. For `zcashd-compat`, also require a successful cold wrapper
+installation, exactly one direct zcashd child, both Zakura and zcashd heights
+advancing, a clean managed child shutdown, and a warm restart with the same
+cached binary hash and modification time. Require continued height progress and
+no pruned block sidecar failure. Report the Droplet lifetime and whether
+immediate teardown or the scheduled reaper will remove it.
+
+## Handle unavailable assets
+
+- If an image or state snapshot is missing or stale, run
+  `gh workflow run zakura-pr-node-bake.yml`, wait for it to finish, and retry.
+- If the state database format is incompatible, rebake after the needed format
+  lands on `main`. If the target PR needs an unsupported newer format, stop and
+  report it. Do not rename or manually patch an incompatible fixture.
+- If the first zcashd fixture does not exist, pass the bake workflow's documented
+  seed inputs to `gh workflow run` with an existing cleanly stopped zcashd
+  datadir. Do not create an untracked fixture or fetch a chain archive on a run
+  Droplet.
+- If the bake cannot produce a valid asset, stop and report the failing guard or
+  missing prerequisite. Do not silently fall back to a slow manual setup.

--- a/.agents/skills/test-zakura-pr-node/agents/openai.yaml
+++ b/.agents/skills/test-zakura-pr-node/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test Zakura PR Node"
+  short_description: "Run Golden DigitalOcean node tests"
+  default_prompt: "Use $test-zakura-pr-node to run this Zakura or zcashd compatibility test with the maintained Golden DigitalOcean assets."

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -220,7 +220,7 @@ umount "$TESTNET_MNT"
 # and state bake still succeeds before the first explicit zcashd seed. Once a
 # fixture exists, each scheduled bake clones and refreshes the latest snapshot.
 if [ -n "${ZCASHD_VOLUME_NAME:-}" ]; then
-  ZAKURA_STATE_DIR="$MAINNET_MNT/tip" \
+  FIXTURE_STATE_DIR="$MAINNET_MNT/tip" \
   ZCASHD_VOLUME_NAME="$ZCASHD_VOLUME_NAME" \
   ZCASHD_TX_RETENTION="$ZCASHD_TX_RETENTION" \
     bash /root/pr-node-zcashd-refresh.sh

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -103,10 +103,21 @@ fetch_state() {
   local tarball="${dest%/}.tar.zst"
   echo "Fetching ${url} -> ${dest}"
   df -h "$(dirname "$dest")"
-  # --retry-all-errors + -C - resumes interrupted multi-GB transfers instead of
-  # failing the whole bake (plain --retry does not cover mid-stream resets).
-  curl -fL --retry 8 --retry-delay 15 --retry-all-errors -C - \
-    -o "$tarball" "$url"
+  # Start a fresh curl process after each failure so -C - recomputes the
+  # current file size. Curl's internal retries can restart a partial transfer.
+  local downloaded=false attempt
+  for attempt in $(seq 1 9); do
+    if curl -fL -C - -o "$tarball" "$url"; then
+      downloaded=true
+      break
+    fi
+    echo "Download attempt ${attempt}/9 failed; resuming ${tarball} in 15 seconds." >&2
+    sleep 15
+  done
+  [[ "$downloaded" == true ]] || {
+    echo "Failed to download ${url} after 9 attempts." >&2
+    return 1
+  }
   local checksum_verified=false
   if [ -n "$sha" ]; then
     echo "${sha}  ${tarball}" | sha256sum -c -

--- a/.github/workflows/scripts/pr-node-bake.sh
+++ b/.github/workflows/scripts/pr-node-bake.sh
@@ -2,8 +2,8 @@
 # Runs ON the bake droplet (zakura-pr-node-bake.yml): installs build deps and
 # rustup, clones the repo and warms a release cargo cache, bakes a loopback SSH
 # identity so deploy.py can target root@localhost on the run droplets, fills the
-# attached per-network volumes with extracted chain state, and cleans the
-# droplet for imaging.
+# attached per-network volumes with extracted chain state, optionally refreshes
+# a zcashd-compat fixture volume, and cleans the droplet for imaging.
 #
 # Config via /root/bake.env (sourced by the caller before exec):
 #   GH_REPO                  owner/name of this repository
@@ -14,7 +14,12 @@
 #   TIP_MAINNET_LATEST_JSON  latest.json pointer for the mainnet pruned tip
 #   SANDBLAST_URL            pinned pre-spam-region mainnet archive snapshot
 #   SANDBLAST_SHA256         its sha256
+#   SANDBLAST_HEIGHT         its chain tip height
+#   SANDBLAST_DB_FORMAT      its Zakura database major version
 #   TESTNET_SNAPSHOTS_BASE   testnet snapshots site (serves /snapshots.json)
+#   ZCASHD_VOLUME_NAME       optional zcashd mainnet fixture volume
+#   ZCASHD_SOURCE_SNAPSHOT_ID prior zcashd snapshot ID (empty on first seed)
+#   ZCASHD_TX_RETENTION      pruned raw-block retention used by compat refresh
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
@@ -81,14 +86,20 @@ mount_volume() {
   [ -e "$dev" ] || { echo "volume device not found: $dev" >&2; return 1; }
   blkid "$dev" >/dev/null 2>&1 || mkfs.ext4 -q "$dev"
   mkdir -p "$mnt"
-  mount "$dev" "$mnt"
+  local existing_mount
+  existing_mount=$(findmnt -rn -S "$dev" -o TARGET | head -n 1 || true)
+  if [ -n "$existing_mount" ] && [ "$existing_mount" != "$mnt" ]; then
+    umount "$existing_mount"
+  fi
+  mountpoint -q "$mnt" || mount "$dev" "$mnt"
 }
 
 # Download to the (large) volume, verify sha256 when given, extract into
 # <mount>/<mode>/ so the node's state cache_dir can point straight at it,
 # and assert the expected state/v*/<network> tree came out.
 fetch_state() {
-  local url="$1" sha="$2" dest="$3" network="$4"
+  local url="$1" sha="$2" dest="$3" network="$4" mode="$5" height="$6" db_format="$7"
+  local tx_retention="${8:-null}"
   local tarball="${dest%/}.tar.zst"
   echo "Fetching ${url} -> ${dest}"
   df -h "$(dirname "$dest")"
@@ -96,16 +107,58 @@ fetch_state() {
   # failing the whole bake (plain --retry does not cover mid-stream resets).
   curl -fL --retry 8 --retry-delay 15 --retry-all-errors -C - \
     -o "$tarball" "$url"
+  local checksum_verified=false
   if [ -n "$sha" ]; then
     echo "${sha}  ${tarball}" | sha256sum -c -
+    checksum_verified=true
   fi
   mkdir -p "$dest"
   zstd -dc "$tarball" | tar -x -C "$dest"
   rm -f "$tarball"
-  ls -d "$dest"/state/v*/"$network" >/dev/null || {
+  local state_path disk_db_format major_version
+  state_path=$(find "$dest/state" -mindepth 2 -maxdepth 2 -type d -path "*/v*/$network" -print 2>/dev/null | \
+    sort -V | tail -n 1)
+  [ -n "$state_path" ] || {
     echo "extracted state not found under ${dest}/state/v*/${network}" >&2
     return 1
   }
+  major_version=$(basename "$(dirname "$state_path")" | sed 's/^v//')
+  if [ -f "$state_path/version" ]; then
+    disk_db_format=$(tr -d '[:space:]' < "$state_path/version")
+  else
+    disk_db_format="${major_version}.0.0"
+  fi
+  if [ -n "$db_format" ] && [ "$db_format" != "$disk_db_format" ]; then
+    echo "snapshot metadata DB format $db_format does not match extracted state $disk_db_format" >&2
+    return 1
+  fi
+  jq -n \
+    --arg fixture "zakura-state" \
+    --arg network "$network" \
+    --arg mode "$mode" \
+    --arg captured_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg url "$url" \
+    --arg sha256 "$sha" \
+    --argjson checksum_verified "$checksum_verified" \
+    --arg db_format_version "$disk_db_format" \
+    --argjson height "$height" \
+    --argjson tx_retention "$tx_retention" \
+    '{
+      schema_version: 1,
+      fixture: $fixture,
+      network: $network,
+      mode: $mode,
+      captured_at: $captured_at,
+      source: {
+        url: $url,
+        sha256: $sha256,
+        checksum_verified: $checksum_verified
+      },
+      height: $height,
+      db_format_version: $db_format_version,
+      tx_retention: $tx_retention,
+      tip: {height: $height, hash: null}
+    }' > "$dest/fixture-manifest.json"
   echo "Restored $(ls -d "$dest"/state/v*/"$network")"
 }
 
@@ -118,11 +171,19 @@ mount_volume "$TESTNET_VOLUME_NAME" "$TESTNET_MNT"
 TIP_META=$(curl -fsSL --retry 3 "$TIP_MAINNET_LATEST_JSON")
 TIP_URL=$(echo "$TIP_META" | jq -er '.url')
 TIP_SHA=$(echo "$TIP_META" | jq -er '.sha256')
+TIP_HEIGHT=$(echo "$TIP_META" | jq -er '.height')
+TIP_DB=$(echo "$TIP_META" | jq -er '.db_format_version')
+TIP_RETENTION=$(echo "$TIP_META" | jq -er '.tx_retention')
+if [ "$TIP_RETENTION" != "$ZCASHD_TX_RETENTION" ]; then
+  echo "mainnet snapshot retention $TIP_RETENTION does not match configured zcashd retention $ZCASHD_TX_RETENTION" >&2
+  exit 1
+fi
 echo "Mainnet tip: $(echo "$TIP_META" | jq -r '"\(.filename) height=\(.height) db=\(.db_format_version)"')"
-fetch_state "$TIP_URL" "$TIP_SHA" "$MAINNET_MNT/tip" mainnet
+fetch_state "$TIP_URL" "$TIP_SHA" "$MAINNET_MNT/tip" mainnet tip "$TIP_HEIGHT" "$TIP_DB" "$TIP_RETENTION"
 
 # Mainnet sandblast: pinned archive just before the 2022 spam region.
-fetch_state "$SANDBLAST_URL" "$SANDBLAST_SHA256" "$MAINNET_MNT/sandblast" mainnet
+fetch_state "$SANDBLAST_URL" "$SANDBLAST_SHA256" "$MAINNET_MNT/sandblast" mainnet sandblast \
+  "$SANDBLAST_HEIGHT" "$SANDBLAST_DB_FORMAT"
 
 # Testnet tip: newest enabled pruned entry from the snapshots site metadata.
 TESTNET_META=$(curl -fsSL --retry 3 "$TESTNET_SNAPSHOTS_BASE/snapshots.json")
@@ -131,22 +192,38 @@ ENTRY=$(echo "$TESTNET_META" | jq -er \
 [ "$ENTRY" != "null" ] || { echo "no enabled pruned testnet snapshot found" >&2; exit 1; }
 TN_FILE=$(echo "$ENTRY" | jq -er '.file')
 TN_SHA=$(echo "$ENTRY" | jq -er '.sha256')
+TN_HEIGHT=$(echo "$ENTRY" | jq -er '.height')
+TN_DB=$(echo "$ENTRY" | jq -er '.dbFormat')
 TN_BASE=$(echo "$TESTNET_META" | jq -r '.siteBaseUrl // empty')
 echo "Testnet tip: $(echo "$ENTRY" | jq -r '"\(.file) height=\(.height) db=\(.dbFormat)"')"
 if [ -n "$TN_BASE" ] && curl -fsIL --retry 2 "${TN_BASE}/files/${TN_FILE}" >/dev/null 2>&1; then
-  fetch_state "${TN_BASE}/files/${TN_FILE}" "$TN_SHA" "$TESTNET_MNT/tip" testnet
+  fetch_state "${TN_BASE}/files/${TN_FILE}" "$TN_SHA" "$TESTNET_MNT/tip" testnet tip "$TN_HEIGHT" "$TN_DB"
 else
-  fetch_state "${TESTNET_SNAPSHOTS_BASE}/files/${TN_FILE}" "$TN_SHA" "$TESTNET_MNT/tip" testnet
+  fetch_state "${TESTNET_SNAPSHOTS_BASE}/files/${TN_FILE}" "$TN_SHA" "$TESTNET_MNT/tip" testnet tip "$TN_HEIGHT" "$TN_DB"
 fi
 
 sync
-umount "$MAINNET_MNT" "$TESTNET_MNT"
+umount "$TESTNET_MNT"
+
+# The zcashd fixture is independent and optional so the existing Zakura image
+# and state bake still succeeds before the first explicit zcashd seed. Once a
+# fixture exists, each scheduled bake clones and refreshes the latest snapshot.
+if [ -n "${ZCASHD_VOLUME_NAME:-}" ]; then
+  ZAKURA_STATE_DIR="$MAINNET_MNT/tip" \
+  ZCASHD_VOLUME_NAME="$ZCASHD_VOLUME_NAME" \
+  ZCASHD_TX_RETENTION="$ZCASHD_TX_RETENTION" \
+    bash /root/pr-node-zcashd-refresh.sh
+fi
+
+sync
+umount "$MAINNET_MNT"
 
 # --------------------------------------------------------------------------- #
 # Clean the droplet for imaging
 # --------------------------------------------------------------------------- #
 
 apt-get clean
+rm -f /root/zcashd-fixture-refresh.log /root/pr-node-zcashd-refresh.sh
 truncate -s 0 /etc/machine-id
 # Without this, droplets created from the image skip first-boot cloud-init and
 # never receive the CI's DO SSH key (which looks like a network failure).

--- a/.github/workflows/scripts/pr-node-monitor.py
+++ b/.github/workflows/scripts/pr-node-monitor.py
@@ -1,20 +1,11 @@
 #!/usr/bin/env python3
-"""Monitor a running zakurad node and emit a run summary.
-
-Runs ON the ephemeral PR-node droplet (invoked by pr-node-run.sh). Samples the
-node's JSON-RPC endpoint, systemd unit state, and memory use on an interval for
-a fixed duration, then scans the node log for errors/panics and writes
-summary.json (machine) + summary.md (human, posted as the PR comment).
-
-Stdlib only, mirroring deploy/deployer/deploy.py.
-
-Exit status: 0 for an ok/degraded run, 1 for a failed run (service inactive at
-the end, a panic, an unexpected restart, or RPC never came up).
-"""
+"""Monitor an ephemeral Zakura PR node and its optional managed zcashd child."""
 
 from __future__ import annotations
 
 import argparse
+import base64
+import datetime as dt
 import json
 import re
 import subprocess
@@ -23,20 +14,27 @@ import time
 import urllib.request
 from pathlib import Path
 
-# The node gets this long to open the state DB and bind RPC before failing
-# samples start counting against it.
 RPC_GRACE_SECS = 300
+PRUNED_SIDECAR_ERROR = (
+    "cannot serve block because its body has been pruned; a zcashd sidecar "
+    "requiring this block cannot continue syncing"
+)
 
 
-def rpc_call(url: str, method: str):
+def rpc_call(url: str, method: str, cookie_file: str | None = None):
     payload = json.dumps(
         {"jsonrpc": "1.0", "id": "pr-node-monitor", "method": method, "params": []}
     ).encode()
-    req = urllib.request.Request(
-        url, data=payload, headers={"Content-Type": "application/json"}
-    )
+    headers = {"Content-Type": "application/json"}
+    if cookie_file:
+        cookie = Path(cookie_file).read_text().strip()
+        headers["Authorization"] = "Basic " + base64.b64encode(cookie.encode()).decode()
+    req = urllib.request.Request(url, data=payload, headers=headers)
     with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())["result"]
+        response = json.loads(resp.read())
+    if response.get("error") is not None:
+        raise RuntimeError(f"RPC error: {response['error']}")
+    return response["result"]
 
 
 def systemd_props(service: str) -> dict[str, str]:
@@ -54,8 +52,20 @@ def rss_mib(pid: str) -> float | None:
         status = Path(f"/proc/{pid}/status").read_text()
     except OSError:
         return None
-    m = re.search(r"^VmRSS:\s+(\d+)\s+kB", status, re.MULTILINE)
-    return round(int(m.group(1)) / 1024, 1) if m else None
+    match = re.search(r"^VmRSS:\s+(\d+)\s+kB", status, re.MULTILINE)
+    return round(int(match.group(1)) / 1024, 1) if match else None
+
+
+def managed_zcashd_children(parent_pid: str) -> list[int]:
+    if parent_pid == "0":
+        return []
+    proc = subprocess.run(
+        ["pgrep", "--parent", parent_pid, "--exact", "zcashd"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return sorted(int(pid) for pid in proc.stdout.split() if pid.isdigit())
 
 
 def take_sample(args) -> dict:
@@ -64,26 +74,48 @@ def take_sample(args) -> dict:
         info = rpc_call(args.rpc_url, "getblockchaininfo")
         sample["height"] = info.get("blocks")
         sample["estimated"] = info.get("estimatedheight")
-    except Exception as exc:  # noqa: BLE001 — any RPC failure is just a missed sample
+    except Exception as exc:  # noqa: BLE001 - an RPC failure is a missed sample
         sample["rpc_error"] = str(exc)
     try:
         sample["peers"] = len(rpc_call(args.rpc_url, "getpeerinfo"))
     except Exception:  # noqa: BLE001
         pass
+
     props = systemd_props(args.service)
     sample["active_state"] = props.get("ActiveState")
     sample["restarts"] = int(props.get("NRestarts") or 0)
     pid = props.get("MainPID", "0")
     sample["rss_mib"] = rss_mib(pid) if pid != "0" else None
+
+    if args.test_profile == "zcashd-compat":
+        children = managed_zcashd_children(pid)
+        sample["zcashd_child_pids"] = children
+        sample["zcashd_child_count"] = len(children)
+        try:
+            zcashd_info = rpc_call(
+                args.zcashd_rpc_url, "getblockchaininfo", args.zcashd_cookie_file
+            )
+            sample["zcashd_height"] = zcashd_info.get("blocks")
+        except Exception as exc:  # noqa: BLE001
+            sample["zcashd_height"] = None
+            sample["zcashd_rpc_error"] = str(exc)
+        try:
+            sample["zcashd_connections"] = rpc_call(
+                args.zcashd_rpc_url, "getconnectioncount", args.zcashd_cookie_file
+            )
+        except Exception:  # noqa: BLE001
+            sample["zcashd_connections"] = None
     return sample
 
 
 def scan_logs(log_file: str, service: str) -> dict:
-    errors = warns = 0
+    errors = warns = pruned_sidecar_errors = 0
     last_errors: list[str] = []
     try:
         with open(log_file, errors="replace") as fh:
             for line in fh:
+                if PRUNED_SIDECAR_ERROR in line:
+                    pruned_sidecar_errors += 1
                 if " ERROR " in line:
                     errors += 1
                     last_errors.append(line.rstrip()[:300])
@@ -92,46 +124,82 @@ def scan_logs(log_file: str, service: str) -> dict:
                     warns += 1
     except OSError:
         pass
-    # Panics go to stderr (the journal), not the tracing log file.
     journal = subprocess.run(
-        ["journalctl", "-u", service, "--no-pager", "-o", "cat"],
+        ["journalctl", "--boot", "-u", service, "--no-pager", "-o", "cat"],
         capture_output=True,
         text=True,
         check=False,
     ).stdout
-    panics = len(re.findall(r"panicked at", journal)) + len(
-        re.findall(r"panicked at", "".join(last_errors))
-    )
-    return {"errors": errors, "warns": warns, "panics": panics, "last_errors": last_errors}
+    panics = len(re.findall(r"panicked at", journal))
+    return {
+        "errors": errors,
+        "warns": warns,
+        "panics": panics,
+        "pruned_sidecar_errors": pruned_sidecar_errors,
+        "last_errors": last_errors,
+    }
 
 
-def fmt(value, suffix: str = "") -> str:
-    return f"{value}{suffix}" if value is not None else "n/a"
+def height_summary(samples: list[dict], field: str) -> tuple[int | None, int | None, int | None]:
+    values = [sample[field] for sample in samples if sample.get(field) is not None]
+    if not values:
+        return None, None, None
+    return values[0], values[-1], values[-1] - values[0]
 
 
-def build_summary(meta: dict, samples: list[dict], logs: dict, duration_min: float) -> dict:
-    heighted = [s for s in samples if s["height"] is not None]
-    start_h = heighted[0]["height"] if heighted else None
-    end_h = heighted[-1]["height"] if heighted else None
-    progress = (end_h - start_h) if heighted else None
+def load_json(path: str | None):
+    if not path or not Path(path).is_file():
+        return None
+    try:
+        return json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"manifest_error": str(exc)}
+
+
+def asset_age(created: str | None) -> str:
+    if not created:
+        return "unknown"
+    try:
+        timestamp = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
+        age = dt.datetime.now(dt.timezone.utc) - timestamp.astimezone(dt.timezone.utc)
+    except ValueError:
+        return "unknown"
+    hours = max(0, int(age.total_seconds() // 3600))
+    if hours < 48:
+        return f"{hours}h"
+    return f"{hours // 24}d {hours % 24}h"
+
+
+def build_summary(
+    meta: dict,
+    samples: list[dict],
+    logs: dict,
+    duration_min: float,
+    lifecycle: dict | None,
+    zakura_fixture,
+    zcashd_fixture,
+) -> dict:
+    start_h, end_h, progress = height_summary(samples, "height")
     last = samples[-1] if samples else {}
-    peers = [s["peers"] for s in samples if s["peers"] is not None]
-    rss = [s["rss_mib"] for s in samples if s["rss_mib"] is not None]
-    restarts = max((s["restarts"] for s in samples), default=0)
+    peers = [sample["peers"] for sample in samples if sample.get("peers") is not None]
+    rss = [sample["rss_mib"] for sample in samples if sample.get("rss_mib") is not None]
+    restarts = max((sample["restarts"] for sample in samples), default=0)
+    compat = meta.get("test_profile") == "zcashd-compat"
 
+    verdict = "ok"
     if (
         last.get("active_state") != "active"
         or logs["panics"] > 0
         or restarts > 0
-        or not heighted
+        or end_h is None
+        or logs["pruned_sidecar_errors"] > 0
+        or (lifecycle is not None and not lifecycle.get("passed", False))
     ):
         verdict = "failed"
     elif logs["errors"] > 0 or (progress is not None and progress <= 0):
         verdict = "degraded"
-    else:
-        verdict = "ok"
 
-    return {
+    summary = {
         **meta,
         "verdict": verdict,
         "duration_minutes": duration_min,
@@ -139,7 +207,9 @@ def build_summary(meta: dict, samples: list[dict], logs: dict, duration_min: flo
         "end_height": end_h,
         "blocks_synced": progress,
         "blocks_per_hour": (
-            round(progress / duration_min * 60) if progress is not None and duration_min else None
+            round(progress / duration_min * 60)
+            if progress is not None and duration_min
+            else None
         ),
         "estimated_tip_at_end": last.get("estimated"),
         "peers_last": peers[-1] if peers else None,
@@ -150,22 +220,82 @@ def build_summary(meta: dict, samples: list[dict], logs: dict, duration_min: flo
         "log_errors": logs["errors"],
         "log_warns": logs["warns"],
         "panics": logs["panics"],
+        "pruned_sidecar_errors": logs["pruned_sidecar_errors"],
         "last_errors": logs["last_errors"],
+        "cold_warm_lifecycle": lifecycle,
+        "zakura_fixture_manifest": zakura_fixture,
+        "zcashd_fixture_manifest": zcashd_fixture,
     }
+
+    for prefix in ("image", "zakura_snapshot", "zcashd_snapshot"):
+        summary[f"{prefix}_age"] = asset_age(meta.get(f"{prefix}_created"))
+
+    if compat:
+        z_start, z_end, z_progress = height_summary(samples, "zcashd_height")
+        child_pids = sorted(
+            {
+                pid
+                for sample in samples
+                for pid in sample.get("zcashd_child_pids", [])
+            }
+        )
+        missing_children = sum(
+            1
+            for sample in samples
+            if sample.get("elapsed", 0) > RPC_GRACE_SECS
+            and sample.get("zcashd_child_count") != 1
+        )
+        summary.update(
+            {
+                "zcashd_start_height": z_start,
+                "zcashd_end_height": z_end,
+                "zcashd_blocks_synced": z_progress,
+                "zcashd_child_pids": child_pids,
+                "zcashd_child_restarts": max(0, len(child_pids) - 1),
+                "zcashd_child_missing_samples": missing_children,
+                "zcashd_connections_at_end": last.get("zcashd_connections"),
+                "height_drift_at_end": (
+                    abs(end_h - z_end) if end_h is not None and z_end is not None else None
+                ),
+            }
+        )
+        if (
+            z_end is None
+            or lifecycle is None
+            or not lifecycle.get("passed", False)
+            or last.get("zcashd_child_count") != 1
+            or last.get("zcashd_connections") != 1
+            or summary["zcashd_child_restarts"] > 0
+            or missing_children > 0
+        ):
+            summary["verdict"] = "failed"
+        elif z_progress is not None and z_progress <= 0 and summary["verdict"] == "ok":
+            summary["verdict"] = "degraded"
+    return summary
+
+
+def fmt(value, suffix: str = "") -> str:
+    return f"{value}{suffix}" if value is not None else "n/a"
 
 
 def write_markdown(out: Path, summary: dict, samples: list[dict], notes_file: str | None):
     icon = {"ok": "✅", "degraded": "⚠️", "failed": "❌"}[summary["verdict"]]
     mode, network = summary.get("mode", "?"), summary.get("network", "?")
+    profile = summary.get("test_profile", "zakura")
+    if profile == "zakura":
+        title = f"## Zakura PR node run — {mode}/{network} {icon}"
+    else:
+        title = f"## Zakura PR node run — {profile}/{mode}/{network} {icon}"
     lines = [
-        f"## Zakura PR node run — {mode}/{network} {icon}",
+        title,
         "",
         "| | |",
         "|---|---|",
         f"| Verdict | **{summary['verdict']}** |",
+        f"| Test profile | `{profile}` |",
         f"| Commit | `{summary.get('sha', '?')}` |",
         f"| Duration | {summary['duration_minutes']:g} min |",
-        f"| Height | {fmt(summary['start_height'])} → {fmt(summary['end_height'])} "
+        f"| Zakura height | {fmt(summary['start_height'])} → {fmt(summary['end_height'])} "
         f"(+{fmt(summary['blocks_synced'])}) |",
         f"| Blocks/hour | {fmt(summary['blocks_per_hour'])} |",
         f"| Estimated tip at end | {fmt(summary['estimated_tip_at_end'])} |",
@@ -176,29 +306,77 @@ def write_markdown(out: Path, summary: dict, samples: list[dict], notes_file: st
         f"| Log errors/warns/panics | {summary['log_errors']} / {summary['log_warns']} / "
         f"{summary['panics']} |",
     ]
+    if profile == "zcashd-compat":
+        lines += [
+            f"| zcashd height | {fmt(summary['zcashd_start_height'])} → "
+            f"{fmt(summary['zcashd_end_height'])} (+{fmt(summary['zcashd_blocks_synced'])}) |",
+            f"| Height drift at end | {fmt(summary['height_drift_at_end'])} |",
+            f"| zcashd child | {len(summary['zcashd_child_pids'])} PID(s) observed, "
+            f"{summary['zcashd_child_restarts']} unexpected restart(s) |",
+            f"| zcashd connections at end | {fmt(summary['zcashd_connections_at_end'])} |",
+            f"| Pruned sidecar diagnostic | {summary['pruned_sidecar_errors']} occurrence(s) |",
+            f"| Cold stop/warm restart | "
+            f"{'passed' if (summary.get('cold_warm_lifecycle') or {}).get('passed') else 'failed'} |",
+        ]
 
-    shown = [s for s in samples if s["height"] is not None]
+    lines += [
+        "",
+        "### Golden assets",
+        "",
+        "| Asset | Name | ID | Created | Age |",
+        "|---|---|---|---|---|",
+        f"| Base image | `{summary.get('image_name', 'unknown')}` | "
+        f"`{summary.get('image_id', 'unknown')}` | {summary.get('image_created', 'unknown')} | "
+        f"{summary.get('image_age', 'unknown')} |",
+        f"| Zakura state | `{summary.get('zakura_snapshot_name', 'none')}` | "
+        f"`{summary.get('zakura_snapshot_id', 'none')}` | "
+        f"{summary.get('zakura_snapshot_created', 'unknown')} | "
+        f"{summary.get('zakura_snapshot_age', 'unknown')} |",
+    ]
+    if profile == "zcashd-compat":
+        lines.append(
+            f"| zcashd state | `{summary.get('zcashd_snapshot_name', 'none')}` | "
+            f"`{summary.get('zcashd_snapshot_id', 'none')}` | "
+            f"{summary.get('zcashd_snapshot_created', 'unknown')} | "
+            f"{summary.get('zcashd_snapshot_age', 'unknown')} |"
+        )
+
+    shown = [sample for sample in samples if sample.get("height") is not None]
     if shown:
-        # Subsample to ~12 rows so an hour-long run stays readable.
         step = max(1, len(shown) // 12)
         picked = shown[::step]
         if picked[-1] is not shown[-1]:
             picked.append(shown[-1])
-        lines += ["", "### Height over time", "", "| Elapsed | Height | Peers | RSS (MiB) |", "|---|---|---|---|"]
-        for s in picked:
-            lines.append(
-                f"| {int(s['elapsed'] // 60)}m | {fmt(s['height'])} | {fmt(s['peers'])} "
-                f"| {fmt(s['rss_mib'])} |"
-            )
+        headers = "| Elapsed | Zakura | zcashd | Peers | RSS (MiB) |" if profile == "zcashd-compat" else "| Elapsed | Height | Peers | RSS (MiB) |"
+        separator = "|---|---|---|---|---|" if profile == "zcashd-compat" else "|---|---|---|---|"
+        lines += ["", "### Height over time", "", headers, separator]
+        for sample in picked:
+            if profile == "zcashd-compat":
+                lines.append(
+                    f"| {int(sample['elapsed'] // 60)}m | {fmt(sample['height'])} | "
+                    f"{fmt(sample.get('zcashd_height'))} | {fmt(sample['peers'])} | "
+                    f"{fmt(sample['rss_mib'])} |"
+                )
+            else:
+                lines.append(
+                    f"| {int(sample['elapsed'] // 60)}m | {fmt(sample['height'])} | "
+                    f"{fmt(sample['peers'])} | {fmt(sample['rss_mib'])} |"
+                )
+
+    manifests = [
+        ("Zakura", summary.get("zakura_fixture_manifest")),
+        ("zcashd", summary.get("zcashd_fixture_manifest")),
+    ]
+    manifests = [(name, value) for name, value in manifests if value is not None]
+    if manifests:
+        lines += ["", "### Fixture manifests"]
+        for name, value in manifests:
+            lines += ["", f"**{name}**", "", "```json", json.dumps(value, indent=2), "```"]
 
     if summary["last_errors"]:
-        lines += ["", "### Last errors", "", "```"]
-        lines += summary["last_errors"]
-        lines += ["```"]
-
+        lines += ["", "### Last errors", "", "```", *summary["last_errors"], "```"]
     if notes_file and Path(notes_file).is_file():
         lines += ["", "### Notes", "", Path(notes_file).read_text().rstrip()]
-
     (out / "summary.md").write_text("\n".join(lines) + "\n")
 
 
@@ -206,17 +384,24 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--duration-minutes", type=float, required=True)
     parser.add_argument("--interval", type=float, default=30)
+    parser.add_argument("--test-profile", choices=("zakura", "zcashd-compat"), default="zakura")
     parser.add_argument("--rpc-url", default="http://127.0.0.1:8232")
+    parser.add_argument("--zcashd-rpc-url", default="http://127.0.0.1:8232")
+    parser.add_argument("--zcashd-cookie-file")
     parser.add_argument("--service", default="zakurad")
     parser.add_argument("--log-file", default="/var/log/zakura/zakura.log")
-    parser.add_argument("--notes", default=None, help="markdown notes file to append")
-    parser.add_argument("--meta", default="", help="comma-separated key=value run metadata")
-    parser.add_argument("--out", required=True, help="output directory")
+    parser.add_argument("--notes")
+    parser.add_argument("--meta", default="", help="comma-separated key=value metadata")
+    parser.add_argument("--lifecycle-file")
+    parser.add_argument("--zakura-fixture-manifest")
+    parser.add_argument("--zcashd-fixture-manifest")
+    parser.add_argument("--out", required=True)
     args = parser.parse_args()
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
     meta = dict(kv.split("=", 1) for kv in args.meta.split(",") if "=" in kv)
+    meta["test_profile"] = args.test_profile
 
     start = time.monotonic()
     deadline = start + args.duration_minutes * 60
@@ -226,12 +411,16 @@ def main() -> int:
         sample["elapsed"] = time.monotonic() - start
         samples.append(sample)
         status = (
-            f"[{int(sample['elapsed'])}s] height={fmt(sample['height'])} "
+            f"[{int(sample['elapsed'])}s] zakura={fmt(sample['height'])} "
             f"peers={fmt(sample['peers'])} rss={fmt(sample['rss_mib'])}MiB "
             f"state={sample['active_state']}"
         )
+        if args.test_profile == "zcashd-compat":
+            status += (
+                f" zcashd={fmt(sample.get('zcashd_height'))} "
+                f"child={fmt(sample.get('zcashd_child_pids'))}"
+            )
         print(status, flush=True)
-        # Bail out early once the node is clearly gone (past the startup grace).
         if sample["elapsed"] > RPC_GRACE_SECS and sample["active_state"] == "failed":
             print("service failed; stopping monitor early", flush=True)
             break
@@ -239,8 +428,16 @@ def main() -> int:
             break
         time.sleep(args.interval)
 
-    logs = scan_logs(args.log_file, args.service)
-    summary = build_summary(meta, samples, logs, args.duration_minutes)
+    summary = build_summary(
+        meta,
+        samples,
+        scan_logs(args.log_file, args.service),
+        args.duration_minutes,
+        load_json(args.lifecycle_file),
+        load_json(args.zakura_fixture_manifest),
+        load_json(args.zcashd_fixture_manifest),
+    )
+    (out / "samples.json").write_text(json.dumps(samples, indent=2) + "\n")
     (out / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
     write_markdown(out, summary, samples, args.notes)
     print(f"verdict: {summary['verdict']}", flush=True)

--- a/.github/workflows/scripts/pr-node-monitor.py
+++ b/.github/workflows/scripts/pr-node-monitor.py
@@ -19,6 +19,10 @@ PRUNED_SIDECAR_ERROR = (
     "cannot serve block because its body has been pruned; a zcashd sidecar "
     "requiring this block cannot continue syncing"
 )
+EXPECTED_ZCASHD_STARTUP_ERROR = re.compile(
+    r'^\S+\s+INFO zcashd_compat\.zcashd: \S+ ERROR Init: main: Read: Failed to open file '
+    r'/mnt/zcashd/(?:peers|banlist)\.dat stream="stdout"$'
+)
 
 
 def rpc_call(url: str, method: str, cookie_file: str | None = None):
@@ -108,18 +112,25 @@ def take_sample(args) -> dict:
     return sample
 
 
-def scan_logs(log_file: str, service: str) -> dict:
-    errors = warns = pruned_sidecar_errors = 0
+def scan_logs(log_file: str, service: str, test_profile: str) -> dict:
+    errors = warns = pruned_sidecar_errors = expected_zcashd_startup_errors = 0
     last_errors: list[str] = []
     try:
         with open(log_file, errors="replace") as fh:
             for line in fh:
+                line = line.rstrip()
                 if PRUNED_SIDECAR_ERROR in line:
                     pruned_sidecar_errors += 1
                 if " ERROR " in line:
-                    errors += 1
-                    last_errors.append(line.rstrip()[:300])
-                    last_errors = last_errors[-5:]
+                    if (
+                        test_profile == "zcashd-compat"
+                        and EXPECTED_ZCASHD_STARTUP_ERROR.fullmatch(line)
+                    ):
+                        expected_zcashd_startup_errors += 1
+                    else:
+                        errors += 1
+                        last_errors.append(line[:300])
+                        last_errors = last_errors[-5:]
                 elif " WARN " in line:
                     warns += 1
     except OSError:
@@ -136,6 +147,7 @@ def scan_logs(log_file: str, service: str) -> dict:
         "warns": warns,
         "panics": panics,
         "pruned_sidecar_errors": pruned_sidecar_errors,
+        "expected_zcashd_startup_errors": expected_zcashd_startup_errors,
         "last_errors": last_errors,
     }
 
@@ -221,6 +233,7 @@ def build_summary(
         "log_warns": logs["warns"],
         "panics": logs["panics"],
         "pruned_sidecar_errors": logs["pruned_sidecar_errors"],
+        "expected_zcashd_startup_errors": logs["expected_zcashd_startup_errors"],
         "last_errors": logs["last_errors"],
         "cold_warm_lifecycle": lifecycle,
         "zakura_fixture_manifest": zakura_fixture,
@@ -315,6 +328,8 @@ def write_markdown(out: Path, summary: dict, samples: list[dict], notes_file: st
             f"{summary['zcashd_child_restarts']} unexpected restart(s) |",
             f"| zcashd connections at end | {fmt(summary['zcashd_connections_at_end'])} |",
             f"| Pruned sidecar diagnostic | {summary['pruned_sidecar_errors']} occurrence(s) |",
+            f"| Expected zcashd startup errors | "
+            f"{summary['expected_zcashd_startup_errors']} occurrence(s) |",
             f"| Cold stop/warm restart | "
             f"{'passed' if (summary.get('cold_warm_lifecycle') or {}).get('passed') else 'failed'} |",
         ]
@@ -431,7 +446,7 @@ def main() -> int:
     summary = build_summary(
         meta,
         samples,
-        scan_logs(args.log_file, args.service),
+        scan_logs(args.log_file, args.service, args.test_profile),
         args.duration_minutes,
         load_json(args.lifecycle_file),
         load_json(args.zakura_fixture_manifest),

--- a/.github/workflows/scripts/pr-node-run.sh
+++ b/.github/workflows/scripts/pr-node-run.sh
@@ -1,17 +1,8 @@
 #!/usr/bin/env bash
-# Runs ON the ephemeral PR-node droplet (zakura-pr-node.yml): mounts the cloned
-# state volume, checks out the PR commit in the baked repo clone, builds zakurad
-# incrementally against the baked cargo cache via deploy.py (over the baked
-# root@localhost loopback), deploys it as the zakurad systemd service, and
-# monitors it for the requested duration.
-#
-# Config via /root/run.env (sourced by the caller before exec):
-#   GH_REPO / GH_CLONE_TOKEN  repo slug + per-run token for the PR-ref fetch
-#   MODE                      tip | sandblast | genesis
-#   NETWORK                   mainnet | testnet
-#   SHA / REFSPEC             commit to test + refspec that reaches it
-#   DURATION_MINUTES          how long to monitor the running node
-#   VOLUME_NAME               state volume name ("" in genesis mode)
+# Runs on an ephemeral PR-node droplet. The standard profile mounts one Golden
+# Zakura state clone. The zcashd-compat profile also mounts a Golden zcashd
+# datadir, exercises a cold managed install and a clean stop/warm restart, then
+# monitors both nodes.
 set -euo pipefail
 
 OUT_DIR=/root/out
@@ -23,73 +14,261 @@ note() {
   echo "- $1" >> "$NOTES"
 }
 
+mount_snapshot() {
+  local volume_name="$1"
+  local mount_dir="$2"
+  local device="/dev/disk/by-id/scsi-0DO_Volume_${volume_name}"
+  for _ in $(seq 1 30); do
+    [ -e "$device" ] && break
+    sleep 2
+  done
+  [ -e "$device" ] || { echo "volume device not found: $device" >&2; exit 1; }
+  mkdir -p "$mount_dir"
+  mount "$device" "$mount_dir"
+  mountpoint -q "$mount_dir" || { echo "volume was not mounted at $mount_dir" >&2; exit 1; }
+}
+
+copy_fixture_manifest() {
+  local output="$1"
+  shift
+  local candidate
+  for candidate in "$@"; do
+    if [ -f "$candidate" ]; then
+      cp "$candidate" "$output"
+      note "Fixture manifest: \`$candidate\`."
+      return 0
+    fi
+  done
+  note "**WARNING:** fixture manifest was not present in the Golden state clone."
+  return 0
+}
+
+validate_compat_fixtures() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+zakura_path, zcashd_path = map(Path, sys.argv[1:])
+zakura = json.loads(zakura_path.read_text())
+zcashd = json.loads(zcashd_path.read_text())
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(f"incompatible Golden fixture pair: {message}")
+
+def uint(value):
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+def block_hash(value):
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+require(zakura.get("schema_version") == 1, "Zakura schema_version must be 1")
+require(zakura.get("fixture") == "zakura-state", "Zakura fixture kind is invalid")
+require(zakura.get("network") == "mainnet", "Zakura fixture is not mainnet")
+require(zakura.get("mode") == "tip", "Zakura fixture is not tip mode")
+require(zcashd.get("schema_version") == 1, "zcashd schema_version must be 1")
+require(zcashd.get("fixture") == "zcashd-mainnet", "zcashd fixture kind is invalid")
+require(zcashd.get("network") == "mainnet", "zcashd fixture is not mainnet")
+require(zcashd.get("status") in {"candidate", "verified"}, "zcashd status is invalid")
+
+zakura_tip = zakura.get("tip") or {}
+zcashd_tip = zcashd.get("tip") or {}
+refresh = zcashd.get("refresh") or {}
+refresh_zakura_tip = refresh.get("zakura_tip") or {}
+require(uint(zakura_tip.get("height")), "Zakura tip height is invalid")
+require(block_hash(zakura_tip.get("hash")), "Zakura tip hash is invalid")
+require(uint(zcashd_tip.get("height")), "zcashd tip height is invalid")
+require(block_hash(zcashd_tip.get("hash")), "zcashd tip hash is invalid")
+require(refresh.get("clean_shutdown") is True, "zcashd refresh was not cleanly shut down")
+require(refresh_zakura_tip == zakura_tip, "zcashd refresh Zakura tip does not match the Zakura fixture")
+
+lag = refresh.get("lag_blocks")
+retention = refresh.get("tx_retention")
+require(uint(lag), "zcashd refresh lag is invalid")
+require(isinstance(retention, int) and not isinstance(retention, bool) and retention > 0,
+        "zcashd refresh retention is invalid")
+require(lag < retention, "zcashd lag is outside the recorded pruning retention")
+require(zakura.get("tx_retention") == retention, "fixture retention values do not match")
+require(zakura_tip["height"] - zcashd_tip["height"] == lag,
+        "recorded lag does not match the paired fixture tips")
+print(f"paired Golden fixtures validated: Zakura {zakura_tip['height']}, "
+      f"zcashd {zcashd_tip['height']}, lag {lag}/{retention}, status {zcashd['status']}")
+PY
+}
+
+rpc_result() {
+  local url="$1"
+  local method="$2"
+  local cookie_file="${3:-}"
+  local auth=()
+  if [ -n "$cookie_file" ]; then
+    [ -s "$cookie_file" ] || return 1
+    auth=(--user "$(<"$cookie_file")")
+  fi
+  curl -fsS "${auth[@]}" \
+    -H 'Content-Type: application/json' \
+    --data "{\"jsonrpc\":\"1.0\",\"id\":\"pr-node-run\",\"method\":\"${method}\",\"params\":[]}" \
+    "$url" | python3 -c 'import json,sys; response=json.load(sys.stdin); assert response.get("error") is None, response.get("error"); print(response["result"])'
+}
+
+wait_for_compat() {
+  local zakura_height=""
+  local zcashd_height=""
+  local main_pid=""
+  local child_pid=""
+  local children=()
+  for _ in $(seq 1 180); do
+    main_pid=$(systemctl show zakurad --property MainPID --value)
+    mapfile -t children < <(pgrep --parent "${main_pid:-0}" --exact zcashd 2>/dev/null || true)
+    child_pid=""
+    if [ "${#children[@]}" -eq 1 ]; then
+      child_pid=${children[0]}
+    fi
+    zakura_height=$(rpc_result http://127.0.0.1:18232 getblockcount 2>/dev/null || true)
+    zcashd_height=$(rpc_result http://127.0.0.1:8232 getblockcount /mnt/zcashd/.cookie 2>/dev/null || true)
+    if [[ "$zakura_height" =~ ^[0-9]+$ && "$zcashd_height" =~ ^[0-9]+$ && "$child_pid" =~ ^[0-9]+$ ]]; then
+      printf '%s %s %s\n' "$zakura_height" "$zcashd_height" "$child_pid"
+      return 0
+    fi
+    sleep 5
+  done
+  echo "managed zcashd and Zakura did not become RPC-ready in 15 minutes" >&2
+  return 1
+}
+
+wait_for_compat_progress() {
+  local start_zakura="$1"
+  local start_zcashd="$2"
+  local status=""
+  local zakura_height=""
+  local zcashd_height=""
+  local child_pid=""
+  for _ in $(seq 1 180); do
+    status=$(wait_for_compat) || return 1
+    read -r zakura_height zcashd_height child_pid <<< "$status"
+    if [ "$zakura_height" -gt "$start_zakura" ] && [ "$zcashd_height" -gt "$start_zcashd" ]; then
+      printf '%s %s %s\n' "$zakura_height" "$zcashd_height" "$child_pid"
+      return 0
+    fi
+    sleep 5
+  done
+  echo "Zakura and managed zcashd did not both advance in 15 minutes" >&2
+  return 1
+}
+
 cloud-init status --wait >/dev/null 2>&1 || true
+TEST_PROFILE=${TEST_PROFILE:-zakura}
 
 # ---------------------------------------------------------------------------- #
-# State: mount the per-run clone of the baked volume snapshot
+# Golden state volumes
 # ---------------------------------------------------------------------------- #
 
 if [ "$MODE" = "genesis" ]; then
   STATE_CACHE_DIR=/var/lib/zakura
   STORAGE_MODE=archive
   mkdir -p "$STATE_CACHE_DIR"
-  df -h /
 else
-  DEV="/dev/disk/by-id/scsi-0DO_Volume_${VOLUME_NAME}"
-  for _ in $(seq 1 30); do [ -e "$DEV" ] && break; sleep 2; done
-  [ -e "$DEV" ] || { echo "state volume device not found: $DEV" >&2; exit 1; }
-  mkdir -p /mnt/snapshots
-  mount "$DEV" /mnt/snapshots
+  mount_snapshot "$ZAKURA_VOLUME_NAME" /mnt/snapshots
   STATE_CACHE_DIR="/mnt/snapshots/${MODE}"
   case "$MODE" in
     tip)       STORAGE_MODE=pruned ;;
     sandblast) STORAGE_MODE=archive ;;
     *)         echo "unknown snapshot mode: $MODE" >&2; exit 1 ;;
   esac
-  [ -d "$STATE_CACHE_DIR" ] || { echo "no ${MODE}/ state on the volume" >&2; exit 1; }
-  df -h /mnt/snapshots
+  [ -d "$STATE_CACHE_DIR" ] || { echo "no ${MODE}/ state on the Zakura volume" >&2; exit 1; }
+  if [ "$TEST_PROFILE" = "zcashd-compat" ]; then
+    [ -f "$STATE_CACHE_DIR/fixture-manifest.json" ] || {
+      echo "compat requires the canonical Zakura fixture-manifest.json" >&2
+      exit 1
+    }
+    cp "$STATE_CACHE_DIR/fixture-manifest.json" "$OUT_DIR/zakura-fixture-manifest.json"
+    note "Fixture manifest: \`$STATE_CACHE_DIR/fixture-manifest.json\`."
+  else
+    copy_fixture_manifest "$OUT_DIR/zakura-fixture-manifest.json" \
+      "$STATE_CACHE_DIR/fixture-manifest.json" \
+      "$STATE_CACHE_DIR/zakura-fixture.json" \
+      /mnt/snapshots/fixture-manifest.json \
+      /mnt/snapshots/zakura-fixture.json
+  fi
 fi
 
+if [ "$TEST_PROFILE" = "zcashd-compat" ]; then
+  [ "$MODE" = "tip" ] && [ "$NETWORK" = "mainnet" ] || {
+    echo "zcashd-compat requires snapshot_mode=tip and network=mainnet" >&2
+    exit 1
+  }
+  [ -n "${ZCASHD_VOLUME_NAME:-}" ] || { echo "zcashd Golden volume is missing" >&2; exit 1; }
+  mount_snapshot "$ZCASHD_VOLUME_NAME" /mnt/zcashd
+  for required in blocks chainstate unity; do
+    [ -d "/mnt/zcashd/$required" ] || {
+      echo "zcashd Golden fixture is missing /mnt/zcashd/$required" >&2
+      exit 1
+    }
+  done
+  [ -f /mnt/zcashd/fixture-manifest.json ] || {
+    echo "compat requires the canonical zcashd fixture-manifest.json" >&2
+    exit 1
+  }
+  cp /mnt/zcashd/fixture-manifest.json "$OUT_DIR/zcashd-fixture-manifest.json"
+  note "Fixture manifest: \`/mnt/zcashd/fixture-manifest.json\`."
+  validate_compat_fixtures \
+    "$OUT_DIR/zakura-fixture-manifest.json" \
+    "$OUT_DIR/zcashd-fixture-manifest.json"
+fi
+
+df -h / /mnt/snapshots /mnt/zcashd 2>/dev/null || true
+
 # ---------------------------------------------------------------------------- #
-# Source: fetch the PR ref into the baked clone
+# Exact source ref
 # ---------------------------------------------------------------------------- #
 
 cd /root/zakura
-# git-over-HTTPS wants basic auth (the bearer form is API-only); this is the
-# same header actions/checkout configures.
 GIT_AUTH=$(printf 'x-access-token:%s' "${GH_CLONE_TOKEN}" | base64 -w0)
-git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
-  fetch --no-tags origin "${REFSPEC}"
+git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" fetch --no-tags origin "${REFSPEC}"
 git checkout --detach "${SHA}"
+# Deployment is test harness, not code under test. Use the workflow revision's
+# renderer so old target refs understand the Golden zcashd profile while Cargo
+# still builds exactly SHA from this checkout.
+mkdir -p deploy/deployer/templates
+install -m 755 /root/pr-node-deploy.py deploy/deployer/deploy.py
+install -m 644 /root/pr-node-zakura.toml deploy/deployer/templates/zakura.toml
+install -m 644 /root/pr-node-zakurad.service deploy/deployer/templates/zakurad.service
+[ "$(git rev-parse HEAD)" = "$SHA" ] || {
+  echo "target checkout moved away from requested SHA $SHA" >&2
+  exit 1
+}
 rm -f /root/run.env
 unset GH_CLONE_TOKEN GIT_AUTH
-
-# ---------------------------------------------------------------------------- #
-# Preflight: baked state DB format vs the PR tree's format
-# ---------------------------------------------------------------------------- #
 
 CODE_VER=$(grep -oE 'DATABASE_FORMAT_VERSION: .* [0-9]+' zakura-state/src/constants.rs | grep -oE '[0-9]+' | tail -n1)
 if [ "$MODE" != "genesis" ]; then
   DIR_VER=$(find "$STATE_CACHE_DIR/state" -mindepth 1 -maxdepth 1 -type d -name 'v*' 2>/dev/null | \
     sed 's#.*/v##' | sort -n | tail -1)
   if [ -z "$DIR_VER" ]; then
-    note "**WARNING:** no state/v* directory found under \`$STATE_CACHE_DIR\` — the node will sync from scratch."
+    note "**WARNING:** no state/v* directory found under \`$STATE_CACHE_DIR\`."
+    [ "$TEST_PROFILE" != "zcashd-compat" ] || {
+      echo "zcashd-compat requires a compatible Golden Zakura state DB" >&2
+      exit 1
+    }
   elif [ "$DIR_VER" = "$CODE_VER" ]; then
     note "State DB format v${DIR_VER} matches the PR tree."
   elif [ "$DIR_VER" = "$((CODE_VER - 1))" ]; then
-    note "State snapshot is v${DIR_VER}, PR tree is v${CODE_VER}: zakurad restores the previous major format in place (a format upgrade runs during the test)."
+    note "State snapshot is v${DIR_VER}, PR tree is v${CODE_VER}. The in-place format upgrade is part of this run."
   else
-    note "**WARNING: DB format mismatch** — snapshot is v${DIR_VER} but the PR tree is v${CODE_VER}. The baked state will be ignored and the node syncs from scratch; re-bake the image or use genesis mode."
+    note "**WARNING: DB format mismatch.** Snapshot is v${DIR_VER}, PR tree is v${CODE_VER}."
+    [ "$TEST_PROFILE" != "zcashd-compat" ] || {
+      echo "zcashd-compat refuses an incompatible Golden Zakura state DB" >&2
+      exit 1
+    }
   fi
 fi
 
 # ---------------------------------------------------------------------------- #
-# Build + deploy via deploy.py against the baked loopback SSH identity
+# Build and deploy through the normal deployer
 # ---------------------------------------------------------------------------- #
 
-# Enforce the loopback SSH config regardless of what the image baked: this
-# droplet regenerated its host keys on first boot, so any recorded localhost
-# host key is stale and would fail deploy.py's connections as a changed key.
 cat > /root/.ssh/config <<'CFG'
 Host localhost
     IdentityFile /root/.ssh/pr_node_loopback
@@ -106,7 +285,45 @@ case "$NETWORK" in
   *) echo "unknown network: $NETWORK" >&2; exit 1 ;;
 esac
 
-cat > /root/fleet.toml <<TOML
+if [ "$TEST_PROFILE" = "zcashd-compat" ]; then
+  # The wrapper cache belongs to this ephemeral clone. Removing only its binary
+  # cache makes the first start exercise the pinned embedded install path; the
+  # second start must reuse it unchanged.
+  WRAPPER_CACHE="$STATE_CACHE_DIR/zcashd-compat/bin"
+  case "$WRAPPER_CACHE" in
+    /mnt/snapshots/tip/zcashd-compat/bin) ;;
+    *) echo "refusing to clear unexpected wrapper cache path: $WRAPPER_CACHE" >&2; exit 1 ;;
+  esac
+  rm -rf -- "$WRAPPER_CACHE"
+
+  cat > /root/fleet.toml <<TOML
+[defaults]
+service_kill_mode = "mixed"
+service_timeout_stop_sec = "6m"
+
+[defaults.zcashd_compat]
+enabled = true
+manage_zcashd = true
+zcashd_source = "embedded"
+zcashd_datadir = "/mnt/zcashd"
+zcashd_extra_args = ["-server=1", "-rpcbind=127.0.0.1", "-rpcallowip=127.0.0.1"]
+shutdown_grace_period = "5m"
+
+[[nodes]]
+name = "pr-node"
+ssh_string = "root@localhost"
+commit = "${SHA}"
+network = "${NET_TOML}"
+state_cache_dir = "${STATE_CACHE_DIR}"
+storage_mode = "${STORAGE_MODE}"
+p2p_stack = "legacy"
+rpc_listen_addr = "127.0.0.1:18232"
+rpc_enable_cookie_auth = false
+metrics_endpoint = "127.0.0.1:9999"
+TOML
+  ZAKURA_RPC_URL=http://127.0.0.1:18232
+else
+  cat > /root/fleet.toml <<TOML
 [[nodes]]
 name = "pr-node"
 ssh_string = "root@localhost"
@@ -119,30 +336,152 @@ rpc_listen_addr = "127.0.0.1:8232"
 rpc_enable_cookie_auth = false
 metrics_endpoint = "127.0.0.1:9999"
 TOML
+  ZAKURA_RPC_URL=http://127.0.0.1:8232
+fi
 
 export CARGO_TARGET_DIR=/root/cargo-target
 BUILD_START=$(date +%s)
 python3 deploy/deployer/deploy.py build --config /root/fleet.toml
-note "Incremental build took $(( $(date +%s) - BUILD_START ))s (warm baked cache)."
+[ -x "deploy/deployer/.build-cache/zakurad-${SHA}" ] || {
+  echo "deployer did not produce the SHA-keyed binary for $SHA" >&2
+  exit 1
+}
+note "Incremental build took $(( $(date +%s) - BUILD_START ))s using the baked Cargo cache."
+note "Built exact target commit \`$SHA\`; only the workflow's deployer harness was overlaid."
 
+mkdir -p /var/log/zakura
+: > /var/log/zakura/zakura.log
 python3 deploy/deployer/deploy.py deploy --config /root/fleet.toml
 python3 deploy/deployer/deploy.py status --config /root/fleet.toml || true
 
 # ---------------------------------------------------------------------------- #
-# Monitor for the requested duration, then package outputs
+# Managed zcashd cold start, clean stop, and warm restart
 # ---------------------------------------------------------------------------- #
 
-MONITOR_RC=0
-python3 /root/pr-node-monitor.py \
-  --duration-minutes "${DURATION_MINUTES}" \
-  --interval 30 \
-  --rpc-url http://127.0.0.1:8232 \
-  --service zakurad \
-  --log-file /var/log/zakura/zakura.log \
-  --notes "$NOTES" \
-  --meta "mode=${MODE},network=${NETWORK},sha=${SHA}" \
-  --out "$OUT_DIR" || MONITOR_RC=$?
+if [ "$TEST_PROFILE" = "zcashd-compat" ]; then
+  read -r COLD_READY_ZAKURA_HEIGHT COLD_READY_ZCASHD_HEIGHT COLD_READY_CHILD_PID < <(wait_for_compat)
+  read -r COLD_ZAKURA_HEIGHT COLD_ZCASHD_HEIGHT COLD_CHILD_PID < <(
+    wait_for_compat_progress "$COLD_READY_ZAKURA_HEIGHT" "$COLD_READY_ZCASHD_HEIGHT"
+  )
+  [ "$COLD_READY_CHILD_PID" = "$COLD_CHILD_PID" ] || {
+    echo "managed zcashd restarted during the cold progress check" >&2
+    exit 1
+  }
+  CACHED_ZCASHD=$(find "$WRAPPER_CACHE" -type f -name zcashd -perm -u+x -print -quit)
+  [ -n "$CACHED_ZCASHD" ] || { echo "managed zcashd cache was not populated" >&2; exit 1; }
+  case "$CACHED_ZCASHD" in
+    "$WRAPPER_CACHE"/*/x86_64-pc-linux-gnu/zcashd) ;;
+    *) echo "managed zcashd resolved outside its source-defined cache layout: $CACHED_ZCASHD" >&2; exit 1 ;;
+  esac
+  COLD_CACHE_SHA=$(sha256sum "$CACHED_ZCASHD" | awk '{print $1}')
+  COLD_CACHE_MTIME=$(stat -c %Y "$CACHED_ZCASHD")
+  note "Cold start installed managed zcashd. Both nodes advanced from Zakura ${COLD_READY_ZAKURA_HEIGHT}, zcashd ${COLD_READY_ZCASHD_HEIGHT} to Zakura ${COLD_ZAKURA_HEIGHT}, zcashd ${COLD_ZCASHD_HEIGHT}."
 
+  STOP_START_LINE=$(( $(wc -l < /var/log/zakura/zakura.log) + 1 ))
+  systemctl stop zakurad
+  for _ in $(seq 1 30); do
+    if ! pgrep --exact zcashd >/dev/null 2>&1; then break; fi
+    sleep 2
+  done
+  ! pgrep --exact zcashd >/dev/null 2>&1 || { echo "managed zcashd survived Zakura stop" >&2; exit 1; }
+  STOP_LOG="$OUT_DIR/cold-stop.log"
+  tail -n "+${STOP_START_LINE}" /var/log/zakura/zakura.log > "$STOP_LOG"
+  for evidence in \
+    "Shutdown: main: done" \
+    "zcashd-compat zcashd exited cleanly after SIGTERM" \
+    "zcashd-compat zcashd child stopped on shutdown" \
+    "stopping zakurad"; do
+    grep -Fq "$evidence" "$STOP_LOG" || {
+      echo "clean-shutdown evidence missing: $evidence" >&2
+      exit 1
+    }
+  done
+
+  systemctl start zakurad
+  read -r WARM_ZAKURA_HEIGHT WARM_ZCASHD_HEIGHT WARM_CHILD_PID < <(wait_for_compat)
+  WARM_CACHE_SHA=$(sha256sum "$CACHED_ZCASHD" | awk '{print $1}')
+  WARM_CACHE_MTIME=$(stat -c %Y "$CACHED_ZCASHD")
+  [ "$COLD_CACHE_SHA" = "$WARM_CACHE_SHA" ] && [ "$COLD_CACHE_MTIME" = "$WARM_CACHE_MTIME" ] || {
+    echo "warm restart replaced the managed zcashd cache" >&2
+    exit 1
+  }
+  [ "$COLD_CHILD_PID" != "$WARM_CHILD_PID" ] || {
+    echo "warm restart did not launch a new managed zcashd child" >&2
+    exit 1
+  }
+  python3 - "$OUT_DIR/compat-lifecycle.json" \
+    "$COLD_CHILD_PID" "$WARM_CHILD_PID" "$COLD_CACHE_SHA" \
+    "$COLD_READY_ZAKURA_HEIGHT" "$COLD_READY_ZCASHD_HEIGHT" \
+    "$COLD_ZAKURA_HEIGHT" "$COLD_ZCASHD_HEIGHT" \
+    "$WARM_ZAKURA_HEIGHT" "$WARM_ZCASHD_HEIGHT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    out,
+    cold_pid,
+    warm_pid,
+    cache_sha,
+    cold_ready_z,
+    cold_ready_d,
+    cold_z,
+    cold_d,
+    warm_z,
+    warm_d,
+) = sys.argv[1:]
+Path(out).write_text(json.dumps({
+    "passed": True,
+    "cold_child_pid": int(cold_pid),
+    "warm_child_pid": int(warm_pid),
+    "managed_binary_sha256": cache_sha,
+    "cache_reused": True,
+    "clean_shutdown_evidence": [
+        "Shutdown: main: done",
+        "zcashd-compat zcashd exited cleanly after SIGTERM",
+        "zcashd-compat zcashd child stopped on shutdown",
+        "stopping zakurad",
+    ],
+    "cold_ready_heights": {"zakura": int(cold_ready_z), "zcashd": int(cold_ready_d)},
+    "cold_progress_heights": {"zakura": int(cold_z), "zcashd": int(cold_d)},
+    "warm_heights": {"zakura": int(warm_z), "zcashd": int(warm_d)},
+}, indent=2) + "\n")
+PY
+  note "Managed zcashd stopped cleanly and warm restarted from the unchanged cache at heights Zakura ${WARM_ZAKURA_HEIGHT}, zcashd ${WARM_ZCASHD_HEIGHT}."
+fi
+
+# ---------------------------------------------------------------------------- #
+# Monitor and package evidence
+# ---------------------------------------------------------------------------- #
+
+META="mode=${MODE},network=${NETWORK},sha=${SHA},image_id=${IMAGE_ID},image_name=${IMAGE_NAME},image_created=${IMAGE_CREATED},zakura_snapshot_id=${ZAKURA_SNAPSHOT_ID},zakura_snapshot_name=${ZAKURA_SNAPSHOT_NAME},zakura_snapshot_created=${ZAKURA_SNAPSHOT_CREATED},zcashd_snapshot_id=${ZCASHD_SNAPSHOT_ID:-},zcashd_snapshot_name=${ZCASHD_SNAPSHOT_NAME:-},zcashd_snapshot_created=${ZCASHD_SNAPSHOT_CREATED:-}"
+MONITOR_ARGS=(
+  --duration-minutes "${DURATION_MINUTES}"
+  --interval 30
+  --test-profile "$TEST_PROFILE"
+  --rpc-url "$ZAKURA_RPC_URL"
+  --service zakurad
+  --log-file /var/log/zakura/zakura.log
+  --notes "$NOTES"
+  --meta "$META"
+  --out "$OUT_DIR"
+)
+if [ -f "$OUT_DIR/zakura-fixture-manifest.json" ]; then
+  MONITOR_ARGS+=(--zakura-fixture-manifest "$OUT_DIR/zakura-fixture-manifest.json")
+fi
+if [ "$TEST_PROFILE" = "zcashd-compat" ]; then
+  MONITOR_ARGS+=(
+    --zcashd-rpc-url http://127.0.0.1:8232
+    --zcashd-cookie-file /mnt/zcashd/.cookie
+    --lifecycle-file "$OUT_DIR/compat-lifecycle.json"
+  )
+  if [ -f "$OUT_DIR/zcashd-fixture-manifest.json" ]; then
+    MONITOR_ARGS+=(--zcashd-fixture-manifest "$OUT_DIR/zcashd-fixture-manifest.json")
+  fi
+fi
+
+MONITOR_RC=0
+python3 /root/pr-node-monitor.py "${MONITOR_ARGS[@]}" || MONITOR_RC=$?
 tail -n 2000 /var/log/zakura/zakura.log > "$OUT_DIR/zakura-tail.log" 2>/dev/null || true
 zstd -T0 -q -f /var/log/zakura/zakura.log -o "$OUT_DIR/zakura-full.log.zst" 2>/dev/null || true
 

--- a/.github/workflows/scripts/pr-node-zcashd-refresh.sh
+++ b/.github/workflows/scripts/pr-node-zcashd-refresh.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 : "${ZCASHD_VOLUME_NAME:?missing ZCASHD_VOLUME_NAME}"
-: "${ZAKURA_STATE_DIR:?missing ZAKURA_STATE_DIR}"
+: "${FIXTURE_STATE_DIR:?missing FIXTURE_STATE_DIR}"
 : "${ZCASHD_TX_RETENTION:?missing ZCASHD_TX_RETENTION}"
 
 if ! [[ "$ZCASHD_TX_RETENTION" =~ ^[0-9]+$ ]] || (( ZCASHD_TX_RETENTION == 0 )); then
@@ -68,7 +68,7 @@ jq -e '.schema_version == 1 and .fixture == "zcashd-mainnet" and .network == "ma
        and (.tip.height | type == "number") and (.tip.hash | test("^[0-9a-f]{64}$"))' \
   "$MANIFEST" >/dev/null
 
-ZAKURA_MANIFEST="$ZAKURA_STATE_DIR/fixture-manifest.json"
+ZAKURA_MANIFEST="$FIXTURE_STATE_DIR/fixture-manifest.json"
 [[ -f "$ZAKURA_MANIFEST" ]] || { echo "Zakura tip fixture manifest is missing" >&2; exit 1; }
 ZAKURA_CAPTURED_HEIGHT=$(jq -er '.tip.height // .height' "$ZAKURA_MANIFEST")
 ZCASHD_CAPTURED_HEIGHT=$(jq -er '.tip.height' "$MANIFEST")
@@ -106,7 +106,7 @@ identity_dir = "/root/.zakura-fixture-identity"
 p2p_stack = "legacy"
 
 [state]
-cache_dir = "${ZAKURA_STATE_DIR}"
+cache_dir = "${FIXTURE_STATE_DIR}"
 storage_mode = { pruned = { tx_retention = ${ZCASHD_TX_RETENTION} } }
 
 [rpc]
@@ -223,7 +223,7 @@ FINAL_LAG=$((ZAKURA_HEIGHT - ZCASHD_HEIGHT))
 }
 
 ZAKURAD_VERSION=$("$ZAKURAD" --version | head -n 1)
-ZCASHD_BIN=$(find "$ZAKURA_STATE_DIR/zcashd-compat/bin" -type f -name zcashd -perm -111 | sort | tail -n 1)
+ZCASHD_BIN=$(find "$FIXTURE_STATE_DIR/zcashd-compat/bin" -type f -name zcashd -perm -111 | sort | tail -n 1)
 [[ -n "$ZCASHD_BIN" ]] || { echo "managed zcashd binary was not cached" >&2; exit 1; }
 ZCASHD_VERSION=$("$ZCASHD_BIN" --version | head -n 1)
 ZCASHD_BINARY_SHA256=$(sha256sum "$ZCASHD_BIN" | awk '{print $1}')
@@ -279,7 +279,7 @@ jq \
   "$MANIFEST" > "$TMP_MANIFEST"
 mv "$TMP_MANIFEST" "$MANIFEST"
 
-ZAKURA_TMP="$ZAKURA_STATE_DIR/fixture-manifest.json.tmp"
+ZAKURA_TMP="$FIXTURE_STATE_DIR/fixture-manifest.json.tmp"
 jq --arg captured_at "$CAPTURED_AT" --arg hash "$ZAKURA_HASH" --argjson height "$ZAKURA_HEIGHT" \
   '.captured_at = $captured_at | .tip = {height: $height, hash: $hash}' \
   "$ZAKURA_MANIFEST" > "$ZAKURA_TMP"

--- a/.github/workflows/scripts/pr-node-zcashd-refresh.sh
+++ b/.github/workflows/scripts/pr-node-zcashd-refresh.sh
@@ -34,7 +34,11 @@ stop_node() {
   kill -INT "$PID" 2>/dev/null || true
   for _ in $(seq 1 66); do
     if ! kill -0 "$PID" 2>/dev/null; then
-      wait "$PID" || true
+      if ! wait "$PID"; then
+        echo "zakurad exited unsuccessfully during supervised zcashd shutdown" >&2
+        PID=""
+        return 1
+      fi
       PID=""
       return 0
     fi
@@ -131,6 +135,7 @@ rpc_result() {
     "$url" | jq -er 'if .error == null then .result else error(.error | tostring) end'
 }
 
+: > "$LOG"
 "$ZAKURAD" -c "$CONFIG" start --zcashd-compat >>"$LOG" 2>&1 &
 PID=$!
 
@@ -225,6 +230,16 @@ ZCASHD_BINARY_SHA256=$(sha256sum "$ZCASHD_BIN" | awk '{print $1}')
 
 stop_node
 pgrep -x zcashd >/dev/null && { echo "zcashd remained running after clean Zakura shutdown" >&2; exit 1; }
+for evidence in \
+  "Shutdown: main: done" \
+  "zcashd-compat zcashd exited cleanly after SIGTERM" \
+  "zcashd-compat zcashd child stopped on shutdown" \
+  "stopping zakurad"; do
+  grep -Fq "$evidence" "$LOG" || {
+    echo "clean-shutdown evidence missing from fixture refresh: $evidence" >&2
+    exit 1
+  }
+done
 
 # These are runtime artifacts, not reusable chain state. Keep deletion explicit
 # so an unexpected new top-level zcashd artifact fails the bake below.

--- a/.github/workflows/scripts/pr-node-zcashd-refresh.sh
+++ b/.github/workflows/scripts/pr-node-zcashd-refresh.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Refreshes a cloned zcashd mainnet fixture against the freshly baked pruned
+# Zakura tip, then leaves only reusable chain state and provenance on disk.
+set -euo pipefail
+
+: "${ZCASHD_VOLUME_NAME:?missing ZCASHD_VOLUME_NAME}"
+: "${ZAKURA_STATE_DIR:?missing ZAKURA_STATE_DIR}"
+: "${ZCASHD_TX_RETENTION:?missing ZCASHD_TX_RETENTION}"
+
+if ! [[ "$ZCASHD_TX_RETENTION" =~ ^[0-9]+$ ]] || (( ZCASHD_TX_RETENTION == 0 )); then
+  echo "ZCASHD_TX_RETENTION must be a positive integer" >&2
+  exit 1
+fi
+
+DEVICE="/dev/disk/by-id/scsi-0DO_Volume_${ZCASHD_VOLUME_NAME}"
+for _ in $(seq 1 60); do [[ -e "$DEVICE" ]] && break; sleep 2; done
+[[ -e "$DEVICE" ]] || { echo "zcashd fixture volume device not found: $DEVICE" >&2; exit 1; }
+
+ZCASHD_DIR=/mnt/bake-zcashd-mainnet
+mkdir -p "$ZCASHD_DIR"
+existing_mount=$(findmnt -rn -S "$DEVICE" -o TARGET | head -n 1 || true)
+if [[ -n "$existing_mount" && "$existing_mount" != "$ZCASHD_DIR" ]]; then
+  umount "$existing_mount"
+fi
+mountpoint -q "$ZCASHD_DIR" || mount "$DEVICE" "$ZCASHD_DIR"
+
+ZAKURAD=/root/cargo-target/release/zakurad
+CONFIG=/root/zcashd-fixture-zakurad.toml
+LOG=/root/zcashd-fixture-refresh.log
+PID=""
+
+stop_node() {
+  [[ -n "$PID" ]] || return 0
+  kill -INT "$PID" 2>/dev/null || true
+  for _ in $(seq 1 66); do
+    if ! kill -0 "$PID" 2>/dev/null; then
+      wait "$PID" || true
+      PID=""
+      return 0
+    fi
+    sleep 5
+  done
+  echo "zakurad did not finish its supervised zcashd shutdown within 330 seconds" >&2
+  return 1
+}
+
+cleanup() {
+  stop_node || true
+  sync
+  mountpoint -q "$ZCASHD_DIR" && umount "$ZCASHD_DIR" || true
+}
+trap cleanup EXIT
+
+for directory in blocks chainstate unity; do
+  [[ -d "$ZCASHD_DIR/$directory" ]] || {
+    echo "zcashd fixture is missing $directory/" >&2
+    exit 1
+  }
+done
+MANIFEST="$ZCASHD_DIR/fixture-manifest.json"
+[[ -f "$MANIFEST" ]] || { echo "zcashd fixture manifest is missing" >&2; exit 1; }
+jq -e '.schema_version == 1 and .fixture == "zcashd-mainnet" and .network == "mainnet"
+       and (.status == "candidate" or .status == "verified")
+       and (.tip.height | type == "number") and (.tip.hash | test("^[0-9a-f]{64}$"))' \
+  "$MANIFEST" >/dev/null
+
+ZAKURA_MANIFEST="$ZAKURA_STATE_DIR/fixture-manifest.json"
+[[ -f "$ZAKURA_MANIFEST" ]] || { echo "Zakura tip fixture manifest is missing" >&2; exit 1; }
+ZAKURA_CAPTURED_HEIGHT=$(jq -er '.tip.height // .height' "$ZAKURA_MANIFEST")
+ZCASHD_CAPTURED_HEIGHT=$(jq -er '.tip.height' "$MANIFEST")
+MANIFEST_TX_RETENTION=$(jq -er '.tx_retention' "$ZAKURA_MANIFEST")
+[[ "$ZAKURA_CAPTURED_HEIGHT" =~ ^[0-9]+$ && "$ZCASHD_CAPTURED_HEIGHT" =~ ^[0-9]+$ ]] || {
+  echo "fixture manifests contain invalid heights" >&2
+  exit 1
+}
+[[ "$MANIFEST_TX_RETENTION" == "$ZCASHD_TX_RETENTION" ]] || {
+  echo "Zakura fixture retention $MANIFEST_TX_RETENTION does not match configured retention $ZCASHD_TX_RETENTION" >&2
+  exit 1
+}
+(( ZCASHD_CAPTURED_HEIGHT <= ZAKURA_CAPTURED_HEIGHT )) || {
+  echo "refusing refresh: captured zcashd tip $ZCASHD_CAPTURED_HEIGHT is ahead of Zakura $ZAKURA_CAPTURED_HEIGHT" >&2
+  exit 1
+}
+CAPTURED_LAG=$((ZAKURA_CAPTURED_HEIGHT - ZCASHD_CAPTURED_HEIGHT))
+(( CAPTURED_LAG < ZCASHD_TX_RETENTION )) || {
+  echo "refusing refresh: captured zcashd lag $CAPTURED_LAG is outside Zakura's $ZCASHD_TX_RETENTION-block pruning retention" >&2
+  exit 1
+}
+
+AVAILABLE_KIB=$(df --output=avail "$ZCASHD_DIR" | tail -n 1 | tr -d ' ')
+(( AVAILABLE_KIB >= 10 * 1024 * 1024 )) || {
+  echo "zcashd fixture volume has less than 10 GiB free before refresh" >&2
+  exit 1
+}
+
+cat > "$CONFIG" <<TOML
+[network]
+network = "Mainnet"
+listen_addr = "127.0.0.1:8233"
+cache_dir = "/root/.cache/zakura-fixture-network"
+identity_dir = "/root/.zakura-fixture-identity"
+p2p_stack = "legacy"
+
+[state]
+cache_dir = "${ZAKURA_STATE_DIR}"
+storage_mode = { pruned = { tx_retention = ${ZCASHD_TX_RETENTION} } }
+
+[rpc]
+listen_addr = "127.0.0.1:18232"
+enable_cookie_auth = false
+
+[tracing]
+log_file = "${LOG}"
+use_color = false
+
+[zcashd_compat]
+enabled = true
+manage_zcashd = true
+zcashd_source = "embedded"
+zcashd_datadir = "${ZCASHD_DIR}"
+zcashd_extra_args = ["-rpcbind=127.0.0.1", "-rpcallowip=127.0.0.1", "-disablewallet=1"]
+shutdown_grace_period = "5m"
+TOML
+
+rpc_result() {
+  local url="$1" cookie="$2" method="$3" params="${4:-[]}" auth=()
+  [[ -z "$cookie" ]] || auth=(--user "$(cat "$cookie")")
+  curl --noproxy '*' -fsS "${auth[@]}" \
+    -H 'Content-Type: application/json' \
+    --data "{\"jsonrpc\":\"1.0\",\"id\":\"fixture\",\"method\":\"${method}\",\"params\":${params}}" \
+    "$url" | jq -er 'if .error == null then .result else error(.error | tostring) end'
+}
+
+"$ZAKURAD" -c "$CONFIG" start --zcashd-compat >>"$LOG" 2>&1 &
+PID=$!
+
+ZCASHD_COOKIE="$ZCASHD_DIR/.cookie"
+for _ in $(seq 1 120); do
+  kill -0 "$PID" 2>/dev/null || { echo "zakurad exited during fixture startup" >&2; tail -n 200 "$LOG" >&2; exit 1; }
+  if rpc_result http://127.0.0.1:18232 '' getblockcount >/dev/null 2>&1 &&
+     [[ -f "$ZCASHD_COOKIE" ]] &&
+     rpc_result http://127.0.0.1:8232 "$ZCASHD_COOKIE" getblockcount >/dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+rpc_result http://127.0.0.1:18232 '' getblockcount >/dev/null
+rpc_result http://127.0.0.1:8232 "$ZCASHD_COOKIE" getblockcount >/dev/null
+
+# Verify that the claimed seed chain is actually present before accepting any
+# blocks synced during this refresh.
+CLAIMED_HEIGHT=$(jq -er '.tip.height' "$MANIFEST")
+CLAIMED_HASH=$(jq -er '.tip.hash' "$MANIFEST")
+OBSERVED_CLAIMED_HASH=$(rpc_result http://127.0.0.1:8232 "$ZCASHD_COOKIE" getblockhash "[$CLAIMED_HEIGHT]")
+[[ "$OBSERVED_CLAIMED_HASH" == "$CLAIMED_HASH" ]] || {
+  echo "zcashd fixture hash at height $CLAIMED_HEIGHT does not match its manifest" >&2
+  exit 1
+}
+
+ZCASHD_INITIAL=$(rpc_result http://127.0.0.1:8232 "$ZCASHD_COOKIE" getblockcount)
+ZAKURA_INITIAL=$(rpc_result http://127.0.0.1:18232 '' getblockcount)
+(( ZCASHD_INITIAL <= ZAKURA_INITIAL )) || {
+  echo "refusing refresh: live zcashd tip $ZCASHD_INITIAL is ahead of Zakura $ZAKURA_INITIAL" >&2
+  exit 1
+}
+INITIAL_LAG=$((ZAKURA_INITIAL - ZCASHD_INITIAL))
+(( INITIAL_LAG < ZCASHD_TX_RETENTION )) || {
+  echo "refusing refresh: live zcashd lag $INITIAL_LAG is outside Zakura's $ZCASHD_TX_RETENTION-block pruning retention" >&2
+  exit 1
+}
+
+SYNC_TIMEOUT_SECONDS=${ZCASHD_SYNC_TIMEOUT_SECONDS:-10800}
+FINAL_MAX_DRIFT=${ZCASHD_FINAL_MAX_DRIFT:-10}
+DEADLINE=$(( $(date +%s) + SYNC_TIMEOUT_SECONDS ))
+STABLE=0
+while (( $(date +%s) < DEADLINE )); do
+  kill -0 "$PID" 2>/dev/null || { echo "zakurad exited while refreshing zcashd" >&2; exit 1; }
+  ZCASHD_HEIGHT=$(rpc_result http://127.0.0.1:8232 "$ZCASHD_COOKIE" getblockcount)
+  ZAKURA_HEIGHT=$(rpc_result http://127.0.0.1:18232 '' getblockcount)
+  (( ZCASHD_HEIGHT <= ZAKURA_HEIGHT )) || {
+    echo "refusing refresh: zcashd tip $ZCASHD_HEIGHT advanced ahead of Zakura $ZAKURA_HEIGHT" >&2
+    exit 1
+  }
+  FORWARD_LAG=$((ZAKURA_HEIGHT - ZCASHD_HEIGHT))
+  (( FORWARD_LAG < ZCASHD_TX_RETENTION )) || {
+    echo "zcashd lag reached $FORWARD_LAG blocks, outside the $ZCASHD_TX_RETENTION-block retention window" >&2
+    exit 1
+  }
+  DRIFT=$FORWARD_LAG
+  echo "fixture refresh heights: zakurad=$ZAKURA_HEIGHT zcashd=$ZCASHD_HEIGHT drift=$DRIFT"
+  if (( DRIFT <= FINAL_MAX_DRIFT )); then
+    STABLE=$((STABLE + 1))
+    (( STABLE >= 2 )) && break
+  else
+    STABLE=0
+  fi
+  sleep 30
+done
+(( STABLE >= 2 )) || { echo "zcashd fixture did not catch up before timeout" >&2; exit 1; }
+
+ZCASHD_HEIGHT=$(rpc_result http://127.0.0.1:8232 "$ZCASHD_COOKIE" getblockcount)
+ZCASHD_HASH=$(rpc_result http://127.0.0.1:8232 "$ZCASHD_COOKIE" getblockhash "[$ZCASHD_HEIGHT]")
+ZAKURA_HEIGHT=$(rpc_result http://127.0.0.1:18232 '' getblockcount)
+ZAKURA_HASH=$(rpc_result http://127.0.0.1:18232 '' getblockhash "[$ZAKURA_HEIGHT]")
+ZAKURA_HASH_AT_ZCASHD_HEIGHT=$(rpc_result http://127.0.0.1:18232 '' getblockhash "[$ZCASHD_HEIGHT]")
+FINAL_LAG=$((ZAKURA_HEIGHT - ZCASHD_HEIGHT))
+(( FINAL_LAG >= 0 )) || {
+  echo "refusing fixture: final zcashd tip $ZCASHD_HEIGHT is ahead of Zakura $ZAKURA_HEIGHT" >&2
+  exit 1
+}
+(( FINAL_LAG < ZCASHD_TX_RETENTION )) || {
+  echo "refusing fixture: final zcashd lag $FINAL_LAG is outside Zakura's $ZCASHD_TX_RETENTION-block pruning retention" >&2
+  exit 1
+}
+[[ "$ZAKURA_HASH_AT_ZCASHD_HEIGHT" == "$ZCASHD_HASH" ]] || {
+  echo "refusing fixture: Zakura and zcashd are on different chains at height $ZCASHD_HEIGHT" >&2
+  exit 1
+}
+
+ZAKURAD_VERSION=$("$ZAKURAD" --version | head -n 1)
+ZCASHD_BIN=$(find "$ZAKURA_STATE_DIR/zcashd-compat/bin" -type f -name zcashd -perm -111 | sort | tail -n 1)
+[[ -n "$ZCASHD_BIN" ]] || { echo "managed zcashd binary was not cached" >&2; exit 1; }
+ZCASHD_VERSION=$("$ZCASHD_BIN" --version | head -n 1)
+ZCASHD_BINARY_SHA256=$(sha256sum "$ZCASHD_BIN" | awk '{print $1}')
+
+stop_node
+pgrep -x zcashd >/dev/null && { echo "zcashd remained running after clean Zakura shutdown" >&2; exit 1; }
+
+# These are runtime artifacts, not reusable chain state. Keep deletion explicit
+# so an unexpected new top-level zcashd artifact fails the bake below.
+for runtime_file in .cookie .lock banlist.dat db.log debug.log fee_estimates.dat mempool.dat peers.dat wallet.dat zcash.conf; do
+  rm -f "$ZCASHD_DIR/$runtime_file"
+done
+rm -rf "$ZCASHD_DIR/database" "$ZCASHD_DIR/wallets"
+
+CAPTURED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP_MANIFEST="$ZCASHD_DIR/fixture-manifest.json.tmp"
+jq \
+  --arg captured_at "$CAPTURED_AT" \
+  --arg zcashd_hash "$ZCASHD_HASH" \
+  --arg zakura_hash "$ZAKURA_HASH" \
+  --arg zakurad_version "$ZAKURAD_VERSION" \
+  --arg zcashd_version "$ZCASHD_VERSION" \
+  --arg zcashd_binary_sha256 "$ZCASHD_BINARY_SHA256" \
+  --arg source_snapshot_id "${ZCASHD_SOURCE_SNAPSHOT_ID:-}" \
+  --argjson zcashd_height "$ZCASHD_HEIGHT" \
+  --argjson zakura_height "$ZAKURA_HEIGHT" \
+  --argjson lag_blocks "$FINAL_LAG" \
+  --argjson tx_retention "$ZCASHD_TX_RETENTION" \
+  '.captured_at = $captured_at
+   | .tip = {height: $zcashd_height, hash: $zcashd_hash}
+   | .refresh = {
+       captured_at: $captured_at,
+       clean_shutdown: true,
+       zakura_tip: {height: $zakura_height, hash: $zakura_hash},
+       lag_blocks: $lag_blocks,
+       tx_retention: $tx_retention,
+       zakurad_version: $zakurad_version,
+       zcashd_version: $zcashd_version,
+       zcashd_binary_sha256: $zcashd_binary_sha256,
+       source_snapshot_id: (if $source_snapshot_id == "" then null else $source_snapshot_id end)
+     }
+   | .contents = ["blocks", "chainstate", "unity", "fixture-manifest.json"]' \
+  "$MANIFEST" > "$TMP_MANIFEST"
+mv "$TMP_MANIFEST" "$MANIFEST"
+
+ZAKURA_TMP="$ZAKURA_STATE_DIR/fixture-manifest.json.tmp"
+jq --arg captured_at "$CAPTURED_AT" --arg hash "$ZAKURA_HASH" --argjson height "$ZAKURA_HEIGHT" \
+  '.captured_at = $captured_at | .tip = {height: $height, hash: $hash}' \
+  "$ZAKURA_MANIFEST" > "$ZAKURA_TMP"
+mv "$ZAKURA_TMP" "$ZAKURA_MANIFEST"
+
+for path in "$ZCASHD_DIR"/* "$ZCASHD_DIR"/.[!.]* "$ZCASHD_DIR"/..?*; do
+  [[ -e "$path" ]] || continue
+  case "$(basename "$path")" in
+    blocks|chainstate|unity|fixture-manifest.json|lost+found) ;;
+    *) echo "unexpected top-level zcashd fixture artifact: $path" >&2; exit 1 ;;
+  esac
+done
+
+AVAILABLE_KIB=$(df --output=avail "$ZCASHD_DIR" | tail -n 1 | tr -d ' ')
+(( AVAILABLE_KIB >= 5 * 1024 * 1024 )) || {
+  echo "zcashd fixture volume has less than 5 GiB free after refresh" >&2
+  exit 1
+}
+
+rm -f "$CONFIG"
+rm -rf /root/.cache/zakura-fixture-network /root/.zakura-fixture-identity
+sync
+umount "$ZCASHD_DIR"
+trap - EXIT
+echo "zcashd fixture refreshed cleanly at height $ZCASHD_HEIGHT (Zakura $ZAKURA_HEIGHT, drift $FINAL_LAG)."

--- a/.github/workflows/scripts/pr-node-zcashd-seed.sh
+++ b/.github/workflows/scripts/pr-node-zcashd-seed.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Copies a clean, stopped mainnet zcashd datadir from an explicitly approved
+# seed Droplet onto a newly attached PR-node fixture volume.
+set -euo pipefail
+
+: "${ZCASHD_VOLUME_NAME:?missing ZCASHD_VOLUME_NAME}"
+: "${ZCASHD_SEED_DATADIR:?missing ZCASHD_SEED_DATADIR}"
+: "${ZCASHD_SEED_HEIGHT:?missing ZCASHD_SEED_HEIGHT}"
+: "${ZCASHD_SEED_HASH:?missing ZCASHD_SEED_HASH}"
+: "${ZCASHD_SEED_DROPLET_ID:?missing ZCASHD_SEED_DROPLET_ID}"
+: "${ZCASHD_SEED_CHECKSUM_VERIFIED:?missing ZCASHD_SEED_CHECKSUM_VERIFIED}"
+
+[[ "$ZCASHD_SEED_HEIGHT" =~ ^[0-9]+$ ]] || {
+  echo "zcashd seed height must be a non-negative integer" >&2
+  exit 1
+}
+[[ "$ZCASHD_SEED_HASH" =~ ^[0-9a-fA-F]{64}$ ]] || {
+  echo "zcashd seed hash must be 64 hexadecimal characters" >&2
+  exit 1
+}
+case "$ZCASHD_SEED_CHECKSUM_VERIFIED" in
+  true|false) ;;
+  *) echo "zcashd seed checksum verification must be true or false" >&2; exit 1 ;;
+esac
+if [[ "$ZCASHD_SEED_CHECKSUM_VERIFIED" == true ]]; then
+  [[ "${ZCASHD_SEED_ARCHIVE_SHA256:-}" =~ ^[0-9a-fA-F]{64}$ ]] || {
+    echo "a verified seed requires its archive SHA256" >&2
+    exit 1
+  }
+  [[ -n "${ZCASHD_SEED_ARCHIVE_URL:-}" ]] || {
+    echo "a verified seed requires its archive URL" >&2
+    exit 1
+  }
+fi
+
+SOURCE=$(realpath -e "$ZCASHD_SEED_DATADIR")
+for directory in blocks chainstate unity; do
+  [[ -d "$SOURCE/$directory" ]] || {
+    echo "seed datadir is missing $SOURCE/$directory" >&2
+    exit 1
+  }
+done
+
+# Copying a live LevelDB datadir can yield a corrupt fixture even when the
+# resulting filesystem snapshot itself is crash consistent.
+for executable in /proc/[0-9]*/exe; do
+  executable_name=$(basename "$(readlink -f "$executable" 2>/dev/null || true)")
+  case "$executable_name" in
+    zakurad*|zcashd*)
+      echo "refusing to copy while $executable_name is running ($executable)" >&2
+      exit 1
+      ;;
+  esac
+done
+for proc_path in /proc/[0-9]*/fd/* /proc/[0-9]*/cwd /proc/[0-9]*/root; do
+  target=$(readlink -f "$proc_path" 2>/dev/null || true)
+  case "$target" in
+    "$SOURCE"|"$SOURCE"/*)
+      echo "refusing to copy while a process has the datadir open: $proc_path -> $target" >&2
+      exit 1
+      ;;
+  esac
+done
+
+DEVICE="/dev/disk/by-id/scsi-0DO_Volume_${ZCASHD_VOLUME_NAME}"
+for _ in $(seq 1 60); do [[ -e "$DEVICE" ]] && break; sleep 2; done
+[[ -e "$DEVICE" ]] || { echo "zcashd fixture volume device not found: $DEVICE" >&2; exit 1; }
+
+MOUNT=/mnt/zakura-pr-zcashd-seed
+mkdir -p "$MOUNT"
+if ! blkid "$DEVICE" >/dev/null 2>&1; then
+  mkfs.ext4 -q -L zakura-zcashd-fixture "$DEVICE"
+fi
+existing_mount=$(findmnt -rn -S "$DEVICE" -o TARGET | head -n 1 || true)
+if [[ -n "$existing_mount" && "$existing_mount" != "$MOUNT" ]]; then
+  umount "$existing_mount"
+fi
+mountpoint -q "$MOUNT" || mount "$DEVICE" "$MOUNT"
+
+cleanup() {
+  sync
+  mountpoint -q "$MOUNT" && umount "$MOUNT"
+}
+trap cleanup EXIT
+
+shopt -s nullglob dotglob
+existing=("$MOUNT"/*)
+shopt -u nullglob dotglob
+(( ${#existing[@]} == 1 )) && [[ "${existing[0]}" == "$MOUNT/lost+found" ]] && existing=()
+(( ${#existing[@]} == 0 )) || {
+  echo "refusing to seed a non-empty fixture volume" >&2
+  printf 'existing path: %s\n' "${existing[@]}" >&2
+  exit 1
+}
+
+for directory in blocks chainstate unity; do
+  echo "Copying $SOURCE/$directory"
+  cp -a "$SOURCE/$directory" "$MOUNT/$directory"
+done
+
+STATUS=verified
+[[ "$ZCASHD_SEED_CHECKSUM_VERIFIED" == true ]] || STATUS=candidate
+export STATUS
+python3 - "$MOUNT/fixture-manifest.json.tmp" <<'PY'
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+manifest = {
+    "schema_version": 1,
+    "fixture": "zcashd-mainnet",
+    "network": "mainnet",
+    "status": os.environ["STATUS"],
+    "captured_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "origin": {
+        "kind": "existing_droplet",
+        "droplet_id": os.environ["ZCASHD_SEED_DROPLET_ID"],
+        "datadir": os.environ["ZCASHD_SEED_DATADIR"],
+        "archive_url": os.environ.get("ZCASHD_SEED_ARCHIVE_URL") or None,
+        "archive_sha256": os.environ.get("ZCASHD_SEED_ARCHIVE_SHA256") or None,
+        "archive_checksum_verified": os.environ["ZCASHD_SEED_CHECKSUM_VERIFIED"] == "true",
+    },
+    "tip": {
+        "height": int(os.environ["ZCASHD_SEED_HEIGHT"]),
+        "hash": os.environ["ZCASHD_SEED_HASH"].lower(),
+    },
+    "contents": ["blocks", "chainstate", "unity", "fixture-manifest.json"],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as output:
+    json.dump(manifest, output, indent=2, sort_keys=True)
+    output.write("\n")
+PY
+mv "$MOUNT/fixture-manifest.json.tmp" "$MOUNT/fixture-manifest.json"
+sync
+echo "Seed fixture copied with status $STATUS."

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -14,9 +14,9 @@ on:
   workflow_dispatch:
     inputs:
       droplet_size:
-        description: "Bake droplet size (its disk becomes the image's minimum disk)"
+        description: "Bake Droplet size (needs at least 16 GiB effective RAM; its disk becomes the image minimum)"
         required: false
-        default: c-8
+        default: g-8vcpu-32gb
       region:
         description: "DO region (must host the run droplets too)"
         required: false
@@ -88,7 +88,7 @@ jobs:
         id: droplet
         env:
           REGION: ${{ inputs.region || 'nyc3' }}
-          DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
+          DROPLET_SIZE: ${{ inputs.droplet_size || 'g-8vcpu-32gb' }}
           SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
           EVENT_NAME: ${{ github.event_name }}
           ZCASHD_SEED_DROPLET_ID: ${{ inputs.zcashd_seed_droplet_id }}

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -290,7 +290,7 @@ jobs:
           SANDBLAST_URL: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_URL || 'https://zakura.valargroup.dev/mainnet/historical/zakura-mainnet-20260717T095333Z-1707210.tar.zst' }}
           SANDBLAST_SHA256: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_SHA256 || '2bcb3786252300b4163b38a49b2d3a8015ba581d7d3efc854e6ed662a18258ac' }}
           SANDBLAST_HEIGHT: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_HEIGHT || '1707210' }}
-          SANDBLAST_DB_FORMAT: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_DB_FORMAT || '28.0.1' }}
+          SANDBLAST_DB_FORMAT: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_DB_FORMAT || '28.0.0' }}
           TESTNET_SNAPSHOTS_BASE: ${{ vars.ZAKURA_TESTNET_SNAPSHOTS_URL || 'http://167.99.103.111:8091' }}
           ZCASHD_VOLUME_NAME: ${{ steps.droplet.outputs.zcashd_vol }}
           ZCASHD_SOURCE_SNAPSHOT_ID: ${{ steps.droplet.outputs.zcashd_snapshot_id }}

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -4,9 +4,11 @@ name: PR node image bake
 #   - one base droplet image: build deps + rustup + repo clone + warm cargo
 #     release cache + a loopback SSH identity for deploy.py,
 #   - one volume snapshot per network with extracted chain state
-#     (mainnet: tip/ + sandblast/, testnet: tip/).
-# Runs weekly so the tip states and the cargo cache never drift far from main;
-# PR-node runs sync the remaining gap during their hour.
+#     (mainnet: tip/ + sandblast/, testnet: tip/),
+#   - one separate zcashd mainnet fixture snapshot when a prior fixture or an
+#     explicitly confirmed first-seed Droplet is available.
+# Runs twice weekly so the 10,000-block pruned retention window can tolerate one
+# missed refresh; PR-node runs sync the remaining gap during their hour.
 
 on:
   workflow_dispatch:
@@ -19,8 +21,34 @@ on:
         description: "DO region (must host the run droplets too)"
         required: false
         default: nyc3
+      zcashd_seed_droplet_id:
+        description: "First seed only: active same-region Droplet with a cleanly stopped zcashd datadir"
+        required: false
+      zcashd_seed_confirm:
+        description: "First seed only: type COPY_CLEAN_ZCASHD_STATE"
+        required: false
+      zcashd_seed_datadir:
+        description: "First seed only: source zcashd datadir"
+        required: false
+        default: /root/.zcashd
+      zcashd_seed_height:
+        description: "First seed only: cleanly flushed zcashd tip height"
+        required: false
+      zcashd_seed_hash:
+        description: "First seed only: cleanly flushed zcashd tip hash"
+        required: false
+      zcashd_seed_archive_url:
+        description: "First seed provenance: original archive URL"
+        required: false
+      zcashd_seed_archive_sha256:
+        description: "First seed provenance: expected archive SHA256"
+        required: false
+      zcashd_seed_checksum_verified:
+        description: "First seed provenance: full archive checksum was verified"
+        type: boolean
+        default: false
   schedule:
-    - cron: "0 4 * * 1" # weekly Monday 04:00 UTC
+    - cron: "0 4 * * 1,4" # Monday and Thursday 04:00 UTC
 
 permissions:
   contents: read
@@ -32,8 +60,8 @@ concurrency:
 jobs:
   bake:
     runs-on: ubuntu-latest
-    # Cold cargo build + three snapshot downloads + a ~50GB image snapshot.
-    timeout-minutes: 210
+    # Cold cargo build + state downloads + zcashd catch-up + image snapshot.
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -62,33 +90,134 @@ jobs:
           REGION: ${{ inputs.region || 'nyc3' }}
           DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
           SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
+          EVENT_NAME: ${{ github.event_name }}
+          ZCASHD_SEED_DROPLET_ID: ${{ inputs.zcashd_seed_droplet_id }}
+          ZCASHD_SEED_CONFIRM: ${{ inputs.zcashd_seed_confirm }}
         run: |
           set -euo pipefail
           MAINNET_VOL="zakura-pr-bake-mainnet-${GITHUB_RUN_ID}"
           TESTNET_VOL="zakura-pr-bake-testnet-${GITHUB_RUN_ID}"
+          MAINNET_VOL_ID=""
+          TESTNET_VOL_ID=""
+          ZCASHD_VOL=""
+          ZCASHD_VOL_ID=""
+          ZCASHD_SOURCE="none"
+          ZCASHD_SNAPSHOT=""
+          ZCASHD_SEED_IP=""
+          DROPLET_ID=""
+
+          # Validate the high-risk source operation before allocating anything.
+          if [ -n "${ZCASHD_SEED_DROPLET_ID}" ]; then
+            [ "${EVENT_NAME}" = workflow_dispatch ] || {
+              echo "zcashd seeding is only allowed on a manual workflow_dispatch run" >&2
+              exit 1
+            }
+            [ "${ZCASHD_SEED_CONFIRM}" = COPY_CLEAN_ZCASHD_STATE ] || {
+              echo "zcashd_seed_confirm must be COPY_CLEAN_ZCASHD_STATE" >&2
+              exit 1
+            }
+            SEED_JSON=$(doctl compute droplet get "${ZCASHD_SEED_DROPLET_ID}" --output json)
+            [ "$(echo "$SEED_JSON" | jq -r '.[0].status')" = active ] || {
+              echo "zcashd seed Droplet must be active" >&2
+              exit 1
+            }
+            [ "$(echo "$SEED_JSON" | jq -r '.[0].region.slug')" = "${REGION}" ] || {
+              echo "zcashd seed Droplet must be in ${REGION}" >&2
+              exit 1
+            }
+            ZCASHD_SEED_IP=$(echo "$SEED_JSON" | jq -er '.[0].networks.v4[] | select(.type == "public") | .ip_address' | head -n 1)
+          fi
+
+          cleanup_create_failure() {
+            rc=$?
+            trap - EXIT
+            [ "$rc" -ne 0 ] || return
+            set +e
+            if [ -n "$ZCASHD_VOL_ID" ] && [ -n "${ZCASHD_SEED_DROPLET_ID}" ]; then
+              doctl compute volume-action detach "$ZCASHD_VOL_ID" "${ZCASHD_SEED_DROPLET_ID}" --wait || true
+            fi
+            [ -z "$DROPLET_ID" ] || doctl compute droplet delete "$DROPLET_ID" -f || true
+            for volume_id in "$MAINNET_VOL_ID" "$TESTNET_VOL_ID" "$ZCASHD_VOL_ID"; do
+              [ -z "$volume_id" ] && continue
+              for _ in $(seq 1 12); do
+                doctl compute volume delete "$volume_id" -f && break
+                sleep 10
+              done
+            done
+            exit "$rc"
+          }
+          trap cleanup_create_failure EXIT
+
           MAINNET_VOL_ID=$(doctl compute volume create "$MAINNET_VOL" \
             --region "${REGION}" --size 300GiB --format ID --no-header)
+          echo "mainnet_vol=$MAINNET_VOL" >> "$GITHUB_OUTPUT"
+          echo "mainnet_vol_id=$MAINNET_VOL_ID" >> "$GITHUB_OUTPUT"
           TESTNET_VOL_ID=$(doctl compute volume create "$TESTNET_VOL" \
             --region "${REGION}" --size 100GiB --format ID --no-header)
+          echo "testnet_vol=$TESTNET_VOL" >> "$GITHUB_OUTPUT"
+          echo "testnet_vol_id=$TESTNET_VOL_ID" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${ZCASHD_SEED_DROPLET_ID}" ]; then
+            ZCASHD_VOL="zakura-pr-bake-zcashd-mainnet-${GITHUB_RUN_ID}"
+            ZCASHD_VOL_ID=$(doctl compute volume create "$ZCASHD_VOL" \
+              --region "${REGION}" --size 350GiB --format ID --no-header)
+            echo "zcashd_vol=$ZCASHD_VOL" >> "$GITHUB_OUTPUT"
+            echo "zcashd_vol_id=$ZCASHD_VOL_ID" >> "$GITHUB_OUTPUT"
+            doctl compute volume-action attach "$ZCASHD_VOL_ID" "${ZCASHD_SEED_DROPLET_ID}" --wait
+            ZCASHD_SOURCE=seed
+          else
+            ZCASHD_SNAPSHOT=$(doctl compute snapshot list --resource volume --format ID,Name --no-header | \
+              awk '$2 ~ /^zakura-pr-state-zcashd-mainnet-/ {print $2, $1}' | sort | tail -n 1 | awk '{print $2}')
+            if [ -n "$ZCASHD_SNAPSHOT" ]; then
+              doctl compute snapshot get "$ZCASHD_SNAPSHOT" --output json | \
+                jq -e --arg region "$REGION" '.[0].regions | index($region) != null' >/dev/null || {
+                  echo "latest zcashd fixture snapshot is not available in ${REGION}" >&2
+                  exit 1
+                }
+              MIN_SIZE=$(doctl compute snapshot get "$ZCASHD_SNAPSHOT" --format MinDiskSize --no-header)
+              ZCASHD_SIZE=350
+              (( MIN_SIZE <= ZCASHD_SIZE )) || ZCASHD_SIZE=$MIN_SIZE
+              ZCASHD_VOL="zakura-pr-bake-zcashd-mainnet-${GITHUB_RUN_ID}"
+              ZCASHD_VOL_ID=$(doctl compute volume create "$ZCASHD_VOL" \
+                --region "${REGION}" --snapshot "$ZCASHD_SNAPSHOT" --size "${ZCASHD_SIZE}GiB" \
+                --format ID --no-header)
+              echo "zcashd_vol=$ZCASHD_VOL" >> "$GITHUB_OUTPUT"
+              echo "zcashd_vol_id=$ZCASHD_VOL_ID" >> "$GITHUB_OUTPUT"
+              ZCASHD_SOURCE=snapshot
+            else
+              echo "No zcashd fixture exists yet. Continuing the existing Zakura-only bake."
+              echo "Run this workflow manually with the guarded zcashd_seed_* inputs to create it."
+            fi
+          fi
           {
             echo "mainnet_vol=$MAINNET_VOL"
             echo "testnet_vol=$TESTNET_VOL"
             echo "mainnet_vol_id=$MAINNET_VOL_ID"
             echo "testnet_vol_id=$TESTNET_VOL_ID"
+            echo "zcashd_vol=$ZCASHD_VOL"
+            echo "zcashd_vol_id=$ZCASHD_VOL_ID"
+            echo "zcashd_source=$ZCASHD_SOURCE"
+            echo "zcashd_snapshot_id=$ZCASHD_SNAPSHOT"
+            echo "zcashd_seed_ip=$ZCASHD_SEED_IP"
           } >> "$GITHUB_OUTPUT"
 
           NAME="zakura-pr-bake-${GITHUB_RUN_ID}"
+          VOLUME_ARGS=(--volumes "${MAINNET_VOL_ID}" --volumes "${TESTNET_VOL_ID}")
+          if [ "$ZCASHD_SOURCE" = snapshot ]; then
+            VOLUME_ARGS+=(--volumes "${ZCASHD_VOL_ID}")
+          fi
           doctl compute droplet create "$NAME" \
             --region "${REGION}" \
             --size "${DROPLET_SIZE}" \
             --image ubuntu-24-04-x64 \
             --ssh-keys "${SSH_FINGERPRINT}" \
-            --volumes "${MAINNET_VOL_ID}" \
-            --volumes "${TESTNET_VOL_ID}" \
+            "${VOLUME_ARGS[@]}" \
             --tag-name zakura-image-bake \
             --wait --format ID,PublicIPv4 --no-header > /tmp/droplet.txt
-          echo "id=$(awk '{print $1}' /tmp/droplet.txt)" >> "$GITHUB_OUTPUT"
+          DROPLET_ID=$(awk '{print $1}' /tmp/droplet.txt)
+          echo "id=$DROPLET_ID" >> "$GITHUB_OUTPUT"
           echo "ip=$(awk '{print $2}' /tmp/droplet.txt)" >> "$GITHUB_OUTPUT"
+          trap - EXIT
 
       - name: Wait for SSH
         env:
@@ -103,6 +232,53 @@ jobs:
           done
           echo "SSH did not come up in time"; exit 1
 
+      - name: Seed zcashd fixture from existing Droplet
+        if: steps.droplet.outputs.zcashd_source == 'seed'
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+          DROPLET_ID: ${{ steps.droplet.outputs.id }}
+          ZCASHD_VOLUME_NAME: ${{ steps.droplet.outputs.zcashd_vol }}
+          ZCASHD_VOLUME_ID: ${{ steps.droplet.outputs.zcashd_vol_id }}
+          ZCASHD_SEED_IP: ${{ steps.droplet.outputs.zcashd_seed_ip }}
+          ZCASHD_SEED_DROPLET_ID: ${{ inputs.zcashd_seed_droplet_id }}
+          ZCASHD_SEED_DATADIR: ${{ inputs.zcashd_seed_datadir || '/root/.zcashd' }}
+          ZCASHD_SEED_HEIGHT: ${{ inputs.zcashd_seed_height }}
+          ZCASHD_SEED_HASH: ${{ inputs.zcashd_seed_hash }}
+          ZCASHD_SEED_ARCHIVE_URL: ${{ inputs.zcashd_seed_archive_url }}
+          ZCASHD_SEED_ARCHIVE_SHA256: ${{ inputs.zcashd_seed_archive_sha256 }}
+          ZCASHD_SEED_CHECKSUM_VERIFIED: ${{ inputs.zcashd_seed_checksum_verified || false }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+              -i /tmp/do_ssh "root@${ZCASHD_SEED_IP}" true 2>/dev/null; then
+              break
+            fi
+            sleep 10
+          done
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+            -i /tmp/do_ssh "root@${ZCASHD_SEED_IP}" true
+          umask 077
+          {
+            printf 'ZCASHD_VOLUME_NAME=%q\n'              "$ZCASHD_VOLUME_NAME"
+            printf 'ZCASHD_SEED_DATADIR=%q\n'             "$ZCASHD_SEED_DATADIR"
+            printf 'ZCASHD_SEED_HEIGHT=%q\n'              "$ZCASHD_SEED_HEIGHT"
+            printf 'ZCASHD_SEED_HASH=%q\n'                "$ZCASHD_SEED_HASH"
+            printf 'ZCASHD_SEED_DROPLET_ID=%q\n'          "$ZCASHD_SEED_DROPLET_ID"
+            printf 'ZCASHD_SEED_ARCHIVE_URL=%q\n'         "$ZCASHD_SEED_ARCHIVE_URL"
+            printf 'ZCASHD_SEED_ARCHIVE_SHA256=%q\n'      "$ZCASHD_SEED_ARCHIVE_SHA256"
+            printf 'ZCASHD_SEED_CHECKSUM_VERIFIED=%q\n'   "$ZCASHD_SEED_CHECKSUM_VERIFIED"
+          } > /tmp/zcashd-seed.env
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            /tmp/zcashd-seed.env .github/workflows/scripts/pr-node-zcashd-seed.sh \
+            "root@${ZCASHD_SEED_IP}:/root/"
+          rm -f /tmp/zcashd-seed.env
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=240 -i /tmp/do_ssh "root@${ZCASHD_SEED_IP}" \
+            'set -euo pipefail; trap '\''rm -f /root/zcashd-seed.env /root/pr-node-zcashd-seed.sh'\'' EXIT; set -a; . /root/zcashd-seed.env; set +a; bash /root/pr-node-zcashd-seed.sh'
+          doctl compute volume-action detach "$ZCASHD_VOLUME_ID" "$ZCASHD_SEED_DROPLET_ID" --wait
+          doctl compute volume-action attach "$ZCASHD_VOLUME_ID" "$DROPLET_ID" --wait
+
       - name: Run bake script
         env:
           IP: ${{ steps.droplet.outputs.ip }}
@@ -113,7 +289,12 @@ jobs:
           # Pre-spam-region archive snapshot; same artifact checkpoint-sync-bench pins.
           SANDBLAST_URL: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_URL || 'https://zakura.valargroup.dev/mainnet/historical/zakura-mainnet-20260717T095333Z-1707210.tar.zst' }}
           SANDBLAST_SHA256: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_SHA256 || '2bcb3786252300b4163b38a49b2d3a8015ba581d7d3efc854e6ed662a18258ac' }}
+          SANDBLAST_HEIGHT: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_HEIGHT || '1707210' }}
+          SANDBLAST_DB_FORMAT: ${{ vars.ZAKURA_PR_NODE_SANDBLAST_DB_FORMAT || '28.0.1' }}
           TESTNET_SNAPSHOTS_BASE: ${{ vars.ZAKURA_TESTNET_SNAPSHOTS_URL || 'http://167.99.103.111:8091' }}
+          ZCASHD_VOLUME_NAME: ${{ steps.droplet.outputs.zcashd_vol }}
+          ZCASHD_SOURCE_SNAPSHOT_ID: ${{ steps.droplet.outputs.zcashd_snapshot_id }}
+          ZCASHD_TX_RETENTION: ${{ vars.ZAKURA_PR_NODE_ZCASHD_TX_RETENTION || '10000' }}
         run: |
           set -euo pipefail
           umask 077
@@ -125,10 +306,16 @@ jobs:
             printf 'TIP_MAINNET_LATEST_JSON=%q\n' "${TIP_MAINNET_LATEST_JSON}"
             printf 'SANDBLAST_URL=%q\n'           "${SANDBLAST_URL}"
             printf 'SANDBLAST_SHA256=%q\n'        "${SANDBLAST_SHA256}"
+            printf 'SANDBLAST_HEIGHT=%q\n'        "${SANDBLAST_HEIGHT}"
+            printf 'SANDBLAST_DB_FORMAT=%q\n'     "${SANDBLAST_DB_FORMAT}"
             printf 'TESTNET_SNAPSHOTS_BASE=%q\n'  "${TESTNET_SNAPSHOTS_BASE}"
+            printf 'ZCASHD_VOLUME_NAME=%q\n'      "${ZCASHD_VOLUME_NAME}"
+            printf 'ZCASHD_SOURCE_SNAPSHOT_ID=%q\n' "${ZCASHD_SOURCE_SNAPSHOT_ID}"
+            printf 'ZCASHD_TX_RETENTION=%q\n'     "${ZCASHD_TX_RETENTION}"
           } > /tmp/bake.env
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
-            /tmp/bake.env .github/workflows/scripts/pr-node-bake.sh "root@${IP}:/root/"
+            /tmp/bake.env .github/workflows/scripts/pr-node-bake.sh \
+            .github/workflows/scripts/pr-node-zcashd-refresh.sh "root@${IP}:/root/"
           rm -f /tmp/bake.env
           # Keepalives: the cold build and snapshot downloads are long and low-output.
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
@@ -139,11 +326,15 @@ jobs:
         env:
           MAINNET_VOL_ID: ${{ steps.droplet.outputs.mainnet_vol_id }}
           TESTNET_VOL_ID: ${{ steps.droplet.outputs.testnet_vol_id }}
+          ZCASHD_VOL_ID: ${{ steps.droplet.outputs.zcashd_vol_id }}
         run: |
           set -euo pipefail
           STAMP=$(date -u +%Y%m%d-%H%M)
           doctl compute volume snapshot "${MAINNET_VOL_ID}" --snapshot-name "zakura-pr-state-mainnet-${STAMP}"
           doctl compute volume snapshot "${TESTNET_VOL_ID}" --snapshot-name "zakura-pr-state-testnet-${STAMP}"
+          if [ -n "${ZCASHD_VOL_ID}" ]; then
+            doctl compute volume snapshot "${ZCASHD_VOL_ID}" --snapshot-name "zakura-pr-state-zcashd-mainnet-${STAMP}"
+          fi
 
       - name: Snapshot droplet image
         env:
@@ -174,8 +365,13 @@ jobs:
           DROPLET_ID: ${{ steps.droplet.outputs.id }}
           MAINNET_VOL_ID: ${{ steps.droplet.outputs.mainnet_vol_id }}
           TESTNET_VOL_ID: ${{ steps.droplet.outputs.testnet_vol_id }}
+          ZCASHD_VOL_ID: ${{ steps.droplet.outputs.zcashd_vol_id }}
+          ZCASHD_SEED_DROPLET_ID: ${{ inputs.zcashd_seed_droplet_id }}
         run: |
           set +e
+          if [ -n "${ZCASHD_VOL_ID}" ] && [ -n "${ZCASHD_SEED_DROPLET_ID}" ]; then
+            doctl compute volume-action detach "${ZCASHD_VOL_ID}" "${ZCASHD_SEED_DROPLET_ID}" --wait || true
+          fi
           if [ -n "${DROPLET_ID}" ]; then
             for _ in 1 2 3; do
               doctl compute droplet delete "${DROPLET_ID}" -f && break
@@ -183,7 +379,7 @@ jobs:
             done
           fi
           # Volumes detach asynchronously after the droplet delete.
-          for VOL_ID in "${MAINNET_VOL_ID}" "${TESTNET_VOL_ID}"; do
+          for VOL_ID in "${MAINNET_VOL_ID}" "${TESTNET_VOL_ID}" "${ZCASHD_VOL_ID}"; do
             [ -z "${VOL_ID}" ] && continue
             for _ in $(seq 1 12); do
               doctl compute volume delete "${VOL_ID}" -f && break
@@ -195,7 +391,7 @@ jobs:
           doctl compute image list-user --format ID,Name --no-header | \
             awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | head -n -2 | \
             while read -r _name id; do doctl compute image delete "$id" -f; done
-          for NET in mainnet testnet; do
+          for NET in mainnet testnet zcashd-mainnet; do
             doctl compute snapshot list --resource volume --format ID,Name --no-header | \
               awk -v pre="zakura-pr-state-${NET}-" 'index($2, pre) == 1 {print $2, $1}' | \
               sort | head -n -2 | \

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -330,11 +330,43 @@ jobs:
         run: |
           set -euo pipefail
           STAMP=$(date -u +%Y%m%d-%H%M)
-          doctl compute volume snapshot "${MAINNET_VOL_ID}" --snapshot-name "zakura-pr-state-mainnet-${STAMP}"
-          doctl compute volume snapshot "${TESTNET_VOL_ID}" --snapshot-name "zakura-pr-state-testnet-${STAMP}"
+          MAINNET_SNAPSHOT_NAME="zakura-pr-state-mainnet-${STAMP}"
+          TESTNET_SNAPSHOT_NAME="zakura-pr-state-testnet-${STAMP}"
+          ZCASHD_SNAPSHOT_NAME="zakura-pr-state-zcashd-mainnet-${STAMP}"
+
+          cleanup_partial_snapshot_family() {
+            rc=$?
+            trap - EXIT
+            [ "$rc" -ne 0 ] || return
+            set +e
+            echo "State snapshot creation failed; deleting the partial ${STAMP} family." >&2
+            for snapshot_name in \
+              "$MAINNET_SNAPSHOT_NAME" \
+              "$TESTNET_SNAPSHOT_NAME" \
+              "$ZCASHD_SNAPSHOT_NAME"; do
+              for _ in $(seq 1 6); do
+                if ! snapshot_ids=$(doctl compute snapshot list --resource volume --format ID,Name --no-header | \
+                  awk -v name="$snapshot_name" '$2 == name {print $1}'); then
+                  sleep 5
+                  continue
+                fi
+                [ -n "$snapshot_ids" ] || break
+                while read -r snapshot_id; do
+                  [ -n "$snapshot_id" ] && doctl compute snapshot delete "$snapshot_id" -f
+                done <<< "$snapshot_ids"
+                sleep 5
+              done
+            done
+            exit "$rc"
+          }
+          trap cleanup_partial_snapshot_family EXIT
+
+          doctl compute volume snapshot "${MAINNET_VOL_ID}" --snapshot-name "$MAINNET_SNAPSHOT_NAME"
+          doctl compute volume snapshot "${TESTNET_VOL_ID}" --snapshot-name "$TESTNET_SNAPSHOT_NAME"
           if [ -n "${ZCASHD_VOL_ID}" ]; then
-            doctl compute volume snapshot "${ZCASHD_VOL_ID}" --snapshot-name "zakura-pr-state-zcashd-mainnet-${STAMP}"
+            doctl compute volume snapshot "${ZCASHD_VOL_ID}" --snapshot-name "$ZCASHD_SNAPSHOT_NAME"
           fi
+          trap - EXIT
 
       - name: Snapshot droplet image
         env:

--- a/.github/workflows/zakura-pr-node-reaper.yml
+++ b/.github/workflows/zakura-pr-node-reaper.yml
@@ -5,10 +5,10 @@ name: PR node reaper
 # their run for SSH inspection; this deletes them (and every other leaked
 # resource) on a TTL so nothing accrues cost indefinitely:
 #   - zakura-pr-node droplets older than max_age_hours (default 24h)
-#   - zakura-image-bake droplets older than 6h (failed bakes)
+#   - zakura-image-bake droplets older than 8h (failed bakes)
 #   - detached zakura-pr-* volumes older than 2h (run/bake leftovers)
-#   - zakura-pr-node-* images and zakura-pr-state-* volume snapshots beyond
-#     the newest 2 each
+#   - zakura-pr-node-* images and Zakura/zcashd state snapshots beyond the
+#     newest 2 in each family
 
 on:
   workflow_dispatch:
@@ -62,7 +62,7 @@ jobs:
             done
           }
           reap_tag zakura-pr-node    $(( MAX_AGE_HOURS * 3600 ))
-          reap_tag zakura-image-bake $(( 6 * 3600 ))
+          reap_tag zakura-image-bake $(( 8 * 3600 ))
 
       - name: Reap detached state volumes
         env:
@@ -99,7 +99,7 @@ jobs:
               echo "deleting image $name (id $id)"
               doctl compute image delete "$id" -f || true
             done
-          for NET in mainnet testnet; do
+          for NET in mainnet testnet zcashd-mainnet; do
             doctl compute snapshot list --resource volume --format ID,Name --no-header | \
               awk -v pre="zakura-pr-state-${NET}-" 'index($2, pre) == 1 {print $2, $1}' | \
               sort | head -n -2 | \

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -20,6 +20,11 @@ on:
       ref:
         description: "Branch, tag, or SHA to test (exactly one of pr_number / ref)"
         required: false
+      test_profile:
+        description: "Node profile to exercise"
+        type: choice
+        options: [zakura, zcashd-compat]
+        default: zakura
       snapshot_mode:
         description: "Chain state to start from"
         type: choice
@@ -55,7 +60,7 @@ jobs:
   node:
     runs-on: ubuntu-latest
     # duration_minutes (<=60 typically) + incremental build + provisioning overhead.
-    timeout-minutes: 110
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -69,10 +74,15 @@ jobs:
           REF: ${{ inputs.ref }}
           MODE: ${{ inputs.snapshot_mode }}
           NETWORK: ${{ inputs.network }}
+          TEST_PROFILE: ${{ inputs.test_profile || 'zakura' }}
         run: |
           set -euo pipefail
           if [ "${MODE}" = "sandblast" ] && [ "${NETWORK}" != "mainnet" ]; then
             echo "snapshot_mode=sandblast is mainnet-only (the spam region is a mainnet range)" >&2
+            exit 1
+          fi
+          if [ "${TEST_PROFILE}" = "zcashd-compat" ] && { [ "${MODE}" != "tip" ] || [ "${NETWORK}" != "mainnet" ]; }; then
+            echo "test_profile=zcashd-compat requires snapshot_mode=tip and network=mainnet" >&2
             exit 1
           fi
           if { [ -n "${PR_NUMBER}" ] && [ -n "${REF}" ]; } || { [ -z "${PR_NUMBER}" ] && [ -z "${REF}" ]; }; then
@@ -121,54 +131,123 @@ jobs:
           install -m 600 /dev/null /tmp/do_ssh
           printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh
 
-      - name: Pick baked image and state snapshot
+      - name: Pick Golden image and state snapshots
         id: baked
         env:
           MODE: ${{ inputs.snapshot_mode }}
           NETWORK: ${{ inputs.network }}
+          TEST_PROFILE: ${{ inputs.test_profile || 'zakura' }}
         run: |
           set -euo pipefail
-          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
-            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
+          IMAGE_ROW=$(doctl compute image list-user --format ID,Name,Created --no-header | \
+            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1, $3}' | sort | tail -1)
+          read -r IMAGE_NAME IMAGE IMAGE_CREATED <<< "${IMAGE_ROW}"
           if [ -z "${IMAGE}" ]; then
             echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
             exit 1
           fi
-          echo "image_id=${IMAGE}" >> "$GITHUB_OUTPUT"
+          {
+            echo "image_id=${IMAGE}"
+            echo "image_name=${IMAGE_NAME}"
+            echo "image_created=${IMAGE_CREATED}"
+            echo "zakura_snap_id="
+            echo "zakura_snap_name="
+            echo "zakura_snap_created="
+            echo "zcashd_snap_id="
+            echo "zcashd_snap_name="
+            echo "zcashd_snap_created="
+          } >> "$GITHUB_OUTPUT"
           if [ "${MODE}" = "genesis" ]; then
-            echo "vol_snap_id=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          SNAP=$(doctl compute snapshot list --resource volume --format ID,Name --no-header | \
-            awk -v pre="zakura-pr-state-${NETWORK}-" 'index($2, pre) == 1 {print $2, $1}' | \
-            sort | tail -1 | awk '{print $2}')
-          if [ -z "${SNAP}" ]; then
+          SNAPSHOTS=$(doctl compute snapshot list --resource volume --format ID,Name,CreatedAt --no-header)
+          if [ "${TEST_PROFILE}" = "zcashd-compat" ]; then
+            PAIR_ROW=$(awk '
+              index($2, "zakura-pr-state-mainnet-") == 1 {
+                stamp = substr($2, length("zakura-pr-state-mainnet-") + 1)
+                z_name[stamp] = $2; z_id[stamp] = $1; z_created[stamp] = $3
+              }
+              index($2, "zakura-pr-state-zcashd-mainnet-") == 1 {
+                stamp = substr($2, length("zakura-pr-state-zcashd-mainnet-") + 1)
+                d_name[stamp] = $2; d_id[stamp] = $1; d_created[stamp] = $3
+              }
+              END {
+                for (stamp in z_id) {
+                  if (stamp in d_id) {
+                    print stamp, z_name[stamp], z_id[stamp], z_created[stamp], d_name[stamp], d_id[stamp], d_created[stamp]
+                  }
+                }
+              }
+            ' <<< "${SNAPSHOTS}" | sort | tail -1)
+            read -r PAIR_STAMP ZAKURA_SNAP_NAME ZAKURA_SNAP ZAKURA_SNAP_CREATED \
+              ZCASHD_SNAP_NAME ZCASHD_SNAP ZCASHD_SNAP_CREATED <<< "${PAIR_ROW}"
+            if [ -z "${PAIR_STAMP}" ]; then
+              echo "no complete mainnet Zakura/zcashd Golden snapshot pair found; run the bake workflow first" >&2
+              exit 1
+            fi
+          else
+            ZAKURA_ROW=$(awk -v pre="zakura-pr-state-${NETWORK}-" \
+              'index($2, pre) == 1 {print $2, $1, $3}' <<< "${SNAPSHOTS}" | sort | tail -1)
+            read -r ZAKURA_SNAP_NAME ZAKURA_SNAP ZAKURA_SNAP_CREATED <<< "${ZAKURA_ROW}"
+          fi
+          if [ -z "${ZAKURA_SNAP}" ]; then
             echo "no zakura-pr-state-${NETWORK}-* volume snapshot found; run the bake workflow first" >&2
             exit 1
           fi
-          echo "vol_snap_id=${SNAP}" >> "$GITHUB_OUTPUT"
+          {
+            echo "zakura_snap_id=${ZAKURA_SNAP}"
+            echo "zakura_snap_name=${ZAKURA_SNAP_NAME}"
+            echo "zakura_snap_created=${ZAKURA_SNAP_CREATED}"
+          } >> "$GITHUB_OUTPUT"
+          if [ "${TEST_PROFILE}" = "zcashd-compat" ]; then
+            {
+              echo "zcashd_snap_id=${ZCASHD_SNAP}"
+              echo "zcashd_snap_name=${ZCASHD_SNAP_NAME}"
+              echo "zcashd_snap_created=${ZCASHD_SNAP_CREATED}"
+            } >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Create droplet (+ state volume)
+      - name: Create droplet and Golden state volumes
         id: droplet
         env:
           MODE: ${{ inputs.snapshot_mode }}
+          TEST_PROFILE: ${{ inputs.test_profile || 'zakura' }}
           DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
           SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
           IMAGE_ID: ${{ steps.baked.outputs.image_id }}
-          VOL_SNAP_ID: ${{ steps.baked.outputs.vol_snap_id }}
+          ZAKURA_SNAP_ID: ${{ steps.baked.outputs.zakura_snap_id }}
+          ZCASHD_SNAP_ID: ${{ steps.baked.outputs.zcashd_snap_id }}
           SLUG: ${{ steps.target.outputs.slug }}
         run: |
           set -euo pipefail
           VOLUME_ARGS=()
-          VOLUME_NAME=""
-          VOLUME_ID=""
+          ZAKURA_VOLUME_NAME=""
+          ZAKURA_VOLUME_ID=""
+          ZCASHD_VOLUME_NAME=""
+          ZCASHD_VOLUME_ID=""
           if [ "${MODE}" != "genesis" ]; then
-            VOLUME_NAME="zakura-pr-vol-${GITHUB_RUN_ID}"
-            SIZE=$(doctl compute snapshot get "${VOL_SNAP_ID}" --format MinDiskSize --no-header)
-            VOLUME_ID=$(doctl compute volume create "${VOLUME_NAME}" \
-              --region nyc3 --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
+            ZAKURA_VOLUME_NAME="zakura-pr-vol-${GITHUB_RUN_ID}"
+            SIZE=$(doctl compute snapshot get "${ZAKURA_SNAP_ID}" --format MinDiskSize --no-header)
+            ZAKURA_VOLUME_ID=$(doctl compute volume create "${ZAKURA_VOLUME_NAME}" \
+              --region nyc3 --snapshot "${ZAKURA_SNAP_ID}" --size "${SIZE}GiB" \
               --format ID --no-header)
-            VOLUME_ARGS=(--volumes "${VOLUME_ID}")
+            VOLUME_ARGS+=(--volumes "${ZAKURA_VOLUME_ID}")
+            {
+              echo "zakura_volume_name=${ZAKURA_VOLUME_NAME}"
+              echo "zakura_volume_id=${ZAKURA_VOLUME_ID}"
+            } >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${TEST_PROFILE}" = "zcashd-compat" ]; then
+            ZCASHD_VOLUME_NAME="zakura-pr-zcashd-vol-${GITHUB_RUN_ID}"
+            SIZE=$(doctl compute snapshot get "${ZCASHD_SNAP_ID}" --format MinDiskSize --no-header)
+            ZCASHD_VOLUME_ID=$(doctl compute volume create "${ZCASHD_VOLUME_NAME}" \
+              --region nyc3 --snapshot "${ZCASHD_SNAP_ID}" --size "${SIZE}GiB" \
+              --format ID --no-header)
+            VOLUME_ARGS+=(--volumes "${ZCASHD_VOLUME_ID}")
+            {
+              echo "zcashd_volume_name=${ZCASHD_VOLUME_NAME}"
+              echo "zcashd_volume_id=${ZCASHD_VOLUME_ID}"
+            } >> "$GITHUB_OUTPUT"
           fi
           NAME="zakura-pr-${SLUG}-${GITHUB_RUN_ID}"
           doctl compute droplet create "$NAME" \
@@ -182,8 +261,6 @@ jobs:
           {
             echo "id=$(awk '{print $1}' /tmp/droplet.txt)"
             echo "ip=$(awk '{print $2}' /tmp/droplet.txt)"
-            echo "volume_name=${VOLUME_NAME}"
-            echo "volume_id=${VOLUME_ID}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Wait for SSH
@@ -206,10 +283,21 @@ jobs:
           GH_CLONE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MODE: ${{ inputs.snapshot_mode }}
           NETWORK: ${{ inputs.network }}
+          TEST_PROFILE: ${{ inputs.test_profile || 'zakura' }}
           SHA: ${{ steps.target.outputs.sha }}
           REFSPEC: ${{ steps.target.outputs.refspec }}
           DURATION_MINUTES: ${{ inputs.duration_minutes || '60' }}
-          VOLUME_NAME: ${{ steps.droplet.outputs.volume_name }}
+          IMAGE_ID: ${{ steps.baked.outputs.image_id }}
+          IMAGE_NAME: ${{ steps.baked.outputs.image_name }}
+          IMAGE_CREATED: ${{ steps.baked.outputs.image_created }}
+          ZAKURA_SNAPSHOT_ID: ${{ steps.baked.outputs.zakura_snap_id }}
+          ZAKURA_SNAPSHOT_NAME: ${{ steps.baked.outputs.zakura_snap_name }}
+          ZAKURA_SNAPSHOT_CREATED: ${{ steps.baked.outputs.zakura_snap_created }}
+          ZCASHD_SNAPSHOT_ID: ${{ steps.baked.outputs.zcashd_snap_id }}
+          ZCASHD_SNAPSHOT_NAME: ${{ steps.baked.outputs.zcashd_snap_name }}
+          ZCASHD_SNAPSHOT_CREATED: ${{ steps.baked.outputs.zcashd_snap_created }}
+          ZAKURA_VOLUME_NAME: ${{ steps.droplet.outputs.zakura_volume_name }}
+          ZCASHD_VOLUME_NAME: ${{ steps.droplet.outputs.zcashd_volume_name }}
         run: |
           set -euo pipefail
           umask 077
@@ -218,16 +306,33 @@ jobs:
             printf 'GH_CLONE_TOKEN=%q\n'    "${GH_CLONE_TOKEN}"
             printf 'MODE=%q\n'              "${MODE}"
             printf 'NETWORK=%q\n'           "${NETWORK}"
+            printf 'TEST_PROFILE=%q\n'      "${TEST_PROFILE}"
             printf 'SHA=%q\n'               "${SHA}"
             printf 'REFSPEC=%q\n'           "${REFSPEC}"
             printf 'DURATION_MINUTES=%q\n'  "${DURATION_MINUTES}"
-            printf 'VOLUME_NAME=%q\n'       "${VOLUME_NAME}"
+            printf 'IMAGE_ID=%q\n'          "${IMAGE_ID}"
+            printf 'IMAGE_NAME=%q\n'        "${IMAGE_NAME}"
+            printf 'IMAGE_CREATED=%q\n'     "${IMAGE_CREATED}"
+            printf 'ZAKURA_SNAPSHOT_ID=%q\n'      "${ZAKURA_SNAPSHOT_ID}"
+            printf 'ZAKURA_SNAPSHOT_NAME=%q\n'    "${ZAKURA_SNAPSHOT_NAME}"
+            printf 'ZAKURA_SNAPSHOT_CREATED=%q\n' "${ZAKURA_SNAPSHOT_CREATED}"
+            printf 'ZCASHD_SNAPSHOT_ID=%q\n'      "${ZCASHD_SNAPSHOT_ID}"
+            printf 'ZCASHD_SNAPSHOT_NAME=%q\n'    "${ZCASHD_SNAPSHOT_NAME}"
+            printf 'ZCASHD_SNAPSHOT_CREATED=%q\n' "${ZCASHD_SNAPSHOT_CREATED}"
+            printf 'ZAKURA_VOLUME_NAME=%q\n'      "${ZAKURA_VOLUME_NAME}"
+            printf 'ZCASHD_VOLUME_NAME=%q\n'      "${ZCASHD_VOLUME_NAME}"
           } > /tmp/run.env
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
             /tmp/run.env \
             .github/workflows/scripts/pr-node-run.sh \
             .github/workflows/scripts/pr-node-monitor.py \
             "root@${IP}:/root/"
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            deploy/deployer/deploy.py "root@${IP}:/root/pr-node-deploy.py"
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            deploy/deployer/templates/zakura.toml "root@${IP}:/root/pr-node-zakura.toml"
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            deploy/deployer/templates/zakurad.service "root@${IP}:/root/pr-node-zakurad.service"
           rm -f /tmp/run.env
           # Keepalives: the monitored hour is long and low-output.
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
@@ -272,6 +377,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR: ${{ steps.target.outputs.pr }}
+          TEST_PROFILE: ${{ inputs.test_profile || 'zakura' }}
           MODE: ${{ inputs.snapshot_mode }}
           NETWORK: ${{ inputs.network }}
           IP: ${{ steps.droplet.outputs.ip }}
@@ -279,7 +385,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const marker = `<!-- zakura-pr-node:${process.env.MODE}:${process.env.NETWORK} -->`;
+            const marker = process.env.TEST_PROFILE === 'zakura'
+              ? `<!-- zakura-pr-node:${process.env.MODE}:${process.env.NETWORK} -->`
+              : `<!-- zakura-pr-node:${process.env.TEST_PROFILE}:${process.env.MODE}:${process.env.NETWORK} -->`;
             let summary;
             try {
               summary = fs.readFileSync('/tmp/out/summary.md', 'utf8');
@@ -320,7 +428,7 @@ jobs:
         if: always() && steps.droplet.outputs.ip != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
-          name: zakura-pr-node-${{ github.run_id }}
+          name: zakura-pr-node-${{ inputs.test_profile || 'zakura' }}-${{ github.run_id }}
           path: /tmp/out/
           retention-days: 14
           if-no-files-found: ignore
@@ -329,7 +437,8 @@ jobs:
         if: always()
         env:
           DROPLET_ID: ${{ steps.droplet.outputs.id }}
-          VOLUME_ID: ${{ steps.droplet.outputs.volume_id }}
+          ZAKURA_VOLUME_ID: ${{ steps.droplet.outputs.zakura_volume_id }}
+          ZCASHD_VOLUME_ID: ${{ steps.droplet.outputs.zcashd_volume_id }}
           TEARDOWN: ${{ inputs.teardown_after_run }}
           SSH_FAILED: ${{ steps.sshwait.outcome == 'failure' }}
         run: |
@@ -345,11 +454,13 @@ jobs:
               sleep 5
             done
           fi
-          if [ -n "${VOLUME_ID}" ]; then
-            # The volume detaches asynchronously after the droplet delete.
-            for _ in $(seq 1 12); do
-              doctl compute volume delete "${VOLUME_ID}" -f && break
-              sleep 10
-            done
-          fi
+          for VOLUME_ID in "${ZAKURA_VOLUME_ID}" "${ZCASHD_VOLUME_ID}"; do
+            if [ -n "${VOLUME_ID}" ]; then
+              # Volumes detach asynchronously after the droplet delete.
+              for _ in $(seq 1 12); do
+                doctl compute volume delete "${VOLUME_ID}" -f && break
+                sleep 10
+              done
+            fi
+          done
           true

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -40,9 +40,9 @@ on:
         required: false
         default: "60"
       droplet_size:
-        description: "Droplet size (disk must be >= the baked image's disk)"
+        description: "Droplet size, or auto for a profile-safe default (disk must fit the baked image)"
         required: false
-        default: c-8
+        default: auto
       teardown_after_run:
         description: "Delete the droplet immediately after the run"
         type: boolean
@@ -212,7 +212,7 @@ jobs:
         env:
           MODE: ${{ inputs.snapshot_mode }}
           TEST_PROFILE: ${{ inputs.test_profile || 'zakura' }}
-          DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
+          DROPLET_SIZE: ${{ inputs.droplet_size || 'auto' }}
           SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
           IMAGE_ID: ${{ steps.baked.outputs.image_id }}
           ZAKURA_SNAP_ID: ${{ steps.baked.outputs.zakura_snap_id }}
@@ -220,6 +220,16 @@ jobs:
           SLUG: ${{ steps.target.outputs.slug }}
         run: |
           set -euo pipefail
+          if [ "${DROPLET_SIZE}" = auto ]; then
+            if [ "${TEST_PROFILE}" = zcashd-compat ]; then
+              # The compat preflight requires at least 16 GiB of effective
+              # guest RAM. A nominal 16 GB c-8 reports less than that in Linux.
+              DROPLET_SIZE=g-8vcpu-32gb
+            else
+              DROPLET_SIZE=c-8
+            fi
+          fi
+          echo "Using ${DROPLET_SIZE} for the ${TEST_PROFILE} profile."
           VOLUME_ARGS=()
           ZAKURA_VOLUME_NAME=""
           ZAKURA_VOLUME_ID=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,21 @@
 - Run formatting and the checks relevant to the code you changed.
 - For fixes, explain the root cause, how the solution addresses it, and how the tests exercise the affected behavior.
 
+## DigitalOcean Real-Node Tests
+
+- For normal DigitalOcean tests of Zakura or the managed zcashd compatibility
+  wrapper, use `.github/workflows/zakura-pr-node.yml` and its Golden assets.
+  Do not provision an ad hoc test Droplet or manually download or unpack chain
+  state on a test Droplet.
+- Only `.github/workflows/zakura-pr-node-bake.yml` may create or refresh the
+  Golden image and state fixtures. If an asset is missing, stale, or
+  incompatible with the requested database format, stop and report it or run
+  the bake workflow. Do not bypass the Golden path with an untracked fixture.
+- Select `test_profile=zakura` for ordinary Zakura tests and
+  `test_profile=zcashd-compat` when the managed zcashd wrapper is under test.
+  Follow `.agents/skills/test-zakura-pr-node/SKILL.md` and
+  `docs/pr-node-do-setup.md` for dispatch, validation, and cleanup.
+
 ## Project Structure & Module Organization
 
 Zakura is a Rust workspace. Main crates include:

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -49,6 +49,8 @@ DEFAULTS = {
     # For fleets provisioned outside the deployer with hand-tuned configs.
     "manage_config": True,
     "service_name": "zakurad",
+    "service_kill_mode": "",
+    "service_timeout_stop_sec": "",
     "bin_path": "/usr/local/bin/zakurad",
     "config_path": "/etc/zakura/zakura.toml",
     "log_file": "/var/log/zakura/zakura.log",
@@ -72,6 +74,8 @@ DEFAULTS = {
     # Optional fleet-wide [defaults.zakura] table -> rendered [network.zakura].
     # Keys: dev_network, listen_addr, bootstrap_peers. Absent -> no section.
     "zakura": None,
+    # Optional fleet-wide [zcashd_compat] table.
+    "zcashd_compat": None,
     # Process deploys are for manually supervised nodes, like the testnet
     # zcashd-compat Zakura sidecar, where systemd would fight the local runbook.
     "working_dir": "",
@@ -95,6 +99,8 @@ class Node:
     deploy_kind: str
     manage_config: bool
     service_name: str
+    service_kill_mode: str
+    service_timeout_stop_sec: str
     bin_path: str
     config_path: str
     log_file: str
@@ -112,6 +118,7 @@ class Node:
     checkpoint_sync: bool
     vct_fast_sync: bool
     zakura: object  # dict | None: fleet-wide [network.zakura] settings
+    zcashd_compat: object  # dict | None: fleet-wide [zcashd_compat] settings
     working_dir: str
     start_command: str
     process_pattern: str
@@ -219,6 +226,8 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             deploy_kind=merged["deploy_kind"],
             manage_config=merged["manage_config"],
             service_name=merged["service_name"],
+            service_kill_mode=merged["service_kill_mode"],
+            service_timeout_stop_sec=merged["service_timeout_stop_sec"],
             bin_path=merged["bin_path"],
             config_path=merged["config_path"],
             log_file=merged["log_file"],
@@ -238,6 +247,7 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             checkpoint_sync=merged["checkpoint_sync"],
             vct_fast_sync=merged["vct_fast_sync"],
             zakura=merged.get("zakura"),
+            zcashd_compat=merged.get("zcashd_compat"),
             working_dir=merged["working_dir"],
             start_command=merged["start_command"],
             process_pattern=merged["process_pattern"],
@@ -421,17 +431,12 @@ def render_template(name: str, subst: dict[str, str]) -> str:
     return text
 
 
-def render_zakura_block(zakura: object) -> str:
-    """Render a fleet-wide [network.zakura] section from a dict, or "" if unset.
-
-    Recognises `dev_network` (str), `listen_addr` (str), and `bootstrap_peers`
-    (list of `node_id@addr` strings). Unknown keys are passed through verbatim so
-    the deployer does not need to learn every Zakura field.
-    """
-    if not zakura:
+def render_toml_table(section: str, values: object) -> str:
+    """Render a simple TOML table from a dict, or "" when it is unset."""
+    if not values:
         return ""
-    lines = ["[network.zakura]"]
-    for key, value in zakura.items():
+    lines = [f"[{section}]"]
+    for key, value in values.items():
         if isinstance(value, bool):
             lines.append(f"{key} = {'true' if value else 'false'}")
         elif isinstance(value, (int, float)):
@@ -442,10 +447,19 @@ def render_zakura_block(zakura: object) -> str:
                 lines.append(f"{key} = [\n{items}]")
             else:
                 lines.append(f"{key} = []")
-        else:
+        elif value is not None:
             lines.append(f'{key} = "{value}"')
-    # Leading/trailing blank lines so the section reads cleanly between [network] and [state].
     return "\n" + "\n".join(lines) + "\n"
+
+
+def render_zakura_block(zakura: object) -> str:
+    """Render fleet-wide settings under [network.zakura]."""
+    return render_toml_table("network.zakura", zakura)
+
+
+def render_zcashd_compat_block(zcashd_compat: object) -> str:
+    """Render fleet-wide settings under [zcashd_compat]."""
+    return render_toml_table("zcashd_compat", zcashd_compat)
 
 
 def render_node_config(node: Node) -> str:
@@ -482,6 +496,7 @@ def render_node_config(node: Node) -> str:
         "RPC_BLOCK": rpc_block,
         "CHECKPOINT_SYNC": "true" if node.checkpoint_sync else "false",
         "VCT_FAST_SYNC": "true" if node.vct_fast_sync else "false",
+        "ZCASHD_COMPAT_BLOCK": render_zcashd_compat_block(node.zcashd_compat),
     })
 
 
@@ -496,12 +511,18 @@ def render_service(node: Node) -> str:
             f"RequiresMountsFor={DATA_MOUNT}\n"
             f"AssertPathIsMountPoint={DATA_MOUNT}\n"
         )
+    stop_lines = ""
+    if node.service_kill_mode:
+        stop_lines += f"KillMode={node.service_kill_mode}\n"
+    if node.service_timeout_stop_sec:
+        stop_lines += f"TimeoutStopSec={node.service_timeout_stop_sec}\n"
     return render_template("zakurad.service", {
         "SERVICE_NAME": node.service_name,
         "BIN_PATH": node.bin_path,
         "CONFIG_PATH": node.config_path,
         "LOG_FILE": node.log_file,
         "MOUNT_LINES": mount_lines,
+        "STOP_LINES": stop_lines,
     })
 
 

--- a/deploy/deployer/templates/zakura.toml
+++ b/deploy/deployer/templates/zakura.toml
@@ -14,6 +14,7 @@ storage_mode = "{{STORAGE_MODE}}"
 
 [rpc]
 {{RPC_BLOCK}}
+{{ZCASHD_COMPAT_BLOCK}}
 
 {{METRICS_BLOCK}}
 [consensus]

--- a/deploy/deployer/templates/zakurad.service
+++ b/deploy/deployer/templates/zakurad.service
@@ -12,7 +12,7 @@ Type=simple
 ExecStart={{BIN_PATH}} -c {{CONFIG_PATH}} start
 Restart=always
 RestartSec=5
-LimitNOFILE=65535
+{{STOP_LINES}}LimitNOFILE=65535
 # zakurad writes its own structured logs to {{LOG_FILE}} (see [tracing] log_file).
 # Journal captures startup/panic output that precedes the log file opening.
 StandardOutput=journal

--- a/deploy/deployer/test_deploy.py
+++ b/deploy/deployer/test_deploy.py
@@ -121,6 +121,8 @@ class MountRenderingTests(unittest.TestCase):
             "deploy_kind": "systemd",
             "manage_config": True,
             "service_name": "zakurad",
+            "service_kill_mode": "",
+            "service_timeout_stop_sec": "",
             "bin_path": "/usr/local/bin/zakurad",
             "config_path": "/etc/zakura/zakura.toml",
             "log_file": "/var/log/zakura/zakura.log",
@@ -138,6 +140,7 @@ class MountRenderingTests(unittest.TestCase):
             "checkpoint_sync": True,
             "vct_fast_sync": True,
             "zakura": None,
+            "zcashd_compat": None,
             "working_dir": "",
             "start_command": "",
             "process_pattern": "",
@@ -160,6 +163,40 @@ class MountRenderingTests(unittest.TestCase):
 
         self.assertNotIn("RequiresMountsFor=/mnt/data", service)
         self.assertNotIn("AssertPathIsMountPoint=/mnt/data", service)
+
+    def test_render_service_stop_policy(self):
+        service = deploy.render_service(self.node(
+            service_kill_mode="mixed",
+            service_timeout_stop_sec="6m",
+        ))
+
+        self.assertIn("KillMode=mixed", service)
+        self.assertIn("TimeoutStopSec=6m", service)
+
+    def test_render_zcashd_compat_config(self):
+        config = deploy.render_node_config(self.node(
+            rpc_listen_addr="127.0.0.1:18232",
+            zcashd_compat={
+                "enabled": True,
+                "manage_zcashd": True,
+                "zcashd_source": "embedded",
+                "zcashd_datadir": "/mnt/zcashd",
+                "zcashd_extra_args": [
+                    "-rpcbind=127.0.0.1",
+                    "-rpcallowip=127.0.0.1",
+                ],
+                "shutdown_grace_period": "5m",
+            },
+        ))
+
+        self.assertIn('listen_addr = "127.0.0.1:18232"', config)
+        self.assertIn("[zcashd_compat]", config)
+        self.assertIn("enabled = true", config)
+        self.assertIn("manage_zcashd = true", config)
+        self.assertIn('zcashd_source = "embedded"', config)
+        self.assertIn('zcashd_datadir = "/mnt/zcashd"', config)
+        self.assertIn('    "-rpcbind=127.0.0.1",', config)
+        self.assertIn('shutdown_grace_period = "5m"', config)
 
 
 if __name__ == "__main__":

--- a/docs/pr-node-do-setup.md
+++ b/docs/pr-node-do-setup.md
@@ -117,9 +117,11 @@ gh workflow run zakura-pr-node.yml \
 ```
 
 Provide exactly one of `pr_number` or `ref`. Other inputs are
-`duration_minutes` (default `60`), `droplet_size` (default `c-8`), and
-`teardown_after_run`. The run Droplet's disk must be at least as large as the
-baked image's disk.
+`duration_minutes` (default `60`), `droplet_size` (default `auto`), and
+`teardown_after_run`. `auto` uses `c-8` for ordinary Zakura tests and
+`g-8vcpu-32gb` for zcashd compatibility so the guest has more than the
+preflight's 16 GiB effective-memory minimum. An explicit run Droplet size must
+also have a disk at least as large as the baked image's disk.
 
 The summary is available in the Actions job summary and in a
 `zakura-pr-node-<profile>-<run id>` artifact with `summary.json` and node logs.

--- a/docs/pr-node-do-setup.md
+++ b/docs/pr-node-do-setup.md
@@ -1,67 +1,135 @@
-# PR node on DigitalOcean — ephemeral 1-hour real-node PR testing
+# Golden DigitalOcean PR nodes
 
-The `PR node` workflow (`zakura-pr-node.yml`) boots a droplet in `nyc3` from a
-pre-baked image (build deps + warm cargo release cache + a repo clone), attaches
-a clone of a pre-baked chain-state volume, builds `zakurad` from a PR branch
-incrementally, runs it for ~1 hour, and posts a metrics summary as a PR comment.
-The droplet stays up afterwards for SSH inspection and is auto-deleted by the
-reaper within 24 hours.
+The PR-node workflows provide the supported path for real node tests on
+DigitalOcean. A run starts from a Golden image, clones the required state
+fixtures, builds the requested PR or ref, and monitors the node. Normal runs do
+not download or unpack chain snapshots.
+
+Do not replace this path with an ad hoc Droplet. Only
+`zakura-pr-node-bake.yml` creates or refreshes Golden assets.
+
+## Golden asset architecture
+
+| Asset family | Role | Profiles |
+| --- | --- | --- |
+| `zakura-pr-node-*` | Build image | All |
+| `zakura-pr-state-mainnet-*` | Zakura mainnet state | Mainnet |
+| `zakura-pr-state-testnet-*` | Zakura testnet state | Testnet `zakura` |
+| `zakura-pr-state-zcashd-mainnet-*` | zcashd state | `zcashd-compat` |
+
+The image contains Ubuntu, build dependencies, a repository clone, and a warm
+release build cache. The mainnet Zakura fixture contains `tip/` and
+`sandblast/`; the testnet fixture contains `tip/`. The clean zcashd fixture
+contains `blocks/`, `chainstate/`, `unity/`, and its `fixture-manifest.json`
+provenance manifest.
+
+State assets are volume snapshots rather than part of the Droplet image. Each
+run clones only what its profile needs:
+
+```text
+zakura          = base image + one Zakura state volume
+zcashd-compat   = base image + Zakura mainnet state + zcashd mainnet state
+genesis         = base image only
+```
+
+This keeps ordinary Zakura tests small while making zcashd compatibility tests
+fast and reproducible.
 
 ## Workflows
 
-- **`zakura-pr-node-bake.yml`** (weekly + manual) — bakes the golden assets:
-  one `zakura-pr-node-<stamp>` droplet image and one
-  `zakura-pr-state-{mainnet,testnet}-<stamp>` volume snapshot per network.
-  The mainnet volume holds `tip/` (daily pruned snapshot) and `sandblast/`
-  (archive pinned at height 1,707,210 — just before the 2022 "sandblasting"
-  spam region, so a run stress-syncs through high-density blocks). The testnet
-  volume holds `tip/`. Keeps the newest 2 of each asset.
-- **`zakura-pr-node.yml`** (manual) — the entrypoint; see Running below.
-- **`zakura-pr-node-reaper.yml`** (hourly + manual) — deletes run droplets
-  older than 24h, failed bake droplets older than 6h, detached `zakura-pr-*`
-  volumes older than 2h, and prunes images/volume snapshots beyond the
-  newest 2.
+- **`zakura-pr-node-bake.yml`** runs twice weekly and on demand. It bakes one
+  `zakura-pr-node-<stamp>` image, Zakura state snapshots for mainnet and
+  testnet, and a `zakura-pr-state-zcashd-mainnet-<stamp>` snapshot when a
+  zcashd fixture exists. Mainnet Zakura state contains `tip/` and `sandblast/`.
+  The latter starts at height 1,707,210, immediately before the 2022
+  sandblasting region. Testnet state contains `tip/`.
+- **`zakura-pr-node.yml`** is the test entrypoint. It clones the selected
+  assets, builds the requested target, runs it, and writes a job summary and
+  artifact. A PR target also receives one upserted summary comment per profile,
+  mode, and network.
+- **`zakura-pr-node-reaper.yml`** runs hourly. It deletes run Droplets older
+  than 24 hours, failed bake Droplets older than 6 hours, and detached run or
+  bake volumes older than 2 hours. It retains the newest two images and the
+  newest two snapshots in every state family.
 
 ## Prerequisites
 
 - Secrets: `DIGITALOCEAN_ACCESS_TOKEN`, `DO_SSH_PRIVATE_KEY`.
-- Variables: `DO_SSH_KEY_FINGERPRINT`.
-- Optional variable overrides for the bake's snapshot sources:
-  `ZAKURA_PR_NODE_TIP_LATEST_JSON`, `ZAKURA_PR_NODE_SANDBLAST_URL` /
-  `ZAKURA_PR_NODE_SANDBLAST_SHA256`, `ZAKURA_TESTNET_SNAPSHOTS_URL`.
+- Variable: `DO_SSH_KEY_FINGERPRINT`.
+- Optional Zakura source overrides:
+  `ZAKURA_PR_NODE_TIP_LATEST_JSON`, `ZAKURA_PR_NODE_SANDBLAST_URL`,
+  `ZAKURA_PR_NODE_SANDBLAST_SHA256`, `ZAKURA_PR_NODE_SANDBLAST_HEIGHT`,
+  `ZAKURA_PR_NODE_SANDBLAST_DB_FORMAT`, and
+  `ZAKURA_TESTNET_SNAPSHOTS_URL`.
+- Optional zcashd retention override:
+  `ZAKURA_PR_NODE_ZCASHD_TX_RETENTION` (default `10000`).
 
-Run the bake workflow once before the first PR-node run.
+Run the bake workflow before the first PR-node test.
 
-## Running
+## Choose a test profile
 
-From the Actions tab or the CLI:
+| Profile | Purpose | Valid state modes |
+| --- | --- | --- |
+| `zakura` | Node tests | `tip`, mainnet `sandblast`, or `genesis` |
+| `zcashd-compat` | Managed wrapper | Mainnet `tip` only |
+
+Use `zakura` for ordinary sync, validation, performance, and regression tests.
+The compat profile covers the managed zcashd wrapper's download, lifecycle,
+restart, and pruned state behavior. It starts Zakura from
+`/mnt/snapshots/tip` and zcashd from `/mnt/zcashd`, then removes only the
+ephemeral `/mnt/snapshots/tip/zcashd-compat/bin` cache before the first start.
+The run verifies a cold wrapper installation, exactly one direct zcashd child,
+both heights advancing, clean managed child shutdown, and a warm restart with
+the same cached binary hash and modification time. Monitoring also rejects the
+pruned block sidecar failure.
+
+## Run a test
+
+Dispatch from the Actions tab or with `gh`:
 
 ```bash
-# Test PR #123 from a tip snapshot on mainnet for an hour (the default):
-gh workflow run zakura-pr-node.yml -f pr_number=123
+# Test PR 123 near the mainnet tip for one hour.
+gh workflow run zakura-pr-node.yml \
+  -f pr_number=123 \
+  -f test_profile=zakura
 
-# Stress-sync PR #123 through the sandblast region for 30 minutes:
-gh workflow run zakura-pr-node.yml -f pr_number=123 -f snapshot_mode=sandblast -f duration_minutes=30
+# Test PR 123 with the managed zcashd wrapper.
+gh workflow run zakura-pr-node.yml \
+  -f pr_number=123 \
+  -f test_profile=zcashd-compat \
+  -f network=mainnet \
+  -f snapshot_mode=tip
 
-# Checkpoint-sync a branch from genesis on testnet, delete the droplet after:
-gh workflow run zakura-pr-node.yml -f ref=my-branch -f snapshot_mode=genesis \
-  -f network=testnet -f teardown_after_run=true
+# Stress-sync a ref through the sandblasting region for 30 minutes.
+gh workflow run zakura-pr-node.yml \
+  -f ref=my-branch \
+  -f test_profile=zakura \
+  -f snapshot_mode=sandblast \
+  -f duration_minutes=30
+
+# Explicitly checkpoint-sync from genesis on testnet, then tear down.
+gh workflow run zakura-pr-node.yml \
+  -f ref=my-branch \
+  -f test_profile=zakura \
+  -f snapshot_mode=genesis \
+  -f network=testnet \
+  -f teardown_after_run=true
 ```
 
-Inputs: exactly one of `pr_number` / `ref`; `snapshot_mode` ∈ `tip` (start near
-the chain tip and follow it), `sandblast` (mainnet-only archive at 1,707,210),
-`genesis` (fresh checkpoint sync, no volume); `network` ∈ `mainnet`/`testnet`;
-`duration_minutes` (default 60); `droplet_size` (default `c-8`; its disk must be
-≥ the baked image's disk, so ≥ the bake `droplet_size`); `teardown_after_run`.
+Provide exactly one of `pr_number` or `ref`. Other inputs are
+`duration_minutes` (default `60`), `droplet_size` (default `c-8`), and
+`teardown_after_run`. The run Droplet's disk must be at least as large as the
+baked image's disk.
 
-The summary lands in the job step summary, as an upserted PR comment (one per
-mode×network, matched by a hidden marker), and in a `zakura-pr-node-<run id>`
-artifact together with `summary.json` and the node logs. Runs for a bare `ref`
-without an open PR skip the comment.
+The summary is available in the Actions job summary and in a
+`zakura-pr-node-<profile>-<run id>` artifact with `summary.json` and node logs.
+Bare refs without an open PR skip the PR comment. Summaries identify the
+selected image and snapshots, their creation times and ages, and their fixture
+manifests.
 
-## Inspecting a kept node
+## Inspect a retained run
 
-The step summary prints the droplet IP. On the droplet:
+The job summary prints the Droplet IP. On the Droplet:
 
 ```bash
 systemctl status zakurad
@@ -69,35 +137,78 @@ tail -f /var/log/zakura/zakura.log
 cd /root/zakura && python3 deploy/deployer/deploy.py status --config /root/fleet.toml
 ```
 
-The node keeps running (and syncing) until the reaper deletes the droplet ~24h
-after creation. Re-dispatching for the same PR updates the existing comment.
+Unless `teardown_after_run=true`, the node remains available for SSH inspection
+until the reaper deletes its Droplet and cloned volumes. Re-dispatching the same
+PR updates the existing comment for that profile.
 
-## How it stays fast
+## Refresh the zcashd fixture
 
-The bake pre-installs apt/rustup toolchains, pre-clones the repo, warms
+After the first seed, each scheduled bake clones the latest zcashd snapshot,
+syncs it forward, shuts zcashd down cleanly, and publishes a new snapshot. The
+Monday and Thursday schedule leaves enough margin for one missed refresh within
+the default 10,000-block retention window. The bake requires the zcashd lag to
+remain nonnegative and below
+`ZAKURA_PR_NODE_ZCASHD_TX_RETENTION` before and after sync, then requires it to
+catch up. This keeps the sidecar within Zakura's retained transaction window.
+
+To create the first fixture, use an active seed Droplet in the same region that
+the CI SSH key can reach. Both Zakura and zcashd must have stopped cleanly, and
+no process may have the datadir open. Supply the recorded seed tip and the
+explicit copy confirmation:
+
+```bash
+gh workflow run zakura-pr-node-bake.yml \
+  -f zcashd_seed_droplet_id=DROPLET_ID \
+  -f zcashd_seed_confirm=COPY_CLEAN_ZCASHD_STATE \
+  -f zcashd_seed_datadir=/root/.zcashd \
+  -f zcashd_seed_height=HEIGHT \
+  -f zcashd_seed_hash=BLOCK_HASH \
+  -f zcashd_seed_checksum_verified=false
+```
+
+The seed contributes only `blocks/`, `chainstate/`, and `unity/`. Runtime
+cookies, locks, wallets, peer history, logs, and identities are not part of the
+fixture. `fixture-manifest.json` records the source, tip, checksum status,
+refresh lag, clean shutdown, node versions, and zcashd binary hash. A seed with
+`zcashd_seed_checksum_verified=false` is marked `candidate`, and that status is
+preserved by later refreshes. The expected archive URL and SHA256 may still be
+supplied as provenance for a candidate seed. A verified seed must provide both
+`zcashd_seed_archive_url` and `zcashd_seed_archive_sha256`. Do not manually
+download a zcashd archive onto a PR-node run.
+
+## Missing, stale, or incompatible assets
+
+- If an asset is missing or too stale for the intended test, dispatch the bake
+  workflow, wait for it to finish, and retry the test.
+- If a Zakura state database is too old, rebake after the needed format lands
+  on `main`. Zakura can upgrade one state major version in place; older state is
+  intentionally rejected. If the target PR needs a newer unsupported format,
+  stop and report it rather than implying that the branch can be baked.
+- If no first zcashd fixture exists, use the documented seed inputs with an
+  existing cleanly stopped datadir.
+- If a bake guard fails, stop and report the failed prerequisite. Do not fall
+  back to an untracked Droplet, archive download, renamed snapshot, or patched
+  fixture.
+- Use `snapshot_mode=genesis` only for a test that explicitly requires genesis,
+  not as a fallback for unavailable Golden state.
+
+## Why runs stay fast
+
+The base image pre-installs the toolchain, pre-clones the repository, warms
 `CARGO_TARGET_DIR=/root/cargo-target` with a release build of `main`, and bakes
-a `root@localhost` SSH identity so `deploy/deployer/deploy.py` is reused
-unmodified on the droplet (worktree build keyed on the PR SHA, systemd install
-with rollback, status/log commands). A PR run only pays: volume clone + droplet
-boot (~2 min), incremental `cargo build` of the diff vs `main`, then the
-monitored run itself.
+a loopback SSH identity so `deploy/deployer/deploy.py` can install the selected
+worktree. State volume clones are created from maintained snapshots. A normal
+run pays only for volume cloning, Droplet boot, an incremental build, and the
+monitored test.
 
-## DB format-version note
+## Cost and cleanup
 
-Snapshots store `state/v<N>/`. zakurad restores a state one major version back
-(a reusable-format upgrade runs in place); anything older is ignored and the
-node syncs from scratch — the run summary calls this out. After a DB format
-bump lands on `main`, re-run the bake so the volume snapshots catch up.
-
-## Cost note
-
-Per run: `c-8` droplet ~$0.25/h (~$6 if kept the full 24h) + the state volume
-(300 GiB ≈ $30/mo pro-rated, so ≪$1/day). Standing: 2 images + 2×2 volume
-snapshots ≈ $30–40/mo. If runs were force-killed, check:
+Run Droplets and cloned volumes continue billing until deletion. Prefer
+`teardown_after_run=true` when no SSH investigation is needed. Otherwise the
+reaper removes them within 24 hours. After a force cancelled workflow, dispatch
+`zakura-pr-node-reaper.yml` or inspect tagged resources:
 
 ```bash
 doctl compute droplet list --tag-name zakura-pr-node
 doctl compute volume list | grep zakura-pr-
 ```
-
-or just dispatch the reaper workflow.


### PR DESCRIPTION
## Motivation

Managed zcashd compatibility tests still depended on manually downloading and unpacking roughly 270 GiB of state. Besides being slow, that made it easy to pair zcashd with Zakura state outside the pruned node's 10,000-block retention window.

## Solution

Extend the existing PR-node system with a `zcashd-compat` profile that combines the Golden base image with timestamp-matched Zakura and zcashd volume snapshots. The twice-weekly bake clones and advances the prior zcashd fixture, verifies height, hash, database format, retention, and clean shutdown, writes provenance manifests, and keeps the newest two complete snapshot families. The guarded first-seed path copies only stopped chain state; its current fixture remains `candidate` because the source archive checksum was not completed.

Compatibility runs validate the paired manifests, perform a cold managed-wrapper install, require both nodes to advance with exactly one supervised zcashd child and connection, then prove clean shutdown and warm-cache reuse. Ordinary Zakura tests retain their existing image and state path; the large zcashd state stays on a separate 350 GiB volume. Repository guidance, operator documentation, and an agent skill route future real-node tests through these Golden assets instead of ad hoc downloads.

The fixture intentionally excludes `peers.dat` and `banlist.dat`. zcashd recreates them on first start, so those two exact self-healing startup messages are reported separately without hiding unexpected errors.

## Testing

- `actionlint` on the PR-node workflows
- `bash -n` and `shellcheck` on the PR-node shell scripts
- Python compilation and `python3 -m unittest deploy/deployer/test_deploy.py` (9 tests)
- Monitor verdict fixtures, live-log classification, repository skill validation, and Markdown lint
- [Golden bake run 29782655645](https://github.com/zakura-core/zakura/actions/runs/29782655645) passed: seeded the candidate fixture at height 3,417,532, refreshed Zakura and zcashd to height 3,419,404 with zero lag, created the paired state snapshots and base image, and completed resource cleanup
- [Compatibility smoke run 29787849898](https://github.com/zakura-core/zakura/actions/runs/29787849898) passed against exact target SHA `361aff729ca1fa05615d814f2fc5a042108c9503`: both nodes advanced 3,419,446 → 3,419,453, ended at zero drift with one child and one connection, reused the unchanged managed binary after all four clean-shutdown markers, reported zero unexpected errors and zero pruned-sidecar diagnostics, and completed immediate teardown

## Follow up

Replace the candidate zcashd fixture with a checksum-verified seed; scheduled refreshes intentionally preserve the original verification status.

## AI disclosure

Codex was used to implement and review the workflows, deployment harness, tests, documentation, and agent guidance.
