### PR TITLE
fix(metrics): register build info before readiness

### DIFF
--- a/changelog-unreleased/422.md
+++ b/changelog-unreleased/422.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only fixes test-facing metrics endpoint readiness ordering and has no
+operator- or crate-consumer-visible effect.

--- a/zakurad/src/components/metrics.rs
+++ b/zakurad/src/components/metrics.rs
@@ -24,8 +24,6 @@ impl MetricsEndpoint {
 
             match endpoint_result {
                 Ok(()) => {
-                    info!("Opened metrics endpoint at {}", addr);
-
                     // Expose binary metadata to metrics, using a single time series with
                     // value 1:
                     //     https://www.robustperception.io/exposing-the-software-version-to-prometheus
@@ -34,6 +32,8 @@ impl MetricsEndpoint {
                         "version" => env!("CARGO_PKG_VERSION")
                     )
                     .increment(1);
+
+                    info!("Opened metrics endpoint at {}", addr);
                 }
                 Err(e) => panic!(
                     "Opening metrics endpoint listener {addr:?} failed: {e:?}. \


### PR DESCRIPTION
## Motivation

The `metrics_endpoint` acceptance test intermittently scraped the Prometheus endpoint immediately after observing the `Opened metrics endpoint` log, before the `zakura_build_info` counter was registered. The endpoint returned HTTP success but an empty response without the expected build-info metric.

## Solution

Register and increment the build-info counter before emitting the endpoint readiness log. Observing that log now guarantees the metric expected by the acceptance test is available.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- acceptance coverage is left to draft CI
- local Markdown lint was unavailable; draft CI will run it

## Changelog

Added an explicit no-changelog fragment because this is an internal readiness-ordering fix.

### Specifications & References

Failure observed in `zakura::acceptance::metrics_endpoint`: the HTTP response did not contain `# TYPE zakura_build_info counter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup ordering only in metrics initialization; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a **race in metrics endpoint startup** where acceptance tests could scrape Prometheus right after the readiness log but before `zakura_build_info` was registered, yielding HTTP 200 with an empty body.
> 
> In `MetricsEndpoint::new`, the **build-info counter is now incremented before** the `Opened metrics endpoint` log, so that log implies the metric the `metrics_endpoint` test expects is already present. A no-changelog note records that this is internal/test-facing ordering only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b0c3b3b50160fe79ca87920d89c65dc012a367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->