### PR TITLE
fix: use Zakura branding in user-facing messages

### DIFF
--- a/.github/actions/setup-zakura-build/action.yml
+++ b/.github/actions/setup-zakura-build/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup Zebra Build Environment'
+name: 'Setup Zakura Build Environment'
 description: 'Install protoc and RocksDB as system libraries'
 runs:
   using: 'composite'

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -51,7 +51,7 @@ jobs:
           cache-on-failure: true
       - uses: ./.github/actions/setup-zakura-build
 
-      - name: Build Zebra book
+      - name: Build Zakura book
         run: |
           mdbook build book --dest-dir "$(pwd)"/target/docs
         env:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -168,7 +168,7 @@ jobs:
           - id: custom-dirs-conf
             name: Custom cache and cookie directories
             env_vars: -e ZAKURA_STATE__CACHE_DIR=/tmp/zakura-cache
-            grep_patterns: -e "Opened Zebra state cache at /tmp/zakura-cache"
+            grep_patterns: -e "Opened Zakura state cache at /tmp/zakura-cache"
 
           # Feature-based configurations
           - id: prometheus-feature

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  compat-zakurad-start-supervised   Start zakurad with zcashd supervision enabled"
 	@echo "  compat-zakurad-start-unsupervised Start zakurad with zcashd supervision disabled"
 	@echo "  compat-zcashd-start-standalone   Start zcashd -zebra-compat as a standalone process"
-	@echo "  compat-zakurad-status             Check zakurad liveness and Zebra RPC health"
+	@echo "  compat-zakurad-status             Check zakurad liveness and Zakura RPC health"
 	@echo "  compat-zcashd-status             Check zcashd liveness and zebra-compat RPC health"
 	@echo "  compat-status-sync               Run both status checks and enforce max drift"
 	@echo "  compat-test-regtest              Run full zcashd-compat test suite (regtest, spawns processes)"

--- a/changelog-unreleased/335.md
+++ b/changelog-unreleased/335.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Replace outdated Zebra branding in Zakura logs, errors, RPC responses, CLI
+  help, and operator tooling
+  ([#335](https://github.com/zakura-core/zakura/pull/335)).

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -1221,7 +1221,7 @@ class Handler(BaseHTTPRequestHandler):
 def main() -> None:
     global COLLECTOR
 
-    parser = argparse.ArgumentParser(description="Serve a Zebra fleet status dashboard.")
+    parser = argparse.ArgumentParser(description="Serve a Zakura fleet status dashboard.")
     parser.add_argument("--config", required=True, help="path to deploy/deployer nodes TOML")
     parser.add_argument("--host", default="0.0.0.0", help="dashboard bind host")
     parser.add_argument("--port", type=int, default=8090, help="dashboard bind port")

--- a/deploy/runner/zakura-metrics-dashboard.py
+++ b/deploy/runner/zakura-metrics-dashboard.py
@@ -542,7 +542,7 @@ def list_runs(archive):
 COLLECTOR = None
 ARCHIVE = None
 
-PAGE = r"""<!doctype html><html><head><meta charset=utf-8><title>Zebra metrics</title>
+PAGE = r"""<!doctype html><html><head><meta charset=utf-8><title>Zakura metrics</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
@@ -578,7 +578,7 @@ PAGE = r"""<!doctype html><html><head><meta charset=utf-8><title>Zebra metrics</
  #ovwrap{flex:1;min-height:0;margin-top:8px}
  #ovcanvas{width:100%!important;height:100%!important;max-height:none}
 </style></head><body>
-<header><h1>Zebra observability</h1><div id=status>connecting…</div>
+<header><h1>Zakura observability</h1><div id=status>connecting…</div>
 <div id=verdict class=idle>—</div>
 <div class=toolbar>
  <span class=grp><button id=x_time class=on onclick="setXMode('time')">Time</button><button id=x_height onclick="setXMode('height')">Height</button></span>

--- a/scripts/zakura-dashboard.service
+++ b/scripts/zakura-dashboard.service
@@ -25,7 +25,7 @@
 # followed by `sudo systemctl restart zakura-dashboard`.
 
 [Unit]
-Description=Zebra sync observability dashboard (live + recorded-run archive)
+Description=Zakura sync observability dashboard (live + recorded-run archive)
 After=network-online.target
 Wants=network-online.target
 

--- a/scripts/zakura-metrics-dashboard.py
+++ b/scripts/zakura-metrics-dashboard.py
@@ -533,7 +533,7 @@ def list_runs(archive):
 COLLECTOR = None
 ARCHIVE = None
 
-PAGE = r"""<!doctype html><html><head><meta charset=utf-8><title>Zebra metrics</title>
+PAGE = r"""<!doctype html><html><head><meta charset=utf-8><title>Zakura metrics</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
@@ -571,7 +571,7 @@ PAGE = r"""<!doctype html><html><head><meta charset=utf-8><title>Zebra metrics</
  #ovwrap{flex:1;min-height:0;margin-top:8px}
  #ovcanvas{width:100%!important;height:100%!important;max-height:none}
 </style></head><body>
-<header><h1>Zebra observability</h1><div id=status>connecting…</div>
+<header><h1>Zakura observability</h1><div id=status>connecting…</div>
 <div id=verdict class=idle>—</div>
 <div class=toolbar>
  <span class=grp><button id=x_time class=on onclick="setXMode('time')">Time</button><button id=x_height onclick="setXMode('height')">Height</button></span>

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -263,7 +263,7 @@ where
                 Poll::Ready(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
                     tracing::warn!(
                         "batch task cancelled: {task_cancelled}\n\
-                         Is Zebra shutting down?"
+                         Is Zakura shutting down?"
                     );
 
                     return Poll::Ready(Err(task_cancelled.into()));

--- a/tower-batch-control/tests/ed25519.rs
+++ b/tower-batch-control/tests/ed25519.rs
@@ -134,7 +134,7 @@ impl Service<BatchControl<Item>> for Verifier {
                             // We use a new channel for each batch,
                             // so we always get the correct batch result here.
                             let result = rx.borrow()
-                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zebra shutting down?")?;
+                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zakura shutting down?")?;
 
                             if result.is_ok() {
                                 tracing::trace!(?result, "validated ed25519 signature");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -219,7 +219,7 @@ fn render_command_line(program: &OsStr, args: &[OsString]) -> String {
 }
 
 fn print_help() {
-    println!("Workspace automation for Zebra.");
+    println!("Workspace automation for Zakura.");
     println!();
     let mut help = String::new();
     print_usage(&mut help).expect("writing help to a string should succeed");
@@ -231,7 +231,7 @@ fn print_usage(output: &mut impl fmt::Write) -> fmt::Result {
     writeln!(output)?;
     writeln!(
         output,
-        "Builds a Zebra release binary on {DEFAULT_UBUNTU_IMAGE} using Docker,"
+        "Builds a Zakura release binary on {DEFAULT_UBUNTU_IMAGE} using Docker,"
     )?;
     writeln!(
         output,

--- a/zakura-chain/src/diagnostic/task/future.rs
+++ b/zakura-chain/src/diagnostic/task/future.rs
@@ -54,7 +54,7 @@ impl CheckForPanics for JoinError {
                 } else if is_shutting_down() {
                     debug!(
                         ?task_cancelled,
-                        "ignoring task termination because Zebra is shutting down"
+                        "ignoring task termination because Zakura is shutting down"
                     );
 
                     task_cancelled

--- a/zakura-chain/src/diagnostic/task/thread.rs
+++ b/zakura-chain/src/diagnostic/task/thread.rs
@@ -38,7 +38,7 @@ where
                 } else if is_shutting_down() {
                     debug!(
                         ?thread_output,
-                        "ignoring thread exit because Zebra is shutting down"
+                        "ignoring thread exit because Zakura is shutting down"
                     );
 
                     thread_output

--- a/zakura-chain/src/error.rs
+++ b/zakura-chain/src/error.rs
@@ -77,7 +77,7 @@ pub enum Error {
     Amount(#[from] BalanceError),
 
     /// Zebra's type could not be converted to its librustzcash equivalent.
-    #[error("Zebra's type could not be converted to its librustzcash equivalent: {0}")]
+    #[error("Zakura's type could not be converted to its librustzcash equivalent: {0}")]
     Conversion(String),
 }
 

--- a/zakura-chain/src/primitives/zcash_primitives.rs
+++ b/zakura-chain/src/primitives/zcash_primitives.rs
@@ -157,7 +157,7 @@ impl TryFrom<&transparent::Output> for zcash_transparent::bundle::TxOut {
     fn try_from(output: &transparent::Output) -> Result<Self, Self::Error> {
         let serialized_output_bytes = output
             .zcash_serialize_to_vec()
-            .expect("zcash_primitives and Zebra transparent output formats must be compatible");
+            .expect("zcash_primitives and Zakura transparent output formats must be compatible");
 
         zcash_transparent::bundle::TxOut::read(&mut serialized_output_bytes.as_slice())
     }

--- a/zakura-chain/src/serialization/error.rs
+++ b/zakura-chain/src/serialization/error.rs
@@ -100,7 +100,7 @@ impl From<crate::Error> for SerializationError {
             crate::Error::MissingNetworkUpgrade => Self::Parse("missing network upgrade"),
             crate::Error::Amount(_) => Self::BadTransactionBalance,
             crate::Error::Conversion(_) => {
-                Self::Parse("Zebra's type could not be converted to its librustzcash equivalent")
+                Self::Parse("Zakura's type could not be converted to its librustzcash equivalent")
             }
         }
     }

--- a/zakura-chain/src/transaction/hash.rs
+++ b/zakura-chain/src/transaction/hash.rs
@@ -80,7 +80,7 @@ impl From<&Transaction> for Hash {
         let hasher = TxIdBuilder::new(transaction);
         hasher
             .txid()
-            .expect("zcash_primitives and Zebra transaction formats must be compatible")
+            .expect("zcash_primitives and Zakura transaction formats must be compatible")
     }
 }
 

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -566,7 +566,7 @@ fn empty_v5_librustzcash_round_trip() {
     let nu = tx.network_upgrade().expect("network upgrade");
 
     tx.to_librustzcash(nu).expect(
-        "librustzcash deserialization might work for empty zebra serialized transactions. \
+        "librustzcash deserialization might work for empty Zakura serialized transactions. \
         Hint: if empty transactions fail, but other transactions work, delete this test",
     );
 }
@@ -664,9 +664,9 @@ fn fake_v5_librustzcash_round_trip_for_network(network: Network) {
 
             let nu = fake_tx.network_upgrade().expect("network upgrade");
 
-            fake_tx
-                .to_librustzcash(nu)
-                .expect("librustzcash deserialization must work for zebra serialized transactions");
+            fake_tx.to_librustzcash(nu).expect(
+                "librustzcash deserialization must work for Zakura serialized transactions",
+            );
         }
     }
 }
@@ -684,7 +684,7 @@ fn zip244_round_trip() -> Result<()> {
         let nu = tx.network_upgrade().expect("network upgrade");
 
         tx.to_librustzcash(nu)
-            .expect("librustzcash deserialization must work for zebra serialized transactions");
+            .expect("librustzcash deserialization must work for Zakura serialized transactions");
     }
 
     Ok(())

--- a/zakura-consensus/src/checkpoint.rs
+++ b/zakura-consensus/src/checkpoint.rs
@@ -732,7 +732,7 @@ where
             // This is probably a bad checkpoint list, a zebra bug, or a bad
             // chain (in a testing mode like regtest).
             assert_eq!(expected_hash, checkpoint_hash,
-                           "checkpoints in the range should match: bad checkpoint list, zebra bug, or bad chain"
+                           "checkpoints in the range should match: bad checkpoint list, Zakura bug, or bad chain"
                 );
         }
 
@@ -883,7 +883,7 @@ where
         // See the detailed checkpoint comparison comment above.
         assert_eq!(
             expected_hash, previous_checkpoint_hash,
-            "the previous checkpoint should match: bad checkpoint list, zebra bug, or bad chain"
+            "the previous checkpoint should match: bad checkpoint list, Zakura bug, or bad chain"
         );
 
         let block_count = rev_valid_blocks.len();
@@ -1008,7 +1008,7 @@ pub enum VerifyCheckpointError {
         expected: block::Hash,
         found: block::Hash,
     },
-    #[error("zebra is shutting down")]
+    #[error("Zakura is shutting down")]
     ShuttingDown,
 }
 

--- a/zakura-consensus/src/primitives.rs
+++ b/zakura-consensus/src/primitives.rs
@@ -28,7 +28,7 @@ pub async fn spawn_fifo_and_convert<
     spawn_fifo(f)
         .await
         .map_err(|_| {
-            "threadpool unexpectedly dropped response channel sender. Is Zebra shutting down?"
+            "threadpool unexpectedly dropped response channel sender. Is Zakura shutting down?"
         })?
         .map_err(BoxError::from)
 }

--- a/zakura-consensus/src/primitives/ed25519.rs
+++ b/zakura-consensus/src/primitives/ed25519.rs
@@ -196,7 +196,7 @@ impl Service<BatchControl<Item>> for Verifier {
                             // We use a new channel for each batch,
                             // so we always get the correct batch result here.
                             let result = rx.borrow()
-                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zebra shutting down?")?;
+                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zakura shutting down?")?;
 
                             if result.is_ok() {
                                 tracing::trace!(?result, "validated ed25519 signature");

--- a/zakura-consensus/src/primitives/halo2.rs
+++ b/zakura-consensus/src/primitives/halo2.rs
@@ -453,7 +453,7 @@ impl Service<BatchControl<Item>> for Verifier {
                             let is_valid = *rx
                                 .borrow()
                                 .as_ref()
-                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zebra shutting down?")?;
+                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zakura shutting down?")?;
 
                             if is_valid {
                                 tracing::trace!(?is_valid, "verified halo2 proof");

--- a/zakura-consensus/src/primitives/redjubjub.rs
+++ b/zakura-consensus/src/primitives/redjubjub.rs
@@ -191,7 +191,7 @@ impl Service<BatchControl<Item>> for Verifier {
                             // We use a new channel for each batch,
                             // so we always get the correct batch result here.
                             let result = rx.borrow()
-                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zebra shutting down?")?;
+                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zakura shutting down?")?;
 
                             if result.is_ok() {
                                 tracing::trace!(?result, "validated redjubjub signature");

--- a/zakura-consensus/src/primitives/redpallas.rs
+++ b/zakura-consensus/src/primitives/redpallas.rs
@@ -208,7 +208,7 @@ impl Service<BatchControl<Item>> for Verifier {
                             // We use a new channel for each batch,
                             // so we always get the correct batch result here.
                             let result = rx.borrow()
-                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zebra shutting down?")?;
+                                .ok_or("threadpool unexpectedly dropped response channel sender. Is Zakura shutting down?")?;
 
                             if result.is_ok() {
                                 tracing::trace!(?result, "validated redpallas signature");

--- a/zakura-consensus/src/router.rs
+++ b/zakura-consensus/src/router.rs
@@ -314,7 +314,7 @@ where
                 match checkpoint_state_service.oneshot(request).await {
                     Ok(zakura_state::Response::BlockHash(Some(state_hash))) => assert_eq!(
                         *checkpoint_hash, state_hash,
-                        "invalid block in state: a previous Zebra instance followed an \
+                        "invalid block in state: a previous Zakura instance followed an \
                          incorrect chain. Delete and re-sync your state to use the best chain"
                     ),
 
@@ -327,7 +327,7 @@ where
                         } else {
                             tracing::warn!(
                                 "state is not fully synced yet, remaining checkpoints will be \
-                                 verified next time Zebra starts up. Zebra will be less secure \
+                                 verified next time Zakura starts up. Zakura will be less secure \
                                  until it is restarted. Use consensus.checkpoint_sync = true \
                                  in zakura.toml to make sure you are following a valid chain"
                             );
@@ -344,7 +344,7 @@ where
                         if !already_warned {
                             tracing::warn!(
                                 "unexpected error: {e:?} in state request while verifying previous \
-                                 state checkpoints. Is Zebra shutting down?"
+                                 state checkpoints. Is Zakura shutting down?"
                             );
                             already_warned = true;
                         }

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -149,7 +149,7 @@ impl Handler {
         // TODO: can this be avoided?
         let tmp_state = std::mem::replace(self, Handler::Finished(Ok(Response::Nil)));
 
-        debug!(handler = %tmp_state, %msg, "received peer response to Zebra request");
+        debug!(handler = %tmp_state, %msg, "received peer response to Zakura request");
 
         *self = match (tmp_state, msg) {
             (
@@ -804,7 +804,7 @@ where
                     } = tmp_state
                     {
                         if let Ok(response) = response.as_ref() {
-                            debug!(%response, "finished receiving peer response to Zebra request");
+                            debug!(%response, "finished receiving peer response to Zakura request");
                             // Add a metric for inbound responses to outbound requests.
                             metrics::counter!(
                                 "zakura.net.in.responses",
@@ -813,7 +813,7 @@ where
                             )
                             .increment(1);
                         } else {
-                            debug!(error = ?response, "error in peer response to Zebra request");
+                            debug!(error = ?response, "error in peer response to Zakura request");
                         }
 
                         let _ = tx.send(response.map_err(Into::into));
@@ -1001,7 +1001,7 @@ where
             return;
         }
 
-        debug!(state = %self.state, %request, "sending request from Zebra to peer");
+        debug!(state = %self.state, %request, "sending request from Zakura to peer");
 
         // Add a metric for outbound requests.
         metrics::counter!(
@@ -1598,7 +1598,7 @@ where
             }
         }
 
-        debug!(state = %self.state, %req, %rsp, "sent Zebra response to peer");
+        debug!(state = %self.state, %req, %rsp, "sent Zakura response to peer");
 
         // Give the inbound service time to clear its queue,
         // before checking the connection for the next inbound or outbound request.

--- a/zakura-network/src/peer/priority.rs
+++ b/zakura-network/src/peer/priority.rs
@@ -141,7 +141,7 @@ pub fn address_is_valid_for_inbound_listeners(
     // Ignore ports used by potentially compatible nodes: other coins and unsupported Zcash regtest.
     if listener_addr.port() == 18344 {
         return Err(
-            "invalid peer port: port is for Regtest, but Zebra does not support that network",
+            "invalid peer port: port is for Regtest, but Zakura does not support that network",
         );
     } else if [8033, 18033, 16125, 26125].contains(&listener_addr.port()) {
         // These coins use the same network magic numbers as Zcash, so we have to reject them by port:

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -699,7 +699,7 @@ pub(crate) async fn open_listener(config: &Config) -> (TcpListener, SocketAddr) 
         Err(e) => panic!(
             "Opening Zcash network protocol listener {:?} failed: {e:?}. \
              Hint: Check if another zakurad or zcashd process is running. \
-             Try changing the network listen_addr in the Zebra config.",
+             Try changing the network listen_addr in the Zakura config.",
             config.listen_addr,
         ),
     };
@@ -1065,7 +1065,7 @@ where
             // # Concurrency
             //
             // Demand is potentially unlimited, so it must go last in a biased select!.
-            next_demand = demand_rx.next() => next_demand.ok_or("demand stream closed, is Zebra shutting down?".into()).map(|MorePeers|{
+            next_demand = demand_rx.next() => next_demand.ok_or("demand stream closed, is Zakura shutting down?".into()).map(|MorePeers|{
                 if active_outbound_connections.update_count() >= config.peerset_outbound_connection_limit() {
                     // Too many open outbound connections or pending handshakes already
                     DemandDrop
@@ -1220,7 +1220,7 @@ where
         Err(e) => {
             info!(
                 ?e,
-                "candidate set returned an error, is Zebra shutting down?"
+                "candidate set returned an error, is Zakura shutting down?"
             );
             return Err(e);
         }

--- a/zakura-network/src/protocol/external/types.rs
+++ b/zakura-network/src/protocol/external/types.rs
@@ -40,7 +40,7 @@ impl Version {
         // shut down if our own version is too old
         assert!(
             constants::CURRENT_NETWORK_PROTOCOL_VERSION >= min_spec,
-            "Zebra does not implement the minimum specified {:?} protocol version for {:?} at {:?}",
+            "Zakura does not implement the minimum specified {:?} protocol version for {:?} at {:?}",
             NetworkUpgrade::current(network, height),
             network,
             height,

--- a/zakura-node-services/src/mempool.rs
+++ b/zakura-node-services/src/mempool.rs
@@ -1,4 +1,4 @@
-//! The Zebra mempool.
+//! The Zakura mempool.
 //!
 //! A service that manages known unmined Zcash transactions.
 
@@ -25,17 +25,30 @@ pub use self::{
     transaction_dependencies::TransactionDependencies,
 };
 
-/// The mempool is disabled until Zebra is close to the chain tip.
+/// The mempool is disabled until Zakura is close to the chain tip.
 #[derive(Debug)]
 pub struct MempoolDisabledError;
 
 impl fmt::Display for MempoolDisabledError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("mempool is not active: wait for Zebra to sync to the tip")
+        f.write_str("mempool is not active: wait for Zakura to sync to the tip")
     }
 }
 
 impl std::error::Error for MempoolDisabledError {}
+
+#[cfg(test)]
+mod tests {
+    use super::MempoolDisabledError;
+
+    #[test]
+    fn mempool_disabled_error_uses_zakura_branding() {
+        assert_eq!(
+            MempoolDisabledError.to_string(),
+            "mempool is not active: wait for Zakura to sync to the tip"
+        );
+    }
+}
 
 /// A peer source for per-peer mempool download accounting.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -2269,7 +2269,7 @@ where
         #[cfg(not(target_os = "windows"))]
         if self.network.is_regtest() {
             match nix::sys::signal::raise(nix::sys::signal::SIGINT) {
-                Ok(_) => Ok("Zebra server stopping".to_string()),
+                Ok(_) => Ok("Zakura server stopping".to_string()),
                 Err(error) => Err(ErrorObject::owned(
                     ErrorCode::InternalError.code(),
                     format!("Failed to shut down: {error}").as_str(),

--- a/zakura-rpc/src/methods/types/get_block_template.rs
+++ b/zakura-rpc/src/methods/types/get_block_template.rs
@@ -770,14 +770,14 @@ where
         tracing::info!(
             ?estimated_distance_to_chain_tip,
             ?local_tip_height,
-            "Zebra has not synced to the chain tip. \
+            "Zakura has not synced to the chain tip. \
              Hint: check your network connection, clock, and time zone settings."
         );
 
         return Err(ErrorObject::owned(
             NOT_SYNCED_ERROR_CODE.code(),
             format!(
-                "Zebra has not synced to the chain tip, \
+                "Zakura has not synced to the chain tip, \
                  estimated distance: {estimated_distance_to_chain_tip:?}, \
                  local tip: {local_tip_height:?}. \
                  Hint: check your network connection, clock, and time zone settings."

--- a/zakura-rpc/src/methods/types/get_block_template/proposal.rs
+++ b/zakura-rpc/src/methods/types/get_block_template/proposal.rs
@@ -219,7 +219,7 @@ pub fn proposal_block_from_template(
         | NetworkUpgrade::Nu6_3
         | NetworkUpgrade::Nu7 => block_commitments_hash.bytes_in_serialized_order(),
         _ => Err(SerializationError::Parse(
-            "Zebra does not support generating pre-Canopy block templates",
+            "Zakura does not support generating pre-Canopy block templates",
         ))?,
     }
     .into();

--- a/zakura-rpc/src/methods/types/validate_address.rs
+++ b/zakura-rpc/src/methods/types/validate_address.rs
@@ -70,7 +70,7 @@ pub fn validate_address(
         tracing::info!(
             ?network,
             address_network = ?address.network(),
-            "invalid address in validateaddress RPC: Zebra's configured network must match address network"
+            "invalid address in validateaddress RPC: Zakura's configured network must match address network"
         );
         return Ok(validate_address::ValidateAddressResponse::invalid());
     }

--- a/zakura-rpc/src/methods/types/z_validate_address.rs
+++ b/zakura-rpc/src/methods/types/z_validate_address.rs
@@ -113,7 +113,7 @@ pub fn z_validate_address(
         tracing::info!(
             ?network,
             address_network = ?address.network(),
-            "invalid address network in z_validateaddress RPC: address is for {:?} but Zebra is on {:?}",
+            "invalid address network in z_validateaddress RPC: address is for {:?} but Zakura is on {:?}",
             address.network(),
             network
         );

--- a/zakura-rpc/src/queue.rs
+++ b/zakura-rpc/src/queue.rs
@@ -173,7 +173,7 @@ impl Runner {
                     }
                     Err(TryRecvError::Closed) => {
                         tracing::info!(
-                            "sendrawtransaction queue was closed: is Zebra shutting down?"
+                            "sendrawtransaction queue was closed: is Zakura shutting down?"
                         );
                         return;
                     }

--- a/zakura-rpc/src/server.rs
+++ b/zakura-rpc/src/server.rs
@@ -132,7 +132,7 @@ impl RpcServer {
         let http_middleware_layer = if conf.enable_cookie_auth {
             let cookie = Cookie::default();
             cookie::write_to_disk(&cookie, &conf.cookie_dir, Some(&conf.cookie_file_name))
-                .expect("Zebra must be able to write the auth cookie to the disk");
+                .expect("Zakura must be able to write the auth cookie to the disk");
             HttpRequestMiddlewareLayer::new(Some(cookie), max_request_body_size)
         } else {
             HttpRequestMiddlewareLayer::new(None, max_request_body_size)

--- a/zakura-script/src/tests.rs
+++ b/zakura-script/src/tests.rs
@@ -447,7 +447,7 @@ fn sighash_divergence_v5_p2pkh_malformed_0x84_wrong_canonical_type_rejected() {
     assert!(
         result.is_err(),
         "Malformed hash_type 0x84 signed with wrong canonical type should be rejected \
-         by both Zebra and zcashd (sighash mismatch)"
+         by both Zakura and zcashd (sighash mismatch)"
     );
 }
 
@@ -1733,12 +1733,12 @@ fn poc_p2sh_1001_accurate_multisigs_should_stay_below_block_sigop_limit() -> Res
 
     assert_eq!(
         zebra_count, zcashd_accurate_count,
-        "Zebra should count each accurate 1-of-1 P2SH multisig spend as 1 sigop, not 20"
+        "Zakura should count each accurate 1-of-1 P2SH multisig spend as 1 sigop, not 20"
     );
 
     assert!(
         zebra_count <= 20_000,
-        "A zcashd-valid block-level sigop total should not cross Zebra's MAX_BLOCK_SIGOPS"
+        "A zcashd-valid block-level sigop total should not cross Zakura's MAX_BLOCK_SIGOPS"
     );
 
     Ok(())

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -151,7 +151,7 @@ pub enum CommitBlockError {
     HeaderCommitError(#[from] Box<CommitHeaderRangeError>),
 
     /// The write task exited (likely during shutdown).
-    #[error("block commit task exited. Is Zebra shutting down?")]
+    #[error("block commit task exited. Is Zakura shutting down?")]
     #[non_exhaustive]
     WriteTaskExited,
 }

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -394,7 +394,7 @@ impl StateService {
             .map(CheckpointVerifiedBlock::from)
             .map(ChainTipBlock::from);
 
-        tracing::info!(chain_tip = ?initial_tip.as_ref().map(|tip| (tip.hash, tip.height)), "loaded Zebra state cache");
+        tracing::info!(chain_tip = ?initial_tip.as_ref().map(|tip| (tip.hash, tip.height)), "loaded Zakura state cache");
 
         let (chain_tip_sender, latest_chain_tip, chain_tip_change) =
             ChainTipSender::new(initial_tip, network);
@@ -607,7 +607,7 @@ impl StateService {
         match self.invalid_block_write_reset_receiver.try_recv() {
             Ok(reset_tip_hash) => self.finalized_block_write_last_sent_hash = reset_tip_hash,
             Err(TryRecvError::Disconnected) => {
-                info!("Block commit task closed the block reset channel. Is Zebra shutting down?");
+                info!("Block commit task closed the block reset channel. Is Zakura shutting down?");
                 return;
             }
             // There are no errors, so we can just use the last block hash we sent
@@ -668,7 +668,7 @@ impl StateService {
                 Err(TryRecvError::Disconnected) => {
                     info!(
                         "Block commit task closed the non-finalized rejected hash channel. \
-                         Is Zebra shutting down?"
+                         Is Zakura shutting down?"
                     );
                     break;
                 }
@@ -2137,7 +2137,7 @@ impl Service<ReadRequest> for ReadStateService {
                     read::best_tip(&latest_non_finalized_state, &state.db)
                 else {
                     return Err(
-                        "state is empty: wait for Zebra to sync before submitting a proposal"
+                        "state is empty: wait for Zakura to sync before submitting a proposal"
                             .into(),
                     );
                 };

--- a/zakura-state/src/service/check.rs
+++ b/zakura-state/src/service/check.rs
@@ -323,7 +323,7 @@ pub(crate) fn difficulty_threshold_and_time_are_valid(
     // https://zips.z.cash/protocol/protocol.pdf#blockheader
     let genesis_height = NetworkUpgrade::Genesis
         .activation_height(&network)
-        .expect("Zebra always has a genesis height available");
+        .expect("Zakura always has a genesis height available");
 
     if candidate_time <= median_time_past && candidate_height != genesis_height {
         Err(ValidateContextError::TimeTooEarly {

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -1501,7 +1501,7 @@ impl FinalizedState {
     ///
     /// TODO: move the stop height check to the syncer (#3442)
     fn exit_process() -> ! {
-        tracing::info!("exiting Zebra");
+        tracing::info!("exiting Zakura");
 
         // Some OSes require a flush to send all output to the terminal.
         // Zebra's logging doesn't depend on `tokio`, so we flush the stdlib sync streams.

--- a/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/zakura-state/src/service/finalized_state/disk_db.rs
@@ -1095,7 +1095,7 @@ impl DiskDb {
 
         match db_result {
             Ok(db) => {
-                info!("Opened Zebra state cache at {}", path.display());
+                info!("Opened Zakura state cache at {}", path.display());
 
                 let db = DiskDb {
                     db_kind: db_kind.to_string(),
@@ -1118,7 +1118,7 @@ impl DiskDb {
 
             Err(e) => panic!(
                 "Opening database {path:?} failed. \
-                        Hint: Try changing the state cache_dir in the Zebra config. \
+                        Hint: Try changing the state cache_dir in the Zakura config. \
                         Error: {e}",
             ),
         }
@@ -1433,7 +1433,7 @@ impl DiskDb {
                     min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
                     ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
                     "unable to increase the open file limit, \
-                     assuming Zebra can open a minimum number of files"
+                     assuming Zakura can open a minimum number of files"
                 );
 
                 return DiskDb::MIN_OPEN_FILE_LIMIT;
@@ -1444,9 +1444,9 @@ impl DiskDb {
             panic!(
                 "open file limit too low: \
                  unable to set the number of open files to {}, \
-                 the minimum number of files required by Zebra. \
+                 the minimum number of files required by Zakura. \
                  Current limit is {:?}. \
-                 Hint: Increase the open file limit to {} before launching Zebra",
+                 Hint: Increase the open file limit to {} before launching Zakura",
                 DiskDb::MIN_OPEN_FILE_LIMIT,
                 current_limit,
                 DiskDb::IDEAL_OPEN_FILE_LIMIT
@@ -1456,8 +1456,8 @@ impl DiskDb {
                 ?current_limit,
                 min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
                 ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
-                "the maximum number of open files is below Zebra's ideal limit. \
-                 Hint: Increase the open file limit to {} before launching Zebra",
+                "the maximum number of open files is below Zakura's ideal limit. \
+                 Hint: Increase the open file limit to {} before launching Zakura",
                 DiskDb::IDEAL_OPEN_FILE_LIMIT
             );
         } else if cfg!(windows) {
@@ -1466,13 +1466,13 @@ impl DiskDb {
             info!(
                 min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
                 ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
-                "assuming the open file limit is high enough for Zebra",
+                "assuming the open file limit is high enough for Zakura",
             );
             #[cfg(test)]
             debug!(
                 min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
                 ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
-                "assuming the open file limit is high enough for Zebra",
+                "assuming the open file limit is high enough for Zakura",
             );
         } else {
             #[cfg(not(test))]
@@ -1480,14 +1480,14 @@ impl DiskDb {
                 ?current_limit,
                 min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
                 ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
-                "the open file limit is high enough for Zebra",
+                "the open file limit is high enough for Zakura",
             );
             #[cfg(test)]
             debug!(
                 ?current_limit,
                 min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
                 ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
-                "the open file limit is high enough for Zebra",
+                "the open file limit is high enough for Zakura",
             );
         }
 
@@ -1762,7 +1762,7 @@ impl DiskDb {
         if let Some(default_cf) = self.cf_handle("default") {
             assert!(
                 self.zs_is_empty(&default_cf),
-                "Zebra should not store data in the 'default' column family"
+                "Zakura should not store data in the 'default' column family"
             );
         }
     }

--- a/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -501,7 +501,7 @@ impl DbFormatChange {
                 // the database format should be valid. This check is done below.
                 info!(
                     %running_version,
-                    "checking database format produced by a previous zebra instance \
+                    "checking database format produced by a previous Zakura instance \
                      is current and valid"
                 );
             }
@@ -684,7 +684,7 @@ impl DbFormatChange {
             // database is marked, so the upgrade MUST be complete at this point.
             info!(
                 newer_running_version = ?upgrade.version(),
-                "Zebra automatically upgraded the database format"
+                "Zakura automatically upgraded the database format"
             );
             Self::mark_as_upgraded_to(db, &upgrade.version());
         }
@@ -821,7 +821,7 @@ impl DbFormatChange {
 
         assert!(
             running_version > disk_version,
-            "can't upgrade a database that is being opened by an older or the same Zebra version:\n\
+            "can't upgrade a database that is being opened by an older or the same Zakura version:\n\
              disk: {disk_version}\n\
              upgrade: {format_upgrade_version}\n\
              running: {running_version}"
@@ -837,7 +837,7 @@ impl DbFormatChange {
 
         assert!(
             format_upgrade_version <= &running_version,
-            "can't upgrade to a newer version than the running Zebra version:\n\
+            "can't upgrade to a newer version than the running Zakura version:\n\
              disk: {disk_version}\n\
              upgrade: {format_upgrade_version}\n\
              running: {running_version}"
@@ -880,7 +880,7 @@ impl DbFormatChange {
 
         assert!(
             disk_version >= running_version,
-            "can't downgrade a database that is being opened by a newer Zebra version:\n\
+            "can't downgrade a database that is being opened by a newer Zakura version:\n\
              disk: {disk_version}\n\
              running: {running_version}"
         );

--- a/zakura-state/src/service/finalized_state/zakura_db/prune.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/prune.rs
@@ -55,7 +55,7 @@ pub enum PruneFinalizedStateError {
     /// The on-disk state database format does not match the running code.
     #[error(
         "state database format mismatch: on disk {on_disk:?}, running code {in_code}; \
-         use a Zebra binary with the same state format"
+         use a Zakura binary with the same state format"
     )]
     FormatMismatch {
         /// Version read from disk.

--- a/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/rollback.rs
@@ -100,7 +100,7 @@ pub enum RollbackFinalizedStateError {
     /// The on-disk state database format does not match the running code.
     #[error(
         "state database format mismatch: on disk {on_disk:?}, running code {in_code}; \
-         use a Zebra binary with the same state format"
+         use a Zakura binary with the same state format"
     )]
     FormatMismatch {
         /// Version read from disk.

--- a/zakura-state/src/service/non_finalized_state/backup.rs
+++ b/zakura-state/src/service/non_finalized_state/backup.rs
@@ -141,7 +141,7 @@ pub(super) async fn run_backup_task(
 
     tracing::warn!(
         ?err,
-        "got recv error waiting on non-finalized state change, is Zebra shutting down?"
+        "got recv error waiting on non-finalized state change, is Zakura shutting down?"
     )
 }
 

--- a/zakura-state/src/service/non_finalized_state/chain.rs
+++ b/zakura-state/src/service/non_finalized_state/chain.rs
@@ -736,7 +736,7 @@ impl Chain {
         if !self.is_empty() && height < self.non_finalized_tip_height() {
             let next_height = height
                 .next()
-                .expect("Zebra should never reach the max height in normal operation.");
+                .expect("Zakura should never reach the max height in normal operation.");
 
             self.sprout_trees_by_height
                 .entry(next_height)
@@ -935,7 +935,7 @@ impl Chain {
         if !self.is_empty() && height < self.non_finalized_tip_height() {
             let next_height = height
                 .next()
-                .expect("Zebra should never reach the max height in normal operation.");
+                .expect("Zakura should never reach the max height in normal operation.");
 
             self.sapling_trees_by_height
                 .entry(next_height)
@@ -1246,7 +1246,7 @@ impl Chain {
         if !self.is_empty() && height < self.non_finalized_tip_height() {
             let next_height = height
                 .next()
-                .expect("Zebra should never reach the max height in normal operation.");
+                .expect("Zakura should never reach the max height in normal operation.");
 
             self.orchard_trees_by_height
                 .entry(next_height)
@@ -1305,7 +1305,7 @@ impl Chain {
         if !self.is_empty() && height < self.non_finalized_tip_height() {
             let next_height = height
                 .next()
-                .expect("Zebra should never reach the max height in normal operation.");
+                .expect("Zakura should never reach the max height in normal operation.");
 
             self.ironwood_trees_by_height
                 .entry(next_height)

--- a/zakura-state/src/service/read/difficulty.rs
+++ b/zakura-state/src/service/read/difficulty.rs
@@ -38,7 +38,7 @@ use crate::{
 pub const EXTRA_TIME_TO_MINE_A_BLOCK: u32 = POST_BLOSSOM_POW_TARGET_SPACING * 2;
 
 fn finalized_state_query_interrupted_error() -> BoxError {
-    "Zebra is committing too many blocks to the state, \
+    "Zakura is committing too many blocks to the state, \
      wait until it syncs to the chain tip"
         .into()
 }
@@ -161,7 +161,7 @@ fn best_relevant_chain_and_history_tree(
     db: &ZakuraDb,
 ) -> Result<(Height, block::Hash, Vec<Arc<Block>>, Arc<HistoryTree>), BoxError> {
     let state_tip_before_queries = read::best_tip(non_finalized_state, db).ok_or_else(|| {
-        BoxError::from("Zebra's state is empty, wait until it syncs to the chain tip")
+        BoxError::from("Zakura's state is empty, wait until it syncs to the chain tip")
     })?;
 
     let best_relevant_chain =

--- a/zakura-state/src/service/read/find.rs
+++ b/zakura-state/src/service/read/find.rs
@@ -128,7 +128,7 @@ where
                 }
             }
 
-            Err("Zebra is committing too many blocks to the state, \
+            Err("Zakura is committing too many blocks to the state, \
                     wait until it syncs to the chain tip"
                 .into())
         }
@@ -683,7 +683,7 @@ fn best_relevant_chain(
     db: &ZakuraDb,
 ) -> Result<Vec<Arc<Block>>, BoxError> {
     let state_tip_before_queries = read::best_tip(non_finalized_state, db).ok_or_else(|| {
-        BoxError::from("Zebra's state is empty, wait until it syncs to the chain tip")
+        BoxError::from("Zakura's state is empty, wait until it syncs to the chain tip")
     })?;
 
     let best_relevant_chain =
@@ -701,7 +701,7 @@ fn best_relevant_chain(
         read::best_tip(non_finalized_state, db).expect("already checked for an empty tip");
 
     if state_tip_before_queries != state_tip_after_queries {
-        return Err("Zebra is committing too many blocks to the state, \
+        return Err("Zakura is committing too many blocks to the state, \
                     wait until it syncs to the chain tip"
             .into());
     }

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -421,7 +421,7 @@ impl WriteBlockWorkerTask {
             // TODO: split these checks into separate functions
 
             if invalid_block_reset_sender.is_closed() {
-                info!("StateService closed the block reset channel. Is Zebra shutting down?");
+                info!("StateService closed the block reset channel. Is Zakura shutting down?");
                 return;
             }
 
@@ -556,7 +556,7 @@ impl WriteBlockWorkerTask {
 
                     if send_result.is_err() {
                         info!(
-                            "StateService closed the block reset channel. Is Zebra shutting down?"
+                            "StateService closed the block reset channel. Is Zakura shutting down?"
                         );
                         return;
                     }
@@ -567,7 +567,7 @@ impl WriteBlockWorkerTask {
         // Do this check even if the channel got closed before any finalized blocks were sent.
         // This can happen if we're past the finalized tip.
         if invalid_block_reset_sender.is_closed() {
-            info!("StateService closed the block reset channel. Is Zebra shutting down?");
+            info!("StateService closed the block reset channel. Is Zakura shutting down?");
             return;
         }
 

--- a/zakura-test/scripts/shutdown-errors
+++ b/zakura-test/scripts/shutdown-errors
@@ -16,7 +16,7 @@ SHUTDOWN_DELAY_INCREMENT=1
 # the test stops after a successful run with a delay this long
 SHUTDOWN_DELAY_LIMIT=30
 
-echo "Building Zebra"
+echo "Building Zakura"
 echo
 
 cargo build --bin zakurad || exit $?
@@ -24,7 +24,7 @@ cargo build --bin zakurad || exit $?
 EXIT_STATUS=0
 while [ $EXIT_STATUS -eq 0 ] && [ $SHUTDOWN_DELAY -le $SHUTDOWN_DELAY_LIMIT ]; do
     echo
-    echo "Running Zebra for $SHUTDOWN_DELAY seconds"
+    echo "Running Zakura for $SHUTDOWN_DELAY seconds"
     echo
 
     # shut down Zebra if this script exits while it's running,
@@ -35,7 +35,7 @@ while [ $EXIT_STATUS -eq 0 ] && [ $SHUTDOWN_DELAY -le $SHUTDOWN_DELAY_LIMIT ]; d
     sleep $SHUTDOWN_DELAY
 
     echo
-    echo "Killing Zebra after $SHUTDOWN_DELAY seconds"
+    echo "Killing Zakura after $SHUTDOWN_DELAY seconds"
     echo
 
     kill %?zakurad
@@ -48,7 +48,7 @@ while [ $EXIT_STATUS -eq 0 ] && [ $SHUTDOWN_DELAY -le $SHUTDOWN_DELAY_LIMIT ]; d
     fi
 
     echo
-    echo "Killing Zebra after $SHUTDOWN_DELAY seconds exited with $EXIT_STATUS"
+    echo "Killing Zakura after $SHUTDOWN_DELAY seconds exited with $EXIT_STATUS"
     echo
 
     SHUTDOWN_DELAY=$[SHUTDOWN_DELAY + SHUTDOWN_DELAY_INCREMENT]

--- a/zakurad/src/commands/prune_state.rs
+++ b/zakurad/src/commands/prune_state.rs
@@ -24,7 +24,7 @@ pub struct PruneStateCmd {
     /// `zakura.toml`, while the standalone `zakura-prune-state` binary defaults to
     /// `zakura_state::Config::default()`. Pass `--cache-dir` to be explicit and avoid pruning the
     /// wrong (or an empty) state directory.
-    #[clap(long, short, help = "path to directory with the Zebra chain state")]
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
     cache_dir: Option<PathBuf>,
 
     /// The network of the chain to prune.

--- a/zakurad/src/commands/rollback_state.rs
+++ b/zakurad/src/commands/rollback_state.rs
@@ -24,7 +24,7 @@ pub struct RollbackStateCmd {
     /// `zakura.toml`, while the standalone `zakura-rollback-state` binary defaults to
     /// `zakura_state::Config::default()`. Pass `--cache-dir` to be explicit and avoid rolling back
     /// the wrong (or an empty) state directory.
-    #[clap(long, short, help = "path to directory with the Zebra chain state")]
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
     cache_dir: Option<PathBuf>,
 
     /// The network of the chain to roll back.

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -1001,7 +1001,7 @@ impl StartCmd {
             }
         };
 
-        info!("exiting Zebra: asking other tasks to stop");
+        info!("exiting Zakura: asking other tasks to stop");
 
         // ongoing tasks
         rpc_task_handle.abort();
@@ -1052,7 +1052,7 @@ impl StartCmd {
         old_databases_task_handle.abort();
 
         info!(
-            "exiting Zebra: all tasks have been asked to stop, waiting for remaining tasks to finish"
+            "exiting Zakura: all tasks have been asked to stop, waiting for remaining tasks to finish"
         );
 
         exit_status

--- a/zakurad/src/commands/tip_height.rs
+++ b/zakurad/src/commands/tip_height.rs
@@ -22,7 +22,7 @@ use crate::prelude::APPLICATION;
 #[derive(Command, Debug, Default, Parser)]
 pub struct TipHeightCmd {
     /// Path to Zebra's cached state.
-    #[clap(long, short, help = "path to directory with the Zebra chain state")]
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
     cache_dir: Option<PathBuf>,
 
     /// The network to obtain the chain tip.

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -988,7 +988,7 @@ async fn setup(
         network_config,
         inbound_service.clone(),
         latest_chain_tip.clone(),
-        "Zebra user agent".to_string(),
+        "Zakura user agent".to_string(),
         PeerServices::NODE_NETWORK,
         protected_peer_ips,
         None,
@@ -1180,7 +1180,7 @@ mod submitblock_test {
             network_config,
             inbound_service.clone(),
             latest_chain_tip.clone(),
-            "Zebra user agent".to_string(),
+            "Zakura user agent".to_string(),
             PeerServices::NODE_NETWORK,
         )
         .await;

--- a/zakurad/src/components/mempool.rs
+++ b/zakurad/src/components/mempool.rs
@@ -1,4 +1,4 @@
-//! Zebra mempool.
+//! Zakura mempool.
 //!
 //! A zakurad application component that manages the active collection, reception,
 //! gossip, verification, in-memory storage, eviction, and rejection of unmined Zcash
@@ -136,7 +136,7 @@ fn transaction_misbehavior(
 /// Indicates whether it is enabled or disabled and, if enabled, contains
 /// the necessary data to run it.
 //
-// Zebra only has one mempool, so the enum variant size difference doesn't matter.
+// Zakura only has one mempool, so the enum variant size difference doesn't matter.
 #[allow(clippy::large_enum_variant)]
 #[derive(Default)]
 enum ActiveState {
@@ -399,7 +399,7 @@ impl Mempool {
         is_debug_enabled
     }
 
-    /// Returns `true` if Zebra is caught up enough to start the mempool.
+    /// Returns `true` if Zakura is caught up enough to start the mempool.
     ///
     /// During Zakura sync, [`SyncStatus`] is updated from state's effective
     /// best-header frontier. That frontier uses the verified block tip when it
@@ -415,7 +415,10 @@ impl Mempool {
     fn enable_at_tip(&mut self, tip_action: &TipAction) {
         let (last_seen_tip_hash, tip_height) = tip_action.best_tip_hash_and_height();
 
-        info!(?tip_height, "activating mempool: Zebra is close to the tip");
+        info!(
+            ?tip_height,
+            "activating mempool: Zakura is close to the tip"
+        );
 
         let tx_downloads = Box::pin(TxDownloads::new(
             Timeout::new(self.outbound.clone(), TRANSACTION_DOWNLOAD_TIMEOUT),
@@ -443,16 +446,17 @@ impl Mempool {
         let is_caught_up_to_start = self.is_caught_up_to_start();
 
         // TODO: revisit these state transitions after header sync can prove
-        // whether Zebra is behind the network tip.
+        // whether Zakura is behind the network tip.
         match (is_caught_up_to_start, self.is_enabled(), tip_action) {
             // the active state is up to date, or there is no tip action to activate the mempool
             (false, false, _) | (true, true, _) | (true, false, None) => return false,
 
-            // Enable state - there should be a chain tip when Zebra is close to the network tip
+            // Enable state - there should be a chain tip when Zakura is close
+            // to the network tip.
             (true, false, Some(tip_action)) => self.enable_at_tip(tip_action),
 
             // TODO: only disable an already-active mempool when a validated
-            // Zakura header/block-sync frontier proves Zebra is behind a
+            // Zakura header/block-sync frontier proves Zakura is behind a
             // higher-work chain that follows this node's consensus rules.
             //
             // The legacy sync status can be triggered by lower-work forks,

--- a/zakurad/src/components/metrics.rs
+++ b/zakurad/src/components/metrics.rs
@@ -38,7 +38,7 @@ impl MetricsEndpoint {
                 Err(e) => panic!(
                     "Opening metrics endpoint listener {addr:?} failed: {e:?}. \
                      Hint: Check if another zakurad or zcashd process is running. \
-                     Try changing the metrics endpoint_addr in the Zebra config.",
+                     Try changing the metrics endpoint_addr in the Zakura config.",
                 ),
             }
         }

--- a/zakurad/src/components/miner.rs
+++ b/zakurad/src/components/miner.rs
@@ -631,7 +631,7 @@ where
     let span = Span::current();
     let solved_headers =
         tokio::task::spawn_blocking(move || span.in_scope(move || {
-            let miner_thread_handle = ThreadBuilder::default().name("zebra-miner").priority(ThreadPriority::Min).spawn(move |priority_result| {
+            let miner_thread_handle = ThreadBuilder::default().name("zakura-miner").priority(ThreadPriority::Min).spawn(move |priority_result| {
                 if let Err(error) = priority_result {
                     info!(?error, "could not set miner to run at a low priority: running at default priority");
                 }

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -1574,7 +1574,7 @@ where
                     } else {
                         info!(
                             "task error during obtain tips task: {e:?},\
-                     is Zebra shutting down?"
+                     is Zakura shutting down?"
                         );
                         Err(e.into())
                     }

--- a/zakurad/src/components/tokio.rs
+++ b/zakurad/src/components/tokio.rs
@@ -135,10 +135,10 @@ fn finish_runtime(runtime: Runtime, result: Result<(), Report>) {
 
     match result {
         Ok(()) => {
-            info!("shutting down Zebra");
+            info!("shutting down Zakura");
         }
         Err(error) => {
-            warn!(?error, "shutting down Zebra due to an error");
+            warn!(?error, "shutting down Zakura due to an error");
             APPLICATION.shutdown(Shutdown::Forced);
         }
     }

--- a/zakurad/src/components/tracing/endpoint.rs
+++ b/zakurad/src/components/tracing/endpoint.rs
@@ -90,7 +90,7 @@ impl TracingEndpoint {
                         panic!(
                             "Opening tracing endpoint listener {addr:?} failed: {err:?}. \
                             Hint: Check if another zakurad or zcashd process is running. \
-                            Try changing the tracing endpoint_addr in the Zebra config.",
+                            Try changing the tracing endpoint_addr in the Zakura config.",
                         );
                     }
                 };

--- a/zakurad/src/components/zcashd_compat/supervisor.rs
+++ b/zakurad/src/components/zcashd_compat/supervisor.rs
@@ -206,7 +206,7 @@ pub fn reject_peer_selection_extra_args(extra_args: &[String]) -> Result<(), Rep
         if PEER_SELECTION_OPTIONS.contains(&name) {
             return Err(eyre!(
                 "zcashd_compat.zcashd_extra_args contains {arg:?}: peer-selection options are not \
-                 allowed because the zcashd P2P sidecar must connect only to the local Zebra node"
+                 allowed because the zcashd P2P sidecar must connect only to the local Zakura node"
             ));
         }
     }

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -2019,11 +2019,12 @@ fn lwd_integration_test(test_type: TestType) -> Result<()> {
     let state_version_message = wait_for_state_version_message(&mut zakurad)?;
 
     if test_type.needs_zakura_cached_state() {
-        zakurad
-            .expect_stdout_line_matches(r"loaded Zebra state cache .*tip.*=.*Height\([0-9]{7}\)")?;
+        zakurad.expect_stdout_line_matches(
+            r"loaded Zakura state cache .*tip.*=.*Height\([0-9]{7}\)",
+        )?;
     } else {
         // Timeout the test if we're somehow accidentally using a cached state
-        zakurad.expect_stdout_line_matches("loaded Zebra state cache .*tip.*=.*None")?;
+        zakurad.expect_stdout_line_matches("loaded Zakura state cache .*tip.*=.*None")?;
     }
 
     // Wait for the state to upgrade and the RPC port, if the upgrade is short.
@@ -2397,11 +2398,11 @@ fn zakura_state_conflict() -> Result<()> {
         ));
         dir_conflict_full.push(config.network.network.to_string().to_lowercase());
         format!(
-            "Opened Zebra state cache at {}",
+            "Opened Zakura state cache at {}",
             dir_conflict_full.display()
         )
     } else {
-        String::from("Opened Zebra state cache at ")
+        String::from("Opened Zakura state cache at ")
     };
 
     check_config_conflict(
@@ -2763,7 +2764,7 @@ async fn state_format_test(
     tracing::info!(?network, "running {test_name} using zakurad");
 
     zakurad.expect_stdout_line_matches("creating new database with the current format")?;
-    zakurad.expect_stdout_line_matches("loaded Zebra state cache")?;
+    zakurad.expect_stdout_line_matches("loaded Zakura state cache")?;
 
     // Give Zebra enough time to actually write the database to disk.
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -2849,7 +2850,7 @@ async fn state_format_test(
             zakurad.expect_stdout_line_matches("marked database format as downgraded")?;
         } else {
             zakurad.expect_stdout_line_matches("trying to open current database format")?;
-            zakurad.expect_stdout_line_matches("loaded Zebra state cache")?;
+            zakurad.expect_stdout_line_matches("loaded Zakura state cache")?;
         }
 
         // Give Zebra enough time to actually write the database to disk.
@@ -3448,7 +3449,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
     let indexer_listen_addr = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
 
-    tracing::info!("waiting for Zebra state cache to be opened");
+    tracing::info!("waiting for Zakura state cache to be opened");
 
     tokio::time::sleep(LAUNCH_DELAY).await;
 
@@ -3502,12 +3503,12 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
             .get_block(height.0 as i32)
             .await
             .map_err(|err| eyre!(err))?
-            .expect("Zebra test child should have the expected block");
+            .expect("Zakura test child should have the expected block");
 
         assert_eq!(
             zebra_block,
             Arc::new(expected_block),
-            "Zebra should have the same block"
+            "Zakura should have the same block"
         );
 
         let ReadResponse::Block(read_state_block) = read_state
@@ -3567,7 +3568,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
                     .bytes_in_serialized_order()
             }
             _ => Err(eyre!(
-                "Zebra does not support generating pre-Canopy block templates"
+                "Zakura does not support generating pre-Canopy block templates"
             ))?,
         }
         .into();
@@ -3628,12 +3629,12 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
             .get_block(height.0 as i32)
             .await
             .map_err(|err| eyre!(err))?
-            .expect("Zebra test child should have the expected block");
+            .expect("Zakura test child should have the expected block");
 
         assert_eq!(
             zebra_block,
             Arc::new(expected_block),
-            "Zebra should have the same block"
+            "Zakura should have the same block"
         );
 
         let ReadResponse::Block(read_state_block) = read_state
@@ -3652,7 +3653,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
         );
     }
 
-    tracing::info!("restarting Zebra on Regtest");
+    tracing::info!("restarting Zakura on Regtest");
 
     child.kill(false)?;
     let output = child.wait_with_output()?;
@@ -3671,7 +3672,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
     let _rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
     let indexer_listen_addr = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
 
-    tracing::info!("waiting for Zebra state cache to be opened");
+    tracing::info!("waiting for Zakura state cache to be opened");
 
     tokio::time::sleep(LAUNCH_DELAY).await;
 
@@ -3794,7 +3795,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         mining_conf,
         false,
         "0.0.1",
-        "Zebra tests",
+        "Zakura tests",
         mempool.clone(),
         state.clone(),
         read_state.clone(),
@@ -4214,7 +4215,7 @@ async fn invalidate_and_reconsider_block() -> Result<()> {
     let mut child = test_dir.spawn_child(args!["start"])?;
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
 
-    tracing::info!("waiting for Zebra state cache to be opened");
+    tracing::info!("waiting for Zakura state cache to be opened");
 
     tokio::time::sleep(LAUNCH_DELAY).await;
 
@@ -4234,12 +4235,12 @@ async fn invalidate_and_reconsider_block() -> Result<()> {
             .get_block(height.0 as i32)
             .await
             .map_err(|err| eyre!(err))?
-            .expect("Zebra test child should have the expected block");
+            .expect("Zakura test child should have the expected block");
 
         assert_eq!(
             zebra_block,
             Arc::new(expected_block),
-            "Zebra should have the same block"
+            "Zakura should have the same block"
         );
     }
 
@@ -4312,7 +4313,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
 
     // Start Zebra and generate some blocks.
 
-    tracing::info!("starting Zebra and generating some blocks");
+    tracing::info!("starting Zakura and generating some blocks");
     let mut child = test_dir.spawn_child(args!["start"])?;
     // Avoid dropping the test directory and cleanup of the state cache needed by the next zakurad instance.
     let test_dir = child.dir.take().expect("should have test directory");
@@ -4339,7 +4340,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     // Check that Zebra will restore its non-finalized state from backup when the finalized tip is past the
     // max checkpoint height and that it can still commit more blocks to its state.
 
-    tracing::info!("restarting Zebra to check that non-finalized state is restored");
+    tracing::info!("restarting Zakura to check that non-finalized state is restored");
     let mut child = test_dir.spawn_child(args!["start"])?;
     let test_dir = child.dir.take().expect("should have test directory");
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
@@ -4350,7 +4351,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     let blockchain_info = rpc_client.blockchain_info().await?;
     tracing::info!(
         ?blockchain_info,
-        "got blockchain info after restarting Zebra"
+        "got blockchain info after restarting Zakura"
     );
 
     assert_eq!(
@@ -4359,7 +4360,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
         "tip block hash should match tip hash of previous zakurad instance"
     );
 
-    tracing::info!("checking that Zebra can commit blocks after restoring non-finalized state");
+    tracing::info!("checking that Zakura can commit blocks after restoring non-finalized state");
     rpc_client
         .generate(1)
         .await
@@ -4381,7 +4382,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     };
 
     tracing::info!(
-        "restarting Zebra to check that non-finalized state is _not_ restored when \
+        "restarting Zakura to check that non-finalized state is _not_ restored when \
          the finalized tip is below the max checkpoint height"
     );
     child.kill(true)?;
@@ -4393,7 +4394,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     // Check that the non-finalized state is not restored from backup when the finalized tip height is below the
     // max checkpoint height and that it can still commit more blocks to its state
 
-    tracing::info!("restarting Zebra with configured checkpoints to check that non-finalized state is not restored");
+    tracing::info!("restarting Zakura with configured checkpoints to check that non-finalized state is not restored");
     let network = Network::new_regtest(RegtestParameters {
         checkpoints: Some(configured_checkpoints),
         ..Default::default()
@@ -4412,7 +4413,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     assert_eq!(
         rpc_client.blockchain_info().await?.best_block_hash(),
         network.genesis_hash(),
-        "Zebra should not restore blocks from non-finalized backup if \
+        "Zakura should not restore blocks from non-finalized backup if \
          its finalized tip is below the max checkpoint height"
     );
 
@@ -4444,7 +4445,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     // and the non-finalized backup cache is disabled or empty.
 
     tracing::info!(
-        "restarting Zebra to check that blocks are committed when the non-finalized state \
+        "restarting Zakura to check that blocks are committed when the non-finalized state \
          is initially empty and the finalized tip is past the max checkpoint height"
     );
     config.state.should_backup_non_finalized_state = false;
@@ -4457,7 +4458,7 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     // Wait for Zebra to load its state cache
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    tracing::info!("checking that Zebra commits blocks with empty non-finalized state");
+    tracing::info!("checking that Zakura commits blocks with empty non-finalized state");
     rpc_client
         .generate(1)
         .await
@@ -4644,7 +4645,7 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
 
     tokio::time::sleep(Duration::from_secs(30)).await;
 
-    tracing::info!("calling getpeerinfo to confirm Zebra has dropped the peer connection");
+    tracing::info!("calling getpeerinfo to confirm Zakura has dropped the peer connection");
 
     // Call `getpeerinfo` to check that the zakurad instances have disconnected
     for i in 0..600 {

--- a/zakurad/tests/common/cached_state.rs
+++ b/zakurad/tests/common/cached_state.rs
@@ -235,7 +235,7 @@ pub async fn raw_future_blocks(
 
     assert!(
         test_type.needs_zakura_cached_state() && test_type.needs_zakura_rpc_server(),
-        "raw_future_blocks needs zebra cached state and rpc server"
+        "raw_future_blocks needs Zakura cached state and rpc server"
     );
 
     let should_sync = true;

--- a/zakurad/tests/common/get_block_template_rpcs/submit_block.rs
+++ b/zakurad/tests/common/get_block_template_rpcs/submit_block.rs
@@ -50,7 +50,7 @@ pub(crate) async fn run() -> Result<()> {
     let should_sync = false;
     let (mut zakurad, zakura_rpc_address) =
         spawn_zakurad_for_rpc(network, test_name, test_type, should_sync)?
-            .expect("Already checked zebra state path with can_spawn_zakurad_for_test_type");
+            .expect("already checked Zakura state path with can_spawn_zakurad_for_test_type");
 
     let rpc_address = zakura_rpc_address.expect("submitblock test must have RPC port");
 

--- a/zakurad/tests/common/lightwalletd/sync.rs
+++ b/zakurad/tests/common/lightwalletd/sync.rs
@@ -219,14 +219,14 @@ pub fn are_zakurad_and_lightwalletd_tips_synced(
                 lightwalletd_tip_height,
                 zakurad_tip_height,
                 zakura_rpc_address = ?zakura_rpc_address,
-                "lightwalletd tip is behind Zebra tip, waiting for sync",
+                "lightwalletd tip is behind Zakura tip, waiting for sync",
             );
         } else {
             tracing::debug!(
                 lightwalletd_tip_height,
                 zakurad_tip_height,
                 zakura_rpc_address = ?zakura_rpc_address,
-                "lightwalletd tip matches Zebra tip",
+                "lightwalletd tip matches Zakura tip",
             );
         }
 

--- a/zakurad/tests/common/test_type.rs
+++ b/zakurad/tests/common/test_type.rs
@@ -190,7 +190,7 @@ impl TestType {
             Err(_) => {
                 eprintln!(
                     "skipped {test_name:?} {self:?} lightwalletd test, \
-                     could not load Zebra configuration",
+                     could not load Zakura configuration",
                 );
                 return None;
             }
@@ -369,12 +369,12 @@ impl TestType {
 
         if self.needs_zakura_cached_state() {
             // Fail if we need a cached Zebra state, but it's empty
-            zakurad_failure_messages.push("loaded Zebra state cache .*tip.*=.*None".to_string());
+            zakurad_failure_messages.push("loaded Zakura state cache .*tip.*=.*None".to_string());
         }
         if matches!(*self, LaunchWithEmptyState { .. }) {
             // Fail if we need an empty Zebra state, but it has blocks
             zakurad_failure_messages
-                .push(r"loaded Zebra state cache .*tip.*=.*Height\([1-9][0-9]*\)".to_string());
+                .push(r"loaded Zakura state cache .*tip.*=.*Height\([1-9][0-9]*\)".to_string());
         }
 
         let zakurad_ignore_messages = Vec::new();

--- a/zakurad/tests/common/zcashd_compat/reorg.rs
+++ b/zakurad/tests/common/zcashd_compat/reorg.rs
@@ -70,7 +70,7 @@ pub async fn equal_work_race() -> Result<()> {
 
     assert_eq!(
         zcashd_tip_now, old_zcashd_tip,
-        "zcashd should keep the first-seen equal-work tip until Zebra extends"
+        "zcashd should keep the first-seen equal-work tip until Zakura extends"
     );
     assert_ne!(
         zcashd_tip_now.1, zakura_tip.1,
@@ -291,7 +291,7 @@ pub async fn zakura_tip_behind_local() -> Result<()> {
     let zcashd_tip_now = zcashd_tip(&setup.zcashd_client).await?;
     assert_eq!(
         zcashd_tip_now, old_zcashd_tip,
-        "zcashd must hold its chain while Zebra's tip is behind"
+        "zcashd must hold its chain while Zakura's tip is behind"
     );
 
     // Once Zebra mines a strictly-more-work replacement branch, zcashd follows.

--- a/zakurad/tests/common/zcashd_compat/startup.rs
+++ b/zakurad/tests/common/zcashd_compat/startup.rs
@@ -78,7 +78,7 @@ pub async fn sidecar_follows_tip() -> Result<()> {
 
         assert_eq!(
             zcashd_best, zebra_best,
-            "zcashd should follow Zebra's best block over P2P"
+            "zcashd should follow Zakura's best block over P2P"
         );
     }
 
@@ -91,12 +91,12 @@ pub async fn sidecar_follows_tip() -> Result<()> {
     assert_eq!(
         peers.len(),
         1,
-        "the sidecar zcashd must peer with exactly one node (Zebra), got: {peers:?}"
+        "the sidecar zcashd must peer with exactly one node (Zakura), got: {peers:?}"
     );
     assert_eq!(
         peers[0]["inbound"].as_bool(),
         Some(false),
-        "the sidecar's single peer must be an outbound -connect to Zebra: {:?}",
+        "the sidecar's single peer must be an outbound -connect to Zakura: {:?}",
         peers[0]
     );
 

--- a/zakurad/tests/end_of_support.rs
+++ b/zakurad/tests/end_of_support.rs
@@ -81,7 +81,7 @@ async fn end_of_support_task() -> Result<()> {
     tokio::time::timeout(Duration::from_secs(15), eos_future)
         .await
         .expect_err(
-            "end of support task unexpectedly exited: it should keep running until Zebra exits",
+            "end of support task unexpectedly exited: it should keep running until Zakura exits",
         );
 
     assert!(logs_contain(


### PR DESCRIPTION
## Motivation

Zakura inherited user-visible strings that still identify the running node as
Zebra. Issue #327 reports the mempool activation log, but the same stale brand
also appears in RPC errors, CLI help, shutdown diagnostics, state/database
messages, dashboards, and developer tooling.

## Solution

- Replace stale Zebra branding in executable messages with Zakura.
- Update coupled output assertions and test diagnostics.
- Add regression coverage for the mempool-disabled error text.
- Preserve intentional Zebra identifiers used for upstream links, legacy
  configuration, interoperability user agents, historical warnings, gRPC
  package names, and protocol domain separation.

Closes #327.

## Testing

- `cargo test -p zakura-node-services mempool_disabled_error_uses_zakura_branding`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx --yes markdownlint-cli@0.45.0 changelog-unreleased/335.md --config .trunk/configs/.markdownlint.yaml`
- `bash -n zakura-test/scripts/shutdown-errors`
- `git diff --check`
- Audited remaining executable Zebra identifiers and confirmed the preserved
  ones are intentional compatibility or historical identifiers.

### Specifications & References

- https://github.com/zakura-core/zakura/issues/327

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and test-expectation updates only; no consensus, auth, or data-path logic changes.
> 
> **Overview**
> Replaces **Zebra** with **Zakura** in operator-visible text across the node: logs, errors, RPC/CLI messages, shutdown diagnostics, state/database hints, dashboards, CI grep patterns, and Makefile help. Intentional upstream identifiers (e.g. zebra-compat, legacy URLs) are left as-is per the PR description.
> 
> Adds a **changelog** entry and a small **regression test** on `MempoolDisabledError` display text. Acceptance and Docker tests are updated to expect strings like `loaded Zakura state cache` and `Opened Zakura state cache`. The composite GitHub action is renamed to **Setup Zakura Build Environment**; the miner blocking thread is named `zakura-miner` instead of `zebra-miner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000c23f34a03567e4534078b501eeb98aab4bee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->