### PR TITLE
perf(network): compute address metrics in one pass

### DIFF
--- a/changelog-unreleased/437.md
+++ b/changelog-unreleased/437.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only improves internal address book metrics performance and has no
+operator- or crate-consumer-visible effect.

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -817,30 +817,31 @@ impl AddressBook {
     /// in production code, to avoid deadlocks.
     /// (Using the watch channel receiver does not lock the address book mutex.)
     fn address_metrics_internal(&self, now: chrono::DateTime<Utc>) -> AddressMetrics {
-        let responded = self.state_peers(PeerAddrState::Responded).count();
-        let never_attempted_gossiped = self
-            .state_peers(PeerAddrState::NeverAttemptedGossiped)
-            .count();
-        let failed = self.state_peers(PeerAddrState::Failed).count();
-        let attempt_pending = self.state_peers(PeerAddrState::AttemptPending).count();
-
-        let recently_live = self.recently_live_peers(now).len();
-        let recently_stopped_responding = responded
-            .checked_sub(recently_live)
-            .expect("all recently live peers must have responded");
-
-        let num_addresses = self.len();
-
-        AddressMetrics {
-            responded,
-            never_attempted_gossiped,
-            failed,
-            attempt_pending,
-            recently_live,
-            recently_stopped_responding,
-            num_addresses,
+        let mut metrics = AddressMetrics {
             address_limit: self.addr_limit,
+            ..AddressMetrics::default()
+        };
+
+        for peer in self.by_addr.descending_values() {
+            match peer.last_connection_state {
+                PeerAddrState::Responded => {
+                    metrics.responded += 1;
+                    metrics.recently_live += usize::from(peer.was_recently_live(now));
+                }
+                PeerAddrState::NeverAttemptedGossiped => {
+                    metrics.never_attempted_gossiped += 1;
+                }
+                PeerAddrState::Failed => metrics.failed += 1,
+                PeerAddrState::AttemptPending => metrics.attempt_pending += 1,
+            }
         }
+
+        metrics.recently_stopped_responding = metrics
+            .responded
+            .checked_sub(metrics.recently_live)
+            .expect("all recently live peers must have responded");
+        metrics.num_addresses = self.len();
+        metrics
     }
 
     /// Update the metrics for this address book.

--- a/zakura-network/src/address_book/tests.rs
+++ b/zakura-network/src/address_book/tests.rs
@@ -4,9 +4,17 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 
-use crate::constants::MAX_BANNED_IPS;
+use chrono::Utc;
+use tracing::Span;
+use zakura_chain::{parameters::Network::Mainnet, serialization::DateTime32};
 
-use super::{BanList, BannedIps};
+use crate::{
+    constants::{DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK, MAX_BANNED_IPS},
+    meta_addr::{MetaAddr, PeerSocketAddr},
+    protocol::external::types::PeerServices,
+};
+
+use super::{AddressBook, AddressMetrics, BanList, BannedIps};
 
 mod prop;
 mod vectors;
@@ -36,4 +44,48 @@ fn banned_ips_match_ipv4_and_ipv4_mapped_ipv6() {
 
     assert!(BannedIps::with_banned_ip(ipv4).contains(ipv4_mapped));
     assert!(BannedIps::with_banned_ip(ipv4_mapped).contains(ipv4));
+}
+
+#[test]
+fn address_metrics_count_each_peer_state() {
+    let addrs: [PeerSocketAddr; 4] = [
+        "11.1.1.1:8233".parse().unwrap(),
+        "11.1.1.2:8233".parse().unwrap(),
+        "11.1.1.3:8233".parse().unwrap(),
+        "11.1.1.4:8233".parse().unwrap(),
+    ];
+    let initial_addrs = addrs.map(|addr| {
+        MetaAddr::new_gossiped_meta_addr(addr, PeerServices::NODE_NETWORK, DateTime32::MIN)
+    });
+    let mut address_book = AddressBook::new_with_addrs(
+        "0.0.0.0:0".parse().unwrap(),
+        &Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
+        MAX_ADDRS_IN_ADDRESS_BOOK,
+        Span::none(),
+        initial_addrs,
+    );
+
+    address_book.update(MetaAddr::new_reconnect(addrs[0]));
+    address_book.update(MetaAddr::new_responded(addrs[0], None));
+    address_book.update(MetaAddr::new_reconnect(addrs[1]));
+    address_book.update(MetaAddr::new_errored(
+        addrs[1],
+        Option::<PeerServices>::None,
+    ));
+    address_book.update(MetaAddr::new_reconnect(addrs[2]));
+
+    assert_eq!(
+        address_book.address_metrics(Utc::now()),
+        AddressMetrics {
+            responded: 1,
+            never_attempted_gossiped: 1,
+            failed: 1,
+            attempt_pending: 1,
+            recently_live: 1,
+            recently_stopped_responding: 0,
+            num_addresses: 4,
+            address_limit: MAX_ADDRS_IN_ADDRESS_BOOK,
+        }
+    );
 }


### PR DESCRIPTION
## Motivation

Live-head profiling showed address-book metrics repeatedly scanning and cloning the full peer set.

## Solution

Count every address state and recently live peer in one borrowed pass.

## Testing

A [paired 60-minute live-head run](https://github.com/zakura-core/zakura/actions/runs/30130051928) from the same tip reduced estimated CPU in `AddressBook::update_metrics` by 77.2% (8.90 to 2.03 CPU-seconds), accounting for 16.2% of baseline whole-node CPU. Whole-process task-clock fell 31.3% (42.39 to 29.14 CPU-seconds); that wider result is observational because the candidate handled 6.1% fewer handshakes, ended with a 7.8% smaller address book, and processed one fewer block.

Release microbenchmarks improved 4.8–5.2× with identical outputs. Focused tests, `zakura-network` clippy, and CI pass.

## Changelog

Internal performance improvement; no operator-visible behavior change.