### PR TITLE
fix(network): ban malformed getblocks responses

### DIFF
--- a/changelog-unreleased/372.md
+++ b/changelog-unreleased/372.md
@@ -1,0 +1,4 @@
+## Security
+
+- Reject locator hashes echoed inside legacy tip-extension responses
+  ([#372](https://github.com/zakura-core/zakura/pull/372)).

--- a/changelog-unreleased/376.md
+++ b/changelog-unreleased/376.md
@@ -1,0 +1,5 @@
+## Security
+
+- Ban peers that return oversized, duplicate, or locator-echoing block hash
+  responses to `getblocks`
+  ([#376](https://github.com/zakura-core/zakura/pull/376)).

--- a/zakura-network/src/lib.rs
+++ b/zakura-network/src/lib.rs
@@ -194,7 +194,9 @@ pub use crate::{
     peer_set::{init, init_with_zakura_header_sync},
     policies::RetryLimit,
     protocol::{
-        external::{Version, VersionMessage, MAX_TX_INV_IN_SENT_MESSAGE},
+        external::{
+            Version, VersionMessage, MAX_FIND_BLOCKS_RESPONSE_HASHES, MAX_TX_INV_IN_SENT_MESSAGE,
+        },
         internal::{InventoryResponse, PeerSource, Request, Response},
     },
 };

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -23,10 +23,10 @@ use zakura_chain::{
 
 use crate::{
     constants::{
-        self, MAX_ADDRS_IN_MESSAGE, MAX_OVERLOAD_DROP_PROBABILITY, MIN_OVERLOAD_DROP_PROBABILITY,
-        OVERLOAD_PROTECTION_INTERVAL, PEER_ADDR_RESPONSE_LIMIT,
+        self, MAX_ADDRS_IN_MESSAGE, MAX_OVERLOAD_DROP_PROBABILITY, MAX_PEER_MISBEHAVIOR_SCORE,
+        MIN_OVERLOAD_DROP_PROBABILITY, OVERLOAD_PROTECTION_INTERVAL, PEER_ADDR_RESPONSE_LIMIT,
     },
-    meta_addr::MetaAddr,
+    meta_addr::{MetaAddr, MetaAddrChange},
     peer::{
         connection::peer_tx::PeerTx, error::AlreadyErrored, ClientRequest, ClientRequestReceiver,
         ConnectionInfo, ErrorSlot, InProgressClientRequest, MustUseClientResponseSender, PeerError,
@@ -34,7 +34,7 @@ use crate::{
     },
     peer_set::ConnectionTracker,
     protocol::{
-        external::{types::Nonce, InventoryHash, Message},
+        external::{types::Nonce, InventoryHash, Message, MAX_FIND_BLOCKS_RESPONSE_HASHES},
         internal::{InventoryResponse, Request, Response},
     },
     BoxError, PeerSocketAddr, MAX_TX_INV_IN_SENT_MESSAGE,
@@ -57,7 +57,9 @@ pub(super) enum Handler {
         ping_sent_at: Instant,
     },
     Peers,
-    FindBlocks,
+    FindBlocks {
+        requested_locators: HashSet<block::Hash>,
+    },
     FindHeaders,
     BlocksByHash {
         pending_hashes: HashSet<block::Hash>,
@@ -79,7 +81,7 @@ impl fmt::Display for Handler {
             Handler::Ping { .. } => "Ping".to_string(),
             Handler::Peers => "Peers".to_string(),
 
-            Handler::FindBlocks => "FindBlocks".to_string(),
+            Handler::FindBlocks { .. } => "FindBlocks".to_string(),
             Handler::FindHeaders => "FindHeaders".to_string(),
             Handler::BlocksByHash {
                 pending_hashes,
@@ -113,7 +115,7 @@ impl Handler {
             Handler::Ping { .. } => "Ping".into(),
             Handler::Peers => "Peers".into(),
 
-            Handler::FindBlocks => "FindBlocks".into(),
+            Handler::FindBlocks { .. } => "FindBlocks".into(),
             Handler::FindHeaders => "FindHeaders".into(),
 
             Handler::BlocksByHash { .. } => "BlocksByHash".into(),
@@ -399,14 +401,33 @@ impl Handler {
 
             // TODO:
             // - use `any(inv)` rather than `all(inv)`?
-            (Handler::FindBlocks, Message::Inv(items))
+            (Handler::FindBlocks { requested_locators }, Message::Inv(items))
                 if items
                     .iter()
                     .all(|item| matches!(item, InventoryHash::Block(_))) =>
             {
-                Handler::Finished(Ok(Response::BlockHashes(
-                    block_hashes(&items[..]).collect(),
-                )))
+                if items.len() > MAX_FIND_BLOCKS_RESPONSE_HASHES {
+                    Handler::Finished(Err(PeerError::InvalidFindBlocksResponse(
+                        "response contains too many block hashes",
+                    )))
+                } else {
+                    let hashes: Vec<_> = block_hashes(&items).collect();
+                    let unique_hashes: HashSet<_> = hashes.iter().copied().collect();
+
+                    let violation = if unique_hashes.len() != hashes.len() {
+                        Some("response contains duplicate block hashes")
+                    } else if !requested_locators.is_disjoint(&unique_hashes) {
+                        Some("response echoes a requested locator hash")
+                    } else {
+                        None
+                    };
+
+                    if let Some(violation) = violation {
+                        Handler::Finished(Err(PeerError::InvalidFindBlocksResponse(violation)))
+                    } else {
+                        Handler::Finished(Ok(Response::BlockHashes(hashes)))
+                    }
+                }
             }
             (Handler::FindHeaders, Message::Headers(headers)) => {
                 Handler::Finished(Ok(Response::BlockHeaders(headers)))
@@ -591,6 +612,9 @@ where
     /// The corresponding peer message receiver is passed to [`Connection::run`].
     pub(super) peer_tx: PeerTx<Tx>,
 
+    /// A channel for reporting peer address changes to the address book.
+    pub(super) address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
+
     /// A connection tracker that reduces the open connection count when dropped.
     /// Used to limit the number of open connections in Zebra.
     ///
@@ -646,6 +670,7 @@ where
         client_rx: futures::channel::mpsc::Receiver<ClientRequest>,
         error_slot: ErrorSlot,
         peer_tx: Tx,
+        address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
         connection_tracker: ConnectionTracker,
         connection_info: Arc<ConnectionInfo>,
         addr_label: String,
@@ -660,6 +685,7 @@ where
             client_rx: client_rx.into(),
             error_slot,
             peer_tx: peer_tx.into(),
+            address_book_updater,
             connection_tracker,
             addr_label,
             last_metrics_state: None,
@@ -781,6 +807,38 @@ where
 
                 // Check whether the handler is finished before waiting for a response message,
                 // because the response might be `Nil` or synthetic.
+                State::AwaitingResponse {
+                    handler: Handler::Finished(Err(PeerError::InvalidFindBlocksResponse(_))),
+                    ref span,
+                    ..
+                } => {
+                    let span = span.clone();
+                    debug!(parent: &span, "banning peer for invalid getblocks response");
+
+                    let tmp_state = std::mem::replace(&mut self.state, State::Failed);
+                    let State::AwaitingResponse {
+                        handler: Handler::Finished(Err(error)),
+                        tx,
+                        ..
+                    } = tmp_state
+                    else {
+                        unreachable!("already checked for an invalid getblocks response");
+                    };
+
+                    let error = SharedPeerError::from(error);
+                    let _ = tx.send(Err(error.clone()));
+
+                    if let Some(addr) = self.connection_info.connected_addr.get_address_book_addr()
+                    {
+                        let _ = self
+                            .address_book_updater
+                            .send(MetaAddr::new_misbehavior(addr, MAX_PEER_MISBEHAVIOR_SCORE))
+                            .await;
+                    }
+
+                    self.fail_with(error).await;
+                }
+
                 State::AwaitingResponse {
                     handler: Handler::Finished(_),
                     ref span,
@@ -1086,13 +1144,12 @@ where
             }
 
             (AwaitingRequest, FindBlocks { known_blocks, stop }) => {
+                let requested_locators = known_blocks.iter().copied().collect();
                 self
                     .peer_tx
                     .send(Message::GetBlocks { known_blocks, stop })
                     .await
-                    .map(|()|
-                         Handler::FindBlocks
-                    )
+                    .map(|()| Handler::FindBlocks { requested_locators })
             }
             (AwaitingRequest, FindHeaders { known_blocks, stop }) => {
                 self

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -117,6 +117,7 @@ fn new_test_connection_with_protection<A>(
     let mock_inbound_service = MockService::build().finish();
     let (client_tx, client_rx) = mpsc::channel(0);
     let shared_error_slot = ErrorSlot::default();
+    let (address_book_updater, _address_book_updates) = tokio::sync::mpsc::channel(1);
 
     // Normally the network has more capacity than the sender's single implicit slot,
     // but the smaller capacity makes some tests easier.
@@ -166,6 +167,7 @@ fn new_test_connection_with_protection<A>(
         client_rx,
         shared_error_slot.clone(),
         peer_tx,
+        address_book_updater,
         ActiveConnectionCounter::new_counter().track_connection(),
         Arc::new(connection_info),
         addr_label,
@@ -192,6 +194,7 @@ fn new_never_closing_test_connection<A>(
     let mock_inbound_service = MockService::build().finish();
     let (client_tx, client_rx) = mpsc::channel(0);
     let shared_error_slot = ErrorSlot::default();
+    let (address_book_updater, _address_book_updates) = tokio::sync::mpsc::channel(1);
 
     let fake_addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4).into();
     let fake_version = CURRENT_NETWORK_PROTOCOL_VERSION;
@@ -221,6 +224,7 @@ fn new_never_closing_test_connection<A>(
         client_rx,
         shared_error_slot.clone(),
         NeverClosingSink,
+        address_book_updater,
         connection_tracker,
         Arc::new(connection_info),
         addr_label,

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -22,16 +22,183 @@ use zakura_chain::{block, serialization::SerializationError};
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
-    constants::{MAX_OVERLOAD_DROP_PROBABILITY, MIN_OVERLOAD_DROP_PROBABILITY, REQUEST_TIMEOUT},
+    constants::{
+        MAX_OVERLOAD_DROP_PROBABILITY, MAX_PEER_MISBEHAVIOR_SCORE, MIN_OVERLOAD_DROP_PROBABILITY,
+        REQUEST_TIMEOUT,
+    },
+    meta_addr::MetaAddr,
     peer::{
-        connection::{overload_drop_connection_probability, Connection, State},
+        connection::{overload_drop_connection_probability, Connection, Handler, State},
         ClientRequest, ErrorSlot,
     },
     peer_set::ActiveConnectionCounter,
     protocol::external::Message,
     types::Nonce,
-    PeerError, PeerSource, Request, Response,
+    PeerError, PeerSource, Request, Response, MAX_FIND_BLOCKS_RESPONSE_HASHES,
 };
+
+#[test]
+fn maximum_find_blocks_response_is_accepted() {
+    let locator = block_hash(0);
+    let hashes: Vec<_> = (1..=MAX_FIND_BLOCKS_RESPONSE_HASHES)
+        .map(block_hash)
+        .collect();
+    let mut handler = Handler::FindBlocks {
+        requested_locators: HashSet::from([locator]),
+    };
+
+    let ignored = handler.process_message(
+        Message::Inv(hashes.iter().copied().map(Into::into).collect()),
+        &mut Vec::new(),
+        None,
+    );
+
+    assert!(ignored.is_none());
+    assert!(matches!(
+        handler,
+        Handler::Finished(Ok(Response::BlockHashes(response))) if response == hashes
+    ));
+}
+
+#[tokio::test]
+async fn oversized_find_blocks_response_bans_peer() {
+    let locator = block_hash(0);
+    let response = (1..=MAX_FIND_BLOCKS_RESPONSE_HASHES + 1)
+        .map(block_hash)
+        .collect();
+
+    assert_invalid_find_blocks_response_bans_peer(
+        locator,
+        response,
+        "response contains too many block hashes",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn duplicate_find_blocks_response_bans_peer() {
+    let locator = block_hash(0);
+    let duplicate = block_hash(1);
+
+    assert_invalid_find_blocks_response_bans_peer(
+        locator,
+        vec![duplicate, duplicate],
+        "response contains duplicate block hashes",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn locator_echo_find_blocks_response_bans_peer() {
+    let locator = block_hash(0);
+
+    assert_invalid_find_blocks_response_bans_peer(
+        locator,
+        vec![block_hash(1), locator],
+        "response echoes a requested locator hash",
+    )
+    .await;
+}
+
+async fn assert_invalid_find_blocks_response_bans_peer(
+    locator: block::Hash,
+    response: Vec<block::Hash>,
+    expected_error: &str,
+) {
+    let _init_guard = zakura_test::init();
+
+    let (mut peer_tx, peer_rx) = mpsc::channel(1);
+    let (
+        mut connection,
+        mut client_tx,
+        mut inbound_service,
+        mut peer_outbound_messages,
+        shared_error_slot,
+    ) = new_protected_test_connection();
+    let (address_book_updater, mut address_book_updates) = tokio::sync::mpsc::channel(1);
+    connection.address_book_updater = address_book_updater;
+    let peer_addr = connection
+        .connection_info
+        .connected_addr
+        .get_address_book_addr()
+        .expect("protected test connections have direct peer addresses");
+
+    let connection_task = tokio::spawn(connection.run(peer_rx));
+    let (request_tx, request_rx) = oneshot::channel();
+    client_tx
+        .send(ClientRequest {
+            request: Request::FindBlocks {
+                known_blocks: vec![locator],
+                stop: None,
+            },
+            tx: request_tx,
+            inv_collector: None,
+            transient_addr: None,
+            span: Span::current(),
+        })
+        .await
+        .expect("connection accepts the FindBlocks request");
+
+    assert_eq!(
+        peer_outbound_messages.next().await,
+        Some(Message::GetBlocks {
+            known_blocks: vec![locator],
+            stop: None,
+        })
+    );
+
+    peer_tx
+        .send(Ok(Message::Inv(
+            response.into_iter().map(Into::into).collect(),
+        )))
+        .await
+        .expect("peer response channel is open");
+
+    assert_eq!(
+        address_book_updates.recv().await,
+        Some(MetaAddr::new_misbehavior(
+            peer_addr,
+            MAX_PEER_MISBEHAVIOR_SCORE,
+        )),
+        "invalid responses must immediately receive a banning score"
+    );
+
+    let response_error = request_rx
+        .await
+        .expect("connection returns a response")
+        .expect_err("invalid FindBlocks responses fail the request");
+    assert!(
+        response_error.inner_debug().contains(expected_error),
+        "unexpected response error: {response_error:?}"
+    );
+
+    connection_task
+        .await
+        .expect("invalid response shuts down the connection cleanly");
+    assert!(
+        client_tx.is_closed(),
+        "the banned peer must be disconnected"
+    );
+    assert!(
+        shared_error_slot
+            .try_get_error()
+            .expect("invalid response fails the connection")
+            .inner_debug()
+            .contains(expected_error),
+        "connection failure must identify the protocol violation"
+    );
+    inbound_service.expect_no_requests().await;
+}
+
+fn block_hash(index: usize) -> block::Hash {
+    let mut bytes = [0; 32];
+    bytes[..8].copy_from_slice(
+        &u64::try_from(index)
+            .expect("test hash index fits in u64")
+            .to_le_bytes(),
+    );
+    block::Hash(bytes)
+}
 
 /// Test that the connection run loop works as a future
 #[tokio::test]

--- a/zakura-network/src/peer/error.rs
+++ b/zakura-network/src/peer/error.rs
@@ -123,6 +123,10 @@ pub enum PeerError {
     #[error("Remote peer sent handshake messages after handshake")]
     DuplicateHandshake,
 
+    /// A remote peer sent a structurally invalid response to `getblocks`.
+    #[error("Remote peer sent an invalid getblocks response: {0}")]
+    InvalidFindBlocksResponse(&'static str),
+
     /// This node's internal services were overloaded, so the connection was dropped
     /// to shed load.
     #[error("Internal services over capacity")]
@@ -196,6 +200,7 @@ impl PeerError {
             // TODO: add error kinds or summaries to `SerializationError`
             PeerError::Serialization(inner) => format!("Serialization({inner})").into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
+            PeerError::InvalidFindBlocksResponse(_) => "InvalidFindBlocksResponse".into(),
             PeerError::Overloaded => "Overloaded".into(),
             PeerError::NoReadyPeers => "NoReadyPeers".into(),
             PeerError::InboundTimeout => "InboundTimeout".into(),

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -1745,6 +1745,7 @@ where
                 server_rx,
                 error_slot.clone(),
                 peer_tx,
+                address_book_updater.clone(),
                 connection_tracker,
                 connection_info.clone(),
                 addr_label,

--- a/zakura-network/src/protocol/external.rs
+++ b/zakura-network/src/protocol/external.rs
@@ -20,7 +20,7 @@ pub(crate) use addr::canonical::canonical_ip;
 pub use addr::{canonical_peer_addr, canonical_socket_addr, AddrInVersion};
 pub use codec::Codec;
 pub use inv::{InventoryHash, MAX_TX_INV_IN_SENT_MESSAGE};
-pub use message::{Message, VersionMessage};
+pub use message::{Message, VersionMessage, MAX_FIND_BLOCKS_RESPONSE_HASHES};
 pub use types::{Nonce, Version};
 
 pub use zakura_chain::serialization::MAX_PROTOCOL_MESSAGE_LEN;

--- a/zakura-network/src/protocol/external/message.rs
+++ b/zakura-network/src/protocol/external/message.rs
@@ -19,6 +19,9 @@ use proptest_derive::Arbitrary;
 #[cfg(any(test, feature = "proptest-impl"))]
 use zakura_chain::serialization::arbitrary::datetime_full;
 
+/// The maximum number of block hashes in an `inv` response to `getblocks`.
+pub const MAX_FIND_BLOCKS_RESPONSE_HASHES: usize = 500;
+
 /// A Bitcoin-like network message for the Zcash protocol.
 ///
 /// The Zcash network protocol is mostly inherited from Bitcoin, and a list of
@@ -128,7 +131,8 @@ pub enum Message {
     ///
     /// The peer responds with an `inv` packet with the hashes of subsequent blocks.
     /// If supplied, the `stop` parameter specifies the last header to request.
-    /// Otherwise, an inv packet with the maximum number (500) are sent.
+    /// Otherwise, an `inv` packet with up to
+    /// [`MAX_FIND_BLOCKS_RESPONSE_HASHES`] hashes is sent.
     ///
     /// The known blocks list contains zero or more block hashes.
     ///

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -1614,6 +1614,14 @@ where
             return Ok(None);
         }
 
+        if unknown_hashes.contains(&locator) {
+            debug!(
+                ?locator,
+                "discarding FindBlocks extension response with locator hash in advertised suffix"
+            );
+            return Ok(None);
+        }
+
         for &hash in unknown_hashes {
             if Self::state_contains_service(state, hash).await? {
                 debug!(

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2033,6 +2033,65 @@ async fn build_extend_rejects_oversized_response_before_state_queries(
 }
 
 #[tokio::test]
+async fn build_extend_rejects_locator_echo_before_state_queries() -> Result<(), crate::BoxError> {
+    let (
+        _chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let tip = block::Hash::from([0x20; 32]);
+    let expected_next = block::Hash::from([0x21; 32]);
+    let unknown = block::Hash::from([0x22; 32]);
+    let trailing = block::Hash::from([0x23; 32]);
+    let tips = HashSet::from([sync::CheckedTip { tip, expected_next }]);
+    let extend_handle = tokio::spawn(TestChainSync::build_extend(
+        Timeout::new(peer_set.clone(), sync::TIPS_RESPONSE_TIMEOUT),
+        state_service.clone(),
+        tips,
+    ));
+
+    peer_set
+        .expect_request(zn::Request::FindBlocks {
+            known_blocks: vec![tip],
+            stop: None,
+        })
+        .await
+        .respond(zn::Response::BlockHashes(vec![
+            expected_next,
+            unknown,
+            tip,
+            trailing,
+        ]));
+
+    for _ in 0..(sync::FANOUT - 1) {
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![tip],
+                stop: None,
+            })
+            .await
+            .respond(Err(zn::BoxError::from("synthetic test locator echo error")));
+    }
+
+    let (download_set, prospective_tips, discovered) = extend_handle
+        .await
+        .expect("build_extend task should not panic")?;
+    assert!(download_set.is_empty());
+    assert!(prospective_tips.is_empty());
+    assert_eq!(discovered, 0);
+
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn build_extend_ignores_known_trailing_find_blocks_hash() -> Result<(), crate::BoxError> {
     let (
         _chain_sync,


### PR DESCRIPTION
## Motivation

Malformed `getblocks` responses were previously scoped to a single sync
request. A peer could send too many block hashes, duplicate hashes, or echo a
requested locator without receiving a peer-level penalty, then repeat the same
structural violation on later requests.

## Solution

Validate block-hash `inv` responses at the peer connection boundary. Retain the
requested locator set until the response arrives, reject responses containing
more than the protocol maximum of 500 hashes, duplicates, or any requested
locator, assign the full banning score through the address-book updater, and
close the connection.

Direct peers are banned by IP. Connections without a safe address-book identity
(proxy or isolated connections) are still disconnected, but are not assigned a
ban to avoid penalizing a shared proxy address.

## Testing

Focused connection tests pass for all three ban triggers and for an accepted
response at the exact 500-hash limit:

- `cargo test -p zakura-network find_blocks_response`
- `cargo fmt --all -- --check`

Full risk-proportional verification will run after this draft is opened.

## Changelog

A changelog fragment will be added after this draft provides the PR number.

### Specifications & References

- Stacked on #372.
- Follow-up to #355.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches peer connection lifecycle and address-book banning on a security-sensitive P2P path; behavior is well-tested but misclassification could disconnect or ban legitimate peers.
> 
> **Overview**
> **Hardens P2P sync against abusive `getblocks` replies.** Peers could previously return oversized, duplicate, or locator-echoing block-hash `inv` responses with only per-request failure and no persistent penalty.
> 
> The connection layer now keeps the requested locator set on `FindBlocks`, rejects responses over **500** hashes (`MAX_FIND_BLOCKS_RESPONSE_HASHES`), duplicate hashes, or any hash that matches a sent locator, and surfaces `PeerError::InvalidFindBlocksResponse`. On that error the node fails the client request, applies **maximum misbehavior score** via the new per-connection `address_book_updater` when a safe address-book identity exists, and tears down the connection.
> 
> Tests cover acceptance at the 500-hash limit and ban paths for oversize, duplicate, and locator-echo cases. A security changelog entry documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba71c0e7190e862f8c680b7a732db79a786c9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->