### PR TITLE
fix(rpc): bind verbose block headers to resolved hashes

### DIFF
--- a/changelog.d/328.md
+++ b/changelog.d/328.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Kept verbose block-header metadata bound to the resolved block across chain
+  reorganizations
+  ([#328](https://github.com/zakura-core/zakura/pull/328)).

--- a/changelog.d/328.md
+++ b/changelog.d/328.md
@@ -1,4 +1,6 @@
-## Fixed
+## root
+
+### Fixed
 
 - Kept verbose block-header metadata bound to the resolved block across chain
   reorganizations

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -1535,7 +1535,10 @@ where
             let zakura_state::ReadResponse::SaplingTree(sapling_tree) = self
                 .read_state
                 .clone()
-                .oneshot(zakura_state::ReadRequest::SaplingTree(hash_or_height))
+                // Use the resolved hash so a reorg cannot combine this header
+                // with the Sapling tree from a different block at the same
+                // height.
+                .oneshot(zakura_state::ReadRequest::SaplingTree(hash.into()))
                 .await
                 .map_misc_error()?
             else {

--- a/zakura-rpc/src/methods/tests/vectors.rs
+++ b/zakura-rpc/src/methods/tests/vectors.rs
@@ -790,8 +790,10 @@ async fn rpc_getblock_includes_empty_ironwood_tree_after_nu6_3_activation() {
             next_block_hash: None,
         });
 
+    // The header was requested by height, but follow-up reads must use its
+    // resolved hash so a reorg cannot substitute another block at this height.
     read_state
-        .expect_request(ReadRequest::SaplingTree(hash_or_height))
+        .expect_request(ReadRequest::SaplingTree(hash.into()))
         .await
         .respond(ReadResponse::SaplingTree(Some(Arc::new(
             zakura_chain::sapling::tree::NoteCommitmentTree::default(),


### PR DESCRIPTION
## Motivation

Verbose `getblockheader` first resolves a caller-provided height to a block
header and hash, then previously queried the Sapling tree using the original
height. A reorg between those reads could combine one block's header with a
different block's Sapling tree at the same height.

## Solution

Use the resolved block hash for the Sapling-tree follow-up query. A concurrent
reorg can now produce data for the resolved block or a normal missing-tree
error, but cannot substitute another block at the same height.

The existing mocked height-based `getblock` vector now requires the follow-up
query to use the resolved hash, so it fails with the old request sequence.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p zakura-rpc
  rpc_getblock_includes_empty_ironwood_tree_after_nu6_3_activation`

## Changelog

- Added `changelog.d/328.md`.

### Specifications & References

- https://github.com/ZcashFoundation/zebra/issues/10550

### Follow-up Work

A stacked follow-up PR will make the full verbose block-header response and
`gettxout` state reads use single best-chain snapshots.
