### PR TITLE
test: speed up slow unit tests

### DIFF
--- a/changelog-unreleased/413.md
+++ b/changelog-unreleased/413.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only speeds up tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -2951,9 +2951,12 @@ async fn v4_with_joinsplit_is_rejected_for_modification(
     assert_eq!(result, expected_error);
 }
 
-/// Test if a V4 transaction with Sapling spends is accepted by the verifier.
+/// Test if V4 and V5 transactions with Sapling spends are accepted by the verifier.
+///
+/// Keeping both versions in one test amortizes Sapling verifying-key
+/// initialization under nextest's process-per-test execution model.
 #[test]
-fn v4_with_sapling_spends() {
+fn v4_and_v5_with_sapling_spends() {
     let _init_guard = zakura_test::init();
     zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
         let network = Network::Mainnet;
@@ -2992,6 +2995,46 @@ fn v4_with_sapling_spends() {
             result.expect("unexpected error response").tx_id(),
             expected_hash
         );
+
+        for net in Network::iter() {
+            let nu5_activation = NetworkUpgrade::Nu5.activation_height(&net);
+
+            let tx = v5_transactions(net.block_iter())
+                .filter(|tx| {
+                    !tx.is_coinbase()
+                        && tx.inputs().is_empty()
+                        && tx.expiry_height() >= nu5_activation
+                })
+                .find(|tx| tx.sapling_spends_per_anchor().next().is_some())
+                .expect("V5 tx with Sapling spends");
+
+            let expected_hash = tx.unmined_id();
+            let height = tx.expiry_height().expect("expiry height");
+
+            let verifier = Verifier::new_for_tests(
+                &net,
+                service_fn(|_| async { unreachable!("State service should not be called") }),
+            );
+
+            assert_eq!(
+                timeout(
+                    test_timeout(),
+                    verifier.oneshot(Request::Block {
+                        transaction_hash: tx.hash(),
+                        transaction: Arc::new(tx),
+                        known_utxos: Arc::new(HashMap::new()),
+                        known_outpoint_hashes: Arc::new(HashSet::new()),
+                        height,
+                        time: DateTime::<Utc>::MAX_UTC,
+                    })
+                )
+                .await
+                .expect("timeout expired")
+                .expect("unexpected error response")
+                .tx_id(),
+                expected_hash
+            );
+        }
     });
 }
 
@@ -3594,50 +3637,6 @@ fn modify_first_sapling_spend_proof_in_transfers<A: sapling::AnchorVariant + Clo
         sapling::TransferData::JustOutputs { .. } => {
             panic!("expected Sapling shielded data with spends")
         }
-    }
-}
-
-/// Test if a V5 transaction with Sapling spends is accepted by the verifier.
-#[tokio::test]
-async fn v5_with_sapling_spends() {
-    let _init_guard = zakura_test::init();
-
-    for net in Network::iter() {
-        let nu5_activation = NetworkUpgrade::Nu5.activation_height(&net);
-
-        let tx = v5_transactions(net.block_iter())
-            .filter(|tx| {
-                !tx.is_coinbase() && tx.inputs().is_empty() && tx.expiry_height() >= nu5_activation
-            })
-            .find(|tx| tx.sapling_spends_per_anchor().next().is_some())
-            .expect("V5 tx with Sapling spends");
-
-        let expected_hash = tx.unmined_id();
-        let height = tx.expiry_height().expect("expiry height");
-
-        let verifier = Verifier::new_for_tests(
-            &net,
-            service_fn(|_| async { unreachable!("State service should not be called") }),
-        );
-
-        assert_eq!(
-            timeout(
-                test_timeout(),
-                verifier.oneshot(Request::Block {
-                    transaction_hash: tx.hash(),
-                    transaction: Arc::new(tx),
-                    known_utxos: Arc::new(HashMap::new()),
-                    known_outpoint_hashes: Arc::new(HashSet::new()),
-                    height,
-                    time: DateTime::<Utc>::MAX_UTC,
-                })
-            )
-            .await
-            .expect("timeout expired")
-            .expect("unexpected error response")
-            .tx_id(),
-            expected_hash
-        );
     }
 }
 

--- a/zakura-network/src/zakura/testkit/node.rs
+++ b/zakura-network/src/zakura/testkit/node.rs
@@ -672,16 +672,26 @@ mod tests {
         // the per-IP cap of 1 must turn away a second distinct identity from
         // 127.0.0.1. Before the fix, peer1 was charged to the decoy IP, leaving
         // the loopback bucket empty and wrongly admitting peer2.
-        let excess = node
-            .connect_native_to_addr(
-                ipv4_loopback_addr(&peer2.node_addr().await),
-                TEST_NET_TIMEOUT,
-            )
-            .await;
+        let peer2_addr = ipv4_loopback_addr(&peer2.node_addr().await);
+        let excess = tokio::time::timeout(
+            Duration::from_secs(5),
+            crate::zakura::handler::serve_native_dial_connection(
+                &node.endpoint(),
+                peer2_addr,
+                node.limits(),
+            ),
+        )
+        .await
+        .expect("the rejected one-shot dial must finish promptly");
         assert!(
-            excess.is_err(),
+            excess.is_ok(),
             "second same-loopback identity must be rejected by the per-IP cap, proving the \
              first dial was charged to the confirmed path and not the advertised decoy",
+        );
+        assert_eq!(
+            node.supervisor().registered_ids().await.len(),
+            1,
+            "the rejected peer must not be registered",
         );
 
         node.shutdown().await;

--- a/zakura-rpc/src/server/tests/vectors.rs
+++ b/zakura-rpc/src/server/tests/vectors.rs
@@ -74,9 +74,11 @@ async fn rpc_server_spawn() {
 
     info!("spawned RPC server, checking services...");
 
-    mempool.expect_no_requests().await;
-    read_state.expect_no_requests().await;
-    block_verifier_router.expect_no_requests().await;
+    tokio::join!(
+        mempool.expect_no_requests(),
+        read_state.expect_no_requests(),
+        block_verifier_router.expect_no_requests(),
+    );
 }
 
 /// Test that the JSON-RPC server spawns on an OS-assigned unallocated port.
@@ -145,10 +147,12 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
 
     info!("spawned RPC server, checking services...");
 
-    mempool.expect_no_requests().await;
-    state.expect_no_requests().await;
-    read_state.expect_no_requests().await;
-    block_verifier_router.expect_no_requests().await;
+    tokio::join!(
+        mempool.expect_no_requests(),
+        state.expect_no_requests(),
+        read_state.expect_no_requests(),
+        block_verifier_router.expect_no_requests(),
+    );
 
     if do_shutdown {
         rpc.abort();
@@ -158,7 +162,6 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
 /// Test if the RPC server will panic correctly when there is a port conflict.
 #[tokio::test]
 async fn rpc_server_spawn_port_conflict() {
-    use std::time::Duration;
     let _init_guard = zakura_test::init();
 
     let port = zakura_test::net::random_known_port();
@@ -202,14 +205,14 @@ async fn rpc_server_spawn_port_conflict() {
         .await
         .expect("RPC server should start");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
     RpcServer::start(rpc_impl, conf)
         .await
         .expect_err("RPC server should not start");
 
-    mempool.expect_no_requests().await;
-    state.expect_no_requests().await;
-    read_state.expect_no_requests().await;
-    block_verifier_router.expect_no_requests().await;
+    tokio::join!(
+        mempool.expect_no_requests(),
+        state.expect_no_requests(),
+        read_state.expect_no_requests(),
+        block_verifier_router.expect_no_requests(),
+    );
 }

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -59,6 +59,30 @@ fn early_upgrade_network() -> zakura_chain::parameters::Network {
         .expect("failed to build configured network")
 }
 
+/// A testnet with room between upgrades for tests that need era-specific
+/// transactions or several consecutive blocks within one upgrade.
+fn spaced_upgrade_network() -> zakura_chain::parameters::Network {
+    ParametersBuilder::default()
+        .with_activation_heights(ConfiguredActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(10),
+            sapling: Some(15),
+            blossom: Some(20),
+            heartwood: Some(25),
+            canopy: Some(30),
+            nu5: Some(35),
+            nu6: Some(40),
+            nu6_1: Some(45),
+            nu6_2: Some(47),
+            nu6_3: Some(48),
+            nu7: Some(50),
+        })
+        .expect("failed to set activation heights")
+        .extend_funding_streams()
+        .to_network()
+        .expect("failed to build configured network")
+}
+
 type TestRootMap = HashMap<
     u32,
     (
@@ -277,25 +301,7 @@ fn v4_transaction_with_interstitial_anchor(old_anchor_tree: &SproutTree) -> Arc<
 fn vct_generated_final_frontier_bytes_are_node_loader_compatible() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -670,25 +676,7 @@ fn vct_fast_path_matches_legacy_and_rejects_wrong_roots() -> Result<()> {
 fn vct_frozen_frontier_hole_refuses_instead_of_recomputing() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -775,25 +763,7 @@ fn vct_frozen_frontier_hole_refuses_instead_of_recomputing() -> Result<()> {
 fn vct_retryable_root_miss_keeps_checkpoint_response_pending() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -879,25 +849,7 @@ fn vct_peer_source_defers_unverifiable_tip_root_until_successor() -> Result<()> 
 
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = spaced_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -1120,25 +1072,7 @@ fn vct_peer_source_bad_root_refill_commits_same_height() -> Result<()> {
 
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let nu5_height = NetworkUpgrade::Nu5
         .activation_height(&network)
         .expect("NU5 activation height is configured");
@@ -1263,25 +1197,7 @@ fn vct_peer_source_bad_root_refill_commits_same_height() -> Result<()> {
 fn vct_frozen_frontier_survives_reopen() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -1440,25 +1356,7 @@ fn vct_frozen_frontier_survives_reopen() -> Result<()> {
 fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = spaced_upgrade_network();
     let nu5_height = NetworkUpgrade::Nu5
         .activation_height(&network)
         .expect("NU5 activation height is configured");
@@ -1791,25 +1689,7 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
 fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let nu5_height = NetworkUpgrade::Nu5
         .activation_height(&network)
         .expect("NU5 activation height is configured");
@@ -2021,25 +1901,7 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
 fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = spaced_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -2321,25 +2183,7 @@ fn vct_dedup_skips_redundant_check_and_guards_stale_cache() -> Result<()> {
 fn vct_clear_prevalidation_cache_disarms_skip_then_dedup_resumes() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -2429,25 +2273,7 @@ fn vct_clear_prevalidation_cache_disarms_skip_then_dedup_resumes() -> Result<()>
 fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 
@@ -2570,25 +2396,7 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
 fn vct_peer_source_filled_incrementally_drives_byte_identical_state() -> Result<()> {
     let _init_guard = zakura_test::init();
 
-    let network = ParametersBuilder::default()
-        .with_activation_heights(ConfiguredActivationHeights {
-            before_overwinter: Some(1),
-            overwinter: Some(10),
-            sapling: Some(15),
-            blossom: Some(20),
-            heartwood: Some(25),
-            canopy: Some(30),
-            nu5: Some(35),
-            nu6: Some(40),
-            nu6_1: Some(45),
-            nu6_2: Some(47),
-            nu6_3: Some(48),
-            nu7: Some(50),
-        })
-        .expect("failed to set activation heights")
-        .extend_funding_streams()
-        .to_network()
-        .expect("failed to build configured network");
+    let network = early_upgrade_network();
     let ledger_strategy =
         LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
 

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -3030,14 +3030,14 @@ async fn regtest_block_templates_are_valid_block_submissions() -> Result<()> {
     Ok(())
 }
 
-/// A rejected block body must not poison the children of a later valid block with the same header
-/// hash.
+/// A rejected block body must not poison a later valid block with the same
+/// header hash or its children.
 ///
 /// This is a regression test for [GHSA-8gxx-hc65-vv82][ghsa-8gxx]. Under the transaction digest
 /// scheme defined by [ZIP-244][zip-244], two different block bodies can share the same header hash.
-/// `zakura-state` previously retained the contextual validation error from the poisoned body and
-/// incorrectly propagated it to children of the later valid block, causing them to be incorrectly
-/// rejected.
+/// `zakura-state` previously retained the contextual validation error from the
+/// poisoned body. This made the valid body appear known as sent and propagated
+/// the error to its children, causing both to be incorrectly rejected.
 ///
 /// [ghsa-8gxx]: https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82
 /// [zip-244]: https://zips.z.cash/zip-0244
@@ -3158,119 +3158,6 @@ async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()>
         client.blockchain_info().await?.blocks(),
         Height(4),
         "the valid child must not inherit the rejected block body error"
-    );
-
-    zakurad.kill(false)?;
-    let output = zakurad.wait_with_output()?;
-    output.assert_failure()?.assert_was_killed()?;
-
-    Ok(())
-}
-
-/// A contextually rejected block must not remain known as sent.
-///
-/// Sync checks [`zakura_state::Request::KnownBlock`] before downloading a block body. If a rejected
-/// block remains in the state's sent hashes, an honest block body with the same header hash is
-/// incorrectly reported as a duplicate and never reaches contextual verification.
-#[tokio::test]
-async fn rejected_block_is_not_known_as_sent() -> Result<()> {
-    const EXTRA_COINBASE_DATA: &str = "zakura-chain-stall-poc";
-
-    let _init_guard = zakura_test::init();
-
-    let network = Network::new_regtest(
-        ConfiguredActivationHeights {
-            nu5: Some(1),
-            ..Default::default()
-        }
-        .into(),
-    );
-    let mut config = os_assigned_rpc_port_config(false, &network)?;
-    config.mempool.debug_enable_at_height = Some(0);
-    config.mining.extra_coinbase_data =
-        Some(ExtraCoinbaseData::try_from(EXTRA_COINBASE_DATA.to_owned())?);
-
-    let mut block_builder = testdir()?
-        .with_config(&mut config)?
-        .spawn_child(args!["start"])?
-        .with_timeout(EXTENDED_LAUNCH_DELAY);
-    let rpc_address = read_listen_addr_from_logs(&mut block_builder, OPENED_RPC_ENDPOINT_MSG)?;
-    block_builder.expect_stdout_line_matches("activating mempool")?;
-
-    let client = RpcRequestClient::new(rpc_address);
-    let mut blocks = Vec::new();
-    for expected_height in 1..=3 {
-        let (block, height) = client.block_from_template(&network).await?;
-        assert_eq!(height.0, expected_height);
-        client.submit_block(block.clone()).await?;
-        blocks.push(block);
-    }
-
-    block_builder.kill(false)?;
-    let output = block_builder.wait_with_output()?;
-    output.assert_failure()?.assert_was_killed()?;
-
-    let mut zakurad = testdir()?
-        .with_config(&mut config)?
-        .spawn_child(args!["start"])?
-        .with_timeout(EXTENDED_LAUNCH_DELAY);
-    let rpc_address = read_listen_addr_from_logs(&mut zakurad, OPENED_RPC_ENDPOINT_MSG)?;
-    zakurad.expect_stdout_line_matches("activating mempool")?;
-
-    let client = RpcRequestClient::new(rpc_address);
-    client.submit_block(blocks[0].clone()).await?;
-    client.submit_block(blocks[1].clone()).await?;
-
-    let valid_block = blocks[2].clone();
-    let mut poisoned_block = valid_block.clone();
-    let coinbase = Arc::make_mut(
-        poisoned_block
-            .transactions
-            .first_mut()
-            .expect("block templates contain a coinbase transaction"),
-    );
-    let transparent::Input::Coinbase { data, .. } = coinbase
-        .inputs_mut()
-        .first_mut()
-        .expect("coinbase transactions contain a transparent input")
-    else {
-        panic!("the first coinbase transaction input must be a coinbase input");
-    };
-    assert!(
-        data.ends_with(EXTRA_COINBASE_DATA.as_bytes()),
-        "the coinbase transaction must contain the configured extra data"
-    );
-    let last_data_byte = data
-        .last_mut()
-        .expect("configured extra coinbase data is non-empty");
-    *last_data_byte = b'a';
-
-    assert_eq!(
-        poisoned_block.hash(),
-        valid_block.hash(),
-        "changing a NU5 coinbase scriptSig must not change the block header hash"
-    );
-
-    let poisoned_block_data = hex::encode(poisoned_block.zcash_serialize_to_vec()?);
-    let poisoned_response: SubmitBlockResponse = client
-        .json_result_from_call("submitblock", format!(r#"["{poisoned_block_data}"]"#))
-        .await
-        .map_err(|err| eyre!(err))?;
-    assert_eq!(
-        poisoned_response,
-        SubmitBlockResponse::ErrorResponse(SubmitBlockErrorResponse::Rejected),
-        "the poisoned block body must be rejected"
-    );
-
-    let valid_block_data = hex::encode(valid_block.zcash_serialize_to_vec()?);
-    let valid_response: SubmitBlockResponse = client
-        .json_result_from_call("submitblock", format!(r#"["{valid_block_data}"]"#))
-        .await
-        .map_err(|err| eyre!(err))?;
-    assert_eq!(
-        valid_response,
-        SubmitBlockResponse::Accepted,
-        "KnownBlock must drain rejected hashes before checking sent hashes"
     );
 
     zakurad.kill(false)?;

--- a/zakurad/tests/acceptance.rs
+++ b/zakurad/tests/acceptance.rs
@@ -1657,30 +1657,27 @@ async fn tracing_endpoint() -> Result<()> {
     Ok(())
 }
 
-/// Test that the JSON-RPC endpoint responds to a request,
-/// when configured with a single thread.
+/// Test the JSON-RPC endpoint with single- and multi-threaded configurations.
+///
+/// The multi-threaded node also checks zcashd-compatible content types, avoiding
+/// a third node startup for those requests.
 #[tokio::test]
-async fn rpc_endpoint_single_thread() -> Result<()> {
-    rpc_endpoint(false).await
-}
+async fn rpc_endpoints() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    if zakura_test::net::zebra_skip_network_tests() {
+        return Ok(());
+    }
 
-/// Test that the JSON-RPC endpoint responds to a request,
-/// when configured with multiple threads.
-#[tokio::test]
-async fn rpc_endpoint_parallel_threads() -> Result<()> {
-    rpc_endpoint(true).await
+    tokio::try_join!(rpc_endpoint(false, false), rpc_endpoint(true, true))?;
+
+    Ok(())
 }
 
 /// Test that the JSON-RPC endpoint responds to a request.
 ///
 /// Set `parallel_cpu_threads` to true to auto-configure based on the number of CPU cores.
 #[tracing::instrument]
-async fn rpc_endpoint(parallel_cpu_threads: bool) -> Result<()> {
-    let _init_guard = zakura_test::init();
-    if zakura_test::net::zebra_skip_network_tests() {
-        return Ok(());
-    }
-
+async fn rpc_endpoint(parallel_cpu_threads: bool, check_content_types: bool) -> Result<()> {
     // Write a configuration that has RPC listen_addr set
     // [Note on port conflict](#Note on port conflict)
     let mut config = os_assigned_rpc_port_config(parallel_cpu_threads, &Mainnet)?;
@@ -1712,6 +1709,10 @@ async fn rpc_endpoint(parallel_cpu_threads: bool) -> Result<()> {
     let subversion = parsed["result"]["subversion"].as_str().unwrap();
     assert!(subversion.contains("Zakura"), "Got {subversion}");
 
+    if check_content_types {
+        check_rpc_endpoint_content_types(&client).await?;
+    }
+
     child.kill(false)?;
 
     let output = child.wait_with_output()?;
@@ -1730,25 +1731,7 @@ async fn rpc_endpoint(parallel_cpu_threads: bool) -> Result<()> {
 /// This test ensures that the curl examples of zcashd rpc methods will also work in Zebra.
 ///
 /// https://zcash.github.io/rpc/getblockchaininfo.html
-#[tokio::test]
-async fn rpc_endpoint_client_content_type() -> Result<()> {
-    let _init_guard = zakura_test::init();
-    if zakura_test::net::zebra_skip_network_tests() {
-        return Ok(());
-    }
-
-    // Let the OS assign the RPC port to avoid races with parallel tests.
-    let mut config = os_assigned_rpc_port_config(true, &Mainnet)?;
-
-    let dir = testdir()?.with_config(&mut config)?;
-    let mut child = dir.spawn_child(args!["start"])?;
-
-    // Wait until port is open.
-    let rpc_address = read_listen_addr_from_logs(&mut child, OPENED_RPC_ENDPOINT_MSG)?;
-
-    // Create an http client
-    let client = RpcRequestClient::new(rpc_address);
-
+async fn check_rpc_endpoint_content_types(client: &RpcRequestClient) -> Result<()> {
     // Call to `getinfo` RPC method with a no content type.
     let res = client
         .call_with_no_content_type("getinfo", "[]".to_string())

--- a/zakurad/tests/common/regtest.rs
+++ b/zakurad/tests/common/regtest.rs
@@ -31,15 +31,18 @@ use crate::common::{
     launch::{ZakuradTestDirExt, EXTENDED_LAUNCH_DELAY},
 };
 
-/// Number of blocks that should be submitted before the test is considered successful.
-const NUM_BLOCKS_TO_SUBMIT: usize = 200;
+/// The early NU5 boundary used to cover pre-NU5 and NU5 block submissions.
+const NU5_ACTIVATION_HEIGHT: u32 = 5;
+
+/// Number of blocks submitted across the configured NU5 boundary.
+const NUM_BLOCKS_TO_SUBMIT: usize = 10;
 
 pub(crate) async fn submit_blocks_test() -> Result<()> {
     let _init_guard = zakura_test::init();
 
     let net = Network::new_regtest(
         ConfiguredActivationHeights {
-            nu5: Some(100),
+            nu5: Some(NU5_ACTIVATION_HEIGHT),
             ..Default::default()
         }
         .into(),


### PR DESCRIPTION
## Motivation

PR #412’s unit-test timings exposed avoidable fixed waits and repeated setup
among the slowest tests. Together, these tests consumed an estimated 83–100
seconds of aggregate test work and materially extended the slowest nextest
shard.

## Solution

- replace the network rejection test’s maintained 30-second redial with a
  bounded one-shot dial
- share two node startups across the three RPC endpoint scenarios
- run independent RPC absence assertions concurrently and remove an
  unnecessary port-conflict sleep
- use compact upgrade schedules in VCT tests that do not require era spacing
- combine the V4 and V5 Sapling-spend verifier cases so the verifying key is
  initialized once
- combine two overlapping rejected-block regressions into one scenario that
  checks the valid same-hash block and its child
- move the Regtest NU5 boundary to height 5 and submit 10 blocks instead of
  submitting 200 blocks to cross NU5 at height 100

The estimated aggregate saving is now 94–115 seconds. Fresh CI timings will be
authoritative.

## Testing

Before opening this draft, the original focused tests passed locally:

- `cargo test -p zakura-network outbound_dial_charges_confirmed_path_not_advertised_decoy -- --nocapture`
- `cargo test -p zakura --test acceptance rpc_endpoints`
- `cargo test -p zakura-consensus v4_and_v5_with_sapling_spends`
- `cargo test -p zakura-rpc rpc_server_spawn_`
- `cargo test -p zakura-state service::finalized_state::tests::prop::vct_`
- `cargo fmt --all -- --check`
- `git diff --check`

For the acceptance follow-up:

- `cargo fmt --all -- --check`
- `git diff --check`
- CPU-heavy acceptance tests are left to draft CI

## Changelog

Added an explicit no-changelog fragment because these are internal test-only
changes.

### Specifications & References

- #412

### Follow-up Work

Tune the remaining property-test matrices and mini-suites separately using
fresh CI timing data.
