### PR TITLE
fix(mempool): retry failed transaction advertisements

### DIFF
--- a/changelog-unreleased/341.md
+++ b/changelog-unreleased/341.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Retry transaction advertisements after transient peer-set failures instead
+  of dropping them
+  ([#341](https://github.com/zakura-core/zakura/pull/341)).

--- a/zakura-node-services/src/mempool.rs
+++ b/zakura-node-services/src/mempool.rs
@@ -92,6 +92,11 @@ pub enum Request {
         limit: usize,
     },
 
+    /// Restore transaction IDs after their peer-set advertisement failed.
+    ///
+    /// The mempool ignores IDs that are no longer stored.
+    RequeuePendingGossipTransactionIds(HashSet<UnminedTxId>),
+
     /// Query matching [`UnminedTx`] in the mempool,
     /// using a unique set of [`UnminedTxId`]s.
     TransactionsById(HashSet<UnminedTxId>),
@@ -186,6 +191,12 @@ pub enum Request {
 pub enum Response {
     /// Returns all [`UnminedTxId`]s from the mempool.
     TransactionIds(HashSet<UnminedTxId>),
+
+    /// Returns transaction IDs awaiting proactive peer advertisement.
+    PendingGossipTransactionIds(HashSet<UnminedTxId>),
+
+    /// Confirms that stored transaction IDs were restored to the pending set.
+    RequeuedPendingGossipTransactionIds,
 
     /// Returns matching [`UnminedTx`] from the mempool.
     ///

--- a/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -649,6 +649,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Use `Request::MempoolTransactionIds` to check the transaction was inserted to mempool
+    tokio::time::resume();
     let mempool_response = inbound_service
         .clone()
         .oneshot(Request::MempoolTransactionIds)
@@ -659,6 +660,17 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         Response::TransactionIds(vec![tx1_id]),
         "`MempoolTransactionIds` requests should always respond `Ok(Vec<UnminedTxId> | Nil)`",
     );
+
+    // Transaction gossip starts when the mempool processes the verified
+    // transaction, so acknowledge it before pausing time again.
+    let mut hs = HashSet::new();
+    hs.insert(tx1_id);
+    peer_set
+        .expect_request(Request::AdvertiseTransactionIds(hs, None))
+        .await
+        .respond(Response::Nil);
+    tokio::task::yield_now().await;
+    tokio::time::pause();
 
     // Add a new block to the state (make the chain tip advance)
     let block_two: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_2_BYTES
@@ -672,45 +684,10 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         .await
         .unwrap();
 
-    // Test transaction 1 is gossiped
-    let mut hs = HashSet::new();
-    hs.insert(tx1_id);
-
-    // Transaction and Block IDs are gossipped, in any order, after waiting for the gossip delay
+    // Block gossip waits for the multi-gossip delay.
     tokio::time::sleep(PEER_GOSSIP_DELAY).await;
-    let possible_requests = &mut [
-        Request::AdvertiseTransactionIds(hs, None),
-        Request::AdvertiseBlock(block_two.hash(), None),
-    ]
-    .to_vec();
-
     peer_set
-        .expect_request_that(|request| {
-            let is_possible = possible_requests.contains(request);
-
-            *possible_requests = possible_requests
-                .clone()
-                .into_iter()
-                .filter(|possible| possible != request)
-                .collect();
-
-            is_possible
-        })
-        .await
-        .respond(Response::Nil);
-
-    peer_set
-        .expect_request_that(|request| {
-            let is_possible = possible_requests.contains(request);
-
-            *possible_requests = possible_requests
-                .clone()
-                .into_iter()
-                .filter(|possible| possible != request)
-                .collect();
-
-            is_possible
-        })
+        .expect_request(Request::AdvertiseBlock(block_two.hash(), None))
         .await
         .respond(Response::Nil);
 
@@ -790,6 +767,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Use `Request::MempoolTransactionIds` to check the transaction was inserted to mempool
+    tokio::time::resume();
     let mempool_response = inbound_service
         .clone()
         .oneshot(Request::MempoolTransactionIds)
@@ -801,6 +779,16 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         Response::TransactionIds(vec![tx2_id]),
         "`MempoolTransactionIds` requests should always respond `Ok(Vec<UnminedTxId> | Nil)`",
     );
+
+    // Test transaction 2 is gossiped.
+    let mut hs = HashSet::new();
+    hs.insert(tx2_id);
+    peer_set
+        .expect_request(Request::AdvertiseTransactionIds(hs, None))
+        .await
+        .respond(Response::Nil);
+    tokio::task::yield_now().await;
+    tokio::time::pause();
 
     // Check if tx1 was added to the rejected list as well
     let response = mempool
@@ -823,16 +811,6 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
             .unbox_mempool_error(),
         MempoolError::StorageEffectsChain(SameEffectsChainRejectionError::Expired)
     );
-
-    // Test transaction 2 is gossiped, after waiting for the multi-gossip delay
-    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
-
-    let mut hs = HashSet::new();
-    hs.insert(tx2_id);
-    peer_set
-        .expect_request(Request::AdvertiseTransactionIds(hs, None))
-        .await
-        .respond(Response::Nil);
 
     // Add all the rest of the continuous blocks we have to test tx2 will never expire.
     let more_blocks: Vec<Arc<Block>> = vec![

--- a/zakurad/src/components/mempool.rs
+++ b/zakurad/src/components/mempool.rs
@@ -920,7 +920,16 @@ impl Service<Request> for Mempool {
 
                     trace!(?req, res_count = ?res.len(), "answered mempool request");
 
-                    async move { Ok(Response::TransactionIds(res)) }.boxed()
+                    async move { Ok(Response::PendingGossipTransactionIds(res)) }.boxed()
+                }
+
+                Request::RequeuePendingGossipTransactionIds(ref tx_ids) => {
+                    trace!(?req, "got mempool request");
+
+                    let stored_tx_ids: HashSet<_> = storage.tx_ids().collect();
+                    pending_gossip_tx_ids.extend(tx_ids.intersection(&stored_tx_ids).copied());
+
+                    async move { Ok(Response::RequeuedPendingGossipTransactionIds) }.boxed()
                 }
 
                 Request::TransactionsById(ref ids) => {
@@ -1168,8 +1177,12 @@ impl Service<Request> for Mempool {
 
                 let resp = match req {
                     // Return empty responses for queries.
-                    Request::TransactionIds | Request::TakePendingGossipTransactionIds { .. } => {
-                        Response::TransactionIds(Default::default())
+                    Request::TransactionIds => Response::TransactionIds(Default::default()),
+                    Request::TakePendingGossipTransactionIds { .. } => {
+                        Response::PendingGossipTransactionIds(Default::default())
+                    }
+                    Request::RequeuePendingGossipTransactionIds(_) => {
+                        Response::RequeuedPendingGossipTransactionIds
                     }
 
                     Request::TransactionsById(_) => Response::Transactions(Default::default()),

--- a/zakurad/src/components/mempool.rs
+++ b/zakurad/src/components/mempool.rs
@@ -926,8 +926,13 @@ impl Service<Request> for Mempool {
                 Request::RequeuePendingGossipTransactionIds(ref tx_ids) => {
                     trace!(?req, "got mempool request");
 
-                    let stored_tx_ids: HashSet<_> = storage.tx_ids().collect();
-                    pending_gossip_tx_ids.extend(tx_ids.intersection(&stored_tx_ids).copied());
+                    pending_gossip_tx_ids.extend(tx_ids.iter().filter_map(|tx_id| {
+                        storage
+                            .transactions()
+                            .get(&tx_id.mined_id())
+                            .filter(|stored_tx| stored_tx.transaction.id == *tx_id)
+                            .map(|_| *tx_id)
+                    }));
 
                     async move { Ok(Response::RequeuedPendingGossipTransactionIds) }.boxed()
                 }

--- a/zakurad/src/components/mempool/gossip.rs
+++ b/zakurad/src/components/mempool/gossip.rs
@@ -2,11 +2,9 @@
 //!
 //! This module is just a function [`run_mempool_transaction_id_gossip`] that
 //! treats mempool insertion events received in a channel as wakeup signals,
-//! drains the transaction IDs that still need gossip from the mempool service,
-//! and advertises them to peers. Draining from the mempool service lets the task
-//! recover the IDs behind any wakeups dropped by a lagged channel.
-
-use std::collections::HashSet;
+//! takes the transaction IDs that still need gossip from the mempool service,
+//! and advertises them to peers. Failed advertisements restore IDs that remain
+//! in the mempool, allowing retries without reintroducing removed transactions.
 
 use tokio::sync::broadcast::{
     self,
@@ -16,7 +14,6 @@ use tower::{timeout::Timeout, Service, ServiceExt};
 
 use zakura_network::MAX_TX_INV_IN_SENT_MESSAGE;
 
-use zakura_chain::transaction::UnminedTxId;
 use zakura_network as zn;
 use zakura_node_services::mempool::{MempoolChange, Request, Response};
 
@@ -86,7 +83,8 @@ where
                             ?skip_count,
                             "dropped mempool changes before gossiping, draining pending transaction IDs"
                         );
-                        metrics::counter!("mempool.gossip.lagged.events.total")
+                        metrics::counter!("mempool.gossip.lagged.events.total").increment(1);
+                        metrics::counter!("mempool.gossip.lagged.messages.total")
                             .increment(skip_count);
                         // Exit the wait loop to re-advertise the pending transaction IDs.
                         break;
@@ -110,7 +108,8 @@ where
                             ?skip_count,
                             "dropped mempool changes before gossiping, draining pending transaction IDs"
                         );
-                        metrics::counter!("mempool.gossip.lagged.events.total")
+                        metrics::counter!("mempool.gossip.lagged.events.total").increment(1);
+                        metrics::counter!("mempool.gossip.lagged.messages.total")
                             .increment(skip_count);
                     }
                     Err(closed @ TryRecvError::Closed) => Err(closed)?,
@@ -122,20 +121,20 @@ where
             drain_pending_without_wakeup = false;
         }
 
-        let advertised_count = advertise_pending_mempool_transaction_ids(
+        let (attempted_count, should_retry) = advertise_pending_mempool_transaction_ids(
             &mut mempool,
             &mut broadcast_network,
             combined_changes,
         )
         .await?;
 
-        if advertised_count == 0 {
+        if attempted_count == 0 {
             continue;
         }
 
-        // A full batch means more transaction IDs may still be pending, so
-        // drain again after the delay instead of waiting for another wakeup.
-        drain_pending_without_wakeup = advertised_count == MAX_TX_INV_IN_SENT_MESSAGE;
+        // Retry failed advertisements, and keep draining after a full batch
+        // because more transaction IDs may still be pending.
+        drain_pending_without_wakeup = should_retry;
 
         // wait for at least the network timeout between gossips
         //
@@ -150,14 +149,14 @@ async fn advertise_pending_mempool_transaction_ids<ZN, ZM>(
     mempool: &mut ZM,
     broadcast_network: &mut Timeout<ZN>,
     combined_changes: usize,
-) -> Result<u64, BoxError>
+) -> Result<(u64, bool), BoxError>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
     ZN::Future: Send,
     ZM: Service<Request, Response = Response, Error = BoxError> + Send + Clone + 'static,
     ZM::Future: Send + 'static,
 {
-    let Response::TransactionIds(tx_ids) = mempool
+    let Response::PendingGossipTransactionIds(tx_ids) = mempool
         .ready()
         .await?
         .call(Request::TakePendingGossipTransactionIds {
@@ -171,47 +170,23 @@ where
         .into());
     };
 
-    let mut advertised_count = 0;
-    let mut chunk = HashSet::<UnminedTxId>::new();
-
-    for tx_id in tx_ids {
-        chunk.insert(tx_id);
-
-        if chunk.len() >= MAX_TX_INV_IN_SENT_MESSAGE_USIZE {
-            advertised_count +=
-                advertise_transaction_id_chunk(broadcast_network, &mut chunk, combined_changes)
-                    .await?;
-        }
+    if tx_ids.is_empty() {
+        return Ok((0, false));
     }
 
-    if !chunk.is_empty() {
-        advertised_count +=
-            advertise_transaction_id_chunk(broadcast_network, &mut chunk, combined_changes).await?;
+    if tx_ids.len() > MAX_TX_INV_IN_SENT_MESSAGE_USIZE {
+        return Err(std::io::Error::other(
+            "mempool returned more pending gossip IDs than requested",
+        )
+        .into());
     }
 
-    if advertised_count > 0 {
-        metrics::counter!("mempool.gossip.pending.transactions.total").increment(advertised_count);
-        metrics::counter!("mempool.gossiped.transactions.total").increment(advertised_count);
-    }
-
-    Ok(advertised_count)
-}
-
-/// Advertise a single bounded transaction ID chunk and clear it for reuse.
-async fn advertise_transaction_id_chunk<ZN>(
-    broadcast_network: &mut Timeout<ZN>,
-    chunk: &mut HashSet<UnminedTxId>,
-    combined_changes: usize,
-) -> Result<u64, BoxError>
-where
-    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
-    ZN::Future: Send,
-{
-    let txs_len: u64 = chunk
+    let txs_len: u64 = tx_ids
         .len()
         .try_into()
-        .expect("transaction ID chunk length fits in u64");
-    let request = zn::Request::AdvertiseTransactionIds(std::mem::take(chunk), None);
+        .expect("bounded pending transaction ID count fits in u64");
+    let retry_tx_ids = tx_ids.clone();
+    let request = zn::Request::AdvertiseTransactionIds(tx_ids, None);
 
     info!(%request, changes = %combined_changes, "sending pending mempool transaction broadcast");
     debug!(
@@ -220,9 +195,38 @@ where
         "full list of pending mempool transactions in broadcast"
     );
 
-    let _ = broadcast_network.ready().await?.call(request).await;
+    let broadcast_result = match broadcast_network.ready().await {
+        Ok(network) => network.call(request).await,
+        Err(error) => Err(error),
+    };
 
-    Ok(txs_len)
+    if let Err(error) = broadcast_result {
+        warn!(
+            ?error,
+            transactions = txs_len,
+            "failed to advertise pending mempool transactions, retrying"
+        );
+        metrics::counter!("mempool.gossip.failed.broadcasts.total").increment(1);
+
+        let response = mempool
+            .ready()
+            .await?
+            .call(Request::RequeuePendingGossipTransactionIds(retry_tx_ids))
+            .await?;
+        if !matches!(response, Response::RequeuedPendingGossipTransactionIds) {
+            return Err(std::io::Error::other(
+                "requeue pending transaction IDs request returned a different response variant",
+            )
+            .into());
+        }
+
+        return Ok((txs_len, true));
+    }
+
+    metrics::counter!("mempool.gossip.pending.transactions.total").increment(txs_len);
+    metrics::counter!("mempool.gossiped.transactions.total").increment(txs_len);
+
+    Ok((txs_len, txs_len == MAX_TX_INV_IN_SENT_MESSAGE))
 }
 
 #[cfg(test)]
@@ -236,7 +240,7 @@ mod tests {
     use tokio::sync::{broadcast, mpsc};
     use tower::service_fn;
 
-    use zakura_chain::transaction;
+    use zakura_chain::transaction::{self, UnminedTxId};
 
     use super::*;
 
@@ -271,7 +275,7 @@ mod tests {
                     Request::TakePendingGossipTransactionIds { limit } => {
                         assert_eq!(
                             limit, MAX_TX_INV_IN_SENT_MESSAGE_USIZE,
-                            "gossip task should bound each pending drain to one inv"
+                            "gossip task should bound each pending take to one inv"
                         );
                         limit_sender
                             .send(limit)
@@ -284,7 +288,15 @@ mod tests {
                             .pop_front()
                             .unwrap_or_default();
 
-                        Ok(Response::TransactionIds(tx_ids))
+                        Ok(Response::PendingGossipTransactionIds(tx_ids))
+                    }
+                    Request::RequeuePendingGossipTransactionIds(tx_ids) => {
+                        let mut pending_batches = pending_batches
+                            .lock()
+                            .expect("pending batch mutex should not be poisoned");
+                        pending_batches.push_front(tx_ids);
+
+                        Ok(Response::RequeuedPendingGossipTransactionIds)
                     }
                     unexpected_request => {
                         panic!("unexpected mempool request: {unexpected_request:?}")
@@ -479,6 +491,69 @@ mod tests {
         );
 
         gossip_task.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_broadcast_keeps_transaction_ids_pending_for_retry() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _init_guard = zakura_test::init();
+
+        let pending_tx_ids = test_tx_ids(2, 1);
+        let (mut mempool, _limit_receiver) = mempool_service(vec![pending_tx_ids.clone()]);
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let peer_set = service_fn({
+            let attempts = Arc::clone(&attempts);
+            move |_request| {
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                        Err(std::io::Error::other("transient peer-set failure").into())
+                    } else {
+                        Ok(zn::Response::Nil)
+                    }
+                }
+            }
+        });
+        let mut peer_set = Timeout::new(peer_set, Duration::from_secs(1));
+        let pending_count: u64 = pending_tx_ids
+            .len()
+            .try_into()
+            .expect("test transaction count fits in u64");
+
+        let (attempted_count, should_retry) =
+            advertise_pending_mempool_transaction_ids(&mut mempool, &mut peer_set, 1)
+                .await
+                .expect("failed advertisements should remain retryable");
+        assert_eq!(attempted_count, pending_count);
+        assert!(should_retry, "failed advertisements should be retried");
+
+        let (advertised_count, should_retry) =
+            advertise_pending_mempool_transaction_ids(&mut mempool, &mut peer_set, 0)
+                .await
+                .expect("the retry should succeed");
+        assert_eq!(advertised_count, pending_count);
+        assert!(
+            !should_retry,
+            "a successful partial batch should wait for another wakeup"
+        );
+
+        let response = mempool
+            .ready()
+            .await
+            .expect("mempool should be ready")
+            .call(Request::TakePendingGossipTransactionIds {
+                limit: MAX_TX_INV_IN_SENT_MESSAGE_USIZE,
+            })
+            .await
+            .expect("pending gossip query should succeed");
+        let Response::PendingGossipTransactionIds(remaining_tx_ids) = response else {
+            panic!("pending gossip query returned a different response variant");
+        };
+        assert!(
+            remaining_tx_ids.is_empty(),
+            "successfully advertised transaction IDs should be acknowledged"
+        );
     }
 
     #[tokio::test]

--- a/zakurad/src/components/mempool/gossip.rs
+++ b/zakurad/src/components/mempool/gossip.rs
@@ -282,12 +282,15 @@ mod tests {
     ) -> (
         impl Service<Request, Response = Response, Error = BoxError, Future: Send> + Clone,
         mpsc::Receiver<usize>,
+        mpsc::Receiver<HashSet<UnminedTxId>>,
     ) {
         let pending_batches = Arc::new(Mutex::new(VecDeque::from(pending_batches)));
         let (limit_sender, limit_receiver) = mpsc::channel(16);
+        let (requeue_sender, requeue_receiver) = mpsc::channel(16);
         let service = service_fn(move |request| {
             let pending_batches = pending_batches.clone();
             let limit_sender = limit_sender.clone();
+            let requeue_sender = requeue_sender.clone();
 
             async move {
                 match request {
@@ -310,10 +313,14 @@ mod tests {
                         Ok(Response::PendingGossipTransactionIds(tx_ids))
                     }
                     Request::RequeuePendingGossipTransactionIds(tx_ids) => {
-                        let mut pending_batches = pending_batches
+                        pending_batches
                             .lock()
-                            .expect("pending batch mutex should not be poisoned");
-                        pending_batches.push_front(tx_ids);
+                            .expect("pending batch mutex should not be poisoned")
+                            .push_front(tx_ids.clone());
+                        requeue_sender
+                            .send(tx_ids)
+                            .await
+                            .expect("requeue receiver should be open");
 
                         Ok(Response::RequeuedPendingGossipTransactionIds)
                     }
@@ -324,7 +331,7 @@ mod tests {
             }
         });
 
-        (service, limit_receiver)
+        (service, limit_receiver, requeue_receiver)
     }
 
     fn peer_set_service() -> (
@@ -371,7 +378,8 @@ mod tests {
         let _init_guard = zakura_test::init();
 
         let pending_tx_ids = test_tx_ids(2, 1);
-        let (mempool, mut limit_receiver) = mempool_service(vec![pending_tx_ids.clone()]);
+        let (mempool, mut limit_receiver, _requeue_receiver) =
+            mempool_service(vec![pending_tx_ids.clone()]);
         let (peer_set, mut advertised_receiver) = peer_set_service();
         let (sender, receiver) = broadcast::channel(MEMPOOL_CHANGE_CHANNEL_CAPACITY);
 
@@ -405,7 +413,8 @@ mod tests {
 
         let pending_tx_ids = test_tx_ids(2, 1);
         let dropped_tx_ids = test_tx_ids(2, 2);
-        let (mempool, mut limit_receiver) = mempool_service(vec![pending_tx_ids.clone()]);
+        let (mempool, mut limit_receiver, _requeue_receiver) =
+            mempool_service(vec![pending_tx_ids.clone()]);
         let (peer_set, mut advertised_receiver) = peer_set_service();
         let (sender, receiver) = broadcast::channel(1);
 
@@ -454,7 +463,7 @@ mod tests {
 
         let first_batch = test_tx_ids(MAX_TX_INV_IN_SENT_MESSAGE_USIZE, 1);
         let second_batch = test_tx_ids(2, 2);
-        let (mempool, mut limit_receiver) =
+        let (mempool, mut limit_receiver, _requeue_receiver) =
             mempool_service(vec![first_batch.clone(), second_batch.clone()]);
         let (peer_set, mut advertised_receiver) = peer_set_service();
         let (sender, receiver) = broadcast::channel(1);
@@ -512,52 +521,91 @@ mod tests {
         gossip_task.abort();
     }
 
-    #[tokio::test]
-    async fn failed_broadcast_keeps_transaction_ids_pending_for_retry() {
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_broadcast_is_requeued_and_retried_without_another_wakeup() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         let _init_guard = zakura_test::init();
 
         let pending_tx_ids = test_tx_ids(2, 1);
-        let (mut mempool, _limit_receiver) = mempool_service(vec![pending_tx_ids.clone()]);
+        let (mempool, mut limit_receiver, mut requeue_receiver) =
+            mempool_service(vec![pending_tx_ids.clone()]);
+        let mut mempool_query = mempool.clone();
         let attempts = Arc::new(AtomicUsize::new(0));
+        let (advertised_sender, mut advertised_receiver) = mpsc::channel(2);
         let peer_set = service_fn({
             let attempts = Arc::clone(&attempts);
-            move |_request| {
+            move |request| {
                 let attempts = Arc::clone(&attempts);
+                let advertised_sender = advertised_sender.clone();
                 async move {
+                    advertised_sender
+                        .send(request)
+                        .await
+                        .expect("advertisement receiver should be open");
+
                     if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
-                        Err(std::io::Error::other("transient peer-set failure").into())
+                        std::future::pending().await
                     } else {
                         Ok(zn::Response::Nil)
                     }
                 }
             }
         });
-        let mut peer_set = Timeout::new(peer_set, Duration::from_secs(1));
-        let pending_count: u64 = pending_tx_ids
-            .len()
-            .try_into()
-            .expect("test transaction count fits in u64");
+        let (sender, receiver) = broadcast::channel(MEMPOOL_CHANGE_CHANNEL_CAPACITY);
+        sender
+            .send(MempoolChange::added(test_tx_ids(1, 2)))
+            .expect("receiver should be subscribed");
 
-        let (attempted_count, should_retry) =
-            advertise_pending_mempool_transaction_ids(&mut mempool, &mut peer_set, 1)
-                .await
-                .expect("failed advertisements should remain retryable");
-        assert_eq!(attempted_count, pending_count);
-        assert!(should_retry, "failed advertisements should be retried");
+        let gossip_task = tokio::spawn(run_mempool_transaction_id_gossip(
+            receiver, peer_set, mempool,
+        ));
 
-        let (advertised_count, should_retry) =
-            advertise_pending_mempool_transaction_ids(&mut mempool, &mut peer_set, 0)
+        assert_eq!(
+            limit_receiver
+                .recv()
                 .await
-                .expect("the retry should succeed");
-        assert_eq!(advertised_count, pending_count);
-        assert!(
-            !should_retry,
-            "a successful partial batch should wait for another wakeup"
+                .expect("first attempt should take pending txids"),
+            MAX_TX_INV_IN_SENT_MESSAGE_USIZE
+        );
+        assert_eq!(
+            expect_advertised_transaction_ids(&mut advertised_receiver).await,
+            pending_tx_ids,
+            "first attempt should advertise the pending transaction IDs",
         );
 
-        let response = mempool
+        tokio::time::advance(TIPS_RESPONSE_TIMEOUT).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            requeue_receiver
+                .recv()
+                .await
+                .expect("timed out advertisement should be requeued"),
+            pending_tx_ids,
+        );
+        assert!(
+            limit_receiver.try_recv().is_err(),
+            "retry should wait for the peer gossip delay",
+        );
+
+        tokio::time::advance(PEER_GOSSIP_DELAY).await;
+
+        assert_eq!(
+            limit_receiver
+                .recv()
+                .await
+                .expect("retry should take requeued txids without another wakeup"),
+            MAX_TX_INV_IN_SENT_MESSAGE_USIZE
+        );
+        assert_eq!(
+            expect_advertised_transaction_ids(&mut advertised_receiver).await,
+            pending_tx_ids,
+            "retry should advertise the same transaction IDs",
+        );
+
+        tokio::task::yield_now().await;
+        let response = mempool_query
             .ready()
             .await
             .expect("mempool should be ready")
@@ -571,15 +619,22 @@ mod tests {
         };
         assert!(
             remaining_tx_ids.is_empty(),
-            "successfully advertised transaction IDs should be acknowledged"
+            "successfully advertised transaction IDs should not remain pending"
         );
+        assert!(
+            !gossip_task.is_finished(),
+            "gossip task should remain alive after a successful retry"
+        );
+
+        gossip_task.abort();
     }
 
     #[tokio::test]
     async fn empty_pending_mempool_gossip_wakeup_does_not_advertise() {
         let _init_guard = zakura_test::init();
 
-        let (mempool, mut limit_receiver) = mempool_service(vec![HashSet::new()]);
+        let (mempool, mut limit_receiver, _requeue_receiver) =
+            mempool_service(vec![HashSet::new()]);
         let (peer_set, mut advertised_receiver) = peer_set_service();
         let (sender, receiver) = broadcast::channel(MEMPOOL_CHANGE_CHANNEL_CAPACITY);
 

--- a/zakurad/src/components/mempool/gossip.rs
+++ b/zakurad/src/components/mempool/gossip.rs
@@ -6,6 +6,8 @@
 //! and advertises them to peers. Failed advertisements restore IDs that remain
 //! in the mempool, allowing retries without reintroducing removed transactions.
 
+use std::collections::HashSet;
+
 use tokio::sync::broadcast::{
     self,
     error::{RecvError, TryRecvError},
@@ -14,6 +16,7 @@ use tower::{timeout::Timeout, Service, ServiceExt};
 
 use zakura_network::MAX_TX_INV_IN_SENT_MESSAGE;
 
+use zakura_chain::transaction::UnminedTxId;
 use zakura_network as zn;
 use zakura_node_services::mempool::{MempoolChange, Request, Response};
 
@@ -195,12 +198,15 @@ where
         "full list of pending mempool transactions in broadcast"
     );
 
-    let broadcast_result = match broadcast_network.ready().await {
-        Ok(network) => network.call(request).await,
-        Err(error) => Err(error),
+    let network = match broadcast_network.ready().await {
+        Ok(network) => network,
+        Err(error) => {
+            requeue_pending_mempool_transaction_ids(mempool, retry_tx_ids).await?;
+            return Err(error);
+        }
     };
 
-    if let Err(error) = broadcast_result {
+    if let Err(error) = network.call(request).await {
         warn!(
             ?error,
             transactions = txs_len,
@@ -208,18 +214,7 @@ where
         );
         metrics::counter!("mempool.gossip.failed.broadcasts.total").increment(1);
 
-        let response = mempool
-            .ready()
-            .await?
-            .call(Request::RequeuePendingGossipTransactionIds(retry_tx_ids))
-            .await?;
-        if !matches!(response, Response::RequeuedPendingGossipTransactionIds) {
-            return Err(std::io::Error::other(
-                "requeue pending transaction IDs request returned a different response variant",
-            )
-            .into());
-        }
-
+        requeue_pending_mempool_transaction_ids(mempool, retry_tx_ids).await?;
         return Ok((txs_len, true));
     }
 
@@ -227,6 +222,30 @@ where
     metrics::counter!("mempool.gossiped.transactions.total").increment(txs_len);
 
     Ok((txs_len, txs_len == MAX_TX_INV_IN_SENT_MESSAGE))
+}
+
+/// Restore a failed advertisement batch to the mempool's pending gossip set.
+async fn requeue_pending_mempool_transaction_ids<ZM>(
+    mempool: &mut ZM,
+    tx_ids: HashSet<UnminedTxId>,
+) -> Result<(), BoxError>
+where
+    ZM: Service<Request, Response = Response, Error = BoxError> + Send + Clone + 'static,
+    ZM::Future: Send + 'static,
+{
+    let response = mempool
+        .ready()
+        .await?
+        .call(Request::RequeuePendingGossipTransactionIds(tx_ids))
+        .await?;
+    if !matches!(response, Response::RequeuedPendingGossipTransactionIds) {
+        return Err(std::io::Error::other(
+            "requeue pending transaction IDs request returned a different response variant",
+        )
+        .into());
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/zakurad/src/components/mempool/gossip.rs
+++ b/zakurad/src/components/mempool/gossip.rs
@@ -630,6 +630,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn readiness_error_requeues_transaction_ids_and_propagates() {
+        #[derive(Clone)]
+        struct ReadinessErrorPeerSet;
+
+        impl Service<zn::Request> for ReadinessErrorPeerSet {
+            type Response = zn::Response;
+            type Error = BoxError;
+            type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+            fn poll_ready(
+                &mut self,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Result<(), Self::Error>> {
+                std::task::Poll::Ready(Err(
+                    std::io::Error::other("terminal peer-set failure").into()
+                ))
+            }
+
+            fn call(&mut self, _request: zn::Request) -> Self::Future {
+                panic!("call must not run after a readiness error");
+            }
+        }
+
+        let _init_guard = zakura_test::init();
+
+        let pending_tx_ids = test_tx_ids(2, 1);
+        let (mut mempool, _limit_receiver, mut requeue_receiver) =
+            mempool_service(vec![pending_tx_ids.clone()]);
+        let mut peer_set = Timeout::new(ReadinessErrorPeerSet, TIPS_RESPONSE_TIMEOUT);
+
+        advertise_pending_mempool_transaction_ids(&mut mempool, &mut peer_set, 1)
+            .await
+            .expect_err("terminal readiness errors should propagate");
+        assert_eq!(
+            requeue_receiver
+                .recv()
+                .await
+                .expect("readiness error should requeue the taken transaction IDs"),
+            pending_tx_ids,
+        );
+    }
+
+    #[tokio::test]
     async fn empty_pending_mempool_gossip_wakeup_does_not_advertise() {
         let _init_guard = zakura_test::init();
 

--- a/zakurad/src/components/mempool/tests/vector.rs
+++ b/zakurad/src/components/mempool/tests/vector.rs
@@ -1673,20 +1673,51 @@ async fn mempool_responds_to_await_output() -> Result<(), Report> {
         "pending gossip transaction IDs should contain the verified transaction",
     );
 
-    let pending_gossip_tx_ids = mempool
+    // A failed advertisement restores IDs only when their transactions are
+    // still present in production mempool storage.
+    let response = mempool
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::RequeuePendingGossipTransactionIds(
+            pending_gossip_tx_ids.clone(),
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(
+        response,
+        Response::RequeuedPendingGossipTransactionIds
+    ));
+
+    let requeued_gossip_tx_ids = mempool
         .ready()
         .await
         .unwrap()
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = pending_gossip_tx_ids else {
+    let Response::PendingGossipTransactionIds(requeued_gossip_tx_ids) = requeued_gossip_tx_ids
+    else {
         panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
+    assert_eq!(
+        requeued_gossip_tx_ids, pending_gossip_tx_ids,
+        "stored transaction IDs should be pending again after requeue",
+    );
 
+    let response = mempool
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::TakePendingGossipTransactionIds { limit: 1 })
+        .await
+        .unwrap();
+    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = response else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
+    };
     assert!(
         pending_gossip_tx_ids.is_empty(),
-        "pending gossip transaction IDs should be cleared after successful advertisement",
+        "pending gossip transaction IDs should be cleared after the requeued batch is taken",
     );
 
     Ok(())

--- a/zakurad/src/components/mempool/tests/vector.rs
+++ b/zakurad/src/components/mempool/tests/vector.rs
@@ -917,13 +917,42 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::TransactionIds(pending_gossip_tx_ids) = pending_gossip_tx_ids else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = pending_gossip_tx_ids else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert!(
         pending_gossip_tx_ids.is_empty(),
         "invalidated transaction IDs should be removed from pending gossip",
+    );
+
+    let response = mempool
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::RequeuePendingGossipTransactionIds(
+            [txid].into_iter().collect(),
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(
+        response,
+        Response::RequeuedPendingGossipTransactionIds
+    ));
+
+    let response = mempool
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::TakePendingGossipTransactionIds { limit: 1 })
+        .await
+        .unwrap();
+    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = response else {
+        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    };
+    assert!(
+        pending_gossip_tx_ids.is_empty(),
+        "requeue should ignore transaction IDs that are no longer stored",
     );
 
     Ok(())
@@ -1634,14 +1663,14 @@ async fn mempool_responds_to_await_output() -> Result<(), Report> {
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::TransactionIds(pending_gossip_tx_ids) = pending_gossip_tx_ids else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = pending_gossip_tx_ids else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert_eq!(
         pending_gossip_tx_ids,
         [unmined_tx_id].into_iter().collect(),
-        "pending gossip transaction IDs should contain the verified transaction once",
+        "pending gossip transaction IDs should contain the verified transaction",
     );
 
     let pending_gossip_tx_ids = mempool
@@ -1651,13 +1680,13 @@ async fn mempool_responds_to_await_output() -> Result<(), Report> {
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::TransactionIds(pending_gossip_tx_ids) = pending_gossip_tx_ids else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = pending_gossip_tx_ids else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert!(
         pending_gossip_tx_ids.is_empty(),
-        "pending gossip transaction IDs should be cleared after being drained",
+        "pending gossip transaction IDs should be cleared after successful advertisement",
     );
 
     Ok(())
@@ -1701,13 +1730,13 @@ async fn pending_gossip_transaction_ids_are_bounded() -> Result<(), Report> {
         .call(Request::TakePendingGossipTransactionIds { limit: 0 })
         .await
         .unwrap();
-    let Response::TransactionIds(zero_limit_drain) = response else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(zero_limit_query) = response else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert!(
-        zero_limit_drain.is_empty(),
-        "zero-limit pending gossip drain should return no txids",
+        zero_limit_query.is_empty(),
+        "zero-limit pending gossip query should return no txids",
     );
 
     let response = service
@@ -1717,14 +1746,14 @@ async fn pending_gossip_transaction_ids_are_bounded() -> Result<(), Report> {
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::TransactionIds(first_drain) = response else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(first_batch) = response else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert_eq!(
-        first_drain.len(),
+        first_batch.len(),
         1,
-        "bounded pending gossip drain should return at most the requested limit",
+        "bounded pending gossip query should return at most the requested limit",
     );
 
     let response = service
@@ -1734,21 +1763,21 @@ async fn pending_gossip_transaction_ids_are_bounded() -> Result<(), Report> {
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::TransactionIds(second_drain) = response else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(second_batch) = response else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert_eq!(
-        second_drain.len(),
+        second_batch.len(),
         1,
-        "bounded pending gossip drain should leave excess txids pending",
+        "bounded pending gossip query should leave excess txids pending",
     );
 
-    let drained_tx_ids: HashSet<_> = first_drain.union(&second_drain).copied().collect();
+    let advertised_tx_ids: HashSet<_> = first_batch.union(&second_batch).copied().collect();
     assert_eq!(
-        drained_tx_ids,
+        advertised_tx_ids,
         tx_ids.into_iter().collect(),
-        "bounded drains should eventually return all pending txids",
+        "bounded queries should eventually return all pending txids",
     );
 
     let response = service
@@ -1758,13 +1787,13 @@ async fn pending_gossip_transaction_ids_are_bounded() -> Result<(), Report> {
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::TransactionIds(third_drain) = response else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(third_batch) = response else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert!(
-        third_drain.is_empty(),
-        "pending gossip transaction IDs should be empty after bounded drains",
+        third_batch.is_empty(),
+        "pending gossip transaction IDs should be empty after successful advertisements",
     );
 
     Ok(())
@@ -1886,8 +1915,8 @@ async fn evicted_transaction_ids_are_removed_from_pending_gossip() -> Result<(),
         .call(Request::TakePendingGossipTransactionIds { limit: 2 })
         .await
         .unwrap();
-    let Response::TransactionIds(pending_gossip_tx_ids) = response else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = response else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert!(
@@ -1928,8 +1957,8 @@ async fn disabled_mempool_pending_gossip_drain_is_empty() -> Result<(), Report> 
         .call(Request::TakePendingGossipTransactionIds { limit: 1 })
         .await
         .unwrap();
-    let Response::TransactionIds(pending_gossip_tx_ids) = response else {
-        panic!("wrong response from mempool to TakePendingGossipTransactionIds request");
+    let Response::PendingGossipTransactionIds(pending_gossip_tx_ids) = response else {
+        panic!("wrong response from mempool to PendingGossipTransactionIds request");
     };
 
     assert!(


### PR DESCRIPTION
## Motivation

PR #64 made the mempool service the recovery source for transaction gossip channel lag, but its bounded take removed IDs before the peer-set advertisement completed. A readiness error or broadcast timeout therefore still dropped those IDs permanently.

## Solution

- Keep a retry copy of each bounded pending-gossip batch.
- Requeue only IDs that are still stored in the mempool after peer-set failures.
- Retry transient broadcast failures after the gossip delay while propagating terminal readiness failures after preserving their batch.
- Remove redundant post-query chunking and distinguish lag events from skipped channel messages in metrics.
- Update paused-time integration coverage so successful advertisements are acknowledged before their timeout.

Filtering requeued IDs through indexed current-mempool lookups prevents mined, expired, invalidated, or evicted transactions from being restored after a failed advertisement.

## Testing

- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/341.md --config .trunk/configs/.markdownlint.yaml`
- `cargo clippy -p zakura -p zakura-node-services --all-targets -- -D warnings`
- `cargo test -p zakura --lib` — 310 passed
- `cargo test -p zakura-node-services` — passed, including doc tests

The primary paused-time regression test hangs the first peer-set call, advances through `TIPS_RESPONSE_TIMEOUT`, verifies the IDs are requeued, advances `PEER_GOSSIP_DELAY`, and verifies the same IDs are automatically advertised successfully without another channel wakeup. It then confirms pending gossip is empty and the task remains alive. Additional tests verify terminal readiness errors requeue IDs and propagate, stored IDs survive take/requeue/take, and IDs no longer present in storage are not requeued.

### Specifications & References

- Follow-up to #64.

### Follow-up Work

None.

### AI Disclosure

- [x] AI tools were used for implementation, review, and verification.