### PR TITLE
test(acceptance): wait for ephemeral state startup

### DIFF
--- a/changelog-unreleased/366.md
+++ b/changelog-unreleased/366.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -520,9 +520,11 @@ fn ephemeral(cache_dir_config: EphemeralConfig, cache_dir_check: EphemeralCheck)
     let mut child = run_dir
         .path()
         .with_config(&mut config)?
-        .spawn_child(args!["start"])?;
-    // Run the program and kill it after a few seconds
-    std::thread::sleep(EXTENDED_LAUNCH_DELAY);
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
+
+    // Wait until ephemeral state initialization has completed.
+    child.expect_stdout_line_matches("loaded Zakura state cache")?;
     child.kill(false)?;
     let output = child.wait_with_output()?;
 


### PR DESCRIPTION
## Motivation

The four ephemeral state directory acceptance tests each waited for a fixed 45-second launch delay. Their assertions only require state initialization to have completed, so most of that delay was idle time.

## Solution

Wait for the existing loaded Zakura state cache log message instead. Keep the 45-second extended launch delay as the failure timeout, preserving tolerance for slow CI runners while allowing successful tests to continue immediately.

## Testing

- cargo fmt --all -- --check
- cargo test -p zakura --test acceptance ephemeral_
- Repeated the four-test run twice; all four variants passed both times.
- Warm local run completed the four tests in 6.89 seconds total.
- ./scripts/changelog.py check

## Changelog

Added changelog-unreleased/366.md with an explicit no-changelog marker because this PR only changes internal tests.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing change in acceptance tests; no production or public API impact.
> 
> **Overview**
> **Ephemeral state acceptance tests** (`ephemeral` helper and its four variants) no longer block on a fixed **45s** `EXTENDED_LAUNCH_DELAY` before killing `zakurad`. The child process gets **`with_timeout(EXTENDED_LAUNCH_DELAY)`** so log waits still fail on slow CI, and the test **waits for stdout** matching **`loaded Zakura state cache`** before shutdown.
> 
> Adds **`changelog-unreleased/366.md`** with a **no-changelog** marker (tests only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6870c3c4e8c2385e821f400e9437341819f789f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->