### PR TITLE
ci: share droplet provisioning and extract the perf-bench compare script

### DIFF
--- a/.github/actions/do-cli/action.yml
+++ b/.github/actions/do-cli/action.yml
@@ -1,22 +1,14 @@
 name: "DigitalOcean CLI"
-description: "Install and authenticate doctl, and optionally write the fleet SSH key."
+description: "Install and authenticate doctl, and optionally write the fleet SSH key to /tmp/do_ssh."
 
 inputs:
   token:
     description: "DigitalOcean API token (secrets.DIGITALOCEAN_ACCESS_TOKEN)"
     required: true
   ssh_private_key:
-    description: "Optional SSH private key to write (secrets.DO_SSH_PRIVATE_KEY). Omit for API-only jobs like the reaper."
+    description: "Optional SSH private key (secrets.DO_SSH_PRIVATE_KEY). Omit for API-only jobs like the reaper."
     required: false
     default: ""
-  ssh_key_path:
-    description: "Where to write the SSH private key. Calling workflows hardcode /tmp/do_ssh in their own scp/ssh steps, so overriding this means overriding do-wait-ssh and those steps too."
-    required: false
-    default: "/tmp/do_ssh"
-  version:
-    description: "doctl release to install"
-    required: false
-    default: "1.120.0"
 
 runs:
   using: composite
@@ -28,20 +20,21 @@ runs:
       shell: bash
       env:
         DIGITALOCEAN_ACCESS_TOKEN: ${{ inputs.token }}
-        DOCTL_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
+        DOCTL_VERSION=1.120.0
         curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
         sudo install /tmp/doctl /usr/local/bin/doctl
         doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
 
+    # /tmp/do_ssh is hardcoded here and in do-wait-ssh because every calling
+    # workflow's own scp/ssh steps use that path too.
     - name: Write SSH key
       if: inputs.ssh_private_key != ''
       shell: bash
       env:
         DO_SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
-        SSH_KEY_PATH: ${{ inputs.ssh_key_path }}
       run: |
         set -euo pipefail
-        install -m 600 /dev/null "${SSH_KEY_PATH}"
-        printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > "${SSH_KEY_PATH}"
+        install -m 600 /dev/null /tmp/do_ssh
+        printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh

--- a/.github/actions/do-cli/action.yml
+++ b/.github/actions/do-cli/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ""
   ssh_key_path:
-    description: "Where to write the SSH private key"
+    description: "Where to write the SSH private key. Calling workflows hardcode /tmp/do_ssh in their own scp/ssh steps, so overriding this means overriding do-wait-ssh and those steps too."
     required: false
     default: "/tmp/do_ssh"
   version:

--- a/.github/actions/do-cli/action.yml
+++ b/.github/actions/do-cli/action.yml
@@ -1,0 +1,47 @@
+name: "DigitalOcean CLI"
+description: "Install and authenticate doctl, and optionally write the fleet SSH key."
+
+inputs:
+  token:
+    description: "DigitalOcean API token (secrets.DIGITALOCEAN_ACCESS_TOKEN)"
+    required: true
+  ssh_private_key:
+    description: "Optional SSH private key to write (secrets.DO_SSH_PRIVATE_KEY). Omit for API-only jobs like the reaper."
+    required: false
+    default: ""
+  ssh_key_path:
+    description: "Where to write the SSH private key"
+    required: false
+    default: "/tmp/do_ssh"
+  version:
+    description: "doctl release to install"
+    required: false
+    default: "1.120.0"
+
+runs:
+  using: composite
+  steps:
+    # `doctl auth init` persists the token to the runner's doctl config, so
+    # later steps in the calling job get an authenticated doctl without
+    # re-exporting the secret into their own environment.
+    - name: Install doctl
+      shell: bash
+      env:
+        DIGITALOCEAN_ACCESS_TOKEN: ${{ inputs.token }}
+        DOCTL_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
+        sudo install /tmp/doctl /usr/local/bin/doctl
+        doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
+
+    - name: Write SSH key
+      if: inputs.ssh_private_key != ''
+      shell: bash
+      env:
+        DO_SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
+        SSH_KEY_PATH: ${{ inputs.ssh_key_path }}
+      run: |
+        set -euo pipefail
+        install -m 600 /dev/null "${SSH_KEY_PATH}"
+        printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > "${SSH_KEY_PATH}"

--- a/.github/actions/do-droplet/action.yml
+++ b/.github/actions/do-droplet/action.yml
@@ -105,7 +105,6 @@ runs:
       run: |
         set -euo pipefail
         VOLUME_ARGS=()
-        VOLUME_ID=""
         if [ -n "${VOL_SNAP_ID}" ]; then
           # A snapshot restore cannot shrink, so the clone takes the snapshot's
           # own minimum disk size.
@@ -114,6 +113,13 @@ runs:
             --region "${REGION}" --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
             --format ID --no-header)
           VOLUME_ARGS=(--volumes "${VOLUME_ID}")
+          # Publish the volume before creating the droplet: a droplet create
+          # that fails (no capacity, size smaller than the image disk) would
+          # otherwise strand a volume the caller's teardown never learns about.
+          {
+            echo "volume_id=${VOLUME_ID}"
+            echo "volume_name=${VOLUME_NAME}"
+          } >> "$GITHUB_OUTPUT"
         fi
         doctl compute droplet create "${NAME}" \
           --region "${REGION}" \
@@ -126,6 +132,4 @@ runs:
         {
           echo "id=$(awk '{print $1}' /tmp/droplet.txt)"
           echo "ip=$(awk '{print $2}' /tmp/droplet.txt)"
-          echo "volume_id=${VOLUME_ID}"
-          echo "volume_name=${VOLUME_ID:+${VOLUME_NAME}}"
         } >> "$GITHUB_OUTPUT"

--- a/.github/actions/do-droplet/action.yml
+++ b/.github/actions/do-droplet/action.yml
@@ -1,0 +1,131 @@
+name: "Create a baked-image droplet"
+description: >-
+  Resolve the newest baked PR-node image (and optionally a chain-state volume
+  snapshot), then create a tagged droplet from them.
+
+inputs:
+  name:
+    description: "Droplet name"
+    required: true
+  size:
+    description: "Droplet size slug (disk must be >= the baked image's disk)"
+    required: true
+  ssh_fingerprint:
+    description: "DigitalOcean SSH key fingerprint (vars.DO_SSH_KEY_FINGERPRINT)"
+    required: true
+  tag:
+    description: "Droplet tag. Must be one the reaper sweeps, and is applied at creation so a later failure cannot leak an untagged droplet."
+    required: true
+  region:
+    description: "DigitalOcean region"
+    required: false
+    default: "nyc3"
+  image:
+    description: "Image ID or slug. Empty resolves the newest zakura-pr-node-* bake."
+    required: false
+    default: ""
+  state_network:
+    description: "Attach a clone of the newest zakura-pr-state-<network>-* snapshot (mainnet/testnet). Empty starts with no state volume."
+    required: false
+    default: ""
+  volume_name:
+    description: "Name for the cloned state volume. Required with state_network, and must start with zakura-pr- so the reaper sweeps it if it leaks."
+    required: false
+    default: ""
+
+outputs:
+  id:
+    description: "Droplet ID"
+    value: ${{ steps.create.outputs.id }}
+  ip:
+    description: "Droplet public IPv4"
+    value: ${{ steps.create.outputs.ip }}
+  image_id:
+    description: "Image the droplet was created from"
+    value: ${{ steps.image.outputs.image_id }}
+  volume_id:
+    description: "Cloned state volume ID, empty when state_network is unset"
+    value: ${{ steps.create.outputs.volume_id }}
+  volume_name:
+    description: "Cloned state volume name, empty when state_network is unset"
+    value: ${{ steps.create.outputs.volume_name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve baked image and state snapshot
+      id: image
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        STATE_NETWORK: ${{ inputs.state_network }}
+        VOLUME_NAME: ${{ inputs.volume_name }}
+      run: |
+        set -euo pipefail
+        if [ -z "${IMAGE}" ]; then
+          # Names are timestamped, so the lexical max is the newest bake.
+          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
+            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
+          if [ -z "${IMAGE}" ]; then
+            echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
+            exit 1
+          fi
+        fi
+        echo "image_id=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+        if [ -z "${STATE_NETWORK}" ]; then
+          echo "vol_snap_id=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ -z "${VOLUME_NAME}" ]; then
+          echo "volume_name is required when state_network is set" >&2
+          exit 1
+        fi
+        SNAP=$(doctl compute snapshot list --resource volume --format ID,Name --no-header | \
+          awk -v pre="zakura-pr-state-${STATE_NETWORK}-" 'index($2, pre) == 1 {print $2, $1}' | \
+          sort | tail -1 | awk '{print $2}')
+        if [ -z "${SNAP}" ]; then
+          echo "no zakura-pr-state-${STATE_NETWORK}-* volume snapshot found; run the bake workflow first" >&2
+          exit 1
+        fi
+        echo "vol_snap_id=${SNAP}" >> "$GITHUB_OUTPUT"
+
+    - name: Create droplet
+      id: create
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+        REGION: ${{ inputs.region }}
+        DROPLET_SIZE: ${{ inputs.size }}
+        SSH_FINGERPRINT: ${{ inputs.ssh_fingerprint }}
+        TAG: ${{ inputs.tag }}
+        IMAGE_ID: ${{ steps.image.outputs.image_id }}
+        VOL_SNAP_ID: ${{ steps.image.outputs.vol_snap_id }}
+        VOLUME_NAME: ${{ inputs.volume_name }}
+      run: |
+        set -euo pipefail
+        VOLUME_ARGS=()
+        VOLUME_ID=""
+        if [ -n "${VOL_SNAP_ID}" ]; then
+          # A snapshot restore cannot shrink, so the clone takes the snapshot's
+          # own minimum disk size.
+          SIZE=$(doctl compute snapshot get "${VOL_SNAP_ID}" --format MinDiskSize --no-header)
+          VOLUME_ID=$(doctl compute volume create "${VOLUME_NAME}" \
+            --region "${REGION}" --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
+            --format ID --no-header)
+          VOLUME_ARGS=(--volumes "${VOLUME_ID}")
+        fi
+        doctl compute droplet create "${NAME}" \
+          --region "${REGION}" \
+          --size "${DROPLET_SIZE}" \
+          --image "${IMAGE_ID}" \
+          --ssh-keys "${SSH_FINGERPRINT}" \
+          "${VOLUME_ARGS[@]}" \
+          --tag-name "${TAG}" \
+          --wait --format ID,PublicIPv4 --no-header > /tmp/droplet.txt
+        {
+          echo "id=$(awk '{print $1}' /tmp/droplet.txt)"
+          echo "ip=$(awk '{print $2}' /tmp/droplet.txt)"
+          echo "volume_id=${VOLUME_ID}"
+          echo "volume_name=${VOLUME_ID:+${VOLUME_NAME}}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/do-droplet/action.yml
+++ b/.github/actions/do-droplet/action.yml
@@ -16,14 +16,6 @@ inputs:
   tag:
     description: "Droplet tag. Must be one the reaper sweeps, and is applied at creation so a later failure cannot leak an untagged droplet."
     required: true
-  region:
-    description: "DigitalOcean region"
-    required: false
-    default: "nyc3"
-  image:
-    description: "Image ID or slug. Empty resolves the newest zakura-pr-node-* bake."
-    required: false
-    default: ""
   state_network:
     description: "Attach a clone of the newest zakura-pr-state-<network>-* snapshot (mainnet/testnet). Empty starts with no state volume."
     required: false
@@ -57,19 +49,16 @@ runs:
       id: image
       shell: bash
       env:
-        IMAGE: ${{ inputs.image }}
         STATE_NETWORK: ${{ inputs.state_network }}
         VOLUME_NAME: ${{ inputs.volume_name }}
       run: |
         set -euo pipefail
+        # Image names are timestamped, so the lexical max is the newest bake.
+        IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
+          awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
         if [ -z "${IMAGE}" ]; then
-          # Names are timestamped, so the lexical max is the newest bake.
-          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
-            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
-          if [ -z "${IMAGE}" ]; then
-            echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
-            exit 1
-          fi
+          echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
+          exit 1
         fi
         echo "image_id=${IMAGE}" >> "$GITHUB_OUTPUT"
 
@@ -95,7 +84,6 @@ runs:
       shell: bash
       env:
         NAME: ${{ inputs.name }}
-        REGION: ${{ inputs.region }}
         DROPLET_SIZE: ${{ inputs.size }}
         SSH_FINGERPRINT: ${{ inputs.ssh_fingerprint }}
         TAG: ${{ inputs.tag }}
@@ -104,13 +92,15 @@ runs:
         VOLUME_NAME: ${{ inputs.volume_name }}
       run: |
         set -euo pipefail
+        # nyc3 throughout: it must match the region the bake ran in, since the
+        # image and volume snapshots only exist there.
         VOLUME_ARGS=()
         if [ -n "${VOL_SNAP_ID}" ]; then
           # A snapshot restore cannot shrink, so the clone takes the snapshot's
           # own minimum disk size.
           SIZE=$(doctl compute snapshot get "${VOL_SNAP_ID}" --format MinDiskSize --no-header)
           VOLUME_ID=$(doctl compute volume create "${VOLUME_NAME}" \
-            --region "${REGION}" --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
+            --region nyc3 --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
             --format ID --no-header)
           VOLUME_ARGS=(--volumes "${VOLUME_ID}")
           # Publish the volume before creating the droplet: a droplet create
@@ -122,7 +112,7 @@ runs:
           } >> "$GITHUB_OUTPUT"
         fi
         doctl compute droplet create "${NAME}" \
-          --region "${REGION}" \
+          --region nyc3 \
           --size "${DROPLET_SIZE}" \
           --image "${IMAGE_ID}" \
           --ssh-keys "${SSH_FINGERPRINT}" \

--- a/.github/actions/do-teardown/action.yml
+++ b/.github/actions/do-teardown/action.yml
@@ -1,0 +1,49 @@
+name: "Tear down a droplet"
+description: >-
+  Best-effort delete of a droplet and any volumes it used. Never fails the job:
+  whatever survives is swept by the hourly reaper.
+
+inputs:
+  droplet_id:
+    description: "Droplet to delete. Empty is a no-op (creation never got that far)."
+    required: false
+    default: ""
+  volume_ids:
+    description: "Whitespace-separated volume IDs to delete after the droplet"
+    required: false
+    default: ""
+  enabled:
+    description: "Anything other than 'true' keeps the resources for inspection and prints why"
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Teardown
+      shell: bash
+      env:
+        DROPLET_ID: ${{ inputs.droplet_id }}
+        VOLUME_IDS: ${{ inputs.volume_ids }}
+        ENABLED: ${{ inputs.enabled }}
+      run: |
+        set +e
+        if [ "${ENABLED}" != "true" ]; then
+          echo "Teardown skipped; the reaper deletes these resources within 24h of creation."
+          exit 0
+        fi
+        if [ -n "${DROPLET_ID}" ]; then
+          for _ in 1 2 3; do
+            doctl compute droplet delete "${DROPLET_ID}" -f && break
+            sleep 5
+          done
+        fi
+        # Volumes detach asynchronously after the droplet delete, so the first
+        # few attempts are expected to fail while the detach settles.
+        for VOL_ID in ${VOLUME_IDS}; do
+          for _ in $(seq 1 12); do
+            doctl compute volume delete "${VOL_ID}" -f && break
+            sleep 10
+          done
+        done
+        true

--- a/.github/actions/do-teardown/action.yml
+++ b/.github/actions/do-teardown/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         set +e
         if [ "${ENABLED}" != "true" ]; then
-          echo "Teardown skipped; the reaper deletes these resources within 24h of creation."
+          echo "Teardown skipped; droplet ${DROPLET_ID:-none} and volumes ${VOLUME_IDS:-none} kept for inspection (the reaper deletes them within 24h of creation)."
           exit 0
         fi
         if [ -n "${DROPLET_ID}" ]; then
@@ -41,9 +41,12 @@ runs:
         # Volumes detach asynchronously after the droplet delete, so the first
         # few attempts are expected to fail while the detach settles.
         for VOL_ID in ${VOLUME_IDS}; do
+          DELETED=""
           for _ in $(seq 1 12); do
-            doctl compute volume delete "${VOL_ID}" -f && break
+            doctl compute volume delete "${VOL_ID}" -f && { DELETED=1; break; }
             sleep 10
           done
+          # Say so explicitly: this line is what a leak audit greps for.
+          [ -n "${DELETED}" ] || echo "volume ${VOL_ID} still attached; the reaper will remove it" >&2
         done
         true

--- a/.github/actions/do-wait-ssh/action.yml
+++ b/.github/actions/do-wait-ssh/action.yml
@@ -1,22 +1,10 @@
 name: "Wait for droplet SSH"
-description: "Poll a freshly created droplet until it accepts SSH, or fail."
+description: "Poll a freshly created droplet for up to 5 minutes until it accepts SSH, or fail."
 
 inputs:
   ip:
     description: "Droplet public IPv4"
     required: true
-  ssh_key_path:
-    description: "SSH private key written by the do-cli action"
-    required: false
-    default: "/tmp/do_ssh"
-  attempts:
-    description: "Number of connection attempts"
-    required: false
-    default: "30"
-  delay:
-    description: "Seconds between attempts"
-    required: false
-    default: "10"
 
 runs:
   using: composite
@@ -25,16 +13,13 @@ runs:
       shell: bash
       env:
         IP: ${{ inputs.ip }}
-        SSH_KEY_PATH: ${{ inputs.ssh_key_path }}
-        ATTEMPTS: ${{ inputs.attempts }}
-        DELAY: ${{ inputs.delay }}
       run: |
         set -euo pipefail
-        for _ in $(seq 1 "${ATTEMPTS}"); do
+        for _ in $(seq 1 30); do
           if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-               -o ConnectTimeout=5 -i "${SSH_KEY_PATH}" "root@${IP}" true 2>/dev/null; then
+               -o ConnectTimeout=5 -i /tmp/do_ssh "root@${IP}" true 2>/dev/null; then
             echo "SSH up"; exit 0
           fi
-          sleep "${DELAY}"
+          sleep 10
         done
         echo "SSH did not come up in time"; exit 1

--- a/.github/actions/do-wait-ssh/action.yml
+++ b/.github/actions/do-wait-ssh/action.yml
@@ -1,0 +1,40 @@
+name: "Wait for droplet SSH"
+description: "Poll a freshly created droplet until it accepts SSH, or fail."
+
+inputs:
+  ip:
+    description: "Droplet public IPv4"
+    required: true
+  ssh_key_path:
+    description: "SSH private key written by the do-cli action"
+    required: false
+    default: "/tmp/do_ssh"
+  attempts:
+    description: "Number of connection attempts"
+    required: false
+    default: "30"
+  delay:
+    description: "Seconds between attempts"
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for SSH
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        SSH_KEY_PATH: ${{ inputs.ssh_key_path }}
+        ATTEMPTS: ${{ inputs.attempts }}
+        DELAY: ${{ inputs.delay }}
+      run: |
+        set -euo pipefail
+        for _ in $(seq 1 "${ATTEMPTS}"); do
+          if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+               -o ConnectTimeout=5 -i "${SSH_KEY_PATH}" "root@${IP}" true 2>/dev/null; then
+            echo "SSH up"; exit 0
+          fi
+          sleep "${DELAY}"
+        done
+        echo "SSH did not come up in time"; exit 1

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,7 +58,16 @@ Deploys are manual, SSH-based, and run from self-hosted deployer runners; there 
 - **`checkpoint-sync-bench.yml`** — manual fixed-height sync benchmark with checkpoint or semantic verification on the `zakura-bench` self-hosted runner, with a persistent metrics dashboard. See the workflow header for one-time runner setup.
 - **`zakura-perf-bench.yml`** — CPU profiles mainnet workloads on ephemeral droplets. Historical mode restores `sandblast` state for fixed-height throughput and optional parallel A/B; live-head mode uses the production default P2P stack, catches up from the baked pruned tip, and requires head health throughout one observational profile window. Both produce flamegraphs, CPU counters, metrics, available traces, and block-latency digests (see `docs/cpu-profiling.md`).
 
-These workflows use the helper scripts in `.github/workflows/scripts/` (`pr-node-bake.sh`, `pr-node-run.sh`, `pr-node-monitor.py`).
+These workflows use the helper scripts in `.github/workflows/scripts/` (`pr-node-bake.sh`, `pr-node-run.sh`, `pr-node-monitor.py`, `perf-bench-run.sh`, `perf-bench-compare.py`).
+
+Droplet lifecycle is shared, not copy-pasted, through the composite actions in `.github/actions/`:
+
+- **`do-cli`** — installs the pinned `doctl`, authenticates it for the rest of the job, and optionally writes the fleet SSH key to `/tmp/do_ssh`.
+- **`do-droplet`** — resolves the newest `zakura-pr-node-*` baked image (and optionally clones the newest `zakura-pr-state-<network>-*` volume snapshot), then creates the tagged droplet. Outputs `id`, `ip`, `image_id`, `volume_id`, `volume_name`.
+- **`do-wait-ssh`** — polls a new droplet until it accepts SSH. Give the step an `id` if teardown needs to distinguish "unreachable" from "ran".
+- **`do-teardown`** — best-effort delete of a droplet and its volumes, retrying the volumes while the detach settles. Never fails a job; `enabled: false` keeps the resources and says so.
+
+`zakura-pr-node-bake.yml` uses `do-cli`/`do-wait-ssh`/`do-teardown` but creates its droplet inline: it starts from a stock Ubuntu image (it is what produces the baked one) and attaches two blank volumes it later snapshots per network.
 
 ## Fork maintenance
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ on:
       - supply-chain/**
       - "scripts/**.sh"
       - ".github/workflows/scripts/**"
+      - ".github/actions/**"
       # ci-python-tests covers these suites, so changes to them must trigger it.
       - "deploy/**"
       - ".github/scripts/**"
@@ -29,6 +30,7 @@ on:
       - supply-chain/**
       - "scripts/**.sh"
       - ".github/workflows/scripts/**"
+      - ".github/actions/**"
       # ci-python-tests covers these suites, so changes to them must trigger it.
       - "deploy/**"
       - ".github/scripts/**"
@@ -176,6 +178,10 @@ jobs:
       - name: Mempool load harness tests
         if: ${{ !cancelled() }}
         run: python3 .github/workflows/scripts/test_mempool_load.py
+
+      - name: Perf-bench compare tests
+        if: ${{ !cancelled() }}
+        run: python3 .github/workflows/scripts/test_perf_bench_compare.py
 
       - name: Affected semver package tests
         if: ${{ !cancelled() }}

--- a/.github/workflows/scripts/perf-bench-compare.py
+++ b/.github/workflows/scripts/perf-bench-compare.py
@@ -18,11 +18,20 @@ import sys
 
 
 def load_meta(path: str) -> dict | None:
-    """Return a leg's meta.json, or None when the leg produced none."""
+    """Return a leg's meta.json, or None when there is no usable one.
+
+    The producer tolerates a failed meta write (perf-bench-run.sh logs a
+    warning and carries on), and json.dump truncates before it writes, so an
+    empty or half-written file is a real outcome -- treat it like an absent
+    one instead of failing the compare job with a traceback.
+    """
     try:
         with open(path, encoding="utf-8") as meta_file:
             return json.load(meta_file)
     except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as err:
+        print(f"{path}: unusable meta.json ({err})", file=sys.stderr)
         return None
 
 
@@ -39,7 +48,8 @@ def render(primary: dict | None, baseline: dict | None) -> tuple[str, bool]:
     if failed:
         return f"No comparison: zakurad failed in {', '.join(failed)}.", False
 
-    # A zero-throughput baseline is a broken run, not a division to report.
+    # A zero-throughput baseline has no meaningful ratio; report it as nan
+    # rather than crashing, and let the blocks/s column show what happened.
     speedup = primary["bps"] / baseline["bps"] if baseline["bps"] else float("nan")
     lines = [
         "## A/B result",
@@ -67,12 +77,15 @@ def main(argv: list[str]) -> int:
         return 2
 
     markdown, comparable = render(load_meta(argv[1]), load_meta(argv[2]))
-    print(markdown)
 
+    # Flag first: if printing the summary fails, the caller must still see a
+    # decision rather than silently skipping the CPU diff.
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a", encoding="utf-8") as out:
             out.write(f"compare={'true' if comparable else 'false'}\n")
+
+    print(markdown)
     return 0
 
 

--- a/.github/workflows/scripts/perf-bench-compare.py
+++ b/.github/workflows/scripts/perf-bench-compare.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Render the A/B step summary for the perf bench workflow's two legs.
+
+Usage: perf-bench-compare.py PRIMARY_META BASELINE_META
+
+Both paths are the `meta.json` a leg leaves in its artifact. The markdown goes
+to stdout (the workflow appends it to the step summary); when GITHUB_OUTPUT is
+set, `compare=true|false` is written to it. `false` means the legs are not
+comparable -- one produced no meta.json, or zakurad exited non-zero on one of
+them -- and the caller must skip the CPU profile diff.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def load_meta(path: str) -> dict | None:
+    """Return a leg's meta.json, or None when the leg produced none."""
+    try:
+        with open(path, encoding="utf-8") as meta_file:
+            return json.load(meta_file)
+    except FileNotFoundError:
+        return None
+
+
+def failed_legs(metas) -> list[str]:
+    return [meta["leg"] for meta in metas if meta.get("node_exit_status", 0)]
+
+
+def render(primary: dict | None, baseline: dict | None) -> tuple[str, bool]:
+    """Return the summary markdown and whether the legs are comparable."""
+    if primary is None or baseline is None:
+        return "one or both legs produced no meta.json; nothing to compare", False
+
+    failed = failed_legs((primary, baseline))
+    if failed:
+        return f"No comparison: zakurad failed in {', '.join(failed)}.", False
+
+    # A zero-throughput baseline is a broken run, not a division to report.
+    speedup = primary["bps"] / baseline["bps"] if baseline["bps"] else float("nan")
+    lines = [
+        "## A/B result",
+        "",
+        "| leg | ref | blocks/s | post-commit blk/s | verdict |",
+        "|---|---|---:|---:|---|",
+    ]
+    for meta in (baseline, primary):
+        lines.append(
+            f"| {meta['leg']} | `{meta['sha'][:9]}` | {meta['bps']} "
+            f"| {meta['post_bps']} | {meta.get('verdict') or 'n/a'} |"
+        )
+    lines.append("")
+    lines.append(
+        f"**Speedup (primary vs baseline): {speedup:.2f}×** "
+        f"({baseline['bps']} → {primary['bps']} blocks/s, "
+        "both legs on identical parallel droplets)"
+    )
+    return "\n".join(lines), True
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} PRIMARY_META BASELINE_META", file=sys.stderr)
+        return 2
+
+    markdown, comparable = render(load_meta(argv[1]), load_meta(argv[2]))
+    print(markdown)
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as out:
+            out.write(f"compare={'true' if comparable else 'false'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/scripts/test_perf_bench_compare.py
+++ b/.github/workflows/scripts/test_perf_bench_compare.py
@@ -35,10 +35,17 @@ def load_module(name: str, path: Path):
 compare = load_module("perf_bench_compare", SCRIPTS / "perf-bench-compare.py")
 
 
+# Distinct 40-char hex shas, so a wrong truncation length is visible.
+SHAS = {
+    "primary": "1a2b3c4d5e6f7890abcdef1234567890abcdef12",
+    "baseline": "fedcba0987654321fedcba0987654321fedcba09",
+}
+
+
 def meta(leg: str, **overrides) -> dict:
     base = {
         "leg": leg,
-        "sha": f"{leg[0]}" * 40,
+        "sha": SHAS[leg],
         "bps": 100.0,
         "post_bps": 90.0,
         "verdict": "ok",
@@ -49,6 +56,33 @@ def meta(leg: str, **overrides) -> dict:
 
 
 class Render(unittest.TestCase):
+    def test_summary_matches_the_workflow_output_byte_for_byte(self):
+        """Golden output: this is the summary the removed YAML heredoc produced.
+
+        The point of extracting the script was to keep that summary identical,
+        so assert the whole string -- a changed column set, truncation length,
+        or number format is a regression, not a detail.
+        """
+        # verdict "" is what perf-bench-run.sh writes when it skips or fails
+        # classification, which is every live_head run.
+        markdown, comparable = compare.render(
+            meta("primary", bps=151.75, post_bps=88.5, verdict="faster"),
+            meta("baseline", bps=101.0, post_bps=70.25, verdict=""),
+        )
+        self.assertTrue(comparable)
+        self.assertEqual(
+            markdown,
+            "## A/B result\n"
+            "\n"
+            "| leg | ref | blocks/s | post-commit blk/s | verdict |\n"
+            "|---|---|---:|---:|---|\n"
+            "| baseline | `fedcba098` | 101.0 | 70.25 | n/a |\n"
+            "| primary | `1a2b3c4d5` | 151.75 | 88.5 | faster |\n"
+            "\n"
+            "**Speedup (primary vs baseline): 1.50×** "
+            "(101.0 → 151.75 blocks/s, both legs on identical parallel droplets)",
+        )
+
     def test_reports_speedup_and_both_legs(self):
         markdown, comparable = compare.render(meta("primary", bps=150.0), meta("baseline"))
         self.assertTrue(comparable)
@@ -86,8 +120,33 @@ class Render(unittest.TestCase):
         self.assertIn("| n/a |", markdown)
 
 
+class LoadMeta(unittest.TestCase):
+    def load(self, contents: str | None):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "meta.json"
+            if contents is not None:
+                path.write_text(contents, encoding="utf-8")
+            with contextlib.redirect_stderr(io.StringIO()):
+                return compare.load_meta(str(path))
+
+    def test_absent_file(self):
+        self.assertIsNone(self.load(None))
+
+    def test_truncated_write_is_treated_as_absent(self):
+        # perf-bench-run.sh tolerates a failed meta write, and json.dump
+        # truncates before writing, so a zero-length file reaches this script.
+        self.assertIsNone(self.load(""))
+        self.assertIsNone(self.load('{"leg": "primary", "bps":'))
+
+    def test_valid_file_is_parsed(self):
+        self.assertEqual(self.load('{"leg": "primary"}'), {"leg": "primary"})
+
+
 class Main(unittest.TestCase):
-    def run_main(self, primary: dict | None, baseline: dict | None):
+    # Seeded so a truncating open() would be caught: this line must survive.
+    EXISTING_OUTPUT = "some_other_step_output=1\n"
+
+    def run_main(self, primary, baseline, primary_raw: str | None = None):
         """Run main() in a temp dir and return (exit code, GITHUB_OUTPUT text)."""
         with tempfile.TemporaryDirectory() as tmp:
             paths = []
@@ -96,15 +155,20 @@ class Main(unittest.TestCase):
                 if value is not None:
                     path.write_text(json.dumps(value), encoding="utf-8")
                 paths.append(str(path))
+            if primary_raw is not None:
+                Path(paths[0]).write_text(primary_raw, encoding="utf-8")
             output = Path(tmp) / "github_output"
-            output.touch()
+            output.write_text(self.EXISTING_OUTPUT, encoding="utf-8")
             os.environ["GITHUB_OUTPUT"] = str(output)
-            try:
-                with contextlib.redirect_stdout(io.StringIO()):
-                    code = compare.main(["perf-bench-compare.py", *paths])
-            finally:
-                del os.environ["GITHUB_OUTPUT"]
-            return code, output.read_text(encoding="utf-8")
+            self.addCleanup(os.environ.pop, "GITHUB_OUTPUT", None)
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+                io.StringIO()
+            ):
+                code = compare.main(["perf-bench-compare.py", *paths])
+            written = output.read_text(encoding="utf-8")
+            # The step output file is shared with every other step in the job.
+            self.assertTrue(written.startswith(self.EXISTING_OUTPUT))
+            return code, written[len(self.EXISTING_OUTPUT) :]
 
     def test_comparable_run_sets_the_output_flag(self):
         code, output = self.run_main(meta("primary"), meta("baseline"))
@@ -116,8 +180,15 @@ class Main(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(output, "compare=false\n")
 
+    def test_unusable_meta_clears_the_flag_instead_of_failing_the_step(self):
+        # A traceback here would red the compare job and skip the CPU diff.
+        code, output = self.run_main(None, meta("baseline"), primary_raw="")
+        self.assertEqual(code, 0)
+        self.assertEqual(output, "compare=false\n")
+
     def test_wrong_argument_count_is_a_usage_error(self):
-        self.assertEqual(compare.main(["perf-bench-compare.py"]), 2)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(compare.main(["perf-bench-compare.py"]), 2)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/scripts/test_perf_bench_compare.py
+++ b/.github/workflows/scripts/test_perf_bench_compare.py
@@ -83,14 +83,6 @@ class Render(unittest.TestCase):
             "(101.0 → 151.75 blocks/s, both legs on identical parallel droplets)",
         )
 
-    def test_reports_speedup_and_both_legs(self):
-        markdown, comparable = compare.render(meta("primary", bps=150.0), meta("baseline"))
-        self.assertTrue(comparable)
-        self.assertIn("## A/B result", markdown)
-        self.assertIn("1.50×", markdown)
-        # Baseline row first, so the table reads baseline -> primary.
-        self.assertLess(markdown.index("| baseline |"), markdown.index("| primary |"))
-
     def test_missing_meta_is_not_comparable(self):
         markdown, comparable = compare.render(None, meta("baseline"))
         self.assertFalse(comparable)
@@ -114,10 +106,6 @@ class Render(unittest.TestCase):
         markdown, comparable = compare.render(meta("primary"), meta("baseline", bps=0))
         self.assertTrue(comparable)
         self.assertIn("nan×", markdown)
-
-    def test_missing_verdict_renders_as_not_available(self):
-        markdown, _ = compare.render(meta("primary", verdict=None), meta("baseline"))
-        self.assertIn("| n/a |", markdown)
 
 
 class LoadMeta(unittest.TestCase):

--- a/.github/workflows/scripts/test_perf_bench_compare.py
+++ b/.github/workflows/scripts/test_perf_bench_compare.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Unit tests for the perf-bench A/B summary renderer.
+
+Run directly: python3 .github/workflows/scripts/test_perf_bench_compare.py
+
+Loads the script by path because it is hyphenated and therefore not importable
+as a module, matching test_mempool_load.py.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so anything resolving a class's module through
+    # sys.modules (dataclasses, pickle) works on Python 3.12+.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+compare = load_module("perf_bench_compare", SCRIPTS / "perf-bench-compare.py")
+
+
+def meta(leg: str, **overrides) -> dict:
+    base = {
+        "leg": leg,
+        "sha": f"{leg[0]}" * 40,
+        "bps": 100.0,
+        "post_bps": 90.0,
+        "verdict": "ok",
+        "node_exit_status": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+class Render(unittest.TestCase):
+    def test_reports_speedup_and_both_legs(self):
+        markdown, comparable = compare.render(meta("primary", bps=150.0), meta("baseline"))
+        self.assertTrue(comparable)
+        self.assertIn("## A/B result", markdown)
+        self.assertIn("1.50×", markdown)
+        # Baseline row first, so the table reads baseline -> primary.
+        self.assertLess(markdown.index("| baseline |"), markdown.index("| primary |"))
+
+    def test_missing_meta_is_not_comparable(self):
+        markdown, comparable = compare.render(None, meta("baseline"))
+        self.assertFalse(comparable)
+        self.assertIn("nothing to compare", markdown)
+
+    def test_failed_leg_names_the_leg_and_blocks_comparison(self):
+        markdown, comparable = compare.render(
+            meta("primary"), meta("baseline", node_exit_status=101)
+        )
+        self.assertFalse(comparable)
+        self.assertIn("zakurad failed in baseline", markdown)
+        self.assertNotIn("A/B result", markdown)
+
+    def test_both_legs_failed_are_both_named(self):
+        markdown, _ = compare.render(
+            meta("primary", node_exit_status=1), meta("baseline", node_exit_status=1)
+        )
+        self.assertIn("primary, baseline", markdown)
+
+    def test_zero_baseline_throughput_does_not_divide_by_zero(self):
+        markdown, comparable = compare.render(meta("primary"), meta("baseline", bps=0))
+        self.assertTrue(comparable)
+        self.assertIn("nan×", markdown)
+
+    def test_missing_verdict_renders_as_not_available(self):
+        markdown, _ = compare.render(meta("primary", verdict=None), meta("baseline"))
+        self.assertIn("| n/a |", markdown)
+
+
+class Main(unittest.TestCase):
+    def run_main(self, primary: dict | None, baseline: dict | None):
+        """Run main() in a temp dir and return (exit code, GITHUB_OUTPUT text)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = []
+            for name, value in (("primary", primary), ("baseline", baseline)):
+                path = Path(tmp) / f"{name}.json"
+                if value is not None:
+                    path.write_text(json.dumps(value), encoding="utf-8")
+                paths.append(str(path))
+            output = Path(tmp) / "github_output"
+            output.touch()
+            os.environ["GITHUB_OUTPUT"] = str(output)
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    code = compare.main(["perf-bench-compare.py", *paths])
+            finally:
+                del os.environ["GITHUB_OUTPUT"]
+            return code, output.read_text(encoding="utf-8")
+
+    def test_comparable_run_sets_the_output_flag(self):
+        code, output = self.run_main(meta("primary"), meta("baseline"))
+        self.assertEqual(code, 0)
+        self.assertEqual(output, "compare=true\n")
+
+    def test_absent_leg_artifact_clears_the_output_flag(self):
+        code, output = self.run_main(meta("primary"), None)
+        self.assertEqual(code, 0)
+        self.assertEqual(output, "compare=false\n")
+
+    def test_wrong_argument_count_is_a_usage_error(self):
+        self.assertEqual(compare.main(["perf-bench-compare.py"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/zakura-mempool-load.yml
+++ b/.github/workflows/zakura-mempool-load.yml
@@ -138,74 +138,28 @@ jobs:
             echo "slug=${SLUG}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Install doctl
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          DOCTL_VERSION=1.120.0
-          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
-          sudo install /tmp/doctl /usr/local/bin/doctl
-          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
+      - name: Install doctl and the fleet SSH key
+        uses: ./.github/actions/do-cli
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          ssh_private_key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
 
-      - name: Write SSH key
-        env:
-          DO_SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-        run: |
-          install -m 600 /dev/null /tmp/do_ssh
-          printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh
-
-      - name: Pick baked image
-        id: baked
-        run: |
-          set -euo pipefail
-          # Reuses the PR-node bake: same deps and warm cargo cache. No chain
-          # state volume -- this workload generates its own chain from genesis.
-          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
-            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
-          if [ -z "${IMAGE}" ]; then
-            echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
-            exit 1
-          fi
-          echo "image_id=${IMAGE}" >> "$GITHUB_OUTPUT"
-
+      # Reuses the PR-node bake: same deps and warm cargo cache. No chain state
+      # volume -- this workload generates its own chain from genesis.
       - name: Create droplet
         id: droplet
-        env:
-          DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
-          SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
-          IMAGE_ID: ${{ steps.baked.outputs.image_id }}
-          SLUG: ${{ steps.target.outputs.slug }}
-        run: |
-          set -euo pipefail
-          NAME="zakura-mempool-${SLUG}-${GITHUB_RUN_ID}"
-          # The zakura-mempool-load tag is what the hourly reaper sweeps, so it
-          # must be set at creation -- before anything else can fail.
-          doctl compute droplet create "$NAME" \
-            --region nyc3 \
-            --size "${DROPLET_SIZE}" \
-            --image "${IMAGE_ID}" \
-            --ssh-keys "${SSH_FINGERPRINT}" \
-            --tag-name zakura-mempool-load \
-            --wait --format ID,PublicIPv4 --no-header > /tmp/droplet.txt
-          {
-            echo "id=$(awk '{print $1}' /tmp/droplet.txt)"
-            echo "ip=$(awk '{print $2}' /tmp/droplet.txt)"
-          } >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/do-droplet
+        with:
+          name: zakura-mempool-${{ steps.target.outputs.slug }}-${{ github.run_id }}
+          size: ${{ inputs.droplet_size || 'c-8' }}
+          ssh_fingerprint: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
+          tag: zakura-mempool-load
 
       - name: Wait for SSH
         id: sshwait
-        env:
-          IP: ${{ steps.droplet.outputs.ip }}
-        run: |
-          set -euo pipefail
-          for _ in $(seq 1 30); do
-            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i /tmp/do_ssh "root@${IP}" true 2>/dev/null; then
-              echo "SSH up"; exit 0
-            fi
-            sleep 10
-          done
-          echo "SSH did not come up in time"; exit 1
+        uses: ./.github/actions/do-wait-ssh
+        with:
+          ip: ${{ steps.droplet.outputs.ip }}
 
       - name: Run the mempool load workload
         env:
@@ -361,21 +315,8 @@ jobs:
 
       - name: Teardown
         if: always()
-        env:
-          DROPLET_ID: ${{ steps.droplet.outputs.id }}
-          TEARDOWN: ${{ inputs.teardown_after_run && 'true' || 'false' }}
-          SSH_FAILED: ${{ steps.sshwait.outcome == 'failure' }}
-        run: |
-          set +e
+        uses: ./.github/actions/do-teardown
+        with:
+          droplet_id: ${{ steps.droplet.outputs.id }}
           # A droplet we can never SSH into is useless to keep for inspection.
-          if [ "${TEARDOWN}" != "true" ] && [ "${SSH_FAILED}" != "true" ]; then
-            echo "Droplet kept for inspection; the reaper deletes it ~24h after creation."
-            exit 0
-          fi
-          if [ -n "${DROPLET_ID}" ]; then
-            for _ in 1 2 3; do
-              doctl compute droplet delete "${DROPLET_ID}" -f && break
-              sleep 5
-            done
-          fi
-          true
+          enabled: ${{ (inputs.teardown_after_run || steps.sshwait.outcome == 'failure') && 'true' || 'false' }}

--- a/.github/workflows/zakura-mempool-load.yml
+++ b/.github/workflows/zakura-mempool-load.yml
@@ -319,4 +319,7 @@ jobs:
         with:
           droplet_id: ${{ steps.droplet.outputs.id }}
           # A droplet we can never SSH into is useless to keep for inspection.
-          enabled: ${{ (inputs.teardown_after_run || steps.sshwait.outcome == 'failure') && 'true' || 'false' }}
+          # string-compare the input: it is null under any non-dispatch trigger,
+          # and this workflow defaults to tearing down, so null must not become
+          # "keep" and leak a droplet.
+          enabled: ${{ (format('{0}', inputs.teardown_after_run) != 'false' || steps.sshwait.outcome == 'failure') && 'true' || 'false' }}

--- a/.github/workflows/zakura-perf-bench.yml
+++ b/.github/workflows/zakura-perf-bench.yml
@@ -149,87 +149,28 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install doctl
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          DOCTL_VERSION=1.120.0
-          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
-          sudo install /tmp/doctl /usr/local/bin/doctl
-          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
-
-      - name: Write SSH key
-        env:
-          DO_SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-        run: |
-          install -m 600 /dev/null /tmp/do_ssh
-          printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh
-
-      - name: Pick baked image and state snapshot
-        id: baked
-        run: |
-          set -euo pipefail
-          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
-            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
-          if [ -z "${IMAGE}" ]; then
-            echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
-            exit 1
-          fi
-          echo "image_id=${IMAGE}" >> "$GITHUB_OUTPUT"
-          SNAP=$(doctl compute snapshot list --resource volume --format ID,Name --no-header | \
-            awk -v pre="zakura-pr-state-mainnet-" 'index($2, pre) == 1 {print $2, $1}' | \
-            sort | tail -1 | awk '{print $2}')
-          if [ -z "${SNAP}" ]; then
-            echo "no zakura-pr-state-mainnet-* volume snapshot found; run the bake workflow first" >&2
-            exit 1
-          fi
-          echo "vol_snap_id=${SNAP}" >> "$GITHUB_OUTPUT"
+      - name: Install doctl and the fleet SSH key
+        uses: ./.github/actions/do-cli
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          ssh_private_key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
 
       - name: Create droplet (+ state volume)
         id: droplet
-        env:
-          LEG: ${{ matrix.leg.leg }}
-          DROPLET_SIZE: ${{ inputs.droplet_size || 'c-16' }}
-          SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
-          IMAGE_ID: ${{ steps.baked.outputs.image_id }}
-          VOL_SNAP_ID: ${{ steps.baked.outputs.vol_snap_id }}
-        run: |
-          set -euo pipefail
-          VOLUME_NAME="zakura-pr-perf-vol-${GITHUB_RUN_ID}-${LEG}"
-          SIZE=$(doctl compute snapshot get "${VOL_SNAP_ID}" --format MinDiskSize --no-header)
-          VOLUME_ID=$(doctl compute volume create "${VOLUME_NAME}" \
-            --region nyc3 --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
-            --format ID --no-header)
-          NAME="zakura-perf-${LEG}-${GITHUB_RUN_ID}"
+        uses: ./.github/actions/do-droplet
+        with:
+          name: zakura-perf-${{ matrix.leg.leg }}-${{ github.run_id }}
+          size: ${{ inputs.droplet_size || 'c-16' }}
+          ssh_fingerprint: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
           # tagged zakura-pr-node so the hourly reaper covers failed teardowns
-          doctl compute droplet create "$NAME" \
-            --region nyc3 \
-            --size "${DROPLET_SIZE}" \
-            --image "${IMAGE_ID}" \
-            --ssh-keys "${SSH_FINGERPRINT}" \
-            --volumes "${VOLUME_ID}" \
-            --tag-name zakura-pr-node \
-            --wait --format ID,PublicIPv4 --no-header > /tmp/droplet.txt
-          {
-            echo "id=$(awk '{print $1}' /tmp/droplet.txt)"
-            echo "ip=$(awk '{print $2}' /tmp/droplet.txt)"
-            echo "volume_name=${VOLUME_NAME}"
-            echo "volume_id=${VOLUME_ID}"
-          } >> "$GITHUB_OUTPUT"
+          tag: zakura-pr-node
+          state_network: mainnet
+          volume_name: zakura-pr-perf-vol-${{ github.run_id }}-${{ matrix.leg.leg }}
 
       - name: Wait for SSH
-        env:
-          IP: ${{ steps.droplet.outputs.ip }}
-        run: |
-          set -euo pipefail
-          for _ in $(seq 1 30); do
-            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i /tmp/do_ssh "root@${IP}" true 2>/dev/null; then
-              echo "SSH up"; exit 0
-            fi
-            sleep 10
-          done
-          echo "SSH did not come up in time"; exit 1
+        uses: ./.github/actions/do-wait-ssh
+        with:
+          ip: ${{ steps.droplet.outputs.ip }}
 
       - name: Run the profiled bench leg
         env:
@@ -303,26 +244,14 @@ jobs:
           retention-days: 30
 
       - name: Teardown droplet + volume
-        if: always() && steps.droplet.outputs.id != ''
-        env:
-          DROPLET_ID: ${{ steps.droplet.outputs.id }}
-          VOLUME_ID: ${{ steps.droplet.outputs.volume_id }}
+        if: always()
+        uses: ./.github/actions/do-teardown
+        with:
+          droplet_id: ${{ steps.droplet.outputs.id }}
+          volume_ids: ${{ steps.droplet.outputs.volume_id }}
           # string-compare: on schedule/pull_request the input is null, and
           # GitHub's loose `null == false` coercion would skip teardown
-          TEARDOWN: ${{ format('{0}', inputs.teardown_after_run) == 'false' && 'false' || 'true' }}
-        run: |
-          set -euo pipefail
-          if [ "${TEARDOWN}" != "true" ]; then
-            echo "teardown_after_run=false; droplet ${DROPLET_ID} left up (reaper removes it within 24h)"
-            exit 0
-          fi
-          doctl compute droplet delete -f "${DROPLET_ID}" || true
-          # volume detach happens as part of droplet deletion; retry the delete
-          for _ in $(seq 1 10); do
-            if doctl compute volume delete -f "${VOLUME_ID}" 2>/dev/null; then exit 0; fi
-            sleep 6
-          done
-          echo "volume ${VOLUME_ID} still attached; the reaper will remove it" >&2
+          enabled: ${{ format('{0}', inputs.teardown_after_run) == 'false' && 'false' || 'true' }}
 
   compare:
     name: A/B compare
@@ -343,48 +272,37 @@ jobs:
           path: legs/
 
       - name: Compare legs
+        id: compare
+        run: |
+          set -euo pipefail
+          python3 .github/workflows/scripts/perf-bench-compare.py \
+            "legs/zakura-perf-bench-${GITHUB_RUN_ID}-primary/meta.json" \
+            "legs/zakura-perf-bench-${GITHUB_RUN_ID}-baseline/meta.json" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      # Only when both legs ran zakurad to completion: a diff against a leg that
+      # died early describes the crash, not the change.
+      - name: Diff CPU profiles
+        if: steps.compare.outputs.compare == 'true'
         run: |
           set -euo pipefail
           P="legs/zakura-perf-bench-${GITHUB_RUN_ID}-primary"
           B="legs/zakura-perf-bench-${GITHUB_RUN_ID}-baseline"
-          [ -f "$P/meta.json" ] && [ -f "$B/meta.json" ] \
-            || { echo "one or both legs produced no meta.json; nothing to compare" >> "$GITHUB_STEP_SUMMARY"; exit 0; }
-          FAILED_LEGS=$(python3 - "$P/meta.json" "$B/meta.json" <<'PY'
-          import json, sys
-          legs = (json.load(open(path)) for path in sys.argv[1:3])
-          print(", ".join(leg["leg"] for leg in legs if leg.get("node_exit_status", 0)))
-          PY
-          )
-          if [ -n "$FAILED_LEGS" ]; then
-            echo "No comparison: zakurad failed in ${FAILED_LEGS}." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          python3 - "$P/meta.json" "$B/meta.json" >> "$GITHUB_STEP_SUMMARY" <<'PY'
-          import json, sys
-          p, b = (json.load(open(a)) for a in sys.argv[1:3])
-          speedup = p["bps"] / b["bps"] if b["bps"] else float("nan")
-          print("## A/B result\n")
-          print("| leg | ref | blocks/s | post-commit blk/s | verdict |")
-          print("|---|---|---:|---:|---|")
-          for m in (b, p):
-              print(f"| {m['leg']} | `{m['sha'][:9]}` | {m['bps']} | {m['post_bps']} | {m.get('verdict') or 'n/a'} |")
-          print(f"\n**Speedup (primary vs baseline): {speedup:.2f}×** ({b['bps']} → {p['bps']} blocks/s, both legs on identical parallel droplets)")
-          PY
           mkdir -p compare-out
-          if [ -s "$P/profile.folded" ] && [ -s "$B/profile.folded" ]; then
-            python3 scripts/zakura-bench-digest.py diff \
-              --baseline "$B/profile.folded" --primary "$P/profile.folded" \
-              --title "primary vs baseline" | tee compare-out/profile-diff.md >> "$GITHUB_STEP_SUMMARY"
-            if cargo install inferno --locked >/dev/null 2>&1; then
-              export PATH="$HOME/.cargo/bin:$PATH"
-              inferno-diff-folded "$B/profile.folded" "$P/profile.folded" 2>/dev/null \
-                | inferno-flamegraph --title "CPU diff: baseline → primary" \
-                > compare-out/flamegraph-diff.svg 2>/dev/null \
-                || rm -f compare-out/flamegraph-diff.svg
-            fi
-          else
+          if [ ! -s "$P/profile.folded" ] || [ ! -s "$B/profile.folded" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "_(no CPU diff: one or both legs have no folded stacks)_" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 scripts/zakura-bench-digest.py diff \
+            --baseline "$B/profile.folded" --primary "$P/profile.folded" \
+            --title "primary vs baseline" | tee compare-out/profile-diff.md >> "$GITHUB_STEP_SUMMARY"
+          if cargo install inferno --locked >/dev/null 2>&1; then
+            export PATH="$HOME/.cargo/bin:$PATH"
+            inferno-diff-folded "$B/profile.folded" "$P/profile.folded" 2>/dev/null \
+              | inferno-flamegraph --title "CPU diff: baseline → primary" \
+              > compare-out/flamegraph-diff.svg 2>/dev/null \
+              || rm -f compare-out/flamegraph-diff.svg
           fi
 
       - name: Upload compare artifacts

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -43,23 +43,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install doctl
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          DOCTL_VERSION=1.120.0
-          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
-          sudo install /tmp/doctl /usr/local/bin/doctl
-          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
+      - name: Install doctl and the fleet SSH key
+        uses: ./.github/actions/do-cli
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          ssh_private_key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
 
-      - name: Write SSH key
-        env:
-          DO_SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-        run: |
-          install -m 600 /dev/null /tmp/do_ssh
-          printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh
-
+      # Not the shared do-droplet action: the bake starts from a stock Ubuntu
+      # image (it is what produces the baked one) and attaches two blank
+      # volumes it later snapshots per network.
       - name: Create state volumes + bake droplet
         id: droplet
         env:
@@ -95,17 +87,9 @@ jobs:
           echo "ip=$(awk '{print $2}' /tmp/droplet.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Wait for SSH
-        env:
-          IP: ${{ steps.droplet.outputs.ip }}
-        run: |
-          set -euo pipefail
-          for _ in $(seq 1 30); do
-            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i /tmp/do_ssh "root@${IP}" true 2>/dev/null; then
-              echo "SSH up"; exit 0
-            fi
-            sleep 10
-          done
-          echo "SSH did not come up in time"; exit 1
+        uses: ./.github/actions/do-wait-ssh
+        with:
+          ip: ${{ steps.droplet.outputs.ip }}
 
       - name: Run bake script
         env:
@@ -177,28 +161,17 @@ jobs:
           done
           echo "image snapshot did not complete in time"; exit 1
 
-      - name: Cleanup droplet + volumes, prune old assets
+      - name: Cleanup droplet + volumes
         if: always()
-        env:
-          DROPLET_ID: ${{ steps.droplet.outputs.id }}
-          MAINNET_VOL_ID: ${{ steps.droplet.outputs.mainnet_vol_id }}
-          TESTNET_VOL_ID: ${{ steps.droplet.outputs.testnet_vol_id }}
+        uses: ./.github/actions/do-teardown
+        with:
+          droplet_id: ${{ steps.droplet.outputs.id }}
+          volume_ids: ${{ steps.droplet.outputs.mainnet_vol_id }} ${{ steps.droplet.outputs.testnet_vol_id }}
+
+      - name: Prune old images and volume snapshots
+        if: always()
         run: |
           set +e
-          if [ -n "${DROPLET_ID}" ]; then
-            for _ in 1 2 3; do
-              doctl compute droplet delete "${DROPLET_ID}" -f && break
-              sleep 5
-            done
-          fi
-          # Volumes detach asynchronously after the droplet delete.
-          for VOL_ID in "${MAINNET_VOL_ID}" "${TESTNET_VOL_ID}"; do
-            [ -z "${VOL_ID}" ] && continue
-            for _ in $(seq 1 12); do
-              doctl compute volume delete "${VOL_ID}" -f && break
-              sleep 10
-            done
-          done
           # Keep the newest 2 images and 2 volume snapshots per network so runs
           # never depend on the latest bake having succeeded.
           doctl compute image list-user --format ID,Name --no-header | \

--- a/.github/workflows/zakura-pr-node-reaper.yml
+++ b/.github/workflows/zakura-pr-node-reaper.yml
@@ -33,15 +33,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Only for the local composite action below; the reap steps need no
+      # repository content.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # API-only job: no SSH key needed.
       - name: Install doctl
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          DOCTL_VERSION=1.120.0
-          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
-          sudo install /tmp/doctl /usr/local/bin/doctl
-          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
+        uses: ./.github/actions/do-cli
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Reap expired droplets
         env:

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -104,101 +104,29 @@ jobs:
             echo "slug=${SLUG}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Install doctl
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          DOCTL_VERSION=1.120.0
-          curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
-          sudo install /tmp/doctl /usr/local/bin/doctl
-          doctl auth init -t "${DIGITALOCEAN_ACCESS_TOKEN}"
-
-      - name: Write SSH key
-        env:
-          DO_SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-        run: |
-          install -m 600 /dev/null /tmp/do_ssh
-          printf '%s\n' "${DO_SSH_PRIVATE_KEY}" > /tmp/do_ssh
-
-      - name: Pick baked image and state snapshot
-        id: baked
-        env:
-          MODE: ${{ inputs.snapshot_mode }}
-          NETWORK: ${{ inputs.network }}
-        run: |
-          set -euo pipefail
-          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
-            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
-          if [ -z "${IMAGE}" ]; then
-            echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
-            exit 1
-          fi
-          echo "image_id=${IMAGE}" >> "$GITHUB_OUTPUT"
-          if [ "${MODE}" = "genesis" ]; then
-            echo "vol_snap_id=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          SNAP=$(doctl compute snapshot list --resource volume --format ID,Name --no-header | \
-            awk -v pre="zakura-pr-state-${NETWORK}-" 'index($2, pre) == 1 {print $2, $1}' | \
-            sort | tail -1 | awk '{print $2}')
-          if [ -z "${SNAP}" ]; then
-            echo "no zakura-pr-state-${NETWORK}-* volume snapshot found; run the bake workflow first" >&2
-            exit 1
-          fi
-          echo "vol_snap_id=${SNAP}" >> "$GITHUB_OUTPUT"
+      - name: Install doctl and the fleet SSH key
+        uses: ./.github/actions/do-cli
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          ssh_private_key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
 
       - name: Create droplet (+ state volume)
         id: droplet
-        env:
-          MODE: ${{ inputs.snapshot_mode }}
-          DROPLET_SIZE: ${{ inputs.droplet_size || 'c-8' }}
-          SSH_FINGERPRINT: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
-          IMAGE_ID: ${{ steps.baked.outputs.image_id }}
-          VOL_SNAP_ID: ${{ steps.baked.outputs.vol_snap_id }}
-          SLUG: ${{ steps.target.outputs.slug }}
-        run: |
-          set -euo pipefail
-          VOLUME_ARGS=()
-          VOLUME_NAME=""
-          VOLUME_ID=""
-          if [ "${MODE}" != "genesis" ]; then
-            VOLUME_NAME="zakura-pr-vol-${GITHUB_RUN_ID}"
-            SIZE=$(doctl compute snapshot get "${VOL_SNAP_ID}" --format MinDiskSize --no-header)
-            VOLUME_ID=$(doctl compute volume create "${VOLUME_NAME}" \
-              --region nyc3 --snapshot "${VOL_SNAP_ID}" --size "${SIZE}GiB" \
-              --format ID --no-header)
-            VOLUME_ARGS=(--volumes "${VOLUME_ID}")
-          fi
-          NAME="zakura-pr-${SLUG}-${GITHUB_RUN_ID}"
-          doctl compute droplet create "$NAME" \
-            --region nyc3 \
-            --size "${DROPLET_SIZE}" \
-            --image "${IMAGE_ID}" \
-            --ssh-keys "${SSH_FINGERPRINT}" \
-            "${VOLUME_ARGS[@]}" \
-            --tag-name zakura-pr-node \
-            --wait --format ID,PublicIPv4 --no-header > /tmp/droplet.txt
-          {
-            echo "id=$(awk '{print $1}' /tmp/droplet.txt)"
-            echo "ip=$(awk '{print $2}' /tmp/droplet.txt)"
-            echo "volume_name=${VOLUME_NAME}"
-            echo "volume_id=${VOLUME_ID}"
-          } >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/do-droplet
+        with:
+          name: zakura-pr-${{ steps.target.outputs.slug }}-${{ github.run_id }}
+          size: ${{ inputs.droplet_size || 'c-8' }}
+          ssh_fingerprint: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
+          tag: zakura-pr-node
+          # genesis syncs from scratch, so it gets no state volume
+          state_network: ${{ inputs.snapshot_mode != 'genesis' && inputs.network || '' }}
+          volume_name: zakura-pr-vol-${{ github.run_id }}
 
       - name: Wait for SSH
         id: sshwait
-        env:
-          IP: ${{ steps.droplet.outputs.ip }}
-        run: |
-          set -euo pipefail
-          for _ in $(seq 1 30); do
-            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i /tmp/do_ssh "root@${IP}" true 2>/dev/null; then
-              echo "SSH up"; exit 0
-            fi
-            sleep 10
-          done
-          echo "SSH did not come up in time"; exit 1
+        uses: ./.github/actions/do-wait-ssh
+        with:
+          ip: ${{ steps.droplet.outputs.ip }}
 
       - name: Build, deploy, and monitor the node
         env:
@@ -327,29 +255,9 @@ jobs:
 
       - name: Teardown (immediate or on unreachable droplet)
         if: always()
-        env:
-          DROPLET_ID: ${{ steps.droplet.outputs.id }}
-          VOLUME_ID: ${{ steps.droplet.outputs.volume_id }}
-          TEARDOWN: ${{ inputs.teardown_after_run }}
-          SSH_FAILED: ${{ steps.sshwait.outcome == 'failure' }}
-        run: |
-          set +e
+        uses: ./.github/actions/do-teardown
+        with:
+          droplet_id: ${{ steps.droplet.outputs.id }}
+          volume_ids: ${{ steps.droplet.outputs.volume_id }}
           # A droplet we can never SSH into is useless to keep for inspection.
-          if [ "${TEARDOWN}" != "true" ] && [ "${SSH_FAILED}" != "true" ]; then
-            echo "Droplet kept for inspection; the reaper deletes it ~24h after creation."
-            exit 0
-          fi
-          if [ -n "${DROPLET_ID}" ]; then
-            for _ in 1 2 3; do
-              doctl compute droplet delete "${DROPLET_ID}" -f && break
-              sleep 5
-            done
-          fi
-          if [ -n "${VOLUME_ID}" ]; then
-            # The volume detaches asynchronously after the droplet delete.
-            for _ in $(seq 1 12); do
-              doctl compute volume delete "${VOLUME_ID}" -f && break
-              sleep 10
-            done
-          fi
-          true
+          enabled: ${{ (inputs.teardown_after_run || steps.sshwait.outcome == 'failure') && 'true' || 'false' }}

--- a/.github/workflows/zakura-pr-node.yml
+++ b/.github/workflows/zakura-pr-node.yml
@@ -260,4 +260,7 @@ jobs:
           droplet_id: ${{ steps.droplet.outputs.id }}
           volume_ids: ${{ steps.droplet.outputs.volume_id }}
           # A droplet we can never SSH into is useless to keep for inspection.
-          enabled: ${{ (inputs.teardown_after_run || steps.sshwait.outcome == 'failure') && 'true' || 'false' }}
+          # string-compare the input: it is null under any non-dispatch trigger,
+          # and `null || ...` would quietly resolve to "keep" (this workflow's
+          # default) rather than to an explicit decision.
+          enabled: ${{ (format('{0}', inputs.teardown_after_run) == 'true' || steps.sshwait.outcome == 'failure') && 'true' || 'false' }}

--- a/docs/cpu-profiling.md
+++ b/docs/cpu-profiling.md
@@ -45,7 +45,7 @@ Interpretation notes:
 
 ## Knobs
 
-Workflow inputs cover the common cases; the droplet-side script (`.github/workflows/scripts/perf-bench-run.sh`) documents the finer-grained profiling and live-head gate knobs.
+Workflow inputs cover the common cases; the droplet-side script (`.github/workflows/scripts/perf-bench-run.sh`) documents the finer-grained profiling and live-head gate knobs. The A/B summary table is rendered by `.github/workflows/scripts/perf-bench-compare.py`, which also decides whether the legs are comparable at all (a leg whose `zakurad` exited non-zero, or produced no readable `meta.json`, suppresses the comparison and the CPU diff).
 
 ## Local profiling recipes
 


### PR DESCRIPTION
## Motivation

Follow-up to the review on #419, which flagged two things that PR made
obvious but deliberately left alone:

- DigitalOcean droplet provisioning is copy-pasted across five workflows
  ("there are four other workflows that copy this similar set up ... It 100
  percent can be abstracted out").
- The A/B step summary was generated by Python heredocs embedded in YAML
  ("I've never seen python be executed like this within a yaml file ... could
  we clean this up?").

#419 was tested extensively as a unit, so unifying provisioning there would
have invalidated that testing. This PR does it separately, with no behavior
change intended.

## Solution

Provisioning moves into four composite actions in `.github/actions/`:

| action | responsibility |
| --- | --- |
| `do-cli` | pinned `doctl` install + auth, optional fleet SSH key |
| `do-droplet` | resolve the newest baked image, optionally clone the newest `zakura-pr-state-<network>-*` snapshot, create the tagged droplet |
| `do-wait-ssh` | poll a new droplet until it accepts SSH |
| `do-teardown` | best-effort droplet + volume delete, retried while the detach settles |

`zakura-pr-node.yml`, `zakura-perf-bench.yml`, `zakura-mempool-load.yml`,
`zakura-pr-node-bake.yml`, and `zakura-pr-node-reaper.yml` call these instead
of carrying their own copies.

On lines of code, the honest total is **+658 / -377, net +281**, and it is
worth being explicit about where that goes rather than quoting the workflow
subset:

| bucket | net |
| --- | --- |
| workflows (the dedup itself) | **-246** |
| composite actions | +242, of which 98 is shell and 144 is input/output schema |
| new compare script | +93, replacing ~30 lines of heredoc |
| new tests | +183, replacing none |

Five copies of ~50 lines of provisioning shell collapse into 98. The rest is
the composite-action metadata tax plus a test suite that did not exist before,
which is what makes the extraction verifiable rather than hopeful. The actions
are deliberately not parameterized beyond what callers use -- `image`,
`region`, `ssh_key_path`, `version`, `attempts`, and `delay` were all dropped
after the audits pointed out no caller sets them (and that `ssh_key_path` could
not be set without also editing every caller's hardcoded `/tmp/do_ssh`).

`zakura-pr-node-bake.yml` still creates its droplet inline and uses only the
other three actions: it starts from a stock Ubuntu image (it is what produces
the baked one) and attaches two blank volumes it later snapshots per network.

Resource names, tags, regions, and the teardown-vs-keep conditions are
unchanged, so the hourly reaper keeps sweeping exactly what it did before.
The reaper itself gains an `actions/checkout` only so it can reference the
local action.

The two heredocs become `.github/workflows/scripts/perf-bench-compare.py`. It
writes the leg table to the step summary and sets a `compare` step output, so
the CPU profile diff is now a separate step gated on both legs having run to
completion, rather than on shell control flow.

The second commit closes latent hazards found while auditing the first:

- `do-droplet` publishes `volume_id` as soon as the volume exists, so a
  droplet create that fails afterwards no longer strands a volume the
  caller's teardown never learns about (it was left to the reaper's 2h
  detached sweep, on `main` too).
- `do-teardown` regains the two diagnostics the extraction dropped: the kept
  resources are named in the skip message, and an undeletable volume says so
  on stderr. Those strings are what a leak audit greps for.
- `zakura-pr-node` / `zakura-mempool-load` string-compare `teardown_after_run`
  the way `zakura-perf-bench` already did. Behavior-identical today (both are
  dispatch-only), but `null || ...` will not silently resolve to "keep" if
  either gains a `schedule:` or `workflow_call:` trigger.
- `perf-bench-compare.py` treats an unreadable `meta.json` like an absent one
  rather than failing the step with a traceback: `perf-bench-run.sh` tolerates
  a failed meta write and `json.dump` truncates before writing, so a
  zero-length file is a real outcome. The `compare` flag is now written before
  the summary is printed.

## Testing

- `actionlint -shellcheck=shellcheck` over all workflows: clean for every
  touched file (the only output is pre-existing `SC2317` info in
  `test-docker.yml`, untouched here). Note `actionlint` does **not** parse
  `action.yml` files, so the composite actions' shell was extracted and
  shellchecked separately — also clean.
- `python3 .github/workflows/scripts/test_perf_bench_compare.py`: 12 unit
  tests pass, run in CI by the `fast lints` job (confirmed in this PR's run).
  The suite includes a golden-output case asserting the exact markdown the
  removed heredoc produced; the extracted script's output was separately
  diffed byte-for-byte against `main`'s heredoc on the same input.
- Mutation-checked the suite: a truncated sha, a dropped table column, an
  ASCII arrow, a truncating `GITHUB_OUTPUT` open, a changed speedup
  precision, and a flipped row order are each caught.
- `markdownlint --config .trunk/configs/.markdownlint.yaml`: clean.
- `./scripts/changelog.py check`: passes.
- Every `uses: ./.github/actions/...` reference was machine-checked against
  its `action.yml` for unknown and missing-required inputs.
- Two independent audits of the diff (behavior-equivalence and CI-wiring)
  found no breaking issues; their actionable items are in the second commit.
- Not run locally: `codespell` (CI covers it) and the droplet workflows
  themselves, which need the DO secrets and a dispatch. A `zakura-pr-node`
  dispatch on this branch is the cheapest end-to-end proof before this leaves
  draft.

## Changelog

No fragment: CI, scripts, and docs only.

### Specifications & References

- Review comments on #419.

### Follow-up Work

- **`status-checks.patch.yml` mirror drift.** That file says its `paths-ignore`
  "MUST be an exact inverse of paths in lint.yml", but it only lists the
  Rust/config subset — `scripts/**.sh`, `.github/workflows/scripts/**`,
  `deploy/**`, and `.github/scripts/**` are already absent on `main`, and this
  PR adds a fifth (`.github/actions/**`). The effect is that script-only PRs
  (#419 included, and this one) get two checks named `lint success`: the real
  one and the stub. I deliberately did **not** "fix" this by adding the new
  path to `paths-ignore`: the stub serves four required checks from one shared
  path list, so ignoring an actions-only path there would leave `test success`,
  `test crate build success`, and `semver-checks` permanently "Expected" and
  block the PR. The real fix is a per-check inverse path set, which is its own
  change.
- Four other workflows still generate output from Python heredocs
  (`create-release.yml`, `release-binaries.yml`, `update-release-state.yml`,
  `zakura-continuous-sync.yml`). They are release-pipeline code and were left
  out to keep this diff reviewable.
- No linter covers shell inside `action.yml`. This is unchanged by this PR —
  that shell lived in workflow `run:` blocks before, which CI does not lint
  either (there is no `actionlint` job) — but the code is now shared by five
  workflows, so it is worth closing. `actionlint` would cover the workflow
  half; the action half needs a small extraction step like the one used to
  verify this PR.
