### PR TITLE
chore(release): include PR 342 in v1.0.3-rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Replace outdated Zebra branding in Zakura logs, errors, RPC responses, CLI
   help, and operator tooling
   ([#335](https://github.com/zakura-core/zakura/pull/335)).
+- Stop advertising dependent transactions after their expired parent is removed
+  from the mempool
+  ([#342](https://github.com/zakura-core/zakura/pull/342)).
 
 ## [1.0.2] - 2026-07-20
 

--- a/changelog-unreleased/342.md
+++ b/changelog-unreleased/342.md
@@ -1,5 +1,0 @@
-## Fixed
-
-- Stop advertising dependent transactions after their expired parent is removed
-  from the mempool
-  ([#342](https://github.com/zakura-core/zakura/pull/342)).


### PR DESCRIPTION
## Motivation

PR #343 assembled the `v1.0.3-rc0` changelog before PR #342 merged. Consequently, the release section already existed while PR #342's entry remained under `changelog-unreleased`, causing release changelog validation to reject the duplicate release version.

## Solution

Move PR #342's release note into the existing unpublished `1.0.3-rc0` section and consume its numbered fragment.

## Testing

- `make pre-release-changelog RELEASE_TAG=v1.0.3-rc0`
- `markdownlint CHANGELOG.md --config .trunk/configs/.markdownlint.yaml`
- `git diff --check`

No compilation was run because this is a Markdown-only release metadata change.

## Changelog

This PR corrects the assembled `1.0.3-rc0` changelog itself; it does not add another fragment.

### Specifications & References

- #342
- #343

### Follow-up Work

None.

AI assistance was used to diagnose the changelog state, edit the release metadata, and prepare this pull request.