### PR TITLE
feat(release): add hotfix release path with private staging rehearsals

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -6,103 +6,104 @@ labels: "A-release, C-exclude-from-changelog, P-Critical :ambulance:"
 assignees: ""
 ---
 
-A hotfix release should only be created when a bug or critical issue is discovered in an existing release, and waiting for the next scheduled release is impractical or unacceptable.
+A hotfix release should only be created when a bug or critical issue is
+discovered in an existing release, and waiting for the next scheduled release
+is impractical or unacceptable. It ships the fix on top of the release
+operators are already running, instead of everything unreleased on `main`.
 
-## Create the Release PR
+For an **embargoed security fix**, follow
+[`docs/security-hotfix-release.md`](https://github.com/zakura-core/zakura/blob/main/docs/security-hotfix-release.md):
+all preparation below happens in the private staging repo, this PR is opened
+at forward-merge time, and the extra steps there (advisory, dress rehearsal,
+canary soak, announcement) apply on top of this checklist.
 
-- [ ] Create a branch to fix the issue based on the tag of the release being fixed (not the `main` branch).
-      for example: `hotfix-v2.3.1` - this needs to be different to the tag name
-- [ ] Make the required changes
-- [ ] Create a hotfix release PR by adding `&template=hotfix-release-checklist.md` to the comparing url ([Example](https://github.com/zakura-core/zakura/compare/bump-v1.0.0?expand=1&template=hotfix-release-checklist.md)).
-- [ ] Add one `changelog-unreleased/<PR-number>.md` fragment describing the
-      operator-visible hotfix.
-- [ ] Add the `C-exclude-from-changelog` label because the release PR consumes
-      its own fragment rather than carrying it into the next release.
-- [ ] Add the `A-release` tag to the release pull request in order for the `check_no_git_refs_in_cargo_lock` to run.
-- [ ] Add the `do-not-merge` tag to prevent Mergify from merging, since after PR approval the
-      release is done from the branch itself.
-- [ ] Ensure the `check_no_git_refs_in_cargo_lock` check passes.
+## Create the Hotfix Branch
 
-## Update Versions
+- [ ] Cut `hotfix/v<version>` from the tag of the release being fixed (not
+      from `main`). The branch **must** be named for the exact tag it will
+      release — the `Create release` workflow refuses to tag `v<version>`
+      from any other branch. The `hotfix/v*` ruleset blocks deletion and
+      force-pushes.
+- [ ] Make the required changes, minimal and with tests.
+- [ ] For a public (non-embargoed) hotfix: open this PR from the branch with
+      `&template=hotfix-release-checklist.md` in the compare URL, and add the
+      `do-not-merge` label — the release is dispatched from the branch itself,
+      and the PR is merged (as a merge commit) only after the release.
+- [ ] Add the `A-release` label so `check-no-git-dependencies` runs, and
+      ensure it passes.
 
-If it is a Zakura hotfix, the release level should always follow semantic
-versioning as a `patch` release. If it is a crate hotfix, it should simply
-follow semver, depending on the thing being fixed.
+## Update Versions and Prepare the Release
 
-- [ ] Follow the "Update Zakura Version" section in the regular checklist for
-  instructions.
-- [ ] After all package version bumps, run
-      `make prepare-release-changelog RELEASE_TAG=v<version>`.
-- [ ] Review and commit the generated root changelog and fragment deletion.
-- [ ] Run
-      `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<previous-version>`.
+Hotfixes are `patch` releases of the `zakura` package, plus semver bumps for
+each changed crate — follow the "Update Versions" sections of the
+[regular checklist](https://github.com/zakura-core/zakura/blob/main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md)
+for the commands, using the branch checkout (release.toml allows
+`hotfix/v*`).
 
-## Update the Release PR
+- [ ] Bump the `zakura` package version and changed-crate versions.
+- [ ] Generate and commit the stored config snapshot
+      (`zakurad/tests/common/configs/v<version>.toml`) — `last_config_is_stored`
+      fails without it.
+- [ ] Assemble the changelog section for `v<version>`:
+  - public hotfix with fragments on the branch: run
+    `make prepare-release-changelog RELEASE_TAG=v<version>` and commit the
+    result;
+  - embargoed hotfix (no public PR yet): write the release section by hand,
+    exactly as assembly would produce it — for a stable tag that includes
+    absorbing any `v<version>-rc*` sections — and verify with
+    `./scripts/changelog.py release v<version> --check`.
+- [ ] Do **not** bump `ESTIMATED_RELEASE_HEIGHT`: a hotfix inherits the base
+      release's end-of-support schedule (see the process doc for why). Check
+      the remaining runway and state it in the release notes if it is short.
+- [ ] Run `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<base-version>`
+      and get it passing on the final commit.
+- [ ] Verify crate packaging: `./scripts/check-crate-packaging.sh --verify`.
 
-- [ ] Push the version increments and the release constants to the hotfix release branch.
+## Publish the Release
 
-# Publish the Release
-
-## Create the GitHub Pre-Release (if Zakura hotfix)
-
-- [ ] Wait for the hotfix release PR to be reviewed and approved.
-- [ ] Create a new release
-- [ ] Set the tag name to the version tag,
-      for example: `v2.3.1`
-- [ ] Set the release to target the hotfix release branch
-- [ ] Set the release title to `Zakura` followed by the version tag,
-      for example: `Zakura 2.3.1`
-- [ ] Populate the release description with the final changelog you created;
-      starting just _after_ the title `## [Zakura ...` of the current version being released,
-      and ending just _before_ the title of the previous release.
-- [ ] Mark the release as 'pre-release', until it has been built and tested
-- [ ] Publish the pre-release to GitHub using "Publish Release"
-
-## Test the Pre-Release (if Zakura hotfix)
-
-- [ ] Wait until the Docker binaries have been built on the hotfix release branch, and the quick tests have passed:
-  - [ ] [release-binaries.yml](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Apush)
-
-## Publish Release (if Zakura hotfix)
-
-- [ ] [Publish the release to GitHub](https://github.com/zakura-core/zakura/releases) by disabling 'pre-release', then clicking "Set as the latest release"
+- [ ] Push the final branch to `zakura-core/zakura`.
+- [ ] Dispatch the
+      [Create release workflow](https://github.com/zakura-core/zakura/actions/workflows/create-release.yml)
+      **from the `hotfix/v<version>` branch** with the exact tag. The
+      workflow validates, builds and verifies the assets, then waits at the
+      `release` environment.
+- [ ] Approve the `release` environment deployment (right commit? right
+      tag?). The workflow publishes a complete pre-release and creates the
+      protected tag; the tag push starts Docker publishing.
+- [ ] Update the release description from the changelog section.
+- [ ] Sign the release: `make sign-release TAG=v<version>`.
+- [ ] Stable hotfix only: promote the release — disable 'pre-release' **and**
+      "Set as the latest release". Release candidates are never promoted.
 
 ## Publish Crates
 
-- [ ] Checkout the hotfix release branch
-- [ ] [Run `cargo login`](https://github.com/zakura-core/zakura/dev/crate-owners.html#logging-in-to-cratesio)
-- [ ] Run `cargo clean` in the zakura repo
-- [ ] Publish the changed crates to crates.io; edit the list to only include
-      the crates that have been changed (`git diff --stat <previous-tag>`),
-      but keep their overall order — unchanged crates are not bumped or
-      published:
+- [ ] From a fresh checkout of the new tag: `cargo login`, then publish the
+      changed crates in dependency order per the regular checklist
+      (`cargo release publish --verbose --execute -p <crate>`), editing the
+      list to only the crates that changed.
+- [ ] Check `cargo install --locked --force --version <version> zakura` works
+      and put the output in a comment on this PR.
 
-```
-for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakura-tower-batch-control zakura-node-services zakura-script zakura-state zakura-consensus zakura-network zakura-rpc zakura-utils zakura; do cargo release publish --verbose --execute --allow-branch {hotfix-release-branch} -p $c; done
-```
+## Publish Docker Images
 
-- [ ] Check that the published version of Zakura can be installed from `crates.io`:
-      `cargo install --locked --force --version 2.minor.patch zakura && ~/.cargo/bin/zakurad`
-      and put the output in a comment on the PR.
+- [ ] Wait for the tag-push
+      [release-binaries.yml run](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Apush)
+      to publish images, and confirm the new tags in the
+      [Docker Hub zakura space](https://hub.docker.com/r/zakuracore/zakura/tags).
+      Hyphenated tags (release candidates) never move `latest`.
 
-## Publish Docker Images (if Zakura hotfix)
+## Merge the Hotfix into Main
 
-- [ ] Wait for the [the Docker images to be published successfully](https://github.com/zakura-core/zakura/actions/workflows/release-binaries.yml?query=event%3Apush).
-- [ ] Wait for the new tag in the [Docker Hub zakura space](https://hub.docker.com/r/valaroman/zakura/tags)
-
-## Merge hotfix into main
-
-- [ ] Solve any conflicts between the hotfix branch and `main`. Do not force-push
-      into the branch! We need to include the commit that was released into `main`.
-- [ ] Get the PR reviewed again if changes were made
-- [ ] Admin-merge the PR with a merge commit (if by the time you are following
-      this we have switched to merge commits by default, then just remove
-      the `do-not-merge` label)
+- [ ] Forward-merge `hotfix/v<version>` into `main` **immediately** via this
+      PR. Solve conflicts in the branch without force-pushing — the released
+      commit must become an ancestor of `main`.
+- [ ] Merge with a **merge commit** (admin merge; do not squash), so the
+      tagged commit is preserved in `main`'s history.
+- [ ] Delete the hotfix branch after the merge; the tag is permanent.
 
 ## Release Failures
 
-If building or running fails after tagging:
-
-<details>
-1. Create a new hotfix release, starting from the top of this document.
-</details>
+If the pre-tag build or validation fails, no tag exists: fix the branch and
+re-dispatch `Create release` with the same version. If a failure is found
+after the tag exists, start a new `patch` hotfix from the top of this
+document — tags are immutable and are never reused.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,10 @@
 # This workflow is the only supported path for creating v* release tags.
 # It builds and verifies every release asset before a protected environment
 # allows the release GitHub App to publish a draft and create the immutable tag.
+#
+# It dispatches from main, or from a hotfix/vX.Y.Z branch named for the exact
+# tag it releases (see docs/security-hotfix-release.md). The
+# source_first_release input is the emergency "Mode B" path described there.
 name: Create release
 
 on:
@@ -12,6 +16,11 @@ on:
         type: string
       allow_bootstrap_release_state:
         description: "Emergency override: accept legacy-bootstrap Mainnet release state (note it in the release PR)"
+        required: false
+        default: false
+        type: boolean
+      source_first_release:
+        description: "Emergency mode: skip the staged asset build and publish a source-only release immediately; the tag-push run of release-binaries.yml builds and attaches binaries afterwards (see docs/security-hotfix-release.md, Mode B)"
         required: false
         default: false
         type: boolean
@@ -51,10 +60,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$SOURCE_REF" != "refs/heads/main" ]; then
-            echo "Create release must be dispatched from the main branch, not ${SOURCE_REF}." >&2
-            exit 1
-          fi
+          case "$SOURCE_REF" in
+            refs/heads/main) ;;
+            refs/heads/hotfix/v*)
+              # Hotfix branches are named for the exact tag they release, so a
+              # tag can never be dispatched from another release's branch.
+              if [ "$SOURCE_REF" != "refs/heads/hotfix/${RELEASE_TAG}" ]; then
+                echo "Tag ${RELEASE_TAG} must be dispatched from hotfix/${RELEASE_TAG}, not ${SOURCE_REF}." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Create release must be dispatched from main or a hotfix/v* branch, not ${SOURCE_REF}." >&2
+              exit 1
+              ;;
+          esac
 
           # This validates only release state committed to the source ref.
           # Resolving the moving R2 pointer belongs to update-release-state.yml.
@@ -68,6 +88,10 @@ jobs:
   build-assets:
     name: Build and verify release assets
     needs: [validate]
+    # Mode B (source_first_release) trades the pre-tag asset build for speed:
+    # the tag-push run of release-binaries.yml rebuilds and attaches assets to
+    # the published release instead.
+    if: ${{ !inputs.source_first_release }}
     uses: ./.github/workflows/release-binaries.yml
     # The nested publish-zakurad-assets job declares contents: write, and a
     # called workflow may not request more than the caller grants. The staging
@@ -86,15 +110,27 @@ jobs:
     name: Publish release and create tag
     runs-on: ubuntu-latest
     needs: [validate, build-assets]
+    # Tolerate build-assets being skipped, but only when Mode B asked for it.
+    if: >-
+      ${{
+        !cancelled()
+        && needs.validate.result == 'success'
+        && (
+          needs.build-assets.result == 'success'
+          || (inputs.source_first_release && needs.build-assets.result == 'skipped')
+        )
+      }}
     environment: release
     steps:
       - name: Download staged release assets
+        if: ${{ !inputs.source_first_release }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: staged-release-assets
           path: ./assets
 
       - name: Verify staged release assets
+        if: ${{ !inputs.source_first_release }}
         env:
           RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
           REPOSITORY: ${{ github.repository }}
@@ -199,8 +235,14 @@ jobs:
           RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
           REPOSITORY: ${{ github.repository }}
           TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
+          SOURCE_FIRST: ${{ inputs.source_first_release && 'true' || 'false' }}
         run: |
           set -euo pipefail
+
+          release_body="Release created by the protected Create release workflow."
+          if [ "$SOURCE_FIRST" = "true" ]; then
+            release_body="Source-first release: binaries are being built and attached by the tag-push release-binaries run."
+          fi
 
           # On HTTP errors `gh api` prints the JSON error body to stdout, so
           # branch on the exit status instead of the captured output, and only
@@ -258,13 +300,14 @@ jobs:
               jq -n \
                 --arg tag "$RELEASE_TAG" \
                 --arg sha "$TARGET_SHA" \
+                --arg body "$release_body" \
                 '{
                   tag_name: $tag,
                   target_commitish: $sha,
                   name: $tag,
                   draft: true,
                   prerelease: true,
-                  body: "Release created by the protected Create release workflow."
+                  body: $body
                 }' \
               | gh api --method POST \
                   "repos/${REPOSITORY}/releases" \
@@ -273,22 +316,26 @@ jobs:
             )"
           fi
 
-          mapfile -t asset_files < <(
-            find ./assets -maxdepth 1 -type f ! -name 'SHA256SUMS.txt' | sort
-          )
-          asset_files+=("./assets/SHA256SUMS.txt")
-          for asset in "${asset_files[@]}"; do
-            name="$(basename "$asset")"
-            encoded_name="$(jq -rn --arg name "$name" '$name | @uri')"
-            echo "Uploading ${name}."
-            curl --fail --silent --show-error \
-              --request POST \
-              --header "Authorization: Bearer ${GH_TOKEN}" \
-              --header "Content-Type: application/octet-stream" \
-              --data-binary "@${asset}" \
-              --output /dev/null \
-              "https://uploads.github.com/repos/${REPOSITORY}/releases/${draft_id}/assets?name=${encoded_name}"
-          done
+          if [ "$SOURCE_FIRST" = "true" ]; then
+            echo "Source-first release: publishing without assets; the tag-push run attaches them."
+          else
+            mapfile -t asset_files < <(
+              find ./assets -maxdepth 1 -type f ! -name 'SHA256SUMS.txt' | sort
+            )
+            asset_files+=("./assets/SHA256SUMS.txt")
+            for asset in "${asset_files[@]}"; do
+              name="$(basename "$asset")"
+              encoded_name="$(jq -rn --arg name "$name" '$name | @uri')"
+              echo "Uploading ${name}."
+              curl --fail --silent --show-error \
+                --request POST \
+                --header "Authorization: Bearer ${GH_TOKEN}" \
+                --header "Content-Type: application/octet-stream" \
+                --data-binary "@${asset}" \
+                --output /dev/null \
+                "https://uploads.github.com/repos/${REPOSITORY}/releases/${draft_id}/assets?name=${encoded_name}"
+            done
+          fi
 
           html_url="$(
             gh api --method PATCH "repos/${REPOSITORY}/releases/${draft_id}" \

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -7,6 +7,14 @@
 # own non-hyphenated tag. To repair or re-upload assets for an existing tag,
 # run workflow_dispatch with publish_assets_to_release.
 #
+# Repo guards: every step that touches the outside world (Docker Hub login
+# and pushes, build provenance attestation) only runs when
+# github.repository == 'zakura-core/zakura', and push-variant Docker builds
+# degrade to build-only elsewhere. A tag pushed to any other clone — in
+# particular the private staging repo used for release dress rehearsals, see
+# docs/security-hotfix-release.md — builds and assembles a complete release
+# in that repo without publishing anything.
+#
 # The tag must match the `zakura` package version: release binaries are built
 # in Docker without `.git`, so `zakurad --version` reports CARGO_PKG_VERSION,
 # and a tag pushed without bumping the package version ships binaries that
@@ -368,7 +376,10 @@ jobs:
             mv ../SHA256SUMS.txt SHA256SUMS.txt
           )
 
+      # Repo guard: provenance is only meaningful (and only available) from
+      # the canonical public repository; private rehearsal repos skip it.
       - name: Attest build provenance
+        if: ${{ github.repository == 'zakura-core/zakura' }}
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 #v4.1.1
         with:
           subject-path: |
@@ -477,15 +488,23 @@ jobs:
           version: lab:latest
           driver: docker
 
+      # Repo guard: only the canonical repository publishes to Docker Hub.
+      # Any other clone (for example a private staging repo rehearsing a
+      # release tag) degrades to build-only, so rehearsals are green and
+      # publish-safe by construction.
       - name: Login to DockerHub
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: >-
+          ${{ github.repository == 'zakura-core/zakura'
+            && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 #v4.4.0
         with:
           username: valaroman
           password: ${{ secrets.DOCKERHUB_TOKEN_ZAKURA }}
 
       - name: Build runtime image
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub }}
+        if: >-
+          ${{ github.repository != 'zakura-core/zakura'
+            || (!startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           IMAGE_TAG: zakuracore/zakura:release-ci-${{ matrix.name }}
@@ -507,7 +526,9 @@ jobs:
           docker image inspect "$IMAGE_TAG" >/dev/null
 
       - name: Build and push runtime image
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: >-
+          ${{ github.repository == 'zakura-core/zakura'
+            && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -529,7 +550,10 @@ jobs:
 
   publish-docker-manifest:
     name: Publish Docker multi-arch manifest
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+    # Repo guard: publishing only happens from the canonical repository.
+    if: >-
+      ${{ github.repository == 'zakura-core/zakura'
+        && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
     runs-on: ubuntu-latest
     needs: [resolve-release, build]
     steps:
@@ -591,8 +615,14 @@ jobs:
           version: lab:latest
           driver: docker
 
+      # Repo guard: only the canonical repository publishes to Docker Hub.
+      # Any other clone (for example a private staging repo rehearsing a
+      # release tag) degrades to build-only, so rehearsals are green and
+      # publish-safe by construction.
       - name: Login to DockerHub
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: >-
+          ${{ github.repository == 'zakura-core/zakura'
+            && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 #v4.4.0
         with:
           username: valaroman
@@ -608,7 +638,9 @@ jobs:
             --platform "$DOCKER_PLATFORM"
 
       - name: Build zcashd compat runtime image
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub }}
+        if: >-
+          ${{ github.repository != 'zakura-core/zakura'
+            || (!startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           IMAGE_TAG: zakuracore/zakura:zcashd-compat-release-ci-${{ matrix.name }}
@@ -631,7 +663,9 @@ jobs:
           docker image inspect "$IMAGE_TAG" >/dev/null
 
       - name: Build and push zcashd compat runtime image
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+        if: >-
+          ${{ github.repository == 'zakura-core/zakura'
+            && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -654,7 +688,10 @@ jobs:
 
   publish-zcashd-compat-docker-manifest:
     name: Publish zcashd compat Docker amd64 manifest
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub
+    # Repo guard: publishing only happens from the canonical repository.
+    if: >-
+      ${{ github.repository == 'zakura-core/zakura'
+        && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
     runs-on: ubuntu-latest
     needs: [resolve-release, resolve-zcashd-compat-manifest, build-zcashd-compat]
     steps:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,14 @@ Please submit issues privately through GitHub's security advisory reporting for 
 
 If an issue also affects upstream [Zebra](https://github.com/ZcashFoundation/zebra), please also report it to the Zcash Foundation by following [upstream's security policy](https://github.com/ZcashFoundation/zebra/blob/main/SECURITY.md). Issues in Zakura's own additions (for example the experimental Zakura P2P v2 stack) should be reported only to us.
 
+## Coordinated Security Releases
+
+For significant vulnerabilities, the fix is developed and validated under
+embargo and shipped as a coordinated hotfix release; the process — private
+staging and rehearsal, canary soak, the release-day runbook, and how the
+advisory is published — is documented in
+[`docs/security-hotfix-release.md`](docs/security-hotfix-release.md).
+
 ## Sending Disclosures
 
 In the case where we become aware of security issues affecting other projects that has never affected Zakura or Zcash, our intention is to inform those projects of security issues on a best effort basis.

--- a/changelog-unreleased/347.md
+++ b/changelog-unreleased/347.md
@@ -1,0 +1,5 @@
+<!-- changelog: none -->
+
+This PR only changes release automation, release checklists, and process
+documentation; it has no operator- or crate-consumer-visible effect on
+zakurad or the published crates.

--- a/docs/security-hotfix-release.md
+++ b/docs/security-hotfix-release.md
@@ -1,0 +1,423 @@
+# Security Hotfix Release Process
+
+This document describes how we ship a release for a **significant security
+issue**: the fix is developed under embargo, and the public goes from "no
+information" to "signed, tagged GitHub release + crates.io release" in one
+coordinated event. It complements [`SECURITY.md`](../SECURITY.md) (how
+vulnerabilities are reported and disclosed), the
+[release checklist](../.github/PULL_REQUEST_TEMPLATE/release-checklist.md)
+(the standard runbook), and the
+[hotfix release checklist](../.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md)
+(the hotfix runbook this process feeds into). Where this document is silent,
+the standard release process applies. Ordinary security fixes — low severity,
+already public, or fine to ship in a scheduled release — don't need this
+process.
+
+**Design principle: one maintainer can execute this end-to-end.** Nothing in
+the process requires a second person. A second person makes it better (see
+[Scaling up](#scaling-up-when-a-second-person-is-available)), and for the
+worst bug classes you should try hard to get one, but the process must not
+deadlock because nobody else is awake.
+
+## Goals and non-goals
+
+Goals:
+
+1. Develop and validate the fix entirely in private — in a private staging
+   repo with CI, plus a soak on nodes we operate — before anything is public.
+2. At a chosen time (**T-0**), go from private to public tag + GitHub release
+   + crates.io release with a minimal, well-understood exposure window.
+3. Keep the existing release protections: `v*` tags are created only by the
+   release App via the `Create release` workflow (with a break-glass org-owner
+   bypass), tags stay immutable, and binaries are always built and
+   provenance-attested by the public repository's CI
+   (see [release tag protection](release-tag-protection.md)).
+4. Every step is rehearsable in advance and resumable if interrupted.
+
+Non-goals:
+
+1. **Hiding the fix after T-0.** Once public, the diff is the disclosure for a
+   capable attacker; the only real mitigation is how fast operators upgrade.
+2. **Hiding that a release is happening.** Workflow runs and release-state
+   refreshes are public. We protect the content, not the schedule.
+3. Automating signing or crates publication (both stay manual).
+4. Zero-gap binaries (they're built by public CI after the code is public).
+
+## Overview
+
+```text
+        PRIVATE                                  │  PUBLIC (T-0 onward)
+                                                 │
+reporter ─> GHSA draft advisory ─────────────────┼─> advisory published
+                 │                               │        ▲
+                 ▼                               │        │
+zakura-core/zakura-private (staging repo w/ CI)  │        │
+  fix PR in staging: review + full test suites   │        │
+  tag dress rehearsal -> private release+assets  │        │
+  canary soak on nodes we operate                │        │
+                 │                               │        │
+                 └──────────── T-0 ──────────────┼─> push -> Create release
+                                                 │   tag + release (~T+10–30)
+                                                 │   crates, sign, promote,
+                                                 │   announce
+```
+
+## The private staging repo
+
+All embargoed work happens in a **dedicated local clone** whose only remote is
+private. Do not work in your everyday checkout: pushing an embargoed branch to
+the public remote by muscle memory is the most likely catastrophic mistake in
+this design, and solo there's nobody to catch it. Name branches
+`security/<codename>` (codename carries no content); install
+[`scripts/hooks/pre-push`](../scripts/hooks/pre-push) in the everyday clone —
+it rejects `security/*` pushes — as cheap insurance.
+
+**`zakura-core/zakura-private`** is where validation and review happen: a
+private repo, created and curated once, maintainers-only. Validation runs in
+this repo's GitHub Actions rather than on laptops, so it doesn't depend on any
+one maintainer's hardware. It is deliberately **not a synced mirror**: there
+is no sync automation to maintain — at incident start you push current public
+`main` (and tags) into it from your clone, and its freshness is whatever you
+pushed. It doubles as the backup and handoff point: another maintainer can
+take over from what's pushed there plus the GHSA draft.
+
+One-time curation makes a pushed copy of this repository quiet and safe by
+construction:
+
+- **Scheduled and infrastructure workflows are disabled** (continuous sync,
+  e2e, deploys, benchmarks, release-state refresh, PR-node automation, …);
+  lint, unit/crate tests, Docker tests, and `release-binaries.yml` stay
+  enabled. Disabled state is keyed by workflow path and survives later pushes;
+  glance at the Actions tab at incident start in case public `main` gained
+  new scheduled workflows since.
+- **Repo guards in the public workflows**: steps that touch the outside world
+  — Docker Hub login and pushes, build attestation — are skipped, and
+  push-variant Docker builds degrade to build-only, whenever
+  `github.repository != 'zakura-core/zakura'`. Missing secrets already make
+  publishing from the staging repo impossible; the guards are what make its
+  rehearsals green-by-design instead of red noise.
+- **No publishing credentials, ever**: no Docker Hub token, no crates token,
+  no release App key. The only optional secret is the deploy SSH key, if we
+  adopt workflow-driven soak deploys (see
+  [Scaling up](#scaling-up-when-a-second-person-is-available)).
+
+Two things a private venue can never be: a GitHub fork (forks of public repos
+cannot be private — at T-0 you push commits to the public repo directly, there
+is no cross-repo PR), and a GHSA temporary fork used for development (they run
+no Actions and we don't need them).
+
+### Rehearsing the release privately
+
+Everything the public T-0 run gates on can be rehearsed in the staging repo:
+
+| Public T-0 gate | Staging rehearsal |
+| --- | --- |
+| `Create release` validate job | `make pre-release RELEASE_TAG=v<version> BASE_TAG=v<previous>` (a CI job or locally — it's a check script, not a build) |
+| Release asset build + version self-check | The tag dress rehearsal (below) |
+| Docker image builds | The tag dress rehearsal (below) |
+| Crates publishability | `./scripts/check-crate-packaging.sh --verify`, plus the no-git-dependencies check |
+
+**The tag dress rehearsal.** Once the branch is final, push the real
+`vX.Y.Z` tag *to the staging repo*. Nothing collides — it is a separate
+repository with no tag rulesets — and the push triggers
+`release-binaries.yml` exactly as the public T-0 tag will: version checks,
+both release binaries, Docker images (build-only, under the repo guards), and
+a complete **private release** with the assembled asset set, which you
+download, inspect, and deploy for the soak. This is the closest possible
+approximation of T-0 with zero public footprint.
+
+Correctness testing is separate from release mechanics: no test suite runs at
+public T-0 (the `main` ruleset requires no status checks), so run the fix as
+a PR in the staging repo — lint, unit/crate, and Docker test workflows run
+there, and the PR is where review (cold self-review, the reporter, or another
+maintainer) happens — plus whichever nextest profiles the change warrants.
+Maintainers with capable hardware can substitute local runs for any of this;
+the staging repo is the baseline that depends on nobody's laptop.
+
+Staging CI is near-parity, not parity: repository `vars` don't replicate
+(builds fall back to slower GitHub-hosted runners, billed as private-repo
+Actions minutes), caches differ, and attestation is skipped — see caveat 6.
+
+## GHSA advisory (parallel track)
+
+For each incident, open a **draft security advisory** on the public repo
+(visible only to maintainers and invitees). It is the reporter channel (per
+`SECURITY.md`, reports already arrive there), the CVE request vehicle, the
+canonical description published at T-0 — and, solo, the **continuity record**:
+keep it current enough (state, branch name in the staging repo, planned T-0)
+that another maintainer could pick up the incident if you become unavailable.
+Detail level at publication is per-incident; `SECURITY.md` already reserves
+the right to withhold reproduction details for counterfeiting-class bugs.
+
+## Developing the fix
+
+### Choosing the base
+
+| Base | When | Notes |
+| --- | --- | --- |
+| `hotfix/vX.Y.Z` cut from the last release tag | Default for solo, and whenever `main` has unreleased work operators shouldn't absorb mid-emergency | Minimal auditable diff; **mechanically simplest solo**: direct maintainer push, no PR review rule, no Mergify interaction. The branch must be named for the exact tag it releases — the `Create release` validate job enforces this. Fix must be forward-merged to `main` right after release. |
+| `main` | `main` is essentially the last release plus safe changes | Direct pushes to `main` are blocked for everyone; org admins can open the PR for the record and bypass-merge it. Freeze the Mergify `batched` queue first. |
+
+Record the choice and reasoning in the advisory.
+
+### What the branch must contain before T-0
+
+T-0 involves zero authoring — only pushing and clicking. The branch carries:
+
+1. **The fix**, minimal and with tests. Solo review protocol: write it one
+   day, review the diff cold the next; where an external reporter exists,
+   they are your reviewer. (See caveat 1 — this is the process's sharpest
+   compromise.)
+2. **The complete release prep**, per the
+   [hotfix release checklist](../.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md):
+   - `zakura` package version bump (hotfixes are `patch`) and changed-crate
+     bumps (`cargo release version ...`);
+   - the stored config snapshot
+     (`zakurad/tests/common/configs/v<version>.toml` — `last_config_is_stored`
+     fails without it);
+   - the assembled changelog section. There is no public PR to hang a
+     fragment on, so write the release section by hand, exactly as fragment
+     assembly would have produced it (for a stable tag that includes
+     absorbing any `v<version>-rc*` sections into the release section), and
+     verify with `./scripts/changelog.py release v<version> --check` — it is
+     part of `make pre-release` and fails on anything assembly wouldn't have
+     written;
+   - `ESTIMATED_RELEASE_HEIGHT` in `end_of_support.rs` deliberately **not**
+     bumped. A hotfix inherits the base release's end-of-support halt height:
+     it protects operators now without extending the schedule on which they
+     must take the next regular release, and it removes a fiddly
+     estimate-the-height step from the emergency path. If the base release is
+     already old, the hotfix ships with a short remaining runway — check it,
+     state it in the release notes and announcement, and plan the next
+     scheduled release accordingly;
+   - `make pre-release` passing, packaging checked with `--verify`.
+3. **Commit messages written for public consumption** — world-readable at T-0.
+   Recommended: accurate but minimal conventional commits
+   ("fix(consensus): harden <area> validation"), detail deferred to the
+   advisory.
+
+Release state (checkpoints + VCT frontier): staleness beyond 14 days only
+warns, so a hotfix normally ships whatever the base already has. If it's
+badly stale, refreshing it runs the *public* `update-release-state.yml`
+workflow and merges a public draft PR — a mild, deniable timing signal. If
+that PR floors `ESTIMATED_RELEASE_HEIGHT` upward, drop that hunk: hotfixes
+never move end-of-support. The `allow_bootstrap_release_state` override exists
+for a broken publisher; note it in the release PR if used.
+
+### Canary soak
+
+Deploy the binaries from the tag dress rehearsal (download the private
+release's assets) **manually** to nodes we operate — no workflow needed.
+Testnet first; for consensus-relevant fixes, at least one mainnet canary.
+Soak until confident: in sync with the public network, no divergence, no
+restarts, clean metrics. Suggested floor: 24h for consensus-touching changes;
+compressing it is an explicit, recorded decision, not a default. Canary
+binaries are unsigned and private-built — fine for our own infrastructure,
+never for anything public.
+
+## Going public: the solo T-0 runbook
+
+### Standing preconditions (verify now, not during an incident)
+
+- [ ] The `release` environment lists each release-capable maintainer as a
+      required reviewer and **"Prevent self-review" is unchecked** — otherwise
+      a solo release deadlocks at the approval gate.
+- [ ] The `release` environment's deployment branch policy includes
+      `hotfix/v*`, and the `hotfix/v*` branch ruleset (block deletion and
+      force-push) is active.
+- [ ] `gh` authenticated; crates.io login current; minisign secret key
+      accessible; you can reach the announcement channels.
+
+### The day before
+
+- [ ] Staging rehearsals green **on the final commit** — CI suites and the
+      tag dress rehearsal; soak criteria met.
+- [ ] Optional [pre-announcement](#pre-announcement) published.
+- [ ] Main-base only: freeze the Mergify `batched` queue.
+- [ ] Partner/upstream notifications sent per `SECURITY.md`
+      (see [Coordination](#coordination-with-upstream-and-the-ecosystem)).
+- [ ] Block ~2 hours of uninterrupted time. Every step below is resumable
+      (`Create release` reuses drafts and is safe to re-dispatch; the crates
+      loop restarts per-crate; signing is idempotent) — but don't start T-0 if
+      you can't plausibly finish it.
+
+### T-0 sequence — Mode A (default)
+
+Complete, verified assets exist before the tag does. Times from recent
+`Create release` runs (~18–30 min dispatch-to-tag).
+
+| Clock | Step |
+| --- | --- |
+| T-0 | Push `hotfix/vX.Y.Z` (or bypass-merge to `main`). |
+| T+2 | Dispatch `Create release` **from the hotfix branch** (or `main`) with the exact tag. |
+| T+2–25 | Hands-off build. Meanwhile: fresh checkout for crates publish, final announcement text. |
+| T+25 | Approve the `release` environment (yourself — this is your deliberate stop-and-check point, not a formality: right commit? right tag?). |
+| T+30 | Tag + complete pre-release published; tag-push run starts Docker publishing. |
+| T+30 | Start the crates publish loop (below) — it runs ~30–60 min, mostly waiting. |
+| T+35 | `make sign-release TAG=v<version>` (signs `SHA256SUMS.txt`, uploads `.minisig`). |
+| T+40 | Promote (stable only: clear pre-release **and** set latest). Publish the GHSA advisory. Announce. |
+| T+45–75 | Docker images land; confirm assets, images, and manifest per the standard checklist. |
+
+### Mode B — source-first (active exploitation only)
+
+Dispatching `Create release` with the `source_first_release` input skips the
+staged asset build: validation only (~4–8 min), approve, and the **tag +
+source-only release publish at ~T+10**. The tag-push run of
+`release-binaries.yml` then sees an incomplete asset set and rebuilds and
+attaches assets to the existing release, so binaries land ~T+35–50, then
+sign, promote, follow-up announcement. Announce at T+10 stating explicitly
+what exists: "source and crates now; signed binaries by ~HH:MM UTC"
+(`cargo install --locked zakura` is the fastest verified install path in this
+window).
+
+What Mode B trades, explicitly:
+
+- an **immutable tag exists before its binaries are verified**; if the
+  post-tag build fails, the repair path is `release-binaries.yml`
+  `workflow_dispatch` with `publish_assets_to_release`. The tag dress
+  rehearsal of the same commit is what keeps this risk small — and juggling a
+  repair alone is exactly the failure mode Mode A avoids;
+- until signing, the release page has no `SHA256SUMS.txt`/signature, so
+  `VERIFY.md` verification is impossible;
+- it saves ~15–25 minutes to tag/source/crates and does **not** meaningfully
+  accelerate signed binaries. Worth it under active exploitation; not
+  otherwise. **Solo default is Mode A.**
+
+### Crates publish
+
+From a fresh checkout of the new tag, per the standard checklist: `cargo
+login`, then the publish loop in dependency order (`zakura-test … zakura`),
+edited to the crates that changed. Hotfix notes: crates.io is **public and
+irreversible from the first crate** — it's part of T-0, never earlier;
+`release.toml` allows publishing from `hotfix/v*` checkouts; a mid-loop
+failure is fixed forward by publishing the remainder, not by yanking.
+
+### Pre-announcement
+
+Optional, recommended for high severity: 24–72h before T-0, announce that **a
+security release will be published at \<date, time UTC\>** — nothing else — so
+operators are watching when it lands. Long-standing ecosystem practice (Zcash
+2018; Bitcoin Core CVE-2018-17144). Trade-off: it also tells attackers when to
+start diffing; net positive when operator reaction time dominates. If
+severity warrants partner notifications under `SECURITY.md`, it usually
+warrants a pre-announcement.
+
+### Post-release
+
+- [ ] Hotfix base: forward-merge `hotfix/vX.Y.Z` into `main` via a normal
+      public PR, immediately. Use a **merge commit** (admin merge), not a
+      squash, so the tagged commit becomes an ancestor of `main`.
+- [ ] Main base: un-freeze Mergify.
+- [ ] Confirm installer-metadata/post-release automation completed as usual.
+- [ ] Delete embargoed branches, rehearsal tags, and the private rehearsal
+      release from the staging repo.
+- [ ] Update the advisory with fuller detail when appropriate; credit the
+      reporter.
+- [ ] Retro: what leaked, what was slow, what the rehearsal missed; update
+      this document.
+
+## The T-0 exposure window
+
+Mode A: the fix is publicly visible ~30 minutes before a complete signed
+release exists. Mode B: ~10 minutes before a tag + source release, ~35–50
+before signed binaries. The window cannot be zero: binaries are
+provenance-attested by public-repo CI and the release manifest embeds the
+repository and URLs (verified at publish) — attaching private-built binaries
+would permanently weaken what `VERIFY.md` means, on exactly the release where
+it matters most — and GitHub has no "staged but hidden" state for commits.
+Mitigations: the private dress rehearsal makes the public run one-shot;
+pre-announcement compresses operator reaction time; Mode B compresses
+time-to-source when it matters.
+
+## Coordination with upstream and the ecosystem
+
+Zakura is a Zebra fork; incidents come in three shapes:
+
+- **Inherited from Zebra**: `SECURITY.md` obliges responsible disclosure with
+  the Zcash Foundation and ECC; T-0 is then chosen *jointly* (expect the
+  slower party to set it).
+- **Zebra ships a fix first**: the clock is already running — this process
+  executes compressed (base decision, port, soak as severity allows, release;
+  skip the pre-announcement — upstream's release was it).
+- **Zakura-only code** (e.g. the P2P v2 stack): we control timing; notify
+  upstream/partners per `SECURITY.md` where relevant.
+
+Partner notifications follow `SECURITY.md`'s RD-Crypto-Spec commitments,
+including the counterfeiting-bug deviation (partners may be told to upgrade
+without full detail).
+
+## Caveats and risks
+
+1. **No second review of consensus-critical code.** The sharpest compromise
+   in the solo design. Mitigations: minimal diffs, the cold-review protocol,
+   the reporter as reviewer, a longer soak. For counterfeiting-class bugs,
+   try hard to break solo and bring in one other maintainer — the embargo
+   widens by one person; the review exists.
+2. **Two-person controls become one-person checkpoints.** The environment
+   approval still forces a pause and leaves an audit trail, but it no longer
+   proves a second person agreed. (The App-only tag creation and tag
+   immutability are unchanged.)
+3. **You are the single point of failure at T-0.** ~90 minutes of attention,
+   interruptions happen; every step is resumable, and the GHSA draft holds
+   enough state for another maintainer to take over.
+4. **Patch-diffing is inevitable** from T-0. Only upgrade speed mitigates it.
+5. **Accidental early push** of an embargoed branch is unrecoverable and,
+   solo, uncaught: dedicated clone, `security/*` naming, the pre-push hook.
+   If it happens anyway: assume disclosure, go to Mode B immediately.
+6. **Staging CI is near-parity, not parity** (hosted-runner fallbacks,
+   different caches, no attestation): the dress rehearsal is the best signal
+   available before T-0, and the public run can still surprise — Mode A
+   contains that risk before the tag exists; Mode B moves part of it after.
+7. **Mode B's tag precedes its verified binaries** and its release page is
+   temporarily unverifiable; the announcement must say exactly what exists.
+8. **crates.io is irreversible** and partial publishes are possible; the
+   `--verify` packaging rehearsal exists to prevent them.
+9. **Hotfix branches weaken the everything-releases-from-`main` invariant**,
+   and solo the compensating controls are thin by design (the branch ruleset,
+   the tag-name/branch-name match, the environment checkpoint, mandatory
+   forward-merge, audit trail).
+10. **Canaries run embargoed code on the public network.** Usually invisible;
+    for fixes with observable behavior changes (peering, message patterns),
+    consider whether the canary itself leaks.
+11. **Unrehearsed processes rot.** Drills (below) are part of the process.
+
+## Drills
+
+Run a full solo drill on a fake "vulnerability": trivial private fix, real
+staging-repo rehearsals (including the tag dress rehearsal), real releases —
+**always tagged as release candidates** (`vX.Y.Z-rcN`). RCs are the
+designed-safe drill vehicle: hyphenated tags never move the Docker `latest`
+aliases, RCs are never promoted to the GitHub "Latest" release, and published
+pre-releases are already a normal, permanent part of the repository's
+history. Exercise Mode A once and Mode B once (separate RCs of the same
+line), including `make sign-release` against the RC tag — signing an RC is
+harmless and exercises the signing tooling; promotion stays un-exercised by
+design. Skip the crates publish: the packaging `--verify` rehearsal covers it
+without spending permanent registry versions. Time every step; replace the
+estimates in the runbook with measured numbers.
+
+## Scaling up (when a second person is available)
+
+The process is solo-complete; each additional person upgrades a specific
+weakness, in this order of value:
+
+1. **A reviewer for the fix** (removes caveat 1) — they only need access to
+   the private repo, nothing else.
+2. **A real second approver** at T-0: they approve the `release` environment
+   and act as standby if you're interrupted (upgrades caveats 2 and 3).
+3. **Workflow-driven soak deploys** — register the self-hosted deploy
+   runner(s) and the deploy SSH key in the staging repo so canaries deploy
+   through the same workflow as production instead of by hand — and, with
+   more hands, keeping the staging repo continuously synced instead of pushed
+   on demand.
+
+## Open policy points
+
+1. **Is solo acceptable for every severity class?** Position above: yes as a
+   floor, but counterfeiting-class bugs should break solo for review if at
+   all possible.
+2. **Pre-announcement**: opt-in per incident (as written) or standard for
+   every hotfix? 24h or 72h lead?
+3. **Soak floor**: 24h + 1 mainnet canary for consensus-touching fixes —
+   right floor? Who signs off on compressing it?
+4. **Drill cadence**: quarterly, or aligned to release cadence?

--- a/docs/security-hotfix-release.md
+++ b/docs/security-hotfix-release.md
@@ -25,8 +25,9 @@ Goals:
 
 1. Develop and validate the fix entirely in private — in a private staging
    repo with CI, plus a soak on nodes we operate — before anything is public.
-2. At a chosen time (**T-0**), go from private to public tag + GitHub release
-   + crates.io release with a minimal, well-understood exposure window.
+2. At a chosen time (**T-0**), go from private to a public tag, GitHub
+   release, and crates.io release with a minimal, well-understood exposure
+   window.
 3. Keep the existing release protections: `v*` tags are created only by the
    release App via the `Create release` workflow (with a break-glass org-owner
    bypass), tags stay immutable, and binaries are always built and
@@ -118,7 +119,7 @@ Everything the public T-0 run gates on can be rehearsed in the staging repo:
 | Crates publishability | `./scripts/check-crate-packaging.sh --verify`, plus the no-git-dependencies check |
 
 **The tag dress rehearsal.** Once the branch is final, push the real
-`vX.Y.Z` tag *to the staging repo*. Nothing collides — it is a separate
+`vX.Y.Z` tag _to the staging repo_. Nothing collides — it is a separate
 repository with no tag rulesets — and the push triggers
 `release-binaries.yml` exactly as the public T-0 tag will: version checks,
 both release binaries, Docker images (build-only, under the repo guards), and
@@ -198,7 +199,7 @@ T-0 involves zero authoring — only pushing and clicking. The branch carries:
 
 Release state (checkpoints + VCT frontier): staleness beyond 14 days only
 warns, so a hotfix normally ships whatever the base already has. If it's
-badly stale, refreshing it runs the *public* `update-release-state.yml`
+badly stale, refreshing it runs the _public_ `update-release-state.yml`
 workflow and merges a public draft PR — a mild, deniable timing signal. If
 that PR floors `ESTIMATED_RELEASE_HEIGHT` upward, drop that hunk: hotfixes
 never move end-of-support. The `allow_bootstrap_release_state` override exists
@@ -334,7 +335,7 @@ time-to-source when it matters.
 Zakura is a Zebra fork; incidents come in three shapes:
 
 - **Inherited from Zebra**: `SECURITY.md` obliges responsible disclosure with
-  the Zcash Foundation and ECC; T-0 is then chosen *jointly* (expect the
+  the Zcash Foundation and ECC; T-0 is then chosen _jointly_ (expect the
   slower party to set it).
 - **Zebra ships a fix first**: the clock is already running — this process
   executes compressed (base decision, port, soak as severity allows, release;

--- a/release.toml
+++ b/release.toml
@@ -1,5 +1,6 @@
-# Only allow releases from the main branch
-allow-branch = [ 'main' ]
+# Only allow releases from the main branch or a hotfix release branch
+# (see docs/security-hotfix-release.md)
+allow-branch = [ 'main', 'hotfix/v*' ]
 
 # Workspace crate versions are deliberately independent: a crate is bumped and
 # published only when it has changes to publish. Do not configure

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Reject pushes of embargoed security branches from an everyday clone.
+#
+# Embargoed fixes are developed on security/<codename> branches in a dedicated
+# clone whose only remote is the private staging repo
+# (docs/security-hotfix-release.md). Pushing such a branch to the public
+# remote by muscle memory is the most likely catastrophic mistake in that
+# process; this hook is the cheap insurance. Install it in your everyday
+# public clone with:
+#
+#   cp scripts/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+#
+# git calls pre-push with lines "<local ref> <local sha> <remote ref> <remote sha>".
+set -euo pipefail
+
+while read -r local_ref _local_sha remote_ref _remote_sha; do
+  for ref in "$local_ref" "$remote_ref"; do
+    case "$ref" in
+      refs/heads/security/*)
+        echo "pre-push: refusing to push embargoed branch ${ref}." >&2
+        echo "pre-push: embargoed work belongs in the dedicated private clone only" >&2
+        echo "pre-push: (see docs/security-hotfix-release.md)." >&2
+        exit 1
+        ;;
+    esac
+  done
+done
+
+exit 0


### PR DESCRIPTION
## Motivation

The hotfix release checklist predates the protected `Create release` flow: it still describes manually creating releases and tags, which App-only tag creation no longer permits, so the repository currently has no executable hotfix path. Separately, release mechanics can only be tested by running them publicly — there is no way to rehearse a release tag end-to-end before it exists.

## Solution

Adds a documented, rehearsable hotfix release process (`docs/security-hotfix-release.md`) and the mechanics it needs:

- **Repo guards in `release-binaries.yml`**: Docker Hub login/pushes and build provenance attestation only run when `github.repository == 'zakura-core/zakura'`; push-variant Docker builds degrade to build-only elsewhere. A `v*` tag pushed to a private staging copy of the repo builds, verifies, and assembles a complete private release without publishing anything — the "tag dress rehearsal". This also protects any other clone of the repo for free.
- **Hotfix branch path in `create-release.yml`**: the workflow can be dispatched from `hotfix/vX.Y.Z` branches, and only from the branch named for the exact tag being released.
- **`source_first_release` input (Mode B)**: emergency path that skips the staged asset build and publishes the tag + source-only release immediately; the tag-push run of `release-binaries.yml` attaches binaries via the existing attach path.
- **`release.toml`**: allow `cargo release` from `hotfix/v*` checkouts.
- **Rewritten hotfix checklist** aligned with the protected release flow.
- **`scripts/hooks/pre-push`**: optional hook rejecting `security/*` branch pushes from everyday clones.
- **`SECURITY.md`**: references the coordinated release process.

Settings changes that accompany this PR (not expressible in git): `hotfix/v*` added to the `release` environment deployment branch policy, and a branch ruleset for `hotfix/v*` blocking deletion/force-push.

## Testing

- Workflow YAML parses; `./scripts/changelog.py check` passes.
- The repo guards and dress rehearsal are being proven end-to-end by pushing this branch and a test `v*` tag to a private staging copy and confirming the tag-push run completes green with a complete private release. Evidence will be added to this PR.
- Mode A/Mode B runbook drills are planned as release candidates on the current rc line, per the process doc.

## Changelog

Fragment added after the draft PR number exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)