### PR TITLE
fix(sync): reject locator echoes in extensions

### DIFF
--- a/changelog-unreleased/372.md
+++ b/changelog-unreleased/372.md
@@ -1,0 +1,4 @@
+## Security
+
+- Reject locator hashes echoed inside legacy tip-extension responses
+  ([#372](https://github.com/zakura-core/zakura/pull/372)).

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -1614,6 +1614,14 @@ where
             return Ok(None);
         }
 
+        if unknown_hashes.contains(&locator) {
+            debug!(
+                ?locator,
+                "discarding FindBlocks extension response with locator hash in advertised suffix"
+            );
+            return Ok(None);
+        }
+
         for &hash in unknown_hashes {
             if Self::state_contains_service(state, hash).await? {
                 debug!(

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2033,6 +2033,65 @@ async fn build_extend_rejects_oversized_response_before_state_queries(
 }
 
 #[tokio::test]
+async fn build_extend_rejects_locator_echo_before_state_queries() -> Result<(), crate::BoxError> {
+    let (
+        _chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let tip = block::Hash::from([0x20; 32]);
+    let expected_next = block::Hash::from([0x21; 32]);
+    let unknown = block::Hash::from([0x22; 32]);
+    let trailing = block::Hash::from([0x23; 32]);
+    let tips = HashSet::from([sync::CheckedTip { tip, expected_next }]);
+    let extend_handle = tokio::spawn(TestChainSync::build_extend(
+        Timeout::new(peer_set.clone(), sync::TIPS_RESPONSE_TIMEOUT),
+        state_service.clone(),
+        tips,
+    ));
+
+    peer_set
+        .expect_request(zn::Request::FindBlocks {
+            known_blocks: vec![tip],
+            stop: None,
+        })
+        .await
+        .respond(zn::Response::BlockHashes(vec![
+            expected_next,
+            unknown,
+            tip,
+            trailing,
+        ]));
+
+    for _ in 0..(sync::FANOUT - 1) {
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![tip],
+                stop: None,
+            })
+            .await
+            .respond(Err(zn::BoxError::from("synthetic test locator echo error")));
+    }
+
+    let (download_set, prospective_tips, discovered) = extend_handle
+        .await
+        .expect("build_extend task should not panic")?;
+    assert!(download_set.is_empty());
+    assert!(prospective_tips.is_empty());
+    assert_eq!(discovered, 0);
+
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn build_extend_ignores_known_trailing_find_blocks_hash() -> Result<(), crate::BoxError> {
     let (
         _chain_sync,


### PR DESCRIPTION
## Motivation

Legacy tip extension accepts a requested locator when a peer echoes it inside
the retained response suffix. Because extension runs before the locator is
necessarily committed, the state lookup can report it as unknown and allow a
backward prospective tip.

## Solution

Reject a locator found anywhere in the retained extension suffix before making
state queries. Keep the existing compatibility behavior for the discarded
leading and trailing hashes.

## Testing

The added regression test supplies an uncommitted locator in the response
suffix and asserts that the response is discarded without any state query.

- `cargo test -p zakura build_extend_rejects_locator_echo_before_state_queries`
- `cargo test -p zakura components::sync`
- `cargo fmt --all -- --check`
- `cargo clippy -p zakura --all-targets -- -D warnings`
- `./scripts/changelog.py check`

GitHub CI is green, including the full unit-test shards and Zakura E2E checks.

## Changelog

Added `changelog-unreleased/372.md` under Security.

### Specifications & References

- Follow-up to #355.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive change to chain sync tip validation; scope is narrow (one early reject + test) but incorrect filtering could affect legitimate peer responses.
> 
> **Overview**
> Closes a **security gap** in legacy tip extension: a peer could echo the requested locator hash inside the retained `FindBlocks` suffix and trick the node into treating backward chain data as a valid prospective tip when that locator was not yet committed (follow-up to #355).
> 
> **`validate_extend_find_blocks_response`** now drops extension responses if the advertised unknown suffix contains the locator (`tip.tip`), **before** any state `KnownBlock` lookups—same ordering as the oversized-response guard.
> 
> A regression test asserts an echoed uncommitted locator yields an empty extend result with **no** state service calls. Unreleased changelog notes the fix under Security.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05406ad1a7efe6a9ce7334522ee29e7944af467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->