### PR TITLE
fix(network): disconnect peers when bans are applied

### DIFF
--- a/changelog-unreleased/429.md
+++ b/changelog-unreleased/429.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Disconnected ready and in-flight peer connections when their IP ban is
+  applied, without waiting for unrelated peer-set activity
+  ([#429](https://github.com/zakura-core/zakura/pull/429)).

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -81,17 +81,14 @@ impl BanList {
 
 impl fmt::Debug for BannedIps {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("BannedIps")
-            .field(
-                "bans",
-                &self
-                    .inner
-                    .bans
-                    .read()
-                    .expect("ban list lock should not be poisoned"),
-            )
-            .finish_non_exhaustive()
+        let mut debug = formatter.debug_struct("BannedIps");
+
+        match self.inner.bans.read() {
+            Ok(bans) => debug.field("bans", &*bans),
+            Err(_) => debug.field("bans", &"<poisoned>"),
+        };
+
+        debug.finish_non_exhaustive()
     }
 }
 

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -4,12 +4,15 @@
 use std::{
     cmp::Reverse,
     collections::{HashMap, HashSet, VecDeque},
+    fmt,
     net::{IpAddr, SocketAddr},
     sync::{Arc, Mutex, RwLock},
+    task::Waker,
     time::Instant,
 };
 
 use chrono::Utc;
+use futures::task::AtomicWaker;
 use ordered_map::OrderedMap;
 use tokio::sync::watch;
 use tracing::Span;
@@ -28,9 +31,16 @@ use crate::{
 mod tests;
 
 /// Read-only access to currently banned peer IP addresses.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 pub struct BannedIps {
-    inner: Arc<RwLock<BanList>>,
+    inner: Arc<BannedIpsInner>,
+}
+
+/// Shared ban state and the peer set's ban-change notification.
+#[derive(Default)]
+struct BannedIpsInner {
+    bans: RwLock<BanList>,
+    peer_set_waker: AtomicWaker,
 }
 
 /// A bounded FIFO list of banned peer IP addresses.
@@ -45,11 +55,13 @@ struct BanList {
 
 impl BanList {
     /// Inserts `ip`, evicting the oldest IP when the list exceeds its bound.
-    fn insert(&mut self, ip: IpAddr) {
+    ///
+    /// Returns `true` if the list changed.
+    fn insert(&mut self, ip: IpAddr) -> bool {
         let ip = canonical_ip(ip);
 
         if !self.ips.insert(ip) {
-            return;
+            return false;
         }
 
         self.insertion_order.push_back(ip);
@@ -62,6 +74,24 @@ impl BanList {
 
             self.ips.remove(&oldest);
         }
+
+        true
+    }
+}
+
+impl fmt::Debug for BannedIps {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BannedIps")
+            .field(
+                "bans",
+                &self
+                    .inner
+                    .bans
+                    .read()
+                    .expect("ban list lock should not be poisoned"),
+            )
+            .finish_non_exhaustive()
     }
 }
 
@@ -71,19 +101,38 @@ impl BannedIps {
         let ip = canonical_ip(ip);
 
         self.inner
+            .bans
             .read()
             .expect("ban list lock should not be poisoned")
             .ips
             .contains(&ip)
     }
 
-    #[cfg(test)]
-    pub(crate) fn with_banned_ip(ip: IpAddr) -> Self {
-        let bans = Self::default();
-        bans.inner
+    /// Inserts a banned IP and wakes the peer set after releasing the write lock.
+    pub(crate) fn insert(&self, ip: IpAddr) -> bool {
+        let inserted = self
+            .inner
+            .bans
             .write()
             .expect("ban list lock should not be poisoned")
             .insert(ip);
+
+        if inserted {
+            self.inner.peer_set_waker.wake();
+        }
+
+        inserted
+    }
+
+    /// Registers the peer set task for notification when a new IP is banned.
+    pub(crate) fn register_waker(&self, waker: &Waker) {
+        self.inner.peer_set_waker.register(waker);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_banned_ip(ip: IpAddr) -> Self {
+        let bans = Self::default();
+        bans.insert(ip);
         bans
     }
 }
@@ -539,15 +588,7 @@ impl AddressBook {
             if updated.misbehavior() >= constants::MAX_PEER_MISBEHAVIOR_SCORE {
                 // Ban and skip outbound connections with excessively misbehaving peers.
                 let banned_ip = updated.addr.ip();
-                {
-                    let mut bans_by_ip = self
-                        .bans_by_ip
-                        .inner
-                        .write()
-                        .expect("ban list lock should not be poisoned");
-
-                    bans_by_ip.insert(banned_ip);
-                }
+                self.bans_by_ip.insert(banned_ip);
 
                 // `most_recent_by_ip` is only populated when
                 // `max_connections_per_ip == 1`. The ban path runs for any

--- a/zakura-network/src/address_book/tests.rs
+++ b/zakura-network/src/address_book/tests.rs
@@ -2,7 +2,14 @@
 
 #![allow(clippy::unwrap_in_result)]
 
-use std::net::{IpAddr, Ipv4Addr};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Wake, Waker},
+};
 
 use crate::constants::MAX_BANNED_IPS;
 
@@ -10,6 +17,19 @@ use super::{BanList, BannedIps};
 
 mod prop;
 mod vectors;
+
+#[derive(Default)]
+struct WakeCounter(AtomicUsize);
+
+impl Wake for WakeCounter {
+    fn wake(self: Arc<Self>) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
 
 #[test]
 fn ban_list_evicts_the_oldest_ip_at_capacity() {
@@ -36,4 +56,29 @@ fn banned_ips_match_ipv4_and_ipv4_mapped_ipv6() {
 
     assert!(BannedIps::with_banned_ip(ipv4).contains(ipv4_mapped));
     assert!(BannedIps::with_banned_ip(ipv4_mapped).contains(ipv4));
+}
+
+#[test]
+fn new_bans_wake_after_becoming_visible() {
+    let bans = BannedIps::default();
+    let before_registration = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let ipv4 = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+    let ipv4_mapped = IpAddr::V6(Ipv4Addr::new(192, 0, 2, 2).to_ipv6_mapped());
+
+    assert!(bans.insert(before_registration));
+    assert!(bans.contains(before_registration));
+
+    let wake_counter = Arc::new(WakeCounter::default());
+    bans.register_waker(&Waker::from(wake_counter.clone()));
+
+    assert!(bans.insert(ipv4));
+    assert!(bans.contains(ipv4));
+    assert_eq!(wake_counter.0.load(Ordering::SeqCst), 1);
+
+    assert!(!bans.insert(ipv4_mapped));
+    assert_eq!(
+        wake_counter.0.load(Ordering::SeqCst),
+        1,
+        "a duplicate canonical IP must not produce another wake"
+    );
 }

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -722,6 +722,33 @@ where
             .count()
     }
 
+    /// Disconnects every ready or busy peer whose canonical IP is banned.
+    fn disconnect_from_banned_peers(&mut self) {
+        let banned_peers: Vec<_> = self
+            .ready_services
+            .keys()
+            .chain(self.cancel_handles.keys())
+            .filter(|addr| self.bans.contains(addr.ip()))
+            .copied()
+            .collect();
+
+        for peer in banned_peers {
+            warn!(
+                peer = %peer.addr_label(self.expose_peer_addresses),
+                "peer ip is banned, disconnecting peer"
+            );
+            self.remove(&peer);
+        }
+
+        if let Some((_request, _sender, remaining_peers)) = &mut self.queued_broadcast_all {
+            remaining_peers.retain(|addr| !self.bans.contains(addr.ip()));
+        }
+
+        if let Some((_request, remaining_peers)) = &mut self.queued_sidecar_block_gossip {
+            remaining_peers.retain(|addr| !self.bans.contains(addr.ip()));
+        }
+    }
+
     /// Returns `true` if Zebra is already connected to the IP and port in `addr`.
     fn has_peer_with_addr(&self, addr: PeerSocketAddr) -> bool {
         self.ready_services.contains_key(&addr) || self.cancel_handles.contains_key(&addr)
@@ -771,6 +798,15 @@ where
                         peer = %key.addr_label(self.expose_peer_addresses),
                         "got Change::Insert from Discover"
                     );
+
+                    if self.bans.contains(key.ip()) {
+                        warn!(
+                            peer = %key.addr_label(self.expose_peer_addresses),
+                            "discovered peer ip is banned, dropping service"
+                        );
+                        std::mem::drop(svc);
+                        continue;
+                    }
 
                     // # Security
                     //
@@ -1643,6 +1679,12 @@ where
         // task. If there are no ready peers, and no new peers, network requests will pause until:
         // - an unready peer becomes ready, or
         // - a new peer arrives.
+
+        // Register before checking the persistent ban state. A ban inserted
+        // before registration is found by the scan, while one inserted after
+        // registration wakes this task for another scan.
+        self.bans.register_waker(cx.waker());
+        self.disconnect_from_banned_peers();
 
         // Drain stall events first, so disconnects free up slots that
         // `poll_discover` can fill in the same poll cycle.

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -5,6 +5,11 @@ use std::{
     collections::HashSet,
     iter,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Wake, Waker},
     time::Duration,
 };
 
@@ -28,6 +33,39 @@ use crate::{
 };
 
 use super::{PeerSetBuilder, PeerVersions};
+
+#[derive(Default)]
+struct WakeCounter(AtomicUsize);
+
+impl Wake for WakeCounter {
+    fn wake(self: Arc<Self>) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn mock_discovery_for_addresses(
+    addresses: Vec<PeerSocketAddr>,
+) -> (
+    impl futures::Stream<Item = Result<Change<PeerSocketAddr, LoadTrackedClient>, BoxError>>,
+    Vec<ClientTestHarness>,
+) {
+    let version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let mut handles = Vec::with_capacity(addresses.len());
+    let changes = addresses
+        .into_iter()
+        .map(|addr| {
+            let (client, handle) = ClientTestHarness::build().with_version(version).finish();
+            handles.push(handle);
+            Ok::<_, BoxError>(Change::Insert(addr, client.into()))
+        })
+        .collect::<Vec<_>>();
+
+    (stream::iter(changes).chain(stream::pending()), handles)
+}
 
 #[test]
 fn peer_set_ready_single_connection() {
@@ -339,6 +377,128 @@ fn broadcast_all_queued_removes_banned_peers() {
         } else {
             assert!(receiver.try_recv().is_ok());
         }
+    });
+}
+
+#[test]
+fn ban_change_wakes_and_disconnects_every_connection_for_ip() {
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let banned_ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let banned_addr: PeerSocketAddr = SocketAddr::new(banned_ip, 1).into();
+    let mapped_banned_addr: PeerSocketAddr =
+        SocketAddr::new(IpAddr::V6(Ipv4Addr::new(192, 0, 2, 1).to_ipv6_mapped()), 2).into();
+    let unrelated_addr: PeerSocketAddr =
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)), 3).into();
+    let (discovered_peers, _handles) =
+        mock_discovery_for_addresses(vec![banned_addr, mapped_banned_addr, unrelated_addr]);
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+    let bans = BannedIps::default();
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .max_conns_per_ip(max(2, DEFAULT_MAX_CONNS_PER_IP))
+            .build();
+        peer_set.bans = bans.clone();
+
+        {
+            let ready = peer_set.ready().await.expect("peer set is always ready");
+            assert_eq!(ready.ready_services.len(), 3);
+        }
+
+        let wake_counter = Arc::new(WakeCounter::default());
+        let waker = Waker::from(wake_counter.clone());
+        let mut context = Context::from_waker(&waker);
+        let _ = Service::poll_ready(&mut peer_set, &mut context);
+        let wake_count_before_ban = wake_counter.0.load(Ordering::SeqCst);
+
+        let mut busy_service = peer_set
+            .take_ready_service(&mapped_banned_addr)
+            .expect("mapped banned peer is ready");
+        let in_flight_response = busy_service.call(Request::Peers);
+        peer_set.push_unready(mapped_banned_addr, busy_service);
+
+        let (broadcast_sender, _broadcast_receiver) = tokio::sync::mpsc::channel(1);
+        peer_set.queued_broadcast_all = Some((
+            Request::Peers,
+            broadcast_sender,
+            HashSet::from([banned_addr, mapped_banned_addr]),
+        ));
+        peer_set.queued_sidecar_block_gossip = Some((
+            Request::AdvertiseBlock(block::Hash([7; 32]), None),
+            HashSet::from([banned_addr, mapped_banned_addr]),
+        ));
+
+        assert!(bans.insert(banned_ip));
+        assert!(
+            wake_counter.0.load(Ordering::SeqCst) > wake_count_before_ban,
+            "inserting a new ban must wake the registered peer set"
+        );
+
+        let _ = Service::poll_ready(&mut peer_set, &mut context);
+
+        assert!(!peer_set.ready_services.contains_key(&banned_addr));
+        assert!(!peer_set.ready_services.contains_key(&mapped_banned_addr));
+        assert!(!peer_set.cancel_handles.contains_key(&mapped_banned_addr));
+        assert!(
+            peer_set.unready_services.is_empty(),
+            "the canceled in-flight service must be polled and dropped"
+        );
+        assert_eq!(peer_set.num_peers_with_ip(banned_ip), 0);
+        assert!(
+            peer_set.ready_services.contains_key(&unrelated_addr),
+            "a ban must preserve peers with unrelated canonical IPs"
+        );
+        std::mem::drop(in_flight_response);
+        assert!(
+            peer_set
+                .queued_broadcast_all
+                .as_ref()
+                .is_none_or(|(_, _, peers)| peers.is_empty()),
+            "banned peers must be removed from queued broadcasts"
+        );
+        assert!(
+            peer_set
+                .queued_sidecar_block_gossip
+                .as_ref()
+                .is_none_or(|(_, peers)| peers.is_empty()),
+            "banned peers must be removed from queued sidecar gossip"
+        );
+    });
+}
+
+#[test]
+fn ban_before_waker_registration_rejects_discovered_peer() {
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let banned_ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let mapped_banned_addr: PeerSocketAddr =
+        SocketAddr::new(IpAddr::V6(Ipv4Addr::new(192, 0, 2, 1).to_ipv6_mapped()), 1).into();
+    let (discovered_peers, _handles) = mock_discovery_for_addresses(vec![mapped_banned_addr]);
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+    let bans = BannedIps::with_banned_ip(banned_ip);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+        peer_set.bans = bans;
+
+        let wake_counter = Arc::new(WakeCounter::default());
+        let waker = Waker::from(wake_counter);
+        let mut context = Context::from_waker(&waker);
+        let _ = Service::poll_ready(&mut peer_set, &mut context);
+
+        assert!(!peer_set.ready_services.contains_key(&mapped_banned_addr));
+        assert!(!peer_set.cancel_handles.contains_key(&mapped_banned_addr));
+        assert_eq!(peer_set.num_peers_with_ip(banned_ip), 0);
     });
 }
 


### PR DESCRIPTION
## Motivation

The address book records an IP ban after its accumulated misbehavior reaches the threshold, but that shared state does not wake `PeerSet`. An idle banned connection can therefore remain open until unrelated discovery, readiness, inventory, or background activity happens; an in-flight connection can remain active until its request completes.

## Solution

- Store a single-consumer `AtomicWaker` with the shared bounded ban list.
- Register the peer-set task before scanning persistent ban state, and wake it only after a new ban is visible and the write lock is released.
- On each awakened poll, drop all ready connections and cancel all in-flight connections for the canonical banned IP, including IPv4-mapped IPv6 forms and multiple ports.
- Remove banned peers from queued broadcast state and reject completed handshakes whose IP was banned during discovery.

This ordering closes both sides of the race: bans created before registration are observed by the scan, while bans created after registration schedule another poll.

## Testing

Passed:
- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `cargo test -p zakura-network --lib new_bans_wake_after_becoming_visible -- --nocapture`
- `cargo test -p zakura-network --lib ban_change_wakes_and_disconnects_every_connection_for_ip -- --nocapture`
- `cargo test -p zakura-network --lib ban_before_waker_registration_rejects_discovered_peer -- --nocapture`
- `cargo test -p zakura --test acceptance disconnects_from_misbehaving_peers -- --ignored --nocapture`
- `markdownlint changelog-unreleased/429.md --config .trunk/configs/.markdownlint.yaml`
- `./scripts/changelog.py check`

`cargo test -p zakura-network --lib` passed 1,131 tests and failed only the three pre-existing macOS loopback tests that bind `127.0.0.2` (`AddrNotAvailable`):
- `listener_bans_zcashd_compat_peer_before_reserved_slot`
- `listener_reserves_one_zcashd_compat_inbound_slot`
- `listener_zcashd_compat_reconnect_bypasses_recent_ip_limit`

The regression coverage verifies pre-registration visibility, post-registration wakeup, duplicate-ban coalescing, canonical IP matching, multiple ports, ready and in-flight cancellation, queued-state cleanup, and preservation of unrelated peers.

## Changelog

- Added `changelog-unreleased/429.md` for the operator-visible disconnection fix.

### Specifications & References

This PR is independent of #428: that PR reduces how long reports wait before the address book applies a ban; this PR makes an applied ban wake and disconnect the peer set without unrelated traffic.