### PR TITLE
fix(state): make history tree snapshot decoding fallible

### DIFF
--- a/zakura-chain/src/history_tree.rs
+++ b/zakura-chain/src/history_tree.rs
@@ -36,6 +36,9 @@ pub enum HistoryTreeError {
 
     #[error("I/O error: {0}")]
     IOError(#[from] io::Error),
+
+    #[error("invalid cached history tree: {reason}")]
+    InvalidCachedTree { reason: &'static str },
 }
 
 impl PartialEq for HistoryTreeError {
@@ -89,6 +92,12 @@ impl NonEmptyHistoryTree {
         peaks: BTreeMap<u32, Entry>,
         current_height: Height,
     ) -> Result<Self, HistoryTreeError> {
+        if peaks.is_empty() {
+            return Err(HistoryTreeError::InvalidCachedTree {
+                reason: "a non-empty history tree must have at least one peak",
+            });
+        }
+
         let network_upgrade = NetworkUpgrade::current(network, current_height);
         let inner = match network_upgrade {
             NetworkUpgrade::Genesis
@@ -96,7 +105,9 @@ impl NonEmptyHistoryTree {
             | NetworkUpgrade::Overwinter
             | NetworkUpgrade::Sapling
             | NetworkUpgrade::Blossom => {
-                panic!("HistoryTree does not exist for pre-Heartwood upgrades")
+                return Err(HistoryTreeError::InvalidCachedTree {
+                    reason: "history trees do not exist before Heartwood",
+                });
             }
             NetworkUpgrade::Heartwood | NetworkUpgrade::Canopy => {
                 let tree = Tree::<PreOrchard>::new_from_cache(

--- a/zakura-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/chain.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 
 use bincode::Options;
 use serde_big_array::BigArray;
+use thiserror::Error;
 
 use zakura_chain::{
     amount::NonNegative,
@@ -21,6 +22,37 @@ use zakura_chain::{
 };
 
 use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
+
+/// An error decoding a persisted history-tree snapshot.
+#[derive(Debug, Error)]
+pub enum HistoryTreeDecodeError {
+    /// The snapshot does not use either supported serialization format.
+    #[error(
+        "history tree snapshot is neither the current nor legacy format: \
+         current format error: {current}; legacy format error: {legacy}"
+    )]
+    InvalidEncoding {
+        /// The current-width decoding error.
+        current: bincode::Error,
+        /// The legacy-width decoding error.
+        legacy: bincode::Error,
+    },
+
+    /// The snapshot was created for a different network kind.
+    #[error(
+        "history tree snapshot network kind {stored:?} does not match configured network kind {configured:?}"
+    )]
+    NetworkMismatch {
+        /// The network kind stored in the snapshot.
+        stored: NetworkKind,
+        /// The configured network kind.
+        configured: NetworkKind,
+    },
+
+    /// The decoded snapshot does not contain a valid history tree.
+    #[error("invalid history tree snapshot: {0}")]
+    HistoryTree(#[from] HistoryTreeError),
+}
 
 impl IntoDisk for ValueBalance<NonNegative> {
     type Bytes = [u8; 48];
@@ -52,18 +84,46 @@ pub struct HistoryTreeParts {
 }
 
 impl HistoryTreeParts {
+    /// Decodes current-width or legacy-width history-tree snapshot bytes.
+    pub(crate) fn try_from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, HistoryTreeDecodeError> {
+        let bytes = bytes.as_ref();
+        let options = bincode::DefaultOptions::new();
+
+        // Try the current entry width first. Databases written before NU6.3 widened
+        // `zcash_history::Entry` store narrower entries that fail to parse at the current width,
+        // so fall back to the legacy width and zero-pad each entry up to the current width.
+        //
+        // Legacy-width rows can fail the current-width decoder with errors other than
+        // `UnexpectedEof`, because the wider entry can read into the next legacy entry and
+        // interpret arbitrary entry bytes as bincode control bytes.
+        match options.deserialize::<HistoryTreeParts>(bytes) {
+            Ok(parts) => Ok(parts),
+            Err(current) => options
+                .deserialize::<LegacyHistoryTreeParts>(bytes)
+                .map(HistoryTreeParts::from)
+                .map_err(|legacy| HistoryTreeDecodeError::InvalidEncoding { current, legacy }),
+        }
+    }
+
     /// Converts [`HistoryTreeParts`] to a [`NonEmptyHistoryTree`].
     pub(crate) fn with_network(
         self,
         network: &Network,
-    ) -> Result<NonEmptyHistoryTree, HistoryTreeError> {
-        assert_eq!(
-            self.network_kind,
-            network.kind(),
-            "history tree network kind should match current network"
-        );
+    ) -> Result<NonEmptyHistoryTree, HistoryTreeDecodeError> {
+        let configured = network.kind();
+        if self.network_kind != configured {
+            return Err(HistoryTreeDecodeError::NetworkMismatch {
+                stored: self.network_kind,
+                configured,
+            });
+        }
 
-        NonEmptyHistoryTree::from_cache(network, self.size, self.peaks, self.current_height)
+        Ok(NonEmptyHistoryTree::from_cache(
+            network,
+            self.size,
+            self.peaks,
+            self.current_height,
+        )?)
     }
 }
 
@@ -130,23 +190,7 @@ impl From<LegacyHistoryTreeParts> for HistoryTreeParts {
 
 impl FromDisk for HistoryTreeParts {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
-        let bytes = bytes.as_ref();
-        let options = bincode::DefaultOptions::new();
-
-        // Try the current entry width first. Databases written before NU6.3 widened
-        // `zcash_history::Entry` store narrower entries that fail to parse at the current width,
-        // so fall back to the legacy width and zero-pad each entry up to the current width.
-        //
-        // Legacy-width rows can fail the current-width decoder with errors other than
-        // `UnexpectedEof`, because the wider entry can read into the next legacy entry and
-        // interpret arbitrary entry bytes as bincode control bytes.
-        options
-            .deserialize::<HistoryTreeParts>(bytes)
-            .or_else(|_| {
-                options
-                    .deserialize::<LegacyHistoryTreeParts>(bytes)
-                    .map(HistoryTreeParts::from)
-            })
+        HistoryTreeParts::try_from_bytes(bytes)
             .expect("deserialization format should match the serialization format used by IntoDisk")
     }
 }

--- a/zakura-state/src/service/finalized_state/disk_format/chain/tests.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/chain/tests.rs
@@ -1,6 +1,100 @@
 //! Chain-format serialization tests.
 
+use zakura_chain::{
+    block::Block,
+    history_tree::{HistoryTreeBlockParts, NonEmptyHistoryTree},
+    ironwood, orchard,
+    parameters::NetworkUpgrade,
+    sapling,
+    serialization::ZcashDeserializeInto,
+};
+
+use crate::{
+    constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
+    service::finalized_state::{disk_format::RawBytes, ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
+    Config,
+};
+
 use super::*;
+
+fn valid_history_tree() -> NonEmptyHistoryTree {
+    let network = Network::Mainnet;
+    let block: Block = zakura_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into()
+        .expect("test block must deserialize");
+    let sapling_root = sapling::tree::Root::default();
+    let orchard_root = orchard::tree::Root::default();
+    let ironwood_root = ironwood::tree::Root::default();
+    let height = NetworkUpgrade::Heartwood
+        .activation_height(&network)
+        .expect("Heartwood has a Mainnet activation height");
+
+    NonEmptyHistoryTree::from_cache(
+        &network,
+        1,
+        NonEmptyHistoryTree::from_parts(
+            &network,
+            HistoryTreeBlockParts {
+                header: &block.header,
+                height,
+                sapling_root: &sapling_root,
+                orchard_root: &orchard_root,
+                ironwood_root: &ironwood_root,
+                sapling_tx: 0,
+                orchard_tx: 0,
+                ironwood_tx: 0,
+            },
+        )
+        .expect("test history tree must be valid")
+        .peaks()
+        .clone(),
+        height,
+    )
+    .expect("cached test history tree must be valid")
+}
+
+fn legacy_parts_from(tree: &NonEmptyHistoryTree) -> LegacyHistoryTreeParts {
+    LegacyHistoryTreeParts {
+        network_kind: tree.network().kind(),
+        size: tree.size(),
+        peaks: tree
+            .peaks()
+            .iter()
+            .map(|(index, entry)| {
+                let serialized = bincode::DefaultOptions::new()
+                    .serialize(entry)
+                    .expect("history tree entry serialization succeeds");
+                let mut inner = [0; LEGACY_MAX_ENTRY_SIZE];
+                inner.copy_from_slice(&serialized[..LEGACY_MAX_ENTRY_SIZE]);
+                (*index, LegacyEntry { inner })
+            })
+            .collect(),
+        current_height: tree.current_height(),
+    }
+}
+
+fn ephemeral_db(network: &Network) -> ZakuraDb {
+    ZakuraDb::new(
+        &Config::ephemeral(),
+        STATE_DATABASE_KIND,
+        &state_database_format_version_in_code(),
+        network,
+        true,
+        STATE_COLUMN_FAMILIES_IN_CODE
+            .iter()
+            .map(ToString::to_string),
+        false,
+    )
+    .expect("opening an ephemeral finalized state database succeeds")
+}
+
+fn write_raw_history_tree(db: &ZakuraDb, key: RawBytes, bytes: Vec<u8>) {
+    db.raw_history_tree_cf()
+        .new_batch_for_writing()
+        .zs_insert(&key, &RawBytes::new_raw_bytes(bytes))
+        .write_batch()
+        .expect("writing test history tree bytes succeeds");
+}
 
 /// A history tree written by a pre-NU6.3 database format must be read in place,
 /// zero-padding each entry up to the current width.
@@ -30,7 +124,8 @@ fn history_tree_parts_reads_legacy_entry_width() {
         .serialize(&legacy)
         .expect("legacy serialization succeeds");
 
-    let parts = HistoryTreeParts::from_bytes(&legacy_bytes);
+    let parts =
+        HistoryTreeParts::try_from_bytes(&legacy_bytes).expect("legacy snapshot must decode");
 
     assert_eq!(parts.network_kind, NetworkKind::Mainnet);
     assert_eq!(parts.size, 42);
@@ -87,7 +182,8 @@ fn history_tree_parts_reads_legacy_entry_width_after_non_eof_current_error() {
         "test fixture must exercise a legacy row with a non-EOF current-width error"
     );
 
-    let parts = HistoryTreeParts::from_bytes(&legacy_bytes);
+    let parts =
+        HistoryTreeParts::try_from_bytes(&legacy_bytes).expect("legacy snapshot must decode");
 
     assert_eq!(parts.network_kind, NetworkKind::Mainnet);
     assert_eq!(parts.size, 42);
@@ -111,10 +207,115 @@ fn history_tree_parts_round_trips_current_width() {
     };
 
     let bytes = parts.as_bytes();
-    let parsed = HistoryTreeParts::from_bytes(&bytes);
+    let parsed = HistoryTreeParts::try_from_bytes(&bytes).expect("current snapshot must decode");
 
     assert_eq!(parsed.network_kind, NetworkKind::Testnet);
     assert_eq!(parsed.size, 3);
     assert_eq!(parsed.current_height, Height(9));
     assert_eq!(parsed.as_bytes(), bytes);
+}
+
+#[test]
+fn malformed_history_tree_parts_return_both_decode_errors() {
+    let error = HistoryTreeParts::try_from_bytes([0xFF]).expect_err("malformed bytes must fail");
+
+    assert!(matches!(
+        error,
+        HistoryTreeDecodeError::InvalidEncoding {
+            current: _,
+            legacy: _
+        }
+    ));
+}
+
+#[test]
+fn history_tree_parts_reject_wrong_network() {
+    let parts = HistoryTreeParts::from(&valid_history_tree());
+
+    let error = parts
+        .with_network(&Network::new_default_testnet())
+        .expect_err("Mainnet snapshot must not load on Testnet");
+
+    assert!(matches!(
+        error,
+        HistoryTreeDecodeError::NetworkMismatch {
+            stored: NetworkKind::Mainnet,
+            configured: NetworkKind::Testnet,
+        }
+    ));
+}
+
+#[test]
+fn history_tree_parts_reject_invalid_tree_structure() {
+    let height = NetworkUpgrade::Heartwood
+        .activation_height(&Network::Mainnet)
+        .expect("Heartwood has a Mainnet activation height");
+    let parts = HistoryTreeParts {
+        network_kind: NetworkKind::Mainnet,
+        size: 1,
+        peaks: BTreeMap::from([(0, zcash_history::Entry::from_raw_bytes_padded(&[]))]),
+        current_height: height,
+    };
+
+    let error = parts
+        .with_network(&Network::Mainnet)
+        .expect_err("invalid cached entry must fail reconstruction");
+
+    assert!(matches!(error, HistoryTreeDecodeError::HistoryTree(_)));
+}
+
+#[test]
+fn try_history_tree_reads_current_snapshot() {
+    let network = Network::Mainnet;
+    let db = ephemeral_db(&network);
+    let tree = valid_history_tree();
+    let parts = HistoryTreeParts::from(&tree);
+    write_raw_history_tree(&db, RawBytes::new_raw_bytes(Vec::new()), parts.as_bytes());
+
+    let decoded = db
+        .try_history_tree()
+        .expect("valid current snapshot must load");
+
+    assert_eq!(decoded.hash(), Some(tree.hash()));
+}
+
+#[test]
+fn try_history_tree_reads_legacy_snapshot() {
+    let network = Network::Mainnet;
+    let db = ephemeral_db(&network);
+    let tree = valid_history_tree();
+    let legacy = legacy_parts_from(&tree);
+    let legacy_bytes = bincode::DefaultOptions::new()
+        .serialize(&legacy)
+        .expect("legacy serialization succeeds");
+    write_raw_history_tree(
+        &db,
+        RawBytes::new_raw_bytes(Height(1).as_bytes().as_ref().to_vec()),
+        legacy_bytes,
+    );
+
+    let decoded = db
+        .try_history_tree()
+        .expect("valid legacy snapshot must load");
+
+    assert_eq!(decoded.hash(), Some(tree.hash()));
+}
+
+#[test]
+fn try_history_tree_propagates_malformed_snapshot() {
+    let network = Network::Mainnet;
+    let db = ephemeral_db(&network);
+    write_raw_history_tree(&db, RawBytes::new_raw_bytes(Vec::new()), vec![0xFF]);
+
+    let error = db
+        .try_history_tree()
+        .expect_err("malformed snapshot must fail");
+
+    assert!(matches!(
+        error,
+        HistoryTreeDecodeError::InvalidEncoding {
+            current: _,
+            legacy: _
+        }
+    ));
 }

--- a/zakura-state/src/service/finalized_state/disk_format/chain/tests.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/chain/tests.rs
@@ -217,7 +217,10 @@ fn history_tree_parts_round_trips_current_width() {
 
 #[test]
 fn malformed_history_tree_parts_return_both_decode_errors() {
-    let error = HistoryTreeParts::try_from_bytes([0xFF]).expect_err("malformed bytes must fail");
+    let error = match HistoryTreeParts::try_from_bytes([0xFF]) {
+        Ok(_) => panic!("malformed bytes must fail"),
+        Err(error) => error,
+    };
 
     assert!(matches!(
         error,
@@ -253,13 +256,32 @@ fn history_tree_parts_reject_invalid_tree_structure() {
     let parts = HistoryTreeParts {
         network_kind: NetworkKind::Mainnet,
         size: 1,
-        peaks: BTreeMap::from([(0, zcash_history::Entry::from_raw_bytes_padded(&[]))]),
+        peaks: BTreeMap::new(),
         current_height: height,
     };
 
     let error = parts
         .with_network(&Network::Mainnet)
         .expect_err("invalid cached entry must fail reconstruction");
+
+    assert!(matches!(error, HistoryTreeDecodeError::HistoryTree(_)));
+}
+
+#[test]
+fn history_tree_parts_reject_pre_heartwood_height() {
+    let parts = HistoryTreeParts {
+        network_kind: NetworkKind::Mainnet,
+        size: 1,
+        peaks: BTreeMap::from([(
+            0,
+            zcash_history::Entry::from_raw_bytes_padded(&[0; LEGACY_MAX_ENTRY_SIZE]),
+        )]),
+        current_height: Height(1),
+    };
+
+    let error = parts
+        .with_network(&Network::Mainnet)
+        .expect_err("pre-Heartwood snapshot must fail reconstruction");
 
     assert!(matches!(error, HistoryTreeDecodeError::HistoryTree(_)));
 }
@@ -290,7 +312,7 @@ fn try_history_tree_reads_legacy_snapshot() {
         .expect("legacy serialization succeeds");
     write_raw_history_tree(
         &db,
-        RawBytes::new_raw_bytes(Height(1).as_bytes().as_ref().to_vec()),
+        RawBytes::new_raw_bytes(Height(1).as_bytes().to_vec()),
         legacy_bytes,
     );
 

--- a/zakura-state/src/service/finalized_state/zakura_db/chain.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/chain.rs
@@ -30,7 +30,10 @@ use crate::{
     request::FinalizedBlock,
     service::finalized_state::{
         disk_db::DiskWriteBatch,
-        disk_format::{chain::HistoryTreeParts, RawBytes},
+        disk_format::{
+            chain::{HistoryTreeDecodeError, HistoryTreeParts},
+            RawBytes,
+        },
         zakura_db::{metrics::value_pool_metrics, ZakuraDb},
         TypedColumnFamily,
     },
@@ -54,7 +57,7 @@ pub type LegacyHistoryTreePartsCf<'cf> = TypedColumnFamily<'cf, Height, HistoryT
 
 /// A generic raw key type for reading history trees from the database, regardless of the database version.
 /// This type should not be used in new code.
-pub type RawHistoryTreePartsCf<'cf> = TypedColumnFamily<'cf, RawBytes, HistoryTreeParts>;
+pub type RawHistoryTreePartsCf<'cf> = TypedColumnFamily<'cf, RawBytes, RawBytes>;
 
 /// The name of the tip-only chain value pools column family.
 ///
@@ -120,7 +123,16 @@ impl ZakuraDb {
     /// If history trees have not been activated yet (pre-Heartwood), or the state is empty,
     /// returns an empty history tree.
     pub fn history_tree(&self) -> Arc<HistoryTree> {
-        let history_tree_cf = self.history_tree_cf();
+        self.try_history_tree()
+            .expect("stored history tree snapshots must be valid")
+    }
+
+    /// Tries to return the ZIP-221 history tree of the finalized tip.
+    ///
+    /// If history trees have not been activated yet (pre-Heartwood), or the state is empty,
+    /// returns an empty history tree.
+    pub fn try_history_tree(&self) -> Result<Arc<HistoryTree>, HistoryTreeDecodeError> {
+        let raw_history_tree_cf = self.raw_history_tree_cf();
 
         // # Backwards Compatibility
         //
@@ -136,40 +148,52 @@ impl ZakuraDb {
         //
         // So we use the empty key `()`. Since the key has a constant value, we will always read
         // the latest tree.
-        let mut history_tree_parts = history_tree_cf.zs_get(&());
+        let empty_key = RawBytes::new_raw_bytes(Vec::new());
+        let mut history_tree_bytes = raw_history_tree_cf.zs_get(&empty_key);
 
-        if history_tree_parts.is_none() {
-            let legacy_history_tree_cf = self.legacy_history_tree_cf();
-
+        if history_tree_bytes.is_none() {
             // In Zebra 1.4.0 and later, we only update the history tip tree when it has changed (for every block after heartwood).
             // But we write with a `()` key, not a height key.
             // So we need to look for the most recent update height if the `()` key has never been written.
-            history_tree_parts = legacy_history_tree_cf
+            history_tree_bytes = raw_history_tree_cf
                 .zs_last_key_value()
-                .map(|(_height_key, tree_value)| tree_value);
+                .map(|(_raw_key, tree_value)| tree_value);
         }
 
-        let history_tree = history_tree_parts.map(|parts| {
-            parts.with_network(&self.db.network()).expect(
-                "deserialization format should match the serialization format used by IntoDisk",
-            )
-        });
-        Arc::new(HistoryTree::from(history_tree))
+        let history_tree = history_tree_bytes
+            .map(|bytes| {
+                HistoryTreeParts::try_from_bytes(bytes.raw_bytes())?
+                    .with_network(&self.db.network())
+            })
+            .transpose()?;
+
+        Ok(Arc::new(HistoryTree::from(history_tree)))
     }
 
     /// Returns all the history tip trees.
     /// We only store the history tree for the tip, so this method is only used in tests and
     /// upgrades.
     pub(crate) fn history_trees_full_tip(&self) -> BTreeMap<RawBytes, Arc<HistoryTree>> {
+        self.try_history_trees_full_tip()
+            .expect("stored history tree snapshots must be valid")
+    }
+
+    /// Tries to return all the history tip trees.
+    ///
+    /// We only store the history tree for the tip, so this method is only used in tests and
+    /// upgrades.
+    pub(crate) fn try_history_trees_full_tip(
+        &self,
+    ) -> Result<BTreeMap<RawBytes, Arc<HistoryTree>>, HistoryTreeDecodeError> {
         let raw_history_tree_cf = self.raw_history_tree_cf();
 
         raw_history_tree_cf
             .zs_forward_range_iter(..)
-            .map(|(raw_key, history_tree_parts)| {
-                let history_tree = history_tree_parts.with_network(&self.db.network()).expect(
-                    "deserialization format should match the serialization format used by IntoDisk",
-                );
-                (raw_key, Arc::new(HistoryTree::from(history_tree)))
+            .map(|(raw_key, history_tree_bytes)| {
+                let history_tree =
+                    HistoryTreeParts::try_from_bytes(history_tree_bytes.raw_bytes())?
+                        .with_network(&self.db.network())?;
+                Ok((raw_key, Arc::new(HistoryTree::from(history_tree))))
             })
             .collect()
     }


### PR DESCRIPTION
## Motivation

History-tree snapshots were decoded through an infallible database conversion. Malformed current or legacy bytes panicked, snapshots written for another network hit an assertion, and empty or pre-Heartwood caches could reach assertions in tree reconstruction. The later durable root-authentication frontier needs startup to reject incoherent snapshots as typed local-state errors.

## Solution

- add a typed snapshot error for malformed current/legacy bytes, network mismatch, and `HistoryTreeError`
- preserve current-first decoding with legacy-width fallback
- add raw-byte-backed `try_history_tree()` and fallible full-tip reads
- return `HistoryTreeError` for empty and pre-Heartwood non-empty caches
- keep the existing current and legacy serialized formats unchanged

No database format version or migration is included.

## Testing

- `cargo test -p zakura-state history_tree --lib`
- `cargo test -p zakura-state`
- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-chain -p zakura-state --all-targets -- -D warnings`

The tests exercise current and legacy snapshots, legacy fallback after a non-EOF current decoder error, malformed bytes, wrong-network snapshots, empty and pre-Heartwood caches, and raw database reads for both valid formats and corrupt data.

### Specifications & References

- [Header-sync VCT root authentication design](https://github.com/zakura-core/zakura/blob/6a0e701064b226724e9ca67e2e5f61bc080dc22d/docs/design/header-sync-vct-root-authentication.md)

### Follow-up Work

Introduce the sealed verified-root type together with the atomic database cleanup migration and durable authentication-frontier initialization.