### PR TITLE
fix(network): keep discovery service state fresh

### DIFF
--- a/changelog-unreleased/375.md
+++ b/changelog-unreleased/375.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Refresh long-lived discovery sessions before service summaries expire and
+  remove service membership derived from expired signed records
+  ([#375](https://github.com/zakura-core/zakura/pull/375)).

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -2463,6 +2463,14 @@ impl ZakuraDiscoveryInner {
             .retain(|node_id, _| connected_node_ids.contains(node_id));
         for entry in self.active_services.values_mut() {
             entry.prune_expired_live_summaries(now_unix_secs);
+            if entry
+                .record
+                .as_ref()
+                .is_some_and(|record| record.body.expires_at_unix_secs < now_unix_secs)
+            {
+                entry.record = None;
+                entry.refresh_live_derived_services();
+            }
         }
         self.active_services
             .retain(|_, entry| !entry.is_empty_live_only());
@@ -7897,6 +7905,29 @@ mod tests {
             .connected;
         assert!(!stale_candidates.contains(&live_only_node_id));
         assert!(stale_candidates.contains(&record_backed_node_id));
+    }
+
+    #[tokio::test]
+    async fn expired_connected_record_service_membership_is_pruned() {
+        let (connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handle = discovery_handle_with_connected(connected_rx);
+        let record = runtime_record_with(1, service(43), test_addr(43));
+        let node_id = record.body.node_id;
+        let expires_at = record.body.expires_at_unix_secs;
+        connected_tx.send_replace(vec![peer_id_for(node_id)]);
+
+        handle
+            .import_connected_peer_record(record, node_id)
+            .await
+            .expect("connected record imports");
+        assert_eq!(
+            handle.active_services(node_id).await,
+            Some(vec![service(43)])
+        );
+
+        let mut inner = handle.inner.lock().await;
+        inner.sync_active_services(&[node_id], expires_at.saturating_add(1));
+        assert!(!inner.active_services.contains_key(&node_id));
     }
 
     #[tokio::test]

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -1866,9 +1866,11 @@ impl ZakuraDiscoveryHandle {
             return Ok(());
         }
 
-        let Some(expires_at_unix_secs) =
-            effective_live_summary_expiry(services.expires_at_unix_secs, now)
-        else {
+        let Some(expires_at_unix_secs) = effective_live_summary_expiry(
+            services.expires_at_unix_secs,
+            now,
+            inner.config.clock_skew_tolerance,
+        ) else {
             if let Some(entry) = inner.active_services.get_mut(&peer_node_id) {
                 entry.live_summaries.clear();
                 if entry.record.is_none() {
@@ -3365,14 +3367,22 @@ fn push_unique_service(services: &mut Vec<ZakuraServiceId>, service: ZakuraServi
     }
 }
 
-fn effective_live_summary_expiry(declared_expires_at: u64, now_unix_secs: u64) -> Option<u64> {
-    if declared_expires_at <= now_unix_secs {
+fn effective_live_summary_expiry(
+    declared_expires_at: u64,
+    now_unix_secs: u64,
+    clock_skew_tolerance: Duration,
+) -> Option<u64> {
+    let local_expiry = now_unix_secs.saturating_add(DEFAULT_LIVE_SERVICE_SUMMARY_TTL.as_secs());
+    if declared_expires_at > now_unix_secs {
+        return Some(declared_expires_at.min(local_expiry));
+    }
+    if declared_expires_at.saturating_add(clock_skew_tolerance.as_secs()) <= now_unix_secs {
         return None;
     }
-    Some(
-        declared_expires_at
-            .min(now_unix_secs.saturating_add(DEFAULT_LIVE_SERVICE_SUMMARY_TTL.as_secs())),
-    )
+    // This response arrived on the authenticated live stream but is already expired locally. Use
+    // a bounded receipt TTL only inside the accepted skew window; future expiries still honor a
+    // peer's intentionally shorter lifetime.
+    Some(local_expiry)
 }
 
 fn header_sync_candidate_preference(
@@ -6916,6 +6926,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connected_services_tolerate_clock_skew_with_a_local_receipt_ttl() {
+        let (connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handle = discovery_handle_with_connected(connected_rx);
+        let node_id = secret_key().public();
+        connected_tx.send_replace(vec![peer_id_for(node_id)]);
+
+        handle
+            .import_connected_peer_services_at(
+                first_party_services(
+                    node_id,
+                    NOW - 1,
+                    vec![ServiceSummaryEnvelope::discovery(&discovery_summary())
+                        .expect("test discovery summary encodes")],
+                ),
+                node_id,
+                NOW,
+            )
+            .await
+            .expect("a live first-party summary inside the clock-skew window imports");
+        let cached = handle
+            .live_service_summaries_at(node_id, NOW)
+            .await
+            .expect("clock-skew-tolerant summary remains live");
+        assert_eq!(
+            cached[0].expires_at_unix_secs,
+            NOW + DEFAULT_LIVE_SERVICE_SUMMARY_TTL.as_secs()
+        );
+
+        handle
+            .import_connected_peer_services_at(
+                first_party_services(
+                    node_id,
+                    NOW - DEFAULT_DISCOVERY_CLOCK_SKEW_TOLERANCE.as_secs() - 1,
+                    vec![ServiceSummaryEnvelope::discovery(&discovery_summary())
+                        .expect("test discovery summary encodes")],
+                ),
+                node_id,
+                NOW,
+            )
+            .await
+            .expect("a stale live summary is ignored without rejecting the connection");
+        assert!(handle
+            .live_service_summaries_at(node_id, NOW)
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
     async fn connected_services_mismatched_node_id_rejected_without_live_summary() {
         let (connected_tx, connected_rx) = watch::channel(Vec::new());
         let handle = discovery_handle_with_connected(connected_rx);
@@ -7249,7 +7307,7 @@ mod tests {
             .import_connected_peer_services_at(
                 first_party_services(
                     preferred_id,
-                    now,
+                    now.saturating_sub(DEFAULT_DISCOVERY_CLOCK_SKEW_TOLERANCE.as_secs()),
                     vec![ServiceSummaryEnvelope::header_sync(&preferred_summary)
                         .expect("test header summary encodes")],
                 ),
@@ -7257,7 +7315,7 @@ mod tests {
                 now,
             )
             .await
-            .expect("expired first-party header summary is dropped");
+            .expect("stale first-party header summary is dropped");
 
         assert_eq!(
             handle
@@ -7814,7 +7872,7 @@ mod tests {
                 .import_connected_peer_services_at(
                     first_party_services(
                         node_id,
-                        now,
+                        now.saturating_sub(DEFAULT_DISCOVERY_CLOCK_SKEW_TOLERANCE.as_secs()),
                         vec![ServiceSummaryEnvelope {
                             service_id: service.clone(),
                             summary_tag: 999,
@@ -7825,7 +7883,7 @@ mod tests {
                     now,
                 )
                 .await
-                .expect("expired first-party live summary is dropped");
+                .expect("stale first-party live summary is dropped");
         }
 
         assert_eq!(handle.active_services(live_only_node_id).await, None);

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -1524,6 +1524,42 @@ impl ZakuraDiscoveryHandle {
         self.self_record.borrow().clone()
     }
 
+    /// Returns a locally authored record that remains valid through the next refresh interval.
+    ///
+    /// A node can keep its native connections longer than the record TTL. Refreshing lazily before
+    /// a discovery exchange prevents a long-running node from sending an expired `Hello` to a new
+    /// peer after its startup record has aged out.
+    pub(crate) async fn current_self_record_for_gossip(
+        &self,
+    ) -> Result<Arc<ZakuraNodeRecord>, DiscoveryWireError> {
+        self.current_self_record_for_gossip_at(current_unix_secs(), current_sequence_tick())
+            .await
+    }
+
+    async fn current_self_record_for_gossip_at(
+        &self,
+        now_unix_secs: u64,
+        wall_clock_sequence: u64,
+    ) -> Result<Arc<ZakuraNodeRecord>, DiscoveryWireError> {
+        let mut inner = self.inner.lock().await;
+        let current = self.current_self_record();
+        if current.body.expires_at_unix_secs
+            > now_unix_secs.saturating_add(inner.config.refresh_interval.as_secs())
+        {
+            return Ok(current);
+        }
+        let record_ttl = inner.config.record_ttl;
+        let record = Arc::new(inner.local.build_self_record(
+            now_unix_secs,
+            wall_clock_sequence,
+            record_ttl,
+        )?);
+        // Publish before releasing the state lock so concurrent refreshers cannot publish a lower
+        // sequence after a newer record.
+        self.self_record_tx.send_replace(record.clone());
+        Ok(record)
+    }
+
     /// Returns the local node id used in authored self-records.
     pub fn local_node_id(&self) -> NodeId {
         self.self_record.borrow().body.node_id
@@ -6628,6 +6664,38 @@ mod tests {
                 ..context()
             })
             .expect("updated record verifies");
+    }
+
+    #[tokio::test]
+    async fn self_record_for_gossip_refreshes_before_expiry() {
+        let (_connected_tx, connected_rx) = watch::channel(Vec::new());
+        let config = ZakuraDiscoveryConfig {
+            record_ttl: Duration::from_secs(60),
+            refresh_interval: Duration::from_secs(10),
+            ..ZakuraDiscoveryConfig::default()
+        };
+        let handle = discovery_handle_at_with_sequence(
+            local_config_with(secret_key(), vec![test_addr(43)], vec![service(1)]),
+            config,
+            connected_rx,
+            NOW,
+            100,
+        );
+        let initial = handle.current_self_record();
+
+        let still_current = handle
+            .current_self_record_for_gossip_at(NOW + 49, 101)
+            .await
+            .expect("current self-record remains valid past the refresh window");
+        assert_eq!(still_current, initial);
+
+        let refreshed = handle
+            .current_self_record_for_gossip_at(NOW + 50, 102)
+            .await
+            .expect("self-record refresh signs");
+        assert!(refreshed.body.sequence > initial.body.sequence);
+        assert_eq!(refreshed.body.expires_at_unix_secs, NOW + 110);
+        assert_eq!(handle.current_self_record(), refreshed);
     }
 
     #[test]

--- a/zakura-network/src/zakura/discovery/service.rs
+++ b/zakura-network/src/zakura/discovery/service.rs
@@ -34,8 +34,8 @@ use super::pipe::{discovery_pipe, DsEnv, DsLocal, DISCOVERY_FRAME_MESSAGE_TYPE};
 use super::protocol::{
     BlockSyncServiceSummary, DiscoveryBookError, DiscoveryMessage, DiscoveryRecordError,
     GetServices, HeaderSyncServiceSummary, ServiceSummaryEnvelope, Services, ZakuraDiscoveryHandle,
-    ZakuraNodeRecord, ZakuraServiceId, MAX_DISCOVERY_RECORDS_PER_RESPONSE,
-    ZAKURA_DISCOVERY_STREAM_VERSION, ZAKURA_STREAM_DISCOVERY,
+    ZakuraNodeRecord, ZakuraServiceId, DEFAULT_LIVE_SERVICE_SUMMARY_TTL,
+    MAX_DISCOVERY_RECORDS_PER_RESPONSE, ZAKURA_DISCOVERY_STREAM_VERSION, ZAKURA_STREAM_DISCOVERY,
 };
 
 /// Maximum time discovery waits for first-party exchange responses before releasing the session.
@@ -413,9 +413,15 @@ fn spawn_discovery_exchange(start: DiscoveryExchangeStart) {
             panic_source_connection_cancel.cancel();
         },
         async move {
-            let exchanged = source.run().await;
+            let exchanged = source.run_initial_exchange().await;
+            let mut other_service_owner =
+                exchanged && peer_has_other_service_owner(&connection_owners, &peer_id, conn_id);
+            while other_service_owner && source.refresh_after_interval().await.is_ok() {
+                other_service_owner =
+                    peer_has_other_service_owner(&connection_owners, &peer_id, conn_id);
+            }
             let closes_discovery_only_connection = exchanged
-                && !peer_has_other_service_owner(&connection_owners, &peer_id, conn_id)
+                && !other_service_owner
                 && handle
                     .is_current_session(&peer_id, conn_id, session_id)
                     .await;
@@ -654,7 +660,7 @@ struct DiscoverySource {
 }
 
 impl DiscoverySource {
-    async fn run(self) -> bool {
+    async fn run_initial_exchange(&self) -> bool {
         if self.exchange().await.is_err() {
             return false;
         }
@@ -670,6 +676,16 @@ impl DiscoverySource {
             .await
     }
 
+    async fn refresh_after_interval(&self) -> Result<(), ()> {
+        let cancel = self.session.cancel_token();
+        let refresh_interval = discovery_exchange_interval(self.handle.refresh_interval().await);
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => Err(()),
+            _ = tokio::time::sleep(refresh_interval) => self.exchange().await,
+        }
+    }
+
     /// Gossips the current self-record and asks the peer for records and services.
     ///
     /// Returns `Err(())` once the stream's send side is gone, so the caller
@@ -683,7 +699,18 @@ impl DiscoverySource {
             return Err(());
         }
 
-        let record = (*self.handle.current_self_record()).clone();
+        let record = self
+            .handle
+            .current_self_record_for_gossip()
+            .await
+            .map_err(|error| {
+                tracing::debug!(
+                    ?error,
+                    peer = ?self.session.peer_id(),
+                    "failed to refresh Zakura discovery self-record"
+                );
+            })?;
+        let record = (*record).clone();
         self.handle_send_result(self.session.try_send_hello(record))?;
 
         let limit = self
@@ -766,6 +793,10 @@ fn peer_has_other_service_owner(
         .any(|owner| owner.owns_connection_for_peer(peer_id, conn_id))
 }
 
+fn discovery_exchange_interval(record_refresh_interval: Duration) -> Duration {
+    record_refresh_interval.min(DEFAULT_LIVE_SERVICE_SUMMARY_TTL / 2)
+}
+
 /// Returns the iroh node id encoded by a discovery peer id, if it is a 32-byte
 /// node id.
 fn node_id_from_peer_id(peer_id: &ZakuraPeerId) -> Option<NodeId> {
@@ -811,9 +842,20 @@ mod tests {
         ZakuraDiscoveryConfig, ZakuraDiscoveryLocalConfig, ZakuraHandshakeConfig,
         ZakuraHeaderSyncConfig, LOCAL_MAX_MESSAGE_BYTES, MAX_BS_RESPONSE_BYTES,
         ZAKURA_CAP_BLOCK_SYNC, ZAKURA_CAP_DISCOVERY, ZAKURA_CAP_HEADER_SYNC,
-        ZAKURA_STREAM_HEADER_SYNC,
+        ZAKURA_CAP_LEGACY_GOSSIP, ZAKURA_STREAM_HEADER_SYNC,
     };
     use zakura_chain::{block, parameters::Network};
+
+    struct HeaderAdvisoryFixture {
+        discovery_handle: ZakuraDiscoveryHandle,
+        header_sync: HeaderSyncHandle,
+        header_actions: tokio::sync::mpsc::Receiver<HeaderSyncAction>,
+        header_task: JoinHandle<()>,
+        peer_node_id: NodeId,
+        peer_id: ZakuraPeerId,
+        peer_send: FramedSend,
+        _peer_recv: FramedRecv,
+    }
 
     #[derive(Debug)]
     struct TestConnectionOwner {
@@ -839,29 +881,6 @@ mod tests {
         fn remove_peer(&self, _peer: &ZakuraPeerId, _conn_id: ZakuraConnId) {}
     }
 
-    #[test]
-    fn connection_ownership_is_scoped_to_the_exact_connection() {
-        let peer = ZakuraPeerId::new(vec![37; 32]).expect("test peer id is within bounds");
-        let owners: Vec<Arc<dyn Service>> = vec![Arc::new(TestConnectionOwner {
-            peer: peer.clone(),
-            conn_id: 2,
-        })];
-
-        assert!(!peer_has_other_service_owner(&owners, &peer, 1));
-        assert!(peer_has_other_service_owner(&owners, &peer, 2));
-    }
-
-    struct HeaderAdvisoryFixture {
-        discovery_handle: ZakuraDiscoveryHandle,
-        header_sync: HeaderSyncHandle,
-        header_actions: tokio::sync::mpsc::Receiver<HeaderSyncAction>,
-        header_task: JoinHandle<()>,
-        peer_node_id: NodeId,
-        peer_id: ZakuraPeerId,
-        peer_send: FramedSend,
-        _peer_recv: FramedRecv,
-    }
-
     impl Drop for HeaderAdvisoryFixture {
         fn drop(&mut self) {
             self.header_task.abort();
@@ -873,6 +892,30 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system clock is after Unix epoch")
             .as_secs()
+    }
+
+    #[test]
+    fn periodic_exchange_refreshes_before_live_service_summaries_expire() {
+        assert_eq!(
+            discovery_exchange_interval(Duration::from_secs(10 * 60)),
+            Duration::from_secs(15)
+        );
+        assert_eq!(
+            discovery_exchange_interval(Duration::from_secs(10)),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn connection_ownership_is_scoped_to_the_exact_connection() {
+        let peer = ZakuraPeerId::new(vec![37; 32]).expect("test peer id is within bounds");
+        let owners: Vec<Arc<dyn Service>> = vec![Arc::new(TestConnectionOwner {
+            peer: peer.clone(),
+            conn_id: 2,
+        })];
+
+        assert!(!peer_has_other_service_owner(&owners, &peer, 1));
+        assert!(peer_has_other_service_owner(&owners, &peer, 2));
     }
 
     fn header_summary(best_height: block::Height) -> HeaderSyncServiceSummary {
@@ -1078,6 +1121,23 @@ mod tests {
             .await?;
 
         Ok(())
+    }
+
+    async fn wait_for_next_discovery_hello(
+        peer_recv: &mut FramedRecv,
+    ) -> Result<ZakuraNodeRecord, crate::BoxError> {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let frame = peer_recv
+                    .recv()
+                    .await
+                    .expect("discovery refresh stream remains open");
+                if let DiscoveryMessage::Hello { record } = decode_discovery_frame(&frame)? {
+                    return Ok(record);
+                }
+            }
+        })
+        .await?
     }
 
     async fn wait_for_discovery_inbound_peers(handle: &ZakuraDiscoveryHandle, expected: usize) {
@@ -1685,7 +1745,7 @@ mod tests {
             session_id: 1,
             progress: progress.clone(),
         };
-        let source_task = tokio::spawn(async move { source.run().await });
+        let source_task = tokio::spawn(async move { source.run_initial_exchange().await });
         for _ in 0..3 {
             recv.recv()
                 .await
@@ -1763,6 +1823,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn admitted_legacy_gossip_keeps_discovery_connection_alive() -> Result<(), crate::BoxError>
+    {
+        let (connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
+        let handle = ZakuraDiscoveryHandle::new(
+            ZakuraDiscoveryLocalConfig {
+                secret_key: SecretKey::from_bytes(&[46u8; 32]),
+                direct_addrs: Vec::new(),
+                services: vec![ZakuraServiceId::discovery()],
+                zakura_protocol_min: handshake.zakura_protocol_min,
+                zakura_protocol_max: handshake.zakura_protocol_max,
+                network_id: handshake.network_id,
+                chain_id: handshake.chain_id,
+                last_authored_sequence: None,
+            },
+            ZakuraDiscoveryConfig {
+                refresh_interval: Duration::from_millis(20),
+                ..ZakuraDiscoveryConfig::default()
+            },
+            connected_rx,
+        )?;
+        let service = DiscoveryService::new(handle.clone());
+        let peer_secret = SecretKey::from_bytes(&[47u8; 32]);
+        let peer_node_id = peer_secret.public();
+        let peer_id = ZakuraPeerId::new(peer_node_id.as_bytes().to_vec())?;
+        service.set_connection_owners(vec![Arc::new(TestConnectionOwner {
+            peer: peer_id.clone(),
+            conn_id: 0,
+        })]);
+        connected_tx.send_replace(vec![peer_id.clone()]);
+
+        let connection_cancel = CancellationToken::new();
+        let (peer_send, service_recv) = framed_channel(16);
+        let (service_send, mut peer_recv) = framed_channel(16);
+        service.add_peer(Peer::new(
+            peer_id,
+            None,
+            ZAKURA_CAP_DISCOVERY | ZAKURA_CAP_LEGACY_GOSSIP,
+            HashMap::from([(ZAKURA_STREAM_DISCOVERY, (service_recv, service_send))]),
+            connection_cancel.clone(),
+        ));
+
+        wait_for_discovery_inbound_peers(&handle, 1).await;
+        complete_peer_side_discovery_exchange(&peer_send, &mut peer_recv, &peer_secret, &handshake)
+            .await?;
+        wait_for_next_discovery_hello(&mut peer_recv).await?;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), connection_cancel.cancelled())
+                .await
+                .is_err(),
+            "an admitted legacy-gossip service owns the shared connection"
+        );
+        assert_eq!(handle.peer_snapshot().inbound_peers, 1);
+
+        connection_cancel.cancel();
+        wait_for_discovery_inbound_peers(&handle, 0).await;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn admitted_block_sync_keeps_discovery_connection_alive() -> Result<(), crate::BoxError> {
         let (connected_tx, connected_rx) = watch::channel(Vec::new());
         let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
@@ -1777,7 +1897,10 @@ mod tests {
                 chain_id: handshake.chain_id,
                 last_authored_sequence: None,
             },
-            ZakuraDiscoveryConfig::default(),
+            ZakuraDiscoveryConfig {
+                refresh_interval: Duration::from_millis(20),
+                ..ZakuraDiscoveryConfig::default()
+            },
             connected_rx,
         )?;
         let service = DiscoveryService::new(handle.clone());
@@ -1818,21 +1941,23 @@ mod tests {
         wait_for_discovery_inbound_peers(&handle, 1).await;
         complete_peer_side_discovery_exchange(&peer_send, &mut peer_recv, &peer_secret, &handshake)
             .await?;
-        wait_for_discovery_inbound_peers(&handle, 0).await;
+        wait_for_next_discovery_hello(&mut peer_recv).await?;
         assert!(
             tokio::time::timeout(Duration::from_millis(100), connection_cancel.cancelled())
                 .await
                 .is_err(),
             "an admitted block-sync service owns the shared connection"
         );
+        assert_eq!(handle.peer_snapshot().inbound_peers, 1);
 
         connection_cancel.cancel();
+        wait_for_discovery_inbound_peers(&handle, 0).await;
         Ok(())
     }
 
     #[tokio::test]
-    async fn discovery_short_lived_exchange_keeps_header_sync_connection(
-    ) -> Result<(), crate::BoxError> {
+    async fn discovery_refreshes_while_header_sync_owns_connection() -> Result<(), crate::BoxError>
+    {
         let (connected_tx, connected_rx) = watch::channel(Vec::new());
         let handshake = ZakuraHandshakeConfig::for_network(&Network::Mainnet);
         let local_secret = SecretKey::from_bytes(&[42u8; 32]);
@@ -1847,7 +1972,10 @@ mod tests {
                 chain_id: handshake.chain_id,
                 last_authored_sequence: None,
             },
-            ZakuraDiscoveryConfig::default(),
+            ZakuraDiscoveryConfig {
+                refresh_interval: Duration::from_millis(20),
+                ..ZakuraDiscoveryConfig::default()
+            },
             connected_rx,
         )?;
         let (header_sync, _header_actions, header_task) = spawn_test_header_sync()?;
@@ -1905,7 +2033,12 @@ mod tests {
         wait_for_discovery_inbound_peers(&discovery_handle, 1).await;
         complete_peer_side_discovery_exchange(&peer_send, &mut peer_recv, &peer_secret, &handshake)
             .await?;
-        wait_for_discovery_inbound_peers(&discovery_handle, 0).await;
+        let refreshed_record = wait_for_next_discovery_hello(&mut peer_recv).await?;
+        assert_eq!(
+            refreshed_record.body.node_id,
+            discovery_handle.local_node_id()
+        );
+        assert_eq!(discovery_handle.peer_snapshot().inbound_peers, 1);
         assert_eq!(header_sync.peer_snapshot().inbound_peers, 1);
         assert!(
             tokio::time::timeout(Duration::from_millis(100), connection_cancel.cancelled())
@@ -1914,6 +2047,8 @@ mod tests {
             "discovery releases only its own session while header sync owns the connection"
         );
 
+        connection_cancel.cancel();
+        wait_for_discovery_inbound_peers(&discovery_handle, 0).await;
         header_task.abort();
         Ok(())
     }

--- a/zakura-network/src/zakura/testkit/cluster.rs
+++ b/zakura-network/src/zakura/testkit/cluster.rs
@@ -2336,11 +2336,7 @@ mod tests {
             contains_peer(&registered.borrow(), peer_id.as_bytes()),
             "discovery must not disconnect a connection owned by the admitted legacy service"
         );
-        assert_eq!(
-            victim.discovery().peer_snapshot().inbound_peers,
-            0,
-            "the one-shot discovery session is released after settling"
-        );
+        assert_eq!(victim.discovery().peer_snapshot().inbound_peers, 1);
 
         peer.send_raw_frame(
             ZAKURA_STREAM_GOSSIP,


### PR DESCRIPTION
## Motivation

Discovery performed one exchange and then stopped even when another admitted service kept the shared connection alive. Live service summaries expire after 30 seconds, while the configured discovery refresh interval can be much longer, so otherwise healthy nodes could retain different and increasingly stale service views.

Connected-peer service membership derived from a signed record also survived after that record expired.

## Solution

- Keep the discovery session active while another exact service owner retains the connection.
- Refresh discovery at least every 15 seconds, before the default live-summary TTL expires.
- Re-author an expiring self-record before publishing the next `Hello`.
- Serialize self-record publication so concurrent refreshers cannot publish an older sequence after a newer one.
- Bound live-summary receipt lifetimes, tolerate configured clock skew, and preserve deliberately shorter future expirations.
- Remove connected-peer service membership when its signed record expires while retaining independently fresh live summaries.

## Testing

Regressions cover self-record refresh, refresh interval bounds, periodic exchange over admitted header, block, and legacy connections, clock-skew-tolerant live summaries, deliberately shorter expiry, and connected signed-record expiry.

The production legacy transport regression now also verifies the discovery session remains admitted and legacy gossip plus request-response remain usable after repeated refreshes.

Checks run before opening this draft:

- [x] `cargo fmt --all -- --check`
- [x] focused refresh, self-record, expiry, header-sync, and legacy transport regressions
- [x] `cargo test -p zakura-network` (1,038 passed; 4 ignored)
- [x] `cargo clippy -p zakura-network --all-targets -- -D warnings`
- [x] `git diff --check agent/discovery-session-lifecycle...HEAD`

## Changelog

Added `changelog-unreleased/375.md`.

### Specifications & References

This PR is stacked on #374, which is stacked on #373. Its review diff contains only discovery refresh and expiry behavior.

### Follow-up Work

- Persist and reload `last_authored_sequence`; the wall-clock seed handles normal same-key restarts, but a backward clock step can still produce a non-increasing sequence.
- Add a deployment smoke test with three routable public nodes for the path that hermetic local tests intentionally cannot exercise.
