### PR TITLE
fix(network): keep header sync progressing across durable reanchors

### DIFF
--- a/changelog-unreleased/435.md
+++ b/changelog-unreleased/435.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Prevented Zakura block sync from permanently stalling when a needed height
+  left the work queue while a higher height stayed claimed, which pinned the
+  block download floor and grew the reorder buffer without bound
+  ([#435](https://github.com/zakura-core/zakura/pull/435)).

--- a/changelog-unreleased/438.md
+++ b/changelog-unreleased/438.md
@@ -1,6 +1,6 @@
 ## Fixed
 
-- Prevented Zakura header sync from livelocking when the durable header tip
-  matched the anchor already in use, which cancelled every outstanding forward
-  header range before it could commit
+- Prevented Zakura header sync from livelocking or stalling root authentication
+  when durable reanchors discarded in-flight work or left fallback ranges
+  disconnected from the authenticated frontier
   ([#438](https://github.com/zakura-core/zakura/pull/438)).

--- a/changelog-unreleased/438.md
+++ b/changelog-unreleased/438.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Prevented Zakura header sync from livelocking when the durable header tip
+  matched the anchor already in use, which cancelled every outstanding forward
+  header range before it could commit
+  ([#438](https://github.com/zakura-core/zakura/pull/438)).

--- a/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/zakura-network/src/zakura/block_sync/reactor.rs
@@ -1243,18 +1243,27 @@ impl BlockSyncReactor {
         dispatched
     }
 
+    /// Where the next producer query starts: the lowest height above the request
+    /// floor that the WorkQueue does not already hold.
+    ///
+    /// This is deliberately *not* `max_claimed() + 1`. A forward-only cursor can
+    /// never re-offer a height that left `pending`/`in_flight` while a higher
+    /// height stayed claimed, so a single such height permanently pins the
+    /// download floor one below it and the reorder buffer grows without bound.
+    /// Both observed stalls reached that state: a destructive `reset_above` racing
+    /// an unreceived request, and a refill batch whose surviving heights advanced
+    /// `max_claimed` past the one the `has_outstanding_request` filter dropped.
     fn next_needed_block_query_start(&self) -> Option<block::Height> {
-        let last_claimed = self
+        let from = self
             .state
             .work_queue
-            .max_claimed()
-            .unwrap_or(self.request_floor);
+            .first_unclaimed_above(self.request_floor)?;
 
-        if last_claimed >= self.state.best_header_tip {
+        if from > self.state.best_header_tip {
             return None;
         }
 
-        last_claimed.next().ok()
+        Some(from)
     }
 
     fn refill_query_limit_blocks(&self, from: block::Height) -> u32 {

--- a/zakura-network/src/zakura/block_sync/tests.rs
+++ b/zakura-network/src/zakura/block_sync/tests.rs
@@ -1361,6 +1361,117 @@ fn work_queue_extend_dedups_against_pending_in_flight_and_floor() {
 }
 
 #[test]
+fn work_queue_first_unclaimed_above_is_floor_anchored_not_frontier_anchored() {
+    // Nothing claimed: the cursor sits just above the floor.
+    let queue = work_queue_with(5, []);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(6)),
+    );
+
+    // A gap-free claimed run: the cursor is the height after it, and stays there
+    // across the pending -> in_flight transition.
+    let queue = work_queue_with(
+        5,
+        (6..=9).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(10)),
+    );
+    queue.take_in_range(block::Height(6), block::Height(9), 4);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(10)),
+    );
+
+    // A height dropped from the claimed set while higher heights stay claimed is
+    // what a destructive `reset_above` racing an unreceived request leaves behind.
+    // The cursor must fall back to it, not stay above the frontier.
+    queue.reset_above(block::Height(5));
+    queue.extend([
+        needed(6, BlockSizeEstimate::Advertised(100)),
+        needed(8, BlockSizeEstimate::Advertised(100)),
+        needed(9, BlockSizeEstimate::Advertised(100)),
+    ]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(7)),
+        "an interior hole is the cursor even though higher heights are claimed",
+    );
+
+    // Filling the hole restores the forward cursor.
+    queue.extend([needed(7, BlockSizeEstimate::Advertised(100))]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(10)),
+    );
+
+    // A claimed set disconnected from the floor is a hole at the floor itself.
+    let queue = work_queue_with(
+        5,
+        (100..=102).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(5)),
+        Some(block::Height(6)),
+    );
+
+    // A lagging caller mirror never rewinds the cursor below the queue's own floor.
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(1)),
+        Some(block::Height(6)),
+    );
+}
+
+#[test]
+fn work_queue_first_unclaimed_above_ignores_entries_retained_at_or_below_a_forward_reset() {
+    // A *forward* destructive reset pins the floor and pops only the `> floor`
+    // suffix, so the whole `(old_floor, new_floor]` prefix stays claimed at or
+    // below the new floor. Those entries must not count toward the contiguity
+    // check, or they inflate it until a sparse range above the floor reads as
+    // gap-free and the cursor skips the very holes it exists to find.
+    let queue = work_queue_with(
+        5,
+        (6..=20).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    queue.reset_above(block::Height(12));
+    queue.extend([
+        needed(15, BlockSizeEstimate::Advertised(100)),
+        needed(16, BlockSizeEstimate::Advertised(100)),
+    ]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(12)),
+        Some(block::Height(13)),
+        "13 is unclaimed; the retained 6..=12 prefix must not hide it",
+    );
+
+    // The same holds once the retained prefix is in flight rather than pending.
+    let queue = work_queue_with(
+        5,
+        (6..=20).map(|height| needed(height, BlockSizeEstimate::Advertised(100))),
+    );
+    queue.take_in_range(block::Height(6), block::Height(12), 7);
+    queue.reset_above(block::Height(12));
+    queue.extend([needed(15, BlockSizeEstimate::Advertised(100))]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(12)),
+        Some(block::Height(13)),
+    );
+
+    // With the hole filled, the fast path still reports the forward cursor even
+    // though the retained prefix is present.
+    queue.extend([
+        needed(13, BlockSizeEstimate::Advertised(100)),
+        needed(14, BlockSizeEstimate::Advertised(100)),
+    ]);
+    assert_eq!(
+        queue.first_unclaimed_above(block::Height(12)),
+        Some(block::Height(16)),
+    );
+}
+
+#[test]
 fn work_queue_take_respects_servable_range_contiguity_and_max() {
     // Heights 10,11,12 then a gap then 20,21.
     let queue = work_queue_with(
@@ -2527,6 +2638,72 @@ async fn reactor_suppresses_duplicate_needed_block_query_until_response() {
         .await
         .expect("header-tip event after response queues");
     wait_for_query_needed_blocks(&mut actions, block::Height(0), block::Height(4)).await;
+
+    reactor_task.abort();
+}
+
+/// Regression: a body height that is missing from the WorkQueue while *higher*
+/// heights are claimed must still be re-offered by the producer.
+///
+/// Two production stalls reached exactly this state — a destructive
+/// `reset_above` racing an unreceived request, and a refill batch whose
+/// surviving heights advanced the claimed frontier past the one the
+/// `has_outstanding_request` filter dropped. With a `max_claimed() + 1` cursor
+/// the height is never queried again: the download floor pins one below it, the
+/// reorder buffer grows unbounded, and the node stops committing while still
+/// receiving blocks from a dozen servable peers.
+#[tokio::test]
+async fn reactor_requeries_a_height_stranded_below_higher_claimed_work() {
+    let config = immediate_body_download_config();
+    let (_tip_tx, tip_rx) = watch::channel((block::Height(0), block::Hash([0; 32])));
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        },
+        (block::Height(0), block::Hash([0; 32])),
+        tip_rx,
+        config,
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let best_hash = block::Hash([10; 32]);
+
+    handle
+        .send(BlockSyncEvent::HeaderTipChanged {
+            height: block::Height(10),
+            hash: best_hash,
+        })
+        .await
+        .expect("header-tip event queues");
+    wait_for_query_needed_blocks(&mut actions, block::Height(0), block::Height(10)).await;
+
+    // The response covers only 5..=8: heights 1..=4 are above the floor, still
+    // body-missing, and now sit below the claimed frontier.
+    handle
+        .send(BlockSyncEvent::NeededBlocks(
+            (5..=8)
+                .map(|height| BlockSyncBlockMeta {
+                    height: block::Height(height),
+                    hash: block::Hash([u8::try_from(height).expect("test height fits u8"); 32]),
+                    size: BlockSizeEstimate::Advertised(1_000),
+                })
+                .collect(),
+        ))
+        .await
+        .expect("needed-block response queues");
+
+    handle
+        .send(BlockSyncEvent::HeaderTipChanged {
+            height: block::Height(10),
+            hash: best_hash,
+        })
+        .await
+        .expect("header-tip event after response queues");
+
+    // Fails on the frontier-anchored cursor, which asks for height 9 and strands
+    // 1..=4 for the lifetime of the process.
+    wait_for_query_needed_blocks(&mut actions, block::Height(0), block::Height(10)).await;
 
     reactor_task.abort();
 }

--- a/zakura-network/src/zakura/block_sync/work_queue.rs
+++ b/zakura-network/src/zakura/block_sync/work_queue.rs
@@ -632,14 +632,76 @@ impl WorkQueue {
         self.lock().in_flight.keys().next_back().copied()
     }
 
-    pub(super) fn max_claimed(&self) -> Option<block::Height> {
+    /// The lowest height above the floor that is in neither `pending` nor
+    /// `in_flight` — the producer's query cursor.
+    ///
+    /// Anchored to the floor rather than to the highest claimed height, so a
+    /// height that leaves the claimed set while higher heights stay claimed is
+    /// offered to the next query instead of being stranded below a forward-only
+    /// cursor. That happens whenever a destructive `reset_above` races an
+    /// unreceived request, and whenever a refill batch is filtered down but its
+    /// surviving heights still push `max_claimed` past the filtered one.
+    ///
+    /// `floor` is the caller's mirror of the download floor; the queue's own floor
+    /// wins when the mirror lags, since heights at or below it are already GC'd.
+    ///
+    /// O(1) in the gap-free case: `pending`/`in_flight` are disjoint, so once the
+    /// lowest claimed height is known to be `anchor + 1`, the claimed set spans
+    /// `(anchor, max_claimed]` contiguously exactly when its size equals that span.
+    /// Only a real gap pays for the merge walk, which stops at the first hole.
+    pub(super) fn first_unclaimed_above(&self, floor: block::Height) -> Option<block::Height> {
         let inner = self.lock();
-        inner
+        let anchor = inner.floor.max(floor);
+        let start = anchor.next().ok()?;
+
+        let max_claimed = inner
             .pending
             .keys()
             .next_back()
             .copied()
-            .max(inner.in_flight.keys().next_back().copied())
+            .max(inner.in_flight.keys().next_back().copied());
+        let Some(max_claimed) = max_claimed.filter(|max| *max >= start) else {
+            return Some(start);
+        };
+
+        // The length check only decides contiguity when *every* key is above the
+        // anchor, so it is gated on the lowest claimed height being `start` itself.
+        // Entries at or below the anchor otherwise inflate the count and make a
+        // sparse range look contiguous: a forward `reset_above` pins the floor and
+        // pops only the `> floor` suffix, so it leaves the whole
+        // `(old_floor, new_floor]` prefix claimed at or below the new floor. A
+        // lagging caller `floor` mirror is excluded the same way.
+        let min_claimed = match (
+            inner.pending.keys().next().copied(),
+            inner.in_flight.keys().next().copied(),
+        ) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            (single, None) | (None, single) => single,
+        };
+        if min_claimed == Some(start) {
+            let span = u64::from(max_claimed.0 - anchor.0);
+            let claimed = inner.pending.len().saturating_add(inner.in_flight.len()) as u64;
+            if claimed == span {
+                return max_claimed.next().ok();
+            }
+        }
+
+        let mut pending = inner.pending.range(start..).peekable();
+        let mut in_flight = inner.in_flight.range(start..).peekable();
+        let mut expected = start;
+        loop {
+            let next = match (pending.peek(), in_flight.peek()) {
+                (None, None) => return Some(expected),
+                (Some((height, _)), None) | (None, Some((height, _))) => **height,
+                (Some((left, _)), Some((right, _))) => **left.min(right),
+            };
+            if next > expected {
+                return Some(expected);
+            }
+            pending.next_if(|(height, _)| **height == next);
+            in_flight.next_if(|(height, _)| **height == next);
+            expected = next.next().ok()?;
+        }
     }
 
     /// Expected hash for a height in `pending` or `in_flight` (late-response

--- a/zakura-network/src/zakura/exchange.rs
+++ b/zakura-network/src/zakura/exchange.rs
@@ -429,6 +429,9 @@ pub fn apply_frontier_update(
             frontier.finalized =
                 higher_frontier(current.frontier.finalized, requested.frontier.finalized);
             frontier.verified_body = requested.frontier.verified_body;
+            if frontier == current.frontier {
+                return None;
+            }
         }
         FrontierChange::HeaderAdvanced => {
             if requested.frontier.best_header.height <= current.frontier.best_header.height {
@@ -654,6 +657,47 @@ mod tests {
         assert_eq!(updated.frontier.finalized, frontier(5, 5));
         assert_eq!(updated.frontier.verified_body, frontier(6, 6));
         assert_eq!(updated.frontier.best_header, frontier(10, 10));
+    }
+
+    #[test]
+    fn reset_that_moves_nothing_is_ignored() {
+        let current = update(
+            frontier(5, 5),
+            frontier(8, 8),
+            frontier(10, 10),
+            FrontierChange::Snapshot,
+        );
+        let requested = update(
+            frontier(5, 5),
+            frontier(8, 8),
+            frontier(2, 2),
+            FrontierChange::VerifiedReset,
+        );
+
+        assert!(
+            apply_frontier_update(current, requested).is_none(),
+            "a reset that leaves every frontier where it was must not wake subscribers"
+        );
+    }
+
+    #[test]
+    fn reset_to_the_same_height_on_another_chain_is_accepted() {
+        let current = update(
+            frontier(5, 5),
+            frontier(8, 8),
+            frontier(10, 10),
+            FrontierChange::Snapshot,
+        );
+        let requested = update(
+            frontier(5, 5),
+            frontier(8, 9),
+            frontier(10, 10),
+            FrontierChange::VerifiedReset,
+        );
+
+        let updated = apply_frontier_update(current, requested).expect("a same-height reorg moves");
+
+        assert_eq!(updated.frontier.verified_body, frontier(8, 9));
     }
 
     #[test]

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -2701,6 +2701,16 @@ impl HeaderSyncReactor {
     }
 
     async fn reanchor_to_durable_header_tip(&mut self, height: block::Height, hash: block::Hash) {
+        if (height, hash) == (self.state.best_header_tip, self.state.best_header_hash) {
+            // The durable tip is the anchor forward work already links to, so
+            // clearing and re-requesting that work would fetch the same headers
+            // from the same anchor. Reset the link-failure counter so a genuine
+            // stale anchor still gets the usual failure budget before retrying.
+            metrics::counter!("sync.header.stale_anchor.reanchor_unchanged").increment(1);
+            self.state.stale_anchor.reset();
+            return;
+        }
+
         metrics::counter!("sync.header.stale_anchor.reanchored").increment(1);
 
         self.state.stale_anchor.reset();

--- a/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/zakura-network/src/zakura/header_sync/reactor.rs
@@ -2715,7 +2715,8 @@ impl HeaderSyncReactor {
 
         self.state.stale_anchor.reset();
         self.state.schedule.clear_forward();
-        self.state.clear_retained_roots("verified_tip_reanchor");
+        self.state
+            .clear_unowned_retained_roots("verified_tip_reanchor");
         self.state
             .buffered
             .retain(|(priority, _), _| *priority != RangePriority::Forward);

--- a/zakura-network/src/zakura/header_sync/state.rs
+++ b/zakura-network/src/zakura/header_sync/state.rs
@@ -250,6 +250,7 @@ impl HeaderSyncCore {
             return;
         };
         if self.root_auth_coverage_expected_from_forward(start)
+            || self.root_auth_operation_pending_at(start)
             || self.retained_roots.contains_key(&start)
         {
             return;
@@ -266,6 +267,15 @@ impl HeaderSyncCore {
             return;
         }
 
+        let mut batch_start = self
+            .schedule
+            .retain_contiguous_root_auth_from(start)
+            .unwrap_or(start);
+        self.buffered.retain(|(priority, buffered_start), _| {
+            *priority != RangePriority::AuthenticateRoots
+                || self.schedule.has_root_auth_start(*buffered_start)
+        });
+
         let resident_cap = u64::from(batch_count.saturating_mul(HEADER_SYNC_MAX_RESIDENT_BATCHES));
         let available = resident_cap.saturating_sub(
             self.schedule
@@ -278,11 +288,6 @@ impl HeaderSyncCore {
             return;
         }
 
-        let mut batch_start = self
-            .schedule
-            .highest_end(RangePriority::AuthenticateRoots)
-            .unwrap_or(start)
-            .max(start);
         let mut added = 0u64;
         while batch_start < end && remaining >= 2 {
             let count = count_between(batch_start, end)
@@ -379,6 +384,12 @@ impl HeaderSyncCore {
             })
     }
 
+    fn root_auth_operation_pending_at(&self, start: block::Height) -> bool {
+        self.pending_operations
+            .values()
+            .any(|pending| pending.root_auth.is_some() && pending.range.start_height() == start)
+    }
+
     pub(super) fn admit_retained_root_payload(
         &mut self,
         wire_request: HeaderSyncWireRequestIdentity,
@@ -470,6 +481,28 @@ impl HeaderSyncCore {
     pub(super) fn clear_retained_roots(&mut self, reason: &'static str) {
         let dropped = self.retained_roots.len();
         self.retained_roots.clear();
+        if dropped > 0 {
+            metrics::counter!(
+                "sync.header.root_auth.retain.dropped",
+                "reason" => reason
+            )
+            .increment(dropped as u64);
+        }
+    }
+
+    pub(super) fn clear_unowned_retained_roots(&mut self, reason: &'static str) {
+        let owned_starts: HashSet<_> = self
+            .pending_operations
+            .values()
+            .filter_map(|pending| match pending.root_auth.map(|auth| auth.source) {
+                Some(RootAuthSource::Retained(start)) => Some(start),
+                Some(RootAuthSource::Fallback) | None => None,
+            })
+            .collect();
+        let before = self.retained_roots.len();
+        self.retained_roots
+            .retain(|start, _| owned_starts.contains(start));
+        let dropped = before.saturating_sub(self.retained_roots.len());
         if dropped > 0 {
             metrics::counter!(
                 "sync.header.root_auth.retain.dropped",

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -656,7 +656,7 @@ fn root_auth_miss_prefetches_bounded_overlapping_ranges() {
 }
 
 #[test]
-fn root_auth_frontier_advance_refills_released_fallback_capacity() {
+fn partial_root_auth_frontier_advance_rebases_fallback_at_exact_frontier() {
     let network = Network::Mainnet;
     let anchor = (block::Height(0), network.genesis_hash());
     let mut startup = startup_for(
@@ -691,10 +691,6 @@ fn root_auth_frontier_advance_refills_released_fallback_capacity() {
     };
     state.header_root_auth = Some(advanced);
     state.prune_root_auth_pipeline(advanced, true);
-    let pruned_resident = state
-        .schedule
-        .resident_heights_for(RangePriority::AuthenticateRoots);
-    assert!(pruned_resident < initial_resident);
 
     state.refresh_root_auth_range(&startup);
     assert_eq!(
@@ -709,6 +705,21 @@ fn root_auth_frontier_advance_refills_released_fallback_capacity() {
             .highest_end(RangePriority::AuthenticateRoots)
             .expect("refilled fallback window has a high end")
             > initial_end
+    );
+    let first = state
+        .schedule
+        .authenticate_roots
+        .front()
+        .expect("fallback is rebuilt from the new authentication frontier");
+    assert_eq!(first.start_height(), block::Height(4));
+    assert_eq!(first.anchor_hash, Some(advanced.authenticated_hash));
+    assert!(
+        !state
+            .schedule
+            .authenticate_roots
+            .iter()
+            .any(|range| range.start_height() == block::Height(5)),
+        "speculative ranges above the old partial-advance gap must be discarded"
     );
 }
 
@@ -3185,6 +3196,60 @@ async fn local_root_auth_failure_retries_retained_payload_without_scoring() {
                     },
                 ..
             } => panic!("retained local failure must not immediately fall back to the network"),
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn durable_reanchor_preserves_inflight_retained_root_authentication() {
+    let (mut fixture, operation, _auth, source_peer) =
+        reactor_with_pending_retained_root_authentication(None).await;
+    let durable_tip = (
+        block::Height(3),
+        block::Hash::from(mainnet_header(&BLOCK_MAINNET_3_BYTES).as_ref()),
+    );
+
+    // The retained authentication was dispatched after committing the first
+    // forward range, which advanced the frontier generation from zero to one.
+    fixture
+        .handle
+        .send(HeaderSyncEvent::BestHeaderTipLoaded {
+            tip_height: durable_tip.0,
+            tip_hash: durable_tip.1,
+            reanchor_from: Some(1),
+        })
+        .await
+        .unwrap();
+    fixture
+        .handle
+        .send(HeaderSyncEvent::HeaderRootAuthenticationFailed {
+            operation,
+            kind: HeaderRootAuthenticationFailureKind::Local,
+        })
+        .await
+        .unwrap();
+
+    loop {
+        match next_non_query_action(&mut fixture.actions).await {
+            HeaderSyncAction::AuthenticateHeaderRoots { operation, .. } => {
+                assert_eq!(operation.wire_request.peer, source_peer);
+                break;
+            }
+            HeaderSyncAction::SendMessage {
+                msg:
+                    HeaderSyncMessage::GetHeaders {
+                        start_height: block::Height(1),
+                        want_tree_aux_roots: true,
+                        ..
+                    },
+                ..
+            } => {
+                panic!("reanchor scheduled duplicate fallback over in-flight retained auth")
+            }
+            HeaderSyncAction::Misbehavior { .. } => {
+                panic!("local retained authentication failure must not score a peer")
+            }
             _ => {}
         }
     }

--- a/zakura-network/src/zakura/header_sync/tests.rs
+++ b/zakura-network/src/zakura/header_sync/tests.rs
@@ -19,9 +19,10 @@ use crate::zakura::{
     framed_channel,
     testkit::{TraceCapture, TraceValue},
     trace::{header_sync_trace as hs_trace, HEADER_SYNC_TABLE},
-    FramedSend, HeaderSyncServiceSummary, OrderedSessionDemand, Peer, Service,
-    ServicePeerDirection, ServicePeerLimits, ServicePeerSnapshot, ZakuraConnId,
-    ZakuraHeaderSyncCandidateState, ZAKURA_CAP_HEADER_SYNC,
+    ChainFrontier, FramedSend, Frontier, FrontierChange, FrontierUpdate, HeaderSyncServiceSummary,
+    OrderedSessionDemand, Peer, Service, ServicePeerDirection, ServicePeerLimits,
+    ServicePeerSnapshot, ZakuraConnId, ZakuraHeaderSyncCandidateState, ZakuraSyncExchange,
+    ZAKURA_CAP_HEADER_SYNC,
 };
 use chrono::Duration;
 use metrics::{
@@ -9845,6 +9846,150 @@ async fn forward_link_wedge_reloads_the_durable_tip_without_banning() {
         }
     }
     panic!("after re-anchor, header sync did not emit the reanchor action and request forward from the verified tip");
+}
+
+/// Drain reactor actions until the reactor stays quiet for `quiet` milliseconds,
+/// returning everything it emitted.
+async fn drain_actions_while_busy(
+    actions: &mut mpsc::Receiver<HeaderSyncAction>,
+    quiet: u64,
+) -> Vec<HeaderSyncAction> {
+    let mut drained = Vec::new();
+    while let Ok(Some(action)) =
+        tokio::time::timeout(std::time::Duration::from_millis(quiet), actions.recv()).await
+    {
+        drained.push(action);
+    }
+    drained
+}
+
+/// A durable reanchor that resolves to the anchor header sync already holds must
+/// leave forward work alone.
+///
+/// Continuous sync livelocked here: every verified-body reset queried the durable
+/// header tip, state answered with the unchanged tip, and the reanchor cancelled
+/// every outstanding forward range before any of them could commit. Over one
+/// 53-second window that cost 1,609 `GetHeaders` and zero committed ranges.
+#[tokio::test(flavor = "current_thread")]
+async fn no_op_durable_reanchor_keeps_outstanding_forward_work() {
+    let headers = [
+        mainnet_header(&BLOCK_MAINNET_1_BYTES),
+        mainnet_header(&BLOCK_MAINNET_2_BYTES),
+        mainnet_header(&BLOCK_MAINNET_3_BYTES),
+    ];
+    let anchor = (block::Height(0), Network::Mainnet.genesis_hash());
+    let committed = (block::Height(3), block::Hash::from(headers[2].as_ref()));
+    let (network, _) = checkpoint_testnet_with_hash(committed.0, committed.1);
+    let mut fixture = spawn_test_reactor(startup_for(network, anchor, Some(anchor)));
+    let peer_id = peer(151);
+
+    connect_peer(&fixture, peer_id.clone()).await;
+    advertise_tip(&fixture, peer_id.clone(), anchor.0, committed.0, 3, 1).await;
+    let (_, request_id, start, count) = next_outbound_get_headers(&mut fixture.actions).await;
+    assert_eq!((start, count), (block::Height(1), 3));
+
+    // The durable header tip read answers with the anchor already in use.
+    fixture
+        .handle
+        .send(HeaderSyncEvent::BestHeaderTipLoaded {
+            tip_height: anchor.0,
+            tip_hash: anchor.1,
+            reanchor_from: Some(0),
+        })
+        .await
+        .unwrap();
+
+    // The peer answers the range that was already in flight when the reanchor ran.
+    send_headers(
+        &fixture,
+        &peer_id,
+        request_id,
+        finalized_headers_message(headers.to_vec()),
+    )
+    .await;
+
+    let mut requeued = false;
+    let mut committed_range = false;
+    for action in drain_actions_while_busy(&mut fixture.actions, 300).await {
+        match action {
+            HeaderSyncAction::CommitHeaderRange { .. } => committed_range = true,
+            HeaderSyncAction::SendMessage {
+                msg: HeaderSyncMessage::GetHeaders { start_height, .. },
+                ..
+            } if start_height == start => requeued = true,
+            _ => {}
+        }
+    }
+
+    assert!(
+        !requeued,
+        "a reanchor to the unchanged anchor re-requested a forward range that was already in flight"
+    );
+    assert!(
+        committed_range,
+        "a reanchor to the unchanged anchor discarded an in-flight forward range, so its response never committed"
+    );
+}
+
+/// A verified-body reset that moves nothing must not ask for a durable reanchor.
+///
+/// The state emits `TipAction::Reset` far more often than the verified tip
+/// actually moves; 191 of the 213 resets in the failing run changed no frontier
+/// at all. Each one still drove a full durable-tip query.
+#[tokio::test(flavor = "current_thread")]
+async fn unchanged_verified_reset_does_not_query_a_durable_reanchor() {
+    let network = regtest_network();
+    let anchor = (block::Height(0), network.genesis_hash());
+    let frontier = ChainFrontier {
+        finalized: Frontier::new(anchor.0, anchor.1),
+        verified_body: Frontier::new(anchor.0, anchor.1),
+        best_header: Frontier::new(anchor.0, anchor.1),
+    };
+    let exchange = ZakuraSyncExchange::new(
+        FrontierUpdate {
+            frontier,
+            change: FrontierChange::Snapshot,
+        },
+        ZakuraTrace::noop(),
+    );
+    let mut startup = startup_for(network, anchor, Some(anchor));
+    startup.frontier_updates = Some(exchange.subscribe_frontier());
+    let mut fixture = spawn_test_reactor(startup);
+
+    // Let the startup queries settle before measuring.
+    let _ = drain_actions_while_busy(&mut fixture.actions, 200).await;
+
+    // The chain-tip mirror republishes the same frontier on every state
+    // `TipAction::Reset`, which the state emits far more often than the verified
+    // tip actually moves.
+    for _ in 0..4 {
+        exchange.publish_frontier(
+            FrontierUpdate {
+                frontier,
+                change: FrontierChange::VerifiedReset,
+            },
+            "test_chain_tip_mirror",
+        );
+        tokio::task::yield_now().await;
+    }
+
+    let reanchor_queries = drain_actions_while_busy(&mut fixture.actions, 300)
+        .await
+        .into_iter()
+        .filter(|action| {
+            matches!(
+                action,
+                HeaderSyncAction::QueryBestHeaderTip {
+                    reanchor_from: Some(_)
+                }
+            )
+        })
+        .count();
+
+    assert_eq!(
+        reanchor_queries, 0,
+        "verified-body resets that moved nothing asked state to reanchor the header tip"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/zakura-network/src/zakura/header_sync/work_queue.rs
+++ b/zakura-network/src/zakura/header_sync/work_queue.rs
@@ -390,7 +390,75 @@ impl HeaderWorkQueue {
             .retain(|range, _| range.priority != RangePriority::AuthenticateRoots);
         self.delayed_retries
             .retain(|(_, priority), _| *priority != RangePriority::AuthenticateRoots);
+        self.retry_avoidance.retain(|_, ranges| {
+            ranges.retain(|(_, priority), _| *priority != RangePriority::AuthenticateRoots);
+            !ranges.is_empty()
+        });
         self.rebuild_start_indexes();
+    }
+
+    /// Keep only the root-authentication chain that starts at `start`.
+    ///
+    /// Each root-authentication range repeats its predecessor's terminal header
+    /// as a successor witness, so a usable speculative chain has each next
+    /// range start at the previous range's end. Ranges above a gap cannot
+    /// authenticate the current frontier and must not consume resident capacity.
+    pub(super) fn retain_contiguous_root_auth_from(
+        &mut self,
+        start: block::Height,
+    ) -> Option<block::Height> {
+        let mut kept_starts = HashSet::new();
+        let mut next_start = start;
+
+        loop {
+            let next_range = self
+                .authenticate_roots
+                .iter()
+                .chain(self.active.keys())
+                .find(|range| {
+                    range.priority == RangePriority::AuthenticateRoots
+                        && range.start_height() == next_start
+                })
+                .copied();
+            let Some(next_range) = next_range else {
+                break;
+            };
+            if !kept_starts.insert(next_start) {
+                break;
+            }
+            let next_end = next_range.end_height();
+            if next_end <= next_start {
+                break;
+            }
+            next_start = next_end;
+        }
+
+        self.authenticate_roots
+            .retain(|range| kept_starts.contains(&range.start_height()));
+        self.active.retain(|range, _| {
+            range.priority != RangePriority::AuthenticateRoots
+                || kept_starts.contains(&range.start_height())
+        });
+        self.delayed_retries.retain(|(height, priority), _| {
+            *priority != RangePriority::AuthenticateRoots || kept_starts.contains(height)
+        });
+        self.retry_avoidance.retain(|_, ranges| {
+            ranges.retain(|(height, priority), _| {
+                *priority != RangePriority::AuthenticateRoots || kept_starts.contains(height)
+            });
+            !ranges.is_empty()
+        });
+        self.rebuild_start_indexes();
+
+        (!kept_starts.is_empty()).then_some(next_start)
+    }
+
+    pub(super) fn has_root_auth_start(&self, start: block::Height) -> bool {
+        self.pending_starts
+            .contains(&(RangePriority::AuthenticateRoots, start))
+            || self
+                .active_starts
+                .contains(&(RangePriority::AuthenticateRoots, start))
     }
 
     /// Drop pending/active root-auth ranges whose start is strictly below `start`.
@@ -817,6 +885,36 @@ mod tests {
             queue.authenticate_roots.iter().copied().collect::<Vec<_>>(),
             vec![next, future]
         );
+    }
+
+    #[test]
+    fn root_auth_contiguity_prunes_ranges_above_a_frontier_gap() {
+        let mut queue = HeaderWorkQueue::new();
+        let first = range(1, 3, RangePriority::AuthenticateRoots);
+        let next = range(3, 3, RangePriority::AuthenticateRoots);
+        let orphan = range(8, 3, RangePriority::AuthenticateRoots);
+        let forward = range(1, 3, RangePriority::Forward);
+        queue.ensure(first, RangePriority::AuthenticateRoots);
+        queue.ensure(next, RangePriority::AuthenticateRoots);
+        queue.ensure(orphan, RangePriority::AuthenticateRoots);
+        queue.ensure_forward(forward);
+
+        assert_eq!(
+            queue.retain_contiguous_root_auth_from(block::Height(1)),
+            Some(block::Height(5))
+        );
+        assert_eq!(
+            queue.authenticate_roots.iter().copied().collect::<Vec<_>>(),
+            vec![first, next]
+        );
+        assert!(queue.forward.contains(&forward));
+
+        assert_eq!(
+            queue.retain_contiguous_root_auth_from(block::Height(2)),
+            None
+        );
+        assert!(queue.authenticate_roots.is_empty());
+        assert!(queue.forward.contains(&forward));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

A continuous-sync node stalled at height 111,273 after a durable reanchor raced an in-flight retained VCT-root authentication.

The failure had two coupled parts:

1. #427 queried the durable header tip for every `VerifiedReset`. Most resets moved no frontier, but `reanchor_to_durable_header_tip` still cleared forward work and retained roots. In one 53.6-second window, 1,609 `GetHeaders` requests produced zero committed ranges.
2. One destructive reanchor cleared a retained payload while its cloned authentication action remained in flight. Header sync then scheduled fallback ranges from the old frontier. When the retained authentication completed, it advanced into the middle of that speculative window. `refresh_root_auth_range` resumed from the global highest scheduled end, so no range ever began at the exact new frontier and root authentication stopped permanently.

The frozen authenticated height then pinned the body target immediately below a checkpoint, leaving downloaded bodies unverifiable.

## Solution

This PR makes both the reanchor trigger and the root-authentication pipeline idempotent and self-healing.

- Return early when a durable reanchor resolves to the exact `(height, hash)` already in use.
- Ignore a `VerifiedReset` that leaves every published frontier unchanged, while preserving genuine same-height reorgs.
- During a genuine reanchor, retain payloads owned by pending root-authentication operations. Also treat an exact-frontier pending operation as coverage, so clearing an auxiliary cache cannot schedule a duplicate fallback request.
- Normalize fallback work to the contiguous range chain reachable from `authenticated_height + 1`. Orphan ranges above a gap are discarded before resident-cap and append calculations, and fallback is rebuilt from the exact authenticated frontier.

Normal speculative prefetch remains intact when its next range starts exactly at the new frontier.

## Testing

The regressions reproduce both production failure components:

- `no_op_durable_reanchor_keeps_outstanding_forward_work` verifies an unchanged durable read does not cancel an in-flight forward range.
- `unchanged_verified_reset_does_not_query_a_durable_reanchor` verifies unchanged resets do not trigger durable reads.
- `durable_reanchor_preserves_inflight_retained_root_authentication` dispatches retained authentication, performs a genuine reanchor, and verifies the pending payload remains owned and retryable without duplicate fallback.
- `partial_root_auth_frontier_advance_rebases_fallback_at_exact_frontier` advances authentication into the interior of a speculative batch and verifies fallback restarts at the exact next height.
- `root_auth_contiguity_prunes_ranges_above_a_frontier_gap` verifies orphan root-auth ranges are removed without disturbing forward work.

Verification completed:

- `cargo test -p zakura-network --lib` — 1,150 passed, 4 intentionally ignored.
- `cargo test -p zakura-network root_auth --lib` — 30 passed.
- `cargo clippy -p zakura-network --all-targets -- -D warnings`.
- `cargo fmt --all -- --check`.
- `./scripts/changelog.py check`.
- `markdownlint changelog-unreleased/438.md`.

## Changelog

Updated `changelog-unreleased/438.md` to cover both forward livelock and root-authentication progress.

## Follow-up Work

The checkpoint-aware body-target policy remains a separate resilience improvement. Root-authentication progress is restored by this PR, so the observed body/checkpoint deadlock no longer depends on that escape path.

Targets #435 because that branch is where this investigation started; retarget to `main` if #435 merges first.