### PR TITLE
chore(docs): remove obsolete KaTeX header

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,6 @@
 # /docker/                                @ZcashFoundation/devops-reviewers
 # cloudbuild.yaml                         @ZcashFoundation/devops-reviewers
 # codecov.yml                             @ZcashFoundation/devops-reviewers
-# katex-header.html                       @ZcashFoundation/devops-reviewers
 
 # Unsafe Code
 # /zakura-script/                          @ZcashFoundation/unsafe-rust-reviewers

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,7 +143,7 @@ jobs:
         env:
           # The -A and -W settings must be the same as the `rustdocflags` in:
           # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L87
-          RUSTDOCFLAGS: --html-in-header katex-header.html -A rustdoc::private_intra_doc_links -D warnings
+          RUSTDOCFLAGS: -A rustdoc::private_intra_doc_links -D warnings
 
   fmt:
     name: fmt

--- a/changelog-unreleased/370.md
+++ b/changelog-unreleased/370.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only removes obsolete documentation rendering infrastructure and has
+no operator- or crate-consumer-visible effect.

--- a/katex-header.html
+++ b/katex-header.html
@@ -1,8 +1,0 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
-<style>
-.katex { font-size: 1em !important; }
-pre.rust, .docblock code, .docblock-short code { font-size: 0.85em !important; }
-</style>
-


### PR DESCRIPTION
## Motivation

katex-header.html was added for a temporary rustdoc formula test in 2020. That formula was removed shortly afterward, and the repository no longer contains rustdoc using KaTeX delimiters.

## Solution

Delete katex-header.html, stop injecting it into the advisory rustdoc build, and remove its stale CODEOWNERS entry. Preserve the existing rustdoc warning flags.

## Testing

- PASS: ./scripts/changelog.py check
- PASS: ./scripts/changelog.py check-pr --base origin/main --head HEAD --pr 370
- PASS: python3 -m unittest discover -s scripts/tests -p test_changelog.py
- PASS: Markdown lint for changelog-unreleased/370.md
- PASS: YAML syntax validation for .github/workflows/lint.yml
- PASS: git diff --check origin/main...HEAD
- PASS: repository search confirms no remaining KaTeX or katex-header.html references

Rust compilation was skipped because this PR only removes documentation rendering infrastructure and adjusts CI configuration.

## Changelog

- Added changelog-unreleased/370.md with an explicit no-changelog marker because this cleanup has no operator- or crate-consumer-visible effect.

### Specifications & References

- The original KaTeX change was introduced by #832 as a temporary rendering test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/CI-only cleanup with no runtime, auth, or dependency changes.
> 
> **Overview**
> Removes leftover **KaTeX** rustdoc plumbing from a 2020 experiment: deletes `katex-header.html` and stops passing `--html-in-header katex-header.html` in the nightly **docs** job’s `RUSTDOCFLAGS`, while keeping the same warning flags (`-A rustdoc::private_intra_doc_links -D warnings`).
> 
> Also drops the stale **CODEOWNERS** line for that file and adds `changelog-unreleased/370.md` marked as no user-visible changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27a4c92e25af6714b59f81c2a1810570bd82a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->