### PR TITLE
fix(zakurad): write generated configs atomically

### DIFF
--- a/zakurad/src/commands/generate.rs
+++ b/zakurad/src/commands/generate.rs
@@ -3,6 +3,7 @@
 use crate::config::ZakuradConfig;
 use abscissa_core::{Command, Runnable};
 use clap::Parser;
+use zakura_chain::common::atomic_write;
 
 /// Generate a default `zakura.toml` configuration
 #[derive(Command, Debug, Default, Parser)]
@@ -78,11 +79,9 @@ impl Runnable for GenerateCmd {
         output += &document_network_p2p_config(&conf);
         match self.output_file {
             Some(ref output_file) => {
-                use std::{fs::File, io::Write};
-                File::create(output_file)
-                    .expect("must be able to open output file")
-                    .write_all(output.as_bytes())
-                    .expect("must be able to write output");
+                atomic_write(output_file.as_str().into(), output.as_bytes())
+                    .expect("must be able to write output atomically")
+                    .expect("must be able to replace output file atomically");
             }
             None => {
                 println!("{output}");

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -264,6 +264,8 @@ fn generate_args() -> Result<()> {
 
     // Add a config file name to tempdir path
     let generated_config_path = testdir.path().join("zakura.toml");
+    let previous_config = "previous config contents";
+    fs::write(&generated_config_path, previous_config)?;
 
     // Valid
     let child =
@@ -281,6 +283,13 @@ fn generate_args() -> Result<()> {
         generated_config_path.exists(),
         &output,
         "generated config file not found"
+    );
+    let generated_config = fs::read_to_string(&generated_config_path)?;
+    assert_with_context!(
+        generated_config.starts_with("# Default configuration for zakurad.")
+            && !generated_config.contains(previous_config),
+        &output,
+        "generated config did not replace previous contents"
     );
 
     Ok(())


### PR DESCRIPTION
## Motivation

The `generate` subcommand opened its output with `File::create` and wrote the config directly. A failed or interrupted write could therefore truncate an existing operator-specified config and leave partial contents behind.

## Solution

Write generated config files with `zakura_chain::common::atomic_write`, which stages the contents in the destination directory and atomically replaces the destination only after the write and sync succeed.

The existing `generate_args` acceptance test now pre-populates the destination and verifies that the generated config replaces those prior contents.

## Testing

- `cargo fmt --all -- --check`

### Specifications & References

None.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to config file generation CLI behavior; reuses an existing atomic-write helper already used elsewhere in the codebase.
> 
> **Overview**
> The `generate` subcommand no longer overwrites an existing output path with `File::create` and a direct write. It now persists through **`zakura_chain::common::atomic_write`**, staging the full config in the destination directory and swapping it in only after the write succeeds, so a failed or interrupted run is less likely to leave a truncated operator config.
> 
> The **`generate_args`** acceptance test seeds the target `zakura.toml` with placeholder text and checks that a successful run replaces it with a fresh generated skeleton (header present, old contents gone).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b3212e7979b0b9cc7b7afbc198f7c1f5c0410c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->