### PR TITLE
ci: gate config compatibility and move cache writer

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,7 +48,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: stable
-          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+          # This job packages crates with --no-verify but does not compile them.
+          cache: false
 
       - name: Validate source, tag, and package version
         id: validate

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -56,6 +56,89 @@ env:
   COLORBT_SHOW_HIDDEN: 1
 
 jobs:
+  # Decide whether this change can affect generated or historical zakurad
+  # configuration. Scheduled runs have no source change to check, while manual
+  # runs explicitly request the complete workflow.
+  changes:
+    name: detect config-relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      config: ${{ steps.filter.outputs.config }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          case "$EVENT_NAME" in
+            pull_request)
+              changed=$(gh api --paginate \
+                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+                --jq '.[].filename')
+              ;;
+            push)
+              # The first push of a branch and force-pushes that orphan the old
+              # tip have no usable `before` commit. Compare against the default
+              # branch in that case.
+              if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]] || \
+                 ! changed=$(gh api \
+                   "repos/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${GITHUB_SHA}" \
+                   --jq '.files[].filename'); then
+                changed=$(gh api \
+                  "repos/${GITHUB_REPOSITORY}/compare/${DEFAULT_BRANCH}...${GITHUB_SHA}" \
+                  --jq '.files[].filename')
+              fi
+              ;;
+            merge_group)
+              changed=$(gh api \
+                "repos/${GITHUB_REPOSITORY}/compare/${MERGE_BASE_SHA}...${MERGE_HEAD_SHA}" \
+                --jq '.files[].filename')
+              ;;
+            workflow_dispatch)
+              echo "config=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            schedule)
+              echo "config=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          config=false
+          while IFS= read -r path; do
+            case "$path" in
+              Cargo.toml | Cargo.lock | rust-toolchain.toml | \
+              zakurad/Cargo.toml | zakura-chain/Cargo.toml | \
+              zakura-consensus/Cargo.toml | zakura-network/Cargo.toml | \
+              zakura-rpc/Cargo.toml | zakura-state/Cargo.toml | \
+              */build.rs | \
+              zakurad/src/* | \
+              zakura-chain/src/parameters/* | \
+              zakura-consensus/src/config.rs | \
+              zakura-network/src/config.rs | zakura-network/src/config/* | \
+              zakura-rpc/src/config.rs | zakura-rpc/src/config/* | \
+              zakura-state/src/config.rs | \
+              zakurad/tests/acceptance.rs | zakurad/tests/common/* | \
+              .config/nextest.toml | \
+              .github/actions/setup-zakura-build/* | \
+              .github/workflows/tests-unit.yml)
+                config=true
+                break
+                ;;
+            esac
+          done <<< "$changed"
+
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+
   # Compile the whole workspace and every test binary ONCE, then hand the result
   # to the shard jobs as a nextest archive. Previously each of the 3 shards ran
   # `cargo nextest run`, so each recompiled the full workspace + all dependencies
@@ -79,8 +162,8 @@ jobs:
         with:
           toolchain: stable
           # PR debug builds restore the cache populated by the main-branch
-          # config job. Main and nightly runs keep separate caches because main
-          # uses `ci-tests`, while nightly uses the exact release profile.
+          # pruned-storage job. Main and nightly runs keep separate caches because
+          # main uses `ci-tests`, while nightly uses the exact release profile.
           cache-shared-key: ${{ github.event_name == 'pull_request' && 'zakura-drb-debug' || (github.event_name == 'schedule' && 'unit-tests-release' || 'unit-tests-ci-tests') }}
           cache-on-failure: true
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -164,6 +247,8 @@ jobs:
 
   zakura-config:
     name: zakura config compatibility
+    needs: [build-tests, changes]
+    if: needs.changes.outputs.config == 'true'
     permissions:
       contents: read
       id-token: write
@@ -177,21 +262,19 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: stable
-          # These acceptance jobs all do the same debug build of the workspace
-          # with the same features, so they share one build cache instead of each
-          # keeping its own multi-GB copy. `cache-shared-key` (unlike `cache-key`,
-          # which only appends to a per-job key and never shares) is stable across
-          # jobs, consolidating their cache entries across workflow runs.
-          cache-shared-key: zakura-drb-debug
-          cache-on-failure: true
-          # This is the only writer for the shared debug cache.
-          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+          # The test binaries come from build-tests, so this job does not compile.
+          cache: false
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
         with:
           tool: cargo-nextest
       - uses: ./.github/actions/setup-zakura-build
+      - name: Download nextest archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: nextest-archive
+          path: ${{ runner.temp }}
       - name: Check generated zakurad config compatibility
-        run: cargo nextest run --profile zakura-config --locked --features default-release-binaries --no-fail-fast
+        run: cargo nextest run --profile zakura-config --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst" --no-fail-fast
 
   network-dependent:
     name: network-dependent acceptance tests
@@ -210,7 +293,10 @@ jobs:
           toolchain: stable
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
-          cache-save-if: false
+          # This main-only debug build is the sole writer for the shared cache.
+          # If this job is removed or stops compiling, move cache ownership to
+          # network-dependent or a dedicated main-branch debug build job.
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
         with:
           tool: cargo-nextest
@@ -278,6 +364,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - changes
       - build-tests
       - unit-tests
       - zakura-config
@@ -290,9 +377,9 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          # The release-only dependency check is skipped outside its event scope.
+          # These jobs are skipped outside their event or changed-path scope.
           # Failed, non-skipped jobs still fail this aggregate status.
-          allowed-skips: check-no-git-dependencies, pruned-storage
+          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config
 
   report-nightly-result:
     name: report nightly release test result

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -125,6 +125,7 @@ jobs:
               zakura-chain/src/parameters/* | \
               zakura-consensus/src/config.rs | \
               zakura-network/src/config.rs | zakura-network/src/config/* | \
+              zakura-network/src/zakura/handler.rs | \
               zakura-rpc/src/config.rs | zakura-rpc/src/config/* | \
               zakura-state/src/config.rs | \
               zakurad/tests/acceptance.rs | zakurad/tests/common/* | \

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -293,10 +293,7 @@ jobs:
           toolchain: stable
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
-          # This main-only debug build is the sole writer for the shared cache.
-          # If this job is removed or stops compiling, move cache ownership to
-          # network-dependent or a dedicated main-branch debug build job.
-          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-save-if: false
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
         with:
           tool: cargo-nextest
@@ -322,7 +319,10 @@ jobs:
           toolchain: stable
           cache-shared-key: zakura-drb-debug
           cache-on-failure: true
-          cache-save-if: false
+          # This main-only debug build is the sole writer for the shared cache.
+          # If this job is removed or stops compiling, move cache ownership to
+          # network-dependent or a dedicated main-branch debug build job.
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
         with:
           tool: cargo-nextest


### PR DESCRIPTION
## Motivation

The unit-test workflow ran config compatibility for every Rust change and rebuilt the debug workspace solely to execute one config test. That job also owned `zakura-drb-debug` because PR unit tests need debug artifacts while main unit tests build with the `ci-tests` profile.

## Solution

- Detect config-contract changes on pull requests, pushes, and merge groups.
- Run config compatibility for relevant paths and manual runs, while skipping unrelated changes and nightly release-profile runs.
- Execute config compatibility from the existing nextest archive instead of recompiling.
- Move the sole `zakura-drb-debug` cache write to the main-only pruned-storage job.
- Document that cache ownership must move to network-dependent or a dedicated debug builder if pruned-storage is removed or stops compiling.
- Keep detector failures visible to the aggregate `test success` gate while allowing intentional config-check skips.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests-unit.yml", aliases: true)'`
- Embedded change-detector script checked with `bash -n`.
- `git diff --check`.
- `./scripts/changelog.py check`.

This is a low-risk CI-only change, so local Rust compilation was not run; draft CI provides the end-to-end workflow validation.

## Changelog

No fragment is required because this PR changes neither Rust source nor Cargo metadata.

### Follow-up Work

If the pruned-storage job is removed or converted to an archive consumer, move `zakura-drb-debug` write ownership as documented in the workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no application code; the main caveat is mis-gated config skips if the path list is incomplete.
> 
> **Overview**
> **CI-only workflow changes** that skip redundant work on unrelated Rust PRs and consolidate who writes the shared debug Cargo cache.
> 
> A new **`changes`** job uses the GitHub API to list touched files on PRs, pushes, and merge groups, and sets `config=true` only when paths that can affect generated or historical `zakurad` config change (or on `workflow_dispatch`). **`zakura-config`** now depends on that output and **`build-tests`**, runs only when `config=true`, and reuses the uploaded nextest archive instead of compiling again with its own `zakura-drb-debug` cache.
> 
> **`pruned-storage`** on `main` becomes the sole writer for **`zakura-drb-debug`** (`cache-save-if` on main); **`zakura-config`** and **`create-release`** disable Rust caching where they do not compile. Comments in **`build-tests`** point PR debug cache restores at that job. **`test-success`** treats skipped **`zakura-config`** as allowed, while **`changes`** still gates the aggregate so detector failures are not ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 077da7380618b57bb66757f7dbc21c9b54793d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->