### PR TITLE
test(network): wait for peer listener before dialing

### DIFF
--- a/changelog-unreleased/408.md
+++ b/changelog-unreleased/408.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only makes an acceptance test's node startup deterministic and has no
+operator- or crate-consumer-visible effect.

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -4624,11 +4624,12 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
     config.network.crawl_new_peer_interval = Duration::from_secs(5);
     // Invalid blocks log the full custom network at warn level. Keep the
     // expected logs from filling the child process pipes while this test polls
-    // the nodes over RPC.
-    config.tracing.filter = Some("error".to_string());
+    // the nodes over RPC, but allow the listener readiness event used below.
+    config.tracing.filter = Some("error,zakura_network::peer_set::initialize=info".to_string());
 
     let rpc_listen_addr = config.rpc.listen_addr.unwrap();
     let rpc_client_1 = RpcRequestClient::new_with_timeout(rpc_listen_addr, EXTENDED_LAUNCH_DELAY);
+    let node_1_listen_addr = config.network.listen_addr;
 
     tracing::info!(
         ?rpc_listen_addr,
@@ -4642,6 +4643,18 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
         .spawn_child(args!["start"])?
         .with_timeout(test_type.zakurad_timeout())
         .with_failure_regex_iter(zakurad_failure_messages, zakurad_ignore_messages);
+
+    // A refused initial dial marks the only configured address unreachable in
+    // this isolated test, so only start node 2 once node 1 is listening.
+    let node_1_listener_result = zakurad_child_1.expect_stdout_line_matches(regex::escape(
+        &format!("Opened Zcash protocol endpoint at {node_1_listen_addr}"),
+    ));
+    if let Err(error) = node_1_listener_result {
+        zakurad_child_1
+            .kill_and_consume_output(true)
+            .wrap_err("failed to stop the PoW-disabled zakurad child")?;
+        return Err(error);
+    }
 
     let network2 = testnet::Parameters::build()
         .with_activation_heights(ConfiguredActivationHeights {
@@ -4660,12 +4673,13 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
         .expect("failed to build configured network");
 
     config.network.network = network2;
-    config.network.initial_testnet_peers = [config.network.listen_addr.to_string()].into();
+    config.network.initial_testnet_peers = [node_1_listen_addr.to_string()].into();
     config.network.listen_addr = "127.0.0.1:0".parse()?;
     config.rpc.listen_addr = Some(format!("127.0.0.1:{}", random_known_port()).parse()?);
     config.network.crawl_new_peer_interval = Duration::from_secs(5);
     config.network.cache_dir = false.into();
     config.state.ephemeral = true;
+    config.tracing.filter = Some("error".to_string());
 
     let rpc_listen_addr = config.rpc.listen_addr.unwrap();
     let rpc_client_2 = RpcRequestClient::new_with_timeout(rpc_listen_addr, EXTENDED_LAUNCH_DELAY);


### PR DESCRIPTION
## Motivation

`disconnects_from_misbehaving_peers` spawned its second node immediately after
spawning the first. If the second node dialed before the first node bound its
network listener, the refused initial connection marked the test's only peer
address unreachable. The isolated node then had no peer to connect to, so the
test failed at its connection timeout.

## Solution

Wait for the first node's network-listener readiness log before spawning the
second node. This removes the startup-order race while preserving the existing
invalid-PoW and peer-disconnection assertions.

The first node temporarily enables only the network initialization logs needed
for the readiness check. The second node returns to the error-only filter so
the expected invalid-block logs cannot fill its child-process pipes.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p zakura --test acceptance -- -D warnings`
- `cargo test --locked -p zakura --test acceptance disconnects_from_misbehaving_peers -- --ignored --exact --nocapture`
- 22 successful focused runs in total, including two batches of eight
  concurrent test processes

The focused test was rerun successfully after rebasing onto the latest `main`.

## Changelog

`changelog-unreleased/408.md` uses the explicit no-changelog marker because
this change only affects test orchestration.

### Specifications & References

- Mirrors the startup synchronization from
  [Zebra #10823](https://github.com/ZcashFoundation/zebra/pull/10823).

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Acceptance-test orchestration and changelog metadata only; no production network or runtime behavior changes.
> 
> **Overview**
> **Eliminates flaky failures** in the `disconnects_from_misbehaving_peers` acceptance test by synchronizing the two-node startup sequence.
> 
> The second zakurad child used to dial immediately after the first was spawned. If the dial happened before node 1 bound its Zcash protocol listener, the refused connection could mark the sole peer address unreachable and the test would time out waiting for a connection. The test now **blocks on** the `Opened Zcash protocol endpoint at …` log from `zakura_network::peer_set::initialize` before starting node 2, and wires `initial_testnet_peers` to the saved listen address.
> 
> Tracing is split so node 1 temporarily allows `error,zakura_network::peer_set::initialize=info` for that readiness line while node 2 keeps an **error-only** filter to avoid pipe fill from invalid-block warnings. `changelog-unreleased/408.md` records an explicit **no changelog** entry (test orchestration only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59039caed027595aa20d821bd3ea9a1342db514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->