### PR TITLE
build: bump zcash_primitives to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,8 +1904,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1953,8 +1952,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4641,9 +4639,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
 dependencies = [
  "aes",
  "bitvec",
@@ -4785,9 +4783,9 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -7058,7 +7056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -9301,8 +9299,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "bech32",
  "bs58",
@@ -9315,8 +9312,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "corez",
  "hex",
@@ -9326,8 +9322,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d2ed9a9fa7b466a7adedab1ad5a21f8330e4943756912fc776cf7f3beae32b"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9337,8 +9332,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36391ebfce7df2510c6564f79e608ed93f1c0692c6464e2397b248e06dae3912"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -9364,9 +9358,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20 0.9.1",
  "chacha20poly1305",
@@ -9377,9 +9371,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
+version = "0.30.0"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -9408,9 +9401,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+version = "0.30.0"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -9431,9 +9423,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2973d210e74ebd81adc50828fbbb284ab6aaa099308097c42c47dc63cf3420fc"
+version = "0.10.1"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "corez",
  "document-features",
@@ -9470,9 +9461,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,7 +1904,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1952,7 +1953,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -9299,7 +9301,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32",
  "bs58",
@@ -9312,7 +9315,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -9322,7 +9326,8 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d2ed9a9fa7b466a7adedab1ad5a21f8330e4943756912fc776cf7f3beae32b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9331,8 +9336,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -9372,7 +9378,8 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -9402,7 +9409,8 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -9424,7 +9432,8 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -9462,7 +9471,8 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=57b844dc00bf1f25254b5859b8d5faa8e5730f98#57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,16 @@ edition = "2021"
 
 [workspace.dependencies]
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.15.0"
+orchard = "0.15.4"
 sapling-crypto = "0.7"
 zcash_address = "0.13.0"
 zcash_encoding = "0.4"
 zcash_history = "0.5.0"
 zcash_keys = "0.15.0"
-zcash_primitives = "0.29.0"
-zcash_proofs = "0.29.0"
-zcash_transparent = "0.9.0"
-zcash_protocol = "0.10.0"
+zcash_primitives = "0.30.0"
+zcash_proofs = "0.30.0"
+zcash_transparent = "0.10.0"
+zcash_protocol = "0.10.1"
 zip32 = "0.2"
 zakura-vct-sprout-history = "=1.0.0"
 abscissa_core = "0.7"
@@ -179,6 +179,18 @@ zcash_note_encryption = "0.4.1"
 zcash_script = "0.4.5"
 config = { version = "0.15.14", features = ["toml"] }
 which = "8.0.0"
+
+[patch.crates-io]
+equihash = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_history = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
 
 [workspace.metadata.release]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ sapling-crypto = "0.7"
 zcash_address = "0.13.0"
 zcash_encoding = "0.4"
 zcash_history = "0.5.0"
-zcash_keys = "0.15.0"
+zcash_keys = "0.16.0"
 zcash_primitives = "0.30.0"
 zcash_proofs = "0.30.0"
 zcash_transparent = "0.10.0"
@@ -179,18 +179,6 @@ zcash_note_encryption = "0.4.1"
 zcash_script = "0.4.5"
 config = { version = "0.15.14", features = ["toml"] }
 which = "8.0.0"
-
-[patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_history = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "57b844dc00bf1f25254b5859b8d5faa8e5730f98" }
 
 [workspace.metadata.release]
 

--- a/changelog-unreleased/433.md
+++ b/changelog-unreleased/433.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only updates internal Zcash crate dependencies and has no
+operator-visible effect.

--- a/deny.toml
+++ b/deny.toml
@@ -217,7 +217,7 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 
 # List of URLs for allowed Git repositories
-allow-git = ["https://github.com/zcash/librustzcash"]
+allow-git = []
 
 [sources.allow-org]
 github = [

--- a/deny.toml
+++ b/deny.toml
@@ -217,7 +217,7 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = ["https://github.com/zcash/librustzcash"]
 
 [sources.allow-org]
 github = [

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -28,12 +28,6 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [imports.zcashd]
 url = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[policy.equihash]
-audit-as-crates-io = true
-
-[policy.f4jumble]
-audit-as-crates-io = true
-
 [policy.zakura]
 audit-as-crates-io = false
 
@@ -72,30 +66,6 @@ audit-as-crates-io = false
 
 [policy.zakura-utils]
 audit-as-crates-io = false
-
-[policy.zcash_address]
-audit-as-crates-io = true
-
-[policy.zcash_encoding]
-audit-as-crates-io = true
-
-[policy.zcash_history]
-audit-as-crates-io = true
-
-[policy.zcash_keys]
-audit-as-crates-io = true
-
-[policy.zcash_primitives]
-audit-as-crates-io = true
-
-[policy.zcash_proofs]
-audit-as-crates-io = true
-
-[policy.zcash_protocol]
-audit-as-crates-io = true
-
-[policy.zcash_transparent]
-audit-as-crates-io = true
 
 [[exemptions.abscissa_core]]
 version = "0.7.0"
@@ -678,7 +648,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.equihash]]
-version = "0.3.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.erased-serde]]
@@ -690,7 +660,7 @@ version = "0.6.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.f4jumble]]
-version = "0.1.1@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
@@ -2737,36 +2707,12 @@ criteria = "safe-to-deploy"
 version = "1.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.zcash_address]]
-version = "0.13.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
-criteria = "safe-to-deploy"
-
 [[exemptions.zcash_encoding]]
-version = "0.4.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_history]]
-version = "0.5.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_keys]]
-version = "0.15.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_note_encryption]]
 version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_primitives]]
-version = "0.30.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_proofs]]
-version = "0.30.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_protocol]]
-version = "0.10.1@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_script]]
@@ -2775,10 +2721,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zcash_spec]]
 version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_transparent]]
-version = "0.10.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -28,6 +28,12 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [imports.zcashd]
 url = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[policy.equihash]
+audit-as-crates-io = true
+
+[policy.f4jumble]
+audit-as-crates-io = true
+
 [policy.zakura]
 audit-as-crates-io = false
 
@@ -66,6 +72,30 @@ audit-as-crates-io = false
 
 [policy.zakura-utils]
 audit-as-crates-io = false
+
+[policy.zcash_address]
+audit-as-crates-io = true
+
+[policy.zcash_encoding]
+audit-as-crates-io = true
+
+[policy.zcash_history]
+audit-as-crates-io = true
+
+[policy.zcash_keys]
+audit-as-crates-io = true
+
+[policy.zcash_primitives]
+audit-as-crates-io = true
+
+[policy.zcash_proofs]
+audit-as-crates-io = true
+
+[policy.zcash_protocol]
+audit-as-crates-io = true
+
+[policy.zcash_transparent]
+audit-as-crates-io = true
 
 [[exemptions.abscissa_core]]
 version = "0.7.0"
@@ -648,7 +678,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.equihash]]
-version = "0.3.0"
+version = "0.3.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 criteria = "safe-to-deploy"
 
 [[exemptions.erased-serde]]
@@ -660,7 +690,7 @@ version = "0.6.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.f4jumble]]
-version = "0.1.1"
+version = "0.1.1@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
@@ -1439,6 +1469,10 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.orchard]]
+version = "0.15.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.ordered-map]]
 version = "0.4.2"
 criteria = "safe-to-deploy"
@@ -1476,7 +1510,7 @@ version = "0.9.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.pasta_curves]]
-version = "0.5.1"
+version = "0.5.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.paste]]
@@ -2703,8 +2737,36 @@ criteria = "safe-to-deploy"
 version = "1.3.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.zcash_address]]
+version = "0.13.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+criteria = "safe-to-deploy"
+
 [[exemptions.zcash_encoding]]
-version = "0.4.0"
+version = "0.4.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_history]]
+version = "0.5.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_keys]]
+version = "0.15.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_note_encryption]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_primitives]]
+version = "0.30.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_proofs]]
+version = "0.30.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_protocol]]
+version = "0.10.1@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_script]]
@@ -2713,6 +2775,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zcash_spec]]
 version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_transparent]]
+version = "0.10.0@git:57b844dc00bf1f25254b5859b8d5faa8e5730f98"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -112,36 +112,36 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_keys]]
-version = "0.15.0"
-when = "2026-07-09"
+version = "0.16.0"
+when = "2026-07-25"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_primitives]]
-version = "0.29.0"
-when = "2026-07-09"
+version = "0.30.0"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_proofs]]
-version = "0.29.0"
-when = "2026-07-09"
+version = "0.30.0"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.10.0"
-when = "2026-07-09"
+version = "0.10.1"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_transparent]]
-version = "0.9.0"
-when = "2026-07-09"
+version = "0.10.0"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"


### PR DESCRIPTION
Update Zakura's librustzcash dependency family to the published releases aligned with zcash_primitives 0.30.0. zcash_keys 0.16.0 now uses zcash_transparent 0.10.0, so this removes the temporary git patch and its cargo-vet and cargo-deny accommodations while retaining a single TransparentAddress type.

This is dependency-only and has no operator-visible effect.
