### PR TITLE
fix(network): anchor the block-sync producer cursor to the download floor

### DIFF
--- a/changelog-unreleased/435.md
+++ b/changelog-unreleased/435.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Prevented Zakura block sync from permanently stalling when a needed height
+  left the work queue while a higher height stayed claimed, which pinned the
+  block download floor and grew the reorder buffer without bound
+  ([#435](https://github.com/zakura-core/zakura/pull/435)).

--- a/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/zakura-network/src/zakura/block_sync/reactor.rs
@@ -1243,18 +1243,27 @@ impl BlockSyncReactor {
         dispatched
     }
 
+    /// Where the next producer query starts: the lowest height above the request
+    /// floor that the WorkQueue does not already hold.
+    ///
+    /// This is deliberately *not* `max_claimed() + 1`. A forward-only cursor can
+    /// never re-offer a height that left `pending`/`in_flight` while a higher
+    /// height stayed claimed, so a single such height permanently pins the
+    /// download floor one below it and the reorder buffer grows without bound.
+    /// Both observed stalls reached that state: a destructive `reset_above` racing
+    /// an unreceived request, and a refill batch whose surviving heights advanced
+    /// `max_claimed` past the one the `has_outstanding_request` filter dropped.
     fn next_needed_block_query_start(&self) -> Option<block::Height> {
-        let last_claimed = self
+        let from = self
             .state
             .work_queue
-            .max_claimed()
-            .unwrap_or(self.request_floor);
+            .first_unclaimed_above(self.request_floor)?;
 
-        if last_claimed >= self.state.best_header_tip {
+        if from > self.state.best_header_tip {
             return None;
         }
 
-        last_claimed.next().ok()
+        Some(from)
     }
 
     fn refill_query_limit_blocks(&self, from: block::Height) -> u32 {

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -1361,6 +1361,117 @@ fn work_queue_extend_dedups_against_pending_in_flight_and_floor() {
 }
 
 #[test]
+fn work_queue_first_unclaimed_above_is_floor_anchored_not_frontier_anchored() {
+    // Nothing claimed: the cursor sits just above the floor.
+    let queue = work_queue_with(5, []);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(6)),
+    );
+
+    // A gap-free claimed run: the cursor is the height after it, and stays there
+    // across the pending -> in_flight transition.
+    let queue = work_queue_with(
+        5,
+        (6..=9).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(10)),
+    );
+    queue.take_in_range(block::Height(6), block::Height(9), 4);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(10)),
+    );
+
+    // A height dropped from the claimed set while higher heights stay claimed is
+    // what a destructive `reset_above` racing an unreceived request leaves behind.
+    // The cursor must fall back to it, not stay above the frontier.
+    queue.reset_above(block::Height(5));
+    queue.extend([
+        needed(6, BlockSizeEstimate::Advertised(100)),
+        needed(8, BlockSizeEstimate::Advertised(100)),
+        needed(9, BlockSizeEstimate::Advertised(100)),
+    ]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(7)),
+        "an interior hole is the cursor even though higher heights are claimed",
+    );
+
+    // Filling the hole restores the forward cursor.
+    queue.extend([needed(7, BlockSizeEstimate::Advertised(100))]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(10)),
+    );
+
+    // A claimed set disconnected from the floor is a hole at the floor itself.
+    let queue = work_queue_with(
+        5,
+        (100..=102).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(6)),
+    );
+
+    // A lagging caller mirror never rewinds the cursor below the queue's own floor.
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(1)),
+        Some(block::Height(6)),
+    );
+}
+
+#[test]
+fn work_queue_first_unclaimed_above_ignores_entries_retained_at_or_below_a_forward_reset() {
+    // A *forward* destructive reset pins the floor and pops only the `> floor`
+    // suffix, so the whole `(old_floor, new_floor]` prefix stays claimed at or
+    // below the new floor. Those entries must not count toward the contiguity
+    // check, or they inflate it until a sparse range above the floor reads as
+    // gap-free and the cursor skips the very holes it exists to find.
+    let queue = work_queue_with(
+        5,
+        (6..=20).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    queue.reset_above(block::Height(12));
+    queue.extend([
+        needed(15, BlockSizeEstimate::Advertised(100)),
+        needed(16, BlockSizeEstimate::Advertised(100)),
+    ]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(12)),
+        Some(block::Height(13)),
+        "13 is unclaimed; the retained 6..=12 prefix must not hide it",
+    );
+
+    // The same holds once the retained prefix is in flight rather than pending.
+    let queue = work_queue_with(
+        5,
+        (6..=20).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    queue.take_in_range(block::Height(6), block::Height(12), 7);
+    queue.reset_above(block::Height(12));
+    queue.extend([needed(15, BlockSizeEstimate::Advertised(100))]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(12)),
+        Some(block::Height(13)),
+    );
+
+    // With the hole filled, the fast path still reports the forward cursor even
+    // though the retained prefix is present.
+    queue.extend([
+        needed(13, BlockSizeEstimate::Advertised(100)),
+        needed(14, BlockSizeEstimate::Advertised(100)),
+    ]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(12)),
+        Some(block::Height(16)),
+    );
+}
+
+#[test]
 fn work_queue_take_respects_servable_range_contiguity_and_max() {
     // Heights 10,11,12 then a gap then 20,21.
     let queue = work_queue_with(
@@ -2527,6 +2638,72 @@ async fn reactor_suppresses_duplicate_needed_block_query_until_response() {
         .await
         .expect("header-tip event after response queues");
     wait_for_query_needed_blocks(&mut actions, block::Height(0), block::Height(4)).await;
+
+    reactor_task.abort();
+}
+
+/// Regression: a body height that is missing from the WorkQueue while *higher*
+/// heights are claimed must still be re-offered by the producer.
+///
+/// Two production stalls reached exactly this state — a destructive
+/// `reset_above` racing an unreceived request, and a refill batch whose
+/// surviving heights advanced the claimed frontier past the one the
+/// `has_outstanding_request` filter dropped. With a `max_claimed() + 1` cursor
+/// the height is never queried again: the download floor pins one below it, the
+/// reorder buffer grows unbounded, and the node stops committing while still
+/// receiving blocks from a dozen servable peers.
+#[tokio::test]
+async fn reactor_requeries_a_height_stranded_below_higher_claimed_work() {
+    let config = immediate_body_download_config();
+    let (_tip_tx, tip_rx) = watch::channel((block::Height(0), block::Hash([0; 32])));
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        },
+        (block::Height(0), block::Hash([0; 32])),
+        tip_rx,
+        config,
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let best_hash = block::Hash([10; 32]);
+
+    handle
+        .send(BlockSyncEvent::HeaderTipChanged {
+            height: block::Height(10),
+            hash: best_hash,
+        })
+        .await
+        .expect("header-tip event queues");
+    wait_for_query_needed_blocks(&mut actions, block::Height(0), block::Height(10)).await;
+
+    // The response covers only 5..=8: heights 1..=4 are above the floor, still
+    // body-missing, and now sit below the claimed frontier.
+    handle
+        .send(BlockSyncEvent::NeededBlocks(
+            (5..=8)
+                .map(|height| BlockSyncBlockMeta {
+                    height: block::Height(height),
+                    hash: block::Hash([u8::try_from(height).expect("test height fits u8"); 32]),
+                    size: BlockSizeEstimate::Advertised(1_000),
+                })
+                .collect(),
+        ))
+        .await
+        .expect("needed-block response queues");
+
+    handle
+        .send(BlockSyncEvent::HeaderTipChanged {
+            height: block::Height(10),
+            hash: best_hash,
+        })
+        .await
+        .expect("header-tip event after response queues");
+
+    // Fails on the frontier-anchored cursor, which asks for height 9 and strands
+    // 1..=4 for the lifetime of the process.
+    wait_for_query_needed_blocks(&mut actions, block::Height(0), block::Height(10)).await;
 
     reactor_task.abort();
 }

--- a/zakura-network/src/zakura/block_sync/work_queue.rs
+++ b/zakura-network/src/zakura/block_sync/work_queue.rs
@@ -632,14 +632,76 @@ impl WorkQueue {
         self.lock().in_flight.keys().next_back().copied()
     }
 
-    pub(super) fn max_claimed(&self) -> Option<block::Height> {
+    /// The lowest height above the floor that is in neither `pending` nor
+    /// `in_flight` — the producer's query cursor.
+    ///
+    /// Anchored to the floor rather than to the highest claimed height, so a
+    /// height that leaves the claimed set while higher heights stay claimed is
+    /// offered to the next query instead of being stranded below a forward-only
+    /// cursor. That happens whenever a destructive `reset_above` races an
+    /// unreceived request, and whenever a refill batch is filtered down but its
+    /// surviving heights still push `max_claimed` past the filtered one.
+    ///
+    /// `floor` is the caller's mirror of the download floor; the queue's own floor
+    /// wins when the mirror lags, since heights at or below it are already GC'd.
+    ///
+    /// O(1) in the gap-free case: `pending`/`in_flight` are disjoint, so once the
+    /// lowest claimed height is known to be `anchor + 1`, the claimed set spans
+    /// `(anchor, max_claimed]` contiguously exactly when its size equals that span.
+    /// Only a real gap pays for the merge walk, which stops at the first hole.
+    pub(super) fn first_unclaimed_above(&self, floor: block::Height) -> Option<block::Height> {
         let inner = self.lock();
-        inner
+        let anchor = inner.floor.max(floor);
+        let start = anchor.next().ok()?;
+
+        let max_claimed = inner
             .pending
             .keys()
             .next_back()
             .copied()
-            .max(inner.in_flight.keys().next_back().copied())
+            .max(inner.in_flight.keys().next_back().copied());
+        let Some(max_claimed) = max_claimed.filter(|max| *max >= start) else {
+            return Some(start);
+        };
+
+        // The length check only decides contiguity when *every* key is above the
+        // anchor, so it is gated on the lowest claimed height being `start` itself.
+        // Entries at or below the anchor otherwise inflate the count and make a
+        // sparse range look contiguous: a forward `reset_above` pins the floor and
+        // pops only the `> floor` suffix, so it leaves the whole
+        // `(old_floor, new_floor]` prefix claimed at or below the new floor. A
+        // lagging caller `floor` mirror is excluded the same way.
+        let min_claimed = match (
+            inner.pending.keys().next().copied(),
+            inner.in_flight.keys().next().copied(),
+        ) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            (single, None) | (None, single) => single,
+        };
+        if min_claimed == Some(start) {
+            let span = u64::from(max_claimed.0 - anchor.0);
+            let claimed = inner.pending.len().saturating_add(inner.in_flight.len()) as u64;
+            if claimed == span {
+                return max_claimed.next().ok();
+            }
+        }
+
+        let mut pending = inner.pending.range(start..).peekable();
+        let mut in_flight = inner.in_flight.range(start..).peekable();
+        let mut expected = start;
+        loop {
+            let next = match (pending.peek(), in_flight.peek()) {
+                (None, None) => return Some(expected),
+                (Some((height, _)), None) | (None, Some((height, _))) => **height,
+                (Some((left, _)), Some((right, _))) => **left.min(right),
+            };
+            if next > expected {
+                return Some(expected);
+            }
+            pending.next_if(|(height, _)| **height == next);
+            in_flight.next_if(|(height, _)| **height == next);
+            expected = next.next().ok()?;
+        }
     }
 
     /// Expected hash for a height in `pending` or `in_flight` (late-response


### PR DESCRIPTION
## Motivation

Two continuous-sync nodes stopped committing blocks while staying connected and
healthy: the download floor froze, the reorder buffer grew to ~1 GB on each, and
neither recovered.

Root cause is the block-sync producer cursor. `next_needed_block_query_start`
asked the state for needed blocks starting at `work_queue.max_claimed() + 1` —
the height after the *highest* live `pending ∪ in_flight` key. That cursor is
forward-only, so **any height that leaves the claimed set while a higher height
stays claimed can never be offered to a later query**. One such height pins the
download floor one below it permanently.

The two nodes got there by different routes:

- **Stale response re-seeds above a reset.** A `QueryNeededBlocks` dispatched
  *before* a destructive reset returned *after* `reset_above` emptied the queue.
  `handle_needed_blocks` has no generation check, so it extended the emptied
  queue with 4,000 heights starting ~72k above the new floor. 146 µs later the
  forced post-reset refill queried from 663306 instead of 587554:

  ```
  4420.450731  QUERY from=659306 limit=4000       <- dispatched pre-reset
  4420.483296  frontier reset "destructive", floor -> 587553
  4420.505407  work_extended new=4000 queue=4000  <- stale response lands
  4420.505567  QUERY from=663306                  <- should have been 587554
  ```

- **A height stranded by its own batch.** The post-reset query *did* re-anchor
  (`from=776804`) and covered 780000, but `!has_outstanding_request` filtered
  that height out. The other 3,966 heights queued, `max_claimed` moved to
  780829, and the cursor jumped to 780830. None of the 164 later queries covered
  780000 again.

Neither queue ever drained to empty, so the `unwrap_or(request_floor)` fallback
never fired.

## Solution

Anchor the cursor to the download floor instead of the claimed frontier.
`WorkQueue::first_unclaimed_above` returns the lowest height above the floor
held in neither `pending` nor `in_flight`, so a hole is re-offered on the next
query rather than stranded.

This is deliberately fixed at the invariant rather than at the two loss sites.
Every removal outside `advance_floor` (a `<= floor` prefix) and `reset_above` (a
`> floor` suffix) moves a height *between* `pending` and `in_flight` — the
claimed union only ever loses a prefix or a suffix, so an interior hole can only
enter via a filtered `extend` or a floor left below the lowest claimed height.
That enumeration is exhaustive, and the two observed stalls are exactly its two
members.

The gap-free case stays O(1): the maps are disjoint, so once the lowest claimed
height is known to be the first height above the anchor, the claimed set is
contiguous exactly when its size equals the span it covers. That check is gated
on the lowest claimed height rather than applied unconditionally — a *forward*
`reset_above` pins the floor and pops only the `> floor` suffix, leaving the
whole `(old_floor, new_floor]` prefix claimed at or below the new floor, and
counting those entries would inflate the span until a sparse range read as
gap-free, reintroducing the same stranding. Only a real gap pays for the merge
walk, which stops at the first hole.

`max_claimed` has no remaining callers and is removed.

## Testing

`cargo test -p zakura-network` (1144 passed), `cargo fmt --all -- --check`,
`cargo clippy -p zakura-network --all-targets -- -D warnings`.

`work_queue_first_unclaimed_above_is_floor_anchored_not_frontier_anchored`
covers the empty queue, a gap-free run across the `pending -> in_flight`
transition, an interior hole from a reset plus partial refill, hole refill
restoring the forward cursor, a claimed set disconnected from the floor, and a
lagging caller mirror.

`work_queue_first_unclaimed_above_ignores_entries_retained_at_or_below_a_forward_reset`
covers the retained-prefix case in both maps. It fails on an ungated length
check (returns 17 where 13 is unclaimed).

`reactor_requeries_a_height_stranded_below_higher_claimed_work` answers the
producer query with a sparse batch and asserts the next `QueryNeededBlocks`
starts at the stranded height. Verified to fail on the old cursor.

## Changelog

To be added after this draft PR gets its number.

### Follow-up Work

These are known gaps in this PR, tracked deliberately rather than folded in:

1. **No end-to-end replication.** The tests reproduce the invariant violation
   and the resulting cursor value, not the full production sequence
   (destructive reset -> stale response landing post-reset -> floor pin ->
   unbounded reorder). The harness can drive that via
   `BlockSyncEvent::ChainTipReset` with a connected peer and real bodies; a
   reset-heavy continuous-sync soak on a patched binary is the strongest check
   and has not been run.

2. **Stale `NeededBlocks` responses can still install wrong-fork hashes.**
   Separate latent bug, *not* what stalled either node here (both showed
   `floor_gap_state="absent"` with `outstanding=0` — not scheduled at all,
   rather than scheduled with a bad hash). `extend` dedupes on height and
   ignores the hash, so a later fresh response cannot correct an installed one,
   and the receive path drops a body whose hash differs from the queued
   expectation — that height then becomes unsatisfiable. The reactor clears
   `pending_needed_query` on a destructive reset but `handle_needed_blocks`
   processes whatever arrives. A reactor-local epoch stamp is *not* sufficient
   (a differing query can be dispatched while an earlier one is outstanding, so
   a post-reset dispatch makes a still-outstanding pre-reset response look
   current); it needs either a query id echoed on the response or letting
   `extend` overwrite the hash of a `pending` entry. This cursor fix does not
   cover it — a wrong-hash entry is claimed, not a hole.

3. **Floor-gap diagnostics** (a real `available_peers` count in place of the
   `0usize` stub) are split into a follow-up PR so they do not muddy review of
   the correctness fix; the `available` naming also overstates what it measures.
