### PR TITLE
fix(ci): ignore attestations in compat manifest check

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -848,7 +848,18 @@ jobs:
           docker buildx imagetools inspect "zakuracore/zakura:zcashd-compat-${image_version}" \
             --format '{{json .Manifest}}' \
             | jq -e '
-                [ .manifests[].platform | "\(.os)/\(.architecture)" ] as $platforms
+                # BuildKit provenance adds an unknown/unknown attestation
+                # descriptor. Ignore only attestations, then require exactly
+                # the runnable platform published by this image.
+                [
+                  .manifests[]
+                  | select(
+                      .annotations["vnd.docker.reference.type"]
+                      != "attestation-manifest"
+                    )
+                  | .platform
+                  | "\(.os)/\(.architecture)"
+                ] as $platforms
                 | $platforms == ["linux/amd64"]
               ' >/dev/null
 


### PR DESCRIPTION
## Motivation

The v1.0.4 tag-triggered `Release binaries` workflow published the
zcashd-compat Docker manifest, then failed its platform assertion.

BuildKit attaches a provenance descriptor with an `unknown/unknown` platform
alongside the runnable `linux/amd64` image. The workflow compared every
descriptor against exactly `["linux/amd64"]`, so valid provenance made the
release job fail after publication.

## Solution

Exclude descriptors explicitly marked as `attestation-manifest` before
requiring the remaining runnable platform list to equal
`["linux/amd64"]`.

Unexpected runnable platforms and unknown descriptors that are not recognized
attestations still fail the check.

## Testing

- Parsed `.github/workflows/release-binaries.yml` with Ruby's YAML parser.
- Ran `actionlint` v1.7.7 against the edited workflow.
- Verified a jq fixture containing `linux/amd64` and a BuildKit attestation
  passes.
- Verified a jq fixture containing an unexpected runnable `linux/arm64`
  platform fails.
- Inspected the published `zcashd-compat-1.0.4` registry index and confirmed it
  contains the expected `linux/amd64` image plus an
  `attestation-manifest` descriptor.

## Changelog

No changelog fragment: this is an internal release-CI verification fix and
does not change Rust source, Cargo metadata, or user-visible node behavior.

### Specifications & References

- Failed release run:
  https://github.com/zakura-core/zakura/actions/runs/30176078924
- Original failed job:
  https://github.com/zakura-core/zakura/actions/runs/30176078924/job/89725044913

### Follow-up Work

After this fix merges, repair the existing v1.0.4 Docker release by manually
dispatching `release-binaries.yml` from `main` with:

- `release_tag=v1.0.4`
- `publish_docker_to_dockerhub=true`

## AI Disclosure

This CI failure was diagnosed and the focused fix was prepared with Codex
assistance. The published registry manifest and both acceptance and rejection
cases for the jq assertion were checked explicitly.
