### PR TITLE
test(acceptance): narrow shielded coinbase coverage

### DIFF
--- a/changelog-unreleased/383.md
+++ b/changelog-unreleased/383.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+Internal test runtime reduction with no production behavior changes.

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -368,9 +368,11 @@ def check_pull_request(
             )
         return
 
+    # Compare from the merge base so fragments added to a moving base branch do
+    # not look like deletions made by a stale pull request branch.
     changed_paths = run_git(
         repo_root,
-        ["diff", "--name-only", base, head],
+        ["diff", "--name-only", f"{base}...{head}"],
     ).splitlines()
     changed = [
         path

--- a/scripts/tests/test_changelog.py
+++ b/scripts/tests/test_changelog.py
@@ -82,8 +82,13 @@ class ChangelogTests(unittest.TestCase):
             changelog,
             "run_git",
             return_value="changelog-unreleased/123.md\n",
-        ):
+        ) as run_git:
             changelog.check_pull_request(self.root, "base", "head", "123", False, False)
+
+        run_git.assert_called_once_with(
+            self.root,
+            ["diff", "--name-only", "base...head"],
+        )
 
     def test_pull_request_cannot_delete_another_fragment(self):
         path = self.root / "changelog-unreleased" / "123.md"

--- a/zakurad/tests/common/coinbase.rs
+++ b/zakurad/tests/common/coinbase.rs
@@ -3,8 +3,6 @@
 use std::sync::Arc;
 
 use color_eyre::eyre::{self, Context};
-use futures::future::try_join_all;
-use strum::IntoEnumIterator;
 
 use zakura_chain::{
     amount::Amount,
@@ -31,7 +29,14 @@ use super::{
     regtest::MiningRpcMethods,
 };
 
-/// Tests that Zebra can mine blocks with valid coinbase transactions on Regtest.
+/// Tests shielded coinbase construction through a live Regtest node.
+///
+/// A node configured with a Sapling or Unified mining address must return a
+/// shielded coinbase through `getblocktemplate`. The resulting block must be
+/// accepted by the production `submitblock`, consensus, and state path.
+///
+/// Detailed address routing and upgrade-matrix behavior is tested by
+/// `shielded_coinbase_paths`.
 pub(crate) async fn regtest_coinbase() -> eyre::Result<()> {
     async fn regtest_coinbase(addr_type: MinerAddressType) -> eyre::Result<()> {
         let _init_guard = zakura_test::init();
@@ -72,26 +77,24 @@ pub(crate) async fn regtest_coinbase() -> eyre::Result<()> {
         )?);
         zakurad.expect_stdout_line_matches("activating mempool")?;
 
-        for _ in 0..2 {
-            let (mut block, height) = client.block_from_template(&net).await?;
+        let (mut block, height) = client.block_from_template(&net).await?;
 
-            // If the network requires PoW, find a valid nonce.
-            if !net.disable_pow() {
-                let header = Arc::make_mut(&mut block.header);
+        // If the network requires PoW, find a valid nonce.
+        if !net.disable_pow() {
+            let header = Arc::make_mut(&mut block.header);
 
-                loop {
-                    let hash = header.hash();
+            loop {
+                let hash = header.hash();
 
-                    if difficulty_is_valid(header, &net, &height, &hash).is_ok() {
-                        break;
-                    }
-
-                    increment_big_endian(header.nonce.as_mut());
+                if difficulty_is_valid(header, &net, &height, &hash).is_ok() {
+                    break;
                 }
-            }
 
-            client.submit_block(block).await?;
+                increment_big_endian(header.nonce.as_mut());
+            }
         }
+
+        client.submit_block(block).await?;
 
         zakurad.kill(false)?;
 
@@ -102,7 +105,10 @@ pub(crate) async fn regtest_coinbase() -> eyre::Result<()> {
             .wrap_err("possible port conflict with another zakurad instance")
     }
 
-    try_join_all(MinerAddressType::iter().map(regtest_coinbase))
-        .await
-        .map(|_| ())
+    tokio::try_join!(
+        regtest_coinbase(MinerAddressType::Sapling),
+        regtest_coinbase(MinerAddressType::Unified),
+    )?;
+
+    Ok(())
 }


### PR DESCRIPTION
## Motivation

`regtest_coinbase` duplicates transparent mining coverage and repeats block
generation after a tip change, making the acceptance test substantially slower
than needed. Its unique coverage is validating real Sapling and Orchard
coinbase proofs through the full production block-verification path.

The changelog-fragment check also used a moving base tip directly. When another
PR added a fragment to `main`, an older branch appeared to delete that fragment
and failed CI despite never touching it.

## Solution

- Keep only concurrent Sapling and Unified mining-address cases.
- Generate and submit one block per address type.
- Document the test's narrow end-to-end shielded coinbase purpose and point
  detailed routing and upgrade-matrix coverage to `shielded_coinbase_paths`.
- Check PR-owned changelog changes from the Git merge base, ignoring unrelated
  fragments subsequently added to `main` while still detecting changes made by
  the PR.

This reduces the test from three daemon launches and six generated blocks to
two daemon launches and two generated blocks.

## Testing

- `cargo fmt --all -- --check`
- `python3 -m unittest scripts/tests/test_changelog.py` (16 passed)
- Reproduced PR #383's previous changelog failure using its old base/head SHAs;
  the merge-base implementation passes.
- `./scripts/changelog.py check-pr --base origin/main --head HEAD --pr 383`
- `git diff --check`
- Full local acceptance run skipped as requested; PR CI is the timing and
  integration verification.

## Changelog

Added `changelog-unreleased/383.md` with `<!-- changelog: none -->` because the
changes affect tests and internal CI tooling only.

### Specifications & References

No production behavior or API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only runtime reduction and changelog validation fix; no production behavior or API changes.
> 
> **Overview**
> **Faster shielded coinbase acceptance** — `regtest_coinbase` now runs only **Sapling** and **Unified** mining addresses in parallel, mines and submits **one block per case** (instead of all address types with two blocks each), and documents that detailed routing lives in `shielded_coinbase_paths`.
> 
> **Changelog CI** — `check_pull_request` uses a **merge-base** git diff (`base...head`) so fragments added on `main` after a branch diverged are not treated as unexpected deletions on older PRs. Tests assert the new `git diff` invocation.
> 
> Adds fragment `383.md` marked **no changelog** for internal test/tooling-only work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28edadaa7abee6d2d56c2a804b674dee5592f1a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->