### PR TITLE
chore(release): consume v1.0.3-rc0 changelog fragments

### DIFF
--- a/.agents/skills/release-zakura/SKILL.md
+++ b/.agents/skills/release-zakura/SKILL.md
@@ -105,7 +105,13 @@ After the `zakura` package version bump is final, run:
 make prepare-release-changelog RELEASE_TAG=<tag>
 ```
 
-Review and commit the generated root changelog and fragment deletions.
+This target is defined in `make/release.mk`. It must consume every numbered
+`changelog-unreleased/<PR-number>.md` fragment into the root changelog,
+including explicit no-changelog fragments. Keep
+`changelog-unreleased/README.md`; it documents the fragment format and is not a
+pending fragment.
+
+Review and commit the generated root changelog and numbered fragment deletions.
 For a stable release, confirm the generated section combines and replaces all
 matching release-candidate sections; no `X.Y.Z-rc*` section for that stable
 version should remain in the root changelog.

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -177,8 +177,11 @@ cargo release replace --verbose --execute --allow-branch '*' -p zakura
 make prepare-release-changelog RELEASE_TAG=v<version>
 ```
 
-- [ ] Review the generated root changelog and confirm every
-      `changelog-unreleased/<PR-number>.md` file was consumed.
+- [ ] Confirm the `make/release.mk` target consumed every numbered
+      `changelog-unreleased/<PR-number>.md` file, including no-changelog
+      fragments. Keep `changelog-unreleased/README.md`; it documents the
+      fragment format.
+- [ ] Review the generated root changelog.
 - [ ] For a stable release, confirm the generated section combines and replaces
       every matching `v<version>-rc*` changelog section.
 - [ ] Commit the generated changelog and fragment deletions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Make retained peer-ban insertion and eviction O(1) rather than O(N),
   preventing ban-list maintenance from slowing as the 20,000-IP bound fills
   ([#286](https://github.com/zakura-core/zakura/pull/286)).
+- Stop the experimental dummy CPU miner from continuing to use a stale block
+  template after template generation fails
+  ([#333](https://github.com/zakura-core/zakura/pull/333)).
+- Replace outdated Zebra branding in Zakura logs, errors, RPC responses, CLI
+  help, and operator tooling
+  ([#335](https://github.com/zakura-core/zakura/pull/335)).
 
 ## [1.0.2] - 2026-07-20
 

--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,5 @@ help:
 	@echo ""
 	@echo "  Release:"
 	@echo "  prepare-release-changelog RELEASE_TAG=vX.Y.Z   Assemble and consume pending changelog fragments"
-	@echo "  pre-release RELEASE_TAG=vX.Y.Z BASE_TAG=vX.Y.Z   Run changelog, version, release-state, and packaging checks"
+	@echo "  pre-release RELEASE_TAG=vX.Y.Z BASE_TAG=vX.Y.Z   Verify committed changelog; fail if stale; run remaining release checks"
 	@echo "  sign-release TAG=vX.Y.Z          Sign a release's SHA256SUMS.txt with the maintainer minisign key (see VERIFY.md)"

--- a/changelog-unreleased/315.md
+++ b/changelog-unreleased/315.md
@@ -1,4 +1,0 @@
-<!-- changelog: none -->
-
-This PR changes internal contribution and release tooling only, with no
-operator- or crate-consumer-visible effect.

--- a/changelog-unreleased/333.md
+++ b/changelog-unreleased/333.md
@@ -1,5 +1,0 @@
-## Fixed
-
-- Stop the experimental dummy CPU miner from continuing to use a stale block
-  template after template generation fails
-  ([#333](https://github.com/zakura-core/zakura/pull/333)).

--- a/changelog-unreleased/334.md
+++ b/changelog-unreleased/334.md
@@ -1,4 +1,0 @@
-<!-- changelog: none -->
-
-This PR removes unused developer formatter metadata and corrects the scope of
-an existing changelog entry; it does not change user-visible behavior.

--- a/changelog-unreleased/335.md
+++ b/changelog-unreleased/335.md
@@ -1,5 +1,0 @@
-## Fixed
-
-- Replace outdated Zebra branding in Zakura logs, errors, RPC responses, CLI
-  help, and operator tooling
-  ([#335](https://github.com/zakura-core/zakura/pull/335)).

--- a/make/release.mk
+++ b/make/release.mk
@@ -22,7 +22,10 @@ pre-release:
 
 pre-release-changelog:
 	@test -n "$(RELEASE_TAG)" || { echo "RELEASE_TAG is required, e.g. make pre-release-changelog RELEASE_TAG=v1.0.0" >&2; exit 1; }
-	./scripts/changelog.py release "$(RELEASE_TAG)" --check
+	@./scripts/changelog.py release "$(RELEASE_TAG)" --check || { \
+		echo "WARNING: release changelog is stale; run make prepare-release-changelog RELEASE_TAG=$(RELEASE_TAG), review the diff, and commit it." >&2; \
+		exit 1; \
+	}
 
 pre-release-version:
 	@test -n "$(RELEASE_TAG)" || { echo "RELEASE_TAG is required, e.g. make pre-release-version RELEASE_TAG=v1.0.0" >&2; exit 1; }


### PR DESCRIPTION
## Motivation

The v1.0.3-rc0 release PR was merged without running the changelog assembler. Four pending fragments remained, and two user-visible fixes were absent from the versioned release notes. The release command also needed to be unambiguous in the operator checklist and agent skill.

## Solution

- Run `make prepare-release-changelog RELEASE_TAG=v1.0.3-rc0`, adding the missing #333 and #335 notes and consuming all numbered files in `changelog-unreleased/`.
- Confirm the target exists in `make/release.mk` and is exposed by top-level `make help`.
- Update the release checklist and release skill to require consuming every numbered fragment, including no-changelog fragments, while retaining `changelog-unreleased/README.md` as documentation.
- Make `make pre-release` emit an explicit warning and fail when the committed changelog is stale.

## Testing

- `make help`
- `make prepare-release-changelog RELEASE_TAG=v1.0.3-rc0`
- `make pre-release-changelog RELEASE_TAG=v1.0.3-rc0`
- Added a temporary numbered fragment and confirmed `make pre-release-changelog` failed with the stale-changelog warning and remediation command.
- `python3 -m unittest discover -s scripts/tests -p 'test_changelog.py'`\n- `markdownlint .agents/skills/release-zakura/SKILL.md .github/PULL_REQUEST_TEMPLATE/release-checklist.md CHANGELOG.md --config .trunk/configs/.markdownlint.yaml`\n- `git diff --check`\n\n## Changelog\n\nThis release follow-up consumes the pending fragments and is excluded from creating a new fragment.\n\n### Specifications & References\n\nFollow-up to #337; the assembler, Make target, and initial documented release step were introduced by #315.\n\n### Follow-up Work\n\nNone.