### PR TITLE
fix(network): avoid pruned peers for historical FindBlocks

### DIFF
--- a/changelog-unreleased/442.md
+++ b/changelog-unreleased/442.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Avoided querying pruned peers for historical block discovery
+  ([#442](https://github.com/zakura-core/zakura/pull/442)).

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -913,17 +913,17 @@ where
         self.select_p2c_peer_from_list(&self.ready_services.keys().copied().collect())
     }
 
-    /// Returns true if pruned peers are eligible for generic block downloads.
-    fn pruned_peers_are_block_download_eligible(&self) -> bool {
+    /// Returns true if pruned peers are eligible for generic block requests.
+    fn pruned_peers_are_block_request_eligible(&self) -> bool {
         self.minimum_peer_version
             .chain_tip()
             .estimate_distance_to_network_chain_tip(&self.network)
             .is_some_and(|(distance, _)| distance <= PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE)
     }
 
-    /// Returns ready peers eligible for generic block downloads.
-    fn ready_generic_block_peers(&self) -> HashSet<D::Key> {
-        let include_pruned = self.pruned_peers_are_block_download_eligible();
+    /// Returns ready peers eligible for generic block requests.
+    fn ready_generic_block_request_peers(&self) -> HashSet<D::Key> {
+        let include_pruned = self.pruned_peers_are_block_request_eligible();
 
         self.ready_services
             .iter()
@@ -1049,8 +1049,8 @@ where
 
     /// Routes a request using P2C load-balancing.
     fn route_p2c(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
-        let peer = if matches!(&req, Request::BlocksByHash(_)) {
-            self.select_p2c_peer_from_list(&self.ready_generic_block_peers())
+        let peer = if matches!(&req, Request::BlocksByHash(_) | Request::FindBlocks { .. }) {
+            self.select_p2c_peer_from_list(&self.ready_generic_block_request_peers())
         } else {
             self.select_ready_p2c_peer()
         };
@@ -1207,7 +1207,7 @@ where
             .copied()
             .collect();
         let block_request = matches!(hash, InventoryHash::Block(_));
-        let include_pruned = !block_request || self.pruned_peers_are_block_download_eligible();
+        let include_pruned = !block_request || self.pruned_peers_are_block_request_eligible();
         let maybe_peer_list: HashSet<_> = self
             .ready_services
             .iter()

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -1304,10 +1304,14 @@ fn find_blocks_stall_not_tracked_for_zcashd_compat() {
     let sidecar_ip = Ipv4Addr::LOCALHOST;
     let sidecar_addr: PeerSocketAddr =
         SocketAddr::new(IpAddr::V6(sidecar_ip.to_ipv6_mapped()), 1).into();
-    let (sidecar, mut sidecar_handle) = ClientTestHarness::build()
+    let (mut sidecar, mut sidecar_handle) = ClientTestHarness::build()
         .with_version(CURRENT_NETWORK_PROTOCOL_VERSION)
         .with_connected_addr(ConnectedAddr::new_inbound_direct(sidecar_addr))
         .finish();
+    std::sync::Arc::get_mut(&mut sidecar.connection_info)
+        .expect("test harness has the only connection info reference")
+        .remote
+        .services = PeerServices::NODE_NETWORK;
     let discovered_peers = stream::iter([Ok::<_, BoxError>(Change::Insert(
         sidecar_addr,
         sidecar.into(),

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -885,6 +885,104 @@ fn near_tip_block_downloads_allow_pruned_peers() {
     });
 }
 
+/// Check that historical block discovery excludes pruned peers.
+#[test]
+fn historical_find_blocks_require_node_network() {
+    let test_hash = block::Hash([4; 32]);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version, peer_version],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, mut handles) = peer_versions
+        .mock_peer_discovery_with_services(&[PeerServices::empty(), PeerServices::NODE_NETWORK]);
+    let (minimum_peer_version, best_tip) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+    best_tip.send_best_tip_height(Some(block::Height(2_000_000)));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(
+        PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE + 1,
+    ));
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .max_conns_per_ip(max(2, DEFAULT_MAX_CONNS_PER_IP))
+            .build();
+
+        let peer_ready = peer_set.ready().await.expect("peer set is ready");
+        let request = Request::FindBlocks {
+            known_blocks: vec![test_hash],
+            stop: None,
+        };
+        let _response = peer_ready.call(request.clone());
+
+        assert!(
+            handles[0]
+                .try_to_receive_outbound_client_request()
+                .request()
+                .is_none(),
+            "historical FindBlocks request routed to pruned peer"
+        );
+        assert_eq!(
+            handles[1]
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("full node received historical FindBlocks request")
+                .request,
+            request
+        );
+    });
+}
+
+/// Check that pruned peers handle block discovery near the network tip.
+#[test]
+fn near_tip_find_blocks_allow_pruned_peers() {
+    let test_hash = block::Hash([5; 32]);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, mut handles) =
+        peer_versions.mock_peer_discovery_with_services(&[PeerServices::empty()]);
+    let (minimum_peer_version, best_tip) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+    best_tip.send_best_tip_height(Some(block::Height(2_500_000)));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(
+        PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE,
+    ));
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        let peer_ready = peer_set.ready().await.expect("peer set is ready");
+        let request = Request::FindBlocks {
+            known_blocks: vec![test_hash],
+            stop: None,
+        };
+        let _response = peer_ready.call(request.clone());
+
+        assert_eq!(
+            handles[0]
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("pruned peer received near-tip FindBlocks request")
+                .request,
+            request
+        );
+    });
+}
+
 /// Check that a pruned peer can serve a block it explicitly advertised.
 #[test]
 fn advertised_block_downloads_allow_pruned_peers() {


### PR DESCRIPTION
## Motivation

Pruned peers retain chain hashes but do not advertise pruned block bodies in `FindBlocks` responses. During historical sync, routing `FindBlocks` to peers without `NODE_NETWORK` can therefore produce empty responses, retry delays, and disconnect churn.

## Solution

Apply the existing 5,000-block pruned-peer routing boundary to `FindBlocks` requests. Historical requests are routed only to peers advertising `NODE_NETWORK`; pruned peers remain eligible near the estimated network tip. `FindHeaders` routing is unchanged.

The zcashd-compat stall-tracker fixture now explicitly advertises `NODE_NETWORK`, keeping that test focused on its intended full-node sidecar scenario.

## Testing

- `cargo test -p zakura-network find_blocks` — 9 passed
- `cargo clippy -p zakura-network --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/442.md --config .trunk/configs/.markdownlint.yaml`

The routing tests verify that historical `FindBlocks` skips a pruned peer and selects a full node, while near-tip `FindBlocks` remains eligible for a pruned peer.

## Changelog

Added `changelog-unreleased/442.md`.

### Specifications & References

- [BIP 159](https://github.com/bitcoin/bips/blob/master/bip-0159.mediawiki)
- Builds on the capability-aware block routing introduced by #440.

### Follow-up Work

None currently identified.