### PR TITLE
test(acceptance): replace launch sleeps with readiness waits

### DIFF
--- a/changelog-unreleased/369.md
+++ b/changelog-unreleased/369.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -1188,6 +1188,7 @@ async fn sync_checkpoints_local() -> Result<()> {
     let producer_network = Network::new_regtest(RegtestParameters::default());
     let producer_p2p_addr = format!("127.0.0.1:{}", random_known_port()).parse()?;
     let mut producer_config = os_assigned_rpc_port_config(false, &producer_network)?;
+    producer_config.mempool.debug_enable_at_height = Some(0);
     producer_config.network.listen_addr = producer_p2p_addr;
     producer_config.network.initial_testnet_peers = [].into();
     producer_config.network.cache_dir = false.into();
@@ -1197,7 +1198,7 @@ async fn sync_checkpoints_local() -> Result<()> {
         .spawn_child(args!["start"])?
         .with_timeout(LARGE_CHECKPOINT_TIMEOUT);
     let producer_rpc_addr = read_listen_addr_from_logs(&mut producer, OPENED_RPC_ENDPOINT_MSG)?;
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    producer.expect_stdout_line_matches("activating mempool")?;
 
     let producer_rpc =
         RpcRequestClient::new_with_timeout(producer_rpc_addr, Duration::from_secs(15 * 60));
@@ -1478,11 +1479,10 @@ async fn metrics_endpoint() -> Result<()> {
     config.metrics.endpoint_addr = Some(endpoint.parse().unwrap());
 
     let dir = testdir()?.with_config(&mut config)?;
-    let child = dir.spawn_child(args!["start"])?;
-
-    // Run `zakurad` for a few seconds before testing the endpoint
-    // Since we're an async function, we have to use a sleep future, not thread sleep.
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    let mut child = dir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
+    child.expect_stdout_line_matches(format!("Opened metrics endpoint at {endpoint}"))?;
 
     // Create an http client
     let client: Client<_, Full<Bytes>> = Client::builder(TokioExecutor::new()).build_http();
@@ -1514,9 +1514,6 @@ async fn metrics_endpoint() -> Result<()> {
     )?;
     std::str::from_utf8(&body).expect("unexpected invalid UTF-8 in metrics exporter response");
 
-    // Make sure metrics was started
-    output.stdout_line_contains(format!("Opened metrics endpoint at {endpoint}").as_str())?;
-
     // [Note on port conflict](#Note on port conflict)
     output
         .assert_was_killed()
@@ -1547,11 +1544,10 @@ async fn tracing_endpoint() -> Result<()> {
     config.tracing.endpoint_addr = Some(endpoint.parse().unwrap());
 
     let dir = testdir()?.with_config(&mut config)?;
-    let child = dir.spawn_child(args!["start"])?;
-
-    // Run `zakurad` for a few seconds before testing the endpoint
-    // Since we're an async function, we have to use a sleep future, not thread sleep.
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    let mut child = dir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
+    child.expect_stdout_line_matches(format!("Opened tracing endpoint at {endpoint}"))?;
 
     // Create an http client
     let client: Client<_, Full<Bytes>> = Client::builder(TokioExecutor::new()).build_http();
@@ -1601,10 +1597,6 @@ async fn tracing_endpoint() -> Result<()> {
 
     let output = child.wait_with_output()?;
     let output = output.assert_failure()?;
-
-    // Make sure tracing endpoint was started
-    output.stdout_line_contains(format!("Opened tracing endpoint at {endpoint}").as_str())?;
-    // TODO: Match some trace level messages from output
 
     // Make sure the endpoint header is correct
     // The header is split over two lines. But we don't want to require line
@@ -3083,10 +3075,10 @@ async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()>
 
     let mut block_builder = testdir()?
         .with_config(&mut config)?
-        .spawn_child(args!["start"])?;
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     let rpc_address = read_listen_addr_from_logs(&mut block_builder, OPENED_RPC_ENDPOINT_MSG)?;
-
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    block_builder.expect_stdout_line_matches("activating mempool")?;
 
     let client = RpcRequestClient::new(rpc_address);
     let mut blocks = Vec::new();
@@ -3103,10 +3095,10 @@ async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()>
 
     let mut zakurad = testdir()?
         .with_config(&mut config)?
-        .spawn_child(args!["start"])?;
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     let rpc_address = read_listen_addr_from_logs(&mut zakurad, OPENED_RPC_ENDPOINT_MSG)?;
-
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    zakurad.expect_stdout_line_matches("activating mempool")?;
 
     let client = RpcRequestClient::new(rpc_address);
     client.submit_block(blocks[0].clone()).await?;
@@ -3345,7 +3337,8 @@ async fn pruned_storage_mode_prunes_during_regtest_sync() -> Result<()> {
 
     let mut zakurad = testdir()?
         .with_config(&mut config)?
-        .spawn_child(args!["start"])?;
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     let rpc_address = read_listen_addr_from_logs(&mut zakurad, OPENED_RPC_ENDPOINT_MSG)?;
     // `with_config` set the state cache dir to the test directory; keep the
     // `TempDir` alive so we can reopen the database after shutdown.
@@ -3355,7 +3348,7 @@ async fn pruned_storage_mode_prunes_during_regtest_sync() -> Result<()> {
         .take()
         .expect("zakurad should have a test directory");
 
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    zakurad.expect_stdout_line_matches("activating mempool")?;
 
     let client = RpcRequestClient::new(rpc_address);
 
@@ -3450,10 +3443,6 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
     let mut child = test_dir.spawn_child(args!["start"])?;
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
     let indexer_listen_addr = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
-
-    tracing::info!("waiting for Zakura state cache to be opened");
-
-    tokio::time::sleep(LAUNCH_DELAY).await;
 
     tracing::info!("starting read state with syncer");
     // Spawn a read state with the RPC syncer to check that it has the same best chain as Zebra
@@ -3673,10 +3662,6 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
     let mut child = test_dir.spawn_child(args!["start"])?;
     let _rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
     let indexer_listen_addr = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
-
-    tracing::info!("waiting for Zakura state cache to be opened");
-
-    tokio::time::sleep(LAUNCH_DELAY).await;
 
     tracing::info!("starting read state with syncer");
     // Spawn a read state with the RPC syncer to check that it has the same best chain as Zebra
@@ -4211,15 +4196,15 @@ async fn invalidate_and_reconsider_block() -> Result<()> {
     );
     let mut config = os_assigned_rpc_port_config(false, &net)?;
     config.state.ephemeral = false;
+    config.mempool.debug_enable_at_height = Some(0);
 
     let test_dir = testdir()?.with_config(&mut config)?;
 
-    let mut child = test_dir.spawn_child(args!["start"])?;
+    let mut child = test_dir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
-
-    tracing::info!("waiting for Zakura state cache to be opened");
-
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    child.expect_stdout_line_matches("activating mempool")?;
 
     let rpc_client = RpcRequestClient::new(rpc_address);
     let mut blocks = Vec::new();
@@ -4615,23 +4600,24 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
 
     tracing::info!("waiting for zakurad nodes to connect");
 
-    // Wait a few seconds for Zebra to start up and make outbound peer connections
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    let peer_info = tokio::time::timeout(EXTENDED_LAUNCH_DELAY, async {
+        loop {
+            if let Ok(peer_info) = rpc_client_2
+                .json_result_from_call::<Vec<PeerInfo>>("getpeerinfo", "[]")
+                .await
+            {
+                if !peer_info.is_empty() {
+                    break peer_info;
+                }
+            }
 
-    tracing::info!("checking for peers");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .map_err(|_| eyre!("zakurad nodes did not connect before the launch timeout"))?;
 
-    // Call `getpeerinfo` to check that the zakurad instances have connected
-    let peer_info: Vec<PeerInfo> = rpc_client_2
-        .json_result_from_call("getpeerinfo", "[]")
-        .await
-        .map_err(|err| eyre!(err))?;
-
-    assert!(!peer_info.is_empty(), "should have outbound peer");
-
-    tracing::info!(
-        ?peer_info,
-        "found peer connection, committing genesis block"
-    );
+    tracing::info!(?peer_info, "found peer connection, committing genesis block");
 
     let genesis_block = network1.block_parsed_iter().next().unwrap();
     rpc_client_1.submit_block(genesis_block.clone()).await?;

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -4617,7 +4617,10 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
     .await
     .map_err(|_| eyre!("zakurad nodes did not connect before the launch timeout"))?;
 
-    tracing::info!(?peer_info, "found peer connection, committing genesis block");
+    tracing::info!(
+        ?peer_info,
+        "found peer connection, committing genesis block"
+    );
 
     let genesis_block = network1.block_parsed_iter().next().unwrap();
     rpc_client_1.submit_block(genesis_block.clone()).await?;

--- a/zakurad/tests/common/coinbase.rs
+++ b/zakurad/tests/common/coinbase.rs
@@ -27,7 +27,7 @@ use zakurad::components::With;
 
 use super::{
     config::{os_assigned_rpc_port_config, read_listen_addr_from_logs, testdir},
-    launch::{ZakuradTestDirExt, LAUNCH_DELAY},
+    launch::{ZakuradTestDirExt, EXTENDED_LAUNCH_DELAY},
     regtest::MiningRpcMethods,
 };
 
@@ -63,14 +63,14 @@ pub(crate) async fn regtest_coinbase() -> eyre::Result<()> {
 
         let mut zakurad = testdir()?
             .with_config(&mut config)?
-            .spawn_child(args!["start"])?;
-
-        tokio::time::sleep(LAUNCH_DELAY).await;
+            .spawn_child(args!["start"])?
+            .with_timeout(EXTENDED_LAUNCH_DELAY);
 
         let client = RpcRequestClient::new(read_listen_addr_from_logs(
             &mut zakurad,
             OPENED_RPC_ENDPOINT_MSG,
         )?);
+        zakurad.expect_stdout_line_matches("activating mempool")?;
 
         for _ in 0..2 {
             let (mut block, height) = client.block_from_template(&net).await?;

--- a/zakurad/tests/common/regtest.rs
+++ b/zakurad/tests/common/regtest.rs
@@ -28,7 +28,7 @@ use zakura_test::args;
 
 use crate::common::{
     config::{os_assigned_rpc_port_config, read_listen_addr_from_logs, testdir},
-    launch::{ZakuradTestDirExt, LAUNCH_DELAY},
+    launch::{ZakuradTestDirExt, EXTENDED_LAUNCH_DELAY},
 };
 
 /// Number of blocks that should be submitted before the test is considered successful.
@@ -49,11 +49,11 @@ pub(crate) async fn submit_blocks_test() -> Result<()> {
 
     let mut zakurad = testdir()?
         .with_config(&mut config)?
-        .spawn_child(args!["start"])?;
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
 
     let rpc_address = read_listen_addr_from_logs(&mut zakurad, OPENED_RPC_ENDPOINT_MSG)?;
-
-    tokio::time::sleep(LAUNCH_DELAY).await;
+    zakurad.expect_stdout_line_matches("activating mempool")?;
 
     let client = RpcRequestClient::new(rpc_address);
 

--- a/zakurad/tests/common/zcashd_compat/launch.rs
+++ b/zakurad/tests/common/zcashd_compat/launch.rs
@@ -21,7 +21,7 @@ use super::{
 };
 use crate::common::{
     config::{read_listen_addr_from_logs, testdir},
-    launch::{ZakuradTestDirExt, LAUNCH_DELAY},
+    launch::ZakuradTestDirExt,
 };
 
 /// How long to poll zcashd's own RPC before giving up.
@@ -155,9 +155,6 @@ pub async fn spawn_zakurad_with_zcashd_compat_config(
     ])?;
 
     let _ = read_listen_addr_from_logs(&mut zakurad, OPENED_RPC_ENDPOINT_MSG)?;
-
-    // Extra stability margin before poking zcashd
-    sleep(LAUNCH_DELAY).await;
 
     let zakura_client = RpcRequestClient::new(zakura_rpc_addr);
     let zcashd_client = ZcashdRpcClient::new(


### PR DESCRIPTION
## Motivation

Several acceptance helpers waited a fixed 20-second launch delay after starting zakurad, even when the test had a precise readiness event or an RPC endpoint it could poll. These waits make successful tests slow and still do not prove that the required component is ready.

## Solution

Replace every awaited LAUNCH_DELAY associated with spawned test nodes by the relevant bounded readiness condition:

- wait for the RPC endpoint and mempool activation before block generation;
- wait for metrics and tracing endpoints before making HTTP requests;
- rely on existing chain-tip notification timeouts for state-sync tests;
- poll managed zcashd RPC and peer connectivity using existing deadlines.

The two-block, three-address regtest coinbase coverage remains unchanged.

## Testing

- cargo fmt --all -- --check
- ./scripts/changelog.py check
- regtest_coinbase: passed in 31.36s
- metrics_endpoint: passed in 4.39s
- tracing_endpoint with filter-reload: passed in 5.94s
- rejected_block_does_not_reject_same_hash_block_children: passed in 14.81s
- trusted_chain_sync_handles_forks_correctly: passed in 8.00s
- invalidate_and_reconsider_block: passed in 9.88s
- regtest_block_templates_are_valid_block_submissions: passed in 10.18s
- pruned_storage_mode_prunes_during_regtest_sync: passed in 23.58s

The ignored checkpoint, misbehaving-peer, and managed-zcashd paths compile successfully but require their specialized slow or external test environments.

## Changelog

Added changelog-unreleased/369.md with an explicit no-changelog marker because this PR only changes internal tests.

### Follow-up Work

Fixed synchronous launch sleeps and behavior-specific delays are outside this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness changes; no production code paths modified.
> 
> **Overview**
> **Acceptance tests no longer burn ~20s on a fixed `LAUNCH_DELAY` after spawning `zakurad`.** They now block on concrete readiness signals and existing timeouts instead.
> 
> Regtest/mining paths wait for **"activating mempool"** (with `mempool.debug_enable_at_height = Some(0)` where needed) after RPC listen addresses are parsed. Metrics and tracing tests wait for the **"Opened … endpoint"** log before HTTP calls, using `with_timeout(EXTENDED_LAUNCH_DELAY)` on the child. The misbehaving-peer test **polls `getpeerinfo`** until peers exist, bounded by `EXTENDED_LAUNCH_DELAY`.
> 
> State-sync tests drop the extra **"waiting for state cache"** sleep and rely on chain-tip notification timeouts. Managed zcashd-compat setup drops the post-RPC sleep before `wait_for_zcashd_rpc`. A changelog entry marks **no operator-visible changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e06971d801161545463e8baf5bb008c3d6871a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->