### PR TITLE
refactor(network): align header range records internally

### DIFF
--- a/zakura-network/src/zakura/discovery/service.rs
+++ b/zakura-network/src/zakura/discovery/service.rs
@@ -773,10 +773,11 @@ mod tests {
     use crate::zakura::{
         framed_channel, spawn_block_sync_reactor, spawn_header_sync_reactor, BlockSyncFrontiers,
         BlockSyncStartup, HeaderSyncAction, HeaderSyncFrontiers, HeaderSyncMessage,
-        HeaderSyncPeerSession, HeaderSyncStartup, HeaderSyncStatus, ServicePeerLimits,
-        ZakuraBlockSyncConfig, ZakuraDiscoveryConfig, ZakuraDiscoveryLocalConfig,
-        ZakuraHandshakeConfig, ZakuraHeaderSyncConfig, LOCAL_MAX_MESSAGE_BYTES,
-        MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_BLOCK_SYNC, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
+        HeaderSyncPeerSession, HeaderSyncStartup, HeaderSyncStatus, HeaderSyncWireRequestIdentity,
+        ServicePeerLimits, ZakuraBlockSyncConfig, ZakuraDiscoveryConfig,
+        ZakuraDiscoveryLocalConfig, ZakuraHandshakeConfig, ZakuraHeaderSyncConfig,
+        LOCAL_MAX_MESSAGE_BYTES, MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_BLOCK_SYNC,
+        ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
     };
     use zakura_chain::{block, parameters::Network};
 
@@ -1082,12 +1083,12 @@ mod tests {
         fixture
             .header_sync
             .send(HeaderSyncEvent::WireHeaders {
-                peer: fixture.peer_id.clone(),
-                session_id: 0,
-                request_id,
-                headers: Vec::new(),
-                body_sizes: Vec::new(),
-                tree_aux_roots: Vec::new(),
+                wire_request: HeaderSyncWireRequestIdentity {
+                    peer: fixture.peer_id.clone(),
+                    session_id: 0,
+                    request_id,
+                },
+                entries: Vec::new(),
             })
             .await?;
         tokio::time::sleep(Duration::from_millis(20)).await;

--- a/zakura-network/src/zakura/header_sync/error.rs
+++ b/zakura-network/src/zakura/header_sync/error.rs
@@ -59,6 +59,24 @@ pub enum HeaderSyncWireError {
         count: u32,
     },
 
+    /// An aligned payload contained no header entries.
+    #[error("Zakura header-sync header range payload is empty")]
+    EmptyHeaderRangePayload,
+
+    /// An aligned payload entry did not have the next contiguous height.
+    #[error(
+        "Zakura header-sync entry height {entry_height:?} does not match expected height \
+         {expected_height:?} at offset {offset}"
+    )]
+    EntryHeightMismatch {
+        /// Zero-based entry offset within the payload.
+        offset: usize,
+        /// Expected contiguous entry height.
+        expected_height: block::Height,
+        /// Actual entry height.
+        entry_height: block::Height,
+    },
+
     /// A locally constructed `Headers` message had a different number of size hints.
     #[error("Zakura header-sync Headers body-size count {body_sizes} does not match header count {headers}")]
     BodySizeCountMismatch {

--- a/zakura-network/src/zakura/header_sync/error.rs
+++ b/zakura-network/src/zakura/header_sync/error.rs
@@ -52,7 +52,7 @@ pub enum HeaderSyncWireError {
     #[error(
         "Zakura header-sync range starting at {start:?} has invalid or overflowing count {count}"
     )]
-    InvalidRangeGeometry {
+    InvalidRange {
         /// First requested or delivered height.
         start: block::Height,
         /// Number of heights.

--- a/zakura-network/src/zakura/header_sync/events.rs
+++ b/zakura-network/src/zakura/header_sync/events.rs
@@ -224,18 +224,10 @@ pub enum HeaderSyncEvent {
     },
     /// Inbound `Headers` response with its mandatory request ID.
     WireHeaders {
-        /// Serving peer.
-        peer: ZakuraPeerId,
-        /// Ordered-stream generation that delivered the response.
-        session_id: u64,
-        /// Request ID echoed by the peer.
-        request_id: HeaderSyncRequestId,
-        /// Headers in ascending height order.
-        headers: Vec<Arc<block::Header>>,
-        /// Advisory serialized body sizes, parallel to `headers`.
-        body_sizes: Vec<u32>,
-        /// Per-height commitment roots, parallel to `headers`.
-        tree_aux_roots: Vec<BlockCommitmentRoots>,
+        /// Exact request identity for this response.
+        wire_request: HeaderSyncWireRequestIdentity,
+        /// Structurally aligned per-height records.
+        entries: Vec<HeaderRangeEntry>,
     },
     /// Inbound `GetHeaders` request with its mandatory request ID.
     WireGetHeaders {

--- a/zakura-network/src/zakura/header_sync/mod.rs
+++ b/zakura-network/src/zakura/header_sync/mod.rs
@@ -54,7 +54,7 @@ pub use events::{
     HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMisbehavior, HeaderSyncOperationIdentity,
     HeaderSyncOperationKind, HeaderSyncRequestId, HeaderSyncStartup, HeaderSyncWireRequestIdentity,
 };
-pub use range::{CheckedHeaderRange, HeaderRangePayload};
+pub use range::{CheckedHeaderRange, HeaderRangeEntry, HeaderRangePayload};
 pub use reactor::spawn_header_sync_reactor;
 pub use service::HeaderSyncPeerSession;
 pub(crate) use service::{

--- a/zakura-network/src/zakura/header_sync/pipe.rs
+++ b/zakura-network/src/zakura/header_sync/pipe.rs
@@ -416,8 +416,13 @@ pub(super) fn deliver(
         else {
             unreachable!("Headers frame type agreement guarantees a Headers message");
         };
-        let entries = HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
-            .expect("decoded Headers vectors are structurally aligned");
+        let entries = HeaderRangeEntry::from_parallel(
+            expected.start_height,
+            headers,
+            body_sizes,
+            tree_aux_roots,
+        )
+        .expect("decoded Headers vectors are structurally aligned");
         let request_id = request_id.expect("decoded Headers response has a mandatory request ID");
         return forward(
             handle,

--- a/zakura-network/src/zakura/header_sync/pipe.rs
+++ b/zakura-network/src/zakura/header_sync/pipe.rs
@@ -391,7 +391,7 @@ pub(super) fn deliver(
             return Flow::Reject(SinkReject::protocol(protocol_error));
         };
 
-        let (msg, _request_id) = match HeaderSyncMessage::decode_frame(
+        let (msg, request_id) = match HeaderSyncMessage::decode_frame(
             frame,
             HeaderSyncDecodeContext::for_headers_response(expected, expected.count),
         ) {
@@ -416,17 +416,18 @@ pub(super) fn deliver(
         else {
             unreachable!("Headers frame type agreement guarantees a Headers message");
         };
+        let entries = HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
+            .expect("decoded Headers vectors are structurally aligned");
+        let request_id = request_id.expect("decoded Headers response has a mandatory request ID");
         return forward(
             handle,
             HeaderSyncEvent::WireHeaders {
-                peer: peer_id,
-                session_id,
-                // The response was correlated by peeking this exact ID, so the
-                // decoded ID is the expectation's by construction.
-                request_id: expected.request_id,
-                headers,
-                body_sizes,
-                tree_aux_roots,
+                wire_request: HeaderSyncWireRequestIdentity {
+                    peer: peer_id,
+                    session_id,
+                    request_id,
+                },
+                entries,
             },
         );
     }
@@ -788,16 +789,16 @@ mod tests {
 
         assert!(matches!(pipe.run_one(second_frame), Flow::Continue(())));
         match events.try_recv() {
-            Ok(HeaderSyncEvent::WireHeaders { request_id, .. }) => {
-                assert_eq!(request_id, second_id);
+            Ok(HeaderSyncEvent::WireHeaders { wire_request, .. }) => {
+                assert_eq!(wire_request.request_id, second_id);
             }
             other => panic!("expected second response to be forwarded by id, got {other:?}"),
         }
 
         assert!(matches!(pipe.run_one(first_frame), Flow::Continue(())));
         match events.try_recv() {
-            Ok(HeaderSyncEvent::WireHeaders { request_id, .. }) => {
-                assert_eq!(request_id, first_id);
+            Ok(HeaderSyncEvent::WireHeaders { wire_request, .. }) => {
+                assert_eq!(wire_request.request_id, first_id);
             }
             other => panic!("expected first response to be forwarded by id, got {other:?}"),
         }

--- a/zakura-network/src/zakura/header_sync/range.rs
+++ b/zakura-network/src/zakura/header_sync/range.rs
@@ -6,6 +6,58 @@ use super::{
     *,
 };
 
+/// One header and all data associated with its height.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HeaderRangeEntry {
+    /// Header at this entry's implicit range height.
+    pub header: Arc<block::Header>,
+    /// Advisory serialized body-size hint.
+    pub body_size: u32,
+    /// Commitment roots when the response includes roots.
+    pub tree_aux_root: Option<BlockCommitmentRoots>,
+}
+
+impl HeaderRangeEntry {
+    /// Convert parallel vectors into aligned records at a system boundary.
+    pub fn from_parallel(
+        headers: Vec<Arc<block::Header>>,
+        body_sizes: Vec<u32>,
+        tree_aux_roots: Vec<BlockCommitmentRoots>,
+    ) -> Result<Vec<Self>, HeaderSyncWireError> {
+        validate_body_sizes_len(headers.len(), body_sizes.len())?;
+        validate_tree_aux_roots_len(headers.len(), tree_aux_roots.len())?;
+        let mut roots = if tree_aux_roots.is_empty() {
+            None
+        } else {
+            Some(tree_aux_roots.into_iter())
+        };
+        Ok(headers
+            .into_iter()
+            .zip(body_sizes)
+            .map(|(header, body_size)| Self {
+                header,
+                body_size,
+                tree_aux_root: roots.as_mut().and_then(Iterator::next),
+            })
+            .collect())
+    }
+
+    /// Split aligned records for APIs that still require parallel vectors.
+    pub fn into_parallel(
+        entries: Vec<Self>,
+    ) -> (Vec<Arc<block::Header>>, Vec<u32>, Vec<BlockCommitmentRoots>) {
+        let mut headers = Vec::with_capacity(entries.len());
+        let mut body_sizes = Vec::with_capacity(entries.len());
+        let mut roots = Vec::with_capacity(entries.len());
+        for entry in entries {
+            headers.push(entry.header);
+            body_sizes.push(entry.body_size);
+            roots.extend(entry.tree_aux_root);
+        }
+        (headers, body_sizes, roots)
+    }
+}
+
 /// A non-empty inclusive header-height range whose endpoint cannot overflow.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct CheckedHeaderRange {
@@ -59,39 +111,48 @@ impl CheckedHeaderRange {
 #[derive(Clone, Debug)]
 pub struct HeaderRangePayload {
     range: CheckedHeaderRange,
-    headers: Vec<Arc<block::Header>>,
-    body_sizes: Vec<u32>,
-    tree_aux_roots: Option<Vec<BlockCommitmentRoots>>,
+    entries: Vec<HeaderRangeEntry>,
 }
 
 impl HeaderRangePayload {
     /// Validate and construct an aligned payload.
     pub fn new(
         start: block::Height,
-        headers: Vec<Arc<block::Header>>,
-        body_sizes: Vec<u32>,
-        tree_aux_roots: Option<Vec<BlockCommitmentRoots>>,
+        entries: Vec<HeaderRangeEntry>,
     ) -> Result<Self, HeaderSyncWireError> {
-        validate_body_sizes_len(headers.len(), body_sizes.len())?;
-        if let Some(roots) = tree_aux_roots.as_ref() {
-            validate_tree_aux_roots_len(headers.len(), roots.len())?;
-            validate_tree_aux_root_heights(start, roots)?;
+        let root_count = entries
+            .iter()
+            .filter(|entry| entry.tree_aux_root.is_some())
+            .count();
+        if root_count != 0 && root_count != entries.len() {
+            return Err(HeaderSyncWireError::TreeAuxRootCountMismatch {
+                headers: entries.len(),
+                roots: root_count,
+            });
+        }
+        if root_count != 0 {
+            let roots = entries
+                .iter()
+                .map(|entry| {
+                    entry
+                        .tree_aux_root
+                        .as_ref()
+                        .expect("all payload entries have roots")
+                        .clone()
+                })
+                .collect::<Vec<_>>();
+            validate_tree_aux_root_heights(start, &roots)?;
         }
 
         let count =
-            u32::try_from(headers.len()).map_err(|_| HeaderSyncWireError::HeaderCountLimit {
-                actual: headers.len(),
+            u32::try_from(entries.len()).map_err(|_| HeaderSyncWireError::HeaderCountLimit {
+                actual: entries.len(),
                 max: usize::try_from(u32::MAX).unwrap_or(usize::MAX),
             })?;
         let range = CheckedHeaderRange::from_count(start, count)
             .ok_or(HeaderSyncWireError::InvalidRangeGeometry { start, count })?;
 
-        Ok(Self {
-            range,
-            headers,
-            body_sizes,
-            tree_aux_roots,
-        })
+        Ok(Self { range, entries })
     }
 
     /// Return the delivered height range.
@@ -99,19 +160,42 @@ impl HeaderRangePayload {
         self.range
     }
 
-    /// Return the delivered headers.
-    pub fn headers(&self) -> &[Arc<block::Header>] {
-        &self.headers
+    /// Return the structurally aligned entries.
+    pub fn entries(&self) -> &[HeaderRangeEntry] {
+        &self.entries
     }
 
-    /// Return the aligned body-size hints.
-    pub fn body_sizes(&self) -> &[u32] {
-        &self.body_sizes
+    /// Iterate over the delivered headers without cloning.
+    pub fn headers(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &Arc<block::Header>> + ExactSizeIterator {
+        self.entries.iter().map(|entry| &entry.header)
     }
 
-    /// Return the aligned roots when the request asked for them.
-    pub fn tree_aux_roots(&self) -> Option<&[BlockCommitmentRoots]> {
-        self.tree_aux_roots.as_deref()
+    /// Iterate over aligned body-size hints.
+    pub fn body_sizes(&self) -> impl DoubleEndedIterator<Item = u32> + ExactSizeIterator + '_ {
+        self.entries.iter().map(|entry| entry.body_size)
+    }
+
+    /// Iterate over aligned roots when every entry includes one.
+    pub fn tree_aux_roots(
+        &self,
+    ) -> Option<impl DoubleEndedIterator<Item = &BlockCommitmentRoots> + ExactSizeIterator> {
+        self.has_tree_aux_roots().then(|| {
+            self.entries.iter().map(|entry| {
+                entry
+                    .tree_aux_root
+                    .as_ref()
+                    .expect("rooted payload entries all have roots")
+            })
+        })
+    }
+
+    /// Return whether every entry includes a tree-aux root.
+    pub fn has_tree_aux_roots(&self) -> bool {
+        self.entries
+            .first()
+            .is_some_and(|entry| entry.tree_aux_root.is_some())
     }
 
     /// Keep only the part of this payload strictly after `covered_through`.
@@ -123,11 +207,7 @@ impl HeaderRangePayload {
 
         let covered_count = usize::try_from(suffix.start().0 - self.range.start().0)
             .expect("payload length fits in usize");
-        self.headers = self.headers.split_off(covered_count);
-        self.body_sizes = self.body_sizes.split_off(covered_count);
-        if let Some(roots) = self.tree_aux_roots.as_mut() {
-            *roots = roots.split_off(covered_count);
-        }
+        self.entries = self.entries.split_off(covered_count);
         self.range = suffix;
         Some(self)
     }
@@ -141,18 +221,25 @@ impl HeaderRangePayload {
         Vec<u32>,
         Option<Vec<BlockCommitmentRoots>>,
     ) {
-        (
-            self.range,
-            self.headers,
-            self.body_sizes,
-            self.tree_aux_roots,
-        )
+        let has_roots = self.has_tree_aux_roots();
+        let mut headers = Vec::with_capacity(self.entries.len());
+        let mut body_sizes = Vec::with_capacity(self.entries.len());
+        let mut roots = has_roots.then(|| Vec::with_capacity(self.entries.len()));
+        for entry in self.entries {
+            headers.push(entry.header);
+            body_sizes.push(entry.body_size);
+            if let (Some(roots), Some(root)) = (roots.as_mut(), entry.tree_aux_root) {
+                roots.push(root);
+            }
+        }
+        (self.range, headers, body_sizes, roots)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zakura_test::vectors::BLOCK_MAINNET_1_BYTES;
 
     #[test]
     fn checked_range_rejects_empty_reversed_and_overflowing_geometry() {
@@ -184,8 +271,8 @@ mod tests {
     }
 
     #[test]
-    fn payload_rejects_misaligned_body_sizes_before_buffering() {
-        let error = HeaderRangePayload::new(block::Height(1), Vec::new(), vec![1], None)
+    fn entry_conversion_rejects_misaligned_body_sizes() {
+        let error = HeaderRangeEntry::from_parallel(Vec::new(), vec![1], Vec::new())
             .expect_err("body sizes must align with headers");
 
         assert!(matches!(
@@ -193,6 +280,24 @@ mod tests {
             HeaderSyncWireError::BodySizeCountMismatch {
                 headers: 0,
                 body_sizes: 1,
+            }
+        ));
+    }
+
+    #[test]
+    fn entry_conversion_rejects_missing_roots_for_non_empty_headers() {
+        let header = Arc::new(
+            block::Header::zcash_deserialize(&BLOCK_MAINNET_1_BYTES[..])
+                .expect("test header parses"),
+        );
+        let error = HeaderRangeEntry::from_parallel(vec![header], vec![1], Vec::new())
+            .expect_err("roots must align with non-empty headers");
+
+        assert!(matches!(
+            error,
+            HeaderSyncWireError::TreeAuxRootCountMismatch {
+                headers: 1,
+                roots: 0,
             }
         ));
     }

--- a/zakura-network/src/zakura/header_sync/range.rs
+++ b/zakura-network/src/zakura/header_sync/range.rs
@@ -34,7 +34,7 @@ impl HeaderRangeEntry {
             })?;
         if count != 0 {
             CheckedHeaderRange::from_count(start, count)
-                .ok_or(HeaderSyncWireError::InvalidRangeGeometry { start, count })?;
+                .ok_or(HeaderSyncWireError::InvalidRange { start, count })?;
         }
         let mut roots = if tree_aux_roots.is_empty() {
             None
@@ -147,7 +147,7 @@ impl HeaderRangePayload {
                 max: usize::try_from(u32::MAX).unwrap_or(usize::MAX),
             })?;
         CheckedHeaderRange::from_count(first.height, count).ok_or(
-            HeaderSyncWireError::InvalidRangeGeometry {
+            HeaderSyncWireError::InvalidRange {
                 start: first.height,
                 count,
             },
@@ -159,7 +159,7 @@ impl HeaderRangePayload {
                 .0
                 .checked_add(1)
                 .map(block::Height)
-                .ok_or(HeaderSyncWireError::InvalidRangeGeometry {
+                .ok_or(HeaderSyncWireError::InvalidRange {
                     start: first.height,
                     count,
                 })?;

--- a/zakura-network/src/zakura/header_sync/range.rs
+++ b/zakura-network/src/zakura/header_sync/range.rs
@@ -1,15 +1,15 @@
 use super::{
     error::HeaderSyncWireError,
-    validation::{
-        validate_body_sizes_len, validate_tree_aux_root_heights, validate_tree_aux_roots_len,
-    },
+    validation::{validate_body_sizes_len, validate_tree_aux_roots_len},
     *,
 };
 
 /// One header and all data associated with its height.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HeaderRangeEntry {
-    /// Header at this entry's implicit range height.
+    /// Authoritative height for this entry.
+    pub height: block::Height,
+    /// Header at this entry's height.
     pub header: Arc<block::Header>,
     /// Advisory serialized body-size hint.
     pub body_size: u32,
@@ -20,12 +20,22 @@ pub struct HeaderRangeEntry {
 impl HeaderRangeEntry {
     /// Convert parallel vectors into aligned records at a system boundary.
     pub fn from_parallel(
+        start: block::Height,
         headers: Vec<Arc<block::Header>>,
         body_sizes: Vec<u32>,
         tree_aux_roots: Vec<BlockCommitmentRoots>,
     ) -> Result<Vec<Self>, HeaderSyncWireError> {
         validate_body_sizes_len(headers.len(), body_sizes.len())?;
         validate_tree_aux_roots_len(headers.len(), tree_aux_roots.len())?;
+        let count =
+            u32::try_from(headers.len()).map_err(|_| HeaderSyncWireError::HeaderCountLimit {
+                actual: headers.len(),
+                max: usize::try_from(u32::MAX).unwrap_or(usize::MAX),
+            })?;
+        if count != 0 {
+            CheckedHeaderRange::from_count(start, count)
+                .ok_or(HeaderSyncWireError::InvalidRangeGeometry { start, count })?;
+        }
         let mut roots = if tree_aux_roots.is_empty() {
             None
         } else {
@@ -34,10 +44,22 @@ impl HeaderRangeEntry {
         Ok(headers
             .into_iter()
             .zip(body_sizes)
-            .map(|(header, body_size)| Self {
-                header,
-                body_size,
-                tree_aux_root: roots.as_mut().and_then(Iterator::next),
+            .enumerate()
+            .map(|(offset, (header, body_size))| {
+                let offset =
+                    u32::try_from(offset).expect("header count was validated to fit in u32");
+                let height = block::Height(
+                    start
+                        .0
+                        .checked_add(offset)
+                        .expect("header range endpoint was checked before assigning heights"),
+                );
+                Self {
+                    height,
+                    header,
+                    body_size,
+                    tree_aux_root: roots.as_mut().and_then(Iterator::next),
+                }
             })
             .collect())
     }
@@ -110,16 +132,46 @@ impl CheckedHeaderRange {
 /// A non-empty delivered header range with structurally aligned per-height data.
 #[derive(Clone, Debug)]
 pub struct HeaderRangePayload {
-    range: CheckedHeaderRange,
     entries: Vec<HeaderRangeEntry>,
 }
 
 impl HeaderRangePayload {
     /// Validate and construct an aligned payload.
-    pub fn new(
-        start: block::Height,
-        entries: Vec<HeaderRangeEntry>,
-    ) -> Result<Self, HeaderSyncWireError> {
+    pub fn new(entries: Vec<HeaderRangeEntry>) -> Result<Self, HeaderSyncWireError> {
+        let first = entries
+            .first()
+            .ok_or(HeaderSyncWireError::EmptyHeaderRangePayload)?;
+        let count =
+            u32::try_from(entries.len()).map_err(|_| HeaderSyncWireError::HeaderCountLimit {
+                actual: entries.len(),
+                max: usize::try_from(u32::MAX).unwrap_or(usize::MAX),
+            })?;
+        CheckedHeaderRange::from_count(first.height, count).ok_or(
+            HeaderSyncWireError::InvalidRangeGeometry {
+                start: first.height,
+                count,
+            },
+        )?;
+
+        for (offset, adjacent) in entries.windows(2).enumerate() {
+            let expected_height = adjacent[0]
+                .height
+                .0
+                .checked_add(1)
+                .map(block::Height)
+                .ok_or(HeaderSyncWireError::InvalidRangeGeometry {
+                    start: first.height,
+                    count,
+                })?;
+            if adjacent[1].height != expected_height {
+                return Err(HeaderSyncWireError::EntryHeightMismatch {
+                    offset: offset + 1,
+                    expected_height,
+                    entry_height: adjacent[1].height,
+                });
+            }
+        }
+
         let root_count = entries
             .iter()
             .filter(|entry| entry.tree_aux_root.is_some())
@@ -131,33 +183,50 @@ impl HeaderRangePayload {
             });
         }
         if root_count != 0 {
-            let roots = entries
-                .iter()
-                .map(|entry| {
-                    entry
-                        .tree_aux_root
-                        .as_ref()
-                        .expect("all payload entries have roots")
-                        .clone()
-                })
-                .collect::<Vec<_>>();
-            validate_tree_aux_root_heights(start, &roots)?;
+            let first_root_height = entries
+                .first()
+                .and_then(|entry| entry.tree_aux_root.as_ref())
+                .expect("all payload entries have roots")
+                .height;
+            let last_root_height = entries
+                .last()
+                .and_then(|entry| entry.tree_aux_root.as_ref())
+                .expect("all payload entries have roots")
+                .height;
+            for (offset, entry) in entries.iter().enumerate() {
+                let root_height = entry
+                    .tree_aux_root
+                    .as_ref()
+                    .expect("all payload entries have roots")
+                    .height;
+                if root_height != entry.height {
+                    return Err(HeaderSyncWireError::TreeAuxRootHeightMismatch {
+                        offset,
+                        expected_height: entry.height,
+                        root_height,
+                        first_root_height,
+                        last_root_height,
+                    });
+                }
+            }
         }
 
-        let count =
-            u32::try_from(entries.len()).map_err(|_| HeaderSyncWireError::HeaderCountLimit {
-                actual: entries.len(),
-                max: usize::try_from(u32::MAX).unwrap_or(usize::MAX),
-            })?;
-        let range = CheckedHeaderRange::from_count(start, count)
-            .ok_or(HeaderSyncWireError::InvalidRangeGeometry { start, count })?;
-
-        Ok(Self { range, entries })
+        Ok(Self { entries })
     }
 
     /// Return the delivered height range.
     pub fn range(&self) -> CheckedHeaderRange {
-        self.range
+        CheckedHeaderRange::from_bounds(
+            self.entries
+                .first()
+                .expect("validated payload is non-empty")
+                .height,
+            self.entries
+                .last()
+                .expect("validated payload is non-empty")
+                .height,
+        )
+        .expect("validated payload entry heights are contiguous")
     }
 
     /// Return the structurally aligned entries.
@@ -200,15 +269,17 @@ impl HeaderRangePayload {
 
     /// Keep only the part of this payload strictly after `covered_through`.
     pub fn suffix_after(mut self, covered_through: block::Height) -> Option<Self> {
-        let suffix = self.range.suffix_after(covered_through)?;
-        if suffix == self.range {
+        let split_index = self
+            .entries
+            .partition_point(|entry| entry.height <= covered_through);
+        if split_index == self.entries.len() {
+            return None;
+        }
+        if split_index == 0 {
             return Some(self);
         }
 
-        let covered_count = usize::try_from(suffix.start().0 - self.range.start().0)
-            .expect("payload length fits in usize");
-        self.entries = self.entries.split_off(covered_count);
-        self.range = suffix;
+        self.entries = self.entries.split_off(split_index);
         Some(self)
     }
 
@@ -221,6 +292,7 @@ impl HeaderRangePayload {
         Vec<u32>,
         Option<Vec<BlockCommitmentRoots>>,
     ) {
+        let range = self.range();
         let has_roots = self.has_tree_aux_roots();
         let mut headers = Vec::with_capacity(self.entries.len());
         let mut body_sizes = Vec::with_capacity(self.entries.len());
@@ -232,14 +304,44 @@ impl HeaderRangePayload {
                 roots.push(root);
             }
         }
-        (self.range, headers, body_sizes, roots)
+        (range, headers, body_sizes, roots)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zakura_chain::{orchard, sapling};
     use zakura_test::vectors::BLOCK_MAINNET_1_BYTES;
+
+    fn header() -> Arc<block::Header> {
+        Arc::new(
+            block::Header::zcash_deserialize(&BLOCK_MAINNET_1_BYTES[..])
+                .expect("test header parses"),
+        )
+    }
+
+    fn root(height: block::Height) -> BlockCommitmentRoots {
+        BlockCommitmentRoots {
+            height,
+            sapling_root: sapling::tree::NoteCommitmentTree::default().root(),
+            orchard_root: orchard::tree::NoteCommitmentTree::default().root(),
+            ironwood_root: zakura_chain::ironwood::tree::NoteCommitmentTree::default().root(),
+            sapling_tx: 0,
+            orchard_tx: 0,
+            ironwood_tx: 0,
+            auth_data_root: block::merkle::AuthDataRoot::from([0u8; 32]),
+        }
+    }
+
+    fn entry(height: u32, body_size: u32, root_height: Option<u32>) -> HeaderRangeEntry {
+        HeaderRangeEntry {
+            height: block::Height(height),
+            header: header(),
+            body_size,
+            tree_aux_root: root_height.map(|height| root(block::Height(height))),
+        }
+    }
 
     #[test]
     fn checked_range_rejects_empty_reversed_and_overflowing_geometry() {
@@ -272,8 +374,9 @@ mod tests {
 
     #[test]
     fn entry_conversion_rejects_misaligned_body_sizes() {
-        let error = HeaderRangeEntry::from_parallel(Vec::new(), vec![1], Vec::new())
-            .expect_err("body sizes must align with headers");
+        let error =
+            HeaderRangeEntry::from_parallel(block::Height(1), Vec::new(), vec![1], Vec::new())
+                .expect_err("body sizes must align with headers");
 
         assert!(matches!(
             error,
@@ -286,12 +389,9 @@ mod tests {
 
     #[test]
     fn entry_conversion_rejects_missing_roots_for_non_empty_headers() {
-        let header = Arc::new(
-            block::Header::zcash_deserialize(&BLOCK_MAINNET_1_BYTES[..])
-                .expect("test header parses"),
-        );
-        let error = HeaderRangeEntry::from_parallel(vec![header], vec![1], Vec::new())
-            .expect_err("roots must align with non-empty headers");
+        let error =
+            HeaderRangeEntry::from_parallel(block::Height(1), vec![header()], vec![1], Vec::new())
+                .expect_err("roots must align with non-empty headers");
 
         assert!(matches!(
             error,
@@ -300,5 +400,80 @@ mod tests {
                 roots: 0,
             }
         ));
+    }
+
+    #[test]
+    fn entry_conversion_assigns_checked_contiguous_heights() {
+        let entries = HeaderRangeEntry::from_parallel(
+            block::Height(7),
+            vec![header(), header()],
+            vec![10, 20],
+            vec![root(block::Height(7)), root(block::Height(8))],
+        )
+        .expect("range geometry and parallel vectors are valid");
+
+        assert_eq!(
+            entries.iter().map(|entry| entry.height).collect::<Vec<_>>(),
+            vec![block::Height(7), block::Height(8)]
+        );
+    }
+
+    #[test]
+    fn payload_rejects_discontinuous_entry_heights() {
+        let error = HeaderRangePayload::new(vec![entry(7, 10, None), entry(9, 20, None)])
+            .expect_err("entry heights must be contiguous");
+
+        assert!(matches!(
+            error,
+            HeaderSyncWireError::EntryHeightMismatch {
+                offset: 1,
+                expected_height: block::Height(8),
+                entry_height: block::Height(9),
+            }
+        ));
+    }
+
+    #[test]
+    fn payload_rejects_root_height_different_from_entry_height() {
+        let error = HeaderRangePayload::new(vec![entry(7, 10, Some(8))])
+            .expect_err("root height must equal its entry height");
+
+        assert!(matches!(
+            error,
+            HeaderSyncWireError::TreeAuxRootHeightMismatch {
+                offset: 0,
+                expected_height: block::Height(7),
+                root_height: block::Height(8),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn payload_suffix_preserves_aligned_entry_data() {
+        let payload = HeaderRangePayload::new(vec![
+            entry(7, 10, None),
+            entry(8, 20, None),
+            entry(9, 30, None),
+        ])
+        .expect("entries form a valid payload");
+
+        let suffix = payload
+            .suffix_after(block::Height(7))
+            .expect("two-entry suffix remains");
+
+        assert_eq!(
+            suffix.range(),
+            CheckedHeaderRange::from_bounds(block::Height(8), block::Height(9))
+                .expect("bounds are ascending")
+        );
+        assert_eq!(
+            suffix
+                .entries()
+                .iter()
+                .map(|entry| (entry.height, entry.body_size))
+                .collect::<Vec<_>>(),
+            vec![(block::Height(8), 20), (block::Height(9), 30)]
+        );
     }
 }

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1462,13 +1462,10 @@ impl HeaderSyncReactor {
         };
         let peer_max_headers_per_response = peer_state.max_headers_per_response;
         let in_flight_count = peer_state.outstanding.len();
-        let (headers, body_sizes, tree_aux_roots) = HeaderRangeEntry::into_parallel(entries);
 
         self.handle_headers_for_outstanding(
             peer,
-            headers,
-            body_sizes,
-            tree_aux_roots,
+            entries,
             outstanding,
             peer_max_headers_per_response,
             in_flight_count,
@@ -1480,13 +1477,23 @@ impl HeaderSyncReactor {
     async fn handle_headers_for_outstanding(
         &mut self,
         peer: ZakuraPeerId,
-        headers: Vec<Arc<block::Header>>,
-        body_sizes: Vec<u32>,
-        tree_aux_roots: Vec<BlockCommitmentRoots>,
+        entries: Vec<HeaderRangeEntry>,
         mut outstanding: OutstandingRange,
         peer_max_headers_per_response: u32,
         in_flight_count: usize,
     ) {
+        let headers = entries
+            .iter()
+            .map(|entry| entry.header.clone())
+            .collect::<Vec<_>>();
+        let body_sizes = entries
+            .iter()
+            .map(|entry| entry.body_size)
+            .collect::<Vec<_>>();
+        let tree_aux_roots = entries
+            .iter()
+            .filter_map(|entry| entry.tree_aux_root.clone())
+            .collect::<Vec<_>>();
         if validate_body_sizes_len(headers.len(), body_sizes.len()).is_err()
             || validate_tree_aux_roots_len(headers.len(), tree_aux_roots.len()).is_err()
         {
@@ -1552,6 +1559,41 @@ impl HeaderSyncReactor {
             self.schedule().await;
             return;
         }
+
+        let payload = match HeaderRangePayload::new(entries) {
+            Ok(payload) if payload.range().start() == outstanding.range_request.start_height() => {
+                payload
+            }
+            Ok(payload) => {
+                let error = HeaderSyncWireError::EntryHeightMismatch {
+                    offset: 0,
+                    expected_height: outstanding.range_request.start_height(),
+                    entry_height: payload.range().start(),
+                };
+                tracing::debug!(
+                    ?peer,
+                    ?error,
+                    "Zakura header-sync rejected an entry range starting at the wrong height"
+                );
+                self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::MalformedMessage)
+                    .await;
+                self.retry_or_finish_outstanding(&peer, outstanding);
+                self.schedule().await;
+                return;
+            }
+            Err(error) => {
+                tracing::debug!(
+                    ?peer,
+                    ?error,
+                    "Zakura header-sync rejected malformed aligned header entries"
+                );
+                self.report_misbehavior(peer.clone(), HeaderSyncMisbehavior::MalformedMessage)
+                    .await;
+                self.retry_or_finish_outstanding(&peer, outstanding);
+                self.schedule().await;
+                return;
+            }
+        };
 
         if let Err(reason) =
             self.validate_vct_repair_response(&outstanding, &headers, &tree_aux_roots)
@@ -1672,10 +1714,6 @@ impl HeaderSyncReactor {
             return;
         }
 
-        let entries = HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
-            .expect("validated response vectors are aligned");
-        let payload = HeaderRangePayload::new(outstanding.range_request.start_height(), entries)
-            .expect("validated non-empty response has checked aligned payload data");
         let end_height = payload.range().end();
         if outstanding.range_request.finalized {
             let last_hash = payload

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -355,15 +355,11 @@ impl HeaderSyncReactor {
                 }
             }
             HeaderSyncEvent::WireHeaders {
-                peer,
-                session_id,
-                request_id,
-                headers,
-                body_sizes,
-                tree_aux_roots,
+                wire_request,
+                entries,
             } => {
-                if self.is_current_session(&peer, session_id) {
-                    self.handle_headers(peer, request_id, headers, body_sizes, tree_aux_roots)
+                if self.is_current_session(&wire_request.peer, wire_request.session_id) {
+                    self.handle_headers(wire_request.peer, wire_request.request_id, entries)
                         .await;
                 } else {
                     metrics::counter!("sync.header.session.stale_event").increment(1);
@@ -1444,14 +1440,12 @@ impl HeaderSyncReactor {
         peers
     }
 
-    #[tracing::instrument(skip(self, headers))]
+    #[tracing::instrument(skip(self, entries))]
     async fn handle_headers(
         &mut self,
         peer: ZakuraPeerId,
         request_id: HeaderSyncRequestId,
-        headers: Vec<Arc<block::Header>>,
-        body_sizes: Vec<u32>,
-        tree_aux_roots: Vec<BlockCommitmentRoots>,
+        entries: Vec<HeaderRangeEntry>,
     ) {
         metrics::counter!("sync.header.response.received").increment(1);
         let Some(peer_state) = self.state.peers.get_mut(&peer) else {
@@ -1468,6 +1462,7 @@ impl HeaderSyncReactor {
         };
         let peer_max_headers_per_response = peer_state.max_headers_per_response;
         let in_flight_count = peer_state.outstanding.len();
+        let (headers, body_sizes, tree_aux_roots) = HeaderRangeEntry::into_parallel(entries);
 
         self.handle_headers_for_outstanding(
             peer,
@@ -1677,16 +1672,10 @@ impl HeaderSyncReactor {
             return;
         }
 
-        let payload = HeaderRangePayload::new(
-            outstanding.range_request.start_height(),
-            headers,
-            body_sizes,
-            outstanding
-                .range_request
-                .want_tree_aux_roots
-                .then_some(tree_aux_roots),
-        )
-        .expect("validated non-empty response has checked aligned payload data");
+        let entries = HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
+            .expect("validated response vectors are aligned");
+        let payload = HeaderRangePayload::new(outstanding.range_request.start_height(), entries)
+            .expect("validated non-empty response has checked aligned payload data");
         let end_height = payload.range().end();
         if outstanding.range_request.finalized {
             let last_hash = payload

--- a/zakura-network/src/zakura/header_sync/reactor/trace.rs
+++ b/zakura-network/src/zakura/header_sync/reactor/trace.rs
@@ -818,6 +818,8 @@ pub(super) fn header_sync_wire_error_kind(error: &HeaderSyncWireError) -> &'stat
         HeaderSyncWireError::OversizedPayload { .. } => "oversized_payload",
         HeaderSyncWireError::HeaderCountLimit { .. } => "header_count_limit",
         HeaderSyncWireError::InvalidRangeGeometry { .. } => "invalid_range_geometry",
+        HeaderSyncWireError::EmptyHeaderRangePayload => "empty_header_range_payload",
+        HeaderSyncWireError::EntryHeightMismatch { .. } => "entry_height_mismatch",
         HeaderSyncWireError::BodySizeCountMismatch { .. } => "body_size_count_mismatch",
         HeaderSyncWireError::TreeAuxRootCountMismatch { .. } => "tree_aux_root_count_mismatch",
         HeaderSyncWireError::TreeAuxRootHeightMismatch { .. } => "tree_aux_root_height_mismatch",
@@ -1094,6 +1096,7 @@ mod tests {
                     request_id: request_id(),
                 },
                 entries: vec![HeaderRangeEntry {
+                    height: block::Height(1),
                     header: header.clone(),
                     body_size: 1,
                     tree_aux_root: None,
@@ -1199,14 +1202,12 @@ mod tests {
                 HeaderSyncAction::CommitHeaderRange {
                     operation: operation(peer.clone()),
                     anchor: block::Hash([0; 32]),
-                    payload: HeaderRangePayload::new(
-                        block::Height(1),
-                        vec![HeaderRangeEntry {
-                            header,
-                            body_size: 1,
-                            tree_aux_root: None,
-                        }],
-                    )
+                    payload: HeaderRangePayload::new(vec![HeaderRangeEntry {
+                        height: block::Height(1),
+                        header,
+                        body_size: 1,
+                        tree_aux_root: None,
+                    }])
                     .expect("test payload is aligned"),
                     finalized: false,
                 },
@@ -1364,6 +1365,18 @@ mod tests {
             (
                 HeaderSyncWireError::HeaderCountLimit { actual: 2, max: 1 },
                 "header_count_limit",
+            ),
+            (
+                HeaderSyncWireError::EmptyHeaderRangePayload,
+                "empty_header_range_payload",
+            ),
+            (
+                HeaderSyncWireError::EntryHeightMismatch {
+                    offset: 1,
+                    expected_height: block::Height(2),
+                    entry_height: block::Height(3),
+                },
+                "entry_height_mismatch",
             ),
             (
                 HeaderSyncWireError::BodySizeCountMismatch {

--- a/zakura-network/src/zakura/header_sync/reactor/trace.rs
+++ b/zakura-network/src/zakura/header_sync/reactor/trace.rs
@@ -817,7 +817,7 @@ pub(super) fn header_sync_wire_error_kind(error: &HeaderSyncWireError) -> &'stat
     match error {
         HeaderSyncWireError::OversizedPayload { .. } => "oversized_payload",
         HeaderSyncWireError::HeaderCountLimit { .. } => "header_count_limit",
-        HeaderSyncWireError::InvalidRangeGeometry { .. } => "invalid_range_geometry",
+        HeaderSyncWireError::InvalidRange { .. } => "invalid_range",
         HeaderSyncWireError::EmptyHeaderRangePayload => "empty_header_range_payload",
         HeaderSyncWireError::EntryHeightMismatch { .. } => "entry_height_mismatch",
         HeaderSyncWireError::BodySizeCountMismatch { .. } => "body_size_count_mismatch",

--- a/zakura-network/src/zakura/header_sync/reactor/trace.rs
+++ b/zakura-network/src/zakura/header_sync/reactor/trace.rs
@@ -444,10 +444,13 @@ fn trace_event_fields(row: &mut serde_json::Map<String, Value>, event: &HeaderSy
             insert_peer(row, hs_trace::PEER, peer);
             trace_header_sync_message_fields(row, msg);
         }
-        HeaderSyncEvent::WireHeaders { peer, headers, .. } => {
+        HeaderSyncEvent::WireHeaders {
+            wire_request,
+            entries,
+        } => {
             insert_optional_str(row, hs_trace::KIND, Some("wire_headers"));
-            insert_peer(row, hs_trace::PEER, peer);
-            insert_u64(row, hs_trace::RANGE_COUNT, headers.len() as u64);
+            insert_peer(row, hs_trace::PEER, &wire_request.peer);
+            insert_u64(row, hs_trace::RANGE_COUNT, entries.len() as u64);
         }
         HeaderSyncEvent::WireGetHeaders {
             peer,
@@ -939,7 +942,7 @@ mod tests {
         header_sync::{
             events::HeaderSyncFrontiers, service::HeaderSyncPeerSession, state::RangePriority,
         },
-        HeaderRangePayload, HeaderSyncOperationIdentity, HeaderSyncOperationKind,
+        HeaderRangeEntry, HeaderRangePayload, HeaderSyncOperationIdentity, HeaderSyncOperationKind,
         HeaderSyncServiceSummary, HeaderSyncWireRequestIdentity,
     };
 
@@ -1085,12 +1088,16 @@ mod tests {
                 msg: HeaderSyncMessage::Status(status()),
             },
             HeaderSyncEvent::WireHeaders {
-                peer: peer.clone(),
-                session_id: 7,
-                request_id: request_id(),
-                headers: vec![header.clone()],
-                body_sizes: vec![1],
-                tree_aux_roots: Vec::new(),
+                wire_request: HeaderSyncWireRequestIdentity {
+                    peer: peer.clone(),
+                    session_id: 7,
+                    request_id: request_id(),
+                },
+                entries: vec![HeaderRangeEntry {
+                    header: header.clone(),
+                    body_size: 1,
+                    tree_aux_root: None,
+                }],
             },
             HeaderSyncEvent::WireGetHeaders {
                 peer: peer.clone(),
@@ -1192,8 +1199,15 @@ mod tests {
                 HeaderSyncAction::CommitHeaderRange {
                     operation: operation(peer.clone()),
                     anchor: block::Hash([0; 32]),
-                    payload: HeaderRangePayload::new(block::Height(1), vec![header], vec![1], None)
-                        .expect("test payload is aligned"),
+                    payload: HeaderRangePayload::new(
+                        block::Height(1),
+                        vec![HeaderRangeEntry {
+                            header,
+                            body_size: 1,
+                            tree_aux_root: None,
+                        }],
+                    )
+                    .expect("test payload is aligned"),
                     finalized: false,
                 },
                 "commit_header_range",

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1067,15 +1067,29 @@ async fn send_headers(
     else {
         panic!("send_headers requires a Headers message");
     };
+    let entries = if !headers.is_empty() && tree_aux_roots.is_empty() {
+        headers
+            .into_iter()
+            .zip(body_sizes)
+            .map(|(header, body_size)| HeaderRangeEntry {
+                header,
+                body_size,
+                tree_aux_root: None,
+            })
+            .collect()
+    } else {
+        HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
+            .expect("test response vectors align")
+    };
     fixture
         .handle
         .send(HeaderSyncEvent::WireHeaders {
-            peer: peer.clone(),
-            session_id: 0,
-            request_id,
-            headers,
-            body_sizes,
-            tree_aux_roots,
+            wire_request: HeaderSyncWireRequestIdentity {
+                peer: peer.clone(),
+                session_id: 0,
+                request_id,
+            },
+            entries,
         })
         .await
         .unwrap();
@@ -2028,7 +2042,7 @@ async fn vct_repair_bypasses_covered_range_and_commits_exact_h_and_successor() {
                 assert_eq!(operation.wire_request.peer, peer_id);
                 assert_eq!(payload.range().start(), block::Height(1));
                 assert_eq!(payload.headers().len(), 2);
-                assert_eq!(payload.tree_aux_roots().map(<[_]>::len), Some(2),);
+                assert_eq!(payload.tree_aux_roots().map(|roots| roots.len()), Some(2));
                 assert!(
                     !finalized,
                     "repair ranges are canonical but not checkpoint-terminating"
@@ -5056,24 +5070,34 @@ async fn replacement_session_ignores_old_wire_response_with_reused_id() {
     fixture
         .handle
         .send(HeaderSyncEvent::WireHeaders {
-            peer: peer_id.clone(),
-            session_id: 1,
-            request_id,
-            headers: headers.clone(),
-            body_sizes: vec![0],
-            tree_aux_roots: roots_from_height(block::Height(4), 1),
+            wire_request: HeaderSyncWireRequestIdentity {
+                peer: peer_id.clone(),
+                session_id: 1,
+                request_id,
+            },
+            entries: HeaderRangeEntry::from_parallel(
+                headers.clone(),
+                vec![0],
+                roots_from_height(block::Height(4), 1),
+            )
+            .expect("test response vectors align"),
         })
         .await
         .unwrap();
     fixture
         .handle
         .send(HeaderSyncEvent::WireHeaders {
-            peer: peer_id.clone(),
-            session_id: 2,
-            request_id,
-            headers,
-            body_sizes: vec![0],
-            tree_aux_roots: roots_from_height(block::Height(4), 1),
+            wire_request: HeaderSyncWireRequestIdentity {
+                peer: peer_id.clone(),
+                session_id: 2,
+                request_id,
+            },
+            entries: HeaderRangeEntry::from_parallel(
+                headers,
+                vec![0],
+                roots_from_height(block::Height(4), 1),
+            )
+            .expect("test response vectors align"),
         })
         .await
         .unwrap();
@@ -5931,10 +5955,15 @@ async fn partial_coverage_trims_and_commits_an_already_buffered_suffix() {
             next_non_query_action(&mut fixture.actions).await
         {
             assert_eq!(payload.range().start(), block::Height(4));
-            assert_eq!(payload.headers(), [mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
-            assert_eq!(payload.body_sizes(), [44]);
             assert_eq!(
-                payload.tree_aux_roots().map(|roots| roots[0].height),
+                payload.headers().cloned().collect::<Vec<_>>(),
+                [mainnet_header(&BLOCK_MAINNET_4_BYTES)]
+            );
+            assert_eq!(payload.body_sizes().collect::<Vec<_>>(), [44]);
+            assert_eq!(
+                payload
+                    .tree_aux_roots()
+                    .and_then(|mut roots| roots.next().map(|root| root.height)),
                 Some(block::Height(4))
             );
             break;
@@ -5997,7 +6026,10 @@ async fn loaded_best_tip_reconciles_outstanding_and_buffered_work() {
             next_non_query_action(&mut fixture.actions).await
         {
             assert_eq!(payload.range().start(), block::Height(4));
-            assert_eq!(payload.headers(), [mainnet_header(&BLOCK_MAINNET_4_BYTES)]);
+            assert_eq!(
+                payload.headers().cloned().collect::<Vec<_>>(),
+                [mainnet_header(&BLOCK_MAINNET_4_BYTES)]
+            );
             break;
         }
     }

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -1072,13 +1072,18 @@ async fn send_headers(
             .into_iter()
             .zip(body_sizes)
             .map(|(header, body_size)| HeaderRangeEntry {
+                height: test_header_height(header.as_ref()),
                 header,
                 body_size,
                 tree_aux_root: None,
             })
             .collect()
     } else {
-        HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
+        let start = tree_aux_roots
+            .first()
+            .map(|root| root.height)
+            .unwrap_or(block::Height(0));
+        HeaderRangeEntry::from_parallel(start, headers, body_sizes, tree_aux_roots)
             .expect("test response vectors align")
     };
     fixture
@@ -5076,6 +5081,7 @@ async fn replacement_session_ignores_old_wire_response_with_reused_id() {
                 request_id,
             },
             entries: HeaderRangeEntry::from_parallel(
+                block::Height(4),
                 headers.clone(),
                 vec![0],
                 roots_from_height(block::Height(4), 1),
@@ -5093,6 +5099,7 @@ async fn replacement_session_ignores_old_wire_response_with_reused_id() {
                 request_id,
             },
             entries: HeaderRangeEntry::from_parallel(
+                block::Height(4),
                 headers,
                 vec![0],
                 roots_from_height(block::Height(4), 1),

--- a/zakura-network/src/zakura/header_sync/validation.rs
+++ b/zakura-network/src/zakura/header_sync/validation.rs
@@ -115,11 +115,12 @@ pub async fn validate_headers_stateless(
 }
 
 /// Check that a header range links to its anchor and is internally contiguous.
-pub fn validate_header_range_links(
+pub fn validate_header_range_links<'a>(
     anchor: block::Hash,
-    headers: &[Arc<block::Header>],
+    headers: impl IntoIterator<Item = &'a Arc<block::Header>>,
 ) -> Result<(), HeaderSyncWireError> {
-    let Some(first) = headers.first() else {
+    let mut headers = headers.into_iter();
+    let Some(first) = headers.next() else {
         return Ok(());
     };
 
@@ -127,7 +128,14 @@ pub fn validate_header_range_links(
         return Err(HeaderSyncWireError::FirstHeaderDoesNotLink);
     }
 
-    validate_internal_continuity(headers)
+    let mut previous_hash = block::Hash::from(first.as_ref());
+    for header in headers {
+        if previous_hash != header.previous_block_hash {
+            return Err(HeaderSyncWireError::NonContiguousHeaders);
+        }
+        previous_hash = block::Hash::from(header.as_ref());
+    }
+    Ok(())
 }
 
 /// Run all context-free validation checks for an inbound full-block tip flood.

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -734,6 +734,7 @@ mod tests {
             node: usize,
             peer: ZakuraPeerId,
             request_id: HeaderSyncRequestId,
+            start_height: block::Height,
             msg: HeaderSyncMessage,
         ) {
             let HeaderSyncMessage::Headers {
@@ -753,8 +754,13 @@ mod tests {
                         session_id: E2E_SESSION_ID,
                         request_id,
                     },
-                    entries: HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
-                        .expect("test response vectors align"),
+                    entries: HeaderRangeEntry::from_parallel(
+                        start_height,
+                        headers,
+                        body_sizes,
+                        tree_aux_roots,
+                    )
+                    .expect("test response vectors align"),
                 })
                 .await
                 .unwrap();
@@ -1008,6 +1014,7 @@ mod tests {
                                     request_id,
                                 },
                                 entries: HeaderRangeEntry::from_parallel(
+                                    start,
                                     headers,
                                     body_sizes,
                                     tree_aux_roots,
@@ -3471,7 +3478,12 @@ mod tests {
                 victim,
                 out_of_range,
                 request_id,
-                headers_message(vec![mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone()]),
+                block::Height(1),
+                HeaderSyncMessage::Headers {
+                    headers: vec![mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone()],
+                    body_sizes: vec![0],
+                    tree_aux_roots: roots_from_height(block::Height(1), 1),
+                },
             )
             .await;
         cluster
@@ -3513,6 +3525,7 @@ mod tests {
                 victim,
                 response_too_long,
                 request_id,
+                block::Height(1),
                 headers_message(vec![
                     mainnet_block(&BLOCK_MAINNET_1_BYTES).header.clone(),
                     mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone(),
@@ -3552,6 +3565,7 @@ mod tests {
                 bad_continuity_victim,
                 bad_continuity,
                 request_id,
+                block::Height(1),
                 headers_message(vec![
                     mainnet_block(&BLOCK_MAINNET_1_BYTES).header.clone(),
                     Arc::new(non_contiguous),
@@ -3585,6 +3599,7 @@ mod tests {
                 bad_pow_victim,
                 bad_pow,
                 request_id,
+                block::Height(1),
                 headers_message(vec![Arc::new(bad_pow_header)]),
             )
             .await;
@@ -3619,6 +3634,7 @@ mod tests {
                 bad_daa_victim,
                 bad_daa,
                 request_id,
+                block::Height(1),
                 headers_message(vec![
                     mainnet_block(&BLOCK_MAINNET_1_BYTES).header.clone(),
                     mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone(),

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -152,11 +152,12 @@ mod tests {
             block_sync::{MAX_BS_FRAME_BYTES, ZAKURA_CAP_BLOCK_SYNC, ZAKURA_STREAM_BLOCK_SYNC},
             spawn_header_sync_reactor, BlockApplyResult, BlockSizeEstimate, BlockSyncAction,
             BlockSyncBlockMeta, BlockSyncEvent, BlockSyncFrontiers, BlockSyncMessage,
-            BlockSyncStatus, DiscoveryMessage, Frame, FramedRecv, FramedSend, HeaderSyncAction,
-            HeaderSyncCommitFailureKind, HeaderSyncDecodeContext, HeaderSyncEvent,
-            HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMessage, HeaderSyncMisbehavior,
-            HeaderSyncOperationIdentity, HeaderSyncPeerSession, HeaderSyncRequestId,
-            HeaderSyncStartup, HeaderSyncStatus, Peer, Service, ServicePeerLimits, Stream,
+            BlockSyncStatus, DiscoveryMessage, Frame, FramedRecv, FramedSend, HeaderRangeEntry,
+            HeaderSyncAction, HeaderSyncCommitFailureKind, HeaderSyncDecodeContext,
+            HeaderSyncEvent, HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMessage,
+            HeaderSyncMisbehavior, HeaderSyncOperationIdentity, HeaderSyncPeerSession,
+            HeaderSyncRequestId, HeaderSyncStartup, HeaderSyncStatus,
+            HeaderSyncWireRequestIdentity, Peer, Service, ServicePeerLimits, Stream,
             ZakuraBlockSyncConfig, ZakuraConnId, ZakuraHeaderSyncConfig, ZakuraLocalLimits,
             ZakuraTrace, MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
             ZAKURA_CAP_LEGACY_GOSSIP, ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_STREAM_DISCOVERY,
@@ -747,12 +748,13 @@ mod tests {
                 .view
                 .handle
                 .send(HeaderSyncEvent::WireHeaders {
-                    peer,
-                    session_id: E2E_SESSION_ID,
-                    request_id,
-                    headers,
-                    body_sizes,
-                    tree_aux_roots,
+                    wire_request: HeaderSyncWireRequestIdentity {
+                        peer,
+                        session_id: E2E_SESSION_ID,
+                        request_id,
+                    },
+                    entries: HeaderRangeEntry::from_parallel(headers, body_sizes, tree_aux_roots)
+                        .expect("test response vectors align"),
                 })
                 .await
                 .unwrap();
@@ -999,13 +1001,18 @@ mod tests {
                         let _ = nodes[*target]
                             .handle
                             .send(HeaderSyncEvent::WireHeaders {
-                                peer: local.peer_id.clone(),
-                                session_id: E2E_SESSION_ID,
-                                // Echo the requester's ID, exactly as the wire does.
-                                request_id,
-                                headers,
-                                body_sizes,
-                                tree_aux_roots,
+                                wire_request: HeaderSyncWireRequestIdentity {
+                                    peer: local.peer_id.clone(),
+                                    session_id: E2E_SESSION_ID,
+                                    // Echo the requester's ID, exactly as the wire does.
+                                    request_id,
+                                },
+                                entries: HeaderRangeEntry::from_parallel(
+                                    headers,
+                                    body_sizes,
+                                    tree_aux_roots,
+                                )
+                                .expect("test response vectors align"),
                             })
                             .await;
                         let _ = local


### PR DESCRIPTION
## Motivation

Header-sync responses still cross internal async boundaries as separate header, body-size, and root vectors after v7 decoding. Keeping those vectors independent makes trimming and buffering vulnerable to per-height misalignment even though the wire payload has already been validated.

## Solution

- introduce `HeaderRangeEntry` to bind one header to its body-size hint and optional roots
- convert v7 parallel vectors into entries immediately after decoding
- store and trim one entry vector in `HeaderRangePayload`
- carry the existing `HeaderSyncWireRequestIdentity` through `WireHeaders`
- keep `HeaderSyncMessage`, the v7 byte layout, and stream version unchanged

## Testing

- `cargo fmt --all`
- `cargo test -p zakura-network --lib zakura::header_sync` (165 passed)
- `cargo clippy -p zakura-network --lib --tests -- -D warnings`
- IDE diagnostics: clean

### Specifications & References

- Follow-up to #298

### Follow-up Work

A stacked v8 PR will make correlated wire messages self-contained and serialize aligned entries atomically.