### PR TITLE
fix(network): scope discovery ownership to exact sessions

### DIFF
--- a/changelog-unreleased/373.md
+++ b/changelog-unreleased/373.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Let native Zakura peer sets converge beyond bootstrap nodes by advertising
+  reachable addresses and safely dialing valid gossiped discovery records
+  ([#373](https://github.com/zakura-core/zakura/pull/373)).

--- a/changelog-unreleased/373.md
+++ b/changelog-unreleased/373.md
@@ -1,5 +1,7 @@
 ## Fixed
 
 - Let native Zakura peer sets converge beyond bootstrap nodes by advertising
-  reachable addresses and safely dialing valid gossiped discovery records
+  reachable addresses, safely dialing valid gossiped discovery records, and
+  applying discovery IP safety and connection limits consistently across IPv4
+  transition encodings
   ([#373](https://github.com/zakura-core/zakura/pull/373)).

--- a/changelog-unreleased/373.md
+++ b/changelog-unreleased/373.md
@@ -5,3 +5,13 @@
   applying discovery IP safety and connection limits consistently across IPv4
   transition encodings
   ([#373](https://github.com/zakura-core/zakura/pull/373)).
+
+## Security
+
+- Harden the native discovery candidate dialer against untrusted gossip: charge
+  each dialed connection to the network path iroh actually confirms (so a record
+  cannot escape the per-IP connection cap by listing a decoy address first),
+  scope dial-failure backoff to `(node_id, ip)` instead of IP alone (so a signed
+  record cannot back an honest peer's IP off for every candidate that shares it),
+  and reject RFC 5737 / RFC 3849 documentation ranges as dial targets
+  ([#373](https://github.com/zakura-core/zakura/pull/373)).

--- a/changelog-unreleased/374.md
+++ b/changelog-unreleased/374.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Scope discovery cleanup and shared-connection ownership to the exact admitted
+  peer session, preventing stale teardown and unintended service disconnects
+  ([#374](https://github.com/zakura-core/zakura/pull/374)).

--- a/changelog-unreleased/374.md
+++ b/changelog-unreleased/374.md
@@ -1,5 +1,5 @@
 ## Fixed
 
 - Scope discovery cleanup and shared-connection ownership to the exact admitted
-  peer session, preventing stale teardown and unintended service disconnects
+  peer session to prevent stale teardown and unintended service disconnects
   ([#374](https://github.com/zakura-core/zakura/pull/374)).

--- a/zakura-network/src/zakura.rs
+++ b/zakura-network/src/zakura.rs
@@ -21,6 +21,7 @@ mod exchange;
 mod handler;
 mod handshake;
 mod header_sync;
+mod ip;
 mod legacy_gossip;
 #[cfg(any(test, feature = "zakura-testkit"))]
 pub mod testkit;
@@ -33,6 +34,7 @@ pub use exchange::*;
 pub use handler::*;
 pub use handshake::*;
 pub use header_sync::*;
+pub(crate) use ip::canonical_ip;
 pub use legacy_gossip::*;
 pub use trace::{
     commit_state_trace, peer_label as zakura_trace_peer_label,

--- a/zakura-network/src/zakura/block_sync/service.rs
+++ b/zakura-network/src/zakura/block_sync/service.rs
@@ -383,6 +383,15 @@ impl Service for BlockSyncService {
         block_sync_streams()
     }
 
+    fn owns_connection_for_peer(&self, peer: &ZakuraPeerId, conn_id: ZakuraConnId) -> bool {
+        self.inner
+            .peers
+            .lock()
+            .expect("block-sync peer map mutex is never poisoned")
+            .get(peer)
+            .is_some_and(|record| record.conn_id == conn_id)
+    }
+
     fn wants_peer(
         &self,
         peer: &ZakuraPeerId,

--- a/zakura-network/src/zakura/discovery/candidate_dialer.rs
+++ b/zakura-network/src/zakura/discovery/candidate_dialer.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use iroh::{NodeAddr, NodeId};
-use tokio::task::JoinSet;
+use tokio::{task::JoinSet, time::Instant};
 use tracing::debug;
 
 use super::dialer::native_bootstrap_dial;
@@ -53,6 +53,12 @@ struct DiscoveryDialWorkerResult {
     node_id: NodeId,
     reserved_ips: Vec<IpAddr>,
     result: DiscoveryDialResult,
+}
+
+#[derive(Copy, Clone, Debug)]
+struct DiscoveryIpBackoff {
+    failure_count: u32,
+    retry_at: Instant,
 }
 
 /// Spawn the long-lived discovery candidate dialer for `endpoint`.
@@ -98,12 +104,15 @@ pub(crate) async fn run_native_discovery_dialer(
     let mut registered = endpoint.supervisor().subscribe();
     let mut in_flight = HashSet::new();
     let mut in_flight_by_ip = HashMap::new();
+    let mut dial_backoff_by_ip = HashMap::new();
+    let dial_backoff = discovery.dial_backoff().await;
     let mut workers = JoinSet::new();
 
     loop {
         if shutdown.is_cancelled() {
             return;
         }
+        prune_discovery_ip_backoff(&mut dial_backoff_by_ip, dial_backoff.1, Instant::now());
 
         spawn_discovery_dial_candidates(
             &endpoint,
@@ -111,6 +120,7 @@ pub(crate) async fn run_native_discovery_dialer(
             &limits,
             &mut in_flight,
             &mut in_flight_by_ip,
+            &dial_backoff_by_ip,
             &mut workers,
         )
         .await;
@@ -128,6 +138,13 @@ pub(crate) async fn run_native_discovery_dialer(
                         release_discovery_in_flight_ips(
                             &mut in_flight_by_ip,
                             &worker_result.reserved_ips,
+                        );
+                        apply_discovery_ip_dial_result(
+                            &mut dial_backoff_by_ip,
+                            &worker_result.reserved_ips,
+                            worker_result.result,
+                            dial_backoff,
+                            Instant::now(),
                         );
                         apply_discovery_dial_result(
                             &discovery,
@@ -159,6 +176,7 @@ async fn spawn_discovery_dial_candidates(
     limits: &ZakuraLocalLimits,
     in_flight: &mut HashSet<NodeId>,
     in_flight_by_ip: &mut HashMap<IpAddr, usize>,
+    dial_backoff_by_ip: &HashMap<IpAddr, DiscoveryIpBackoff>,
     workers: &mut JoinSet<DiscoveryDialWorkerResult>,
 ) {
     if !endpoint.has_native_admission_capacity() {
@@ -170,9 +188,14 @@ async fn spawn_discovery_dial_candidates(
         if !endpoint.has_native_admission_capacity() {
             return;
         }
-        let Some((node_addr, reserved_ips)) =
-            discovery_node_addr_with_reserved_ip_capacity(endpoint, &candidate, in_flight_by_ip)
-                .await
+        let Some((node_addr, reserved_ips)) = discovery_node_addr_with_reserved_ip_capacity(
+            endpoint,
+            &candidate,
+            in_flight_by_ip,
+            dial_backoff_by_ip,
+            Instant::now(),
+        )
+        .await
         else {
             continue;
         };
@@ -198,11 +221,15 @@ async fn discovery_node_addr_with_reserved_ip_capacity(
     endpoint: &ZakuraEndpoint,
     candidate: &ZakuraDiscoveryDialCandidate,
     in_flight_by_ip: &HashMap<IpAddr, usize>,
+    dial_backoff_by_ip: &HashMap<IpAddr, DiscoveryIpBackoff>,
+    now: Instant,
 ) -> Option<(NodeAddr, Vec<IpAddr>)> {
     let mut direct_addrs = Vec::new();
     let mut reserved_ips = Vec::new();
     for addr in &candidate.direct_addrs {
-        if can_accept_discovery_dial_ip(endpoint, addr.ip(), in_flight_by_ip).await {
+        if !discovery_ip_is_in_backoff(dial_backoff_by_ip, addr.ip(), now)
+            && can_accept_discovery_dial_ip(endpoint, addr.ip(), in_flight_by_ip).await
+        {
             if !reserved_ips.contains(&addr.ip()) {
                 reserved_ips.push(addr.ip());
             }
@@ -246,6 +273,74 @@ fn release_discovery_in_flight_ips(in_flight_by_ip: &mut HashMap<IpAddr, usize>,
             in_flight_by_ip.remove(ip);
         }
     }
+}
+
+fn discovery_ip_is_in_backoff(
+    dial_backoff_by_ip: &HashMap<IpAddr, DiscoveryIpBackoff>,
+    ip: IpAddr,
+    now: Instant,
+) -> bool {
+    dial_backoff_by_ip
+        .get(&ip)
+        .is_some_and(|backoff| now < backoff.retry_at)
+}
+
+fn prune_discovery_ip_backoff(
+    dial_backoff_by_ip: &mut HashMap<IpAddr, DiscoveryIpBackoff>,
+    retention: Duration,
+    now: Instant,
+) {
+    dial_backoff_by_ip
+        .retain(|_, backoff| now.saturating_duration_since(backoff.retry_at) <= retention);
+}
+
+fn apply_discovery_ip_dial_result(
+    dial_backoff_by_ip: &mut HashMap<IpAddr, DiscoveryIpBackoff>,
+    ips: &[IpAddr],
+    result: DiscoveryDialResult,
+    dial_backoff: (Duration, Duration),
+    now: Instant,
+) {
+    match result {
+        DiscoveryDialResult::Registered
+        | DiscoveryDialResult::ConnectedElsewhere
+        | DiscoveryDialResult::ShortLivedRegistered => {
+            for ip in ips {
+                dial_backoff_by_ip.remove(ip);
+            }
+        }
+        DiscoveryDialResult::Failed => {
+            for ip in ips {
+                let failure_count = dial_backoff_by_ip
+                    .get(ip)
+                    .map_or(1, |backoff| backoff.failure_count.saturating_add(1));
+                dial_backoff_by_ip.insert(
+                    *ip,
+                    DiscoveryIpBackoff {
+                        failure_count,
+                        retry_at: now
+                            + discovery_ip_dial_backoff(
+                                failure_count,
+                                dial_backoff.0,
+                                dial_backoff.1,
+                            ),
+                    },
+                );
+            }
+        }
+        DiscoveryDialResult::LocalResourceLimit => {}
+    }
+}
+
+fn discovery_ip_dial_backoff(
+    failure_count: u32,
+    dial_backoff_base: Duration,
+    dial_backoff_max: Duration,
+) -> Duration {
+    let shift = failure_count.saturating_sub(1).min(10);
+    dial_backoff_base
+        .saturating_mul(1u32 << shift)
+        .min(dial_backoff_max)
 }
 
 async fn run_discovery_dial_once(
@@ -425,6 +520,56 @@ mod tests {
 
     fn peer_id(byte: u8) -> ZakuraPeerId {
         ZakuraPeerId::new(vec![byte; 32]).expect("32-byte test peer id is valid")
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_targets_back_off_all_records_for_the_same_ip() {
+        let ip = IpAddr::from([93, 184, 216, 34]);
+        let now = Instant::now();
+        let dial_backoff = (Duration::from_secs(60), Duration::from_secs(3_600));
+        let mut backoff_by_ip = HashMap::new();
+
+        apply_discovery_ip_dial_result(
+            &mut backoff_by_ip,
+            &[ip],
+            DiscoveryDialResult::Failed,
+            dial_backoff,
+            now,
+        );
+        assert!(discovery_ip_is_in_backoff(&backoff_by_ip, ip, now));
+        assert!(!discovery_ip_is_in_backoff(
+            &backoff_by_ip,
+            ip,
+            now + Duration::from_secs(60)
+        ));
+
+        let second_attempt = now + Duration::from_secs(60);
+        apply_discovery_ip_dial_result(
+            &mut backoff_by_ip,
+            &[ip],
+            DiscoveryDialResult::Failed,
+            dial_backoff,
+            second_attempt,
+        );
+        assert!(discovery_ip_is_in_backoff(
+            &backoff_by_ip,
+            ip,
+            second_attempt + Duration::from_secs(119)
+        ));
+        assert!(!discovery_ip_is_in_backoff(
+            &backoff_by_ip,
+            ip,
+            second_attempt + Duration::from_secs(120)
+        ));
+
+        apply_discovery_ip_dial_result(
+            &mut backoff_by_ip,
+            &[ip],
+            DiscoveryDialResult::Registered,
+            dial_backoff,
+            second_attempt,
+        );
+        assert!(!backoff_by_ip.contains_key(&ip));
     }
 
     #[tokio::test(start_paused = true)]

--- a/zakura-network/src/zakura/discovery/candidate_dialer.rs
+++ b/zakura-network/src/zakura/discovery/candidate_dialer.rs
@@ -8,7 +8,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    net::IpAddr,
+    net::{IpAddr, Ipv4Addr},
     time::Duration,
 };
 
@@ -227,11 +227,12 @@ async fn discovery_node_addr_with_reserved_ip_capacity(
     let mut direct_addrs = Vec::new();
     let mut reserved_ips = Vec::new();
     for addr in &candidate.direct_addrs {
-        if !discovery_ip_is_in_backoff(dial_backoff_by_ip, addr.ip(), now)
-            && can_accept_discovery_dial_ip(endpoint, addr.ip(), in_flight_by_ip).await
+        let dial_ip = canonical_discovery_dial_ip(addr.ip());
+        if !discovery_ip_is_in_backoff(dial_backoff_by_ip, dial_ip, now)
+            && can_accept_discovery_dial_ip(endpoint, dial_ip, in_flight_by_ip).await
         {
-            if !reserved_ips.contains(&addr.ip()) {
-                reserved_ips.push(addr.ip());
+            if !reserved_ips.contains(&dial_ip) {
+                reserved_ips.push(dial_ip);
             }
             direct_addrs.push(*addr);
         }
@@ -243,6 +244,20 @@ async fn discovery_node_addr_with_reserved_ip_capacity(
             reserved_ips,
         )
     })
+}
+
+fn canonical_discovery_dial_ip(ip: IpAddr) -> IpAddr {
+    let IpAddr::V6(ipv6) = ip else {
+        return ip;
+    };
+    let octets = ipv6.octets();
+    if octets[..10] == [0; 10] && octets[10..12] == [0xff; 2] {
+        IpAddr::V4(Ipv4Addr::new(
+            octets[12], octets[13], octets[14], octets[15],
+        ))
+    } else {
+        ip
+    }
 }
 
 async fn can_accept_discovery_dial_ip(
@@ -525,6 +540,10 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn failed_targets_back_off_all_records_for_the_same_ip() {
         let ip = IpAddr::from([93, 184, 216, 34]);
+        let mapped_ip: IpAddr = "::ffff:93.184.216.34"
+            .parse()
+            .expect("mapped test address parses");
+        assert_eq!(canonical_discovery_dial_ip(mapped_ip), ip);
         let now = Instant::now();
         let dial_backoff = (Duration::from_secs(60), Duration::from_secs(3_600));
         let mut backoff_by_ip = HashMap::new();
@@ -537,6 +556,11 @@ mod tests {
             now,
         );
         assert!(discovery_ip_is_in_backoff(&backoff_by_ip, ip, now));
+        assert!(discovery_ip_is_in_backoff(
+            &backoff_by_ip,
+            canonical_discovery_dial_ip(mapped_ip),
+            now
+        ));
         assert!(!discovery_ip_is_in_backoff(
             &backoff_by_ip,
             ip,

--- a/zakura-network/src/zakura/discovery/candidate_dialer.rs
+++ b/zakura-network/src/zakura/discovery/candidate_dialer.rs
@@ -9,9 +9,11 @@
 use std::{
     collections::{HashMap, HashSet},
     net::{IpAddr, Ipv4Addr},
+    panic::AssertUnwindSafe,
     time::Duration,
 };
 
+use futures::FutureExt;
 use iroh::{NodeAddr, NodeId};
 use tokio::{task::JoinSet, time::Instant};
 use tracing::debug;
@@ -207,14 +209,37 @@ async fn spawn_discovery_dial_candidates(
 
         discovery.mark_dial_attempt(&node_id).await;
         metrics::counter!("zakura.p2p.discovery.dial.started").increment(1);
-        workers.spawn(run_discovery_dial_once(
-            endpoint.clone(),
-            node_addr,
-            limits.clone(),
+        workers.spawn({
+            let reserved_ips_on_panic = reserved_ips.clone();
+            AssertUnwindSafe(run_discovery_dial_once(
+                endpoint.clone(),
+                node_addr,
+                limits.clone(),
+                node_id,
+                reserved_ips,
+            ))
+            .catch_unwind()
+            .map(move |result| {
+                recover_discovery_dial_worker_panic(node_id, reserved_ips_on_panic, result)
+            })
+        });
+    }
+}
+
+fn recover_discovery_dial_worker_panic(
+    node_id: NodeId,
+    reserved_ips: Vec<IpAddr>,
+    result: std::thread::Result<DiscoveryDialWorkerResult>,
+) -> DiscoveryDialWorkerResult {
+    result.unwrap_or_else(|_| {
+        metrics::counter!("zakura.p2p.discovery.dial.worker_panicked").increment(1);
+        tracing::error!(?node_id, "Zakura discovery dial worker panicked");
+        DiscoveryDialWorkerResult {
             node_id,
             reserved_ips,
-        ));
-    }
+            result: DiscoveryDialResult::Failed,
+        }
+    })
 }
 
 async fn discovery_node_addr_with_reserved_ip_capacity(
@@ -535,6 +560,29 @@ mod tests {
 
     fn peer_id(byte: u8) -> ZakuraPeerId {
         ZakuraPeerId::new(vec![byte; 32]).expect("32-byte test peer id is valid")
+    }
+
+    #[test]
+    fn panicked_worker_returns_metadata_needed_to_release_reservations() {
+        let node_id = iroh::SecretKey::from_bytes(&[3; 32]).public();
+        let ip = IpAddr::from([93, 184, 216, 34]);
+        let mut in_flight = HashSet::from([node_id]);
+        let mut in_flight_by_ip = HashMap::new();
+        reserve_discovery_in_flight_ips(&mut in_flight_by_ip, &[ip]);
+
+        let worker_result = recover_discovery_dial_worker_panic(
+            node_id,
+            vec![ip],
+            Err(Box::new("test worker panic")),
+        );
+        assert_eq!(worker_result.node_id, node_id);
+        assert_eq!(worker_result.reserved_ips, vec![ip]);
+        assert_eq!(worker_result.result, DiscoveryDialResult::Failed);
+
+        in_flight.remove(&worker_result.node_id);
+        release_discovery_in_flight_ips(&mut in_flight_by_ip, &worker_result.reserved_ips);
+        assert!(in_flight.is_empty());
+        assert!(in_flight_by_ip.is_empty());
     }
 
     #[tokio::test(start_paused = true)]

--- a/zakura-network/src/zakura/discovery/candidate_dialer.rs
+++ b/zakura-network/src/zakura/discovery/candidate_dialer.rs
@@ -58,6 +58,15 @@ struct DiscoveryDialWorkerResult {
     result: DiscoveryDialResult,
 }
 
+/// Exponential dial backoff for a single `(node_id, ip)` pair.
+///
+/// Backoff is keyed by `(NodeId, IpAddr)`, not `IpAddr` alone: a signature on a
+/// gossip record proves control of the node key, not ownership of the addresses
+/// it advertises. Keying failure backoff by IP alone would let an attacker sign
+/// throwaway node ids that all advertise an honest peer's IP and, by failing
+/// those dials, back that IP off for every legitimate candidate that shares it.
+/// The in-flight reservation cap (`in_flight_by_ip`) stays IP-scoped because it
+/// bounds a real local resource (concurrent dials to one address).
 #[derive(Copy, Clone, Debug)]
 struct DiscoveryIpBackoff {
     failure_count: u32,
@@ -107,7 +116,7 @@ pub(crate) async fn run_native_discovery_dialer(
     let mut registered = endpoint.supervisor().subscribe();
     let mut in_flight = HashSet::new();
     let mut in_flight_by_ip = HashMap::new();
-    let mut dial_backoff_by_ip = HashMap::new();
+    let mut dial_backoff_by_node_ip = HashMap::new();
     let dial_backoff = discovery.dial_backoff().await;
     let mut workers = JoinSet::new();
 
@@ -115,7 +124,7 @@ pub(crate) async fn run_native_discovery_dialer(
         if shutdown.is_cancelled() {
             return;
         }
-        prune_discovery_ip_backoff(&mut dial_backoff_by_ip, dial_backoff.1, Instant::now());
+        prune_discovery_ip_backoff(&mut dial_backoff_by_node_ip, dial_backoff.1, Instant::now());
 
         spawn_discovery_dial_candidates(
             &endpoint,
@@ -123,7 +132,7 @@ pub(crate) async fn run_native_discovery_dialer(
             &limits,
             &mut in_flight,
             &mut in_flight_by_ip,
-            &dial_backoff_by_ip,
+            &dial_backoff_by_node_ip,
             &mut workers,
         )
         .await;
@@ -143,7 +152,8 @@ pub(crate) async fn run_native_discovery_dialer(
                             &worker_result.reserved_ips,
                         );
                         apply_discovery_ip_dial_result(
-                            &mut dial_backoff_by_ip,
+                            &mut dial_backoff_by_node_ip,
+                            worker_result.node_id,
                             &worker_result.reserved_ips,
                             worker_result.result,
                             dial_backoff,
@@ -179,7 +189,7 @@ async fn spawn_discovery_dial_candidates(
     limits: &ZakuraLocalLimits,
     in_flight: &mut HashSet<NodeId>,
     in_flight_by_ip: &mut HashMap<IpAddr, usize>,
-    dial_backoff_by_ip: &HashMap<IpAddr, DiscoveryIpBackoff>,
+    dial_backoff_by_node_ip: &HashMap<(NodeId, IpAddr), DiscoveryIpBackoff>,
     workers: &mut JoinSet<DiscoveryDialWorkerResult>,
 ) {
     if !endpoint.has_native_admission_capacity() {
@@ -195,7 +205,7 @@ async fn spawn_discovery_dial_candidates(
             endpoint,
             &candidate,
             in_flight_by_ip,
-            dial_backoff_by_ip,
+            dial_backoff_by_node_ip,
             Instant::now(),
         )
         .await
@@ -247,14 +257,14 @@ async fn discovery_node_addr_with_reserved_ip_capacity(
     endpoint: &ZakuraEndpoint,
     candidate: &ZakuraDiscoveryDialCandidate,
     in_flight_by_ip: &HashMap<IpAddr, usize>,
-    dial_backoff_by_ip: &HashMap<IpAddr, DiscoveryIpBackoff>,
+    dial_backoff_by_node_ip: &HashMap<(NodeId, IpAddr), DiscoveryIpBackoff>,
     now: Instant,
 ) -> Option<(NodeAddr, Vec<IpAddr>)> {
     let mut direct_addrs = Vec::new();
     let mut reserved_ips = Vec::new();
     for addr in &candidate.direct_addrs {
         let dial_ip = canonical_ip(addr.ip());
-        if !discovery_ip_is_in_backoff(dial_backoff_by_ip, dial_ip, now)
+        if !discovery_ip_is_in_backoff(dial_backoff_by_node_ip, candidate.node_id, dial_ip, now)
             && can_accept_discovery_dial_ip(endpoint, dial_ip, in_flight_by_ip).await
         {
             if !reserved_ips.contains(&dial_ip) {
@@ -303,26 +313,28 @@ fn release_discovery_in_flight_ips(in_flight_by_ip: &mut HashMap<IpAddr, usize>,
 }
 
 fn discovery_ip_is_in_backoff(
-    dial_backoff_by_ip: &HashMap<IpAddr, DiscoveryIpBackoff>,
+    dial_backoff_by_node_ip: &HashMap<(NodeId, IpAddr), DiscoveryIpBackoff>,
+    node_id: NodeId,
     ip: IpAddr,
     now: Instant,
 ) -> bool {
-    dial_backoff_by_ip
-        .get(&ip)
+    dial_backoff_by_node_ip
+        .get(&(node_id, ip))
         .is_some_and(|backoff| now < backoff.retry_at)
 }
 
 fn prune_discovery_ip_backoff(
-    dial_backoff_by_ip: &mut HashMap<IpAddr, DiscoveryIpBackoff>,
+    dial_backoff_by_node_ip: &mut HashMap<(NodeId, IpAddr), DiscoveryIpBackoff>,
     retention: Duration,
     now: Instant,
 ) {
-    dial_backoff_by_ip
+    dial_backoff_by_node_ip
         .retain(|_, backoff| now.saturating_duration_since(backoff.retry_at) <= retention);
 }
 
 fn apply_discovery_ip_dial_result(
-    dial_backoff_by_ip: &mut HashMap<IpAddr, DiscoveryIpBackoff>,
+    dial_backoff_by_node_ip: &mut HashMap<(NodeId, IpAddr), DiscoveryIpBackoff>,
+    node_id: NodeId,
     ips: &[IpAddr],
     result: DiscoveryDialResult,
     dial_backoff: (Duration, Duration),
@@ -333,16 +345,16 @@ fn apply_discovery_ip_dial_result(
         | DiscoveryDialResult::ConnectedElsewhere
         | DiscoveryDialResult::ShortLivedRegistered => {
             for ip in ips {
-                dial_backoff_by_ip.remove(ip);
+                dial_backoff_by_node_ip.remove(&(node_id, *ip));
             }
         }
         DiscoveryDialResult::Failed => {
             for ip in ips {
-                let failure_count = dial_backoff_by_ip
-                    .get(ip)
+                let failure_count = dial_backoff_by_node_ip
+                    .get(&(node_id, *ip))
                     .map_or(1, |backoff| backoff.failure_count.saturating_add(1));
-                dial_backoff_by_ip.insert(
-                    *ip,
+                dial_backoff_by_node_ip.insert(
+                    (node_id, *ip),
                     DiscoveryIpBackoff {
                         failure_count,
                         retry_at: now
@@ -549,6 +561,10 @@ mod tests {
         ZakuraPeerId::new(vec![byte; 32]).expect("32-byte test peer id is valid")
     }
 
+    fn node_id(byte: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[byte; 32]).public()
+    }
+
     #[test]
     fn panicked_worker_returns_metadata_needed_to_release_reservations() {
         let node_id = iroh::SecretKey::from_bytes(&[3; 32]).public();
@@ -573,7 +589,9 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn failed_targets_back_off_all_records_for_the_same_ip() {
+    async fn failed_dials_back_off_only_the_failing_node_for_that_ip() {
+        let failing_node = node_id(1);
+        let honest_node = node_id(2);
         let ip = IpAddr::from([93, 184, 216, 34]);
         let mapped_ip: IpAddr = "::ffff:93.184.216.34"
             .parse()
@@ -589,54 +607,76 @@ mod tests {
         assert_eq!(canonical_ip(teredo_ip), ip);
         let now = Instant::now();
         let dial_backoff = (Duration::from_secs(60), Duration::from_secs(3_600));
-        let mut backoff_by_ip = HashMap::new();
+        let mut backoff_by_node_ip = HashMap::new();
 
         apply_discovery_ip_dial_result(
-            &mut backoff_by_ip,
+            &mut backoff_by_node_ip,
+            failing_node,
             &[ip],
             DiscoveryDialResult::Failed,
             dial_backoff,
             now,
         );
-        assert!(discovery_ip_is_in_backoff(&backoff_by_ip, ip, now));
+        // The failing node is backed off for this IP, canonicalised so v4/v6
+        // variants of the same address share the entry.
         assert!(discovery_ip_is_in_backoff(
-            &backoff_by_ip,
+            &backoff_by_node_ip,
+            failing_node,
+            ip,
+            now
+        ));
+        assert!(discovery_ip_is_in_backoff(
+            &backoff_by_node_ip,
+            failing_node,
             canonical_ip(mapped_ip),
             now
         ));
+        // A different node advertising the same IP is NOT poisoned: a signature
+        // proves node-key control, not IP ownership.
         assert!(!discovery_ip_is_in_backoff(
-            &backoff_by_ip,
+            &backoff_by_node_ip,
+            honest_node,
+            ip,
+            now
+        ));
+        assert!(!discovery_ip_is_in_backoff(
+            &backoff_by_node_ip,
+            failing_node,
             ip,
             now + Duration::from_secs(60)
         ));
 
         let second_attempt = now + Duration::from_secs(60);
         apply_discovery_ip_dial_result(
-            &mut backoff_by_ip,
+            &mut backoff_by_node_ip,
+            failing_node,
             &[ip],
             DiscoveryDialResult::Failed,
             dial_backoff,
             second_attempt,
         );
         assert!(discovery_ip_is_in_backoff(
-            &backoff_by_ip,
+            &backoff_by_node_ip,
+            failing_node,
             ip,
             second_attempt + Duration::from_secs(119)
         ));
         assert!(!discovery_ip_is_in_backoff(
-            &backoff_by_ip,
+            &backoff_by_node_ip,
+            failing_node,
             ip,
             second_attempt + Duration::from_secs(120)
         ));
 
         apply_discovery_ip_dial_result(
-            &mut backoff_by_ip,
+            &mut backoff_by_node_ip,
+            failing_node,
             &[ip],
             DiscoveryDialResult::Registered,
             dial_backoff,
             second_attempt,
         );
-        assert!(!backoff_by_ip.contains_key(&ip));
+        assert!(!backoff_by_node_ip.contains_key(&(failing_node, ip)));
     }
 
     #[tokio::test(start_paused = true)]

--- a/zakura-network/src/zakura/discovery/candidate_dialer.rs
+++ b/zakura-network/src/zakura/discovery/candidate_dialer.rs
@@ -8,7 +8,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    net::{IpAddr, Ipv4Addr},
+    net::IpAddr,
     panic::AssertUnwindSafe,
     time::Duration,
 };
@@ -22,6 +22,7 @@ use super::dialer::native_bootstrap_dial;
 use super::protocol::{ZakuraDiscoveryDialCandidate, ZakuraDiscoveryHandle};
 use super::redial::ZAKURA_REDIAL_HEALTHY_CONNECTION;
 use crate::zakura::{
+    canonical_ip,
     trace::{discovery_trace as d_trace, peer_label, DISCOVERY_TABLE},
     ZakuraEndpoint, ZakuraHandlerError, ZakuraLocalLimits, ZakuraPeerId,
 };
@@ -252,7 +253,7 @@ async fn discovery_node_addr_with_reserved_ip_capacity(
     let mut direct_addrs = Vec::new();
     let mut reserved_ips = Vec::new();
     for addr in &candidate.direct_addrs {
-        let dial_ip = canonical_discovery_dial_ip(addr.ip());
+        let dial_ip = canonical_ip(addr.ip());
         if !discovery_ip_is_in_backoff(dial_backoff_by_ip, dial_ip, now)
             && can_accept_discovery_dial_ip(endpoint, dial_ip, in_flight_by_ip).await
         {
@@ -269,20 +270,6 @@ async fn discovery_node_addr_with_reserved_ip_capacity(
             reserved_ips,
         )
     })
-}
-
-fn canonical_discovery_dial_ip(ip: IpAddr) -> IpAddr {
-    let IpAddr::V6(ipv6) = ip else {
-        return ip;
-    };
-    let octets = ipv6.octets();
-    if octets[..10] == [0; 10] && octets[10..12] == [0xff; 2] {
-        IpAddr::V4(Ipv4Addr::new(
-            octets[12], octets[13], octets[14], octets[15],
-        ))
-    } else {
-        ip
-    }
 }
 
 async fn can_accept_discovery_dial_ip(
@@ -591,7 +578,15 @@ mod tests {
         let mapped_ip: IpAddr = "::ffff:93.184.216.34"
             .parse()
             .expect("mapped test address parses");
-        assert_eq!(canonical_discovery_dial_ip(mapped_ip), ip);
+        let six_to_four_ip: IpAddr = "2002:5db8:d822::"
+            .parse()
+            .expect("6to4 test address parses");
+        let teredo_ip: IpAddr = "2001:0:c000:22d::a247:27dd"
+            .parse()
+            .expect("Teredo test address parses");
+        assert_eq!(canonical_ip(mapped_ip), ip);
+        assert_eq!(canonical_ip(six_to_four_ip), ip);
+        assert_eq!(canonical_ip(teredo_ip), ip);
         let now = Instant::now();
         let dial_backoff = (Duration::from_secs(60), Duration::from_secs(3_600));
         let mut backoff_by_ip = HashMap::new();
@@ -606,7 +601,7 @@ mod tests {
         assert!(discovery_ip_is_in_backoff(&backoff_by_ip, ip, now));
         assert!(discovery_ip_is_in_backoff(
             &backoff_by_ip,
-            canonical_discovery_dial_ip(mapped_ip),
+            canonical_ip(mapped_ip),
             now
         ));
         assert!(!discovery_ip_is_in_backoff(

--- a/zakura-network/src/zakura/discovery/dialer.rs
+++ b/zakura-network/src/zakura/discovery/dialer.rs
@@ -1,6 +1,6 @@
 //! Bootstrap and candidate dial entry points for native discovery.
 
-use std::{net::SocketAddr, str::FromStr};
+use std::{collections::HashMap, net::SocketAddr, str::FromStr};
 
 use iroh::{NodeAddr, NodeId};
 
@@ -34,15 +34,33 @@ pub(crate) fn spawn_native_bootstrap_dialer(
         DEFAULT_ZAKURA_REDIAL_MAX_BACKOFF,
     );
 
-    let mut tasks = Vec::with_capacity(bootstrap_peers.len());
+    let local_node_id = endpoint.local_node_id();
+    let mut direct_addrs_by_node = HashMap::<NodeId, Vec<SocketAddr>>::new();
     for entry in bootstrap_peers {
+        let node_addr = match parse_bootstrap_peer(&entry) {
+            Ok(node_addr) => node_addr,
+            Err(error) => {
+                tracing::warn!(?error, ?entry, "invalid Zakura bootstrap peer");
+                continue;
+            }
+        };
+        if node_addr.node_id == local_node_id {
+            tracing::debug!(?entry, "ignoring local Zakura bootstrap peer");
+            continue;
+        }
+        direct_addrs_by_node
+            .entry(node_addr.node_id)
+            .or_default()
+            .extend(node_addr.direct_addresses().copied());
+    }
+
+    let mut tasks = Vec::with_capacity(direct_addrs_by_node.len());
+    for (node_id, direct_addrs) in direct_addrs_by_node {
         let endpoint = endpoint.clone();
         let limits = limits.clone();
+        let node_addr = NodeAddr::new(node_id).with_direct_addresses(direct_addrs);
         tasks.push(tokio::spawn(async move {
-            match parse_bootstrap_peer(&entry) {
-                Ok(node_addr) => native_dial_supervised(endpoint, node_addr, limits, policy).await,
-                Err(error) => tracing::warn!(?error, ?entry, "invalid Zakura bootstrap peer"),
-            }
+            native_dial_supervised(endpoint, node_addr, limits, policy).await
         }));
     }
     tasks

--- a/zakura-network/src/zakura/discovery/dialer.rs
+++ b/zakura-network/src/zakura/discovery/dialer.rs
@@ -12,9 +12,9 @@ use crate::zakura::{
 
 /// Spawn supervised dials for configured native bootstrap peers.
 ///
-/// Returns one task handle per configured peer so the caller can track them
-/// under the endpoint shutdown owner; each maintained dial also observes the
-/// endpoint shutdown token directly via [`native_dial_supervised`].
+/// Returns one task per unique remote identity after merging its configured addresses and removing
+/// the local identity, so the caller can track each maintained dial under the endpoint shutdown
+/// owner. Every dial also observes the shutdown token directly via [`native_dial_supervised`].
 pub(crate) fn spawn_native_bootstrap_dialer(
     endpoint: ZakuraEndpoint,
     bootstrap_peers: Vec<String>,
@@ -34,7 +34,22 @@ pub(crate) fn spawn_native_bootstrap_dialer(
         DEFAULT_ZAKURA_REDIAL_MAX_BACKOFF,
     );
 
-    let local_node_id = endpoint.local_node_id();
+    let node_addrs = grouped_remote_bootstrap_peers(bootstrap_peers, endpoint.local_node_id());
+    let mut tasks = Vec::with_capacity(node_addrs.len());
+    for node_addr in node_addrs {
+        let endpoint = endpoint.clone();
+        let limits = limits.clone();
+        tasks.push(tokio::spawn(async move {
+            native_dial_supervised(endpoint, node_addr, limits, policy).await
+        }));
+    }
+    tasks
+}
+
+fn grouped_remote_bootstrap_peers(
+    bootstrap_peers: Vec<String>,
+    local_node_id: NodeId,
+) -> Vec<NodeAddr> {
     let mut direct_addrs_by_node = HashMap::<NodeId, Vec<SocketAddr>>::new();
     for entry in bootstrap_peers {
         let node_addr = match parse_bootstrap_peer(&entry) {
@@ -54,16 +69,14 @@ pub(crate) fn spawn_native_bootstrap_dialer(
             .extend(node_addr.direct_addresses().copied());
     }
 
-    let mut tasks = Vec::with_capacity(direct_addrs_by_node.len());
-    for (node_id, direct_addrs) in direct_addrs_by_node {
-        let endpoint = endpoint.clone();
-        let limits = limits.clone();
-        let node_addr = NodeAddr::new(node_id).with_direct_addresses(direct_addrs);
-        tasks.push(tokio::spawn(async move {
-            native_dial_supervised(endpoint, node_addr, limits, policy).await
-        }));
-    }
-    tasks
+    direct_addrs_by_node
+        .into_iter()
+        .map(|(node_id, mut direct_addrs)| {
+            direct_addrs.sort_unstable();
+            direct_addrs.dedup();
+            NodeAddr::new(node_id).with_direct_addresses(direct_addrs)
+        })
+        .collect()
 }
 
 pub(crate) async fn native_bootstrap_dial(
@@ -106,5 +119,29 @@ mod tests {
         {
             parse_bootstrap_peer(peer).expect("default Zakura bootstrap peer should parse");
         }
+    }
+
+    #[test]
+    fn bootstrap_peers_skip_self_and_merge_duplicate_remote_identities() {
+        let local_id = iroh::SecretKey::from_bytes(&[1; 32]).public();
+        let remote_id = iroh::SecretKey::from_bytes(&[2; 32]).public();
+        let first_addr: SocketAddr = "127.0.0.1:8234".parse().expect("test address parses");
+        let second_addr: SocketAddr = "127.0.0.1:8235".parse().expect("test address parses");
+        let grouped = grouped_remote_bootstrap_peers(
+            vec![
+                format!("{local_id}@{first_addr}"),
+                format!("{remote_id}@{first_addr}"),
+                format!("{remote_id}@{second_addr}"),
+                format!("{remote_id}@{second_addr}"),
+            ],
+            local_id,
+        );
+
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].node_id, remote_id);
+        assert_eq!(
+            grouped[0].direct_addresses().copied().collect::<Vec<_>>(),
+            vec![first_addr, second_addr]
+        );
     }
 }

--- a/zakura-network/src/zakura/discovery/mod.rs
+++ b/zakura-network/src/zakura/discovery/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use candidate_dialer::run_native_discovery_dialer;
 pub(crate) use candidate_dialer::{
     insert_static_bootstrap_candidates, spawn_native_discovery_dialer,
 };
-pub(crate) use dialer::spawn_native_bootstrap_dialer;
+pub(crate) use dialer::{parse_bootstrap_peer, spawn_native_bootstrap_dialer};
 pub use protocol::*;
 pub(crate) use redial::{native_dial_supervised, RedialPolicy};
 pub(crate) use runtime::{build_discovery_handle, default_advertised_services};

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -21,9 +21,9 @@ use zakura_chain::{
 };
 
 use crate::zakura::{
-    BlockSyncStatus, ServiceAdmissionDecision, ServicePeerDirection, ServicePeerLimits,
-    ServicePeerSnapshot, ZakuraConnId, ZakuraNetworkId, ZakuraPeerId, MAX_BS_BLOCKS_PER_REQUEST,
-    MAX_BS_RESPONSE_BYTES,
+    canonical_ip, BlockSyncStatus, ServiceAdmissionDecision, ServicePeerDirection,
+    ServicePeerLimits, ServicePeerSnapshot, ZakuraConnId, ZakuraNetworkId, ZakuraPeerId,
+    MAX_BS_BLOCKS_PER_REQUEST, MAX_BS_RESPONSE_BYTES,
 };
 
 /// Native discovery stream kind.
@@ -3427,21 +3427,17 @@ fn is_discovery_dialable_addr(addr: &SocketAddr) -> bool {
         return false;
     }
 
-    match addr.ip() {
+    match canonical_ip(addr.ip()) {
         IpAddr::V4(ip) => is_discovery_dialable_ipv4(&ip),
-        IpAddr::V6(ip) => ipv6_mapped_ipv4(&ip).map_or_else(
-            || {
-                !ip.is_unspecified()
-                    && !ip.is_loopback()
-                    && !ip.is_multicast()
-                    && !is_ipv6_unicast_link_local(&ip)
-                    && !is_ipv6_unique_local(&ip)
-                    && !is_ipv6_site_local(&ip)
-                    && !is_ipv6_ipv4_compatible(&ip)
-                    && !is_ipv6_nat64_translation(&ip)
-            },
-            |mapped| is_discovery_dialable_ipv4(&mapped),
-        ),
+        IpAddr::V6(ip) => {
+            !ip.is_unspecified()
+                && !ip.is_loopback()
+                && !ip.is_multicast()
+                && !is_ipv6_unicast_link_local(&ip)
+                && !is_ipv6_unique_local(&ip)
+                && !is_ipv6_site_local(&ip)
+                && !is_ipv6_nat64_translation(&ip)
+        }
     }
 }
 
@@ -3464,7 +3460,7 @@ fn is_static_discovery_configured_addr_usable(addr: &SocketAddr) -> bool {
         return false;
     }
 
-    match addr.ip() {
+    match canonical_ip(addr.ip()) {
         IpAddr::V4(ip) => !ip.is_unspecified() && !ip.is_multicast() && !ip.is_broadcast(),
         IpAddr::V6(ip) => !ip.is_unspecified() && !ip.is_multicast(),
     }
@@ -3472,12 +3468,6 @@ fn is_static_discovery_configured_addr_usable(addr: &SocketAddr) -> bool {
 
 fn is_ipv6_unicast_link_local(ip: &Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xffc0) == 0xfe80
-}
-
-fn ipv6_mapped_ipv4(ip: &Ipv6Addr) -> Option<Ipv4Addr> {
-    let octets = ip.octets();
-    (octets[..10] == [0; 10] && octets[10..12] == [0xff; 2])
-        .then(|| Ipv4Addr::new(octets[12], octets[13], octets[14], octets[15]))
 }
 
 fn is_ipv4_protocol_assignment(ip: &Ipv4Addr) -> bool {
@@ -3510,10 +3500,6 @@ fn is_ipv6_unique_local(ip: &Ipv6Addr) -> bool {
 // the modern RFC 4193 unique-local range.
 fn is_ipv6_site_local(ip: &Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xffc0) == 0xfec0
-}
-
-fn is_ipv6_ipv4_compatible(ip: &Ipv6Addr) -> bool {
-    ip.octets()[..12] == [0; 12]
 }
 
 fn is_ipv6_nat64_translation(ip: &Ipv6Addr) -> bool {
@@ -5756,6 +5742,18 @@ mod tests {
             ),
             SocketAddr::new(
                 IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 1)),
+                8233,
+            ),
+            // 6to4 embeds 10.0.0.1 in bits 16..48.
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0x2002, 0x0a00, 1, 0, 0, 0, 0, 0)),
+                8233,
+            ),
+            // Teredo stores the client IPv4 address bitwise-inverted in the final 32 bits.
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(
+                    0x2001, 0, 0xc000, 0x022d, 0, 0, 0xf5ff, 0xfffe,
+                )),
                 8233,
             ),
             SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x0a00, 1)), 8233),

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -3437,6 +3437,8 @@ fn is_discovery_dialable_addr(addr: &SocketAddr) -> bool {
                     && !is_ipv6_unicast_link_local(&ip)
                     && !is_ipv6_unique_local(&ip)
                     && !is_ipv6_site_local(&ip)
+                    && !is_ipv6_ipv4_compatible(&ip)
+                    && !is_ipv6_nat64_translation(&ip)
             },
             |mapped| is_discovery_dialable_ipv4(&mapped),
         ),
@@ -3445,12 +3447,16 @@ fn is_discovery_dialable_addr(addr: &SocketAddr) -> bool {
 
 fn is_discovery_dialable_ipv4(ip: &Ipv4Addr) -> bool {
     !ip.is_unspecified()
+        && ip.octets()[0] != 0
         && !ip.is_loopback()
         && !ip.is_multicast()
         && !ip.is_broadcast()
         && !ip.is_link_local()
         && !ip.is_private()
         && !is_ipv4_shared(ip)
+        && !is_ipv4_protocol_assignment(ip)
+        && !is_ipv4_benchmarking(ip)
+        && !is_ipv4_reserved(ip)
 }
 
 fn is_static_discovery_configured_addr_usable(addr: &SocketAddr) -> bool {
@@ -3474,6 +3480,20 @@ fn ipv6_mapped_ipv4(ip: &Ipv6Addr) -> Option<Ipv4Addr> {
         .then(|| Ipv4Addr::new(octets[12], octets[13], octets[14], octets[15]))
 }
 
+fn is_ipv4_protocol_assignment(ip: &Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 192 && octets[1] == 0 && octets[2] == 0
+}
+
+fn is_ipv4_benchmarking(ip: &Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 198 && matches!(octets[1], 18 | 19)
+}
+
+fn is_ipv4_reserved(ip: &Ipv4Addr) -> bool {
+    ip.octets()[0] >= 240
+}
+
 // `Ipv4Addr::is_shared` is still unstable, so match the RFC 6598 100.64.0.0/10 range directly,
 // mirroring `is_ipv6_unicast_link_local`.
 fn is_ipv4_shared(ip: &Ipv4Addr) -> bool {
@@ -3490,6 +3510,15 @@ fn is_ipv6_unique_local(ip: &Ipv6Addr) -> bool {
 // the modern RFC 4193 unique-local range.
 fn is_ipv6_site_local(ip: &Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xffc0) == 0xfec0
+}
+
+fn is_ipv6_ipv4_compatible(ip: &Ipv6Addr) -> bool {
+    ip.octets()[..12] == [0; 12]
+}
+
+fn is_ipv6_nat64_translation(ip: &Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x0064 && segments[1] == 0xff9b && (segments[2..6] == [0; 4] || segments[2] == 1)
 }
 
 // Import accepts records inside the clock-skew window, but runtime liveness is strict.
@@ -5705,13 +5734,17 @@ mod tests {
         // direct addresses. Untrusted gossip must therefore be restricted to globally routable
         // targets; otherwise an authenticated discovery peer could seed signed records pointing at
         // the honest node's private/internal network and turn the candidate dialer into an internal
-        // SSRF/scanner. RFC 1918 private, RFC 6598 shared (CGNAT), and RFC 4193 unique-local ranges
-        // are neither loopback nor link-local, so the original filter let them through.
+        // SSRF/scanner. Private, shared, special-purpose, IPv4-embedded, NAT64 translation, and
+        // unique/site-local ranges are not all covered by the standard loopback/link-local checks.
         let bad_addrs = [
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)), 8233),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(172, 16, 5, 5)), 8233),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8233),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)), 8233),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 1, 2, 3)), 8233),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 0, 1)), 8233),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 18, 0, 1)), 8233),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(240, 0, 0, 1)), 8233),
             SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)), 8233),
             SocketAddr::new(
                 IpAddr::V6(Ipv6Addr::new(0xfd12, 0x3456, 0, 0, 0, 0, 0, 1)),
@@ -5723,6 +5756,15 @@ mod tests {
             ),
             SocketAddr::new(
                 IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 1)),
+                8233,
+            ),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x0a00, 1)), 8233),
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0x0064, 0xff9b, 0, 0, 0, 0, 0x0a00, 1)),
+                8233,
+            ),
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0x0064, 0xff9b, 1, 0, 0, 0, 0x0a00, 1)),
                 8233,
             ),
             SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfec0, 0, 0, 0, 0, 0, 0, 1)), 8233),

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -912,9 +912,9 @@ pub struct ZakuraDiscoveryPersistedEntry {
 
 /// A locally dialable discovery candidate.
 ///
-/// Candidates may come from first-party confirmed signed discovery records or from trusted static
-/// bootstrap configuration. Only signed records are eligible for peer samples; unsigned static
-/// candidates are local dial hints.
+/// Candidates may come from signed discovery records or from trusted static bootstrap
+/// configuration. Only signed records are eligible for peer samples; unsigned static candidates
+/// are local dial hints.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ZakuraDiscoveryDialCandidate {
     /// Candidate iroh node id.
@@ -1952,6 +1952,14 @@ impl ZakuraDiscoveryHandle {
         )
     }
 
+    pub(crate) async fn dial_backoff(&self) -> (Duration, Duration) {
+        let inner = self.inner.lock().await;
+        (
+            inner.config.dial_backoff_base,
+            inner.config.dial_backoff_max,
+        )
+    }
+
     /// Returns service-aware candidates, using fallback to general peers only when requested.
     pub async fn service_candidates(
         &self,
@@ -2693,7 +2701,6 @@ impl ZakuraDiscoveryBook {
                         dial_backoff.0,
                         dial_backoff.1,
                     )
-                    && entry_has_confirmed_dial_authority(entry)
                     && has_wanted_services(&entry.record, wanted_services)
                     && has_discovery_usable_direct_addrs(entry)
             })
@@ -3407,10 +3414,6 @@ fn has_discovery_usable_direct_addrs(entry: &ZakuraDiscoveryEntry) -> bool {
         })
 }
 
-fn entry_has_confirmed_dial_authority(entry: &ZakuraDiscoveryEntry) -> bool {
-    entry.is_static || entry.source == Some(entry.record.body.node_id)
-}
-
 /// Returns true only for addresses that are safe to dial from untrusted discovery gossip.
 ///
 /// A signed `ZakuraNodeRecord` proves control of the node key, not ownership of the advertised
@@ -3425,23 +3428,29 @@ fn is_discovery_dialable_addr(addr: &SocketAddr) -> bool {
     }
 
     match addr.ip() {
-        IpAddr::V4(ip) => {
-            !ip.is_unspecified()
-                && !ip.is_loopback()
-                && !ip.is_multicast()
-                && !ip.is_broadcast()
-                && !ip.is_link_local()
-                && !ip.is_private()
-                && !is_ipv4_shared(&ip)
-        }
-        IpAddr::V6(ip) => {
-            !ip.is_unspecified()
-                && !ip.is_loopback()
-                && !ip.is_multicast()
-                && !is_ipv6_unicast_link_local(&ip)
-                && !is_ipv6_unique_local(&ip)
-        }
+        IpAddr::V4(ip) => is_discovery_dialable_ipv4(&ip),
+        IpAddr::V6(ip) => ipv6_mapped_ipv4(&ip).map_or_else(
+            || {
+                !ip.is_unspecified()
+                    && !ip.is_loopback()
+                    && !ip.is_multicast()
+                    && !is_ipv6_unicast_link_local(&ip)
+                    && !is_ipv6_unique_local(&ip)
+                    && !is_ipv6_site_local(&ip)
+            },
+            |mapped| is_discovery_dialable_ipv4(&mapped),
+        ),
     }
+}
+
+fn is_discovery_dialable_ipv4(ip: &Ipv4Addr) -> bool {
+    !ip.is_unspecified()
+        && !ip.is_loopback()
+        && !ip.is_multicast()
+        && !ip.is_broadcast()
+        && !ip.is_link_local()
+        && !ip.is_private()
+        && !is_ipv4_shared(ip)
 }
 
 fn is_static_discovery_configured_addr_usable(addr: &SocketAddr) -> bool {
@@ -3459,6 +3468,12 @@ fn is_ipv6_unicast_link_local(ip: &Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xffc0) == 0xfe80
 }
 
+fn ipv6_mapped_ipv4(ip: &Ipv6Addr) -> Option<Ipv4Addr> {
+    let octets = ip.octets();
+    (octets[..10] == [0; 10] && octets[10..12] == [0xff; 2])
+        .then(|| Ipv4Addr::new(octets[12], octets[13], octets[14], octets[15]))
+}
+
 // `Ipv4Addr::is_shared` is still unstable, so match the RFC 6598 100.64.0.0/10 range directly,
 // mirroring `is_ipv6_unicast_link_local`.
 fn is_ipv4_shared(ip: &Ipv4Addr) -> bool {
@@ -3469,6 +3484,12 @@ fn is_ipv4_shared(ip: &Ipv4Addr) -> bool {
 // `Ipv6Addr::is_unique_local` is still unstable, so match the RFC 4193 fc00::/7 range directly.
 fn is_ipv6_unique_local(ip: &Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+// Deprecated RFC 3879 site-local addresses remain internal targets even though they are outside
+// the modern RFC 4193 unique-local range.
+fn is_ipv6_site_local(ip: &Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfec0
 }
 
 // Import accepts records inside the clock-skew window, but runtime liveness is strict.
@@ -5696,6 +5717,15 @@ mod tests {
                 IpAddr::V6(Ipv6Addr::new(0xfd12, 0x3456, 0, 0, 0, 0, 0, 1)),
                 8233,
             ),
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 1)),
+                8233,
+            ),
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 1)),
+                8233,
+            ),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfec0, 0, 0, 0, 0, 0, 0, 1)), 8233),
         ];
 
         for (index, bad_addr) in bad_addrs.into_iter().enumerate() {
@@ -5747,7 +5777,7 @@ mod tests {
     }
 
     #[test]
-    fn discovery_book_gossiped_public_third_party_record_is_not_dialable() {
+    fn discovery_book_gossiped_public_third_party_record_is_dialable() {
         let mut book = ZakuraDiscoveryBook::default();
         let gossip_source = secret_key().public();
         let public_target = signed_record_with_addrs(
@@ -5770,7 +5800,7 @@ mod tests {
             &public_target
         );
 
-        assert!(
+        assert_eq!(
             book.dial_candidates(
                 10,
                 &[service(1)],
@@ -5784,11 +5814,13 @@ mod tests {
                     DEFAULT_DISCOVERY_DIAL_BACKOFF_MAX,
                 ),
                 &mut StdRng::seed_from_u64(7),
-            )
-            .is_empty(),
-            "unconfirmed third-party public gossip must not drive native dials"
+            ),
+            vec![candidate_for(&public_target, false)],
+            "valid public gossip must expand discovery beyond directly connected peers"
         );
 
+        // A later first-party exchange still updates the record's source metadata without changing
+        // its dialability.
         assert_eq!(
             book.import_record(public_target.clone(), Some(target_id), NOW + 1, &context())
                 .expect("first-party self-record confirmation imports"),

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -2551,7 +2551,9 @@ impl ZakuraDiscoveryBook {
                 last_short_lived_exchange: None,
                 failure_count: 0,
             });
-        candidate.direct_addrs = direct_addrs;
+        candidate.direct_addrs.extend(direct_addrs);
+        candidate.direct_addrs.sort_unstable();
+        candidate.direct_addrs.dedup();
         candidate.last_seen = now;
         Ok(())
     }
@@ -5876,10 +5878,16 @@ mod tests {
         let mut book = ZakuraDiscoveryBook::default();
         let node_id = secret_key().public();
         let loopback_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8233);
+        let second_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8234);
         let node_addr = NodeAddr::new(node_id).with_direct_addresses([loopback_addr]);
 
         book.insert_static_candidate(node_addr, NOW)
             .expect("configured static loopback candidate imports");
+        book.insert_static_candidate(
+            NodeAddr::new(node_id).with_direct_addresses([second_addr]),
+            NOW + 1,
+        )
+        .expect("additional address for the same static identity imports");
 
         let mut rng = StdRng::seed_from_u64(7);
         assert!(book.sample_peers(10, &[], &[], NOW, &mut rng).is_empty());
@@ -5900,7 +5908,7 @@ mod tests {
             ),
             vec![ZakuraDiscoveryDialCandidate {
                 node_id,
-                direct_addrs: vec![loopback_addr],
+                direct_addrs: vec![loopback_addr, second_addr],
                 is_static: true,
             }]
         );

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -3437,6 +3437,7 @@ fn is_discovery_dialable_addr(addr: &SocketAddr) -> bool {
                 && !is_ipv6_unique_local(&ip)
                 && !is_ipv6_site_local(&ip)
                 && !is_ipv6_nat64_translation(&ip)
+                && !is_ipv6_documentation(&ip)
         }
     }
 }
@@ -3451,6 +3452,7 @@ fn is_discovery_dialable_ipv4(ip: &Ipv4Addr) -> bool {
         && !ip.is_private()
         && !is_ipv4_shared(ip)
         && !is_ipv4_protocol_assignment(ip)
+        && !is_ipv4_documentation(ip)
         && !is_ipv4_benchmarking(ip)
         && !is_ipv4_reserved(ip)
 }
@@ -3482,6 +3484,26 @@ fn is_ipv4_benchmarking(ip: &Ipv4Addr) -> bool {
 
 fn is_ipv4_reserved(ip: &Ipv4Addr) -> bool {
     ip.octets()[0] >= 240
+}
+
+// `Ipv4Addr::is_documentation` is still unstable, so match the three RFC 5737
+// documentation ranges (TEST-NET-1/2/3) directly. These are reserved for docs
+// and examples, never globally routable, so an advertised documentation address
+// can only be an attempt to steer a dial at an internal or bogus target.
+fn is_ipv4_documentation(ip: &Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    matches!(
+        (octets[0], octets[1], octets[2]),
+        (192, 0, 2) | (198, 51, 100) | (203, 0, 113)
+    )
+}
+
+// `Ipv6Addr::is_documentation` is still unstable, so match the RFC 3849
+// 2001:db8::/32 documentation range directly (IPv6 counterpart of the RFC 5737
+// TEST-NET ranges).
+fn is_ipv6_documentation(ip: &Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x2001 && segments[1] == 0x0db8
 }
 
 // `Ipv4Addr::is_shared` is still unstable, so match the RFC 6598 100.64.0.0/10 range directly,
@@ -4466,9 +4488,9 @@ mod tests {
         ZakuraNodeRecordBody {
             node_id: secret_key.public(),
             direct_addrs: vec![
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)), 8233),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(45, 33, 30, 10)), 8233),
                 SocketAddr::new(
-                    IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 10)),
+                    IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x10)),
                     18233,
                 ),
             ],
@@ -4542,7 +4564,7 @@ mod tests {
     }
 
     fn test_addr(index: u8) -> SocketAddr {
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, index)), 8233)
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(45, 33, 30, index)), 8233)
     }
 
     fn candidate_for(record: &ZakuraNodeRecord, is_static: bool) -> ZakuraDiscoveryDialCandidate {
@@ -5029,7 +5051,7 @@ mod tests {
                 record
                     .body
                     .direct_addrs
-                    .push("198.51.100.1:8233".parse().unwrap())
+                    .push("45.33.30.1:8233".parse().unwrap())
             }),
             Box::new(|record, _context| record.body.services.push(service(9))),
             Box::new(|record, _context| record.body.zakura_protocol_min = 0),
@@ -5147,7 +5169,7 @@ mod tests {
         let secret_key = secret_key();
         let mut too_many_addrs = body(&secret_key);
         too_many_addrs.direct_addrs =
-            vec!["192.0.2.1:8233".parse().unwrap(); MAX_DIRECT_ADDRS_PER_RECORD + 1];
+            vec!["45.33.30.1:8233".parse().unwrap(); MAX_DIRECT_ADDRS_PER_RECORD + 1];
         assert!(ZakuraNodeRecord::sign(too_many_addrs, &secret_key).is_err());
 
         let mut too_many_services = body(&secret_key);
@@ -5695,7 +5717,7 @@ mod tests {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8233),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)), 8233),
             SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)), 8233),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 20)), 0),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(45, 33, 30, 20)), 0),
         ];
 
         for (index, bad_addr) in bad_addrs.into_iter().enumerate() {
@@ -5731,6 +5753,16 @@ mod tests {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 0, 1)), 8233),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 18, 0, 1)), 8233),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(240, 0, 0, 1)), 8233),
+            // RFC 5737 documentation ranges (TEST-NET-1/2/3) are reserved for
+            // docs, never globally routable.
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 5)), 8233),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 5)), 8233),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), 8233),
+            // RFC 3849 IPv6 documentation range 2001:db8::/32.
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 5)),
+                8233,
+            ),
             SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)), 8233),
             SocketAddr::new(
                 IpAddr::V6(Ipv6Addr::new(0xfd12, 0x3456, 0, 0, 0, 0, 0, 1)),

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -1590,7 +1590,7 @@ impl ZakuraDiscoveryHandle {
     ) -> ServiceAdmissionDecision {
         let mut inner = self.inner.lock().await;
         if let Some(peer) = inner.admitted_peers.get_mut(&peer_id) {
-            if (conn_id, session_id) < (peer.conn_id, peer.session_id) {
+            if (conn_id, session_id) <= (peer.conn_id, peer.session_id) {
                 return ServiceAdmissionDecision::RejectNotUseful;
             }
 
@@ -8034,6 +8034,12 @@ mod tests {
                 .admit_peer_session(2, 2, peer.clone(), ServicePeerDirection::Inbound)
                 .await,
             ServiceAdmissionDecision::Admit
+        );
+        assert_eq!(
+            handle
+                .admit_peer_session(2, 2, peer.clone(), ServicePeerDirection::Inbound)
+                .await,
+            ServiceAdmissionDecision::RejectNotUseful
         );
 
         handle.remove_session(&peer, 2, 1).await;

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -1224,6 +1224,7 @@ struct ZakuraDiscoveryInner {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct ZakuraDiscoveryAdmittedPeer {
     conn_id: ZakuraConnId,
+    session_id: u64,
     direction: ServicePeerDirection,
 }
 
@@ -1576,13 +1577,28 @@ impl ZakuraDiscoveryHandle {
         peer_id: ZakuraPeerId,
         direction: ServicePeerDirection,
     ) -> ServiceAdmissionDecision {
+        self.admit_peer_session(conn_id, 0, peer_id, direction)
+            .await
+    }
+
+    pub(crate) async fn admit_peer_session(
+        &self,
+        conn_id: ZakuraConnId,
+        session_id: u64,
+        peer_id: ZakuraPeerId,
+        direction: ServicePeerDirection,
+    ) -> ServiceAdmissionDecision {
         let mut inner = self.inner.lock().await;
         if let Some(peer) = inner.admitted_peers.get_mut(&peer_id) {
-            if conn_id < peer.conn_id {
+            if (conn_id, session_id) < (peer.conn_id, peer.session_id) {
                 return ServiceAdmissionDecision::RejectNotUseful;
             }
 
-            *peer = ZakuraDiscoveryAdmittedPeer { conn_id, direction };
+            *peer = ZakuraDiscoveryAdmittedPeer {
+                conn_id,
+                session_id,
+                direction,
+            };
             self.publish_peer_snapshot_locked(&inner);
             return ServiceAdmissionDecision::Admit;
         }
@@ -1600,9 +1616,14 @@ impl ZakuraDiscoveryHandle {
         if admitted >= cap {
             ServiceAdmissionDecision::RejectFull
         } else {
-            inner
-                .admitted_peers
-                .insert(peer_id, ZakuraDiscoveryAdmittedPeer { conn_id, direction });
+            inner.admitted_peers.insert(
+                peer_id,
+                ZakuraDiscoveryAdmittedPeer {
+                    conn_id,
+                    session_id,
+                    direction,
+                },
+            );
             self.publish_peer_snapshot_locked(&inner);
             ServiceAdmissionDecision::Admit
         }
@@ -1619,6 +1640,38 @@ impl ZakuraDiscoveryHandle {
             inner.admitted_peers.remove(peer_id);
         }
         self.publish_peer_snapshot_locked(&inner);
+    }
+
+    /// Remove one exact ordered discovery stream generation.
+    pub(crate) async fn remove_session(
+        &self,
+        peer_id: &ZakuraPeerId,
+        conn_id: ZakuraConnId,
+        session_id: u64,
+    ) {
+        let mut inner = self.inner.lock().await;
+        if inner
+            .admitted_peers
+            .get(peer_id)
+            .is_some_and(|peer| (peer.conn_id, peer.session_id) == (conn_id, session_id))
+        {
+            inner.admitted_peers.remove(peer_id);
+        }
+        self.publish_peer_snapshot_locked(&inner);
+    }
+
+    /// Returns whether an ordered discovery stream is the currently admitted generation.
+    pub(crate) async fn is_current_session(
+        &self,
+        peer_id: &ZakuraPeerId,
+        conn_id: ZakuraConnId,
+        session_id: u64,
+    ) -> bool {
+        let inner = self.inner.lock().await;
+        inner
+            .admitted_peers
+            .get(peer_id)
+            .is_some_and(|peer| (peer.conn_id, peer.session_id) == (conn_id, session_id))
     }
 
     fn publish_peer_snapshot_locked(&self, inner: &ZakuraDiscoveryInner) {
@@ -7961,6 +8014,32 @@ mod tests {
         );
 
         handle.remove_peer(&peer, 2).await;
+        assert_eq!(handle.peer_snapshot().inbound_peers, 0);
+    }
+
+    #[tokio::test]
+    async fn stale_discovery_stream_cleanup_cannot_remove_newer_stream_on_same_connection() {
+        let (_connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handle = discovery_handle_with_connected(connected_rx);
+        let peer = peer_id_for(secret_key().public());
+
+        assert_eq!(
+            handle
+                .admit_peer_session(2, 1, peer.clone(), ServicePeerDirection::Inbound)
+                .await,
+            ServiceAdmissionDecision::Admit
+        );
+        assert_eq!(
+            handle
+                .admit_peer_session(2, 2, peer.clone(), ServicePeerDirection::Inbound)
+                .await,
+            ServiceAdmissionDecision::Admit
+        );
+
+        handle.remove_session(&peer, 2, 1).await;
+        assert_eq!(handle.peer_snapshot().inbound_peers, 1);
+
+        handle.remove_session(&peer, 2, 2).await;
         assert_eq!(handle.peer_snapshot().inbound_peers, 0);
     }
 

--- a/zakura-network/src/zakura/discovery/service.rs
+++ b/zakura-network/src/zakura/discovery/service.rs
@@ -862,7 +862,7 @@ mod tests {
         let body = ZakuraNodeRecordBody {
             node_id: secret_key.public(),
             direct_addrs: vec![SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 44)),
+                IpAddr::V4(Ipv4Addr::new(45, 33, 30, 44)),
                 8233,
             )],
             services: vec![ZakuraServiceId::header_sync()],
@@ -960,7 +960,7 @@ mod tests {
         let body = ZakuraNodeRecordBody {
             node_id: secret_key.public(),
             direct_addrs: vec![SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 45)),
+                IpAddr::V4(Ipv4Addr::new(45, 33, 30, 45)),
                 8233,
             )],
             services: vec![ZakuraServiceId::discovery()],

--- a/zakura-network/src/zakura/discovery/service.rs
+++ b/zakura-network/src/zakura/discovery/service.rs
@@ -11,7 +11,7 @@
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex as StdMutex,
     },
     time::Duration,
 };
@@ -25,7 +25,7 @@ use crate::zakura::{
     CloseCause, Flow, Frame, FramedRecv, FramedSend, HeaderSyncEvent, HeaderSyncHandle,
     OrderedSendError, Peer, PeerStreamSession, Pipe, Service, ServiceAdmissionDecision,
     ServicePeerDirection, SinkReject, Stream, StreamMode, ZakuraConnId, ZakuraPeerId,
-    LOCAL_MAX_CONTROL_FRAME_BYTES, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
+    LOCAL_MAX_CONTROL_FRAME_BYTES, ZAKURA_CAP_DISCOVERY,
 };
 
 #[cfg(test)]
@@ -155,6 +155,7 @@ pub struct DiscoveryService {
     handle: ZakuraDiscoveryHandle,
     header_sync: Option<HeaderSyncHandle>,
     block_sync: Option<BlockSyncHandle>,
+    connection_owners: Arc<StdMutex<Vec<Arc<dyn Service>>>>,
 }
 
 impl DiscoveryService {
@@ -164,6 +165,7 @@ impl DiscoveryService {
             handle,
             header_sync: None,
             block_sync: None,
+            connection_owners: Arc::new(StdMutex::new(Vec::new())),
         }
     }
 
@@ -177,7 +179,15 @@ impl DiscoveryService {
             handle,
             header_sync: Some(header_sync),
             block_sync,
+            connection_owners: Arc::new(StdMutex::new(Vec::new())),
         }
+    }
+
+    pub(crate) fn set_connection_owners(&self, owners: Vec<Arc<dyn Service>>) {
+        *self
+            .connection_owners
+            .lock()
+            .expect("discovery connection-owner mutex is never poisoned") = owners;
     }
 
     /// Returns the underlying discovery runtime handle.
@@ -233,12 +243,16 @@ impl Service for DiscoveryService {
         let service_cancel = discovery_session.cancel_token();
         let connection_cancel = peer.cancel_token();
         let close_cause = peer.close_cause();
-        let other_service_negotiated = has_other_negotiated_service(peer.negotiated);
         let (_peer_id, _stream_kind, recv, _send, _session_cancel) = session.into_parts();
 
         let handle = self.handle.clone();
         let header_sync = self.header_sync.clone();
         let block_sync = self.block_sync.clone();
+        let connection_owners = self
+            .connection_owners
+            .lock()
+            .expect("discovery connection-owner mutex is never poisoned")
+            .clone();
         // SR-1: a panic in the admission task (before it hands off to the
         // exchange) must still disconnect this one peer and cancel its discovery
         // session instead of leaving admitted state behind a half-live
@@ -281,6 +295,7 @@ impl Service for DiscoveryService {
                     handle,
                     header_sync,
                     block_sync,
+                    connection_owners,
                     peer_node_id,
                     discovery_session,
                     conn_id,
@@ -289,7 +304,6 @@ impl Service for DiscoveryService {
                     service_cancel,
                     connection_cancel,
                     close_cause,
-                    other_service_negotiated,
                 });
             },
         );
@@ -308,6 +322,7 @@ struct DiscoveryExchangeStart {
     handle: ZakuraDiscoveryHandle,
     header_sync: Option<HeaderSyncHandle>,
     block_sync: Option<BlockSyncHandle>,
+    connection_owners: Vec<Arc<dyn Service>>,
     peer_node_id: NodeId,
     discovery_session: DiscoveryPeerSession,
     conn_id: ZakuraConnId,
@@ -316,7 +331,6 @@ struct DiscoveryExchangeStart {
     service_cancel: CancellationToken,
     connection_cancel: CancellationToken,
     close_cause: CloseCause,
-    other_service_negotiated: bool,
 }
 
 fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
@@ -324,6 +338,7 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
         handle,
         header_sync,
         block_sync,
+        connection_owners,
         peer_node_id,
         discovery_session,
         conn_id,
@@ -332,11 +347,9 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
         service_cancel,
         connection_cancel,
         close_cause,
-        other_service_negotiated,
     } = start;
     let peer_id = discovery_session.peer_id().clone();
     let progress = Arc::new(DiscoveryExchangeProgress::default());
-    let source_header_sync = header_sync.clone();
     let sink = DiscoverySink {
         handle: handle.clone(),
         header_sync,
@@ -376,6 +389,8 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
     let source = DiscoverySource {
         handle: handle.clone(),
         session: discovery_session,
+        conn_id,
+        session_id,
         progress,
     };
     // SR-1: a panic in the source task skips its `service_cancel.cancel()`,
@@ -399,18 +414,17 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
         },
         async move {
             let exchanged = source.run().await;
-            if exchanged {
+            let closes_discovery_only_connection = exchanged
+                && !peer_has_other_service_owner(&connection_owners, &peer_id, conn_id)
+                && handle
+                    .is_current_session(&peer_id, conn_id, session_id)
+                    .await;
+            if closes_discovery_only_connection {
                 handle.mark_short_lived_exchange(&peer_node_id).await;
             }
             service_cancel.cancel();
             handle.remove_session(&peer_id, conn_id, session_id).await;
-            if exchanged
-                && !peer_has_other_service_owner(
-                    source_header_sync.as_ref(),
-                    peer_node_id,
-                    other_service_negotiated,
-                )
-            {
+            if closes_discovery_only_connection {
                 source_close_cause.record("discovery_exchange_complete");
                 connection_cancel.cancel();
             }
@@ -634,6 +648,8 @@ fn decode_header_sync_summaries(
 struct DiscoverySource {
     handle: ZakuraDiscoveryHandle,
     session: DiscoveryPeerSession,
+    conn_id: ZakuraConnId,
+    session_id: u64,
     progress: Arc<DiscoveryExchangeProgress>,
 }
 
@@ -645,11 +661,13 @@ impl DiscoverySource {
         let cancel = self.session.cancel_token();
         tokio::select! {
             biased;
-            _ = cancel.cancelled() => {}
+            _ = cancel.cancelled() => return false,
             _ = self.progress.wait_complete() => {}
             _ = tokio::time::sleep(DISCOVERY_EXCHANGE_SETTLE_TIMEOUT) => {}
         }
-        true
+        self.handle
+            .is_current_session(self.session.peer_id(), self.conn_id, self.session_id)
+            .await
     }
 
     /// Gossips the current self-record and asks the peer for records and services.
@@ -657,6 +675,14 @@ impl DiscoverySource {
     /// Returns `Err(())` once the stream's send side is gone, so the caller
     /// stops the periodic loop.
     async fn exchange(&self) -> Result<(), ()> {
+        if !self
+            .handle
+            .is_current_session(self.session.peer_id(), self.conn_id, self.session_id)
+            .await
+        {
+            return Err(());
+        }
+
         let record = (*self.handle.current_self_record()).clone();
         self.handle_send_result(self.session.try_send_hello(record))?;
 
@@ -731,24 +757,13 @@ impl DiscoveryExchangeProgress {
 }
 
 fn peer_has_other_service_owner(
-    header_sync: Option<&HeaderSyncHandle>,
-    peer_node_id: NodeId,
-    other_service_negotiated: bool,
+    connection_owners: &[Arc<dyn Service>],
+    peer_id: &ZakuraPeerId,
+    conn_id: ZakuraConnId,
 ) -> bool {
-    if other_service_negotiated {
-        return true;
-    }
-
-    header_sync.is_some_and(|header_sync| {
-        header_sync
-            .candidate_state()
-            .admitted_node_ids
-            .contains(&peer_node_id)
-    })
-}
-
-fn has_other_negotiated_service(negotiated: u64) -> bool {
-    negotiated & !(ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_HEADER_SYNC) != 0
+    connection_owners
+        .iter()
+        .any(|owner| owner.owns_connection_for_peer(peer_id, conn_id))
 }
 
 /// Returns the iroh node id encoded by a discovery peer id, if it is a 32-byte
@@ -790,24 +805,50 @@ mod tests {
     };
     use crate::zakura::{
         framed_channel, spawn_block_sync_reactor, spawn_header_sync_reactor, BlockSyncFrontiers,
-        BlockSyncStartup, HeaderSyncAction, HeaderSyncFrontiers, HeaderSyncMessage,
-        HeaderSyncPeerSession, HeaderSyncStartup, HeaderSyncStatus, HeaderSyncWireRequestIdentity,
-        ServicePeerLimits, ZakuraBlockSyncConfig, ZakuraDiscoveryConfig,
-        ZakuraDiscoveryLocalConfig, ZakuraHandshakeConfig, ZakuraHeaderSyncConfig,
-        LOCAL_MAX_MESSAGE_BYTES, MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_BLOCK_SYNC,
-        ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
+        BlockSyncService, BlockSyncStartup, HeaderSyncAction, HeaderSyncFrontiers,
+        HeaderSyncMessage, HeaderSyncPeerSession, HeaderSyncService, HeaderSyncStartup,
+        HeaderSyncStatus, HeaderSyncWireRequestIdentity, ServicePeerLimits, ZakuraBlockSyncConfig,
+        ZakuraDiscoveryConfig, ZakuraDiscoveryLocalConfig, ZakuraHandshakeConfig,
+        ZakuraHeaderSyncConfig, LOCAL_MAX_MESSAGE_BYTES, MAX_BS_RESPONSE_BYTES,
+        ZAKURA_CAP_BLOCK_SYNC, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
+        ZAKURA_STREAM_HEADER_SYNC,
     };
     use zakura_chain::{block, parameters::Network};
 
+    #[derive(Debug)]
+    struct TestConnectionOwner {
+        peer: ZakuraPeerId,
+        conn_id: ZakuraConnId,
+    }
+
+    impl Service for TestConnectionOwner {
+        fn name(&self) -> &'static str {
+            "test-connection-owner"
+        }
+
+        fn streams(&self) -> &[Stream] {
+            &[]
+        }
+
+        fn owns_connection_for_peer(&self, peer: &ZakuraPeerId, conn_id: ZakuraConnId) -> bool {
+            peer == &self.peer && conn_id == self.conn_id
+        }
+
+        fn add_peer(&self, _peer: Peer) {}
+
+        fn remove_peer(&self, _peer: &ZakuraPeerId, _conn_id: ZakuraConnId) {}
+    }
+
     #[test]
-    fn discovery_and_header_sync_do_not_count_as_another_service_owner() {
-        assert!(!has_other_negotiated_service(ZAKURA_CAP_DISCOVERY));
-        assert!(!has_other_negotiated_service(
-            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_HEADER_SYNC
-        ));
-        assert!(has_other_negotiated_service(
-            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_HEADER_SYNC | ZAKURA_CAP_BLOCK_SYNC
-        ));
+    fn connection_ownership_is_scoped_to_the_exact_connection() {
+        let peer = ZakuraPeerId::new(vec![37; 32]).expect("test peer id is within bounds");
+        let owners: Vec<Arc<dyn Service>> = vec![Arc::new(TestConnectionOwner {
+            peer: peer.clone(),
+            conn_id: 2,
+        })];
+
+        assert!(!peer_has_other_service_owner(&owners, &peer, 1));
+        assert!(peer_has_other_service_owner(&owners, &peer, 2));
     }
 
     struct HeaderAdvisoryFixture {
@@ -1545,7 +1586,128 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discovery_only_short_lived_exchange_closes_connection_and_backs_off(
+    async fn stale_discovery_source_cannot_send_after_stream_replacement(
+    ) -> Result<(), crate::BoxError> {
+        let (_connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
+        let handle = ZakuraDiscoveryHandle::new(
+            ZakuraDiscoveryLocalConfig {
+                secret_key: SecretKey::from_bytes(&[38u8; 32]),
+                direct_addrs: Vec::new(),
+                services: vec![ZakuraServiceId::discovery()],
+                zakura_protocol_min: handshake.zakura_protocol_min,
+                zakura_protocol_max: handshake.zakura_protocol_max,
+                network_id: handshake.network_id,
+                chain_id: handshake.chain_id,
+                last_authored_sequence: None,
+            },
+            ZakuraDiscoveryConfig::default(),
+            connected_rx,
+        )?;
+        let peer_node_id = SecretKey::from_bytes(&[39u8; 32]).public();
+        let peer_id = ZakuraPeerId::new(peer_node_id.as_bytes().to_vec())?;
+        assert_eq!(
+            handle
+                .admit_peer_session(2, 1, peer_id.clone(), ServicePeerDirection::Inbound)
+                .await,
+            ServiceAdmissionDecision::Admit
+        );
+
+        let (send, mut recv) = framed_channel(4);
+        let source = DiscoverySource {
+            handle: handle.clone(),
+            session: DiscoveryPeerSession {
+                peer_id: peer_id.clone(),
+                direction: ServicePeerDirection::Inbound,
+                send,
+                cancel: CancellationToken::new(),
+            },
+            conn_id: 2,
+            session_id: 1,
+            progress: Arc::new(DiscoveryExchangeProgress::default()),
+        };
+        assert_eq!(
+            handle
+                .admit_peer_session(2, 2, peer_id, ServicePeerDirection::Inbound)
+                .await,
+            ServiceAdmissionDecision::Admit
+        );
+
+        assert_eq!(source.exchange().await, Err(()));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), recv.recv())
+                .await
+                .is_err(),
+            "a replaced discovery stream must not emit another exchange"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn discovery_source_replaced_during_settle_does_not_complete_exchange(
+    ) -> Result<(), crate::BoxError> {
+        let (_connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
+        let handle = ZakuraDiscoveryHandle::new(
+            ZakuraDiscoveryLocalConfig {
+                secret_key: SecretKey::from_bytes(&[48u8; 32]),
+                direct_addrs: Vec::new(),
+                services: vec![ZakuraServiceId::discovery()],
+                zakura_protocol_min: handshake.zakura_protocol_min,
+                zakura_protocol_max: handshake.zakura_protocol_max,
+                network_id: handshake.network_id,
+                chain_id: handshake.chain_id,
+                last_authored_sequence: None,
+            },
+            ZakuraDiscoveryConfig::default(),
+            connected_rx,
+        )?;
+        let peer_node_id = SecretKey::from_bytes(&[49u8; 32]).public();
+        let peer_id = ZakuraPeerId::new(peer_node_id.as_bytes().to_vec())?;
+        assert_eq!(
+            handle
+                .admit_peer_session(2, 1, peer_id.clone(), ServicePeerDirection::Inbound)
+                .await,
+            ServiceAdmissionDecision::Admit
+        );
+
+        let (send, mut recv) = framed_channel(4);
+        let progress = Arc::new(DiscoveryExchangeProgress::default());
+        let source = DiscoverySource {
+            handle: handle.clone(),
+            session: DiscoveryPeerSession {
+                peer_id: peer_id.clone(),
+                direction: ServicePeerDirection::Inbound,
+                send,
+                cancel: CancellationToken::new(),
+            },
+            conn_id: 2,
+            session_id: 1,
+            progress: progress.clone(),
+        };
+        let source_task = tokio::spawn(async move { source.run().await });
+        for _ in 0..3 {
+            recv.recv()
+                .await
+                .expect("initial discovery request is sent");
+        }
+
+        assert_eq!(
+            handle
+                .admit_peer_session(2, 2, peer_id, ServicePeerDirection::Inbound)
+                .await,
+            ServiceAdmissionDecision::Admit
+        );
+        progress.mark_hello();
+        progress.mark_peers();
+        progress.mark_services();
+
+        assert!(!source_task.await?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn discovery_exchange_closes_connection_when_block_sync_is_not_admitted(
     ) -> Result<(), crate::BoxError> {
         let (connected_tx, connected_rx) = watch::channel(Vec::new());
         let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
@@ -1578,7 +1740,7 @@ mod tests {
         service.add_peer(Peer::new(
             peer_id,
             None,
-            ZAKURA_CAP_DISCOVERY,
+            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_BLOCK_SYNC,
             streams,
             connection_cancel.clone(),
         ));
@@ -1588,7 +1750,7 @@ mod tests {
             .await?;
         tokio::time::timeout(Duration::from_secs(2), connection_cancel.cancelled())
             .await
-            .expect("discovery-only exchange closes the shared connection");
+            .expect("unadmitted block sync does not keep the shared connection alive");
         wait_for_discovery_inbound_peers(&handle, 0).await;
 
         connected_tx.send_replace(Vec::new());
@@ -1597,6 +1759,74 @@ mod tests {
             .await
             .is_empty());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn admitted_block_sync_keeps_discovery_connection_alive() -> Result<(), crate::BoxError> {
+        let (connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
+        let handle = ZakuraDiscoveryHandle::new(
+            ZakuraDiscoveryLocalConfig {
+                secret_key: SecretKey::from_bytes(&[44u8; 32]),
+                direct_addrs: Vec::new(),
+                services: vec![ZakuraServiceId::discovery(), ZakuraServiceId::block_sync()],
+                zakura_protocol_min: handshake.zakura_protocol_min,
+                zakura_protocol_max: handshake.zakura_protocol_max,
+                network_id: handshake.network_id,
+                chain_id: handshake.chain_id,
+                last_authored_sequence: None,
+            },
+            ZakuraDiscoveryConfig::default(),
+            connected_rx,
+        )?;
+        let service = DiscoveryService::new(handle.clone());
+        let (block_sync, _block_events) =
+            BlockSyncService::new_for_test(ZakuraBlockSyncConfig::default());
+        let block_sync = Arc::new(block_sync);
+        service.set_connection_owners(vec![block_sync.clone()]);
+
+        let peer_secret = SecretKey::from_bytes(&[45u8; 32]);
+        let peer_node_id = peer_secret.public();
+        let peer_id = ZakuraPeerId::new(peer_node_id.as_bytes().to_vec())?;
+        connected_tx.send_replace(vec![peer_id.clone()]);
+        let connection_cancel = CancellationToken::new();
+
+        let (_peer_block_send, service_block_recv) = framed_channel(4);
+        let (service_block_send, _peer_block_recv) = framed_channel(4);
+        block_sync.add_peer(Peer::new(
+            peer_id.clone(),
+            None,
+            ZAKURA_CAP_BLOCK_SYNC,
+            HashMap::from([(
+                crate::zakura::ZAKURA_STREAM_BLOCK_SYNC,
+                (service_block_recv, service_block_send),
+            )]),
+            connection_cancel.clone(),
+        ));
+
+        let (peer_send, service_recv) = framed_channel(16);
+        let (service_send, mut peer_recv) = framed_channel(16);
+        service.add_peer(Peer::new(
+            peer_id,
+            None,
+            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_BLOCK_SYNC,
+            HashMap::from([(ZAKURA_STREAM_DISCOVERY, (service_recv, service_send))]),
+            connection_cancel.clone(),
+        ));
+
+        wait_for_discovery_inbound_peers(&handle, 1).await;
+        complete_peer_side_discovery_exchange(&peer_send, &mut peer_recv, &peer_secret, &handshake)
+            .await?;
+        wait_for_discovery_inbound_peers(&handle, 0).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), connection_cancel.cancelled())
+                .await
+                .is_err(),
+            "an admitted block-sync service owns the shared connection"
+        );
+
+        connection_cancel.cancel();
         Ok(())
     }
 
@@ -1626,21 +1856,26 @@ mod tests {
             header_sync.clone(),
             None,
         );
+        let header_service = Arc::new(HeaderSyncService::new(header_sync.clone()));
+        service.set_connection_owners(vec![header_service.clone()]);
         let peer_secret = SecretKey::from_bytes(&[43u8; 32]);
         let peer_node_id = peer_secret.public();
         let peer_id = ZakuraPeerId::new(peer_node_id.as_bytes().to_vec())?;
         connected_tx.send_replace(vec![peer_id.clone()]);
 
-        let (header_send, _header_recv) = framed_channel(8);
-        let header_session = HeaderSyncPeerSession::from_parts_with_direction(
+        let connection_cancel = CancellationToken::new();
+        let (_peer_header_send, service_header_recv) = framed_channel(8);
+        let (service_header_send, _peer_header_recv) = framed_channel(8);
+        header_service.add_peer(Peer::new(
             peer_id.clone(),
-            ServicePeerDirection::Inbound,
-            header_send,
-            CancellationToken::new(),
-        );
-        header_sync
-            .send(HeaderSyncEvent::PeerConnected(header_session))
-            .await?;
+            None,
+            ZAKURA_CAP_HEADER_SYNC,
+            HashMap::from([(
+                ZAKURA_STREAM_HEADER_SYNC,
+                (service_header_recv, service_header_send),
+            )]),
+            connection_cancel.clone(),
+        ));
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
                 if header_sync
@@ -1656,7 +1891,6 @@ mod tests {
         .await
         .expect("header sync admits the peer");
 
-        let connection_cancel = CancellationToken::new();
         let (peer_send, service_recv) = framed_channel(16);
         let (service_send, mut peer_recv) = framed_channel(16);
         let streams = HashMap::from([(ZAKURA_STREAM_DISCOVERY, (service_recv, service_send))]);

--- a/zakura-network/src/zakura/discovery/service.rs
+++ b/zakura-network/src/zakura/discovery/service.rs
@@ -211,7 +211,9 @@ impl Service for DiscoveryService {
     }
 
     fn add_peer(&self, mut peer: Peer) {
-        let Some((recv, send)) = peer.take_stream(ZAKURA_STREAM_DISCOVERY) else {
+        let Some((session_id, recv, send)) =
+            peer.take_stream_with_session_id(ZAKURA_STREAM_DISCOVERY)
+        else {
             return;
         };
         let Some(peer_node_id) = node_id_from_peer_id(&peer.id) else {
@@ -256,8 +258,9 @@ impl Service for DiscoveryService {
             },
             async move {
                 let decision = handle
-                    .admit_peer(
+                    .admit_peer_session(
                         conn_id,
+                        session_id,
                         discovery_session.peer_id().clone(),
                         discovery_session.direction(),
                     )
@@ -281,6 +284,7 @@ impl Service for DiscoveryService {
                     peer_node_id,
                     discovery_session,
                     conn_id,
+                    session_id,
                     recv,
                     service_cancel,
                     connection_cancel,
@@ -307,6 +311,7 @@ struct DiscoveryExchangeStart {
     peer_node_id: NodeId,
     discovery_session: DiscoveryPeerSession,
     conn_id: ZakuraConnId,
+    session_id: u64,
     recv: FramedRecv,
     service_cancel: CancellationToken,
     connection_cancel: CancellationToken,
@@ -322,6 +327,7 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
         peer_node_id,
         discovery_session,
         conn_id,
+        session_id,
         recv,
         service_cancel,
         connection_cancel,
@@ -337,6 +343,8 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
         block_sync,
         peer_node_id,
         session: discovery_session.clone(),
+        conn_id,
+        session_id,
         progress: progress.clone(),
     };
     let sink_service_cancel = service_cancel.clone();
@@ -371,10 +379,10 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
         progress,
     };
     // SR-1: a panic in the source task skips its `service_cancel.cancel()`,
-    // `handle.remove_peer()`, and discovery-only connection cancellation,
+    // `handle.remove_session()`, and discovery-only connection cancellation,
     // leaving admitted discovery state behind a half-live connection. On the
     // unwind path, disconnect this one peer; the connection teardown then drives
-    // the async `remove_peer` through the registry. Normal exits run the inline
+    // the async session removal through the registry. Normal exits run the inline
     // cleanup below, so `on_panic` is the panic-only path.
     let source_task_peer_id = peer_id.clone();
     let panic_source_service_cancel = service_cancel.clone();
@@ -395,7 +403,7 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
                 handle.mark_short_lived_exchange(&peer_node_id).await;
             }
             service_cancel.cancel();
-            handle.remove_peer(&peer_id, conn_id).await;
+            handle.remove_session(&peer_id, conn_id, session_id).await;
             if exchanged
                 && !peer_has_other_service_owner(
                     source_header_sync.as_ref(),
@@ -417,6 +425,8 @@ struct DiscoverySink {
     block_sync: Option<BlockSyncHandle>,
     peer_node_id: NodeId,
     session: DiscoveryPeerSession,
+    conn_id: ZakuraConnId,
+    session_id: u64,
     progress: Arc<DiscoveryExchangeProgress>,
 }
 
@@ -450,6 +460,14 @@ async fn run_discovery_pipe(
 
 impl DiscoverySink {
     async fn handle_message(&self, message: DiscoveryMessage) -> Result<(), SinkReject> {
+        if !self
+            .handle
+            .is_current_session(self.session.peer_id(), self.conn_id, self.session_id)
+            .await
+        {
+            return Ok(());
+        }
+
         match message {
             DiscoveryMessage::Hello { record } => self.handle_hello(record).await,
             DiscoveryMessage::GetPeers {

--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -1566,15 +1566,15 @@ pub(crate) fn service_registry(
     block_sync: Option<BlockSyncHandle>,
     block_sync_config: ZakuraBlockSyncConfig,
     legacy_service: Arc<dyn Service>,
-    discovery_service: Arc<dyn Service>,
+    discovery_service: Arc<super::DiscoveryService>,
 ) -> Result<Arc<ServiceRegistry>, BoxError> {
-    let mut services = vec![legacy_service.clone(), discovery_service];
-    if let Some(header_sync) = &header_sync {
-        services.push(Arc::new(HeaderSyncService::new(header_sync.clone())) as Arc<dyn Service>);
+    let mut services = vec![legacy_service.clone()];
+    let header_sync_service = if let Some(header_sync) = &header_sync {
+        Arc::new(HeaderSyncService::new(header_sync.clone())) as Arc<dyn Service>
     } else {
-        services
-            .push(Arc::new(HeaderSyncPassthroughService::new(legacy_service)) as Arc<dyn Service>);
-    }
+        Arc::new(HeaderSyncPassthroughService::new(legacy_service.clone())) as Arc<dyn Service>
+    };
+    services.push(header_sync_service.clone());
     let block_sync = match block_sync {
         Some(block_sync) => BlockSyncService::new_with_handle(block_sync_config, block_sync),
         None => match header_sync.as_ref() {
@@ -1585,7 +1585,14 @@ pub(crate) fn service_registry(
             None => BlockSyncService::new(block_sync_config),
         },
     };
-    services.push(Arc::new(block_sync) as Arc<dyn Service>);
+    let block_sync = Arc::new(block_sync) as Arc<dyn Service>;
+    discovery_service.set_connection_owners(vec![
+        legacy_service,
+        header_sync_service,
+        block_sync.clone(),
+    ]);
+    services.push(discovery_service as Arc<dyn Service>);
+    services.push(block_sync);
 
     Ok(Arc::new(
         ServiceRegistry::new(services).map_err(|error| -> BoxError { Box::new(error) })?,
@@ -3088,7 +3095,7 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
         discovery.clone(),
         header_sync.clone(),
         block_sync.clone(),
-    )) as Arc<dyn Service>;
+    ));
     let legacy_service = sink_factory(supervisor.clone(), trace.clone());
     let registry = service_registry(
         &supervisor,
@@ -5660,7 +5667,9 @@ mod tests {
         )
     }
 
-    fn test_discovery_service(supervisor: &ZakuraSupervisorHandle) -> Arc<dyn Service> {
+    fn test_discovery_service(
+        supervisor: &ZakuraSupervisorHandle,
+    ) -> Arc<crate::zakura::DiscoveryService> {
         let (_handle, service) =
             test_discovery_service_with_peer_limits(supervisor, ServicePeerLimits::default());
         service
@@ -5669,7 +5678,7 @@ mod tests {
     fn test_discovery_service_with_peer_limits(
         supervisor: &ZakuraSupervisorHandle,
         peer_limits: ServicePeerLimits,
-    ) -> (ZakuraDiscoveryHandle, Arc<dyn Service>) {
+    ) -> (ZakuraDiscoveryHandle, Arc<crate::zakura::DiscoveryService>) {
         let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
         let handle = ZakuraDiscoveryHandle::new(
             ZakuraDiscoveryLocalConfig {
@@ -5689,8 +5698,7 @@ mod tests {
             supervisor.subscribe(),
         )
         .expect("test discovery handle builds");
-        let service =
-            Arc::new(crate::zakura::DiscoveryService::new(handle.clone())) as Arc<dyn Service>;
+        let service = Arc::new(crate::zakura::DiscoveryService::new(handle.clone()));
         (handle, service)
     }
 

--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -48,7 +48,7 @@ use super::{
 use crate::{
     protocol::external::InventoryHash,
     zakura::{
-        direct_endpoint_builder, drive_header_sync_actions, spawn_block_sync_reactor,
+        canonical_ip, direct_endpoint_builder, drive_header_sync_actions, spawn_block_sync_reactor,
         spawn_header_sync_reactor, BlockSyncAction, BlockSyncFrontiers, BlockSyncHandle,
         BlockSyncService, BlockSyncStartup, Clock, CloseCause, Frame, FramedRecv, FramedSend,
         Frontier, FrontierChange, FrontierUpdate, HeaderSyncAction, HeaderSyncFrontiers,
@@ -1103,6 +1103,7 @@ impl ZakuraSupervisorHandle {
         disconnect_token: CancellationToken,
         _accepted_capabilities: u64,
     ) -> ZakuraRegistration {
+        let remote_ip = remote_ip.map(canonical_ip);
         let mut state = self.inner.lock().await;
         // A re-registration for a peer id that is already active from the same
         // IP is a duplicate redial, not a new per-IP allocation: the incumbent
@@ -1242,6 +1243,7 @@ impl ZakuraSupervisorHandle {
         remote_ip: IpAddr,
         in_flight_count: usize,
     ) -> bool {
+        let remote_ip = canonical_ip(remote_ip);
         let state = self.inner.lock().await;
         let active_count = state
             .active_by_ip
@@ -6630,6 +6632,66 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn ipv4_embedded_ipv6_addresses_share_the_supervisor_ip_bucket() {
+        async fn register_from_ip(
+            supervisor: &ZakuraSupervisorHandle,
+            peer: ZakuraPeerId,
+            ip: IpAddr,
+        ) -> ZakuraRegistration {
+            let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+            let outbound_handle = ZakuraPeerHandle::new_for_tests(peer.clone(), outbound_tx);
+            supervisor
+                .register(
+                    test_conn_id(),
+                    peer.clone(),
+                    Some(ip),
+                    [peer.as_bytes()[0]; TRANSCRIPT_HASH_BYTES],
+                    outbound_handle,
+                    CancellationToken::new(),
+                    ZAKURA_CAP_DISCOVERY,
+                )
+                .await
+        }
+
+        let ipv4: IpAddr = "93.184.216.34".parse().expect("IPv4 test address parses");
+        let mapped: IpAddr = "::ffff:93.184.216.34"
+            .parse()
+            .expect("mapped test address parses");
+        let compatible: IpAddr = "::93.184.216.34"
+            .parse()
+            .expect("compatible test address parses");
+        let six_to_four: IpAddr = "2002:5db8:d822::"
+            .parse()
+            .expect("6to4 test address parses");
+        let teredo: IpAddr = "2001:0:c000:22d::a247:27dd"
+            .parse()
+            .expect("Teredo test address parses");
+        let nat64: IpAddr = "64:ff9b::5db8:d822"
+            .parse()
+            .expect("NAT64 test address parses");
+        let supervisor = ZakuraSupervisorHandle::new(1);
+
+        assert!(matches!(
+            register_from_ip(&supervisor, test_peer(60), six_to_four).await,
+            ZakuraRegistration::Registered { .. }
+        ));
+
+        for alias in [ipv4, mapped, compatible, six_to_four, teredo, nat64] {
+            assert!(
+                !supervisor
+                    .can_accept_remote_ip_with_in_flight(alias, 0)
+                    .await,
+                "{alias} must share the occupied IPv4 identity bucket"
+            );
+        }
+
+        assert!(matches!(
+            register_from_ip(&supervisor, test_peer(61), ipv4).await,
+            ZakuraRegistration::Rejected(ZakuraRejectReason::ResourceLimit)
+        ));
     }
 
     // A restarted or resyncing peer redials from its stable IP while its previous

--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -1625,18 +1625,22 @@ fn random_stream_session_seed() -> u64 {
     }
 }
 
-/// Resolve the inbound peer's UDP source IP from the endpoint's node map so the
-/// per-IP connection cap can be enforced for Router-accepted connections.
+/// Resolve a connected peer's confirmed UDP source IP from the endpoint's node
+/// map so the per-IP connection cap can be enforced against the path that
+/// actually carries the connection.
 ///
-/// Iroh exposes the peer address on `Incoming`, which the Router consumes before
-/// `ProtocolHandler::accept`. After the native control handshake the connection
-/// has exchanged real QUIC payload over its direct path, so the endpoint's node
-/// map knows the peer's UDP address: prefer the connection's confirmed current
-/// path (`conn_type`), then fall back to the direct address that most recently
-/// delivered payload from this peer. Relay-only paths have no single
-/// attributable source IP, so they correctly yield `None` (the global
-/// connection cap still bounds them).
-fn inbound_remote_ip(endpoint: &Endpoint, node_id: NodeId) -> Option<IpAddr> {
+/// Used for both directions. Inbound: iroh exposes the peer address on
+/// `Incoming`, which the Router consumes before `ProtocolHandler::accept`.
+/// Outbound: a dialed peer may advertise several addresses, but only one path
+/// ends up carrying the connection — charging the first *advertised* address
+/// lets a record list a decoy address to escape the cap. In both cases, after
+/// the native control handshake the connection has exchanged real QUIC payload
+/// over its direct path, so the endpoint's node map knows the peer's UDP
+/// address: prefer the connection's confirmed current path (`conn_type`), then
+/// fall back to the direct address that most recently delivered payload from
+/// this peer. Relay-only paths have no single attributable source IP, so they
+/// correctly yield `None` (the global connection cap still bounds them).
+fn confirmed_remote_ip(endpoint: &Endpoint, node_id: NodeId) -> Option<IpAddr> {
     if let Some(mut conn_type) = endpoint.conn_type(node_id) {
         match conn_type.get() {
             ConnectionType::Direct(addr) | ConnectionType::Mixed(addr, _) => {
@@ -1804,7 +1808,7 @@ impl ZakuraProtocolHandler {
         let remote_ip = self
             .endpoint
             .as_ref()
-            .and_then(|endpoint| inbound_remote_ip(endpoint, remote_node_id));
+            .and_then(|endpoint| confirmed_remote_ip(endpoint, remote_node_id));
         let local_node_id = self
             .endpoint
             .as_ref()
@@ -3209,7 +3213,6 @@ pub(crate) async fn serve_native_dial_connection(
         .clone()
         .try_acquire_owned()
         .map_err(|_| ZakuraHandlerError::ResourceLimit("admission"))?;
-    let remote_ip = node_addr.direct_addresses().next().map(|addr| addr.ip());
     let connection = timeout(
         limits.control_timeout,
         endpoint.router.endpoint().connect(node_addr, P2P_V2_ALPN),
@@ -3239,6 +3242,12 @@ pub(crate) async fn serve_native_dial_connection(
         .await?
     };
     let conn_limits = limits.clamp(&negotiated.limits);
+    // Charge the connection to the path iroh actually confirmed, not the first
+    // address the record advertised: a record can list an unreachable decoy as
+    // its first direct address to escape the per-IP cap while the connection is
+    // served over a different (shared) address. The handshake above exchanged
+    // QUIC payload, so the node map now knows the confirmed path.
+    let remote_ip = confirmed_remote_ip(endpoint.router.endpoint(), remote_node_id);
     let direction = ServicePeerDirection::Outbound;
     endpoint
         .handler

--- a/zakura-network/src/zakura/handler.rs
+++ b/zakura-network/src/zakura/handler.rs
@@ -552,6 +552,11 @@ pub struct ZakuraHeaderSyncDriverStartup {
 }
 
 impl ZakuraEndpoint {
+    /// Returns the local iroh identity used to authenticate native connections.
+    pub(crate) fn local_node_id(&self) -> NodeId {
+        self.router.endpoint().node_id()
+    }
+
     /// Returns the connector injected into the legacy handshake path.
     pub fn connector(&self) -> super::ZakuraHandshakeConnector {
         super::ZakuraHandshakeConnector::new_with_endpoint(self.clone())
@@ -2916,6 +2921,42 @@ fn bind_native_endpoint(
     }
 }
 
+fn discovery_direct_addrs(config: &Config, local_node_id: NodeId) -> Vec<SocketAddr> {
+    let Some(listen_addr) = config.zakura.listen_addr else {
+        return Vec::new();
+    };
+    let mut direct_addrs = Vec::new();
+
+    if !listen_addr.ip().is_unspecified() {
+        direct_addrs.push(listen_addr);
+    }
+    if let Some(external_addr) = config.external_addr {
+        direct_addrs.push(SocketAddr::new(external_addr.ip(), listen_addr.port()));
+    }
+    for entry in &config.zakura.bootstrap_peers {
+        let Ok(node_addr) = super::discovery::parse_bootstrap_peer(entry) else {
+            continue;
+        };
+        if node_addr.node_id == local_node_id {
+            direct_addrs.extend(node_addr.direct_addresses().copied());
+        }
+    }
+
+    direct_addrs.sort_unstable();
+    direct_addrs.dedup();
+    direct_addrs
+}
+
+fn remote_bootstrap_peer_count(bootstrap_peers: &[String], local_node_id: NodeId) -> usize {
+    bootstrap_peers
+        .iter()
+        .filter_map(|entry| super::discovery::parse_bootstrap_peer(entry).ok())
+        .filter(|node_addr| node_addr.node_id != local_node_id)
+        .map(|node_addr| node_addr.node_id)
+        .collect::<HashSet<_>>()
+        .len()
+}
+
 /// Start a Zakura endpoint and router when P2P v2 is enabled.
 pub async fn spawn_zakura_endpoint(
     config: &Config,
@@ -2937,6 +2978,7 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
     let limits = ZakuraLocalLimits::from_config(config);
     validate_idle_invariant(&limits)?;
     let secret_key = zakura_secret_key(config)?;
+    let local_node_id = secret_key.public();
     let discovery_secret_key = secret_key.clone();
     let builder = direct_endpoint_builder(secret_key).transport_config(limits.transport_config());
     // Bind a fixed address when configured so this node has a stable, advertisable
@@ -2958,11 +3000,11 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
     );
     let discovery = super::discovery::build_discovery_handle(
         discovery_secret_key,
-        config.zakura.listen_addr.into_iter().collect(),
+        discovery_direct_addrs(config, local_node_id),
         super::discovery::default_advertised_services(),
         &handshake_config,
         config.zakura.max_connections,
-        config.zakura.bootstrap_peers.len(),
+        remote_bootstrap_peer_count(&config.zakura.bootstrap_peers, local_node_id),
         supervisor.subscribe(),
     )?;
     let anchor = config.zakura.header_sync.anchor(&config.network)?;
@@ -4830,6 +4872,48 @@ mod tests {
         }
 
         endpoint.close().await;
+    }
+
+    #[test]
+    fn discovery_uses_external_ip_with_the_native_listen_port() {
+        let secret_key = SecretKey::generate(OsRng);
+        let mut config = Config::default();
+        config.zakura.listen_addr = Some("0.0.0.0:8234".parse().expect("test address parses"));
+        config.external_addr = Some("203.0.113.42:8233".parse().expect("test address parses"));
+        config.zakura.bootstrap_peers.clear();
+
+        assert_eq!(
+            discovery_direct_addrs(&config, secret_key.public()),
+            vec!["203.0.113.42:8234".parse().expect("test address parses")]
+        );
+    }
+
+    #[test]
+    fn discovery_uses_matching_local_bootstrap_address_and_counts_only_remote_peers() {
+        let local_secret_key = SecretKey::generate(OsRng);
+        let remote_secret_key = SecretKey::generate(OsRng);
+        let local_node_id = local_secret_key.public();
+        let remote_node_id = remote_secret_key.public();
+        let local_entry = format!("{local_node_id}@198.51.100.7:8234");
+        let remote_entry = format!("{remote_node_id}@198.51.100.8:8234");
+        let mut config = Config::default();
+        config.zakura.listen_addr = Some("0.0.0.0:8234".parse().expect("test address parses"));
+        config.external_addr = None;
+        config.zakura.bootstrap_peers = vec![
+            local_entry,
+            remote_entry.clone(),
+            remote_entry,
+            "malformed".to_string(),
+        ];
+
+        assert_eq!(
+            discovery_direct_addrs(&config, local_node_id),
+            vec!["198.51.100.7:8234".parse().expect("test address parses")]
+        );
+        assert_eq!(
+            remote_bootstrap_peer_count(&config.zakura.bootstrap_peers, local_node_id),
+            1
+        );
     }
 
     #[derive(Debug, Clone)]

--- a/zakura-network/src/zakura/header_sync/service.rs
+++ b/zakura-network/src/zakura/header_sync/service.rs
@@ -6,6 +6,7 @@ use std::{
     },
 };
 
+use iroh::NodeId;
 use tokio::{sync::mpsc, task};
 use tokio_util::sync::CancellationToken;
 
@@ -453,6 +454,29 @@ impl Service for HeaderSyncService {
 
     fn streams(&self) -> &[Stream] {
         header_sync_streams()
+    }
+
+    fn owns_connection_for_peer(&self, peer: &ZakuraPeerId, conn_id: ZakuraConnId) -> bool {
+        let owns_stream = self
+            .peers
+            .lock()
+            .expect("header-sync peer map mutex is never poisoned")
+            .get(peer)
+            .is_some_and(|record| record.conn_id == conn_id);
+        if !owns_stream {
+            return false;
+        }
+
+        let Ok(bytes) = <[u8; 32]>::try_from(peer.as_bytes()) else {
+            return false;
+        };
+        let Ok(node_id) = NodeId::from_bytes(&bytes) else {
+            return false;
+        };
+        self.header_sync
+            .candidate_state()
+            .admitted_node_ids
+            .contains(&node_id)
     }
 
     fn wants_peer(

--- a/zakura-network/src/zakura/ip.rs
+++ b/zakura-network/src/zakura/ip.rs
@@ -1,0 +1,85 @@
+//! Canonical IP identities used by Zakura connection admission and discovery.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Returns one identity for an IPv4 address and its unambiguous IPv6 transition encodings.
+///
+/// Admission accounting must not let a peer choose a separate bucket merely by encoding the same
+/// IPv4 identity as IPv4-mapped, IPv4-compatible, 6to4, Teredo, or well-known-prefix NAT64 IPv6.
+/// Network-specific NAT64 prefixes cannot be decoded without local prefix configuration, so they
+/// remain IPv6 identities and discovery rejects the reserved local-use prefix separately.
+pub(crate) fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V4(_) => ip,
+        IpAddr::V6(ipv6) => ipv4_embedded_in_ipv6(ipv6).map_or(ip, IpAddr::V4),
+    }
+}
+
+fn ipv4_embedded_in_ipv6(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let octets = ip.octets();
+
+    // RFC 4291 IPv4-mapped IPv6: ::ffff:192.0.2.1.
+    if octets[..10] == [0; 10] && octets[10..12] == [0xff; 2] {
+        return Some(ipv4_from_octets(&octets[12..16]));
+    }
+
+    // Deprecated RFC 4291 IPv4-compatible IPv6: ::192.0.2.1. Keep the native IPv6
+    // unspecified and loopback addresses distinct from the former transition format.
+    if octets[..12] == [0; 12] && octets[12..16] != [0, 0, 0, 0] && octets[12..16] != [0, 0, 0, 1] {
+        return Some(ipv4_from_octets(&octets[12..16]));
+    }
+
+    // RFC 3056 6to4: 2002:V4ADDR::/48.
+    if octets[..2] == [0x20, 0x02] {
+        return Some(ipv4_from_octets(&octets[2..6]));
+    }
+
+    // RFC 4380 Teredo: the client IPv4 address is bitwise-inverted in the final 32 bits.
+    if octets[..4] == [0x20, 0x01, 0, 0] {
+        return Some(Ipv4Addr::new(
+            !octets[12],
+            !octets[13],
+            !octets[14],
+            !octets[15],
+        ));
+    }
+
+    // RFC 6052 well-known NAT64 prefix: 64:ff9b::/96.
+    if octets[..12] == [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0] {
+        return Some(ipv4_from_octets(&octets[12..16]));
+    }
+
+    None
+}
+
+fn ipv4_from_octets(octets: &[u8]) -> Ipv4Addr {
+    Ipv4Addr::new(octets[0], octets[1], octets[2], octets[3])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_unambiguous_ipv4_transition_encodings() {
+        let ipv4: IpAddr = "93.184.216.34".parse().expect("IPv4 test address parses");
+        for encoded in [
+            "::ffff:93.184.216.34",
+            "::93.184.216.34",
+            "2002:5db8:d822::",
+            "2001:0:c000:22d::a247:27dd",
+            "64:ff9b::5db8:d822",
+        ] {
+            let encoded = encoded.parse().expect("IPv6 test address parses");
+            assert_eq!(canonical_ip(encoded), ipv4, "failed to decode {encoded}");
+        }
+    }
+
+    #[test]
+    fn preserves_native_and_ambiguous_ipv6_addresses() {
+        for address in ["::", "::1", "2001:db8::1", "64:ff9b:1::5db8:d822"] {
+            let address = address.parse().expect("IPv6 test address parses");
+            assert_eq!(canonical_ip(address), address);
+        }
+    }
+}

--- a/zakura-network/src/zakura/legacy_gossip.rs
+++ b/zakura-network/src/zakura/legacy_gossip.rs
@@ -1317,6 +1317,14 @@ impl LegacyGossipOutbound {
         }
     }
 
+    fn contains_connection(&self, peer: &ZakuraPeerId, conn_id: ZakuraConnId) -> bool {
+        self.sessions
+            .lock()
+            .expect("legacy gossip outbound mutex is never poisoned")
+            .get(peer)
+            .is_some_and(|session| session.conn_id() == conn_id)
+    }
+
     #[cfg(test)]
     fn contains(&self, peer: &ZakuraPeerId) -> bool {
         self.sessions
@@ -2341,6 +2349,10 @@ impl ZakuraService for LegacyGossipSink {
         legacy_gossip_streams()
     }
 
+    fn owns_connection_for_peer(&self, peer: &ZakuraPeerId, conn_id: ZakuraConnId) -> bool {
+        self.outbound.contains_connection(peer, conn_id)
+    }
+
     fn add_peer(&self, mut peer: Peer) {
         let Some((mut recv, send)) = peer.take_stream(ZAKURA_STREAM_GOSSIP) else {
             return;
@@ -2378,15 +2390,14 @@ impl ZakuraService for LegacyGossipSink {
         );
 
         let recv_task_peer_id = peer_id.clone();
-        let recv_panic_peer_id = recv_task_peer_id.clone();
-        let recv_panic_outbound = outbound.clone();
+        let recv_teardown_peer_id = recv_task_peer_id.clone();
+        let recv_teardown_outbound = outbound.clone();
         let recv_panic_cancel = cancel_token.clone();
         spawn_supervised_peer_task(
             recv_task_peer_id,
-            || {},
+            move || recv_teardown_outbound.remove(&recv_teardown_peer_id, conn_id),
             move || {
                 recv_panic_cancel.cancel();
-                recv_panic_outbound.remove(&recv_panic_peer_id, conn_id);
             },
             async move {
                 loop {
@@ -4303,6 +4314,8 @@ mod tests {
             outbound.contains(&peer_id),
             "replacement legacy gossip session is registered",
         );
+        assert!(!sink.owns_connection_for_peer(&peer_id, old_conn_id));
+        assert!(sink.owns_connection_for_peer(&peer_id, new_conn_id));
 
         let (stale_peer, _stale_peer_send) = legacy_gossip_peer_with_conn(
             peer_id.clone(),
@@ -4322,6 +4335,35 @@ mod tests {
             !outbound.contains(&peer_id),
             "live cleanup removes the replacement legacy gossip session",
         );
+    }
+
+    #[tokio::test]
+    async fn local_legacy_gossip_exit_releases_connection_ownership() -> Result<(), BoxError> {
+        let (inbound_tx, inbound_rx) = mpsc::channel(1);
+        drop(inbound_rx);
+        let outbound = LegacyGossipOutbound::default();
+        let sink = LegacyGossipSink {
+            inbound_tx,
+            outbound: outbound.clone(),
+            trace: ZakuraTrace::noop(),
+        };
+        let peer_id = ZakuraPeerId::new(vec![95; 32]).expect("test peer id is within bounds");
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let (peer, peer_send) = legacy_gossip_peer(peer_id.clone(), cancel_token);
+        sink.add_peer(peer);
+        peer_send
+            .send(LegacyGossipFrame::AdvertiseBlock(block_hash(95)).encode_frame()?)
+            .await
+            .map_err(|_| -> BoxError { "failed to send test gossip frame".into() })?;
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while outbound.contains(&peer_id) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .map_err(|_| -> BoxError { "local gossip exit kept stale ownership".into() })?;
+        Ok(())
     }
 
     #[tokio::test]

--- a/zakura-network/src/zakura/legacy_gossip.rs
+++ b/zakura-network/src/zakura/legacy_gossip.rs
@@ -1540,9 +1540,9 @@ impl Service<Request> for LegacyGossipAdapter {
 
 /// Tower service that adapts legacy request/response traffic onto Zakura streams.
 ///
-/// Legacy `Peers` discovery is intentionally not adapted here. Zakura v1 controlled
-/// networks use configured [`crate::zakura::ZakuraConfig::bootstrap_peers`] until
-/// native Zakura discovery is available, keeping this compatibility layer narrow.
+/// Legacy `Peers` discovery is intentionally not adapted here. Native peers use
+/// the signed Zakura discovery protocol, while legacy address discovery stays on
+/// the legacy peer set, keeping this compatibility layer narrow.
 #[derive(Clone, Debug)]
 pub struct LegacyRequestAdapter {
     client: ZakuraRequestClient,

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -2303,10 +2303,10 @@ mod tests {
         let _guard = zakura_test::init();
         // Advertise dialable (non-loopback) addresses so the gossiped records are
         // kept in the dialable book rather than dropped as locally non-dialable.
-        let addr_a = "203.0.113.10:9"
+        let addr_a = "45.33.30.10:9"
             .parse::<std::net::SocketAddr>()
             .expect("valid test addr");
-        let addr_b = "203.0.113.11:9"
+        let addr_b = "45.33.30.11:9"
             .parse::<std::net::SocketAddr>()
             .expect("valid test addr");
         let a = ZakuraTestNode::builder(52)

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -157,13 +157,14 @@ mod tests {
             HeaderSyncEvent, HeaderSyncFrontiers, HeaderSyncHandle, HeaderSyncMessage,
             HeaderSyncMisbehavior, HeaderSyncOperationIdentity, HeaderSyncPeerSession,
             HeaderSyncRequestId, HeaderSyncStartup, HeaderSyncStatus,
-            HeaderSyncWireRequestIdentity, Peer, Service, ServicePeerLimits, Stream,
-            ZakuraBlockSyncConfig, ZakuraConnId, ZakuraHeaderSyncConfig, ZakuraLocalLimits,
-            ZakuraTrace, MAX_BS_RESPONSE_BYTES, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
+            HeaderSyncWireRequestIdentity, LegacyGossipFrame, LegacyGossipSink, LegacyRequestFrame,
+            Peer, Service, ServicePeerLimits, Stream, ZakuraBlockSyncConfig, ZakuraConnId,
+            ZakuraHeaderSyncConfig, ZakuraLocalLimits, ZakuraTrace, MAX_BS_RESPONSE_BYTES,
+            MSG_RESPONSE_TRANSACTION_IDS, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
             ZAKURA_CAP_LEGACY_GOSSIP, ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_STREAM_DISCOVERY,
-            ZAKURA_STREAM_GOSSIP, ZAKURA_STREAM_HEADER_SYNC,
+            ZAKURA_STREAM_GOSSIP, ZAKURA_STREAM_HEADER_SYNC, ZAKURA_STREAM_LEGACY_REQUESTS,
         },
-        Config,
+        BoxError, Config, Request, Response,
     };
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
@@ -2270,6 +2271,104 @@ mod tests {
 
         zero_cap_peer.shutdown().await;
         discovery_peer.shutdown().await;
+        victim.shutdown().await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn admitted_legacy_service_keeps_discovery_connection_alive() -> Result<(), BoxError> {
+        let _guard = zakura_test::init();
+        let (legacy_requests_tx, mut legacy_requests_rx) = mpsc::unbounded_channel();
+        let victim = ZakuraTestNode::builder(33601)
+            .supported_capabilities(ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_LEGACY_GOSSIP)
+            .service_from_supervisor(move |supervisor| {
+                Arc::new(LegacyGossipSink::spawn(
+                    tower::service_fn(move |request: Request| {
+                        let legacy_requests_tx = legacy_requests_tx.clone();
+                        async move {
+                            let response = if matches!(&request, Request::MempoolTransactionIds) {
+                                Response::TransactionIds(Vec::new())
+                            } else {
+                                Response::Nil
+                            };
+                            let _ = legacy_requests_tx.send(request);
+                            Ok::<_, BoxError>(response)
+                        }
+                    }),
+                    supervisor,
+                ))
+            })
+            .spawn()
+            .await?;
+        let registered = victim.supervisor().subscribe();
+        let peer = HostilePeer::connect_native_with_capabilities(
+            &victim,
+            33602,
+            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_LEGACY_GOSSIP,
+        )
+        .await?;
+        let peer_id = peer.id()?;
+
+        await_until("legacy peer registered", Duration::from_secs(5), || {
+            contains_peer(&registered.borrow(), peer_id.as_bytes())
+        })
+        .await?;
+        peer.send_raw_frame(
+            ZAKURA_STREAM_GOSSIP,
+            LegacyGossipFrame::AdvertiseBlock(block::Hash([91; 32])).encode_frame()?,
+        )
+        .await?;
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), legacy_requests_rx.recv())
+                .await?
+                .is_some(),
+            "the real legacy service admits and handles the gossip stream"
+        );
+
+        peer.send_raw_frame(ZAKURA_STREAM_DISCOVERY, discovery_get_peers_frame())
+            .await?;
+        await_until("discovery peer admitted", Duration::from_secs(5), || {
+            victim.discovery().peer_snapshot().inbound_peers == 1
+        })
+        .await?;
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            contains_peer(&registered.borrow(), peer_id.as_bytes()),
+            "discovery must not disconnect a connection owned by the admitted legacy service"
+        );
+        assert_eq!(
+            victim.discovery().peer_snapshot().inbound_peers,
+            0,
+            "the one-shot discovery session is released after settling"
+        );
+
+        peer.send_raw_frame(
+            ZAKURA_STREAM_GOSSIP,
+            LegacyGossipFrame::AdvertiseBlock(block::Hash([92; 32])).encode_frame()?,
+        )
+        .await?;
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), legacy_requests_rx.recv())
+                .await?
+                .is_some(),
+            "legacy gossip remains usable after the discovery exchange settles"
+        );
+        let response = peer
+            .request_frame(
+                ZAKURA_STREAM_LEGACY_REQUESTS,
+                336,
+                LegacyRequestFrame::MempoolTransactionIds.encode_frame()?,
+            )
+            .await?;
+        assert_eq!(response.message_type, MSG_RESPONSE_TRANSACTION_IDS);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), legacy_requests_rx.recv())
+                .await?
+                .is_some(),
+            "legacy request-response remains usable after discovery settles"
+        );
+
+        peer.shutdown().await;
         victim.shutdown().await;
         Ok(())
     }

--- a/zakura-network/src/zakura/testkit/hostile.rs
+++ b/zakura-network/src/zakura/testkit/hostile.rs
@@ -284,6 +284,28 @@ impl HostilePeer {
         Ok(())
     }
 
+    /// Open a request stream, send one frame, and read its first response frame.
+    pub async fn request_frame(
+        &self,
+        stream_kind: u16,
+        request_id: u64,
+        frame: Frame,
+    ) -> Result<Frame, BoxError> {
+        let (mut send, mut recv) = self.connection.open_bi().await?;
+        let prelude = StreamPrelude {
+            magic: STREAM_PRELUDE_MAGIC,
+            stream_kind,
+            stream_version: 1,
+            request_id: Some(request_id),
+            max_frame_bytes: self.limits.max_frame_bytes,
+        };
+        send.write_all(&prelude.encode()?).await?;
+        send.write_all(&frame.encode(self.limits.max_frame_bytes)?)
+            .await?;
+        send.finish()?;
+        Self::read_frame(&mut recv, self.limits.max_frame_bytes).await
+    }
+
     /// Accept the next bidi stream opened by the victim and respond with raw frames.
     pub async fn respond_to_next_request(&self, frames: Vec<Frame>) -> Result<(), BoxError> {
         let (mut send, _recv) = self.connection.accept_bi().await?;

--- a/zakura-network/src/zakura/testkit/node.rs
+++ b/zakura-network/src/zakura/testkit/node.rs
@@ -132,6 +132,17 @@ impl ZakuraTestNode {
         timeout: Duration,
     ) -> Result<(), BoxError> {
         let peer_addr = peer.node_addr().await;
+        self.connect_native_to_addr(peer_addr, timeout).await
+    }
+
+    /// Start a native dial to an explicit [`NodeAddr`] and wait until this node
+    /// registers it. Lets tests advertise a specific direct-address list (for
+    /// example a decoy address ahead of the reachable one).
+    pub async fn connect_native_to_addr(
+        &self,
+        peer_addr: NodeAddr,
+        timeout: Duration,
+    ) -> Result<(), BoxError> {
         self.endpoint.add_node_addr(peer_addr.clone())?;
         let mut handle = self.endpoint.spawn_native_dial(peer_addr.clone());
         let peer_id = peer_addr.node_id.as_bytes().to_vec();
@@ -655,6 +666,79 @@ mod tests {
         node.connect_native(&peer2, TEST_NET_TIMEOUT)
             .await
             .expect("second same-IP peer registers with raised per-IP cap");
+
+        node.shutdown().await;
+        peer1.shutdown().await;
+        peer2.shutdown().await;
+    }
+
+    // Pin a peer's advertised addresses to its IPv4 loopback path so same-host
+    // dials share one source IP (test nodes also bind an IPv6 loopback socket).
+    fn ipv4_loopback_addr(peer_addr: &NodeAddr) -> NodeAddr {
+        let addr = NodeAddr::new(peer_addr.node_id).with_direct_addresses(
+            peer_addr
+                .direct_addresses()
+                .copied()
+                .filter(|addr| addr.is_ipv4() && addr.ip().is_loopback()),
+        );
+        assert!(
+            addr.direct_addresses().next().is_some(),
+            "test peer must advertise an IPv4 loopback direct address",
+        );
+        addr
+    }
+
+    #[tokio::test]
+    async fn outbound_dial_charges_confirmed_path_not_advertised_decoy() {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        // Regression for the per-IP cap bypass in `serve_native_dial_connection`:
+        // it used to charge the connection to the first *advertised* direct
+        // address instead of the path iroh actually confirmed. A record could
+        // then list an unreachable decoy first and escape the per-IP cap while
+        // being served over a different (shared) address.
+        let peer1 = ZakuraTestNode::builder(9201)
+            .spawn()
+            .await
+            .expect("peer1 spawns");
+        let peer2 = ZakuraTestNode::builder(9202)
+            .spawn()
+            .await
+            .expect("peer2 spawns");
+        let node = ZakuraTestNode::builder(9203)
+            .max_connections_per_ip(1)
+            .spawn()
+            .await
+            .expect("dialer spawns");
+
+        // Advertise peer1 with an unreachable decoy (RFC 5737 TEST-NET-1,
+        // guaranteed non-routable) ahead of its real loopback address. The dial
+        // is served over loopback, so the connection must be charged to
+        // 127.0.0.1, not the decoy.
+        let peer1_loopback = ipv4_loopback_addr(&peer1.node_addr().await);
+        let decoy = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 1);
+        let decoy_first = NodeAddr::new(peer1_loopback.node_id).with_direct_addresses(
+            std::iter::once(decoy).chain(peer1_loopback.direct_addresses().copied()),
+        );
+        node.connect_native_to_addr(decoy_first, TEST_NET_TIMEOUT)
+            .await
+            .expect("peer1 registers over its reachable loopback path despite the decoy");
+
+        // With the connection correctly charged to the confirmed loopback IP,
+        // the per-IP cap of 1 must turn away a second distinct identity from
+        // 127.0.0.1. Before the fix, peer1 was charged to the decoy IP, leaving
+        // the loopback bucket empty and wrongly admitting peer2.
+        let excess = node
+            .connect_native_to_addr(
+                ipv4_loopback_addr(&peer2.node_addr().await),
+                TEST_NET_TIMEOUT,
+            )
+            .await;
+        assert!(
+            excess.is_err(),
+            "second same-loopback identity must be rejected by the per-IP cap, proving the \
+             first dial was charged to the confirmed path and not the advertised decoy",
+        );
 
         node.shutdown().await;
         peer1.shutdown().await;

--- a/zakura-network/src/zakura/testkit/node.rs
+++ b/zakura-network/src/zakura/testkit/node.rs
@@ -498,9 +498,9 @@ impl ZakuraTestNodeBuilder {
                 discovery.clone(),
                 header_sync.clone(),
                 block_sync_handle.clone(),
-            )) as Arc<dyn Service>
+            ))
         } else {
-            Arc::new(DiscoveryService::new(discovery.clone())) as Arc<dyn Service>
+            Arc::new(DiscoveryService::new(discovery.clone()))
         };
         let registry = service_registry(
             &supervisor,

--- a/zakura-network/src/zakura/transport/service.rs
+++ b/zakura-network/src/zakura/transport/service.rs
@@ -323,6 +323,14 @@ pub trait Service: fmt::Debug + Send + Sync + 'static {
         true
     }
 
+    /// Return whether this service has actually admitted `peer` and still owns its connection.
+    ///
+    /// Discovery uses this after its initial exchange so a merely negotiated capability cannot
+    /// keep a connection alive when the owning service rejected or parked its stream.
+    fn owns_connection_for_peer(&self, _peer: &ZakuraPeerId, _conn_id: ZakuraConnId) -> bool {
+        false
+    }
+
     /// Add a connected peer and spawn any per-stream work owned by this service.
     fn add_peer(&self, peer: Peer);
 


### PR DESCRIPTION
## Motivation

Discovery stream replacement and connection teardown were keyed too broadly. Cleanup from an older discovery stream generation could remove or close its replacement, while a negotiated capability bit could keep a connection alive even when the corresponding service rejected or parked its stream.

The same ownership error caused the inverse failure for native legacy traffic: discovery could disconnect a shared connection even after the real legacy gossip and request-response service had admitted it.

## Solution

- Track a monotonically increasing session generation for each discovery stream.
- Reject stale admission, messages, sends, cleanup, and connection teardown.
- Add a service ownership predicate scoped to the exact `(peer, connection)` pair.
- Implement exact ownership for legacy gossip, header sync, and block sync.
- Close discovery-only connections when another capability was negotiated but never admitted.
- Release legacy ownership on every local ordered-gossip exit path.

## Testing

Regressions cover stale generation cleanup, stale source sends, replacement during exchange settlement, exact connection ownership, negotiated-but-unadmitted block sync, admitted header and block sync, and legacy ownership release.

The transport-level legacy regression uses the production `LegacyGossipSink`. It verifies real ordered gossip admission and legacy request-response before and after the discovery exchange settles, while confirming discovery does not disconnect the shared connection.

Checks run before opening this draft:

- [x] `cargo fmt --all -- --check`
- [x] focused generation, ownership, header-sync, block-sync, and legacy transport regressions
- [x] `cargo test -p zakura-network` at the top of the stack (1,038 passed; 4 ignored)
- [x] `cargo clippy -p zakura-network --all-targets -- -D warnings` at the top of the stack
- [x] `git diff --check agent/discovery-dialability...HEAD`

## Changelog

Added `changelog-unreleased/374.md`.

### Specifications & References

This PR is stacked on #373. Its review diff contains only discovery stream and connection lifecycle changes.

### Follow-up Work

Periodic discovery refresh and record expiry are isolated in #375.
