### PR TITLE
ci(sync): attribute halted audits to the failed run

### DIFF
--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -401,7 +401,20 @@ def audit_problem(data: dict[str, Any], max_completion_age: int) -> str | None:
     state = data.get("controller_state") or {}
     sample = data.get("sample") or {}
     if state.get("failed"):
-        return f"controller halted: {state.get('failure')}"
+        failed_sha = state.get("last_failed_sha")
+        failed_run = state.get("last_failed_run")
+        if failed_sha in (None, "") and failed_run in (None, ""):
+            failed_sha = state.get("running_sha")
+            failed_run = state.get("current_run")
+        provenance = (
+            ("sha", failed_sha),
+            ("run", failed_run),
+            ("failed_at", state.get("failed_at")),
+        )
+        suffix = "".join(
+            f" | {key}={value}" for key, value in provenance if value not in (None, "")
+        )
+        return f"controller halted: {state.get('failure')}{suffix}"
     if not data.get("service_active") and state.get("phase") == "syncing":
         return "node service inactive while controller says syncing"
     if sample.get("metrics_status") != "ok" and state.get("phase") == "syncing":

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -233,6 +233,84 @@ class ContinuousSyncTests(unittest.TestCase):
     def test_deploy_creates_zakurad_config_parent_directory(self):
         self.assertIn('dirname "$config_path"', deploy.INSTALL_SCRIPT)
 
+    def test_audit_problem_attributes_halt_to_failed_run(self):
+        problem = deploy.audit_problem(
+            {
+                "mode": "Zakura/v2-only",
+                "controller_state": {
+                    "failed": True,
+                    "failure": "height 2340298 made no progress for 601s",
+                    "running_sha": "stale-running-sha",
+                    "last_failed_sha": "361aff729ca1fa05615d814f2fc5a042108c9503",
+                    "current_run": "stale-current-run",
+                    "last_failed_run": "20260720T180000Z-361aff729ca1",
+                    "failed_at": "20260720T190554Z",
+                },
+            },
+            max_completion_age=0,
+        )
+
+        self.assertEqual(
+            problem,
+            "controller halted: height 2340298 made no progress for 601s"
+            " | sha=361aff729ca1fa05615d814f2fc5a042108c9503"
+            " | run=20260720T180000Z-361aff729ca1"
+            " | failed_at=20260720T190554Z"
+        )
+
+    def test_audit_problem_does_not_mix_partial_failed_provenance(self):
+        problem = deploy.audit_problem(
+            {
+                "controller_state": {
+                    "failed": True,
+                    "failure": "sync stalled",
+                    "running_sha": "newer-running-sha",
+                    "last_failed_sha": "failed-sha",
+                    "current_run": "newer-current-run",
+                    "failed_at": "20260720T190554Z",
+                },
+            },
+            max_completion_age=0,
+        )
+
+        self.assertEqual(
+            problem,
+            "controller halted: sync stalled"
+            " | sha=failed-sha"
+            " | failed_at=20260720T190554Z",
+        )
+
+    def test_audit_problem_uses_legacy_running_provenance(self):
+        problem = deploy.audit_problem(
+            {
+                "controller_state": {
+                    "failed": True,
+                    "failure": "build failed",
+                    "running_sha": "legacy-sha",
+                    "current_run": "legacy-run",
+                },
+            },
+            max_completion_age=0,
+        )
+
+        self.assertEqual(
+            problem,
+            "controller halted: build failed | sha=legacy-sha | run=legacy-run",
+        )
+
+    def test_audit_problem_keeps_legacy_halt_without_provenance(self):
+        problem = deploy.audit_problem(
+            {
+                "controller_state": {
+                    "failed": True,
+                    "failure": "build failed",
+                },
+            },
+            max_completion_age=0,
+        )
+
+        self.assertEqual(problem, "controller halted: build failed")
+
     def test_forced_ssh_wrapper_uses_current_status_script(self):
         self.assertIn(
             "exec /usr/local/sbin/zakura-monitor-status.py",


### PR DESCRIPTION
## Motivation

Scheduled audits replay durable halts without identifying the commit or run that failed. That can misattribute an old failure to a newer release.

## Solution

Include the failure-bound SHA, run ID, and failure time. Use the legacy running pair only when both failed-run fields are absent. Partial failed state never mixes with current state. State without provenance keeps the old line.

## Testing

- Four focused provenance tests pass.
- Both changed files parse with ast.parse.
- git diff --check passes.
- Full file result: 23 tests pass. Two unchanged symlink tests are blocked by native Windows WinError 1314.