### PR TITLE
test(state): await chain tip notifications

### DIFF
--- a/changelog-unreleased/362.md
+++ b/changelog-unreleased/362.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes test synchronization and has no operator- or
+crate-consumer-visible effect.

--- a/zakura-state/src/service/tests.rs
+++ b/zakura-state/src/service/tests.rs
@@ -6,7 +6,7 @@
 
 use std::{env, sync::Arc, time::Duration};
 
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, time::timeout};
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 
 use zakura_chain::{
@@ -36,7 +36,7 @@ use crate::{
         FakeChainHelper,
     },
     BoxError, CheckpointVerifiedBlock, Config, ReadRequest, ReadResponse, Request, Response,
-    SemanticallyVerifiedBlock,
+    SemanticallyVerifiedBlock, CHAIN_TIP_UPDATE_WAIT_LIMIT,
 };
 
 const LAST_BLOCK_HEIGHT: u32 = 10;
@@ -1094,7 +1094,8 @@ proptest! {
     ) {
         let _init_guard = zakura_test::init();
 
-        let (mut state_service, _read_only_state_service, latest_chain_tip, mut chain_tip_change) = Runtime::new().unwrap().block_on(async {
+        let runtime = Runtime::new().unwrap();
+        let (mut state_service, _read_only_state_service, latest_chain_tip, mut chain_tip_change) = runtime.block_on(async {
             // We're waiting to verify each block here, so we don't need the maximum checkpoint height.
             StateService::new(Config::ephemeral(), &network, Height::MAX, 0).await
         });
@@ -1121,12 +1122,16 @@ proptest! {
 
             prop_assert!(result.is_ok(), "unexpected failed finalized block commit: {:?}", result);
 
-            // Wait for the channels to be updated by the block commit task.
-            // TODO: add a blocking method on ChainTipChange
-            std::thread::sleep(Duration::from_secs(1));
+            let actual_action = runtime
+                .block_on(timeout(
+                    CHAIN_TIP_UPDATE_WAIT_LIMIT,
+                    chain_tip_change.wait_for_tip_change(),
+                ))
+                .expect("tip change arrives because the committed block updates the channel")
+                .expect("tip sender remains open while the state service is alive");
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
+            prop_assert_eq!(actual_action, expected_action);
         }
 
         for block in non_finalized_blocks {
@@ -1142,12 +1147,16 @@ proptest! {
 
             prop_assert!(result.is_ok(), "unexpected failed non-finalized block commit: {:?}", result);
 
-            // Wait for the channels to be updated by the block commit task.
-            // TODO: add a blocking method on ChainTipChange
-            std::thread::sleep(Duration::from_secs(1));
+            let actual_action = runtime
+                .block_on(timeout(
+                    CHAIN_TIP_UPDATE_WAIT_LIMIT,
+                    chain_tip_change.wait_for_tip_change(),
+                ))
+                .expect("tip change arrives because the committed block updates the channel")
+                .expect("tip sender remains open while the state service is alive");
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
+            prop_assert_eq!(actual_action, expected_action);
         }
     }
 }

--- a/zakura-state/src/service/tests.rs
+++ b/zakura-state/src/service/tests.rs
@@ -1123,10 +1123,13 @@ proptest! {
             prop_assert!(result.is_ok(), "unexpected failed finalized block commit: {:?}", result);
 
             let actual_action = runtime
-                .block_on(timeout(
-                    CHAIN_TIP_UPDATE_WAIT_LIMIT,
-                    chain_tip_change.wait_for_tip_change(),
-                ))
+                .block_on(async {
+                    timeout(
+                        CHAIN_TIP_UPDATE_WAIT_LIMIT,
+                        chain_tip_change.wait_for_tip_change(),
+                    )
+                    .await
+                })
                 .expect("tip change arrives because the committed block updates the channel")
                 .expect("tip sender remains open while the state service is alive");
 
@@ -1148,10 +1151,13 @@ proptest! {
             prop_assert!(result.is_ok(), "unexpected failed non-finalized block commit: {:?}", result);
 
             let actual_action = runtime
-                .block_on(timeout(
-                    CHAIN_TIP_UPDATE_WAIT_LIMIT,
-                    chain_tip_change.wait_for_tip_change(),
-                ))
+                .block_on(async {
+                    timeout(
+                        CHAIN_TIP_UPDATE_WAIT_LIMIT,
+                        chain_tip_change.wait_for_tip_change(),
+                    )
+                    .await
+                })
                 .expect("tip change arrives because the committed block updates the channel")
                 .expect("tip sender remains open while the state service is alive");
 


### PR DESCRIPTION
## Motivation

`chain_tip_sender_is_updated` takes about 45 seconds because it sleeps for one second after each block commit across four proptest cases. The sleeps mask the asynchronous channel update instead of synchronizing with it directly.

## Solution

Keep the Tokio runtime alive for the test and await each `ChainTipChange` notification with the existing two-second timeout. Assert the returned `TipAction` directly.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-state --lib chain_tip_sender_is_updated -- --nocapture`
  - Before: 44.81s
  - After: 0.79s (98.2% faster)
- CI-recorded test time: 0.780s
- Unit Tests passed three consecutive executions on commit `1d4347666`:
  - Original run (attempt 1)
  - Manual rerun 1 (attempt 2)
  - Manual rerun 2 (attempt 3)
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/362.md --config .trunk/configs/.markdownlint.yaml`

## Changelog

Added `changelog-unreleased/362.md` with the explicit no-changelog marker because this only changes internal test synchronization.

### Specifications & References

None.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change; production state service behavior is unchanged.
> 
> **Overview**
> **`chain_tip_sender_is_updated`** no longer sleeps one second after each finalized or non-finalized block commit. It keeps a single Tokio runtime for the test and, after each commit, awaits **`ChainTipChange::wait_for_tip_change()`** inside **`timeout(CHAIN_TIP_UPDATE_WAIT_LIMIT)`**, then asserts the returned **`TipAction`** matches the expected grow/reset action.
> 
> A changelog entry marks this as test-only with no operator or crate-consumer impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d43476662b1d593ea55d2c33ec0e4fa80148dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->