### PR TITLE
fix(sync): keep reserve dispatch flowing during registry-miss backoff

### DIFF
--- a/changelog-unreleased/393.md
+++ b/changelog-unreleased/393.md
@@ -1,0 +1,4 @@
+## Security
+
+- Prevented one unavailable legacy-sync block hash from pausing dispatch of otherwise available
+  block hashes ([#393](https://github.com/zakura-core/zakura/pull/393)).

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -794,11 +794,12 @@ where
     /// Required blocks that registry-missed and are waiting for their backoff to elapse before being
     /// retried, keyed by hash with the [`tokio::time::Instant`] each backoff expires.
     ///
-    /// While this is non-empty, new speculative downloads are gated in [`Self::sync_round`] so the
-    /// in-flight pipeline drains and frees ready-peer slots for the critical head-of-line block.
-    /// The retries themselves are never gated: they fire from the `select!` timer arm so draining
-    /// and tip extension continue concurrently during the backoff. A map so that a second block missing while the first is still
-    /// backing off isn't dropped: every registry-missed required block stays scheduled.
+    /// While this is non-empty, [`Self::sync_round`] limits new speculative dispatch to one hash per
+    /// loop step: unrelated reserve hashes keep flowing (one unavailable hash must not stall the
+    /// whole reserve), but the loop still returns to the `select!` timer arm that fires the retries,
+    /// instead of blocking on peer-set readiness behind a full-reserve dispatch. A map so that a
+    /// second block missing while the first is still backing off isn't dropped: every
+    /// registry-missed required block stays scheduled.
     registry_miss_retry: HashMap<block::Hash, tokio::time::Instant>,
 
     /// Receiver that is `true` when the downloader is past the lookahead limit.
@@ -1339,13 +1340,15 @@ where
                 || (self.downloads.in_flight() >= lookahead_limit / 2
                     && self.past_lookahead_limit_receiver.cloned_watch_data());
 
-            // Head-of-line priority: while a required block is missing from all current peers and
-            // waiting on its registry-miss backoff, pause *new* speculative dispatch so in-flight
-            // downloads drain and free up ready-peer slots. Otherwise lookahead work can keep every
-            // peer busy and starve the critical retry. This is inert in healthy sync.
-            let head_of_line_starved = !self.registry_miss_retry.is_empty();
+            // While a required block is waiting on its registry-miss backoff, keep dispatching
+            // unrelated reserve hashes, but only one per loop step. Pausing dispatch entirely
+            // would let one unavailable hash stall every other download for its whole retry
+            // budget, and dispatching the whole reserve can block on peer-set readiness until
+            // in-flight downloads drain, starving the retry timer in the `select!` below. One
+            // hash per step keeps the timer reachable while unrelated sync work continues.
+            let registry_retry_pending = !self.registry_miss_retry.is_empty();
 
-            if !past_lookahead && !head_of_line_starved && !reserve.is_empty() {
+            if !past_lookahead && !reserve.is_empty() {
                 debug!(
                     tips.len = self.prospective_tips.len(),
                     in_flight = self.downloads.in_flight(),
@@ -1355,15 +1358,25 @@ where
                     "requesting more blocks",
                 );
 
-                let response = timeout(
-                    BLOCK_VERIFY_TIMEOUT,
-                    self.request_blocks(std::mem::take(&mut reserve)),
-                )
-                .await
-                .map_err(Report::from)?;
-                reserve = Self::handle_hash_response(response, self.expose_peer_addresses)?;
+                let mut dispatch = std::mem::take(&mut reserve);
+                let deferred = if registry_retry_pending {
+                    dispatch.split_off(1)
+                } else {
+                    IndexSet::new()
+                };
+
+                let response = timeout(BLOCK_VERIFY_TIMEOUT, self.request_blocks(dispatch))
+                    .await
+                    .map_err(Report::from)?;
+                let mut undispatched =
+                    Self::handle_hash_response(response, self.expose_peer_addresses)?;
+                undispatched.extend(deferred);
+                reserve = undispatched;
                 last_progress = Instant::now();
-                continue;
+
+                if !registry_retry_pending {
+                    continue;
+                }
             }
 
             // There's nothing left to discover, but blocks are still in flight. Those blocks can be
@@ -1453,7 +1466,7 @@ where
 
                     // Retry required blocks that registry-missed once their backoff elapses. This
                     // is not gated by speculative lookahead dispatch, so the head-of-line block gets
-                    // another chance after the in-flight downloads have had time to drain.
+                    // another chance while unrelated dispatch continues in bounded steps.
                     _ = OptionFuture::from(registry_retry_at.map(sleep_until)),
                         if registry_retry_at.is_some() =>
                     {
@@ -2150,11 +2163,11 @@ where
     /// A [`NotFoundKind::Registry`] miss means the peer set found that *every* ready peer is marked
     /// missing the block, so it can't be served right now. Rather than blocking the loop on an inline
     /// `sleep`, the hash is recorded in [`Self::registry_miss_retry`] with a backoff deadline; while
-    /// any such retry is pending, [`Self::sync_round`] gives it head-of-line priority by pausing new
-    /// speculative dispatch and re-dispatching the hash from its `select!` timer arm once the backoff
-    /// elapses. Bounded by [`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]; only a block that stays missing
-    /// for the whole budget (e.g. a bad tip) falls through to [`Self::handle_block_response`] and
-    /// restarts the round to obtain fresh tips and peers.
+    /// any such retry is pending, [`Self::sync_round`] limits unrelated dispatch to one hash per loop
+    /// step and re-dispatches the hash from its `select!` timer arm once the backoff elapses.
+    /// Bounded by [`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]; only a block that stays missing for the
+    /// whole budget (e.g. a bad tip) falls through to [`Self::handle_block_response`] and restarts
+    /// the round to obtain fresh tips and peers.
     async fn handle_block_response_with_missing_retry(
         &mut self,
         response: Result<(Height, block::Hash), BlockDownloadVerifyError>,
@@ -2235,10 +2248,9 @@ where
                         );
                         metrics::counter!("sync.missing.block.registry.retry.count").increment(1);
 
-                        // Schedule the retry instead of blocking the loop on an inline `sleep`. While
-                        // it's pending, `sync_round` gates new speculative dispatch (head-of-line
-                        // priority) and keeps draining, so peers free up before the timer fires and
-                        // the block can finally reach one that has it.
+                        // Schedule the retry instead of blocking the loop on an inline `sleep`.
+                        // `sync_round` keeps dispatching unrelated work in bounded steps while the
+                        // timer runs; see `Self::registry_miss_retry` for the dispatch invariant.
                         self.registry_miss_retry.insert(
                             hash,
                             tokio::time::Instant::now() + REGISTRY_MISS_RETRY_BACKOFF,

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2492,6 +2492,7 @@ async fn registry_miss_retry_allows_bounded_reserve_dispatch() {
 /// of the available reserve.
 #[tokio::test]
 async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
+    // Keep the negative dispatch assertion fast while still allowing the mock service to be polled.
     let (
         mut chain_sync,
         _sync_status,
@@ -2501,6 +2502,8 @@ async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
         _mock_chain_tip_sender,
     ) = setup_chain_sync_with_options(Height(0), Duration::from_millis(50));
 
+    // Seed the post-NotFoundRegistry backoff state directly. Peer routing is covered elsewhere;
+    // this test follows sync_round across the retry deadline.
     let missing_hash = block::Hash::from([0xAB; 32]);
     chain_sync
         .handle_block_response_with_missing_retry(Err(BlockDownloadVerifyError::DownloadFailed {
@@ -2510,6 +2513,8 @@ async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
         .await
         .expect("a registry miss within budget should stay within the retry loop");
 
+    // The first reserve hash proves progress during the backoff. The second proves dispatch stays
+    // bounded until the missed hash has been retried.
     let first_reserve_hash = block::Hash::from([0x11; 32]);
     let second_reserve_hash = block::Hash::from([0x22; 32]);
     let reserve = [first_reserve_hash, second_reserve_hash]
@@ -2520,6 +2525,7 @@ async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
         let sync_round = chain_sync.sync_round(reserve);
         tokio::pin!(sync_round);
 
+        // Keep the round polled while the mock verifies the externally observable request order.
         tokio::select! {
             result = &mut sync_round => {
                 panic!("the sync round should still be waiting, got {result:?}")
@@ -2532,6 +2538,8 @@ async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
                         iter::once(first_reserve_hash).collect(),
                     ))
                     .await;
+
+                // This negative assertion distinguishes bounded dispatch from normal batching.
                 peer_set.expect_no_requests().await;
 
                 // Wait out the backoff (with margin for a delayed timer under test load): the
@@ -2539,11 +2547,16 @@ async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
                 // the deferred reserve hash.
                 tokio::time::sleep(sync::REGISTRY_MISS_RETRY_BACKOFF + Duration::from_millis(100))
                     .await;
+
+                // The retry timer is the first biased select arm, so the missed hash must be the
+                // next request rather than being overtaken by the deferred reserve hash.
                 let retry = peer_set
                     .expect_request(zn::Request::BlocksByHash(
                         iter::once(missing_hash).collect(),
                     ))
                     .await;
+
+                // Once the due retry is queued, the remaining reserve work may resume.
                 let second = peer_set
                     .expect_request(zn::Request::BlocksByHash(
                         iter::once(second_reserve_hash).collect(),
@@ -2555,6 +2568,8 @@ async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
         }
     };
 
+    // All three requests are deliberately left unanswered; cancel their download tasks before
+    // dropping the mock request handles.
     chain_sync.downloads.cancel_all();
     drop(requests);
 }

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2422,6 +2422,130 @@ async fn registry_miss_retry_accumulates_budget_for_the_same_block() {
     peer_set.expect_no_requests().await;
 }
 
+/// A registry-miss retry is specific to one hash, so it must not globally stall unrelated reserve
+/// work. Dispatch is limited to one hash per loop step so the retry timer remains reachable.
+#[tokio::test]
+async fn registry_miss_retry_allows_bounded_reserve_dispatch() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync_with_options(Height(0), Duration::from_millis(50));
+
+    let missing_hash = block::Hash::from([0xAB; 32]);
+    chain_sync
+        .handle_block_response_with_missing_retry(Err(BlockDownloadVerifyError::DownloadFailed {
+            error: not_found_registry_error(missing_hash),
+            hash: missing_hash,
+        }))
+        .await
+        .expect("a registry miss within budget should stay within the retry loop");
+
+    let first_reserve_hash = block::Hash::from([0x11; 32]);
+    let second_reserve_hash = block::Hash::from([0x22; 32]);
+    let reserve = [first_reserve_hash, second_reserve_hash]
+        .into_iter()
+        .collect();
+
+    let first_request = {
+        let sync_round = chain_sync.sync_round(reserve);
+        tokio::pin!(sync_round);
+
+        tokio::select! {
+            result = &mut sync_round => {
+                panic!("the sync round should still be waiting, got {result:?}")
+            }
+            request = async {
+                let request = peer_set
+                    .expect_request(zn::Request::BlocksByHash(
+                        iter::once(first_reserve_hash).collect(),
+                    ))
+                    .await;
+                peer_set.expect_no_requests().await;
+                request
+            } => request,
+        }
+    };
+
+    chain_sync.downloads.cancel_all();
+    drop(first_request);
+}
+
+/// The audit regression scenario: one required hash registry-misses while later reserve hashes
+/// are available. The missed hash must be retried on its backoff timer without blocking dispatch
+/// of the available reserve.
+#[tokio::test]
+async fn registry_missed_hash_retries_while_reserve_dispatch_continues() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync_with_options(Height(0), Duration::from_millis(50));
+
+    let missing_hash = block::Hash::from([0xAB; 32]);
+    chain_sync
+        .handle_block_response_with_missing_retry(Err(BlockDownloadVerifyError::DownloadFailed {
+            error: not_found_registry_error(missing_hash),
+            hash: missing_hash,
+        }))
+        .await
+        .expect("a registry miss within budget should stay within the retry loop");
+
+    let first_reserve_hash = block::Hash::from([0x11; 32]);
+    let second_reserve_hash = block::Hash::from([0x22; 32]);
+    let reserve = [first_reserve_hash, second_reserve_hash]
+        .into_iter()
+        .collect();
+
+    let requests = {
+        let sync_round = chain_sync.sync_round(reserve);
+        tokio::pin!(sync_round);
+
+        tokio::select! {
+            result = &mut sync_round => {
+                panic!("the sync round should still be waiting, got {result:?}")
+            }
+            requests = async {
+                // The first reserve hash is dispatched immediately; the second is deferred while
+                // the registry-miss retry is pending.
+                let first = peer_set
+                    .expect_request(zn::Request::BlocksByHash(
+                        iter::once(first_reserve_hash).collect(),
+                    ))
+                    .await;
+                peer_set.expect_no_requests().await;
+
+                // Wait out the backoff (with margin for a delayed timer under test load): the
+                // timer arm re-dispatches the missed hash, then the next loop step dispatches
+                // the deferred reserve hash.
+                tokio::time::sleep(sync::REGISTRY_MISS_RETRY_BACKOFF + Duration::from_millis(100))
+                    .await;
+                let retry = peer_set
+                    .expect_request(zn::Request::BlocksByHash(
+                        iter::once(missing_hash).collect(),
+                    ))
+                    .await;
+                let second = peer_set
+                    .expect_request(zn::Request::BlocksByHash(
+                        iter::once(second_reserve_hash).collect(),
+                    ))
+                    .await;
+
+                (first, retry, second)
+            } => requests,
+        }
+    };
+
+    chain_sync.downloads.cancel_all();
+    drop(requests);
+}
+
 fn setup() -> (
     // ChainSync
     impl Future<Output = Result<(), Report>> + Send,

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2426,6 +2426,7 @@ async fn registry_miss_retry_accumulates_budget_for_the_same_block() {
 /// work. Dispatch is limited to one hash per loop step so the retry timer remains reachable.
 #[tokio::test]
 async fn registry_miss_retry_allows_bounded_reserve_dispatch() {
+    // Keep negative request assertions fast while still allowing the mock service to be polled.
     let (
         mut chain_sync,
         _sync_status,
@@ -2435,6 +2436,8 @@ async fn registry_miss_retry_allows_bounded_reserve_dispatch() {
         _mock_chain_tip_sender,
     ) = setup_chain_sync_with_options(Height(0), Duration::from_millis(50));
 
+    // Seed the state produced after a required download returns NotFoundRegistry. Calling the
+    // handler directly keeps this test focused on sync-round scheduling rather than peer routing.
     let missing_hash = block::Hash::from([0xAB; 32]);
     chain_sync
         .handle_block_response_with_missing_retry(Err(BlockDownloadVerifyError::DownloadFailed {
@@ -2444,6 +2447,8 @@ async fn registry_miss_retry_allows_bounded_reserve_dispatch() {
         .await
         .expect("a registry miss within budget should stay within the retry loop");
 
+    // Two ordered hashes distinguish bounded progress from the normal full-reserve dispatch:
+    // the first must be queued now, while the second must remain deferred.
     let first_reserve_hash = block::Hash::from([0x11; 32]);
     let second_reserve_hash = block::Hash::from([0x22; 32]);
     let reserve = [first_reserve_hash, second_reserve_hash]
@@ -2454,22 +2459,30 @@ async fn registry_miss_retry_allows_bounded_reserve_dispatch() {
         let sync_round = chain_sync.sync_round(reserve);
         tokio::pin!(sync_round);
 
+        // Poll the sync round while observing its peer-set requests. The round should remain live
+        // because the registry retry is still scheduled for its future backoff deadline.
         tokio::select! {
             result = &mut sync_round => {
                 panic!("the sync round should still be waiting, got {result:?}")
             }
             request = async {
+                // Regression check: a pending retry must not globally suppress unrelated work.
                 let request = peer_set
                     .expect_request(zn::Request::BlocksByHash(
                         iter::once(first_reserve_hash).collect(),
                     ))
                     .await;
+
+                // Bounded-dispatch check: do not queue the second reserve hash before returning to
+                // the select loop, where the registry retry timer can be polled.
                 peer_set.expect_no_requests().await;
                 request
             } => request,
         }
     };
 
+    // The first request is deliberately left unanswered; cancel its download task before dropping
+    // the mock request handle so the test exits without leaving in-flight work behind.
     chain_sync.downloads.cancel_all();
     drop(first_request);
 }


### PR DESCRIPTION
Fixes: Zellic 3.5

## Motivation

While a required block waits out its registry-miss backoff, legacy chain sync pauses all new reserve dispatch, so one unavailable hash stalls otherwise-available sync work for up to the full retry budget (roughly two minutes) before the round restarts.

## Solution

While any registry-miss retry is pending, limit speculative dispatch to one hash per loop step instead of pausing it. Unrelated reserve hashes keep flowing, and the loop still reaches the `select!` retry timer promptly: dispatching the whole reserve can block on peer-set readiness until in-flight downloads drain, which would starve the timer.

No routing-cause split on `SharedPeerError` is needed: `PeerSet::poll_ready` only returns `Ready` with at least one ready peer, the peer set is only reachable through its `tower::Buffer` worker (which pairs `poll_ready` and `call` atomically per request), and `route_inv`'s failure branch takes no ready service, so a synthetic `NotFoundRegistry` always means every ready peer is marked missing the hash. Peer-set saturation surfaces as readiness backpressure, not as this error, and bounded dispatch is safe under saturation anyway. The pre-existing `pool.route_inv.notfound.no_ready.count` metric stays as a tripwire on that invariant.

## Changelog

Added `changelog-unreleased/393.md` under `Security`.

### Specifications & References

- [ZCA-831](https://linear.app/zcale/issue/ZCA-831/zellic-35-registry-miss-globally-stalls-sync-dispatch)
