### PR TITLE
fix(utils): speedup-semver CI; version removed tools as 2.0.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -208,6 +208,9 @@ jobs:
       - name: Mempool load harness tests
         run: python3 .github/workflows/scripts/test_mempool_load.py
 
+      - name: Affected semver package tests
+        run: python3 .github/workflows/scripts/test_affected_semver_packages.py
+
       - name: Deployer tests
         run: python3 deploy/deployer/test_deploy.py
 

--- a/.github/workflows/scripts/affected_semver_packages.py
+++ b/.github/workflows/scripts/affected_semver_packages.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""List publishable crates needing semver checks for a Git diff."""
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def is_publishable(package):
+    publish = package.get("publish")
+    return publish is None or bool(publish)
+
+
+def package_graph(metadata):
+    workspace_ids = set(metadata["workspace_members"])
+    packages = {
+        package["id"]: package
+        for package in metadata["packages"]
+        if package["id"] in workspace_ids
+    }
+    roots = {
+        package_id: Path(package["manifest_path"]).parent.resolve()
+        for package_id, package in packages.items()
+    }
+    owners = {root: package_id for package_id, root in roots.items()}
+    reverse_dependencies = {package_id: set() for package_id in packages}
+
+    for dependent_id, package in packages.items():
+        for dependency in package["dependencies"]:
+            dependency_path = dependency.get("path")
+            if dependency.get("kind") == "dev" or dependency_path is None:
+                continue
+
+            dependency_id = owners.get(Path(dependency_path).resolve())
+            if dependency_id is not None:
+                reverse_dependencies[dependency_id].add(dependent_id)
+
+    return packages, roots, reverse_dependencies
+
+
+def directly_changed_packages(metadata, changed_files):
+    packages, roots, _ = package_graph(metadata)
+    workspace_root = Path(metadata["workspace_root"]).resolve()
+    changed_paths = [Path(path) for path in changed_files]
+
+    if Path("Cargo.toml") in changed_paths:
+        return set(packages)
+
+    roots_by_depth = sorted(
+        roots.items(),
+        key=lambda item: len(item[1].parts),
+        reverse=True,
+    )
+    changed = set()
+
+    for changed_path in changed_paths:
+        absolute_path = (workspace_root / changed_path).resolve()
+
+        for package_id, package_root in roots_by_depth:
+            try:
+                relative_path = absolute_path.relative_to(package_root)
+            except ValueError:
+                continue
+
+            if (
+                relative_path.name == "Cargo.toml"
+                or relative_path == Path("build.rs")
+                or relative_path.suffix == ".rs"
+            ):
+                changed.add(package_id)
+            break
+
+    return changed
+
+
+def affected_publishable_packages(metadata, changed_files=None, check_all=False):
+    packages, _, reverse_dependencies = package_graph(metadata)
+    if check_all:
+        directly_changed = set(packages)
+    else:
+        directly_changed = directly_changed_packages(metadata, changed_files or [])
+
+    seen = set(directly_changed)
+    pending = set(directly_changed)
+    while pending:
+        next_pending = {
+            dependent_id
+            for package_id in pending
+            for dependent_id in reverse_dependencies[package_id]
+            if dependent_id not in seen
+        }
+        seen.update(next_pending)
+        pending = next_pending
+
+    dependency_counts = {package_id: 0 for package_id in seen}
+    for dependency_id in seen:
+        for dependent_id in reverse_dependencies[dependency_id]:
+            if dependent_id in seen:
+                dependency_counts[dependent_id] += 1
+
+    ordered = []
+    ready = {
+        package_id
+        for package_id, count in dependency_counts.items()
+        if count == 0
+    }
+    while ready:
+        package_id = min(ready, key=lambda item: packages[item]["name"])
+        ready.remove(package_id)
+        ordered.append(package_id)
+
+        for dependent_id in reverse_dependencies[package_id]:
+            if dependent_id not in dependency_counts:
+                continue
+            dependency_counts[dependent_id] -= 1
+            if dependency_counts[dependent_id] == 0:
+                ready.add(dependent_id)
+
+    if len(ordered) != len(seen):
+        remaining = seen.difference(ordered)
+        ordered.extend(sorted(remaining, key=lambda item: packages[item]["name"]))
+
+    return [
+        packages[package_id]["name"]
+        for package_id in ordered
+        if is_publishable(packages[package_id])
+    ]
+
+
+def command_output(command, cwd):
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument(
+        "--all",
+        action="store_true",
+        help="list every publishable workspace crate",
+    )
+    selection.add_argument("--base", help="base Git revision")
+    parser.add_argument("--head", default="HEAD", help="head Git revision")
+    args = parser.parse_args()
+
+    if args.head != "HEAD" and args.base is None:
+        parser.error("--head requires --base")
+
+    repo_root = Path(__file__).resolve().parents[3]
+    metadata = json.loads(
+        command_output(
+            [
+                "cargo",
+                "metadata",
+                "--format-version",
+                "1",
+                "--no-deps",
+                "--locked",
+            ],
+            repo_root,
+        )
+    )
+
+    changed_files = None
+    if not args.all:
+        changed_files = command_output(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--diff-filter=ACMRDTUXB",
+                args.base,
+                args.head,
+                "--",
+            ],
+            repo_root,
+        ).splitlines()
+
+    packages = affected_publishable_packages(
+        metadata,
+        changed_files=changed_files,
+        check_all=args.all,
+    )
+    sys.stdout.write("".join(f"{package}\n" for package in packages))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/test_affected_semver_packages.py
+++ b/.github/workflows/scripts/test_affected_semver_packages.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Tests for affected_semver_packages.py."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import affected_semver_packages
+
+
+class AffectedSemverPackagesTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name).resolve()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def package(self, name, *, publish=None, dependencies=None):
+        package_root = self.root / name
+        package = {
+            "id": name,
+            "name": name,
+            "manifest_path": str(package_root / "Cargo.toml"),
+            "dependencies": dependencies or [],
+        }
+        if publish is not None:
+            package["publish"] = publish
+        return package
+
+    def dependency(self, name, *, kind=None):
+        return {
+            "name": name,
+            "kind": kind,
+            "path": str(self.root / name),
+        }
+
+    def metadata(self, packages):
+        return {
+            "workspace_root": str(self.root),
+            "workspace_members": [package["id"] for package in packages],
+            "packages": packages,
+        }
+
+    def test_includes_publishable_reverse_dependencies(self):
+        packages = [
+            self.package("base"),
+            self.package(
+                "dependent",
+                dependencies=[self.dependency("base")],
+            ),
+            self.package(
+                "transitive",
+                dependencies=[self.dependency("dependent", kind="build")],
+            ),
+            self.package(
+                "dev-only",
+                dependencies=[self.dependency("base", kind="dev")],
+            ),
+            self.package(
+                "private-middle",
+                publish=[],
+                dependencies=[self.dependency("base")],
+            ),
+            self.package(
+                "public-after-private",
+                dependencies=[self.dependency("private-middle")],
+            ),
+        ]
+
+        affected = affected_semver_packages.affected_publishable_packages(
+            self.metadata(packages),
+            changed_files=["base/src/lib.rs"],
+        )
+
+        self.assertEqual(
+            affected,
+            ["base", "dependent", "public-after-private", "transitive"],
+        )
+
+    def test_root_manifest_selects_every_publishable_package(self):
+        packages = [
+            self.package("z-last"),
+            self.package("a-first"),
+            self.package("private", publish=[]),
+        ]
+
+        affected = affected_semver_packages.affected_publishable_packages(
+            self.metadata(packages),
+            changed_files=["Cargo.toml"],
+        )
+
+        self.assertEqual(affected, ["a-first", "z-last"])
+
+    def test_ignores_lockfiles_and_non_rust_package_files(self):
+        packages = [self.package("base")]
+
+        affected = affected_semver_packages.affected_publishable_packages(
+            self.metadata(packages),
+            changed_files=["Cargo.lock", "base/README.md"],
+        )
+
+        self.assertEqual(affected, [])
+
+    def test_package_manifest_selects_that_package(self):
+        registry_dependency = {
+            "name": "registry-package",
+            "kind": None,
+        }
+        packages = [
+            self.package("base", dependencies=[registry_dependency]),
+            self.package("other"),
+        ]
+
+        affected = affected_semver_packages.affected_publishable_packages(
+            self.metadata(packages),
+            changed_files=["base/Cargo.toml"],
+        )
+
+        self.assertEqual(affected, ["base"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,8 +1,9 @@
 # Gate PRs on cargo-semver-checks against the latest STABLE crates.io release
-# of each publishable workspace crate. A PR that changes a published API must
-# carry the corresponding version bump in the same PR — the check passes once
-# the bump level covers the change, so an intentional break plus its major
-# bump is green, and a second break in the same cycle needs no further bump.
+# of each changed publishable workspace crate and its publishable reverse
+# dependencies. A PR that changes a published API must carry the corresponding
+# version bump in the same PR — the check passes once the bump level covers the
+# change, so an intentional break plus its major bump is green, and a second
+# break in the same cycle needs no further bump.
 #
 # Retro driver: v1.0.3 shipped with semver debt discovered on release day
 # (#361 forced zakura-chain 2.0.0 / zakura-consensus 4.0.0 / zakura-script
@@ -30,13 +31,8 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
       - .github/workflows/semver-checks.yml
-  push:
-    branches: [main]
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - .github/workflows/semver-checks.yml
+      - .github/workflows/scripts/affected_semver_packages.py
+      - .github/workflows/scripts/test_affected_semver_packages.py
   workflow_dispatch:
 
 permissions:
@@ -54,9 +50,43 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Find crates affected by this change
+        id: affected
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          python3 .github/workflows/scripts/test_affected_semver_packages.py
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            packages="$(
+              python3 .github/workflows/scripts/affected_semver_packages.py --all
+            )"
+          else
+            packages="$(
+              python3 .github/workflows/scripts/affected_semver_packages.py \
+                --base "$BASE_SHA" \
+                --head "$GITHUB_SHA"
+            )"
+          fi
+
+          {
+            echo "packages<<EOF"
+            echo "$packages"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$packages" ]]; then
+            echo "Checking affected packages:"
+            echo "$packages"
+          else
+            echo "No publishable crates need semver checks."
+          fi
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        if: steps.affected.outputs.packages != ''
         id: toolchain
         with:
           toolchain: stable
@@ -70,9 +100,10 @@ jobs:
       # target-dir cleaner deletes unrecognized target/ entries before
       # saving, so this cache needs its own steps. Keyed on the rustc
       # version: the rustdoc JSON format (and the tool's own invalidation)
-      # rotates with the toolchain. The run_id suffix makes every main run
-      # save a fresh entry; restores prefix-match the newest one.
+      # rotates with the toolchain. The run_id suffix makes every manual main
+      # run save a fresh entry; restores prefix-match the newest one.
       - name: Restore baseline rustdoc cache
+        if: steps.affected.outputs.packages != ''
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
@@ -82,16 +113,25 @@ jobs:
       # Deliberately unpinned (like cargo-hack): cargo-semver-checks must
       # track new stable rustdoc formats; pin only if a regression forces it.
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
+        if: steps.affected.outputs.packages != ''
         with:
           tool: cargo-semver-checks
 
       - uses: ./.github/actions/setup-zakura-build
+        if: steps.affected.outputs.packages != ''
 
-      - name: Check workspace crates against stable crates.io baselines
-        run: cargo semver-checks --workspace --default-features
+      - name: Check affected crates against stable crates.io baselines
+        if: steps.affected.outputs.packages != ''
+        env:
+          PACKAGES: ${{ steps.affected.outputs.packages }}
+        run: |
+          while IFS= read -r package; do
+            [[ -n "$package" ]] || continue
+            cargo semver-checks --package "$package" --default-features
+          done <<< "$PACKAGES"
 
       - name: Save baseline rustdoc cache
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.affected.outputs.packages != ''
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "color-eyre",
  "hex",

--- a/changelog-unreleased/406.md
+++ b/changelog-unreleased/406.md
@@ -1,0 +1,6 @@
+## Removed
+
+- Removed the obsolete `block-template-to-proposal` and `search-issue-refs`
+  binaries and the `search-issue-refs`, `regex`, and `reqwest` Cargo feature
+  flags in `zakura-utils` 2.0.0
+  ([#406](https://github.com/zakura-core/zakura/pull/406)).

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "1.1.0"
+version = "2.0.0"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -172,7 +172,7 @@ zakura-script = { path = "../zakura-script", version = "2.0.0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "1.1.0", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "2.0.0", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -328,7 +328,7 @@ zakura-test = { path = "../zakura-test", version = "2.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "1.1.0" }
+zakura-utils = { path = "../zakura-utils", version = "2.0.0" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used


### PR DESCRIPTION
## Motivation

Removing the obsolete zakura-utils binaries and Cargo feature flags in #404 was a breaking change to the published 1.1.0 package, but its version was not bumped. The workspace-wide semver check therefore fails after spending roughly 11 minutes checking unrelated crates first.

## Solution

- Bump zakura-utils to 2.0.0 and update both zakura dependency requirements and Cargo.lock.
- On pull requests, semver-check only changed publishable crates and their publishable normal/build reverse dependencies.
- Skip the expensive setup when no publishable crate is affected.
- Keep a full-workspace check available through manual workflow dispatch, and stop rerunning the full workspace after every push to main.
- Add unit coverage for crate selection, reverse dependencies, private intermediates, dev-only dependencies, and API-neutral file changes.

## Testing

- cargo check -p zakura-utils --locked
- cargo metadata --no-deps --format-version 1 --locked
- python3 -B .github/workflows/scripts/test_affected_semver_packages.py
- cargo semver-checks --package zakura-utils --default-features
- cargo semver-checks --package zakura --default-features
- YAML parse for the changed workflows
- git diff --check

The real selector chooses zakura-utils followed by zakura for this PR. Both semver comparisons pass locally; zakura reports all 223 applicable checks passing.

## Changelog

changelog-unreleased/406.md records zakura-utils 2.0.0 and the removed binaries and Cargo feature flags.

### Follow-up Work

Measure cached CI runtime before considering a per-crate matrix. cargo-semver-checks 0.49.0 generates current and baseline rustdoc serially within each crate, and a matrix would trade runner cost and duplicated builds for lower wall time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release-gating semver behavior and crate versioning; incorrect crate selection could miss API breaks, though unit tests cover the selector logic.
> 
> **Overview**
> Bumps **zakura-utils** to **2.0.0** (with **zakurad** path version updates and lockfile) so prior breaking removals align with semver, and documents them in the unreleased changelog.
> 
> **Semver CI** no longer runs `cargo semver-checks --workspace` on every PR. A new script maps the PR diff to **publishable** crates (`.rs`, `Cargo.toml`, `build.rs`; root `Cargo.toml` selects all) and walks **normal/build** reverse dependents, skipping dev-only edges and `publish = false` intermediates. The workflow runs checks per selected package, skips toolchain/setup when the list is empty, drops **push-to-main** full runs, and uses **`--all`** on manual dispatch. Unit tests for the selector run in the lint workflow’s Python CI step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87dba8a8a9135561e883dd56bb0ca077bbbf06e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->