### PR TITLE
ci: speed up x86 release binary builds

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -197,7 +197,7 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            runner: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
+            runner: zakura-release-x64-64-core
             platform: linux/amd64
             target_triple: x86_64-unknown-linux-gnu
           - name: linux-aarch64
@@ -225,7 +225,7 @@ jobs:
           short_sha="$(git rev-parse --short=12 HEAD)"
           docker buildx build \
             --platform "${{ matrix.platform }}" \
-            --target release \
+            --target release-zakurad \
             --file ./docker/Dockerfile \
             --build-arg "FEATURES=${FEATURES}" \
             --build-arg "SHORT_SHA=${short_sha}" \
@@ -469,7 +469,7 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            runner: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
+            runner: zakura-release-x64-64-core
             platform: linux/amd64
             docker_tag_suffix: amd64
           - name: linux-aarch64
@@ -600,7 +600,7 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            runner: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
+            runner: zakura-release-x64-64-core
             platform: linux/amd64
             docker_tag_suffix: amd64
     steps:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -42,12 +42,26 @@ on:
         required: false
         type: boolean
         default: false
+      dry_run:
+        description: "Build and validate without uploading or publishing outputs"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       release_tag:
         description: "Release tag to build and publish assets for (for example v0.0.1-alpha.1)"
         required: false
         type: string
+      checkout_ref:
+        description: "Exact commit to build in dry-run mode (defaults to the dispatched ref)"
+        required: false
+        type: string
+      dry_run:
+        description: "Build and validate without uploading or publishing outputs"
+        required: false
+        type: boolean
+        default: false
       publish_assets_to_release:
         description: "Upload zakurad assets to the GitHub release tag (use to repair an existing release)"
         required: false
@@ -83,6 +97,8 @@ jobs:
           REF_TYPE: ${{ github.ref_type }}
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          STAGE_RELEASE_ASSETS: ${{ inputs.stage_release_assets }}
           GITHUB_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
           REPOSITORY: ${{ github.repository }}
@@ -96,7 +112,13 @@ jobs:
             release_tag="$INPUT_RELEASE_TAG"
             # Reusable staging builds pin the validated commit before its tag
             # exists. workflow_dispatch repairs still build from the tag.
-            if [ -n "$INPUT_CHECKOUT_REF" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              checkout_ref="${INPUT_CHECKOUT_REF:-$GITHUB_SHA}"
+            elif [ -n "$INPUT_CHECKOUT_REF" ]; then
+              if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$STAGE_RELEASE_ASSETS" != "true" ]; then
+                echo "workflow_dispatch checkout_ref requires dry_run." >&2
+                exit 1
+              fi
               checkout_ref="$INPUT_CHECKOUT_REF"
             elif [ -n "$release_tag" ]; then
               checkout_ref="$release_tag"
@@ -295,6 +317,7 @@ jobs:
           EOF
 
       - name: Upload matrix artifacts
+        if: ${{ !inputs.dry_run }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: zakurad-assets-${{ matrix.name }}
@@ -310,10 +333,13 @@ jobs:
       attestations: write
     if: >-
       ${{
-        inputs.stage_release_assets
-        || (
-          needs.resolve-release.outputs.assets_published != 'true'
-          && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_assets_to_release)
+        !inputs.dry_run
+        && (
+          inputs.stage_release_assets
+          || (
+            needs.resolve-release.outputs.assets_published != 'true'
+            && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_assets_to_release)
+          )
         )
       }}
     steps:
@@ -494,7 +520,8 @@ jobs:
       # publish-safe by construction.
       - name: Login to DockerHub
         if: >-
-          ${{ github.repository == 'zakura-core/zakura'
+          ${{ !inputs.dry_run
+            && github.repository == 'zakura-core/zakura'
             && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 #v4.4.0
         with:
@@ -503,7 +530,8 @@ jobs:
 
       - name: Build runtime image
         if: >-
-          ${{ github.repository != 'zakura-core/zakura'
+          ${{ inputs.dry_run
+            || github.repository != 'zakura-core/zakura'
             || (!startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
@@ -527,7 +555,8 @@ jobs:
 
       - name: Build and push runtime image
         if: >-
-          ${{ github.repository == 'zakura-core/zakura'
+          ${{ !inputs.dry_run
+            && github.repository == 'zakura-core/zakura'
             && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
@@ -553,6 +582,7 @@ jobs:
     # Repo guard: publishing only happens from the canonical repository.
     if: >-
       ${{ github.repository == 'zakura-core/zakura'
+        && !inputs.dry_run
         && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
     runs-on: ubuntu-latest
     needs: [resolve-release, build]
@@ -621,7 +651,8 @@ jobs:
       # publish-safe by construction.
       - name: Login to DockerHub
         if: >-
-          ${{ github.repository == 'zakura-core/zakura'
+          ${{ !inputs.dry_run
+            && github.repository == 'zakura-core/zakura'
             && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 #v4.4.0
         with:
@@ -639,7 +670,8 @@ jobs:
 
       - name: Build zcashd compat runtime image
         if: >-
-          ${{ github.repository != 'zakura-core/zakura'
+          ${{ inputs.dry_run
+            || github.repository != 'zakura-core/zakura'
             || (!startsWith(github.ref, 'refs/tags/v') && !inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
@@ -664,7 +696,8 @@ jobs:
 
       - name: Build and push zcashd compat runtime image
         if: >-
-          ${{ github.repository == 'zakura-core/zakura'
+          ${{ !inputs.dry_run
+            && github.repository == 'zakura-core/zakura'
             && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
         env:
           FEATURES: ${{ vars.RUST_PROD_FEATURES || 'default-release-binaries' }}
@@ -691,6 +724,7 @@ jobs:
     # Repo guard: publishing only happens from the canonical repository.
     if: >-
       ${{ github.repository == 'zakura-core/zakura'
+        && !inputs.dry_run
         && (startsWith(github.ref, 'refs/tags/v') || inputs.publish_docker_to_dockerhub) }}
     runs-on: ubuntu-latest
     needs: [resolve-release, resolve-zcashd-compat-manifest, build-zcashd-compat]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,11 @@
 
 # If you want to include a file in the Docker image, add it to .dockerignore.
 #
-# We use 4 (TODO: 5) stages:
+# We use 5 (TODO: 6) stages:
 # - deps: installs build dependencies and sets default values
 # - tests: prepares a test image
-# - release: builds release binaries
+# - release-zakurad: builds the standalone release binary
+# - release: adds the maintenance binaries used by the runtime image
 # - runtime: prepares the release image
 # - TODO: Add a `monitoring` stage
 #
@@ -130,11 +131,11 @@ COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoi
 ENTRYPOINT [ "entrypoint.sh", "test" ]
 CMD [ "cargo", "test" ]
 
-# This stage builds the zakurad release binaries.
+# This stage builds the standalone zakurad release binary.
 #
 # It also adds `cache mounts` as this stage is completely independent from the
 # `test` stage. The resulting binaries are used in the `runtime` stage.
-FROM deps AS release
+FROM deps AS release-zakurad
 
 ARG SHORT_SHA
 ARG FEATURES
@@ -167,8 +168,38 @@ RUN --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
     --mount=type=cache,target=${CARGO_TARGET_DIR} \
     --mount=type=cache,target=${CARGO_HOME} \
     [ -n "${SHORT_SHA}" ] && export SHORT_SHA="${SHORT_SHA}" || true; \
-    cargo build --locked --release --features "${FEATURES}" --package zakura --bin zakurad --bin zakura-rollback-state --bin zakura-prune-state && \
-    cp ${CARGO_TARGET_DIR}/release/zakurad /usr/local/bin && \
+    cargo build --locked --release --features "${FEATURES}" --package zakura --bin zakurad && \
+    cp ${CARGO_TARGET_DIR}/release/zakurad /usr/local/bin
+
+# This stage adds the maintenance binaries used by the runtime image.
+FROM release-zakurad AS release
+
+ARG SHORT_SHA
+ARG FEATURES
+ARG CARGO_HOME
+ARG CARGO_TARGET_DIR
+
+RUN --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
+    --mount=type=bind,source=tower-fallback,target=tower-fallback \
+    --mount=type=bind,source=deploy/zakura-watchdog,target=deploy/zakura-watchdog \
+    --mount=type=bind,source=xtask,target=xtask \
+    --mount=type=bind,source=zakura-chain,target=zakura-chain \
+    --mount=type=bind,source=zakura-consensus,target=zakura-consensus \
+    --mount=type=bind,source=zakura-jsonl-trace,target=zakura-jsonl-trace \
+    --mount=type=bind,source=zakura-network,target=zakura-network \
+    --mount=type=bind,source=zakura-node-services,target=zakura-node-services \
+    --mount=type=bind,source=zakura-rpc,target=zakura-rpc \
+    --mount=type=bind,source=zakura-script,target=zakura-script \
+    --mount=type=bind,source=zakura-state,target=zakura-state \
+    --mount=type=bind,source=zakura-test,target=zakura-test \
+    --mount=type=bind,source=zakura-utils,target=zakura-utils \
+    --mount=type=bind,source=zakurad,target=zakurad \
+    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+    --mount=type=cache,target=${CARGO_TARGET_DIR} \
+    --mount=type=cache,target=${CARGO_HOME} \
+    [ -n "${SHORT_SHA}" ] && export SHORT_SHA="${SHORT_SHA}" || true; \
+    cargo build --locked --release --features "${FEATURES}" --package zakura --bin zakura-rollback-state --bin zakura-prune-state && \
     cp ${CARGO_TARGET_DIR}/release/zakura-rollback-state /usr/local/bin && \
     cp ${CARGO_TARGET_DIR}/release/zakura-prune-state /usr/local/bin
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,13 @@
 
 # If you want to include a file in the Docker image, add it to .dockerignore.
 #
-# We use 5 (TODO: 6) stages:
+# We use 6 (TODO: 7) stages:
 # - deps: installs build dependencies and sets default values
 # - tests: prepares a test image
 # - release-zakurad: builds the standalone release binary
 # - release: adds the maintenance binaries used by the runtime image
 # - runtime: prepares the release image
+# - runtime-zcashd-compat: adds zcashd compatibility to the release image
 # - TODO: Add a `monitoring` stage
 #
 # We first set default values for build arguments used across the stages.
@@ -134,7 +135,7 @@ CMD [ "cargo", "test" ]
 # This stage builds the standalone zakurad release binary.
 #
 # It also adds `cache mounts` as this stage is completely independent from the
-# `test` stage. The resulting binaries are used in the `runtime` stage.
+# `test` stage. The resulting binary is used by the `release` stage.
 FROM deps AS release-zakurad
 
 ARG SHORT_SHA


### PR DESCRIPTION
## Motivation

The x86 release build spends about 15 minutes performing a cold optimized Rust
build on a standard four-core runner. The standalone release archive also builds
and links two maintenance binaries that it does not package.

## Solution

- Run all x86 release compilation jobs on the
  `zakura-release-x64-64-core` larger-runner pool.
- Add a `release-zakurad` Docker target that builds only `zakurad`.
- Keep the existing `release` target responsible for adding
  `zakura-rollback-state` and `zakura-prune-state` to runtime images.
- Add a manual `dry_run` mode and `checkout_ref` input for safely benchmarking
  the complete build matrix without uploading Actions artifacts, publishing
  GitHub release assets, or pushing Docker images/manifests.

## Testing

- `git diff --check origin/main...HEAD`
- Parsed `.github/workflows/release-binaries.yml` with Ruby YAML
- `cargo metadata --locked --no-deps --format-version 1` and verified all three
  binary targets
- `./scripts/changelog.py check`
- GitHub Actions PR checks
- [Successful dry-run benchmark](https://github.com/zakura-core/zakura/actions/runs/29952894850)
  against commit `af2d104796b1142690b7c36d81a647f03084e076`
- [Repeat dry run](https://github.com/zakura-core/zakura/actions/runs/29960096538)
  against the same commit

The successful dry run completed the x86 standalone release build in 2m51s,
down from 14m52s on the four-core runner: an 81% reduction, or about 5.2x
faster. The complete x86 asset job took 3m12s. The regular and zcashd-compatible
x86 Docker build steps each took 2m30s. Every x86 job succeeded.

The same run verified dry-run isolation: packaging succeeded, Actions artifact
uploads were skipped, Docker Hub login and pushes were skipped, publish jobs
were skipped, and the workflow uploaded zero artifacts.

The repeat run completed both ARM builds and still has zero uploaded artifacts,
but its x86 jobs have spent more than 45 minutes waiting for GitHub to allocate
64-core VMs. No x86 build has started, so this delay is runner capacity rather
than compilation time.

A local Docker/BuildKit executable is unavailable, so the new release target
was not compiled locally. The PR remains in draft.

## Changelog

No changelog fragment is required because this PR only changes CI and Docker
build configuration. The PR is labeled `C-exclude-from-changelog`.

### Follow-up Work

- Evaluate 64-core larger-runner cold-start availability if repeat runs
  continue to wait substantially longer than the saved compilation time.
