### PR TITLE
fix(chain): reject SIGHASH_SINGLE without matching output

### DIFF
--- a/changelog-unreleased/377.md
+++ b/changelog-unreleased/377.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR hardens a signature hash precondition without changing node validation behavior.

--- a/zakura-chain/src/transaction.rs
+++ b/zakura-chain/src/transaction.rs
@@ -345,10 +345,6 @@ impl Transaction {
     /// transactions ignore it because ZIP-244 commits to the spent output's
     /// `scriptPubKey` instead.
     ///
-    /// This method only calculates a digest. For V5 and later transactions,
-    /// callers must separately reject `SIGHASH_SINGLE` when the transparent
-    /// input does not have a corresponding output.
-    ///
     /// # Panics
     ///
     /// - if `hash_type` is not one of the six canonical signature hash types
@@ -356,6 +352,8 @@ impl Transaction {
     /// - if called on a v1 or v2 transaction
     /// - if the input index points to a transparent::Input::CoinBase
     /// - if the input index is out of bounds for self.inputs()
+    /// - if a V5 or later `SIGHASH_SINGLE` transparent input does not have a
+    ///   corresponding output
     /// - if the tx contains `nConsensusBranchId` field and `nu` doesn't match it
     /// - if the tx is not convertible to its `librustzcash` equivalent
     /// - if `nu` doesn't contain a consensus branch id convertible to its `librustzcash`

--- a/zakura-chain/src/transaction/sighash.rs
+++ b/zakura-chain/src/transaction/sighash.rs
@@ -194,15 +194,15 @@ impl SigHasher {
     /// transactions ignore it because ZIP-244 commits to the spent output's
     /// `scriptPubKey` instead.
     ///
-    /// This method only calculates a digest. For V5 and later transactions,
-    /// callers must separately reject `SIGHASH_SINGLE` when the transparent
-    /// input does not have a corresponding output. Callers that need raw
-    /// pre-V5 hash type bytes must use [`SigHasher::sighash_v4_raw`].
+    /// Callers that need raw pre-V5 hash type bytes must use
+    /// [`SigHasher::sighash_v4_raw`].
     ///
     /// # Panics
     ///
     /// - If `hash_type` is not one of the six canonical signature hash types.
     /// - If the input index is out of bounds for the transaction inputs.
+    /// - If a V5 or later `SIGHASH_SINGLE` transparent input does not have a
+    ///   corresponding output.
     pub fn sighash(
         &self,
         hash_type: HashType,
@@ -212,6 +212,15 @@ impl SigHasher {
             CanonicalHashType::try_from(hash_type).expect("hash type should be canonical");
 
         if let Some(zip244) = &self.zip244 {
+            if let Some((input_index, _)) = &input_index_script_code {
+                assert!(
+                    !canonical_hash_type.is_single()
+                        || zip244.has_corresponding_output(*input_index),
+                    "sighash precondition violated: V5+ SIGHASH_SINGLE requires a corresponding \
+                     transparent output",
+                );
+            }
+
             return zip244.sighash(
                 canonical_hash_type,
                 input_index_script_code.as_ref().map(|(index, _)| *index),

--- a/zakura-chain/src/transaction/tests/vectors.rs
+++ b/zakura-chain/src/transaction/tests/vectors.rs
@@ -6,6 +6,7 @@ use color_eyre::eyre::{Result, WrapErr};
 use lazy_static::lazy_static;
 use rand::{seq::IteratorRandom, thread_rng};
 use std::io::ErrorKind;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::{
     block::{Block, Height, MAX_BLOCK_BYTES},
@@ -1282,18 +1283,31 @@ fn zip244_sighash() -> Result<()> {
             (HashType::NONE_ANYONECANPAY, test.sighash_none_anyone),
             (HashType::SINGLE_ANYONECANPAY, test.sighash_single_anyone),
         ] {
-            let Some(expected) = expected else {
+            let Some(input_index) = test.transparent_input else {
+                assert!(
+                    expected.is_none(),
+                    "test #{i}: transparent sighash without input"
+                );
                 continue;
             };
-            let input_index = usize::try_from(
-                test.transparent_input
-                    .expect("transparent sighash vector has an input index"),
-            )
-            .expect("u32 input index fits in usize");
-            let result = hex::encode(sighasher.sighash(
-                hash_type,
-                Some((input_index, test.script_pubkeys[input_index].clone())),
-            ));
+            let input_index = usize::try_from(input_index).expect("u32 input index fits in usize");
+            let input = Some((input_index, test.script_pubkeys[input_index].clone()));
+            let Some(expected) = expected else {
+                assert!(
+                    hash_type == HashType::SINGLE || hash_type == HashType::SINGLE_ANYONECANPAY,
+                    "test #{i}: only SIGHASH_SINGLE can require a corresponding output",
+                );
+                assert!(
+                    input_index >= transaction.outputs().len(),
+                    "test #{i}: missing SIGHASH_SINGLE digest requires a missing output",
+                );
+                assert!(
+                    catch_unwind(AssertUnwindSafe(|| sighasher.sighash(hash_type, input))).is_err(),
+                    "test #{i}: SIGHASH_SINGLE without a corresponding output must fail",
+                );
+                continue;
+            };
+            let result = hex::encode(sighasher.sighash(hash_type, input));
             assert_eq!(
                 hex::encode(expected),
                 result,

--- a/zakura-chain/src/transaction/zip244.rs
+++ b/zakura-chain/src/transaction/zip244.rs
@@ -843,6 +843,7 @@ pub(super) struct Zip244SighashCache {
     scriptpubkeys: Blake2bHash,
     sequence: Blake2bHash,
     outputs: Blake2bHash,
+    transparent_output_count: usize,
     single_outputs: Vec<Blake2bHash>,
     txins: Vec<Option<Blake2bHash>>,
     transparent_bundle_present: bool,
@@ -878,6 +879,7 @@ impl Zip244SighashCache {
             scriptpubkeys: hash_scriptpubkeys(previous_outputs),
             sequence,
             outputs,
+            transparent_output_count: parts.outputs.len(),
             single_outputs: parts
                 .outputs
                 .iter()
@@ -931,6 +933,11 @@ impl Zip244SighashCache {
         )
     }
 
+    /// Returns whether `input_index` has a corresponding transparent output.
+    pub(super) fn has_corresponding_output(&self, input_index: usize) -> bool {
+        input_index < self.transparent_output_count
+    }
+
     fn transparent_sig_digest(
         &self,
         hash_type: CanonicalHashType,
@@ -972,7 +979,7 @@ impl Zip244SighashCache {
                 .single_outputs
                 .get(index)
                 .copied()
-                .unwrap_or_else(|| hash_outputs(&[])),
+                .expect("SIGHASH_SINGLE input has a corresponding transparent output"),
             Some(_) if none => hash_outputs(&[]),
             _ => self.outputs,
         };

--- a/zakura-script/src/tests.rs
+++ b/zakura-script/src/tests.rs
@@ -540,12 +540,26 @@ fn build_and_verify_v5_p2pkh_single_with_missing_output(
         all_previous_outputs.clone(),
     )
     .expect("sighasher creation should succeed");
-    let sighash = sighasher.sighash(
-        canonical_hash_type,
-        Some((signed_input_index, lock_script_bytes.clone())),
-    );
+    let sighash = if signed_input_index >= placeholder_tx.outputs().len() {
+        // The chain sighash API now rejects this invalid request, so preserve
+        // the old digest only to construct a regression transaction that
+        // reaches the script layer's defense in depth check.
+        <[u8; 32]>::from_hex(if anyone_can_pay {
+            "217872a1e1ce0b5738454081962541b094bdddf8ad4bec7a8894df7904bd679e"
+        } else {
+            "2820a4ba1ac63e86c2ed01941a837197f65e0be2a2fed06c73938e60daed8320"
+        })
+        .expect("fixed missing-output sighash is valid hex")
+    } else {
+        sighasher
+            .sighash(
+                canonical_hash_type,
+                Some((signed_input_index, lock_script_bytes.clone())),
+            )
+            .into()
+    };
 
-    let msg = Message::from_digest(*sighash.as_ref());
+    let msg = Message::from_digest(sighash);
     let signature = secp.sign_ecdsa(&msg, &secret_key);
     let der_sig = signature.serialize_der();
 


### PR DESCRIPTION
## Motivation

[ZCA-797](https://linear.app/zcale/issue/ZCA-797/c34-missing-sighash-single-output-check) identified that `SigHasher` could return a V5+ `SIGHASH_SINGLE` digest when the input had no corresponding output. Final Consensus [ZIP-244 §S.2a](https://github.com/zcash/zips/blob/cdc5dfe15ac9524518822383eb8a6b0b19388f62/zips/zip-0244.rst#L519-L529) requires validation failure in that case.

## Solution

Reject the invalid request at the public sighash boundary, remove the empty-output fallback, and cover the failure with the ZIP-244 vectors while retaining script-layer regression coverage.

## Testing

Formatting, workspace clippy, targeted chain/script/consensus tests, and GitHub Actions pass.

## Changelog

`changelog-unreleased/377.md` marks this internal-only.

AI disclosure: Codex was used for investigation, implementation, tests, and this PR description.