### PR TITLE
ci: check crate semver against stable baselines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -140,6 +140,11 @@ snapshot the test rejects.
 If you're publishing crates for the first time, [log in to crates.io](https://github.com/zakura-core/zakura/dev/crate-owners.html#logging-in-to-cratesio),
 and make sure you're a member of owners group.
 
+The `Semver checks` CI job enforces bump-with-change against stable
+crates.io baselines on every Rust PR, so most bumps already exist by release
+time; the steps below review and complete them (for example, for non-API
+changes that still warrant publishing).
+
 Check that the release will work:
 
 - [ ] Review the changed-crate version advisory from `make pre-release`. It

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,91 @@
+# Gate PRs on cargo-semver-checks against the latest STABLE crates.io release
+# of each publishable workspace crate. A PR that changes a published API must
+# carry the corresponding version bump in the same PR — the check passes once
+# the bump level covers the change, so an intentional break plus its major
+# bump is green, and a second break in the same cycle needs no further bump.
+#
+# Retro driver: v1.0.3 shipped with semver debt discovered on release day
+# (#361 forced zakura-chain 2.0.0 / zakura-consensus 4.0.0 / zakura-script
+# 2.0.0 mid-incident). This job settles bump levels when the change merges,
+# not when the release is being cut.
+#
+# Notes:
+# - `--default-features` matches the documented release-prep invocation and
+#   keeps optional heavy features (e.g. lightwalletd-grpc-tests and its
+#   protoc dependency) out of the rustdoc builds. Feature-gated public APIs
+#   are not semver-checked, mirroring existing release practice.
+# - publish = false members (xtask, zakura-watchdog) are skipped automatically.
+# - A NEW publishable crate that has never been published to crates.io fails
+#   with "no baseline": add `--exclude <crate>` to the check command in the
+#   same PR that introduces the crate, and remove it after its first publish.
+# - Baseline downloads come from crates.io; an outage fails the job
+#   (deliberately fail-closed — re-run when the registry recovers).
+name: Semver checks
+
+on:
+  pull_request:
+    branches: [main, "feat/**", "release/**"]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - .github/workflows/semver-checks.yml
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - .github/workflows/semver-checks.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  semver-checks:
+    name: semver-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+          cache-key: semver-checks
+          cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # Deliberately unpinned (like cargo-hack): cargo-semver-checks must
+      # track new stable rustdoc formats; pin only if a regression forces it.
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 #v2.83.2
+        with:
+          tool: cargo-semver-checks
+
+      - uses: ./.github/actions/setup-zakura-build
+
+      - name: Check workspace crates against stable crates.io baselines
+        run: cargo semver-checks --workspace --default-features
+
+      - name: Explain the failure
+        if: failure()
+        run: |
+          cat >&2 <<'EOF'
+          cargo-semver-checks found published-API changes not covered by a
+          version bump. Either bump the affected crate in THIS PR to the
+          level the report requires:
+
+            cargo release version --verbose --execute --allow-branch '*' -p <crate> major|minor
+
+          (this also rewrites workspace-internal dependency requirements),
+          or revert the API change if it was accidental. See
+          CHANGELOG_GUIDELINES.md ("Library crates") and the release
+          checklist ("Update Crate Versions").
+          EOF

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -57,11 +57,27 @@ jobs:
           persist-credentials: false
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        id: toolchain
         with:
           toolchain: stable
           cache-key: semver-checks
           cache-on-failure: true
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # cargo-semver-checks reuses generated baseline rustdoc JSON from
+      # target/semver-checks/cache (~1-2 MB per crate baseline; a hit skips
+      # that baseline's download and rustdoc build entirely). rust-cache's
+      # target-dir cleaner deletes unrecognized target/ entries before
+      # saving, so this cache needs its own steps. Keyed on the rustc
+      # version: the rustdoc JSON format (and the tool's own invalidation)
+      # rotates with the toolchain. The run_id suffix makes every main run
+      # save a fresh entry; restores prefix-match the newest one.
+      - name: Restore baseline rustdoc cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: target/semver-checks/cache
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ github.run_id }}
+          restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       # Deliberately unpinned (like cargo-hack): cargo-semver-checks must
       # track new stable rustdoc formats; pin only if a regression forces it.
@@ -73,6 +89,13 @@ jobs:
 
       - name: Check workspace crates against stable crates.io baselines
         run: cargo semver-checks --workspace --default-features
+
+      - name: Save baseline rustdoc cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: target/semver-checks/cache
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ github.run_id }}
 
       - name: Explain the failure
         if: failure()

--- a/.github/workflows/status-checks.patch.yml
+++ b/.github/workflows/status-checks.patch.yml
@@ -9,8 +9,9 @@ on:
   pull_request:
     branches: [main, "feat/**", "release/**"]
     paths-ignore:
-      # This MUST be an exact inverse of paths in lint.yml, tests-unit.yml, and test-crates.yml
-      # to ensure mutual exclusion - only one set of workflows runs
+      # This MUST be an exact inverse of paths in lint.yml, tests-unit.yml,
+      # test-crates.yml, and semver-checks.yml to ensure mutual exclusion -
+      # only one set of workflows runs
       - '**/*.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
@@ -21,6 +22,7 @@ on:
       - .github/workflows/lint.yml
       - .github/workflows/tests-unit.yml
       - .github/workflows/test-crates.yml
+      - .github/workflows/semver-checks.yml
 
 permissions:
   contents: read
@@ -43,3 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No crate build needed - no Rust files modified"
+
+  semver-checks:
+    name: semver-checks
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No semver checks needed - no Rust files modified"

--- a/CHANGELOG_GUIDELINES.md
+++ b/CHANGELOG_GUIDELINES.md
@@ -88,10 +88,19 @@ is in
 
 ## Library crates
 
-The repository does not maintain per-crate changelogs. Release preparation
-uses `cargo semver-checks`, `cargo public-api diff`, and the code diff to choose
-version bumps for changed publishable crates. Those checks are release inputs,
-not permanent changelog entries.
+The repository does not maintain per-crate changelogs. Version bumps for
+published-API changes land **in the PR that makes the change**: the
+`Semver checks` CI job compares every publishable crate against its latest
+stable crates.io release, and a PR that changes a published API must carry
+the version bump that covers it —
+
+```sh
+cargo release version --verbose --execute --allow-branch '*' -p <crate> major # [ minor ]
+```
+
+(which also rewrites workspace-internal dependency requirements). Release
+preparation reviews the accumulated bumps — with `cargo public-api diff` and
+the code diff where useful — rather than originating them on release day.
 
 ## Release assembly
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ PRs are welcome. Please:
 2. **Keep PRs focused.** Prefer one logical change per PR and avoid unrelated refactors.
 3. **Test the change.** Run checks appropriate to the affected code. Explain how the tests exercise the root cause and verify the solution, rather than only listing commands.
 4. **Follow conventional commits.** PRs are squash-merged to `main`, so the PR title becomes the commit message. Follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) standard.
+5. **Carry semver bumps with API changes.** The `Semver checks` CI job compares publishable crates against their latest stable crates.io releases; a PR that changes a published API must bump the affected crate's version in the same PR (see [`CHANGELOG_GUIDELINES.md`](CHANGELOG_GUIDELINES.md), "Library crates").
 
 Zakura is a validator node — it excludes features not strictly needed for block validation and chain sync. Features like wallets, block explorers, and mining pools belong in [Zaino](https://github.com/zingolabs/zaino), [Zallet](https://github.com/zcash/wallet), or [librustzcash](https://github.com/zcash/librustzcash).
 

--- a/changelog-unreleased/397.md
+++ b/changelog-unreleased/397.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+Adds the Semver checks CI workflow and a cargo-semver-checks lint-level
+override in zakura-test's manifest; CI-only, no operator-visible effect.

--- a/zakura-test/Cargo.toml
+++ b/zakura-test/Cargo.toml
@@ -48,3 +48,11 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
+
+# `MockService` deliberately has two same-named inherent methods per
+# assertion type (`expect_no_requests` on the panic impl returns `()`, on
+# the proptest impl returns `Result`). cargo-semver-checks pairs inherent
+# methods by name across impl blocks, so this lint false-positives at
+# version parity — verified against the byte-identical published 2.0.0.
+[package.metadata.cargo-semver-checks.lints]
+inherent_method_now_returns_unit = "allow"


### PR DESCRIPTION
## Motivation

Retro finding 3 from the v1.0.3 hotfix: semver debt surfaced on release day. After the rc cuts, #361 removed public API still present in the published stable crates, so the rc line's planned patch de-rcs were semver violations — found only because release prep happened to run `cargo semver-checks` against stable baselines, forcing majors (zakura-chain 2.0.0, zakura-consensus 4.0.0, zakura-script 2.0.0) plus a second bump-and-merge cycle mid-incident. The concurrent regular release would have shipped all of those violations. Root cause: nothing checks PRs against the *published stable* API surface, so bump levels stay unsettled until release day.

## Solution

New `Semver checks` workflow: `cargo semver-checks --workspace --default-features` against each publishable crate's latest stable crates.io release, on every Rust PR (paths-filtered to `**/*.rs`, `**/Cargo.toml`, `**/Cargo.lock`), push to `main`, and manual dispatch. The check is version-aware — an intentional break passes once the PR carries the covering bump — so this enforces bump-with-change at merge time (CONTRIBUTING.md item 5; CHANGELOG_GUIDELINES.md "Library crates" rewritten; release checklist notes that release prep now reviews accumulated bumps rather than originating them).

Design notes:

- `--default-features` matches the release checklist's documented invocation and keeps optional heavy features out of the rustdoc builds (the all-features heuristic pulls in `lightwalletd-grpc-tests`, whose build script needs `protoc`). Feature-gated public APIs are not semver-checked, mirroring existing release practice.
- Raw CLI with the repo's pinned `setup-rust-toolchain`/`taiki-e/install-action` steps and cache-saves-on-main policy, instead of `obi1kenobi/cargo-semver-checks-action` (which manages its own toolchain and cache). `setup-zakura-build` supplies protoc/RocksDB for the workspace rustdoc builds.
- `status-checks.patch.yml` gains the matching `paths-ignore` entry and a `semver-checks` shim job, so the check can be flipped to required later. (No ruleset currently declares required checks; if a native merge queue ever requires this check, a `merge_group` no-op job must be added too.)
- Fail-closed on crates.io outages — a silent fail-open would recreate the retro problem; the job is re-runnable.
- New never-published crates fail with "no baseline": the workflow header documents adding a temporary `--exclude <crate>` in the introducing PR.

**zakura-test lint override** (the one non-mechanical bit): `MockService` deliberately has two same-named `expect_no_requests` methods (the panic-assertion impl returns `()`, the proptest impl returns `Result`). cargo-semver-checks pairs inherent methods by name across impl blocks, so `inherent_method_now_returns_unit` fires even at version parity — verified against the byte-identical published 2.0.0, meaning no bump can ever clear it (and the v1.0.3 incident's zakura-test 2.0.0 bump was plausibly chasing this same artifact). `zakura-test/Cargo.toml` sets that one lint to `allow` with a comment.

## Testing

- Full local run of the exact CI command (`cargo semver-checks --workspace --default-features`, cargo-semver-checks 0.49.0) in a dedicated worktree at `origin/main`: all publishable crates pass against their crates.io stable baselines with the lint override in place; `publish = false` members (xtask, zakura-watchdog) are skipped automatically. Cold all-features sweep earlier measured ~17 min locally; `timeout-minutes: 90` gives CI headroom.
- The false positive was verified byte-level: published `zakura-test-2.0.0.crate` downloaded from static.crates.io and diffed against the workspace — identical `mock_service.rs`, lint still fired without the override; passes with it (`222 pass, 31 skip`).
- `actionlint` clean on both workflow files.
- This PR itself touches `Cargo.toml`, so the real `semver-checks` job runs on this PR — its result is the end-to-end CI validation.

## Changelog

`changelog-unreleased/<this-PR>.md` with the explicit no-changelog marker (added right after opening): CI + a lint-config-only `Cargo.toml` change, no operator-visible effect.

### Specifications & References

- v1.0.3 retro finding 3; cargo-semver-checks baseline selection verified from source (latest non-yanked non-prerelease registry version, capped at the current version)

### Follow-up Work

- Consider making `semver-checks` a required status check once it has a few weeks of history
- Fix or rename-away the `MockService` same-name pattern upstream if the false positive class ever bites another crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)