### PR TITLE
fix(state)!: make gettxout use one coherent state view

### DIFF
--- a/changelog-unreleased/421.md
+++ b/changelog-unreleased/421.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Make `gettxout` derive its state-backed fields from one coherent best-chain
+  view, avoiding mixed tip, confirmation, and transaction metadata during
+  concurrent state changes
+  ([#421](https://github.com/zakura-core/zakura/pull/421)).

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -3202,32 +3202,16 @@ where
             };
         }
 
-        // TODO: Ensure that the returned tip hash is always valid for the response, i.e. that Zebra can't return a tip that
-        //       hadn't yet included the queried transaction output.
-
-        // Get the best block tip hash
-        let tip_rsp = self
-            .read_state
-            .clone()
-            .oneshot(zakura_state::ReadRequest::Tip)
-            .await
-            .map_misc_error()?;
-
-        let best_block_hash = match tip_rsp {
-            zakura_state::ReadResponse::Tip(tip) => tip.ok_or_misc_error("No blocks in state")?.1,
-            _ => unreachable!("unmatched response to a `Tip` request"),
-        };
-
-        // State path
         let rsp = self
             .read_state
             .clone()
-            .oneshot(zakura_state::ReadRequest::Transaction(txid))
+            .oneshot(zakura_state::ReadRequest::BestChainUnspentOutput(outpoint))
             .await
             .map_misc_error()?;
 
         match rsp {
-            zakura_state::ReadResponse::Transaction(Some(tx)) => {
+            zakura_state::ReadResponse::BestChainUnspentOutput(Some(output_info)) => {
+                let tx = output_info.transaction;
                 let outputs = tx.tx.outputs();
                 let index: usize = n.try_into().expect("u32 always fits in usize");
                 let output = match outputs.get(index) {
@@ -3236,33 +3220,10 @@ where
                     None => return Ok(GetTxOutResponse(None)),
                 };
 
-                // Prune state outputs that are spent
-                let is_spent = {
-                    let rsp = self
-                        .read_state
-                        .clone()
-                        .oneshot(zakura_state::ReadRequest::IsTransparentOutputSpent(
-                            outpoint,
-                        ))
-                        .await
-                        .map_misc_error()?;
-
-                    match rsp {
-                        zakura_state::ReadResponse::IsTransparentOutputSpent(spent) => spent,
-                        _ => unreachable!(
-                            "unmatched response to an `IsTransparentOutputSpent` request"
-                        ),
-                    }
-                };
-
-                if is_spent {
-                    return Ok(GetTxOutResponse(None));
-                }
-
                 Ok(GetTxOutResponse(Some(
                     types::transaction::OutputObject::from_output(
                         output,
-                        best_block_hash.to_string(),
+                        output_info.tip_hash.to_string(),
                         tx.confirmations,
                         tx.tx.version(),
                         tx.tx.is_coinbase(),
@@ -3270,8 +3231,8 @@ where
                     ),
                 )))
             }
-            zakura_state::ReadResponse::Transaction(None) => Ok(GetTxOutResponse(None)),
-            _ => unreachable!("unmatched response to a `Transaction` request"),
+            zakura_state::ReadResponse::BestChainUnspentOutput(None) => Ok(GetTxOutResponse(None)),
+            _ => unreachable!("unmatched response to a `BestChainUnspentOutput` request"),
         }
     }
 }

--- a/zakura-rpc/src/methods/tests/vectors.rs
+++ b/zakura-rpc/src/methods/tests/vectors.rs
@@ -3279,6 +3279,46 @@ async fn rpc_addnode() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn rpc_gettxout_empty_state() {
+    let _init_guard = zakura_test::init();
+
+    let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let (state, read_state, tip, _) = zakura_state::init_test_services(&Mainnet).await;
+    let (block_verifier_router, _, _, _) = zakura_consensus::router::init_test(
+        zakura_consensus::Config::default(),
+        &Mainnet,
+        state.clone(),
+    )
+    .await;
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        state,
+        Buffer::new(read_state, 1),
+        block_verifier_router,
+        MockSyncStatus::default(),
+        tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let missing_txid = zakura_chain::transaction::Hash([0; 32]).encode_hex::<String>();
+    let error = rpc
+        .get_tx_out(missing_txid, 0, Some(false))
+        .await
+        .expect_err("gettxout on an empty state remains an RPC error");
+
+    assert_eq!(error.message(), "No blocks in state");
+    mempool.expect_no_requests().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_gettxout() {
     let _init_guard = zakura_test::init();
 
@@ -3315,9 +3355,16 @@ async fn rpc_gettxout() {
 
     // TODO: Create a mempool test
 
+    let expected_best_block = blocks
+        .last()
+        .expect("test chain has a tip")
+        .hash()
+        .to_string();
+
     // Build a state test for all transactions
     let run_test_case = |_block_idx: usize, _block: Arc<Block>, tx: Arc<Transaction>| {
         let read_state = read_state.clone();
+        let expected_best_block = expected_best_block.clone();
         let txid = tx.hash();
         let hex_txid = txid.encode_hex::<String>();
 
@@ -3328,6 +3375,9 @@ async fn rpc_gettxout() {
             let get_tx_output = response.expect("We should have a GetTxOut struct");
 
             let output_object = get_tx_output.0.unwrap();
+            assert_eq!(output_object.best_block(), &expected_best_block);
+            assert_eq!(output_object.version(), tx.version());
+            assert_eq!(output_object.coinbase(), tx.is_coinbase());
             assert_eq!(
                 output_object.value(),
                 crate::methods::types::zec::Zec::from(tx.outputs()[0].value()).lossy_zec()

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -56,8 +56,8 @@ pub use request::{
 pub use request::Spend;
 
 pub use response::{
-    AnyTx, GetBlockTemplateChainInfo, KnownBlock, MinedTx, NonFinalizedBlocksListener,
-    ReadResponse, Response,
+    AnyTx, BestChainUnspentOutput, GetBlockTemplateChainInfo, KnownBlock, MinedTx,
+    NonFinalizedBlocksListener, ReadResponse, Response,
 };
 pub use service::{
     chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip, TipAction},

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -1409,6 +1409,12 @@ pub enum ReadRequest {
     /// Checks verified blocks in the finalized chain and the _best_ non-finalized chain.
     UnspentBestChainUtxo(transparent::OutPoint),
 
+    /// Looks up an unspent output and its transaction and tip context using one
+    /// coherent best-chain view.
+    ///
+    /// Returns [`ReadResponse::BestChainUnspentOutput`].
+    BestChainUnspentOutput(transparent::OutPoint),
+
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// returning `None` immediately if it is unknown.
     ///
@@ -1729,6 +1735,7 @@ impl ReadRequest {
             ReadRequest::TransactionIdsForBlock(_) => "transaction_ids_for_block",
             ReadRequest::AnyChainTransactionIdsForBlock(_) => "any_chain_transaction_ids_for_block",
             ReadRequest::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
+            ReadRequest::BestChainUnspentOutput(_) => "best_chain_unspent_output",
             ReadRequest::AnyChainUtxo { .. } => "any_chain_utxo",
             ReadRequest::BlockLocator => "block_locator",
             ReadRequest::FindBlockHashes { .. } => "find_block_hashes",

--- a/zakura-state/src/response.rs
+++ b/zakura-state/src/response.rs
@@ -187,6 +187,16 @@ pub struct MinedTx {
     pub block_time: DateTime<Utc>,
 }
 
+/// An unspent output's transaction and tip context from one coherent best-chain view.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BestChainUnspentOutput {
+    /// The best-chain tip hash used to calculate `transaction.confirmations`.
+    pub tip_hash: block::Hash,
+
+    /// The transaction that creates the unspent output.
+    pub transaction: MinedTx,
+}
+
 impl MinedTx {
     /// Creates a new [`MinedTx`]
     pub fn new(
@@ -478,6 +488,10 @@ pub enum ReadResponse {
     /// _best_ non-finalized chain, or the finalized chain.
     UnspentBestChainUtxo(Option<transparent::Utxo>),
 
+    /// An unspent output and its transaction and tip context from one coherent
+    /// best-chain view.
+    BestChainUnspentOutput(Option<BestChainUnspentOutput>),
+
     /// The response to an `AnyChainUtxo` request, from verified blocks in
     /// _any_ non-finalized chain, or the finalized chain.
     ///
@@ -665,6 +679,7 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::MissingBlockBodyMetadata(_)
             | ReadResponse::BlockSizeHints(_)
             | ReadResponse::Blocks(_)
+            | ReadResponse::BestChainUnspentOutput(_)
             | ReadResponse::NonFinalizedBlocksListener(_)
             | ReadResponse::IsTransparentOutputSpent(_) => {
                 Err("there is no corresponding Response for this ReadResponse")

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -23,6 +23,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(test)]
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    mpsc::{self, Receiver, Sender},
+    Mutex,
+};
+
 use futures::future::FutureExt;
 use tokio::sync::oneshot;
 use tower::{util::BoxService, Service, ServiceExt};
@@ -255,9 +262,87 @@ pub struct ReadStateService {
 
     /// Watch channel publishing the next VCT supplied-root repair needed by the finalized writer.
     vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
+
     /// Compact durable header-root authentication progress.
     header_root_auth_receiver:
         tokio::sync::watch::Receiver<Option<finalized_state::HeaderRootAuthState>>,
+
+    #[cfg(test)]
+    best_chain_read_view_test_hook: Option<BestChainReadViewTestHook>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Capture points exposed only to deterministic state interleaving tests.
+pub(in crate::service) enum BestChainReadViewCapturePhase {
+    /// After the non-finalized generation is captured, before the RocksDB snapshot.
+    BeforeFinalizedSnapshot,
+    /// After the RocksDB snapshot is captured, before its first read.
+    AfterFinalizedSnapshot,
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+/// A one-shot pause used to force a state transition during view capture.
+pub(in crate::service) struct BestChainReadViewTestHook {
+    phase: BestChainReadViewCapturePhase,
+    entered: Sender<()>,
+    resume: Arc<Mutex<Receiver<()>>>,
+    fired: Arc<AtomicBool>,
+    visits: Arc<AtomicUsize>,
+    pause_every_visit: bool,
+}
+
+#[cfg(test)]
+impl BestChainReadViewTestHook {
+    /// Creates a hook, bounded enter/resume channels, and a visit counter.
+    pub(in crate::service) fn new(
+        phase: BestChainReadViewCapturePhase,
+    ) -> (Self, Receiver<()>, Sender<()>, Arc<AtomicUsize>) {
+        Self::new_with_behavior(phase, false)
+    }
+
+    /// Creates a hook that pauses every capture attempt until retry exhaustion.
+    pub(in crate::service) fn every_visit(
+        phase: BestChainReadViewCapturePhase,
+    ) -> (Self, Receiver<()>, Sender<()>, Arc<AtomicUsize>) {
+        Self::new_with_behavior(phase, true)
+    }
+
+    fn new_with_behavior(
+        phase: BestChainReadViewCapturePhase,
+        pause_every_visit: bool,
+    ) -> (Self, Receiver<()>, Sender<()>, Arc<AtomicUsize>) {
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let (resume_sender, resume_receiver) = mpsc::channel();
+        let visits = Arc::new(AtomicUsize::new(0));
+        let hook = Self {
+            phase,
+            entered: entered_sender,
+            resume: Arc::new(Mutex::new(resume_receiver)),
+            fired: Arc::new(AtomicBool::new(false)),
+            visits: visits.clone(),
+            pause_every_visit,
+        };
+
+        (hook, entered_receiver, resume_sender, visits)
+    }
+
+    fn run(&self, phase: BestChainReadViewCapturePhase) {
+        if self.phase != phase {
+            return;
+        }
+
+        self.visits.fetch_add(1, Ordering::SeqCst);
+        if self.pause_every_visit || !self.fired.swap(true, Ordering::SeqCst) {
+            self.entered.send(()).expect("test receiver remains open");
+            self.resume
+                .lock()
+                .expect("test hook mutex is not poisoned")
+                .recv_timeout(Duration::from_secs(10))
+                .expect("test releases the read-view capture hook");
+        }
+    }
 }
 
 impl Drop for StateService {
@@ -1105,6 +1190,9 @@ impl StateService {
 }
 
 impl ReadStateService {
+    /// Maximum attempts to capture one non-finalized generation and RocksDB sequence.
+    const BEST_CHAIN_READ_VIEW_ATTEMPTS: usize = 3;
+
     /// Creates a new read-only state service, using the provided finalized state and
     /// block write task handle.
     ///
@@ -1134,6 +1222,8 @@ impl ReadStateService {
             _highest_completed_checkpoint_sender: highest_completed_checkpoint_sender,
             vct_root_repair_receiver,
             header_root_auth_receiver,
+            #[cfg(test)]
+            best_chain_read_view_test_hook: None,
         };
 
         tracing::debug!("created new read-only state service");
@@ -1174,6 +1264,75 @@ impl ReadStateService {
     fn latest_best_chain(&self) -> Option<Arc<Chain>> {
         self.non_finalized_state_receiver
             .borrow_mapped(|non_finalized_state| non_finalized_state.best_chain().cloned())
+    }
+
+    /// Captures one coherent view across the watched non-finalized state and RocksDB.
+    ///
+    /// The writer publishes its non-finalized chain before moving the same chain's
+    /// oldest blocks into the finalized database. This ordering guarantees overlap,
+    /// rather than a gap, between a captured chain and a later RocksDB snapshot.
+    /// Marking the watch generation as seen before capture, then checking it after
+    /// the snapshot, detects every concurrent chain publication, including ABA
+    /// changes. A changed generation retries from scratch. The RocksDB snapshot
+    /// pins every finalized column family to one sequence for the lifetime of the
+    /// returned view.
+    ///
+    /// If the watch channel closes, its final value is immutable. Re-capture that
+    /// value before taking a fresh database snapshot so an unseen final publication
+    /// cannot be combined with an older chain handle.
+    ///
+    /// The overlap guarantee applies when the primary state writer supplies the
+    /// watch channel. In a read-only service, database catch-up and a caller-managed
+    /// non-finalized sender are independent. An empty non-finalized state still gets
+    /// a coherent finalized snapshot, but a caller that publishes non-finalized
+    /// chains must preserve the same publish-before-finalize ordering.
+    fn best_chain_read_view(&self) -> Result<read::BestChainReadView<'_>, BoxError> {
+        let mut receiver = self.non_finalized_state_receiver.clone();
+
+        for _ in 0..Self::BEST_CHAIN_READ_VIEW_ATTEMPTS {
+            receiver.mark_as_seen();
+            let best_chain = receiver
+                .borrow_mapped(|non_finalized_state| non_finalized_state.best_chain().cloned());
+            #[cfg(test)]
+            if let Some(hook) = &self.best_chain_read_view_test_hook {
+                hook.run(BestChainReadViewCapturePhase::BeforeFinalizedSnapshot);
+            }
+            let finalized = self.db.snapshot();
+            #[cfg(test)]
+            if let Some(hook) = &self.best_chain_read_view_test_hook {
+                hook.run(BestChainReadViewCapturePhase::AfterFinalizedSnapshot);
+            }
+
+            match receiver.has_changed() {
+                Ok(true) => continue,
+                Ok(false) => {
+                    return Ok(read::BestChainReadView::new(best_chain, finalized));
+                }
+                Err(_) => {
+                    // A closed channel cannot change again, but its final value might
+                    // have arrived during the first capture. Re-read that final value,
+                    // then take a fresh database snapshot in that order.
+                    let best_chain = receiver.borrow_mapped(|non_finalized_state| {
+                        non_finalized_state.best_chain().cloned()
+                    });
+                    let finalized = self.db.snapshot();
+
+                    return Ok(read::BestChainReadView::new(best_chain, finalized));
+                }
+            }
+        }
+
+        Err("best chain changed while capturing a coherent read view".into())
+    }
+
+    #[cfg(test)]
+    /// Installs a one-shot deterministic capture hook on this service clone.
+    pub(in crate::service) fn with_best_chain_read_view_test_hook(
+        mut self,
+        hook: BestChainReadViewTestHook,
+    ) -> Self {
+        self.best_chain_read_view_test_hook = Some(hook);
+        self
     }
 
     /// Test-only access to the inner database.
@@ -1953,6 +2112,18 @@ impl Service<ReadRequest> for ReadStateService {
                 read::unspent_utxo(state.latest_best_chain(), &state.db, outpoint),
             )),
 
+            // Used by the gettxout RPC.
+            ReadRequest::BestChainUnspentOutput(outpoint) => {
+                let view = state.best_chain_read_view()?;
+                if view.tip().is_none() {
+                    return Err("No blocks in state".into());
+                }
+
+                Ok(ReadResponse::BestChainUnspentOutput(
+                    view.unspent_output(outpoint)?,
+                ))
+            }
+
             // Manually used by the StateService to implement part of AwaitUtxo.
             ReadRequest::AnyChainUtxo(outpoint) => Ok(ReadResponse::AnyChainUtxo(read::any_utxo(
                 state.latest_non_finalized_state(),
@@ -2368,6 +2539,12 @@ pub async fn init(
 /// Each `network` has its own separate on-disk database.
 ///
 /// To share access to the state, clone the returned [`ReadStateService`].
+///
+/// The returned non-finalized sender is caller-managed. Callers that publish
+/// non-finalized chains while the secondary database catches up must publish the
+/// chain before finalized state can advance past the shared overlap. Coherent
+/// multi-source reads rely on that publish-before-finalize ordering. Database
+/// snapshots pin one local secondary sequence; catch-up freshness is separate.
 pub fn init_read_only(
     config: Config,
     network: &Network,

--- a/zakura-state/src/service/finalized_state.rs
+++ b/zakura-state/src/service/finalized_state.rs
@@ -123,6 +123,7 @@ pub use zakura_db::commitment_roots_db::{
 };
 pub use zakura_db::highest_completed_checkpoint::*;
 pub use zakura_db::ZakuraDb;
+pub(super) use zakura_db::ZakuraDbSnapshot;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use disk_format::KV;

--- a/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/zakura-state/src/service/finalized_state/disk_db.rs
@@ -113,6 +113,12 @@ pub struct DiskDb {
     db: Arc<DB>,
 }
 
+/// An immutable RocksDB view tied to a [`DiskDb`].
+pub(in crate::service::finalized_state) struct DiskDbSnapshot<'a> {
+    db: &'a DiskDb,
+    snapshot: rocksdb::SnapshotWithThreadMode<'a, DB>,
+}
+
 /// Wrapper struct to ensure low-level database writes go through the correct API.
 ///
 /// [`rocksdb::WriteBatch`] is a batched set of database updates,
@@ -434,6 +440,49 @@ impl PartialEq for DiskDb {
 
 impl Eq for DiskDb {}
 
+impl DiskDbSnapshot<'_> {
+    /// Returns the column family handle for `cf_name`.
+    pub(in crate::service::finalized_state) fn cf_handle(
+        &self,
+        cf_name: &str,
+    ) -> Option<rocksdb::ColumnFamilyRef<'_>> {
+        self.db.cf_handle(cf_name)
+    }
+
+    /// Returns the value for `key` from this snapshot, if present.
+    pub(in crate::service::finalized_state) fn zs_get<C, K, V>(&self, cf: &C, key: &K) -> Option<V>
+    where
+        C: rocksdb::AsColumnFamilyRef,
+        K: IntoDisk,
+        V: FromDisk,
+    {
+        let key_bytes = key.as_bytes();
+        let value_bytes = self
+            .snapshot
+            .get_pinned_cf(cf, key_bytes)
+            .expect("unexpected database failure");
+
+        value_bytes.map(V::from_bytes)
+    }
+
+    /// Returns the highest key and its value from this snapshot.
+    pub(in crate::service::finalized_state) fn zs_last_key_value<C, K, V>(
+        &self,
+        cf: &C,
+    ) -> Option<(K, V)>
+    where
+        C: rocksdb::AsColumnFamilyRef,
+        K: FromDisk,
+        V: FromDisk,
+    {
+        self.snapshot
+            .iterator_cf(cf, rocksdb::IteratorMode::End)
+            .next()
+            .map(|result| result.expect("unexpected database failure"))
+            .map(|(key, value)| (K::from_bytes(key), V::from_bytes(value)))
+    }
+}
+
 /// # Deprecation
 ///
 /// These impls should not be used in new code, use [`TypedColumnFamily`] instead.
@@ -586,6 +635,19 @@ impl DiskWriteBatch {
 }
 
 impl DiskDb {
+    /// Returns an immutable view of all column families at one RocksDB sequence.
+    ///
+    /// This pins consistency inside this database instance. A read-only secondary
+    /// does not coordinate snapshot retention with its primary, so callers must
+    /// keep secondary snapshots short-lived and treat catch-up freshness as a
+    /// separate concern.
+    pub(in crate::service::finalized_state) fn snapshot(&self) -> DiskDbSnapshot<'_> {
+        DiskDbSnapshot {
+            db: self,
+            snapshot: self.db.snapshot(),
+        }
+    }
+
     /// Prints rocksdb metrics for each column family along with total database disk size, live data disk size and database memory size.
     pub fn print_db_metrics(&self) {
         let mut total_size_on_disk = 0;

--- a/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -60,7 +60,10 @@ pub(crate) const PARALLEL_BLOCK_READ_THRESHOLD: usize = 16;
 pub mod prune;
 pub mod rollback;
 pub mod shielded;
+mod snapshot;
 pub mod transparent;
+
+pub(in crate::service) use snapshot::ZakuraDbSnapshot;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 // TODO: when the database is split out of zakura-state, always expose these methods.

--- a/zakura-state/src/service/finalized_state/zakura_db/snapshot.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/snapshot.rs
@@ -1,0 +1,78 @@
+//! Immutable reads from one RocksDB sequence.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use zakura_chain::{
+    block::{self, Height},
+    transaction::{self, Transaction},
+    transparent,
+};
+
+use crate::service::finalized_state::{
+    disk_db::DiskDbSnapshot,
+    disk_format::{OutputLocation, TransactionLocation},
+};
+
+use super::ZakuraDb;
+
+/// A coherent immutable view of the finalized state.
+pub(in crate::service) struct ZakuraDbSnapshot<'a> {
+    db: DiskDbSnapshot<'a>,
+}
+
+impl ZakuraDb {
+    /// Captures a coherent immutable view of the finalized state.
+    pub(in crate::service) fn snapshot(&self) -> ZakuraDbSnapshot<'_> {
+        ZakuraDbSnapshot {
+            db: self.db.snapshot(),
+        }
+    }
+}
+
+impl ZakuraDbSnapshot<'_> {
+    /// Returns the finalized tip captured by this snapshot.
+    pub(in crate::service) fn tip(&self) -> Option<(block::Height, block::Hash)> {
+        let hash_by_height = self.db.cf_handle("hash_by_height")?;
+        self.db.zs_last_key_value(&hash_by_height)
+    }
+
+    /// Returns the transaction and its mined context captured by this snapshot.
+    pub(in crate::service) fn transaction(
+        &self,
+        hash: transaction::Hash,
+    ) -> Option<(Arc<Transaction>, Height, DateTime<Utc>)> {
+        let transaction_location = self.transaction_location(hash)?;
+        let block_header_by_height = self.db.cf_handle("block_header_by_height")?;
+        let header: Arc<block::Header> = self
+            .db
+            .zs_get(&block_header_by_height, &transaction_location.height)?;
+        let tx_by_loc = self.db.cf_handle("tx_by_loc")?;
+        let transaction = self.db.zs_get(&tx_by_loc, &transaction_location)?;
+
+        Some((transaction, transaction_location.height, header.time))
+    }
+
+    /// Returns true if `outpoint` is unspent in this snapshot.
+    pub(in crate::service) fn contains_unspent_output(
+        &self,
+        outpoint: &transparent::OutPoint,
+    ) -> bool {
+        let Some(transaction_location) = self.transaction_location(outpoint.hash) else {
+            return false;
+        };
+        let output_location = OutputLocation::from_outpoint(transaction_location, outpoint);
+        let Some(utxo_by_out_loc) = self.db.cf_handle("utxo_by_out_loc") else {
+            return false;
+        };
+        let output: Option<transparent::Output> =
+            self.db.zs_get(&utxo_by_out_loc, &output_location);
+
+        output.is_some()
+    }
+
+    fn transaction_location(&self, hash: transaction::Hash) -> Option<TransactionLocation> {
+        let tx_loc_by_hash = self.db.cf_handle("tx_loc_by_hash")?;
+        self.db.zs_get(&tx_loc_by_hash, &hash)
+    }
+}

--- a/zakura-state/src/service/read.rs
+++ b/zakura-state/src/service/read.rs
@@ -19,6 +19,9 @@ pub mod block;
 pub mod difficulty;
 pub mod find;
 pub mod tree;
+mod view;
+
+pub(super) use view::BestChainReadView;
 
 #[cfg(test)]
 mod tests;

--- a/zakura-state/src/service/read/tests.rs
+++ b/zakura-state/src/service/read/tests.rs
@@ -2,4 +2,5 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+mod atomic_view;
 mod vectors;

--- a/zakura-state/src/service/read/tests/atomic_view.rs
+++ b/zakura-state/src/service/read/tests/atomic_view.rs
@@ -551,6 +551,65 @@ async fn coherent_view_survives_non_finalized_to_finalized_transition() -> Resul
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_uses_newer_finalized_tip_during_read_only_catch_up() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    let stale_tip = non_finalized_child(&blocks[0]);
+    let finalized_tip = non_finalized_child(&stale_tip);
+
+    let mut non_finalized = NonFinalizedState::new(&Mainnet);
+    non_finalized.commit_new_chain(stale_tip.clone().prepare(), &finalized)?;
+    let (read_state, _non_finalized_sender) = read_service(&finalized, non_finalized);
+
+    commit_finalized(&mut finalized, stale_tip);
+    commit_finalized(&mut finalized, finalized_tip.clone());
+
+    let output = query_unspent_output(read_state, outpoint(&finalized_tip)).await;
+
+    assert_eq!(output.tip_hash, finalized_tip.hash());
+    assert_eq!(
+        output.transaction.tx.hash(),
+        finalized_tip.transactions[0].hash()
+    );
+    assert_eq!(output.transaction.confirmations, 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_does_not_resurrect_output_spent_after_stale_chain_tip() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    let (created_block, queried_outpoint, replacement_output) =
+        with_zero_value_transparent_output(non_finalized_child(&blocks[0]), 0x52);
+
+    let mut non_finalized = NonFinalizedState::new(&Mainnet);
+    non_finalized.commit_new_chain(created_block.clone().prepare(), &finalized)?;
+    let (read_state, _non_finalized_sender) = read_service(&finalized, non_finalized);
+
+    commit_finalized(&mut finalized, created_block.clone());
+    let spending_block = with_transparent_spend(
+        non_finalized_child(&created_block),
+        queried_outpoint,
+        replacement_output,
+    );
+    commit_finalized(&mut finalized, spending_block);
+
+    let response = read_state
+        .oneshot(ReadRequest::BestChainUnspentOutput(queried_outpoint))
+        .await
+        .expect("coherent state request succeeds");
+
+    assert_eq!(response, ReadResponse::BestChainUnspentOutput(None));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn coherent_view_preserves_empty_state_error() {
     let _init_guard = zakura_test::init();
     let finalized = finalized_state();

--- a/zakura-state/src/service/read/tests/atomic_view.rs
+++ b/zakura-state/src/service/read/tests/atomic_view.rs
@@ -1,0 +1,661 @@
+//! Deterministic interleavings for coherent best-chain read views.
+
+use std::{
+    sync::{atomic::Ordering, Arc},
+    time::Duration,
+};
+
+use tokio::{sync::watch, time::timeout};
+use tower::ServiceExt;
+use zakura_chain::{
+    amount::{Amount, NonNegative},
+    block::{Block, Height},
+    parameters::{Network::Mainnet, NetworkUpgrade},
+    serialization::ZcashDeserializeInto,
+    transaction::{LockTime, Transaction},
+    transparent,
+};
+use zakura_test::prelude::Result;
+
+use crate::{
+    arbitrary::Prepare,
+    config::StorageMode,
+    service::{
+        finalized_state::{FinalizedState, HighestCompletedCheckpoint},
+        non_finalized_state::NonFinalizedState,
+        BestChainReadViewCapturePhase, BestChainReadViewTestHook, ReadStateService,
+        VctRootRepairStatus,
+    },
+    tests::FakeChainHelper,
+    CheckpointVerifiedBlock, Config, PruningConfig, ReadRequest, ReadResponse, WatchReceiver,
+};
+
+fn continuous_mainnet_blocks() -> Vec<Arc<Block>> {
+    zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .values()
+        .map(|bytes| bytes.zcash_deserialize_into().unwrap())
+        .collect()
+}
+
+fn finalized_state() -> FinalizedState {
+    FinalizedState::new(&crate::Config::ephemeral(), &Mainnet)
+        .expect("opening an ephemeral finalized state succeeds")
+}
+
+fn commit_finalized(state: &mut FinalizedState, block: Arc<Block>) {
+    state
+        .commit_finalized_direct(
+            CheckpointVerifiedBlock::from(block).into(),
+            None,
+            None,
+            "atomic best-chain read-view test",
+        )
+        .expect("continuous test block commits to finalized state");
+}
+
+fn read_service(
+    finalized: &FinalizedState,
+    non_finalized: NonFinalizedState,
+) -> (ReadStateService, watch::Sender<NonFinalizedState>) {
+    let (non_finalized_sender, non_finalized_receiver) = watch::channel(non_finalized);
+    let (_checkpoint_sender, checkpoint_receiver) =
+        watch::channel(None::<HighestCompletedCheckpoint>);
+    let (_repair_sender, repair_receiver) = watch::channel(VctRootRepairStatus::default());
+
+    let read_state = ReadStateService::new(
+        finalized,
+        None,
+        WatchReceiver::new(non_finalized_receiver),
+        checkpoint_receiver,
+        None,
+        repair_receiver,
+    );
+
+    (read_state, non_finalized_sender)
+}
+
+fn outpoint(block: &Block) -> transparent::OutPoint {
+    transparent::OutPoint {
+        hash: block.transactions[0].hash(),
+        index: 0,
+    }
+}
+
+/// Builds a linked block for state-interleaving tests using the current transaction envelope.
+///
+/// The continuous genesis vectors use V1 transactions, but non-finalized state starts above the
+/// mandatory Canopy checkpoint and intentionally rejects V1-V3. These tests bypass semantic
+/// consensus checks and preserve the vectors' transparent values while exercising V6 state
+/// accounting. Committing each block still drives the real non-finalized chain implementation.
+fn non_finalized_child(parent: &Arc<Block>) -> Arc<Block> {
+    let mut child = parent.make_fake_child();
+    let block = Arc::make_mut(&mut child);
+
+    for transaction in &mut block.transactions {
+        let inputs = transaction.inputs().to_vec();
+        let mut outputs = transaction.outputs().to_vec();
+        let transparent::Input::Coinbase { height, .. } = &inputs[0] else {
+            panic!("the first transaction must be coinbase");
+        };
+        // V6 coinbase input data is not enough to make the txid unique, so bind the
+        // synthetic block height into an output script that is committed by the txid.
+        let mut lock_script = outputs[0].lock_script.as_raw_bytes().to_vec();
+        lock_script.extend_from_slice(&height.0.to_le_bytes());
+        outputs[0].lock_script = transparent::Script::new(&lock_script);
+
+        *Arc::make_mut(transaction) = Transaction::V6 {
+            network_upgrade: NetworkUpgrade::Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(0),
+            inputs,
+            outputs,
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+            ironwood_shielded_data: None,
+        };
+    }
+
+    child
+}
+
+fn with_coinbase_tag(mut block: Arc<Block>, tag: u8) -> Arc<Block> {
+    let mutable_block = Arc::make_mut(&mut block);
+    let transaction = Arc::make_mut(&mut mutable_block.transactions[0]);
+    let transparent::Input::Coinbase { data, .. } = &mut transaction.inputs_mut()[0] else {
+        panic!("the first transaction must be coinbase");
+    };
+    data.push(tag);
+    let output = &mut transaction.outputs_mut()[0];
+    let mut lock_script = output.lock_script.as_raw_bytes().to_vec();
+    lock_script.push(tag);
+    output.lock_script = transparent::Script::new(&lock_script);
+
+    block
+}
+
+fn with_transparent_spend(
+    mut block: Arc<Block>,
+    spent_outpoint: transparent::OutPoint,
+    replacement_output: transparent::Output,
+) -> Arc<Block> {
+    Arc::make_mut(&mut block)
+        .transactions
+        .push(Arc::new(Transaction::V6 {
+            network_upgrade: NetworkUpgrade::Nu6_3,
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(0),
+            inputs: vec![transparent::Input::PrevOut {
+                outpoint: spent_outpoint,
+                unlock_script: transparent::Script::new(&[]),
+                sequence: u32::MAX,
+            }],
+            outputs: vec![replacement_output],
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+            ironwood_shielded_data: None,
+        }));
+
+    block
+}
+
+fn with_zero_value_transparent_output(
+    mut block: Arc<Block>,
+    tag: u8,
+) -> (Arc<Block>, transparent::OutPoint, transparent::Output) {
+    let output = transparent::Output::new(
+        Amount::<NonNegative>::zero(),
+        transparent::Script::new(&[tag]),
+    );
+    let transaction = Arc::new(Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu6_3,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(0),
+        inputs: vec![],
+        outputs: vec![output.clone()],
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        ironwood_shielded_data: None,
+    });
+    let outpoint = transparent::OutPoint {
+        hash: transaction.hash(),
+        index: 0,
+    };
+    Arc::make_mut(&mut block).transactions.push(transaction);
+
+    (block, outpoint, output)
+}
+
+async fn query_unspent_output(
+    read_state: ReadStateService,
+    outpoint: transparent::OutPoint,
+) -> crate::BestChainUnspentOutput {
+    let response = read_state
+        .oneshot(ReadRequest::BestChainUnspentOutput(outpoint))
+        .await
+        .expect("coherent state request succeeds");
+
+    let ReadResponse::BestChainUnspentOutput(Some(output)) = response else {
+        panic!("expected an unspent best-chain output");
+    };
+
+    output
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn decomposed_gettxout_reads_can_mix_real_chain_views() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    commit_finalized(&mut finalized, blocks[1].clone());
+    let (read_state, _non_finalized_sender) =
+        read_service(&finalized, NonFinalizedState::new(&Mainnet));
+
+    let ReadResponse::Tip(Some(old_tip)) = read_state
+        .clone()
+        .oneshot(ReadRequest::Tip)
+        .await
+        .expect("tip request succeeds")
+    else {
+        panic!("expected a populated tip");
+    };
+    commit_finalized(&mut finalized, blocks[2].clone());
+    let ReadResponse::Transaction(Some(transaction)) = read_state
+        .oneshot(ReadRequest::Transaction(blocks[1].transactions[0].hash()))
+        .await
+        .expect("transaction request succeeds")
+    else {
+        panic!("expected a mined transaction");
+    };
+
+    let (old_tip_height, old_tip_hash) = old_tip;
+    assert_eq!(old_tip_hash, blocks[1].hash());
+    assert_eq!(transaction.tx.hash(), blocks[1].transactions[0].hash());
+    assert_eq!(transaction.confirmations, 2);
+    let confirmations_from_old_tip = 1 + old_tip_height.0 - transaction.height.0;
+    assert_eq!(confirmations_from_old_tip, 1);
+    assert_ne!(transaction.confirmations, confirmations_from_old_tip);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_retries_non_finalized_tip_advance() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    let block1 = non_finalized_child(&blocks[0]);
+    let block2 = non_finalized_child(&block1);
+
+    let mut non_finalized = NonFinalizedState::new(&Mainnet);
+    non_finalized.commit_new_chain(block1.clone().prepare(), &finalized)?;
+    let mut advanced = non_finalized.clone();
+    advanced.commit_block(block2.clone().prepare(), &finalized)?;
+    let (read_state, non_finalized_sender) = read_service(&finalized, non_finalized);
+    let (hook, entered, resume, visits) =
+        BestChainReadViewTestHook::new(BestChainReadViewCapturePhase::BeforeFinalizedSnapshot);
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request = tokio::spawn(query_unspent_output(read_state, outpoint(&block1)));
+
+    entered
+        .recv_timeout(Duration::from_secs(10))
+        .expect("request reaches the capture hook");
+    non_finalized_sender
+        .send(advanced)
+        .expect("read-state receiver remains open");
+    resume.send(()).expect("capture hook remains open");
+    let output = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request completes after release")
+        .expect("request task does not panic");
+
+    assert_eq!(output.tip_hash, block2.hash());
+    assert_eq!(output.transaction.tx.hash(), block1.transactions[0].hash());
+    assert_eq!(output.transaction.confirmations, 2);
+    assert!(visits.load(Ordering::SeqCst) >= 2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_retries_when_finalized_output_becomes_spent() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+
+    // Seed a zero-value non-coinbase UTXO through the checkpoint-verified direct-commit
+    // fixture path. The coherent read and non-finalized spend accounting remain real.
+    let (finalized_output_block, queried_outpoint, replacement_output) =
+        with_zero_value_transparent_output(non_finalized_child(&blocks[0]), 0x51);
+    commit_finalized(&mut finalized, finalized_output_block.clone());
+
+    let mut original = NonFinalizedState::new(&Mainnet);
+    let mut tip = non_finalized_child(&finalized_output_block);
+    original.commit_new_chain(tip.clone().prepare(), &finalized)?;
+    for _height in 3..=100 {
+        tip = non_finalized_child(&tip);
+        original.commit_block(tip.clone().prepare(), &finalized)?;
+    }
+
+    let spending_tip = with_transparent_spend(
+        non_finalized_child(&tip),
+        queried_outpoint,
+        replacement_output,
+    );
+    let mut spent = original.clone();
+    spent.commit_block(spending_tip.prepare(), &finalized)?;
+
+    let (read_state, non_finalized_sender) = read_service(&finalized, original);
+    let (hook, entered, resume, visits) =
+        BestChainReadViewTestHook::new(BestChainReadViewCapturePhase::BeforeFinalizedSnapshot);
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request = tokio::spawn(async move {
+        read_state
+            .oneshot(ReadRequest::BestChainUnspentOutput(queried_outpoint))
+            .await
+    });
+
+    entered
+        .recv_timeout(Duration::from_secs(10))
+        .expect("request reaches the capture hook");
+    non_finalized_sender
+        .send(spent)
+        .expect("read-state receiver remains open");
+    resume.send(()).expect("capture hook remains open");
+    let response = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request completes after release")
+        .expect("request task does not panic")
+        .expect("coherent state request succeeds");
+
+    assert_eq!(response, ReadResponse::BestChainUnspentOutput(None));
+    assert!(visits.load(Ordering::SeqCst) >= 2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_retries_same_height_reorg() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+
+    let old_tip = non_finalized_child(&blocks[0]).set_work(10);
+    let new_tip = with_coinbase_tag(non_finalized_child(&blocks[0]).set_work(20), 1);
+    assert_ne!(
+        old_tip.transactions[0].hash(),
+        new_tip.transactions[0].hash()
+    );
+    assert_ne!(old_tip.hash(), new_tip.hash());
+
+    let mut non_finalized = NonFinalizedState::new(&Mainnet);
+    non_finalized.commit_new_chain(old_tip.clone().prepare(), &finalized)?;
+    let mut reorged = non_finalized.clone();
+    reorged.commit_new_chain(new_tip.clone().prepare(), &finalized)?;
+    let (read_state, non_finalized_sender) = read_service(&finalized, non_finalized);
+    let (hook, entered, resume, visits) =
+        BestChainReadViewTestHook::new(BestChainReadViewCapturePhase::BeforeFinalizedSnapshot);
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request = tokio::spawn(query_unspent_output(read_state, outpoint(&new_tip)));
+
+    entered
+        .recv_timeout(Duration::from_secs(10))
+        .expect("request reaches the capture hook");
+    non_finalized_sender
+        .send(reorged)
+        .expect("read-state receiver remains open");
+    resume.send(()).expect("capture hook remains open");
+    let output = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request completes after release")
+        .expect("request task does not panic");
+
+    assert_eq!(output.tip_hash, new_tip.hash());
+    assert_eq!(output.transaction.tx.hash(), new_tip.transactions[0].hash());
+    assert_eq!(output.transaction.confirmations, 1);
+    assert!(visits.load(Ordering::SeqCst) >= 2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_detects_same_height_reorg_aba() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+
+    let old_tip = non_finalized_child(&blocks[0]).set_work(10);
+    let intermediate_tip = non_finalized_child(&blocks[0]).set_work(20);
+    assert_eq!(
+        old_tip.transactions[0].hash(),
+        intermediate_tip.transactions[0].hash()
+    );
+
+    let mut original = NonFinalizedState::new(&Mainnet);
+    original.commit_new_chain(old_tip.clone().prepare(), &finalized)?;
+    let mut reorged = original.clone();
+    reorged.commit_new_chain(intermediate_tip.prepare(), &finalized)?;
+    let (read_state, non_finalized_sender) = read_service(&finalized, original.clone());
+    let (hook, entered, resume, visits) =
+        BestChainReadViewTestHook::new(BestChainReadViewCapturePhase::BeforeFinalizedSnapshot);
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request = tokio::spawn(query_unspent_output(read_state, outpoint(&old_tip)));
+
+    entered
+        .recv_timeout(Duration::from_secs(10))
+        .expect("request reaches the capture hook");
+    non_finalized_sender
+        .send(reorged)
+        .expect("read-state receiver remains open");
+    non_finalized_sender
+        .send(original)
+        .expect("read-state receiver remains open");
+    resume.send(()).expect("capture hook remains open");
+    let output = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request completes after release")
+        .expect("request task does not panic");
+
+    assert_eq!(output.tip_hash, old_tip.hash());
+    assert_eq!(output.transaction.tx.hash(), old_tip.transactions[0].hash());
+    assert_eq!(output.transaction.confirmations, 1);
+    assert!(visits.load(Ordering::SeqCst) >= 2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_returns_error_after_bounded_retries() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    let block1 = non_finalized_child(&blocks[0]);
+    let block2 = non_finalized_child(&block1);
+
+    let mut original = NonFinalizedState::new(&Mainnet);
+    original.commit_new_chain(block1.clone().prepare(), &finalized)?;
+    let mut advanced = original.clone();
+    advanced.commit_block(block2.prepare(), &finalized)?;
+    let (read_state, non_finalized_sender) = read_service(&finalized, original.clone());
+    let (hook, entered, resume, visits) = BestChainReadViewTestHook::every_visit(
+        BestChainReadViewCapturePhase::BeforeFinalizedSnapshot,
+    );
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request_outpoint = outpoint(&block1);
+    let request = tokio::spawn(async move {
+        read_state
+            .oneshot(ReadRequest::BestChainUnspentOutput(request_outpoint))
+            .await
+    });
+
+    for next_state in [advanced.clone(), original, advanced] {
+        entered
+            .recv_timeout(Duration::from_secs(10))
+            .expect("request reaches every capture attempt");
+        non_finalized_sender
+            .send(next_state)
+            .expect("read-state receiver remains open");
+        resume.send(()).expect("capture hook remains open");
+    }
+
+    let response = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request returns after bounded retries")
+        .expect("request task does not panic");
+    let error = response.expect_err("unstable capture returns a normal state error");
+
+    assert_eq!(visits.load(Ordering::SeqCst), 3);
+    assert!(error
+        .to_string()
+        .contains("best chain changed while capturing a coherent read view"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_pins_finalized_only_advance() {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    commit_finalized(&mut finalized, blocks[1].clone());
+
+    let (read_state, _non_finalized_sender) =
+        read_service(&finalized, NonFinalizedState::new(&Mainnet));
+    let (hook, entered, resume, _visits) =
+        BestChainReadViewTestHook::new(BestChainReadViewCapturePhase::AfterFinalizedSnapshot);
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request = tokio::spawn(query_unspent_output(read_state, outpoint(&blocks[1])));
+
+    entered
+        .recv_timeout(Duration::from_secs(10))
+        .expect("request reaches the capture hook");
+    commit_finalized(&mut finalized, blocks[2].clone());
+    resume.send(()).expect("capture hook remains open");
+    let output = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request completes after release")
+        .expect("request task does not panic");
+
+    assert_eq!(output.tip_hash, blocks[1].hash());
+    assert_eq!(
+        output.transaction.tx.hash(),
+        blocks[1].transactions[0].hash()
+    );
+    assert_eq!(output.transaction.confirmations, 1);
+    assert_eq!(
+        finalized.db.tip().expect("live state has a tip").1,
+        blocks[2].hash()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_survives_non_finalized_to_finalized_transition() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    let block1 = non_finalized_child(&blocks[0]);
+
+    let mut non_finalized = NonFinalizedState::new(&Mainnet);
+    non_finalized.commit_new_chain(block1.clone().prepare(), &finalized)?;
+    let (read_state, _non_finalized_sender) = read_service(&finalized, non_finalized);
+    let (hook, entered, resume, _visits) =
+        BestChainReadViewTestHook::new(BestChainReadViewCapturePhase::AfterFinalizedSnapshot);
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request = tokio::spawn(query_unspent_output(read_state, outpoint(&block1)));
+
+    entered
+        .recv_timeout(Duration::from_secs(10))
+        .expect("request reaches the capture hook");
+    commit_finalized(&mut finalized, block1.clone());
+    resume.send(()).expect("capture hook remains open");
+    let output = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request completes after release")
+        .expect("request task does not panic");
+
+    assert_eq!(output.tip_hash, block1.hash());
+    assert_eq!(output.transaction.tx.hash(), block1.transactions[0].hash());
+    assert_eq!(output.transaction.confirmations, 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_preserves_empty_state_error() {
+    let _init_guard = zakura_test::init();
+    let finalized = finalized_state();
+    let (read_state, _non_finalized_sender) =
+        read_service(&finalized, NonFinalizedState::new(&Mainnet));
+    let missing = transparent::OutPoint {
+        hash: zakura_chain::transaction::Hash([0; 32]),
+        index: 0,
+    };
+
+    let error = read_state
+        .oneshot(ReadRequest::BestChainUnspentOutput(missing))
+        .await
+        .expect_err("an empty state remains an RPC error");
+
+    assert!(error.to_string().contains("No blocks in state"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_returns_none_for_missing_output_in_nonempty_state() {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    let (read_state, _non_finalized_sender) =
+        read_service(&finalized, NonFinalizedState::new(&Mainnet));
+    let missing = transparent::OutPoint {
+        hash: zakura_chain::transaction::Hash([0; 32]),
+        index: 0,
+    };
+
+    let response = read_state
+        .oneshot(ReadRequest::BestChainUnspentOutput(missing))
+        .await
+        .expect("a missing output in nonempty state is a normal response");
+
+    assert_eq!(response, ReadResponse::BestChainUnspentOutput(None));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_errors_when_unspent_output_transaction_was_pruned() {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let config = Config {
+        storage_mode: StorageMode::Pruned(PruningConfig { tx_retention: 5 }),
+        ..Config::ephemeral()
+    };
+    let mut finalized =
+        FinalizedState::new_with_debug_without_storage_validation(&config, &Mainnet, false, false)
+            .expect("opening an ephemeral pruned state succeeds")
+            .with_checkpoint_raw_tx_retention(Height(10), &config);
+
+    for block in &blocks {
+        commit_finalized(&mut finalized, block.clone());
+    }
+
+    let pruned_outpoint = outpoint(&blocks[1]);
+    assert!(finalized.db.utxo(&pruned_outpoint).is_some());
+    assert!(finalized.db.transaction(pruned_outpoint.hash).is_none());
+    let (read_state, _non_finalized_sender) =
+        read_service(&finalized, NonFinalizedState::new(&Mainnet));
+
+    let error = read_state
+        .oneshot(ReadRequest::BestChainUnspentOutput(pruned_outpoint))
+        .await
+        .expect_err("an unspent output without its pruned transaction is not JSON null");
+
+    assert!(error
+        .to_string()
+        .contains("creating transaction is unavailable in the captured state view"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn coherent_view_recaptures_after_non_finalized_channel_closes() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let blocks = continuous_mainnet_blocks();
+    let mut finalized = finalized_state();
+    commit_finalized(&mut finalized, blocks[0].clone());
+    let block1 = non_finalized_child(&blocks[0]);
+    let block2 = non_finalized_child(&block1);
+
+    let mut original = NonFinalizedState::new(&Mainnet);
+    original.commit_new_chain(block1.clone().prepare(), &finalized)?;
+    let mut advanced = original.clone();
+    advanced.commit_block(block2.clone().prepare(), &finalized)?;
+    let (read_state, non_finalized_sender) = read_service(&finalized, original);
+    let (hook, entered, resume, visits) =
+        BestChainReadViewTestHook::new(BestChainReadViewCapturePhase::BeforeFinalizedSnapshot);
+    let read_state = read_state.with_best_chain_read_view_test_hook(hook);
+    let request = tokio::spawn(query_unspent_output(read_state, outpoint(&block1)));
+
+    entered
+        .recv_timeout(Duration::from_secs(10))
+        .expect("request reaches the capture hook");
+    non_finalized_sender
+        .send(advanced)
+        .expect("read-state receiver remains open");
+    drop(non_finalized_sender);
+    resume.send(()).expect("capture hook remains open");
+    let output = timeout(Duration::from_secs(10), request)
+        .await
+        .expect("request completes after channel closure")
+        .expect("request task does not panic");
+
+    assert_eq!(output.tip_hash, block2.hash());
+    assert_eq!(output.transaction.tx.hash(), block1.transactions[0].hash());
+    assert_eq!(output.transaction.confirmations, 2);
+    assert_eq!(visits.load(Ordering::SeqCst), 1);
+
+    Ok(())
+}

--- a/zakura-state/src/service/read/tests/atomic_view.rs
+++ b/zakura-state/src/service/read/tests/atomic_view.rs
@@ -21,7 +21,7 @@ use crate::{
     arbitrary::Prepare,
     config::StorageMode,
     service::{
-        finalized_state::{FinalizedState, HighestCompletedCheckpoint},
+        finalized_state::{FinalizedState, HeaderRootAuthState, HighestCompletedCheckpoint},
         non_finalized_state::NonFinalizedState,
         BestChainReadViewCapturePhase, BestChainReadViewTestHook, ReadStateService,
         VctRootRepairStatus,
@@ -61,6 +61,8 @@ fn read_service(
     let (_checkpoint_sender, checkpoint_receiver) =
         watch::channel(None::<HighestCompletedCheckpoint>);
     let (_repair_sender, repair_receiver) = watch::channel(VctRootRepairStatus::default());
+    let (_header_root_auth_sender, header_root_auth_receiver) =
+        watch::channel(None::<HeaderRootAuthState>);
 
     let read_state = ReadStateService::new(
         finalized,
@@ -69,6 +71,7 @@ fn read_service(
         checkpoint_receiver,
         None,
         repair_receiver,
+        header_root_auth_receiver,
     );
 
     (read_state, non_finalized_sender)

--- a/zakura-state/src/service/read/view.rs
+++ b/zakura-state/src/service/read/view.rs
@@ -1,0 +1,87 @@
+//! Coherent best-chain reads across memory and finalized storage.
+
+use std::sync::Arc;
+
+use zakura_chain::{block, transaction::Transaction, transparent};
+
+use crate::{
+    response::{BestChainUnspentOutput, MinedTx},
+    service::{finalized_state::ZakuraDbSnapshot, non_finalized_state::Chain},
+    BoxError,
+};
+
+/// A best-chain view captured at one non-finalized generation and one RocksDB sequence.
+pub(in crate::service) struct BestChainReadView<'a> {
+    best_chain: Option<Arc<Chain>>,
+    finalized: ZakuraDbSnapshot<'a>,
+}
+
+impl<'a> BestChainReadView<'a> {
+    /// Creates a coherent best-chain view from captured state.
+    pub(in crate::service) fn new(
+        best_chain: Option<Arc<Chain>>,
+        finalized: ZakuraDbSnapshot<'a>,
+    ) -> Self {
+        Self {
+            best_chain,
+            finalized,
+        }
+    }
+
+    /// Returns the tip represented by this view.
+    pub(in crate::service) fn tip(&self) -> Option<(block::Height, block::Hash)> {
+        self.best_chain
+            .as_ref()
+            .map(|chain| chain.non_finalized_tip())
+            .or_else(|| self.finalized.tip())
+    }
+
+    /// Returns an unspent output's transaction and tip context from this view.
+    pub(in crate::service) fn unspent_output(
+        &self,
+        outpoint: transparent::OutPoint,
+    ) -> Result<Option<BestChainUnspentOutput>, BoxError> {
+        let chain = self.best_chain.as_ref();
+
+        if chain.is_some_and(|chain| chain.spent_utxos.contains_key(&outpoint)) {
+            return Ok(None);
+        }
+
+        let output_exists = chain
+            .and_then(|chain| chain.created_utxo(&outpoint))
+            .is_some()
+            || self.finalized.contains_unspent_output(&outpoint);
+
+        if !output_exists {
+            return Ok(None);
+        }
+
+        let (tx, height, block_time): (Arc<Transaction>, _, _) = chain
+            .and_then(|chain| {
+                chain
+                    .transaction(outpoint.hash)
+                    .map(|(tx, height, time)| (tx.clone(), height, time))
+            })
+            .or_else(|| self.finalized.transaction(outpoint.hash))
+            .ok_or_else(|| {
+                // `gettxout` needs the creating transaction's version. A pruned raw
+                // transaction cannot supply it, and returning `None` would falsely
+                // report a known unspent output as absent.
+                BoxError::from("creating transaction is unavailable in the captured state view")
+            })?;
+        let (tip_height, tip_hash) = self
+            .tip()
+            .ok_or_else(|| BoxError::from("coherent best-chain view has no tip"))?;
+        let confirmations = tip_height
+            .0
+            .checked_sub(height.0)
+            .ok_or_else(|| BoxError::from("transaction height is above the captured tip"))?
+            .checked_add(1)
+            .ok_or_else(|| BoxError::from("confirmation count exceeds u32"))?;
+
+        Ok(Some(BestChainUnspentOutput {
+            tip_hash,
+            transaction: MinedTx::new(tx, height, confirmations, block_time),
+        }))
+    }
+}

--- a/zakura-state/src/service/read/view.rs
+++ b/zakura-state/src/service/read/view.rs
@@ -22,6 +22,22 @@ impl<'a> BestChainReadView<'a> {
         best_chain: Option<Arc<Chain>>,
         finalized: ZakuraDbSnapshot<'a>,
     ) -> Self {
+        // A read-only secondary can advance its finalized snapshot before it
+        // publishes the corresponding non-finalized state. Once finalized
+        // storage reaches or passes the captured chain tip, it supersedes the
+        // entire stale overlay. Keeping that overlay could resurrect outputs
+        // already spent in the newer finalized view.
+        let best_chain = match best_chain {
+            Some(chain)
+                if finalized.tip().is_some_and(|(finalized_height, _)| {
+                    finalized_height >= chain.non_finalized_tip().0
+                }) =>
+            {
+                None
+            }
+            best_chain => best_chain,
+        };
+
         Self {
             best_chain,
             finalized,


### PR DESCRIPTION
## Motivation

`gettxout` builds one response from separate state requests for the tip, UTXO, and creating transaction. Finalized or non-finalized state can advance between those reads. The response can therefore combine `bestblock`, confirmations, version, and coinbase status from different chain views.

A composite Tower request alone does not fix this. Finalized RocksDB can still change while that request runs.

## Solution

Add one `BestChainUnspentOutput` state request that:

- captures one non-finalized chain generation;
- captures one RocksDB snapshot across every finalized column family it reads;
- validates the watch generation after snapshot capture, including ABA changes;
- retries up to three total attempts, then returns an error;
- re-captures the final chain before taking a fresh snapshot if the watch channel closes.

`gettxout` now derives every state-backed field from that response. Missing or spent outputs still return null. Empty state keeps its existing error. A known UTXO with a pruned creating transaction returns an error because its transaction version is unavailable.

## Testing

- 12 deterministic atomic-view tests pass.
- 21 read-service tests pass.
- 2 focused `gettxout` RPC tests pass.
- `cargo check -p zakura-state -p zakura-rpc` passes.
- `cargo fmt --all -- --check` passes.
- `cargo clippy -p zakura-state -p zakura-rpc --all-targets -- -D warnings` passes.
- `git diff --check` passes.

The race tests cover finalized-only advance, non-finalized advance, same-height reorg, ABA, non-finalized to finalized movement, channel closure, bounded instability, and a finalized UTXO spent by a concurrently published non-finalized branch.

## Changelog

`changelog-unreleased/421.md`

### Specifications & References

Part of #360.

### Follow-up Work

Verbose `getblockheader` remains separate. This PR does not close #360.

This adds public `ReadRequest` and `ReadResponse` variants. Downstream exhaustive matches must handle them.
