### PR TITLE
ci: avoid redundant PR checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,8 @@
 ## Changelog
 
 <!--
-- Add changelog-unreleased/<PR-number>.md after opening the draft PR.
+- For Rust or Cargo.toml changes, add changelog-unreleased/<PR-number>.md after
+  opening the draft PR.
 - Use the explicit no-changelog marker for internal-only changes.
 -->
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,7 @@ These workflows run on pull requests, pushes to `main` / `feat/**` / `release/**
 | `zakura-e2e.yml` | The heaviest PR-path job, isolated in its own workflow: regtest docker-compose end-to-end gate, multi-node testkit test, block-sync fuzz on every push to `main`, and long four-node modes nightly. PR runs are gated by a `changes` job or the `run-zakura-e2e` label. | PR/push (self-gated), merge queue, nightly, manual |
 | `status-checks.patch.yml` | Empty jobs with the same names as required checks, so branch protection passes when path filters skip `lint.yml` / `tests-unit.yml` / `test-crates.yml`. Its `paths-ignore` list **must stay the exact inverse** of those workflows' `paths`. | PR on non-Rust paths only |
 | `docs-check.yml` | markdownlint, codespell, and lychee link checking over all Markdown. | PR/push on Markdown paths |
-| `changelog.yml` | Validates the one-fragment-per-PR contract and tests release assembly. | Every PR/push/merge group |
+| `changelog.yml` | Requires one fragment for Rust/Cargo.toml PRs and tests release assembly. | Every PR/push/merge group |
 | `coverage.yml` | llvm-cov + nextest coverage uploaded to Codecov. A 120-minute instrumented build, kept off the PR path. | Push to `main`/`release/**`, nightly, manual |
 | `benchmarks.yml` | Criterion benchmarks. Runs on PRs carrying the `C-benchmark` label; results publish to the dashboard data on `gh-pages/dev/bench`. | Labeled PRs, manual |
 | `zcashd-compat-regtest.yml` | zcashd interoperability regtest suite (spawns fresh `zakurad` + `zcashd`, no external infrastructure). **Temporarily manual-only**: see the workflow header for the sidecar-zcashd re-enable condition. | Manual |

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -3,7 +3,7 @@ name: Test Docker Config
 on:
   pull_request:
     branches: [main, "feat/**", "release/**"]
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -3,7 +3,7 @@ name: Unit Tests
 on:
   pull_request:
     branches: [main, "feat/**", "release/**"]
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/zakura-e2e.yml
+++ b/.github/workflows/zakura-e2e.yml
@@ -18,7 +18,7 @@ on:
   #   the merged PR did not touch an obviously Zakura-specific path.
   pull_request:
     branches: [main, "feat/**", "release/**"]
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
   push:
     branches: [main, "feat/**", "release/**"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,10 @@ cargo nextest run --profile sync-large-checkpoints-empty
 
 - PR titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) (PRs are squash-merged — the PR title becomes the commit message)
 - Use `.github/pull_request_template.md`. For fixes, connect the root cause to both the solution and the test coverage.
-- Every ordinary PR adds one `changelog-unreleased/<PR-number>.md` fragment,
-  including an explicit no-changelog fragment for internal-only work. Do not
-  edit the shared changelog in ordinary PRs. See `CHANGELOG_GUIDELINES.md`.
+- Every PR that changes a Rust source file or any `Cargo.toml` adds one
+  `changelog-unreleased/<PR-number>.md` fragment, including an explicit
+  no-changelog fragment for internal-only work. Do not edit the shared
+  changelog in ordinary PRs. See `CHANGELOG_GUIDELINES.md`.
 
 ## Project Overview
 
@@ -175,8 +176,8 @@ cargo nextest run --profile sync-large-checkpoints-empty
 
 ## Changelog
 
-- After opening a draft PR, add exactly one
-  `changelog-unreleased/<PR-number>.md` file for that PR.
+- After opening a draft PR that changes a Rust source file or any `Cargo.toml`,
+  add exactly one `changelog-unreleased/<PR-number>.md` file for that PR.
 - Put user-visible `zakurad` entries under the appropriate Keep a Changelog
   category heading.
 - For internal-only work, use `<!-- changelog: none -->` and explain why.

--- a/CHANGELOG_GUIDELINES.md
+++ b/CHANGELOG_GUIDELINES.md
@@ -33,12 +33,13 @@ no earlier Zakura releases to describe deltas against:
 
 After v1.0.0, normal changelog maintenance (everything below) resumes.
 
-## One fragment per pull request
+## One fragment per Rust pull request
 
-Ordinary PRs do not edit the shared root changelog. After opening a draft PR,
-add exactly one `changelog-unreleased/<PR-number>.md` file. Keeping each PR in
-its own file avoids merge conflicts while preserving the link between the
-change, its review, and its release note.
+PRs that change a Rust source file or any `Cargo.toml` do not edit the shared
+root changelog. After opening a draft PR, add exactly one
+`changelog-unreleased/<PR-number>.md` file. Keeping each PR in its own file
+avoids merge conflicts while preserving the link between the change, its
+review, and its release note. Other PRs do not need a fragment.
 
 A user-visible fragment contains one or more Keep a Changelog categories:
 
@@ -49,8 +50,8 @@ A user-visible fragment contains one or more Keep a Changelog categories:
   ([#123](https://github.com/zakura-core/zakura/pull/123)).
 ```
 
-Internal-only PRs still own a fragment, but use an explicit exclusion with a
-reason:
+Internal-only Rust or `Cargo.toml` PRs still own a fragment, but use an explicit
+exclusion with a reason:
 
 ```markdown
 <!-- changelog: none -->
@@ -58,9 +59,9 @@ reason:
 This PR only changes tests and has no operator-visible effect.
 ```
 
-Dependabot and release PRs are the only automated exceptions to the one-file
-check. The `C-exclude-from-changelog` label remains useful release metadata,
-but does not replace the explicit fragment for ordinary PRs.
+Dependabot and release PRs are automated exceptions to the one-file check. The
+`C-exclude-from-changelog` label remains useful release metadata, but does not
+replace the explicit fragment for Rust or `Cargo.toml` PRs.
 
 Run `./scripts/changelog.py check` locally. CI validates the syntax and checks
 that the fragment filename matches the PR number. The concise format reference
@@ -73,8 +74,8 @@ is in
   follow [Semantic Versioning](https://semver.org).
 - Add a fragment entry in the same PR as any **user-visible** change: behavior,
   RPCs, command-line, configuration, performance, or supported platforms.
-- Use the explicit no-changelog fragment for internal-only changes such as
-  refactors, CI, tests, and docs.
+- Use the explicit no-changelog fragment for internal-only Rust or
+  `Cargo.toml` changes such as refactors and tests.
 - Categories: `### Added`, `### Changed`, `### Deprecated`, `### Removed`,
   `### Fixed`, `### Security`. Prefer `Fixed` if you're not sure.
 - Write for node operators: describe the observable effect, not the

--- a/changelog-unreleased/371.md
+++ b/changelog-unreleased/371.md
@@ -1,4 +1,0 @@
-<!-- changelog: none -->
-
-This PR only changes continuous-integration triggers and has no operator- or
-crate-consumer-visible effect.

--- a/changelog-unreleased/371.md
+++ b/changelog-unreleased/371.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes continuous-integration triggers and has no operator- or
+crate-consumer-visible effect.

--- a/changelog-unreleased/README.md
+++ b/changelog-unreleased/README.md
@@ -1,11 +1,13 @@
 # Changelog fragments
 
-Every ordinary pull request owns exactly one file in this directory. This
-keeps concurrent work out of the shared changelogs and makes the unreleased
-notes reviewable with the change that introduced them.
+Every pull request that changes a Rust source file or any `Cargo.toml` owns
+exactly one file in this directory. This keeps concurrent work out of the
+shared changelogs and makes the unreleased notes reviewable with the change
+that introduced them. Other pull requests do not need a fragment.
 
-After opening a draft PR, create `changelog-unreleased/<PR-number>.md`. Put
-each operator-visible change under its Keep a Changelog category:
+After opening a draft Rust or `Cargo.toml` PR, create
+`changelog-unreleased/<PR-number>.md`. Put each operator-visible change under
+its Keep a Changelog category:
 
 ```markdown
 ## Fixed
@@ -22,7 +24,8 @@ Write complete Keep a Changelog list items, including the PR link. Multiple
 changes and categories belong in the same fragment. Parameter changes still
 need a row in `CHANGELOG_PARAMS.md`.
 
-For an internal-only PR, use an explicit marker and explain the exclusion:
+For an internal-only Rust or `Cargo.toml` PR, use an explicit marker and
+explain the exclusion:
 
 ```markdown
 <!-- changelog: none -->

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -368,11 +368,16 @@ def check_pull_request(
             )
         return
 
-    changed = run_git(
+    changed_paths = run_git(
         repo_root,
-        ["diff", "--name-only", base, head, "--", FRAGMENT_DIRECTORY],
+        ["diff", "--name-only", base, head],
     ).splitlines()
-    changed = [path for path in changed if path != f"{FRAGMENT_DIRECTORY}/README.md"]
+    changed = [
+        path
+        for path in changed_paths
+        if path.startswith(f"{FRAGMENT_DIRECTORY}/")
+        and path != f"{FRAGMENT_DIRECTORY}/README.md"
+    ]
     expected = f"{FRAGMENT_DIRECTORY}/{pull_request}.md"
     unexpected = [path for path in changed if path != expected]
     if unexpected:
@@ -380,7 +385,11 @@ def check_pull_request(
             "each PR owns one fragment; unexpected fragment changes: "
             + ", ".join(unexpected)
         )
-    if expected not in changed and not allow_missing:
+    changes_rust = any(
+        Path(path).suffix == ".rs" or Path(path).name == "Cargo.toml"
+        for path in changed_paths
+    )
+    if expected not in changed and not allow_missing and changes_rust:
         raise ChangelogError(
             f"add {expected}; use {NO_CHANGELOG_MARKER} for an internal-only PR"
         )

--- a/scripts/tests/test_changelog.py
+++ b/scripts/tests/test_changelog.py
@@ -99,6 +99,38 @@ class ChangelogTests(unittest.TestCase):
                     self.root, "base", "head", "123", False, False
                 )
 
+    def test_rust_pull_request_requires_fragment(self):
+        with mock.patch.object(
+            changelog,
+            "run_git",
+            return_value="zakura-chain/src/lib.rs\n",
+        ):
+            with self.assertRaisesRegex(changelog.ChangelogError, "add .*123.md"):
+                changelog.check_pull_request(
+                    self.root, "base", "head", "123", False, False
+                )
+
+    def test_cargo_toml_pull_request_requires_fragment(self):
+        with mock.patch.object(
+            changelog,
+            "run_git",
+            return_value="zakura-chain/Cargo.toml\n",
+        ):
+            with self.assertRaisesRegex(changelog.ChangelogError, "add .*123.md"):
+                changelog.check_pull_request(
+                    self.root, "base", "head", "123", False, False
+                )
+
+    def test_non_rust_pull_request_does_not_require_fragment(self):
+        with mock.patch.object(
+            changelog,
+            "run_git",
+            return_value=".github/workflows/changelog.yml\nCargo.lock\n",
+        ):
+            changelog.check_pull_request(
+                self.root, "base", "head", "123", False, False
+            )
+
     def test_release_versions_root_changelog_and_consumes_fragments(self):
         path = self.root / "changelog-unreleased" / "123.md"
         path.write_text(


### PR DESCRIPTION
## Motivation

Draft PRs already run CI when opened and whenever their head changes. Moving an unchanged PR to ready for review currently starts duplicate Unit Tests, Test Docker Config, and Zakura E2E workflows on the same commit. PR #369 demonstrated all three duplicate runs.

The changelog check also requires internal-only fragments for every ordinary PR, including changes that cannot affect Rust behavior.

## Solution

- Remove the `ready_for_review` activity from the three test workflow triggers. Keep opened, synchronized, reopened, and label events; label changes can intentionally enable release and Zakura E2E jobs. Existing successful checks remain associated with the unchanged head commit when a PR becomes ready.
- Require a numbered changelog fragment only when the cumulative PR diff contains a `*.rs` file or any `Cargo.toml`. Continue validating all existing fragments and rejecting changes to another PR’s fragment.
- Update the contribution and changelog documentation to match the relaxed rule.

## Testing

- `python3 -m unittest discover -s scripts/tests -p test_changelog.py` (16 passed)
- `./scripts/changelog.py check` (validated 14 fragments)
- `./scripts/changelog.py check-pr --base origin/main --head HEAD --pr 371`
- `git diff --check`
- Reviewed all affected workflow trigger and job conditions.

## Changelog

No fragment is required because this PR changes no Rust source or `Cargo.toml`; the updated validator accepts PR #371 without one.

### Specifications & References

Observed on PR #369: the ready-for-review event at 2026-07-22 13:57:29 UTC started duplicate runs of all three workflows at 13:57:32 UTC on the same head SHA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger and changelog-validation changes only; no runtime or Rust behavior changes.
> 
> **Overview**
> **Stops duplicate CI when a draft PR is marked ready for review** by dropping the `ready_for_review` pull-request trigger from **Unit Tests**, **Test Docker Config**, and **Zakura E2E**. Those workflows still run on open, sync, reopen, and label changes, so unchanged commits keep their existing check results when a PR leaves draft.
> 
> **Relaxes changelog policy** so `changelog-unreleased/<PR>.md` is required only when the PR diff touches a `*.rs` file or any `Cargo.toml`. `scripts/changelog.py` now diffs the full PR against base to decide; docs (`AGENTS.md`, `CHANGELOG_GUIDELINES.md`, PR template, workflow README) match. Unit tests cover Rust/Cargo vs docs-only PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c820e3d9590f2759aa5b3572c9c7b3a3cc7ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->