### PR TITLE
fix(mempool): report expired transaction dependents

### DIFF
--- a/changelog-unreleased/342.md
+++ b/changelog-unreleased/342.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Stop advertising dependent transactions after their expired parent is removed
+  from the mempool
+  ([#342](https://github.com/zakura-core/zakura/pull/342)).

--- a/zakurad/src/components/mempool/storage.rs
+++ b/zakurad/src/components/mempool/storage.rs
@@ -931,19 +931,18 @@ impl Storage {
         tip_height: zakura_chain::block::Height,
     ) -> HashSet<UnminedTxId> {
         let mut tx_ids = HashSet::new();
-        let mut unmined_tx_ids = HashSet::new();
 
         for (&tx_id, tx) in self.transactions() {
             if let Some(expiry_height) = tx.transaction.transaction.expiry_height() {
                 if tip_height >= expiry_height {
                     tx_ids.insert(tx_id);
-                    unmined_tx_ids.insert(tx.transaction.id);
                 }
             }
         }
 
         // expiry height is effecting data, so we match by non-malleable TXID
-        self.verified
+        let removed_tx_ids = self
+            .verified
             .remove_all_that(|tx| tx_ids.contains(&tx.transaction.id.mined_id()));
 
         // also reject it
@@ -956,7 +955,7 @@ impl Storage {
             );
         }
 
-        unmined_tx_ids
+        removed_tx_ids
     }
 
     /// Check if transaction should be downloaded and/or verified.

--- a/zakurad/src/components/mempool/storage/tests/vectors.rs
+++ b/zakurad/src/components/mempool/storage/tests/vectors.rs
@@ -470,6 +470,55 @@ fn mempool_expired_basic_for_network(network: Network) -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn mempool_expiration_reports_removed_dependent_transactions() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let mut storage = Storage::new(&config::Config {
+        tx_cost_limit: 160_000_000,
+        eviction_memory_time: EVICTION_MEMORY_TIME,
+        ..Default::default()
+    });
+    let block: Block = Network::Mainnet.test_block(982681, 925483).unwrap();
+
+    let mut parent = block.transactions[1].as_ref().clone();
+    *parent.expiry_height_mut() = Height(1);
+    let parent_id = parent.unmined_id();
+    let parent_mined_id = parent_id.mined_id();
+    assert!(
+        !parent.outputs().is_empty(),
+        "test parent transaction should have an output"
+    );
+
+    let mut dependent = block.transactions[2].as_ref().clone();
+    *dependent.expiry_height_mut() = Height(2);
+    let dependent_id = dependent.unmined_id();
+
+    let verified = |tx| {
+        VerifiedUnminedTx::new(
+            tx,
+            Amount::try_from(1_000_000).expect("valid amount"),
+            0,
+            0,
+            std::sync::Arc::new(vec![]),
+        )
+        .expect("verification should pass")
+    };
+
+    storage.insert(verified(parent.into()), Vec::new(), None)?;
+    storage.insert(
+        verified(dependent.into()),
+        vec![OutPoint::from_usize(parent_mined_id, 0)],
+        None,
+    )?;
+
+    let removed = storage.remove_expired_transactions(Height(1));
+
+    assert_eq!(removed, HashSet::from([parent_id, dependent_id]));
+    assert_eq!(storage.transaction_count(), 0);
+
+    Ok(())
+}
+
 /// Check that the transaction dependencies are updated when transactions with spent mempool outputs
 /// are inserted into storage, and that the `Storage.remove()` method also removes any transactions
 /// that directly or indirectly spend outputs of a removed transaction.


### PR DESCRIPTION
## Motivation

When an expired transaction has mempool descendants, dependency-aware removal deletes the parent and all descendants. However, expiration handling discarded the complete removal result and reported only directly expired transaction IDs. The mempool's pending gossip set could therefore retain and later advertise removed descendants.

## Solution

Return the complete ID set produced by dependency-aware removal while continuing to reject only the directly expired transactions.

Add a regression test with an expired parent and a still-unexpired dependent, verifying that both removed IDs are reported and storage is emptied.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura mempool_expiration_reports_removed_dependent_transactions --lib`
- `./scripts/changelog.py check`
- `markdownlint changelog-unreleased/342.md --config .trunk/configs/.markdownlint.yaml`

## Changelog

- Added `changelog-unreleased/342.md` under `Fixed`.
