### PR TITLE
fix(tests): capture logs without racing the global tracing subscriber

### DIFF
--- a/zakura-test/src/lib.rs
+++ b/zakura-test/src/lib.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 #[allow(missing_docs)]
 pub mod command;
 
+pub mod log_capture;
 pub mod mock_service;
 pub mod net;
 pub mod network_addr;
@@ -107,6 +108,7 @@ pub fn init() -> impl Drop {
         tracing_subscriber::registry()
             .with(filter_layer)
             .with(fmt_layer)
+            .with(log_capture::LogCaptureLayer)
             .with(ErrorLayer::default())
             .try_init()
             .ok();

--- a/zakura-test/src/log_capture.rs
+++ b/zakura-test/src/log_capture.rs
@@ -1,0 +1,106 @@
+//! Capturing log messages from the process-wide tracing subscriber in tests.
+//!
+//! `tracing_test::traced_test` and test-scoped subscribers can't be used in test binaries
+//! that call [`crate::init`]:
+//! - a second process-wide subscriber races with the one set by [`crate::init`], and
+//! - a thread-scoped subscriber creates a second span registry, which corrupts span
+//!   bookkeeping when tasks migrate between threads with different default subscribers.
+//!
+//! Instead, [`crate::init`] installs a `LogCaptureLayer` in the single process-wide
+//! subscriber, and tests read the messages it captures through a [`LogCapture`] handle.
+
+use std::sync::{Arc, Mutex, Weak};
+
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, Layer};
+
+/// The message buffers of the [`LogCapture`]s that are currently alive.
+///
+/// This is process-wide state, because it is read by the [`LogCaptureLayer`] in the
+/// process-wide subscriber set by [`crate::init`].
+static ACTIVE_CAPTURES: Mutex<Vec<Weak<Mutex<Vec<String>>>>> = Mutex::new(Vec::new());
+
+/// A handle to log messages captured from the process-wide tracing subscriber.
+///
+/// Capturing starts when the handle is created, and stops when it is dropped.
+///
+/// Captured messages come from every thread and task in the process, including other
+/// tests running concurrently in the same test binary. So tests should only assert on
+/// messages that no other test in the binary can produce.
+///
+/// Messages are only captured if they pass the subscriber's filter, which is `RUST_LOG`
+/// or the [`crate::init`] defaults. Warnings and errors always pass the default filter.
+pub struct LogCapture {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl LogCapture {
+    /// Starts capturing log messages, and returns a handle for reading them.
+    pub fn new() -> Self {
+        let messages = Arc::new(Mutex::new(Vec::new()));
+
+        let mut captures = ACTIVE_CAPTURES
+            .lock()
+            .expect("no code panics while holding the capture list lock");
+        // Remove buffers whose `LogCapture` handles have been dropped.
+        captures.retain(|capture| capture.strong_count() > 0);
+        captures.push(Arc::downgrade(&messages));
+
+        Self { messages }
+    }
+
+    /// Returns true if any captured log message contains `needle`.
+    pub fn contains(&self, needle: &str) -> bool {
+        self.messages
+            .lock()
+            .expect("no code panics while holding the message buffer lock")
+            .iter()
+            .any(|message| message.contains(needle))
+    }
+}
+
+impl Default for LogCapture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A tracing layer that copies log messages into the active [`LogCapture`] buffers.
+///
+/// Does nothing unless a [`LogCapture`] is alive, so it is always installed by
+/// [`crate::init`].
+pub(crate) struct LogCaptureLayer;
+
+impl<S: tracing::Subscriber> Layer<S> for LogCaptureLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let captures = ACTIVE_CAPTURES
+            .lock()
+            .expect("no code panics while holding the capture list lock");
+        if captures.is_empty() {
+            return;
+        }
+
+        let mut message = String::new();
+        event.record(&mut MessageVisitor(&mut message));
+
+        for capture in captures.iter().filter_map(Weak::upgrade) {
+            capture
+                .lock()
+                .expect("no code panics while holding the message buffer lock")
+                .push(message.clone());
+        }
+    }
+}
+
+/// A field visitor that extracts an event's `message` field.
+struct MessageVisitor<'a>(&'a mut String);
+
+impl Visit for MessageVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            use std::fmt::Write as _;
+
+            let _ = write!(self.0, "{value:?}");
+        }
+    }
+}

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -62,14 +62,6 @@ impl io::Write for TestWriter {
     }
 }
 
-/// Return whether `logs` contains `expected`.
-fn captured_logs_contain(logs: &Arc<Mutex<Vec<u8>>>, expected: &str) -> bool {
-    let logs = logs
-        .lock()
-        .expect("log buffer is only locked by non-panicking writer operations");
-    String::from_utf8_lossy(&logs).contains(expected)
-}
-
 /// Check that a network stack with an empty address book only contains the local listener port,
 /// by querying the inbound service via a local TCP connection.
 ///
@@ -320,13 +312,12 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
 ) -> Result<(), crate::BoxError> {
-    let logs = Arc::new(Mutex::new(Vec::new()));
-    let log_sink = Arc::clone(&logs);
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(move || TestWriter(Arc::clone(&log_sink)))
-        .with_ansi(false)
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    // `tracing_test::traced_test` can't be used here: it sets a second process-wide
+    // subscriber, which races with the one set by `zakura_test::init()` in the other
+    // tests in this binary. Capture logs from the `zakura_test` subscriber instead.
+    // Only this test configures zcashd-compat pruning retention, so no other test in
+    // this binary can log the pruned block error message.
+    let captured_logs = zakura_test::log_capture::LogCapture::new();
 
     // `setup` configures checkpoint retention against `Height::MAX`, so block 1 is committed
     // to the retained chain indexes without storing its transaction bytes. Genesis is retained.
@@ -418,7 +409,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         "an unknown hash maps to missing inventory"
     );
     assert!(
-        !captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        !captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "an unknown hash must not log a pruning error"
     );
 
@@ -432,7 +423,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         "inbound maps the unavailable block body to missing inventory"
     );
     assert!(
-        !captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        !captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "an ordinary peer must not log a zcashd-compat pruning error"
     );
 
@@ -453,7 +444,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         "an unconfigured legacy peer still receives missing inventory"
     );
     assert!(
-        !captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        !captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "an unconfigured legacy peer must not log a zcashd-compat pruning error"
     );
 
@@ -475,7 +466,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         )
     }
     assert!(
-        captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "the configured zcashd-compat peer must log the pruning error"
     );
 


### PR DESCRIPTION
## Motivation

`cargo test -p zakura --release --lib` reliably fails:

```
thread '...inbound_pruned_block_is_not_advertised_and_getdata_logs_error' panicked:
Could not set global tracing subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")
```

Root cause: this test used `#[tracing_test::traced_test]`, which installs a **process-wide** tracing subscriber so `logs_contain()` works. The other 301 tests in the zakurad lib binary install a different global subscriber via `zakura_test::init()`. Under plain `cargo test`, all tests share one process, so whichever init runs first wins and the `traced_test` init panics. CI never caught this because nextest runs each test in its own process.

A test-scoped second subscriber doesn't work either (tried first): two live span registries in one process corrupt span bookkeeping when tasks cross threads (`tried to drop a ref to Id(N), but no such span exists!` in the peer connection task), so the process must keep exactly one registry.

## Solution

Keep the single global subscriber and make it capturable:

- New `zakura_test::log_capture` module: `zakura_test::init()` now always installs a `LogCaptureLayer`. It is inert (empty-list check, early return) unless a test holds a live `LogCapture` handle, in which case it copies event messages into that handle's buffer. Handles deregister on drop via `Weak` references.
- The test drops `traced_test`, creates a `LogCapture` at the start, and asserts with `captured_logs.contains(...)`.

The capture is process-wide, so it sees logs from concurrently running tests (documented on `LogCapture` and in the test). That is safe here because only this test configures zcashd-compat pruning retention, so no other test in the binary can emit `ZCASHD_COMPAT_PRUNED_BLOCK_ERROR`.

`zakurad/tests/end_of_support.rs` still uses `tracing-test`, which stays correct: that binary uses it consistently and never calls `zakura_test::init()`.

## Testing

- `cargo test -p zakura --release --lib`: 302 passed, 0 failed — the previously failing test now passes both in the full single-process run (the original failure mode) and alone, with the pruned-block error message captured and asserted.
- `cargo test -p zakura-test --release`: all passing.
- `cargo fmt --all -- --check`, `cargo clippy -p zakura-test -p zakura --all-targets --release`, and `cargo doc -p zakura-test --no-deps`: clean, no warnings.

The full-suite run exercises the root cause directly: all 302 tests share one process and one global subscriber, and the log assertions still pass through the capture layer.