### PR TITLE
ci: disable ThinLTO for main unit tests

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -32,7 +32,7 @@ on:
   merge_group:
 
   schedule:
-    # Keep release-mode coverage off the critical PR path.
+    # Verify the exact production release profile, including ThinLTO, nightly.
     - cron: "0 8 * * *"
 
   workflow_dispatch:
@@ -64,7 +64,7 @@ jobs:
   # Building once removes two of the three compile passes while preserving
   # parallel test execution across the shard jobs.
   build-tests:
-    name: build test binaries (${{ github.event_name == 'pull_request' && 'debug' || 'ci-tests' }})
+    name: build test binaries (${{ github.event_name == 'pull_request' && 'debug' || (github.event_name == 'schedule' && 'release' || 'ci-tests') }})
     permissions:
       contents: read
       id-token: write
@@ -79,9 +79,9 @@ jobs:
         with:
           toolchain: stable
           # PR debug builds restore the cache populated by the main-branch
-          # config job. Full-coverage runs use the release-derived `ci-tests`
-          # profile, with a separate cache from production release builds.
-          cache-shared-key: ${{ github.event_name == 'pull_request' && 'zakura-drb-debug' || 'unit-tests-ci-tests' }}
+          # config job. Main and nightly runs keep separate caches because main
+          # uses `ci-tests`, while nightly uses the exact release profile.
+          cache-shared-key: ${{ github.event_name == 'pull_request' && 'zakura-drb-debug' || (github.event_name == 'schedule' && 'unit-tests-release' || 'unit-tests-ci-tests') }}
           cache-on-failure: true
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
@@ -94,7 +94,9 @@ jobs:
           # The archive stores compiled binaries, so it must be built in the same
           # mode the shards run. The run-time-only filters (`--profile`,
           # `--partition`, `--run-ignored`) are applied by the shard jobs, not here.
-          if [[ "${FULL_COVERAGE}" == "true" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            cargo nextest archive --locked --release --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
+          elif [[ "${FULL_COVERAGE}" == "true" ]]; then
             cargo nextest archive --locked --cargo-profile ci-tests --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
           else
             cargo nextest archive --locked --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
@@ -291,3 +293,35 @@ jobs:
           # The release-only dependency check is skipped outside its event scope.
           # Failed, non-skipped jobs still fail this aggregate status.
           allowed-skips: check-no-git-dependencies, pruned-storage
+
+  report-nightly-result:
+    name: report nightly release test result
+    needs: test-success
+    if: always() && github.event_name == 'schedule'
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Create, update, or close the nightly failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NIGHTLY_RESULT: ${{ needs.test-success.result }}
+        run: |
+          issue_title="[nightly] Release-mode test suite failed"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          issue_number="$(gh issue list --state open --search "\"${issue_title}\" in:title" --json number --jq '.[0].number // empty')"
+
+          if [[ "${NIGHTLY_RESULT}" != "success" ]]; then
+            message="The nightly release-mode test suite failed: ${run_url}"
+            if [[ -n "${issue_number}" ]]; then
+              gh issue comment "${issue_number}" --body "${message}"
+            else
+              gh issue create --title "${issue_title}" --body "${message}"
+            fi
+          elif [[ -n "${issue_number}" ]]; then
+            gh issue comment "${issue_number}" --body "The nightly release-mode test suite recovered: ${run_url}"
+            gh issue close "${issue_number}" --reason completed
+          fi

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -64,7 +64,7 @@ jobs:
   # Building once removes two of the three compile passes while preserving
   # parallel test execution across the shard jobs.
   build-tests:
-    name: build test binaries (${{ github.event_name == 'pull_request' && 'debug' || 'release' }})
+    name: build test binaries (${{ github.event_name == 'pull_request' && 'debug' || 'ci-tests' }})
     permissions:
       contents: read
       id-token: write
@@ -79,8 +79,9 @@ jobs:
         with:
           toolchain: stable
           # PR debug builds restore the cache populated by the main-branch
-          # config job. Full-coverage runs keep a separate release cache.
-          cache-shared-key: ${{ github.event_name == 'pull_request' && 'zakura-drb-debug' || 'unit-tests-release' }}
+          # config job. Full-coverage runs use the release-derived `ci-tests`
+          # profile, with a separate cache from production release builds.
+          cache-shared-key: ${{ github.event_name == 'pull_request' && 'zakura-drb-debug' || 'unit-tests-ci-tests' }}
           cache-on-failure: true
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
@@ -94,7 +95,7 @@ jobs:
           # mode the shards run. The run-time-only filters (`--profile`,
           # `--partition`, `--run-ignored`) are applied by the shard jobs, not here.
           if [[ "${FULL_COVERAGE}" == "true" ]]; then
-            cargo nextest archive --locked --release --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
+            cargo nextest archive --locked --cargo-profile ci-tests --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
           else
             cargo nextest archive --locked --features default-release-binaries --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst"
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,6 +341,12 @@ debug = "line-tables-only"
 # Disable debug info for dependencies to reduce binary size.
 debug = false
 
+[profile.ci-tests]
+inherits = "release"
+# Unit tests need release-mode execution speed, but do not benefit from
+# optimizing across crate boundaries.
+lto = "off"
+
 [workspace.lints.rust]
 # The linter should ignore these expected config flags/values
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/changelog-unreleased/411.md
+++ b/changelog-unreleased/411.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes the compilation profile used by CI unit tests and has no
+operator- or crate-consumer-visible effect.


### PR DESCRIPTION
## Motivation

Main unit-test runs currently compile every test binary with the production release profile, including ThinLTO. ThinLTO improves shipped binaries but adds a large link-time cost that routine unit tests do not need. We still want nightly coverage of the exact production compilation profile.

## Solution

- Add a `ci-tests` profile that inherits release settings but disables LTO.
- Use `ci-tests` for full-coverage runs on main, the merge queue, and manual dispatches.
- Keep scheduled nightly runs on Cargo’s literal `--release` profile, including ThinLTO.
- Give debug, `ci-tests`, and release builds distinct Rust cache keys.
- Open one deduplicated GitHub issue when the nightly suite fails, update it on repeated failures, and close it on recovery.
- Leave PR debug builds and production release builds unchanged.

## Testing

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- YAML syntax parsed with Ruby Psych
- `git diff --check`
- [Full-coverage `ci-tests` run](https://github.com/zakura-core/zakura/actions/runs/30009045448): passed
  - Build/archive step: 13m48s, down from 23m36s on the exact base commit (9m48s / 41.5% faster)
  - Build job: 14m35s, down from 24m15s (9m40s / 39.9% faster)
  - All three full-coverage test shards passed

The timing run used a cold cache for the new key because PR branches cannot save Rust caches. Main can populate the cache after merge.

## Changelog

`changelog-unreleased/411.md` declares this internal-only.

### Follow-up Work

The Docker configuration workflow separately compiles all test binaries with the production release profile. Recent Docker image builds took 12m15s and 14m59s, so Docker becomes approximately co-critical after this change. Optimize that build separately while retaining ThinLTO for shipped node binaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI build profiles, caching, and issue reporting; shipped binaries and PR debug test paths are unchanged.
> 
> **Overview**
> **Routine full-coverage unit tests no longer link with ThinLTO**, cutting archive/build time on main, merge queue, and manual runs while keeping release-like optimizations.
> 
> A new **`ci-tests` Cargo profile** inherits `release` but sets `lto = "off"`. The `build-tests` job archives with `--cargo-profile ci-tests` when `FULL_COVERAGE` is true and the event is not the nightly schedule; **scheduled runs still use `--release`** (ThinLTO) so production linking stays covered. Rust cache keys are split between `unit-tests-ci-tests` and `unit-tests-release`.
> 
> A **`report-nightly-result` job** runs only on schedule: it opens or comments on a deduplicated GitHub issue when the nightly suite fails, and closes it with a recovery comment when `test-success` passes again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1397c1f8f55eb66ed275c5a615963eae39a9a4fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->