### PR TITLE
fix(consensus): ban peers serving context-invalid blocks

### DIFF
--- a/changelog-unreleased/330.md
+++ b/changelog-unreleased/330.md
@@ -1,0 +1,5 @@
+## Security
+
+- Ban peers that serve blocks with invalid median times, difficulty
+  thresholds, or block commitments
+  ([#330](https://github.com/zakura-core/zakura/pull/330)).

--- a/changelog-unreleased/330.md
+++ b/changelog-unreleased/330.md
@@ -1,5 +1,5 @@
 ## Security
 
-- Ban peers that serve blocks with invalid median times, difficulty
-  thresholds, or block commitments
+- Ban peers that directly serve blocks with invalid median times, difficulty
+  thresholds, or block commitments, without blaming peers for invalid ancestors
   ([#330](https://github.com/zakura-core/zakura/pull/330)).

--- a/changelog-unreleased/330.md
+++ b/changelog-unreleased/330.md
@@ -1,5 +1,5 @@
 ## Security
 
-- Ban peers that directly serve blocks with invalid median times, difficulty
-  thresholds, or block commitments, without blaming peers for invalid ancestors
+- Ban peers that directly serve blocks with contextual consensus violations,
+  without blaming peers for invalid ancestors
   ([#330](https://github.com/zakura-core/zakura/pull/330)).

--- a/zakura-consensus/src/block/tests.rs
+++ b/zakura-consensus/src/block/tests.rs
@@ -1206,3 +1206,30 @@ fn state_commit_duplicate_errors_are_duplicate_requests() {
     );
     assert_eq!(err.misbehavior_score(), 0);
 }
+
+/// Peer-attributable contextual errors must keep their misbehavior score after
+/// the state wraps them for the consensus verifier.
+#[test]
+fn state_commit_context_errors_keep_misbehavior_scores() {
+    let invalid_commitment = zakura_state::CommitBlockError::ValidateContextError(Box::new(
+        zakura_state::ValidateContextError::InvalidBlockCommitment(
+            zakura_chain::block::CommitmentError::InvalidChainHistoryActivationReserved {
+                actual: [1; 32],
+            },
+        ),
+    ));
+    let source: BoxError = Box::new(zakura_state::CommitSemanticallyVerifiedError::from(
+        invalid_commitment,
+    ));
+
+    let err = map_commit_error(source, zakura_chain::block::Hash([0; 32]));
+
+    assert!(
+        matches!(err, VerifyBlockError::Commit(_)),
+        "state commit errors must be unwrapped into VerifyBlockError::Commit, got: {err:?}"
+    );
+    assert_eq!(err.misbehavior_score(), 100);
+
+    let router_error = crate::router::RouterError::from(err);
+    assert_eq!(router_error.misbehavior_score(), 100);
+}

--- a/zakura-consensus/src/checkpoint/tests.rs
+++ b/zakura-consensus/src/checkpoint/tests.rs
@@ -889,3 +889,24 @@ fn state_commit_duplicate_errors_are_duplicate_requests() {
     assert!(err.is_duplicate_request());
     assert_eq!(err.misbehavior_score(), 0);
 }
+
+/// Checkpoint commit failures can depend on auxiliary roots supplied by a
+/// different peer, so they must not be attributed to the block supplier.
+#[test]
+fn state_checkpoint_commit_context_errors_are_unscored() {
+    let invalid_auxiliary_root = zs::CommitBlockError::ValidateContextError(Box::new(
+        zs::ValidateContextError::InvalidBlockCommitment(
+            zakura_chain::block::CommitmentError::InvalidPreNu5OrchardRoot {
+                expected: [0; 32],
+                actual: [1; 32],
+            },
+        ),
+    ));
+    let source: BoxError = Box::new(zs::CommitCheckpointVerifiedError::from(
+        invalid_auxiliary_root,
+    ));
+
+    let err = VerifyCheckpointError::CommitCheckpointVerified(source);
+
+    assert_eq!(err.misbehavior_score(), 0);
+}

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -193,9 +193,10 @@ impl CommitBlockError {
 
     /// Returns a suggested misbehaviour score increment for a certain error.
     ///
-    /// Contextual failures only score when they prove that the supplied block
-    /// violates consensus relative to its declared parent. Transient and local
-    /// state failures remain unscored.
+    /// Callers must only apply this score when the failure is attributable to
+    /// the peer supplying a fully verified block. Checkpoint commit failures
+    /// can depend on auxiliary roots from another peer and must remain
+    /// unscored by checkpoint verification.
     pub fn misbehavior_score(&self) -> u32 {
         match self {
             CommitBlockError::ValidateContextError(error)

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -199,17 +199,7 @@ impl CommitBlockError {
     /// unscored by checkpoint verification.
     pub fn misbehavior_score(&self) -> u32 {
         match self {
-            CommitBlockError::ValidateContextError(error)
-                if matches!(
-                    error.as_ref(),
-                    ValidateContextError::TimeTooEarly { .. }
-                        | ValidateContextError::TimeTooLate { .. }
-                        | ValidateContextError::InvalidDifficultyThreshold { .. }
-                        | ValidateContextError::InvalidBlockCommitment(_)
-                ) =>
-            {
-                100
-            }
+            CommitBlockError::ValidateContextError(error) => error.misbehavior_score(),
             _ => 0,
         }
     }
@@ -883,6 +873,48 @@ pub enum ValidateContextError {
 }
 
 impl ValidateContextError {
+    // Keep this match exhaustive so new contextual errors must make an explicit
+    // peer-attribution decision.
+    fn misbehavior_score(&self) -> u32 {
+        match self {
+            ValidateContextError::NonSequentialBlock { .. }
+            | ValidateContextError::TimeTooEarly { .. }
+            | ValidateContextError::TimeTooLate { .. }
+            | ValidateContextError::InvalidDifficultyThreshold { .. }
+            | ValidateContextError::DuplicateTransparentSpend { .. }
+            | ValidateContextError::MissingTransparentOutput { .. }
+            | ValidateContextError::EarlyTransparentSpend { .. }
+            | ValidateContextError::UnshieldedTransparentCoinbaseSpend { .. }
+            | ValidateContextError::ImmatureTransparentCoinbaseSpend { .. }
+            | ValidateContextError::DuplicateSproutNullifier { .. }
+            | ValidateContextError::DuplicateSaplingNullifier { .. }
+            | ValidateContextError::DuplicateOrchardNullifier { .. }
+            | ValidateContextError::DuplicateIronwoodNullifier { .. }
+            | ValidateContextError::NegativeRemainingTransactionValue { .. }
+            | ValidateContextError::CalculateRemainingTransactionValue { .. }
+            | ValidateContextError::CalculateTransactionValueBalances { .. }
+            | ValidateContextError::CalculateBlockChainValueChange { .. }
+            | ValidateContextError::AddValuePool { .. }
+            | ValidateContextError::InvalidBlockCommitment(_)
+            | ValidateContextError::UnknownSproutAnchor { .. }
+            | ValidateContextError::UnknownSaplingAnchor { .. }
+            | ValidateContextError::UnknownOrchardAnchor { .. }
+            | ValidateContextError::UnknownIronwoodAnchor { .. } => 100,
+
+            ValidateContextError::MissingSproutTipTree(_)
+            | ValidateContextError::BlockPreviouslyInvalidated { .. }
+            | ValidateContextError::NotReadyToBeCommitted
+            | ValidateContextError::InvalidAncestorBlock(_)
+            | ValidateContextError::VctSuppliedRootUnavailable { .. }
+            | ValidateContextError::VctSuppliedRootAwaitingSuccessor { .. }
+            | ValidateContextError::VctBlockAuthDataRootMismatch { .. }
+            | ValidateContextError::VctSproutHandoffRootMismatch { .. }
+            | ValidateContextError::OrphanedBlock { .. }
+            | ValidateContextError::NoteCommitmentTreeError(_)
+            | ValidateContextError::HistoryTreeError(_) => 0,
+        }
+    }
+
     /// Returns the missing VCT supplied-root height for retryable root stalls.
     ///
     /// This is the subset of [`Self::vct_retryable_height`] where the supplied root itself is
@@ -964,7 +996,24 @@ mod tests {
     fn commit_block_error_misbehavior_scores() {
         let block_time = DateTime::from_timestamp(1_000_000, 0)
             .expect("test timestamp is in the supported range");
+        let height = Height(5);
+        let transaction_hash = transaction::Hash([2; 32]);
+        let outpoint = transparent::OutPoint {
+            hash: transaction_hash,
+            index: 0,
+        };
+        let amount_error = amount::Error::Constraint {
+            value: -1,
+            range: 0..=1,
+        };
+        let value_balance_error = ValueBalanceError::Transparent(amount_error.clone());
+        let orchard_nullifier = orchard::Nullifier::try_from([0; 32])
+            .expect("zero is a canonical Orchard nullifier encoding");
         let peer_faults = [
+            ValidateContextError::NonSequentialBlock {
+                candidate_height: height,
+                parent_height: Height(3),
+            },
             ValidateContextError::TimeTooEarly {
                 candidate_time: block_time,
                 median_time_past: block_time,
@@ -977,14 +1026,105 @@ mod tests {
                 difficulty_threshold: INVALID_COMPACT_DIFFICULTY,
                 expected_difficulty: Network::Mainnet.target_difficulty_limit().to_compact(),
             },
+            ValidateContextError::DuplicateTransparentSpend {
+                outpoint,
+                location: "test chain",
+            },
+            ValidateContextError::MissingTransparentOutput {
+                outpoint,
+                location: "test chain",
+            },
+            ValidateContextError::EarlyTransparentSpend { outpoint },
+            ValidateContextError::UnshieldedTransparentCoinbaseSpend { outpoint },
+            ValidateContextError::ImmatureTransparentCoinbaseSpend {
+                outpoint,
+                spend_height: height,
+                min_spend_height: Height(100),
+                created_height: Height(1),
+            },
+            ValidateContextError::DuplicateSproutNullifier {
+                nullifier: sprout::Nullifier::from([0; 32]),
+                in_finalized_state: false,
+            },
+            ValidateContextError::DuplicateSaplingNullifier {
+                nullifier: sapling::Nullifier::from([0; 32]),
+                in_finalized_state: false,
+            },
+            ValidateContextError::DuplicateOrchardNullifier {
+                nullifier: orchard_nullifier,
+                in_finalized_state: false,
+            },
+            ValidateContextError::DuplicateIronwoodNullifier {
+                nullifier: orchard_nullifier,
+                in_finalized_state: false,
+            },
+            ValidateContextError::NegativeRemainingTransactionValue {
+                amount_error: amount_error.clone(),
+                height,
+                tx_index_in_block: 1,
+                transaction_hash,
+            },
+            ValidateContextError::CalculateRemainingTransactionValue {
+                amount_error,
+                height,
+                tx_index_in_block: 1,
+                transaction_hash,
+            },
+            ValidateContextError::CalculateTransactionValueBalances {
+                value_balance_error: value_balance_error.clone(),
+                height,
+                tx_index_in_block: 1,
+                transaction_hash,
+            },
+            ValidateContextError::CalculateBlockChainValueChange {
+                value_balance_error: value_balance_error.clone(),
+                height,
+                block_hash: block::Hash([3; 32]),
+                transaction_count: 2,
+                spent_utxo_count: 1,
+            },
+            ValidateContextError::AddValuePool {
+                value_balance_error,
+                chain_value_pools: Box::new(ValueBalance::<NonNegative>::zero()),
+                block_value_pool_change: Box::new(ValueBalance::<NegativeAllowed>::zero()),
+                height: Some(height),
+            },
             ValidateContextError::InvalidBlockCommitment(
                 CommitmentError::InvalidChainHistoryActivationReserved { actual: [1; 32] },
             ),
+            ValidateContextError::UnknownSproutAnchor {
+                anchor: sprout::tree::Root::default(),
+                height: Some(height),
+                tx_index_in_block: Some(1),
+                transaction_hash,
+            },
+            ValidateContextError::UnknownSaplingAnchor {
+                anchor: sapling::tree::Root::default(),
+                height: Some(height),
+                tx_index_in_block: Some(1),
+                transaction_hash,
+            },
+            ValidateContextError::UnknownOrchardAnchor {
+                anchor: orchard::tree::Root::default(),
+                height: Some(height),
+                tx_index_in_block: Some(1),
+                transaction_hash,
+            },
+            ValidateContextError::UnknownIronwoodAnchor {
+                anchor: ironwood::tree::Root::default(),
+                height: Some(height),
+                tx_index_in_block: Some(1),
+                transaction_hash,
+            },
         ];
 
         for error in peer_faults {
             let commit_error = CommitBlockError::ValidateContextError(Box::new(error));
-            assert_eq!(commit_error.misbehavior_score(), 100);
+            assert_eq!(
+                commit_error.misbehavior_score(),
+                100,
+                "direct contextual consensus failure must be scored: {commit_error:?}"
+            );
         }
 
         let transient_context_error = CommitBlockError::ValidateContextError(Box::new(
@@ -996,6 +1136,13 @@ mod tests {
             ValidateContextError::InvalidAncestorBlock(block::Hash([1; 32])),
         ));
         assert_eq!(invalid_ancestor_error.misbehavior_score(), 0);
+
+        let stale_fork_error =
+            CommitBlockError::ValidateContextError(Box::new(ValidateContextError::OrphanedBlock {
+                candidate_height: Height(3),
+                finalized_tip_height: height,
+            }));
+        assert_eq!(stale_fork_error.misbehavior_score(), 0);
 
         let dup_err = CommitBlockError::Duplicate {
             hash_or_height: None,

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -953,7 +953,7 @@ mod tests {
     use zakura_chain::{
         block::{CommitmentError, Height},
         parameters::Network,
-        work::difficulty::INVALID_COMPACT_DIFFICULTY,
+        work::difficulty::{ParameterDifficulty, INVALID_COMPACT_DIFFICULTY},
     };
 
     #[test]

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -610,6 +610,9 @@ pub enum ValidateContextError {
     #[non_exhaustive]
     NotReadyToBeCommitted,
 
+    #[error("block descends from invalid ancestor {0}")]
+    InvalidAncestorBlock(block::Hash),
+
     #[error(
         "verified-commitment-trees fast path has no valid supplied root for height \
          {height:?}: the note-commitment frontier is frozen, so this block cannot be \
@@ -988,6 +991,11 @@ mod tests {
             ValidateContextError::NotReadyToBeCommitted,
         ));
         assert_eq!(transient_context_error.misbehavior_score(), 0);
+
+        let invalid_ancestor_error = CommitBlockError::ValidateContextError(Box::new(
+            ValidateContextError::InvalidAncestorBlock(block::Hash([1; 32])),
+        ));
+        assert_eq!(invalid_ancestor_error.misbehavior_score(), 0);
 
         let dup_err = CommitBlockError::Duplicate {
             hash_or_height: None,

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -192,8 +192,25 @@ impl CommitBlockError {
     }
 
     /// Returns a suggested misbehaviour score increment for a certain error.
+    ///
+    /// Contextual failures only score when they prove that the supplied block
+    /// violates consensus relative to its declared parent. Transient and local
+    /// state failures remain unscored.
     pub fn misbehavior_score(&self) -> u32 {
-        0
+        match self {
+            CommitBlockError::ValidateContextError(error)
+                if matches!(
+                    error.as_ref(),
+                    ValidateContextError::TimeTooEarly { .. }
+                        | ValidateContextError::TimeTooLate { .. }
+                        | ValidateContextError::InvalidDifficultyThreshold { .. }
+                        | ValidateContextError::InvalidBlockCommitment(_)
+                ) =>
+            {
+                100
+            }
+            _ => 0,
+        }
     }
 }
 
@@ -933,17 +950,43 @@ impl DuplicateNullifierError for orchard::Nullifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zakura_chain::block::Height;
+    use zakura_chain::{
+        block::{CommitmentError, Height},
+        parameters::Network,
+        work::difficulty::INVALID_COMPACT_DIFFICULTY,
+    };
 
     #[test]
     fn commit_block_error_misbehavior_scores() {
-        let context_err = CommitBlockError::ValidateContextError(Box::new(
-            ValidateContextError::NonSequentialBlock {
-                candidate_height: Height(5),
-                parent_height: Height(3),
+        let block_time = DateTime::from_timestamp(1_000_000, 0)
+            .expect("test timestamp is in the supported range");
+        let peer_faults = [
+            ValidateContextError::TimeTooEarly {
+                candidate_time: block_time,
+                median_time_past: block_time,
             },
+            ValidateContextError::TimeTooLate {
+                candidate_time: block_time,
+                block_time_max: block_time,
+            },
+            ValidateContextError::InvalidDifficultyThreshold {
+                difficulty_threshold: INVALID_COMPACT_DIFFICULTY,
+                expected_difficulty: Network::Mainnet.target_difficulty_limit().to_compact(),
+            },
+            ValidateContextError::InvalidBlockCommitment(
+                CommitmentError::InvalidChainHistoryActivationReserved { actual: [1; 32] },
+            ),
+        ];
+
+        for error in peer_faults {
+            let commit_error = CommitBlockError::ValidateContextError(Box::new(error));
+            assert_eq!(commit_error.misbehavior_score(), 100);
+        }
+
+        let transient_context_error = CommitBlockError::ValidateContextError(Box::new(
+            ValidateContextError::NotReadyToBeCommitted,
         ));
-        assert_eq!(context_err.misbehavior_score(), 0);
+        assert_eq!(transient_context_error.misbehavior_score(), 0);
 
         let dup_err = CommitBlockError::Duplicate {
             hash_or_height: None,

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -77,10 +77,10 @@ pub enum VctRootRepairState {
     },
 }
 
-/// The maximum size of the parent error map.
+/// The maximum size of the rejected ancestor map.
 ///
 /// We allow enough space for multiple concurrent chain forks with errors.
-const PARENT_ERROR_MAP_LIMIT: usize = MAX_BLOCK_REORG_HEIGHT as usize * 2;
+const REJECTED_ANCESTOR_MAP_LIMIT: usize = MAX_BLOCK_REORG_HEIGHT as usize * 2;
 
 /// Run contextual validation on the prepared block and add it to the
 /// non-finalized state if it is contextually valid.
@@ -571,8 +571,9 @@ impl WriteBlockWorkerTask {
             return;
         }
 
-        // Save any errors to propagate down to queued child blocks
-        let mut parent_error_map: IndexMap<block::Hash, ValidateContextError> = IndexMap::new();
+        // Track rejected ancestors so queued descendants can be rejected without
+        // attributing the ancestor's validation failure to the descendant's peer.
+        let mut rejected_ancestor_map: IndexMap<block::Hash, block::Hash> = IndexMap::new();
 
         while let Some(msg) = deferred_non_finalized_messages
             .pop_front()
@@ -624,15 +625,15 @@ impl WriteBlockWorkerTask {
             let parent_hash = queued_child.block.header.previous_block_hash;
             let child_height = queued_child.height;
             let child_block = queued_child.block.clone();
-            let parent_error = parent_error_map.get(&parent_hash);
+            let rejected_ancestor_hash = rejected_ancestor_map.get(&parent_hash).copied();
 
             // If the parent block was marked as rejected, also reject all its children.
             //
             // At this point, we know that all the block's descendants
             // are invalid, because we checked all the consensus rules before
             // committing the failing ancestor block to the non-finalized state.
-            let result = if let Some(parent_error) = parent_error {
-                Err(parent_error.clone())
+            let result = if let Some(ancestor_hash) = rejected_ancestor_hash {
+                Err(ValidateContextError::InvalidAncestorBlock(ancestor_hash))
             } else {
                 tracing::trace!(?child_hash, "validating queued child");
                 validate_and_commit_non_finalized(
@@ -646,14 +647,15 @@ impl WriteBlockWorkerTask {
             //       after `update_latest_chain_channels()`,
             //       and send the result on rsp_tx here
 
-            if let Err(ref error) = result {
+            if result.is_err() {
                 // If the block is invalid, mark any descendant blocks as rejected.
-                parent_error_map.insert(child_hash, error.clone());
+                rejected_ancestor_map
+                    .insert(child_hash, rejected_ancestor_hash.unwrap_or(child_hash));
 
-                // Make sure the error map doesn't get too big.
-                if parent_error_map.len() > PARENT_ERROR_MAP_LIMIT {
+                // Make sure the rejected ancestor map doesn't get too big.
+                if rejected_ancestor_map.len() > REJECTED_ANCESTOR_MAP_LIMIT {
                     // We only add one hash at a time, so we only need to remove one extra here.
-                    parent_error_map.shift_remove_index(0);
+                    rejected_ancestor_map.shift_remove_index(0);
                 }
 
                 // Signal the StateService to drop this hash from
@@ -676,7 +678,7 @@ impl WriteBlockWorkerTask {
 
             // A successfully committed block supersedes any contextual error
             // recorded for a different block body with the same header hash.
-            parent_error_map.shift_remove(&child_hash);
+            rejected_ancestor_map.shift_remove(&child_hash);
 
             if should_seed_zakura_header_from_non_finalized_commit(
                 *seed_zakura_header_from_best_chain_commits,

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -1323,6 +1323,77 @@ async fn should_restart_sync_returns_false() {
     );
 }
 
+/// A queued descendant inherits only an unscored invalid-ancestor failure, so
+/// its advertiser is not blamed for the invalid block served by another peer.
+#[test]
+fn invalid_ancestor_does_not_score_descendant_advertiser() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        _peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+    let (misbehavior_tx, mut misbehavior_rx) = tokio::sync::mpsc::channel(2);
+    chain_sync.misbehavior_sender = misbehavior_tx;
+
+    let parent_advertiser: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+    let child_advertiser: PeerSocketAddr = "127.0.0.2:8233".parse().unwrap();
+    let parent_hash = block::Hash([0xA1; 32]);
+    let child_hash = block::Hash([0xB2; 32]);
+
+    let parent_error = zs::CommitBlockError::ValidateContextError(Box::new(
+        zs::ValidateContextError::InvalidBlockCommitment(
+            zakura_chain::block::CommitmentError::InvalidChainHistoryActivationReserved {
+                actual: [1; 32],
+            },
+        ),
+    ));
+    let parent_error = RouterError::Block {
+        source: Box::new(VerifyBlockError::Commit(parent_error)),
+    };
+    let parent_response = BlockDownloadVerifyError::Invalid {
+        error: parent_error,
+        height: Height(42),
+        hash: parent_hash,
+        advertiser_addr: Some(parent_advertiser),
+    };
+
+    assert!(chain_sync
+        .handle_block_response(Err(parent_response))
+        .is_err());
+    assert_eq!(
+        misbehavior_rx.try_recv(),
+        Ok((parent_advertiser, 100)),
+        "the peer that served the invalid block must be scored"
+    );
+
+    let child_error = zs::CommitBlockError::ValidateContextError(Box::new(
+        zs::ValidateContextError::InvalidAncestorBlock(parent_hash),
+    ));
+    let child_error = RouterError::Block {
+        source: Box::new(VerifyBlockError::Commit(child_error)),
+    };
+    let child_response = BlockDownloadVerifyError::Invalid {
+        error: child_error,
+        height: Height(43),
+        hash: child_hash,
+        advertiser_addr: Some(child_advertiser),
+    };
+
+    assert!(chain_sync
+        .handle_block_response(Err(child_response))
+        .is_err());
+    assert!(
+        matches!(
+            misbehavior_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ),
+        "the different peer that served the descendant must not be scored"
+    );
+}
+
 /// A scratch state can have finalized genesis tip metadata before
 /// `KnownBlock(genesis)` can find a block body. In that state, committing the
 /// downloaded genesis block returns duplicate/finalized; the genesis bootstrap


### PR DESCRIPTION
## Motivation

Peers that serve blocks with objectively invalid contextual data were not
penalized. `CommitBlockError::misbehavior_score()` returned zero for contextual
validation failures, so the inbound and sync services rejected these blocks
without reporting their suppliers to the address book.

This let a peer repeatedly consume block download and verification resources
without reaching the peer-ban threshold.

## Solution

- Assign a misbehavior score of 100 to direct contextual consensus violations,
  including non-sequential heights, invalid times and difficulty, invalid
  transparent spends and value accounting, duplicate shielded nullifiers,
  unknown shielded anchors, and invalid block commitments.
- Classify every `ValidateContextError` exhaustively, so future variants require
  an explicit peer-attribution decision.
- Keep transient, stale-fork, operator-invalidation, local state/tree, and
  checkpoint auxiliary-root failures unscored.
- Classify queued descendants with an unscored invalid-ancestor error, so only
  the peer that supplied the directly invalid block is penalized.
- Verify that wrapped state errors retain their score through the consensus
  verifier and router paths used by block download services.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `npx --yes markdownlint-cli changelog-unreleased/330.md --config
  .trunk/configs/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `cargo test -p zakura-state commit_block_error_misbehavior_scores --locked`
- `cargo test -p zakura
  invalid_ancestor_does_not_score_descendant_advertiser --locked`
- `cargo test -p zakura-state -p zakura-consensus --lib --locked` —
  559 passed; 3 ignored
- `cargo test -p zakura --lib --locked` — 310 passed
- `cargo clippy -p zakura-state -p zakura-consensus -p zakura --all-targets
  --locked -- -D warnings`

The state regression enumerates every directly scored contextual error and
verifies that transient, stale-fork, invalid-ancestor, and duplicate commit
errors remain unscored. The consensus tests verify score propagation through
`VerifyBlockError` and `RouterError` while preserving the checkpoint
auxiliary-root attribution boundary. The sync regression uses different parent
and child advertisers and verifies that only the parent advertiser is scored.

## Changelog

- Added `changelog-unreleased/330.md` with an operator-facing security entry.

### Specifications & References

- [Zcash block header consensus rules](https://zips.z.cash/protocol/protocol.pdf#blockheader)
- [Zcash difficulty adjustment rules](https://zips.z.cash/protocol/protocol.pdf#diffadjustment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer-banning behavior in block download and sync; incorrect scoring could ban honest peers, though attribution rules and tests narrow that risk.
>
> **Overview**
> **Peers that serve blocks failing contextual checks on median time, difficulty threshold, or block commitments now receive a misbehavior increment of 100**, so sync and inbound paths can ban repeat offenders instead of silently rejecting blocks.
>
> **Queued descendants of a rejected parent no longer inherit the parent’s validation error.** The non-finalized write loop tracks a rejected-ancestor hash and fails children with unscored `ValidateContextError::InvalidAncestorBlock`, so a peer advertising a child block is not penalized for another peer’s bad ancestor. Transient, duplicate, and checkpoint auxiliary-root failures stay at score 0; docs on `CommitBlockError::misbehavior_score` spell out when scores apply.
>
> Tests cover score propagation through `VerifyBlockError` / `RouterError`, checkpoint commit boundaries, and chain sync handling so the parent advertiser is scored and the child advertiser is not.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5fe74046ed7002ecd0ae4cc219ed6330af9dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
