### PR TITLE
fix(network): canonicalize banned peer IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Treat IPv4 and IPv4-mapped IPv6 peer addresses as the same address when
+  enforcing bans, preventing banned peers from reconnecting through the
+  alternate representation
+  ([#314](https://github.com/zakura-core/zakura/pull/314)).
 - Keep valid internal-miner work running across mempool-only block template
   updates ([#226](https://github.com/zakura-core/zakura/pull/226)).
 - Honor `disable_pow = true` during native header sync on configured Testnets,

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -19,7 +19,7 @@ use zakura_chain::{parameters::Network, serialization::DateTime32};
 use crate::{
     constants::{self, ADDR_RESPONSE_LIMIT_DENOMINATOR, MAX_ADDRS_IN_MESSAGE},
     meta_addr::MetaAddrChange,
-    protocol::external::{canonical_peer_addr, canonical_socket_addr},
+    protocol::external::{canonical_ip, canonical_peer_addr, canonical_socket_addr},
     types::{MetaAddr, PeerServices},
     AddressBookPeers, PeerAddrState, PeerSocketAddr,
 };
@@ -43,14 +43,10 @@ struct BanList {
     insertion_order: VecDeque<IpAddr>,
 }
 
-fn canonical_banned_ip(ip: IpAddr) -> IpAddr {
-    canonical_socket_addr(SocketAddr::new(ip, 0)).ip()
-}
-
 impl BanList {
     /// Inserts `ip`, evicting the oldest IP when the list exceeds its bound.
     fn insert(&mut self, ip: IpAddr) {
-        let ip = canonical_banned_ip(ip);
+        let ip = canonical_ip(ip);
 
         if !self.ips.insert(ip) {
             return;
@@ -72,7 +68,7 @@ impl BanList {
 impl BannedIps {
     /// Returns whether `ip` is currently banned.
     pub fn contains(&self, ip: IpAddr) -> bool {
-        let ip = canonical_banned_ip(ip);
+        let ip = canonical_ip(ip);
 
         self.inner
             .read()

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -43,9 +43,15 @@ struct BanList {
     insertion_order: VecDeque<IpAddr>,
 }
 
+fn canonical_banned_ip(ip: IpAddr) -> IpAddr {
+    canonical_socket_addr(SocketAddr::new(ip, 0)).ip()
+}
+
 impl BanList {
     /// Inserts `ip`, evicting the oldest IP when the list exceeds its bound.
     fn insert(&mut self, ip: IpAddr) {
+        let ip = canonical_banned_ip(ip);
+
         if !self.ips.insert(ip) {
             return;
         }
@@ -66,6 +72,8 @@ impl BanList {
 impl BannedIps {
     /// Returns whether `ip` is currently banned.
     pub fn contains(&self, ip: IpAddr) -> bool {
+        let ip = canonical_banned_ip(ip);
+
         self.inner
             .read()
             .expect("ban list lock should not be poisoned")

--- a/zakura-network/src/address_book/tests.rs
+++ b/zakura-network/src/address_book/tests.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use crate::constants::MAX_BANNED_IPS;
 
-use super::BanList;
+use super::{BanList, BannedIps};
 
 mod prop;
 mod vectors;
@@ -27,4 +27,13 @@ fn ban_list_evicts_the_oldest_ip_at_capacity() {
     assert!(bans.ips.contains(&newest));
     assert_eq!(bans.ips.len(), MAX_BANNED_IPS);
     assert_eq!(bans.insertion_order.len(), MAX_BANNED_IPS);
+}
+
+#[test]
+fn banned_ips_match_ipv4_and_ipv4_mapped_ipv6() {
+    let ipv4 = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let ipv4_mapped = IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped());
+
+    assert!(BannedIps::with_banned_ip(ipv4).contains(ipv4_mapped));
+    assert!(BannedIps::with_banned_ip(ipv4_mapped).contains(ipv4));
 }

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -45,7 +45,7 @@ use crate::{
     },
     peer_set::{ConnectionTracker, InventoryChange},
     protocol::{
-        external::{canonical_socket_addr, types::*, AddrInVersion, Codec, InventoryHash, Message},
+        external::{canonical_ip, types::*, AddrInVersion, Codec, InventoryHash, Message},
         internal::{Request, Response},
     },
     types::MetaAddr,
@@ -184,12 +184,6 @@ pub struct ConnectionInfo {
     /// requests are still shed for backpressure, but the connection is not
     /// severed). See [`Connection::handle_inbound_overload`].
     pub is_protected_peer: bool,
-}
-
-/// Canonicalizes `ip` so an IPv4-mapped IPv6 address (`::ffff:A.B.C.D`) compares
-/// equal to its plain IPv4 form, matching how inbound peer accounting keys peers.
-fn canonical_ip(ip: IpAddr) -> IpAddr {
-    canonical_socket_addr(SocketAddr::new(ip, 0)).ip()
 }
 
 /// The peer address that we are handshaking with.

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -136,7 +136,7 @@ use crate::{
         InventoryChange, InventoryRegistry,
     },
     protocol::{
-        external::{canonical_socket_addr, InventoryHash},
+        external::{canonical_ip, canonical_socket_addr, InventoryHash},
         internal::{Request, Response},
     },
     BannedIps, BoxError, Config, PeerError, PeerSocketAddr, SharedPeerError,
@@ -161,16 +161,6 @@ pub struct MorePeers;
 pub struct CancelClientWork;
 
 type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'static>>;
-
-/// Canonicalizes an [`IpAddr`] so an IPv4-mapped IPv6 address (`::ffff:A.B.C.D`) compares
-/// equal to its canonical IPv4 form.
-///
-/// The ban map and address book are keyed on canonical IPs, but a dual-stack listener reports
-/// inbound IPv4 peers as IPv4-mapped IPv6. Canonicalizing before comparing keeps ban re-checks
-/// and per-IP connection accounting from treating the two forms as different hosts.
-fn canonical_ip(ip: IpAddr) -> IpAddr {
-    canonical_socket_addr(SocketAddr::new(ip, 0)).ip()
-}
 
 /// Classification of a `FindBlocks`/`FindHeaders` response, sent from a
 /// response-wrapping future to [`PeerSet::poll_ready`] via an mpsc channel so

--- a/zakura-network/src/protocol/external.rs
+++ b/zakura-network/src/protocol/external.rs
@@ -16,6 +16,7 @@ pub mod arbitrary;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use addr::canonical::canonical_ip;
 pub use addr::{canonical_peer_addr, canonical_socket_addr, AddrInVersion};
 pub use codec::Codec;
 pub use inv::{InventoryHash, MAX_TX_INV_IN_SENT_MESSAGE};

--- a/zakura-network/src/protocol/external/addr/canonical.rs
+++ b/zakura-network/src/protocol/external/addr/canonical.rs
@@ -46,6 +46,12 @@ pub fn canonical_socket_addr(socket_addr: impl Into<SocketAddr>) -> SocketAddr {
     socket_addr
 }
 
+/// Canonicalizes an [`IpAddr`] so an IPv4-mapped IPv6 address
+/// (`::ffff:A.B.C.D`) compares equal to its canonical IPv4 form.
+pub(crate) fn canonical_ip(ip: IpAddr) -> IpAddr {
+    canonical_socket_addr(SocketAddr::new(ip, 0)).ip()
+}
+
 /// Transform a [`PeerSocketAddr`] into a canonical Zebra [`PeerSocketAddr`], converting
 /// IPv6-mapped IPv4 addresses, and removing IPv6 scope IDs and flow information.
 ///


### PR DESCRIPTION
## Motivation

Peers using an IPv4-mapped IPv6 address can bypass an existing IP ban. The
misbehavior path records the canonical IPv4 address, while ban checks can use
the original mapped IPv6 representation, so the equivalent addresses do not
match in the ban set.

## Solution

Canonicalize IP addresses at the `BannedIps` boundary for both insertion and
lookup. Reuse #238's `canonical_ip` implementation from the shared address
canonicalization module, so the ban list, peer set, and handshake paths apply
the same normalization rule.

Add a regression test covering both directions: inserting IPv4 and looking up
mapped IPv6, and inserting mapped IPv6 and looking up IPv4.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-network --lib -- -D warnings`
- `npx --yes markdownlint-cli CHANGELOG.md --config .trunk/configs/.markdownlint.yaml`
- `cargo test -p zakura-network --lib banned_ips_match_ipv4_and_ipv4_mapped_ipv6`
- `cargo test -p zakura-network --lib address_book::tests`
- `cargo test -p zakura-network --lib mapped_and_canonical`
- `cargo test -p zakura-network --lib broadcast_all_queued_bans_mapped_ipv6_against_canonical_ban`
- `cargo test -p zakura-network --lib`: 1,017 passed, 3 failed, and 4 ignored.
  The three failures bind a test client to `127.0.0.2`, which is unavailable on
  this macOS host. The same
  `listener_bans_zcashd_compat_peer_before_reserved_slot` failure reproduces on
  unchanged `main` before reaching ban logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches peer misbehavior enforcement (security-sensitive); change is narrow and aligns ban storage with existing canonicalization elsewhere in the network stack.
> 
> **Overview**
> **Fixes a ban bypass** where peers could reconnect using IPv4-mapped IPv6 (`::ffff:x.x.x.x`) while the ban list held the plain IPv4 form (or the reverse), so `contains` missed the match.
> 
> **`BannedIps` now canonicalizes on both insert and lookup** via shared `canonical_ip` from the address canonicalization module. Duplicate local helpers in handshake and peer set are removed in favor of that single export.
> 
> A regression test covers ban/lookup symmetry for IPv4 vs mapped IPv6. CHANGELOG documents the fix ([#314]).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c4543e4e352e98621379d65b974f6d97db8a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->