### PR TITLE
fix(sync): recover near-tip legacy sync stall with a FindHeaders fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Advance legacy sync from a state restarted 1-2 blocks behind the network
+  tip: when `FindBlocks` responses are too short to survive the zcashd
+  trailing-hash guard, the syncer now falls back to `FindHeaders` and
+  downloads the blocks whose header parent links anchor in its own chain,
+  instead of repeatedly exhausting the prospective tip set without progress.
 - Keep valid internal-miner work running across mempool-only block template
   updates ([#226](https://github.com/zakura-core/zakura/pull/226)).
 - Honor `disable_pow = true` during native header sync on configured Testnets,

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -63,6 +63,49 @@ pub use status::SyncStatus;
 /// Controls the number of peers used for each ObtainTips and ExtendTips request.
 const FANOUT: usize = 3;
 
+/// Returns the hashes from a bounded header response that continuously extends
+/// a block already present in state.
+fn anchored_header_hashes(
+    headers: Vec<block::CountedHeader>,
+    known_hashes: &HashSet<block::Hash>,
+) -> Vec<block::Hash> {
+    if headers.len() > MAX_TIPS_RESPONSE_HASH_COUNT {
+        debug!(
+            headers.len = headers.len(),
+            max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
+            "discarding oversized FindHeaders response"
+        );
+        return Vec::new();
+    }
+
+    let mut run = Vec::new();
+    let mut run_parent = None;
+    for counted in headers {
+        let hash = counted.header.hash();
+        if known_hashes.contains(&hash) {
+            if !run.is_empty() {
+                return Vec::new();
+            }
+            run_parent = Some(hash);
+            continue;
+        }
+
+        let parent = counted.header.previous_block_hash;
+        let anchored = match run_parent {
+            Some(run_parent) => parent == run_parent,
+            None => known_hashes.contains(&parent),
+        };
+        if !anchored {
+            return Vec::new();
+        }
+
+        run.push(hash);
+        run_parent = Some(hash);
+    }
+
+    run
+}
+
 /// Controls how many times we will retry each block download.
 ///
 /// Failing block downloads is important because it defends against peers who
@@ -1566,6 +1609,10 @@ where
         }
 
         let mut download_set = IndexSet::new();
+        // Responses that offered new blocks but were too short to survive the
+        // trailing-hash strip and the two-hash tip requirement below. They are
+        // the signature of a node restarted 1-2 blocks behind the network.
+        let mut too_short_responses: usize = 0;
         while let Some(res) = requests.next().await {
             match res
                 .unwrap_or_else(|e @ JoinError { .. }| {
@@ -1612,6 +1659,9 @@ where
                         }
                     };
                     if hashes.is_empty() {
+                        // The peer offered exactly one block (we are one block
+                        // behind it), and the strip discarded it.
+                        too_short_responses += 1;
                         continue;
                     }
 
@@ -1652,6 +1702,7 @@ where
                         }
                     } else {
                         debug!("discarding response that extends only one block");
+                        too_short_responses += 1;
                         continue;
                     };
 
@@ -1687,6 +1738,28 @@ where
             }
         }
 
+        // A node that restarts 1-2 blocks behind the network cannot advance
+        // through the fanout above: peers answer `FindBlocks` with 1-2 hashes,
+        // the trailing-hash strip and the two-hash tip requirement discard the
+        // whole response, and gossip cannot fill the gap because the missing
+        // blocks were announced before this node was listening. Fall back to
+        // `FindHeaders`: header parent links prove the offered blocks extend
+        // our chain (which bare hashes cannot), so the trailing-hash quirk does
+        // not apply and even a single-block extension is safe to download.
+        if download_set.is_empty() && too_short_responses > 0 {
+            let anchored = self.headers_anchored_download_set(block_locator).await?;
+            info!(
+                too_short_responses,
+                anchored = anchored.len(),
+                "FindBlocks responses were too short to extend tips; \
+                 downloading header-anchored blocks instead"
+            );
+            metrics::counter!("sync.obtain.header_fallback.count").increment(1);
+            metrics::histogram!("sync.obtain.header_fallback.hash.count")
+                .record(anchored.len() as f64);
+            download_set.extend(anchored);
+        }
+
         debug!(?self.prospective_tips);
 
         // Check that the new tips we got are actually unknown.
@@ -1711,6 +1784,76 @@ where
             .record(stage_start.elapsed().as_secs_f64());
 
         Self::handle_hash_response(response, self.expose_peer_addresses).map_err(Into::into)
+    }
+
+    /// Asks peers for headers extending `block_locator` and returns the hashes
+    /// of offered blocks that provably extend our own chain, in parent-to-child
+    /// order.
+    ///
+    /// This is the near-tip fallback for [`Self::obtain_tips`]: a `FindBlocks`
+    /// response carrying only 1-2 hashes is discarded by the zcashd
+    /// trailing-hash strip, but a header response needs no strip because each
+    /// header names its parent. Only the run of headers that anchors in our
+    /// state counts, using the same anchoring rule as
+    /// [`Self::legacy_peers_blocks_ahead`]: the first unknown header's parent
+    /// must be a block we have, and every later header must link to its
+    /// predecessor in the response. A foreign-fork or gapped response
+    /// contributes nothing.
+    ///
+    /// Best-effort like the `obtain_tips` fanout: failed or unexpected
+    /// responses are skipped. Errors only if the state service fails.
+    #[instrument(skip(self, block_locator))]
+    async fn headers_anchored_download_set(
+        &mut self,
+        block_locator: Vec<block::Hash>,
+    ) -> Result<IndexSet<block::Hash>, Report> {
+        let mut requests = FuturesUnordered::new();
+        for attempt in 0..FANOUT {
+            if attempt > 0 {
+                // Let other tasks run, so we're more likely to choose a different peer.
+                tokio::task::yield_now().await;
+            }
+            let ready_tip_network = self.tip_network.ready().await.map_err(|e| eyre!(e))?;
+            requests.push(tokio::spawn(ready_tip_network.call(
+                zn::Request::FindHeaders {
+                    known_blocks: block_locator.clone(),
+                    stop: None,
+                },
+            )));
+        }
+
+        let mut download_set = IndexSet::new();
+        while let Some(res) = requests.next().await {
+            let headers = match res {
+                Ok(Ok(zn::Response::BlockHeaders(headers))) => headers,
+                Err(e) if e.is_panic() => {
+                    // Avoid swallowing panics.
+                    panic!("panic in headers anchored download set task: {e:?}");
+                }
+                // Best-effort fanout: ignore failed or cancelled requests and
+                // any unexpected response, exactly like the obtain_tips fanout.
+                _ => continue,
+            };
+
+            let mut known_hashes = HashSet::new();
+            if headers.len() <= MAX_TIPS_RESPONSE_HASH_COUNT {
+                let mut checked_hashes = HashSet::new();
+                for counted in &headers {
+                    for hash in [counted.header.hash(), counted.header.previous_block_hash] {
+                        if checked_hashes.insert(hash) && self.state_contains(hash).await? {
+                            known_hashes.insert(hash);
+                        }
+                    }
+                }
+            }
+            let run = anchored_header_hashes(headers, &known_hashes);
+
+            // security: the first response determines our download order, like
+            // the obtain_tips fanout above.
+            download_set.extend(run);
+        }
+
+        Ok(download_set)
     }
 
     /// Asks peers to extend the given prospective `tips`, returning the newly discovered block

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -92,6 +92,55 @@ fn oversized_find_blocks_response_is_rejected() {
     assert!(sync::has_valid_tips_response_hash_count(stripped));
 }
 
+#[test]
+fn malformed_find_headers_responses_are_rejected() -> Result<(), crate::BoxError> {
+    let block1: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block2: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
+
+    let mut foreign_header = *block2.header;
+    foreign_header.previous_block_hash = block::Hash([0xff; 32]);
+
+    let block1_header = block::CountedHeader {
+        header: block1.header.clone(),
+    };
+    let block2_header = block::CountedHeader {
+        header: block2.header.clone(),
+    };
+    let cases = [
+        (
+            "foreign fork",
+            vec![block::CountedHeader {
+                header: Arc::new(foreign_header),
+            }],
+        ),
+        (
+            "unknown header followed by a known header",
+            vec![block2_header.clone(), block1_header],
+        ),
+        (
+            // An anchored first header followed by an unknown header that does
+            // not link to it: the run must not survive a broken parent chain.
+            "gapped run",
+            vec![block2_header.clone(), block2_header.clone()],
+        ),
+        (
+            "oversized response",
+            vec![block2_header; sync::MAX_TIPS_RESPONSE_HASH_COUNT + 1],
+        ),
+    ];
+
+    let known_hashes = HashSet::from([block1.hash()]);
+    for (name, headers) in cases {
+        let hashes = sync::anchored_header_hashes(headers, &known_hashes);
+
+        assert!(hashes.is_empty(), "{name} must contribute no hashes");
+    }
+
+    Ok(())
+}
+
 /// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips.
 ///
 /// This test also makes sure that the syncer downloads blocks in order.
@@ -326,6 +375,147 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     );
 
     // Check that nothing unexpected happened.
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    let chain_sync_result = chain_sync_task_handle.now_or_never();
+    assert!(
+        chain_sync_result.is_none(),
+        "unexpected error or panic in chain sync task: {chain_sync_result:?}",
+    );
+
+    Ok(())
+}
+
+/// A node restarted exactly one block behind the network must still advance.
+///
+/// Peers answer `FindBlocks` with a single hash, which the zcashd trailing-hash
+/// strip discards, so `obtain_tips` alone can never extend the chain (the
+/// near-tip sync dead zone). The syncer must fall back to `FindHeaders`, verify
+/// that the offered header anchors at our tip via its parent link, and download
+/// the block.
+#[tokio::test]
+async fn sync_near_tip_one_block_uses_header_fallback() -> Result<(), crate::BoxError> {
+    // Get services
+    let (
+        chain_sync_future,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup();
+
+    // Get blocks: the local chain already has blocks 0-1, the network has block 2.
+    let block0: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block0_hash = block0.hash();
+
+    let block1: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block1_hash = block1.hash();
+
+    let block2: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
+    let block2_hash = block2.hash();
+
+    // Start the syncer
+    let chain_sync_task_handle = tokio::spawn(chain_sync_future);
+
+    // ChainSync::request_genesis: genesis is already in the state.
+    state_service
+        .expect_request(zs::Request::KnownBlock(block0_hash))
+        .await
+        .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
+
+    // ChainSync::obtain_tips
+
+    // State is asked for a block locator.
+    state_service
+        .expect_request(zs::Request::BlockLocator)
+        .await
+        .respond(zs::Response::BlockLocator(vec![block1_hash]));
+
+    // A peer one block ahead answers with a single hash. Stripping the
+    // possibly-appended trailing hash discards the entire response, so this
+    // response alone must trigger the header fallback.
+    peer_set
+        .expect_request(zn::Request::FindBlocks {
+            known_blocks: vec![block1_hash],
+            stop: None,
+        })
+        .await
+        .respond(zn::Response::BlockHashes(vec![block2_hash]));
+
+    // Clear remaining block locator requests
+    for _ in 0..(sync::FANOUT - 1) {
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block1_hash],
+                stop: None,
+            })
+            .await
+            .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+    }
+
+    // ChainSync::headers_anchored_download_set
+
+    // The fallback asks peers for headers with the same locator.
+    peer_set
+        .expect_request(zn::Request::FindHeaders {
+            known_blocks: vec![block1_hash],
+            stop: None,
+        })
+        .await
+        .respond(zn::Response::BlockHeaders(vec![block::CountedHeader {
+            header: block2.header.clone(),
+        }]));
+
+    // Block 2's header is unknown, and its parent link anchors at our tip.
+    state_service
+        .expect_request(zs::Request::KnownBlock(block2_hash))
+        .await
+        .respond(zs::Response::KnownBlock(None));
+    state_service
+        .expect_request(zs::Request::KnownBlock(block1_hash))
+        .await
+        .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
+
+    // Clear remaining header requests
+    for _ in 0..(sync::FANOUT - 1) {
+        peer_set
+            .expect_request(zn::Request::FindHeaders {
+                known_blocks: vec![block1_hash],
+                stop: None,
+            })
+            .await
+            .respond(Err(zn::BoxError::from(
+                "synthetic test header fallback error",
+            )));
+    }
+
+    // The queued download is re-checked against the state.
+    state_service
+        .expect_request(zs::Request::KnownBlock(block2_hash))
+        .await
+        .respond(zs::Response::KnownBlock(None));
+
+    // Block 2 is fetched and committed.
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block2_hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![Available((
+            block2.clone(),
+            None,
+        ))]));
+
+    block_verifier_router
+        .expect_request(zakura_consensus::Request::Commit(block2))
+        .await
+        .respond(block2_hash);
+
+    // Check that nothing unexpected happened.
+    peer_set.expect_no_requests().await;
     block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 


### PR DESCRIPTION
## Motivation

An operator migrating a Zebra 6.1.0 archive node to Zakura 1.0.2 reported that legacy sync made zero progress from a valid restored state: 29 consecutive sync rounds ended in `exhausted prospective tip set` while the committed tip stayed at 3,419,261 and `/ready` degraded to 503, even though the canonical successor block existed before the syncer started.

**Root cause** — a structural dead zone in `obtain_tips`, inherited verbatim from upstream Zebra: every Mainnet `FindBlocks` response is stripped of its last hash (zcashd append-quirk guard), and a `CheckedTip` requires two remaining unknown hashes (`rchunks_exact(2)`). A peer N blocks ahead answers with N hashes, so N=1 strips to nothing and N=2 strips to one hash that cannot mint a tip — and the tip-creation `continue` also skips queueing the hash for download. Block gossip cannot fill the gap either: the missing blocks were announced while the node was still cloning/upgrading its database, and gossiped children cannot commit without their parent. The node is stuck until the network gets 3+ blocks ahead. Upstream documents the exact failure in its regtest exception comment but only fixed it for regtest; the Zebra "control run" in the report succeeded purely because it was restarted after the network was 3 blocks ahead (`extending tips ... in_flight=2`).

The Zakura migration workflow (stop Zebra → clone 275 GB → format upgrade → fresh peer cache) makes entering this dead zone near-deterministic, which is why it bites Zakura operators but is latent in Zebra.

## Solution

`obtain_tips` now counts responses that offered new blocks but were too short to survive the strip and the two-hash tip requirement. When the fanout ends with an empty download set and at least one such response, it falls back to a `FindHeaders` fanout with the same block locator and queues only the run of offered headers that **provably extends our chain** — the first unknown header's parent must be a block in our state, and every later header must link to its predecessor (`anchored_header_hashes`, same anchoring rule as the watchdog's `legacy_peers_blocks_ahead`). Anchored hashes enter the download set without minting a prospective tip and flow through the existing state re-check, download, and full verification pipeline.

Because headers name their parents, the zcashd trailing-hash quirk cannot poison this path, so even a single-block extension is safe — closing both the 1-behind and 2-behind cases while leaving the ≥3 bulk path byte-identical. Foreign-fork, gapped, out-of-order, and oversized header responses contribute nothing.

**Security posture** (audited against a fully adversarial peer model): the fallback only selects hashes to download; all blocks still pass full semantic + contextual verification, and no `CheckedTip` is ever minted from headers. Forged header chains (hash linkage is not PoW-checked) can queue junk hashes, but this is strictly *more* filtered than the existing `FindBlocks` path, which already accepts up to ~499 unanchored hashes from any peer; consequences (bounded notfound retries, round restart) are identical in kind. The trigger cannot fire while any peer returns a usable ≥3-hash response. Work per response is bounded (500-header cap, sequential state lookups, 6 s per-request timeout inside the 45 s round budget).

The trigger logs at `info` with `too_short_responses` and anchored counts (the reporter's scenario becomes diagnosable from default logs) and emits `sync.obtain.header_fallback.count` / `.hash.count` metrics.

## Testing

- `sync_near_tip_one_block_uses_header_fallback` — full mock-service reproduction of the report: state at block 1, peers answer `FindBlocks` with a single hash (discarded today, stalling forever); asserts the syncer issues `FindHeaders`, anchors the offered header at the tip via its parent link, downloads and commits the block. Fails on `main` by construction.
- `malformed_find_headers_responses_are_rejected` — negative cases for `anchored_header_hashes`: foreign-fork parent, unknown-then-known ordering, gapped (non-linking successor) run, and oversized response each contribute zero hashes.
- `cargo test -p zakura --lib components::sync` — all 60 tests pass; `cargo fmt` and `cargo clippy -p zakura --all-targets` clean; `markdownlint-cli2` clean on `CHANGELOG.md`.
- Field validation still pending: stop a tip-synced node, wait 1–2 Mainnet blocks (~75–150 s), restart — it should log the fallback line and commit within one sync round instead of exhausting for minutes.

### Specifications & References

- External bug report: "legacy sync repeatedly exhausts prospective tips without advancing from a valid Zebra state" (Zakura 1.0.2, Zebra 6.1.0 format-28 state).
- Upstream context: ZcashFoundation/zebra `zebrad/src/components/sync.rs` (identical strip + `rchunks_exact(2)` logic; regtest-only exception), upstream issue #3375 (slow syncing near tip).

### Follow-up Work

- Optional hardening: verify header PoW (difficulty threshold + Equihash, as native header sync does) on fallback headers before queueing, raising forgery cost from zero.
- `/ready` lag currently comes from the 75 s time extrapolator; the fallback's anchored-run count is network truth and could feed readiness instead.
- Offer the fallback upstream to Zebra: any zebrad restart spanning 1–2 block arrivals hits the same window, just more rarely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)