### PR TITLE
test: skip empty binary test harnesses

### DIFF
--- a/changelog-unreleased/402.md
+++ b/changelog-unreleased/402.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes which empty binary test harnesses Cargo builds and has no
+operator- or crate-consumer-visible effect.

--- a/changelog-unreleased/402.md
+++ b/changelog-unreleased/402.md
@@ -1,4 +1,4 @@
 <!-- changelog: none -->
 
-This PR only changes which empty binary test harnesses Cargo builds and has no
-operator- or crate-consumer-visible effect.
+This PR only changes which empty test harnesses Cargo builds and preserves
+published feature compatibility without changing operator or crate behavior.

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["algorithms", "asynchronous"]
 
 [lib]
 name = "tower_batch_control"
+test = false
 
 [dependencies]
 futures = { workspace = true }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["algorithms", "asynchronous"]
 
 [lib]
 name = "tower_fallback"
+test = false
 
 [dependencies]
 pin-project = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,4 +9,9 @@ edition.workspace = true
 rust-version.workspace = true
 publish = false
 
+[[bin]]
+name = "xtask"
+path = "src/main.rs"
+test = false
+
 [dependencies]

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -16,6 +16,9 @@ keywords.workspace = true
 # Must be one of <https://crates.io/category_slugs>
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 
+[lib]
+test = false
+
 [[bin]]
 name = "zakura-checkpoints"
 # this setting is required for Zakura's Docker build caches

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -44,6 +44,11 @@ zakura-checkpoints-offline = [
     "zakura-state"
 ]
 
+# Preserve published feature names after removing the obsolete developer tools.
+search-issue-refs = []
+regex = []
+reqwest = []
+
 [dependencies]
 color-eyre = { workspace = true }
 

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -45,7 +45,11 @@ zakura-checkpoints-offline = [
 ]
 
 # Preserve published feature names after removing the obsolete developer tools.
-search-issue-refs = []
+search-issue-refs = [
+    "regex",
+    "reqwest",
+    "tokio"
+]
 regex = []
 reqwest = []
 

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -35,6 +35,21 @@ default-run = "zakurad"
 [lib]
 name = "zakurad"
 
+[[bin]]
+name = "zakurad"
+path = "src/bin/zakurad/main.rs"
+test = false
+
+[[bin]]
+name = "zakura-prune-state"
+path = "src/bin/zakura-prune-state/main.rs"
+test = false
+
+[[bin]]
+name = "zakura-rollback-state"
+path = "src/bin/zakura-rollback-state/main.rs"
+test = false
+
 # `cargo release` settings
 [package.metadata.release]
 pre-release-replacements = [

--- a/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -53,6 +53,13 @@ use InventoryResponse::*;
 /// Increasing this value causes the tests to take longer to complete, so it can't be too large.
 const MAX_PEER_SET_REQUEST_DELAY: Duration = Duration::from_millis(500);
 
+async fn wait_for_gossip() {
+    // Let background gossip tasks arm their timers before this paused runtime
+    // advances to the next gossip deadline.
+    tokio::task::yield_now().await;
+    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+}
+
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn mempool_requests_for_transactions() {
     let (
@@ -677,7 +684,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     hs.insert(tx1_id);
 
     // Transaction and Block IDs are gossipped, in any order, after waiting for the gossip delay
-    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+    wait_for_gossip().await;
     let possible_requests = &mut [
         Request::AdvertiseTransactionIds(hs, None),
         Request::AdvertiseBlock(block_two.hash(), None),
@@ -746,7 +753,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         .unwrap();
 
     // Test the block is gossiped, after waiting for the multi-gossip delay
-    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+    wait_for_gossip().await;
     peer_set
         .expect_request(Request::AdvertiseBlock(block_three.hash(), None))
         .await
@@ -825,7 +832,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     );
 
     // Test transaction 2 is gossiped, after waiting for the multi-gossip delay
-    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+    wait_for_gossip().await;
 
     let mut hs = HashSet::new();
     hs.insert(tx2_id);
@@ -856,7 +863,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
             .unwrap();
 
         // Test the block is gossiped, after waiting for the multi-gossip delay
-        tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+        wait_for_gossip().await;
         peer_set
             .expect_request(Request::AdvertiseBlock(block.hash(), None))
             .await


### PR DESCRIPTION
## Motivation

The unit-test archive builds every Cargo test target under release ThinLTO on
`main`. Seven targets contain no tests, but Cargo still generated and linked
zero-test harness executables for them.

## Solution

Set `test = false` for the empty harnesses:

- `zakurad`
- `zakura-prune-state`
- `zakura-rollback-state`
- `xtask`
- `tower_batch_control`
- `tower_fallback`
- `zakura_utils`

This only disables their empty binary or library test harnesses. It does not
remove production binaries or the unique `tower-batch-control`,
`tower-fallback`, and `zakura-utils` integration tests.

The latest `main` also removed three features published by `zakura-utils`.
Preserve `search-issue-refs`, `regex`, and `reqwest` as compatibility features,
including their published enablement relationship, without restoring the
deleted developer tool or its removed dependencies.

The first rebased unit-test run exposed a paused-time race in
`mempool_transaction_expiration`: the test could advance virtual time before
the background gossip task armed its next delay. Yield to the gossip tasks
before each virtual delay advance so the test and its 500ms mock timeout have
deterministic scheduling.

## Testing

- `cargo metadata --no-deps --format-version 1`
  - testable targets: 33 → 26
  - library test harnesses: 13 → 10
  - integration-test targets: 13 → 13
  - binary test harnesses: 7 → 3
- Matched release CI runs from the same `main` base:
  - nextest binaries: 32 → 25, with the same real tests selected
  - archive size: 1,283,722,140 → 1,272,543,603 bytes
    (10.7 MiB / 0.87% smaller)
  - build and archive step: 24m40s → 24m51s
  - Cargo release build: 24m28s → 24m38s
  - total build job: 26m09s → 25m31s
- `cargo check -p zakura-utils --all-features --locked`
- `cargo test -p zakura --lib
  components::inbound::tests::fake_peer_set::mempool_transaction_expiration
  -- --exact --nocapture`
  - 100 consecutive runs passed
  - 160 runs passed across 8 concurrent workers
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`

The compile timings were effectively unchanged within run-to-run noise. The
measurable benefit is seven fewer executables for nextest to archive, upload,
download, and enumerate on every shard.

## Changelog

`changelog-unreleased/402.md` marks this test-only change as having no
operator- or crate-consumer-visible effect.

### Follow-up Work

Routine `main` tests still build all remaining test executables with release
ThinLTO. That broader profile change is intentionally outside this focused PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/test configuration and test scheduling only; no production runtime or API behavior changes.
> 
> **Overview**
> Stops Cargo from building **seven zero-test harness executables** by setting `test = false` on empty library/binary targets in `zakurad`, `xtask`, `tower-batch-control`, `tower-fallback`, and `zakura-utils`. **Production binaries and real integration tests are unchanged**; CI archives fewer nextest binaries with the same test selection.
> 
> **`zakura-utils`** gains stub compatibility features (`search-issue-refs`, `regex`, `reqwest`) so crates.io feature names still resolve after obsolete developer tools were removed.
> 
> **`mempool_transaction_expiration`** in `fake_peer_set.rs` now calls a shared `wait_for_gossip()` that yields before advancing paused virtual time, fixing a race where gossip timers were not armed before `PEER_GOSSIP_DELAY` elapsed.
> 
> Changelog entry marks **no operator or crate-consumer-visible behavior change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7da67b00e7515fc1fc5aaf6d6eb9ba407ae5f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->