### PR TITLE
feat(state): track completed checkpoints in memory

### DIFF
--- a/changelog-unreleased/351.md
+++ b/changelog-unreleased/351.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR adds internal monitoring state for future header-root authentication;
+it does not change operator-visible behavior or published crate APIs.

--- a/changelog-unreleased/351.md
+++ b/changelog-unreleased/351.md
@@ -1,4 +1,4 @@
 <!-- changelog: none -->
 
-This PR adds internal monitoring state for future header-root authentication;
-it does not change operator-visible behavior or published crate APIs.
+This PR adds state and chain APIs for future header-root authentication;
+it does not change operator-visible behavior.

--- a/zakura-chain/src/parameters/checkpoint/list.rs
+++ b/zakura-chain/src/parameters/checkpoint/list.rs
@@ -7,7 +7,7 @@
 
 use std::{
     collections::{BTreeMap, HashSet},
-    ops::RangeBounds,
+    ops::{Bound, RangeBounds},
     str::FromStr,
     sync::Arc,
 };
@@ -203,6 +203,25 @@ impl CheckpointList {
         R: RangeBounds<block::Height>,
     {
         self.0.range(range).map(|(height, _)| *height).next_back()
+    }
+
+    /// Returns the checkpoint at or immediately below `height`.
+    pub fn checkpoint_at_or_before(
+        &self,
+        height: block::Height,
+    ) -> Option<(block::Height, block::Hash)> {
+        self.0
+            .range(..=height)
+            .next_back()
+            .map(|(&height, &hash)| (height, hash))
+    }
+
+    /// Returns the first checkpoint strictly above `height`.
+    pub fn checkpoint_after(&self, height: block::Height) -> Option<(block::Height, block::Hash)> {
+        self.0
+            .range((Bound::Excluded(height), Bound::Unbounded))
+            .next()
+            .map(|(&height, &hash)| (height, hash))
     }
 
     /// Returns an iterator over all the checkpoints, in increasing height order.

--- a/zakura-chain/src/parameters/checkpoint/list/tests.rs
+++ b/zakura-chain/src/parameters/checkpoint/list/tests.rs
@@ -83,6 +83,10 @@ fn checkpoint_list_neighbor_lookups() -> Result<(), BoxError> {
         Some(checkpoints[1])
     );
     assert_eq!(
+        list.checkpoint_at_or_before(block::Height(10)),
+        Some(checkpoints[1])
+    );
+    assert_eq!(
         list.checkpoint_at_or_before(block::Height(0)),
         Some(checkpoints[0])
     );
@@ -96,6 +100,10 @@ fn checkpoint_list_neighbor_lookups() -> Result<(), BoxError> {
     );
     assert_eq!(
         list.checkpoint_after(block::Height(10)),
+        Some(checkpoints[2])
+    );
+    assert_eq!(
+        list.checkpoint_after(block::Height(15)),
         Some(checkpoints[2])
     );
     assert_eq!(list.checkpoint_after(block::Height(20)), None);

--- a/zakura-chain/src/parameters/checkpoint/list/tests.rs
+++ b/zakura-chain/src/parameters/checkpoint/list/tests.rs
@@ -69,6 +69,40 @@ fn checkpoint_list_multiple() -> Result<(), BoxError> {
     Ok(())
 }
 
+#[test]
+fn checkpoint_list_neighbor_lookups() -> Result<(), BoxError> {
+    let checkpoints = [
+        (block::Height(0), block::Hash([1; 32])),
+        (block::Height(10), block::Hash([2; 32])),
+        (block::Height(20), block::Hash([3; 32])),
+    ];
+    let list = CheckpointList::from_list(checkpoints)?;
+
+    assert_eq!(
+        list.checkpoint_at_or_before(block::Height(15)),
+        Some(checkpoints[1])
+    );
+    assert_eq!(
+        list.checkpoint_at_or_before(block::Height(0)),
+        Some(checkpoints[0])
+    );
+    assert_eq!(
+        list.checkpoint_at_or_before(block::Height(25)),
+        Some(checkpoints[2])
+    );
+    assert_eq!(
+        list.checkpoint_after(block::Height(0)),
+        Some(checkpoints[1])
+    );
+    assert_eq!(
+        list.checkpoint_after(block::Height(10)),
+        Some(checkpoints[2])
+    );
+    assert_eq!(list.checkpoint_after(block::Height(20)), None);
+
+    Ok(())
+}
+
 /// Make sure that an empty checkpoint list fails
 #[test]
 fn checkpoint_list_empty_fail() -> Result<(), BoxError> {

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -60,6 +60,12 @@ pub struct MissingSproutTipTree {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum StateInitError {
+    /// The canonical header store could not reconstruct completed checkpoint progress.
+    #[error("could not reconstruct the highest completed checkpoint: {0}")]
+    HighestCompletedCheckpoint(
+        #[from] crate::service::finalized_state::HighestCompletedCheckpointError,
+    ),
+
     /// A read-only state was requested, but the configured cache directory is
     /// missing or unreadable.
     ///
@@ -436,6 +442,12 @@ pub enum CommitHeaderRangeError {
         /// The conflicting height.
         height: block::Height,
     },
+
+    /// Local checkpoint-frontier reconstruction failed while preparing the range.
+    #[error("could not update the highest completed checkpoint: {0}")]
+    HighestCompletedCheckpoint(
+        #[from] crate::service::finalized_state::HighestCompletedCheckpointError,
+    ),
 
     /// A provisional reorg tried to overwrite too far behind the best header tip.
     #[error(

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -60,12 +60,6 @@ pub struct MissingSproutTipTree {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum StateInitError {
-    /// The canonical header store could not reconstruct completed checkpoint progress.
-    #[error("could not reconstruct the highest completed checkpoint: {0}")]
-    HighestCompletedCheckpoint(
-        #[from] crate::service::finalized_state::HighestCompletedCheckpointError,
-    ),
-
     /// A read-only state was requested, but the configured cache directory is
     /// missing or unreadable.
     ///

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -90,7 +90,10 @@ pub use service::finalized_state::{
     VctSproutHistoryValidationError, VctSproutHistoryValidationSummary,
 };
 pub use service::{
-    finalized_state::{DiskWriteBatch, FromDisk, IntoDisk, WriteDisk, ZakuraDb},
+    finalized_state::{
+        DiskWriteBatch, FromDisk, HighestCompletedCheckpoint, HighestCompletedCheckpointError,
+        IntoDisk, WriteDisk, ZakuraDb,
+    },
     ReadStateService, VctRootRepairState, VctRootRepairStatus,
 };
 

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -245,6 +245,10 @@ pub struct ReadStateService {
     /// Used to check for panics when writing blocks.
     block_write_task: Option<Arc<std::thread::JoinHandle<()>>>,
 
+    /// Watch channel publishing durable completed-checkpoint advances.
+    highest_completed_checkpoint_receiver:
+        tokio::sync::watch::Receiver<Option<finalized_state::HighestCompletedCheckpoint>>,
+
     /// Watch channel publishing the next VCT supplied-root repair needed by the finalized writer.
     vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
 }
@@ -406,6 +410,7 @@ impl StateService {
             block_write_sender,
             invalid_block_write_reset_receiver,
             non_finalized_rejected_receiver,
+            highest_completed_checkpoint_receiver,
             vct_root_repair_receiver,
             block_write_task,
         ) = write::BlockWriteSender::spawn(
@@ -421,6 +426,7 @@ impl StateService {
             &finalized_state,
             block_write_task,
             non_finalized_state_receiver,
+            highest_completed_checkpoint_receiver,
             vct_root_repair_receiver,
         );
 
@@ -1058,6 +1064,9 @@ impl ReadStateService {
         finalized_state: &FinalizedState,
         block_write_task: Option<Arc<std::thread::JoinHandle<()>>>,
         non_finalized_state_receiver: WatchReceiver<NonFinalizedState>,
+        highest_completed_checkpoint_receiver: tokio::sync::watch::Receiver<
+            Option<finalized_state::HighestCompletedCheckpoint>,
+        >,
         vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
     ) -> Self {
         let read_service = Self {
@@ -1065,6 +1074,7 @@ impl ReadStateService {
             db: finalized_state.db.clone(),
             non_finalized_state_receiver,
             block_write_task,
+            highest_completed_checkpoint_receiver,
             vct_root_repair_receiver,
         };
 
@@ -1081,6 +1091,13 @@ impl ReadStateService {
     /// Subscribe to VCT supplied-root repair needs discovered by the finalized writer.
     pub fn subscribe_vct_root_repairs(&self) -> tokio::sync::watch::Receiver<VctRootRepairStatus> {
         self.vct_root_repair_receiver.clone()
+    }
+
+    /// Subscribe to durable completed-checkpoint advances.
+    pub fn subscribe_highest_completed_checkpoint(
+        &self,
+    ) -> tokio::sync::watch::Receiver<Option<finalized_state::HighestCompletedCheckpoint>> {
+        self.highest_completed_checkpoint_receiver.clone()
     }
 
     /// Gets a clone of the latest non-finalized state from the `non_finalized_state_receiver`
@@ -2271,12 +2288,15 @@ pub fn init_read_only(
         tokio::sync::watch::channel(NonFinalizedState::new(network));
     let (_vct_root_repair_sender, vct_root_repair_receiver) =
         tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let (_highest_completed_checkpoint, highest_completed_checkpoint_receiver) =
+        finalized_state::HighestCompletedCheckpointTracker::open(&finalized_state.db)?;
 
     Ok((
         ReadStateService::new(
             &finalized_state,
             None,
             WatchReceiver::new(non_finalized_state_receiver),
+            highest_completed_checkpoint_receiver,
             vct_root_repair_receiver,
         ),
         finalized_state.db.clone(),

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -2298,7 +2298,7 @@ pub fn init_read_only(
     let (_vct_root_repair_sender, vct_root_repair_receiver) =
         tokio::sync::watch::channel(VctRootRepairStatus::default());
     let (highest_completed_checkpoint, highest_completed_checkpoint_receiver) =
-        finalized_state::HighestCompletedCheckpointTracker::open(&finalized_state.db)?;
+        finalized_state::HighestCompletedCheckpointTracker::open(&finalized_state.db);
     let highest_completed_checkpoint_sender = Some(highest_completed_checkpoint.keepalive_sender());
 
     Ok((

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -249,6 +249,10 @@ pub struct ReadStateService {
     highest_completed_checkpoint_receiver:
         tokio::sync::watch::Receiver<Option<finalized_state::HighestCompletedCheckpoint>>,
 
+    /// Keeps the completed-checkpoint watch open in read-only services.
+    _highest_completed_checkpoint_sender:
+        Option<tokio::sync::watch::Sender<Option<finalized_state::HighestCompletedCheckpoint>>>,
+
     /// Watch channel publishing the next VCT supplied-root repair needed by the finalized writer.
     vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
 }
@@ -427,6 +431,7 @@ impl StateService {
             block_write_task,
             non_finalized_state_receiver,
             highest_completed_checkpoint_receiver,
+            None,
             vct_root_repair_receiver,
         );
 
@@ -1067,6 +1072,9 @@ impl ReadStateService {
         highest_completed_checkpoint_receiver: tokio::sync::watch::Receiver<
             Option<finalized_state::HighestCompletedCheckpoint>,
         >,
+        highest_completed_checkpoint_sender: Option<
+            tokio::sync::watch::Sender<Option<finalized_state::HighestCompletedCheckpoint>>,
+        >,
         vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
     ) -> Self {
         let read_service = Self {
@@ -1075,6 +1083,7 @@ impl ReadStateService {
             non_finalized_state_receiver,
             block_write_task,
             highest_completed_checkpoint_receiver,
+            _highest_completed_checkpoint_sender: highest_completed_checkpoint_sender,
             vct_root_repair_receiver,
         };
 
@@ -2288,8 +2297,9 @@ pub fn init_read_only(
         tokio::sync::watch::channel(NonFinalizedState::new(network));
     let (_vct_root_repair_sender, vct_root_repair_receiver) =
         tokio::sync::watch::channel(VctRootRepairStatus::default());
-    let (_highest_completed_checkpoint, highest_completed_checkpoint_receiver) =
+    let (highest_completed_checkpoint, highest_completed_checkpoint_receiver) =
         finalized_state::HighestCompletedCheckpointTracker::open(&finalized_state.db)?;
+    let highest_completed_checkpoint_sender = Some(highest_completed_checkpoint.keepalive_sender());
 
     Ok((
         ReadStateService::new(
@@ -2297,6 +2307,7 @@ pub fn init_read_only(
             None,
             WatchReceiver::new(non_finalized_state_receiver),
             highest_completed_checkpoint_receiver,
+            highest_completed_checkpoint_sender,
             vct_root_repair_receiver,
         ),
         finalized_state.db.clone(),

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -115,6 +115,7 @@ pub use vct::{
     GeneratorError, NextVctBlock,
 };
 pub use zakura_db::commitment_roots_db::COMMITMENT_ROOTS_BY_HEIGHT;
+pub use zakura_db::highest_completed_checkpoint::*;
 pub use zakura_db::ZakuraDb;
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -35,6 +35,7 @@ use super::disk_format::upgrade::restorable_db_versions;
 pub mod block;
 pub mod chain;
 pub(crate) mod commitment_roots_db;
+pub mod highest_completed_checkpoint;
 pub mod metrics;
 
 /// Minimum number of transactions in a block before the per-transaction batch

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -671,12 +671,15 @@ impl ZakuraDb {
             .or_else(|| self.zakura_header_hash(height))
     }
 
-    fn header_height(&self, hash: block::Hash) -> Option<block::Height> {
+    pub(crate) fn header_height(&self, hash: block::Hash) -> Option<block::Height> {
         self.height(hash)
             .or_else(|| self.zakura_header_height(hash))
     }
 
-    fn header_by_height(&self, height: block::Height) -> Option<(block::Hash, Arc<block::Header>)> {
+    pub(crate) fn header_by_height(
+        &self,
+        height: block::Height,
+    ) -> Option<(block::Hash, Arc<block::Header>)> {
         if let Some(hash) = self.hash(height) {
             return self
                 .block_header(height.into())

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests.rs
@@ -22,6 +22,7 @@ use crate::{
 
 mod common;
 mod header_store_coherence;
+mod highest_completed_checkpoint;
 mod prune;
 mod snapshot;
 mod vectors;

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
@@ -38,8 +38,7 @@ fn advances_after_disk_commit_and_reconstructs_after_restart() {
     let (genesis, headers, network) = checkpoint_chain(&[2, 4]);
     let config = persistent_config(cache_dir.path());
     let mut state = state_with_genesis_config(&network, genesis.clone(), config.clone());
-    let (mut tracker, mut receiver) =
-        HighestCompletedCheckpointTracker::open(&state).expect("tracker opens");
+    let (mut tracker, mut receiver) = HighestCompletedCheckpointTracker::open(&state);
     let genesis_checkpoint = checkpoint(Height(0), genesis.hash());
 
     assert_eq!(tracker.current(), Some(genesis_checkpoint));
@@ -87,8 +86,7 @@ fn advances_after_disk_commit_and_reconstructs_after_restart() {
     drop(state);
 
     let reopened = persistent_state(&config, &network);
-    let (tracker, receiver) =
-        HighestCompletedCheckpointTracker::open(&reopened).expect("tracker reconstructs");
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&reopened);
     assert_eq!(tracker.current(), Some(checkpoint_four));
     assert_eq!(*receiver.borrow(), Some(checkpoint_four));
 }
@@ -104,8 +102,7 @@ fn reconstructs_header_completed_frontier_above_body_tip() {
         store_header(&state, height, header);
     }
 
-    let (tracker, receiver) =
-        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&state);
     let checkpoint_five = checkpoint(Height(5), block::Hash::from(headers[4].as_ref()));
 
     assert_eq!(state.finalized_tip_height(), Some(Height::MIN));
@@ -118,8 +115,7 @@ fn failed_write_proposal_has_no_side_effects() {
     let _init_guard = zakura_test::init();
     let (genesis, headers, network) = checkpoint_chain(&[2]);
     let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
-    let (tracker, receiver) =
-        HighestCompletedCheckpointTracker::open(&state).expect("tracker opens");
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&state);
     let initial = tracker.current();
 
     let _proposal = tracker
@@ -130,8 +126,7 @@ fn failed_write_proposal_has_no_side_effects() {
     assert_eq!(tracker.current(), initial);
     assert_eq!(*receiver.borrow(), initial);
 
-    let (reconstructed, reconstructed_receiver) =
-        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let (reconstructed, reconstructed_receiver) = HighestCompletedCheckpointTracker::open(&state);
     assert_eq!(reconstructed.current(), initial);
     assert_eq!(*reconstructed_receiver.borrow(), initial);
 }
@@ -143,8 +138,7 @@ fn reconstruction_error_clears_published_checkpoint() {
     let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
     store_header(&state, Height(1), &headers[0]);
     store_header(&state, Height(2), &headers[1]);
-    let (mut tracker, mut receiver) =
-        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let (mut tracker, mut receiver) = HighestCompletedCheckpointTracker::open(&state);
 
     let checkpoint_two = checkpoint(Height(2), block::Hash::from(headers[1].as_ref()));
     assert_eq!(tracker.current(), Some(checkpoint_two));
@@ -161,6 +155,23 @@ fn reconstruction_error_clears_published_checkpoint() {
 }
 
 #[test]
+fn open_clears_checkpoint_on_reconstruction_error() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
+    store_header(&state, Height(1), &headers[0]);
+
+    let mut conflicting = *headers[1].as_ref();
+    conflicting.nonce.0[0] = conflicting.nonce.0[0].wrapping_add(1);
+    store_header(&state, Height(2), &Arc::new(conflicting));
+
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&state);
+    assert_eq!(tracker.current(), None);
+    assert_eq!(*receiver.borrow(), None);
+    assert!(!receiver.has_changed().expect("tracker sender remains open"));
+}
+
+#[test]
 fn reconstruction_stops_at_first_header_gap() {
     let _init_guard = zakura_test::init();
     let (genesis, headers, network) = checkpoint_chain(&[2, 4]);
@@ -170,8 +181,7 @@ fn reconstruction_stops_at_first_header_gap() {
     store_header(&state, Height(3), &headers[2]);
     store_header(&state, Height(4), &headers[3]);
 
-    let (tracker, receiver) =
-        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&state);
     let genesis_checkpoint = checkpoint(Height(0), genesis.hash());
 
     assert_eq!(
@@ -189,8 +199,7 @@ fn completed_checkpoint_rejects_conflicting_ancestor() {
     let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
     store_header(&state, Height(1), &headers[0]);
     store_header(&state, Height(2), &headers[1]);
-    let (tracker, _receiver) =
-        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let (tracker, _receiver) = HighestCompletedCheckpointTracker::open(&state);
 
     let mut conflicting = *headers[0].as_ref();
     conflicting.nonce.0[0] = conflicting.nonce.0[0].wrapping_add(1);

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
@@ -215,7 +215,7 @@ fn empty_header_proposal_is_unchanged_and_does_not_notify() {
     let _init_guard = zakura_test::init();
     let (genesis, _headers, network) = checkpoint_chain(&[2]);
     let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
-    let (mut tracker, mut receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let (mut tracker, receiver) = HighestCompletedCheckpointTracker::open(&state);
     let initial = checkpoint(Height::MIN, genesis.hash());
 
     let proposal = tracker

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
@@ -38,7 +38,7 @@ fn advances_after_disk_commit_and_reconstructs_after_restart() {
     let (genesis, headers, network) = checkpoint_chain(&[2, 4]);
     let config = persistent_config(cache_dir.path());
     let mut state = state_with_genesis_config(&network, genesis.clone(), config.clone());
-    let (mut tracker, receiver) =
+    let (mut tracker, mut receiver) =
         HighestCompletedCheckpointTracker::open(&state).expect("tracker opens");
     let genesis_checkpoint = checkpoint(Height(0), genesis.hash());
 
@@ -62,7 +62,9 @@ fn advances_after_disk_commit_and_reconstructs_after_restart() {
     tracker.commit_success(proposal);
     let checkpoint_two = checkpoint(Height(2), block::Hash::from(headers[1].as_ref()));
     assert_eq!(tracker.current(), Some(checkpoint_two));
-    assert_eq!(*receiver.borrow(), Some(checkpoint_two));
+    assert!(receiver.has_changed().expect("tracker sender remains open"));
+    assert_eq!(*receiver.borrow_and_update(), Some(checkpoint_two));
+    assert!(!receiver.has_changed().expect("tracker sender remains open"));
 
     let mut batch = DiskWriteBatch::new();
     batch
@@ -78,6 +80,7 @@ fn advances_after_disk_commit_and_reconstructs_after_restart() {
 
     let checkpoint_four = checkpoint(Height(4), block::Hash::from(headers[3].as_ref()));
     assert_eq!(tracker.current(), Some(checkpoint_four));
+    assert!(receiver.has_changed().expect("tracker sender remains open"));
     drop(tracker);
     drop(receiver);
     state.shutdown(true);
@@ -131,6 +134,30 @@ fn failed_write_proposal_has_no_side_effects() {
         HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
     assert_eq!(reconstructed.current(), initial);
     assert_eq!(*reconstructed_receiver.borrow(), initial);
+}
+
+#[test]
+fn reconstruction_error_clears_published_checkpoint() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
+    store_header(&state, Height(1), &headers[0]);
+    store_header(&state, Height(2), &headers[1]);
+    let (mut tracker, mut receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+
+    let checkpoint_two = checkpoint(Height(2), block::Hash::from(headers[1].as_ref()));
+    assert_eq!(tracker.current(), Some(checkpoint_two));
+    assert_eq!(*receiver.borrow_and_update(), Some(checkpoint_two));
+
+    let mut conflicting = *headers[1].as_ref();
+    conflicting.nonce.0[0] = conflicting.nonce.0[0].wrapping_add(1);
+    store_header(&state, Height(2), &Arc::new(conflicting));
+
+    assert!(tracker.rebind_from_db(&state).is_err());
+    assert_eq!(tracker.current(), None);
+    assert!(receiver.has_changed().expect("tracker sender remains open"));
+    assert_eq!(*receiver.borrow_and_update(), None);
 }
 
 #[test]

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
@@ -1,0 +1,290 @@
+use std::sync::Arc;
+
+use zakura_chain::{
+    block::{self, Block, Height},
+    parameters::{
+        testnet::{self, ConfiguredActivationHeights, ConfiguredCheckpoints},
+        Network,
+        Network::Mainnet,
+        NetworkUpgrade,
+    },
+    serialization::ZcashDeserializeInto,
+    work::difficulty::ParameterDifficulty,
+};
+
+use super::common::{
+    mainnet_block, no_extra_checkpoint_test_network, persistent_config, persistent_state,
+    state_with_genesis_config,
+};
+use crate::{
+    service::{
+        check::difficulty::{AdjustedDifficulty, POW_ADJUSTMENT_BLOCK_SPAN},
+        finalized_state::{
+            DiskWriteBatch, HighestCompletedCheckpoint, HighestCompletedCheckpointTracker,
+            WriteDisk, ZakuraDb,
+        },
+    },
+    Config,
+};
+
+const HEADER_BY_HEIGHT: &str = "zakura_header_by_height";
+const HASH_BY_HEIGHT: &str = "zakura_header_hash_by_height";
+const HEIGHT_BY_HASH: &str = "zakura_header_height_by_hash";
+
+#[test]
+fn advances_after_disk_commit_and_reconstructs_after_restart() {
+    let _init_guard = zakura_test::init();
+    let cache_dir = tempfile::tempdir().expect("temporary state directory is created");
+    let (genesis, headers, network) = checkpoint_chain(&[2, 4]);
+    let config = persistent_config(cache_dir.path());
+    let mut state = state_with_genesis_config(&network, genesis.clone(), config.clone());
+    let (mut tracker, receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker opens");
+    let genesis_checkpoint = checkpoint(Height(0), genesis.hash());
+
+    assert_eq!(tracker.current(), Some(genesis_checkpoint));
+    assert_eq!(*receiver.borrow(), Some(genesis_checkpoint));
+
+    let mut batch = DiskWriteBatch::new();
+    batch
+        .prepare_header_range_batch(&state, genesis.hash(), &headers[..2], &[0, 0])
+        .expect("first checkpoint bracket is valid");
+    let proposal = tracker
+        .propose_after_headers(&state, genesis.hash(), &headers[..2])
+        .expect("first checkpoint proposal is valid");
+
+    assert_eq!(tracker.current(), Some(genesis_checkpoint));
+    assert_eq!(*receiver.borrow(), Some(genesis_checkpoint));
+
+    state
+        .write_batch(batch)
+        .expect("first checkpoint bracket writes");
+    tracker.commit_success(proposal);
+    let checkpoint_two = checkpoint(Height(2), block::Hash::from(headers[1].as_ref()));
+    assert_eq!(tracker.current(), Some(checkpoint_two));
+    assert_eq!(*receiver.borrow(), Some(checkpoint_two));
+
+    let mut batch = DiskWriteBatch::new();
+    batch
+        .prepare_header_range_batch(&state, checkpoint_two.hash, &headers[2..], &[0, 0])
+        .expect("second checkpoint bracket is valid");
+    let proposal = tracker
+        .propose_after_headers(&state, checkpoint_two.hash, &headers[2..])
+        .expect("second checkpoint proposal is valid");
+    state
+        .write_batch(batch)
+        .expect("second checkpoint bracket writes");
+    tracker.commit_success(proposal);
+
+    let checkpoint_four = checkpoint(Height(4), block::Hash::from(headers[3].as_ref()));
+    assert_eq!(tracker.current(), Some(checkpoint_four));
+    drop(tracker);
+    drop(receiver);
+    state.shutdown(true);
+    drop(state);
+
+    let reopened = persistent_state(&config, &network);
+    let (tracker, receiver) =
+        HighestCompletedCheckpointTracker::open(&reopened).expect("tracker reconstructs");
+    assert_eq!(tracker.current(), Some(checkpoint_four));
+    assert_eq!(*receiver.borrow(), Some(checkpoint_four));
+}
+
+#[test]
+fn reconstructs_header_completed_frontier_above_body_tip() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2, 5]);
+    let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
+
+    for (index, header) in headers.iter().enumerate() {
+        let height = Height(u32::try_from(index + 1).expect("small test height fits in u32"));
+        store_header(&state, height, header);
+    }
+
+    let (tracker, receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let checkpoint_five = checkpoint(Height(5), block::Hash::from(headers[4].as_ref()));
+
+    assert_eq!(state.finalized_tip_height(), Some(Height::MIN));
+    assert_eq!(tracker.current(), Some(checkpoint_five));
+    assert_eq!(*receiver.borrow(), Some(checkpoint_five));
+}
+
+#[test]
+fn failed_write_proposal_has_no_side_effects() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    let (tracker, receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker opens");
+    let initial = tracker.current();
+
+    let _proposal = tracker
+        .propose_after_headers(&state, genesis.hash(), &headers)
+        .expect("checkpoint proposal is valid");
+
+    // The production write path drops the proposal on a storage error.
+    assert_eq!(tracker.current(), initial);
+    assert_eq!(*receiver.borrow(), initial);
+
+    let (reconstructed, reconstructed_receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    assert_eq!(reconstructed.current(), initial);
+    assert_eq!(*reconstructed_receiver.borrow(), initial);
+}
+
+#[test]
+fn reconstruction_stops_at_first_header_gap() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2, 4]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+
+    store_header(&state, Height(1), &headers[0]);
+    store_header(&state, Height(3), &headers[2]);
+    store_header(&state, Height(4), &headers[3]);
+
+    let (tracker, receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let genesis_checkpoint = checkpoint(Height(0), genesis.hash());
+
+    assert_eq!(
+        state.best_header_tip().map(|(height, _)| height),
+        Some(Height(4))
+    );
+    assert_eq!(tracker.current(), Some(genesis_checkpoint));
+    assert_eq!(*receiver.borrow(), Some(genesis_checkpoint));
+}
+
+#[test]
+fn completed_checkpoint_rejects_conflicting_ancestor() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    store_header(&state, Height(1), &headers[0]);
+    store_header(&state, Height(2), &headers[1]);
+    let (tracker, _receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+
+    let mut conflicting = *headers[0].as_ref();
+    conflicting.nonce.0[0] = conflicting.nonce.0[0].wrapping_add(1);
+
+    assert_eq!(
+        tracker.check_immutable_conflicts(&state, genesis.hash(), &[Arc::new(conflicting)]),
+        Err(Height(1))
+    );
+}
+
+fn checkpoint(height: Height, hash: block::Hash) -> HighestCompletedCheckpoint {
+    HighestCompletedCheckpoint { height, hash }
+}
+
+fn checkpoint_chain(checkpoint_heights: &[u32]) -> (Arc<Block>, Vec<Arc<block::Header>>, Network) {
+    let genesis = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .expect("mainnet genesis block deserializes");
+    let base_network = no_extra_checkpoint_test_network(genesis.hash());
+    let base_state = state_with_genesis_config(&base_network, genesis.clone(), Config::ephemeral());
+    let max_height = checkpoint_heights
+        .iter()
+        .copied()
+        .max()
+        .expect("test checkpoint list is non-empty");
+    let headers = synthetic_headers(&base_state, max_height);
+    let network = checkpoint_network(&genesis, &headers, checkpoint_heights);
+
+    (genesis, headers, network)
+}
+
+fn checkpoint_network(
+    genesis: &Block,
+    headers: &[Arc<block::Header>],
+    checkpoint_heights: &[u32],
+) -> Network {
+    let mut checkpoints = vec![(Height(0), genesis.hash())];
+    checkpoints.extend(checkpoint_heights.iter().map(|height| {
+        let index = usize::try_from(height - 1).expect("test checkpoint index fits in usize");
+        (Height(*height), block::Hash::from(headers[index].as_ref()))
+    }));
+
+    testnet::Parameters::build()
+        .with_network_name("HighestCompletedCheckpointTest")
+        .expect("test network name is valid")
+        .with_genesis_hash(genesis.hash())
+        .expect("test genesis hash is valid")
+        .with_target_difficulty_limit(Mainnet.target_difficulty_limit())
+        .expect("mainnet difficulty limit is valid for test network")
+        .with_activation_heights(ConfiguredActivationHeights {
+            canopy: Some(1),
+            ..Default::default()
+        })
+        .expect("test activation heights are valid")
+        .clear_funding_streams()
+        .with_checkpoints(ConfiguredCheckpoints::HeightsAndHashes(checkpoints))
+        .expect("test checkpoints are valid")
+        .to_network()
+        .expect("test network is valid")
+}
+
+fn synthetic_headers(state: &ZakuraDb, count: u32) -> Vec<Arc<block::Header>> {
+    let network = state.network();
+    let template = mainnet_block(1);
+    let mut context = state
+        .recent_header_context(Height(0))
+        .expect("genesis header context is coherent");
+    let mut previous_hash = network.genesis_hash();
+    let mut previous_height = Height(0);
+
+    (1..=count)
+        .map(|nonce_tag| {
+            let candidate_height = previous_height
+                .next()
+                .expect("test header height remains in range");
+            let previous_time = context[0].1;
+            let target_spacing =
+                NetworkUpgrade::target_spacing_for_height(&network, candidate_height);
+            let candidate_time = previous_time + target_spacing;
+            let expected_difficulty = AdjustedDifficulty::new_from_header_time(
+                candidate_time,
+                previous_height,
+                &network,
+                context.iter().copied(),
+            )
+            .expected_difficulty_threshold();
+
+            let mut header = *template.header;
+            header.previous_block_hash = previous_hash;
+            header.time = candidate_time;
+            header.difficulty_threshold = expected_difficulty;
+            header.nonce.0[0] = header.nonce.0[0]
+                .wrapping_add(u8::try_from(nonce_tag).expect("small test nonce fits in u8"));
+
+            let header = Arc::new(header);
+            previous_hash = block::Hash::from(header.as_ref());
+            previous_height = candidate_height;
+            context.insert(0, (header.difficulty_threshold, header.time));
+            context.truncate(POW_ADJUSTMENT_BLOCK_SPAN);
+            header
+        })
+        .collect()
+}
+
+fn store_header(state: &ZakuraDb, height: Height, header: &Arc<block::Header>) {
+    let header_by_height = state
+        .db()
+        .cf_handle(HEADER_BY_HEIGHT)
+        .expect("header column exists");
+    let hash_by_height = state
+        .db()
+        .cf_handle(HASH_BY_HEIGHT)
+        .expect("height-to-hash column exists");
+    let height_by_hash = state
+        .db()
+        .cf_handle(HEIGHT_BY_HASH)
+        .expect("hash-to-height column exists");
+    let hash = block::Hash::from(header.as_ref());
+    let mut batch = DiskWriteBatch::new();
+    batch.zs_insert(&header_by_height, height, Arc::clone(header));
+    batch.zs_insert(&hash_by_height, height, hash);
+    batch.zs_insert(&height_by_hash, hash, height);
+    state.db().write(batch).expect("test header rows write");
+}

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
@@ -14,14 +14,14 @@ use zakura_chain::{
 
 use super::common::{
     mainnet_block, no_extra_checkpoint_test_network, persistent_config, persistent_state,
-    state_with_genesis_config,
+    state_with_genesis_config, write_full_block_header_and_transactions,
 };
 use crate::{
     service::{
         check::difficulty::{AdjustedDifficulty, POW_ADJUSTMENT_BLOCK_SPAN},
         finalized_state::{
-            DiskWriteBatch, HighestCompletedCheckpoint, HighestCompletedCheckpointTracker,
-            WriteDisk, ZakuraDb,
+            DiskWriteBatch, HighestCompletedCheckpoint, HighestCompletedCheckpointError,
+            HighestCompletedCheckpointTracker, WriteDisk, ZakuraDb,
         },
     },
     Config,
@@ -208,6 +208,197 @@ fn completed_checkpoint_rejects_conflicting_ancestor() {
         tracker.check_immutable_conflicts(&state, genesis.hash(), &[Arc::new(conflicting)]),
         Err(Height(1))
     );
+}
+
+#[test]
+fn empty_header_proposal_is_unchanged_and_does_not_notify() {
+    let _init_guard = zakura_test::init();
+    let (genesis, _headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    let (mut tracker, mut receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let initial = checkpoint(Height::MIN, genesis.hash());
+
+    let proposal = tracker
+        .propose_after_headers(&state, genesis.hash(), &[])
+        .expect("an empty header proposal is valid");
+
+    assert_eq!(proposal.current(), Some(initial));
+    tracker.commit_success(proposal);
+    assert_eq!(tracker.current(), Some(initial));
+    assert!(!receiver.has_changed().expect("tracker sender remains open"));
+}
+
+#[test]
+fn unknown_anchor_is_unchanged_for_proposal_and_immutable_check() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    let (tracker, _receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let initial = tracker.current();
+    let mut unknown_anchor_header = *headers[0].as_ref();
+    unknown_anchor_header.nonce.0[0] = unknown_anchor_header.nonce.0[0].wrapping_add(1);
+    let unknown_anchor = block::Hash::from(&unknown_anchor_header);
+
+    let proposal = tracker
+        .propose_after_headers(&state, unknown_anchor, &headers[1..])
+        .expect("header-range validation owns unknown-anchor errors");
+
+    assert_eq!(proposal.current(), initial);
+    assert_eq!(
+        tracker.check_immutable_conflicts(&state, unknown_anchor, &headers[1..]),
+        Ok(())
+    );
+}
+
+#[test]
+fn reorg_above_completed_checkpoint_rewinds_the_cursor() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2, 6]);
+    let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
+    for (index, header) in headers[..5].iter().enumerate() {
+        let height = Height(u32::try_from(index + 1).expect("small test height fits in u32"));
+        store_header(&state, height, header);
+    }
+    let (mut tracker, mut receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let checkpoint_two = checkpoint(Height(2), block::Hash::from(headers[1].as_ref()));
+    assert_eq!(tracker.current(), Some(checkpoint_two));
+    assert_eq!(*receiver.borrow_and_update(), Some(checkpoint_two));
+
+    let mut conflicting_three = *headers[2].as_ref();
+    conflicting_three.nonce.0[0] = conflicting_three.nonce.0[0].wrapping_add(1);
+    let conflicting_three = Arc::new(conflicting_three);
+    let mut conflicting_four = *headers[3].as_ref();
+    conflicting_four.previous_block_hash = block::Hash::from(conflicting_three.as_ref());
+    let conflicting_four = Arc::new(conflicting_four);
+    let proposal = tracker
+        .propose_after_headers(
+            &state,
+            checkpoint_two.hash,
+            &[conflicting_three, conflicting_four],
+        )
+        .expect("a mutable shorter header reorg is valid");
+
+    assert_eq!(proposal.current(), Some(checkpoint_two));
+    tracker.commit_success(proposal);
+    assert_eq!(tracker.current(), Some(checkpoint_two));
+    assert!(!receiver.has_changed().expect("tracker sender remains open"));
+}
+
+#[test]
+fn immutable_check_allows_conflicts_above_completed_checkpoint() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2, 4]);
+    let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
+    for (index, header) in headers[..3].iter().enumerate() {
+        let height = Height(u32::try_from(index + 1).expect("small test height fits in u32"));
+        store_header(&state, height, header);
+    }
+    let (tracker, _receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let mut conflicting = *headers[2].as_ref();
+    conflicting.nonce.0[0] = conflicting.nonce.0[0].wrapping_add(1);
+
+    assert_eq!(
+        tracker.check_immutable_conflicts(
+            &state,
+            block::Hash::from(headers[1].as_ref()),
+            &[Arc::new(conflicting)],
+        ),
+        Ok(())
+    );
+}
+
+#[test]
+fn immutable_check_is_disabled_without_a_completed_checkpoint() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    store_header(&state, Height(1), &headers[0]);
+    let mut conflicting_checkpoint = *headers[1].as_ref();
+    conflicting_checkpoint.nonce.0[0] = conflicting_checkpoint.nonce.0[0].wrapping_add(1);
+    store_header(&state, Height(2), &Arc::new(conflicting_checkpoint));
+    let (tracker, _receiver) = HighestCompletedCheckpointTracker::open(&state);
+    assert_eq!(tracker.current(), None);
+
+    let mut conflicting_ancestor = *headers[0].as_ref();
+    conflicting_ancestor.nonce.0[0] = conflicting_ancestor.nonce.0[0].wrapping_add(1);
+    assert_eq!(
+        tracker.check_immutable_conflicts(
+            &state,
+            genesis.hash(),
+            &[Arc::new(conflicting_ancestor)],
+        ),
+        Ok(())
+    );
+}
+
+#[test]
+fn proposal_reports_checkpoint_mismatch() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    let (tracker, _receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let mut conflicting_checkpoint = *headers[1].as_ref();
+    conflicting_checkpoint.nonce.0[0] = conflicting_checkpoint.nonce.0[0].wrapping_add(1);
+    let conflicting_checkpoint = Arc::new(conflicting_checkpoint);
+    let actual = block::Hash::from(conflicting_checkpoint.as_ref());
+
+    assert_eq!(
+        tracker.propose_after_headers(
+            &state,
+            genesis.hash(),
+            &[Arc::clone(&headers[0]), conflicting_checkpoint],
+        ),
+        Err(HighestCompletedCheckpointError::CheckpointMismatch {
+            height: Height(2),
+            expected: block::Hash::from(headers[1].as_ref()),
+            actual: Some(actual),
+        })
+    );
+}
+
+#[test]
+fn reconstruction_stops_at_broken_parent_link() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    store_header(&state, Height(1), &headers[0]);
+    let mut broken = *headers[1].as_ref();
+    broken.previous_block_hash = genesis.hash();
+    store_header(&state, Height(2), &Arc::new(broken));
+
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let genesis_checkpoint = checkpoint(Height::MIN, genesis.hash());
+
+    assert_eq!(tracker.current(), Some(genesis_checkpoint));
+    assert_eq!(*receiver.borrow(), Some(genesis_checkpoint));
+}
+
+#[test]
+fn rebind_fast_forwards_to_checkpoint_covered_by_body_tip() {
+    let _init_guard = zakura_test::init();
+    let genesis = mainnet_block(0);
+    let blocks = [mainnet_block(1), mainnet_block(2)];
+    let headers = blocks
+        .iter()
+        .map(|block| Arc::clone(&block.header))
+        .collect::<Vec<_>>();
+    let network = checkpoint_network(&genesis, &headers, &[2]);
+    let state = state_with_genesis_config(&network, Arc::clone(&genesis), Config::ephemeral());
+    store_header(&state, Height(1), &headers[0]);
+    let (mut tracker, mut receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let genesis_checkpoint = checkpoint(Height::MIN, genesis.hash());
+    assert_eq!(*receiver.borrow_and_update(), Some(genesis_checkpoint));
+
+    write_full_block_header_and_transactions(&state, Arc::clone(&blocks[0]));
+    write_full_block_header_and_transactions(&state, Arc::clone(&blocks[1]));
+    tracker
+        .rebind_from_db(&state)
+        .expect("body progress reconstructs checkpoint progress");
+
+    let checkpoint_two = checkpoint(Height(2), blocks[1].hash());
+    assert_eq!(tracker.current(), Some(checkpoint_two));
+    assert!(receiver.has_changed().expect("tracker sender remains open"));
+    assert_eq!(*receiver.borrow_and_update(), Some(checkpoint_two));
 }
 
 fn checkpoint(height: Height, hash: block::Hash) -> HighestCompletedCheckpoint {

--- a/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
@@ -78,15 +78,23 @@ impl HighestCompletedCheckpointTracker {
     ///
     /// Cold open: no `start_hint`, so reconstruct uses the trusted body base (path B)
     /// then walks any headers above the body tip (path D).
-    pub fn open(
-        db: &ZakuraDb,
-    ) -> Result<
-        (Self, watch::Receiver<Option<HighestCompletedCheckpoint>>),
-        HighestCompletedCheckpointError,
-    > {
-        let state = TrackerState::reconstruct(db, &[], None)?;
+    ///
+    /// If durable headers are inconsistent, logs the error and clears progress so startup
+    /// remains recoverable. No checkpoint is published until a later successful write
+    /// reconstructs progress from the durable canonical headers.
+    pub fn open(db: &ZakuraDb) -> (Self, watch::Receiver<Option<HighestCompletedCheckpoint>>) {
+        let state = match TrackerState::reconstruct(db, &[], None) {
+            Ok(state) => state,
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "could not reconstruct the highest completed checkpoint; clearing checkpoint progress"
+                );
+                TrackerState::default()
+            }
+        };
         let (sender, receiver) = watch::channel(state.current);
-        Ok((Self { state, sender }, receiver))
+        (Self { state, sender }, receiver)
     }
 
     /// Returns the latest checkpoint made durable by a successful write.

--- a/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
@@ -63,6 +63,13 @@ struct TrackerState {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct ProposedHighestCompletedCheckpoint(TrackerState);
 
+impl ProposedHighestCompletedCheckpoint {
+    /// Returns the checkpoint that would become current if this proposal commits.
+    pub fn current(&self) -> Option<HighestCompletedCheckpoint> {
+        self.0.current
+    }
+}
+
 /// The process-local highest completed checkpoint and its publication channel.
 ///
 /// Canonical headers are the durable source of truth. This cache is reconstructed on open
@@ -106,6 +113,9 @@ impl HighestCompletedCheckpointTracker {
     ///
     /// Passes the current tracker as `start_hint` so reconstruct resumes (path A) and
     /// only walks from the cursor through the new pending range (path D).
+    /// Empty batches and batches with an unknown anchor leave the proposed state unchanged.
+    /// A conflicting batch uses its final height as the proposed tip and re-walks from the
+    /// completed checkpoint when the conflict reaches the current cursor.
     /// This method does not mutate the tracker.
     pub fn propose_after_headers(
         &self,
@@ -117,10 +127,7 @@ impl HighestCompletedCheckpointTracker {
             return Ok(ProposedHighestCompletedCheckpoint(self.state));
         }
 
-        let Some(anchor_height) = db
-            .header_height(anchor)
-            .or_else(|| (anchor == db.network().genesis_hash()).then_some(Height::MIN))
-        else {
+        let Some(anchor_height) = Self::anchor_height(db, anchor) else {
             // Header-range validation reports the unknown anchor before this proposal is used.
             return Ok(ProposedHighestCompletedCheckpoint(self.state));
         };
@@ -174,6 +181,9 @@ impl HighestCompletedCheckpointTracker {
     }
 
     /// Rejects a reorg that would replace a completed checkpoint or any of its ancestors.
+    ///
+    /// Conflicts above the completed checkpoint are mutable and therefore allowed. An unknown
+    /// anchor is also allowed because header-range validation rejects it before commit.
     pub fn check_immutable_conflicts(
         &self,
         db: &ZakuraDb,
@@ -183,10 +193,7 @@ impl HighestCompletedCheckpointTracker {
         let Some(completed) = self.current() else {
             return Ok(());
         };
-        let Some(anchor_height) = db
-            .header_height(anchor)
-            .or_else(|| (anchor == db.network().genesis_hash()).then_some(Height::MIN))
-        else {
+        let Some(anchor_height) = Self::anchor_height(db, anchor) else {
             return Ok(());
         };
 
@@ -246,6 +253,11 @@ impl HighestCompletedCheckpointTracker {
         if changed {
             let _ = self.sender.send(state.current);
         }
+    }
+
+    fn anchor_height(db: &ZakuraDb, anchor: block::Hash) -> Option<Height> {
+        db.header_height(anchor)
+            .or_else(|| (anchor == db.network().genesis_hash()).then_some(Height::MIN))
     }
 }
 

--- a/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
@@ -1,0 +1,447 @@
+//! In-memory tracking for completely stored canonical checkpoint brackets.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use thiserror::Error;
+use tokio::sync::watch;
+use zakura_chain::block::{self, Height};
+
+use super::ZakuraDb;
+
+/// The highest configured checkpoint whose complete canonical bracket is durable.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct HighestCompletedCheckpoint {
+    /// The completed configured checkpoint height.
+    pub height: Height,
+    /// The configured checkpoint hash stored canonically at `height`.
+    pub hash: block::Hash,
+}
+
+/// Errors restoring or advancing the highest completed checkpoint.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum HighestCompletedCheckpointError {
+    /// The configured checkpoint list does not contain genesis.
+    #[error("the configured checkpoint list does not contain genesis")]
+    MissingGenesisCheckpoint,
+
+    /// A canonical header required to establish the trusted body base is missing.
+    #[error("missing canonical header at trusted body height {height:?}")]
+    MissingCanonicalHeader {
+        /// Missing header height.
+        height: Height,
+    },
+
+    /// A configured checkpoint does not match the canonical header store.
+    #[error(
+        "canonical header at configured checkpoint {height:?} has hash {actual:?}, expected {expected}"
+    )]
+    CheckpointMismatch {
+        /// Configured checkpoint height.
+        height: Height,
+        /// Configured checkpoint hash.
+        expected: block::Hash,
+        /// Canonical hash, if one is stored.
+        actual: Option<block::Hash>,
+    },
+
+    /// A header height operation overflowed.
+    #[error("highest completed checkpoint height overflow")]
+    HeightOverflow,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct TrackerState {
+    current: Option<HighestCompletedCheckpoint>,
+    /// The first configured checkpoint strictly above `current`.
+    next_checkpoint: Option<(Height, block::Hash)>,
+    cursor: Option<(Height, block::Hash)>,
+}
+
+/// A candidate state computed against a header batch before it commits.
+///
+/// Install this candidate only after the corresponding RocksDB write succeeds.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ProposedHighestCompletedCheckpoint(TrackerState);
+
+/// The process-local highest completed checkpoint and its publication channel.
+///
+/// Canonical headers are the durable source of truth. This cache is reconstructed on open
+/// and replaced only after the database write that justifies an advance succeeds.
+#[derive(Debug)]
+pub struct HighestCompletedCheckpointTracker {
+    state: TrackerState,
+    sender: watch::Sender<Option<HighestCompletedCheckpoint>>,
+}
+
+impl HighestCompletedCheckpointTracker {
+    /// Reconstructs checkpoint progress from durable canonical headers.
+    ///
+    /// Cold open: no `start_hint`, so reconstruct uses the trusted body base (path B)
+    /// then walks any headers above the body tip (path D).
+    pub fn open(
+        db: &ZakuraDb,
+    ) -> Result<
+        (Self, watch::Receiver<Option<HighestCompletedCheckpoint>>),
+        HighestCompletedCheckpointError,
+    > {
+        let state = TrackerState::reconstruct(db, &[], None)?;
+        let (sender, receiver) = watch::channel(state.current);
+        Ok((Self { state, sender }, receiver))
+    }
+
+    /// Returns the latest checkpoint made durable by a successful write.
+    pub fn current(&self) -> Option<HighestCompletedCheckpoint> {
+        self.state.current
+    }
+
+    /// Computes the post-commit tracker state using pending headers.
+    ///
+    /// Passes the current tracker as `start_hint` so reconstruct resumes (path A) and
+    /// only walks from the cursor through the new pending range (path D).
+    /// This method does not mutate the tracker.
+    pub fn propose_after_headers(
+        &self,
+        db: &ZakuraDb,
+        anchor: block::Hash,
+        headers: &[Arc<block::Header>],
+    ) -> Result<ProposedHighestCompletedCheckpoint, HighestCompletedCheckpointError> {
+        if headers.is_empty() {
+            return Ok(ProposedHighestCompletedCheckpoint(self.state));
+        }
+
+        let Some(anchor_height) = db
+            .header_height(anchor)
+            .or_else(|| (anchor == db.network().genesis_hash()).then_some(Height::MIN))
+        else {
+            // Header-range validation reports the unknown anchor before this proposal is used.
+            return Ok(ProposedHighestCompletedCheckpoint(self.state));
+        };
+
+        let mut pending = Vec::with_capacity(headers.len());
+        for (index, header) in headers.iter().enumerate() {
+            let offset = u32::try_from(index + 1)
+                .map_err(|_| HighestCompletedCheckpointError::HeightOverflow)?;
+            let height = (anchor_height + i64::from(offset))
+                .ok_or(HighestCompletedCheckpointError::HeightOverflow)?;
+            pending.push((
+                height,
+                block::Hash::from(header.as_ref()),
+                Arc::clone(header),
+            ));
+        }
+
+        // First height where pending disagrees with durable headers (reorg into the range).
+        let first_conflict = pending.iter().find_map(|(height, hash, _)| {
+            db.header_hash(*height)
+                .is_some_and(|stored| stored != *hash)
+                .then_some(*height)
+        });
+        // After a conflict, tip is the end of the pending batch; otherwise max(disk, pending).
+        let post_tip = if first_conflict.is_some() {
+            pending.last().map(|(height, _, _)| *height)
+        } else {
+            db.best_header_tip()
+                .map(|(height, _)| height)
+                .into_iter()
+                .chain(pending.last().map(|(height, _, _)| *height))
+                .max()
+        };
+
+        let mut start_hint = self.state;
+        // Reorg at or below the cursor: rewind the cursor to `current` so path D
+        // re-walks the disputed range instead of trusting the stale cursor.
+        if first_conflict.is_some_and(|height| {
+            start_hint
+                .cursor
+                .is_some_and(|(cursor, _)| height <= cursor)
+        }) {
+            start_hint.cursor = start_hint
+                .current
+                .map(|checkpoint| (checkpoint.height, checkpoint.hash));
+        }
+
+        Ok(ProposedHighestCompletedCheckpoint(
+            TrackerState::reconstruct(db, &pending, Some((start_hint, post_tip)))?,
+        ))
+    }
+
+    /// Rejects a reorg that would replace a completed checkpoint or any of its ancestors.
+    pub fn check_immutable_conflicts(
+        &self,
+        db: &ZakuraDb,
+        anchor: block::Hash,
+        headers: &[Arc<block::Header>],
+    ) -> Result<(), Height> {
+        let Some(completed) = self.current() else {
+            return Ok(());
+        };
+        let Some(anchor_height) = db
+            .header_height(anchor)
+            .or_else(|| (anchor == db.network().genesis_hash()).then_some(Height::MIN))
+        else {
+            return Ok(());
+        };
+
+        for (index, header) in headers.iter().enumerate() {
+            let Ok(offset) = u32::try_from(index + 1) else {
+                break;
+            };
+            let Some(height) = anchor_height + i64::from(offset) else {
+                break;
+            };
+            if height > completed.height {
+                break;
+            }
+            let hash = block::Hash::from(header.as_ref());
+            if db.header_hash(height).is_some_and(|stored| stored != hash) {
+                return Err(height);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Installs a proposal after its corresponding header batch succeeds.
+    pub fn commit_success(&mut self, proposed: ProposedHighestCompletedCheckpoint) {
+        self.replace_state(proposed.0);
+    }
+
+    /// Reconstructs the tracker after a successful body write, rollback, or repair.
+    ///
+    /// Hints with the prior state (path A) so body progress can fast-forward via
+    /// path C without rescanning checkpoints from genesis.
+    pub fn rebind_from_db(&mut self, db: &ZakuraDb) -> Result<(), HighestCompletedCheckpointError> {
+        let state = TrackerState::reconstruct(db, &[], Some((self.state, None)))?;
+        self.replace_state(state);
+        Ok(())
+    }
+
+    fn replace_state(&mut self, state: TrackerState) {
+        let changed = self.state.current != state.current;
+        self.state = state;
+        if changed {
+            let _ = self.sender.send(state.current);
+        }
+    }
+}
+
+impl TrackerState {
+    /// Rebuilds tracker state for `[genesis, canonical_tip]`.
+    ///
+    /// Call paths:
+    /// - startup / cold open: `start_hint = None` → trusted body base, then walk headers
+    /// - post-commit proposal / rebind: `start_hint = Some(prior state)` → resume from
+    ///   `current` / `next_checkpoint` / `cursor` instead of rescanning all checkpoints
+    fn reconstruct(
+        db: &ZakuraDb,
+        pending: &[(Height, block::Hash, Arc<block::Header>)],
+        start_hint: Option<(TrackerState, Option<Height>)>,
+    ) -> Result<Self, HighestCompletedCheckpointError> {
+        // Tip is either the proposed post-commit height or the durable header tip.
+        let disk_tip = db.best_header_tip().map(|(height, _)| height);
+        let canonical_tip = start_hint.and_then(|(_, tip)| tip).or(disk_tip);
+        let Some(canonical_tip) = canonical_tip else {
+            // Empty header store: nothing completed yet.
+            return Ok(Self {
+                current: None,
+                next_checkpoint: None,
+                cursor: None,
+            });
+        };
+
+        let checkpoints = db.network().checkpoint_list();
+        let genesis_hash = checkpoints
+            .hash(Height::MIN)
+            .ok_or(HighestCompletedCheckpointError::MissingGenesisCheckpoint)?;
+
+        let body_tip = db
+            .finalized_tip_height()
+            .filter(|height| *height <= canonical_tip);
+        let hinted_state = start_hint.map(|(state, _)| state);
+
+        // Path A — resume: reuse prior in-memory progress when `current` still matches disk.
+        // Path B — cold start / invalid hint: jump to body tip via checkpoint_at_or_before
+        // (no full checkpoint-list iteration).
+        let mut state = match hinted_state {
+            Some(state)
+                if state.current.is_some_and(|current| {
+                    current.height <= canonical_tip
+                        && Self::validate_checkpoint(db, current).is_ok()
+                }) =>
+            {
+                state
+            }
+            _ => Self::trusted_body_base(db, canonical_tip, genesis_hash)?,
+        };
+
+        // Drop a stale cursor (past tip, or hash no longer canonical / pending) back to
+        // the last completed checkpoint so the walk below re-validates from a known point.
+        if let Some((cursor_height, cursor_hash)) = state.cursor {
+            if cursor_height > canonical_tip
+                || Self::header_hash(db, pending, cursor_height) != Some(cursor_hash)
+            {
+                state.cursor = state
+                    .current
+                    .map(|checkpoint| (checkpoint.height, checkpoint.hash));
+            }
+        }
+
+        // Path C — body fast-forward: finalized bodies cover whole brackets, so advance
+        // `current` / `next_checkpoint` / `cursor` with a single lookup instead of walking
+        // every intermediate header or checkpoint.
+        if let Some(body_height) = body_tip {
+            if state
+                .next_checkpoint
+                .is_some_and(|(height, _)| height <= body_height)
+            {
+                let (height, hash) = checkpoints
+                    .checkpoint_at_or_before(body_height)
+                    .ok_or(HighestCompletedCheckpointError::MissingGenesisCheckpoint)?;
+                let completed = HighestCompletedCheckpoint { height, hash };
+                Self::validate_checkpoint(db, completed)?;
+                state.current = Some(completed);
+                state.next_checkpoint = checkpoints.checkpoint_after(height);
+            }
+
+            if state
+                .cursor
+                .is_none_or(|(cursor_height, _)| cursor_height < body_height)
+            {
+                let body_hash = db.header_hash(body_height).ok_or(
+                    HighestCompletedCheckpointError::MissingCanonicalHeader {
+                        height: body_height,
+                    },
+                )?;
+                state.cursor = Some((body_height, body_hash));
+            }
+        }
+
+        let pending: BTreeMap<_, _> = pending
+            .iter()
+            .map(|(height, hash, header)| (*height, (*hash, header)))
+            .collect();
+        let (mut cursor_height, mut cursor_hash) =
+            state.cursor.unwrap_or((Height::MIN, genesis_hash));
+
+        // Path D — incremental header walk from cursor → tip only. Completes a checkpoint
+        // when the walk hits `next_checkpoint`; otherwise just advances the cursor.
+        while cursor_height < canonical_tip {
+            let next_height = cursor_height
+                .next()
+                .map_err(|_| HighestCompletedCheckpointError::HeightOverflow)?;
+            let Some((hash, header)) = pending
+                .get(&next_height)
+                .map(|(hash, header)| (*hash, Arc::clone(header)))
+                .or_else(|| db.header_by_height(next_height))
+            else {
+                // Gap in the header chain: stop; do not invent progress past the hole.
+                break;
+            };
+            if block::Hash::from(header.as_ref()) != hash
+                || header.previous_block_hash != cursor_hash
+            {
+                // Non-canonical or broken parent link: stop at the last continuous height.
+                break;
+            }
+            if let Some((_, expected)) = state
+                .next_checkpoint
+                .filter(|(height, _)| *height == next_height)
+            {
+                if hash != expected {
+                    return Err(HighestCompletedCheckpointError::CheckpointMismatch {
+                        height: next_height,
+                        expected,
+                        actual: Some(hash),
+                    });
+                }
+                state.current = Some(HighestCompletedCheckpoint {
+                    height: next_height,
+                    hash,
+                });
+                state.next_checkpoint = checkpoints.checkpoint_after(next_height);
+            }
+            cursor_height = next_height;
+            cursor_hash = hash;
+        }
+        state.cursor = Some((cursor_height, cursor_hash));
+
+        Ok(state)
+    }
+
+    /// Cold-start base for reconstruct path B: one `checkpoint_at_or_before(body_tip)`
+    /// (or genesis if there is no body), not a walk over the full checkpoint list.
+    fn trusted_body_base(
+        db: &ZakuraDb,
+        canonical_tip: Height,
+        genesis_hash: block::Hash,
+    ) -> Result<Self, HighestCompletedCheckpointError> {
+        let checkpoints = db.network().checkpoint_list();
+        let (completed, cursor) = if let Some(body_height) = db
+            .finalized_tip_height()
+            .filter(|height| *height <= canonical_tip)
+        {
+            let body_hash = db.header_hash(body_height).ok_or(
+                HighestCompletedCheckpointError::MissingCanonicalHeader {
+                    height: body_height,
+                },
+            )?;
+            let (height, hash) = checkpoints
+                .checkpoint_at_or_before(body_height)
+                .ok_or(HighestCompletedCheckpointError::MissingGenesisCheckpoint)?;
+            (
+                HighestCompletedCheckpoint { height, hash },
+                (body_height, body_hash),
+            )
+        } else {
+            (
+                HighestCompletedCheckpoint {
+                    height: Height::MIN,
+                    hash: genesis_hash,
+                },
+                (Height::MIN, genesis_hash),
+            )
+        };
+        Self::validate_checkpoint(db, completed)?;
+
+        Ok(Self {
+            current: Some(completed),
+            next_checkpoint: checkpoints.checkpoint_after(completed.height),
+            cursor: Some(cursor),
+        })
+    }
+
+    fn validate_checkpoint(
+        db: &ZakuraDb,
+        checkpoint: HighestCompletedCheckpoint,
+    ) -> Result<(), HighestCompletedCheckpointError> {
+        let expected = db
+            .network()
+            .checkpoint_list()
+            .hash(checkpoint.height)
+            .ok_or(HighestCompletedCheckpointError::CheckpointMismatch {
+                height: checkpoint.height,
+                expected: checkpoint.hash,
+                actual: None,
+            })?;
+        let actual = db.header_hash(checkpoint.height);
+        if checkpoint.hash != expected || actual != Some(expected) {
+            return Err(HighestCompletedCheckpointError::CheckpointMismatch {
+                height: checkpoint.height,
+                expected,
+                actual,
+            });
+        }
+        Ok(())
+    }
+
+    fn header_hash(
+        db: &ZakuraDb,
+        pending: &[(Height, block::Hash, Arc<block::Header>)],
+        height: Height,
+    ) -> Option<block::Hash> {
+        pending
+            .iter()
+            .find_map(|(pending_height, hash, _)| (*pending_height == height).then_some(*hash))
+            .or_else(|| db.header_hash(height))
+    }
+}

--- a/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
@@ -49,7 +49,7 @@ pub enum HighestCompletedCheckpointError {
     HeightOverflow,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 struct TrackerState {
     current: Option<HighestCompletedCheckpoint>,
     /// The first configured checkpoint strictly above `current`.
@@ -210,10 +210,26 @@ impl HighestCompletedCheckpointTracker {
     ///
     /// Hints with the prior state (path A) so body progress can fast-forward via
     /// path C without rescanning checkpoints from genesis.
+    ///
+    /// Clears the published checkpoint before returning a reconstruction error.
     pub fn rebind_from_db(&mut self, db: &ZakuraDb) -> Result<(), HighestCompletedCheckpointError> {
-        let state = TrackerState::reconstruct(db, &[], Some((self.state, None)))?;
-        self.replace_state(state);
-        Ok(())
+        match TrackerState::reconstruct(db, &[], Some((self.state, None))) {
+            Ok(state) => {
+                self.replace_state(state);
+                Ok(())
+            }
+            Err(error) => {
+                // A stale completed checkpoint could authorize data that the durable
+                // header store no longer justifies, so reconstruction errors fail closed.
+                self.replace_state(TrackerState::default());
+                Err(error)
+            }
+        }
+    }
+
+    /// Returns a sender clone that keeps subscriptions open without retaining the tracker.
+    pub(crate) fn keepalive_sender(&self) -> watch::Sender<Option<HighestCompletedCheckpoint>> {
+        self.sender.clone()
     }
 
     fn replace_state(&mut self, state: TrackerState) {

--- a/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
@@ -24,8 +24,8 @@ pub enum HighestCompletedCheckpointError {
     #[error("the configured checkpoint list does not contain genesis")]
     MissingGenesisCheckpoint,
 
-    /// A canonical header required to establish the trusted body base is missing.
-    #[error("missing canonical header at trusted body height {height:?}")]
+    /// A canonical header required by `from_finalized_body` is missing.
+    #[error("missing canonical header at finalized body height {height:?}")]
     MissingCanonicalHeader {
         /// Missing header height.
         height: Height,
@@ -76,7 +76,7 @@ pub struct HighestCompletedCheckpointTracker {
 impl HighestCompletedCheckpointTracker {
     /// Reconstructs checkpoint progress from durable canonical headers.
     ///
-    /// Cold open: no `start_hint`, so reconstruct uses the trusted body base (path B)
+    /// Cold open: no `start_hint`, so reconstruct uses `from_finalized_body` (path B)
     /// then walks any headers above the body tip (path D).
     ///
     /// If durable headers are inconsistent, logs the error and clears progress so startup
@@ -125,13 +125,13 @@ impl HighestCompletedCheckpointTracker {
             return Ok(ProposedHighestCompletedCheckpoint(self.state));
         };
 
-        let mut pending = Vec::with_capacity(headers.len());
+        let mut pending_headers = Vec::with_capacity(headers.len());
         for (index, header) in headers.iter().enumerate() {
             let offset = u32::try_from(index + 1)
                 .map_err(|_| HighestCompletedCheckpointError::HeightOverflow)?;
             let height = (anchor_height + i64::from(offset))
                 .ok_or(HighestCompletedCheckpointError::HeightOverflow)?;
-            pending.push((
+            pending_headers.push((
                 height,
                 block::Hash::from(header.as_ref()),
                 Arc::clone(header),
@@ -139,19 +139,19 @@ impl HighestCompletedCheckpointTracker {
         }
 
         // First height where pending disagrees with durable headers (reorg into the range).
-        let first_conflict = pending.iter().find_map(|(height, hash, _)| {
+        let first_conflict = pending_headers.iter().find_map(|(height, hash, _)| {
             db.header_hash(*height)
                 .is_some_and(|stored| stored != *hash)
                 .then_some(*height)
         });
         // After a conflict, tip is the end of the pending batch; otherwise max(disk, pending).
         let post_tip = if first_conflict.is_some() {
-            pending.last().map(|(height, _, _)| *height)
+            pending_headers.last().map(|(height, _, _)| *height)
         } else {
             db.best_header_tip()
                 .map(|(height, _)| height)
                 .into_iter()
-                .chain(pending.last().map(|(height, _, _)| *height))
+                .chain(pending_headers.last().map(|(height, _, _)| *height))
                 .max()
         };
 
@@ -169,7 +169,7 @@ impl HighestCompletedCheckpointTracker {
         }
 
         Ok(ProposedHighestCompletedCheckpoint(
-            TrackerState::reconstruct(db, &pending, Some((start_hint, post_tip)))?,
+            TrackerState::reconstruct(db, &pending_headers, Some((start_hint, post_tip)))?,
         ))
     }
 
@@ -253,7 +253,7 @@ impl TrackerState {
     /// Rebuilds tracker state for `[genesis, canonical_tip]`.
     ///
     /// Call paths:
-    /// - startup / cold open: `start_hint = None` → trusted body base, then walk headers
+    /// - startup / cold open: `start_hint = None` → `from_finalized_body`, then walk headers
     /// - post-commit proposal / rebind: `start_hint = Some(prior state)` → resume from
     ///   `current` / `next_checkpoint` / `cursor` instead of rescanning all checkpoints
     fn reconstruct(
@@ -262,8 +262,8 @@ impl TrackerState {
         start_hint: Option<(TrackerState, Option<Height>)>,
     ) -> Result<Self, HighestCompletedCheckpointError> {
         // Tip is either the proposed post-commit height or the durable header tip.
-        let disk_tip = db.best_header_tip().map(|(height, _)| height);
-        let canonical_tip = start_hint.and_then(|(_, tip)| tip).or(disk_tip);
+        let disk_best_header_tip = db.best_header_tip().map(|(height, _)| height);
+        let canonical_tip = start_hint.and_then(|(_, tip)| tip).or(disk_best_header_tip);
         let Some(canonical_tip) = canonical_tip else {
             // Empty header store: nothing completed yet.
             return Ok(Self {
@@ -295,7 +295,7 @@ impl TrackerState {
             {
                 state
             }
-            _ => Self::trusted_body_base(db, canonical_tip, genesis_hash)?,
+            _ => Self::from_finalized_body(db, canonical_tip, genesis_hash)?,
         };
 
         // Drop a stale cursor (past tip, or hash no longer canonical / pending) back to
@@ -392,9 +392,18 @@ impl TrackerState {
         Ok(state)
     }
 
-    /// Cold-start base for reconstruct path B: one `checkpoint_at_or_before(body_tip)`
-    /// (or genesis if there is no body), not a walk over the full checkpoint list.
-    fn trusted_body_base(
+    /// Builds the cold-start tracker base when no valid in-memory hint is available (path B in reconstruct()).
+    ///
+    /// `current` is the highest configured checkpoint covered by the durable finalized
+    /// body tip at or below `canonical_tip`, or genesis when no such body exists.
+    /// `cursor` is that body tip (or genesis) so a later header walk only covers
+    /// body→tip. Does not scan the full checkpoint list or walk headers.
+    ///
+    /// # Errors
+    ///
+    /// Returns if the body-tip header is missing, the checkpoint list lacks genesis,
+    /// or the completed checkpoint does not match the canonical header store.
+    fn from_finalized_body(
         db: &ZakuraDb,
         canonical_tip: Height,
         genesis_hash: block::Hash,

--- a/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
@@ -63,6 +63,7 @@ struct TrackerState {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct ProposedHighestCompletedCheckpoint(TrackerState);
 
+#[cfg(test)]
 impl ProposedHighestCompletedCheckpoint {
     /// Returns the checkpoint that would become current if this proposal commits.
     pub fn current(&self) -> Option<HighestCompletedCheckpoint> {

--- a/zakura-state/src/service/tests.rs
+++ b/zakura-state/src/service/tests.rs
@@ -28,8 +28,8 @@ use crate::{
     arbitrary::Prepare,
     init_test,
     service::{
-        arbitrary::populated_state, chain_tip::TipAction, headers_by_height_range,
-        non_finalized_state::Chain, read, StateService,
+        arbitrary::populated_state, chain_tip::TipAction, finalized_state::FinalizedState,
+        headers_by_height_range, non_finalized_state::Chain, read, StateService,
     },
     tests::{
         setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
@@ -1223,6 +1223,37 @@ fn read_only_open_with_no_database_returns_error() {
         Err(other) => panic!("expected ReadOnlyDatabaseNotFound, got: {other:?}"),
         Ok(_) => panic!("expected an error when opening a read-only state with no database"),
     }
+}
+
+#[test]
+fn read_only_completed_checkpoint_subscription_stays_open() {
+    let network = Network::Mainnet;
+    let cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
+    let config = Config {
+        cache_dir: cache_dir.path().to_path_buf(),
+        ephemeral: false,
+        ..Config::default()
+    };
+
+    let mut finalized_state = FinalizedState::new(
+        &config,
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .expect("writable state creates the database");
+    finalized_state.db.shutdown(true);
+    drop(finalized_state);
+
+    let (read_service, _db, _non_finalized_sender) =
+        super::init_read_only(config, &network).expect("read-only state opens");
+    let receiver = read_service.subscribe_highest_completed_checkpoint();
+
+    assert_eq!(*receiver.borrow(), None);
+    assert!(!receiver.has_changed().expect("subscription remains open"));
+    drop(read_service);
+    assert!(receiver.has_changed().is_err());
 }
 
 /// Opening a read-only state against a missing or unreadable cache directory must fail with a

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -24,7 +24,9 @@ use crate::{
     error::CommitHeaderRangeError,
     service::{
         check,
-        finalized_state::{FinalizedState, ZakuraDb},
+        finalized_state::{
+            FinalizedState, HighestCompletedCheckpoint, HighestCompletedCheckpointTracker, ZakuraDb,
+        },
         non_finalized_state::NonFinalizedState,
         queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified},
         ChainTipBlock, ChainTipSender, InvalidateError, ReconsiderError,
@@ -164,12 +166,20 @@ fn update_latest_chain_channels(
 
 fn commit_header_range(
     finalized_state: &FinalizedState,
+    completed_checkpoint: &mut HighestCompletedCheckpointTracker,
     anchor: block::Hash,
     headers: Vec<Arc<block::Header>>,
     body_sizes: Vec<u32>,
     tree_aux_roots: Vec<BlockCommitmentRoots>,
     rsp_tx: oneshot::Sender<Result<block::Hash, CommitHeaderRangeError>>,
 ) {
+    if let Err(height) =
+        completed_checkpoint.check_immutable_conflicts(&finalized_state.db, anchor, &headers)
+    {
+        let _ = rsp_tx.send(Err(CommitHeaderRangeError::ImmutableConflict { height }));
+        return;
+    }
+
     let mut batch = crate::service::finalized_state::DiskWriteBatch::new();
     let result = batch
         .prepare_header_range_batch_with_roots(
@@ -180,10 +190,18 @@ fn commit_header_range(
             &tree_aux_roots,
         )
         .and_then(|hash| {
+            let proposed = completed_checkpoint.propose_after_headers(
+                &finalized_state.db,
+                anchor,
+                &headers,
+            )?;
             finalized_state
                 .db
                 .write_batch(batch)
-                .map(|()| hash)
+                .map(|()| {
+                    completed_checkpoint.commit_success(proposed);
+                    hash
+                })
                 .map_err(|error| {
                     tracing::error!(?error, "failed to write validated header range");
 
@@ -215,6 +233,7 @@ struct WriteBlockWorkerTask {
     non_finalized_rejected_sender: UnboundedSender<block::Hash>,
     chain_tip_sender: ChainTipSender,
     non_finalized_state_sender: watch::Sender<NonFinalizedState>,
+    highest_completed_checkpoint: HighestCompletedCheckpointTracker,
     vct_root_repair_sender: watch::Sender<VctRootRepairStatus>,
     /// If `Some`, the non-finalized state is written to this backup directory
     /// synchronously before each channel update, instead of via the async backup task.
@@ -292,6 +311,7 @@ impl BlockWriteSender {
         Self,
         tokio::sync::mpsc::UnboundedReceiver<block::Hash>,
         tokio::sync::mpsc::UnboundedReceiver<block::Hash>,
+        watch::Receiver<Option<HighestCompletedCheckpoint>>,
         watch::Receiver<VctRootRepairStatus>,
         Option<Arc<std::thread::JoinHandle<()>>>,
     ) {
@@ -307,6 +327,10 @@ impl BlockWriteSender {
             tokio::sync::mpsc::unbounded_channel();
         let (vct_root_repair_sender, vct_root_repair_receiver) =
             watch::channel(VctRootRepairStatus::default());
+        let (highest_completed_checkpoint, highest_completed_checkpoint_receiver) =
+            HighestCompletedCheckpointTracker::open(&finalized_state.db).expect(
+                "highest completed checkpoint reconstructs after startup header-store audit",
+            );
 
         let seed_zakura_header_from_best_chain_commits = finalized_state
             .db
@@ -326,6 +350,7 @@ impl BlockWriteSender {
                     non_finalized_rejected_sender,
                     chain_tip_sender,
                     non_finalized_state_sender,
+                    highest_completed_checkpoint,
                     vct_root_repair_sender,
                     backup_dir_path,
                 }
@@ -341,6 +366,7 @@ impl BlockWriteSender {
             },
             invalid_block_write_reset_receiver,
             non_finalized_rejected_receiver,
+            highest_completed_checkpoint_receiver,
             vct_root_repair_receiver,
             Some(Arc::new(task)),
         )
@@ -368,6 +394,7 @@ impl WriteBlockWorkerTask {
             non_finalized_rejected_sender,
             chain_tip_sender,
             non_finalized_state_sender,
+            highest_completed_checkpoint,
             vct_root_repair_sender,
             seed_zakura_header_from_best_chain_commits,
             backup_dir_path,
@@ -393,6 +420,7 @@ impl WriteBlockWorkerTask {
                 }) => {
                     commit_header_range(
                         finalized_state,
+                        highest_completed_checkpoint,
                         anchor,
                         headers,
                         body_sizes,
@@ -497,6 +525,14 @@ impl WriteBlockWorkerTask {
                 next_vct_block,
             ) {
                 Ok((finalized, note_commitment_trees)) => {
+                    if let Err(error) =
+                        highest_completed_checkpoint.rebind_from_db(&finalized_state.db)
+                    {
+                        tracing::warn!(
+                            ?error,
+                            "failed to refresh highest completed checkpoint after finalized block commit"
+                        );
+                    }
                     // Whether this successful commit consumed header-carried
                     // tree-aux roots to skip the note-commitment frontier rebuild.
                     if next_block_took_vct_path {
@@ -589,6 +625,7 @@ impl WriteBlockWorkerTask {
                 } => {
                     commit_header_range(
                         finalized_state,
+                        highest_completed_checkpoint,
                         anchor,
                         headers,
                         body_sizes,
@@ -686,6 +723,7 @@ impl WriteBlockWorkerTask {
             ) {
                 seed_zakura_header_from_committed_block(
                     &finalized_state.db,
+                    highest_completed_checkpoint,
                     child_height,
                     &child_block,
                 );
@@ -726,6 +764,13 @@ impl WriteBlockWorkerTask {
                     )
                     .1
                     .into();
+                if let Err(error) = highest_completed_checkpoint.rebind_from_db(&finalized_state.db)
+                {
+                    tracing::warn!(
+                        ?error,
+                        "failed to refresh highest completed checkpoint after finalized block commit"
+                    );
+                }
             }
 
             // Update the metrics if semantic and contextual validation passes
@@ -754,11 +799,18 @@ impl WriteBlockWorkerTask {
 
 fn seed_zakura_header_from_committed_block(
     finalized_state: &ZakuraDb,
+    highest_completed_checkpoint: &mut HighestCompletedCheckpointTracker,
     height: block::Height,
     block: &Arc<block::Block>,
 ) {
     match finalized_state.seed_zakura_header_from_committed_block(height, block) {
         Ok(()) => {
+            if let Err(error) = highest_completed_checkpoint.rebind_from_db(finalized_state) {
+                tracing::warn!(
+                    ?error,
+                    "failed to refresh highest completed checkpoint after seeding a header"
+                );
+            }
             tracing::trace!(?height, hash = ?block.hash(), "seeded Zakura header from committed block");
         }
         Err(error) => {
@@ -792,7 +844,9 @@ mod tests {
     use crate::{
         arbitrary::Prepare,
         service::{
-            finalized_state::{DiskWriteBatch, FinalizedState, WriteDisk},
+            finalized_state::{
+                DiskWriteBatch, FinalizedState, HighestCompletedCheckpointTracker, WriteDisk,
+            },
             non_finalized_state::NonFinalizedState,
             write::{
                 seed_zakura_header_from_committed_block,
@@ -860,7 +914,15 @@ mod tests {
             best_height,
             best_block.hash(),
         ));
-        seed_zakura_header_from_committed_block(&finalized_state.db, best_height, &best_block);
+        let (mut completed_checkpoint, _receiver) =
+            HighestCompletedCheckpointTracker::open(&finalized_state.db)
+                .expect("checkpoint tracker opens");
+        seed_zakura_header_from_committed_block(
+            &finalized_state.db,
+            &mut completed_checkpoint,
+            best_height,
+            &best_block,
+        );
 
         non_finalized_state
             .commit_new_chain(side_block.clone().prepare(), &finalized_state)

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -883,6 +883,9 @@ mod tests {
             .expect("fake child block has a coinbase height");
 
         let mut non_finalized_state = NonFinalizedState::new(&network);
+        let (mut completed_checkpoint, _receiver) =
+            HighestCompletedCheckpointTracker::open(&finalized_state.db)
+                .expect("empty checkpoint tracker opens");
 
         // The seed path refuses rows that do not link to the stored header row
         // below them, and the fake chain's parent block is not otherwise
@@ -914,9 +917,6 @@ mod tests {
             best_height,
             best_block.hash(),
         ));
-        let (mut completed_checkpoint, _receiver) =
-            HighestCompletedCheckpointTracker::open(&finalized_state.db)
-                .expect("checkpoint tracker opens");
         seed_zakura_header_from_committed_block(
             &finalized_state.db,
             &mut completed_checkpoint,

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -523,14 +523,6 @@ impl WriteBlockWorkerTask {
                 next_vct_block,
             ) {
                 Ok((finalized, note_commitment_trees)) => {
-                    if let Err(error) =
-                        highest_completed_checkpoint.rebind_from_db(&finalized_state.db)
-                    {
-                        tracing::warn!(
-                            ?error,
-                            "failed to refresh highest completed checkpoint after finalized block commit"
-                        );
-                    }
                     // Whether this successful commit consumed header-carried
                     // tree-aux roots to skip the note-commitment frontier rebuild.
                     if next_block_took_vct_path {
@@ -543,9 +535,21 @@ impl WriteBlockWorkerTask {
                     // the stalled-height gauge if it had been raised.
                     vct_write_manager.on_commit_success();
 
+                    // Publish the tip before checkpoint rebind. `commit_finalized`
+                    // already answered the oneshot, so tip waiters can race this
+                    // path; rebind must not delay chain-tip notification.
                     let tip_block = ChainTipBlock::from(finalized);
                     prev_finalized_note_commitment_trees = Some(note_commitment_trees);
                     chain_tip_sender.set_finalized_tip(tip_block);
+
+                    if let Err(error) =
+                        highest_completed_checkpoint.rebind_from_db(&finalized_state.db)
+                    {
+                        tracing::warn!(
+                            ?error,
+                            "failed to refresh highest completed checkpoint after finalized block commit"
+                        );
+                    }
                 }
                 Err((ordered_block, error)) => {
                     // Retryable VCT root stalls (an absent/evicted root, or one not yet

--- a/zakura-state/src/service/write.rs
+++ b/zakura-state/src/service/write.rs
@@ -328,9 +328,7 @@ impl BlockWriteSender {
         let (vct_root_repair_sender, vct_root_repair_receiver) =
             watch::channel(VctRootRepairStatus::default());
         let (highest_completed_checkpoint, highest_completed_checkpoint_receiver) =
-            HighestCompletedCheckpointTracker::open(&finalized_state.db).expect(
-                "highest completed checkpoint reconstructs after startup header-store audit",
-            );
+            HighestCompletedCheckpointTracker::open(&finalized_state.db);
 
         let seed_zakura_header_from_best_chain_commits = finalized_state
             .db
@@ -884,8 +882,7 @@ mod tests {
 
         let mut non_finalized_state = NonFinalizedState::new(&network);
         let (mut completed_checkpoint, _receiver) =
-            HighestCompletedCheckpointTracker::open(&finalized_state.db)
-                .expect("empty checkpoint tracker opens");
+            HighestCompletedCheckpointTracker::open(&finalized_state.db);
 
         // The seed path refuses rows that do not link to the stored header row
         // below them, and the fake chain's parent block is not otherwise


### PR DESCRIPTION
## Motivation

Header-root authentication needs an efficient state-owned fact proving which configured checkpoint bracket is completely stored. Reconstructing the full header prefix on every write is wasteful, while persisting an independent checkpoint row creates another source of truth and a database migration surface.

## Solution

- reconstruct `HighestCompletedCheckpoint` from durable canonical headers and configured checkpoints when state opens
- cache the completed checkpoint and the contiguous in-progress cursor in the state write worker
- compute header-batch proposals without mutating memory, then publish them only after the RocksDB batch succeeds
- refresh progress after finalized-body and committed-header seed writes, clearing published progress if reconstruction fails
- expose a watch subscription for later header-root authentication consumers and keep read-only subscriptions open
- reject header reorgs at or below the completed checkpoint

## Testing

- `cargo test -p zakura-chain checkpoint_list_neighbor_lookups --locked`
- `cargo test -p zakura-state highest_completed_checkpoint --lib --locked` (6 passed)
- `cargo test -p zakura-state side_chain_commit_does_not_seed_zakura_headers --lib --locked`
- `cargo test -p zakura-state read_only_completed_checkpoint_subscription_stays_open --lib --locked`
- `cargo clippy -p zakura-state --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`

Coverage includes successful bracket completion, restart reconstruction, proposal purity on failed writes, interior gaps, immutable completed-checkpoint ancestors, fail-closed reconstruction errors, watch notifications, and read-only subscription lifetime.

## Changelog

Added `changelog-unreleased/351.md` with an explicit no-changelog marker because this adds library APIs for future integration without operator-visible behavior.

### Specifications & References

- `docs/design/header-sync-vct-root-authentication.md`, state-owned completed checkpoint frontier
- Follow-up integration is based on draft PR #323.
- Supersedes the dedicated durable checkpoint-row approach in PR #348.

### Follow-up Work

- Rebase a fresh successor branch from PR #323 onto this PR and make root authentication consume the in-memory tracker.
