### PR TITLE
fix(sync): reset successor work after header reanchors

### DIFF
--- a/changelog-unreleased/386.md
+++ b/changelog-unreleased/386.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Fixed a block sync stall after a header reanchor retained work from the old fork
+  ([#386](https://github.com/zakura-core/zakura/pull/386)).

--- a/zakura-network/src/zakura/block_sync/sequencer_task.rs
+++ b/zakura-network/src/zakura/block_sync/sequencer_task.rs
@@ -473,12 +473,11 @@ impl SequencerTask {
         );
 
         // State can report a forward `Reset` while checkpoint commits advance
-        // under already-submitted or still-downloading successor bodies. Treat
-        // that as verified growth once it is inside our submitted/downloaded
-        // floor, or when we already have successor work in flight. Keep fork
-        // resets destructive when they are not anchored by active successor
-        // work.
-        if frontiers.verified_block_tip > self.sequencer.verified_tip()
+        // under active successor bodies. Preserve them only when the caller knows
+        // their anchor is unchanged; header reanchors can carry coalesced body
+        // growth while those successors belong to the old fork.
+        if preserve_active_successors
+            && frontiers.verified_block_tip > self.sequencer.verified_tip()
             && (frontiers.verified_block_tip <= self.sequencer.floor()
                 || self.has_active_successor_after(
                     frontiers.verified_block_tip,

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -11316,6 +11316,101 @@ async fn reactor_exchange_reanchor_releases_stale_submitted_bodies() {
 }
 
 #[tokio::test]
+async fn reactor_exchange_coalesced_reanchor_releases_stale_successor_body() {
+    let blocks = mainnet_blocks_1_to_3();
+    let reanchored_successor = forked_block(&blocks[1], 101);
+    let mut config = immediate_body_download_config();
+    config.max_inflight_block_bytes = BS_PER_BLOCK_WORST_CASE_BYTES * 2;
+    config.request_timeout = Duration::from_secs(300);
+
+    let initial = FrontierUpdate {
+        frontier: ChainFrontier {
+            finalized: test_frontier(0),
+            verified_body: test_frontier(0),
+            best_header: Frontier::new(block::Height(2), blocks[1].hash()),
+        },
+        change: FrontierChange::Snapshot,
+    };
+    let (exchange, startup) = exchange_block_sync_startup(initial, config.clone());
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+    let (_peer_id, inbound_tx, mut outbound_rx) = connect_peer_with_status(
+        &service,
+        &mut actions,
+        69,
+        block::Height(2),
+        blocks[1].hash(),
+        1,
+        MAX_BS_RESPONSE_BYTES,
+    )
+    .await;
+
+    handle
+        .send(BlockSyncEvent::NeededBlocks(vec![
+            block_meta(&blocks[0]),
+            block_meta(&blocks[1]),
+        ]))
+        .await
+        .expect("old-fork needed metadata queues");
+    assert_eq!(
+        wait_for_outbound_getblocks(&mut outbound_rx).await,
+        (block::Height(1), 2)
+    );
+
+    for block in &blocks[..2] {
+        inbound_tx
+            .send(
+                BlockSyncMessage::Block(block.clone())
+                    .encode_frame()
+                    .expect("block frame encodes"),
+            )
+            .await
+            .expect("block frame queues");
+    }
+
+    let mut submitted = Vec::new();
+    while submitted.len() < 2 {
+        match next_action(&mut actions).await {
+            BlockSyncAction::SubmitBlock { block, .. } => submitted.push(
+                block
+                    .coinbase_height()
+                    .expect("submitted test block has height"),
+            ),
+            BlockSyncAction::QueryNeededBlocks { .. } => {}
+            action => panic!("unexpected action before old-fork bodies submit: {action:?}"),
+        }
+    }
+    assert_eq!(submitted, vec![block::Height(1), block::Height(2)]);
+
+    exchange.publish_frontier(
+        FrontierUpdate {
+            frontier: ChainFrontier {
+                finalized: test_frontier(0),
+                verified_body: Frontier::new(block::Height(1), blocks[0].hash()),
+                best_header: Frontier::new(block::Height(2), reanchored_successor.hash()),
+            },
+            change: FrontierChange::HeaderReanchored,
+        },
+        "test",
+    );
+    wait_for_query_needed_blocks(&mut actions, block::Height(1), block::Height(2)).await;
+
+    handle
+        .send(BlockSyncEvent::NeededBlocks(vec![block_meta(
+            &reanchored_successor,
+        )]))
+        .await
+        .expect("reanchored needed metadata queues");
+    assert_eq!(
+        wait_for_outbound_getblocks(&mut outbound_rx).await,
+        (block::Height(2), 1),
+        "a reanchor carrying body growth must release the stale successor",
+    );
+
+    reactor_task.abort();
+}
+
+#[tokio::test]
 async fn reactor_clamps_tiny_submitted_apply_config_above_checkpoint_range() {
     let blocks = fake_sequential_blocks(4);
     let mut config = immediate_body_download_config();

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -11387,6 +11387,17 @@ async fn reactor_exchange_coalesced_reanchor_releases_stale_successor_body() {
             frontier: ChainFrontier {
                 finalized: test_frontier(0),
                 verified_body: Frontier::new(block::Height(1), blocks[0].hash()),
+                best_header: Frontier::new(block::Height(2), blocks[1].hash()),
+            },
+            change: FrontierChange::VerifiedGrow,
+        },
+        "test",
+    );
+    exchange.publish_frontier(
+        FrontierUpdate {
+            frontier: ChainFrontier {
+                finalized: test_frontier(0),
+                verified_body: Frontier::new(block::Height(1), blocks[0].hash()),
                 best_header: Frontier::new(block::Height(2), reanchored_successor.hash()),
             },
             change: FrontierChange::HeaderReanchored,


### PR DESCRIPTION
## Motivation

During a reorg, the node may already be processing block N from the old fork when the header chain switches to a different block N. If body progress arrives in the same update, block sync mistakes the fork switch for normal progress and leaves the old block marked as in progress. Since requests are tracked by height, it will not request the replacement block, and sync can remain stuck until another reset clears the stale claim.

## Solution

Only resets that explicitly preserve active successors can now be classified as growth. Header reanchors clear successor work above the verified tip, and a regression test covers a coalesced reanchor with a stale submitted successor.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-network --tests -- -D warnings`
- `cargo test -p zakura-network zakura::block_sync::tests` (182 passed)
- `./scripts/changelog.py check`
- `markdownlint changelog-unreleased/386.md`

The full `cargo test -p zakura-network` run passed 1,017 tests but had four unrelated failures. The handshake failure passed when rerun alone; three unchanged legacy listener tests fail alone on macOS with `AddrNotAvailable` while binding their selected loopback source addresses.

## Changelog

Added `changelog-unreleased/386.md` for the operator-visible sync-stall fix.
