### PR TITLE
fix(state): bind block headers to resolved hashes

### DIFF
--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -1897,10 +1897,19 @@ impl Service<ReadRequest> for ReadStateService {
                                 contextual.block.header.clone(),
                                 contextual.hash,
                                 height,
-                                height
-                                    .next()
-                                    .ok()
-                                    .and_then(|next_height| chain.hash_by_height(next_height)),
+                                height.next().ok().and_then(|next_height| {
+                                    chain.hash_by_height(next_height).or_else(|| {
+                                        state
+                                            .db
+                                            .block_header(next_height.into())
+                                            .filter(|next_header| {
+                                                next_header.previous_block_hash == contextual.hash
+                                            })
+                                            .map(|next_header| {
+                                                block::Hash::from(next_header.as_ref())
+                                            })
+                                    })
+                                }),
                             )
                         })
                     })

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -1904,7 +1904,7 @@ impl Service<ReadRequest> for ReadStateService {
                 let next_block_hash =
                     read::find::hash_by_height(best_chain.clone(), &state.db, next_height);
 
-                let header = read::block_header(best_chain, &state.db, height.into())
+                let header = read::block_header(best_chain, &state.db, hash.into())
                     .ok_or_else(|| BoxError::from("block hash or height not found"))?;
 
                 Ok(ReadResponse::BlockHeader {

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -1888,28 +1888,33 @@ impl Service<ReadRequest> for ReadStateService {
             ReadRequest::BlockHeader(hash_or_height) => {
                 let best_chain = state.latest_best_chain();
 
-                let height = hash_or_height
-                    .height_or_else(|hash| {
-                        read::find::height_by_hash(best_chain.clone(), &state.db, hash)
+                let (header, hash, height, next_block_hash) = best_chain
+                    .as_ref()
+                    .and_then(|chain| {
+                        chain.block(hash_or_height).map(|contextual| {
+                            let height = contextual.height;
+                            (
+                                contextual.block.header.clone(),
+                                contextual.hash,
+                                height,
+                                height
+                                    .next()
+                                    .ok()
+                                    .and_then(|next_height| chain.hash_by_height(next_height)),
+                            )
+                        })
                     })
-                    .ok_or_else(|| BoxError::from("block hash or height not found"))?;
+                    .or_else(|| {
+                        let height = hash_or_height.height_or_else(|hash| state.db.height(hash))?;
+                        let hash = hash_or_height.hash_or_else(|height| state.db.hash(height))?;
+                        let header = state.db.block_header(height.into())?;
+                        let next_block_hash = height
+                            .next()
+                            .ok()
+                            .and_then(|next_height| state.db.hash(next_height));
 
-                let hash = hash_or_height
-                    .hash_or_else(|height| {
-                        read::find::hash_by_height(best_chain.clone(), &state.db, height)
+                        Some((header, hash, height, next_block_hash))
                     })
-                    .ok_or_else(|| BoxError::from("block hash or height not found"))?;
-
-                let next_height = height.next()?;
-                let next_block_hash =
-                    read::find::hash_by_height(best_chain.clone(), &state.db, next_height).filter(
-                        |next_hash| {
-                            read::block_header(best_chain.clone(), &state.db, (*next_hash).into())
-                                .is_some_and(|next_header| next_header.previous_block_hash == hash)
-                        },
-                    );
-
-                let header = read::block_header(best_chain, &state.db, hash.into())
                     .ok_or_else(|| BoxError::from("block hash or height not found"))?;
 
                 Ok(ReadResponse::BlockHeader {

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -1908,10 +1908,17 @@ impl Service<ReadRequest> for ReadStateService {
                         let height = hash_or_height.height_or_else(|hash| state.db.height(hash))?;
                         let hash = hash_or_height.hash_or_else(|height| state.db.hash(height))?;
                         let header = state.db.block_header(height.into())?;
-                        let next_block_hash = height
-                            .next()
-                            .ok()
-                            .and_then(|next_height| state.db.hash(next_height));
+                        let next_block_hash = height.next().ok().and_then(|next_height| {
+                            state.db.hash(next_height).or_else(|| {
+                                best_chain
+                                    .as_ref()
+                                    .and_then(|chain| chain.block(next_height.into()))
+                                    .filter(|next_block| {
+                                        next_block.block.header.previous_block_hash == hash
+                                    })
+                                    .map(|next_block| next_block.hash)
+                            })
+                        });
 
                         Some((header, hash, height, next_block_hash))
                     })

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -1902,7 +1902,12 @@ impl Service<ReadRequest> for ReadStateService {
 
                 let next_height = height.next()?;
                 let next_block_hash =
-                    read::find::hash_by_height(best_chain.clone(), &state.db, next_height);
+                    read::find::hash_by_height(best_chain.clone(), &state.db, next_height).filter(
+                        |next_hash| {
+                            read::block_header(best_chain.clone(), &state.db, (*next_hash).into())
+                                .is_some_and(|next_header| next_header.previous_block_hash == hash)
+                        },
+                    );
 
                 let header = read::block_header(best_chain, &state.db, hash.into())
                     .ok_or_else(|| BoxError::from("block hash or height not found"))?;

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -40,8 +40,8 @@ use crate::{
         setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
         FakeChainHelper,
     },
-    BoxError, CheckpointVerifiedBlock, Config, ReadRequest, ReadResponse, Request, Response,
-    SemanticallyVerifiedBlock, CHAIN_TIP_UPDATE_WAIT_LIMIT,
+    BoxError, CheckpointVerifiedBlock, Config, HashOrHeight, ReadRequest, ReadResponse, Request,
+    Response, SemanticallyVerifiedBlock, CHAIN_TIP_UPDATE_WAIT_LIMIT,
 };
 
 const LAST_BLOCK_HEIGHT: u32 = 10;
@@ -1575,7 +1575,7 @@ fn read_only_open_with_ephemeral_config_returns_error() {
 }
 
 /// A delayed read can retain a pre-reorg chain after the winning fork has finalized.
-/// A lookup must resolve the header and successor from one source.
+/// A lookup must keep the header and successor on one lineage.
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Result<()> {
     use crate::{
@@ -1635,6 +1635,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     let (_checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
     let (_repair_sender, repair_receiver) =
         tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let (_header_root_auth_sender, header_root_auth_receiver) = tokio::sync::watch::channel(None);
     let read_state = ReadStateService::new(
         &finalized_state,
         None,
@@ -1642,6 +1643,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
         checkpoint_receiver,
         None,
         repair_receiver,
+        header_root_auth_receiver,
     );
     let winning_finalized = FinalizedBlock::from_checkpoint_verified(
         CheckpointVerifiedBlock::from(winning_block.clone()),
@@ -1662,6 +1664,26 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
             None,
         )
         .unwrap();
+    finalized_state.db.write_batch(batch).unwrap();
+    let response = read_state
+        .clone()
+        .oneshot(ReadRequest::BlockHeader(winning_block.hash().into()))
+        .await
+        .unwrap();
+    let ReadResponse::BlockHeader {
+        header,
+        hash,
+        height,
+        next_block_hash,
+    } = response
+    else {
+        unreachable!();
+    };
+    assert_eq!(height, winning_height);
+    assert_eq!(hash, winning_block.hash());
+    assert_eq!(block::Hash::from(header.as_ref()), winning_block.hash());
+    assert_eq!(next_block_hash, None);
+    let mut batch = DiskWriteBatch::new();
     batch
         .prepare_block_header_and_transaction_data_batch(
             &finalized_state.db,
@@ -1671,6 +1693,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
         )
         .unwrap();
     finalized_state.db.write_batch(batch).unwrap();
+
     let response = read_state
         .clone()
         .oneshot(ReadRequest::BlockHeader(winning_block.hash().into()))
@@ -1707,5 +1730,104 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     assert_eq!(hash, stale_hash);
     assert_eq!(block::Hash::from(header.as_ref()), stale_hash);
     assert_eq!(next_block_hash, Some(stale_child_hash));
+    Ok(())
+}
+
+/// The finalized tip can have a known child in the retained non-finalized chain.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_header_lookup_preserves_finalized_boundary_successor() -> Result<()> {
+    use crate::{
+        request::{FinalizedBlock, Treestate},
+        service::{
+            finalized_state::DiskWriteBatch, non_finalized_state::NonFinalizedState,
+            watch_receiver::WatchReceiver, ReadStateService, VctRootRepairStatus,
+        },
+    };
+
+    let _init_guard = zakura_test::init();
+    let network = Network::Mainnet;
+    let parent = Arc::new(network.test_block(653599, 583999).unwrap());
+    let parent_hash = parent.hash();
+    let parent_height = parent.coinbase_height().unwrap();
+    let child = parent.make_fake_child();
+    let child_hash = child.hash();
+    assert_eq!(child.header.previous_block_hash, parent_hash);
+
+    let config = Config::ephemeral();
+    let finalized_state = FinalizedState::new(&config, &network).unwrap();
+    let mut retained_state = NonFinalizedState::new(&network);
+    retained_state
+        .commit_new_chain(parent.clone().prepare(), &finalized_state)
+        .unwrap();
+    retained_state
+        .commit_block(child.prepare(), &finalized_state)
+        .unwrap();
+    drop(retained_state.finalize());
+    assert!(retained_state
+        .best_chain()
+        .and_then(|chain| chain.block(parent_hash.into()))
+        .is_none());
+    assert_eq!(
+        retained_state
+            .best_chain()
+            .and_then(|chain| chain.block(parent_height.next().unwrap().into()))
+            .map(|block| block.hash),
+        Some(child_hash)
+    );
+
+    let (_retained_sender, retained_receiver) = tokio::sync::watch::channel(retained_state);
+    let (_checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
+    let (_repair_sender, repair_receiver) =
+        tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let (_header_root_auth_sender, header_root_auth_receiver) = tokio::sync::watch::channel(None);
+    let read_state = ReadStateService::new(
+        &finalized_state,
+        None,
+        WatchReceiver::new(retained_receiver),
+        checkpoint_receiver,
+        None,
+        repair_receiver,
+        header_root_auth_receiver,
+    );
+
+    let parent_finalized = FinalizedBlock::from_checkpoint_verified(
+        CheckpointVerifiedBlock::from(parent.clone()),
+        Treestate::default(),
+    );
+    let mut batch = DiskWriteBatch::new();
+    batch
+        .prepare_block_header_and_transaction_data_batch(
+            &finalized_state.db,
+            &parent_finalized,
+            false,
+            None,
+        )
+        .unwrap();
+    finalized_state.db.write_batch(batch).unwrap();
+
+    for hash_or_height in [
+        HashOrHeight::from(parent_hash),
+        HashOrHeight::from(parent_height),
+    ] {
+        let response = read_state
+            .clone()
+            .oneshot(ReadRequest::BlockHeader(hash_or_height))
+            .await
+            .unwrap();
+        let ReadResponse::BlockHeader {
+            header,
+            hash,
+            height,
+            next_block_hash,
+        } = response
+        else {
+            unreachable!();
+        };
+        assert_eq!(height, parent_height);
+        assert_eq!(hash, parent_hash);
+        assert_eq!(block::Hash::from(header.as_ref()), parent_hash);
+        assert_eq!(next_block_hash, Some(child_hash));
+    }
+
     Ok(())
 }

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -1573,3 +1573,93 @@ fn read_only_open_with_ephemeral_config_returns_error() {
         }
     }
 }
+
+/// A delayed read can retain a pre-reorg chain after the winning fork has finalized.
+/// Looking up the requested finalized hash by height must not return the stale fork's header.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Result<()> {
+    use crate::{
+        request::{FinalizedBlock, Treestate},
+        service::{
+            finalized_state::DiskWriteBatch, non_finalized_state::NonFinalizedState,
+            watch_receiver::WatchReceiver, ReadStateService, VctRootRepairStatus,
+        },
+    };
+
+    let _init_guard = zakura_test::init();
+    let network = Network::Mainnet;
+    let winning_block = Arc::new(network.test_block(653599, 583999).unwrap());
+    let config = Config::ephemeral();
+    let finalized_state = FinalizedState::new(
+        &config,
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .unwrap();
+    let mut stale_block = winning_block.clone();
+    // Production inserts blocks only after semantic verification. This state-layer
+    // regression bypasses that boundary and mutates the nonce only to give the
+    // retained fork a distinct block identity.
+    Arc::make_mut(&mut Arc::make_mut(&mut stale_block).header)
+        .nonce
+        .0[0] ^= 1;
+    let stale_hash = stale_block.hash();
+    let winning_height = winning_block.coinbase_height().unwrap();
+    assert_ne!(stale_hash, winning_block.hash());
+    let mut stale_state = NonFinalizedState::new(&network);
+    stale_state
+        .commit_new_chain(stale_block.prepare(), &finalized_state)
+        .unwrap();
+    assert_eq!(
+        stale_state
+            .best_chain()
+            .and_then(|chain| chain.hash_by_height(winning_height)),
+        Some(stale_hash)
+    );
+    let (_stale_sender, stale_receiver) = tokio::sync::watch::channel(stale_state);
+    let (_checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
+    let (_repair_sender, repair_receiver) =
+        tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let read_state = ReadStateService::new(
+        &finalized_state,
+        None,
+        WatchReceiver::new(stale_receiver),
+        checkpoint_receiver,
+        None,
+        repair_receiver,
+    );
+    let winning_finalized = FinalizedBlock::from_checkpoint_verified(
+        CheckpointVerifiedBlock::from(winning_block.clone()),
+        Treestate::default(),
+    );
+    // Use the production finalization sub-batch to stage every database row this
+    // handler reads. Ancestor and tip metadata are irrelevant to this request.
+    let mut batch = DiskWriteBatch::new();
+    batch
+        .prepare_block_header_and_transaction_data_batch(
+            &finalized_state.db,
+            &winning_finalized,
+            false,
+            None,
+        )
+        .unwrap();
+    finalized_state.db.write_batch(batch).unwrap();
+    let response = read_state
+        .oneshot(ReadRequest::BlockHeader(winning_block.hash().into()))
+        .await
+        .unwrap();
+    let ReadResponse::BlockHeader {
+        header,
+        hash,
+        height,
+        ..
+    } = response
+    else {
+        unreachable!();
+    };
+    assert_eq!(height, winning_height);
+    assert_eq!(hash, winning_block.hash());
+    assert_eq!(block::Hash::from(header.as_ref()), winning_block.hash());
+    Ok(())
+}

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -1590,13 +1590,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     let network = Network::Mainnet;
     let winning_block = Arc::new(network.test_block(653599, 583999).unwrap());
     let config = Config::ephemeral();
-    let finalized_state = FinalizedState::new(
-        &config,
-        &network,
-        #[cfg(feature = "elasticsearch")]
-        false,
-    )
-    .unwrap();
+    let finalized_state = FinalizedState::new(&config, &network).unwrap();
     let mut stale_block = winning_block.clone();
     // Production inserts blocks only after semantic verification. This state-layer
     // regression bypasses that boundary and mutates the nonce only to give the
@@ -1612,6 +1606,11 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     let winning_height = winning_block.coinbase_height().unwrap();
     assert_ne!(stale_hash, winning_block.hash());
     assert_ne!(stale_child_hash, winning_child_hash);
+    let mut stale_tip_state = NonFinalizedState::new(&network);
+    stale_tip_state
+        .commit_new_chain(stale_block.clone().prepare(), &finalized_state)
+        .unwrap();
+
     let mut stale_state = NonFinalizedState::new(&network);
     stale_state
         .commit_new_chain(stale_block.prepare(), &finalized_state)
@@ -1631,7 +1630,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
             .and_then(|chain| chain.hash_by_height(winning_height.next().unwrap())),
         Some(stale_child_hash)
     );
-    let (_stale_sender, stale_receiver) = tokio::sync::watch::channel(stale_state);
+    let (stale_sender, stale_receiver) = tokio::sync::watch::channel(stale_state);
     let (_checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
     let (_repair_sender, repair_receiver) =
         tokio::sync::watch::channel(VctRootRepairStatus::default());
@@ -1714,6 +1713,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     assert_eq!(next_block_hash, Some(winning_child_hash));
 
     let response = read_state
+        .clone()
         .oneshot(ReadRequest::BlockHeader(winning_height.into()))
         .await
         .unwrap();
@@ -1730,10 +1730,28 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     assert_eq!(hash, stale_hash);
     assert_eq!(block::Hash::from(header.as_ref()), stale_hash);
     assert_eq!(next_block_hash, Some(stale_child_hash));
+    stale_sender.send_replace(stale_tip_state);
+    let response = read_state
+        .oneshot(ReadRequest::BlockHeader(stale_hash.into()))
+        .await
+        .unwrap();
+    let ReadResponse::BlockHeader {
+        header,
+        hash,
+        height,
+        next_block_hash,
+    } = response
+    else {
+        unreachable!();
+    };
+    assert_eq!(height, winning_height);
+    assert_eq!(hash, stale_hash);
+    assert_eq!(block::Hash::from(header.as_ref()), stale_hash);
+    assert_eq!(next_block_hash, None);
     Ok(())
 }
 
-/// The finalized tip can have a known child in the retained non-finalized chain.
+/// A best-chain successor can cross either finalized/non-finalized state boundary.
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header_lookup_preserves_finalized_boundary_successor() -> Result<()> {
     use crate::{
@@ -1755,12 +1773,17 @@ async fn block_header_lookup_preserves_finalized_boundary_successor() -> Result<
 
     let config = Config::ephemeral();
     let finalized_state = FinalizedState::new(&config, &network).unwrap();
+    let mut retained_tip_state = NonFinalizedState::new(&network);
+    retained_tip_state
+        .commit_new_chain(parent.clone().prepare(), &finalized_state)
+        .unwrap();
+
     let mut retained_state = NonFinalizedState::new(&network);
     retained_state
         .commit_new_chain(parent.clone().prepare(), &finalized_state)
         .unwrap();
     retained_state
-        .commit_block(child.prepare(), &finalized_state)
+        .commit_block(child.clone().prepare(), &finalized_state)
         .unwrap();
     drop(retained_state.finalize());
     assert!(retained_state
@@ -1775,7 +1798,7 @@ async fn block_header_lookup_preserves_finalized_boundary_successor() -> Result<
         Some(child_hash)
     );
 
-    let (_retained_sender, retained_receiver) = tokio::sync::watch::channel(retained_state);
+    let (retained_sender, retained_receiver) = tokio::sync::watch::channel(retained_state);
     let (_checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
     let (_repair_sender, repair_receiver) =
         tokio::sync::watch::channel(VctRootRepairStatus::default());
@@ -1828,6 +1851,40 @@ async fn block_header_lookup_preserves_finalized_boundary_successor() -> Result<
         assert_eq!(block::Hash::from(header.as_ref()), parent_hash);
         assert_eq!(next_block_hash, Some(child_hash));
     }
+
+    retained_sender.send_replace(retained_tip_state);
+    let child_finalized = FinalizedBlock::from_checkpoint_verified(
+        CheckpointVerifiedBlock::from(child),
+        Treestate::default(),
+    );
+    let mut batch = DiskWriteBatch::new();
+    batch
+        .prepare_block_header_and_transaction_data_batch(
+            &finalized_state.db,
+            &child_finalized,
+            false,
+            None,
+        )
+        .unwrap();
+    finalized_state.db.write_batch(batch).unwrap();
+
+    let response = read_state
+        .oneshot(ReadRequest::BlockHeader(parent_hash.into()))
+        .await
+        .unwrap();
+    let ReadResponse::BlockHeader {
+        header,
+        hash,
+        height,
+        next_block_hash,
+    } = response
+    else {
+        unreachable!();
+    };
+    assert_eq!(height, parent_height);
+    assert_eq!(hash, parent_hash);
+    assert_eq!(block::Hash::from(header.as_ref()), parent_hash);
+    assert_eq!(next_block_hash, Some(child_hash));
 
     Ok(())
 }

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -1575,7 +1575,7 @@ fn read_only_open_with_ephemeral_config_returns_error() {
 }
 
 /// A delayed read can retain a pre-reorg chain after the winning fork has finalized.
-/// A hash lookup must not mix the finalized header with the stale fork's successor.
+/// A lookup must resolve the header and successor from one source.
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Result<()> {
     use crate::{
@@ -1607,8 +1607,11 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     let stale_hash = stale_block.hash();
     let stale_child = stale_block.make_fake_child();
     let stale_child_hash = stale_child.hash();
+    let winning_child = winning_block.make_fake_child();
+    let winning_child_hash = winning_child.hash();
     let winning_height = winning_block.coinbase_height().unwrap();
     assert_ne!(stale_hash, winning_block.hash());
+    assert_ne!(stale_child_hash, winning_child_hash);
     let mut stale_state = NonFinalizedState::new(&network);
     stale_state
         .commit_new_chain(stale_block.prepare(), &finalized_state)
@@ -1644,6 +1647,10 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
         CheckpointVerifiedBlock::from(winning_block.clone()),
         Treestate::default(),
     );
+    let winning_child_finalized = FinalizedBlock::from_checkpoint_verified(
+        CheckpointVerifiedBlock::from(winning_child),
+        Treestate::default(),
+    );
     // Use the production finalization sub-batch to stage every database row this
     // handler reads. Ancestor and tip metadata are irrelevant to this request.
     let mut batch = DiskWriteBatch::new();
@@ -1651,6 +1658,14 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
         .prepare_block_header_and_transaction_data_batch(
             &finalized_state.db,
             &winning_finalized,
+            false,
+            None,
+        )
+        .unwrap();
+    batch
+        .prepare_block_header_and_transaction_data_batch(
+            &finalized_state.db,
+            &winning_child_finalized,
             false,
             None,
         )
@@ -1673,7 +1688,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     assert_eq!(height, winning_height);
     assert_eq!(hash, winning_block.hash());
     assert_eq!(block::Hash::from(header.as_ref()), winning_block.hash());
-    assert_eq!(next_block_hash, None);
+    assert_eq!(next_block_hash, Some(winning_child_hash));
 
     let response = read_state
         .oneshot(ReadRequest::BlockHeader(winning_height.into()))

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -1575,7 +1575,7 @@ fn read_only_open_with_ephemeral_config_returns_error() {
 }
 
 /// A delayed read can retain a pre-reorg chain after the winning fork has finalized.
-/// Looking up the requested finalized hash by height must not return the stale fork's header.
+/// A hash lookup must not mix the finalized header with the stale fork's successor.
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Result<()> {
     use crate::{
@@ -1605,17 +1605,28 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
         .nonce
         .0[0] ^= 1;
     let stale_hash = stale_block.hash();
+    let stale_child = stale_block.make_fake_child();
+    let stale_child_hash = stale_child.hash();
     let winning_height = winning_block.coinbase_height().unwrap();
     assert_ne!(stale_hash, winning_block.hash());
     let mut stale_state = NonFinalizedState::new(&network);
     stale_state
         .commit_new_chain(stale_block.prepare(), &finalized_state)
         .unwrap();
+    stale_state
+        .commit_block(stale_child.prepare(), &finalized_state)
+        .unwrap();
     assert_eq!(
         stale_state
             .best_chain()
             .and_then(|chain| chain.hash_by_height(winning_height)),
         Some(stale_hash)
+    );
+    assert_eq!(
+        stale_state
+            .best_chain()
+            .and_then(|chain| chain.hash_by_height(winning_height.next().unwrap())),
+        Some(stale_child_hash)
     );
     let (_stale_sender, stale_receiver) = tokio::sync::watch::channel(stale_state);
     let (_checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
@@ -1646,6 +1657,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
         .unwrap();
     finalized_state.db.write_batch(batch).unwrap();
     let response = read_state
+        .clone()
         .oneshot(ReadRequest::BlockHeader(winning_block.hash().into()))
         .await
         .unwrap();
@@ -1653,7 +1665,7 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
         header,
         hash,
         height,
-        ..
+        next_block_hash,
     } = response
     else {
         unreachable!();
@@ -1661,5 +1673,24 @@ async fn block_header_hash_lookup_does_not_mix_stale_and_finalized_forks() -> Re
     assert_eq!(height, winning_height);
     assert_eq!(hash, winning_block.hash());
     assert_eq!(block::Hash::from(header.as_ref()), winning_block.hash());
+    assert_eq!(next_block_hash, None);
+
+    let response = read_state
+        .oneshot(ReadRequest::BlockHeader(winning_height.into()))
+        .await
+        .unwrap();
+    let ReadResponse::BlockHeader {
+        header,
+        hash,
+        height,
+        next_block_hash,
+    } = response
+    else {
+        unreachable!();
+    };
+    assert_eq!(height, winning_height);
+    assert_eq!(hash, stale_hash);
+    assert_eq!(block::Hash::from(header.as_ref()), stale_hash);
+    assert_eq!(next_block_hash, Some(stale_child_hash));
     Ok(())
 }

--- a/docs/changelog/unreleased/400.md
+++ b/docs/changelog/unreleased/400.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Fixed block-header RPC responses that could return a stale fork's header during a concurrent reorganization
+  ([#400](https://github.com/zakura-core/zakura/pull/400)).

--- a/docs/changelog/unreleased/400.md
+++ b/docs/changelog/unreleased/400.md
@@ -1,4 +1,4 @@
 ## Fixed
 
-- Fixed block-header RPC responses that could return a stale fork's header during a concurrent reorganization
+- Fixed block-header RPC responses that could mix blocks from different forks during a concurrent reorganization
   ([#400](https://github.com/zakura-core/zakura/pull/400)).


### PR DESCRIPTION
## Motivation

A delayed `BlockHeader` read can retain fork A while fork B finalizes. Before this PR, a hash request for B could return A's header labeled as B. The first fix bound the header lookup to B, but `next_block_hash` could still come from A and produce a mixed-fork response.

## Solution

Resolve the header by exact hash. Return `next_block_hash` only when the candidate header names the resolved hash as its parent. A mismatched successor is omitted, matching zcashd's optional `nextblockhash` behavior.

The regression constructs stale A_H and A_H+1 in retained state with B_H in finalized state. It fails before the filter with the exact stale child hash, then checks both boundaries:

- B_H never reports A_H+1.
- A_H still reports its linked A_H+1 successor.

## Testing

- `cargo test -p zakura-state block_header_hash_lookup_does_not_mix_stale_and_finalized_forks -- --nocapture`
- `cargo test -p zakura-state service::tests -- --nocapture`
- `cargo test -p zakura-rpc`
- `cargo fmt --all -- --check`
- `python scripts/changelog.py check`
- `git diff --check`

## Changelog

- `docs/changelog/unreleased/400.md`

### Specifications & References

- #360

### Follow-up Work

Atomic tree, depth, confirmation, and `gettxout` reads remain in #360.