### PR TITLE
refactor(state): centralize commitment root index access

### DIFF
--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -114,6 +114,7 @@ pub use vct::{
     generate_mainnet_from_archive, validate_final_frontiers_bytes, FinalFrontiersValidationError,
     GeneratorError, NextVctBlock,
 };
+pub use zakura_db::commitment_roots_db::COMMITMENT_ROOTS_BY_HEIGHT;
 pub use zakura_db::ZakuraDb;
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -205,10 +206,6 @@ pub const VCT_SYNC_METADATA: &str = "vct_sync_metadata";
 /// This height is the first block committed by code that writes the
 /// [`COMMITMENT_ROOTS_BY_HEIGHT`] serving index.
 pub const VCT_UPGRADE_METADATA: &str = "vct_upgrade_metadata";
-
-/// The name of the column family holding per-height Sapling/Orchard
-/// note-commitment roots, keyed by [`block::Height`].
-pub const COMMITMENT_ROOTS_BY_HEIGHT: &str = "commitment_roots_by_height";
 
 /// The finalized part of the chain state, stored in the db.
 ///

--- a/zakura-state/src/service/finalized_state/commitment_aux.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux.rs
@@ -871,6 +871,25 @@ mod tests {
             .expect("seeding commitment root index succeeds");
     }
 
+    #[test]
+    fn commitment_root_range_stops_at_first_gap() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+
+        seed_index_roots(&db, [10, 12]);
+
+        assert_eq!(
+            db.commitment_roots_by_height_range(block::Height(10)..=block::Height(12))
+                .into_iter()
+                .map(|roots| roots.height)
+                .collect::<Vec<_>>(),
+            vec![block::Height(10)],
+        );
+        assert!(db
+            .commitment_roots_by_height_range(block::Height(11)..=block::Height(12))
+            .is_empty());
+    }
+
     fn set_upgrade_height(db: &ZakuraDb, height: block::Height) {
         let mut batch = DiskWriteBatch::new();
         batch.update_vct_upgrade_marker(db, height);

--- a/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -34,6 +34,7 @@ use super::disk_format::upgrade::restorable_db_versions;
 
 pub mod block;
 pub mod chain;
+pub(crate) mod commitment_roots_db;
 pub mod metrics;
 
 /// Minimum number of transactions in a block before the per-transaction batch

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -40,16 +40,14 @@ use crate::{
     request::FinalizedBlock,
     service::check,
     service::finalized_state::{
-        disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
+        disk_db::{DiskWriteBatch, ReadDisk, WriteDisk},
         disk_format::{
             block::TransactionLocation,
-            shielded::CommitmentRootsByHeight,
             transparent::{AddressBalanceLocationUpdates, OutputLocation},
         },
         vct::VctWriteData,
         zakura_db::{metrics::block_precommit_metrics, ZakuraDb},
-        FromDisk, IntoDisk, RawBytes, COMMITMENT_ROOTS_BY_HEIGHT, PRUNING_METADATA,
-        VCT_SYNC_METADATA, VCT_UPGRADE_METADATA,
+        FromDisk, IntoDisk, RawBytes, PRUNING_METADATA, VCT_SYNC_METADATA, VCT_UPGRADE_METADATA,
     },
     HashOrHeight,
 };
@@ -186,31 +184,6 @@ impl ZakuraDb {
         self.db
             .zs_get(&body_size_by_height, &height)
             .map(AdvertisedBodySize::get)
-    }
-
-    /// Returns provisional header-sync commitment roots for a contiguous height range.
-    pub fn zakura_header_commitment_roots_by_height_range(
-        &self,
-        range: impl RangeBounds<block::Height>,
-    ) -> Vec<BlockCommitmentRoots> {
-        let roots_by_height = self.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-
-        self.db
-            .zs_forward_range_iter::<_, block::Height, CommitmentRootsByHeight, _>(
-                &roots_by_height,
-                range,
-            )
-            .map(|(height, value)| BlockCommitmentRoots {
-                height,
-                sapling_root: value.sapling,
-                orchard_root: value.orchard,
-                ironwood_root: value.ironwood,
-                sapling_tx: value.sapling_tx,
-                orchard_tx: value.orchard_tx,
-                ironwood_tx: value.ironwood_tx,
-                auth_data_root: value.auth_data_root,
-            })
-            .collect()
     }
 
     /// Returns finalized commitment roots for a contiguous height range.
@@ -684,44 +657,6 @@ impl ZakuraDb {
     pub(crate) fn zakura_header(&self, height: block::Height) -> Option<Arc<block::Header>> {
         let header_by_height = self.db.cf_handle(ZAKURA_HEADER_BY_HEIGHT).unwrap();
         self.db.zs_get(&header_by_height, &height)
-    }
-
-    /// Persist provisional header-ahead roots supplied by Zakura header sync.
-    pub fn insert_zakura_header_commitment_roots(
-        &self,
-        roots: impl IntoIterator<Item = BlockCommitmentRoots>,
-    ) -> Result<(), rocksdb::Error> {
-        let cf = self.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-        let mut batch = DiskWriteBatch::new();
-        for roots in roots {
-            batch.zs_insert(
-                &cf,
-                roots.height,
-                CommitmentRootsByHeight {
-                    sapling: roots.sapling_root,
-                    orchard: roots.orchard_root,
-                    ironwood: roots.ironwood_root,
-                    sapling_tx: roots.sapling_tx,
-                    orchard_tx: roots.orchard_tx,
-                    ironwood_tx: roots.ironwood_tx,
-                    auth_data_root: roots.auth_data_root,
-                },
-            );
-        }
-        self.write_batch(batch)
-    }
-
-    /// Delete provisional header-ahead roots by height.
-    pub fn delete_zakura_header_commitment_roots(
-        &self,
-        heights: impl IntoIterator<Item = Height>,
-    ) -> Result<(), rocksdb::Error> {
-        let cf = self.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-        let mut batch = DiskWriteBatch::new();
-        for height in heights {
-            batch.zs_delete(&cf, height);
-        }
-        self.write_batch(batch)
     }
 
     // The header readers below resolve from the consensus header column families
@@ -1330,7 +1265,7 @@ impl ZakuraDb {
         block: &Arc<block::Block>,
     ) -> Result<(), CommitHeaderRangeError> {
         let mut batch = DiskWriteBatch::new();
-        batch.prepare_zakura_header_from_committed_block(&self.db, height, block)?;
+        batch.prepare_zakura_header_from_committed_block(self, height, block)?;
         self.db
             .write(batch)
             .map_err(|error| CommitHeaderRangeError::StorageWriteError {
@@ -1642,9 +1577,7 @@ impl DiskWriteBatch {
             store_raw_transactions,
             precomputed_raw_txs,
         )?;
-        let zakura_header_commitment_roots_by_height =
-            zakura_db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-        self.zs_delete(&zakura_header_commitment_roots_by_height, finalized.height);
+        self.delete_legacy_header_commitment_root(zakura_db, finalized.height);
 
         // The consensus rules are silent on shielded transactions in the genesis block,
         // because there aren't any in the mainnet or testnet genesis blocks.
@@ -1801,7 +1734,7 @@ impl DiskWriteBatch {
         // heights with no committed body (the frontier above the body tip).
         // This is unconditional so it also cleans up rows left by a prior run
         // that had `enable_zakura_header_seed_from_committed_blocks` enabled.
-        self.prepare_zakura_header_release_from_committed_block(db, *height, block)?;
+        self.prepare_zakura_header_release_from_committed_block(zakura_db, *height, block)?;
 
         // Index the block header, hash, and height. This also restores the
         // verified full block row after any provisional cleanup above.
@@ -1872,15 +1805,15 @@ impl DiskWriteBatch {
     #[allow(clippy::unwrap_in_result)]
     pub fn prepare_zakura_header_from_committed_block(
         &mut self,
-        db: &DiskDb,
+        zakura_db: &ZakuraDb,
         height: block::Height,
         block: &Arc<block::Block>,
     ) -> Result<(), CommitHeaderRangeError> {
+        let db = &zakura_db.db;
         let zakura_header_by_height = db.cf_handle(ZAKURA_HEADER_BY_HEIGHT).unwrap();
         let zakura_hash_by_height = db.cf_handle(ZAKURA_HEADER_HASH_BY_HEIGHT).unwrap();
         let zakura_height_by_hash = db.cf_handle(ZAKURA_HEADER_HEIGHT_BY_HASH).unwrap();
         let zakura_body_size_by_height = db.cf_handle(ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT).unwrap();
-        let zakura_roots_by_height = db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
         let tx_by_loc = db.cf_handle("tx_by_loc").unwrap();
 
         let hash = block.hash();
@@ -1940,8 +1873,9 @@ impl DiskWriteBatch {
                     self.zs_delete(&zakura_hash_by_height, old_height);
                     self.zs_delete(&zakura_header_by_height, old_height);
                     self.zs_delete(&zakura_body_size_by_height, old_height);
-                    self.zs_delete(&zakura_roots_by_height, old_height);
                 }
+
+                self.delete_header_reorg_commitment_roots(zakura_db, height, best_header_tip);
             }
         } else if let Some(old_hash) =
             db.zs_get::<_, _, block::Hash>(&zakura_hash_by_height, &height)
@@ -1974,15 +1908,15 @@ impl DiskWriteBatch {
     #[allow(clippy::unwrap_in_result)]
     pub fn prepare_zakura_header_release_from_committed_block(
         &mut self,
-        db: &DiskDb,
+        zakura_db: &ZakuraDb,
         height: block::Height,
         block: &Arc<block::Block>,
     ) -> Result<(), CommitHeaderRangeError> {
+        let db = &zakura_db.db;
         let zakura_header_by_height = db.cf_handle(ZAKURA_HEADER_BY_HEIGHT).unwrap();
         let zakura_hash_by_height = db.cf_handle(ZAKURA_HEADER_HASH_BY_HEIGHT).unwrap();
         let zakura_height_by_hash = db.cf_handle(ZAKURA_HEADER_HEIGHT_BY_HASH).unwrap();
         let zakura_body_size_by_height = db.cf_handle(ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT).unwrap();
-        let zakura_roots_by_height = db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
         let tx_by_loc = db.cf_handle("tx_by_loc").unwrap();
 
         let existing_zakura_header: Option<Arc<block::Header>> =
@@ -2021,7 +1955,14 @@ impl DiskWriteBatch {
                     self.zs_delete(&zakura_hash_by_height, descendant);
                     self.zs_delete(&zakura_header_by_height, descendant);
                     self.zs_delete(&zakura_body_size_by_height, descendant);
-                    self.zs_delete(&zakura_roots_by_height, descendant);
+                }
+
+                if let Ok(first_descendant) = height.next() {
+                    self.delete_header_reorg_commitment_roots(
+                        zakura_db,
+                        first_descendant,
+                        zakura_tip,
+                    );
                 }
             }
         }
@@ -2033,7 +1974,7 @@ impl DiskWriteBatch {
         self.zs_delete(&zakura_hash_by_height, height);
         self.zs_delete(&zakura_header_by_height, height);
         self.zs_delete(&zakura_body_size_by_height, height);
-        self.zs_delete(&zakura_roots_by_height, height);
+        self.delete_legacy_header_commitment_root(zakura_db, height);
 
         Ok(())
     }
@@ -2100,7 +2041,6 @@ impl DiskWriteBatch {
             .db
             .cf_handle(ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT)
             .unwrap();
-        let roots_by_height = zakura_db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
 
         let anchor_height = zakura_db
             .header_height(anchor)
@@ -2279,8 +2219,13 @@ impl DiskWriteBatch {
                 self.zs_delete(&hash_by_height, height);
                 self.zs_delete(&header_by_height, height);
                 self.zs_delete(&body_size_by_height, height);
-                self.zs_delete(&roots_by_height, height);
             }
+
+            self.delete_header_reorg_commitment_roots(
+                zakura_db,
+                first_conflicting_height,
+                best_header_tip,
+            );
         }
 
         for (index, (height, hash, header, body_size)) in validated_headers.into_iter().enumerate()
@@ -2313,19 +2258,7 @@ impl DiskWriteBatch {
                 self.zs_delete(&body_size_by_height, height);
             }
             let roots = &tree_aux_roots[index];
-            self.zs_insert(
-                &roots_by_height,
-                height,
-                CommitmentRootsByHeight {
-                    sapling: roots.sapling_root,
-                    orchard: roots.orchard_root,
-                    ironwood: roots.ironwood_root,
-                    sapling_tx: roots.sapling_tx,
-                    orchard_tx: roots.orchard_tx,
-                    ironwood_tx: roots.ironwood_tx,
-                    auth_data_root: roots.auth_data_root,
-                },
-            );
+            self.insert_legacy_header_commitment_roots(zakura_db, roots);
         }
 
         Ok(block::Hash::from(

--- a/zakura-state/src/service/finalized_state/zakura_db/block/startup_audit.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/startup_audit.rs
@@ -30,9 +30,8 @@ use super::{
 };
 use crate::service::finalized_state::{
     disk_db::{DiskWriteBatch, ReadDisk, WriteDisk},
-    disk_format::{shielded::CommitmentRootsByHeight, FromDisk, IntoDisk},
-    zakura_db::ZakuraDb,
-    COMMITMENT_ROOTS_BY_HEIGHT,
+    disk_format::{FromDisk, IntoDisk},
+    zakura_db::{commitment_roots_db::COMMITMENT_ROOTS_BY_HEIGHT, ZakuraDb},
 };
 
 /// How many violations are included in the repair log line. The full list can
@@ -176,20 +175,13 @@ impl ZakuraDb {
     ) -> Result<Option<ZakuraStoreRepair>, rocksdb::Error> {
         // Databases opened through `ZakuraDb::new` without the zakura column
         // families have no header store to audit.
-        let (
-            Some(header_cf),
-            Some(hash_cf),
-            Some(height_by_hash_cf),
-            Some(body_size_cf),
-            Some(roots_cf),
-        ) = (
+        let (Some(header_cf), Some(hash_cf), Some(height_by_hash_cf), Some(body_size_cf), true) = (
             self.db.cf_handle(ZAKURA_HEADER_BY_HEIGHT),
             self.db.cf_handle(ZAKURA_HEADER_HASH_BY_HEIGHT),
             self.db.cf_handle(ZAKURA_HEADER_HEIGHT_BY_HASH),
             self.db.cf_handle(ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT),
-            self.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT),
-        )
-        else {
+            self.has_commitment_roots_index(),
+        ) else {
             return Ok(None);
         };
 
@@ -205,11 +197,7 @@ impl ZakuraDb {
             // The finalized tip is at the maximum height: no frontier can
             // exist above it.
             (Some(_), None) => true,
-            (Some(_), Some(start)) => self
-                .db
-                .zs_forward_range_iter::<_, Height, CommitmentRootsByHeight, _>(&roots_cf, start..)
-                .next()
-                .is_none(),
+            (Some(_), Some(start)) => self.commitment_root_heights_for_repair(start, 1).is_empty(),
             // No finalized tip: roots rows can be committed history whose
             // tip index is missing, and header sync cannot restore them.
             (None, _) => true,
@@ -400,10 +388,8 @@ impl ZakuraDb {
             (Some(_), Some(start)) => Some(start),
             (None, _) => None,
         } {
-            audit_height_keyed_rows::<CommitmentRootsByHeight>(
-                &self.db,
-                &roots_cf,
-                COMMITMENT_ROOTS_BY_HEIGHT,
+            audit_commitment_root_rows(
+                self,
                 &committed,
                 &in_window,
                 &mut violations,
@@ -479,6 +465,60 @@ where
             .take(AUDIT_BATCH_ROWS)
             .collect(),
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn audit_commitment_root_rows(
+    db: &ZakuraDb,
+    committed: &impl Fn(Height) -> bool,
+    in_window: &impl Fn(Height) -> bool,
+    violations: &mut Vec<ZakuraStoreViolation>,
+    batch: &mut DiskWriteBatch,
+    pending_deletes: &mut usize,
+    deleted_rows: &mut usize,
+    start: Option<Height>,
+) -> Result<usize, rocksdb::Error> {
+    let mut next_start = start.unwrap_or(Height::MIN);
+    let mut scanned_rows = 0;
+
+    loop {
+        let heights = db.commitment_root_heights_for_repair(next_start, AUDIT_BATCH_ROWS);
+        let Some(&last_height) = heights.last() else {
+            break;
+        };
+        scanned_rows += heights.len();
+        next_start = match last_height.next() {
+            Ok(next_height) => next_height,
+            Err(_) => break,
+        };
+
+        for height in heights {
+            if in_window(height) {
+                continue;
+            }
+
+            violations.push(if committed(height) {
+                ZakuraStoreViolation::StaleRowAtCommittedHeight {
+                    cf: COMMITMENT_ROOTS_BY_HEIGHT,
+                    height,
+                }
+            } else {
+                ZakuraStoreViolation::RowAboveLastCoherent {
+                    cf: COMMITMENT_ROOTS_BY_HEIGHT,
+                    height,
+                }
+            });
+
+            batch.delete_commitment_root_for_repair(db, height);
+            *pending_deletes += 1;
+            if *pending_deletes >= AUDIT_BATCH_ROWS {
+                flush_repair_batch(&db.db, batch, pending_deletes)?;
+            }
+            *deleted_rows += 1;
+        }
+    }
+
+    Ok(scanned_rows)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/scenarios.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/header_store_coherence/scenarios.rs
@@ -342,6 +342,7 @@ fn s06_reorg_to_lower_height() {
         .run_all(&[commit_trunk(), commit_branch(BRANCH_B)])
         .expect("setup is clean");
     outcomes.iter().for_each(assert_accepted);
+    let old_tip = branch_tip(BRANCH_B).0;
     assert_eq!(
         harness.state().best_header_tip(),
         Some(branch_tip(BRANCH_B)),
@@ -356,6 +357,13 @@ fn s06_reorg_to_lower_height() {
         Some(branch_tip(BRANCH_A)),
         "the tip height decreased to A's tip",
     );
+    let new_tip = branch_tip(BRANCH_A).0;
+    for height in (new_tip.0 + 1..=old_tip.0).map(Height) {
+        assert!(
+            harness.state().commitment_roots(height).is_none(),
+            "the reorg removes stale commitment roots at {height:?}",
+        );
+    }
 }
 
 /// s07: double reorg at the same fork point (B → A → B_ext), then the losing

--- a/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -156,15 +156,15 @@ impl ZakuraDb {
             .collect()
     }
 
-    /// Returns root rows in `range` for rollback and migration bookkeeping.
-    pub(super) fn commitment_roots_for_migration(
+    /// Visits root rows in `range` for rollback and migration bookkeeping.
+    pub(super) fn visit_commitment_roots_for_migration(
         &self,
         range: impl RangeBounds<Height>,
-    ) -> Vec<(Height, BlockCommitmentRoots)> {
-        self.commitment_roots_cf()
-            .zs_forward_range_iter(range)
-            .map(|(height, row)| (height, domain_roots(height, row)))
-            .collect()
+        mut visit: impl FnMut(Height, BlockCommitmentRoots),
+    ) {
+        for (height, row) in self.commitment_roots_cf().zs_forward_range_iter(range) {
+            visit(height, domain_roots(height, row));
+        }
     }
 }
 

--- a/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -1,0 +1,317 @@
+//! State-owned access to the commitment-root index.
+//!
+//! This module is the lifecycle boundary for commitment-root rows. It keeps
+//! disk-row conversion, contiguous reads, and the distinct body, legacy
+//! header, reorganization, rollback, and repair write policies in one place.
+
+use std::ops::{Bound, RangeBounds, RangeInclusive};
+
+use zakura_chain::{block::Height, parallel::commitment_aux::BlockCommitmentRoots};
+
+use crate::service::finalized_state::{
+    disk_db::DiskWriteBatch, disk_format::shielded::CommitmentRootsByHeight, TypedColumnFamily,
+};
+
+use super::ZakuraDb;
+
+/// The name of the per-height commitment-root column family.
+pub const COMMITMENT_ROOTS_BY_HEIGHT: &str = "commitment_roots_by_height";
+
+type CommitmentRootsCf<'cf> = TypedColumnFamily<'cf, Height, CommitmentRootsByHeight>;
+
+fn disk_row(roots: &BlockCommitmentRoots) -> CommitmentRootsByHeight {
+    CommitmentRootsByHeight {
+        sapling: roots.sapling_root,
+        orchard: roots.orchard_root,
+        auth_data_root: roots.auth_data_root,
+        ironwood: roots.ironwood_root,
+        sapling_tx: roots.sapling_tx,
+        orchard_tx: roots.orchard_tx,
+        ironwood_tx: roots.ironwood_tx,
+    }
+}
+
+fn domain_roots(height: Height, row: CommitmentRootsByHeight) -> BlockCommitmentRoots {
+    BlockCommitmentRoots {
+        height,
+        sapling_root: row.sapling,
+        orchard_root: row.orchard,
+        auth_data_root: row.auth_data_root,
+        ironwood_root: row.ironwood,
+        sapling_tx: row.sapling_tx,
+        orchard_tx: row.orchard_tx,
+        ironwood_tx: row.ironwood_tx,
+    }
+}
+
+fn inclusive_bounds(range: impl RangeBounds<Height>) -> Option<(Height, Height)> {
+    let start = match range.start_bound() {
+        Bound::Included(height) => *height,
+        Bound::Excluded(height) => height.next().ok()?,
+        Bound::Unbounded => Height::MIN,
+    };
+    let end = match range.end_bound() {
+        Bound::Included(height) => *height,
+        Bound::Excluded(height) => height.previous().ok()?,
+        Bound::Unbounded => Height::MAX,
+    };
+
+    (start <= end).then_some((start, end))
+}
+
+impl ZakuraDb {
+    fn commitment_roots_cf(&self) -> CommitmentRootsCf<'_> {
+        CommitmentRootsCf::new(&self.db, COMMITMENT_ROOTS_BY_HEIGHT)
+            .expect("column family was created when database was created")
+    }
+
+    pub(super) fn has_commitment_roots_index(&self) -> bool {
+        CommitmentRootsCf::new(&self.db, COMMITMENT_ROOTS_BY_HEIGHT).is_some()
+    }
+
+    /// Returns the commitment roots stored at `height`.
+    pub fn commitment_roots(&self, height: Height) -> Option<BlockCommitmentRoots> {
+        self.commitment_roots_cf()
+            .zs_get(&height)
+            .map(|row| domain_roots(height, row))
+    }
+
+    /// Returns the contiguous stored prefix of `range`.
+    ///
+    /// The read stops at the first missing height.
+    pub fn commitment_roots_by_height_range(
+        &self,
+        range: RangeInclusive<Height>,
+    ) -> Vec<BlockCommitmentRoots> {
+        self.contiguous_commitment_roots(range)
+    }
+
+    /// Returns legacy header-sync roots for the contiguous stored prefix of `range`.
+    ///
+    /// The index currently contains both body-derived and legacy header-supplied
+    /// rows, so this compatibility name does not imply per-row provenance.
+    pub fn zakura_header_commitment_roots_by_height_range(
+        &self,
+        range: impl RangeBounds<Height>,
+    ) -> Vec<BlockCommitmentRoots> {
+        self.contiguous_commitment_roots(range)
+    }
+
+    fn contiguous_commitment_roots(
+        &self,
+        range: impl RangeBounds<Height>,
+    ) -> Vec<BlockCommitmentRoots> {
+        let Some((start, end)) = inclusive_bounds(range) else {
+            return Vec::new();
+        };
+        let cf = self.commitment_roots_cf();
+        let mut roots = Vec::new();
+
+        for height in (start.0..=end.0).map(Height) {
+            let Some(row) = cf.zs_get(&height) else {
+                break;
+            };
+            roots.push(domain_roots(height, row));
+        }
+
+        roots
+    }
+
+    /// Persists legacy raw header roots outside a larger header transaction.
+    ///
+    /// This temporary compatibility path never overwrites a committed-body row.
+    pub fn insert_zakura_header_commitment_roots(
+        &self,
+        roots: impl IntoIterator<Item = BlockCommitmentRoots>,
+    ) -> Result<(), rocksdb::Error> {
+        let mut batch = DiskWriteBatch::new();
+        for roots in roots {
+            batch.insert_legacy_header_commitment_roots(self, &roots);
+        }
+        self.write_batch(batch)
+    }
+
+    /// Deletes legacy header roots outside a larger header transaction.
+    pub fn delete_zakura_header_commitment_roots(
+        &self,
+        heights: impl IntoIterator<Item = Height>,
+    ) -> Result<(), rocksdb::Error> {
+        let mut batch = DiskWriteBatch::new();
+        for height in heights {
+            batch.delete_legacy_header_commitment_root(self, height);
+        }
+        self.write_batch(batch)
+    }
+
+    /// Returns at most `limit` root heights for startup repair.
+    pub(super) fn commitment_root_heights_for_repair(
+        &self,
+        start: Height,
+        limit: usize,
+    ) -> Vec<Height> {
+        self.commitment_roots_cf()
+            .zs_forward_range_iter(start..)
+            .map(|(height, _row)| height)
+            .take(limit)
+            .collect()
+    }
+
+    /// Returns root rows in `range` for rollback and migration bookkeeping.
+    pub(super) fn commitment_roots_for_migration(
+        &self,
+        range: impl RangeBounds<Height>,
+    ) -> Vec<(Height, BlockCommitmentRoots)> {
+        self.commitment_roots_cf()
+            .zs_forward_range_iter(range)
+            .map(|(height, row)| (height, domain_roots(height, row)))
+            .collect()
+    }
+}
+
+impl DiskWriteBatch {
+    /// Inserts or replaces an authoritative body-derived commitment-root row.
+    pub fn insert_body_derived_commitment_roots(
+        &mut self,
+        db: &ZakuraDb,
+        roots: &BlockCommitmentRoots,
+    ) {
+        let _ = db
+            .commitment_roots_cf()
+            .with_batch_for_writing(self)
+            .zs_insert(&roots.height, &disk_row(roots));
+    }
+
+    /// Inserts a raw legacy header-supplied row unless a committed body owns the height.
+    ///
+    /// "Legacy" identifies the temporary pre-authentication behavior where header sync persists
+    /// peer-supplied roots directly. The verified-root persistence boundary will replace this path.
+    pub(super) fn insert_legacy_header_commitment_roots(
+        &mut self,
+        db: &ZakuraDb,
+        roots: &BlockCommitmentRoots,
+    ) {
+        if db.contains_height(roots.height) {
+            return;
+        }
+
+        let _ = db
+            .commitment_roots_cf()
+            .with_batch_for_writing(self)
+            .zs_insert(&roots.height, &disk_row(roots));
+    }
+
+    /// Deletes one legacy header-supplied row.
+    pub(super) fn delete_legacy_header_commitment_root(&mut self, db: &ZakuraDb, height: Height) {
+        let _ = db
+            .commitment_roots_cf()
+            .with_batch_for_writing(self)
+            .zs_delete(&height);
+    }
+
+    /// Deletes the inclusive legacy-header suffix displaced by a header reorganization.
+    pub(super) fn delete_header_reorg_commitment_roots(
+        &mut self,
+        db: &ZakuraDb,
+        start: Height,
+        end: Height,
+    ) {
+        if start > end {
+            return;
+        }
+
+        let mut writer = db.commitment_roots_cf().with_batch_for_writing(self);
+        for height in (start.0..=end.0).map(Height) {
+            writer = writer.zs_delete(&height);
+        }
+        let _ = writer;
+    }
+
+    /// Truncates authoritative rows strictly above a finalized rollback target.
+    pub(super) fn truncate_commitment_roots_after(&mut self, db: &ZakuraDb, target: Height) {
+        let Ok(start) = target.next() else {
+            return;
+        };
+        let writer = db
+            .commitment_roots_cf()
+            .with_batch_for_writing(self)
+            .zs_delete_range(&start, &Height::MAX)
+            .zs_delete(&Height::MAX);
+        let _ = writer;
+    }
+
+    /// Deletes one row selected by startup repair or a database migration.
+    pub(super) fn delete_commitment_root_for_repair(&mut self, db: &ZakuraDb, height: Height) {
+        let _ = db
+            .commitment_roots_cf()
+            .with_batch_for_writing(self)
+            .zs_delete(&height);
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    /// Inserts a body-derived row assembled from separate test fixture fields.
+    pub fn insert_commitment_roots_by_height(
+        &mut self,
+        db: &ZakuraDb,
+        height: Height,
+        sapling_root: &zakura_chain::sapling::tree::Root,
+        orchard_root: &zakura_chain::orchard::tree::Root,
+        ironwood_root: &zakura_chain::ironwood::tree::Root,
+        sapling_tx: u64,
+        orchard_tx: u64,
+        ironwood_tx: u64,
+        auth_data_root: &zakura_chain::block::merkle::AuthDataRoot,
+    ) {
+        self.insert_body_derived_commitment_roots(
+            db,
+            &BlockCommitmentRoots {
+                height,
+                sapling_root: *sapling_root,
+                orchard_root: *orchard_root,
+                auth_data_root: *auth_data_root,
+                ironwood_root: *ironwood_root,
+                sapling_tx,
+                orchard_tx,
+                ironwood_tx,
+            },
+        );
+    }
+
+    #[cfg(test)]
+    /// Deletes the half-open row range used by legacy serving tests.
+    pub fn delete_range_commitment_roots_by_height(
+        &mut self,
+        db: &ZakuraDb,
+        from: &Height,
+        until_strictly_before: &Height,
+    ) {
+        let _ = db
+            .commitment_roots_cf()
+            .with_batch_for_writing(self)
+            .zs_delete_range(from, until_strictly_before);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn production_root_column_access_is_centralized() {
+        let production_sources = [
+            ("block.rs", include_str!("block.rs")),
+            ("shielded.rs", include_str!("shielded.rs")),
+            ("rollback.rs", include_str!("rollback.rs")),
+            (
+                "block/startup_audit.rs",
+                include_str!("block/startup_audit.rs"),
+            ),
+        ];
+
+        for (path, source) in production_sources {
+            let compact = source.split_whitespace().collect::<String>();
+            assert!(
+                !compact.contains("cf_handle(COMMITMENT_ROOTS_BY_HEIGHT)"),
+                "{path} accesses the commitment-root column family directly",
+            );
+        }
+    }
+}

--- a/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
@@ -1100,11 +1100,11 @@ struct RetainedShieldedRoots {
 fn retained_shielded_roots(db: &ZakuraDb, target_height: Height) -> RetainedShieldedRoots {
     let mut retained = RetainedShieldedRoots::default();
 
-    for (_height, roots) in db.commitment_roots_for_migration(..=target_height) {
+    db.visit_commitment_roots_for_migration(..=target_height, |_height, roots| {
         retained.sapling.insert(roots.sapling_root);
         retained.orchard.insert(roots.orchard_root);
         retained.ironwood.insert(roots.ironwood_root);
-    }
+    });
 
     for (_height, tree) in db.sapling_tree_by_height_range(..=target_height) {
         retained.sapling.insert(tree.root());
@@ -1127,22 +1127,23 @@ fn prune_fast_commitment_anchors_from_index(
     target_height: Height,
     retained_roots: &RetainedShieldedRoots,
 ) {
-    let rolled_back_roots = db.commitment_roots_for_migration((
-        std::ops::Bound::Excluded(target_height),
-        std::ops::Bound::Unbounded,
-    ));
-
-    for (_height, roots) in rolled_back_roots {
-        if !retained_roots.sapling.contains(&roots.sapling_root) {
-            batch.delete_sapling_anchor(db, &roots.sapling_root);
-        }
-        if !retained_roots.orchard.contains(&roots.orchard_root) {
-            batch.delete_orchard_anchor(db, &roots.orchard_root);
-        }
-        if !retained_roots.ironwood.contains(&roots.ironwood_root) {
-            batch.delete_ironwood_anchor(db, &roots.ironwood_root);
-        }
-    }
+    db.visit_commitment_roots_for_migration(
+        (
+            std::ops::Bound::Excluded(target_height),
+            std::ops::Bound::Unbounded,
+        ),
+        |_height, roots| {
+            if !retained_roots.sapling.contains(&roots.sapling_root) {
+                batch.delete_sapling_anchor(db, &roots.sapling_root);
+            }
+            if !retained_roots.orchard.contains(&roots.orchard_root) {
+                batch.delete_orchard_anchor(db, &roots.orchard_root);
+            }
+            if !retained_roots.ironwood.contains(&roots.ironwood_root) {
+                batch.delete_ironwood_anchor(db, &roots.ironwood_root);
+            }
+        },
+    );
 }
 
 fn clear_backup_dir(path: &PathBuf) -> Result<(), std::io::Error> {

--- a/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
@@ -31,7 +31,6 @@ use crate::{
         finalized_state::{
             disk_db::{DiskWriteBatch, ReadDisk, WriteDisk},
             disk_format::{
-                shielded::CommitmentRootsByHeight,
                 transparent::{
                     AddressBalanceLocation, AddressTransaction, AddressUnspentOutput,
                     OutputLocation,
@@ -43,7 +42,7 @@ use crate::{
                 transparent::{BALANCE_BY_TRANSPARENT_ADDR, TX_LOC_BY_SPENT_OUT_LOC},
                 ZakuraDb,
             },
-            COMMITMENT_ROOTS_BY_HEIGHT, STATE_COLUMN_FAMILIES_IN_CODE,
+            STATE_COLUMN_FAMILIES_IN_CODE,
         },
         non_finalized_state::write_semantically_verified_backup_block,
     },
@@ -914,8 +913,6 @@ fn delete_zakura_headers_above(db: &ZakuraDb, batch: &mut DiskWriteBatch, target
         .db
         .cf_handle("zakura_header_body_size_by_height")
         .unwrap();
-    let roots_by_height = db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-
     let Some((tip_height, _tip_hash)) = db
         .db
         .zs_last_key_value::<_, Height, block::Hash>(&hash_by_height)
@@ -930,7 +927,10 @@ fn delete_zakura_headers_above(db: &ZakuraDb, batch: &mut DiskWriteBatch, target
         batch.zs_delete(&hash_by_height, height);
         batch.zs_delete(&header_by_height, height);
         batch.zs_delete(&body_size_by_height, height);
-        batch.zs_delete(&roots_by_height, height);
+    }
+
+    if let Ok(first_deleted) = target_height.next() {
+        batch.delete_header_reorg_commitment_roots(db, first_deleted, tip_height);
     }
 }
 
@@ -1045,7 +1045,7 @@ fn prune_tree_indexes(
 
     // Truncate the per-height commitment-roots serving index above the target, so a rolled-back
     // database does not serve roots for heights it no longer holds.
-    batch.delete_range_commitment_roots_by_height(db, &Height(target_height.0 + 1), &Height::MAX);
+    batch.truncate_commitment_roots_after(db, target_height);
 
     // Delete every sapling/orchard/ironwood subtree whose notes extend past the target height. Subtree
     // indexes are read back from the database and number far fewer than `u16::MAX`, so `index.0 + 1`
@@ -1100,17 +1100,10 @@ struct RetainedShieldedRoots {
 fn retained_shielded_roots(db: &ZakuraDb, target_height: Height) -> RetainedShieldedRoots {
     let mut retained = RetainedShieldedRoots::default();
 
-    let commitment_roots_by_height = db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-    for (_height, roots) in db
-        .db
-        .zs_forward_range_iter::<_, Height, CommitmentRootsByHeight, _>(
-            &commitment_roots_by_height,
-            ..=target_height,
-        )
-    {
-        retained.sapling.insert(roots.sapling);
-        retained.orchard.insert(roots.orchard);
-        retained.ironwood.insert(roots.ironwood);
+    for (_height, roots) in db.commitment_roots_for_migration(..=target_height) {
+        retained.sapling.insert(roots.sapling_root);
+        retained.orchard.insert(roots.orchard_root);
+        retained.ironwood.insert(roots.ironwood_root);
     }
 
     for (_height, tree) in db.sapling_tree_by_height_range(..=target_height) {
@@ -1134,27 +1127,20 @@ fn prune_fast_commitment_anchors_from_index(
     target_height: Height,
     retained_roots: &RetainedShieldedRoots,
 ) {
-    let commitment_roots_by_height = db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-    let rolled_back_roots: BTreeMap<_, CommitmentRootsByHeight> = db
-        .db
-        .zs_forward_range_iter(
-            &commitment_roots_by_height,
-            (
-                std::ops::Bound::Excluded(target_height),
-                std::ops::Bound::Unbounded,
-            ),
-        )
-        .collect();
+    let rolled_back_roots = db.commitment_roots_for_migration((
+        std::ops::Bound::Excluded(target_height),
+        std::ops::Bound::Unbounded,
+    ));
 
     for (_height, roots) in rolled_back_roots {
-        if !retained_roots.sapling.contains(&roots.sapling) {
-            batch.delete_sapling_anchor(db, &roots.sapling);
+        if !retained_roots.sapling.contains(&roots.sapling_root) {
+            batch.delete_sapling_anchor(db, &roots.sapling_root);
         }
-        if !retained_roots.orchard.contains(&roots.orchard) {
-            batch.delete_orchard_anchor(db, &roots.orchard);
+        if !retained_roots.orchard.contains(&roots.orchard_root) {
+            batch.delete_orchard_anchor(db, &roots.orchard_root);
         }
-        if !retained_roots.ironwood.contains(&roots.ironwood) {
-            batch.delete_ironwood_anchor(db, &roots.ironwood);
+        if !retained_roots.ironwood.contains(&roots.ironwood_root) {
+            batch.delete_ironwood_anchor(db, &roots.ironwood_root);
         }
     }
 }
@@ -1518,6 +1504,17 @@ mod tests {
             batch.zs_insert(&header_by_height, height, &header);
             // The value type is irrelevant to deletion-by-key; reuse `Height` as a stand-in.
             batch.zs_insert(&body_size_by_height, height, height);
+            batch.insert_commitment_roots_by_height(
+                &db,
+                height,
+                &sapling_root(h.into()),
+                &orchard_root(h.into()),
+                &ironwood_root(h.into()),
+                0,
+                0,
+                0,
+                &zakura_chain::block::merkle::AuthDataRoot::from([0u8; 32]),
+            );
         }
         db.write_batch(batch)
             .expect("seeding the header store succeeds");
@@ -1555,6 +1552,10 @@ mod tests {
                     .is_some(),
                 "height_by_hash retains the index for height {h}",
             );
+            assert!(
+                db.commitment_roots(height).is_some(),
+                "commitment roots retain height {h}",
+            );
         }
 
         // Heights 4..=5 (> target) are gone from every CF, including the hash→height index.
@@ -1583,6 +1584,10 @@ mod tests {
                     .zs_get::<_, _, Height>(&height_by_hash, &hash_at(h))
                     .is_none(),
                 "height_by_hash drops the index for height {h}",
+            );
+            assert!(
+                db.commitment_roots(height).is_none(),
+                "commitment roots drop height {h}",
             );
         }
     }

--- a/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
@@ -17,10 +17,8 @@ use std::{
     sync::Arc,
 };
 
-use std::ops::RangeInclusive;
-
 use zakura_chain::{
-    block::{merkle::AuthDataRoot, Height},
+    block::Height,
     ironwood, orchard,
     parallel::{commitment_aux::BlockCommitmentRoots, tree::NoteCommitmentTrees},
     sapling, sprout,
@@ -32,10 +30,9 @@ use crate::{
     request::{FinalizedBlock, Treestate},
     service::finalized_state::{
         disk_db::{DiskWriteBatch, ReadDisk, WriteDisk},
-        disk_format::{shielded::CommitmentRootsByHeight, RawBytes},
+        disk_format::RawBytes,
         vct::VctWriteData,
         zakura_db::ZakuraDb,
-        COMMITMENT_ROOTS_BY_HEIGHT,
     },
     MissingSproutTipTree, TransactionLocation, ValidateContextError,
 };
@@ -137,43 +134,6 @@ impl ZakuraDb {
     pub fn contains_orchard_anchor(&self, orchard_anchor: &orchard::tree::Root) -> bool {
         let orchard_anchors = self.db.cf_handle("orchard_anchors").unwrap();
         self.db.zs_contains(&orchard_anchors, &orchard_anchor)
-    }
-
-    /// Returns the per-block Sapling/Orchard commitment roots stored in the
-    /// `commitment_roots_by_height` serving index for the **contiguous** prefix of `range`
-    /// that is present, in ascending height order (design §4).
-    ///
-    /// Reads stop at the first absent height, so the result is always a gap-free run from
-    /// `range.start()` — exactly what the `tree_aux` `BlockRoots` serve and `fetch_roots`
-    /// client expect. A node populates this index for every block it commits (fast or
-    /// legacy), so a fast-synced node — which holds no per-height trees — can still serve
-    /// roots here. Returns an empty vec for a database written before the index existed
-    /// (e.g. a pre-index archive node), where the caller falls back to `produce_block_roots`.
-    pub fn commitment_roots_by_height_range(
-        &self,
-        range: RangeInclusive<Height>,
-    ) -> Vec<BlockCommitmentRoots> {
-        let cf = self.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-        let mut roots = Vec::new();
-        for height in (range.start().0..=range.end().0).map(Height) {
-            let Some(value) = self
-                .db
-                .zs_get::<_, _, CommitmentRootsByHeight>(&cf, &height)
-            else {
-                break;
-            };
-            roots.push(BlockCommitmentRoots {
-                height,
-                sapling_root: value.sapling,
-                orchard_root: value.orchard,
-                ironwood_root: value.ironwood,
-                sapling_tx: value.sapling_tx,
-                orchard_tx: value.orchard_tx,
-                ironwood_tx: value.ironwood_tx,
-                auth_data_root: value.auth_data_root,
-            });
-        }
-        roots
     }
 
     /// POC: returns `(sapling_count, sapling_digest, orchard_count, orchard_digest)`,
@@ -865,16 +825,18 @@ impl DiskWriteBatch {
             // Persist the per-height roots into the serving index even though no per-height
             // tree is written, so this fast-synced node can still serve `tree_aux` roots
             // (design §4); otherwise the root-serving fleet collapses as nodes fast-sync.
-            self.insert_commitment_roots_by_height(
+            self.insert_body_derived_commitment_roots(
                 zakura_db,
-                *height,
-                &sapling_root,
-                &orchard_root,
-                &ironwood_root,
-                sapling_tx,
-                orchard_tx,
-                ironwood_tx,
-                &auth_data_root,
+                &BlockCommitmentRoots {
+                    height: *height,
+                    sapling_root,
+                    orchard_root,
+                    ironwood_root,
+                    sapling_tx,
+                    orchard_tx,
+                    ironwood_tx,
+                    auth_data_root,
+                },
             );
             self.update_history_tree(zakura_db, history_tree);
             return Ok(());
@@ -923,16 +885,18 @@ impl DiskWriteBatch {
         // (not just when a tree changed — the index must be gap-free for contiguous serving),
         // so a legacy/archive node serves `tree_aux` roots from the compact index too, and a
         // node that later fast-syncs above this height already has the lower range covered.
-        self.insert_commitment_roots_by_height(
+        self.insert_body_derived_commitment_roots(
             zakura_db,
-            *height,
-            &note_commitment_trees.sapling.root(),
-            &note_commitment_trees.orchard.root(),
-            &note_commitment_trees.ironwood.root(),
-            sapling_tx,
-            orchard_tx,
-            ironwood_tx,
-            &auth_data_root,
+            &BlockCommitmentRoots {
+                height: *height,
+                sapling_root: note_commitment_trees.sapling.root(),
+                orchard_root: note_commitment_trees.orchard.root(),
+                ironwood_root: note_commitment_trees.ironwood.root(),
+                sapling_tx,
+                orchard_tx,
+                ironwood_tx,
+                auth_data_root,
+            },
         );
 
         self.update_history_tree(zakura_db, history_tree);
@@ -1027,57 +991,6 @@ impl DiskWriteBatch {
     pub fn insert_sapling_anchor(&mut self, zakura_db: &ZakuraDb, root: &sapling::tree::Root) {
         let sapling_anchors = zakura_db.db.cf_handle("sapling_anchors").unwrap();
         self.zs_insert(&sapling_anchors, root, ());
-    }
-
-    /// Inserts the per-height Sapling/Orchard commitment roots into the
-    /// `commitment_roots_by_height` serving index (design §4).
-    ///
-    /// Written on every committed block, fast or legacy, so any node — including a
-    /// fast-synced node that holds no per-height trees — can serve the `tree_aux`
-    /// `BlockRoots` read from this compact 64-byte-per-height index. Idempotent
-    /// (re-inserting the same height overwrites with the identical value).
-    #[allow(clippy::too_many_arguments)]
-    pub fn insert_commitment_roots_by_height(
-        &mut self,
-        zakura_db: &ZakuraDb,
-        height: Height,
-        sapling_root: &sapling::tree::Root,
-        orchard_root: &orchard::tree::Root,
-        ironwood_root: &ironwood::tree::Root,
-        sapling_tx: u64,
-        orchard_tx: u64,
-        ironwood_tx: u64,
-        auth_data_root: &AuthDataRoot,
-    ) {
-        let cf = zakura_db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-        self.zs_insert(
-            &cf,
-            height,
-            CommitmentRootsByHeight {
-                sapling: *sapling_root,
-                orchard: *orchard_root,
-                ironwood: *ironwood_root,
-                sapling_tx,
-                orchard_tx,
-                ironwood_tx,
-                auth_data_root: *auth_data_root,
-            },
-        );
-    }
-
-    /// Deletes the commitment-roots serving-index entries in `[from, to)`.
-    ///
-    /// Used by the finalized rollback to truncate the index above the rollback target, the
-    /// same way the per-height trees and anchors above the target are removed, so a
-    /// rolled-back database does not retain root entries for heights it no longer holds.
-    pub fn delete_range_commitment_roots_by_height(
-        &mut self,
-        zakura_db: &ZakuraDb,
-        from: &Height,
-        to: &Height,
-    ) {
-        let cf = zakura_db.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT).unwrap();
-        self.zs_delete_range(&cf, from, to);
     }
 
     /// Records the verified-commitment-trees fast-sync marker: per-height


### PR DESCRIPTION
## Motivation

Peer-supplied and body-derived commitment roots share one database index, but its reads, writes, and deletion policies were distributed across header commits, body commits, VCT repair, rollback, and startup repair. That made the later verified-only persistence boundary vulnerable to accidental bypasses.

## Solution

- add a state-owned commitment-root database façade for disk-row conversion, point and contiguous reads, and policy-specific mutations
- route body-derived replacement, legacy header insertion, reorg cleanup, rollback truncation, and startup repair through the façade
- preserve body-derived precedence and existing serving behavior while making contiguous reads stop at the first gap
- add regression coverage for gap handling, reorg and rollback suffix deletion, and direct column-family access

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-state`
- `cargo clippy -p zakura-state --all-targets -- -D warnings`
- IDE diagnostics report no errors in the changed state files

### Specifications & References

- Phase 0.8 of the proposed header-sync VCT root-authentication design in #230

### Follow-up Work

- make history-tree snapshot decoding fallible
- introduce the sealed verified-root type together with the database migration and durable authentication frontier