### PR TITLE
ci: run coverage weekly without caching

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,22 +1,10 @@
 name: Coverage
 
 on:
-  # Coverage is a 120-minute instrumented full build. Keep it off the per-push
-  # critical path: run it only on landings to the long-lived branches, once a
-  # night, and on demand. Pushes to short-lived dev branches no longer trigger
-  # it (it is not a merge gate).
-  push:
-    branches: [main, "release/**"]
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - .config/nextest.toml
-      - codecov.yml
-      - .github/workflows/coverage.yml
-
+  # Coverage is an expensive instrumented full build and is not a merge gate.
+  # Run it once a week on Sunday and allow maintainers to trigger it on demand.
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 8 * * 0"
 
   workflow_dispatch:
 
@@ -57,7 +45,8 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
-          cache-on-failure: true
+          # Avoid reserving about 1.2 GB for this infrequent workflow.
+          cache: false
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-llvm-cov,nextest

--- a/changelog-unreleased/359.md
+++ b/changelog-unreleased/359.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes continuous integration and has no operator- or
+crate-consumer-visible effect.


### PR DESCRIPTION
## Motivation

Coverage currently runs after relevant pushes to `main` and release branches,
as well as every night. Its instrumented build also reserves a separate
1.273 GB Actions cache. Coverage is not a merge gate, so this frequency and
cache allocation are unnecessary for now.

## Solution

- Remove automatic push-triggered coverage runs.
- Change the nightly schedule to Sunday at 08:00 UTC.
- Keep `workflow_dispatch` so maintainers can run coverage on demand.
- Disable Rust caching for coverage runs.

The tradeoff is less frequent Codecov data and a cold instrumented build for
weekly or manually triggered runs.

## Testing

- `git diff --check`
- Parsed `.github/workflows/coverage.yml` with Ruby's YAML parser.
- `npx --yes markdownlint-cli changelog-unreleased/359.md --config
  .trunk/configs/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `./scripts/changelog.py check-pr --base origin/main --head HEAD --pr 359`

## Changelog

`changelog-unreleased/359.md` marks this internal CI-only change as having no
operator- or crate-consumer-visible effect.

### Follow-up Work

Delete the existing `v0-rust-coverage-*` cache after this PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI scheduling and cache settings only; no application, auth, or release artifact logic changes.
> 
> **Overview**
> **Coverage** no longer runs on pushes to `main` or `release/**` (including path-filtered Rust changes). It is limited to **weekly** runs (Sunday 08:00 UTC) plus **`workflow_dispatch`**, with comments updated to match.
> 
> The **Rust toolchain setup** for coverage disables Actions cache (`cache: false`) instead of `cache-on-failure`, avoiding ~1.2 GB reserved for this infrequent job.
> 
> A **changelog fragment** marks the change as CI-only with no operator or crate-consumer impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553deb2df6e24cdee1dad159d0c4003fb87288d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->