### PR TITLE
test: remove avoidable slow-test work

### DIFF
--- a/changelog-unreleased/389.md
+++ b/changelog-unreleased/389.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakura-chain/src/serialization/arbitrary.rs
+++ b/zakura-chain/src/serialization/arbitrary.rs
@@ -85,7 +85,7 @@ impl Arbitrary for CompactSizeMessage {
     type Strategy = BoxedStrategy<Self>;
 }
 
-/// Allocate a maximum-sized vector of cloned `item`s, and serialize that array.
+/// Calculate the serialized sizes immediately around `item`'s allocation limit.
 ///
 /// Returns the following calculations on `item`:
 ///   smallest_disallowed_vec_len
@@ -100,24 +100,31 @@ where
     T: TrustedPreallocate + ZcashSerialize + Clone,
 {
     let max_allocation: usize = T::max_allocation().try_into().unwrap();
-    let mut smallest_disallowed_vec = vec![item; max_allocation + 1];
+    let smallest_disallowed_vec_len = max_allocation + 1;
+    let largest_allowed_vec_len = max_allocation;
+    let item_len = item.zcash_serialized_size();
 
-    let smallest_disallowed_serialized = smallest_disallowed_vec
-        .zcash_serialize_to_vec()
-        .expect("Serialization to vec must succeed");
-    let smallest_disallowed_vec_len = smallest_disallowed_vec.len();
-
-    // Create largest_allowed_vec by removing one element from smallest_disallowed_vec without copying (for efficiency)
-    smallest_disallowed_vec.pop();
-    let largest_allowed_vec = smallest_disallowed_vec;
-    let largest_allowed_serialized = largest_allowed_vec
-        .zcash_serialize_to_vec()
-        .expect("Serialization to vec must succeed");
+    // A vector of identical clones is a CompactSize count followed by the
+    // identical serialization of each item. Calculate that exact size without
+    // allocating and serializing multi-megabyte test vectors.
+    let serialized_vec_len = |len: usize| {
+        let count: CompactSizeMessage = len
+            .try_into()
+            .expect("trusted allocation limits fit in a protocol message");
+        count
+            .zcash_serialized_size()
+            .checked_add(
+                item_len
+                    .checked_mul(len)
+                    .expect("test vector serialized size fits in usize"),
+            )
+            .expect("test vector serialized size fits in usize")
+    };
 
     (
         smallest_disallowed_vec_len,
-        smallest_disallowed_serialized.len(),
-        largest_allowed_vec.len(),
-        largest_allowed_serialized.len(),
+        serialized_vec_len(smallest_disallowed_vec_len),
+        largest_allowed_vec_len,
+        serialized_vec_len(largest_allowed_vec_len),
     )
 }

--- a/zakura-chain/src/work/tests/prop.rs
+++ b/zakura-chain/src/work/tests/prop.rs
@@ -14,6 +14,24 @@ use super::super::*;
 
 const DEFAULT_TEST_INPUT_PROPTEST_CASES: u32 = 64;
 
+fn equihash_proptest_cases() -> u32 {
+    env::var("PROPTEST_CASES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_TEST_INPUT_PROPTEST_CASES)
+}
+
+fn test_headers() -> Vec<block::Header> {
+    zakura_test::vectors::BLOCKS
+        .iter()
+        .map(|block_bytes| {
+            let block = Block::zcash_deserialize(&block_bytes[..])
+                .expect("block test vector should deserialize");
+            *block.header
+        })
+        .collect()
+}
+
 #[test]
 fn equihash_solution_roundtrip() {
     let _init_guard = zakura_test::init();
@@ -46,29 +64,43 @@ prop_compose! {
 }
 
 #[test]
+fn equihash_test_vectors_validate() -> color_eyre::eyre::Result<()> {
+    let _init_guard = zakura_test::init();
+
+    for header in test_headers() {
+        header.solution.check(&header, &Network::Mainnet)?;
+    }
+
+    Ok(())
+}
+
+#[test]
 fn equihash_prop_test_solution() -> color_eyre::eyre::Result<()> {
     let _init_guard = zakura_test::init();
 
-    for block_bytes in zakura_test::vectors::BLOCKS.iter() {
-        let block = Block::zcash_deserialize(&block_bytes[..])
-            .expect("block test vector should deserialize");
-        block
-            .header
-            .solution
-            .check(&block.header, &Network::Mainnet)?;
+    let headers = test_headers();
 
-        // The equihash solution test can be really slow, so we use fewer cases by
-        // default. Set the PROPTEST_CASES env var to override this default.
-        proptest!(Config::with_cases(env::var("PROPTEST_CASES")
-                                      .ok()
-                                      .and_then(|v| v.parse().ok())
-                                      .unwrap_or(DEFAULT_TEST_INPUT_PROPTEST_CASES)),
-                |(fake_header in randomized_solutions(*block.header.as_ref()))| {
-            fake_header.solution
-                .check(&fake_header, &Network::Mainnet)
-                .expect_err("block header should not validate on randomized solution");
-        });
+    // Every test vector gets a deterministic invalid solution, so vector
+    // coverage does not depend on random case selection.
+    for real_header in &headers {
+        let mut fake_header = *real_header;
+        fake_header.solution = equihash::Solution::for_proposal();
+        assert_ne!(fake_header.solution, real_header.solution);
+        fake_header
+            .solution
+            .check(&fake_header, &Network::Mainnet)
+            .expect_err("block header should not validate with the null solution");
     }
+
+    // Randomized cases sample across the complete vector set instead of
+    // multiplying the same case budget by every vector.
+    let randomized_headers = proptest::sample::select(headers).prop_flat_map(randomized_solutions);
+    proptest!(Config::with_cases(equihash_proptest_cases()),
+        |(fake_header in randomized_headers)| {
+        fake_header.solution
+            .check(&fake_header, &Network::Mainnet)
+            .expect_err("block header should not validate on randomized solution");
+    });
 
     Ok(())
 }
@@ -92,20 +124,25 @@ prop_compose! {
 fn equihash_prop_test_nonce() -> color_eyre::eyre::Result<()> {
     let _init_guard = zakura_test::init();
 
-    for block_bytes in zakura_test::vectors::BLOCKS.iter() {
-        let block = Block::zcash_deserialize(&block_bytes[..])
-            .expect("block test vector should deserialize");
-        block
-            .header
-            .solution
-            .check(&block.header, &Network::Mainnet)?;
+    let headers = test_headers();
 
-        proptest!(|(fake_header in randomized_nonce(*block.header.as_ref()))| {
-            fake_header.solution
-                .check(&fake_header, &Network::Mainnet)
-                .expect_err("block header should not validate on randomized nonce");
-        });
+    for real_header in &headers {
+        let mut fake_header = *real_header;
+        fake_header.nonce.0[0] ^= 1;
+        assert_ne!(fake_header.nonce, real_header.nonce);
+        fake_header
+            .solution
+            .check(&fake_header, &Network::Mainnet)
+            .expect_err("block header should not validate with a changed nonce");
     }
+
+    let randomized_headers = proptest::sample::select(headers).prop_flat_map(randomized_nonce);
+    proptest!(Config::with_cases(equihash_proptest_cases()),
+        |(fake_header in randomized_headers)| {
+        fake_header.solution
+            .check(&fake_header, &Network::Mainnet)
+            .expect_err("block header should not validate on randomized nonce");
+    });
 
     Ok(())
 }
@@ -131,24 +168,25 @@ prop_compose! {
 fn equihash_prop_test_input() -> color_eyre::eyre::Result<()> {
     let _init_guard = zakura_test::init();
 
-    for block_bytes in zakura_test::vectors::BLOCKS.iter() {
-        let block = Block::zcash_deserialize(&block_bytes[..])
-            .expect("block test vector should deserialize");
-        block
-            .header
-            .solution
-            .check(&block.header, &Network::Mainnet)?;
+    let headers = test_headers();
 
-        proptest!(Config::with_cases(env::var("PROPTEST_CASES")
-                                  .ok()
-                                  .and_then(|v| v.parse().ok())
-                                 .unwrap_or(DEFAULT_TEST_INPUT_PROPTEST_CASES)),
-              |(fake_header in randomized_input(*block.header.as_ref()))| {
-            fake_header.solution
-                .check(&fake_header, &Network::Mainnet)
-                .expect_err("equihash solution should not validate on randomized input");
-        });
+    for real_header in &headers {
+        let mut fake_header = *real_header;
+        fake_header.previous_block_hash.0[0] ^= 1;
+        assert_ne!(fake_header, *real_header);
+        fake_header
+            .solution
+            .check(&fake_header, &Network::Mainnet)
+            .expect_err("equihash solution should not validate with changed input");
     }
+
+    let randomized_headers = proptest::sample::select(headers).prop_flat_map(randomized_input);
+    proptest!(Config::with_cases(equihash_proptest_cases()),
+        |(fake_header in randomized_headers)| {
+        fake_header.solution
+            .check(&fake_header, &Network::Mainnet)
+            .expect_err("equihash solution should not validate on randomized input");
+    });
 
     Ok(())
 }

--- a/zakura-consensus/src/primitives/halo2.rs
+++ b/zakura-consensus/src/primitives/halo2.rs
@@ -271,6 +271,42 @@ pub static VERIFIER_NU6_2: Lazy<VerifierService> =
 pub static VERIFIER_NU6_3_ONWARD: Lazy<VerifierService> =
     Lazy::new(|| batch_verifier(&VERIFYING_KEY_NU6_3_ONWARD));
 
+/// Selects the lazily initialized Halo2 verifier for `network_upgrade`.
+///
+/// Keeping selection separate from initialization lets tests verify every
+/// routing branch without building the expensive Orchard verifying keys.
+fn lazy_verifier_for(network_upgrade: NetworkUpgrade) -> &'static Lazy<VerifierService> {
+    use NetworkUpgrade::*;
+
+    match network_upgrade {
+        // Orchard did not exist before NU5, so these upgrades never carry
+        // Orchard bundles. They are bound to the pre-NU6.2 (insecure)
+        // verifier because that is the only key under which any Orchard
+        // history before NU6.2 verifies; routing them anywhere else cannot be
+        // correct.
+        Genesis | BeforeOverwinter | Overwinter | Sapling | Blossom | Heartwood | Canopy | Nu5
+        | Nu6 | Nu6_1 => &VERIFIER_PRE_NU6_2,
+
+        // NU6.2 ships the fixed circuit and is the only upgrade that uses it:
+        // it is active from the NU6.2 activation height until NU6.3.
+        Nu6_2 => &VERIFIER_NU6_2,
+
+        // NU6.3 adds the `disableCrossAddress` constraint to the Orchard
+        // Action circuit. Every Orchard Action from NU6.3 onward, including
+        // those in V5 transactions, commits to this circuit. Per ZIP 229, the
+        // restriction applies regardless of transaction version, so it cannot
+        // be bypassed with a V5 transaction. The NU6.2 fixed key would both
+        // reject honest NU6.3 proofs and fail to enforce this constraint.
+        Nu6_3 | Nu7 => &VERIFIER_NU6_3_ONWARD,
+
+        // `ZFuture` is post-NU6.3 and inherits the NU6.3 circuit. Keep the
+        // cfg-gated arm explicit so a future upgrade cannot silently fall back
+        // to an older or insecure verifier.
+        #[cfg(zcash_unstable = "zfuture")]
+        ZFuture => &VERIFIER_NU6_3_ONWARD,
+    }
+}
+
 /// Returns the global Halo2 verifier for the Orchard Action circuit active at
 /// `network_upgrade`.
 ///
@@ -292,34 +328,7 @@ pub static VERIFIER_NU6_3_ONWARD: Lazy<VerifierService> =
 /// no version-comparison fallthrough and no default-to-insecure arm, so adding a future upgrade
 /// is a compile error here until it is bound to a key on purpose.
 pub fn verifier_for(network_upgrade: NetworkUpgrade) -> &'static VerifierService {
-    use NetworkUpgrade::*;
-
-    match network_upgrade {
-        // Orchard did not exist before NU5, so these upgrades never carry Orchard bundles. They
-        // are bound to the pre-NU6.2 (insecure) verifier because that is the only key under which
-        // any Orchard history before NU6.2 verifies; routing them anywhere else cannot be correct.
-        Genesis | BeforeOverwinter | Overwinter | Sapling | Blossom | Heartwood | Canopy | Nu5
-        | Nu6 | Nu6_1 => &VERIFIER_PRE_NU6_2,
-
-        // NU6.2 ships the fixed circuit and is the only upgrade that uses it: it is active from the
-        // NU6.2 activation height until NU6.3.
-        Nu6_2 => &VERIFIER_NU6_2,
-
-        // NU6.3 adds the `disableCrossAddress` constraint to the Orchard Action circuit. Every
-        // Orchard Action from NU6.3 onward — including those in V5 transactions — commits to this
-        // circuit, so NU6.3 and later route to the NU6.3-onward key. Per ZIP 229 the cross-address
-        // restriction applies "regardless of transaction version ... so that it cannot be bypassed
-        // by using a version 5 transaction". Verifying these under the NU6.2 fixed key would both
-        // reject honest proofs (different key) and fail to enforce the restriction.
-        Nu6_3 | Nu7 => &VERIFIER_NU6_3_ONWARD,
-
-        // `ZFuture` only exists under the `zcash_unstable = "zfuture"` cfg. It is a post-NU6.3
-        // upgrade, so it inherits the NU6.3 circuit and is bound to the NU6.3-onward key here on
-        // purpose (rather than via a wildcard) to keep this match exhaustive and fail-closed under
-        // every build configuration.
-        #[cfg(zcash_unstable = "zfuture")]
-        ZFuture => &VERIFIER_NU6_3_ONWARD,
-    }
+    lazy_verifier_for(network_upgrade)
 }
 
 /// Halo2 proof verifier implementation

--- a/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/zakura-consensus/src/primitives/halo2/tests.rs
@@ -26,7 +26,7 @@ use zakura_chain::{
 use zcash_protocol::value::ZatBalance;
 
 use super::{
-    verifier_for, Item, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD, VERIFIER_PRE_NU6_2,
+    lazy_verifier_for, Item, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD, VERIFIER_PRE_NU6_2,
     VERIFYING_KEY_NU6_2, VERIFYING_KEY_PRE_NU6_2,
 };
 
@@ -89,22 +89,16 @@ fn pre_nu6_2_proof_only_verifies_under_pre_nu6_2_key() {
     );
 }
 
-/// [`verifier_for`] routes each upgrade to the service that holds the correct
+/// [`lazy_verifier_for`] routes each upgrade to the service that holds the correct
 /// circuit era's key.
 ///
-/// We compare service identity by pointer: the routing functions return borrows of global `Lazy`
-/// services, so each expected route must alias the matching service. Because the route is what
-/// binds an item to a key, routing to the wrong service is exactly routing to the wrong key.
-///
-/// This is an async test because forcing the global `Lazy` verifiers builds their `Batch` layer,
-/// which spawns a worker task and therefore needs a Tokio runtime.
-#[tokio::test(flavor = "multi_thread")]
-async fn verifier_routes_each_network_upgrade_to_the_correct_key() {
-    // Deref each `Lazy` to the inner service it guards, matching what the routing functions
-    // return, so the pointer comparisons below compare the same service type.
-    let pre: &'static super::VerifierService = &VERIFIER_PRE_NU6_2;
-    let nu6_2: &'static super::VerifierService = &VERIFIER_NU6_2;
-    let nu6_3_onward: &'static super::VerifierService = &VERIFIER_NU6_3_ONWARD;
+/// Comparing the `Lazy` handles themselves proves the routing without building
+/// any verifying key or starting a batch worker.
+#[test]
+fn verifier_routes_each_network_upgrade_to_the_correct_key() {
+    let pre = &VERIFIER_PRE_NU6_2;
+    let nu6_2 = &VERIFIER_NU6_2;
+    let nu6_3_onward = &VERIFIER_NU6_3_ONWARD;
 
     // Everything before NU6.2 (including upgrades from before Orchard existed) routes to the
     // insecure key, which is the only key any pre-NU6.2 Orchard history verifies under.
@@ -114,7 +108,7 @@ async fn verifier_routes_each_network_upgrade_to_the_correct_key() {
         NetworkUpgrade::Nu6_1,
     ] {
         assert!(
-            std::ptr::eq(verifier_for(nu), pre),
+            std::ptr::eq(lazy_verifier_for(nu), pre),
             "{nu:?} must route to the pre-NU6.2 (insecure) verifier"
         );
     }
@@ -122,7 +116,7 @@ async fn verifier_routes_each_network_upgrade_to_the_correct_key() {
     // NU6.2 is the only upgrade that uses the fixed key: it is active from the NU6.2 activation
     // height until NU6.3.
     assert!(
-        std::ptr::eq(verifier_for(NetworkUpgrade::Nu6_2), nu6_2),
+        std::ptr::eq(lazy_verifier_for(NetworkUpgrade::Nu6_2), nu6_2),
         "Nu6_2 must route to the NU6.2 (fixed) verifier"
     );
 
@@ -133,7 +127,7 @@ async fn verifier_routes_each_network_upgrade_to_the_correct_key() {
     // upgrades do not fall back to the NU6.2 fixed key.
     for nu in [NetworkUpgrade::Nu6_3, NetworkUpgrade::Nu7] {
         assert!(
-            std::ptr::eq(verifier_for(nu), nu6_3_onward),
+            std::ptr::eq(lazy_verifier_for(nu), nu6_3_onward),
             "{nu:?} must route to the NU6.3-onward verifier even for v5 Orchard bundles"
         );
     }
@@ -142,7 +136,7 @@ async fn verifier_routes_each_network_upgrade_to_the_correct_key() {
     // that very same key — selecting the verifier is what binds a bundle to a key, so this is the
     // regression guard against routing v5@NU6.3 to the fixed key.
     assert!(
-        std::ptr::eq(verifier_for(NetworkUpgrade::Nu6_3), nu6_3_onward),
+        std::ptr::eq(lazy_verifier_for(NetworkUpgrade::Nu6_3), nu6_3_onward),
         "a v5 Orchard bundle at NU6.3 must use the same key as v6 Orchard and Ironwood"
     );
 }

--- a/zakura-network/src/peer/connection/tests/prop.rs
+++ b/zakura-network/src/peer/connection/tests/prop.rs
@@ -60,7 +60,7 @@ proptest! {
             let (
                 connection,
                 mut client_tx,
-                mut inbound_service,
+                inbound_service,
                 mut peer_outbound_messages,
                 shared_error_slot,
             ) = new_test_connection();
@@ -119,7 +119,11 @@ proptest! {
             let error = shared_error_slot.try_get_error();
             assert!(error.is_none());
 
-            inbound_service.expect_no_requests().await?;
+            // Receiving the second response is a causal barrier: the connection
+            // has already processed both peer messages in order. Any attempt to
+            // route either response to the inbound service would poll it before
+            // this response could be returned.
+            prop_assert_eq!(inbound_service.poll_count(), 0);
 
             // Stop the connection thread
             mem::drop(peer_tx);

--- a/zakura-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zakura-network/src/peer_set/candidate_set/tests/prop.rs
@@ -1,18 +1,12 @@
 //! Randomised property tests for candidate peer selection.
 
-use std::{
-    env,
-    net::SocketAddr,
-    str::FromStr,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{env, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use proptest::{
     collection::{hash_map, vec},
     prelude::*,
 };
-use tokio::time::{sleep, timeout};
+use tokio::time::{sleep, timeout, Instant};
 use tracing::Span;
 
 use zakura_chain::{parameters::Network::*, serialization::DateTime32};
@@ -35,10 +29,8 @@ const TEST_ADDRESSES: usize = 2 * MAX_TEST_CANDIDATES as usize;
 /// The default number of proptest cases for each test that includes sleeps.
 const DEFAULT_SLEEP_TEST_PROPTEST_CASES: u32 = 16;
 
-/// The largest extra delay we allow after every test sleep.
-///
-/// This makes the tests more reliable on machines with high CPU load.
-const MAX_SLEEP_EXTRA_DELAY: Duration = Duration::from_secs(1);
+/// The largest unexpected virtual-time delay allowed after a rate-limit sleep.
+const MAX_SLEEP_EXTRA_DELAY: Duration = Duration::from_millis(1);
 
 proptest! {
     /// Test that validated gossiped peers never have a `last_seen` time that's in the future.
@@ -65,6 +57,7 @@ proptest! {
     fn skipping_outbound_peer_connection_skips_rate_limit(next_peer_attempts in 0..TEST_ADDRESSES) {
         let (runtime, _init_guard) = zakura_test::init_async();
         let _guard = runtime.enter();
+        runtime.block_on(async { tokio::time::pause() });
 
         let peer_service = tower::service_fn(|_| async {
             unreachable!("Mock peer service is never used");
@@ -79,8 +72,7 @@ proptest! {
         for _ in 0..next_peer_attempts {
             // An empty address book immediately returns "no next peer".
             //
-            // Check that it takes less than the peer set candidate delay,
-            // and hope that is enough time for test machines with high CPU load.
+            // Check that it takes less virtual time than the peer set candidate delay.
             let less_than_min_interval = MIN_OUTBOUND_PEER_CONNECTION_INTERVAL - Duration::from_millis(1);
             assert_eq!(runtime.block_on(timeout(less_than_min_interval, candidate_set.next())), Ok(None));
         }
@@ -104,6 +96,7 @@ proptest! {
     ) {
         let (runtime, _init_guard) = zakura_test::init_async();
         let _guard = runtime.enter();
+        runtime.block_on(async { tokio::time::pause() });
 
         let peers = peers.into_iter().map(|(ip, port)| {
             MetaAddr::new_initial_peer(canonical_peer_addr(SocketAddr::new(ip, port)))
@@ -128,8 +121,7 @@ proptest! {
             check_candidates_rate_limiting(&mut candidate_set, extra_candidates).await;
         };
 
-        // Allow enough time for the maximum number of candidates,
-        // plus some extra time for test machines with high CPU load.
+        // Allow enough virtual time for the maximum number of candidates.
         // (The max delay asserts usually fail before hitting this timeout.)
         let max_rate_limit_sleep = 3 * MAX_TEST_CANDIDATES * MIN_OUTBOUND_PEER_CONNECTION_INTERVAL;
         let max_extra_delay = (2 * MAX_TEST_CANDIDATES + 1) * MAX_SLEEP_EXTRA_DELAY;
@@ -152,7 +144,7 @@ where
 {
     let mut now = Instant::now();
     let mut minimum_reconnect_instant = now;
-    // Allow extra time for test machines with high CPU load
+    // Allow a small amount of virtual-time drift between timer operations.
     let mut maximum_reconnect_instant = now + MAX_SLEEP_EXTRA_DELAY;
 
     for _ in 0..candidates {

--- a/zakura-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zakura-network/src/peer_set/initialize/recent_by_ip.rs
@@ -52,7 +52,11 @@ impl RecentByIp {
     ///
     /// Returns true if the recently attempted inbound connection count is past the configured limit.
     pub fn is_past_limit_or_add(&mut self, ip: IpAddr) -> bool {
-        let now = Instant::now();
+        self.is_past_limit_or_add_at(ip, Instant::now())
+    }
+
+    /// Applies [`Self::is_past_limit_or_add`] using `now` as the current time.
+    fn is_past_limit_or_add_at(&mut self, ip: IpAddr, now: Instant) -> bool {
         self.prune_by_time(now);
 
         let count = self.by_ip.entry(ip).or_default();

--- a/zakura-network/src/peer_set/initialize/recent_by_ip/tests.rs
+++ b/zakura-network/src/peer_set/initialize/recent_by_ip/tests.rs
@@ -14,27 +14,25 @@ fn old_connection_attempts_are_pruned() {
 
     let mut recent_connections = RecentByIp::new(Some(TEST_TIME_LIMIT), None);
     let ip = "127.0.0.1".parse().expect("should parse");
+    let start = std::time::Instant::now();
 
     assert!(
-        !recent_connections.is_past_limit_or_add(ip),
+        !recent_connections.is_past_limit_or_add_at(ip, start),
         "should not be past limit"
     );
     assert!(
-        recent_connections.is_past_limit_or_add(ip),
+        recent_connections.is_past_limit_or_add_at(ip, start),
         "should be past max_connections_per_ip limit"
     );
 
-    std::thread::sleep(TEST_TIME_LIMIT / 3);
-
     assert!(
-        recent_connections.is_past_limit_or_add(ip),
+        recent_connections.is_past_limit_or_add_at(ip, start + TEST_TIME_LIMIT / 3),
         "should still contain entry after a third of the time limit"
     );
 
-    std::thread::sleep(3 * TEST_TIME_LIMIT / 4);
-
+    let expired = start + 13 * TEST_TIME_LIMIT / 12;
     assert!(
-        !recent_connections.is_past_limit_or_add(ip),
+        !recent_connections.is_past_limit_or_add_at(ip, expired),
         "should prune entry after 13/12 * time_limit"
     );
 
@@ -42,30 +40,28 @@ fn old_connection_attempts_are_pruned() {
 
     let mut recent_connections =
         RecentByIp::new(Some(TEST_TIME_LIMIT), Some(TEST_MAX_CONNS_PER_IP));
+    let start = std::time::Instant::now();
 
     for _ in 0..TEST_MAX_CONNS_PER_IP {
         assert!(
-            !recent_connections.is_past_limit_or_add(ip),
+            !recent_connections.is_past_limit_or_add_at(ip, start),
             "should not be past limit"
         );
     }
 
     assert!(
-        recent_connections.is_past_limit_or_add(ip),
+        recent_connections.is_past_limit_or_add_at(ip, start),
         "should be past max_connections_per_ip limit"
     );
 
-    std::thread::sleep(TEST_TIME_LIMIT / 3);
-
     assert!(
-        recent_connections.is_past_limit_or_add(ip),
+        recent_connections.is_past_limit_or_add_at(ip, start + TEST_TIME_LIMIT / 3),
         "should still be past limit after a third of the reconnection delay"
     );
 
-    std::thread::sleep(3 * TEST_TIME_LIMIT / 4);
-
+    let expired = start + 13 * TEST_TIME_LIMIT / 12;
     assert!(
-        !recent_connections.is_past_limit_or_add(ip),
+        !recent_connections.is_past_limit_or_add_at(ip, expired),
         "should prune entry after 13/12 * time_limit"
     );
 }

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -37,6 +37,7 @@ use crate::{
     constants, init,
     meta_addr::{MetaAddr, PeerAddrState},
     peer::{self, ClientTestHarness, ConnectedAddr, HandshakeRequest, OutboundConnectorRequest},
+    peer_cache_updater::update_peer_cache_once,
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
@@ -51,22 +52,15 @@ use crate::{
 
 use Network::*;
 
-/// The amount of time to run the crawler, before testing what it has done.
-///
-/// Using a very short time can make the crawler not run at all.
-const CRAWLER_RUN_DURATION: Duration = Duration::from_secs(10);
-
 /// The maximum wall-clock time to wait for expected crawler test progress.
 const CRAWLER_TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The maximum wall-clock time to wait for peer-cache startup progress.
+const PEER_CACHE_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A crawler peer limit large enough to exercise multi-peer behavior without
 /// flooding the test runtime with hundreds of immediate fake handshakes.
 const CRAWLER_MANY_PEER_LIMIT_FOR_TESTS: usize = 15;
-
-/// The amount of time to run the peer cache updater task, before testing what it has done.
-///
-/// Using a very short time can make the peer cache updater not run at all.
-const PEER_CACHE_UPDATER_TEST_DURATION: Duration = Duration::from_secs(25);
 
 /// The maximum time to wait for the listener tests to make expected progress.
 const LISTENER_TEST_DURATION: Duration = Duration::from_secs(10);
@@ -275,11 +269,6 @@ async fn peer_limit_one_mainnet() {
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
     let _ = init_with_peer_limit(1, nil_inbound_service, Mainnet, None, None).await;
-
-    // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
-
-    // Any number of address book peers is valid here, because some peers might have failed.
 }
 
 /// Test zakura-network with a peer limit of one inbound and one outbound peer on testnet.
@@ -301,11 +290,6 @@ async fn peer_limit_one_testnet() {
         None,
     )
     .await;
-
-    // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
-
-    // Any number of address book peers is valid here, because some peers might have failed.
 }
 
 /// Test zakura-network with a peer limit of two inbound and three outbound peers on mainnet.
@@ -320,11 +304,6 @@ async fn peer_limit_two_mainnet() {
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
     let _ = init_with_peer_limit(2, nil_inbound_service, Mainnet, None, None).await;
-
-    // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
-
-    // Any number of address book peers is valid here, because some peers might have failed.
 }
 
 /// Test zakura-network with a peer limit of two inbound and three outbound peers on testnet.
@@ -346,11 +325,6 @@ async fn peer_limit_two_testnet() {
         None,
     )
     .await;
-
-    // Let the crawler run for a while.
-    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
-
-    // Any number of address book peers is valid here, because some peers might have failed.
 }
 
 /// Test zakura-network writes a peer cache file, and can read it back manually.
@@ -374,8 +348,9 @@ async fn written_peer_cache_can_be_read_manually() {
         init_with_peer_limit(1, nil_inbound_service, Mainnet, None, config.clone()).await;
     let expected_cached_peer = add_cacheable_peer(&address_book);
 
-    // Let the peer cache updater run for a while.
-    tokio::time::sleep(PEER_CACHE_UPDATER_TEST_DURATION).await;
+    update_peer_cache_once(&config, &address_book)
+        .await
+        .expect("writing the peer cache should succeed");
 
     let cached_peers = config
         .load_peer_cache()
@@ -425,24 +400,34 @@ async fn written_peer_cache_is_automatically_read_on_startup() {
         init_with_peer_limit(1, nil_inbound_service, Mainnet, None, config.clone()).await;
     let expected_cached_peer = add_cacheable_peer(&address_book);
 
-    // Let the peer cache updater run for a while.
-    tokio::time::sleep(PEER_CACHE_UPDATER_TEST_DURATION).await;
+    update_peer_cache_once(&config, &address_book)
+        .await
+        .expect("writing the peer cache should succeed");
 
     let address_book =
         init_with_peer_limit(1, nil_inbound_service, Mainnet, None, config.clone()).await;
 
-    // Let the peer cache reader fill the address book.
-    tokio::time::sleep(CRAWLER_RUN_DURATION).await;
+    tokio::time::timeout(PEER_CACHE_TEST_TIMEOUT, async {
+        loop {
+            if address_book
+                .lock()
+                .expect("previous thread panicked while holding address book lock")
+                .get(expected_cached_peer)
+                .is_some()
+            {
+                break;
+            }
 
-    assert!(
-        address_book
-            .lock()
-            .expect("previous thread panicked while holding address book lock")
-            .get(expected_cached_peer)
-            .is_some(),
-        "expected peer missing from address book loaded from cache: {:?}",
-        config.cache_dir.peer_cache_file_path(&config.network)
-    );
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "expected peer missing from address book loaded from cache: {:?}",
+            config.cache_dir.peer_cache_file_path(&config.network)
+        )
+    });
 }
 
 /// Adds a recent gossiped peer that is eligible for the disk cache.

--- a/zakura-network/src/zakura/discovery/protocol.rs
+++ b/zakura-network/src/zakura/discovery/protocol.rs
@@ -2646,20 +2646,20 @@ impl ZakuraDiscoveryBook {
         // — was attacker-paced, allocation-heavy work performed while holding the global discovery
         // mutex. Per-call clone work is now bounded by `limit`, not the book size. See finding
         // `claude-discovery-expensive-work-under-global-mutex` (SR-2/SR-4).
-        self.entries
-            .iter()
-            .filter(|(node_id, entry)| {
-                !exclude_node_ids.contains(*node_id)
-                    && self.local_node_id != Some(**node_id)
-                    && !entry_is_expired(entry, now)
-                    && has_wanted_services(&entry.record, wanted_services)
-                    && has_discovery_dialable_direct_addrs(&entry.record)
-            })
-            .map(|(_, entry)| &entry.record)
-            .choose_multiple(rng, limit)
-            .into_iter()
-            .cloned()
-            .collect()
+        choose_multiple_cloned(
+            self.entries
+                .iter()
+                .filter(|(node_id, entry)| {
+                    !exclude_node_ids.contains(*node_id)
+                        && self.local_node_id != Some(**node_id)
+                        && !entry_is_expired(entry, now)
+                        && has_wanted_services(&entry.record, wanted_services)
+                        && has_discovery_dialable_direct_addrs(&entry.record)
+                })
+                .map(|(_, entry)| &entry.record),
+            limit,
+            rng,
+        )
     }
 
     /// Returns bounded dial candidates for later dial-loop code.
@@ -3019,6 +3019,23 @@ impl ZakuraDiscoveryBook {
                     .map(|(node_id, _)| *node_id)
             })
     }
+}
+
+/// Chooses at most `limit` references, then clones only the chosen values.
+fn choose_multiple_cloned<'a, T, R>(
+    values: impl Iterator<Item = &'a T>,
+    limit: usize,
+    rng: &mut R,
+) -> Vec<T>
+where
+    T: Clone + 'a,
+    R: rand::Rng + ?Sized,
+{
+    values
+        .choose_multiple(rng, limit)
+        .into_iter()
+        .cloned()
+        .collect()
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -4394,7 +4411,14 @@ fn u16_from_usize(value: usize, field: &'static str) -> Result<u16, DiscoveryWir
 
 #[cfg(test)]
 mod tests {
-    use std::{net::IpAddr, time::Duration};
+    use std::{
+        net::IpAddr,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
     use iroh::SecretKey;
     use rand::{rngs::OsRng, rngs::StdRng, SeedableRng};
@@ -7655,94 +7679,38 @@ mod tests {
     /// (`max_records`, default 10_000) — even though at most `max_imported_records_per_response`
     /// records are ever returned. The clone is now bounded to the chosen sample.
     ///
-    /// The bound is proven machine-independently by comparing the production `sample_peers` against
-    /// an in-test reference that reproduces the pre-fix clone-the-whole-filtered-set behavior, over
-    /// the same large book in the same run. With the fix, production clones only the returned sample
-    /// and is markedly cheaper than the clone-everything reference; before the fix the two are the
-    /// same computation, so the production-is-cheaper bound fails.
+    /// The bound is proven machine-independently by counting clones in the same
+    /// helper used by `sample_peers`.
     #[test]
     fn sample_peers_clone_cost_is_bounded_by_returned_sample() {
-        const BOOK: usize = 1024;
-        const ITERS: usize = 400;
+        const BOOK_SIZE: usize = 1024;
+        const SAMPLE_LIMIT: usize = MAX_DISCOVERY_RECORDS_PER_RESPONSE;
 
-        let wanted = service(1);
-        // Heavy records (maximum direct-address fan-out plus many services, with the wanted service
-        // first so the filter match itself stays cheap) make each *record clone* far more expensive
-        // than the allocation-free per-entry filter scan, so the clone count is the dominant cost
-        // and the bounded-vs-unbounded clone gap is large.
-        let addrs: Vec<SocketAddr> = (1u8..=MAX_DIRECT_ADDRS_PER_RECORD as u8)
-            .map(test_addr)
-            .collect();
-        let mut services = vec![wanted.clone()];
-        services.extend((100..100 + (MAX_SERVICES_PER_RECORD - 1)).map(service));
-
-        let mut book = ZakuraDiscoveryBook::new(ZakuraDiscoveryBookLimits {
-            max_records: BOOK,
-            ..ZakuraDiscoveryBookLimits::default()
-        });
-        for seq in 0..BOOK {
-            let secret = secret_key();
-            let mut record_body = body(&secret);
-            record_body.sequence = seq as u64 + 1;
-            record_body.direct_addrs = addrs.clone();
-            record_body.services = services.clone();
-            let record = ZakuraNodeRecord::sign(record_body, &secret).expect("test record signs");
-            book.import_record(record, None, NOW, &context())
-                .expect("test record imports");
+        struct CloneCounter {
+            clone_count: Arc<AtomicUsize>,
         }
 
-        let cap = book.limits.max_imported_records_per_response;
+        impl Clone for CloneCounter {
+            fn clone(&self) -> Self {
+                self.clone_count.fetch_add(1, Ordering::Relaxed);
+                Self {
+                    clone_count: Arc::clone(&self.clone_count),
+                }
+            }
+        }
 
-        // Reference implementation: the pre-fix behavior of cloning every record that passes the
-        // filter, then reservoir-sampling the clones. Mirrors `sample_peers`'s filter exactly.
-        let naive_sample =
-            |book: &ZakuraDiscoveryBook, rng: &mut StdRng| -> Vec<ZakuraNodeRecord> {
-                book.entries
-                    .iter()
-                    .filter(|(node_id, entry)| {
-                        book.local_node_id != Some(**node_id)
-                            && !entry_is_expired(entry, NOW)
-                            && has_wanted_services(&entry.record, std::slice::from_ref(&wanted))
-                            && has_discovery_dialable_direct_addrs(&entry.record)
-                    })
-                    .map(|(_, entry)| entry.record.clone())
-                    .choose_multiple(rng, cap)
-            };
-
+        let clone_count = Arc::new(AtomicUsize::new(0));
+        let records: Vec<_> = (0..BOOK_SIZE)
+            .map(|_| CloneCounter {
+                clone_count: Arc::clone(&clone_count),
+            })
+            .collect();
         let mut rng = StdRng::seed_from_u64(5);
 
-        // Warm up the allocator and instruction caches before timing.
-        let _ = naive_sample(&book, &mut rng);
-        let _ = book.sample_peers(cap, std::slice::from_ref(&wanted), &[], NOW, &mut rng);
+        let sample = choose_multiple_cloned(records.iter(), SAMPLE_LIMIT, &mut rng);
 
-        let naive_start = std::time::Instant::now();
-        for _ in 0..ITERS {
-            assert_eq!(naive_sample(&book, &mut rng).len(), cap);
-        }
-        let naive_time = naive_start.elapsed();
-
-        let production_start = std::time::Instant::now();
-        for _ in 0..ITERS {
-            assert_eq!(
-                book.sample_peers(cap, std::slice::from_ref(&wanted), &[], NOW, &mut rng)
-                    .len(),
-                cap
-            );
-        }
-        let production_time = production_start.elapsed();
-
-        // Both run the same O(book) filter scan and reservoir sampling; the only difference is how
-        // many records are cloned (production: the returned `cap`; reference: every match in the
-        // book). With the bound in place production must be clearly cheaper than cloning the whole
-        // filtered set. Before the fix they are the identical computation, so production is not
-        // meaningfully cheaper and this fails. The 0.8 factor is a ratio on the same machine, so it
-        // is machine-independent.
-        assert!(
-            production_time.as_nanos() * 5 < naive_time.as_nanos() * 4,
-            "sample_peers did not bound its clone work: production={production_time:?} \
-             clone-everything reference={naive_time:?}; production should be clearly cheaper than \
-             cloning every filtered record"
-        );
+        assert_eq!(sample.len(), SAMPLE_LIMIT);
+        assert_eq!(clone_count.load(Ordering::Relaxed), SAMPLE_LIMIT);
     }
 
     /// Guards the bounded top-k dial-candidate selection added for

--- a/zakura-rpc/src/methods/tests/snapshot.rs
+++ b/zakura-rpc/src/methods/tests/snapshot.rs
@@ -512,7 +512,6 @@ async fn test_rpc_response_data_for_network(network: &Network) {
     let rpc_req = rpc.get_raw_transaction(txid.clone(), Some(0u8), None);
     let (rsp, _) = futures::join!(rpc_req, mempool_req);
     settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_verbosity=0"), rsp));
-    mempool.expect_no_requests().await;
 
     // `getrawtransaction` verbosity=1
     let mempool_req = mempool
@@ -526,7 +525,6 @@ async fn test_rpc_response_data_for_network(network: &Network) {
     let rpc_req = rpc.get_raw_transaction(txid, Some(1u8), None);
     let (rsp, _) = futures::join!(rpc_req, mempool_req);
     settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_verbosity=1"), rsp));
-    mempool.expect_no_requests().await;
 
     // `getrawtransaction` with unknown txid
     let mempool_req = mempool
@@ -541,13 +539,17 @@ async fn test_rpc_response_data_for_network(network: &Network) {
         rpc.get_raw_transaction(transaction::Hash::from([0; 32]).encode_hex(), Some(1), None);
     let (rsp, _) = futures::join!(rpc_req, mempool_req);
     settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_unknown_txid"), rsp));
-    mempool.expect_no_requests().await;
 
     // `getrawtransaction` with an invalid TXID
     let rsp = rpc
         .get_raw_transaction("aBadC0de".to_owned(), Some(1), None)
         .await;
     settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_invalid_txid"), rsp));
+
+    // Each awaited RPC has finished all of its causal mempool work, and each
+    // expected request above was consumed by its paired handler. One absence
+    // window here therefore catches an extra request from any of the variants
+    // without paying the same timeout after every call.
     mempool.expect_no_requests().await;
 
     // `getaddresstxids`

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1144,11 +1144,17 @@ fn vct_peer_source_bad_root_refill_commits_same_height() -> Result<()> {
         .extend_funding_streams()
         .to_network()
         .expect("failed to build configured network");
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 activation height is configured");
+    // The poisoned target is NU5 + 1, and its successor is also required.
+    let tested_block_count =
+        usize::try_from(nu5_height.0 + 3).expect("test activation height fits in usize");
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
     proptest!(ProptestConfig::with_cases(1),
-        |((chain, _count, network, _history_tree) in PreparedChain::default().with_ledger_strategy(ledger_strategy.clone()).with_valid_commitments().no_shrink())| {
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy, tested_block_count).no_shrink())| {
 
             let blocks: Vec<_> = chain.iter().collect();
             let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0;
@@ -1460,6 +1466,12 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
         .extend_funding_streams()
         .to_network()
         .expect("failed to build configured network");
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 activation height is configured");
+    // The handoff is NU5 + 3, so generate exactly through that height.
+    let tested_block_count =
+        usize::try_from(nu5_height.0 + 4).expect("test activation height fits in usize");
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -1467,7 +1479,7 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
-        |((chain, _count, network, _history_tree) in PreparedChain::default().with_ledger_strategy(ledger_strategy.clone()).with_valid_commitments().no_shrink())| {
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy, tested_block_count).no_shrink())| {
 
             let blocks: Vec<_> = chain.iter().collect();
             let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0;
@@ -1805,11 +1817,17 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
         .extend_funding_streams()
         .to_network()
         .expect("failed to build configured network");
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 activation height is configured");
+    // The test consumes two blocks after its NU5 + 3 handoff.
+    let tested_block_count =
+        usize::try_from(nu5_height.0 + 6).expect("test activation height fits in usize");
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
     proptest!(ProptestConfig::with_cases(1),
-        |((chain, _count, network, _history_tree) in PreparedChain::default().with_ledger_strategy(ledger_strategy.clone()).with_valid_commitments().no_shrink())| {
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy, tested_block_count).no_shrink())| {
             let blocks: Vec<_> = chain.iter().collect();
             let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0;
             let heartwood = NetworkUpgrade::Heartwood.activation_height(&network).unwrap().0;

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1894,12 +1894,22 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
                     handoff_trees.sprout.clone(),
                     handoff_trees.ironwood.clone(),
                 );
+                // Match the writer service by carrying the frozen in-memory
+                // frontier through an uninterrupted fast-sync sequence.
+                let mut prev_note_commitment_trees = None;
                 for i in 0..=handoff_index {
                     let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                     let next = (i < handoff_index)
                         .then(|| vct_successor_header(blocks[i + 1].block.clone()));
-                    fast.commit_finalized_direct(cv.into(), None, next, "vct switch fast prefix")
+                    let (_, note_commitment_trees) = fast
+                        .commit_finalized_direct(
+                            cv.into(),
+                            prev_note_commitment_trees.take(),
+                            next,
+                            "vct switch fast prefix",
+                        )
                         .expect("verified fast prefix commits");
+                    prev_note_commitment_trees = Some(note_commitment_trees);
                 }
                 prop_assert_eq!(fast.vct_fast_synced_below(), Some(handoff), "fast sync reached the handoff before the switch");
             }
@@ -1971,13 +1981,22 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
                 handoff_trees.sprout.clone(),
                 handoff_trees.ironwood.clone(),
             );
+            // Match the writer service after this deliberate mode-switch
+            // restart, then carry the frontier through the fast suffix.
+            let mut prev_note_commitment_trees = None;
             for i in (seed + 1)..=post_handoff_tip {
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                 let next = (i < post_handoff_tip)
                     .then(|| vct_successor_header(blocks[i + 1].block.clone()));
-                fast_suffix
-                    .commit_finalized_direct(cv.into(), None, next, "vct switch fast suffix")
+                let (_, note_commitment_trees) = fast_suffix
+                    .commit_finalized_direct(
+                        cv.into(),
+                        prev_note_commitment_trees.take(),
+                        next,
+                        "vct switch fast suffix",
+                    )
                     .expect("fast suffix commits after manual prefix");
+                prev_note_commitment_trees = Some(note_commitment_trees);
             }
             prop_assert_eq!(
                 fast_suffix.vct_fast_count(),

--- a/zakura-state/src/service/finalized_state/tests/rollback.rs
+++ b/zakura-state/src/service/finalized_state/tests/rollback.rs
@@ -1152,13 +1152,15 @@ fn modern_rollback_preserves_empty_genesis_ironwood_tree() -> Result<()> {
 
     proptest!(
         ProptestConfig::with_cases(proptest_cases()),
-        |((chain, _count, network, _history_tree) in PreparedChain::default()
-            .with_ledger_strategy(ledger_strategy)
-            .with_valid_commitments()
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy, target_index + 2)
             .no_shrink())
             | {
-            let synced: Vec<SemanticallyVerifiedBlock> = chain.iter().cloned().collect();
-            prop_assume!(synced.len() > target_index + 1);
+            let synced = chain;
+            prop_assert_eq!(
+                synced.len(),
+                target_index + 2,
+                "generated chain must contain the target and one removed block"
+            );
 
             let dir = TempDir::new().expect("temp dir");
             let config = config_at(dir.path());

--- a/zakura-state/src/service/finalized_state/vct/artifact.rs
+++ b/zakura-state/src/service/finalized_state/vct/artifact.rs
@@ -551,6 +551,41 @@ mod tests {
     #[test]
     fn embedded_mainnet_artifact_matches_frozen_identity_and_current_sprout_root() {
         let (handoff, handoff_hash, sprout_root) = mainnet_artifact_identity();
+        assert_eq!(
+            zakura_vct_sprout_history::TOTAL_LEN,
+            MAINNET_ARTIFACT_LEN,
+            "the embedded artifact length matches its reviewed identity"
+        );
+        assert_eq!(
+            zakura_vct_sprout_history::SHA256,
+            MAINNET_ARTIFACT_SHA256,
+            "the embedded artifact digest matches its reviewed identity"
+        );
+
+        let mut reader = zakura_vct_sprout_history::Reader::new();
+        let mut header = [0; HEADER_LEN];
+        read_exact(&mut reader, &mut header).expect("the embedded artifact header is readable");
+        let (actual_handoff, actual_hash, _record_count, terminal_root, _payload_digest) =
+            decode_header(&header).expect("the embedded artifact header is valid");
+        assert_eq!(actual_handoff, handoff);
+        assert_eq!(actual_hash, handoff_hash);
+        assert_eq!(terminal_root, sprout_root);
+
+        let current_frontier =
+            embedded_final_frontiers(&zakura_chain::parameters::Network::Mainnet)
+                .expect("Mainnet has an embedded final frontier");
+        assert_eq!(
+            sprout_root,
+            current_frontier.sprout.root(),
+            "the frozen repair artifact must remain Sprout-compatible with the latest checkpoint \
+             frontier; regenerate or remove it if Sprout changes"
+        );
+    }
+
+    #[test]
+    #[ignore = "full 71.7 MB artifact replay runs in full-coverage CI"]
+    fn embedded_mainnet_artifact_fully_replays() {
+        let (handoff, handoff_hash, sprout_root) = mainnet_artifact_identity();
         let artifact = embedded_mainnet().expect("the reviewed Mainnet artifact decodes");
 
         artifact

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -10,7 +10,10 @@ use std::{
 
 use futures::FutureExt;
 use indexmap::IndexSet;
-use tokio::{sync::oneshot, task::JoinHandle};
+use tokio::{
+    sync::{oneshot, Notify},
+    task::JoinHandle,
+};
 use tower::{
     buffer::Buffer, builder::ServiceBuilder, load_shed::LoadShed, util::BoxService, ServiceExt,
 };
@@ -46,14 +49,18 @@ use crate::{
 use InventoryResponse::*;
 
 /// An in-memory writer for assertions on test-local tracing output.
-struct TestWriter(Arc<Mutex<Vec<u8>>>);
+struct TestWriter {
+    output: Arc<Mutex<Vec<u8>>>,
+    log_written: Arc<Notify>,
+}
 
 impl io::Write for TestWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0
+        self.output
             .lock()
             .map_err(|_| io::Error::other("log buffer lock should not be poisoned"))?
             .extend_from_slice(buf);
+        self.log_written.notify_one();
         Ok(buf.len())
     }
 
@@ -1127,11 +1134,16 @@ mod submitblock_test {
     async fn submitblock_channel() -> Result<(), crate::BoxError> {
         let logs = Arc::new(Mutex::new(Vec::new()));
         let log_sink = logs.clone();
+        let log_written = Arc::new(Notify::new());
+        let writer_log_written = log_written.clone();
 
         // Set up a tracing subscriber with a custom writer
         let subscriber = fmt()
             .with_max_level(Level::INFO)
-            .with_writer(move || TestWriter(log_sink.clone())) // Write logs to an in-memory buffer
+            .with_writer(move || TestWriter {
+                output: log_sink.clone(),
+                log_written: writer_log_written.clone(),
+            })
             .finish();
 
         let _guard = tracing::subscriber::set_default(subscriber);
@@ -1194,8 +1206,26 @@ mod submitblock_test {
             .in_current_span(),
         );
 
-        // Wait for the block gossip task to process the block
-        tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+        // Wait for the exact event under test. The timeout is only a failure
+        // deadline; the mined-block channel bypasses the periodic gossip delay.
+        tokio::time::timeout(PEER_GOSSIP_DELAY, async {
+            loop {
+                let next_log = log_written.notified();
+                let sent_mined_block = {
+                    let captured_logs = logs.lock().unwrap();
+                    String::from_utf8_lossy(&captured_logs)
+                        .contains("sending mined block broadcast")
+                };
+
+                if sent_mined_block {
+                    break;
+                }
+
+                next_log.await;
+            }
+        })
+        .await
+        .expect("block gossip task should process the submitted block");
 
         // Check that the block was processed as a mnined block by the gossip task
         let captured_logs = logs.lock().unwrap();
@@ -1204,7 +1234,12 @@ mod submitblock_test {
         assert!(log_output.contains("initializing block gossip task"));
         assert!(log_output.contains("sending mined block broadcast"));
 
-        std::mem::drop(gossip_task_handle);
+        std::mem::drop(captured_logs);
+        gossip_task_handle.abort();
+        let gossip_task_error = gossip_task_handle
+            .await
+            .expect_err("block gossip task should run until it is cancelled");
+        assert!(gossip_task_error.is_cancelled());
 
         Ok(())
     }

--- a/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -1227,14 +1227,15 @@ mod submitblock_test {
         .await
         .expect("block gossip task should process the submitted block");
 
-        // Check that the block was processed as a mnined block by the gossip task
-        let captured_logs = logs.lock().unwrap();
-        let log_output = String::from_utf8(captured_logs.clone()).unwrap();
+        // Check that the block was processed as a mined block by the gossip task.
+        let log_output = {
+            let captured_logs = logs.lock().unwrap();
+            String::from_utf8(captured_logs.clone()).unwrap()
+        };
 
         assert!(log_output.contains("initializing block gossip task"));
         assert!(log_output.contains("sending mined block broadcast"));
 
-        std::mem::drop(captured_logs);
         gossip_task_handle.abort();
         let gossip_task_error = gossip_task_handle
             .await

--- a/zakurad/src/components/sync/status/tests.rs
+++ b/zakurad/src/components/sync/status/tests.rs
@@ -39,7 +39,13 @@ proptest! {
         let (runtime, _init_guard) = zakura_test::init_async();
         let _guard = runtime.enter();
 
-        runtime.block_on(timeout(MAX_TEST_EXECUTION, root_task(sync_lengths)))??;
+        runtime.block_on(async move {
+            // These tasks only use mocked synchronization events. Preserve the
+            // timeout behavior without making every negative check wait in real
+            // time.
+            tokio::time::pause();
+            timeout(MAX_TEST_EXECUTION, root_task(sync_lengths)).await
+        })??;
 
         /// The root task that the runtime executes.
         ///

--- a/zakurad/src/components/sync/tests/timing.rs
+++ b/zakurad/src/components/sync/tests/timing.rs
@@ -161,9 +161,13 @@ fn request_genesis_is_rate_limited() {
         misbehavior_tx,
     );
 
-    // run `request_genesis()` with a timeout of 13 seconds
+    // Run `request_genesis()` long enough to observe multiple retries.
     runtime.block_on(async move {
-        // allow extra wall clock time for tests on CPU-bound machines
+        // This test checks Tokio timer behavior using fully mocked services, so
+        // advance retry delays virtually instead of waiting for wall-clock time.
+        tokio::time::pause();
+
+        // Leave half a retry interval for scheduling the final request.
         let retries_timeout = (RETRIES_TO_RUN - 1) as u64 * GENESIS_TIMEOUT_RETRY.as_secs()
             + GENESIS_TIMEOUT_RETRY.as_secs() / 2;
         let _ = timeout(

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -95,7 +95,7 @@ fn oversized_find_blocks_response_is_rejected() {
 /// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips.
 ///
 /// This test also makes sure that the syncer downloads blocks in order.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     // Get services
     let (
@@ -594,7 +594,7 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
 /// with unrelated trailing hashes that are discarded.
 ///
 /// This test also makes sure that the syncer downloads blocks in order.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sync_blocks_trailing_hashes_ok() -> Result<(), crate::BoxError> {
     // Get services
     let (
@@ -1085,7 +1085,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 /// Test that the sync downloader rejects blocks that are too high in extend_tips.
 ///
 /// TODO: also test that it rejects blocks behind the tip limit. (Needs ~100 fake blocks.)
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     // Get services
     let (

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -2997,21 +2997,18 @@ async fn validate_regtest_genesis_block() {
 fn external_address() -> Result<()> {
     let _init_guard = zakura_test::init();
     let testdir = testdir()?.with_config(&mut external_address_test_config(&Mainnet)?)?;
-    let mut child = testdir.spawn_child(args!["start"])?;
+    let mut child = testdir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
 
-    // Give enough time to start connecting to some peers.
-    std::thread::sleep(Duration::from_secs(10));
+    child.expect_stdout_line_matches("Starting zakurad")?;
+    // Wait for an actual outbound handshake to use the configured address.
+    child.expect_stdout_line_matches("using external address for Version messages")?;
 
     child.kill(false)?;
 
     let output = child.wait_with_output()?;
     let output = output.assert_failure()?;
-
-    // Zebra started
-    output.stdout_line_contains("Starting zakurad")?;
-
-    // Make sure we are using external address for Version messages.
-    output.stdout_line_contains("using external address for Version messages")?;
 
     // Make sure the command was killed.
     output.assert_was_killed()?;
@@ -4374,18 +4371,22 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     let mut config = os_assigned_rpc_port_config(false, &network)?;
     config.state.ephemeral = false;
     config.state.debug_skip_non_finalized_state_backup_task = true;
+    config.mempool.debug_enable_at_height = Some(0);
     let test_dir = testdir()?.with_config(&mut config)?;
 
     // Start Zebra and generate some blocks.
 
     tracing::info!("starting Zakura and generating some blocks");
-    let mut child = test_dir.spawn_child(args!["start"])?;
+    let mut child = test_dir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     // Avoid dropping the test directory and cleanup of the state cache needed by the next zakurad instance.
     let test_dir = child.dir.take().expect("should have test directory");
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
-    // Wait for Zebra to load its state cache
-    tokio::time::sleep(Duration::from_secs(5)).await;
     let rpc_client = RpcRequestClient::new(rpc_address);
+    child.expect_stdout_line_matches("verified final checkpoint")?;
+    wake_debug_mempool(&rpc_client).await?;
+    child.expect_stdout_line_matches("activating mempool")?;
     let generated_block_hashes = rpc_client.generate(INITIAL_NON_FINALIZED_BLOCKS).await?;
 
     child.kill(true)?;
@@ -4406,13 +4407,13 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     // max checkpoint height and that it can still commit more blocks to its state.
 
     tracing::info!("restarting Zakura to check that non-finalized state is restored");
-    let mut child = test_dir.spawn_child(args!["start"])?;
+    let mut child = test_dir
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     let test_dir = child.dir.take().expect("should have test directory");
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
     let rpc_client = RpcRequestClient::new(rpc_address);
 
-    // Wait for Zebra to load its state cache
-    tokio::time::sleep(Duration::from_secs(5)).await;
     let blockchain_info = rpc_client.blockchain_info().await?;
     tracing::info!(
         ?blockchain_info,
@@ -4426,6 +4427,8 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     );
 
     tracing::info!("checking that Zakura can commit blocks after restoring non-finalized state");
+    wake_debug_mempool(&rpc_client).await?;
+    child.expect_stdout_line_matches("activating mempool")?;
     rpc_client
         .generate(1)
         .await
@@ -4466,13 +4469,13 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     });
     let mut config = os_assigned_rpc_port_config(false, &network)?;
     config.state.ephemeral = false;
+    config.mempool.debug_enable_at_height = Some(0);
     let mut child = test_dir
         .with_config(&mut config)?
-        .spawn_child(args!["start"])?;
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     let test_dir = child.dir.take().expect("should have test directory");
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
-    // Wait for Zebra to load its state cache
-    tokio::time::sleep(Duration::from_secs(5)).await;
     let rpc_client = RpcRequestClient::new(rpc_address);
 
     assert_eq!(
@@ -4495,6 +4498,8 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     // Commit a block to check that Zebra's state will still commit blocks
     // after checkpoint verification.
 
+    wake_debug_mempool(&rpc_client).await?;
+    child.expect_stdout_line_matches("activating mempool")?;
     rpc_client
         .generate(1)
         .await
@@ -4516,20 +4521,30 @@ async fn restores_non_finalized_state_and_commits_new_blocks() -> Result<()> {
     config.state.should_backup_non_finalized_state = false;
     let mut child = test_dir
         .with_config(&mut config)?
-        .spawn_child(args!["start"])?;
+        .spawn_child(args!["start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
     let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
     let rpc_client = RpcRequestClient::new(rpc_address);
 
-    // Wait for Zebra to load its state cache
-    tokio::time::sleep(Duration::from_secs(5)).await;
-
     tracing::info!("checking that Zakura commits blocks with empty non-finalized state");
+    wake_debug_mempool(&rpc_client).await?;
+    child.expect_stdout_line_matches("activating mempool")?;
     rpc_client
         .generate(1)
         .await
         .expect("should successfully commit more blocks to the state");
 
     child.kill(true)
+}
+
+/// Prompt the mempool service to apply its debug activation setting.
+async fn wake_debug_mempool(rpc_client: &RpcRequestClient) -> Result<()> {
+    let _: Value = rpc_client
+        .json_result_from_call("getmempoolinfo", "[]")
+        .await
+        .map_err(|error| eyre!(error))?;
+
+    Ok(())
 }
 
 /// Check that Zebra will disconnect from misbehaving peers.

--- a/zakurad/tests/end_of_support.rs
+++ b/zakurad/tests/end_of_support.rs
@@ -70,7 +70,7 @@ fn end_of_support_date() {
 }
 
 /// Check that the end of support task is working.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 #[tracing_test::traced_test]
 async fn end_of_support_task() -> Result<()> {
     let (latest_chain_tip, latest_chain_tip_sender) = MockChainTip::new();


### PR DESCRIPTION
## Motivation

The slowest unit-test shard still spends substantial time on fixed production delays, repeated negative mock windows, oversized generated fixtures, and timing-based complexity assertions. Those waits do not exercise additional behavior and make CI slower and more scheduler-sensitive.

## Solution

- Replace fixed sleeps with paused Tokio time, exact log/state events, or synthetic clocks.
- Replace timing benchmarks and oversized allocations with deterministic clone-count and serialized-size assertions.
- Generate only the state-chain prefixes each VCT and rollback scenario consumes.
- Preserve Equihash vector coverage while sharing the randomized case budget across vectors.
- Keep fast VCT artifact metadata and frontier checks on every PR, while moving the complete 71.7 MB replay to the existing merge-queue, main, nightly, and manual full-coverage tier.

## Testing

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --features default-release-binaries -- -D warnings
- git diff --check
- Targeted tests for every changed slow test across zakura, zakura-chain, zakura-consensus, zakura-network, zakura-rpc, and zakura-state
- Full ignored VCT artifact replay
- ./scripts/changelog.py check

Broader draft CI is pending.

## Changelog

- Added changelog-unreleased/389.md with the explicit internal-only marker.

### Follow-up Work

The VCT mode-switch property test also exposed a production restart bug. That bug, its saved CI seed, and the production fix are isolated in #401; this PR only makes the uninterrupted direct-commit test harness carry frontiers like the writer service.

Further live-node fixture consolidation and genuinely expensive proof-verification coverage can be handled separately; this PR keeps those integration and cryptographic floors intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly test and CI ergonomics; the small Halo2 routing split and discovery sampling helper are behavior-preserving refactors with existing regression coverage.
> 
> **Overview**
> Speeds up CI by cutting wall-clock waits, oversized fixtures, and timing-based assertions while keeping the same coverage.
> 
> **Deterministic timing and synchronization:** Outbound peer rate-limit proptests and several sync/status tests use paused Tokio time; `RecentByIp` pruning tests inject `Instant` values instead of `thread::sleep`; acceptance and inbound tests wait on log lines, RPC readiness, or `Notify` rather than fixed delays; peer-cache vector tests call `update_peer_cache_once` and poll until the address book updates.
> 
> **Cheaper assertions and fixtures:** `max_allocation_is_big_enough` derives serialized vector sizes algebraically; discovery `sample_peers` clone-bounding is checked with a clone counter (and production sampling uses `choose_multiple_cloned`); VCT and rollback proptests build only the block-prefix length each scenario needs via `valid_commitment_chain`, and VCT switch tests thread `note_commitment_trees` through commits like the writer service. Equihash proptests add per-vector deterministic negative cases and one shared randomized budget across headers.
> 
> **Test-only production hooks:** Halo2 exposes `lazy_verifier_for` so era routing is tested via `Lazy` pointer equality without initializing verifying keys; the full embedded Mainnet VCT artifact replay is `#[ignore]` on ordinary PR runs while lightweight identity/frontier checks stay always-on.
> 
> **Minor cleanups:** RPC snapshot tests use one final `expect_no_requests`; changelog entry marks the change as internal-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa63c5e7ca365cc286bae535c0e7547c4463965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->