### PR TITLE
fix!(rpc): use consistent best-chain snapshots

### DIFF
--- a/changelog.d/329.md
+++ b/changelog.d/329.md
@@ -1,0 +1,15 @@
+## root
+
+### Fixed
+
+- Keep verbose block-header and `gettxout` responses on one best-chain view
+  during tip changes and reorganizations
+  ([#329](https://github.com/zakura-core/zakura/pull/329)).
+
+## zakura-state
+
+### Added
+
+- Add atomic best-chain read requests for verbose block-header data and unspent
+  transaction output context
+  ([#329](https://github.com/zakura-core/zakura/pull/329)).

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -1503,15 +1503,15 @@ where
                 // Reference for the legacy error code:
                 // <https://github.com/zcash/zcash/blob/99ad6fdc3a549ab510422820eea5e5ce9f60a5fd/src/rpc/blockchain.cpp#L629>
                 .map_error(server::error::LegacyCode::InvalidParameter)?;
-        let zakura_state::ReadResponse::BlockHeader {
-            header,
-            hash,
-            height,
-            next_block_hash,
-        } = self
+        let request = if verbose {
+            zakura_state::ReadRequest::BlockHeaderData(hash_or_height)
+        } else {
+            zakura_state::ReadRequest::BlockHeader(hash_or_height)
+        };
+        let state_response = self
             .read_state
             .clone()
-            .oneshot(zakura_state::ReadRequest::BlockHeader(hash_or_height))
+            .oneshot(request)
             .await
             .map_err(|_| "block height not in best chain")
             .map_error(
@@ -1524,39 +1524,28 @@ where
                 } else {
                     server::error::LegacyCode::InvalidParameter
                 },
-            )?
-        else {
-            panic!("unexpected response to BlockHeader request")
-        };
+            )?;
 
         let response = if !verbose {
+            let zakura_state::ReadResponse::BlockHeader { header, .. } = state_response else {
+                panic!("unexpected response to BlockHeader request")
+            };
+
             GetBlockHeaderResponse::Raw(HexData(header.zcash_serialize_to_vec().map_misc_error()?))
         } else {
-            let zakura_state::ReadResponse::SaplingTree(sapling_tree) = self
-                .read_state
-                .clone()
-                // Use the resolved hash so a reorg cannot combine this header
-                // with the Sapling tree from a different block at the same
-                // height.
-                .oneshot(zakura_state::ReadRequest::SaplingTree(hash.into()))
-                .await
-                .map_misc_error()?
+            let zakura_state::ReadResponse::BlockHeaderData {
+                header,
+                hash,
+                height,
+                next_block_hash,
+                sapling_tree,
+                depth,
+            } = state_response
             else {
-                panic!("unexpected response to SaplingTree request")
+                panic!("unexpected response to BlockHeaderData request")
             };
 
-            // This could be `None` if there's a chain reorg between state queries.
             let sapling_tree = sapling_tree.ok_or_misc_error("missing Sapling tree")?;
-
-            let zakura_state::ReadResponse::Depth(depth) = self
-                .read_state
-                .clone()
-                .oneshot(zakura_state::ReadRequest::Depth(hash))
-                .await
-                .map_misc_error()?
-            else {
-                panic!("unexpected response to SaplingTree request")
-            };
 
             // From <https://zcash.github.io/rpc/getblock.html>
             // TODO: Deduplicate const definition, consider refactoring this to avoid duplicate logic
@@ -3202,32 +3191,16 @@ where
             };
         }
 
-        // TODO: Ensure that the returned tip hash is always valid for the response, i.e. that Zebra can't return a tip that
-        //       hadn't yet included the queried transaction output.
-
-        // Get the best block tip hash
-        let tip_rsp = self
-            .read_state
-            .clone()
-            .oneshot(zakura_state::ReadRequest::Tip)
-            .await
-            .map_misc_error()?;
-
-        let best_block_hash = match tip_rsp {
-            zakura_state::ReadResponse::Tip(tip) => tip.ok_or_misc_error("No blocks in state")?.1,
-            _ => unreachable!("unmatched response to a `Tip` request"),
-        };
-
-        // State path
         let rsp = self
             .read_state
             .clone()
-            .oneshot(zakura_state::ReadRequest::Transaction(txid))
+            .oneshot(zakura_state::ReadRequest::BestChainUnspentOutput(outpoint))
             .await
             .map_misc_error()?;
 
         match rsp {
-            zakura_state::ReadResponse::Transaction(Some(tx)) => {
+            zakura_state::ReadResponse::BestChainUnspentOutput(Some(output_info)) => {
+                let tx = output_info.transaction;
                 let outputs = tx.tx.outputs();
                 let index: usize = n.try_into().expect("u32 always fits in usize");
                 let output = match outputs.get(index) {
@@ -3236,33 +3209,10 @@ where
                     None => return Ok(GetTxOutResponse(None)),
                 };
 
-                // Prune state outputs that are spent
-                let is_spent = {
-                    let rsp = self
-                        .read_state
-                        .clone()
-                        .oneshot(zakura_state::ReadRequest::IsTransparentOutputSpent(
-                            outpoint,
-                        ))
-                        .await
-                        .map_misc_error()?;
-
-                    match rsp {
-                        zakura_state::ReadResponse::IsTransparentOutputSpent(spent) => spent,
-                        _ => unreachable!(
-                            "unmatched response to an `IsTransparentOutputSpent` request"
-                        ),
-                    }
-                };
-
-                if is_spent {
-                    return Ok(GetTxOutResponse(None));
-                }
-
                 Ok(GetTxOutResponse(Some(
                     types::transaction::OutputObject::from_output(
                         output,
-                        best_block_hash.to_string(),
+                        output_info.tip_hash.to_string(),
                         tx.confirmations,
                         tx.tx.version(),
                         tx.tx.is_coinbase(),
@@ -3270,8 +3220,8 @@ where
                     ),
                 )))
             }
-            zakura_state::ReadResponse::Transaction(None) => Ok(GetTxOutResponse(None)),
-            _ => unreachable!("unmatched response to a `Transaction` request"),
+            zakura_state::ReadResponse::BestChainUnspentOutput(None) => Ok(GetTxOutResponse(None)),
+            _ => unreachable!("unmatched response to a `BestChainUnspentOutput` request"),
         }
     }
 }

--- a/zakura-rpc/src/methods/tests/vectors.rs
+++ b/zakura-rpc/src/methods/tests/vectors.rs
@@ -32,8 +32,8 @@ use zakura_network::{
 };
 use zakura_node_services::BoxError;
 use zakura_state::{
-    GetBlockTemplateChainInfo, IntoDisk, LatestChainTip, ReadRequest, ReadResponse,
-    ReadStateService,
+    BestChainUnspentOutput, GetBlockTemplateChainInfo, IntoDisk, LatestChainTip, MinedTx,
+    ReadRequest, ReadResponse, ReadStateService,
 };
 use zakura_test::mock_service::MockService;
 
@@ -781,28 +781,18 @@ async fn rpc_getblock_includes_empty_ironwood_tree_after_nu6_3_activation() {
         tokio::spawn(async move { rpc.get_block(height.0.to_string(), Some(1)).await });
 
     read_state
-        .expect_request(ReadRequest::BlockHeader(hash_or_height))
+        .expect_request(ReadRequest::BlockHeaderData(hash_or_height))
         .await
-        .respond(ReadResponse::BlockHeader {
+        .respond(ReadResponse::BlockHeaderData {
             header: block.header.clone(),
             hash,
             height,
             next_block_hash: None,
+            sapling_tree: Some(Arc::new(
+                zakura_chain::sapling::tree::NoteCommitmentTree::default(),
+            )),
+            depth: Some(0),
         });
-
-    // The header was requested by height, but follow-up reads must use its
-    // resolved hash so a reorg cannot substitute another block at this height.
-    read_state
-        .expect_request(ReadRequest::SaplingTree(hash.into()))
-        .await
-        .respond(ReadResponse::SaplingTree(Some(Arc::new(
-            zakura_chain::sapling::tree::NoteCommitmentTree::default(),
-        ))));
-
-    read_state
-        .expect_request(ReadRequest::Depth(hash))
-        .await
-        .respond(ReadResponse::Depth(Some(0)));
 
     read_state
         .expect_request(ReadRequest::TransactionIdsForBlock(hash.into()))
@@ -1022,24 +1012,18 @@ async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
     let hash_str = block_hash.to_string();
     let block_future = tokio::spawn(async move { rpc_clone.get_block(hash_str, Some(2u8)).await });
 
-    // get_block_header: BlockHeader, SaplingTree, Depth (None = side chain)
+    // get_block_header: all best-chain context comes from one state request.
     read_state
-        .expect_request(ReadRequest::BlockHeader(block_hash.into()))
+        .expect_request(ReadRequest::BlockHeaderData(block_hash.into()))
         .await
-        .respond(ReadResponse::BlockHeader {
+        .respond(ReadResponse::BlockHeaderData {
             header: block_header,
             hash: block_hash,
             height: zakura_chain::block::Height(0),
             next_block_hash: None,
+            sapling_tree: Some(Default::default()),
+            depth: None,
         });
-    read_state
-        .expect_request_that(|req| matches!(req, ReadRequest::SaplingTree(_)))
-        .await
-        .respond(ReadResponse::SaplingTree(Some(Default::default())));
-    read_state
-        .expect_request(ReadRequest::Depth(block_hash))
-        .await
-        .respond(ReadResponse::Depth(None));
 
     // get_block: BlockAndSize, OrchardTree, BlockInfo x2
     read_state
@@ -3335,6 +3319,73 @@ async fn rpc_addnode() {
     );
 
     mempool.expect_no_requests().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_gettxout_uses_one_best_chain_snapshot() {
+    let _init_guard = zakura_test::init();
+
+    let block: Arc<Block> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .get(&1)
+        .expect("test vector should contain block 1")
+        .zcash_deserialize_into()
+        .expect("test block should deserialize");
+    let tx = block.transactions[0].clone();
+    let txid = tx.hash();
+    let outpoint = zakura_chain::transparent::OutPoint {
+        hash: txid,
+        index: 0,
+    };
+    let tip_hash = block.hash();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool, 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let get_tx_out = tokio::spawn(async move {
+        rpc.get_tx_out(txid.encode_hex::<String>(), 0, Some(false))
+            .await
+    });
+
+    read_state
+        .expect_request(ReadRequest::BestChainUnspentOutput(outpoint))
+        .await
+        .respond(ReadResponse::BestChainUnspentOutput(Some(
+            BestChainUnspentOutput {
+                tip_hash,
+                transaction: MinedTx::new(tx, Height(1), 1, block.header.time),
+            },
+        )));
+
+    let response = get_tx_out
+        .await
+        .expect("gettxout task should not panic")
+        .expect("gettxout should succeed")
+        .0
+        .expect("test output should be unspent");
+    let response = serde_json::to_value(response).expect("response should serialize");
+
+    assert_eq!(response["bestblock"], tip_hash.to_string());
+    assert_eq!(response["confirmations"], 1);
+    read_state.expect_no_requests().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -55,8 +55,8 @@ pub use request::{
 pub use request::Spend;
 
 pub use response::{
-    AnyTx, GetBlockTemplateChainInfo, KnownBlock, MinedTx, NonFinalizedBlocksListener,
-    ReadResponse, Response,
+    AnyTx, BestChainUnspentOutput, GetBlockTemplateChainInfo, KnownBlock, MinedTx,
+    NonFinalizedBlocksListener, ReadResponse, Response,
 };
 pub use service::{
     chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip, TipAction},

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -1305,6 +1305,12 @@ pub enum ReadRequest {
     /// [`block::Height`] using `.into()`.
     BlockHeader(HashOrHeight),
 
+    /// Looks up the block header, Sapling tree, and depth using one snapshot of
+    /// the current best chain.
+    ///
+    /// Returns [`ReadResponse::BlockHeaderData`].
+    BlockHeaderData(HashOrHeight),
+
     /// Looks up a transaction by hash in the current best chain.
     ///
     /// Returns
@@ -1354,6 +1360,12 @@ pub enum ReadRequest {
     ///
     /// Checks verified blocks in the finalized chain and the _best_ non-finalized chain.
     UnspentBestChainUtxo(transparent::OutPoint),
+
+    /// Looks up an unspent output and its transaction and tip context using one
+    /// snapshot of the current best chain.
+    ///
+    /// Returns [`ReadResponse::BestChainUnspentOutput`].
+    BestChainUnspentOutput(transparent::OutPoint),
 
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// returning `None` immediately if it is unknown.
@@ -1670,11 +1682,13 @@ impl ReadRequest {
             ReadRequest::AnyChainBlock(_) => "any_chain_block",
             ReadRequest::BlockAndSize(_) => "block_and_size",
             ReadRequest::BlockHeader(_) => "block_header",
+            ReadRequest::BlockHeaderData(_) => "block_header_data",
             ReadRequest::Transaction(_) => "transaction",
             ReadRequest::AnyChainTransaction(_) => "any_chain_transaction",
             ReadRequest::TransactionIdsForBlock(_) => "transaction_ids_for_block",
             ReadRequest::AnyChainTransactionIdsForBlock(_) => "any_chain_transaction_ids_for_block",
             ReadRequest::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
+            ReadRequest::BestChainUnspentOutput(_) => "best_chain_unspent_output",
             ReadRequest::AnyChainUtxo { .. } => "any_chain_utxo",
             ReadRequest::BlockLocator => "block_locator",
             ReadRequest::FindBlockHashes { .. } => "find_block_hashes",

--- a/zakura-state/src/response.rs
+++ b/zakura-state/src/response.rs
@@ -184,6 +184,17 @@ pub struct MinedTx {
     pub block_time: DateTime<Utc>,
 }
 
+/// An unspent output's transaction and tip context from one best-chain
+/// snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BestChainUnspentOutput {
+    /// The best-chain tip hash used to calculate `transaction.confirmations`.
+    pub tip_hash: block::Hash,
+
+    /// The transaction that creates the unspent output.
+    pub transaction: MinedTx,
+}
+
 impl MinedTx {
     /// Creates a new [`MinedTx`]
     pub fn new(
@@ -422,6 +433,22 @@ pub enum ReadResponse {
         next_block_hash: Option<block::Hash>,
     },
 
+    /// Block-header data captured from one snapshot of the current best chain.
+    BlockHeaderData {
+        /// The header of the requested block.
+        header: Arc<block::Header>,
+        /// The hash of the requested block.
+        hash: block::Hash,
+        /// The height of the requested block.
+        height: block::Height,
+        /// The hash of the next block after the requested block.
+        next_block_hash: Option<block::Hash>,
+        /// The Sapling note commitment tree after the requested block.
+        sapling_tree: Option<Arc<sapling::tree::NoteCommitmentTree>>,
+        /// The requested block's depth in the best chain.
+        depth: Option<u32>,
+    },
+
     /// Response to [`ReadRequest::Transaction`] with the specified transaction.
     Transaction(Option<MinedTx>),
 
@@ -474,6 +501,10 @@ pub enum ReadResponse {
     /// The response to a `UnspentBestChainUtxo` request, from verified blocks in the
     /// _best_ non-finalized chain, or the finalized chain.
     UnspentBestChainUtxo(Option<transparent::Utxo>),
+
+    /// An unspent output and its transaction and tip context from one snapshot
+    /// of the current best chain.
+    BestChainUnspentOutput(Option<BestChainUnspentOutput>),
 
     /// The response to an `AnyChainUtxo` request, from verified blocks in
     /// _any_ non-finalized chain, or the finalized chain.
@@ -644,6 +675,7 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::BlockRoots(_)
             | ReadResponse::TipPoolValues { .. }
             | ReadResponse::BlockInfo(_)
+            | ReadResponse::BlockHeaderData { .. }
             | ReadResponse::TransactionIdsForBlock(_)
             | ReadResponse::AnyChainTransactionIdsForBlock(_)
             | ReadResponse::SaplingTree(_)
@@ -662,6 +694,7 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::MissingBlockBodyMetadata(_)
             | ReadResponse::BlockSizeHints(_)
             | ReadResponse::Blocks(_)
+            | ReadResponse::BestChainUnspentOutput(_)
             | ReadResponse::NonFinalizedBlocksListener(_)
             | ReadResponse::IsTransparentOutputSpent(_) => {
                 Err("there is no corresponding Response for this ReadResponse")

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -59,9 +59,9 @@ use crate::{
         read::find,
         watch_receiver::WatchReceiver,
     },
-    BoxError, CheckpointVerifiedBlock, CommitHeaderRangeError, CommitSemanticallyVerifiedError,
-    Config, KnownBlock, ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock,
-    StateInitError,
+    BestChainUnspentOutput, BoxError, CheckpointVerifiedBlock, CommitHeaderRangeError,
+    CommitSemanticallyVerifiedError, Config, KnownBlock, ReadRequest, ReadResponse, Request,
+    Response, SemanticallyVerifiedBlock, StateInitError,
 };
 
 pub mod block_iter;
@@ -1792,6 +1792,40 @@ impl Service<ReadRequest> for ReadStateService {
                 })
             }
 
+            // Used by the verbose getblockheader RPC.
+            ReadRequest::BlockHeaderData(hash_or_height) => {
+                let best_chain = state.latest_best_chain();
+
+                let height = hash_or_height
+                    .height_or_else(|hash| {
+                        read::find::height_by_hash(best_chain.clone(), &state.db, hash)
+                    })
+                    .ok_or_else(|| BoxError::from("block hash or height not found"))?;
+
+                let hash = hash_or_height
+                    .hash_or_else(|height| {
+                        read::find::hash_by_height(best_chain.clone(), &state.db, height)
+                    })
+                    .ok_or_else(|| BoxError::from("block hash or height not found"))?;
+
+                let next_height = height.next()?;
+                let next_block_hash =
+                    read::find::hash_by_height(best_chain.clone(), &state.db, next_height);
+                let header = read::block_header(best_chain.clone(), &state.db, hash.into())
+                    .ok_or_else(|| BoxError::from("block hash or height not found"))?;
+                let sapling_tree = read::sapling_tree(best_chain.clone(), &state.db, hash.into());
+                let depth = read::depth(best_chain, &state.db, hash);
+
+                Ok(ReadResponse::BlockHeaderData {
+                    header,
+                    hash,
+                    height,
+                    next_block_hash,
+                    sapling_tree,
+                    depth,
+                })
+            }
+
             // For the get_raw_transaction RPC and the StateService.
             ReadRequest::Transaction(hash) => Ok(ReadResponse::Transaction(
                 read::mined_transaction(state.latest_best_chain(), &state.db, hash),
@@ -1832,6 +1866,24 @@ impl Service<ReadRequest> for ReadStateService {
             ReadRequest::UnspentBestChainUtxo(outpoint) => Ok(ReadResponse::UnspentBestChainUtxo(
                 read::unspent_utxo(state.latest_best_chain(), &state.db, outpoint),
             )),
+
+            // Used by the gettxout RPC.
+            ReadRequest::BestChainUnspentOutput(outpoint) => {
+                let best_chain = state.latest_best_chain();
+                let output =
+                    read::unspent_utxo(best_chain.clone(), &state.db, outpoint).and_then(|_| {
+                        let (_, tip_hash) = read::tip(best_chain.clone(), &state.db)?;
+                        let transaction =
+                            read::mined_transaction(best_chain, &state.db, outpoint.hash)?;
+
+                        Some(BestChainUnspentOutput {
+                            tip_hash,
+                            transaction,
+                        })
+                    });
+
+                Ok(ReadResponse::BestChainUnspentOutput(output))
+            }
 
             // Manually used by the StateService to implement part of AwaitUtxo.
             ReadRequest::AnyChainUtxo(outpoint) => Ok(ReadResponse::AnyChainUtxo(read::any_utxo(


### PR DESCRIPTION
## Motivation

Verbose `getblockheader` and `gettxout` previously combined several sequential
read-state responses. Each request sampled the latest best chain independently,
so a tip advance or reorganization could produce one RPC response containing
data from different chain views.

This PR is stacked on #328, which provides the narrow resolved-hash fix.

## Solution

- Add a composite block-header read that returns the header, resolved identity,
  next hash, Sapling tree, and depth using one captured best-chain handle.
- Add a composite unspent-output read that returns the creating transaction and
  the tip hash used for its confirmations after checking the output against the
  same best-chain handle.
- Migrate verbose `getblockheader`, its `getblock` callers, and `gettxout` to
  those composite reads.
- Keep the existing state requests intact for downstream compatibility.

### API surface

This adds the public `ReadRequest::BlockHeaderData` and
`ReadRequest::BestChainUnspentOutput` variants, the corresponding
`ReadResponse` variants, and the public `BestChainUnspentOutput` response type.
No existing public item is removed or has its signature changed. However,
adding variants to these exhaustive public enums is source-breaking for
downstream exhaustive matches, so the PR title uses the conventional-commit
breaking-change marker.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p zakura-rpc rpc_gettxout` (2 passed)
- `cargo test -p zakura-rpc rpc_getblock` (9 passed)
- `cargo test -p zakura-state service::read::tests::vectors` (9 passed)
- `cargo clippy -p zakura-state -p zakura-rpc --all-targets -- -D warnings`
- Mock RPC coverage verifies verbose block-header context comes from one state
  response and `gettxout` receives its tip and transaction context together.

## Changelog

- Added `changelog.d/329.md` with root and `zakura-state` entries.

### Specifications & References

- https://github.com/ZcashFoundation/zebra/issues/10550
- Stacked on #328

### Follow-up Work

The legacy granular state request variants remain available. Removing any that
become unused should be considered separately because it would be a breaking
public API change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RPC correctness on the best chain during reorgs and adds public enum variants (source-breaking for exhaustive matches); scope is limited to read paths and well-covered by tests.
> 
> **Overview**
> Verbose **`getblockheader`** and **`gettxout`** no longer stitch together several independent read-state calls. Each RPC now uses one composite request so header, Sapling tree, depth, transaction, and tip hash all come from the **same** best-chain snapshot during tip moves or reorgs.
> 
> **`zakura-state`** adds **`ReadRequest::BlockHeaderData`** and **`ReadRequest::BestChainUnspentOutput`**, with matching **`ReadResponse`** variants and the public **`BestChainUnspentOutput`** type. Handlers capture **`latest_best_chain()`** once and run the related lookups against that handle. Legacy granular requests stay for compatibility.
> 
> RPC tests now expect a single state round-trip for verbose block-header context, and a new test asserts **`gettxout`** gets tip and transaction together via **`BestChainUnspentOutput`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9479cbb2dcfb1ffab6fa02be8ee8c4e59e2aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->