### PR TITLE
ci: restrict Rust cache writes to main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           toolchain: stable
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-criterion
         run: cargo install cargo-criterion --locked
@@ -117,6 +118,7 @@ jobs:
         with:
           toolchain: stable
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install critcmp
         run: cargo install critcmp --locked

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: stable
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Validate source, tag, and package version
         id: validate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,6 +85,7 @@ jobs:
           components: clippy
           toolchain: ${{ matrix.rust-version }}
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-zakura-build
       - name: Run clippy
         run: cargo clippy ${{ matrix.args }} --features "${{ matrix.features }}"
@@ -138,6 +139,7 @@ jobs:
         with:
           toolchain: nightly
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-zakura-build
       - run: cargo doc --no-deps --workspace --all-features --document-private-items --target-dir "$(pwd)"/target/internal
         env:
@@ -200,6 +202,7 @@ jobs:
         with:
           toolchain: nightly
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-udeps
@@ -240,6 +243,7 @@ jobs:
         with:
           toolchain: stable
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-zakura-build
       - run: cargo check --locked --all-features --all-targets
 

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -82,6 +82,7 @@ jobs:
           toolchain: stable
           cache-key: crate-checks
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -78,10 +78,11 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: stable
-          # Single writer for this cache key, so the save no longer races the
-          # other shards ("Unable to reserve cache … another job").
-          cache-key: unit-tests-ubuntu-latest-stable-default-release-binaries-${{ github.event_name == 'pull_request' && 'debug' || 'release' }}
+          # PR debug builds restore the cache populated by the main-branch
+          # config job. Full-coverage runs keep a separate release cache.
+          cache-shared-key: ${{ github.event_name == 'pull_request' && 'zakura-drb-debug' || 'unit-tests-release' }}
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest
@@ -180,6 +181,8 @@ jobs:
           # jobs, consolidating their cache entries across workflow runs.
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
+          # This is the only writer for the shared debug cache.
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest
@@ -204,6 +207,7 @@ jobs:
           toolchain: stable
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
+          cache-save-if: false
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest
@@ -229,6 +233,7 @@ jobs:
           toolchain: stable
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
+          cache-save-if: false
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest
@@ -253,6 +258,7 @@ jobs:
         with:
           toolchain: stable
           cache-on-failure: true
+          cache-save-if: false
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest

--- a/.github/workflows/update-release-state.yml
+++ b/.github/workflows/update-release-state.yml
@@ -145,6 +145,7 @@ jobs:
         if: steps.import.outputs.has_changes == 'true'
         with:
           toolchain: stable
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Re-prove the checkpoint/frontier pairing in cargo
         if: steps.import.outputs.has_changes == 'true'

--- a/.github/workflows/zakura-e2e.yml
+++ b/.github/workflows/zakura-e2e.yml
@@ -130,6 +130,8 @@ jobs:
           # above), so they share a cache with each other but not with that group.
           cache-shared-key: zakura-e2e-debug
           cache-on-failure: true
+          # This is the only writer for the shared e2e debug cache.
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-zakura-build
       # Compile the e2e once. `cargo test --no-run` builds both the integration
       # test binary and the `zakurad` bin (cargo always builds a package's
@@ -199,6 +201,7 @@ jobs:
           # acceptance jobs, so it shares their consolidated build cache.
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
+          cache-save-if: false
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest
@@ -240,6 +243,7 @@ jobs:
           toolchain: stable
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
+          cache-save-if: false
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:
           tool: cargo-nextest
@@ -284,6 +288,7 @@ jobs:
           toolchain: stable
           cache-shared-key: zakura-e2e-debug
           cache-on-failure: true
+          cache-save-if: false
       - uses: ./.github/actions/setup-zakura-build
       # Build once (see the pr-gate job for the ROCKSDB_LIB_DIR / static-link
       # rationale); the run step reuses the compiled artifacts.

--- a/.github/workflows/zcashd-compat-regtest.yml
+++ b/.github/workflows/zcashd-compat-regtest.yml
@@ -46,6 +46,7 @@ jobs:
           toolchain: stable
           cache-key: zcashd-compat-regtest
           cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
         with:


### PR DESCRIPTION
## Motivation

Rust caches produced by pull-request refs are isolated from other pull
requests, but still consume repository cache quota and can evict useful caches
from `main`. They therefore do not help the next PR.

PR #385 demonstrated the other half of the problem: its unit build requested a
debug-only PR key, logged `No cache found`, and rebuilt from the first
dependency because `main` only populated the corresponding release key.

## Solution

- Keep cache restoration enabled on pull requests while allowing writes only
  when the workflow ref is `refs/heads/main`.
- Point PR unit-test archive builds at the shared `zakura-drb-debug` cache that
  `main` populates.
- Make `zakura-config` the sole writer for that shared debug cache; other unit
  and Zakura E2E jobs are restore-only.
- Keep the full-coverage unit-test archive on a separate
  `unit-tests-release` cache written by `main`.
- Give the separate `zakura-e2e-debug` cache one main-only writer and make its
  nightly matrix consumers restore-only.
- Apply the main-only write policy to the remaining enabled Rust caches.

## Testing

- Parsed all eight changed workflow files as YAML.
- Audited every enabled Rust cache step; each now has an explicit
  `cache-save-if` policy.
- PR CI restored the full 1.21 GB `zakura-drb-debug` cache from `main` and
  passed `save-if: false` to the underlying cache action.
- The cached PR unit build finished in 3m00s, compared with PR #385's cold
  5m47s build.
- `git diff --check`

## Changelog

No fragment is required because this PR changes only internal CI workflows.

### Specifications & References

No production behavior or API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow YAML; no application code or release artifacts are affected.
> 
> **Overview**
> Rust **Actions cache writes are limited to `main`**, while PR workflows still **restore** caches. That cuts PR-only cache churn that was evicting useful `main` entries without helping later PRs.
> 
> **Unit and acceptance builds** are retuned around shared keys: PR unit archive builds read **`zakura-drb-debug`** (populated on `main`), with **`zakura-config`** as the sole writer for that shared debug cache; sibling jobs (`network-dependent`, e2e testkit/fuzz/matrix legs, etc.) use **`cache-save-if: false`**. Full-coverage unit runs keep a separate **`unit-tests-release`** cache written only on `main`. **`zakura-e2e-debug`** follows the same pattern—the regtest **pr-gate** job writes on `main`; nightly matrix e2e jobs are restore-only.
> 
> The same **main-only save** policy is applied to the remaining enabled Rust cache steps (benchmarks, lint, crate-checks, release workflows, and similar).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708c6503200289ef1ff56243da0c00468aec1f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->