### PR TITLE
ci: mint a GitHub App token for upstream-sync PR creation

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -241,10 +241,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/upstream-sync-run.sh delete-stale-branch
 
+      # GITHUB_TOKEN is not permitted to create PRs in this org, so PR
+      # creation uses a short-lived app installation token instead.
+      - name: Mint PR creation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        with:
+          client-id: ${{ vars.UPSTREAM_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.UPSTREAM_SYNC_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create human review PR
         id: create-pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           UPSTREAM_SYNC_TARGET_REF: ${{ inputs.target_ref || 'main' }}
         run: .github/scripts/upstream-sync-run.sh create-human-review-pr
 
@@ -315,12 +326,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/upstream-sync-run.sh delete-stale-branch
 
+      # See "Mint PR creation token" in open-needs-human-pr: GITHUB_TOKEN
+      # cannot create PRs in this org, and app-token PRs also trigger CI.
+      - name: Mint PR creation token
+        id: app-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        with:
+          client-id: ${{ vars.UPSTREAM_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.UPSTREAM_SYNC_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create upstream sync PR
         id: create-pr
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: ${{ steps.pr-meta.outputs.branch }}
           base: ${{ inputs.target_ref || 'main' }}
           title: ${{ steps.pr-meta.outputs.title }}


### PR DESCRIPTION
## Motivation

The hourly Upstream PR Triage Pilot has never successfully opened a PR: the `open-pr` and `open-needs-human-pr` jobs fail at PR creation with `GitHub Actions is not permitted to create or approve pull requests`, because org policy blocks `GITHUB_TOKEN` from opening PRs.

## Solution

Mint a short-lived GitHub App installation token in the two PR-opening jobs and use it for `peter-evans/create-pull-request` and the `gh pr create` call in `upstream-sync-run.sh`. App tokens are exempt from that Actions restriction, and unlike `GITHUB_TOKEN`, PRs they open still trigger `pull_request` workflows, so the generated drafts get CI runs. The minted token is scoped down to `contents: write` + `pull-requests: write` regardless of what the app is later granted. All other steps (ledger push, branch cleanup, artifact handling) stay on `GITHUB_TOKEN`.

Setup this PR depends on (merge after these exist, otherwise the job keeps failing, just one step earlier at token mint):

- A GitHub App owned by this org with repository permissions `Contents: Read and write` and `Pull requests: Read and write`, installed on this repo only.
- Actions variable `UPSTREAM_SYNC_APP_CLIENT_ID` = the app's Client ID.
- Actions secret `UPSTREAM_SYNC_APP_PRIVATE_KEY` = the app's PEM private key.

## Test evidence

`actionlint` clean and YAML parses; zizmor runs in CI on this PR. End-to-end can only be exercised once the app exists: dispatch the workflow with `mode=open-pr` and confirm it opens the pending draft for upstream PR 10604 with verified commits.

## AI disclosure

Used Claude Code for the workflow edit and this PR description.
