### PR TITLE
ci(docs): stop link-checking this repository's own PR and issue links

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -21,6 +21,12 @@ exclude = [
     # Template placeholder URLs (0000)
     "^https://github.com/.*/issues/0000",
     "^https://github.com/.*/pull/0000",
+    # This repository's own PR/issue links (changelogs carry hundreds). They are
+    # machine-generated against merged PRs, which never disappear, so the only
+    # way they fail is GitHub itself erroring (502s during incidents) — a
+    # recurring source of docs-check flakes with zero real signal.
+    "^https://github.com/zakura-core/zakura/pull/[0-9]+",
+    "^https://github.com/zakura-core/zakura/issues/[0-9]+",
     # Mergify dashboard (requires auth)
     "^https://dashboard.mergify.com/",
     # IACR eprint server returns 403 to automated link checkers


### PR DESCRIPTION
The changelogs carry hundreds of machine-generated `zakura-core/zakura` pull/issue links. Merged PRs never disappear, so these links only fail when github.com itself errors (502s during incidents), which has repeatedly flaked `docs-check` with zero real signal, even with the authenticated token (lychee treats a received 502 as final and does not retry it). Exclude them like the existing compare/run/settings link classes; external and cross-repo links stay checked.

The PR's own `docs-check` run validates the config and demonstrates the reduced check set.

Implemented with Claude Code; design and review by the PR author.