### PR TITLE
test: speed up slow test cases

### DIFF
--- a/changelog-unreleased/385.md
+++ b/changelog-unreleased/385.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -54,7 +54,10 @@ use Network::*;
 /// The amount of time to run the crawler, before testing what it has done.
 ///
 /// Using a very short time can make the crawler not run at all.
-const CRAWLER_TEST_DURATION: Duration = Duration::from_secs(10);
+const CRAWLER_RUN_DURATION: Duration = Duration::from_secs(10);
+
+/// The maximum wall-clock time to wait for expected crawler test progress.
+const CRAWLER_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A crawler peer limit large enough to exercise multi-peer behavior without
 /// flooding the test runtime with hundreds of immediate fake handshakes.
@@ -65,9 +68,7 @@ const CRAWLER_MANY_PEER_LIMIT_FOR_TESTS: usize = 15;
 /// Using a very short time can make the peer cache updater not run at all.
 const PEER_CACHE_UPDATER_TEST_DURATION: Duration = Duration::from_secs(25);
 
-/// The amount of time to run the listener, before testing what it has done.
-///
-/// Using a very short time can make the listener not run at all.
+/// The maximum time to wait for the listener tests to make expected progress.
 const LISTENER_TEST_DURATION: Duration = Duration::from_secs(10);
 
 /// The amount of time to run zcashd-compat listener tests.
@@ -276,7 +277,7 @@ async fn peer_limit_one_mainnet() {
     let _ = init_with_peer_limit(1, nil_inbound_service, Mainnet, None, None).await;
 
     // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
 
     // Any number of address book peers is valid here, because some peers might have failed.
 }
@@ -302,7 +303,7 @@ async fn peer_limit_one_testnet() {
     .await;
 
     // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
 
     // Any number of address book peers is valid here, because some peers might have failed.
 }
@@ -321,7 +322,7 @@ async fn peer_limit_two_mainnet() {
     let _ = init_with_peer_limit(2, nil_inbound_service, Mainnet, None, None).await;
 
     // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
 
     // Any number of address book peers is valid here, because some peers might have failed.
 }
@@ -347,7 +348,7 @@ async fn peer_limit_two_testnet() {
     .await;
 
     // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
 
     // Any number of address book peers is valid here, because some peers might have failed.
 }
@@ -431,7 +432,7 @@ async fn written_peer_cache_is_automatically_read_on_startup() {
         init_with_peer_limit(1, nil_inbound_service, Mainnet, None, config.clone()).await;
 
     // Let the peer cache reader fill the address book.
-    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
 
     assert!(
         address_book
@@ -462,7 +463,7 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_zero_connect_panic() {
     let _init_guard = zakura_test::init();
 
@@ -473,20 +474,21 @@ async fn crawler_peer_limit_zero_connect_panic() {
         unreachable!("outbound connector should never be called with a zero peer limit")
     });
 
-    let (_config, mut peerset_rx) =
-        spawn_crawler_with_peer_limit(0, unreachable_outbound_connector).await;
+    let (_config, discovered_peers) = spawn_crawler_with_peer_limit(
+        0,
+        ExpectedCrawlerConnections::None,
+        unreachable_outbound_connector,
+    )
+    .await;
 
-    let peer_result = peerset_rx.try_recv();
     assert!(
-        // `Err(TryRecvError::Empty)` means no peers are available and the channel is still open.
-        // `Err(TryRecvError::Closed)` means the channel is closed.
-        peer_result.is_err(),
-        "unexpected peer when outbound limit is zero: {peer_result:?}",
+        discovered_peers.is_empty(),
+        "unexpected peer when outbound limit is zero: {discovered_peers:?}",
     );
 }
 
 /// Test the crawler with an outbound peer limit of one peer, and a connector that always errors.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_one_connect_error() {
     let _init_guard = zakura_test::init();
 
@@ -496,21 +498,22 @@ async fn crawler_peer_limit_one_connect_error() {
     let error_outbound_connector =
         service_fn(|_| async { Err("test outbound connector always returns errors".into()) });
 
-    let (_config, mut peerset_rx) =
-        spawn_crawler_with_peer_limit(1, error_outbound_connector).await;
+    let (_config, discovered_peers) = spawn_crawler_with_peer_limit(
+        1,
+        ExpectedCrawlerConnections::OverLimit,
+        error_outbound_connector,
+    )
+    .await;
 
-    let peer_result = peerset_rx.try_recv();
     assert!(
-        // `Err(TryRecvError::Empty)` means no peers are available and the channel is still open.
-        // `Err(TryRecvError::Closed)` means the channel is closed.
-        peer_result.is_err(),
-        "unexpected peer when all connections error: {peer_result:?}",
+        discovered_peers.is_empty(),
+        "unexpected peer when all connections error: {discovered_peers:?}",
     );
 }
 
 /// Test the crawler with an outbound peer limit of one peer,
 /// and a connector that returns success then disconnects the peer.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_one_connect_ok_then_drop() {
     let _init_guard = zakura_test::init();
 
@@ -535,19 +538,14 @@ async fn crawler_peer_limit_one_connect_ok_then_drop() {
             Ok((addr, fake_client))
         });
 
-    let (config, mut peerset_rx) =
-        spawn_crawler_with_peer_limit(1, success_disconnect_outbound_connector).await;
+    let (config, discovered_peers) = spawn_crawler_with_peer_limit(
+        1,
+        ExpectedCrawlerConnections::OverLimit,
+        success_disconnect_outbound_connector,
+    )
+    .await;
 
-    let mut peer_count: usize = 0;
-    loop {
-        let peer_result = peerset_rx.try_recv();
-        match peer_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_count = discovered_peers.len();
 
     assert!(
         peer_count > config.peerset_outbound_connection_limit(),
@@ -559,7 +557,7 @@ async fn crawler_peer_limit_one_connect_ok_then_drop() {
 
 /// Test the crawler with an outbound peer limit of one peer,
 /// and a connector that returns success then holds the peer open.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_one_connect_ok_stay_open() {
     let _init_guard = zakura_test::init();
 
@@ -587,19 +585,14 @@ async fn crawler_peer_limit_one_connect_ok_stay_open() {
         }
     });
 
-    let (config, mut peerset_rx) =
-        spawn_crawler_with_peer_limit(1, success_stay_open_outbound_connector).await;
+    let (config, discovered_peers) = spawn_crawler_with_peer_limit(
+        1,
+        ExpectedCrawlerConnections::AtLimit,
+        success_stay_open_outbound_connector,
+    )
+    .await;
 
-    let mut peer_change_count: usize = 0;
-    loop {
-        let peer_change_result = peerset_rx.try_recv();
-        match peer_change_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_change_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_change_count = discovered_peers.len();
 
     let mut peer_tracker_count: usize = 0;
     loop {
@@ -634,7 +627,7 @@ async fn crawler_peer_limit_one_connect_ok_stay_open() {
 }
 
 /// Test the crawler with a multi-peer outbound limit, and a connector that always errors.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_many_connect_error() {
     let _init_guard = zakura_test::init();
 
@@ -644,22 +637,22 @@ async fn crawler_peer_limit_many_connect_error() {
     let error_outbound_connector =
         service_fn(|_| async { Err("test outbound connector always returns errors".into()) });
 
-    let (_config, mut peerset_rx) =
-        spawn_crawler_with_peer_limit(CRAWLER_MANY_PEER_LIMIT_FOR_TESTS, error_outbound_connector)
-            .await;
+    let (_config, discovered_peers) = spawn_crawler_with_peer_limit(
+        CRAWLER_MANY_PEER_LIMIT_FOR_TESTS,
+        ExpectedCrawlerConnections::OverLimit,
+        error_outbound_connector,
+    )
+    .await;
 
-    let peer_result = peerset_rx.try_recv();
     assert!(
-        // `Err(TryRecvError::Empty)` means no peers are available and the channel is still open.
-        // `Err(TryRecvError::Closed)` means the channel is closed.
-        peer_result.is_err(),
-        "unexpected peer when all connections error: {peer_result:?}",
+        discovered_peers.is_empty(),
+        "unexpected peer when all connections error: {discovered_peers:?}",
     );
 }
 
 /// Test the crawler with a multi-peer outbound limit,
 /// and a connector that returns success then disconnects the peer.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_many_connect_ok_then_drop() {
     let _init_guard = zakura_test::init();
 
@@ -684,24 +677,14 @@ async fn crawler_peer_limit_many_connect_ok_then_drop() {
             Ok((addr, fake_client))
         });
 
-    // TODO: tweak the crawler timeouts and rate-limits so we get over the actual limit
-    //       (currently, getting over the limit can take 30 seconds or more)
-    let (config, mut peerset_rx) = spawn_crawler_with_peer_limit(
+    let (config, discovered_peers) = spawn_crawler_with_peer_limit(
         CRAWLER_MANY_PEER_LIMIT_FOR_TESTS,
+        ExpectedCrawlerConnections::OverLimit,
         success_disconnect_outbound_connector,
     )
     .await;
 
-    let mut peer_count: usize = 0;
-    loop {
-        let peer_result = peerset_rx.try_recv();
-        match peer_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_count = discovered_peers.len();
 
     assert!(
         peer_count > config.peerset_outbound_connection_limit(),
@@ -713,7 +696,7 @@ async fn crawler_peer_limit_many_connect_ok_then_drop() {
 
 /// Test the crawler with a multi-peer outbound limit,
 /// and a connector that returns success then holds the peer open.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_many_connect_ok_stay_open() {
     let _init_guard = zakura_test::init();
 
@@ -741,22 +724,14 @@ async fn crawler_peer_limit_many_connect_ok_stay_open() {
         }
     });
 
-    let (config, mut peerset_rx) = spawn_crawler_with_peer_limit(
+    let (config, discovered_peers) = spawn_crawler_with_peer_limit(
         CRAWLER_MANY_PEER_LIMIT_FOR_TESTS,
+        ExpectedCrawlerConnections::AtLimit,
         success_stay_open_outbound_connector,
     )
     .await;
 
-    let mut peer_change_count: usize = 0;
-    loop {
-        let peer_change_result = peerset_rx.try_recv();
-        match peer_change_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_change_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_change_count = discovered_peers.len();
 
     let mut peer_tracker_count: usize = 0;
     loop {
@@ -804,15 +779,12 @@ async fn listener_peer_limit_zero_handshake_panic() {
         unreachable!("inbound handshaker should never be called with a zero peer limit")
     });
 
-    let (_config, mut peerset_rx) =
+    let (_config, discovered_peers) =
         spawn_inbound_listener_with_peer_limit(0, None, unreachable_inbound_handshaker).await;
 
-    let peer_result = peerset_rx.try_recv();
     assert!(
-        // `Err(TryRecvError::Empty)` means no peers are available and the channel is still open.
-        // `Err(TryRecvError::Closed)` means the channel is closed.
-        peer_result.is_err(),
-        "unexpected peer when inbound limit is zero: {peer_result:?}",
+        discovered_peers.is_empty(),
+        "unexpected peer when inbound limit is zero: {discovered_peers:?}",
     );
 }
 
@@ -829,15 +801,12 @@ async fn listener_peer_limit_one_handshake_error() {
     let error_inbound_handshaker =
         service_fn(|_| async { Err("test inbound handshaker always returns errors".into()) });
 
-    let (_config, mut peerset_rx) =
+    let (_config, discovered_peers) =
         spawn_inbound_listener_with_peer_limit(1, None, error_inbound_handshaker).await;
 
-    let peer_result = peerset_rx.try_recv();
     assert!(
-        // `Err(TryRecvError::Empty)` means no peers are available and the channel is still open.
-        // `Err(TryRecvError::Closed)` means the channel is closed.
-        peer_result.is_err(),
-        "unexpected peer when all handshakes error: {peer_result:?}",
+        discovered_peers.is_empty(),
+        "unexpected peer when all handshakes error: {discovered_peers:?}",
     );
 }
 
@@ -872,23 +841,14 @@ async fn listener_peer_limit_one_handshake_ok_then_drop() {
             Ok(fake_client)
         });
 
-    let (config, mut peerset_rx) = spawn_inbound_listener_with_peer_limit(
+    let (config, discovered_peers) = spawn_inbound_listener_with_peer_limit(
         1,
         usize::MAX,
         success_disconnect_inbound_handshaker,
     )
     .await;
 
-    let mut peer_count: usize = 0;
-    loop {
-        let peer_result = peerset_rx.try_recv();
-        match peer_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_count = discovered_peers.len();
 
     assert!(
         peer_count > config.peerset_inbound_connection_limit(),
@@ -932,19 +892,10 @@ async fn listener_peer_limit_one_handshake_ok_stay_open() {
             }
         });
 
-    let (config, mut peerset_rx) =
+    let (config, discovered_peers) =
         spawn_inbound_listener_with_peer_limit(1, None, success_stay_open_inbound_handshaker).await;
 
-    let mut peer_change_count: usize = 0;
-    loop {
-        let peer_change_result = peerset_rx.try_recv();
-        match peer_change_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_change_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_change_count = discovered_peers.len();
 
     let mut peer_tracker_count: usize = 0;
     loop {
@@ -1222,15 +1173,12 @@ async fn listener_peer_limit_default_handshake_error() {
     let error_inbound_handshaker =
         service_fn(|_| async { Err("test inbound handshaker always returns errors".into()) });
 
-    let (_config, mut peerset_rx) =
+    let (_config, discovered_peers) =
         spawn_inbound_listener_with_peer_limit(None, None, error_inbound_handshaker).await;
 
-    let peer_result = peerset_rx.try_recv();
     assert!(
-        // `Err(TryRecvError::Empty)` means no peers are available and the channel is still open.
-        // `Err(TryRecvError::Closed)` means the channel is closed.
-        peer_result.is_err(),
-        "unexpected peer when all handshakes error: {peer_result:?}",
+        discovered_peers.is_empty(),
+        "unexpected peer when all handshakes error: {discovered_peers:?}",
     );
 }
 
@@ -1269,23 +1217,14 @@ async fn listener_peer_limit_default_handshake_ok_then_drop() {
             Ok(fake_client)
         });
 
-    let (config, mut peerset_rx) = spawn_inbound_listener_with_peer_limit(
+    let (config, discovered_peers) = spawn_inbound_listener_with_peer_limit(
         None,
         usize::MAX,
         success_disconnect_inbound_handshaker,
     )
     .await;
 
-    let mut peer_count: usize = 0;
-    loop {
-        let peer_result = peerset_rx.try_recv();
-        match peer_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_count = discovered_peers.len();
 
     assert!(
         peer_count > config.peerset_inbound_connection_limit(),
@@ -1329,20 +1268,11 @@ async fn listener_peer_limit_default_handshake_ok_stay_open() {
             }
         });
 
-    let (config, mut peerset_rx) =
+    let (config, discovered_peers) =
         spawn_inbound_listener_with_peer_limit(None, None, success_stay_open_inbound_handshaker)
             .await;
 
-    let mut peer_change_count: usize = 0;
-    loop {
-        let peer_change_result = peerset_rx.try_recv();
-        match peer_change_result {
-            // A peer handshake succeeded.
-            Ok(_peer_change) => peer_change_count += 1,
-            // The channel is closed or there are no messages left in the channel.
-            Err(_) => break,
-        }
-    }
+    let peer_change_count = discovered_peers.len();
 
     let mut peer_tracker_count: usize = 0;
     loop {
@@ -1792,16 +1722,65 @@ where
     address_book
 }
 
+/// The number of connector calls a crawler peer-limit test expects to observe.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum ExpectedCrawlerConnections {
+    /// A zero connection limit must prevent every connector call.
+    None,
+    /// Held-open connections must stop at the configured limit.
+    AtLimit,
+    /// Failed or dropped connections must be replaced beyond the limit.
+    OverLimit,
+}
+
+/// Wait for `event_count` crawler test events while advancing mocked time.
+///
+/// The crawler can keep runnable tasks queued, so Tokio's automatic paused-time
+/// advancement is not sufficient for its connection rate-limit sleeps. It also
+/// uses [`tokio::task::spawn_blocking`] in [`CandidateSet::next`], so each time
+/// advance is paired with a blocking-pool round trip. The round trip is only a
+/// progress aid; correctness comes from the observed events, not FIFO task
+/// scheduling.
+async fn wait_for_crawler_events<T>(
+    events: &mut tokio::sync::mpsc::UnboundedReceiver<T>,
+    event_count: usize,
+    timeout_message: &str,
+) -> Vec<T> {
+    let deadline = Instant::now() + CRAWLER_TEST_TIMEOUT;
+    let mut received_events = Vec::with_capacity(event_count);
+
+    while received_events.len() < event_count {
+        while let Ok(event) = events.try_recv() {
+            received_events.push(event);
+            if received_events.len() == event_count {
+                return received_events;
+            }
+        }
+
+        assert!(!events.is_closed(), "{timeout_message}: channel closed");
+        assert!(Instant::now() < deadline, "{timeout_message}");
+
+        tokio::time::advance(constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL).await;
+        tokio::task::spawn_blocking(|| {})
+            .await
+            .expect("crawler test blocking-task synchronization should not panic");
+        tokio::task::yield_now().await;
+    }
+
+    received_events
+}
+
 /// Run a peer crawler with `peerset_initial_target_size` and `outbound_connector`.
 ///
 /// Uses the default values for all other config fields.
 /// Does not bind a local listener.
 ///
-/// Returns the generated [`Config`], and the peer set receiver.
+/// Returns the generated [`Config`], and the discovered peers.
 async fn spawn_crawler_with_peer_limit<C>(
     peerset_initial_target_size: impl Into<Option<usize>>,
+    expected_connections: ExpectedCrawlerConnections,
     outbound_connector: C,
-) -> (Config, mpsc::Receiver<DiscoveredPeer>)
+) -> (Config, Vec<DiscoveredPeer>)
 where
     C: Service<
             OutboundConnectorRequest,
@@ -1847,20 +1826,34 @@ where
             .update(addr);
     }
 
-    // Create a fake peer set.
-    let nil_peer_set = service_fn(move |req| async move {
-        let rsp = match req {
-            // Return the correct response variant for Peers requests,
-            // reusing one of the peers we already provided.
-            Request::Peers => Response::Peers(vec![fake_peer.unwrap()]),
-            _ => unreachable!("unexpected request: {:?}", req),
-        };
+    // Create a fake peer set. The notification proves the crawler has started
+    // an observable crawl action before this helper stops it. The zero-limit
+    // response stays pending so its timer crawl cannot enqueue more demand
+    // while the test closes the demand channel to establish a drain barrier.
+    let (crawl_observed_tx, mut crawl_observed_rx) = tokio::sync::mpsc::unbounded_channel();
+    let nil_peer_set = service_fn(move |req| {
+        let crawl_observed_tx = crawl_observed_tx.clone();
 
-        Ok(rsp)
+        async move {
+            let rsp = match req {
+                // Return the correct response variant for Peers requests,
+                // reusing one of the peers we already provided.
+                Request::Peers => Response::Peers(vec![fake_peer.unwrap()]),
+                _ => unreachable!("unexpected request: {:?}", req),
+            };
+
+            let _ = crawl_observed_tx.send(());
+
+            if expected_connections == ExpectedCrawlerConnections::None {
+                std::future::pending::<Result<Response, BoxError>>().await
+            } else {
+                Ok(rsp)
+            }
+        }
     });
 
     // Make the channels large enough to hold all the peers.
-    let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_peers);
+    let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_peers);
     let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(over_limit_peers);
 
     let candidates = CandidateSet::new(address_book.clone(), nil_peer_set);
@@ -1873,6 +1866,27 @@ where
     for _ in 0..over_limit_peers {
         let _ = demand_tx.try_send(MorePeers);
     }
+    let mut demand_shutdown_tx = demand_tx.clone();
+
+    // Observe connector completion rather than sleeping for a fixed duration.
+    let (connection_finished_tx, mut connection_finished_rx) =
+        tokio::sync::mpsc::unbounded_channel();
+    let outbound_connector = service_fn(move |request| {
+        let connector = outbound_connector.clone();
+        let connection_finished_tx = connection_finished_tx.clone();
+
+        async move {
+            let result = connector.oneshot(request).await;
+            let _ = connection_finished_tx.send(result.is_ok());
+            result
+        }
+    });
+
+    let expected_connection_count = match expected_connections {
+        ExpectedCrawlerConnections::None => 0,
+        ExpectedCrawlerConnections::AtLimit => config.peerset_outbound_connection_limit(),
+        ExpectedCrawlerConnections::OverLimit => config.peerset_outbound_connection_limit() + 1,
+    };
 
     // Start the crawler.
     let crawl_fut = crawl_and_dial(
@@ -1887,19 +1901,101 @@ where
     );
     let crawl_task_handle = tokio::spawn(crawl_fut);
 
-    // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    wait_for_crawler_events(
+        &mut crawl_observed_rx,
+        1,
+        "peer crawler should attempt a crawl before the timeout",
+    )
+    .await;
 
-    // Stop the crawler and let it finish.
-    crawl_task_handle.abort();
-    tokio::task::yield_now().await;
+    let connection_results = wait_for_crawler_events(
+        &mut connection_finished_rx,
+        expected_connection_count,
+        "peer crawler should make the expected connections before the timeout",
+    )
+    .await;
+    let expected_discovered_peers = connection_results
+        .into_iter()
+        .filter(|connection_succeeded| *connection_succeeded)
+        .count();
 
-    // Check for panics or errors in the crawler.
-    let crawl_result = crawl_task_handle.now_or_never();
-    assert!(
-        crawl_result.is_none() || matches!(crawl_result, Some(Err(ref e)) if e.is_cancelled()),
-        "unexpected error or panic in peer crawler task: {crawl_result:?}",
-    );
+    let peer_deadline = Instant::now() + CRAWLER_TEST_TIMEOUT;
+    let mut discovered_peers = Vec::with_capacity(expected_discovered_peers);
+    while discovered_peers.len() < expected_discovered_peers {
+        while let Ok(peer) = peerset_rx.try_recv() {
+            discovered_peers.push(peer);
+            if discovered_peers.len() == expected_discovered_peers {
+                break;
+            }
+        }
+
+        if discovered_peers.len() < expected_discovered_peers {
+            assert!(
+                Instant::now() < peer_deadline,
+                "successful crawler connections should reach the peer set"
+            );
+            tokio::time::advance(constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL).await;
+            tokio::task::spawn_blocking(|| {})
+                .await
+                .expect("crawler test blocking-task synchronization should not panic");
+            tokio::task::yield_now().await;
+        }
+    }
+
+    if matches!(
+        expected_connections,
+        ExpectedCrawlerConnections::None | ExpectedCrawlerConnections::AtLimit
+    ) {
+        // Closing demand after the expected connections makes the crawler drain
+        // every queued excess signal before it observes channel shutdown. This
+        // is a deterministic barrier proving zero-limit and held-open cases do
+        // not start an additional connection.
+        demand_shutdown_tx.close_channel();
+
+        let shutdown_deadline = Instant::now() + CRAWLER_TEST_TIMEOUT;
+        while !crawl_task_handle.is_finished() {
+            assert!(
+                Instant::now() < shutdown_deadline,
+                "peer crawler should drain queued demand before the timeout"
+            );
+            tokio::task::spawn_blocking(|| {})
+                .await
+                .expect("crawler test blocking-task synchronization should not panic");
+            tokio::task::yield_now().await;
+        }
+
+        let crawl_result = crawl_task_handle.await;
+        match crawl_result {
+            Ok(Err(error)) => assert!(
+                error.to_string().contains("demand stream closed"),
+                "unexpected peer crawler shutdown error: {error:?}"
+            ),
+            other => panic!("unexpected peer crawler shutdown result: {other:?}"),
+        }
+
+        assert!(
+            connection_finished_rx.is_closed(),
+            "queued excess demand must not leave a peer connection in flight"
+        );
+        assert!(
+            connection_finished_rx.try_recv().is_err(),
+            "queued excess demand must not start another peer connection"
+        );
+    } else {
+        // Error and disconnected-connection tests only need to prove that
+        // replacement attempts exceed the configured connection limit.
+        crawl_task_handle.abort();
+
+        let crawl_result = crawl_task_handle.await;
+        assert!(
+            matches!(crawl_result, Err(ref error) if error.is_cancelled()),
+            "unexpected error or panic in peer crawler task: {crawl_result:?}",
+        );
+    }
+
+    while let Ok(peer) = peerset_rx.try_recv() {
+        discovered_peers.push(peer);
+    }
 
     // Check the final address book contents.
     assert_eq!(
@@ -1910,7 +2006,7 @@ where
         address_book.lock().unwrap().address_metrics(Utc::now())
     );
 
-    (config, peerset_rx)
+    (config, discovered_peers)
 }
 
 async fn connect_from(source_ip: Ipv4Addr, listen_addr: SocketAddr) -> TcpStream {
@@ -1965,12 +2061,12 @@ fn assert_listener_task_cancelled(listen_task_handle: JoinHandle<Result<(), BoxE
 /// Binds the local listener to an unused localhost port.
 /// Uses the default values for all other config fields.
 ///
-/// Returns the generated [`Config`], and the peer set receiver.
+/// Returns the generated [`Config`], and the discovered peers.
 async fn spawn_inbound_listener_with_peer_limit<S>(
     peerset_initial_target_size: impl Into<Option<usize>>,
     max_connections_per_ip: impl Into<Option<usize>>,
     listen_handshaker: S,
-) -> (Config, mpsc::Receiver<DiscoveredPeer>)
+) -> (Config, Vec<DiscoveredPeer>)
 where
     S: Service<peer::HandshakeRequest<TcpStream>, Response = peer::Client, Error = BoxError>
         + Clone
@@ -1999,7 +2095,21 @@ where
     // Make enough inbound connections to go over the limit, even if the limit is zero.
     // Make the channels large enough to hold all the connections.
     let over_limit_connections = config.peerset_inbound_connection_limit() * 2 + 1;
-    let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_connections);
+    let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_connections);
+
+    // Observe completed handshakes so the helper can deterministically wait for
+    // every spawned handshake task before inspecting the peer set channel.
+    let (handshake_finished_tx, mut handshake_finished_rx) = tokio::sync::mpsc::unbounded_channel();
+    let listen_handshaker = service_fn(move |request| {
+        let handshaker = listen_handshaker.clone();
+        let handshake_finished_tx = handshake_finished_tx.clone();
+
+        async move {
+            let result = handshaker.oneshot(request).await;
+            let _ = handshake_finished_tx.send(());
+            result
+        }
+    });
 
     let bans = BannedIps::default();
 
@@ -2009,15 +2119,18 @@ where
         tcp_listener,
         MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
         listen_handshaker,
-        peerset_tx.clone(),
+        peerset_tx,
         bans,
         Vec::new(),
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
     // Open inbound connections.
+    let (connection_finished_tx, mut connection_finished_rx) =
+        tokio::sync::mpsc::unbounded_channel();
     let mut outbound_task_handles = Vec::new();
     for _ in 0..over_limit_connections {
+        let connection_finished_tx = connection_finished_tx.clone();
         let outbound_fut = async move {
             let outbound_result = TcpStream::connect(listen_addr).await;
             // Let other tasks run before we block on reading.
@@ -2039,30 +2152,85 @@ where
                     "outbound connection error in inbound listener test"
                 );
             }
+
+            let _ = connection_finished_tx.send(());
         };
 
         let outbound_task_handle = tokio::spawn(outbound_fut);
         outbound_task_handles.push(outbound_task_handle);
     }
+    std::mem::drop(connection_finished_tx);
 
-    // Let the listener run for a while.
-    tokio::time::sleep(LISTENER_TEST_DURATION).await;
+    // All test connections use the same IP, so at most this many connections
+    // can stay open. Once every other connection has closed, the listener has
+    // exercised both its accepted and over-limit paths.
+    let maximum_open_connections = config
+        .peerset_inbound_connection_limit()
+        .min(config.max_connections_per_ip);
+    let expected_closed_connections = over_limit_connections - maximum_open_connections;
 
-    // Stop the listener and outbound tasks, and let them finish.
+    tokio::time::timeout(LISTENER_TEST_DURATION, async {
+        for _ in 0..expected_closed_connections {
+            connection_finished_rx
+                .recv()
+                .await
+                .expect("inbound connection tasks remain active until they report completion");
+        }
+    })
+    .await
+    .expect("inbound listener should process the test connections before the timeout");
+
+    // Stop the listener and outbound tasks, and wait for their cancellation.
     listen_task_handle.abort();
-    for outbound_task_handle in outbound_task_handles {
+    for outbound_task_handle in &outbound_task_handles {
         outbound_task_handle.abort();
     }
-    tokio::task::yield_now().await;
 
-    // Check for panics or errors in the listener.
-    let listen_result = listen_task_handle.now_or_never();
+    let listen_result = listen_task_handle.await;
     assert!(
-        listen_result.is_none() || matches!(listen_result, Some(Err(ref e)) if e.is_cancelled()),
+        matches!(listen_result, Err(ref error) if error.is_cancelled()),
         "unexpected error or panic in inbound peer listener task: {listen_result:?}",
     );
 
-    (config, peerset_rx)
+    for outbound_task_handle in outbound_task_handles {
+        let outbound_result = outbound_task_handle.await;
+        assert!(
+            outbound_result.is_ok()
+                || matches!(outbound_result, Err(ref error) if error.is_cancelled()),
+            "unexpected panic in inbound test connection task: {outbound_result:?}",
+        );
+    }
+
+    let handshake_count = tokio::time::timeout(LISTENER_TEST_DURATION, async move {
+        let mut handshake_count = 0;
+        while handshake_finished_rx.recv().await.is_some() {
+            handshake_count += 1;
+        }
+        handshake_count
+    })
+    .await
+    .expect("inbound handshake tasks should finish before the timeout");
+
+    if config.peerset_inbound_connection_limit() == 0 {
+        assert_eq!(
+            handshake_count, 0,
+            "the handshaker must not run when the inbound peer limit is zero"
+        );
+    } else {
+        assert!(
+            handshake_count > 0,
+            "the listener must exercise the configured handshaker"
+        );
+    }
+
+    let discovered_peers = tokio::time::timeout(
+        LISTENER_TEST_DURATION,
+        peerset_rx.by_ref().collect::<Vec<_>>(),
+    )
+    .await
+    .expect("inbound handshake peer changes should finish before the timeout");
+
+    (config, discovered_peers)
 }
 
 /// Initialize a task that connects to `peer_count` initial peers using the

--- a/zakura-rpc/src/methods/tests/vectors.rs
+++ b/zakura-rpc/src/methods/tests/vectors.rs
@@ -32,8 +32,7 @@ use zakura_network::{
 };
 use zakura_node_services::BoxError;
 use zakura_state::{
-    GetBlockTemplateChainInfo, IntoDisk, LatestChainTip, ReadRequest, ReadResponse,
-    ReadStateService,
+    GetBlockTemplateChainInfo, IntoDisk, ReadRequest, ReadResponse, ReadStateService,
 };
 use zakura_test::mock_service::MockService;
 
@@ -1512,6 +1511,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_getaddresstxids_response() {
     let _init_guard = zakura_test::init();
+    let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     for network in Network::iter() {
         let blocks: Vec<Arc<Block>> = network
@@ -1535,31 +1535,63 @@ async fn rpc_getaddresstxids_response() {
         let (_, read_state, latest_chain_tip, _chain_tip_change) =
             zakura_state::populated_state(blocks.to_owned(), &network).await;
 
+        let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+        let (_tx, rx) = tokio::sync::watch::channel(None);
+        let (rpc, rpc_tx_queue) = RpcImpl::new(
+            network.clone(),
+            Default::default(),
+            Default::default(),
+            "0.0.1",
+            "RPC test",
+            Buffer::new(mempool.clone(), 1),
+            state,
+            Buffer::new(read_state, 1),
+            MockService::build().for_unit_tests(),
+            MockSyncStatus::default(),
+            latest_chain_tip,
+            MockAddressBookPeers::default(),
+            rx,
+            None,
+        );
+
+        let address = address.to_string();
+        let assert_response = |start, end, expected_response_len| {
+            let rpc = rpc.clone();
+            let address = address.clone();
+
+            async move {
+                let response = rpc
+                    .get_address_tx_ids(GetAddressTxIdsRequest {
+                        addresses: vec![address],
+                        start,
+                        end,
+                    })
+                    .await
+                    .expect("arguments are valid so no error can happen here");
+
+                // One founders reward output per coinbase transaction, and no
+                // other transactions.
+                assert_eq!(response.len(), expected_response_len);
+            }
+        };
+
         if network == Mainnet {
             // Exhaustively test possible block ranges for mainnet.
             for start in 1..=10 {
                 for end in start..=10 {
-                    rpc_getaddresstxids_response_with(
-                        &network,
+                    assert_response(
                         Some(start),
                         Some(end),
-                        &address,
-                        &read_state,
-                        &latest_chain_tip,
-                        (end - start + 1) as usize,
+                        usize::try_from(end - start + 1).expect("test range length fits in usize"),
                     )
                     .await;
                 }
             }
         } else {
             // Just test the full range for testnet.
-            rpc_getaddresstxids_response_with(
-                &network,
-                Some(1),
-                Some(10),
-                &address,
-                &read_state,
-                &latest_chain_tip,
+            assert_response(
+                Some(1u32),
+                Some(10u32),
                 // response should be limited to the chain size.
                 10,
             )
@@ -1567,129 +1599,38 @@ async fn rpc_getaddresstxids_response() {
         }
 
         // No range arguments should be equivalent to the full range.
-        rpc_getaddresstxids_response_with(
-            &network,
-            None,
-            None,
-            &address,
-            &read_state,
-            &latest_chain_tip,
-            10,
-        )
-        .await;
+        assert_response(None, None, 10).await;
 
         // Range of 0s should be equivalent to the full range.
-        rpc_getaddresstxids_response_with(
-            &network,
-            Some(0),
-            Some(0),
-            &address,
-            &read_state,
-            &latest_chain_tip,
-            10,
-        )
-        .await;
+        assert_response(Some(0), Some(0), 10).await;
 
         // Start and outside of the range should use the chain tip.
-        rpc_getaddresstxids_response_with(
-            &network,
-            Some(11),
-            Some(11),
-            &address,
-            &read_state,
-            &latest_chain_tip,
-            1,
-        )
-        .await;
+        assert_response(Some(11), Some(11), 1).await;
 
         // End outside the range should use the chain tip.
-        rpc_getaddresstxids_response_with(
-            &network,
-            None,
-            Some(11),
-            &address,
-            &read_state,
-            &latest_chain_tip,
-            10,
-        )
-        .await;
+        assert_response(None, Some(11), 10).await;
 
         // Start outside the range should use the chain tip.
-        rpc_getaddresstxids_response_with(
-            &network,
-            Some(11),
-            None,
-            &address,
-            &read_state,
-            &latest_chain_tip,
-            1,
-        )
-        .await;
+        assert_response(Some(11), None, 1).await;
+
+        // Shut down the queue task, to close the state's file descriptors.
+        rpc_tx_queue.abort();
+
+        // The queue task should not have panicked or exited by itself.
+        // It can still be running, or it can have exited due to the abort.
+        let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
+        assert!(
+            rpc_tx_queue_task_result.is_none()
+                || rpc_tx_queue_task_result
+                    .unwrap()
+                    .unwrap_err()
+                    .is_cancelled()
+        );
     }
-}
 
-async fn rpc_getaddresstxids_response_with(
-    network: &Network,
-    start: Option<u32>,
-    end: Option<u32>,
-    address: &transparent::Address,
-    read_state: &ReadStateService,
-    tip: &LatestChainTip,
-    expected_response_len: usize,
-) {
-    let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-
-    let (_tx, rx) = tokio::sync::watch::channel(None);
-    let (rpc, rpc_tx_queue) = RpcImpl::new(
-        network.clone(),
-        Default::default(),
-        Default::default(),
-        "0.0.1",
-        "RPC test",
-        Buffer::new(mempool.clone(), 1),
-        state,
-        Buffer::new(read_state.clone(), 1),
-        MockService::build().for_unit_tests(),
-        MockSyncStatus::default(),
-        tip.clone(),
-        MockAddressBookPeers::default(),
-        rx,
-        None,
-    );
-
-    // call the method with valid arguments
-    let addresses = vec![address.to_string()];
-    let response = rpc
-        .get_address_tx_ids(GetAddressTxIdsRequest {
-            addresses,
-            start,
-            end,
-        })
-        .await
-        .expect("arguments are valid so no error can happen here");
-
-    // One founders reward output per coinbase transactions, no other transactions.
-    assert_eq!(response.len(), expected_response_len);
-
+    // All range and network variants use the same RPC path, so a single
+    // observer catches an unexpected mempool request from any case.
     mempool.expect_no_requests().await;
-
-    // Shut down the queue task, to close the state's file descriptors.
-    // (If we don't, opening ~100 simultaneous states causes process file descriptor limit errors.)
-    //
-    // TODO: abort all the join handles in all the tests, except one?
-    rpc_tx_queue.abort();
-
-    // The queue task should not have panicked or exited by itself.
-    // It can still be running, or it can have exited due to the abort.
-    let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
-    assert!(
-        rpc_tx_queue_task_result.is_none()
-            || rpc_tx_queue_task_result
-                .unwrap()
-                .unwrap_err()
-                .is_cancelled()
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/zakura-state/src/service/finalized_state/tests.rs
+++ b/zakura-state/src/service/finalized_state/tests.rs
@@ -2,12 +2,43 @@
 
 #![allow(clippy::unwrap_in_result)]
 
-use zakura_chain::block::Height;
+use proptest::prelude::*;
+
+use zakura_chain::{
+    block::{Block, Height},
+    parameters::Network,
+    LedgerState,
+};
+
+use crate::{arbitrary::Prepare, service::check, SemanticallyVerifiedBlock};
 
 mod prop;
 mod rollback;
 mod transparent;
 mod vectors;
+
+/// Generates exactly the valid-commitment block prefix a finalized-state test
+/// consumes, rather than preparing the standard 104-block property-test chain.
+fn valid_commitment_chain(
+    ledger_strategy: BoxedStrategy<LedgerState>,
+    block_count: usize,
+) -> BoxedStrategy<(Vec<SemanticallyVerifiedBlock>, Network)> {
+    ledger_strategy
+        .prop_flat_map(move |ledger| {
+            let network = ledger.network.clone();
+            Block::partial_chain_strategy(
+                ledger,
+                block_count,
+                check::utxo::transparent_coinbase_spend,
+                true,
+            )
+            .prop_map(move |blocks| {
+                let blocks = blocks.iter().cloned().map(Prepare::prepare).collect();
+                (blocks, network.clone())
+            })
+        })
+        .boxed()
+}
 
 #[test]
 fn checkpoint_prune_range_retains_current_height_when_range_ends_before_it() {

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -35,6 +35,30 @@ use super::super::{
 
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
 
+/// A testnet with every network upgrade activated early, so tests can exercise
+/// every transition without committing most of a generated partial chain.
+fn early_upgrade_network() -> zakura_chain::parameters::Network {
+    ParametersBuilder::default()
+        .with_activation_heights(ConfiguredActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(2),
+            sapling: Some(3),
+            blossom: Some(4),
+            heartwood: Some(5),
+            canopy: Some(6),
+            nu5: Some(7),
+            nu6: Some(8),
+            nu6_1: Some(9),
+            nu6_2: Some(10),
+            nu6_3: Some(11),
+            nu7: Some(12),
+        })
+        .expect("failed to set activation heights")
+        .extend_funding_streams()
+        .to_network()
+        .expect("failed to build configured network")
+}
+
 type TestRootMap = HashMap<
     u32,
     (
@@ -371,38 +395,22 @@ fn blocks_with_v5_transactions() -> Result<()> {
 fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            // These are dummy values. The particular values don't matter much,
-            // as long as the nu5 one is smaller than the chains being generated
-            // (MAX_PARTIAL_CHAIN_BLOCKS) to make sure that upgrade is exercised
-            // in the test below. (The test will fail if that does not happen.)
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
+    let nu7_height = NetworkUpgrade::Nu7
+        .activation_height(&network)
+        .expect("NU7 activation height is configured");
+    let tested_block_count =
+        usize::try_from(nu7_height.0 + 1).expect("test activation height fits in usize");
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), NetworkUpgrade::Nu5, None, false);
 
-    // Use no_shrink() because we're ignoring _count and there is nothing to actually shrink.
+    // Every generated block is needed to reach NU7, so there is nothing useful
+    // to shrink.
     proptest!(ProptestConfig::with_cases(env::var("PROPTEST_CASES")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
-        |((chain, _count, network, _history_tree) in PreparedChain::default().with_ledger_strategy(ledger_strategy).with_valid_commitments().no_shrink())| {
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy, tested_block_count).no_shrink())| {
 
             let mut state = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false).expect("opening an ephemeral database should succeed");
             let mut height = Height(0);
@@ -410,10 +418,11 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
             let heartwood_height_plus1 = (heartwood_height + 1).unwrap();
             let nu5_height = NetworkUpgrade::Nu5.activation_height(&network).unwrap();
             let nu5_height_plus1 = (nu5_height + 1).unwrap();
+            prop_assert_eq!(chain.len(), tested_block_count);
 
             let mut failure_count = 0;
             let mut bad_auth_root_failure_count = 0;
-            for block in chain.iter() {
+            for block in &chain {
                 let block_hash = block.hash;
                 let current_height = block.block.coinbase_height().unwrap();
                 // For some specific heights, try to commit a block with
@@ -480,6 +489,7 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
             // Make sure the failure path was triggered
             prop_assert_eq!(failure_count, 4);
             prop_assert_eq!(bad_auth_root_failure_count, 1);
+            prop_assert_eq!(state.finalized_tip_height(), Some(nu7_height));
     });
 
     Ok(())
@@ -497,25 +507,12 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
 fn vct_fast_path_matches_legacy_and_rejects_wrong_roots() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 activation height is configured");
+    let tested_block_count =
+        usize::try_from(nu5_height.0 + 5).expect("test activation height fits in usize");
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -523,16 +520,15 @@ fn vct_fast_path_matches_legacy_and_rejects_wrong_roots() -> Result<()> {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
-        |((chain, _count, network, _history_tree) in PreparedChain::default().with_ledger_strategy(ledger_strategy.clone()).with_valid_commitments().no_shrink())| {
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy.clone(), tested_block_count).no_shrink())| {
 
             let blocks: Vec<_> = chain.iter().collect();
             let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0;
             let heartwood = NetworkUpgrade::Heartwood.activation_height(&network).unwrap().0;
 
-            // Process a bounded prefix [0, last] spanning the Heartwood (history-tree
-            // creation) and NU5 (V1->V2) boundaries plus a couple of V2 blocks; `last` is
-            // the tip we compare at. Chains are far longer than this
-            // (MAX_PARTIAL_CHAIN_BLOCKS), so this is a plain assertion, not a discard.
+            // Process [0, last] across the Heartwood (history-tree creation) and NU5
+            // (V1->V2) boundaries plus a few V2 blocks. The final generated block is
+            // the successor used to verify the commitment at `last`.
             let last = (nu5 + 3) as usize;
             prop_assert!(blocks.len() > last + 1, "generated chain unexpectedly short");
 

--- a/zakura-state/src/service/finalized_state/tests/rollback.rs
+++ b/zakura-state/src/service/finalized_state/tests/rollback.rs
@@ -852,13 +852,15 @@ fn modern_rollback_does_not_rebuild_note_trees_from_genesis() -> Result<()> {
 
     proptest!(
         ProptestConfig::with_cases(proptest_cases()),
-        |((chain, _count, network, _history_tree) in PreparedChain::default()
-            .with_ledger_strategy(ledger_strategy)
-            .with_valid_commitments()
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy, target_index + 2)
             .no_shrink())
             | {
-            let synced: Vec<SemanticallyVerifiedBlock> = chain.iter().cloned().collect();
-            prop_assume!(synced.len() > target_index + 1);
+            let synced = chain;
+            prop_assert_eq!(
+                synced.len(),
+                target_index + 2,
+                "generated chain must contain the target and one removed block"
+            );
             prop_assert!(
                 !synced[target_index + 1..]
                     .iter()

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -439,16 +439,18 @@ fn persistent_mode() -> Result<()> {
     fs::write(&peer_cache_file, "127.0.0.1:1\n")?;
     let testdir = &testdir;
 
-    let mut child = testdir.spawn_child(args!["-v", "start"])?;
+    let mut child = testdir
+        .spawn_child(args!["-v", "start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
 
-    // Run the program and kill it after a few seconds
-    std::thread::sleep(EXTENDED_LAUNCH_DELAY);
+    child.expect_stdout_line_matches("loaded Zakura state cache")?;
+    child.expect_stdout_line_matches("loaded cached peer IP addresses")?;
+    child.expect_stdout_line_matches("cacheable peer list was empty, keeping previous cache")?;
     child.kill(false)?;
     let output = child.wait_with_output()?;
 
     // Make sure the command was killed
     output.assert_was_killed()?;
-    output.stdout_line_contains("loaded cached peer IP addresses")?;
 
     let cache_dir = testdir.path().join("state");
     assert_with_context!(
@@ -2634,21 +2636,16 @@ async fn rpc_submit_block() -> Result<()> {
 fn end_of_support_is_checked_at_start() -> Result<()> {
     let _init_guard = zakura_test::init();
     let testdir = testdir()?.with_config(&mut default_test_config(&Mainnet))?;
-    let mut child = testdir.spawn_child(args!["start"])?;
+    let mut child = testdir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
 
-    // Give enough time to start up the eos task.
-    std::thread::sleep(Duration::from_secs(30));
-
+    child.expect_stdout_line_matches("Starting zakurad")?;
+    child.expect_stdout_line_matches("Starting end of support task")?;
     child.kill(false)?;
 
     let output = child.wait_with_output()?;
     let output = output.assert_failure()?;
-
-    // Zebra started
-    output.stdout_line_contains("Starting zakurad")?;
-
-    // End of support task started.
-    output.stdout_line_contains("Starting end of support task")?;
 
     // Make sure the command was killed
     output.assert_was_killed()?;
@@ -2756,9 +2753,6 @@ async fn state_format_test(
     zakurad.expect_stdout_line_matches("creating new database with the current format")?;
     zakurad.expect_stdout_line_matches("loaded Zakura state cache")?;
 
-    // Give Zebra enough time to actually write the database to disk.
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
     let logs = zakurad.kill_and_return_output(false)?;
 
     assert!(
@@ -2803,9 +2797,6 @@ async fn state_format_test(
         )
         .expect("can't write fake database version to disk");
 
-        // Give zakura_state enough time to actually write the database version to disk.
-        tokio::time::sleep(Duration::from_secs(1)).await;
-
         let running_version = state_database_format_version_in_code();
 
         match fake_version.cmp(&running_version) {
@@ -2842,9 +2833,6 @@ async fn state_format_test(
             zakurad.expect_stdout_line_matches("trying to open current database format")?;
             zakurad.expect_stdout_line_matches("loaded Zakura state cache")?;
         }
-
-        // Give Zebra enough time to actually write the database to disk.
-        tokio::time::sleep(Duration::from_secs(1)).await;
 
         let logs = zakurad.kill_and_return_output(false)?;
 


### PR DESCRIPTION
## Motivation

Several unit and acceptance tests spend most of their runtime waiting rather
than exercising behavior:

- peer-limit helpers unconditionally sleep for 10 seconds;
- acceptance tests use fixed 1-, 30-, and 45-second delays;
- finalized-state properties prepare the standard 104-block chain while only
  consuming a 9- to 13-block prefix; and
- `rpc_getaddresstxids_response` creates an RPC instance for every range and
  pays the mock service's 300 ms no-request observation delay about 66 times.

These costs make the unit-test shards slower without increasing coverage.

## Solution

- Synchronize peer-limit tests on crawler, connection, handshake, and peer-set
  events. Mock-only crawler tests use paused Tokio time to advance the real
  production rate limit; listener tests retain real TCP and real time.
- Wait for the acceptance-test log events that establish readiness instead of
  sleeping after them.
- Generate exactly the valid finalized-state chain prefix each property test
  consumes while retaining explicit upgrade, invalid-commitment, VCT, and
  rollback assertions.
- Reuse one RPC and queue task per network across all `getaddresstxids` range
  cases, with one shared mock observer proving that none use the mempool.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p zakura-network --tests -- -D warnings`
- `cargo clippy -p zakura-state --tests -- -D warnings`
- all rewritten crawler and listener peer-limit tests
- all three rewritten finalized-state property/rollback tests, including with
  `PROPTEST_CASES=3`
- `persistent_mode`, `end_of_support_is_checked_at_start`, and the three
  state-format acceptance-test variants
- `cargo test -p zakura-rpc
  methods::tests::vectors::rpc_getaddresstxids_response -- --exact --nocapture`
  (0.92s test runtime)
- `cargo clippy -p zakura-rpc -p zakura --tests -- -D warnings`

## Changelog

This is an internal test-only change, recorded by the explicit no-changelog
fragment in `changelog-unreleased/385.md`.

### Follow-up Work

Use draft CI to measure Linux shard timing and confirm the Linux-only listener
case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and changelog-none; no production behavior changes.
> 
> **Overview**
> Replaces fixed sleeps in peer-limit, acceptance, finalized-state property, and RPC vector tests with **event-driven synchronization** and **smaller generated fixtures**, cutting wall-clock time without changing production code.
> 
> **Network peer-limit tests** use `#[tokio::test(start_paused = true)]` on mock crawler cases and advance time while waiting on crawl, connector, and peer-set events via `wait_for_crawler_events` and `ExpectedCrawlerConnections`. Inbound listener helpers wait for connection close, handshake completion, and collected `DiscoveredPeer`s instead of a 10s sleep.
> 
> **Acceptance tests** (`persistent_mode`, `end_of_support`, state-format variants) use `with_timeout` and `expect_stdout_line_matches` for readiness instead of multi-second `thread::sleep` / `tokio::time::sleep` after startup.
> 
> **Finalized-state properties** add `valid_commitment_chain` and `early_upgrade_network()` so proptests build only the block prefix they assert on (not the full ~104-block chain).
> 
> **`rpc_getaddresstxids_response`** builds one `RpcImpl` and queue task per network and runs all range cases through it, with a single mempool `expect_no_requests` at the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3644f919c25a60d2469362c013528c268c9cd23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->