### PR TITLE
fix(release): use dated checkpoint update branches

### DIFF
--- a/.github/workflows/update-release-state.yml
+++ b/.github/workflows/update-release-state.yml
@@ -193,12 +193,17 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - name: Choose the dated update branch
+        if: steps.import.outputs.has_changes == 'true'
+        id: update-branch
+        run: echo "name=release/checkpoint-update-$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
       - name: Open or update the draft pull request
         if: steps.import.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
-          branch: adam/update-release-state
+          branch: ${{ steps.update-branch.outputs.name }}
           base: main
           title: "chore(chain): update Mainnet checkpoints and VCT frontier"
           body: |


### PR DESCRIPTION
## Motivation

The automated checkpoint refresh PR used the hard-coded branch `adam/update-release-state`, which made bot-created release-state updates look user-specific and did not identify when the update was generated.

## Solution

Generate the branch name from the workflow run's UTC date and pass `release/checkpoint-update-YYYY-MM-DD` to `peter-evans/create-pull-request`. Re-runs on the same UTC day update the same draft PR; later runs use a new dated branch.

## Testing

- `actionlint .github/workflows/update-release-state.yml`
- Exercised the branch-name shell expression locally and asserted it produces `release/checkpoint-update-$(date -u +%F)`
- Branch is based on the latest `origin/main` (`ea979e11a`)

### Specifications & References

- Follow-up to #317