### PR TITLE
ci: compile main unit tests at O2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,8 +343,9 @@ debug = false
 
 [profile.ci-tests]
 inherits = "release"
-# Unit tests need release-mode execution speed, but do not benefit from
-# optimizing across crate boundaries.
+# Unit tests need optimized execution, but do not need the production profile's
+# most expensive code generation or cross-crate optimization.
+opt-level = 2
 lto = "off"
 
 [workspace.lints.rust]

--- a/changelog-unreleased/412.md
+++ b/changelog-unreleased/412.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes the optimization level used to compile CI unit tests and
+has no operator- or crate-consumer-visible effect.


### PR DESCRIPTION
## Motivation

The main full-coverage unit-test archive skips ThinLTO but still inherits `opt-level = 3` from the production release profile. This measures whether O2 compiles faster without materially increasing test execution time.

## Solution

Set `profile.ci-tests.opt-level = 2`. Nightly `--release` coverage remains unchanged at O3 with ThinLTO, as do production release builds and PR debug tests.

## Testing

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- `git diff --check`
- [Full-coverage O2 run](https://github.com/zakura-core/zakura/actions/runs/30011824953): passed
  - Archive: 12m35s versus 13m08s for O3/no-LTO on the exact main baseline; 33s / 4.2% faster
  - Build job: 13m27s versus 14m12s; 45s / 5.3% faster
  - O2 shards: 1m43s, 1m41s, and 1m43s; all passed

The O3 baseline shards varied from 2m11s to 5m34s in the main run and from 1m45s to 2m52s in the preceding branch run. The O2 run shows no execution regression, but single-run shard differences are too noisy to attribute to the optimization level.

## Changelog

`changelog-unreleased/412.md` declares this internal-only.

### Follow-up Work

The compile saving is modest and Docker remains approximately critical at 15–16 minutes. Optimize the Docker tests-stage build separately. Also skip semver checks when a root `Cargo.toml` diff changes only profile or workspace metadata; this profile-only PR unnecessarily checked all 13 publishable crates.