### PR TITLE
test(state): cover deterministic restart boundaries

### DIFF
--- a/changelog-unreleased/434.md
+++ b/changelog-unreleased/434.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1845,12 +1845,29 @@ fn vct_mode_switches_continue_from_safe_boundaries() -> Result<()> {
                 vct_fast_sync: false,
                 ..fast_config
             };
-            let mut manual = FinalizedState::new(&manual_config, &network).expect("opening an ephemeral database should succeed");
-            for i in (handoff_index + 1)..=post_handoff_tip {
+            {
+                let mut manual = FinalizedState::new(&manual_config, &network).expect("opening an ephemeral database should succeed");
+                let i = handoff_index + 1;
                 let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
                 manual
-                    .commit_finalized_direct(cv.into(), None, None, "vct switch manual suffix")
-                    .expect("manual suffix commits after fast handoff");
+                    .commit_finalized_direct(
+                        cv.into(),
+                        None,
+                        None,
+                        "vct switch first manual block",
+                    )
+                    .expect("first manual block commits after fast handoff");
+            }
+
+            // Restart after the first body-derived post-handoff tree write.
+            // Reopening proves the handoff and first semantic block did not
+            // create duplicate note-commitment trees.
+            let mut manual = FinalizedState::new(&manual_config, &network).expect("database reopens after the first post-handoff block");
+            for i in (handoff_index + 2)..=post_handoff_tip {
+                let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
+                manual
+                    .commit_finalized_direct(cv.into(), None, None, "vct switch resumed manual suffix")
+                    .expect("manual suffix resumes after restart");
             }
             let manual_tip = manual.db.note_commitment_trees_for_tip().unwrap();
             prop_assert_eq!(manual.db.vct_anchor_digest(), golden_anchors, "fast-to-manual anchors match legacy");

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/highest_completed_checkpoint.rs
@@ -92,6 +92,41 @@ fn advances_after_disk_commit_and_reconstructs_after_restart() {
 }
 
 #[test]
+fn reconstructs_after_restart_before_post_write_tracker_update() {
+    let _init_guard = zakura_test::init();
+    let cache_dir = tempfile::tempdir().expect("temporary state directory is created");
+    let (genesis, headers, network) = checkpoint_chain(&[2]);
+    let config = persistent_config(cache_dir.path());
+    let mut state = state_with_genesis_config(&network, genesis.clone(), config.clone());
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&state);
+    let mut batch = DiskWriteBatch::new();
+    batch
+        .prepare_header_range_batch(&state, genesis.hash(), &headers, &[0, 0])
+        .expect("checkpoint bracket is valid");
+    let proposal = tracker
+        .propose_after_headers(&state, genesis.hash(), &headers)
+        .expect("checkpoint proposal is valid");
+    let checkpoint_two = checkpoint(Height(2), block::Hash::from(headers[1].as_ref()));
+    assert_eq!(proposal.current(), Some(checkpoint_two));
+
+    state
+        .write_batch(batch)
+        .expect("checkpoint bracket writes durably");
+
+    // Model the process losing its in-memory state after RocksDB commits but
+    // before the write worker calls `commit_success` to publish the proposal.
+    drop(tracker);
+    drop(receiver);
+    state.shutdown(true);
+    drop(state);
+
+    let reopened = persistent_state(&config, &network);
+    let (tracker, receiver) = HighestCompletedCheckpointTracker::open(&reopened);
+    assert_eq!(tracker.current(), Some(checkpoint_two));
+    assert_eq!(*receiver.borrow(), Some(checkpoint_two));
+}
+
+#[test]
 fn reconstructs_header_completed_frontier_above_body_tip() {
     let _init_guard = zakura_test::init();
     let (genesis, headers, network) = checkpoint_chain(&[2, 5]);

--- a/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -1776,6 +1776,72 @@ mod tests {
     }
 
     #[test]
+    fn authenticated_roots_survive_restart_before_watch_publication() {
+        let cache = tempfile::tempdir().expect("temporary cache directory is created");
+        let config = Config {
+            cache_dir: cache.path().to_owned(),
+            ephemeral: false,
+            ..Config::default()
+        };
+        let (mut db, block, successor, current) = two_block_checkpoint_fixture_with_config(&config);
+        let network = db.network();
+        let completed = HighestCompletedCheckpoint {
+            height: current.completed_checkpoint_height,
+            hash: current.completed_checkpoint_hash,
+        };
+        let roots = roots_from_block(&block);
+
+        let authenticated = db
+            .authenticate_header_roots(
+                completed,
+                current,
+                current.authenticated_hash,
+                Height(1),
+                &[block.header.clone(), successor.header.clone()],
+                &[roots.clone(), roots_from_block(&successor)],
+            )
+            .expect("valid roots authenticate durably");
+
+        // Model the process losing its in-memory state after the atomic
+        // roots/frontier batch commits but before the write worker publishes
+        // the returned state.
+        db.shutdown(true);
+        drop(db);
+
+        let reopened = ZakuraDb::new(
+            &config,
+            STATE_DATABASE_KIND,
+            &state_database_format_version_in_code(),
+            &network,
+            true,
+            STATE_COLUMN_FAMILIES_IN_CODE
+                .iter()
+                .map(ToString::to_string),
+            false,
+        )
+        .expect("database reopens after root authentication");
+        let (tracker, _receiver) = HighestCompletedCheckpointTracker::open(&reopened);
+        let restored = reopened
+            .validate_header_root_auth_state()
+            .expect("authenticated state remains coherent")
+            .expect("authenticated frontier remains present")
+            .state(
+                tracker
+                    .current()
+                    .expect("checkpoint progress reconstructs from durable headers"),
+            );
+
+        assert_eq!(restored, authenticated.state);
+        assert_eq!(
+            reopened.commitment_roots(Height(1)),
+            Some(normalize_unauthenticated_commitment_fields(
+                &reopened.network(),
+                roots
+            ))
+        );
+    }
+
+    #[test]
     fn body_frontier_advance_moves_forward_and_preserves_newer_authentication() {
         let (db, block, _successor, current) = two_block_checkpoint_fixture();
         let mut batch = DiskWriteBatch::new();


### PR DESCRIPTION
## Motivation

The root-authentication and completed-checkpoint write paths persist their
frontiers before publishing process-local state. VCT fast sync also changes
tree derivation modes at its final checkpoint. These restart boundaries need
direct regression coverage so a process loss cannot make a reopened node use
the wrong frontier or create duplicate note-commitment trees.

## Solution

- Reopen the database after root authentication but before publishing the
  authenticated frontier, then reconstruct and validate the durable state.
- Reopen after a completed-checkpoint batch write without committing its
  process-local tracker proposal, then reconstruct the tracker from disk.
- Extend the VCT mode-switch property test with another reopen immediately
  after the first body-derived post-handoff tree.

The tests model process-local state loss deterministically at each durable
write boundary. They intentionally leave operating-system and RocksDB WAL
crash recovery to a separate process-level smoke test.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-state` (450 passed, 4 ignored; binary,
  integration, and doc tests also passed)
- `./scripts/changelog.py check`
- Markdown lint for `changelog-unreleased/434.md`
- Draft CI passed, including all three unit-test shards.

CI timings for the affected tests:

- VCT handoff and post-handoff restart property: 4.196s
- Completed-checkpoint restart recovery: 0.424s
- Root-authentication restart recovery: 0.343s

The three tests took 4.963s of serialized test time. Their shard completed in
2m12s, including runner setup and the rest of its 932 tests.

## Changelog

Added `changelog-unreleased/434.md` with the explicit internal-only marker
because this PR changes tests only.

### Follow-up Work

- Keep a lower-frequency process-level `SIGKILL` smoke test for RocksDB and
  operating-system crash-recovery coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and an internal changelog entry; no production code paths are modified.
> 
> **Overview**
> Adds **deterministic restart-boundary regression tests** so a reopened node still reflects durable finalized-state writes when process-local trackers or watch channels were never updated.
> 
> **Root authentication** (`commitment_roots_db.rs`): after `authenticate_header_roots` commits atomically, the test shuts down before the write worker publishes state, then reopens and checks reconstructed authenticated frontier and commitment roots match.
> 
> **Completed checkpoints** (`highest_completed_checkpoint.rs`): after a durable `write_batch` without calling `commit_success`, reopening must reconstruct `HighestCompletedCheckpointTracker` from disk headers.
> 
> **VCT mode switch** (`prop.rs`): the fast→manual property test now commits the first post-handoff block in one session, **reopens**, then finishes the manual suffix—guarding against duplicate note-commitment trees at the handoff boundary.
> 
> Adds `changelog-unreleased/434.md` marked internal-only (tests only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 860949b9363f7763450362b38705549b5fde1de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->