### PR TITLE
test(acceptance): remove redundant launch delays

### DIFF
--- a/changelog-unreleased/380.md
+++ b/changelog-unreleased/380.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes test timing and failure bounds, with no operator- or
+crate-consumer-visible effect.

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -201,8 +201,8 @@ use common::{
         os_assigned_rpc_port_config, persistent_test_config, read_listen_addr_from_logs, testdir,
     },
     launch::{
-        spawn_zakurad_for_rpc, spawn_zakurad_without_rpc, ZakuradTestDirExt, BETWEEN_NODES_DELAY,
-        EXTENDED_LAUNCH_DELAY, LAUNCH_DELAY,
+        spawn_zakurad_for_rpc, spawn_zakurad_without_rpc, ZakuradTestDirExt, EXTENDED_LAUNCH_DELAY,
+        LAUNCH_DELAY,
     },
     lightwalletd::{can_spawn_lightwalletd_for_rpc, spawn_lightwalletd_for_rpc},
     sync::{
@@ -1671,9 +1671,6 @@ async fn rpc_endpoint(parallel_cpu_threads: bool) -> Result<()> {
     // Create an http client
     let client = RpcRequestClient::new(rpc_address);
 
-    // Run `zakurad` for a few seconds before testing the endpoint
-    std::thread::sleep(LAUNCH_DELAY);
-
     // Make the call to the `getinfo` RPC method
     let res = client.call("getinfo", "[]".to_string()).await?;
 
@@ -2425,16 +2422,17 @@ where
     U: ZakuradTestDirExt + std::fmt::Debug,
 {
     // Start the first node
-    let mut node1 = first_dir.spawn_child(args!["start"])?;
+    let mut node1 = first_dir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
 
     // Wait until node1 has used the conflicting resource.
     node1.expect_stdout_line_matches(first_stdout_regex)?;
 
-    // Wait a bit before launching the second node.
-    std::thread::sleep(BETWEEN_NODES_DELAY);
-
     // Spawn the second node and wait for the expected resource conflict.
-    let mut node2 = second_dir.spawn_child(args!["start"])?;
+    let mut node2 = second_dir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     node2
         .expect_stderr_line_matches(second_stderr_regex)
         .context_from(&mut node1)?;

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -337,20 +337,17 @@ fn start_no_args() -> Result<()> {
     // start caches state, so run one of the start tests with persistent state
     let testdir = testdir()?.with_config(&mut persistent_test_config(&Mainnet)?)?;
 
-    let mut child = testdir.spawn_child(args!["-v", "start"])?;
+    let mut child = testdir
+        .spawn_child(args!["-v", "start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
 
-    // Run the program and kill it after a few seconds
-    std::thread::sleep(LAUNCH_DELAY);
+    child.expect_stdout_line_matches("Starting zakurad")?;
+    child.expect_stdout_line_matches("starting legacy chain check")?;
+    child.expect_stdout_line_matches("no legacy chain found")?;
     child.kill(false)?;
 
     let output = child.wait_with_output()?;
     let output = output.assert_failure()?;
-
-    output.stdout_line_contains("Starting zakurad")?;
-
-    // Make sure the command passed the legacy chain check
-    output.stdout_line_contains("starting legacy chain check")?;
-    output.stdout_line_contains("no legacy chain found")?;
 
     // Make sure the command was killed
     output.assert_was_killed()?;
@@ -365,9 +362,10 @@ fn start_args() -> Result<()> {
     let testdir = testdir()?.with_config(&mut default_test_config(&Mainnet))?;
     let testdir = &testdir;
 
-    let mut child = testdir.spawn_child(args!["start"])?;
-    // Run the program and kill it after a few seconds
-    std::thread::sleep(LAUNCH_DELAY);
+    let mut child = testdir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
+    child.expect_stdout_line_matches("Starting zakurad")?;
     child.kill(false)?;
     let output = child.wait_with_output()?;
 

--- a/zakurad/tests/common/launch.rs
+++ b/zakurad/tests/common/launch.rs
@@ -46,12 +46,6 @@ pub const EXTENDED_LAUNCH_DELAY: Duration = Duration::from_secs(45);
 /// it is using for its RPCs.
 pub const LIGHTWALLETD_DELAY: Duration = Duration::from_secs(60);
 
-/// The amount of time we wait between launching two conflicting nodes.
-///
-/// We use a longer time to make sure the first node has launched before the second starts,
-/// even if CI is under load.
-pub const BETWEEN_NODES_DELAY: Duration = Duration::from_secs(20);
-
 /// The amount of time we wait for lightwalletd to update to the tip.
 ///
 /// `lightwalletd` takes about 60-120 minutes to fully sync,


### PR DESCRIPTION
## Motivation

Several acceptance tests wait for exact resource-readiness logs and then sleep
for another fixed 20 seconds. The sleeps dominate test duration without
strengthening the readiness guarantee.

## Solution

- Call `getinfo` immediately after the RPC endpoint-open log in the single- and
  parallel-thread RPC tests.
- Launch the conflicting node immediately after the first node logs that it
  owns the target socket or database.
- Wait for startup and legacy-chain-check logs in `start_args` and
  `start_no_args` instead of sleeping for 20 seconds.
- Bound the updated child processes with the existing 45-second failure
  timeout.
- Remove the now-unused test-only `BETWEEN_NODES_DELAY` constant.

## Testing

Release acceptance binary compiled locally with
`default-release-binaries,filter-reload`.

Passed 10/10 local repetitions each:

- `rpc_endpoint_single_thread`
- `rpc_endpoint_parallel_threads`
- `zakura_state_conflict`
- `zakura_zcash_listener_conflict`
- `zakura_metrics_conflict`
- `start_args` (about 0.02s locally)
- `start_no_args` (about 0.04–0.05s locally)

`zakura_rpc_conflict` is excluded on macOS. `zakura_tracing_conflict` hung
locally before reaching the removed delay; the bounded `tracing_endpoint` test
passed, and this PR adds a 45-second timeout so CI will produce a bounded
failure with diagnostics rather than hanging. Linux CI is the deciding
coverage for both conflict cases.

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check` (validated 1 fragment)

## Changelog

Added `changelog-unreleased/380.md` with `<!-- changelog: none -->` because only
tests change.

### Specifications & References

No production behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and harness changes; no production or operator-visible behavior.
> 
> **Overview**
> Acceptance tests stop sleeping after readiness is already proven by logs, which cuts runtime without changing what they assert.
> 
> **Startup tests** (`start_no_args`, `start_args`) wait on stdout for startup and legacy-chain-check lines instead of a fixed 20s sleep, and use `with_timeout(EXTENDED_LAUNCH_DELAY)` on the child.
> 
> **RPC tests** call `getinfo` as soon as the RPC-open log appears—no extra `LAUNCH_DELAY` after the port is known.
> 
> **Conflict tests** (`check_config_conflict`) start the second node right after the first logs that it owns the socket or database; the old 20s `BETWEEN_NODES_DELAY` is removed and both children get the 45s extended launch timeout.
> 
> Adds `changelog-unreleased/380.md` marked `changelog: none`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bade5b191f465d06e5f93f827f1a8f1a35525834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->