### PR TITLE
perf(state): track the next completed checkpoint

### DIFF
--- a/changelog-unreleased/353.md
+++ b/changelog-unreleased/353.md
@@ -1,0 +1,4 @@
+## Changed
+
+- Reduced completed-checkpoint tracker startup and steady-state lookup work
+  ([#353](https://github.com/zakura-core/zakura/pull/353)).

--- a/zakura-chain/src/parameters/checkpoint/list.rs
+++ b/zakura-chain/src/parameters/checkpoint/list.rs
@@ -7,7 +7,7 @@
 
 use std::{
     collections::{BTreeMap, HashSet},
-    ops::RangeBounds,
+    ops::{Bound, RangeBounds},
     str::FromStr,
     sync::Arc,
 };
@@ -203,6 +203,25 @@ impl CheckpointList {
         R: RangeBounds<block::Height>,
     {
         self.0.range(range).map(|(height, _)| *height).next_back()
+    }
+
+    /// Returns the checkpoint at or immediately below `height`.
+    pub fn checkpoint_at_or_before(
+        &self,
+        height: block::Height,
+    ) -> Option<(block::Height, block::Hash)> {
+        self.0
+            .range(..=height)
+            .next_back()
+            .map(|(&height, &hash)| (height, hash))
+    }
+
+    /// Returns the first checkpoint strictly above `height`.
+    pub fn checkpoint_after(&self, height: block::Height) -> Option<(block::Height, block::Hash)> {
+        self.0
+            .range((Bound::Excluded(height), Bound::Unbounded))
+            .next()
+            .map(|(&height, &hash)| (height, hash))
     }
 
     /// Returns an iterator over all the checkpoints, in increasing height order.

--- a/zakura-chain/src/parameters/checkpoint/list/tests.rs
+++ b/zakura-chain/src/parameters/checkpoint/list/tests.rs
@@ -69,6 +69,40 @@ fn checkpoint_list_multiple() -> Result<(), BoxError> {
     Ok(())
 }
 
+#[test]
+fn checkpoint_list_neighbor_lookups() -> Result<(), BoxError> {
+    let checkpoints = [
+        (block::Height(0), block::Hash([1; 32])),
+        (block::Height(10), block::Hash([2; 32])),
+        (block::Height(20), block::Hash([3; 32])),
+    ];
+    let list = CheckpointList::from_list(checkpoints)?;
+
+    assert_eq!(
+        list.checkpoint_at_or_before(block::Height(15)),
+        Some(checkpoints[1])
+    );
+    assert_eq!(
+        list.checkpoint_at_or_before(block::Height(0)),
+        Some(checkpoints[0])
+    );
+    assert_eq!(
+        list.checkpoint_at_or_before(block::Height(25)),
+        Some(checkpoints[2])
+    );
+    assert_eq!(
+        list.checkpoint_after(block::Height(0)),
+        Some(checkpoints[1])
+    );
+    assert_eq!(
+        list.checkpoint_after(block::Height(10)),
+        Some(checkpoints[2])
+    );
+    assert_eq!(list.checkpoint_after(block::Height(20)), None);
+
+    Ok(())
+}
+
 /// Make sure that an empty checkpoint list fails
 #[test]
 fn checkpoint_list_empty_fail() -> Result<(), BoxError> {

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
@@ -91,6 +91,26 @@ fn advances_after_disk_commit_and_reconstructs_after_restart() {
 }
 
 #[test]
+fn reconstructs_header_completed_frontier_above_body_tip() {
+    let _init_guard = zakura_test::init();
+    let (genesis, headers, network) = checkpoint_chain(&[2, 5]);
+    let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
+
+    for (index, header) in headers.iter().enumerate() {
+        let height = Height(u32::try_from(index + 1).expect("small test height fits in u32"));
+        store_header(&state, height, header);
+    }
+
+    let (tracker, receiver) =
+        HighestCompletedCheckpointTracker::open(&state).expect("tracker reconstructs");
+    let checkpoint_five = checkpoint(Height(5), block::Hash::from(headers[4].as_ref()));
+
+    assert_eq!(state.finalized_tip_height(), Some(Height::MIN));
+    assert_eq!(tracker.current(), Some(checkpoint_five));
+    assert_eq!(*receiver.borrow(), Some(checkpoint_five));
+}
+
+#[test]
 fn failed_write_proposal_has_no_side_effects() {
     let _init_guard = zakura_test::init();
     let (genesis, headers, network) = checkpoint_chain(&[2]);

--- a/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/highest_completed_checkpoint.rs
@@ -52,6 +52,8 @@ pub enum HighestCompletedCheckpointError {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct TrackerState {
     current: Option<HighestCompletedCheckpoint>,
+    /// The first configured checkpoint strictly above `current`.
+    next_checkpoint: Option<(Height, block::Hash)>,
     cursor: Option<(Height, block::Hash)>,
 }
 
@@ -222,6 +224,7 @@ impl TrackerState {
         let Some(canonical_tip) = canonical_tip else {
             return Ok(Self {
                 current: None,
+                next_checkpoint: None,
                 cursor: None,
             });
         };
@@ -234,50 +237,18 @@ impl TrackerState {
         let body_tip = db
             .finalized_tip_height()
             .filter(|height| *height <= canonical_tip);
-        let (base_current, base_cursor) = if let Some(body_height) = body_tip {
-            let body_hash = db.header_hash(body_height).ok_or(
-                HighestCompletedCheckpointError::MissingCanonicalHeader {
-                    height: body_height,
-                },
-            )?;
-            let completed = checkpoints
-                .iter_cloned()
-                .take_while(|(height, _)| *height <= body_height)
-                .last()
-                .map(|(height, hash)| HighestCompletedCheckpoint { height, hash })
-                .ok_or(HighestCompletedCheckpointError::MissingGenesisCheckpoint)?;
-            Self::validate_checkpoint(db, completed)?;
-            (Some(completed), Some((body_height, body_hash)))
-        } else {
-            let genesis = HighestCompletedCheckpoint {
-                height: Height::MIN,
-                hash: genesis_hash,
-            };
-            Self::validate_checkpoint(db, genesis)?;
-            (Some(genesis), Some((Height::MIN, genesis_hash)))
-        };
-
-        let mut state = start_hint.map(|(state, _)| state).unwrap_or(Self {
-            current: base_current,
-            cursor: base_cursor,
-        });
-
-        if state
-            .current
-            .is_none_or(|current| base_current.is_some_and(|base| base.height > current.height))
-        {
-            state.current = base_current;
-            state.cursor = base_cursor;
-        } else if let Some(current) = state.current {
-            if Self::validate_checkpoint(db, current).is_err() {
-                state.current = base_current;
-                state.cursor = base_cursor;
+        let hinted_state = start_hint.map(|(state, _)| state);
+        let mut state = match hinted_state {
+            Some(state)
+                if state.current.is_some_and(|current| {
+                    current.height <= canonical_tip
+                        && Self::validate_checkpoint(db, current).is_ok()
+                }) =>
+            {
+                state
             }
-        }
-
-        if base_cursor.is_some_and(|base| state.cursor.is_none_or(|cursor| base.0 > cursor.0)) {
-            state.cursor = base_cursor;
-        }
+            _ => Self::trusted_body_base(db, canonical_tip, genesis_hash)?,
+        };
 
         if let Some((cursor_height, cursor_hash)) = state.cursor {
             if cursor_height > canonical_tip
@@ -285,8 +256,34 @@ impl TrackerState {
             {
                 state.cursor = state
                     .current
-                    .map(|checkpoint| (checkpoint.height, checkpoint.hash))
-                    .or(base_cursor);
+                    .map(|checkpoint| (checkpoint.height, checkpoint.hash));
+            }
+        }
+
+        if let Some(body_height) = body_tip {
+            if state
+                .next_checkpoint
+                .is_some_and(|(height, _)| height <= body_height)
+            {
+                let (height, hash) = checkpoints
+                    .checkpoint_at_or_before(body_height)
+                    .ok_or(HighestCompletedCheckpointError::MissingGenesisCheckpoint)?;
+                let completed = HighestCompletedCheckpoint { height, hash };
+                Self::validate_checkpoint(db, completed)?;
+                state.current = Some(completed);
+                state.next_checkpoint = checkpoints.checkpoint_after(height);
+            }
+
+            if state
+                .cursor
+                .is_none_or(|(cursor_height, _)| cursor_height < body_height)
+            {
+                let body_hash = db.header_hash(body_height).ok_or(
+                    HighestCompletedCheckpointError::MissingCanonicalHeader {
+                        height: body_height,
+                    },
+                )?;
+                state.cursor = Some((body_height, body_hash));
             }
         }
 
@@ -313,7 +310,10 @@ impl TrackerState {
             {
                 break;
             }
-            if let Some(expected) = checkpoints.hash(next_height) {
+            if let Some((_, expected)) = state
+                .next_checkpoint
+                .filter(|(height, _)| *height == next_height)
+            {
                 if hash != expected {
                     return Err(HighestCompletedCheckpointError::CheckpointMismatch {
                         height: next_height,
@@ -325,6 +325,7 @@ impl TrackerState {
                     height: next_height,
                     hash,
                 });
+                state.next_checkpoint = checkpoints.checkpoint_after(next_height);
             }
             cursor_height = next_height;
             cursor_hash = hash;
@@ -332,6 +333,46 @@ impl TrackerState {
         state.cursor = Some((cursor_height, cursor_hash));
 
         Ok(state)
+    }
+
+    fn trusted_body_base(
+        db: &ZakuraDb,
+        canonical_tip: Height,
+        genesis_hash: block::Hash,
+    ) -> Result<Self, HighestCompletedCheckpointError> {
+        let checkpoints = db.network().checkpoint_list();
+        let (completed, cursor) = if let Some(body_height) = db
+            .finalized_tip_height()
+            .filter(|height| *height <= canonical_tip)
+        {
+            let body_hash = db.header_hash(body_height).ok_or(
+                HighestCompletedCheckpointError::MissingCanonicalHeader {
+                    height: body_height,
+                },
+            )?;
+            let (height, hash) = checkpoints
+                .checkpoint_at_or_before(body_height)
+                .ok_or(HighestCompletedCheckpointError::MissingGenesisCheckpoint)?;
+            (
+                HighestCompletedCheckpoint { height, hash },
+                (body_height, body_hash),
+            )
+        } else {
+            (
+                HighestCompletedCheckpoint {
+                    height: Height::MIN,
+                    hash: genesis_hash,
+                },
+                (Height::MIN, genesis_hash),
+            )
+        };
+        Self::validate_checkpoint(db, completed)?;
+
+        Ok(Self {
+            current: Some(completed),
+            next_checkpoint: checkpoints.checkpoint_after(completed.height),
+            cursor: Some(cursor),
+        })
     }
 
     fn validate_checkpoint(


### PR DESCRIPTION
## Motivation

The in-memory completed-checkpoint tracker linearly scanned all configured checkpoints when deriving its trusted body base, then performed a checkpoint-map lookup for every header it walked. Mainnet currently has roughly 14,000 configured checkpoints, so both costs are avoidable.

## Solution

- Add range-based neighboring checkpoint lookups to `CheckpointList`.
- Cache the next configured checkpoint in `TrackerState` and advance that pointer only when its height is reached.
- Reuse coherent tracker hints and recompute the trusted body base only on cold open, body-base advancement, or invalidation.
- Preserve the existing post-write publication and checkpoint mismatch behavior.

## Testing

- `cargo test -p zakura-chain checkpoint_list_neighbor_lookups`
- `cargo test -p zakura-state highest_completed_checkpoint`
- `cargo clippy -p zakura-chain -p zakura-state --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`

The tracker tests cover successful post-commit advancement, failed-write isolation, restart reconstruction above the body tip, gap handling, and immutable ancestor conflicts. The list test covers exact, interior, upper-bound, and terminal neighboring lookups.

## Changelog

- Added `changelog-unreleased/353.md` for the tracker performance improvement.

### Specifications & References

- Stacked on #351.