### PR TITLE
chore(release): forward-merge hotfix/v1.0.3-rc1 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [1.0.3-rc1] - 2026-07-21
+
+### Fixed
+
+- Fixed test log capture racing the process-wide tracing subscriber, which
+  could corrupt span bookkeeping in `zakurad` test binaries; `zakura-test` now
+  provides a `log_capture` module that captures messages from its shared
+  subscriber ([#332](https://github.com/zakura-core/zakura/pull/332)).
+
 ## [1.0.3-rc0] - 2026-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,7 +8765,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.0.3-rc0"
+version = "1.0.3-rc1"
 dependencies = [
  "abscissa_core",
  "anyhow",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-test"
-version = "1.0.1-rc0"
+version = "1.0.1-rc1"
 dependencies = [
  "color-eyre",
  "futures",

--- a/changelog-unreleased/347.md
+++ b/changelog-unreleased/347.md
@@ -1,5 +1,0 @@
-<!-- changelog: none -->
-
-This PR only changes release automation, release checklists, and process
-documentation; it has no operator- or crate-consumer-visible effect on
-zakurad or the published crates.

--- a/zakura-test/Cargo.toml
+++ b/zakura-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-test"
-version = "1.0.1-rc0"
+version = "1.0.1-rc1"
 authors.workspace = true
 description = "Test harnesses and test vectors for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-test/src/lib.rs
+++ b/zakura-test/src/lib.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 #[allow(missing_docs)]
 pub mod command;
 
+pub mod log_capture;
 pub mod mock_service;
 pub mod net;
 pub mod network_addr;
@@ -107,6 +108,7 @@ pub fn init() -> impl Drop {
         tracing_subscriber::registry()
             .with(filter_layer)
             .with(fmt_layer)
+            .with(log_capture::LogCaptureLayer)
             .with(ErrorLayer::default())
             .try_init()
             .ok();

--- a/zakura-test/src/log_capture.rs
+++ b/zakura-test/src/log_capture.rs
@@ -1,0 +1,106 @@
+//! Capturing log messages from the process-wide tracing subscriber in tests.
+//!
+//! `tracing_test::traced_test` and test-scoped subscribers can't be used in test binaries
+//! that call [`crate::init`]:
+//! - a second process-wide subscriber races with the one set by [`crate::init`], and
+//! - a thread-scoped subscriber creates a second span registry, which corrupts span
+//!   bookkeeping when tasks migrate between threads with different default subscribers.
+//!
+//! Instead, [`crate::init`] installs a `LogCaptureLayer` in the single process-wide
+//! subscriber, and tests read the messages it captures through a [`LogCapture`] handle.
+
+use std::sync::{Arc, Mutex, Weak};
+
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, Layer};
+
+/// The message buffers of the [`LogCapture`]s that are currently alive.
+///
+/// This is process-wide state, because it is read by the [`LogCaptureLayer`] in the
+/// process-wide subscriber set by [`crate::init`].
+static ACTIVE_CAPTURES: Mutex<Vec<Weak<Mutex<Vec<String>>>>> = Mutex::new(Vec::new());
+
+/// A handle to log messages captured from the process-wide tracing subscriber.
+///
+/// Capturing starts when the handle is created, and stops when it is dropped.
+///
+/// Captured messages come from every thread and task in the process, including other
+/// tests running concurrently in the same test binary. So tests should only assert on
+/// messages that no other test in the binary can produce.
+///
+/// Messages are only captured if they pass the subscriber's filter, which is `RUST_LOG`
+/// or the [`crate::init`] defaults. Warnings and errors always pass the default filter.
+pub struct LogCapture {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl LogCapture {
+    /// Starts capturing log messages, and returns a handle for reading them.
+    pub fn new() -> Self {
+        let messages = Arc::new(Mutex::new(Vec::new()));
+
+        let mut captures = ACTIVE_CAPTURES
+            .lock()
+            .expect("no code panics while holding the capture list lock");
+        // Remove buffers whose `LogCapture` handles have been dropped.
+        captures.retain(|capture| capture.strong_count() > 0);
+        captures.push(Arc::downgrade(&messages));
+
+        Self { messages }
+    }
+
+    /// Returns true if any captured log message contains `needle`.
+    pub fn contains(&self, needle: &str) -> bool {
+        self.messages
+            .lock()
+            .expect("no code panics while holding the message buffer lock")
+            .iter()
+            .any(|message| message.contains(needle))
+    }
+}
+
+impl Default for LogCapture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A tracing layer that copies log messages into the active [`LogCapture`] buffers.
+///
+/// Does nothing unless a [`LogCapture`] is alive, so it is always installed by
+/// [`crate::init`].
+pub(crate) struct LogCaptureLayer;
+
+impl<S: tracing::Subscriber> Layer<S> for LogCaptureLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let captures = ACTIVE_CAPTURES
+            .lock()
+            .expect("no code panics while holding the capture list lock");
+        if captures.is_empty() {
+            return;
+        }
+
+        let mut message = String::new();
+        event.record(&mut MessageVisitor(&mut message));
+
+        for capture in captures.iter().filter_map(Weak::upgrade) {
+            capture
+                .lock()
+                .expect("no code panics while holding the message buffer lock")
+                .push(message.clone());
+        }
+    }
+}
+
+/// A field visitor that extracts an event's `message` field.
+struct MessageVisitor<'a>(&'a mut String);
+
+impl Visit for MessageVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            use std::fmt::Write as _;
+
+            let _ = write!(self.0, "{value:?}");
+        }
+    }
+}

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.0.3-rc0"
+version = "1.0.3-rc1"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -62,14 +62,6 @@ impl io::Write for TestWriter {
     }
 }
 
-/// Return whether `logs` contains `expected`.
-fn captured_logs_contain(logs: &Arc<Mutex<Vec<u8>>>, expected: &str) -> bool {
-    let logs = logs
-        .lock()
-        .expect("log buffer is only locked by non-panicking writer operations");
-    String::from_utf8_lossy(&logs).contains(expected)
-}
-
 /// Check that a network stack with an empty address book only contains the local listener port,
 /// by querying the inbound service via a local TCP connection.
 ///
@@ -320,13 +312,12 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
 ) -> Result<(), crate::BoxError> {
-    let logs = Arc::new(Mutex::new(Vec::new()));
-    let log_sink = Arc::clone(&logs);
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(move || TestWriter(Arc::clone(&log_sink)))
-        .with_ansi(false)
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    // `tracing_test::traced_test` can't be used here: it sets a second process-wide
+    // subscriber, which races with the one set by `zakura_test::init()` in the other
+    // tests in this binary. Capture logs from the `zakura_test` subscriber instead.
+    // Only this test configures zcashd-compat pruning retention, so no other test in
+    // this binary can log the pruned block error message.
+    let captured_logs = zakura_test::log_capture::LogCapture::new();
 
     // `setup` configures checkpoint retention against `Height::MAX`, so block 1 is committed
     // to the retained chain indexes without storing its transaction bytes. Genesis is retained.
@@ -418,7 +409,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         "an unknown hash maps to missing inventory"
     );
     assert!(
-        !captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        !captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "an unknown hash must not log a pruning error"
     );
 
@@ -432,7 +423,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         "inbound maps the unavailable block body to missing inventory"
     );
     assert!(
-        !captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        !captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "an ordinary peer must not log a zcashd-compat pruning error"
     );
 
@@ -453,7 +444,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         "an unconfigured legacy peer still receives missing inventory"
     );
     assert!(
-        !captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        !captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "an unconfigured legacy peer must not log a zcashd-compat pruning error"
     );
 
@@ -475,7 +466,7 @@ async fn inbound_pruned_block_is_not_advertised_and_getdata_logs_error(
         )
     }
     assert!(
-        captured_logs_contain(&logs, super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
+        captured_logs.contains(super::super::ZCASHD_COMPAT_PRUNED_BLOCK_ERROR),
         "the configured zcashd-compat peer must log the pruning error"
     );
 

--- a/zakurad/tests/common/configs/v1.0.3-rc1.toml
+++ b/zakurad/tests/common/configs/v1.0.3-rc1.toml
@@ -1,0 +1,152 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+expose_peer_addresses = false
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+repair_zakura_header_store_on_startup = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"
+


### PR DESCRIPTION
## Motivation

`v1.0.3-rc1` was released from `hotfix/v1.0.3-rc1` per the hotfix process (docs/security-hotfix-release.md, drill per the process doc's Drills section). The released commit must become an ancestor of `main`, immediately.

## Solution

Forward-merges the hotfix branch: the fix (#332, rebased), version bumps (zakura 1.0.3-rc1, zakura-test 1.0.1-rc1), config snapshot, and the assembled `1.0.3-rc1` changelog section (consumes the pending fragments, including #347's).

**Merge with a merge commit (admin merge), not a squash** — the tagged commit `c41fb6a89` must be preserved in `main`'s history. Closes #332.

## Testing

- Staging validation PR: 32 checks green; `make pre-release RELEASE_TAG=v1.0.3-rc1 BASE_TAG=v1.0.3-rc0` passed with `--verify` packaging (13 crates)
- Tag dress rehearsal green; released publicly as [v1.0.3-rc1](https://github.com/zakura-core/zakura/releases/tag/v1.0.3-rc1) via [Create release run 29892214428](https://github.com/zakura-core/zakura/actions/runs/29892214428)

## Changelog

Release PR: fragments are consumed by this branch (labels `A-release`, `C-exclude-from-changelog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)