### PR TITLE
ci(docs): ignore internal PR link flakes

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -21,6 +21,9 @@ exclude = [
     # Template placeholder URLs (0000)
     "^https://github.com/.*/issues/0000",
     "^https://github.com/.*/pull/0000",
+    # Merged PR references are permanent, but GitHub intermittently returns 502
+    # responses for them, causing link-check flakes with no broken-link signal.
+    "^https://github.com/zakura-core/zakura/pull/[0-9]+",
     # Mergify dashboard (requires auth)
     "^https://dashboard.mergify.com/",
     # IACR eprint server returns 403 to automated link checkers

--- a/changelog-unreleased/345.md
+++ b/changelog-unreleased/345.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes link-check configuration and has no operator- or
+crate-consumer-visible effect.


### PR DESCRIPTION
## Motivation

The Docs Check run failed because GitHub returned transient HTTP 502 responses for two valid links to merged Zakura PRs (#309 and #316). Lychee exhausted the request without distinguishing the GitHub outage from a broken link.

## Solution

Exclude links to this repository's numbered PRs from link checking. These references are permanent once merged, while external and cross-repository links remain checked.

## Testing

- Parsed `.lychee.toml` with Python `tomllib`
- Verified the exclusion matches a Zakura PR URL but not a PR URL in another repository
- `./scripts/changelog.py check`
- `markdownlint changelog-unreleased/345.md --config .trunk/configs/.markdownlint.yaml`
- `git diff --check`

No compilation was run because this only changes link-check configuration.

## Changelog

`changelog-unreleased/345.md` marks this CI-only change as having no operator- or crate-consumer-visible effect.

### Specifications & References

- Failed job: https://github.com/zakura-core/zakura/actions/runs/29881618987/job/88803543692

### Follow-up Work

None.

AI assistance was used to diagnose the CI failure, implement the focused exclusion, and prepare this pull request.
