### PR TITLE
ci: build unit-test binaries once and fan out shards from a nextest archive

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -56,23 +56,75 @@ env:
   COLORBT_SHOW_HIDDEN: 1
 
 jobs:
+  # Compile the whole workspace and every test binary ONCE, then hand the result
+  # to the shard jobs as a nextest archive. Previously each of the 3 shards ran
+  # `cargo nextest run`, so each recompiled the full workspace + all dependencies
+  # from scratch — the same ~5m compile floor paid three times in parallel, and
+  # three jobs racing to save one shared build cache (only one save ever wins).
+  # Building once removes two of the three compile passes and takes compilation
+  # off the critical path of every shard.
+  build-tests:
+    name: build test binaries (${{ github.event_name == 'pull_request' && 'debug' || 'release' }})
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+          # Single writer for this cache key, so the save no longer races the
+          # other shards ("Unable to reserve cache … another job").
+          cache-key: unit-tests-ubuntu-latest-stable-default-release-binaries-${{ github.event_name == 'pull_request' && 'debug' || 'release' }}
+          cache-on-failure: true
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
+        with:
+          tool: cargo-nextest
+      - uses: ./.github/actions/setup-zakura-build
+
+      - name: Build and archive test binaries
+        run: |
+          # The archive stores compiled binaries, so it must be built in the same
+          # mode the shards run. The run-time-only filters (`--profile`,
+          # `--partition`, `--run-ignored`) are applied by the shard jobs, not here.
+          if [[ "${FULL_COVERAGE}" == "true" ]]; then
+            cargo nextest archive --locked --release --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
+          else
+            cargo nextest archive --locked --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
+          fi
+        env:
+          FULL_COVERAGE: ${{ github.event_name != 'pull_request' }}
+
+      - name: Upload nextest archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: nextest-archive
+          path: ${{ runner.temp }}/nextest-archive.tar.zst
+          retention-days: 1
+          if-no-files-found: error
+          compression-level: 0 # already zstd-compressed
+
   unit-tests:
     name: ${{ matrix.rust-version }} on ${{ matrix.os }} (shard ${{ matrix.partition }}/3)
+    needs: build-tests
     permissions:
       contents: read
       id-token: write
       statuses: write
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         rust-version: [stable]
-        features: [default-release-binaries]
-        # Shard the broad suite across 3 runners. Each shard recompiles (the fixed
-        # ~2.5m compile floor every runner pays) but runs only its 1/3 slice of the
-        # tests via nextest `--partition`, so the run phase parallelizes ~3x.
+        # Run only this shard's 1/3 slice of the tests from the prebuilt archive
+        # via nextest `--partition`. No compilation happens here.
         partition: [1, 2, 3]
 
     steps:
@@ -82,19 +134,26 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: ${{ matrix.rust-version }}
-          cache-key: unit-tests-${{ matrix.os }}-${{ matrix.rust-version }}-${{ matrix.features }}-${{ github.event_name == 'pull_request' && 'debug' || 'release' }}
-          cache-on-failure: true
+          # Nothing is compiled in this job, so there is no build cache to keep.
+          cache: false
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest
+      # RocksDB is dynamically linked, so the prebuilt test binaries still need
+      # librocksdb present at run time (protoc is only needed to build).
       - uses: ./.github/actions/setup-zakura-build
+      - name: Download nextest archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: nextest-archive
+          path: ${{ runner.temp }}
 
       - name: Run unit tests
         run: |
           if [[ "${FULL_COVERAGE}" == "true" ]]; then
-            cargo nextest run --profile full-tests --locked --release --features "${{ matrix.features }}" --run-ignored=all --partition "hash:${{ matrix.partition }}/3"
+            cargo nextest run --profile full-tests --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst" --run-ignored=all --partition "hash:${{ matrix.partition }}/3"
           else
-            cargo nextest run --profile all-tests --locked --features "${{ matrix.features }}" --partition "hash:${{ matrix.partition }}/3"
+            cargo nextest run --profile all-tests --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst" --partition "hash:${{ matrix.partition }}/3"
           fi
         env:
           FULL_COVERAGE: ${{ github.event_name != 'pull_request' }}
@@ -205,6 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - build-tests
       - unit-tests
       - zakura-config
       - network-dependent

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -173,7 +173,12 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: stable
-          cache-key: zakura-config
+          # These acceptance jobs all do the same debug build of the workspace
+          # with the same features, so they share one build cache instead of each
+          # keeping its own multi-GB copy. `cache-shared-key` (unlike `cache-key`,
+          # which only appends to a per-job key and never shares) is stable across
+          # jobs, so the first to run warms the cache and the rest restore it.
+          cache-shared-key: zakura-drb-debug
           cache-on-failure: true
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
@@ -197,7 +202,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: stable
-          cache-key: network-dependent
+          cache-shared-key: zakura-drb-debug
           cache-on-failure: true
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
@@ -222,7 +227,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: stable
-          cache-key: pruned-storage
+          cache-shared-key: zakura-drb-debug
           cache-on-failure: true
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -61,8 +61,8 @@ jobs:
   # `cargo nextest run`, so each recompiled the full workspace + all dependencies
   # from scratch — the same ~5m compile floor paid three times in parallel, and
   # three jobs racing to save one shared build cache (only one save ever wins).
-  # Building once removes two of the three compile passes and takes compilation
-  # off the critical path of every shard.
+  # Building once removes two of the three compile passes while preserving
+  # parallel test execution across the shard jobs.
   build-tests:
     name: build test binaries (${{ github.event_name == 'pull_request' && 'debug' || 'release' }})
     permissions:
@@ -177,7 +177,7 @@ jobs:
           # with the same features, so they share one build cache instead of each
           # keeping its own multi-GB copy. `cache-shared-key` (unlike `cache-key`,
           # which only appends to a per-job key and never shares) is stable across
-          # jobs, so the first to run warms the cache and the rest restore it.
+          # jobs, consolidating their cache entries across workflow runs.
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2

--- a/.github/workflows/zakura-e2e.yml
+++ b/.github/workflows/zakura-e2e.yml
@@ -125,7 +125,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.16.1 # zizmor: ignore[cache-poisoning] -- CI e2e job; uploads only diagnostic traces and builds a throwaway debug binary, nothing published/released
         with:
           toolchain: stable
-          cache-key: zakura-regtest-e2e-pr-gate
+          # The two regtest-e2e jobs share one debug `cargo test --no-run` build
+          # (default features, distinct from the `default-release-binaries` group
+          # above), so they share a cache with each other but not with that group.
+          cache-shared-key: zakura-e2e-debug
           cache-on-failure: true
       - uses: ./.github/actions/setup-zakura-build
       # Compile the e2e once. `cargo test --no-run` builds both the integration
@@ -192,7 +195,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.16.1 # zizmor: ignore[cache-poisoning] -- CI integration job; uploads only diagnostic test traces
         with:
           toolchain: stable
-          cache-key: zakura-testkit
+          # Same debug + default-release-binaries workspace build as the unit
+          # acceptance jobs, so it shares their consolidated build cache.
+          cache-shared-key: zakura-drb-debug
           cache-on-failure: true
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
@@ -233,7 +238,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.16.1 # zizmor: ignore[cache-poisoning] -- CI fuzz-scenario job; uploads only diagnostic test traces
         with:
           toolchain: stable
-          cache-key: zakura-blocksync-fuzz
+          cache-shared-key: zakura-drb-debug
           cache-on-failure: true
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
@@ -277,7 +282,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.16.1 # zizmor: ignore[cache-poisoning] -- CI e2e job; uploads only diagnostic traces and builds a throwaway debug binary, nothing published/released
         with:
           toolchain: stable
-          cache-key: zakura-regtest-e2e
+          cache-shared-key: zakura-e2e-debug
           cache-on-failure: true
       - uses: ./.github/actions/setup-zakura-build
       # Build once (see the pr-gate job for the ROCKSDB_LIB_DIR / static-link

--- a/changelog-unreleased/331.md
+++ b/changelog-unreleased/331.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes continuous integration and test infrastructure, with no
+operator- or crate-consumer-visible effect.

--- a/zakurad/tests/common/checkpoints.rs
+++ b/zakurad/tests/common/checkpoints.rs
@@ -342,7 +342,7 @@ impl ZakuraCheckpointsTestDirExt for TempDir {
         };
 
         // Fall back to assuming zakura-checkpoints is in the same directory as zakurad.
-        let mut zakura_checkpoints_path: PathBuf = env!("CARGO_BIN_EXE_zakurad").into();
+        let mut zakura_checkpoints_path: PathBuf = super::zakurad_exe_path().into();
         assert!(
             zakura_checkpoints_path.pop(),
             "must have at least one path component",

--- a/zakurad/tests/common/launch.rs
+++ b/zakurad/tests/common/launch.rs
@@ -140,7 +140,7 @@ where
 
         args.merge_with(extra_args);
 
-        self.spawn_child_with_command(env!("CARGO_BIN_EXE_zakurad"), args)
+        self.spawn_child_with_command(&super::zakurad_exe_path(), args)
     }
 
     fn with_config(self, config: &mut ZakuradConfig) -> Result<Self> {

--- a/zakurad/tests/common/launch.rs
+++ b/zakurad/tests/common/launch.rs
@@ -6,7 +6,6 @@
 //! This file is only for test library code.
 
 use std::{
-    env,
     fmt::Debug,
     net::SocketAddr,
     path::{Path, PathBuf},

--- a/zakurad/tests/common/mod.rs
+++ b/zakurad/tests/common/mod.rs
@@ -34,7 +34,7 @@ pub mod zcashd_compat;
 /// they are run from a `cargo nextest` archive on a different job than the one
 /// that built them. Falls back to the path Cargo bakes in at compile time for
 /// ordinary in-tree `cargo test` runs, where the run-time variable is absent.
-pub fn zakurad_exe_path() -> String {
+fn zakurad_exe_path() -> String {
     std::env::var("CARGO_BIN_EXE_zakurad")
         .unwrap_or_else(|_| env!("CARGO_BIN_EXE_zakurad").to_string())
 }

--- a/zakurad/tests/common/mod.rs
+++ b/zakurad/tests/common/mod.rs
@@ -25,3 +25,16 @@ pub mod regtest;
 pub mod sync;
 pub mod test_type;
 pub mod zcashd_compat;
+
+/// Returns the path to the compiled `zakurad` binary under test.
+///
+/// Prefers the value the test runner exports at run time
+/// (`CARGO_BIN_EXE_zakurad`), so the tests keep working when the binaries are
+/// relocated away from the directory they were compiled in — for example when
+/// they are run from a `cargo nextest` archive on a different job than the one
+/// that built them. Falls back to the path Cargo bakes in at compile time for
+/// ordinary in-tree `cargo test` runs, where the run-time variable is absent.
+pub fn zakurad_exe_path() -> String {
+    std::env::var("CARGO_BIN_EXE_zakurad")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_zakurad").to_string())
+}


### PR DESCRIPTION
## Motivation

The unit-test workflow shards the suite across three runners, but each shard
previously compiled the whole workspace. That duplicated the dominant build
cost, caused concurrent cache-save contention, and contributed several large,
job-specific caches to the repository's Actions cache pressure.

## Solution

- Build all test binaries once with `cargo nextest archive` and upload the
  archive for the three test shards.
- Run each shard from that archive without a local build cache.
- Resolve `CARGO_BIN_EXE_zakurad` at run time so archived tests can find the
  relocated binary, while preserving the compile-time path fallback.
- Consolidate compatible acceptance and end-to-end build caches with shared
  keys.
- Keep the binary-path helper private to the test harness.

The measured debug run reduced build-and-shard runner time from 25m39s to
17m10s (about 33%). Its 9m51s workflow wall time was comparable to the 9m22s
baseline because the shared build becomes a prerequisite for every shard.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura --tests --features default-release-binaries`
- `npx --yes markdownlint-cli changelog-unreleased/331.md --config
  .trunk/configs/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `./scripts/changelog.py check-pr --base origin/main --head HEAD --pr 331`
- [Debug archive workflow run](https://github.com/zakura-core/zakura/actions/runs/29852142804)

The merge queue runs the non-PR release/full-coverage path before merge.

## Changelog

`changelog-unreleased/331.md` marks this internal CI and test-infrastructure
change as having no operator- or crate-consumer-visible effect.

### Follow-up Work

Monitor release archive size, transfer time, runner time, and workflow wall
time after the first main-branch run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflows and test harness path resolution; no production or operator-facing behavior.
> 
> **Overview**
> **Unit Tests** workflow now compiles once in a dedicated **`build-tests`** job (`cargo nextest archive`), uploads the archive, and three shard jobs only download it and run partitioned tests—no per-shard `cargo nextest run` compile. The build job is the sole Rust cache writer; shards use `cache: false`. **`test-success`** also depends on **`build-tests`**.
> 
> Several workflows replace per-job **`cache-key`** with shared **`cache-shared-key`** (`zakura-drb-debug` for acceptance/testkit/fuzz jobs; `zakura-e2e-debug` for regtest e2e) to cut duplicate multi-GB caches.
> 
> **`zakurad` acceptance helpers** resolve the daemon binary via runtime **`CARGO_BIN_EXE_zakurad`** when present (nextest archive on another runner), else compile-time **`env!`**, so subprocess tests still find **`zakurad`** / sibling **`zakura-checkpoints`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0abbe5c20838e5edb8e225651f937dc3f40cda74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->