### PR TITLE
fix(rpc): reject mismatched indexer block hashes

### DIFF
--- a/changelog-unreleased/384.md
+++ b/changelog-unreleased/384.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Reject indexer RPC block responses whose advertised hash does not match the
+  decoded block
+  ([#384](https://github.com/zakura-core/zakura/pull/384)).

--- a/zakura-rpc/src/indexer.rs
+++ b/zakura-rpc/src/indexer.rs
@@ -64,8 +64,11 @@ impl BlockAndHash {
     }
 
     /// Try to convert a [`BlockAndHash`] into a tuple of a decoded block and hash.
+    ///
+    /// Returns `None` if the advertised hash does not match the decoded block.
     pub fn decode(self) -> Option<(block::Block, block::Hash)> {
-        self.hash
+        let advertised_hash = self
+            .hash
             .try_into()
             .map(|bytes| block::Hash::from_bytes_in_display_order(&bytes))
             .map_err(|bytes: Vec<_>| {
@@ -74,13 +77,23 @@ impl BlockAndHash {
                     bytes.len()
                 )
             })
-            .ok()
-            .and_then(|hash| {
-                self.data
-                    .zcash_deserialize_into()
-                    .map_err(|err| tracing::warn!(?err, "failed to deserialize block",))
-                    .ok()
-                    .zip(Some(hash))
-            })
+            .ok()?;
+        let block: block::Block = self
+            .data
+            .zcash_deserialize_into()
+            .map_err(|err| tracing::warn!(?err, "failed to deserialize block"))
+            .ok()?;
+        let computed_hash = block.hash();
+
+        if advertised_hash != computed_hash {
+            tracing::warn!(
+                ?advertised_hash,
+                ?computed_hash,
+                "advertised hash does not match decoded block"
+            );
+            return None;
+        }
+
+        Some((block, advertised_hash))
     }
 }

--- a/zakura-rpc/src/indexer/tests/vectors.rs
+++ b/zakura-rpc/src/indexer/tests/vectors.rs
@@ -39,6 +39,17 @@ async fn rpc_server_spawn() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn block_and_hash_decode_rejects_mismatched_hash() -> Result<()> {
+    let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let mut response = indexer::BlockAndHash::new(block.hash(), block);
+    response.hash[0] ^= 1;
+
+    assert!(response.decode().is_none());
+
+    Ok(())
+}
+
 /// Tests that `GetBlock` returns the requested block and rejects invalid
 /// requests.
 async fn test_get_block(


### PR DESCRIPTION
## Motivation

Indexer RPC responses carry a serialized block and an advertised hash independently. `BlockAndHash::decode` accepted both without checking that the hash identified the decoded block. This is correctness hardening for an explicitly trusted synchronization channel, not a high severity issue in the stock node configuration.

## Solution

Recompute the decoded block hash at the RPC boundary and reject responses whose advertised hash differs. Both the streamed-block and finalized-gap paths already use this decoder. This supersedes the ZCA-795 portion of #326 without taking on the broader synchronization and consensus revalidation changes in that draft.

## Changelog

Added `changelog-unreleased/384.md` under Fixed.

### Follow-up Work

The additional trusted-sync hardening proposed in #326 remains separate from this transport invariant.