### PR TITLE
refactor(network)!: encode aligned header entries in v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   preventing ban-list maintenance from slowing as the 20,000-IP bound fills
   ([#286](https://github.com/zakura-core/zakura/pull/286)).
 
+### Changed
+
+- Require header-sync peer protocol v8, with self-contained correlated messages and
+  atomically interleaved header response records. Header-sync v7 peers are incompatible.
+
 ## [1.0.2] - 2026-07-20
 
 ### Added

--- a/zakura-network/src/zakura/discovery/service.rs
+++ b/zakura-network/src/zakura/discovery/service.rs
@@ -1066,13 +1066,11 @@ mod tests {
             loop {
                 if let Some(HeaderSyncAction::SendMessage {
                     peer,
-                    request_id,
-                    msg: HeaderSyncMessage::GetHeaders { .. },
+                    msg: HeaderSyncMessage::GetHeaders { request_id, .. },
                 }) = fixture.header_actions.recv().await
                 {
                     if peer == fixture.peer_id {
-                        return request_id
-                            .expect("an outbound GetHeaders always carries a request ID");
+                        return request_id;
                     }
                 }
             }

--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -213,7 +213,7 @@ const _: () =
     assert!(LEGACY_REQUEST_STREAM_KIND == super::legacy_gossip::ZAKURA_STREAM_LEGACY_REQUESTS);
 const _: () = assert!(DISCOVERY_STREAM_KIND == super::discovery::ZAKURA_STREAM_DISCOVERY);
 const _: () = assert!(HEADER_SYNC_STREAM_KIND == super::header_sync::ZAKURA_STREAM_HEADER_SYNC);
-const _: () = assert!(ZAKURA_STREAM_VERSION_7 == ZAKURA_HEADER_SYNC_STREAM_VERSION);
+const _: () = assert!(ZAKURA_STREAM_VERSION_8 == ZAKURA_HEADER_SYNC_STREAM_VERSION);
 const _: () =
     assert!(LEGACY_REQUEST_BLOCKS_BY_HASH == super::legacy_gossip::MSG_REQUEST_BLOCKS_BY_HASH);
 const _: () = assert!(
@@ -4585,10 +4585,12 @@ fn should_run_freshness_reaper(
 }
 
 /// The stream-kind versions this handler serves. Most known kinds are at version 1;
-/// header sync is at version 7, which correlates each `Headers` response with the
-/// request that solicited it. Earlier header-sync versions are not served.
+/// header sync is at version 8, which carries self-contained correlated messages
+/// and atomically interleaved header records. Earlier versions are not served.
 const ZAKURA_STREAM_VERSION_1: u16 = 1;
+#[cfg(test)]
 const ZAKURA_STREAM_VERSION_7: u16 = 7;
+const ZAKURA_STREAM_VERSION_8: u16 = 8;
 
 /// Returns whether the handler can serve a stream with this kind and version.
 ///
@@ -5964,14 +5966,14 @@ mod tests {
             flags: 0,
             payload: Vec::new(),
         };
+        let request_id = HeaderSyncRequestId::new(1).expect("non-zero request id");
         let get_headers_frame = HeaderSyncMessage::GetHeaders {
+            request_id,
             start_height: block::Height(1),
             count: 1,
             want_tree_aux_roots: false,
         }
-        .encode_frame(Some(
-            HeaderSyncRequestId::new(1).expect("non-zero request id"),
-        ))?;
+        .encode_frame()?;
 
         let (gossip_result, request_result, header_sync_result) = tokio::join!(
             async { registry.deliver(peer.clone(), LEGACY_GOSSIP_STREAM_KIND, gossip_frame) },
@@ -6050,7 +6052,7 @@ mod tests {
         task.await?;
 
         let valid_status_frame =
-            HeaderSyncMessage::Status(status_at_genesis(&Network::Mainnet)).encode_frame(None)?;
+            HeaderSyncMessage::Status(status_at_genesis(&Network::Mainnet)).encode_frame()?;
         let valid_result =
             service.deliver_frame(peer.clone(), HEADER_SYNC_STREAM_KIND, valid_status_frame);
         assert!(
@@ -7701,7 +7703,7 @@ mod tests {
                 },
                 Stream {
                     kind: HEADER_SYNC_STREAM_KIND,
-                    version: ZAKURA_STREAM_VERSION_7,
+                    version: ZAKURA_STREAM_VERSION_8,
                     frame_cap: 1024,
                     capability: ZAKURA_CAP_HEADER_SYNC,
                     mode: StreamMode::Ordered,
@@ -7721,7 +7723,7 @@ mod tests {
             (LEGACY_GOSSIP_STREAM_KIND, ZAKURA_STREAM_VERSION_1),
             (LEGACY_REQUEST_STREAM_KIND, ZAKURA_STREAM_VERSION_1),
             (DISCOVERY_STREAM_KIND, ZAKURA_STREAM_VERSION_1),
-            (HEADER_SYNC_STREAM_KIND, ZAKURA_STREAM_VERSION_7),
+            (HEADER_SYNC_STREAM_KIND, ZAKURA_STREAM_VERSION_8),
             (ZAKURA_STREAM_BLOCK_SYNC, ZAKURA_STREAM_VERSION_1),
         ] {
             assert!(
@@ -7741,6 +7743,10 @@ mod tests {
         assert!(
             !is_supported_stream(&registry, HEADER_SYNC_STREAM_KIND, ZAKURA_STREAM_VERSION_1),
             "header-sync v1 is rejected because native header sync uses exact version matching"
+        );
+        assert!(
+            !is_supported_stream(&registry, HEADER_SYNC_STREAM_KIND, ZAKURA_STREAM_VERSION_7),
+            "header-sync v7 is rejected because v8 changed the correlated message API and layout"
         );
         assert!(
             !is_supported_stream(&registry, HEADER_SYNC_STREAM_KIND, 5),

--- a/zakura-network/src/zakura/header_sync/error.rs
+++ b/zakura-network/src/zakura/header_sync/error.rs
@@ -132,7 +132,7 @@ pub enum HeaderSyncWireError {
     UnsolicitedHeaders,
 
     /// A request-id capable header-sync message was missing its request ID.
-    #[error("Zakura header-sync v7 {message} message is missing a request ID")]
+    #[error("Zakura header-sync v8 {message} message is missing a request ID")]
     MissingRequestId {
         /// Message that required the ID.
         message: &'static str,

--- a/zakura-network/src/zakura/header_sync/events.rs
+++ b/zakura-network/src/zakura/header_sync/events.rs
@@ -376,8 +376,6 @@ pub enum HeaderSyncAction {
     SendMessage {
         /// Destination peer.
         peer: ZakuraPeerId,
-        /// Request ID the session allocated, for correlated messages.
-        request_id: Option<HeaderSyncRequestId>,
         /// Message that was queued.
         msg: HeaderSyncMessage,
     },

--- a/zakura-network/src/zakura/header_sync/pipe.rs
+++ b/zakura-network/src/zakura/header_sync/pipe.rs
@@ -391,7 +391,7 @@ pub(super) fn deliver(
             return Flow::Reject(SinkReject::protocol(protocol_error));
         };
 
-        let (msg, request_id) = match HeaderSyncMessage::decode_frame(
+        let msg = match HeaderSyncMessage::decode_frame(
             frame,
             HeaderSyncDecodeContext::for_headers_response(expected, expected.count),
         ) {
@@ -409,21 +409,16 @@ pub(super) fn deliver(
         };
 
         let HeaderSyncMessage::Headers {
-            headers,
-            body_sizes,
-            tree_aux_roots,
+            request_id,
+            entries,
         } = msg
         else {
             unreachable!("Headers frame type agreement guarantees a Headers message");
         };
-        let entries = HeaderRangeEntry::from_parallel(
-            expected.start_height,
-            headers,
-            body_sizes,
-            tree_aux_roots,
-        )
-        .expect("decoded Headers vectors are structurally aligned");
-        let request_id = request_id.expect("decoded Headers response has a mandatory request ID");
+        debug_assert_eq!(
+            request_id, expected.request_id,
+            "decoded Headers request ID matches the ID used for correlation"
+        );
         return forward(
             handle,
             HeaderSyncEvent::WireHeaders {
@@ -437,7 +432,7 @@ pub(super) fn deliver(
         );
     }
 
-    let (msg, request_id) = match decode_control_frame(frame) {
+    let msg = match decode_control_frame(frame) {
         Ok(msg) => msg,
         Err(error) => {
             let protocol_error =
@@ -450,15 +445,13 @@ pub(super) fn deliver(
         }
     };
 
-    match (msg, request_id) {
-        (
-            HeaderSyncMessage::GetHeaders {
-                start_height,
-                count,
-                want_tree_aux_roots,
-            },
-            Some(request_id),
-        ) => forward(
+    match msg {
+        HeaderSyncMessage::GetHeaders {
+            request_id,
+            start_height,
+            count,
+            want_tree_aux_roots,
+        } => forward(
             handle,
             HeaderSyncEvent::WireGetHeaders {
                 peer: peer_id,
@@ -469,10 +462,7 @@ pub(super) fn deliver(
                 want_tree_aux_roots,
             },
         ),
-        // A `GetHeaders` without a request ID cannot reach here: the decoder rejects
-        // a missing or zero ID before returning. Every other message type is
-        // uncorrelated and carries none.
-        (msg, _) => forward(
+        msg => forward(
             handle,
             HeaderSyncEvent::SessionWireMessage {
                 peer: peer_id,
@@ -556,9 +546,7 @@ fn forward(handle: &HeaderSyncHandle, event: HeaderSyncEvent) -> Flow<()> {
 /// in [`deliver`]; a `Headers` frame reaching this path has no correlated
 /// request, so it is rejected as `UnsolicitedHeaders` exactly as the old
 /// `decode_header_sync_frame` did.
-fn decode_control_frame(
-    frame: Frame,
-) -> Result<(HeaderSyncMessage, Option<HeaderSyncRequestId>), HeaderSyncWireError> {
+fn decode_control_frame(frame: Frame) -> Result<HeaderSyncMessage, HeaderSyncWireError> {
     if u8::try_from(frame.message_type).ok() == Some(MSG_HS_HEADERS) {
         return Err(HeaderSyncWireError::UnsolicitedHeaders);
     }
@@ -780,17 +768,18 @@ mod tests {
             run_inbound,
             &PIPE_SHAPE,
         );
-        let empty_headers = HeaderSyncMessage::Headers {
-            headers: Vec::new(),
-            body_sizes: Vec::new(),
-            tree_aux_roots: Vec::new(),
-        };
-        let second_frame = empty_headers
-            .encode_frame(Some(second_id))
-            .expect("v7 response encodes");
-        let first_frame = empty_headers
-            .encode_frame(Some(first_id))
-            .expect("v7 response encodes");
+        let second_frame = HeaderSyncMessage::Headers {
+            request_id: second_id,
+            entries: Vec::new(),
+        }
+        .encode_frame()
+        .expect("v8 response encodes");
+        let first_frame = HeaderSyncMessage::Headers {
+            request_id: first_id,
+            entries: Vec::new(),
+        }
+        .encode_frame()
+        .expect("v8 response encodes");
 
         assert!(matches!(pipe.run_one(second_frame), Flow::Continue(())));
         match events.try_recv() {
@@ -808,9 +797,12 @@ mod tests {
             other => panic!("expected first response to be forwarded by id, got {other:?}"),
         }
 
-        let duplicate = empty_headers
-            .encode_frame(Some(second_id))
-            .expect("duplicate v7 response encodes");
+        let duplicate = HeaderSyncMessage::Headers {
+            request_id: second_id,
+            entries: Vec::new(),
+        }
+        .encode_frame()
+        .expect("duplicate v8 response encodes");
         assert!(matches!(pipe.run_one(duplicate), Flow::Done));
         assert!(matches!(
             events.try_recv(),
@@ -838,12 +830,11 @@ mod tests {
         );
         for _ in 0..2 {
             let frame = HeaderSyncMessage::Headers {
-                headers: Vec::new(),
-                body_sizes: Vec::new(),
-                tree_aux_roots: Vec::new(),
+                request_id,
+                entries: Vec::new(),
             }
-            .encode_frame(Some(request_id))
-            .expect("v7 response encodes");
+            .encode_frame()
+            .expect("v8 response encodes");
 
             assert!(matches!(pipe.run_one(frame), Flow::Done));
             assert!(matches!(
@@ -961,12 +952,11 @@ mod tests {
             &PIPE_SHAPE,
         );
         let frame = HeaderSyncMessage::Headers {
-            headers: Vec::new(),
-            body_sizes: Vec::new(),
-            tree_aux_roots: Vec::new(),
+            request_id,
+            entries: Vec::new(),
         }
-        .encode_frame(Some(request_id))
-        .expect("v7 response encodes");
+        .encode_frame()
+        .expect("v8 response encodes");
 
         assert!(matches!(pipe.run_one(frame), Flow::Reject(_)));
         match events.try_recv() {
@@ -1028,10 +1018,10 @@ mod tests {
                 .expect("block 2 vector parses"),
         );
         let frame_one = HeaderSyncMessage::NewBlock(block_one.clone())
-            .encode_frame(None)
+            .encode_frame()
             .expect("new block frame encodes");
         let frame_two = HeaderSyncMessage::NewBlock(block_two.clone())
-            .encode_frame(None)
+            .encode_frame()
             .expect("new block frame encodes");
 
         let mut pipe = Pipe::new(
@@ -1093,20 +1083,25 @@ mod tests {
                 .expect("block 1 vector parses"),
         );
         let solicited_headers = HeaderSyncMessage::Headers {
-            headers: vec![block_one.header.clone()],
-            body_sizes: vec![0],
-            tree_aux_roots: vec![BlockCommitmentRoots {
+            request_id,
+            entries: vec![HeaderRangeEntry {
                 height: block::Height(1),
-                sapling_root: sapling::tree::NoteCommitmentTree::default().root(),
-                orchard_root: orchard::tree::NoteCommitmentTree::default().root(),
-                ironwood_root: zakura_chain::ironwood::tree::NoteCommitmentTree::default().root(),
-                sapling_tx: 0,
-                orchard_tx: 0,
-                ironwood_tx: 0,
-                auth_data_root: block::merkle::AuthDataRoot::from([0u8; 32]),
+                header: block_one.header.clone(),
+                body_size: 0,
+                tree_aux_root: Some(BlockCommitmentRoots {
+                    height: block::Height(1),
+                    sapling_root: sapling::tree::NoteCommitmentTree::default().root(),
+                    orchard_root: orchard::tree::NoteCommitmentTree::default().root(),
+                    ironwood_root: zakura_chain::ironwood::tree::NoteCommitmentTree::default()
+                        .root(),
+                    sapling_tx: 0,
+                    orchard_tx: 0,
+                    ironwood_tx: 0,
+                    auth_data_root: block::merkle::AuthDataRoot::from([0u8; 32]),
+                }),
             }],
         }
-        .encode_frame(Some(request_id))
+        .encode_frame()
         .expect("headers frame encodes");
 
         let mut pipe = Pipe::new(

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -268,8 +268,8 @@ impl HeaderSyncReactor {
                         #[cfg(test)]
                         let _ = self.actions.try_send(HeaderSyncAction::SendMessage {
                             peer: requester_id.peer,
-                            request_id: Some(request_id),
                             msg: HeaderSyncMessage::GetHeaders {
+                                request_id,
                                 start_height: range.start_height(),
                                 count: range.count(),
                                 want_tree_aux_roots: range.want_tree_aux_roots,
@@ -1199,6 +1199,7 @@ impl HeaderSyncReactor {
         }
         let send_result = peer_state.session.try_send_headers_with_sizes_and_roots(
             request_id,
+            start_height,
             headers,
             body_sizes,
             tree_aux_roots,
@@ -1802,7 +1803,8 @@ impl HeaderSyncReactor {
             };
 
             let invalid = self.state.buffered.get(&key).and_then(|buffered| {
-                validate_header_range_links(anchor, buffered.payload.headers()).err()
+                let headers = buffered.payload.headers().cloned().collect::<Vec<_>>();
+                validate_header_range_links(anchor, &headers).err()
             });
             if let Some(error) = invalid {
                 let buffered = self
@@ -2385,6 +2387,7 @@ impl HeaderSyncReactor {
     fn publish_work_metrics(&self) {
         let (in_flight, buffered, committing) = self.state.schedule.active_counts();
         let header_bytes = header_sync_header_bytes_for_network(&self.startup.network)
+            .saturating_add(HEADER_SYNC_HEIGHT_BYTES)
             .saturating_add(HEADER_SYNC_BODY_SIZE_BYTES);
         let buffered_headers = self
             .state
@@ -2397,7 +2400,7 @@ impl HeaderSyncReactor {
             .buffered
             .values()
             .map(|range| {
-                let root_bytes = if range.payload.tree_aux_roots().is_some() {
+                let root_bytes = if range.payload.has_tree_aux_roots() {
                     HEADER_SYNC_BLOCK_COMMITMENT_ROOTS_BYTES
                 } else {
                     0
@@ -2539,7 +2542,6 @@ impl HeaderSyncReactor {
                 #[cfg(test)]
                 let _ = self.actions.try_send(HeaderSyncAction::SendMessage {
                     peer: peer.clone(),
-                    request_id: None,
                     msg: HeaderSyncMessage::Status(status),
                 });
                 true

--- a/zakura-network/src/zakura/header_sync/reactor/trace.rs
+++ b/zakura-network/src/zakura/header_sync/reactor/trace.rs
@@ -737,11 +737,11 @@ fn trace_header_sync_message_fields(
                 u64::from(status.max_inflight_requests),
             );
         }
-        HeaderSyncMessage::Headers { headers, .. } => {
+        HeaderSyncMessage::Headers { entries, .. } => {
             insert_u64(
                 row,
                 hs_trace::RANGE_COUNT,
-                u64::try_from(headers.len()).unwrap_or(u64::MAX),
+                u64::try_from(entries.len()).unwrap_or(u64::MAX),
             );
         }
         HeaderSyncMessage::GetHeaders {
@@ -1183,7 +1183,6 @@ mod tests {
             (
                 HeaderSyncAction::SendMessage {
                     peer: peer.clone(),
-                    request_id: None,
                     msg: HeaderSyncMessage::Status(status()),
                 },
                 "send_message",
@@ -1294,11 +1293,16 @@ mod tests {
         let messages = [
             HeaderSyncMessage::Status(status()),
             HeaderSyncMessage::Headers {
-                headers: vec![block.header.clone()],
-                body_sizes: vec![123],
-                tree_aux_roots: Vec::new(),
+                request_id: request_id(),
+                entries: vec![HeaderRangeEntry {
+                    height: block::Height(1),
+                    header: block.header.clone(),
+                    body_size: 123,
+                    tree_aux_root: None,
+                }],
             },
             HeaderSyncMessage::GetHeaders {
+                request_id: request_id(),
                 start_height: block::Height(4),
                 count: 5,
                 want_tree_aux_roots: true,

--- a/zakura-network/src/zakura/header_sync/requester.rs
+++ b/zakura-network/src/zakura/header_sync/requester.rs
@@ -237,18 +237,17 @@ mod tests {
             event => panic!("unexpected requester event: {event:?}"),
         }
         let frame = frames.recv().await.expect("request frame is queued");
-        let (message, decoded_request_id) =
-            HeaderSyncMessage::decode(&frame.payload, HeaderSyncDecodeContext::control())
-                .expect("request frame decodes");
+        let message = HeaderSyncMessage::decode(&frame.payload, HeaderSyncDecodeContext::control())
+            .expect("request frame decodes");
         assert_eq!(
             message,
             HeaderSyncMessage::GetHeaders {
+                request_id,
                 start_height: range.start_height(),
                 count: range.count(),
                 want_tree_aux_roots: range.want_tree_aux_roots,
             }
         );
-        assert_eq!(decoded_request_id, Some(request_id));
 
         shutdown.cancel();
         assert!(matches!(

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -199,7 +199,7 @@ impl HeaderSyncPeerSession {
 
     /// Send a typed status advertisement.
     pub fn try_send_status(&self, status: HeaderSyncStatus) -> Result<(), OrderedSendError> {
-        self.try_send_message(HeaderSyncMessage::Status(status), None)
+        self.try_send_message(HeaderSyncMessage::Status(status))
     }
 
     /// Prepare a correlated header request without making its frame visible to the peer.
@@ -214,11 +214,12 @@ impl HeaderSyncPeerSession {
             ExpectedHeadersResponse::new(request_id, start_height, count, want_tree_aux_roots)
                 .map_err(|error| OrderedSendError::Encode(Box::new(error)))?;
         let frame = HeaderSyncMessage::GetHeaders {
+            request_id,
             start_height,
             count,
             want_tree_aux_roots,
         }
-        .encode_frame(Some(request_id))
+        .encode_frame()
         .map_err(|error| OrderedSendError::Encode(Box::new(error)))?;
 
         let reservation = ExpectedHeadersReservation::new(self.inner.commands.clone(), expected)?;
@@ -235,32 +236,28 @@ impl HeaderSyncPeerSession {
     pub fn try_send_headers_with_sizes_and_roots(
         &self,
         request_id: HeaderSyncRequestId,
+        start_height: block::Height,
         headers: Vec<Arc<block::Header>>,
         body_sizes: Vec<u32>,
         tree_aux_roots: Vec<BlockCommitmentRoots>,
     ) -> Result<(), OrderedSendError> {
-        self.try_send_message(
-            HeaderSyncMessage::Headers {
-                headers,
-                body_sizes,
-                tree_aux_roots,
-            },
-            Some(request_id),
-        )
+        let entries =
+            HeaderRangeEntry::from_parallel(start_height, headers, body_sizes, tree_aux_roots)
+                .map_err(|error| OrderedSendError::Encode(Box::new(error)))?;
+        self.try_send_message(HeaderSyncMessage::Headers {
+            request_id,
+            entries,
+        })
     }
 
     /// Send a typed full tip block announcement.
     pub fn try_send_new_block(&self, block: Arc<block::Block>) -> Result<(), OrderedSendError> {
-        self.try_send_message(HeaderSyncMessage::NewBlock(block), None)
+        self.try_send_message(HeaderSyncMessage::NewBlock(block))
     }
 
-    fn try_send_message(
-        &self,
-        msg: HeaderSyncMessage,
-        request_id: Option<HeaderSyncRequestId>,
-    ) -> Result<(), OrderedSendError> {
+    fn try_send_message(&self, msg: HeaderSyncMessage) -> Result<(), OrderedSendError> {
         let frame = msg
-            .encode_frame(request_id)
+            .encode_frame()
             .map_err(|error| OrderedSendError::Encode(Box::new(error)))?;
         match self.inner.send.try_send(frame) {
             Ok(()) => Ok(()),

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -192,9 +192,9 @@ fn headers_message_from(
     let body_sizes = vec![0; headers.len()];
     let tree_aux_roots = roots_from_height(start_height, headers.len());
     HeaderSyncMessage::Headers {
-        headers,
-        body_sizes,
-        tree_aux_roots,
+        request_id: test_request_id(),
+        entries: HeaderRangeEntry::from_parallel(start_height, headers, body_sizes, tree_aux_roots)
+            .expect("test response vectors align"),
     }
 }
 
@@ -208,9 +208,9 @@ fn headers_message_with_sizes(
         .unwrap_or(block::Height(1));
     let tree_aux_roots = roots_from_height(start_height, headers.len());
     HeaderSyncMessage::Headers {
-        headers,
-        body_sizes,
-        tree_aux_roots,
+        request_id: test_request_id(),
+        entries: HeaderRangeEntry::from_parallel(start_height, headers, body_sizes, tree_aux_roots)
+            .expect("test response vectors align"),
     }
 }
 
@@ -218,12 +218,28 @@ fn rootless_headers_message_from(
     start_height: block::Height,
     headers: Vec<Arc<block::Header>>,
 ) -> HeaderSyncMessage {
-    let _ = start_height;
     let body_sizes = vec![0; headers.len()];
     HeaderSyncMessage::Headers {
-        headers,
-        body_sizes,
-        tree_aux_roots: Vec::new(),
+        request_id: test_request_id(),
+        entries: headers
+            .into_iter()
+            .zip(body_sizes)
+            .enumerate()
+            .map(|(offset, (header, body_size))| {
+                let offset = u32::try_from(offset).expect("test header count fits in u32");
+                HeaderRangeEntry {
+                    height: block::Height(
+                        start_height
+                            .0
+                            .checked_add(offset)
+                            .expect("test header range does not overflow"),
+                    ),
+                    header,
+                    body_size,
+                    tree_aux_root: None,
+                }
+            })
+            .collect(),
     }
 }
 
@@ -242,9 +258,9 @@ fn finalized_headers_message_from(
     let body_sizes = vec![0; headers.len()];
     let tree_aux_roots = roots_from_height(start_height, headers.len());
     HeaderSyncMessage::Headers {
-        headers,
-        body_sizes,
-        tree_aux_roots,
+        request_id: test_request_id(),
+        entries: HeaderRangeEntry::from_parallel(start_height, headers, body_sizes, tree_aux_roots)
+            .expect("test response vectors align"),
     }
 }
 
@@ -258,9 +274,9 @@ fn finalized_headers_message_with_sizes(
         .unwrap_or(block::Height(1));
     let tree_aux_roots = roots_from_height(start_height, headers.len());
     HeaderSyncMessage::Headers {
-        headers,
-        body_sizes,
-        tree_aux_roots,
+        request_id: test_request_id(),
+        entries: HeaderRangeEntry::from_parallel(start_height, headers, body_sizes, tree_aux_roots)
+            .expect("test response vectors align"),
     }
 }
 
@@ -351,7 +367,7 @@ async fn send_get_headers(
 
 /// Encode a correlated message under [`test_request_id`].
 fn encode_correlated(message: &HeaderSyncMessage) -> Result<Vec<u8>, HeaderSyncWireError> {
-    message.encode(Some(test_request_id()))
+    message.encode()
 }
 
 fn headers_context(count: u32, peer_cap: u32) -> HeaderSyncDecodeContext {
@@ -777,17 +793,18 @@ async fn advisory_summary_status_mismatch_uses_status_without_misbehavior_and_ba
             }
             HeaderSyncAction::SendMessage {
                 peer,
-                request_id: sent_request_id,
                 msg:
                     HeaderSyncMessage::GetHeaders {
+                        request_id: message_request_id,
                         start_height,
                         count,
                         want_tree_aux_roots: true,
+                        ..
                     },
             } if peer == peer_id => {
                 assert_eq!(start_height, block::Height(1));
                 assert_eq!(count, 1);
-                request_id = sent_request_id;
+                request_id = Some(message_request_id);
                 saw_status_authoritative_request = true;
                 break;
             }
@@ -850,12 +867,15 @@ async fn advisory_backoff_is_pruned_on_peer_disconnected() {
     {
         if let HeaderSyncAction::SendMessage {
             peer,
-            request_id: sent_request_id,
-            msg: HeaderSyncMessage::GetHeaders { .. },
+            msg:
+                HeaderSyncMessage::GetHeaders {
+                    request_id: sent_request_id,
+                    ..
+                },
         } = action
         {
             if peer == peer_id {
-                request_id = sent_request_id;
+                request_id = Some(sent_request_id);
                 break;
             }
         }
@@ -1012,21 +1032,15 @@ async fn next_outbound_get_headers(
         match next_non_query_action(actions).await {
             HeaderSyncAction::SendMessage {
                 peer,
-                request_id,
                 msg:
                     HeaderSyncMessage::GetHeaders {
+                        request_id,
                         start_height,
                         count,
                         want_tree_aux_roots: true,
+                        ..
                     },
-            } => {
-                return (
-                    peer,
-                    request_id.expect("an outbound GetHeaders always carries a request ID"),
-                    start_height,
-                    count,
-                )
-            }
+            } => return (peer, request_id, start_height, count),
             HeaderSyncAction::Misbehavior { peer, reason } => {
                 panic!("unexpected misbehavior from {peer:?}: {reason:?}")
             }
@@ -1042,12 +1056,11 @@ async fn next_get_headers_request_id(
 ) -> HeaderSyncRequestId {
     loop {
         if let HeaderSyncAction::SendMessage {
-            request_id,
-            msg: HeaderSyncMessage::GetHeaders { .. },
+            msg: HeaderSyncMessage::GetHeaders { request_id, .. },
             ..
         } = next_non_query_action(actions).await
         {
-            return request_id.expect("an outbound GetHeaders always carries a request ID");
+            return request_id;
         }
     }
 }
@@ -1059,32 +1072,8 @@ async fn send_headers(
     request_id: HeaderSyncRequestId,
     msg: HeaderSyncMessage,
 ) {
-    let HeaderSyncMessage::Headers {
-        headers,
-        body_sizes,
-        tree_aux_roots,
-    } = msg
-    else {
+    let HeaderSyncMessage::Headers { entries, .. } = msg else {
         panic!("send_headers requires a Headers message");
-    };
-    let entries = if !headers.is_empty() && tree_aux_roots.is_empty() {
-        headers
-            .into_iter()
-            .zip(body_sizes)
-            .map(|(header, body_size)| HeaderRangeEntry {
-                height: test_header_height(header.as_ref()),
-                header,
-                body_size,
-                tree_aux_root: None,
-            })
-            .collect()
-    } else {
-        let start = tree_aux_roots
-            .first()
-            .map(|root| root.height)
-            .unwrap_or(block::Height(0));
-        HeaderRangeEntry::from_parallel(start, headers, body_sizes, tree_aux_roots)
-            .expect("test response vectors align")
     };
     fixture
         .handle
@@ -1331,50 +1320,37 @@ fn codec_round_trips_status() {
     };
     let message = HeaderSyncMessage::Status(status);
 
-    let encoded = message.encode(None).unwrap();
-    let (decoded, request_id) =
-        HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
-
+    let encoded = message.encode().unwrap();
+    let decoded = HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
     assert_eq!(decoded, message);
-    assert_eq!(request_id, None);
 }
 
 #[test]
 fn codec_round_trips_get_headers_request_id() {
     let request_id = HeaderSyncRequestId::new(42).expect("non-zero id");
     let message = HeaderSyncMessage::GetHeaders {
+        request_id,
         start_height: block::Height(42),
         count: DEFAULT_HS_RANGE,
         want_tree_aux_roots: false,
     };
 
-    let encoded = message.encode(Some(request_id)).unwrap();
-    let (decoded, decoded_request_id) =
-        HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
-
+    let encoded = message.encode().unwrap();
+    let decoded = HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
     assert_eq!(decoded, message);
-    assert_eq!(decoded_request_id, Some(request_id));
 }
 
 #[test]
-fn get_headers_rejects_missing_and_zero_request_ids() {
+fn get_headers_rejects_zero_request_ids() {
     let request_id = HeaderSyncRequestId::new(1).expect("non-zero id");
     let message = HeaderSyncMessage::GetHeaders {
+        request_id,
         start_height: block::Height(42),
         count: DEFAULT_HS_RANGE,
         want_tree_aux_roots: false,
     };
 
-    assert!(matches!(
-        message.encode(None),
-        Err(HeaderSyncWireError::MissingRequestId {
-            message: "GetHeaders"
-        })
-    ));
-
-    let mut encoded = message
-        .encode(Some(request_id))
-        .expect("valid v7 request encodes");
+    let mut encoded = message.encode().expect("valid v8 request encodes");
     encoded[1..9].fill(0);
     assert!(matches!(
         HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control(),),
@@ -1388,39 +1364,175 @@ fn get_headers_rejects_missing_and_zero_request_ids() {
 fn codec_round_trips_headers_with_bounded_vector_and_request_id() {
     let request_id = HeaderSyncRequestId::new(43).expect("non-zero id");
     let headers = vec![mainnet_header(&BLOCK_MAINNET_1_BYTES)];
-    let message = finalized_headers_message_with_sizes(headers, vec![123_456]);
+    let entries = HeaderRangeEntry::from_parallel(
+        block::Height(1),
+        headers,
+        vec![123_456],
+        roots_from_height(block::Height(1), 1),
+    )
+    .expect("test response vectors align");
+    let message = HeaderSyncMessage::Headers {
+        request_id,
+        entries,
+    };
     let expected = ExpectedHeadersResponse::new(request_id, block::Height(1), 1, true).unwrap();
 
-    let encoded = message.encode(Some(request_id)).unwrap();
-    let (decoded, decoded_request_id) = HeaderSyncMessage::decode(
+    let encoded = message.encode().unwrap();
+    let decoded = HeaderSyncMessage::decode(
         &encoded,
         HeaderSyncDecodeContext::for_headers_response(expected, 1),
     )
     .unwrap();
 
     assert_eq!(decoded, message);
-    assert_eq!(decoded_request_id, Some(request_id));
 }
 
 #[test]
-fn headers_rejects_missing_and_zero_request_ids() {
+fn headers_v8_interleaves_each_height_header_body_size_and_root() {
+    let request_id = HeaderSyncRequestId::new(44).expect("non-zero id");
+    let headers = vec![
+        mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        mainnet_header(&BLOCK_MAINNET_2_BYTES),
+    ];
+    let body_sizes = vec![111u32, 222u32];
+    let roots = roots_from_height(block::Height(1), 2);
+
+    let mut expected_v8 = vec![MSG_HS_HEADERS];
+    expected_v8.extend_from_slice(&request_id.get().to_le_bytes());
+    expected_v8.extend_from_slice(&2u32.to_le_bytes());
+    expected_v8.push(1);
+    for (offset, ((header, body_size), root)) in
+        headers.iter().zip(&body_sizes).zip(&roots).enumerate()
+    {
+        let height = u32::try_from(offset)
+            .expect("test offset fits in u32")
+            .checked_add(1)
+            .expect("test height does not overflow");
+        expected_v8.extend_from_slice(&height.to_le_bytes());
+        header
+            .zcash_serialize(&mut expected_v8)
+            .expect("test header serializes");
+        expected_v8.extend_from_slice(&body_size.to_le_bytes());
+        root.zcash_serialize(&mut expected_v8)
+            .expect("test root serializes");
+    }
+
+    let mut grouped_v7 = vec![MSG_HS_HEADERS];
+    grouped_v7.extend_from_slice(&request_id.get().to_le_bytes());
+    grouped_v7.extend_from_slice(&2u32.to_le_bytes());
+    grouped_v7.push(1);
+    for (header, body_size) in headers.iter().zip(&body_sizes) {
+        header
+            .zcash_serialize(&mut grouped_v7)
+            .expect("test header serializes");
+        grouped_v7.extend_from_slice(&body_size.to_le_bytes());
+    }
+    for root in &roots {
+        root.zcash_serialize(&mut grouped_v7)
+            .expect("test root serializes");
+    }
+
+    let message = HeaderSyncMessage::Headers {
+        request_id,
+        entries: HeaderRangeEntry::from_parallel(block::Height(1), headers, body_sizes, roots)
+            .expect("test response vectors align"),
+    };
+    let encoded = message.encode().expect("v8 response encodes");
+    assert_eq!(encoded, expected_v8);
+    assert_ne!(encoded, grouped_v7);
+
+    let expected = ExpectedHeadersResponse::new(request_id, block::Height(1), 2, true)
+        .expect("test request is valid");
+    let decoded = HeaderSyncMessage::decode(
+        &encoded,
+        HeaderSyncDecodeContext::for_headers_response(expected, 2),
+    )
+    .expect("interleaved v8 response decodes");
+    assert_eq!(decoded, message);
+}
+
+#[test]
+fn headers_v8_decode_rejects_explicit_height_outside_requested_sequence() {
+    let request_id = HeaderSyncRequestId::new(45).expect("non-zero id");
+    let message = headers_message_from(
+        block::Height(1),
+        vec![mainnet_header(&BLOCK_MAINNET_1_BYTES)],
+    );
+    let mut encoded = message.encode().expect("valid v8 response encodes");
+    let entry_height_offset = HEADER_SYNC_MESSAGE_TYPE_BYTES
+        + HEADER_SYNC_REQUEST_ID_BYTES
+        + HEADER_SYNC_COUNT_BYTES
+        + HEADER_SYNC_HAS_ROOTS_BYTES;
+    encoded[entry_height_offset..entry_height_offset + HEADER_SYNC_HEIGHT_BYTES]
+        .copy_from_slice(&2u32.to_le_bytes());
+    let expected = ExpectedHeadersResponse::new(request_id, block::Height(1), 1, true)
+        .expect("test request is valid");
+    encoded[1..9].copy_from_slice(&request_id.get().to_le_bytes());
+
+    assert!(matches!(
+        HeaderSyncMessage::decode(
+            &encoded,
+            HeaderSyncDecodeContext::for_headers_response(expected, 1),
+        ),
+        Err(HeaderSyncWireError::EntryHeightMismatch {
+            offset: 0,
+            expected_height: block::Height(1),
+            entry_height: block::Height(2),
+        })
+    ));
+}
+
+#[test]
+fn headers_v8_decode_rejects_root_height_different_from_entry_height() {
+    let request_id = HeaderSyncRequestId::new(46).expect("non-zero id");
+    let message = HeaderSyncMessage::Headers {
+        request_id,
+        entries: HeaderRangeEntry::from_parallel(
+            block::Height(1),
+            vec![mainnet_header(&BLOCK_MAINNET_1_BYTES)],
+            vec![0],
+            roots_from_height(block::Height(1), 1),
+        )
+        .expect("test response vectors align"),
+    };
+    let mut encoded = message.encode().expect("valid v8 response encodes");
+    let root_height_offset = HEADER_SYNC_MESSAGE_TYPE_BYTES
+        + HEADER_SYNC_REQUEST_ID_BYTES
+        + HEADER_SYNC_COUNT_BYTES
+        + HEADER_SYNC_HAS_ROOTS_BYTES
+        + HEADER_SYNC_HEIGHT_BYTES
+        + COMMON_HEADER_BYTES
+        + HEADER_SYNC_BODY_SIZE_BYTES;
+    encoded[root_height_offset..root_height_offset + HEADER_SYNC_HEIGHT_BYTES]
+        .copy_from_slice(&2u32.to_le_bytes());
+    let expected = ExpectedHeadersResponse::new(request_id, block::Height(1), 1, true)
+        .expect("test request is valid");
+
+    assert!(matches!(
+        HeaderSyncMessage::decode(
+            &encoded,
+            HeaderSyncDecodeContext::for_headers_response(expected, 1),
+        ),
+        Err(HeaderSyncWireError::TreeAuxRootHeightMismatch {
+            offset: 0,
+            expected_height: block::Height(1),
+            root_height: block::Height(2),
+            ..
+        })
+    ));
+}
+
+#[test]
+fn headers_rejects_zero_request_ids() {
     let request_id = HeaderSyncRequestId::new(1).expect("non-zero id");
     let message = HeaderSyncMessage::Headers {
-        headers: Vec::new(),
-        body_sizes: Vec::new(),
-        tree_aux_roots: Vec::new(),
+        request_id,
+        entries: Vec::new(),
     };
     let expected = ExpectedHeadersResponse::new(request_id, block::Height(1), 1, false)
         .expect("count is valid");
 
-    assert!(matches!(
-        message.encode(None),
-        Err(HeaderSyncWireError::MissingRequestId { message: "Headers" })
-    ));
-
-    let mut encoded = message
-        .encode(Some(request_id))
-        .expect("valid v7 response encodes");
+    let mut encoded = message.encode().expect("valid v8 response encodes");
     encoded[1..9].fill(0);
     assert!(matches!(
         HeaderSyncMessage::decode(
@@ -1437,8 +1549,7 @@ fn codec_round_trips_headers_with_unknown_body_size_sentinel() {
     let message = finalized_headers_message_with_sizes(headers, vec![0]);
 
     let encoded = encode_correlated(&message).unwrap();
-    let (decoded, _request_id) =
-        HeaderSyncMessage::decode(&encoded, finalized_headers_context(1, 1)).unwrap();
+    let decoded = HeaderSyncMessage::decode(&encoded, finalized_headers_context(1, 1)).unwrap();
 
     assert_eq!(decoded, message);
 }
@@ -1461,12 +1572,9 @@ fn decode_rejects_tree_aux_roots_when_not_requested() {
 fn codec_round_trips_new_block() {
     let message = HeaderSyncMessage::NewBlock(mainnet_block(&BLOCK_MAINNET_1_BYTES));
 
-    let encoded = message.encode(None).unwrap();
-    let (decoded, request_id) =
-        HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
-
+    let encoded = message.encode().unwrap();
+    let decoded = HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
     assert_eq!(decoded, message);
-    assert_eq!(request_id, None);
 }
 
 #[test]
@@ -1477,6 +1585,7 @@ fn codec_rejects_unknown_message_types_and_trailing_bytes() {
     ));
 
     let mut encoded = encode_correlated(&HeaderSyncMessage::GetHeaders {
+        request_id: test_request_id(),
         start_height: block::Height(1),
         count: 1,
         want_tree_aux_roots: false,
@@ -1496,7 +1605,12 @@ fn headers_codec_rejects_body_size_mismatch_truncation_and_trailing_bytes() {
     let message = headers_message_with_sizes(headers.clone(), vec![100]);
 
     assert!(matches!(
-        encode_correlated(&headers_message_with_sizes(headers.clone(), vec![100, 200])),
+        HeaderRangeEntry::from_parallel(
+            block::Height(1),
+            headers.clone(),
+            vec![100, 200],
+            Vec::new(),
+        ),
         Err(HeaderSyncWireError::BodySizeCountMismatch {
             headers: 1,
             body_sizes: 2,
@@ -1504,11 +1618,7 @@ fn headers_codec_rejects_body_size_mismatch_truncation_and_trailing_bytes() {
     ));
 
     assert!(matches!(
-        encode_correlated(&HeaderSyncMessage::Headers {
-            headers: headers.clone(),
-            body_sizes: vec![100],
-            tree_aux_roots: Vec::new(),
-        }),
+        HeaderRangeEntry::from_parallel(block::Height(1), headers.clone(), vec![100], Vec::new(),),
         Err(HeaderSyncWireError::TreeAuxRootCountMismatch {
             headers: 1,
             roots: 0,
@@ -1630,15 +1740,11 @@ fn headers_codec_does_not_use_legacy_160_header_cap() {
     let message = finalized_headers_message(headers);
 
     let encoded = encode_correlated(&message).unwrap();
-    let (decoded, _request_id) =
-        HeaderSyncMessage::decode(&encoded, finalized_headers_context(161, 161)).unwrap();
+    let decoded = HeaderSyncMessage::decode(&encoded, finalized_headers_context(161, 161)).unwrap();
 
     match decoded {
-        HeaderSyncMessage::Headers {
-            headers,
-            body_sizes,
-            tree_aux_roots,
-        } => {
+        HeaderSyncMessage::Headers { entries, .. } => {
+            let (headers, body_sizes, tree_aux_roots) = HeaderRangeEntry::into_parallel(entries);
             assert_eq!(headers.len(), 161);
             assert_eq!(body_sizes, vec![0; 161]);
             assert_eq!(tree_aux_roots, roots_from_height(block::Height(1), 161));
@@ -1650,6 +1756,7 @@ fn headers_codec_does_not_use_legacy_160_header_cap() {
 #[test]
 fn get_headers_rejects_invalid_counts() {
     assert!(encode_correlated(&HeaderSyncMessage::GetHeaders {
+        request_id: test_request_id(),
         start_height: block::Height(1),
         count: 0,
         want_tree_aux_roots: false,
@@ -1657,6 +1764,7 @@ fn get_headers_rejects_invalid_counts() {
     .is_err());
 
     assert!(encode_correlated(&HeaderSyncMessage::GetHeaders {
+        request_id: test_request_id(),
         start_height: block::Height(1),
         count: MAX_HS_RANGE + 1,
         want_tree_aux_roots: false,
@@ -1683,9 +1791,8 @@ fn advertised_defaults_and_clamping_match_design() {
         max_headers_per_response: MAX_HS_RANGE + 10,
         ..HeaderSyncStatus::default()
     };
-    let encoded = HeaderSyncMessage::Status(status).encode(None).unwrap();
-    let (decoded, _request_id) =
-        HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
+    let encoded = HeaderSyncMessage::Status(status).encode().unwrap();
+    let decoded = HeaderSyncMessage::decode(&encoded, HeaderSyncDecodeContext::control()).unwrap();
     match decoded {
         HeaderSyncMessage::Status(status) => {
             assert_eq!(status.max_headers_per_response, MAX_HS_RANGE);
@@ -1715,7 +1822,9 @@ fn header_serialized_sizes_are_exact_and_message_cap_has_headroom() {
     let default_response_bytes = HEADER_SYNC_MESSAGE_TYPE_BYTES
         + HEADER_SYNC_REQUEST_ID_BYTES
         + HEADER_SYNC_COUNT_BYTES
-        + (COMMON_HEADER_BYTES
+        + HEADER_SYNC_HAS_ROOTS_BYTES
+        + (HEADER_SYNC_HEIGHT_BYTES
+            + COMMON_HEADER_BYTES
             + HEADER_SYNC_BODY_SIZE_BYTES
             + HEADER_SYNC_BLOCK_COMMITMENT_ROOTS_BYTES)
             * DEFAULT_HS_RANGE as usize;
@@ -1808,6 +1917,7 @@ async fn restart_rebuilds_schedule_from_durable_best_tip_and_peer_status() {
                     start_height,
                     count,
                     want_tree_aux_roots: true,
+                    ..
                 },
             ..
         } = next_non_query_action(&mut fixture.actions).await
@@ -2576,6 +2686,7 @@ async fn status_updates_peer_caps_and_scheduler_respects_them() {
                     start_height,
                     count,
                     want_tree_aux_roots: true,
+                    ..
                 },
             ..
         } = next_non_query_action(&mut fixture.actions).await
@@ -2591,7 +2702,7 @@ async fn status_updates_peer_caps_and_scheduler_respects_them() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn scheduler_fills_v7_outstanding_request_slots() {
+async fn scheduler_fills_v8_outstanding_request_slots() {
     let network = regtest_network();
     let mut fixture = spawn_test_reactor(startup_for(
         network.clone(),
@@ -2665,6 +2776,7 @@ async fn work_queue_assigns_each_forward_range_to_one_peer() {
                     start_height,
                     count,
                     want_tree_aux_roots: true,
+                    ..
                 },
             ..
         } = next_non_query_action(&mut fixture.actions).await
@@ -2783,6 +2895,7 @@ async fn work_queue_splits_large_ranges_without_duplicate_ownership() {
                     start_height,
                     count,
                     want_tree_aux_roots: true,
+                    ..
                 },
             ..
         } = action
@@ -2827,6 +2940,7 @@ async fn scheduler_starts_forward_work_above_checkpoint_anchor() {
                     start_height,
                     count,
                     want_tree_aux_roots: true,
+                    ..
                 },
             ..
         } = next_non_query_action(&mut fixture.actions).await
@@ -2934,6 +3048,7 @@ async fn forward_ranges_below_checkpoint_handoff_request_tree_aux_roots() {
                     start_height,
                     count,
                     want_tree_aux_roots,
+                    ..
                 },
             ..
         } = next_non_query_action(&mut fixture.actions).await
@@ -3491,12 +3606,11 @@ async fn local_commit_failure_retries_without_peer_misbehavior() {
     let request_id = loop {
         if let HeaderSyncAction::SendMessage {
             peer,
-            request_id,
-            msg: HeaderSyncMessage::GetHeaders { .. },
+            msg: HeaderSyncMessage::GetHeaders { request_id, .. },
         } = next_non_query_action(&mut fixture.actions).await
         {
             if peer == first_peer {
-                break request_id.expect("an outbound GetHeaders always carries a request ID");
+                break request_id;
             }
         }
     };
@@ -3545,6 +3659,7 @@ async fn local_commit_failure_retries_without_peer_misbehavior() {
                         start_height,
                         count,
                         want_tree_aux_roots: true,
+                        ..
                     },
                 ..
             } if peer == first_peer || peer == second_peer => {
@@ -3743,7 +3858,7 @@ fn response_before_publication_completion_is_not_reinstalled() {
 }
 
 #[test]
-fn completed_v7_inbound_request_id_cannot_be_reused() {
+fn completed_v8_inbound_request_id_cannot_be_reused() {
     let (send, _recv) = crate::zakura::framed_channel(32);
     let session = HeaderSyncPeerSession::from_parts_with_direction(
         peer(82),
@@ -3822,7 +3937,7 @@ async fn failed_status_publication_is_retry_paced() {
     let (send, mut recv) = crate::zakura::framed_channel(1);
     send.try_send(
         HeaderSyncMessage::Status(HeaderSyncStatus::default())
-            .encode_frame(None)
+            .encode_frame()
             .expect("filler status frame encodes"),
     )
     .expect("outbound queue starts full");
@@ -3872,8 +3987,7 @@ async fn failed_status_publication_is_retry_paced() {
         .expect("outbound channel remains open");
     assert!(matches!(
         HeaderSyncMessage::decode_frame(frame, HeaderSyncDecodeContext::control())
-            .expect("retry status decodes")
-            .0,
+            .expect("retry status decodes"),
         HeaderSyncMessage::Status(_)
     ));
     assert!(
@@ -3918,6 +4032,7 @@ async fn reconnect_clears_session_bound_outstanding_ranges() {
                 start_height: block::Height(1),
                 count: 1,
                 want_tree_aux_roots: true,
+                ..
             },
             ..
         } if peer == peer_id
@@ -3948,6 +4063,7 @@ async fn reconnect_clears_session_bound_outstanding_ranges() {
                 start_height: block::Height(1),
                 count: 1,
                 want_tree_aux_roots: true,
+                ..
             },
             ..
         } if peer == peer_id
@@ -4924,7 +5040,7 @@ async fn serving_responses_echo_request_ids_in_completion_order() {
     tokio::time::timeout(std::time::Duration::from_secs(1), recv.recv())
         .await
         .expect("initial status arrives")
-        .expect("v7 stream stays open");
+        .expect("v8 stream stays open");
     advertise_tip(
         &fixture,
         peer_id.clone(),
@@ -4982,7 +5098,7 @@ async fn serving_responses_echo_request_ids_in_completion_order() {
         let frame = tokio::time::timeout(std::time::Duration::from_secs(1), recv.recv())
             .await
             .expect("headers response arrives")
-            .expect("v7 stream stays open");
+            .expect("v8 stream stays open");
         assert_eq!(
             HeaderSyncMessage::peek_headers_request_id(&frame.payload).unwrap(),
             request_id
@@ -5970,7 +6086,8 @@ async fn partial_coverage_trims_and_commits_an_already_buffered_suffix() {
             assert_eq!(
                 payload
                     .tree_aux_roots()
-                    .and_then(|mut roots| roots.next().map(|root| root.height)),
+                    .and_then(|mut roots| roots.next())
+                    .map(|root| root.height),
                 Some(block::Height(4))
             );
             break;
@@ -6675,6 +6792,7 @@ async fn forward_link_wedge_reanchors_to_verified_tip_without_banning() {
                         start_height,
                         count: _,
                         want_tree_aux_roots: true,
+                        ..
                     },
                 ..
             } if saw_reanchor_action && start_height == expected_start => {
@@ -6775,19 +6893,20 @@ async fn forward_genesis_backfill_reaches_checkpoint_before_finalized_commit() {
     .await;
     let request_id = loop {
         if let HeaderSyncAction::SendMessage {
-            request_id: sent_request_id,
             msg:
                 HeaderSyncMessage::GetHeaders {
+                    request_id,
                     start_height,
                     count,
                     want_tree_aux_roots: true,
+                    ..
                 },
             ..
         } = next_non_query_action(&mut fixture.actions).await
         {
             assert_eq!(start_height, block::Height(1));
             assert_eq!(count, 3);
-            break sent_request_id.expect("an outbound GetHeaders always carries a request ID");
+            break request_id;
         }
     };
 

--- a/zakura-network/src/zakura/header_sync/wire.rs
+++ b/zakura-network/src/zakura/header_sync/wire.rs
@@ -12,9 +12,11 @@ pub const ZAKURA_STREAM_HEADER_SYNC: u16 = 5;
 /// block's ZIP-244 `auth_data_root` (the co-input to its NU5+ header commitment).
 /// Version 7 prefixes `GetHeaders`/`Headers` with a non-zero request ID so a response is
 /// correlated with the exact request that solicited it, instead of by FIFO arrival order.
+/// Version 8 makes correlated messages self-contained and encodes each `Headers` entry as
+/// one atomic `[height][header][body_size][tree_aux_root]` record when roots are requested.
 /// Each of these is a breaking wire change: a peer that speaks an earlier version cannot
-/// exchange header-sync ranges with version 7 and does not negotiate header sync at all.
-pub const ZAKURA_HEADER_SYNC_STREAM_VERSION: u16 = 7;
+/// exchange header-sync ranges with version 8 and does not negotiate header sync at all.
+pub const ZAKURA_HEADER_SYNC_STREAM_VERSION: u16 = 8;
 
 /// Peer status advertisement.
 pub const MSG_HS_STATUS: u8 = 1;
@@ -38,6 +40,7 @@ pub(super) const HEADER_SYNC_MESSAGE_TYPE_BYTES: usize = 1;
 pub(super) const HEADER_SYNC_REQUEST_ID_BYTES: usize = 8;
 pub(super) const HEADER_SYNC_COUNT_BYTES: usize = 4;
 pub(super) const HEADER_SYNC_HAS_ROOTS_BYTES: usize = 1;
+pub(super) const HEADER_SYNC_HEIGHT_BYTES: usize = 4;
 pub(super) const HEADER_SYNC_BODY_SIZE_BYTES: usize = 4;
 /// Encoded [`BlockCommitmentRoots`]: height + Sapling root + Orchard root + Ironwood root
 /// + three `u64` shielded tx-counts (Sapling/Orchard/Ironwood) + auth-data root.
@@ -64,7 +67,8 @@ const _: () = assert!(
     HEADER_SYNC_MESSAGE_TYPE_BYTES
         + HEADER_SYNC_REQUEST_ID_BYTES
         + HEADER_SYNC_COUNT_BYTES
-        + (COMMON_HEADER_BYTES
+        + (HEADER_SYNC_HEIGHT_BYTES
+            + COMMON_HEADER_BYTES
             + HEADER_SYNC_BODY_SIZE_BYTES
             + HEADER_SYNC_BLOCK_COMMITMENT_ROOTS_BYTES)
             * (DEFAULT_HS_RANGE as usize)
@@ -78,6 +82,8 @@ pub enum HeaderSyncMessage {
     Status(HeaderSyncStatus),
     /// Request `count` headers starting at `start_height`.
     GetHeaders {
+        /// Request ID allocated within this stream session.
+        request_id: HeaderSyncRequestId,
         /// First requested height.
         start_height: block::Height,
         /// Requested header count.
@@ -93,12 +99,10 @@ pub enum HeaderSyncMessage {
     /// A `0` size means "unknown"; the hint is not consensus data. Tree-aux roots
     /// are peer-sourced execution hints and are verified by state before use.
     Headers {
-        /// Headers in ascending height order.
-        headers: Vec<Arc<block::Header>>,
-        /// Advisory serialized body sizes, parallel to `headers`.
-        body_sizes: Vec<u32>,
-        /// Per-height commitment roots, parallel to `headers`.
-        tree_aux_roots: Vec<BlockCommitmentRoots>,
+        /// Request ID echoed from the matching `GetHeaders`.
+        request_id: HeaderSyncRequestId,
+        /// Structurally aligned per-height records in ascending order.
+        entries: Vec<HeaderRangeEntry>,
     },
     /// Full block tip-flood payload.
     NewBlock(Arc<block::Block>),
@@ -115,56 +119,47 @@ impl HeaderSyncMessage {
         }
     }
 
-    /// Encode this message as `[u8 message_type][request id][bounded fields...]`.
-    ///
-    /// `request_id` is required by `GetHeaders`/`Headers` and unused by the other
-    /// message types, which are not correlated.
-    pub fn encode(
-        &self,
-        request_id: Option<HeaderSyncRequestId>,
-    ) -> Result<Vec<u8>, HeaderSyncWireError> {
+    /// Encode this message as `[u8 message_type][bounded fields...]`.
+    pub fn encode(&self) -> Result<Vec<u8>, HeaderSyncWireError> {
         let mut bytes = Vec::new();
         bytes.write_u8(self.message_type())?;
         match self {
             Self::Status(status) => status.encode_to(&mut bytes)?,
             Self::GetHeaders {
+                request_id,
                 start_height,
                 count,
                 want_tree_aux_roots,
             } => {
                 validate_get_headers_count(*count)?;
-                bytes.write_u64::<LittleEndian>(
-                    request_id
-                        .ok_or(HeaderSyncWireError::MissingRequestId {
-                            message: "GetHeaders",
-                        })?
-                        .get(),
-                )?;
+                bytes.write_u64::<LittleEndian>(request_id.get())?;
                 write_height(&mut bytes, *start_height)?;
                 bytes.write_u32::<LittleEndian>(*count)?;
                 bytes.write_u8(u8::from(*want_tree_aux_roots))?;
             }
             Self::Headers {
-                headers,
-                body_sizes,
-                tree_aux_roots,
+                request_id,
+                entries,
             } => {
-                validate_headers_len(headers.len(), usize_from_u32(MAX_HS_RANGE, "headers cap")?)?;
-                validate_body_sizes_len(headers.len(), body_sizes.len())?;
-                validate_tree_aux_roots_len(headers.len(), tree_aux_roots.len())?;
-                bytes.write_u64::<LittleEndian>(
-                    request_id
-                        .ok_or(HeaderSyncWireError::MissingRequestId { message: "Headers" })?
-                        .get(),
-                )?;
-                bytes.write_u32::<LittleEndian>(u32_from_usize(headers.len(), "headers count")?)?;
-                bytes.write_u8(u8::from(!tree_aux_roots.is_empty()))?;
-                for (header, body_size) in headers.iter().zip(body_sizes) {
-                    header.zcash_serialize(&mut bytes)?;
-                    bytes.write_u32::<LittleEndian>(*body_size)?;
-                }
-                for roots in tree_aux_roots {
-                    roots.zcash_serialize(&mut bytes)?;
+                validate_headers_len(entries.len(), usize_from_u32(MAX_HS_RANGE, "headers cap")?)?;
+                validate_entries(entries)?;
+                bytes.write_u64::<LittleEndian>(request_id.get())?;
+                bytes.write_u32::<LittleEndian>(u32_from_usize(entries.len(), "headers count")?)?;
+                let has_roots = entries
+                    .first()
+                    .is_some_and(|entry| entry.tree_aux_root.is_some());
+                bytes.write_u8(u8::from(has_roots))?;
+                for entry in entries {
+                    write_height(&mut bytes, entry.height)?;
+                    entry.header.zcash_serialize(&mut bytes)?;
+                    bytes.write_u32::<LittleEndian>(entry.body_size)?;
+                    if has_roots {
+                        entry
+                            .tree_aux_root
+                            .as_ref()
+                            .expect("validated rooted entries all have roots")
+                            .zcash_serialize(&mut bytes)?;
+                    }
                 }
             }
             Self::NewBlock(block) => {
@@ -180,13 +175,11 @@ impl HeaderSyncMessage {
         Ok(bytes)
     }
 
-    /// Decode a header-sync message and its request ID using the request bounds in `context`.
-    ///
-    /// The request ID is `None` for the message types that do not carry one.
+    /// Decode a header-sync message using the request bounds in `context`.
     pub fn decode(
         bytes: &[u8],
         context: HeaderSyncDecodeContext,
-    ) -> Result<(Self, Option<HeaderSyncRequestId>), HeaderSyncWireError> {
+    ) -> Result<Self, HeaderSyncWireError> {
         if bytes.len() > MAX_HS_MESSAGE_BYTES {
             return Err(HeaderSyncWireError::OversizedPayload {
                 actual: bytes.len(),
@@ -195,31 +188,27 @@ impl HeaderSyncMessage {
         }
         let mut reader = Cursor::new(bytes);
         let message_type = reader.read_u8()?;
-        let mut request_id = None;
         let message = match message_type {
             MSG_HS_STATUS => Self::Status(HeaderSyncStatus::decode_from(&mut reader)?),
             MSG_HS_GET_HEADERS => {
-                request_id = HeaderSyncRequestId::new(reader.read_u64::<LittleEndian>()?);
-                if request_id.is_none() {
-                    return Err(HeaderSyncWireError::MissingRequestId {
+                let request_id = HeaderSyncRequestId::new(reader.read_u64::<LittleEndian>()?)
+                    .ok_or(HeaderSyncWireError::MissingRequestId {
                         message: "GetHeaders",
-                    });
-                }
+                    })?;
                 let start_height = read_height(&mut reader)?;
                 let count = reader.read_u32::<LittleEndian>()?;
                 let want_tree_aux_roots = read_bool_marker(&mut reader, "want_tree_aux_roots")?;
                 validate_get_headers_count(count)?;
                 Self::GetHeaders {
+                    request_id,
                     start_height,
                     count,
                     want_tree_aux_roots,
                 }
             }
             MSG_HS_HEADERS => {
-                request_id = HeaderSyncRequestId::new(reader.read_u64::<LittleEndian>()?);
-                if request_id.is_none() {
-                    return Err(HeaderSyncWireError::MissingRequestId { message: "Headers" });
-                }
+                let request_id = HeaderSyncRequestId::new(reader.read_u64::<LittleEndian>()?)
+                    .ok_or(HeaderSyncWireError::MissingRequestId { message: "Headers" })?;
                 let count = usize_from_u32(reader.read_u32::<LittleEndian>()?, "headers count")?;
                 let has_roots = read_bool_marker(&mut reader, "has_roots")?;
                 let Some(max_headers) = context.headers_response_limit()? else {
@@ -229,30 +218,51 @@ impl HeaderSyncMessage {
                     return Err(HeaderSyncWireError::UnrequestedTreeAuxRoots);
                 }
                 validate_headers_len(count, max_headers)?;
-                let mut headers = Vec::with_capacity(count);
-                let mut body_sizes = Vec::with_capacity(count);
-                let mut tree_aux_roots = if has_roots {
-                    Vec::with_capacity(count)
-                } else {
-                    Vec::new()
-                };
-                for _ in 0..count {
-                    headers.push(Arc::new(block::Header::zcash_deserialize(&mut reader)?));
-                    body_sizes.push(reader.read_u32::<LittleEndian>()?);
+                if count != 0 && context.wants_tree_aux_roots() && !has_roots {
+                    return Err(HeaderSyncWireError::TreeAuxRootCountMismatch {
+                        headers: count,
+                        roots: 0,
+                    });
                 }
-                if has_roots {
-                    for _ in 0..count {
-                        tree_aux_roots.push(BlockCommitmentRoots::zcash_deserialize(&mut reader)?);
+                let requested = context
+                    .requested
+                    .expect("a bounded Headers response has a matching request");
+                let mut entries = Vec::with_capacity(count);
+                for offset in 0..count {
+                    let height = read_height(&mut reader)?;
+                    let height_offset = u32::try_from(offset)
+                        .map_err(|_| HeaderSyncWireError::NumericOverflow("entry height offset"))?;
+                    let expected_height = requested
+                        .start_height
+                        .0
+                        .checked_add(height_offset)
+                        .map(block::Height)
+                        .ok_or(HeaderSyncWireError::NumericOverflow("entry height"))?;
+                    if height != expected_height {
+                        return Err(HeaderSyncWireError::EntryHeightMismatch {
+                            offset,
+                            expected_height,
+                            entry_height: height,
+                        });
                     }
+                    let header = Arc::new(block::Header::zcash_deserialize(&mut reader)?);
+                    let body_size = reader.read_u32::<LittleEndian>()?;
+                    let tree_aux_root = if has_roots {
+                        Some(BlockCommitmentRoots::zcash_deserialize(&mut reader)?)
+                    } else {
+                        None
+                    };
+                    entries.push(HeaderRangeEntry {
+                        height,
+                        header,
+                        body_size,
+                        tree_aux_root,
+                    });
                 }
-                validate_tree_aux_roots_len(count, tree_aux_roots.len())?;
-                if let Some(requested) = context.requested {
-                    validate_tree_aux_root_heights(requested.start_height, &tree_aux_roots)?;
-                }
+                validate_entries(&entries)?;
                 Self::Headers {
-                    headers,
-                    body_sizes,
-                    tree_aux_roots,
+                    request_id,
+                    entries,
                 }
             }
             MSG_HS_NEW_BLOCK => {
@@ -261,7 +271,7 @@ impl HeaderSyncMessage {
             value => return Err(HeaderSyncWireError::UnknownMessageType(value)),
         };
         reject_trailing(bytes, &reader)?;
-        Ok((message, request_id))
+        Ok(message)
     }
 
     /// Return a `Headers` request ID without decoding the full header payload.
@@ -278,27 +288,23 @@ impl HeaderSyncMessage {
     }
 
     /// Convert this message into a bounded Zakura frame.
-    pub fn encode_frame(
-        &self,
-        request_id: Option<HeaderSyncRequestId>,
-    ) -> Result<Frame, HeaderSyncWireError> {
+    pub fn encode_frame(&self) -> Result<Frame, HeaderSyncWireError> {
         Ok(Frame {
             message_type: u16::from(self.message_type()),
             flags: 0,
-            payload: self.encode(request_id)?,
+            payload: self.encode()?,
         })
     }
 
-    /// Decode this message and its request ID from a Zakura frame, after checking flags
-    /// and type agreement.
+    /// Decode this message from a Zakura frame, after checking flags and type agreement.
     pub fn decode_frame(
         frame: Frame,
         context: HeaderSyncDecodeContext,
-    ) -> Result<(Self, Option<HeaderSyncRequestId>), HeaderSyncWireError> {
+    ) -> Result<Self, HeaderSyncWireError> {
         if frame.flags != 0 {
             return Err(HeaderSyncWireError::UnsupportedFlags(frame.flags));
         }
-        let (message, request_id) = Self::decode(&frame.payload, context)?;
+        let message = Self::decode(&frame.payload, context)?;
         let frame_message_type = u8::try_from(frame.message_type)
             .map_err(|_| HeaderSyncWireError::UnknownFrameMessageType(frame.message_type))?;
         if frame_message_type != message.message_type() {
@@ -307,6 +313,66 @@ impl HeaderSyncMessage {
                 payload: message.message_type(),
             });
         }
-        Ok((message, request_id))
+        Ok(message)
     }
+}
+
+fn validate_entries(entries: &[HeaderRangeEntry]) -> Result<(), HeaderSyncWireError> {
+    let roots = entries
+        .iter()
+        .filter(|entry| entry.tree_aux_root.is_some())
+        .count();
+    if roots != 0 && roots != entries.len() {
+        return Err(HeaderSyncWireError::TreeAuxRootCountMismatch {
+            headers: entries.len(),
+            roots,
+        });
+    }
+
+    for (offset, adjacent) in entries.windows(2).enumerate() {
+        let expected_height = adjacent[0]
+            .height
+            .0
+            .checked_add(1)
+            .map(block::Height)
+            .ok_or(HeaderSyncWireError::NumericOverflow("entry height"))?;
+        if adjacent[1].height != expected_height {
+            return Err(HeaderSyncWireError::EntryHeightMismatch {
+                offset: offset + 1,
+                expected_height,
+                entry_height: adjacent[1].height,
+            });
+        }
+    }
+
+    if roots != 0 {
+        let first_root_height = entries
+            .first()
+            .and_then(|entry| entry.tree_aux_root.as_ref())
+            .expect("all non-empty rooted entries have roots")
+            .height;
+        let last_root_height = entries
+            .last()
+            .and_then(|entry| entry.tree_aux_root.as_ref())
+            .expect("all non-empty rooted entries have roots")
+            .height;
+        for (offset, entry) in entries.iter().enumerate() {
+            let root_height = entry
+                .tree_aux_root
+                .as_ref()
+                .expect("all rooted entries have roots")
+                .height;
+            if root_height != entry.height {
+                return Err(HeaderSyncWireError::TreeAuxRootHeightMismatch {
+                    offset,
+                    expected_height: entry.height,
+                    root_height,
+                    first_root_height,
+                    last_root_height,
+                });
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -159,9 +159,9 @@ mod tests {
             HeaderSyncRequestId, HeaderSyncStartup, HeaderSyncStatus,
             HeaderSyncWireRequestIdentity, Peer, Service, ServicePeerLimits, Stream,
             ZakuraBlockSyncConfig, ZakuraConnId, ZakuraHeaderSyncConfig, ZakuraLocalLimits,
-            ZakuraTrace, MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
-            ZAKURA_CAP_LEGACY_GOSSIP, ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_STREAM_DISCOVERY,
-            ZAKURA_STREAM_GOSSIP, ZAKURA_STREAM_HEADER_SYNC,
+            ZakuraTrace, MAX_BS_RESPONSE_BYTES, MSG_HS_HEADERS, ZAKURA_CAP_DISCOVERY,
+            ZAKURA_CAP_HEADER_SYNC, ZAKURA_CAP_LEGACY_GOSSIP, ZAKURA_HEADER_SYNC_STREAM_VERSION,
+            ZAKURA_STREAM_DISCOVERY, ZAKURA_STREAM_GOSSIP, ZAKURA_STREAM_HEADER_SYNC,
         },
         Config,
     };
@@ -202,9 +202,14 @@ mod tests {
             .unwrap_or(block::Height(1));
         let tree_aux_roots = roots_from_height(start_height, headers.len());
         HeaderSyncMessage::Headers {
-            headers,
-            body_sizes,
-            tree_aux_roots,
+            request_id: HeaderSyncRequestId::new(1).expect("test request ID is non-zero"),
+            entries: HeaderRangeEntry::from_parallel(
+                start_height,
+                headers,
+                body_sizes,
+                tree_aux_roots,
+            )
+            .expect("test response vectors align"),
         }
     }
 
@@ -551,7 +556,7 @@ mod tests {
         store: Arc<StdMutex<E2eHeaderStore>>,
         observed_gaps: Arc<Mutex<Vec<(block::Height, block::Height)>>>,
         misbehaviors: Arc<Mutex<Vec<(ZakuraPeerId, HeaderSyncMisbehavior)>>>,
-        sent: Arc<Mutex<Vec<(ZakuraPeerId, Option<HeaderSyncRequestId>, HeaderSyncMessage)>>>,
+        sent: Arc<Mutex<Vec<(ZakuraPeerId, HeaderSyncMessage)>>>,
         outbound_receivers: Arc<StdMutex<Vec<FramedRecv>>>,
     }
 
@@ -734,15 +739,9 @@ mod tests {
             node: usize,
             peer: ZakuraPeerId,
             request_id: HeaderSyncRequestId,
-            start_height: block::Height,
             msg: HeaderSyncMessage,
         ) {
-            let HeaderSyncMessage::Headers {
-                headers,
-                body_sizes,
-                tree_aux_roots,
-            } = msg
-            else {
+            let HeaderSyncMessage::Headers { entries, .. } = msg else {
                 panic!("inject_headers requires a Headers message");
             };
             self.nodes[node]
@@ -754,13 +753,7 @@ mod tests {
                         session_id: E2E_SESSION_ID,
                         request_id,
                     },
-                    entries: HeaderRangeEntry::from_parallel(
-                        start_height,
-                        headers,
-                        body_sizes,
-                        tree_aux_roots,
-                    )
-                    .expect("test response vectors align"),
+                    entries,
                 })
                 .await
                 .unwrap();
@@ -884,7 +877,7 @@ mod tests {
                 Duration::from_secs(5),
                 || {
                     sent.try_lock().is_ok_and(|sent| {
-                        sent.iter().any(|(sent_peer, _, msg)| {
+                        sent.iter().any(|(sent_peer, msg)| {
                             sent_peer == &peer && matches_request(msg)
                         })
                     })
@@ -893,12 +886,15 @@ mod tests {
             .await?;
 
             let sent = sent.lock().await;
-            let (_, request_id, _) = sent
+            let (_, message) = sent
                 .iter()
                 .rev()
-                .find(|(sent_peer, _, msg)| sent_peer == &peer && matches_request(msg))
+                .find(|(sent_peer, msg)| sent_peer == &peer && matches_request(msg))
                 .expect("the awaited GetHeaders is recorded");
-            Ok(request_id.expect("an outbound GetHeaders always carries a request ID"))
+            let HeaderSyncMessage::GetHeaders { request_id, .. } = message else {
+                unreachable!("matching message is GetHeaders");
+            };
+            Ok(*request_id)
         }
 
         async fn wait_for_observed_gap(&self, node: usize) -> Result<(), BoxError> {
@@ -932,27 +928,23 @@ mod tests {
         let local = nodes[index].clone();
         while let Some(action) = actions.recv().await {
             match action {
-                HeaderSyncAction::SendMessage {
-                    peer,
-                    request_id,
-                    msg,
-                } => {
+                HeaderSyncAction::SendMessage { peer, msg } => {
                     let Some(target) = peer_to_index.get(&peer) else {
-                        local.sent.lock().await.push((peer, request_id, msg));
+                        local.sent.lock().await.push((peer, msg));
                         continue;
                     };
                     // `GetHeaders` is correlated on the wire, so the simulated
                     // transport must carry its request ID too.
                     let event = match msg {
                         HeaderSyncMessage::GetHeaders {
+                            request_id,
                             start_height,
                             count,
                             want_tree_aux_roots,
                         } => HeaderSyncEvent::WireGetHeaders {
                             peer: local.peer_id.clone(),
                             session_id: E2E_SESSION_ID,
-                            request_id: request_id
-                                .expect("an outbound GetHeaders always carries a request ID"),
+                            request_id,
                             start_height,
                             count,
                             want_tree_aux_roots,
@@ -974,11 +966,11 @@ mod tests {
                             })
                             .await;
                     } else {
-                        local.sent.lock().await.push((
-                            peer,
-                            None,
-                            HeaderSyncMessage::NewBlock(block),
-                        ));
+                        local
+                            .sent
+                            .lock()
+                            .await
+                            .push((peer, HeaderSyncMessage::NewBlock(block)));
                     }
                 }
                 HeaderSyncAction::QueryHeadersByHeightRange {
@@ -996,11 +988,7 @@ mod tests {
                         .headers_by_range(start, count);
                     let returned_count = u32::try_from(headers.len()).unwrap_or(u32::MAX);
                     if let Some(target) = peer_to_index.get(&peer) {
-                        let HeaderSyncMessage::Headers {
-                            headers,
-                            body_sizes,
-                            tree_aux_roots,
-                        } = headers_message(headers)
+                        let HeaderSyncMessage::Headers { entries, .. } = headers_message(headers)
                         else {
                             unreachable!("headers_message always returns Headers");
                         };
@@ -1013,13 +1001,7 @@ mod tests {
                                     // Echo the requester's ID, exactly as the wire does.
                                     request_id,
                                 },
-                                entries: HeaderRangeEntry::from_parallel(
-                                    start,
-                                    headers,
-                                    body_sizes,
-                                    tree_aux_roots,
-                                )
-                                .expect("test response vectors align"),
+                                entries,
                             })
                             .await;
                         let _ = local
@@ -1482,21 +1464,23 @@ mod tests {
         let headers = (start..end)
             .map(|height| mainnet_block(block_bytes(height)).header.clone())
             .collect();
-        headers_message(headers)
+        let HeaderSyncMessage::Headers { entries, .. } = headers_message(headers) else {
+            unreachable!("headers_message always returns Headers");
+        };
+        HeaderSyncMessage::Headers {
+            request_id: query.request_id,
+            entries,
+        }
     }
 
     async fn complete_controlled_query(
         handle: &HeaderSyncHandle,
         query: &ControlledHeaderQuery,
     ) -> Result<(), BoxError> {
-        let HeaderSyncMessage::Headers {
-            headers,
-            body_sizes,
-            tree_aux_roots,
-        } = headers_for_query(query)
-        else {
+        let HeaderSyncMessage::Headers { entries, .. } = headers_for_query(query) else {
             unreachable!("headers_for_query always returns Headers");
         };
+        let (headers, body_sizes, tree_aux_roots) = HeaderRangeEntry::into_parallel(entries);
         handle
             .send(HeaderSyncEvent::HeaderRangeResponseReady {
                 peer: query.peer.clone(),
@@ -2721,10 +2705,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn native_stream5_v7_correlates_reversed_physical_responses() -> Result<(), BoxError> {
+    async fn native_stream5_v8_correlates_reversed_physical_responses() -> Result<(), BoxError> {
         let _guard = zakura_test::init();
         let mut capture = TraceCapture::for_test_with_keep_override(
-            "native_stream5_v7_correlates_reversed_physical_responses",
+            "native_stream5_v8_correlates_reversed_physical_responses",
             false,
         )?;
         let config = ZakuraHeaderSyncConfig {
@@ -2766,7 +2750,7 @@ mod tests {
         hostile
             .reopen_ordered_stream(ZAKURA_STREAM_HEADER_SYNC, ZAKURA_HEADER_SYNC_STREAM_VERSION)
             .await?;
-        await_until("v7 physical session registered", TEST_NET_TIMEOUT, || {
+        await_until("v8 physical session registered", TEST_NET_TIMEOUT, || {
             victim.header_sync().is_some_and(|handle| {
                 let peers = handle.peer_snapshot();
                 peers.inbound_peers + peers.outbound_peers == 1
@@ -2781,15 +2765,14 @@ mod tests {
             ),
         )
         .await??;
-        let (initial_status, request_id) =
+        let initial_status =
             HeaderSyncMessage::decode_frame(initial_status, HeaderSyncDecodeContext::control())?;
         assert!(matches!(initial_status, HeaderSyncMessage::Status(_)));
-        assert_eq!(request_id, None);
         hostile
             .send_ordered_raw_frame_with_version(
                 ZAKURA_STREAM_HEADER_SYNC,
                 ZAKURA_HEADER_SYNC_STREAM_VERSION,
-                status_for_tip(4, 2, 2).encode_frame(None)?,
+                status_for_tip(4, 2, 2).encode_frame()?,
             )
             .await?;
 
@@ -2806,20 +2789,16 @@ mod tests {
                 ),
             )
             .await??;
-            let (message, request_id) =
+            let message =
                 HeaderSyncMessage::decode_frame(frame, HeaderSyncDecodeContext::control())?;
             if let HeaderSyncMessage::GetHeaders {
+                request_id,
                 start_height,
                 count,
                 want_tree_aux_roots,
             } = message
             {
-                requests.push((
-                    request_id.expect("v7 GetHeaders carries a request id"),
-                    start_height,
-                    count,
-                    want_tree_aux_roots,
-                ));
+                requests.push((request_id, start_height, count, want_tree_aux_roots));
             }
         }
         assert_ne!(requests[0].0, requests[1].0);
@@ -2848,7 +2827,7 @@ mod tests {
                 .send_ordered_raw_frame_with_version(
                     ZAKURA_STREAM_HEADER_SYNC,
                     ZAKURA_HEADER_SYNC_STREAM_VERSION,
-                    headers_for_query(&query).encode_frame(Some(*request_id))?,
+                    headers_for_query(&query).encode_frame()?,
                 )
                 .await?;
         }
@@ -2887,7 +2866,7 @@ mod tests {
                 })
                 .await?;
         }
-        await_until("v7 correlated header tip", TEST_NET_TIMEOUT, || {
+        await_until("v8 correlated header tip", TEST_NET_TIMEOUT, || {
             victim
                 .header_sync()
                 .is_some_and(|handle| handle.best_header_tip().0 == block::Height(4))
@@ -2901,11 +2880,12 @@ mod tests {
                 ZAKURA_STREAM_HEADER_SYNC,
                 ZAKURA_HEADER_SYNC_STREAM_VERSION,
                 HeaderSyncMessage::GetHeaders {
+                    request_id: inbound_request_id,
                     start_height: block::Height(1),
                     count: 1,
                     want_tree_aux_roots: true,
                 }
-                .encode_frame(Some(inbound_request_id))?,
+                .encode_frame()?,
             )
             .await?;
         let query = next_controlled_header_query(&mut actions).await?;
@@ -2924,16 +2904,7 @@ mod tests {
                 ),
             )
             .await??;
-            if frame.message_type
-                == u16::from(
-                    HeaderSyncMessage::Headers {
-                        headers: Vec::new(),
-                        body_sizes: Vec::new(),
-                        tree_aux_roots: Vec::new(),
-                    }
-                    .message_type(),
-                )
-            {
+            if frame.message_type == u16::from(MSG_HS_HEADERS) {
                 assert_eq!(
                     HeaderSyncMessage::peek_headers_request_id(&frame.payload)?,
                     inbound_request_id
@@ -3057,9 +3028,7 @@ mod tests {
         // regardless of which one the hostile peer picks.
         let unsolicited_headers =
             headers_message(vec![mainnet_block(&BLOCK_MAINNET_1_BYTES).header.clone()])
-                .encode_frame(Some(
-                    HeaderSyncRequestId::new(1).expect("non-zero request id"),
-                ))?;
+                .encode_frame()?;
         unsolicited
             .send_raw_frame(ZAKURA_STREAM_HEADER_SYNC, unsolicited_headers)
             .await?;
@@ -3478,11 +3447,15 @@ mod tests {
                 victim,
                 out_of_range,
                 request_id,
-                block::Height(1),
                 HeaderSyncMessage::Headers {
-                    headers: vec![mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone()],
-                    body_sizes: vec![0],
-                    tree_aux_roots: roots_from_height(block::Height(1), 1),
+                    request_id: HeaderSyncRequestId::new(1).expect("test request ID is non-zero"),
+                    entries: HeaderRangeEntry::from_parallel(
+                        block::Height(1),
+                        vec![mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone()],
+                        vec![0],
+                        roots_from_height(block::Height(1), 1),
+                    )
+                    .expect("test response vectors align"),
                 },
             )
             .await;
@@ -3525,7 +3498,6 @@ mod tests {
                 victim,
                 response_too_long,
                 request_id,
-                block::Height(1),
                 headers_message(vec![
                     mainnet_block(&BLOCK_MAINNET_1_BYTES).header.clone(),
                     mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone(),
@@ -3565,7 +3537,6 @@ mod tests {
                 bad_continuity_victim,
                 bad_continuity,
                 request_id,
-                block::Height(1),
                 headers_message(vec![
                     mainnet_block(&BLOCK_MAINNET_1_BYTES).header.clone(),
                     Arc::new(non_contiguous),
@@ -3599,7 +3570,6 @@ mod tests {
                 bad_pow_victim,
                 bad_pow,
                 request_id,
-                block::Height(1),
                 headers_message(vec![Arc::new(bad_pow_header)]),
             )
             .await;
@@ -3634,7 +3604,6 @@ mod tests {
                 bad_daa_victim,
                 bad_daa,
                 request_id,
-                block::Height(1),
                 headers_message(vec![
                     mainnet_block(&BLOCK_MAINNET_1_BYTES).header.clone(),
                     mainnet_block(&BLOCK_MAINNET_2_BYTES).header.clone(),

--- a/zakura-network/src/zakura/trace.rs
+++ b/zakura-network/src/zakura/trace.rs
@@ -417,7 +417,7 @@ pub mod header_sync_trace {
     pub const ACTIVE_CONNECTIONS: &str = "active_connections";
     /// Ordered-stream generation that owns this header-sync event.
     pub const SESSION_ID: &str = "session_id";
-    /// Header-sync v7 request identifier, when present.
+    /// Header-sync v8 request identifier, when present.
     pub const REQUEST_ID: &str = "request_id";
     /// Negotiated header-sync stream version for this peer session.
     pub const STREAM_VERSION: &str = "stream_version";

--- a/zakurad/tests/zakura_regtest_e2e.rs
+++ b/zakurad/tests/zakura_regtest_e2e.rs
@@ -30,7 +30,7 @@
 //!   height 0, 399/400/401, 2,000, near tip with a 1,000-block gap, and after
 //!   the non-finalized reorg.
 //! - `header-faults`: uses a bounded multi-range chain, restarts node2 with
-//!   outstanding header-sync work, and requires v7 request-id trace coverage.
+//!   outstanding header-sync work, and requires v8 request-id trace coverage.
 //!
 //! It shells out to `docker/zakura-regtest-e2e/run.sh`, which builds `zakurad`
 //! (debug) if needed, brings up four Regtest nodes sharing the host network — a
@@ -77,7 +77,7 @@ fn zakura_regtest_dual_stack_e2e() {
     run_zakura_regtest_e2e(None);
 }
 
-#[ignore = "opt-in docker e2e: header-sync v7 fault lane"]
+#[ignore = "opt-in docker e2e: header-sync v8 fault lane"]
 #[test]
 fn zakura_regtest_header_sync_faults() {
     if std::env::var("ZAKURA_E2E_MODE").is_ok_and(|mode| mode != "header-faults") {


### PR DESCRIPTION
## Motivation

The v7 codec correlates requests through an API side channel and serializes headers/body sizes separately from commitment roots. Although the internal layer now binds those values into entries, the message model and byte layout can still represent them independently.

## Solution

- bump the header-sync peer protocol from v7 to v8
- embed request IDs directly in correlated `GetHeaders` and `Headers` messages
- encode each response entry atomically as header, body size, and optional roots
- remove redundant request-ID side channels from codec and test actions
- reject v7 header-sync negotiation while leaving other stream versions unchanged
- update the Unreleased changelog

This PR is intentionally stacked on #309.

## Testing

- `cargo fmt --all`
- `cargo test -p zakura-network --lib zakura::header_sync` (166 passed)
- `cargo test -p zakura-network --lib header_sync_stream_version_contract_is_exact`
- relevant transport/testkit v8 compatibility tests
- `cargo clippy -p zakura-network --lib --tests -- -D warnings`
- `git diff --check`
- IDE diagnostics: clean

### Specifications & References

- Base PR: #309

### Follow-up Work

Retarget this PR to `main` after #309 merges.