### PR TITLE
fix(state): avoid duplicate VCT handoff trees

### DIFF
--- a/changelog-unreleased/401.md
+++ b/changelog-unreleased/401.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed VCT fast-sync handoffs after a restart from writing duplicate note
+  commitment trees that prevented the database from reopening
+  ([#401](https://github.com/zakura-core/zakura/pull/401)).

--- a/zakura-state/proptest-regressions/service/finalized_state/tests/prop.txt
+++ b/zakura-state/proptest-regressions/service/finalized_state/tests/prop.txt
@@ -5,4 +5,3 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 933c998cd42e62c9b80ceae375981200f1039e493262f7d931d973900c75812e # shrinks to (chain, count, network, _history_tree) = (alloc::vec::Vec<zakura_state::request::PreparedBlock><zakura_state::request::PreparedBlock>, len=104, 2, Mainnet, HistoryTree(None))
-cc b55f47639c7edbc02f595c09d7b3a612e969826bf6dbe49ca725f2f50016e692 # no Sapling frontier change across the VCT absent band

--- a/zakura-state/proptest-regressions/service/finalized_state/tests/prop.txt
+++ b/zakura-state/proptest-regressions/service/finalized_state/tests/prop.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 933c998cd42e62c9b80ceae375981200f1039e493262f7d931d973900c75812e # shrinks to (chain, count, network, _history_tree) = (alloc::vec::Vec<zakura_state::request::PreparedBlock><zakura_state::request::PreparedBlock>, len=104, 2, Mainnet, HistoryTree(None))
+cc b55f47639c7edbc02f595c09d7b3a612e969826bf6dbe49ca725f2f50016e692 # no Sapling frontier change across the VCT absent band

--- a/zakura-state/proptest-regressions/service/finalized_state/tests/vct_mode_switches_continue_from_safe_boundaries.txt
+++ b/zakura-state/proptest-regressions/service/finalized_state/tests/vct_mode_switches_continue_from_safe_boundaries.txt
@@ -1,0 +1,5 @@
+# Seeds for the VCT mode-switch property test.
+#
+# This file is intentionally test-specific because source-level proptest
+# regression files are replayed by every property in the source module.
+cc b55f47639c7edbc02f595c09d7b3a612e969826bf6dbe49ca725f2f50016e692 # no Sapling frontier change across the VCT absent band

--- a/zakura-state/proptest-regressions/service/finalized_state/tests/vct_mode_switches_continue_from_safe_boundaries.txt
+++ b/zakura-state/proptest-regressions/service/finalized_state/tests/vct_mode_switches_continue_from_safe_boundaries.txt
@@ -2,4 +2,4 @@
 #
 # This file is intentionally test-specific because source-level proptest
 # regression files are replayed by every property in the source module.
-cc b55f47639c7edbc02f595c09d7b3a612e969826bf6dbe49ca725f2f50016e692 # no Sapling frontier change across the VCT absent band
+cc 2284ccc1eefbedad3d9dba188013e70dcb657b4a70413c256f29612af5386334 # no Sapling frontier change across the VCT absent band

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1703,7 +1703,18 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
-    proptest!(ProptestConfig::with_cases(1),
+    // Keep this regression seed isolated because the default source-level
+    // persistence file is replayed by every property in this module.
+    let mut proptest_config = ProptestConfig::with_cases(1);
+    proptest_config.failure_persistence = Some(Box::new(
+        proptest::test_runner::FileFailurePersistence::Direct(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/proptest-regressions/service/finalized_state/tests/",
+            "vct_mode_switches_continue_from_safe_boundaries.txt",
+        )),
+    ));
+
+    proptest!(proptest_config,
         |((chain, network) in super::valid_commitment_chain(ledger_strategy, tested_block_count).no_shrink())| {
             let blocks: Vec<_> = chain.iter().collect();
             let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0;

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1769,8 +1769,10 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
             let fast_config = Config {
                 cache_dir: fast_to_manual_dir.path().to_path_buf(),
                 ephemeral: false,
+                vct_fast_sync: true,
                 ..Config::default()
             };
+            let restart_index = seed + 1;
             {
                 let mut fast = FinalizedState::new(&fast_config, &network).expect("opening an ephemeral database should succeed");
                 enable_vct_test_fixture_source_with_handoff(
@@ -1782,13 +1784,10 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
                     handoff_trees.sprout.clone(),
                     handoff_trees.ironwood.clone(),
                 );
-                // Match the writer service by carrying the frozen in-memory
-                // frontier through an uninterrupted fast-sync sequence.
                 let mut prev_note_commitment_trees = None;
-                for i in 0..=handoff_index {
+                for i in 0..=restart_index {
                     let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
-                    let next = (i < handoff_index)
-                        .then(|| vct_successor_header(blocks[i + 1].block.clone()));
+                    let next = Some(vct_successor_header(blocks[i + 1].block.clone()));
                     let (_, note_commitment_trees) = fast
                         .commit_finalized_direct(
                             cv.into(),
@@ -1797,6 +1796,46 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
                             "vct switch fast prefix",
                         )
                         .expect("verified fast prefix commits");
+                    prev_note_commitment_trees = Some(note_commitment_trees);
+                }
+            }
+
+            // Restart inside the absent band, losing the frozen in-memory
+            // frontiers before reaching the handoff. The synthetic network has
+            // no embedded VCT source, so bypass the production resume guard
+            // long enough to inject the test fixture.
+            {
+                let mut fast = FinalizedState::new_with_debug_and_storage_validation(
+                    &fast_config,
+                    &network,
+                    false,
+                    false,
+                    true,
+                    false,
+                )
+                .expect("reopening the fast-sync database should succeed");
+                enable_vct_test_fixture_source_with_handoff(
+                    &mut fast,
+                    fixture.clone(),
+                    handoff,
+                    handoff_trees.sapling.clone(),
+                    handoff_trees.orchard.clone(),
+                    handoff_trees.sprout.clone(),
+                    handoff_trees.ironwood.clone(),
+                );
+                let mut prev_note_commitment_trees = None;
+                for i in (restart_index + 1)..=handoff_index {
+                    let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
+                    let next = (i < handoff_index)
+                        .then(|| vct_successor_header(blocks[i + 1].block.clone()));
+                    let (_, note_commitment_trees) = fast
+                        .commit_finalized_direct(
+                            cv.into(),
+                            prev_note_commitment_trees.take(),
+                            next,
+                            "vct switch fast prefix after restart",
+                        )
+                        .expect("verified fast prefix commits after restart");
                     prev_note_commitment_trees = Some(note_commitment_trees);
                 }
                 prop_assert_eq!(fast.vct_fast_synced_below(), Some(handoff), "fast sync reached the handoff before the switch");

--- a/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
@@ -328,6 +328,19 @@ impl ZakuraDb {
         Some(Arc::new(tree))
     }
 
+    #[allow(clippy::unwrap_in_result)]
+    fn latest_stored_sapling_tree(
+        &self,
+        height: &Height,
+    ) -> Option<Arc<sapling::tree::NoteCommitmentTree>> {
+        let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
+        let (_stored_height, tree) = self
+            .db
+            .zs_prev_key_value_back_from(&sapling_trees, height)?;
+
+        Some(Arc::new(tree))
+    }
+
     /// Returns the Sapling note commitment trees in the supplied range, in increasing height order.
     pub fn sapling_tree_by_height_range<R>(
         &self,
@@ -469,6 +482,19 @@ impl ZakuraDb {
         Some(Arc::new(tree))
     }
 
+    #[allow(clippy::unwrap_in_result)]
+    fn latest_stored_orchard_tree(
+        &self,
+        height: &Height,
+    ) -> Option<Arc<orchard::tree::NoteCommitmentTree>> {
+        let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
+        let (_stored_height, tree) = self
+            .db
+            .zs_prev_key_value_back_from(&orchard_trees, height)?;
+
+        Some(Arc::new(tree))
+    }
+
     /// Returns the Orchard note commitment trees in the supplied range, in increasing height order.
     pub fn orchard_tree_by_height_range<R>(
         &self,
@@ -606,6 +632,19 @@ impl ZakuraDb {
             .expect(
                 "Ironwood note commitment trees must exist for all heights below the finalized tip",
             );
+
+        Some(Arc::new(tree))
+    }
+
+    #[allow(clippy::unwrap_in_result)]
+    fn latest_stored_ironwood_tree(
+        &self,
+        height: &Height,
+    ) -> Option<Arc<ironwood::tree::NoteCommitmentTree>> {
+        let ironwood_trees = self.db.cf_handle("ironwood_note_commitment_tree").unwrap();
+        let (_stored_height, tree) = self
+            .db
+            .zs_prev_key_value_back_from(&ironwood_trees, height)?;
 
         Some(Arc::new(tree))
     }
@@ -848,20 +887,41 @@ impl DiskWriteBatch {
             return Ok(());
         }
 
-        let prev_sapling_tree = prev_note_commitment_trees.as_ref().map_or_else(
-            || zakura_db.sapling_tree_for_tip(),
-            |prev_trees| prev_trees.sapling.clone(),
-        );
-        let prev_orchard_tree = prev_note_commitment_trees.as_ref().map_or_else(
-            || zakura_db.orchard_tree_for_tip(),
-            |prev_trees| prev_trees.orchard.clone(),
-        );
-        let prev_ironwood_tree = prev_note_commitment_trees.as_ref().map_or_else(
-            || zakura_db.ironwood_tree_for_tip(),
-            |prev_trees| prev_trees.ironwood.clone(),
-        );
+        // After a restart inside the VCT absent band, the in-memory frontiers
+        // are unavailable and the tip lookups return empty trees. At the
+        // handoff, compare the verified frontiers with the last physically
+        // stored trees below the absent band. This preserves sparse-tree
+        // deduplication when no shielded notes were added during the band.
+        let is_vct_handoff = fast_write.sync_below == Some(*height);
+
+        let prev_sapling_tree = if is_vct_handoff {
+            zakura_db.latest_stored_sapling_tree(height)
+        } else {
+            Some(prev_note_commitment_trees.as_ref().map_or_else(
+                || zakura_db.sapling_tree_for_tip(),
+                |prev_trees| prev_trees.sapling.clone(),
+            ))
+        };
+        let prev_orchard_tree = if is_vct_handoff {
+            zakura_db.latest_stored_orchard_tree(height)
+        } else {
+            Some(prev_note_commitment_trees.as_ref().map_or_else(
+                || zakura_db.orchard_tree_for_tip(),
+                |prev_trees| prev_trees.orchard.clone(),
+            ))
+        };
+        let prev_ironwood_tree = if is_vct_handoff {
+            zakura_db.latest_stored_ironwood_tree(height)
+        } else {
+            Some(prev_note_commitment_trees.as_ref().map_or_else(
+                || zakura_db.ironwood_tree_for_tip(),
+                |prev_trees| prev_trees.ironwood.clone(),
+            ))
+        };
         // Store the Sapling tree, anchor, and any new subtrees only if they have changed
-        if height.is_min() || prev_sapling_tree != note_commitment_trees.sapling {
+        if height.is_min()
+            || prev_sapling_tree.is_none_or(|prev_tree| prev_tree != note_commitment_trees.sapling)
+        {
             self.create_sapling_tree(zakura_db, height, &note_commitment_trees.sapling);
 
             if let Some(subtree) = note_commitment_trees.sapling_subtree {
@@ -870,7 +930,9 @@ impl DiskWriteBatch {
         }
 
         // Store the Orchard tree, anchor, and any new subtrees only if they have changed
-        if height.is_min() || prev_orchard_tree != note_commitment_trees.orchard {
+        if height.is_min()
+            || prev_orchard_tree.is_none_or(|prev_tree| prev_tree != note_commitment_trees.orchard)
+        {
             self.create_orchard_tree(zakura_db, height, &note_commitment_trees.orchard);
 
             if let Some(subtree) = note_commitment_trees.orchard_subtree {
@@ -879,7 +941,10 @@ impl DiskWriteBatch {
         }
 
         // Store the Ironwood tree, anchor, and any new subtrees only if they have changed
-        if height.is_min() || prev_ironwood_tree != note_commitment_trees.ironwood {
+        if height.is_min()
+            || prev_ironwood_tree
+                .is_none_or(|prev_tree| prev_tree != note_commitment_trees.ironwood)
+        {
             self.create_ironwood_tree(zakura_db, height, &note_commitment_trees.ironwood);
 
             if let Some(subtree) = note_commitment_trees.ironwood_subtree {


### PR DESCRIPTION
## Motivation

A node restarted inside the verified-commitment-tree (VCT) absent band loses
its in-memory note-commitment frontiers. At the checkpoint handoff, the normal
tip lookup intentionally returns an empty tree for that band. If a non-empty
shielded frontier did not change during the band, this made the handoff write
that unchanged frontier at a second height. The database format check then
rejected the duplicate sparse-tree row on reopen.

## Solution

At the VCT handoff only, compare each verified frontier with the latest tree
physically stored below the absent band. Write the handoff tree when it changed
or no earlier tree exists, and skip the write when it is unchanged. This
preserves sparse-tree deduplication without weakening the database validator.

The property-test seed is saved in a test-specific persistence file. Isolating
it avoids replaying that input through unrelated properties in the same source
module; the property still runs its normal randomized case as well.

## Testing

After rebasing onto the authenticated-root VCT changes from #352 and the VCT
cleanup from #424, the old saved seed no longer produced an unchanged Sapling
frontier. A fresh current-main seed still reproduces the underlying defect
without this fix: duplicate Sapling trees at heights 4 and 10 cause database
validation to reject the cache on reopen.

With the fix, these checks pass:

- `cargo test --locked -p zakura-state --lib vct_` (57 passed, 1 ignored)
- `cargo test --locked -p zakura-state --lib service::finalized_state::tests::prop::vct_mode_switches_continue_from_safe_boundaries -- --exact`
- `cargo clippy --locked -p zakura-state --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`

## Changelog

Added `changelog-unreleased/401.md`.

### Specifications & References

- `docs/design/verified-commitment-trees.md`

### Follow-up Work

This prevents new duplicate handoff rows. It does not repair a database that
has already written a duplicate row and is rejected during startup validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches finalized-state shielded tree persistence at the VCT handoff boundary; incorrect comparison logic could skip needed writes or still corrupt the DB, but scope is narrow and covered by property tests.
> 
> **Overview**
> Fixes **VCT fast-sync checkpoint handoffs** after a restart inside the absent band: without in-memory frontiers, tip lookups yield empty trees, so unchanged Sapling/Orchard/Ironwood frontiers were written again at the handoff height and **startup validation rejected duplicate sparse-tree rows**.
> 
> At the handoff only, `prepare_trees_batch` compares verified frontiers to **`latest_stored_*_tree`** (last physical row below the band) instead of tip/in-memory state, and **skips per-height tree writes** when the frontier is unchanged—keeping sparse-tree deduplication.
> 
> **Tests:** `vct_mode_switches_continue_from_safe_boundaries` now simulates restart mid absent band before completing the handoff; the proptest regression seed lives in a **test-specific** persistence file so other properties in the module are not replayed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86af74830254adcdde3f1a7fe324f1286296b4d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->