### PR TITLE
chore(release): fix v1.0.3 changelog link and end-of-support note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Allow chain synchronization to immediately retry an honest block body after
   rejecting a body with the same header hash, without waiting for another state
   request to trigger cleanup
-  ([#5](https://github.com/zakura-core/zakura-private/pull/5)).
+  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
 
 ## [1.0.2] - 2026-07-20
 

--- a/changelog-unreleased/396.md
+++ b/changelog-unreleased/396.md
@@ -1,0 +1,5 @@
+<!-- changelog: none -->
+
+Amends the released [1.0.3] changelog entry's advisory link and a stale
+version label in an `end_of_support.rs` doc comment; no operator-visible
+behavior change.

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -24,7 +24,7 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_420_400;
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
 /// - Currently set to 18 days
 ///
-/// Note: v1.0.3-rc0 spans the expected Ironwood activation (height 3,428,143,
+/// Note: v1.0.3 spans the expected Ironwood activation (height 3,428,143,
 /// ~2026-07-28) and halts about eleven days after it (~2026-08-08, height 3,441,136),
 /// forcing migration to the post-Ironwood release.
 pub const EOS_PANIC_AFTER: u32 = 18;


### PR DESCRIPTION
## Motivation

Two post-release amendments from the v1.0.3 retro:

- The published `[1.0.3]` security entry links `zakura-core/zakura-private#5` — the private staging repo's PR, a 404 for everyone outside the org.
- The `end_of_support.rs` support-window note still says "v1.0.3-rc0" (the rc line's phrasing; the concurrent regular-release branch had fixed this, the hotfix branch didn't).

## Solution

- Re-link the `[1.0.3]` security entry to the upstream advisory it follows up, [GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82) — the same link the v1.0.2 security entry used. (Amending a released section directly is the exception to the fragment flow, which only covers unreleased entries; the changelog CI check only inspects the fragment directory.)
- "v1.0.3-rc0" → "v1.0.3" in the end-of-support note. `ESTIMATED_RELEASE_HEIGHT` and the EOS math are unchanged — hotfixes never move end-of-support — so the dates/heights in the note stay accurate.

## Testing

- The GHSA URL returns 200 publicly.
- `cargo check -p zakura` passes (comment-only Rust change).
- `./scripts/changelog.py check` passes with the fragment.

## Changelog

`changelog-unreleased/<this-PR>.md` with the explicit no-changelog marker (added right after opening): amends a released entry's link and a doc comment; no operator-visible behavior change.

### Specifications & References

- v1.0.3 retro, smaller frictions: changelog private link; stale `end_of_support.rs` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)