### PR TITLE
test: speed up network and mempool tests

### DIFF
--- a/changelog-unreleased/391.md
+++ b/changelog-unreleased/391.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakura-network/src/config/tests/vectors.rs
+++ b/zakura-network/src/config/tests/vectors.rs
@@ -1,6 +1,6 @@
 //! Fixed test vectors for zakura-network configuration.
 
-use std::{net::SocketAddr, time::Duration};
+use std::{collections::HashSet, fs, net::SocketAddr, time::Duration};
 
 use static_assertions::const_assert;
 use zakura_chain::{
@@ -84,6 +84,40 @@ fn ensure_peer_connection_limits_consistent() {
     assert!(
         config.peerset_inbound_connection_limit() <= config.peerset_outbound_connection_limit(),
         "this fork caps inbound connections at or below the outbound limit, to prioritize sync",
+    );
+}
+
+#[tokio::test]
+async fn empty_peer_cache_update_preserves_existing_cache() {
+    let _init_guard = zakura_test::init();
+
+    let cache_dir = tempfile::tempdir().expect("temporary peer cache directory creation failed");
+    let config = Config {
+        cache_dir: CacheDir::custom_path(cache_dir.path()),
+        ..Config::default()
+    };
+    let peer_cache_file = config
+        .cache_dir
+        .peer_cache_file_path(&config.network)
+        .expect("test cache directory enables the peer cache");
+    let cached_peers = "127.0.0.1:8233\n";
+    fs::create_dir_all(
+        peer_cache_file
+            .parent()
+            .expect("peer cache file has a parent directory"),
+    )
+    .expect("peer cache directory should be creatable");
+    fs::write(&peer_cache_file, cached_peers).expect("pre-seeded peer cache should be writable");
+
+    config
+        .update_peer_cache(HashSet::new())
+        .await
+        .expect("an empty peer cache update should succeed");
+
+    assert_eq!(
+        fs::read_to_string(peer_cache_file).expect("pre-seeded peer cache should remain readable"),
+        cached_peers,
+        "an empty peer list must not overwrite the existing peer cache",
     );
 }
 

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -1069,6 +1069,7 @@ where
             nonces,
             local_node_id,
             local_direct_addresses,
+            ResponderRegistrationWait::Production,
         )
         .await?
     } else {
@@ -1223,6 +1224,27 @@ where
     Ok(ZakuraUpgradeOutcome::Upgraded { peer_id })
 }
 
+/// Selects the registration wait used by the responder upgrade path.
+enum ResponderRegistrationWait {
+    Production,
+    #[cfg(test)]
+    TestTimeout(Duration),
+}
+
+impl ResponderRegistrationWait {
+    async fn wait(self, connector: &ZakuraHandshakeConnector, peer_id: &ZakuraPeerId) -> bool {
+        match self {
+            Self::Production => connector.wait_for_zakura_registration(peer_id).await,
+            #[cfg(test)]
+            Self::TestTimeout(timeout) => {
+                tokio::time::timeout(timeout, connector.wait_for_zakura_registration(peer_id))
+                    .await
+                    .unwrap_or(false)
+            }
+        }
+    }
+}
+
 /// The TCP responder side of the legacy Zakura upgrade prelude exchange.
 ///
 /// Reads the initiator's [`P2pV2UpgradeInit`] and replies with our
@@ -1235,6 +1257,7 @@ async fn run_responder_upgrade<PeerTransport>(
     nonces: ZakuraLegacyNonces,
     local_node_id: Vec<u8>,
     local_direct_addresses: Vec<Vec<u8>>,
+    registration_wait: ResponderRegistrationWait,
 ) -> Result<ZakuraUpgradeOutcome, HandshakeError>
 where
     PeerTransport: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -1294,7 +1317,7 @@ where
     // and then never completes the native dial would make us discard a working
     // legacy connection with no Zakura replacement. This mirrors the initiator's
     // `spawn_zakura_dial_to_hints_and_wait` hand-off wait.
-    if !connector.wait_for_zakura_registration(&peer_id).await {
+    if !registration_wait.wait(connector, &peer_id).await {
         return Ok(neutral_upgrade_fallback());
     }
 

--- a/zakura-network/src/peer/handshake/tests.rs
+++ b/zakura-network/src/peer/handshake/tests.rs
@@ -411,6 +411,7 @@ async fn responder_upgrade_keeps_legacy_when_native_dial_never_registers() {
         nonces,
         local_node_id,
         local_direct_addresses,
+        ResponderRegistrationWait::TestTimeout(std::time::Duration::from_millis(50)),
     );
 
     let (outcome, _held_peer_conn) = tokio::join!(
@@ -483,6 +484,7 @@ async fn responder_upgrade_disconnects_on_malformed_prelude() {
         nonces,
         vec![1u8; 32],
         vec![b"127.0.0.1:1".to_vec()],
+        ResponderRegistrationWait::Production,
     );
 
     let (outcome, _held_peer_conn) = tokio::join!(

--- a/zakura-network/src/zakura/testkit/node.rs
+++ b/zakura-network/src/zakura/testkit/node.rs
@@ -585,59 +585,17 @@ mod tests {
         assert!(error.to_string().contains("connect_via_upgrade"));
     }
 
-    #[tokio::test]
-    async fn default_test_node_uses_production_per_ip_cap() {
-        // Every loopback test node binds 127.0.0.1, so the supervisor's per-IP
-        // cap collapses all peers into one IP bucket. A default test node must
-        // inherit the production Zakura per-IP cap so security/integration tests
-        // built on it exercise the real per-IP admission gate.
-        let mut peers = Vec::new();
-        for index in 0..=DEFAULT_ZAKURA_MAX_CONNS_PER_IP {
-            peers.push(
-                ZakuraTestNode::builder(9001 + index as u64)
-                    .spawn()
-                    .await
-                    .unwrap_or_else(|error| panic!("loopback peer {index} should spawn: {error}")),
-            );
-        }
+    #[test]
+    fn default_test_node_uses_production_per_ip_cap() {
+        // `handler::tests::inbound_accept_enforces_per_ip_cap` drives the real
+        // native admission path. This test only needs to guard the test-builder
+        // default that selects that production cap.
+        let builder = ZakuraTestNode::builder(10000);
 
-        let node = ZakuraTestNode::builder(10000)
-            .spawn()
-            .await
-            .expect("default test node spawns");
-
-        for (index, peer) in peers
-            .iter()
-            .take(DEFAULT_ZAKURA_MAX_CONNS_PER_IP)
-            .enumerate()
-        {
-            node.connect_native(peer, TEST_NET_TIMEOUT)
-                .await
-                .unwrap_or_else(|error| {
-                    panic!(
-                        "same-IP outbound peer {} should register under the production \
-                         Zakura per-IP cap: {error}",
-                        index + 1
-                    )
-                });
-        }
-
-        let excess_peer = peers
-            .last()
-            .expect("peers contains one peer over the production per-IP cap");
-        let excess = node.connect_native(excess_peer, TEST_NET_TIMEOUT).await;
-        assert!(
-            excess.is_err(),
-            "{}th same-IP outbound dial must be rejected under the production \
-             Zakura per-IP cap, but it registered — the test node is not enforcing \
-             production per-IP admission",
-            DEFAULT_ZAKURA_MAX_CONNS_PER_IP + 1
+        assert_eq!(
+            builder.max_connections_per_ip, DEFAULT_ZAKURA_MAX_CONNS_PER_IP,
+            "the default test node must inherit the production per-IP cap",
         );
-
-        node.shutdown().await;
-        for peer in peers {
-            peer.shutdown().await;
-        }
     }
 
     #[tokio::test]

--- a/zakura-network/src/zakura/testkit/node.rs
+++ b/zakura-network/src/zakura/testkit/node.rs
@@ -572,7 +572,6 @@ impl Drop for ZakuraTestNode {
 mod tests {
     use super::super::TEST_NET_TIMEOUT;
     use super::*;
-    use crate::zakura::DEFAULT_ZAKURA_MAX_CONNS_PER_IP;
 
     #[tokio::test]
     async fn legacy_upgrade_builder_fails_loudly() {
@@ -583,19 +582,6 @@ mod tests {
             .expect_err("legacy-upgrade hook is reserved, not silently ignored");
 
         assert!(error.to_string().contains("connect_via_upgrade"));
-    }
-
-    #[test]
-    fn default_test_node_uses_production_per_ip_cap() {
-        // `handler::tests::inbound_accept_enforces_per_ip_cap` drives the real
-        // native admission path. This test only needs to guard the test-builder
-        // default that selects that production cap.
-        let builder = ZakuraTestNode::builder(10000);
-
-        assert_eq!(
-            builder.max_connections_per_ip, DEFAULT_ZAKURA_MAX_CONNS_PER_IP,
-            "the default test node must inherit the production per-IP cap",
-        );
     }
 
     #[tokio::test]

--- a/zakurad/src/components/mempool/storage.rs
+++ b/zakurad/src/components/mempool/storage.rs
@@ -217,6 +217,9 @@ pub struct Storage {
     /// Same as [`config::Config::eviction_memory_time`].
     eviction_memory_time: Duration,
 
+    /// Maximum entries retained in each rejection list.
+    rejection_list_capacity: usize,
+
     /// Max total cost of the verified mempool set, beyond which transactions
     /// are evicted to make room.
     tx_cost_limit: u64,
@@ -234,9 +237,27 @@ impl Drop for Storage {
 impl Storage {
     #[allow(clippy::field_reassign_with_default)]
     pub(crate) fn new(config: &config::Config) -> Self {
+        Self::new_with_rejection_list_capacity(config, MAX_EVICTION_MEMORY_ENTRIES)
+    }
+
+    /// Constructs storage with a configurable rejection-list capacity.
+    ///
+    /// Production always uses [`MAX_EVICTION_MEMORY_ENTRIES`]. Unit tests use
+    /// smaller capacities to exercise boundary behavior without tens of
+    /// thousands of insertions per property-test case.
+    fn new_with_rejection_list_capacity(
+        config: &config::Config,
+        rejection_list_capacity: usize,
+    ) -> Self {
+        assert!(
+            rejection_list_capacity > 0,
+            "rejection lists must retain at least one entry"
+        );
+
         Self {
             tx_cost_limit: config.tx_cost_limit,
             eviction_memory_time: config.eviction_memory_time,
+            rejection_list_capacity,
             max_datacarrier_bytes: config
                 .max_datacarrier_bytes
                 .unwrap_or(config::DEFAULT_MAX_DATACARRIER_BYTES),
@@ -680,10 +701,10 @@ impl Storage {
     /// Otherwise, peers could make our reject lists use a lot of RAM.
     fn limit_rejection_list_memory(&mut self) {
         // These lists are an optimisation - it's ok to totally clear them as needed.
-        if self.tip_rejected_exact.len() > MAX_EVICTION_MEMORY_ENTRIES {
+        if self.tip_rejected_exact.len() > self.rejection_list_capacity {
             self.tip_rejected_exact.clear();
         }
-        if self.tip_rejected_same_effects.len() > MAX_EVICTION_MEMORY_ENTRIES {
+        if self.tip_rejected_same_effects.len() > self.rejection_list_capacity {
             self.tip_rejected_same_effects.clear();
         }
         // `chain_rejected_same_effects` limits its size by itself
@@ -821,10 +842,11 @@ impl Storage {
             }
             RejectionError::SameEffectsChain(e) => {
                 let eviction_memory_time = self.eviction_memory_time;
+                let rejection_list_capacity = self.rejection_list_capacity;
                 self.chain_rejected_same_effects
                     .entry(e)
                     .or_insert_with(|| {
-                        EvictionList::new(MAX_EVICTION_MEMORY_ENTRIES, eviction_memory_time)
+                        EvictionList::new(rejection_list_capacity, eviction_memory_time)
                     })
                     .insert(tx_id.mined_id());
             }

--- a/zakurad/src/components/mempool/storage/tests/prop.rs
+++ b/zakurad/src/components/mempool/storage/tests/prop.rs
@@ -47,6 +47,69 @@ const EVICTION_MEMORY_TIME: Duration = Duration::from_secs(60 * 60);
 /// Transaction count used in some tests to derive the mempool test size.
 const MEMPOOL_TX_COUNT: usize = 4;
 
+/// Rejection-list capacity used for randomized behavior tests.
+///
+/// A separate deterministic test checks the real production boundary.
+const TEST_REJECTION_LIST_CAPACITY: usize = 16;
+
+fn rejection_id_with_index(mut template: UnminedTxId, index: u32) -> UnminedTxId {
+    let index = index.to_le_bytes();
+    template.mined_id_mut().0[0..4].copy_from_slice(&index);
+    if let Some(auth_digest) = template.auth_digest_mut() {
+        auth_digest.0[0..4].copy_from_slice(&index);
+    }
+
+    template
+}
+
+fn cheap_rejection_id(index: u32) -> UnminedTxId {
+    let mut hash = [0; 32];
+    hash[..4].copy_from_slice(&index.to_le_bytes());
+    UnminedTxId::Legacy(transaction::Hash(hash))
+}
+
+/// Check the real ZIP-401 boundary once using cheap deterministic IDs.
+#[test]
+fn reject_lists_enforce_production_capacity() {
+    let config = Config {
+        tx_cost_limit: 160_000_000,
+        eviction_memory_time: EVICTION_MEMORY_TIME,
+        ..Default::default()
+    };
+    let mut tip_rejected = Storage::new(&config);
+    let mut chain_rejected = Storage::new(&config);
+    let production_capacity: u32 = MAX_EVICTION_MEMORY_ENTRIES
+        .try_into()
+        .expect("production rejection-list capacity fits in u32");
+
+    for index in 0..=production_capacity {
+        let id = cheap_rejection_id(index);
+        tip_rejected.reject(id, SameEffectsTipRejectionError::SpendConflict.into());
+        chain_rejected.reject(id, SameEffectsChainRejectionError::RandomlyEvicted.into());
+
+        if index == production_capacity - 1 {
+            assert_eq!(
+                tip_rejected.rejected_transaction_count(),
+                MAX_EVICTION_MEMORY_ENTRIES
+            );
+            assert_eq!(
+                chain_rejected.rejected_transaction_count(),
+                MAX_EVICTION_MEMORY_ENTRIES
+            );
+        }
+    }
+
+    let oldest = cheap_rejection_id(0);
+    let newest = cheap_rejection_id(production_capacity);
+    assert_eq!(tip_rejected.rejected_transaction_count(), 0);
+    assert_eq!(
+        chain_rejected.rejected_transaction_count(),
+        MAX_EVICTION_MEMORY_ENTRIES
+    );
+    assert!(!chain_rejected.contains_rejected(&oldest));
+    assert!(chain_rejected.contains_rejected(&newest));
+}
+
 proptest! {
     #![proptest_config(
         proptest::test_runner::Config::with_cases(env::var("PROPTEST_CASES")
@@ -59,14 +122,16 @@ proptest! {
     #[test]
     fn reject_lists_are_limited_insert_conflict(
         input in any::<SpendConflictTestInput>(),
-        mut rejection_template in any::<UnminedTxId>()
+        rejection_template in any::<UnminedTxId>()
     ) {
-        let mut storage = Storage::new(
+        let mut storage = Storage::new_with_rejection_list_capacity(
             &Config {
                 tx_cost_limit: 160_000_000,
                 eviction_memory_time: EVICTION_MEMORY_TIME,
                 ..Default::default()
-            });
+            },
+            TEST_REJECTION_LIST_CAPACITY,
+        );
 
         let (first_transaction, second_transaction) = input.conflicting_transactions();
         let input_permutations = vec![
@@ -79,23 +144,21 @@ proptest! {
 
             prop_assert_eq!(storage.insert(transaction_to_accept, Vec::new(), None), Ok(id_to_accept));
 
-            // Make unique IDs by converting the index to bytes, and writing it to each ID
-            let unique_ids = (0..MAX_EVICTION_MEMORY_ENTRIES as u32).map(move |index| {
-                let index = index.to_le_bytes();
-                rejection_template.mined_id_mut().0[0..4].copy_from_slice(&index);
-                if let Some(auth_digest) = rejection_template.auth_digest_mut() {
-                    auth_digest.0[0..4].copy_from_slice(&index);
-                }
-
-                rejection_template
-            });
+            let test_capacity: u32 = TEST_REJECTION_LIST_CAPACITY
+                .try_into()
+                .expect("test rejection-list capacity fits in u32");
+            let unique_ids = (0..test_capacity)
+                .map(|index| rejection_id_with_index(rejection_template, index));
 
             for rejection in unique_ids {
                 storage.reject(rejection, SameEffectsTipRejectionError::SpendConflict.into());
             }
 
             // Make sure there were no duplicates
-            prop_assert_eq!(storage.rejected_transaction_count(), MAX_EVICTION_MEMORY_ENTRIES);
+            prop_assert_eq!(
+                storage.rejected_transaction_count(),
+                TEST_REJECTION_LIST_CAPACITY
+            );
 
             // The transaction_to_reject will conflict with at least one of:
             // - transaction_to_accept, or
@@ -105,7 +168,7 @@ proptest! {
                 Err(MempoolError::StorageEffectsTip(SameEffectsTipRejectionError::SpendConflict))
             );
 
-            // Since we inserted more than MAX_EVICTION_MEMORY_ENTRIES,
+            // Since we inserted more than the configured capacity,
             // the storage should have cleared the reject list
             prop_assert_eq!(storage.rejected_transaction_count(), 0);
 
@@ -118,34 +181,35 @@ proptest! {
     fn reject_lists_are_limited_insert_eviction(
         transactions in vec(standard_verified_unmined_tx_strategy(), MEMPOOL_TX_COUNT + 1)
             .prop_map(SummaryDebug),
-        mut rejection_template in any::<UnminedTxId>()
+        rejection_template in any::<UnminedTxId>()
     ) {
         // Use as cost limit the costs of all transactions except one
         let cost_limit = transactions.iter().take(MEMPOOL_TX_COUNT).map(|tx| tx.cost()).sum();
 
-        let mut storage: Storage = Storage::new(&Config {
-            tx_cost_limit: cost_limit,
-            eviction_memory_time: EVICTION_MEMORY_TIME,
-            ..Default::default()
-        });
+        let mut storage = Storage::new_with_rejection_list_capacity(
+            &Config {
+                tx_cost_limit: cost_limit,
+                eviction_memory_time: EVICTION_MEMORY_TIME,
+                ..Default::default()
+            },
+            TEST_REJECTION_LIST_CAPACITY,
+        );
 
-        // Make unique IDs by converting the index to bytes, and writing it to each ID
-        let unique_ids = (0..MAX_EVICTION_MEMORY_ENTRIES as u32).map(move |index| {
-            let index = index.to_le_bytes();
-            rejection_template.mined_id_mut().0[0..4].copy_from_slice(&index);
-            if let Some(auth_digest) = rejection_template.auth_digest_mut() {
-                auth_digest.0[0..4].copy_from_slice(&index);
-            }
-
-            rejection_template
-        });
+        let test_capacity: u32 = TEST_REJECTION_LIST_CAPACITY
+            .try_into()
+            .expect("test rejection-list capacity fits in u32");
+        let unique_ids =
+            (0..test_capacity).map(|index| rejection_id_with_index(rejection_template, index));
 
         for rejection in unique_ids {
             storage.reject(rejection, SameEffectsChainRejectionError::RandomlyEvicted.into());
         }
 
         // Make sure there were no duplicates
-        prop_assert_eq!(storage.rejected_transaction_count(), MAX_EVICTION_MEMORY_ENTRIES);
+        prop_assert_eq!(
+            storage.rejected_transaction_count(),
+            TEST_REJECTION_LIST_CAPACITY
+        );
 
         for (i, transaction) in transactions.iter().enumerate() {
             let tx_id = transaction.transaction.id;
@@ -179,42 +243,46 @@ proptest! {
         // (More than one an be evicted to meet the limit.)
         prop_assert!(storage.transaction_count() <= MEMPOOL_TX_COUNT);
 
-        // Since we inserted more than MAX_EVICTION_MEMORY_ENTRIES,
+        // Since we inserted more than the configured capacity,
         // the storage should have removed the older entries and kept its size
-        prop_assert_eq!(storage.rejected_transaction_count(), MAX_EVICTION_MEMORY_ENTRIES);
+        prop_assert_eq!(
+            storage.rejected_transaction_count(),
+            TEST_REJECTION_LIST_CAPACITY
+        );
     }
 
     /// Test that the reject list length limits are applied when directly rejecting transactions.
     #[test]
     fn reject_lists_are_limited_reject(
         rejection_error in any::<RejectionError>(),
-        mut rejection_template in any::<UnminedTxId>()
+        rejection_template in any::<UnminedTxId>()
     ) {
-        let mut storage: Storage = Storage::new(&Config {
-            tx_cost_limit: 160_000_000,
-            eviction_memory_time: EVICTION_MEMORY_TIME,
-            ..Default::default()
-        });
+        let mut storage = Storage::new_with_rejection_list_capacity(
+            &Config {
+                tx_cost_limit: 160_000_000,
+                eviction_memory_time: EVICTION_MEMORY_TIME,
+                ..Default::default()
+            },
+            TEST_REJECTION_LIST_CAPACITY,
+        );
 
-        // Make unique IDs by converting the index to bytes, and writing it to each ID
-        let unique_ids = (0..(MAX_EVICTION_MEMORY_ENTRIES + 1) as u32).map(move |index| {
-            let index = index.to_le_bytes();
-            rejection_template.mined_id_mut().0[0..4].copy_from_slice(&index);
-            if let Some(auth_digest) = rejection_template.auth_digest_mut() {
-                auth_digest.0[0..4].copy_from_slice(&index);
-            }
-
-            rejection_template
-        });
+        let test_capacity: u32 = TEST_REJECTION_LIST_CAPACITY
+            .try_into()
+            .expect("test rejection-list capacity fits in u32");
+        let unique_ids = (0..=test_capacity)
+            .map(|index| rejection_id_with_index(rejection_template, index));
 
         for (index, rejection) in unique_ids.enumerate() {
             storage.reject(rejection, rejection_error.clone());
 
-            if index == MAX_EVICTION_MEMORY_ENTRIES - 1 {
+            if index == TEST_REJECTION_LIST_CAPACITY - 1 {
                 // Make sure there were no duplicates
-                prop_assert_eq!(storage.rejected_transaction_count(), MAX_EVICTION_MEMORY_ENTRIES);
-            } else if index == MAX_EVICTION_MEMORY_ENTRIES {
-                // Since we inserted more than MAX_EVICTION_MEMORY_ENTRIES,
+                prop_assert_eq!(
+                    storage.rejected_transaction_count(),
+                    TEST_REJECTION_LIST_CAPACITY
+                );
+            } else if index == TEST_REJECTION_LIST_CAPACITY {
+                // Since we inserted more than the configured capacity,
                 // all with the same error,
                 // the storage should have either cleared the reject list
                 // or removed the oldest ones, depending on the structure
@@ -226,7 +294,10 @@ proptest! {
                         prop_assert_eq!(storage.rejected_transaction_count(), 0);
                     },
                     RejectionError::SameEffectsChain(_) => {
-                        prop_assert_eq!(storage.rejected_transaction_count(), MAX_EVICTION_MEMORY_ENTRIES);
+                        prop_assert_eq!(
+                            storage.rejected_transaction_count(),
+                            TEST_REJECTION_LIST_CAPACITY
+                        );
                     },
                 }
             }

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -416,7 +416,7 @@ async fn db_init_outside_future_executor() -> Result<()> {
     Ok(())
 }
 
-/// Check that persistent block state and peer list caches survive a node run.
+/// Check that persistent block state and peer list caches survive a node restart.
 #[test]
 fn persistent_mode() -> Result<()> {
     let _init_guard = zakura_test::init();
@@ -445,7 +445,6 @@ fn persistent_mode() -> Result<()> {
 
     child.expect_stdout_line_matches("loaded Zakura state cache")?;
     child.expect_stdout_line_matches("loaded cached peer IP addresses")?;
-    child.expect_stdout_line_matches("cacheable peer list was empty, keeping previous cache")?;
     child.kill(false)?;
     let output = child.wait_with_output()?;
 
@@ -460,9 +459,32 @@ fn persistent_mode() -> Result<()> {
     );
 
     assert_with_context!(
-        fs::read_to_string(peer_cache_file)?.trim() == "127.0.0.1:1",
+        fs::read_to_string(&peer_cache_file)?.trim() == "127.0.0.1:1",
         &output,
         "peer cache changed despite having no connected peers"
+    );
+
+    let mut child = testdir
+        .spawn_child(args!["-v", "start"])?
+        .with_timeout(EXTENDED_LAUNCH_DELAY);
+
+    child.expect_stdout_line_matches("loaded Zakura state cache")?;
+    child.expect_stdout_line_matches("loaded cached peer IP addresses")?;
+    child.kill(false)?;
+    let output = child.wait_with_output()?;
+
+    output.assert_was_killed()?;
+
+    assert_with_context!(
+        cache_dir.read_dir()?.count() > 0,
+        &output,
+        "state directory empty after restarting with persistent state config"
+    );
+
+    assert_with_context!(
+        fs::read_to_string(&peer_cache_file)?.trim() == "127.0.0.1:1",
+        &output,
+        "peer cache did not survive node restart"
     );
 
     Ok(())


### PR DESCRIPTION
## Motivation

Several remaining slow tests spend time on production-scale connection
deadlines, redundant many-node setup, or 40,000-entry randomized workloads
even though smaller deterministic seams exercise the same behavior.

## Solution

- Remove the redundant test-node default per-IP scenario; the real native
  admission limit remains covered by
  `handler::tests::inbound_accept_enforces_per_ip_cap`.
- Exercise the real responder Init/Accept/fallback path with a short private
  test wait policy; production still uses the 15-second liveness timeout.
- Run randomized mempool rejection behavior at capacity 16 and add one
  deterministic test at the real 40,000-entry production boundary.
- Replace persistent-mode reliance on the peer-cache updater delay with exact
  state/cache load events before and after a real restart.
- Directly verify that an empty peer-cache update preserves an existing cache
  file, without waiting for the production updater interval.

Production limits and timeout constants are unchanged.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --features default-release-binaries -- -D warnings`
- Targeted responder tests, including the malformed-prelude sibling
- Targeted mempool rejection-list suite: 5 tests passed in 0.98s
- Persistent-mode acceptance test: passed in 4.54s
- Empty peer-cache update regression test: passed in 0.01s
- `./scripts/changelog.py check`
- markdownlint for `changelog-unreleased/391.md`

Locally, the responder timeout test fell from an 18.7-second CI baseline to
6.3 seconds, persistent mode fell from about 20.1 seconds to 4.5 seconds, and
the redundant per-IP-cap scenario that took about 31.9 seconds was removed.

## Changelog

Added an internal-only changelog fragment because this PR changes tests only.

### Specifications & References

- Builds on the test-speedups merged in #389.

### Follow-up Work

Further live-node fixture consolidation remains separate from this focused
layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly tests plus a small `#[cfg(test)]` handshake wait hook; production mempool and handshake timeouts are unchanged.
> 
> **Overview**
> **Test-only speedups** with no intended change to production timeouts or ZIP-401 rejection limits.
> 
> **Network / handshake:** Responder Zakura upgrade tests can use a private `ResponderRegistrationWait::TestTimeout` (e.g. 50ms) instead of the production registration wait, so the “never completes native dial” case finishes quickly while live paths still use production waits. A new config vector test asserts `update_peer_cache` with an empty set does not overwrite a pre-seeded peer cache file. The long `default_test_node_uses_production_per_ip_cap` harness is removed (per-IP admission remains covered elsewhere).
> 
> **Mempool:** `Storage` gains a test-only `new_with_rejection_list_capacity`; proptests run at capacity **16**, and one deterministic test still checks the real **40,000**-entry boundary.
> 
> **Acceptance:** `persistent_mode` drops reliance on the peer-cache updater delay, adds a **second** `zakurad start` to assert state and peer cache survive restart, and no longer expects the “empty cacheable peer list” log line on the first run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3846dbca9eb73436c681f1bb72756074fbdfdd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->