### PR TITLE
fix: check best-tip context before async verification

### DIFF
--- a/changelog-unreleased/394.md
+++ b/changelog-unreleased/394.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR hardens internal verification scheduling without changing accepted transactions or
+operator configuration.

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -570,7 +570,7 @@ where
 
             tracing::trace!(?tx_id, "got state UTXOs");
 
-            let mut async_checks = match tx.as_ref() {
+            let async_checks = match tx.as_ref() {
                 Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
                     tracing::debug!(?tx, "got transaction with wrong version");
                     return Err(TransactionError::WrongVersion);
@@ -604,21 +604,19 @@ where
             };
 
             if let Some(unmined_tx) = mempool_transaction {
-                let check_anchors_and_revealed_nullifiers_query = state
+                // Await this contextual check before polling `async_checks`, because dropping an
+                // async verifier future does not cancel Rayon work it has already queued.
+                let response = state
                     .clone()
                     .oneshot(zs::Request::CheckBestChainTipNullifiersAndAnchors(
                         unmined_tx,
                     ))
-                    .map(|res| {
-                        assert!(
-                            res? == zs::Response::ValidBestChainTipNullifiersAndAnchors,
-                            "unexpected response to CheckBestChainTipNullifiersAndAnchors request"
-                        );
-                        Ok(())
-                    }
-                    );
+                    .await?;
 
-                async_checks.push(check_anchors_and_revealed_nullifiers_query);
+                assert!(
+                    response == zs::Response::ValidBestChainTipNullifiersAndAnchors,
+                    "unexpected response to CheckBestChainTipNullifiersAndAnchors request"
+                );
             }
 
             tracing::trace!(?tx_id, "awaiting async checks...");

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -1497,9 +1497,10 @@ async fn best_tip_state_error_precedes_async_verification_errors() {
         .activation_height(&Network::Mainnet)
         .expect("Canopy activation height is specified");
     let fund_height = (height - 1).expect("fake source fund block height is too small");
+    const SCRIPT_SHOULD_SUCCEED: bool = false;
     let (input, output, known_utxos) = mock_transparent_transfer(
         fund_height,
-        false,
+        SCRIPT_SHOULD_SUCCEED,
         0,
         Amount::try_from(10001).expect("invalid value"),
     );

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -1484,10 +1484,10 @@ async fn mempool_request_with_transparent_coinbase_spend_is_accepted_on_regtest(
         .expect("verification of transaction with mature spend to transparent outputs should pass");
 }
 
-/// Tests that errors from the read state service are correctly converted into
-/// transaction verifier errors.
+/// Tests that errors from the read state service are returned before asynchronous verifier errors
+/// and correctly converted into transaction verifier errors.
 #[tokio::test]
-async fn state_error_converted_correctly() {
+async fn best_tip_state_error_precedes_async_verification_errors() {
     use zakura_state::DuplicateNullifierError;
 
     let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
@@ -1499,7 +1499,7 @@ async fn state_error_converted_correctly() {
     let fund_height = (height - 1).expect("fake source fund block height is too small");
     let (input, output, known_utxos) = mock_transparent_transfer(
         fund_height,
-        true,
+        false,
         0,
         Amount::try_from(10001).expect("invalid value"),
     );
@@ -1533,7 +1533,7 @@ async fn state_error_converted_correctly() {
                     .map(|utxo| utxo.utxo.clone()),
             ));
 
-        state
+        let best_tip_request = state
             .expect_request_that(|req| {
                 matches!(
                     req,
@@ -1541,10 +1541,13 @@ async fn state_error_converted_correctly() {
                 )
             })
             .await
-            .expect("verifier should call mock state service with correct request")
-            .respond(Err::<zakura_state::Response, zakura_state::BoxError>(
-                make_validate_context_error().into(),
-            ));
+            .expect("verifier should call mock state service with correct request");
+
+        // Let the invalid script check win if it is incorrectly polled concurrently.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        best_tip_request.respond(Err::<zakura_state::Response, zakura_state::BoxError>(
+            make_validate_context_error().into(),
+        ));
     });
 
     let verifier_response = verifier

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -1497,10 +1497,10 @@ async fn best_tip_state_error_precedes_async_verification_errors() {
         .activation_height(&Network::Mainnet)
         .expect("Canopy activation height is specified");
     let fund_height = (height - 1).expect("fake source fund block height is too small");
-    const SCRIPT_SHOULD_SUCCEED: bool = false;
+    const REJECTING_SCRIPT: bool = false;
     let (input, output, known_utxos) = mock_transparent_transfer(
         fund_height,
-        SCRIPT_SHOULD_SUCCEED,
+        REJECTING_SCRIPT,
         0,
         Amount::try_from(10001).expect("invalid value"),
     );

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -1544,7 +1544,8 @@ async fn best_tip_state_error_precedes_async_verification_errors() {
             .await
             .expect("verifier should call mock state service with correct request");
 
-        // Let the invalid script check win if it is incorrectly polled concurrently.
+        // Delay the state error to verify that the rejecting script is not polled before
+        // the best-tip response is received.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         best_tip_request.respond(Err::<zakura_state::Response, zakura_state::BoxError>(
             make_validate_context_error().into(),


### PR DESCRIPTION
Fixes: OS-ZCA-ADV-06

## Motivation

Mempool best-tip anchor and nullifier validation currently runs in the same unordered future set as script and shielded authorization checks. Contextual validation can reject the transaction after verification jobs have been submitted. Dropping their waiters does not cancel those jobs, so queued or running verification continues to completion and its results are discarded, consuming shared CPU capacity.

## Solution

Await the mempool-only best-tip check before polling the lazy asynchronous authorization checks. Block verification is unchanged. The regression test now delays a contextual rejection alongside an invalid script and verifies that the contextual error is returned first.

## Changelog

Added `changelog-unreleased/394.md` with the explicit no-changelog marker because this changes internal scheduling without changing accepted transactions or operator configuration.