### PR TITLE
ci: reduce MSRV cache pressure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -109,13 +109,15 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: 1.91 # MSRV
-          cache-on-failure: true
+          # Keep this non-critical-path check cold rather than reserving 1.2 GB
+          # of the repository's Actions cache for a separate Rust toolchain.
+          cache: false
       - uses: ./.github/actions/setup-zakura-build
-      # Build every workspace binary (and, transitively, every library) on the
-      # MSRV toolchain in a single warm target dir instead of a per-binary
-      # matrix. `zakura-watchdog` is excluded: it depends on `sentry`, which
+      # Type-check every workspace binary (and, transitively, every library) on
+      # the MSRV toolchain. Stable CI retains final code generation and linking
+      # coverage. `zakura-watchdog` is excluded: it depends on `sentry`, which
       # requires a newer rustc than the workspace library MSRV.
-      - run: cargo build --workspace --bins --exclude zakura-watchdog
+      - run: cargo check --workspace --bins --exclude zakura-watchdog
 
   docs:
     name: docs

--- a/changelog-unreleased/358.md
+++ b/changelog-unreleased/358.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes continuous integration and has no operator- or
+crate-consumer-visible effect.


### PR DESCRIPTION
## Motivation

The MSRV job reserves a separate 1.246 GB Actions cache because Rust 1.91
artifacts cannot be shared with the stable-toolchain jobs. A recent cold MSRV
build took 4m09s end to end, while the cached job took 1m22s, but neither was
on the overall CI critical path.

## Solution

- Replace `cargo build` with `cargo check` for every workspace binary on Rust
  1.91.
- Disable caching for the MSRV job, releasing its separate 1.246 GB cache entry
  and preventing equivalent PR-scoped entries.
- Retain dependency resolution, build-script and proc-macro execution, and
  type checking on the minimum supported toolchain.

This deliberately stops testing final code generation and linking specifically
on Rust 1.91. Stable CI continues to build and link the workspace binaries.

## Testing

- [Cold MSRV check](https://github.com/zakura-core/zakura/actions/runs/29915653055/job/88908846326)
  passed on Rust 1.91.
- `cargo check` completed in 2m43s; the complete uncached MSRV job took 3m06s.
- For comparison, the previous cold build job took 4m09s and the warm cached
  build job took 1m22s.

## Changelog

`changelog-unreleased/358.md` marks this internal CI-only change as having no
operator- or crate-consumer-visible effect.

### Follow-up Work

Delete the old `v0-rust-msrv-*` cache entry after this change merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; MSRV no longer exercises linking on 1.91, but stable CI still builds binaries and the job is not part of `lint-success`.
> 
> **Overview**
> The **MSRV** job in `lint.yml` no longer uses the Rust toolchain Actions cache (`cache: false` instead of `cache-on-failure: true`), avoiding a ~1.2 GB separate cache entry for Rust 1.91 that cannot be shared with stable jobs.
> 
> MSRV validation switches from **`cargo build --workspace --bins`** to **`cargo check`** (still excluding `zakura-watchdog`). Comments now state that stable CI keeps full compile/link coverage while MSRV focuses on dependency resolution, build scripts, proc-macros, and type checking.
> 
> A changelog entry marks the change as CI-only with no operator or crate-consumer impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304dba120c015de470dfb093796447d56028c4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->