### PR TITLE
perf(consensus): flush crypto batches at block boundary

### DIFF
--- a/changelog-unreleased/417.md
+++ b/changelog-unreleased/417.md
@@ -1,0 +1,6 @@
+## Changed
+
+- Flush partial cryptographic verification batches at semantic block boundaries,
+  avoiding the global 100 ms batch delay during block execution when the
+  boundary signal succeeds
+  ([#417](https://github.com/zakura-core/zakura/pull/417)).

--- a/tower-batch-control/src/lib.rs
+++ b/tower-batch-control/src/lib.rs
@@ -125,6 +125,9 @@ pub use self::service::Batch;
 pub trait RequestWeight {
     /// Returns the weight of a request relative to the maximum threshold for flushing
     /// requests to the underlying service.
+    ///
+    /// Batch bookkeeping treats every queued item as having a weight of at least 1,
+    /// so zero-weight items still start the batch timer and are flushed.
     fn request_weight(&self) -> usize {
         1
     }

--- a/tower-batch-control/src/message.rs
+++ b/tower-batch-control/src/message.rs
@@ -4,13 +4,22 @@ use tokio::sync::{oneshot, OwnedSemaphorePermit};
 
 use super::error::ServiceError;
 
-/// Message sent to the batch worker
+/// Message sent to the batch worker.
 #[derive(Debug)]
-pub(crate) struct Message<Request, Fut> {
-    pub(crate) request: Request,
-    pub(crate) tx: Tx<Fut>,
-    pub(crate) span: tracing::Span,
-    pub(super) _permit: OwnedSemaphorePermit,
+pub(crate) enum Message<Request, Fut> {
+    /// A batch item request.
+    Item {
+        request: Request,
+        tx: Tx<Fut>,
+        span: tracing::Span,
+        _permit: OwnedSemaphorePermit,
+    },
+
+    /// An explicit request to flush the pending batch.
+    Flush {
+        span: tracing::Span,
+        _permit: OwnedSemaphorePermit,
+    },
 }
 
 /// Response sender

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -229,6 +229,11 @@ where
     /// The flush is queued after item requests that have already been sent to
     /// this batch worker. This method waits for queue capacity and returns when
     /// the command has been queued, not when the underlying batch has completed.
+    ///
+    /// If this service holds a readiness reservation from an earlier
+    /// [`poll_ready`](Service::poll_ready) call, the flush consumes it, so
+    /// callers must poll readiness again before the next
+    /// [`call`](Service::call).
     pub async fn flush(&mut self) -> Result<(), crate::BoxError> {
         let _permit = match self.permit.take() {
             Some(permit) => permit,

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -12,7 +12,7 @@ use std::{
 use futures_core::ready;
 use tokio::{
     pin,
-    sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore},
+    sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore, TryAcquireError},
     task::JoinHandle,
 };
 use tokio_util::sync::PollSemaphore;
@@ -250,6 +250,39 @@ where
                 span: tracing::Span::current(),
                 _permit,
             })
+            .map_err(|_| self.get_worker_error())
+    }
+
+    /// Explicitly flushes the current pending batch, if queue capacity is
+    /// immediately available.
+    ///
+    /// Non-blocking twin of [`flush`](Self::flush): the flush is queued after
+    /// item requests that have already been sent to this batch worker, and
+    /// `Ok(true)` means the command has been queued, not that the underlying
+    /// batch has completed. Returns `Ok(false)` without queueing when the
+    /// queue is at capacity: a full queue is already flushing batches on size,
+    /// so an explicit flush would add nothing.
+    ///
+    /// If this service holds a readiness reservation from an earlier
+    /// [`poll_ready`](Service::poll_ready) call, the flush consumes it, so
+    /// callers must poll readiness again before the next
+    /// [`call`](Service::call).
+    pub fn try_flush(&mut self) -> Result<bool, crate::BoxError> {
+        let _permit = match self.permit.take() {
+            Some(permit) => permit,
+            None => match self.semaphore.clone_inner().try_acquire_owned() {
+                Ok(permit) => permit,
+                Err(TryAcquireError::NoPermits) => return Ok(false),
+                Err(TryAcquireError::Closed) => return Err(self.get_worker_error()),
+            },
+        };
+
+        self.tx
+            .send(Message::Flush {
+                span: tracing::Span::current(),
+                _permit,
+            })
+            .map(|()| true)
             .map_err(|_| self.get_worker_error())
     }
 }

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -223,6 +223,30 @@ where
     fn get_worker_error(&self) -> crate::BoxError {
         self.error_handle.get_error_on_closed()
     }
+
+    /// Explicitly flushes the current pending batch.
+    ///
+    /// The flush is queued after item requests that have already been sent to
+    /// this batch worker. This method waits for queue capacity and returns when
+    /// the command has been queued, not when the underlying batch has completed.
+    pub async fn flush(&mut self) -> Result<(), crate::BoxError> {
+        let _permit = match self.permit.take() {
+            Some(permit) => permit,
+            None => self
+                .semaphore
+                .clone_inner()
+                .acquire_owned()
+                .await
+                .map_err(|_| self.get_worker_error())?,
+        };
+
+        self.tx
+            .send(Message::Flush {
+                span: tracing::Span::current(),
+                _permit,
+            })
+            .map_err(|_| self.get_worker_error())
+    }
 }
 
 impl<T, Request: RequestWeight> Service<Request> for Batch<T, Request>
@@ -330,7 +354,7 @@ where
         // acquired, so we can freely allocate a oneshot.
         let (tx, rx) = oneshot::channel();
 
-        match self.tx.send(Message {
+        match self.tx.send(Message::Item {
             request,
             tx,
             span,

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -224,44 +224,14 @@ where
         self.error_handle.get_error_on_closed()
     }
 
-    /// Explicitly flushes the current pending batch.
-    ///
-    /// The flush is queued after item requests that have already been sent to
-    /// this batch worker. This method waits for queue capacity and returns when
-    /// the command has been queued, not when the underlying batch has completed.
-    ///
-    /// If this service holds a readiness reservation from an earlier
-    /// [`poll_ready`](Service::poll_ready) call, the flush consumes it, so
-    /// callers must poll readiness again before the next
-    /// [`call`](Service::call).
-    pub async fn flush(&mut self) -> Result<(), crate::BoxError> {
-        let _permit = match self.permit.take() {
-            Some(permit) => permit,
-            None => self
-                .semaphore
-                .clone_inner()
-                .acquire_owned()
-                .await
-                .map_err(|_| self.get_worker_error())?,
-        };
-
-        self.tx
-            .send(Message::Flush {
-                span: tracing::Span::current(),
-                _permit,
-            })
-            .map_err(|_| self.get_worker_error())
-    }
-
     /// Explicitly flushes the current pending batch, if queue capacity is
     /// immediately available.
     ///
-    /// Non-blocking twin of [`flush`](Self::flush): the flush is queued after
-    /// item requests that have already been sent to this batch worker, and
-    /// `Ok(true)` means the command has been queued, not that the underlying
-    /// batch has completed. Returns `Ok(false)` without queueing when the
-    /// queue is at capacity: a full queue is already flushing batches on size,
-    /// so an explicit flush would add nothing.
+    /// The flush is queued after item requests that have already been sent to
+    /// this batch worker, and `Ok(true)` means the command has been queued, not
+    /// that the underlying batch has completed. Returns `Ok(false)` without
+    /// queueing when the queue is at capacity: a full queue is already flushing
+    /// batches on size, so an explicit flush would add nothing.
     ///
     /// If this service holds a readiness reservation from an earlier
     /// [`poll_ready`](Service::poll_ready) call, the flush consumes it, so

--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -146,7 +146,10 @@ where
 
         match self.service.ready().await {
             Ok(svc) => {
-                self.pending_items_weight += req.request_weight();
+                // Floor each item at weight 1 so `pending_items_weight == 0` always
+                // means "no queued items": a zero-weight item must still start the
+                // batch timer and be flushed. See `RequestWeight::request_weight`.
+                self.pending_items_weight += req.request_weight().max(1);
                 let rsp = svc.call(req.into());
                 let _ = tx.send(Ok(rsp));
             }

--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -53,9 +53,6 @@ where
     /// The total weight of pending requests sent to `service`, since the last batch flush.
     pending_items_weight: usize,
 
-    /// The number of pending requests sent to `service`, since the last batch flush.
-    pending_items_count: usize,
-
     /// The timer for the pending batch, if it has any items.
     ///
     /// The timer is started when the first entry of a new batch is
@@ -123,7 +120,6 @@ where
             rx,
             service,
             pending_items_weight: 0,
-            pending_items_count: 0,
             pending_batch_timer: None,
             concurrent_batches: FuturesUnordered::new(),
             failed: None,
@@ -151,7 +147,6 @@ where
         match self.service.ready().await {
             Ok(svc) => {
                 self.pending_items_weight += req.request_weight();
-                self.pending_items_count += 1;
                 let rsp = svc.call(req.into());
                 let _ = tx.send(Ok(rsp));
             }
@@ -171,7 +166,7 @@ where
     /// Waits until the inner service is ready,
     /// then stores a future which resolves when the batch finishes.
     async fn flush_service(&mut self) {
-        if self.pending_items_count == 0 {
+        if self.pending_items_weight == 0 {
             tracing::trace!("skipping flush for empty batch");
             self.pending_batch_timer = None;
             return;
@@ -189,7 +184,6 @@ where
 
                 // Now we have an empty batch.
                 self.pending_items_weight = 0;
-                self.pending_items_count = 0;
                 self.pending_batch_timer = None;
             }
             Err(error) => {
@@ -258,7 +252,7 @@ where
                             "batch message received",
                         );
 
-                        let is_new_batch = self.pending_items_count == 0;
+                        let is_new_batch = self.pending_items_weight == 0;
 
                         self.process_req(request, tx)
                             // Apply the provided span to request processing.

--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -53,6 +53,9 @@ where
     /// The total weight of pending requests sent to `service`, since the last batch flush.
     pending_items_weight: usize,
 
+    /// The number of pending requests sent to `service`, since the last batch flush.
+    pending_items_count: usize,
+
     /// The timer for the pending batch, if it has any items.
     ///
     /// The timer is started when the first entry of a new batch is
@@ -120,6 +123,7 @@ where
             rx,
             service,
             pending_items_weight: 0,
+            pending_items_count: 0,
             pending_batch_timer: None,
             concurrent_batches: FuturesUnordered::new(),
             failed: None,
@@ -147,6 +151,7 @@ where
         match self.service.ready().await {
             Ok(svc) => {
                 self.pending_items_weight += req.request_weight();
+                self.pending_items_count += 1;
                 let rsp = svc.call(req.into());
                 let _ = tx.send(Ok(rsp));
             }
@@ -166,6 +171,12 @@ where
     /// Waits until the inner service is ready,
     /// then stores a future which resolves when the batch finishes.
     async fn flush_service(&mut self) {
+        if self.pending_items_count == 0 {
+            tracing::trace!("skipping flush for empty batch");
+            self.pending_batch_timer = None;
+            return;
+        }
+
         if self.failed.is_some() {
             tracing::trace!("worker failure: skipping flush");
             return;
@@ -178,6 +189,7 @@ where
 
                 // Now we have an empty batch.
                 self.pending_items_weight = 0;
+                self.pending_items_count = 0;
                 self.pending_batch_timer = None;
             }
             Err(error) => {
@@ -233,7 +245,12 @@ where
                 },
 
                 maybe_msg = self.rx.recv(), if self.can_spawn_new_batches() => match maybe_msg {
-                    Some(msg) => {
+                    Some(Message::Item {
+                        request,
+                        tx,
+                        span,
+                        ..
+                    }) => {
                         tracing::trace!(
                             pending_items_weight = self.pending_items_weight,
                             batch_deadline = ?self.pending_batch_timer.as_ref().map(|sleep| sleep.deadline()),
@@ -241,10 +258,9 @@ where
                             "batch message received",
                         );
 
-                        let span = msg.span;
-                        let is_new_batch = self.pending_items_weight == 0;
+                        let is_new_batch = self.pending_items_count == 0;
 
-                        self.process_req(msg.request, msg.tx)
+                        self.process_req(request, tx)
                             // Apply the provided span to request processing.
                             .instrument(span)
                             .await;
@@ -278,6 +294,16 @@ where
                                 "waiting for full batch or batch timer",
                             );
                         }
+                    }
+                    Some(Message::Flush { span, .. }) => {
+                        tracing::trace!(
+                            pending_items_weight = self.pending_items_weight,
+                            batch_deadline = ?self.pending_batch_timer.as_ref().map(|sleep| sleep.deadline()),
+                            running_batches = self.concurrent_batches.len(),
+                            "explicit batch flush received",
+                        );
+
+                        self.flush_service().instrument(span).await;
                     }
                     None => {
                         tracing::trace!("batch channel closed and emptied, exiting worker task");
@@ -375,9 +401,9 @@ where
 
         // Fail queued requests
         while let Ok(msg) = self.rx.try_recv() {
-            let _ = msg
-                .tx
-                .send(Err(self.failed.as_ref().expect("just set failed").clone()));
+            if let Message::Item { tx, .. } = msg {
+                let _ = tx.send(Err(self.failed.as_ref().expect("just set failed").clone()));
+            }
         }
 
         // Clear any finished batches, ignoring any errors.

--- a/tower-batch-control/tests/ed25519.rs
+++ b/tower-batch-control/tests/ed25519.rs
@@ -35,21 +35,31 @@ type VerifyResult = Result<(), Error>;
 type Sender = watch::Sender<Option<VerifyResult>>;
 
 /// The type of the batch item.
-/// A newtype around an `Ed25519Item` which implements [`RequestWeight`].
+/// An Ed25519 item and its batch weight.
 #[derive(Clone, Debug)]
-struct Item(batch::Item);
+struct Item {
+    item: batch::Item,
+    weight: usize,
+}
 
-impl RequestWeight for Item {}
+impl RequestWeight for Item {
+    fn request_weight(&self) -> usize {
+        self.weight
+    }
+}
 
 impl<'msg, M: AsRef<[u8]> + ?Sized> From<(VerificationKeyBytes, Signature, &'msg M)> for Item {
     fn from(tup: (VerificationKeyBytes, Signature, &'msg M)) -> Self {
-        Self(batch::Item::from(tup))
+        Self {
+            item: batch::Item::from(tup),
+            weight: 1,
+        }
     }
 }
 
 impl Item {
     fn verify_single(self) -> VerifyResult {
-        self.0.verify_single()
+        self.item.verify_single()
     }
 }
 
@@ -123,7 +133,7 @@ impl Service<BatchControl<Item>> for Verifier {
 
     fn call(&mut self, req: BatchControl<Item>) -> Self::Future {
         match req {
-            BatchControl::Item(Item(item)) => {
+            BatchControl::Item(Item { item, .. }) => {
                 tracing::trace!("got ed25519 item");
                 self.batch.queue(item);
                 let mut rx = self.tx.subscribe();
@@ -223,6 +233,34 @@ where
     Ok(())
 }
 
+async fn sign_and_verify_after_explicit_flush(
+    mut verifier: Batch<Verifier, Item>,
+    n: usize,
+    weight: usize,
+) -> Result<(), BoxError> {
+    let mut results = FuturesOrdered::new();
+    for _ in 0..n {
+        let sk = SigningKey::new(thread_rng());
+        let vk_bytes = VerificationKeyBytes::from(&sk);
+        let msg = b"BatchVerifyTest";
+        let sig = sk.sign(&msg[..]);
+
+        let mut item: Item = (vk_bytes, sig, msg).into();
+        item.weight = weight;
+
+        verifier.ready().await?;
+        results.push_back(verifier.call(item));
+    }
+
+    verifier.flush().await?;
+
+    while let Some(result) = results.next().await {
+        result?;
+    }
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn batch_flushes_on_max_items_weight() -> Result<(), Report> {
     use tokio::time::timeout;
@@ -255,6 +293,76 @@ async fn batch_flushes_on_max_latency() -> Result<(), Report> {
         .await
         .map_err(|e| eyre!(e))?
         .map_err(|e| eyre!(e))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_flushes_on_explicit_flush() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    // Use a very high max_items and long max_latency. Without the explicit
+    // flush, this verification would wait for the latency timer.
+    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
+    timeout(
+        Duration::from_secs(1),
+        sign_and_verify_after_explicit_flush(verifier, 10, 1),
+    )
+    .await
+    .map_err(|e| eyre!(e))?
+    .map_err(|e| eyre!(e))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_flush_on_empty_batch_is_noop() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    let mut verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
+    verifier.flush().await.map_err(|e| eyre!(e))?;
+
+    timeout(
+        Duration::from_secs(1),
+        sign_and_verify_after_explicit_flush(verifier, 10, 1),
+    )
+    .await
+    .map_err(|e| eyre!(e))?
+    .map_err(|e| eyre!(e))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_flush_uses_existing_readiness_permit() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    let mut verifier = Batch::new(Verifier::default(), 1, 1, Duration::from_secs(1000));
+    verifier.ready().await.map_err(|e| eyre!(e))?;
+    timeout(Duration::from_secs(1), verifier.flush())
+        .await
+        .map_err(|e| eyre!(e))?
+        .map_err(|e| eyre!(e))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_flushes_zero_weight_item_on_explicit_flush() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
+    timeout(
+        Duration::from_secs(1),
+        sign_and_verify_after_explicit_flush(verifier, 1, 0),
+    )
+    .await
+    .map_err(|e| eyre!(e))?
+    .map_err(|e| eyre!(e))?;
 
     Ok(())
 }

--- a/tower-batch-control/tests/ed25519.rs
+++ b/tower-batch-control/tests/ed25519.rs
@@ -247,6 +247,32 @@ async fn sign_and_verify_after_explicit_flush(
     Ok(())
 }
 
+async fn sign_and_verify_after_try_flush(
+    mut verifier: Batch<Verifier, Item>,
+    n: usize,
+) -> Result<(), BoxError> {
+    let mut results = FuturesOrdered::new();
+    for _ in 0..n {
+        let sk = SigningKey::new(thread_rng());
+        let vk_bytes = VerificationKeyBytes::from(&sk);
+        let msg = b"BatchVerifyTest";
+        let sig = sk.sign(&msg[..]);
+
+        verifier.ready().await?;
+        results.push_back(verifier.call((vk_bytes, sig, msg).into()));
+    }
+
+    if !verifier.try_flush()? {
+        return Err("try_flush should queue a flush on a quiet batch".into());
+    }
+
+    while let Some(result) = results.next().await {
+        result?;
+    }
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn batch_flushes_on_max_items_weight() -> Result<(), Report> {
     use tokio::time::timeout;
@@ -313,6 +339,25 @@ async fn batch_flush_on_empty_batch_is_noop() -> Result<(), Report> {
     timeout(
         Duration::from_secs(1),
         sign_and_verify_after_explicit_flush(verifier, 10),
+    )
+    .await
+    .map_err(|e| eyre!(e))?
+    .map_err(|e| eyre!(e))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_flushes_on_try_flush() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    // Use a very high max_items and long max_latency. Without the non-blocking
+    // flush, this verification would wait for the latency timer.
+    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
+    timeout(
+        Duration::from_secs(1),
+        sign_and_verify_after_try_flush(verifier, 10),
     )
     .await
     .map_err(|e| eyre!(e))?

--- a/tower-batch-control/tests/ed25519.rs
+++ b/tower-batch-control/tests/ed25519.rs
@@ -35,31 +35,21 @@ type VerifyResult = Result<(), Error>;
 type Sender = watch::Sender<Option<VerifyResult>>;
 
 /// The type of the batch item.
-/// An Ed25519 item and its batch weight.
+/// A newtype around an `Ed25519Item` which implements [`RequestWeight`].
 #[derive(Clone, Debug)]
-struct Item {
-    item: batch::Item,
-    weight: usize,
-}
+struct Item(batch::Item);
 
-impl RequestWeight for Item {
-    fn request_weight(&self) -> usize {
-        self.weight
-    }
-}
+impl RequestWeight for Item {}
 
 impl<'msg, M: AsRef<[u8]> + ?Sized> From<(VerificationKeyBytes, Signature, &'msg M)> for Item {
     fn from(tup: (VerificationKeyBytes, Signature, &'msg M)) -> Self {
-        Self {
-            item: batch::Item::from(tup),
-            weight: 1,
-        }
+        Self(batch::Item::from(tup))
     }
 }
 
 impl Item {
     fn verify_single(self) -> VerifyResult {
-        self.item.verify_single()
+        self.0.verify_single()
     }
 }
 
@@ -133,7 +123,7 @@ impl Service<BatchControl<Item>> for Verifier {
 
     fn call(&mut self, req: BatchControl<Item>) -> Self::Future {
         match req {
-            BatchControl::Item(Item { item, .. }) => {
+            BatchControl::Item(Item(item)) => {
                 tracing::trace!("got ed25519 item");
                 self.batch.queue(item);
                 let mut rx = self.tx.subscribe();
@@ -236,7 +226,6 @@ where
 async fn sign_and_verify_after_explicit_flush(
     mut verifier: Batch<Verifier, Item>,
     n: usize,
-    weight: usize,
 ) -> Result<(), BoxError> {
     let mut results = FuturesOrdered::new();
     for _ in 0..n {
@@ -245,11 +234,8 @@ async fn sign_and_verify_after_explicit_flush(
         let msg = b"BatchVerifyTest";
         let sig = sk.sign(&msg[..]);
 
-        let mut item: Item = (vk_bytes, sig, msg).into();
-        item.weight = weight;
-
         verifier.ready().await?;
-        results.push_back(verifier.call(item));
+        results.push_back(verifier.call((vk_bytes, sig, msg).into()));
     }
 
     verifier.flush().await?;
@@ -307,7 +293,7 @@ async fn batch_flushes_on_explicit_flush() -> Result<(), Report> {
     let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
     timeout(
         Duration::from_secs(1),
-        sign_and_verify_after_explicit_flush(verifier, 10, 1),
+        sign_and_verify_after_explicit_flush(verifier, 10),
     )
     .await
     .map_err(|e| eyre!(e))?
@@ -326,7 +312,7 @@ async fn batch_flush_on_empty_batch_is_noop() -> Result<(), Report> {
 
     timeout(
         Duration::from_secs(1),
-        sign_and_verify_after_explicit_flush(verifier, 10, 1),
+        sign_and_verify_after_explicit_flush(verifier, 10),
     )
     .await
     .map_err(|e| eyre!(e))?
@@ -346,23 +332,6 @@ async fn batch_flush_uses_existing_readiness_permit() -> Result<(), Report> {
         .await
         .map_err(|e| eyre!(e))?
         .map_err(|e| eyre!(e))?;
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn batch_flushes_zero_weight_item_on_explicit_flush() -> Result<(), Report> {
-    use tokio::time::timeout;
-    let _init_guard = zakura_test::init();
-
-    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
-    timeout(
-        Duration::from_secs(1),
-        sign_and_verify_after_explicit_flush(verifier, 1, 0),
-    )
-    .await
-    .map_err(|e| eyre!(e))?
-    .map_err(|e| eyre!(e))?;
 
     Ok(())
 }

--- a/tower-batch-control/tests/ed25519.rs
+++ b/tower-batch-control/tests/ed25519.rs
@@ -25,6 +25,9 @@ use tower_fallback::Fallback;
 /// A boxed [`std::error::Error`].
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// Keeps partial batches pending unless a test explicitly releases them.
+const LONG_BATCH_LATENCY: Duration = Duration::from_secs(1000);
+
 /// The type of the batch verifier.
 type BatchVerifier = batch::Verifier;
 
@@ -187,6 +190,19 @@ async fn spawn_fifo<
 
 // =============== testing code ========
 
+fn signed_item(is_valid: bool) -> Item {
+    let sk = SigningKey::new(thread_rng());
+    let vk_bytes = VerificationKeyBytes::from(&sk);
+    let msg = b"BatchVerifyTest";
+    let sig = if is_valid {
+        sk.sign(&msg[..])
+    } else {
+        sk.sign(b"badmsg")
+    };
+
+    (vk_bytes, sig, msg).into()
+}
+
 async fn sign_and_verify<V>(
     mut verifier: V,
     n: usize,
@@ -273,6 +289,39 @@ async fn sign_and_verify_after_try_flush(
     Ok(())
 }
 
+async fn explicit_flush_fallback_matches_single(
+    n: usize,
+    bad_index: usize,
+) -> Result<(), BoxError> {
+    let mut verifier = Fallback::new(
+        Batch::new(Verifier::default(), 100, 1, LONG_BATCH_LATENCY),
+        tower::service_fn(|item: Item| async move { item.verify_single().map_err(BoxError::from) }),
+    );
+    let mut expected_results = Vec::new();
+    let mut batch_results = FuturesOrdered::new();
+
+    for i in 0..n {
+        let item = signed_item(i != bad_index);
+        expected_results.push(item.clone().verify_single().is_ok());
+
+        verifier.ready().await?;
+        batch_results.push_back(verifier.call(item));
+    }
+
+    let mut primary = verifier.primary().clone();
+    if !primary.try_flush()? {
+        return Err("try_flush should queue a flush on a quiet batch".into());
+    }
+
+    let actual_results: Vec<_> = batch_results.map(|result| result.is_ok()).collect().await;
+    assert_eq!(
+        actual_results, expected_results,
+        "explicit batch flush plus fallback must match single verification"
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn batch_flushes_on_max_items_weight() -> Result<(), Report> {
     use tokio::time::timeout;
@@ -282,7 +331,7 @@ async fn batch_flushes_on_max_items_weight() -> Result<(), Report> {
     // flushing is happening based on hitting max_items.
     //
     // Create our own verifier, so we don't shut down a shared verifier used by other tests.
-    let verifier = Batch::new(Verifier::default(), 10, 5, Duration::from_secs(1000));
+    let verifier = Batch::new(Verifier::default(), 10, 5, LONG_BATCH_LATENCY);
     timeout(Duration::from_secs(1), sign_and_verify(verifier, 100, None))
         .await
         .map_err(|e| eyre!(e))?
@@ -316,7 +365,7 @@ async fn batch_flushes_on_explicit_flush() -> Result<(), Report> {
 
     // Use a very high max_items and long max_latency. Without the explicit
     // flush, this verification would wait for the latency timer.
-    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
+    let verifier = Batch::new(Verifier::default(), 100, 10, LONG_BATCH_LATENCY);
     timeout(
         Duration::from_secs(1),
         sign_and_verify_after_explicit_flush(verifier, 10),
@@ -333,7 +382,7 @@ async fn batch_flush_on_empty_batch_is_noop() -> Result<(), Report> {
     use tokio::time::timeout;
     let _init_guard = zakura_test::init();
 
-    let mut verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
+    let mut verifier = Batch::new(Verifier::default(), 100, 10, LONG_BATCH_LATENCY);
     verifier.flush().await.map_err(|e| eyre!(e))?;
 
     timeout(
@@ -354,7 +403,7 @@ async fn batch_flushes_on_try_flush() -> Result<(), Report> {
 
     // Use a very high max_items and long max_latency. Without the non-blocking
     // flush, this verification would wait for the latency timer.
-    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_secs(1000));
+    let verifier = Batch::new(Verifier::default(), 100, 10, LONG_BATCH_LATENCY);
     timeout(
         Duration::from_secs(1),
         sign_and_verify_after_try_flush(verifier, 10),
@@ -371,7 +420,7 @@ async fn batch_flush_uses_existing_readiness_permit() -> Result<(), Report> {
     use tokio::time::timeout;
     let _init_guard = zakura_test::init();
 
-    let mut verifier = Batch::new(Verifier::default(), 1, 1, Duration::from_secs(1000));
+    let mut verifier = Batch::new(Verifier::default(), 1, 1, LONG_BATCH_LATENCY);
     verifier.ready().await.map_err(|e| eyre!(e))?;
     timeout(Duration::from_secs(1), verifier.flush())
         .await
@@ -394,6 +443,141 @@ async fn fallback_verification() -> Result<(), Report> {
     sign_and_verify(verifier, 100, Some(39))
         .await
         .map_err(|e| eyre!(e))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_flush_fallback_matches_single_verification() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    timeout(Duration::from_secs(5), async {
+        // Cover an invalid singleton, then every invalid position in a mixed
+        // batch. These batches are below the size threshold and have a long
+        // latency, so only the explicit flush can drive them to completion.
+        for (n, bad_index) in [(1, 0), (3, 0), (3, 1), (3, 2)] {
+            explicit_flush_fallback_matches_single(n, bad_index).await?;
+        }
+
+        Ok::<_, BoxError>(())
+    })
+    .await
+    .map_err(|error| eyre!(error))?
+    .map_err(|error| eyre!(error))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_flush_isolates_interleaved_request_groups() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    let verifier = Fallback::new(
+        Batch::new(Verifier::default(), 100, 1, LONG_BATCH_LATENCY),
+        tower::service_fn(|item: Item| async move { item.verify_single().map_err(BoxError::from) }),
+    );
+    let mut block_a = verifier.clone();
+    let mut block_b = verifier.clone();
+
+    block_a.ready().await.map_err(|error| eyre!(error))?;
+    let valid_a1 = block_a.call(signed_item(true));
+    block_b.ready().await.map_err(|error| eyre!(error))?;
+    let invalid_b = block_b.call(signed_item(false));
+    block_a.ready().await.map_err(|error| eyre!(error))?;
+    let valid_a2 = block_a.call(signed_item(true));
+
+    let mut primary = verifier.primary().clone();
+    assert!(
+        primary.try_flush().map_err(|error| eyre!(error))?,
+        "the shared batch must have capacity for an explicit flush"
+    );
+
+    let (valid_a1, invalid_b, valid_a2) = timeout(
+        Duration::from_secs(5),
+        futures::future::join3(valid_a1, invalid_b, valid_a2),
+    )
+    .await
+    .map_err(|error| eyre!(error))?;
+
+    valid_a1.map_err(|error| eyre!(error))?;
+    assert!(
+        invalid_b.is_err(),
+        "an invalid request from another group must not inherit a valid result"
+    );
+    valid_a2.map_err(|error| eyre!(error))?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn saturated_try_flush_still_rejects_after_latency() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    let (batch, worker) = Batch::pair(Verifier::default(), 2, 1, Duration::from_millis(10));
+    let mut verifier = Fallback::new(
+        batch.clone(),
+        tower::service_fn(|item: Item| async move { item.verify_single().map_err(BoxError::from) }),
+    );
+
+    verifier.ready().await.map_err(|error| eyre!(error))?;
+    let invalid_result = verifier.call(signed_item(false));
+
+    // Hold the remaining queue permit so the best-effort flush is skipped.
+    let mut reservation = batch.clone();
+    reservation.ready().await.map_err(|error| eyre!(error))?;
+    let mut primary = batch.clone();
+    assert!(
+        !primary.try_flush().map_err(|error| eyre!(error))?,
+        "try_flush must report the saturated queue"
+    );
+
+    drop(reservation);
+    tokio::spawn(worker.run());
+
+    let invalid_result = timeout(Duration::from_secs(5), invalid_result)
+        .await
+        .map_err(|error| eyre!(error))?;
+    assert!(
+        invalid_result.is_err(),
+        "the latency fallback must reject an invalid signature"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failed_flush_still_rejects_via_single_fallback() -> Result<(), Report> {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    let (batch, worker) = Batch::pair(Verifier::default(), 100, 1, LONG_BATCH_LATENCY);
+    let mut verifier = Fallback::new(
+        batch.clone(),
+        tower::service_fn(|item: Item| async move { item.verify_single().map_err(BoxError::from) }),
+    );
+
+    verifier.ready().await.map_err(|error| eyre!(error))?;
+    let invalid_result = verifier.call(signed_item(false));
+
+    // Dropping the worker fails the queued batch request and closes the flush
+    // channel. Fallback must still verify the item singly and reject it.
+    drop(worker);
+    let mut primary = batch.clone();
+    assert!(
+        primary.try_flush().is_err(),
+        "flushing a closed worker must fail"
+    );
+
+    let invalid_result = timeout(Duration::from_secs(5), invalid_result)
+        .await
+        .map_err(|error| eyre!(error))?;
+    assert!(
+        invalid_result.is_err(),
+        "a failed flush must not turn an invalid signature into success"
+    );
 
     Ok(())
 }

--- a/tower-batch-control/tests/ed25519.rs
+++ b/tower-batch-control/tests/ed25519.rs
@@ -239,30 +239,6 @@ where
     Ok(())
 }
 
-async fn sign_and_verify_after_explicit_flush(
-    mut verifier: Batch<Verifier, Item>,
-    n: usize,
-) -> Result<(), BoxError> {
-    let mut results = FuturesOrdered::new();
-    for _ in 0..n {
-        let sk = SigningKey::new(thread_rng());
-        let vk_bytes = VerificationKeyBytes::from(&sk);
-        let msg = b"BatchVerifyTest";
-        let sig = sk.sign(&msg[..]);
-
-        verifier.ready().await?;
-        results.push_back(verifier.call((vk_bytes, sig, msg).into()));
-    }
-
-    verifier.flush().await?;
-
-    while let Some(result) = results.next().await {
-        result?;
-    }
-
-    Ok(())
-}
-
 async fn sign_and_verify_after_try_flush(
     mut verifier: Batch<Verifier, Item>,
     n: usize,
@@ -359,35 +335,19 @@ async fn batch_flushes_on_max_latency() -> Result<(), Report> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn batch_flushes_on_explicit_flush() -> Result<(), Report> {
-    use tokio::time::timeout;
-    let _init_guard = zakura_test::init();
-
-    // Use a very high max_items and long max_latency. Without the explicit
-    // flush, this verification would wait for the latency timer.
-    let verifier = Batch::new(Verifier::default(), 100, 10, LONG_BATCH_LATENCY);
-    timeout(
-        Duration::from_secs(1),
-        sign_and_verify_after_explicit_flush(verifier, 10),
-    )
-    .await
-    .map_err(|e| eyre!(e))?
-    .map_err(|e| eyre!(e))?;
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn batch_flush_on_empty_batch_is_noop() -> Result<(), Report> {
+async fn try_flush_on_empty_batch_is_noop() -> Result<(), Report> {
     use tokio::time::timeout;
     let _init_guard = zakura_test::init();
 
     let mut verifier = Batch::new(Verifier::default(), 100, 10, LONG_BATCH_LATENCY);
-    verifier.flush().await.map_err(|e| eyre!(e))?;
+    assert!(
+        verifier.try_flush().map_err(|error| eyre!(error))?,
+        "an empty batch flush must be queued"
+    );
 
     timeout(
         Duration::from_secs(1),
-        sign_and_verify_after_explicit_flush(verifier, 10),
+        sign_and_verify_after_try_flush(verifier, 10),
     )
     .await
     .map_err(|e| eyre!(e))?
@@ -416,16 +376,15 @@ async fn batch_flushes_on_try_flush() -> Result<(), Report> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn batch_flush_uses_existing_readiness_permit() -> Result<(), Report> {
-    use tokio::time::timeout;
+async fn batch_try_flush_uses_existing_readiness_permit() -> Result<(), Report> {
     let _init_guard = zakura_test::init();
 
     let mut verifier = Batch::new(Verifier::default(), 1, 1, LONG_BATCH_LATENCY);
     verifier.ready().await.map_err(|e| eyre!(e))?;
-    timeout(Duration::from_secs(1), verifier.flush())
-        .await
-        .map_err(|e| eyre!(e))?
-        .map_err(|e| eyre!(e))?;
+    assert!(
+        verifier.try_flush().map_err(|error| eyre!(error))?,
+        "try_flush must reuse an existing readiness permit"
+    );
 
     Ok(())
 }

--- a/tower-batch-control/tests/worker.rs
+++ b/tower-batch-control/tests/worker.rs
@@ -141,6 +141,27 @@ async fn explicit_flush_waits_for_queue_capacity() {
 }
 
 #[tokio::test]
+async fn try_flush_skips_when_queue_saturated() {
+    let _init_guard = zakura_test::init();
+
+    let (service, mut handle) = mock::pair::<_, ()>();
+    let (mut service, worker) = Batch::pair(service, 1, 1, Duration::from_secs(1000));
+    let mut worker = task::spawn(worker.run());
+
+    handle.allow(2);
+    service.ready().await.unwrap();
+    let _response = service.call(());
+
+    // The queued item holds the only permit, so a non-blocking flush is skipped.
+    let mut flush_service = service.clone();
+    assert!(matches!(flush_service.try_flush(), Ok(false)));
+
+    // Once the worker drains the queue, the permit frees and try_flush queues.
+    assert_pending!(worker.poll());
+    assert!(matches!(flush_service.try_flush(), Ok(true)));
+}
+
+#[tokio::test]
 async fn explicit_flush_completes_zero_weight_items() {
     use tokio::time::timeout;
     let _init_guard = zakura_test::init();

--- a/tower-batch-control/tests/worker.rs
+++ b/tower-batch-control/tests/worker.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tokio_test::{assert_pending, assert_ready, assert_ready_err, task};
+use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
 use tower::{Service, ServiceExt};
 use tower_batch_control::{error, Batch};
 use tower_test::mock;
@@ -118,4 +118,24 @@ async fn wakes_pending_waiters_on_failure() {
         err.is::<error::ServiceError>(),
         "ready 2 should fail with a ServiceError, got: {err:?}"
     );
+}
+
+#[tokio::test]
+async fn explicit_flush_waits_for_queue_capacity() {
+    let _init_guard = zakura_test::init();
+
+    let (service, mut handle) = mock::pair::<_, ()>();
+    let (mut service, worker) = Batch::pair(service, 1, 1, Duration::from_secs(1000));
+    let mut worker = task::spawn(worker.run());
+
+    service.ready().await.unwrap();
+    let _response = service.call(());
+
+    let mut flush_service = service.clone();
+    let mut flush = task::spawn(async move { flush_service.flush().await });
+    assert_pending!(flush.poll(), "the queued item holds the only permit");
+
+    handle.allow(2);
+    assert_pending!(worker.poll());
+    assert_ready_ok!(flush.poll());
 }

--- a/tower-batch-control/tests/worker.rs
+++ b/tower-batch-control/tests/worker.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
 use tower::{Service, ServiceExt};
-use tower_batch_control::{error, Batch};
+use tower_batch_control::{error, Batch, BatchControl, RequestWeight};
 use tower_test::mock;
 
 #[tokio::test]
@@ -138,4 +138,55 @@ async fn explicit_flush_waits_for_queue_capacity() {
     handle.allow(2);
     assert_pending!(worker.poll());
     assert_ready_ok!(flush.poll());
+}
+
+#[tokio::test]
+async fn explicit_flush_completes_zero_weight_items() {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    #[derive(Debug)]
+    struct ZeroWeight;
+    impl RequestWeight for ZeroWeight {
+        fn request_weight(&self) -> usize {
+            0
+        }
+    }
+
+    let (service, mut handle) = mock::pair::<BatchControl<ZeroWeight>, ()>();
+    // High max weight and latency: only the explicit flush can flush this batch.
+    let (mut service, worker) = Batch::pair(service, 100, 1, Duration::from_secs(1000));
+    tokio::spawn(worker.run());
+
+    handle.allow(2);
+    service.ready().await.unwrap();
+    let response = service.call(ZeroWeight);
+
+    let mut flush_service = service.clone();
+    timeout(Duration::from_secs(5), flush_service.flush())
+        .await
+        .expect("flush should not time out")
+        .expect("flush should queue");
+
+    // The worker must forward the zero-weight item and then the flush command:
+    // without the weight floor, the empty-batch guard skips this flush and the
+    // item's response future never completes.
+    let (request, send_item) = timeout(Duration::from_secs(5), handle.next_request())
+        .await
+        .expect("item should reach the inner service")
+        .expect("inner service should stay open");
+    assert!(matches!(request, BatchControl::Item(ZeroWeight)));
+    send_item.send_response(());
+
+    let (request, send_flush) = timeout(Duration::from_secs(5), handle.next_request())
+        .await
+        .expect("flush should reach the inner service")
+        .expect("inner service should stay open");
+    assert!(matches!(request, BatchControl::Flush));
+    send_flush.send_response(());
+
+    timeout(Duration::from_secs(5), response)
+        .await
+        .expect("item response should complete")
+        .expect("zero-weight item should verify");
 }

--- a/tower-batch-control/tests/worker.rs
+++ b/tower-batch-control/tests/worker.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
+use tokio_test::{assert_pending, assert_ready, assert_ready_err, task};
 use tower::{Service, ServiceExt};
 use tower_batch_control::{error, Batch, BatchControl, RequestWeight};
 use tower_test::mock;
@@ -121,26 +121,6 @@ async fn wakes_pending_waiters_on_failure() {
 }
 
 #[tokio::test]
-async fn explicit_flush_waits_for_queue_capacity() {
-    let _init_guard = zakura_test::init();
-
-    let (service, mut handle) = mock::pair::<_, ()>();
-    let (mut service, worker) = Batch::pair(service, 1, 1, Duration::from_secs(1000));
-    let mut worker = task::spawn(worker.run());
-
-    service.ready().await.unwrap();
-    let _response = service.call(());
-
-    let mut flush_service = service.clone();
-    let mut flush = task::spawn(async move { flush_service.flush().await });
-    assert_pending!(flush.poll(), "the queued item holds the only permit");
-
-    handle.allow(2);
-    assert_pending!(worker.poll());
-    assert_ready_ok!(flush.poll());
-}
-
-#[tokio::test]
 async fn try_flush_skips_when_queue_saturated() {
     let _init_guard = zakura_test::init();
 
@@ -162,7 +142,7 @@ async fn try_flush_skips_when_queue_saturated() {
 }
 
 #[tokio::test]
-async fn explicit_flush_completes_zero_weight_items() {
+async fn try_flush_completes_zero_weight_items() {
     use tokio::time::timeout;
     let _init_guard = zakura_test::init();
 
@@ -184,10 +164,10 @@ async fn explicit_flush_completes_zero_weight_items() {
     let response = service.call(ZeroWeight);
 
     let mut flush_service = service.clone();
-    timeout(Duration::from_secs(5), flush_service.flush())
-        .await
-        .expect("flush should not time out")
-        .expect("flush should queue");
+    assert!(
+        flush_service.try_flush().expect("flush should not fail"),
+        "flush should queue"
+    );
 
     // The worker must forward the zero-weight item and then the flush command:
     // without the weight floor, the empty-batch guard skips this flush and the

--- a/tower-fallback/src/service.rs
+++ b/tower-fallback/src/service.rs
@@ -31,6 +31,14 @@ impl<S1, S2: Clone> Fallback<S1, S2> {
     pub fn new(svc1: S1, svc2: S2) -> Self {
         Self { svc1, svc2 }
     }
+
+    /// Returns the primary service.
+    ///
+    /// Requests are first attempted using this service, before retrying on the
+    /// fallback service.
+    pub fn primary(&self) -> &S1 {
+        &self.svc1
+    }
 }
 
 impl<S1, S2, Request> Service<Request> for Fallback<S1, S2>

--- a/zakura-consensus/src/block.rs
+++ b/zakura-consensus/src/block.rs
@@ -31,7 +31,7 @@ use zakura_chain::{
 };
 use zakura_state as zs;
 
-use crate::{error::*, transaction as tx, BoxError};
+use crate::{error::*, primitives, transaction as tx, BoxError};
 
 pub mod check;
 pub mod request;
@@ -295,6 +295,12 @@ where
 
             let known_outpoint_hashes: Arc<HashSet<transaction::Hash>> =
                 Arc::new(known_utxos.keys().map(|outpoint| outpoint.hash).collect());
+            // Keep this guard after `known_outpoint_hashes` so its `Drop` removes the
+            // pointer-keyed registration before the `Arc` address can be reused.
+            let _block_batch_flush = primitives::register_block_verifier_batch_flush(
+                &known_outpoint_hashes,
+                block.transactions.len(),
+            );
 
             for (&transaction_hash, transaction) in
                 transaction_hashes.iter().zip(block.transactions.iter())

--- a/zakura-consensus/src/primitives.rs
+++ b/zakura-consensus/src/primitives.rs
@@ -1,5 +1,11 @@
 //! Asynchronous verification of cryptographic primitives.
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use once_cell::sync::Lazy;
 use tokio::sync::oneshot::error::RecvError;
 
 use crate::BoxError;
@@ -16,6 +22,150 @@ const MAX_BATCH_SIZE: usize = 64;
 
 /// The maximum latency bound for any of the batch verifiers.
 const MAX_BATCH_LATENCY: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Registered block transaction-verification batches waiting for an explicit
+/// cryptographic flush.
+static BLOCK_VERIFIER_BATCH_FLUSHES: Lazy<Mutex<HashMap<BlockVerifierBatchFlushKey, BlockFlush>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Opaque identity for a semantic block verifier's transaction batch.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct BlockVerifierBatchFlushKey(usize);
+
+impl BlockVerifierBatchFlushKey {
+    /// Returns a key for a value shared by all transaction requests in one
+    /// block verification.
+    fn new<T>(shared_block_context: &Arc<T>) -> Self {
+        // This cast stores the Arc allocation address as an opaque identity
+        // key. The address is never dereferenced or used for pointer arithmetic.
+        Self(Arc::as_ptr(shared_block_context) as usize)
+    }
+}
+
+/// Registration guard for one semantic block verifier's crypto batch flush.
+#[derive(Debug)]
+pub(crate) struct BlockVerifierBatchFlushGuard {
+    key: BlockVerifierBatchFlushKey,
+}
+
+impl Drop for BlockVerifierBatchFlushGuard {
+    fn drop(&mut self) {
+        BLOCK_VERIFIER_BATCH_FLUSHES
+            .lock()
+            .expect("block verifier batch flush registry mutex should not be poisoned")
+            .remove(&self.key);
+    }
+}
+
+/// Tracks transaction verifier progress toward one block-level flush.
+#[derive(Debug)]
+struct BlockFlush {
+    expected_transactions: usize,
+    started_transactions: usize,
+    flush_queued: bool,
+}
+
+/// Registers a block's transaction verifier batch for one explicit crypto
+/// flush once every transaction has started its asynchronous checks.
+pub(crate) fn register_block_verifier_batch_flush<T>(
+    shared_block_context: &Arc<T>,
+    expected_transactions: usize,
+) -> BlockVerifierBatchFlushGuard {
+    let key = BlockVerifierBatchFlushKey::new(shared_block_context);
+
+    BLOCK_VERIFIER_BATCH_FLUSHES
+        .lock()
+        .expect("block verifier batch flush registry mutex should not be poisoned")
+        .insert(
+            key,
+            BlockFlush {
+                expected_transactions,
+                started_transactions: 0,
+                flush_queued: expected_transactions == 0,
+            },
+        );
+
+    BlockVerifierBatchFlushGuard { key }
+}
+
+/// Returns the block-level batch flush key for `shared_block_context`.
+pub(crate) fn block_verifier_batch_flush_key<T>(
+    shared_block_context: &Arc<T>,
+) -> BlockVerifierBatchFlushKey {
+    BlockVerifierBatchFlushKey::new(shared_block_context)
+}
+
+/// Records that one block transaction has started its async checks, and
+/// flushes the shared crypto batches when all transactions in the block have
+/// reached that boundary.
+pub(crate) async fn start_block_transaction_async_checks(key: BlockVerifierBatchFlushKey) {
+    if block_verifier_batch_flush_ready(key) {
+        flush_block_verifier_batches().await;
+    }
+}
+
+/// Returns `true` if recording `key` made its block ready to flush.
+fn block_verifier_batch_flush_ready(key: BlockVerifierBatchFlushKey) -> bool {
+    let mut flushes = BLOCK_VERIFIER_BATCH_FLUSHES
+        .lock()
+        .expect("block verifier batch flush registry mutex should not be poisoned");
+
+    let Some(flush) = flushes.get_mut(&key) else {
+        return false;
+    };
+
+    flush.started_transactions = flush.started_transactions.saturating_add(1);
+
+    if flush.flush_queued || flush.started_transactions < flush.expected_transactions {
+        return false;
+    }
+
+    flush.flush_queued = true;
+    true
+}
+
+/// Explicitly flushes the shared crypto batch services used by semantic block
+/// transaction verification.
+///
+/// The block verifier still awaits every transaction verifier future before
+/// committing a block; this just starts pending batch work before
+/// [`MAX_BATCH_LATENCY`] expires.
+async fn flush_block_verifier_batches() {
+    if let Some(verifier) = Lazy::get(&ed25519::VERIFIER) {
+        queue_batch_flush("ed25519", verifier.primary().clone().flush().await);
+    }
+
+    if let Some(verifier) = Lazy::get(&sapling::VERIFIER) {
+        queue_batch_flush("sapling", verifier.primary().clone().flush().await);
+    }
+
+    if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {
+        queue_batch_flush("halo2_pre_nu6_2", verifier.primary().clone().flush().await);
+    }
+
+    if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_2) {
+        queue_batch_flush("halo2_nu6_2", verifier.primary().clone().flush().await);
+    }
+
+    if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_3_ONWARD) {
+        queue_batch_flush(
+            "halo2_nu6_3_onward",
+            verifier.primary().clone().flush().await,
+        );
+    }
+}
+
+/// Logs best-effort flush queueing failures without changing verification
+/// semantics.
+fn queue_batch_flush(verifier: &'static str, result: Result<(), BoxError>) {
+    if let Err(error) = result {
+        tracing::trace!(
+            ?error,
+            verifier,
+            "could not queue explicit block verifier batch flush"
+        );
+    }
+}
 
 /// Fires off a task into the Rayon threadpool, awaits the result through a oneshot channel,
 /// then converts the error to a [`BoxError`].
@@ -46,4 +196,48 @@ pub async fn spawn_fifo<T: 'static + Send, F: 'static + FnOnce() -> T + Send>(
     });
 
     rsp_rx.await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_flush_is_ready_when_expected_transactions_start_checks() {
+        let shared_block_context = Arc::new(());
+        let key = block_verifier_batch_flush_key(&shared_block_context);
+        let _guard = register_block_verifier_batch_flush(&shared_block_context, 2);
+
+        assert!(!block_verifier_batch_flush_ready(key));
+        assert!(block_verifier_batch_flush_ready(key));
+        assert!(!block_verifier_batch_flush_ready(key));
+    }
+
+    #[test]
+    fn block_flush_guard_unregisters_batch() {
+        let shared_block_context = Arc::new(());
+        let key = block_verifier_batch_flush_key(&shared_block_context);
+
+        {
+            let _guard = register_block_verifier_batch_flush(&shared_block_context, 1);
+            assert!(block_verifier_batch_flush_ready(key));
+        }
+
+        assert!(!block_verifier_batch_flush_ready(key));
+    }
+
+    #[test]
+    fn block_flush_registration_starts_fresh_after_guard_drop() {
+        let shared_block_context = Arc::new(());
+        let key = block_verifier_batch_flush_key(&shared_block_context);
+
+        {
+            let _guard = register_block_verifier_batch_flush(&shared_block_context, 2);
+            assert!(!block_verifier_batch_flush_ready(key));
+        }
+
+        let _guard = register_block_verifier_batch_flush(&shared_block_context, 2);
+        assert!(!block_verifier_batch_flush_ready(key));
+        assert!(block_verifier_batch_flush_ready(key));
+    }
 }

--- a/zakura-consensus/src/primitives.rs
+++ b/zakura-consensus/src/primitives.rs
@@ -98,9 +98,9 @@ pub(crate) fn block_verifier_batch_flush_key<T>(
 /// Records that one block transaction has started its async checks, and
 /// flushes the shared crypto batches when all transactions in the block have
 /// reached that boundary.
-pub(crate) async fn start_block_transaction_async_checks(key: BlockVerifierBatchFlushKey) {
+pub(crate) fn start_block_transaction_async_checks(key: BlockVerifierBatchFlushKey) {
     if block_verifier_batch_flush_ready(key) {
-        flush_block_verifier_batches().await;
+        flush_block_verifier_batches();
     }
 }
 
@@ -129,41 +129,46 @@ fn block_verifier_batch_flush_ready(key: BlockVerifierBatchFlushKey) -> bool {
 ///
 /// The block verifier still awaits every transaction verifier future before
 /// committing a block; this just starts pending batch work before
-/// [`MAX_BATCH_LATENCY`] expires.
-async fn flush_block_verifier_batches() {
+/// [`MAX_BATCH_LATENCY`] expires. Saturated queues are skipped: a full queue
+/// is already flushing batches on size, and waiting for capacity would couple
+/// block latency to unrelated verifier traffic.
+fn flush_block_verifier_batches() {
     if let Some(verifier) = Lazy::get(&ed25519::VERIFIER) {
-        queue_batch_flush("ed25519", verifier.primary().clone().flush().await);
+        queue_batch_flush("ed25519", verifier.primary().clone().try_flush());
     }
 
     if let Some(verifier) = Lazy::get(&sapling::VERIFIER) {
-        queue_batch_flush("sapling", verifier.primary().clone().flush().await);
+        queue_batch_flush("sapling", verifier.primary().clone().try_flush());
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {
-        queue_batch_flush("halo2_pre_nu6_2", verifier.primary().clone().flush().await);
+        queue_batch_flush("halo2_pre_nu6_2", verifier.primary().clone().try_flush());
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_2) {
-        queue_batch_flush("halo2_nu6_2", verifier.primary().clone().flush().await);
+        queue_batch_flush("halo2_nu6_2", verifier.primary().clone().try_flush());
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_3_ONWARD) {
-        queue_batch_flush(
-            "halo2_nu6_3_onward",
-            verifier.primary().clone().flush().await,
-        );
+        queue_batch_flush("halo2_nu6_3_onward", verifier.primary().clone().try_flush());
     }
 }
 
-/// Logs best-effort flush queueing failures without changing verification
-/// semantics.
-fn queue_batch_flush(verifier: &'static str, result: Result<(), BoxError>) {
-    if let Err(error) = result {
-        tracing::trace!(
-            ?error,
-            verifier,
-            "could not queue explicit block verifier batch flush"
-        );
+/// Logs best-effort flush queueing skips and failures without changing
+/// verification semantics.
+fn queue_batch_flush(verifier: &'static str, result: Result<bool, BoxError>) {
+    match result {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::trace!(verifier, "batch queue saturated, skipping explicit flush");
+        }
+        Err(error) => {
+            tracing::trace!(
+                ?error,
+                verifier,
+                "could not queue explicit block verifier batch flush"
+            );
+        }
     }
 }
 

--- a/zakura-consensus/src/primitives.rs
+++ b/zakura-consensus/src/primitives.rs
@@ -245,4 +245,47 @@ mod tests {
         assert!(!block_verifier_batch_flush_ready(key));
         assert!(block_verifier_batch_flush_ready(key));
     }
+
+    #[test]
+    fn interleaved_block_flush_registrations_are_isolated() {
+        let block_a_context = Arc::new(());
+        let block_b_context = Arc::new(());
+        let block_a_key = block_verifier_batch_flush_key(&block_a_context);
+        let block_b_key = block_verifier_batch_flush_key(&block_b_context);
+        let _block_a_guard = register_block_verifier_batch_flush(&block_a_context, 2);
+        let _block_b_guard = register_block_verifier_batch_flush(&block_b_context, 3);
+
+        assert!(!block_verifier_batch_flush_ready(block_a_key));
+        assert!(!block_verifier_batch_flush_ready(block_b_key));
+        assert!(block_verifier_batch_flush_ready(block_a_key));
+        assert!(!block_verifier_batch_flush_ready(block_a_key));
+        assert!(!block_verifier_batch_flush_ready(block_b_key));
+        assert!(block_verifier_batch_flush_ready(block_b_key));
+        assert!(!block_verifier_batch_flush_ready(block_b_key));
+    }
+
+    #[test]
+    fn cancelled_block_flush_ignores_late_transaction_boundaries() {
+        let cancelled_context = Arc::new(());
+        let cancelled_key = block_verifier_batch_flush_key(&cancelled_context);
+        let cancelled_guard = register_block_verifier_batch_flush(&cancelled_context, 2);
+
+        assert!(!block_verifier_batch_flush_ready(cancelled_key));
+        drop(cancelled_guard);
+
+        assert!(
+            !block_verifier_batch_flush_ready(cancelled_key),
+            "a late boundary from a cancelled block must not queue a flush"
+        );
+
+        let active_context = Arc::new(());
+        let active_key = block_verifier_batch_flush_key(&active_context);
+        let _active_guard = register_block_verifier_batch_flush(&active_context, 1);
+
+        assert!(block_verifier_batch_flush_ready(active_key));
+        assert!(
+            !block_verifier_batch_flush_ready(cancelled_key),
+            "a cancelled block must not advance another registration"
+        );
+    }
 }

--- a/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/zakura-consensus/src/primitives/halo2/tests.rs
@@ -13,9 +13,13 @@
 //!     matching circuit era's key (pre-NU6.2 insecure, NU6.2-until-NU6.3 fixed, or
 //!     NU6.3-onward).
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
+use futures::future::join_all;
 use orchard::bundle::{Authorized, Bundle};
+use tower::{Service, ServiceExt};
+use tower_batch_control::Batch;
+use tower_fallback::Fallback;
 use zakura_chain::{
     block::Block,
     parameters::NetworkUpgrade,
@@ -26,9 +30,14 @@ use zakura_chain::{
 use zcash_protocol::value::ZatBalance;
 
 use super::{
-    lazy_verifier_for, Item, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD, VERIFIER_PRE_NU6_2,
-    VERIFYING_KEY_NU6_2, VERIFYING_KEY_PRE_NU6_2,
+    lazy_verifier_for, Item, ItemVerifyingKey, OrchardFallback, Verifier, VerifierService,
+    VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD, VERIFIER_PRE_NU6_2, VERIFYING_KEY_NU6_2,
+    VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
 };
+
+const EXPLICIT_FLUSH_TEST_MAX_BATCH_WEIGHT: usize = 10_000;
+const EXPLICIT_FLUSH_TEST_LATENCY: Duration = Duration::from_secs(1000);
+const EXPLICIT_FLUSH_TEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Returns one real pre-NU6.2 Orchard bundle and its sighash, extracted from the mainnet test
 /// blocks.
@@ -62,6 +71,54 @@ fn pre_nu6_2_bundle_and_sighash() -> (Bundle<Authorized, ZatBalance>, SigHash) {
     }
 
     panic!("mainnet test blocks must contain a transparent-input-free Orchard transaction");
+}
+
+fn explicit_flush_verifier(vk: &'static ItemVerifyingKey) -> VerifierService {
+    Fallback::new(
+        Batch::new(
+            Verifier::new(vk),
+            EXPLICIT_FLUSH_TEST_MAX_BATCH_WEIGHT,
+            1,
+            EXPLICIT_FLUSH_TEST_LATENCY,
+        ),
+        OrchardFallback { vk },
+    )
+}
+
+async fn assert_explicit_flush_matches_single(vk: &'static ItemVerifyingKey, items: Vec<Item>) {
+    let expected_results: Vec<_> = items
+        .iter()
+        .cloned()
+        .map(|item| item.verify_single(vk))
+        .collect();
+    let mut verifier = explicit_flush_verifier(vk);
+    let mut batch_results = Vec::new();
+
+    for item in items {
+        verifier
+            .ready()
+            .await
+            .expect("test verifier must become ready");
+        batch_results.push(verifier.call(item));
+    }
+
+    let mut primary = verifier.primary().clone();
+    assert!(
+        primary
+            .try_flush()
+            .expect("explicit test flush must not fail"),
+        "explicit test flush must be queued"
+    );
+
+    let actual_results: Vec<_> = join_all(batch_results)
+        .await
+        .into_iter()
+        .map(|result| result.is_ok())
+        .collect();
+    assert_eq!(
+        actual_results, expected_results,
+        "explicit batch flush plus fallback must match single verification"
+    );
 }
 
 /// A real pre-NU6.2 Orchard proof verifies under the pre-NU6.2 key and is rejected by the
@@ -139,4 +196,46 @@ fn verifier_routes_each_network_upgrade_to_the_correct_key() {
         std::ptr::eq(lazy_verifier_for(NetworkUpgrade::Nu6_3), nu6_3_onward),
         "a v5 Orchard bundle at NU6.3 must use the same key as v6 Orchard and Ironwood"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_flush_fallback_matches_single_for_mixed_pre_nu6_2_proofs() {
+    let _init_guard = zakura_test::init();
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let mut invalid_sighash = sighash;
+    invalid_sighash.0[0] ^= 1;
+
+    tokio::time::timeout(
+        EXPLICIT_FLUSH_TEST_TIMEOUT,
+        assert_explicit_flush_matches_single(
+            &VERIFYING_KEY_PRE_NU6_2,
+            vec![
+                Item::new(bundle.clone(), sighash),
+                Item::new(bundle.clone(), invalid_sighash),
+                Item::new(bundle, sighash),
+            ],
+        ),
+    )
+    .await
+    .expect("explicitly flushed Orchard verification must complete");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_flush_rejects_single_proof_under_each_wrong_era_key() {
+    let _init_guard = zakura_test::init();
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+
+    for vk in [&*VERIFYING_KEY_NU6_2, &*VERIFYING_KEY_NU6_3_ONWARD] {
+        assert!(
+            !Item::new(bundle.clone(), sighash).verify_single(vk),
+            "the historical proof must be invalid under the wrong era key"
+        );
+
+        tokio::time::timeout(
+            EXPLICIT_FLUSH_TEST_TIMEOUT,
+            assert_explicit_flush_matches_single(vk, vec![Item::new(bundle.clone(), sighash)]),
+        )
+        .await
+        .expect("explicitly flushed Orchard verification must complete");
+    }
 }

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -340,6 +340,19 @@ impl Request {
     pub fn is_mempool(&self) -> bool {
         matches!(self, Request::Mempool { .. })
     }
+
+    /// Returns the block verifier batch flush key, if this is a block request.
+    fn block_verifier_batch_flush_key(&self) -> Option<primitives::BlockVerifierBatchFlushKey> {
+        match self {
+            Request::Block {
+                known_outpoint_hashes,
+                ..
+            } => Some(primitives::block_verifier_batch_flush_key(
+                known_outpoint_hashes,
+            )),
+            Request::Mempool { .. } => None,
+        }
+    }
 }
 
 impl Response {
@@ -621,9 +634,11 @@ where
                 async_checks.push(check_anchors_and_revealed_nullifiers_query);
             }
 
+            let block_batch_flush_key = req.block_verifier_batch_flush_key();
+
             tracing::trace!(?tx_id, "awaiting async checks...");
 
-            async_checks.check().await?;
+            async_checks.check(block_batch_flush_key).await?;
 
             tracing::trace!(?tx_id, "finished async checks");
 
@@ -1355,15 +1370,44 @@ impl AsyncChecks {
     ///
     /// If any of the checks fail, this method immediately returns the error and cancels all other
     /// checks by dropping them.
-    async fn check(mut self) -> Result<(), BoxError> {
+    async fn check(
+        mut self,
+        block_batch_flush_key: Option<primitives::BlockVerifierBatchFlushKey>,
+    ) -> Result<(), BoxError> {
+        let mut needs_block_batch_flush = block_batch_flush_key.is_some();
+        let mut block_batch_flush = match block_batch_flush_key {
+            Some(key) => async move {
+                tokio::task::yield_now().await;
+                primitives::start_block_transaction_async_checks(key).await;
+            }
+            .boxed(),
+            None => futures::future::pending().boxed(),
+        };
+
         // Wait for all asynchronous checks to complete
         // successfully, or fail verification if they error.
-        while let Some(check) = self.0.next().await {
-            tracing::trace!(?check, remaining = self.0.len());
-            check?;
-        }
+        loop {
+            tokio::select! {
+                biased;
 
-        Ok(())
+                check = self.0.next() => {
+                    let Some(check) = check else {
+                        if needs_block_batch_flush {
+                            block_batch_flush.await;
+                        }
+
+                        return Ok(());
+                    };
+
+                    tracing::trace!(?check, remaining = self.0.len());
+                    check?;
+                }
+
+                () = &mut block_batch_flush, if needs_block_batch_flush => {
+                    needs_block_batch_flush = false;
+                }
+            }
+        }
     }
 }
 

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -1378,7 +1378,7 @@ impl AsyncChecks {
         let mut block_batch_flush = match block_batch_flush_key {
             Some(key) => async move {
                 tokio::task::yield_now().await;
-                primitives::start_block_transaction_async_checks(key).await;
+                primitives::start_block_transaction_async_checks(key);
             }
             .boxed(),
             None => futures::future::pending().boxed(),

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -16,7 +16,8 @@ use futures::{FutureExt, TryFutureExt};
 use halo2::pasta::{group::ff::PrimeField, pallas};
 use tokio::time::timeout;
 use tower::{buffer::Buffer, service_fn, Service, ServiceExt};
-use tower_batch_control::BatchControl;
+use tower_batch_control::{Batch, BatchControl};
+use tower_fallback::Fallback;
 
 use zakura_chain::{
     amount::{Amount, NegativeAllowed, NonNegative},
@@ -3055,6 +3056,24 @@ fn v4_with_invalid_sapling_proof_returns_typed_error() {
             })
             .expect("test vectors include a V4 transaction with Sapling spends");
 
+        let (valid_bundle_one, valid_bundle_two, valid_sighash) = {
+            let sighasher = transaction
+                .sighasher(
+                    NetworkUpgrade::current(&network, height),
+                    Arc::new(Vec::new()),
+                )
+                .expect("test fixture has no transparent inputs");
+            let valid_bundle_one = sighasher
+                .sapling_bundle()
+                .expect("test fixture has Sapling shielded data");
+            let valid_bundle_two = sighasher
+                .sapling_bundle()
+                .expect("test fixture has Sapling shielded data");
+            let valid_sighash = sighasher.sighash(HashType::ALL, None);
+
+            (valid_bundle_one, valid_bundle_two, valid_sighash)
+        };
+
         modify_first_sapling_spend_proof(
             Arc::get_mut(&mut transaction).expect("transaction only has one active reference"),
             SaplingProofModification::Corrupt,
@@ -3072,10 +3091,14 @@ fn v4_with_invalid_sapling_proof_returns_typed_error() {
         let single_bundle = sighasher
             .sapling_bundle()
             .expect("test fixture has Sapling shielded data");
+        let fallback_bundle = sighasher
+            .sapling_bundle()
+            .expect("test fixture has Sapling shielded data");
         let synchronous_check_bundle = sighasher
             .sapling_bundle()
             .expect("test fixture has Sapling shielded data");
         let sighash = sighasher.sighash(HashType::ALL, None);
+        drop(sighasher);
 
         let mut verifier = sapling_crypto::BatchValidator::default();
         assert!(
@@ -3101,6 +3124,112 @@ fn v4_with_invalid_sapling_proof_returns_typed_error() {
         .await;
         assert_sapling_verification_error(
             single_result.expect_err("corrupted Sapling proof must be rejected"),
+        );
+
+        let invalid_item = crate::primitives::sapling::Item::new(fallback_bundle, sighash);
+        let items = vec![
+            crate::primitives::sapling::Item::new(valid_bundle_one, valid_sighash),
+            invalid_item.clone(),
+            crate::primitives::sapling::Item::new(valid_bundle_two, valid_sighash),
+        ];
+        let expected_results: Vec<_> = futures::future::join_all(
+            items
+                .iter()
+                .cloned()
+                .map(crate::primitives::sapling::verify_single),
+        )
+        .await
+        .into_iter()
+        .map(|result| result.is_ok())
+        .collect();
+        assert_eq!(
+            expected_results,
+            [true, false, true],
+            "the fixture must contain valid neighbors around one invalid proof"
+        );
+
+        let mut verifier = Fallback::new(
+            Batch::new(
+                crate::primitives::sapling::Verifier::default(),
+                100,
+                1,
+                std::time::Duration::from_secs(1000),
+            ),
+            service_fn(crate::primitives::sapling::verify_single),
+        );
+        verifier
+            .ready()
+            .await
+            .expect("test verifier must become ready");
+        let invalid_singleton = verifier.call(invalid_item);
+        let mut primary = verifier.primary().clone();
+        assert!(
+            primary
+                .try_flush()
+                .expect("explicit Sapling singleton flush must not fail"),
+            "explicit Sapling singleton flush must be queued"
+        );
+        assert!(
+            timeout(test_timeout(), invalid_singleton)
+                .await
+                .expect("explicitly flushed Sapling singleton must complete")
+                .is_err(),
+            "an explicitly flushed invalid Sapling singleton must be rejected"
+        );
+
+        let mut batch_results = Vec::new();
+        for item in items {
+            verifier
+                .ready()
+                .await
+                .expect("test verifier must become ready");
+            batch_results.push(verifier.call(item));
+        }
+
+        assert!(
+            primary
+                .try_flush()
+                .expect("explicit Sapling test flush must not fail"),
+            "explicit Sapling test flush must be queued"
+        );
+
+        let actual_results: Vec<_> =
+            timeout(test_timeout(), futures::future::join_all(batch_results))
+                .await
+                .expect("explicitly flushed Sapling verification must complete")
+                .into_iter()
+                .map(|result| result.is_ok())
+                .collect();
+        assert_eq!(
+            actual_results, expected_results,
+            "explicit Sapling batch flush plus fallback must match single verification"
+        );
+
+        let known_outpoint_hashes = Arc::new(HashSet::new());
+        let _block_batch_flush =
+            crate::primitives::register_block_verifier_batch_flush(&known_outpoint_hashes, 1);
+        let transaction_hash = transaction.hash();
+        let transaction_verifier = Verifier::new_for_tests(
+            &network,
+            service_fn(|_| async { unreachable!("fixture has no transparent inputs") }),
+        );
+        let block_transaction_result = timeout(
+            test_timeout(),
+            transaction_verifier.oneshot(Request::Block {
+                transaction_hash,
+                transaction,
+                known_utxos: Arc::new(HashMap::new()),
+                known_outpoint_hashes,
+                height,
+                time: DateTime::<Utc>::MAX_UTC,
+            }),
+        )
+        .await
+        .expect("block-boundary-flushed transaction verification must complete");
+        assert_eq!(
+            block_transaction_result,
+            Err(TransactionError::SaplingVerificationFailed),
+            "the block-boundary flush path must reject an invalid Sapling proof"
         );
     });
 }


### PR DESCRIPTION
## Motivation

Semantic block verification can queue signature and proof work, then wait for
the global `MAX_BATCH_LATENCY` of 100 ms before a partial crypto batch starts.
Lowering that timer globally would also change mempool batching, so block
execution needs a targeted boundary signal.

## Solution

Add a bounded, non-blocking explicit flush command, `Batch::try_flush`, and
expose the primary service through `Fallback`. Each semantic block registers
its transaction count, and the final transaction to reach its
asynchronous-check boundary queues best-effort flushes for the initialized
Ed25519, Sapling, and Orchard batch services. Verification remains unchanged.
Every transaction future is still awaited, and the existing size and latency
triggers remain as fallback paths.

Flush commands use the existing semaphore capacity. Batch bookkeeping treats
every queued item as having a weight of at least one, so a zero-weight item
cannot be mistaken for an empty batch. Cancellation removes the block
registration before its pointer identity can be reused.

## Benchmarks

Semantic-verification A/B on the bench runner (this branch `12794b6e0` vs merge
base `ad49535c8`), syncing real mainnet blocks from height 1707210 with
`consensus.checkpoint_sync = false` (everything past the mandatory checkpoints
gets full script+proof verification), DNS-seeder peers:

- `full_verify_concurrency_limit = 1` (approximates near-tip block-at-a-time
  verification), 1000 blocks: 1.04 → 1.24 blocks/s overall (**1.19×**); steady
  state 681 → 591 ms/block, recovering ~90 of the up-to-100 ms
  `MAX_BATCH_LATENCY` wait per block. Run:
  https://github.com/zakura-core/zakura/actions/runs/30039304446
- `full_verify_concurrency_limit = 20` (concurrent catch-up), 3000 blocks:
  4.22 → 4.19 blocks/s post-first-commit (−0.7%, well inside the lane's 8.7%
  noise band) — no regression from per-block flushes shortening batches shared
  across concurrently verified blocks. Run:
  https://github.com/zakura-core/zakura/actions/runs/30038568453

Both runs' red status is a pre-existing bench teardown bug (`set -e` in the
EXIT trap; fix drafted separately) — all four legs completed cleanly and the
data is complete.

## Changelog

Added `changelog-unreleased/417.md`.

### Specifications & References

No consensus rule changes. This ports the previously explored block-boundary
batch-flush design onto current Zakura `main`.

### Follow-up Work

Concurrent semantic catch-up is benchmarked above (neutral at concurrency 20).
Remaining: a tip-following canary A/B on the fleet to measure real
block-arrival-to-commit latency, and optionally a Prometheus counter for
explicit flushes, since release builds compile out the trace-level log line
that would otherwise confirm the path in production.

### AI Disclosure

OpenAI Codex was used to port and harden the implementation, add tests, run
validation, and prepare this description.
