### PR TITLE
ci: save Lychee cache only on main

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore lychee cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -57,12 +57,19 @@ jobs:
             --verbose
             --no-progress
             --cache
-            --max-cache-age 1d
+            --max-cache-age 2d
             --config .lychee.toml
             "**/*.md"
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save lychee cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
 
   spell-check:
     name: spell-check


### PR DESCRIPTION
## Motivation

Pull request link-check runs currently save commit-specific Lychee caches that are scoped to that PR merge ref and cannot benefit other pull requests or `main`. This creates low-value cache entries.

## Solution

- Split the Lychee cache step into explicit restore and save steps.
- Restore the latest accessible Lychee cache on every docs-check run.
- Save `.lycheecache` only for pushes to `main`.
- Allow cached URL results to remain fresh for 48 hours instead of 24 hours.

## Testing

- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/docs-check.yml")'`\n- `git diff --check origin/main...HEAD`\n- Local compilation skipped because this is a low-risk GitHub Actions configuration change; draft CI provides workflow validation.\n\n## Changelog\n\nNo changelog fragment is required because this PR does not change Rust source or a `Cargo.toml`.\n\n### Specifications & References\n\n- [GitHub Actions dependency cache restrictions](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub Actions workflow-only change for docs link checking; no application code, auth, or data paths affected.
> 
> **Overview**
> **Docs link-check CI** now treats the Lychee URL cache as a shared artifact from `main` instead of writing a new cache entry on every PR run.
> 
> The single `actions/cache` step is split into **restore** (every docs-check run, with `restore-keys: cache-lychee-`) and **save** (only when `github.event_name == push` and ref is `refs/heads/main`). Lychee’s `--max-cache-age` is increased from **1d to 2d** so restored entries stay valid a bit longer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a98d8d46994f57fd262d4d010498069bdd496b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->