### PR TITLE
fix(chain): reject NU7 activation without a branch ID

### DIFF
--- a/changelog-unreleased/382.md
+++ b/changelog-unreleased/382.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Reject custom Testnet and Regtest activation heights for network upgrades
+  without consensus branch IDs instead of accepting an unusable configuration
+  ([#382](https://github.com/zakura-core/zakura/pull/382)).

--- a/zakura-chain/src/local_genesis.rs
+++ b/zakura-chain/src/local_genesis.rs
@@ -421,10 +421,6 @@ fn configured_activation_heights(
         return Err("latest_network_upgrade must be BeforeOverwinter or later".into());
     }
 
-    if latest_network_upgrade >= Overwinter && latest_network_upgrade.branch_id().is_none() {
-        return Err("latest_network_upgrade must have a consensus branch ID".into());
-    }
-
     Ok(ConfiguredActivationHeights {
         before_overwinter: Some(1),
         overwinter: (latest_network_upgrade >= Overwinter).then_some(activation_height),

--- a/zakura-chain/src/parameters/network/error.rs
+++ b/zakura-chain/src/parameters/network/error.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use crate::parameters::NetworkUpgrade;
+
 /// An error that can occur when building `Parameters` using `ParametersBuilder`.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ParametersBuilderError {
@@ -50,6 +52,10 @@ pub enum ParametersBuilderError {
     #[error("network upgrades must be activated in order specified by the protocol")]
     #[non_exhaustive]
     OutOfOrderUpgrades,
+
+    #[error("configured network upgrade {network_upgrade} must have a consensus branch ID")]
+    #[non_exhaustive]
+    MissingConsensusBranchId { network_upgrade: NetworkUpgrade },
 
     #[error("difficulty limits are valid expanded values")]
     #[non_exhaustive]

--- a/zakura-chain/src/parameters/network/testnet.rs
+++ b/zakura-chain/src/parameters/network/testnet.rs
@@ -654,6 +654,12 @@ impl ParametersBuilder {
                 .collect::<Result<BTreeMap<_, _>, _>>()?
         };
 
+        if let Some(&network_upgrade) = activation_heights.values().find(|network_upgrade| {
+            **network_upgrade >= Overwinter && network_upgrade.branch_id().is_none()
+        }) {
+            return Err(ParametersBuilderError::MissingConsensusBranchId { network_upgrade });
+        }
+
         let network_upgrades: Vec<_> = activation_heights.iter().map(|(_h, &nu)| nu).collect();
 
         // Check that the provided network upgrade activation heights are in the same order by height as the default testnet activation heights

--- a/zakura-chain/tests/configured_activation_heights.rs
+++ b/zakura-chain/tests/configured_activation_heights.rs
@@ -1,9 +1,9 @@
-#![cfg(not(feature = "zakura-test"))]
-
 //! Checks activation-height validation in production feature builds.
 
+#[cfg(not(feature = "zakura-test"))]
 use zakura_chain::parameters::testnet::{ConfiguredActivationHeights, Parameters};
 
+#[cfg(not(feature = "zakura-test"))]
 #[test]
 fn nu7_activation_requires_consensus_branch_id() {
     let Err(error) = Parameters::build().with_activation_heights(ConfiguredActivationHeights {

--- a/zakura-chain/tests/configured_activation_heights.rs
+++ b/zakura-chain/tests/configured_activation_heights.rs
@@ -1,0 +1,20 @@
+#![cfg(not(feature = "zakura-test"))]
+
+//! Checks activation-height validation in production feature builds.
+
+use zakura_chain::parameters::testnet::{ConfiguredActivationHeights, Parameters};
+
+#[test]
+fn nu7_activation_requires_consensus_branch_id() {
+    let Err(error) = Parameters::build().with_activation_heights(ConfiguredActivationHeights {
+        nu7: Some(1),
+        ..Default::default()
+    }) else {
+        panic!("NU7 must not activate without a production consensus branch ID");
+    };
+
+    assert_eq!(
+        error.to_string(),
+        "configured network upgrade Nu7 must have a consensus branch ID"
+    );
+}

--- a/zakura-network/src/config.rs
+++ b/zakura-network/src/config.rs
@@ -1183,9 +1183,7 @@ impl<'de> Deserialize<'de> for Config {
             (DNetwork::ConfiguredTestnet(params), _) => {
                 build_configured_testnet::<D>(*params, &initial_testnet_peers)?
             }
-            (DNetwork::ConfiguredRegtest { params, .. }, _) => {
-                Network::new_regtest(build_regtest_params(*params))
-            }
+            (DNetwork::ConfiguredRegtest { params, .. }, _) => build_regtest::<D>(*params)?,
             (DNetwork::DefaultForKind(NetworkKind::Mainnet), _) => Network::Mainnet,
             (DNetwork::DefaultForKind(NetworkKind::Testnet), Some(params)) => {
                 build_configured_testnet::<D>(params, &initial_testnet_peers)?
@@ -1194,7 +1192,7 @@ impl<'de> Deserialize<'de> for Config {
                 Network::new_default_testnet()
             }
             (DNetwork::DefaultForKind(NetworkKind::Regtest), Some(params)) => {
-                Network::new_regtest(build_regtest_params(params))
+                build_regtest::<D>(params)?
             }
             (DNetwork::DefaultForKind(NetworkKind::Regtest), None) => {
                 Network::new_regtest(Default::default())
@@ -1460,7 +1458,10 @@ where
     }
 }
 
-fn build_regtest_params(params: DTestnetParameters) -> RegtestParameters {
+fn build_regtest<'de, D>(params: DTestnetParameters) -> Result<Network, D::Error>
+where
+    D: Deserializer<'de>,
+{
     let DTestnetParameters {
         activation_heights,
         pre_nu6_funding_streams,
@@ -1482,11 +1483,15 @@ fn build_regtest_params(params: DTestnetParameters) -> RegtestParameters {
         funding_streams_vec.insert(0, funding_streams);
     }
 
-    RegtestParameters {
+    let params = RegtestParameters {
         activation_heights: activation_heights.unwrap_or_default(),
         funding_streams: Some(funding_streams_vec),
         lockbox_disbursements,
         checkpoints: Some(checkpoints),
         extend_funding_stream_addresses_as_required,
-    }
+    };
+
+    testnet::Parameters::new_regtest(params)
+        .map(Network::new_configured_testnet)
+        .map_err(de::Error::custom)
 }

--- a/zakura-network/src/config/tests/vectors.rs
+++ b/zakura-network/src/config/tests/vectors.rs
@@ -645,6 +645,32 @@ fn configured_regtest_checkpoints_preserve_regtest_identity() {
 }
 
 #[test]
+fn configured_regtest_builder_errors_are_deserialization_errors() {
+    let _init_guard = zakura_test::init();
+
+    for config in [
+        r#"network = { params = { activation_heights = { NU5 = 2, NU6 = 1 } } }"#,
+        r#"
+        network = "Regtest"
+
+        [testnet_parameters.activation_heights]
+        NU5 = 2
+        NU6 = 1
+        "#,
+    ] {
+        let error = toml::from_str::<Config>(config)
+            .expect_err("out-of-order Regtest activations must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("network upgrades must be activated in order specified by the protocol"),
+            "unexpected invalid Regtest activation error for {config:?}: {error}",
+        );
+    }
+}
+
+#[test]
 fn zakura_bootstrap_peers_parse_in_nested_config() {
     let _init_guard = zakura_test::init();
 


### PR DESCRIPTION
## Motivation

A production build can accept an explicitly configured NU7 activation even though NU7 has no production branch ID. This is not a high-severity or remotely exploitable issue: stock Mainnet and Testnet never activate NU7, and only an operator configuring a custom Testnet or Regtest can reach it. It is still worth fixing as a correctness issue because the accepted configuration fails later in consensus code.

## Solution

Reject configured post-Overwinter upgrades without branch IDs and cover the production feature behavior with a regression test. Configured Regtest deserialization now returns validation errors instead of panicking.

## Testing

- `cargo test -p zakura-chain --no-default-features`
- `cargo test -p zakura-network config::tests::vectors`
- `cargo clippy -p zakura-chain --all-targets --no-default-features -- -D warnings`
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `cargo check -p zakura --features default-release-binaries --locked`

## Changelog

Added `changelog-unreleased/382.md`.

AI disclosure: Codex was used to investigate ZCA-800 and implement the focused guard and regression tests.