### PR TITLE
Recover ambiguous one-block sync tips

### DIFF
--- a/changelog-unreleased/446.md
+++ b/changelog-unreleased/446.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Fixed legacy block sync sometimes remaining one block behind when peers return only the current tip hash
+  ([#446](https://github.com/zakura-core/zakura/pull/446)).

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -801,6 +801,15 @@ where
     /// backing off isn't dropped: every registry-missed required block stays scheduled.
     registry_miss_retry: HashMap<block::Hash, tokio::time::Instant>,
 
+    /// The single untrusted terminal `FindBlocks` hash currently being probed, if any.
+    ///
+    /// Mainnet and Testnet exclude the terminal response hash from trusted chain construction for
+    /// zcashd compatibility. When that leaves no other hashes, the terminal hash can still be
+    /// downloaded as a best-effort discovery hint and passed through normal block verification.
+    /// Keeping one hash here bounds that work and prevents a missing hint from entering the retry
+    /// path for required chain hashes.
+    terminal_probe_hash: Option<block::Hash>,
+
     /// Receiver that is `true` when the downloader is past the lookahead limit.
     /// This is based on the downloaded block height and the state tip height.
     past_lookahead_limit_receiver: zs::WatchReceiver<bool>,
@@ -954,6 +963,7 @@ where
             missing_block_retry_counts: HashMap::new(),
             registry_miss_retry_counts: HashMap::new(),
             registry_miss_retry: HashMap::new(),
+            terminal_probe_hash: None,
             past_lookahead_limit_receiver,
             misbehavior_sender,
             trace,
@@ -1225,6 +1235,7 @@ where
         self.missing_block_retry_counts.clear();
         self.registry_miss_retry_counts.clear();
         self.registry_miss_retry.clear();
+        self.terminal_probe_hash = None;
         let state_tip = self.latest_chain_tip.best_tip_height();
         self.trace.round_start(state_tip);
 
@@ -1682,6 +1693,7 @@ where
         }
 
         let mut download_set = IndexSet::new();
+        let mut terminal_candidate = None;
         while let Some(res) = requests.next().await {
             match res
                 .unwrap_or_else(|e @ JoinError { .. }| {
@@ -1707,23 +1719,44 @@ where
                     // block we want to download. So we just accept any
                     // out-of-order first hashes.
 
-                    // We use the last hash for the tip, and we want to avoid bad
-                    // tips from zcashd's quirk of appending an unrelated hash.
-                    // So we discard the last hash on mainnet/testnet.
-                    // (We don't need to worry about missed downloads, because we
-                    // will pick them up again in ExtendTips.)
+                    // We use the last ordered hash for the tip, and we want to avoid bad tips from
+                    // zcashd's quirk of appending an unrelated hash. So we exclude the last hash
+                    // from ordered tip construction on mainnet/testnet. If it is the only response
+                    // hash, retain one bounded candidate for normal block verification without
+                    // trusting it as a tip.
                     //
-                    // In regtest we only connect to Zebra nodes, not zcashd,
-                    // so we trust all hashes in the response and keep them all.
-                    // This is necessary when there are only a small number of
-                    // blocks to sync (e.g. 2 new blocks), where stripping the
-                    // last hash leaves only 1 unknown hash and rchunks_exact(2)
-                    // would discard the entire response.
+                    // In regtest we only connect to Zebra nodes, not zcashd, so we trust all hashes
+                    // in the response and keep them all.
                     let hashes = if self.is_regtest {
                         hashes.as_slice()
                     } else {
                         match hashes.as_slice() {
                             [] => continue,
+                            [candidate] => {
+                                metrics::counter!("sync.obtain.terminal.candidate.observed.count")
+                                    .increment(1);
+
+                                // A single hash cannot establish chain order, but it is useful as
+                                // the same untrusted discovery hint as an `inv`. Keep at most one
+                                // candidate per fanout, and never start another while a previous
+                                // terminal probe is still in flight.
+                                if terminal_candidate.is_none()
+                                    && self.terminal_probe_hash.is_none()
+                                {
+                                    terminal_candidate = Some(*candidate);
+                                    debug!(
+                                        hash = ?candidate,
+                                        "retaining lone terminal FindBlocks hash as an untrusted probe candidate"
+                                    );
+                                } else {
+                                    metrics::counter!(
+                                        "sync.obtain.terminal.candidate.dropped.count"
+                                    )
+                                    .increment(1);
+                                }
+
+                                continue;
+                            }
                             [rest @ .., _last] => rest,
                         }
                     };
@@ -1755,29 +1788,35 @@ where
 
                     trace!(?unknown_hashes);
 
-                    let new_tip = if let Some(end) = unknown_hashes.rchunks_exact(2).next() {
-                        CheckedTip {
+                    let new_tip = unknown_hashes
+                        .rchunks_exact(2)
+                        .next()
+                        .map(|end| CheckedTip {
                             tip: end[0],
                             expected_next: end[1],
-                        }
-                    } else {
-                        debug!("discarding response that extends only one block");
-                        continue;
-                    };
+                        });
 
                     // Make sure we get the same tips, regardless of the
                     // order of peer responses
-                    if !download_set.contains(&new_tip.expected_next) {
-                        debug!(?new_tip,
-                                        "adding new prospective tip, and removing existing tips in the new block hash list");
-                        self.prospective_tips
-                            .retain(|t| !unknown_hashes.contains(&t.expected_next));
-                        self.prospective_tips.insert(new_tip);
+                    if let Some(new_tip) = new_tip {
+                        if !download_set.contains(&new_tip.expected_next) {
+                            debug!(?new_tip,
+                                            "adding new prospective tip, and removing existing tips in the new block hash list");
+                            self.prospective_tips
+                                .retain(|t| !unknown_hashes.contains(&t.expected_next));
+                            self.prospective_tips.insert(new_tip);
+                        } else {
+                            debug!(
+                                ?new_tip,
+                                "discarding prospective tip: already in download set"
+                            );
+                        }
                     } else {
                         debug!(
-                            ?new_tip,
-                            "discarding prospective tip: already in download set"
+                            hash = ?unknown_hashes[0],
+                            "queueing one discovered block without constructing a prospective tip"
                         );
+                        metrics::counter!("sync.obtain.single.interior.hash.count").increment(1);
                     }
 
                     // security: the first response determines our download order
@@ -1804,6 +1843,37 @@ where
             debug!(?hash, "checking if state contains hash");
             if self.state_contains(*hash).await? {
                 return Err(eyre!("queued download of hash behind our chain tip"));
+            }
+        }
+
+        // Probe a lone terminal hash only when the normal ordered response produced no work. The
+        // hash is not a trusted tip and does not enter `prospective_tips`; downloading the block
+        // merely feeds the existing hash-binding, height, proof-of-work, and consensus checks.
+        if download_set.is_empty() && self.terminal_probe_hash.is_none() {
+            if let Some(candidate) = terminal_candidate {
+                if self.downloads.as_ref().get_ref().contains(candidate) {
+                    debug!(
+                        hash = ?candidate,
+                        "skipping in-flight terminal FindBlocks probe candidate"
+                    );
+                    metrics::counter!("sync.obtain.terminal.candidate.in_flight.count")
+                        .increment(1);
+                } else if self.state_contains(candidate).await? {
+                    debug!(
+                        hash = ?candidate,
+                        "skipping known terminal FindBlocks probe candidate"
+                    );
+                    metrics::counter!("sync.obtain.terminal.candidate.known.count").increment(1);
+                } else {
+                    info!(
+                        hash = ?candidate,
+                        "probing lone terminal FindBlocks hash through normal block verification"
+                    );
+                    metrics::counter!("sync.obtain.terminal.probe.queued.count").increment(1);
+                    self.trace.terminal_probe(candidate, "queued", None, None);
+                    self.terminal_probe_hash = Some(candidate);
+                    download_set.insert(candidate);
+                }
             }
         }
 
@@ -2163,11 +2233,58 @@ where
     /// speculative dispatch and re-dispatching the hash from its `select!` timer arm once the backoff
     /// elapses. Bounded by [`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]; only a block that stays missing
     /// for the whole budget (e.g. a bad tip) falls through to [`Self::handle_block_response`] and
-    /// restarts the round to obtain fresh tips and peers.
+    /// restarts the round to obtain fresh tips and peers. A lone terminal-hash probe is not a
+    /// required ordered block, so a miss ends that best-effort probe without using either queue
+    /// retry budget.
     async fn handle_block_response_with_missing_retry(
         &mut self,
         response: Result<(Height, block::Hash), BlockDownloadVerifyError>,
     ) -> Result<(), Report> {
+        let response_hash = response
+            .as_ref()
+            .ok()
+            .map(|(_height, hash)| *hash)
+            .or_else(|| response.as_ref().err().and_then(|error| error.block_hash()));
+
+        if let Some(hash) = response_hash.filter(|hash| Some(*hash) == self.terminal_probe_hash) {
+            self.terminal_probe_hash = None;
+
+            match &response {
+                Ok((height, _hash)) => {
+                    info!(?hash, ?height, "verified lone terminal FindBlocks probe");
+                    metrics::counter!("sync.obtain.terminal.probe.verified.count").increment(1);
+                    self.trace
+                        .terminal_probe(hash, "verified", Some(*height), None);
+                }
+                Err(error) if error.not_found_download().is_some() => {
+                    // This hash was only an untrusted discovery hint, not an ordered hash required
+                    // to complete a known range. Let the next fanout discover it again rather than
+                    // applying the long registry-miss retry budget used for required blocks.
+                    debug!(
+                        ?hash,
+                        ?error,
+                        "lone terminal FindBlocks probe was unavailable"
+                    );
+                    metrics::counter!("sync.obtain.terminal.probe.unavailable.count").increment(1);
+                    self.trace
+                        .terminal_probe(hash, "unavailable", None, Some(error));
+                    self.missing_block_retry_counts.remove(&hash);
+                    self.registry_miss_retry_counts.remove(&hash);
+                    self.registry_miss_retry.remove(&hash);
+                    return Ok(());
+                }
+                Err(error) => {
+                    debug!(
+                        ?hash,
+                        ?error,
+                        "lone terminal FindBlocks probe failed normal block processing"
+                    );
+                    metrics::counter!("sync.obtain.terminal.probe.failed.count").increment(1);
+                    self.trace.terminal_probe(hash, "failed", None, Some(error));
+                }
+            }
+        }
+
         if let Ok((_height, hash)) = response.as_ref() {
             self.missing_block_retry_counts.remove(hash);
             self.registry_miss_retry_counts.remove(hash);

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -1833,10 +1833,15 @@ where
 
         // Probe ambiguous hashes only when the ordered responses produced no work. They don't enter
         // `prospective_tips`, and misses don't use the required-block retry budgets.
-        if download_set.is_empty() && self.ambiguous_probe_hashes.is_empty() {
+        if download_set.is_empty() {
             debug_assert!(probe_candidates.len() <= FANOUT);
+            debug_assert!(self.ambiguous_probe_hashes.len() <= FANOUT);
 
             for candidate in probe_candidates {
+                if self.ambiguous_probe_hashes.len() >= FANOUT {
+                    break;
+                }
+
                 if self.downloads.as_ref().get_ref().contains(candidate) {
                     debug!(
                         hash = ?candidate,

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -33,7 +33,9 @@ use zakura_chain::{
     block::{self, Height, HeightDiff},
     chain_tip::ChainTip,
 };
-use zakura_consensus::{RouterError, VerifyBlockError, VerifyCheckpointError};
+use zakura_consensus::{
+    error::TransactionError, RouterError, VerifyBlockError, VerifyCheckpointError,
+};
 use zakura_network::{self as zn, PeerSocketAddr};
 use zakura_state as zs;
 
@@ -94,6 +96,7 @@ fn is_internal_block_verifier_failure(error: &VerifyBlockError) -> bool {
         | VerifyBlockError::ValidateProposal(_)
         | VerifyBlockError::StateService { .. } => true,
         VerifyBlockError::Commit(error) => is_internal_commit_failure(error),
+        VerifyBlockError::Transaction(TransactionError::InternalDowncastError(_)) => true,
         VerifyBlockError::Block { .. }
         | VerifyBlockError::Equihash { .. }
         | VerifyBlockError::Time(_)

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -1555,6 +1555,7 @@ where
                         // security: use the actual number of new downloads from all peers, so the
                         // last peer to respond can't toggle our mempool.
                         self.recent_syncs.push_extend_tips_length(discovered);
+                        self.promote_ambiguous_probes(&download_set);
                         reserve.extend(download_set);
                         extend = None;
                         last_progress = Instant::now();
@@ -1873,9 +1874,8 @@ where
         debug!(?self.prospective_tips);
 
         // Check that the new tips we got are actually unknown.
+        self.promote_ambiguous_probes(&download_set);
         for hash in &download_set {
-            // Ordered evidence promotes an in-flight probe to required-block retry semantics.
-            self.ambiguous_probe_hashes.remove(hash);
             debug!(?hash, "checking if state contains hash");
             if self.state_contains(*hash).await? {
                 return Err(eyre!("queued download of hash behind our chain tip"));
@@ -1928,6 +1928,15 @@ where
             .record(stage_start.elapsed().as_secs_f64());
 
         Self::handle_hash_response(response, self.expose_peer_addresses).map_err(Into::into)
+    }
+
+    fn promote_ambiguous_probes<'a>(
+        &mut self,
+        ordered_hashes: impl IntoIterator<Item = &'a block::Hash>,
+    ) {
+        for hash in ordered_hashes {
+            self.ambiguous_probe_hashes.remove(hash);
+        }
     }
 
     /// Asks peers to extend the given prospective `tips`, returning the newly discovered block

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -801,14 +801,11 @@ where
     /// backing off isn't dropped: every registry-missed required block stays scheduled.
     registry_miss_retry: HashMap<block::Hash, tokio::time::Instant>,
 
-    /// The single untrusted terminal `FindBlocks` hash currently being probed, if any.
+    /// Untrusted `FindBlocks` hashes currently being probed, bounded by [`FANOUT`].
     ///
-    /// Mainnet and Testnet exclude the terminal response hash from trusted chain construction for
-    /// zcashd compatibility. When that leaves no other hashes, the terminal hash can still be
-    /// downloaded as a best-effort discovery hint and passed through normal block verification.
-    /// Keeping one hash here bounds that work and prevents a missing hint from entering the retry
-    /// path for required chain hashes.
-    terminal_probe_hash: Option<block::Hash>,
+    /// These hashes can't establish chain order, so missing probes must not use the retry path for
+    /// required chain hashes.
+    ambiguous_probe_hashes: HashSet<block::Hash>,
 
     /// Receiver that is `true` when the downloader is past the lookahead limit.
     /// This is based on the downloaded block height and the state tip height.
@@ -963,7 +960,7 @@ where
             missing_block_retry_counts: HashMap::new(),
             registry_miss_retry_counts: HashMap::new(),
             registry_miss_retry: HashMap::new(),
-            terminal_probe_hash: None,
+            ambiguous_probe_hashes: HashSet::new(),
             past_lookahead_limit_receiver,
             misbehavior_sender,
             trace,
@@ -1235,7 +1232,7 @@ where
         self.missing_block_retry_counts.clear();
         self.registry_miss_retry_counts.clear();
         self.registry_miss_retry.clear();
-        self.terminal_probe_hash = None;
+        self.ambiguous_probe_hashes.clear();
         let state_tip = self.latest_chain_tip.best_tip_height();
         self.trace.round_start(state_tip);
 
@@ -1693,7 +1690,7 @@ where
         }
 
         let mut download_set = IndexSet::new();
-        let mut terminal_candidate = None;
+        let mut probe_candidates = IndexSet::new();
         while let Some(res) = requests.next().await {
             match res
                 .unwrap_or_else(|e @ JoinError { .. }| {
@@ -1722,7 +1719,7 @@ where
                     // We use the last ordered hash for the tip, and we want to avoid bad tips from
                     // zcashd's quirk of appending an unrelated hash. So we exclude the last hash
                     // from ordered tip construction on mainnet/testnet. If it is the only response
-                    // hash, retain one bounded candidate for normal block verification without
+                    // hash, retain it as a bounded candidate for normal block verification without
                     // trusting it as a tip.
                     //
                     // In regtest we only connect to Zebra nodes, not zcashd, so we trust all hashes
@@ -1733,27 +1730,11 @@ where
                         match hashes.as_slice() {
                             [] => continue,
                             [candidate] => {
-                                metrics::counter!("sync.obtain.terminal.candidate.observed.count")
-                                    .increment(1);
-
-                                // A single hash cannot establish chain order, but it is useful as
-                                // the same untrusted discovery hint as an `inv`. Keep at most one
-                                // candidate per fanout, and never start another while a previous
-                                // terminal probe is still in flight.
-                                if terminal_candidate.is_none()
-                                    && self.terminal_probe_hash.is_none()
-                                {
-                                    terminal_candidate = Some(*candidate);
-                                    debug!(
-                                        hash = ?candidate,
-                                        "retaining lone terminal FindBlocks hash as an untrusted probe candidate"
-                                    );
-                                } else {
-                                    metrics::counter!(
-                                        "sync.obtain.terminal.candidate.dropped.count"
-                                    )
-                                    .increment(1);
-                                }
+                                probe_candidates.insert(*candidate);
+                                debug!(
+                                    hash = ?candidate,
+                                    "retaining lone terminal FindBlocks hash as an untrusted probe candidate"
+                                );
 
                                 continue;
                             }
@@ -1788,35 +1769,37 @@ where
 
                     trace!(?unknown_hashes);
 
-                    let new_tip = unknown_hashes
+                    if let [candidate] = unknown_hashes {
+                        probe_candidates.insert(*candidate);
+                        debug!(
+                            hash = ?candidate,
+                            "retaining unpaired FindBlocks hash as an untrusted probe candidate"
+                        );
+                        continue;
+                    }
+
+                    let end = unknown_hashes
                         .rchunks_exact(2)
                         .next()
-                        .map(|end| CheckedTip {
-                            tip: end[0],
-                            expected_next: end[1],
-                        });
+                        .expect("responses with fewer than two unknown hashes are handled above");
+                    let new_tip = CheckedTip {
+                        tip: end[0],
+                        expected_next: end[1],
+                    };
 
                     // Make sure we get the same tips, regardless of the
                     // order of peer responses
-                    if let Some(new_tip) = new_tip {
-                        if !download_set.contains(&new_tip.expected_next) {
-                            debug!(?new_tip,
-                                            "adding new prospective tip, and removing existing tips in the new block hash list");
-                            self.prospective_tips
-                                .retain(|t| !unknown_hashes.contains(&t.expected_next));
-                            self.prospective_tips.insert(new_tip);
-                        } else {
-                            debug!(
-                                ?new_tip,
-                                "discarding prospective tip: already in download set"
-                            );
-                        }
+                    if !download_set.contains(&new_tip.expected_next) {
+                        debug!(?new_tip,
+                                        "adding new prospective tip, and removing existing tips in the new block hash list");
+                        self.prospective_tips
+                            .retain(|t| !unknown_hashes.contains(&t.expected_next));
+                        self.prospective_tips.insert(new_tip);
                     } else {
                         debug!(
-                            hash = ?unknown_hashes[0],
-                            "queueing one discovered block without constructing a prospective tip"
+                            ?new_tip,
+                            "discarding prospective tip: already in download set"
                         );
-                        metrics::counter!("sync.obtain.single.interior.hash.count").increment(1);
                     }
 
                     // security: the first response determines our download order
@@ -1840,38 +1823,36 @@ where
 
         // Check that the new tips we got are actually unknown.
         for hash in &download_set {
+            // Ordered evidence promotes an in-flight probe to required-block retry semantics.
+            self.ambiguous_probe_hashes.remove(hash);
             debug!(?hash, "checking if state contains hash");
             if self.state_contains(*hash).await? {
                 return Err(eyre!("queued download of hash behind our chain tip"));
             }
         }
 
-        // Probe a lone terminal hash only when the normal ordered response produced no work. The
-        // hash is not a trusted tip and does not enter `prospective_tips`; downloading the block
-        // merely feeds the existing hash-binding, height, proof-of-work, and consensus checks.
-        if download_set.is_empty() && self.terminal_probe_hash.is_none() {
-            if let Some(candidate) = terminal_candidate {
+        // Probe ambiguous hashes only when the ordered responses produced no work. They don't enter
+        // `prospective_tips`, and misses don't use the required-block retry budgets.
+        if download_set.is_empty() && self.ambiguous_probe_hashes.is_empty() {
+            debug_assert!(probe_candidates.len() <= FANOUT);
+
+            for candidate in probe_candidates {
                 if self.downloads.as_ref().get_ref().contains(candidate) {
                     debug!(
                         hash = ?candidate,
-                        "skipping in-flight terminal FindBlocks probe candidate"
+                        "skipping in-flight ambiguous FindBlocks probe candidate"
                     );
-                    metrics::counter!("sync.obtain.terminal.candidate.in_flight.count")
-                        .increment(1);
                 } else if self.state_contains(candidate).await? {
                     debug!(
                         hash = ?candidate,
-                        "skipping known terminal FindBlocks probe candidate"
+                        "skipping known ambiguous FindBlocks probe candidate"
                     );
-                    metrics::counter!("sync.obtain.terminal.candidate.known.count").increment(1);
                 } else {
                     info!(
                         hash = ?candidate,
-                        "probing lone terminal FindBlocks hash through normal block verification"
+                        "probing ambiguous FindBlocks hash through normal block verification"
                     );
-                    metrics::counter!("sync.obtain.terminal.probe.queued.count").increment(1);
-                    self.trace.terminal_probe(candidate, "queued", None, None);
-                    self.terminal_probe_hash = Some(candidate);
+                    self.ambiguous_probe_hashes.insert(candidate);
                     download_set.insert(candidate);
                 }
             }
@@ -2233,9 +2214,8 @@ where
     /// speculative dispatch and re-dispatching the hash from its `select!` timer arm once the backoff
     /// elapses. Bounded by [`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]; only a block that stays missing
     /// for the whole budget (e.g. a bad tip) falls through to [`Self::handle_block_response`] and
-    /// restarts the round to obtain fresh tips and peers. A lone terminal-hash probe is not a
-    /// required ordered block, so a miss ends that best-effort probe without using either queue
-    /// retry budget.
+    /// restarts the round to obtain fresh tips and peers. An ambiguous-hash probe is not a required
+    /// ordered block, so a miss ends that best-effort probe without using either queue retry budget.
     async fn handle_block_response_with_missing_retry(
         &mut self,
         response: Result<(Height, block::Hash), BlockDownloadVerifyError>,
@@ -2246,41 +2226,45 @@ where
             .map(|(_height, hash)| *hash)
             .or_else(|| response.as_ref().err().and_then(|error| error.block_hash()));
 
-        if let Some(hash) = response_hash.filter(|hash| Some(*hash) == self.terminal_probe_hash) {
-            self.terminal_probe_hash = None;
+        let ambiguous_probe_hash =
+            response_hash.filter(|hash| self.ambiguous_probe_hashes.remove(hash));
+
+        if let Some(hash) = ambiguous_probe_hash {
+            self.missing_block_retry_counts.remove(&hash);
+            self.registry_miss_retry_counts.remove(&hash);
+            self.registry_miss_retry.remove(&hash);
 
             match &response {
                 Ok((height, _hash)) => {
-                    info!(?hash, ?height, "verified lone terminal FindBlocks probe");
-                    metrics::counter!("sync.obtain.terminal.probe.verified.count").increment(1);
-                    self.trace
-                        .terminal_probe(hash, "verified", Some(*height), None);
+                    info!(?hash, ?height, "verified ambiguous FindBlocks probe");
+                    return Ok(());
                 }
                 Err(error) if error.not_found_download().is_some() => {
                     // This hash was only an untrusted discovery hint, not an ordered hash required
                     // to complete a known range. Let the next fanout discover it again rather than
                     // applying the long registry-miss retry budget used for required blocks.
-                    debug!(
-                        ?hash,
-                        ?error,
-                        "lone terminal FindBlocks probe was unavailable"
-                    );
-                    metrics::counter!("sync.obtain.terminal.probe.unavailable.count").increment(1);
-                    self.trace
-                        .terminal_probe(hash, "unavailable", None, Some(error));
-                    self.missing_block_retry_counts.remove(&hash);
-                    self.registry_miss_retry_counts.remove(&hash);
-                    self.registry_miss_retry.remove(&hash);
+                    debug!(?hash, ?error, "ambiguous FindBlocks probe was unavailable");
                     return Ok(());
                 }
                 Err(error) => {
+                    let is_peer_failure = matches!(
+                        error,
+                        BlockDownloadVerifyError::DownloadFailed { .. }
+                            | BlockDownloadVerifyError::Invalid { .. }
+                    );
                     debug!(
                         ?hash,
                         ?error,
-                        "lone terminal FindBlocks probe failed normal block processing"
+                        "ambiguous FindBlocks probe failed normal block processing"
                     );
-                    metrics::counter!("sync.obtain.terminal.probe.failed.count").increment(1);
-                    self.trace.terminal_probe(hash, "failed", None, Some(error));
+
+                    let result = self.handle_block_response(response);
+                    if is_peer_failure {
+                        // One peer's bad block must not cancel other probes from the same fanout.
+                        return Ok(());
+                    }
+
+                    return result.map_err(Into::into);
                 }
             }
         }

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -2247,8 +2247,15 @@ where
                     return Ok(());
                 }
                 Err(error) => {
-                    let is_peer_failure =
-                        matches!(error, BlockDownloadVerifyError::DownloadFailed { .. });
+                    // Only scored verifier errors are definitely attributable to the peer;
+                    // score-zero errors can be internal.
+                    let is_peer_failure = match error {
+                        BlockDownloadVerifyError::DownloadFailed { .. } => true,
+                        BlockDownloadVerifyError::Invalid { error, .. } => {
+                            error.misbehavior_score() != 0
+                        }
+                        _ => false,
+                    };
                     debug!(
                         ?hash,
                         ?error,

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -33,6 +33,7 @@ use zakura_chain::{
     block::{self, Height, HeightDiff},
     chain_tip::ChainTip,
 };
+use zakura_consensus::{RouterError, VerifyBlockError, VerifyCheckpointError};
 use zakura_network::{self as zn, PeerSocketAddr};
 use zakura_state as zs;
 
@@ -78,6 +79,56 @@ fn block_error_peer_label(error: &BlockDownloadVerifyError, expose_peer_addresse
         .advertiser_addr()
         .map(|addr| peer_addr_label(addr, expose_peer_addresses))
         .unwrap_or_else(|| "unattributed".to_string())
+}
+
+fn is_internal_commit_failure(error: &zs::CommitBlockError) -> bool {
+    !matches!(
+        error,
+        zs::CommitBlockError::Duplicate { .. } | zs::CommitBlockError::ValidateContextError(_)
+    )
+}
+
+fn is_internal_block_verifier_failure(error: &VerifyBlockError) -> bool {
+    match error {
+        VerifyBlockError::Depth { .. }
+        | VerifyBlockError::ValidateProposal(_)
+        | VerifyBlockError::StateService { .. } => true,
+        VerifyBlockError::Commit(error) => is_internal_commit_failure(error),
+        VerifyBlockError::Block { .. }
+        | VerifyBlockError::Equihash { .. }
+        | VerifyBlockError::Time(_)
+        | VerifyBlockError::Transaction(_)
+        | VerifyBlockError::Subsidy(_) => false,
+        _ => true,
+    }
+}
+
+fn is_internal_verifier_failure(error: &RouterError) -> bool {
+    match error {
+        RouterError::Block { source } => is_internal_block_verifier_failure(source),
+        RouterError::Checkpoint { source } => match source.as_ref() {
+            VerifyCheckpointError::Finished
+            | VerifyCheckpointError::TooHigh { .. }
+            | VerifyCheckpointError::AlreadyVerified { .. }
+            | VerifyCheckpointError::NewerRequest { .. }
+            | VerifyCheckpointError::Dropped
+            | VerifyCheckpointError::Tip(_)
+            | VerifyCheckpointError::CheckpointList(_)
+            | VerifyCheckpointError::QueuedLimit
+            | VerifyCheckpointError::ShuttingDown => true,
+            VerifyCheckpointError::CommitCheckpointVerified(source) => source
+                .downcast_ref::<zs::CommitCheckpointVerifiedError>()
+                .map(|error| is_internal_commit_failure(error.inner()))
+                .unwrap_or(true),
+            VerifyCheckpointError::VerifyBlock(error) => is_internal_block_verifier_failure(error),
+            VerifyCheckpointError::CoinbaseHeight { .. }
+            | VerifyCheckpointError::BadMerkleRoot { .. }
+            | VerifyCheckpointError::DuplicateTransaction
+            | VerifyCheckpointError::SubsidyError(_)
+            | VerifyCheckpointError::AmountError(_)
+            | VerifyCheckpointError::UnexpectedSideChain { .. } => false,
+        },
+    }
 }
 
 /// Controls how many times the syncer requeues a required block hash after a peer responds
@@ -2252,12 +2303,10 @@ where
                     return Ok(());
                 }
                 Err(error) => {
-                    // Only scored verifier errors are definitely attributable to the peer;
-                    // score-zero errors can be internal.
-                    let is_peer_failure = match error {
+                    let is_probe_local_failure = match error {
                         BlockDownloadVerifyError::DownloadFailed { .. } => true,
                         BlockDownloadVerifyError::Invalid { error, .. } => {
-                            error.misbehavior_score() != 0
+                            !is_internal_verifier_failure(error)
                         }
                         _ => false,
                     };
@@ -2268,7 +2317,7 @@ where
                     );
 
                     let result = self.handle_block_response(response);
-                    if is_peer_failure {
+                    if is_probe_local_failure {
                         // One peer's bad block must not cancel other probes from the same fanout.
                         return Ok(());
                     }

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -2247,11 +2247,8 @@ where
                     return Ok(());
                 }
                 Err(error) => {
-                    let is_peer_failure = matches!(
-                        error,
-                        BlockDownloadVerifyError::DownloadFailed { .. }
-                            | BlockDownloadVerifyError::Invalid { .. }
-                    );
+                    let is_peer_failure =
+                        matches!(error, BlockDownloadVerifyError::DownloadFailed { .. });
                     debug!(
                         ?hash,
                         ?error,

--- a/zakurad/src/components/sync/downloads.rs
+++ b/zakurad/src/components/sync/downloads.rs
@@ -191,6 +191,25 @@ pub(super) enum NotFoundKind {
 }
 
 impl BlockDownloadVerifyError {
+    /// Returns the block hash associated with this error, when the error identifies one.
+    pub(super) fn block_hash(&self) -> Option<block::Hash> {
+        match self {
+            Self::DuplicateBlockQueuedForDownload { hash }
+            | Self::DownloadFailed { hash, .. }
+            | Self::AboveLookaheadHeightLimit { hash, .. }
+            | Self::BehindTipHeightLimit { hash, .. }
+            | Self::InvalidHeight { hash, .. }
+            | Self::Invalid { hash, .. }
+            | Self::ValidationRequestError { hash, .. }
+            | Self::CancelledDuringDownload { hash }
+            | Self::CancelledAwaitingVerifierReadiness { hash, .. }
+            | Self::CancelledDuringVerification { hash, .. } => Some(*hash),
+            Self::NetworkServiceError { .. }
+            | Self::VerifierServiceError { .. }
+            | Self::Timeout => None,
+        }
+    }
+
     /// Returns the connected legacy peer that supplied the invalid block, if known.
     pub(super) fn advertiser_addr(&self) -> Option<PeerSocketAddr> {
         match self {
@@ -929,6 +948,11 @@ where
     /// Get the number of currently in-flight download and verify tasks.
     pub fn in_flight(&self) -> usize {
         self.pending.len()
+    }
+
+    /// Returns `true` if this block already has an in-flight download or verification task.
+    pub(super) fn contains(&self, hash: block::Hash) -> bool {
+        self.cancel_handles.contains_key(&hash)
     }
 
     /// Returns true if there are no in-flight download and verify tasks.

--- a/zakurad/src/components/sync/legacy_trace.rs
+++ b/zakurad/src/components/sync/legacy_trace.rs
@@ -109,24 +109,6 @@ impl LegacySyncTrace {
         });
     }
 
-    /// Records the bounded terminal-hash probe lifecycle separately from generic block work.
-    pub(super) fn terminal_probe(
-        &self,
-        hash: block::Hash,
-        result: &'static str,
-        height: Option<Height>,
-        error: Option<&dyn Display>,
-    ) {
-        self.emit("terminal_probe", |row| {
-            row.insert("hash".to_string(), Value::String(hash.to_string()));
-            row.insert("result".to_string(), Value::String(result.to_string()));
-            insert_height(row, "height", height);
-            if let Some(error) = error {
-                row.insert("error".to_string(), Value::String(error.to_string()));
-            }
-        });
-    }
-
     pub(super) fn block_finish(
         &self,
         hash: block::Hash,

--- a/zakurad/src/components/sync/legacy_trace.rs
+++ b/zakurad/src/components/sync/legacy_trace.rs
@@ -109,6 +109,24 @@ impl LegacySyncTrace {
         });
     }
 
+    /// Records the bounded terminal-hash probe lifecycle separately from generic block work.
+    pub(super) fn terminal_probe(
+        &self,
+        hash: block::Hash,
+        result: &'static str,
+        height: Option<Height>,
+        error: Option<&dyn Display>,
+    ) {
+        self.emit("terminal_probe", |row| {
+            row.insert("hash".to_string(), Value::String(hash.to_string()));
+            row.insert("result".to_string(), Value::String(result.to_string()));
+            insert_height(row, "height", height);
+            if let Some(error) = error {
+                row.insert("error".to_string(), Value::String(error.to_string()));
+            }
+        });
+    }
+
     pub(super) fn block_finish(
         &self,
         hash: block::Hash,

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -22,7 +22,7 @@ use zakura_chain::{
     serialization::ZcashDeserializeInto,
 };
 use zakura_consensus::{
-    Config as ConsensusConfig, RouterError, VerifyBlockError, VerifyCheckpointError,
+    BlockError, Config as ConsensusConfig, RouterError, VerifyBlockError, VerifyCheckpointError,
 };
 use zakura_network::{InventoryResponse, PeerSocketAddr};
 use zakura_state::Config as StateConfig;
@@ -2456,10 +2456,9 @@ async fn ambiguous_probe_registry_miss_does_not_schedule_required_block_retries(
     peer_set.expect_no_requests().await;
 }
 
-/// Internal verifier failures must retain the normal sync-restart behavior, even when the block
-/// was discovered through an ambiguous best-effort probe.
+/// Peer-invalid ambiguous probes end independently, while internal verifier failures restart sync.
 #[tokio::test]
-async fn ambiguous_probe_propagates_verifier_state_service_failures() {
+async fn ambiguous_probe_distinguishes_peer_and_internal_verifier_failures() {
     let (
         mut chain_sync,
         _sync_status,
@@ -2469,22 +2468,44 @@ async fn ambiguous_probe_propagates_verifier_state_service_failures() {
         _mock_chain_tip_sender,
     ) = setup_chain_sync();
 
-    let block_hash = block::Hash::from([0xBD; 32]);
-    chain_sync.ambiguous_probe_hashes.insert(block_hash);
-    let error = BlockDownloadVerifyError::Invalid {
+    let peer_invalid_hash = block::Hash::from([0xBD; 32]);
+    let internal_failure_hash = block::Hash::from([0xBE; 32]);
+    chain_sync
+        .ambiguous_probe_hashes
+        .extend([peer_invalid_hash, internal_failure_hash]);
+    let peer_error = BlockDownloadVerifyError::Invalid {
         error: RouterError::Block {
-            source: Box::new(VerifyBlockError::StateService {
-                source: crate::BoxError::from("synthetic state service failure"),
-                hash: block_hash,
+            source: Box::new(VerifyBlockError::Block {
+                source: BlockError::NoTransactions,
             }),
         },
         height: Height(1),
-        hash: block_hash,
+        hash: peer_invalid_hash,
+        advertiser_addr: Some("127.0.0.1:8233".parse().unwrap()),
+    };
+    chain_sync
+        .handle_block_response_with_missing_retry(Err(peer_error))
+        .await
+        .expect("a peer-invalid candidate should not cancel sibling probes");
+    assert_eq!(
+        chain_sync.ambiguous_probe_hashes,
+        HashSet::from([internal_failure_hash])
+    );
+
+    let internal_error = BlockDownloadVerifyError::Invalid {
+        error: RouterError::Block {
+            source: Box::new(VerifyBlockError::StateService {
+                source: crate::BoxError::from("synthetic state service failure"),
+                hash: internal_failure_hash,
+            }),
+        },
+        height: Height(1),
+        hash: internal_failure_hash,
         advertiser_addr: None,
     };
 
     let result = chain_sync
-        .handle_block_response_with_missing_retry(Err(error))
+        .handle_block_response_with_missing_retry(Err(internal_error))
         .await;
 
     assert!(

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -1886,8 +1886,8 @@ async fn obtain_tips_ignores_known_hash_after_first_unknown() -> Result<(), crat
 }
 
 #[tokio::test]
-async fn obtain_tips_downloads_lone_terminal_hash_as_bounded_probe() -> Result<(), crate::BoxError>
-{
+async fn obtain_tips_bad_or_known_candidate_does_not_suppress_later_block(
+) -> Result<(), crate::BoxError> {
     let (
         mut chain_sync,
         _sync_status,
@@ -1903,39 +1903,56 @@ async fn obtain_tips_downloads_lone_terminal_hash_as_bounded_probe() -> Result<(
         zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
     let block0_hash = block0.hash();
     let block1_hash = block1.hash();
+    let known_hash = block::Hash::from([0x51; 32]);
+    let bad_hash = block::Hash::from([0x52; 32]);
+    let untrusted_terminal_hash = block::Hash::from([0x53; 32]);
 
     let respond_to_requests = async {
         state_service
             .expect_request(zs::Request::BlockLocator)
             .await
             .respond(zs::Response::BlockLocator(vec![block0_hash]));
-
-        // At the network tip, the only unknown block is also the terminal hash that mainnet and
-        // testnet sync normally exclude from trusted tip construction for zcashd compatibility.
-        peer_set
-            .expect_request(zn::Request::FindBlocks {
-                known_blocks: vec![block0_hash],
-                stop: None,
-            })
-            .await
-            .respond(zn::Response::BlockHashes(vec![block1_hash]));
-
-        for _ in 0..(sync::FANOUT - 1) {
+        for hashes in [
+            vec![known_hash],
+            vec![bad_hash],
+            vec![block1_hash, untrusted_terminal_hash],
+        ] {
             peer_set
                 .expect_request(zn::Request::FindBlocks {
                     known_blocks: vec![block0_hash],
                     stop: None,
                 })
                 .await
-                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+                .respond(zn::Response::BlockHashes(hashes));
         }
 
-        // A lone terminal hash is untrusted discovery input. It still gets the normal state,
-        // download, hash-binding, height, proof-of-work, and consensus verification path.
+        // The two-hash response leaves one unpaired interior candidate after compatibility
+        // stripping. It must use the same best-effort path as the lone candidates.
         state_service
             .expect_request(zs::Request::KnownBlock(block1_hash))
             .await
             .respond(zs::Response::KnownBlock(None));
+        state_service
+            .expect_request(zs::Request::KnownBlock(known_hash))
+            .await
+            .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
+        state_service
+            .expect_request(zs::Request::KnownBlock(bad_hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+        state_service
+            .expect_request(zs::Request::KnownBlock(block1_hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+
+        // The first candidate fails immediately, but the later honest candidate is still queued.
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(iter::once(bad_hash).collect()))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((
+                block0.clone(),
+                None,
+            ))]));
         peer_set
             .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
             .await
@@ -1954,295 +1971,39 @@ async fn obtain_tips_downloads_lone_terminal_hash_as_bounded_probe() -> Result<(
     let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
     responded?;
     assert!(extra_hashes?.is_empty());
-
-    let response = chain_sync.downloads.next().await.expect("probe was queued");
+    assert!(chain_sync.prospective_tips.is_empty());
     assert_eq!(
-        response.as_ref().expect("probe was verified"),
-        &(Height(1), block1_hash)
+        chain_sync.ambiguous_probe_hashes,
+        HashSet::from([bad_hash, block1_hash])
     );
+
+    let mut responses = Vec::new();
+    for _ in 0..2 {
+        responses.push(chain_sync.downloads.next().await.expect("probe was queued"));
+    }
+
+    let bad_index = responses
+        .iter()
+        .position(|response| {
+            matches!(response, Err(BlockDownloadVerifyError::DownloadFailed { hash, .. }) if *hash == bad_hash)
+        })
+        .expect("the bad probe failed hash binding");
+    chain_sync
+        .handle_block_response_with_missing_retry(responses.swap_remove(bad_index))
+        .await?;
+    assert_eq!(
+        chain_sync.ambiguous_probe_hashes,
+        HashSet::from([block1_hash]),
+        "a failed candidate must not cancel later honest probes"
+    );
+
+    let response = responses.pop().expect("the honest probe was queued");
+    assert!(matches!(&response, Ok((Height(1), hash)) if *hash == block1_hash));
     chain_sync
         .handle_block_response_with_missing_retry(response)
         .await?;
-    assert_eq!(chain_sync.terminal_probe_hash, None);
-    assert!(chain_sync.prospective_tips.is_empty());
-    peer_set.expect_no_requests().await;
-    block_verifier_router.expect_no_requests().await;
-    state_service.expect_no_requests().await;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn terminal_probe_rejects_a_block_with_a_different_hash_before_verification(
-) -> Result<(), crate::BoxError> {
-    let (
-        mut chain_sync,
-        _sync_status,
-        mut block_verifier_router,
-        mut peer_set,
-        mut state_service,
-        _mock_chain_tip_sender,
-    ) = setup_chain_sync();
-
-    let block0: Arc<Block> =
-        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
-    let block1: Arc<Block> =
-        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
-    let block2: Arc<Block> =
-        zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
-    let block0_hash = block0.hash();
-    let block1_hash = block1.hash();
-
-    let respond_to_requests = async {
-        state_service
-            .expect_request(zs::Request::BlockLocator)
-            .await
-            .respond(zs::Response::BlockLocator(vec![block0_hash]));
-        peer_set
-            .expect_request(zn::Request::FindBlocks {
-                known_blocks: vec![block0_hash],
-                stop: None,
-            })
-            .await
-            .respond(zn::Response::BlockHashes(vec![block1_hash]));
-        for _ in 0..(sync::FANOUT - 1) {
-            peer_set
-                .expect_request(zn::Request::FindBlocks {
-                    known_blocks: vec![block0_hash],
-                    stop: None,
-                })
-                .await
-                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
-        }
-        state_service
-            .expect_request(zs::Request::KnownBlock(block1_hash))
-            .await
-            .respond(zs::Response::KnownBlock(None));
-
-        peer_set
-            .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
-            .await
-            .respond(zn::Response::Blocks(vec![Available((block2, None))]));
-
-        Ok::<_, crate::BoxError>(())
-    };
-
-    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
-    responded?;
-    assert!(extra_hashes?.is_empty());
-
-    let response = chain_sync
-        .downloads
-        .next()
-        .await
-        .expect("terminal probe was queued");
-    assert!(matches!(
-        &response,
-        Err(BlockDownloadVerifyError::DownloadFailed { hash, .. }) if *hash == block1_hash
-    ));
-    assert!(chain_sync
-        .handle_block_response_with_missing_retry(response)
-        .await
-        .is_err());
-    assert_eq!(chain_sync.terminal_probe_hash, None);
-    block_verifier_router.expect_no_requests().await;
-    peer_set.expect_no_requests().await;
-    state_service.expect_no_requests().await;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn obtain_tips_downloads_one_interior_hash_without_trusting_the_terminal_hash(
-) -> Result<(), crate::BoxError> {
-    let (
-        mut chain_sync,
-        _sync_status,
-        mut block_verifier_router,
-        mut peer_set,
-        mut state_service,
-        _mock_chain_tip_sender,
-    ) = setup_chain_sync();
-
-    let block0: Arc<Block> =
-        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
-    let block1: Arc<Block> =
-        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
-    let block0_hash = block0.hash();
-    let block1_hash = block1.hash();
-    let untrusted_terminal_hash = block::Hash::from([0xA5; 32]);
-
-    let respond_to_requests = async {
-        state_service
-            .expect_request(zs::Request::BlockLocator)
-            .await
-            .respond(zs::Response::BlockLocator(vec![block0_hash]));
-        peer_set
-            .expect_request(zn::Request::FindBlocks {
-                known_blocks: vec![block0_hash],
-                stop: None,
-            })
-            .await
-            .respond(zn::Response::BlockHashes(vec![
-                block1_hash,
-                untrusted_terminal_hash,
-            ]));
-
-        state_service
-            .expect_request(zs::Request::KnownBlock(block1_hash))
-            .await
-            .respond(zs::Response::KnownBlock(None));
-        for _ in 0..(sync::FANOUT - 1) {
-            peer_set
-                .expect_request(zn::Request::FindBlocks {
-                    known_blocks: vec![block0_hash],
-                    stop: None,
-                })
-                .await
-                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
-        }
-
-        state_service
-            .expect_request(zs::Request::KnownBlock(block1_hash))
-            .await
-            .respond(zs::Response::KnownBlock(None));
-        peer_set
-            .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
-            .await
-            .respond(zn::Response::Blocks(vec![Available((
-                block1.clone(),
-                None,
-            ))]));
-        block_verifier_router
-            .expect_request(zakura_consensus::Request::Commit(block1))
-            .await
-            .respond(block1_hash);
-
-        Ok::<_, crate::BoxError>(())
-    };
-
-    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
-    responded?;
-    assert!(extra_hashes?.is_empty());
-    assert!(chain_sync.prospective_tips.is_empty());
-    assert_eq!(chain_sync.terminal_probe_hash, None);
-
-    let response = chain_sync
-        .downloads
-        .next()
-        .await
-        .expect("interior hash was queued");
-    assert_eq!(response?, (Height(1), block1_hash));
-    peer_set.expect_no_requests().await;
-    block_verifier_router.expect_no_requests().await;
-    state_service.expect_no_requests().await;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn obtain_tips_does_not_probe_a_known_lone_terminal_hash() -> Result<(), crate::BoxError> {
-    let (
-        mut chain_sync,
-        _sync_status,
-        mut block_verifier_router,
-        mut peer_set,
-        mut state_service,
-        _mock_chain_tip_sender,
-    ) = setup_chain_sync();
-
-    let locator = block::Hash::from([0x41; 32]);
-    let known_terminal = block::Hash::from([0x42; 32]);
-
-    let respond_to_requests = async {
-        state_service
-            .expect_request(zs::Request::BlockLocator)
-            .await
-            .respond(zs::Response::BlockLocator(vec![locator]));
-        peer_set
-            .expect_request(zn::Request::FindBlocks {
-                known_blocks: vec![locator],
-                stop: None,
-            })
-            .await
-            .respond(zn::Response::BlockHashes(vec![known_terminal]));
-        for _ in 0..(sync::FANOUT - 1) {
-            peer_set
-                .expect_request(zn::Request::FindBlocks {
-                    known_blocks: vec![locator],
-                    stop: None,
-                })
-                .await
-                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
-        }
-        state_service
-            .expect_request(zs::Request::KnownBlock(known_terminal))
-            .await
-            .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
-
-        Ok::<_, crate::BoxError>(())
-    };
-
-    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
-    responded?;
-    assert!(extra_hashes?.is_empty());
-    assert_eq!(chain_sync.terminal_probe_hash, None);
-    assert!(chain_sync.prospective_tips.is_empty());
-    peer_set.expect_no_requests().await;
-    block_verifier_router.expect_no_requests().await;
-    state_service.expect_no_requests().await;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn obtain_tips_caps_competing_lone_terminal_candidates_at_one() -> Result<(), crate::BoxError>
-{
-    let (
-        mut chain_sync,
-        _sync_status,
-        mut block_verifier_router,
-        mut peer_set,
-        mut state_service,
-        _mock_chain_tip_sender,
-    ) = setup_chain_sync();
-
-    let locator = block::Hash::from([0x51; 32]);
-    let candidates = [
-        block::Hash::from([0x52; 32]),
-        block::Hash::from([0x53; 32]),
-        block::Hash::from([0x54; 32]),
-    ];
-
-    let respond_to_requests = async {
-        state_service
-            .expect_request(zs::Request::BlockLocator)
-            .await
-            .respond(zs::Response::BlockLocator(vec![locator]));
-        for candidate in candidates {
-            peer_set
-                .expect_request(zn::Request::FindBlocks {
-                    known_blocks: vec![locator],
-                    stop: None,
-                })
-                .await
-                .respond(zn::Response::BlockHashes(vec![candidate]));
-        }
-
-        state_service
-            .expect_request_that(|request| {
-                matches!(request, zs::Request::KnownBlock(hash) if candidates.contains(hash))
-            })
-            .await
-            .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
-
-        Ok::<_, crate::BoxError>(())
-    };
-
-    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
-    responded?;
-    assert!(extra_hashes?.is_empty());
-    assert_eq!(chain_sync.terminal_probe_hash, None);
+    assert!(chain_sync.ambiguous_probe_hashes.is_empty());
+    assert!(chain_sync.registry_miss_retry.is_empty());
     state_service.expect_no_requests().await;
     peer_set.expect_no_requests().await;
     block_verifier_router.expect_no_requests().await;
@@ -2251,7 +2012,7 @@ async fn obtain_tips_caps_competing_lone_terminal_candidates_at_one() -> Result<
 }
 
 #[tokio::test]
-async fn obtain_tips_does_not_reclassify_an_in_flight_hash_as_a_terminal_probe(
+async fn obtain_tips_does_not_reclassify_an_in_flight_hash_as_an_ambiguous_probe(
 ) -> Result<(), crate::BoxError> {
     let (
         mut chain_sync,
@@ -2311,7 +2072,7 @@ async fn obtain_tips_does_not_reclassify_an_in_flight_hash_as_a_terminal_probe(
         futures::join!(chain_sync.obtain_tips(), respond_to_tip_requests);
     responded?;
     assert!(extra_hashes?.is_empty());
-    assert_eq!(chain_sync.terminal_probe_hash, None);
+    assert!(chain_sync.ambiguous_probe_hashes.is_empty());
     state_service.expect_no_requests().await;
     peer_set.expect_no_requests().await;
 
@@ -2658,11 +2419,11 @@ async fn registry_miss_schedules_backoff_retry() {
     peer_set.expect_no_requests().await;
 }
 
-/// A terminal probe is best-effort discovery, not a required ordered block. If no connected peer
+/// An ambiguous probe is best-effort discovery, not a required ordered block. If no connected peer
 /// can serve it, the next tip fanout should rediscover current work instead of spending the
 /// required-block registry retry budget on an untrusted hint.
 #[tokio::test]
-async fn terminal_probe_registry_miss_does_not_schedule_required_block_retries() {
+async fn ambiguous_probe_registry_miss_does_not_schedule_required_block_retries() {
     let (
         mut chain_sync,
         _sync_status,
@@ -2673,7 +2434,7 @@ async fn terminal_probe_registry_miss_does_not_schedule_required_block_retries()
     ) = setup_chain_sync();
 
     let block_hash = block::Hash::from([0xBC; 32]);
-    chain_sync.terminal_probe_hash = Some(block_hash);
+    chain_sync.ambiguous_probe_hashes.insert(block_hash);
     let error = BlockDownloadVerifyError::DownloadFailed {
         error: not_found_registry_error(block_hash),
         hash: block_hash,
@@ -2682,9 +2443,9 @@ async fn terminal_probe_registry_miss_does_not_schedule_required_block_retries()
     chain_sync
         .handle_block_response_with_missing_retry(Err(error))
         .await
-        .expect("an unavailable terminal probe should end without restarting the round");
+        .expect("an unavailable ambiguous probe should end without restarting the round");
 
-    assert_eq!(chain_sync.terminal_probe_hash, None);
+    assert!(chain_sync.ambiguous_probe_hashes.is_empty());
     assert!(!chain_sync.registry_miss_retry.contains_key(&block_hash));
     assert!(!chain_sync
         .registry_miss_retry_counts

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -22,7 +22,8 @@ use zakura_chain::{
     serialization::ZcashDeserializeInto,
 };
 use zakura_consensus::{
-    BlockError, Config as ConsensusConfig, RouterError, VerifyBlockError, VerifyCheckpointError,
+    error::TransactionError, BlockError, Config as ConsensusConfig, RouterError, VerifyBlockError,
+    VerifyCheckpointError,
 };
 use zakura_network::{InventoryResponse, PeerSocketAddr};
 use zakura_state::Config as StateConfig;
@@ -2574,12 +2575,14 @@ async fn ambiguous_probe_distinguishes_peer_and_internal_verifier_failures() {
     let scored_peer_invalid_hash = block::Hash::from([0xBD; 32]);
     let time_invalid_hash = block::Hash::from([0xBE; 32]);
     let side_chain_hash = block::Hash::from([0xBF; 32]);
-    let internal_failure_hash = block::Hash::from([0xC0; 32]);
+    let transaction_internal_hash = block::Hash::from([0xC0; 32]);
+    let state_internal_hash = block::Hash::from([0xC1; 32]);
     chain_sync.ambiguous_probe_hashes.extend([
         scored_peer_invalid_hash,
         time_invalid_hash,
         side_chain_hash,
-        internal_failure_hash,
+        transaction_internal_hash,
+        state_internal_hash,
     ]);
 
     let peer_errors = [
@@ -2611,7 +2614,7 @@ async fn ambiguous_probe_distinguishes_peer_and_internal_verifier_failures() {
         BlockDownloadVerifyError::Invalid {
             error: RouterError::Checkpoint {
                 source: Box::new(VerifyCheckpointError::UnexpectedSideChain {
-                    expected: block::Hash::from([0xC1; 32]),
+                    expected: block::Hash::from([0xC2; 32]),
                     found: side_chain_hash,
                 }),
             },
@@ -2630,23 +2633,49 @@ async fn ambiguous_probe_distinguishes_peer_and_internal_verifier_failures() {
 
     assert_eq!(
         chain_sync.ambiguous_probe_hashes,
-        HashSet::from([internal_failure_hash])
+        HashSet::from([transaction_internal_hash, state_internal_hash])
     );
 
-    let internal_error = BlockDownloadVerifyError::Invalid {
+    let transaction_internal_error = BlockDownloadVerifyError::Invalid {
         error: RouterError::Block {
-            source: Box::new(VerifyBlockError::StateService {
-                source: crate::BoxError::from("synthetic state service failure"),
-                hash: internal_failure_hash,
-            }),
+            source: Box::new(VerifyBlockError::Transaction(
+                TransactionError::InternalDowncastError(
+                    "synthetic transaction service failure".to_string(),
+                ),
+            )),
         },
         height: Height(1),
-        hash: internal_failure_hash,
+        hash: transaction_internal_hash,
         advertiser_addr: None,
     };
 
     let result = chain_sync
-        .handle_block_response_with_missing_retry(Err(internal_error))
+        .handle_block_response_with_missing_retry(Err(transaction_internal_error))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an internal transaction verifier failure must restart the sync round"
+    );
+    assert_eq!(
+        chain_sync.ambiguous_probe_hashes,
+        HashSet::from([state_internal_hash])
+    );
+
+    let state_internal_error = BlockDownloadVerifyError::Invalid {
+        error: RouterError::Block {
+            source: Box::new(VerifyBlockError::StateService {
+                source: crate::BoxError::from("synthetic state service failure"),
+                hash: state_internal_hash,
+            }),
+        },
+        height: Height(1),
+        hash: state_internal_hash,
+        advertiser_addr: None,
+    };
+
+    let result = chain_sync
+        .handle_block_response_with_missing_retry(Err(state_internal_error))
         .await;
 
     assert!(

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2507,11 +2507,9 @@ async fn registry_miss_schedules_backoff_retry() {
     peer_set.expect_no_requests().await;
 }
 
-/// An ambiguous probe is best-effort discovery, not a required ordered block. If no connected peer
-/// can serve it, the next tip fanout should rediscover current work instead of spending the
-/// required-block registry retry budget on an untrusted hint.
+/// An ambiguous probe does not use required-block retries until ordered evidence promotes it.
 #[tokio::test]
-async fn ambiguous_probe_registry_miss_does_not_schedule_required_block_retries() {
+async fn ambiguous_probe_registry_miss_uses_retries_only_after_ordered_promotion() {
     let (
         mut chain_sync,
         _sync_status,
@@ -2541,6 +2539,22 @@ async fn ambiguous_probe_registry_miss_does_not_schedule_required_block_retries(
     assert!(!chain_sync
         .missing_block_retry_counts
         .contains_key(&block_hash));
+
+    chain_sync.ambiguous_probe_hashes.insert(block_hash);
+    chain_sync.promote_ambiguous_probes([&block_hash]);
+    let error = BlockDownloadVerifyError::DownloadFailed {
+        error: not_found_registry_error(block_hash),
+        hash: block_hash,
+    };
+    chain_sync
+        .handle_block_response_with_missing_retry(Err(error))
+        .await
+        .expect("an ordered hash within its retry budget should keep the round alive");
+    assert!(chain_sync.registry_miss_retry.contains_key(&block_hash));
+    assert_eq!(
+        chain_sync.registry_miss_retry_counts.get(&block_hash),
+        Some(&1)
+    );
     peer_set.expect_no_requests().await;
 }
 

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2456,6 +2456,45 @@ async fn ambiguous_probe_registry_miss_does_not_schedule_required_block_retries(
     peer_set.expect_no_requests().await;
 }
 
+/// Internal verifier failures must retain the normal sync-restart behavior, even when the block
+/// was discovered through an ambiguous best-effort probe.
+#[tokio::test]
+async fn ambiguous_probe_propagates_verifier_state_service_failures() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block_hash = block::Hash::from([0xBD; 32]);
+    chain_sync.ambiguous_probe_hashes.insert(block_hash);
+    let error = BlockDownloadVerifyError::Invalid {
+        error: RouterError::Block {
+            source: Box::new(VerifyBlockError::StateService {
+                source: crate::BoxError::from("synthetic state service failure"),
+                hash: block_hash,
+            }),
+        },
+        height: Height(1),
+        hash: block_hash,
+        advertiser_addr: None,
+    };
+
+    let result = chain_sync
+        .handle_block_response_with_missing_retry(Err(error))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an internal verifier failure must restart the sync round"
+    );
+    assert!(chain_sync.ambiguous_probe_hashes.is_empty());
+    peer_set.expect_no_requests().await;
+}
+
 /// A registry miss past its retry budget restarts the round and clears its retry state.
 #[tokio::test]
 async fn registry_miss_restarts_after_retry_limit() {

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2012,6 +2012,94 @@ async fn obtain_tips_bad_or_known_candidate_does_not_suppress_later_block(
 }
 
 #[tokio::test]
+async fn obtain_tips_uses_remaining_ambiguous_probe_capacity() -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block0: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block1: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block0_hash = block0.hash();
+    let block1_hash = block1.hash();
+    let stalled_probe_a = block::Hash::from([0x54; 32]);
+    let stalled_probe_b = block::Hash::from([0x55; 32]);
+    chain_sync
+        .ambiguous_probe_hashes
+        .extend([stalled_probe_a, stalled_probe_b]);
+
+    let respond_to_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![block0_hash]));
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block0_hash],
+                stop: None,
+            })
+            .await
+            .respond(zn::Response::BlockHashes(vec![block1_hash]));
+        for _ in 0..(sync::FANOUT - 1) {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![block0_hash],
+                    stop: None,
+                })
+                .await
+                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+        }
+
+        state_service
+            .expect_request(zs::Request::KnownBlock(block1_hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((
+                block1.clone(),
+                None,
+            ))]));
+        block_verifier_router
+            .expect_request(zakura_consensus::Request::Commit(block1))
+            .await
+            .respond(block1_hash);
+
+        Ok::<_, crate::BoxError>(())
+    };
+
+    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
+    responded?;
+    assert!(extra_hashes?.is_empty());
+    assert_eq!(
+        chain_sync.ambiguous_probe_hashes,
+        HashSet::from([stalled_probe_a, stalled_probe_b, block1_hash]),
+        "a stalled probe must not block fresh candidates while capacity remains"
+    );
+
+    let response = chain_sync.downloads.next().await.expect("probe was queued");
+    chain_sync
+        .handle_block_response_with_missing_retry(response)
+        .await?;
+    assert_eq!(
+        chain_sync.ambiguous_probe_hashes,
+        HashSet::from([stalled_probe_a, stalled_probe_b])
+    );
+    state_service.expect_no_requests().await;
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn obtain_tips_does_not_reclassify_an_in_flight_hash_as_an_ambiguous_probe(
 ) -> Result<(), crate::BoxError> {
     let (

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2544,7 +2544,8 @@ async fn ambiguous_probe_registry_miss_does_not_schedule_required_block_retries(
     peer_set.expect_no_requests().await;
 }
 
-/// Peer-invalid ambiguous probes end independently, while internal verifier failures restart sync.
+/// Peer-invalid ambiguous probes end independently, including score-zero failures, while internal
+/// verifier failures restart sync.
 #[tokio::test]
 async fn ambiguous_probe_distinguishes_peer_and_internal_verifier_failures() {
     let (
@@ -2556,25 +2557,63 @@ async fn ambiguous_probe_distinguishes_peer_and_internal_verifier_failures() {
         _mock_chain_tip_sender,
     ) = setup_chain_sync();
 
-    let peer_invalid_hash = block::Hash::from([0xBD; 32]);
-    let internal_failure_hash = block::Hash::from([0xBE; 32]);
-    chain_sync
-        .ambiguous_probe_hashes
-        .extend([peer_invalid_hash, internal_failure_hash]);
-    let peer_error = BlockDownloadVerifyError::Invalid {
-        error: RouterError::Block {
-            source: Box::new(VerifyBlockError::Block {
-                source: BlockError::NoTransactions,
-            }),
+    let scored_peer_invalid_hash = block::Hash::from([0xBD; 32]);
+    let time_invalid_hash = block::Hash::from([0xBE; 32]);
+    let side_chain_hash = block::Hash::from([0xBF; 32]);
+    let internal_failure_hash = block::Hash::from([0xC0; 32]);
+    chain_sync.ambiguous_probe_hashes.extend([
+        scored_peer_invalid_hash,
+        time_invalid_hash,
+        side_chain_hash,
+        internal_failure_hash,
+    ]);
+
+    let peer_errors = [
+        BlockDownloadVerifyError::Invalid {
+            error: RouterError::Block {
+                source: Box::new(VerifyBlockError::Block {
+                    source: BlockError::NoTransactions,
+                }),
+            },
+            height: Height(1),
+            hash: scored_peer_invalid_hash,
+            advertiser_addr: Some("127.0.0.1:8233".parse().unwrap()),
         },
-        height: Height(1),
-        hash: peer_invalid_hash,
-        advertiser_addr: Some("127.0.0.1:8233".parse().unwrap()),
-    };
-    chain_sync
-        .handle_block_response_with_missing_retry(Err(peer_error))
-        .await
-        .expect("a peer-invalid candidate should not cancel sibling probes");
+        BlockDownloadVerifyError::Invalid {
+            error: RouterError::Block {
+                source: Box::new(VerifyBlockError::Time(
+                    block::BlockTimeError::InvalidBlockTime(
+                        chrono::DateTime::from_timestamp(10, 0).unwrap(),
+                        Height(1),
+                        time_invalid_hash,
+                        chrono::DateTime::from_timestamp(0, 0).unwrap(),
+                    ),
+                )),
+            },
+            height: Height(1),
+            hash: time_invalid_hash,
+            advertiser_addr: Some("127.0.0.1:8234".parse().unwrap()),
+        },
+        BlockDownloadVerifyError::Invalid {
+            error: RouterError::Checkpoint {
+                source: Box::new(VerifyCheckpointError::UnexpectedSideChain {
+                    expected: block::Hash::from([0xC1; 32]),
+                    found: side_chain_hash,
+                }),
+            },
+            height: Height(1),
+            hash: side_chain_hash,
+            advertiser_addr: Some("127.0.0.1:8235".parse().unwrap()),
+        },
+    ];
+
+    for error in peer_errors {
+        chain_sync
+            .handle_block_response_with_missing_retry(Err(error))
+            .await
+            .expect("a peer-invalid candidate should not cancel sibling probes");
+    }
+
     assert_eq!(
         chain_sync.ambiguous_probe_hashes,
         HashSet::from([internal_failure_hash])

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -1886,6 +1886,453 @@ async fn obtain_tips_ignores_known_hash_after_first_unknown() -> Result<(), crat
 }
 
 #[tokio::test]
+async fn obtain_tips_downloads_lone_terminal_hash_as_bounded_probe() -> Result<(), crate::BoxError>
+{
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block0: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block1: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block0_hash = block0.hash();
+    let block1_hash = block1.hash();
+
+    let respond_to_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![block0_hash]));
+
+        // At the network tip, the only unknown block is also the terminal hash that mainnet and
+        // testnet sync normally exclude from trusted tip construction for zcashd compatibility.
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block0_hash],
+                stop: None,
+            })
+            .await
+            .respond(zn::Response::BlockHashes(vec![block1_hash]));
+
+        for _ in 0..(sync::FANOUT - 1) {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![block0_hash],
+                    stop: None,
+                })
+                .await
+                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+        }
+
+        // A lone terminal hash is untrusted discovery input. It still gets the normal state,
+        // download, hash-binding, height, proof-of-work, and consensus verification path.
+        state_service
+            .expect_request(zs::Request::KnownBlock(block1_hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((
+                block1.clone(),
+                None,
+            ))]));
+        block_verifier_router
+            .expect_request(zakura_consensus::Request::Commit(block1))
+            .await
+            .respond(block1_hash);
+
+        Ok::<_, crate::BoxError>(())
+    };
+
+    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
+    responded?;
+    assert!(extra_hashes?.is_empty());
+
+    let response = chain_sync.downloads.next().await.expect("probe was queued");
+    assert_eq!(
+        response.as_ref().expect("probe was verified"),
+        &(Height(1), block1_hash)
+    );
+    chain_sync
+        .handle_block_response_with_missing_retry(response)
+        .await?;
+    assert_eq!(chain_sync.terminal_probe_hash, None);
+    assert!(chain_sync.prospective_tips.is_empty());
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn terminal_probe_rejects_a_block_with_a_different_hash_before_verification(
+) -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block0: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block1: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block2: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
+    let block0_hash = block0.hash();
+    let block1_hash = block1.hash();
+
+    let respond_to_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![block0_hash]));
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block0_hash],
+                stop: None,
+            })
+            .await
+            .respond(zn::Response::BlockHashes(vec![block1_hash]));
+        for _ in 0..(sync::FANOUT - 1) {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![block0_hash],
+                    stop: None,
+                })
+                .await
+                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+        }
+        state_service
+            .expect_request(zs::Request::KnownBlock(block1_hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((block2, None))]));
+
+        Ok::<_, crate::BoxError>(())
+    };
+
+    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
+    responded?;
+    assert!(extra_hashes?.is_empty());
+
+    let response = chain_sync
+        .downloads
+        .next()
+        .await
+        .expect("terminal probe was queued");
+    assert!(matches!(
+        &response,
+        Err(BlockDownloadVerifyError::DownloadFailed { hash, .. }) if *hash == block1_hash
+    ));
+    assert!(chain_sync
+        .handle_block_response_with_missing_retry(response)
+        .await
+        .is_err());
+    assert_eq!(chain_sync.terminal_probe_hash, None);
+    block_verifier_router.expect_no_requests().await;
+    peer_set.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn obtain_tips_downloads_one_interior_hash_without_trusting_the_terminal_hash(
+) -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block0: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block1: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block0_hash = block0.hash();
+    let block1_hash = block1.hash();
+    let untrusted_terminal_hash = block::Hash::from([0xA5; 32]);
+
+    let respond_to_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![block0_hash]));
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block0_hash],
+                stop: None,
+            })
+            .await
+            .respond(zn::Response::BlockHashes(vec![
+                block1_hash,
+                untrusted_terminal_hash,
+            ]));
+
+        state_service
+            .expect_request(zs::Request::KnownBlock(block1_hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+        for _ in 0..(sync::FANOUT - 1) {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![block0_hash],
+                    stop: None,
+                })
+                .await
+                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+        }
+
+        state_service
+            .expect_request(zs::Request::KnownBlock(block1_hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((
+                block1.clone(),
+                None,
+            ))]));
+        block_verifier_router
+            .expect_request(zakura_consensus::Request::Commit(block1))
+            .await
+            .respond(block1_hash);
+
+        Ok::<_, crate::BoxError>(())
+    };
+
+    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
+    responded?;
+    assert!(extra_hashes?.is_empty());
+    assert!(chain_sync.prospective_tips.is_empty());
+    assert_eq!(chain_sync.terminal_probe_hash, None);
+
+    let response = chain_sync
+        .downloads
+        .next()
+        .await
+        .expect("interior hash was queued");
+    assert_eq!(response?, (Height(1), block1_hash));
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn obtain_tips_does_not_probe_a_known_lone_terminal_hash() -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let locator = block::Hash::from([0x41; 32]);
+    let known_terminal = block::Hash::from([0x42; 32]);
+
+    let respond_to_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![locator]));
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![locator],
+                stop: None,
+            })
+            .await
+            .respond(zn::Response::BlockHashes(vec![known_terminal]));
+        for _ in 0..(sync::FANOUT - 1) {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![locator],
+                    stop: None,
+                })
+                .await
+                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+        }
+        state_service
+            .expect_request(zs::Request::KnownBlock(known_terminal))
+            .await
+            .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
+
+        Ok::<_, crate::BoxError>(())
+    };
+
+    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
+    responded?;
+    assert!(extra_hashes?.is_empty());
+    assert_eq!(chain_sync.terminal_probe_hash, None);
+    assert!(chain_sync.prospective_tips.is_empty());
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn obtain_tips_caps_competing_lone_terminal_candidates_at_one() -> Result<(), crate::BoxError>
+{
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let locator = block::Hash::from([0x51; 32]);
+    let candidates = [
+        block::Hash::from([0x52; 32]),
+        block::Hash::from([0x53; 32]),
+        block::Hash::from([0x54; 32]),
+    ];
+
+    let respond_to_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![locator]));
+        for candidate in candidates {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![locator],
+                    stop: None,
+                })
+                .await
+                .respond(zn::Response::BlockHashes(vec![candidate]));
+        }
+
+        state_service
+            .expect_request_that(|request| {
+                matches!(request, zs::Request::KnownBlock(hash) if candidates.contains(hash))
+            })
+            .await
+            .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
+
+        Ok::<_, crate::BoxError>(())
+    };
+
+    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
+    responded?;
+    assert!(extra_hashes?.is_empty());
+    assert_eq!(chain_sync.terminal_probe_hash, None);
+    state_service.expect_no_requests().await;
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn obtain_tips_does_not_reclassify_an_in_flight_hash_as_a_terminal_probe(
+) -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block0: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block1: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block0_hash = block0.hash();
+    let block1_hash = block1.hash();
+
+    let queue_block = chain_sync.downloads.download_and_verify(block1_hash);
+    let respond_to_block_request = async {
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((
+                block1.clone(),
+                None,
+            ))]));
+    };
+    let (queued, ()) = futures::join!(queue_block, respond_to_block_request);
+    queued?;
+
+    let respond_to_tip_requests = async {
+        state_service
+            .expect_request(zs::Request::BlockLocator)
+            .await
+            .respond(zs::Response::BlockLocator(vec![block0_hash]));
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block0_hash],
+                stop: None,
+            })
+            .await
+            .respond(zn::Response::BlockHashes(vec![block1_hash]));
+        for _ in 0..(sync::FANOUT - 1) {
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![block0_hash],
+                    stop: None,
+                })
+                .await
+                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+        }
+
+        Ok::<_, crate::BoxError>(())
+    };
+
+    let (extra_hashes, responded) =
+        futures::join!(chain_sync.obtain_tips(), respond_to_tip_requests);
+    responded?;
+    assert!(extra_hashes?.is_empty());
+    assert_eq!(chain_sync.terminal_probe_hash, None);
+    state_service.expect_no_requests().await;
+    peer_set.expect_no_requests().await;
+
+    block_verifier_router
+        .expect_request(zakura_consensus::Request::Commit(block1))
+        .await
+        .respond(block1_hash);
+    assert_eq!(
+        chain_sync
+            .downloads
+            .next()
+            .await
+            .expect("original block download remained in flight")?,
+        (Height(1), block1_hash)
+    );
+    block_verifier_router.expect_no_requests().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn build_extend_ignores_malformed_find_blocks_responses() -> Result<(), crate::BoxError> {
     let (
         _chain_sync,
@@ -2208,6 +2655,43 @@ async fn registry_miss_schedules_backoff_retry() {
     );
 
     // The retry fires from the sync loop's timer arm, not inline, so no block is re-requested here.
+    peer_set.expect_no_requests().await;
+}
+
+/// A terminal probe is best-effort discovery, not a required ordered block. If no connected peer
+/// can serve it, the next tip fanout should rediscover current work instead of spending the
+/// required-block registry retry budget on an untrusted hint.
+#[tokio::test]
+async fn terminal_probe_registry_miss_does_not_schedule_required_block_retries() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block_hash = block::Hash::from([0xBC; 32]);
+    chain_sync.terminal_probe_hash = Some(block_hash);
+    let error = BlockDownloadVerifyError::DownloadFailed {
+        error: not_found_registry_error(block_hash),
+        hash: block_hash,
+    };
+
+    chain_sync
+        .handle_block_response_with_missing_retry(Err(error))
+        .await
+        .expect("an unavailable terminal probe should end without restarting the round");
+
+    assert_eq!(chain_sync.terminal_probe_hash, None);
+    assert!(!chain_sync.registry_miss_retry.contains_key(&block_hash));
+    assert!(!chain_sync
+        .registry_miss_retry_counts
+        .contains_key(&block_hash));
+    assert!(!chain_sync
+        .missing_block_retry_counts
+        .contains_key(&block_hash));
     peer_set.expect_no_requests().await;
 }
 


### PR DESCRIPTION
## Motivation

Legacy sync on Mainnet and Testnet excludes the final `FindBlocks` response hash from ordered tip construction because zcashd can append an unrelated hash. A one-hash response, or a two-hash response after compatibility stripping, therefore leaves only an unpaired candidate. Discarding that candidate can leave Zakura one block behind despite active peers. The NU6.3 rehearsal reproduced this four times.

## Solution

When the ordered fanout responses yield no work, collect at most one unpaired candidate from each of the three fanout replies and probe every distinct candidate that is unknown and not already in flight. These candidates do not enter `prospective_tips` or the retry queues reserved for ordered blocks. Each candidate still passes the existing requested-hash binding, height, proof-of-work, and consensus verification path before state commit.

A missing or peer-invalid candidate ends independently instead of suppressing its siblings. If a later ordered response names an in-flight candidate, it is promoted to normal required-block retry behavior. This changes sync liveness only; it does not change consensus or protocol validation.
