### PR TITLE
fix(network): prefer archive peers during initial sync

### DIFF
--- a/changelog-unreleased/447.md
+++ b/changelog-unreleased/447.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed legacy initial sync stalls by replacing pruned peers with archive peers
+  until the node reaches the network tip
+  ([#447](https://github.com/zakura-core/zakura/pull/447)).

--- a/changelog-unreleased/447.md
+++ b/changelog-unreleased/447.md
@@ -1,5 +1,6 @@
 ## Fixed
 
 - Fixed legacy initial sync stalls by replacing pruned peers with archive peers
-  until the node reaches the network tip
+  until the node reaches the network tip, and retrying temporary peer
+  unavailability without discarding the sync round
   ([#447](https://github.com/zakura-core/zakura/pull/447)).

--- a/zakura-network/src/peer/error.rs
+++ b/zakura-network/src/peer/error.rs
@@ -28,6 +28,9 @@ pub enum NotFoundClass {
     /// [`PeerError::NotFoundResponse`] — a specific peer lacked the item; retry on another peer.
     Response,
     /// [`PeerError::NotFoundRegistry`] — no ready peer has it; needs fresh tips/peers.
+    ///
+    /// Also includes [`PeerError::NoReadyPeers`], which needs a peer to become ready or connect
+    /// before the request can be retried.
     Registry,
     /// Any other error (not a `notfound`-style failure).
     Other,
@@ -55,7 +58,7 @@ where
         let inner = PeerError::from(source);
         let class = match &inner {
             PeerError::NotFoundResponse(_) => NotFoundClass::Response,
-            PeerError::NotFoundRegistry(_) => NotFoundClass::Registry,
+            PeerError::NotFoundRegistry(_) | PeerError::NoReadyPeers => NotFoundClass::Registry,
             _ => NotFoundClass::Other,
         };
         Self(Arc::new(TracedError::from(inner)), class)
@@ -367,10 +370,11 @@ mod tests {
             SharedPeerError::from(PeerError::NotFoundRegistry(block_inv())).not_found_class(),
             Some(NotFoundClass::Registry),
         );
-        // An unrelated peer error is not a `notfound`-style failure.
+        // NoReadyPeers is also transient at the peer-set boundary, so the syncer uses the same
+        // backoff retry path as a registry miss instead of restarting the entire sync round.
         assert_eq!(
             SharedPeerError::from(PeerError::NoReadyPeers).not_found_class(),
-            None,
+            Some(NotFoundClass::Registry),
         );
     }
 }

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -162,10 +162,6 @@ pub struct CancelClientWork;
 
 type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'static>>;
 
-/// Maximum distance from the estimated network tip where pruned peers are
-/// eligible for generic block downloads.
-const PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE: zakura_chain::block::HeightDiff = 5_000;
-
 /// Classification of a `FindBlocks`/`FindHeaders` response, sent from a
 /// response-wrapping future to [`PeerSet::poll_ready`] via an mpsc channel so
 /// the stall tracker can be updated and the peer disconnected if needed.
@@ -531,6 +527,11 @@ where
         // TODO: drop peers that overload us with inbound messages and never become ready (#7822)
         let _poll_pending_or_ready: Poll<Option<()>> = self.poll_unready(cx)?;
 
+        // A pruned peer cannot serve the historical block bodies needed during initial sync.
+        // Disconnect it to free a connection slot, then ask the crawler to find an archive peer.
+        // Once we are at or near the tip, retain and route to pruned peers normally.
+        self.disconnect_from_pruned_peers_while_syncing();
+
         // Cleanup
 
         // Only checks the versions of ready peers, so it needs to run after `poll_unready()`.
@@ -811,6 +812,46 @@ where
         }
     }
 
+    /// Disconnects peers that cannot serve historical blocks while the node is syncing.
+    fn disconnect_from_pruned_peers_while_syncing(&mut self) {
+        if self
+            .minimum_peer_version
+            .chain_tip()
+            .is_at_or_near_network_tip(&self.network)
+        {
+            return;
+        }
+
+        let pruned_peers: Vec<_> = self
+            .ready_services
+            .iter()
+            .filter_map(|(key, service)| (!service.advertises_node_network()).then_some(*key))
+            .chain(self.unready_services.iter().filter_map(|unready| {
+                unready
+                    .key
+                    .as_ref()
+                    .zip(unready.service.as_ref())
+                    .and_then(|(key, service)| (!service.advertises_node_network()).then_some(*key))
+            }))
+            .collect();
+
+        if pruned_peers.is_empty() {
+            return;
+        }
+
+        for peer in &pruned_peers {
+            debug!(
+                peer = %peer.addr_label(self.expose_peer_addresses),
+                "disconnecting pruned peer while syncing historical blocks"
+            );
+            self.remove(peer);
+        }
+
+        metrics::counter!("pool.disconnected.pruned_while_syncing.count")
+            .increment(u64::try_from(pruned_peers.len()).unwrap_or(u64::MAX));
+        let _ = self.demand_signal.try_send(MorePeers);
+    }
+
     /// Takes a ready service by key.
     fn take_ready_service(&mut self, key: &D::Key) -> Option<D::Service> {
         if let Some(svc) = self.ready_services.remove(key) {
@@ -911,26 +952,6 @@ where
     /// Performs P2C on `self.ready_services` to randomly select a less-loaded ready service.
     fn select_ready_p2c_peer(&self) -> Option<D::Key> {
         self.select_p2c_peer_from_list(&self.ready_services.keys().copied().collect())
-    }
-
-    /// Returns true if pruned peers are eligible for generic block downloads.
-    fn pruned_peers_are_block_download_eligible(&self) -> bool {
-        self.minimum_peer_version
-            .chain_tip()
-            .estimate_distance_to_network_chain_tip(&self.network)
-            .is_some_and(|(distance, _)| distance <= PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE)
-    }
-
-    /// Returns ready peers eligible for generic block downloads.
-    fn ready_generic_block_peers(&self) -> HashSet<D::Key> {
-        let include_pruned = self.pruned_peers_are_block_download_eligible();
-
-        self.ready_services
-            .iter()
-            .filter_map(|(key, service)| {
-                (include_pruned || service.advertises_node_network()).then_some(*key)
-            })
-            .collect()
     }
 
     /// Performs P2C on `ready_service_list` to randomly select a less-loaded ready service.
@@ -1049,13 +1070,7 @@ where
 
     /// Routes a request using P2C load-balancing.
     fn route_p2c(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
-        let peer = if matches!(&req, Request::BlocksByHash(_)) {
-            self.select_p2c_peer_from_list(&self.ready_generic_block_peers())
-        } else {
-            self.select_ready_p2c_peer()
-        };
-
-        if let Some(p2c_key) = peer {
+        if let Some(p2c_key) = self.select_ready_p2c_peer() {
             tracing::trace!(
                 peer = %p2c_key.addr_label(self.expose_peer_addresses),
                 "routing based on p2c"
@@ -1206,16 +1221,11 @@ where
             .missing_peers(hash)
             .copied()
             .collect();
-        let block_request = matches!(hash, InventoryHash::Block(_));
-        let include_pruned = !block_request || self.pruned_peers_are_block_download_eligible();
-        let maybe_peer_list: HashSet<_> = self
+        let maybe_peer_list = self
             .ready_services
-            .iter()
-            .filter_map(|(addr, service)| {
-                (!missing_peer_list.contains(addr)
-                    && (include_pruned || service.advertises_node_network()))
-                .then_some(*addr)
-            })
+            .keys()
+            .filter(|addr| !missing_peer_list.contains(addr))
+            .copied()
             .collect();
 
         // Security: choose a random, less-loaded peer that might have the inventory.
@@ -1257,30 +1267,6 @@ where
                 .boxed();
             }
             return fut.map_err(Into::into).boxed();
-        }
-
-        let has_eligible_peer = !block_request
-            || include_pruned
-            || self
-                .ready_services
-                .values()
-                .any(LoadTrackedClient::advertises_node_network);
-
-        if !has_eligible_peer {
-            metrics::counter!("pool.route_inv.no_eligible_block_peer.count").increment(1);
-            let _ = self.demand_signal.try_send(MorePeers);
-
-            tracing::debug!(
-                ?hash,
-                "no ready full block-serving peer for historical block request"
-            );
-
-            return async move {
-                tokio::task::yield_now().await;
-                Err(SharedPeerError::from(PeerError::NoReadyPeers))
-            }
-            .map_err(Into::into)
-            .boxed();
         }
 
         // Split the synthetic registry-miss by cause so a stall can be diagnosed (the two collapse

--- a/zakura-network/src/peer_set/set/tests/prop.rs
+++ b/zakura-network/src/peer_set/set/tests/prop.rs
@@ -1,6 +1,9 @@
 //! Randomised property tests for the peer set.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 use futures::{stream, FutureExt, StreamExt};
 use proptest::prelude::*;
@@ -20,7 +23,7 @@ use crate::{
         ReceiveRequestAttempt,
     },
     peer_set::PeerSet,
-    protocol::external::types::Version,
+    protocol::external::types::{PeerServices, Version},
     Config, PeerSocketAddr, Request,
 };
 
@@ -325,10 +328,14 @@ fn sidecar_peer_always_receives_block_gossip() {
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, index as u8))
             };
             let peer_address: PeerSocketAddr = SocketAddr::new(ip, index as u16 + 1).into();
-            let (client, harness) = ClientTestHarness::build()
+            let (mut client, harness) = ClientTestHarness::build()
                 .with_version(CURRENT_NETWORK_PROTOCOL_VERSION)
                 .with_connected_addr(ConnectedAddr::new_inbound_direct(peer_address))
                 .finish();
+            Arc::get_mut(&mut client.connection_info)
+                .expect("test client has unique connection info")
+                .remote
+                .services = PeerServices::NODE_NETWORK;
 
             handles.push(harness);
 

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -14,6 +14,7 @@ use tower::{discover::Change, Service, ServiceExt};
 
 use zakura_chain::{
     block,
+    chain_tip::AT_OR_NEAR_TIP_THRESHOLD,
     parameters::{Network, NetworkUpgrade},
 };
 
@@ -30,7 +31,7 @@ use crate::{
     BannedIps, BoxError, PeerSocketAddr, Request, Response, SharedPeerError,
 };
 
-use super::{super::PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE, PeerSetBuilder, PeerVersions};
+use super::{PeerSetBuilder, PeerVersions};
 
 #[test]
 fn peer_set_ready_single_connection() {
@@ -793,9 +794,9 @@ fn peer_set_route_inv_advertised_registry_order(advertised_first: bool) {
     });
 }
 
-/// Check that historical block downloads exclude pruned peers.
+/// Check that syncing disconnects pruned peers and routes blocks to archive peers.
 #[test]
-fn historical_block_downloads_require_node_network() {
+fn syncing_disconnects_pruned_peers() {
     let test_hash = block::Hash([1; 32]);
     let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
@@ -810,9 +811,7 @@ fn historical_block_downloads_require_node_network() {
     let (minimum_peer_version, best_tip) =
         MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
     best_tip.send_best_tip_height(Some(block::Height(2_000_000)));
-    best_tip.send_estimated_distance_to_network_chain_tip(Some(
-        PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE + 1,
-    ));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD + 1));
 
     runtime.block_on(async move {
         let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
@@ -826,11 +825,14 @@ fn historical_block_downloads_require_node_network() {
         let _response = peer_ready.call(request.clone());
 
         assert!(
+            peer_set.ready().now_or_never().is_none(),
+            "peer set should wait while its only archive peer is busy"
+        );
+        assert!(
             handles[0]
                 .try_to_receive_outbound_client_request()
-                .request()
-                .is_none(),
-            "historical block request routed to pruned peer"
+                .is_closed(),
+            "pruned peer should be disconnected while syncing"
         );
         assert_eq!(
             handles[1]
@@ -843,9 +845,56 @@ fn historical_block_downloads_require_node_network() {
     });
 }
 
-/// Check that pruned peers handle generic block downloads near the network tip.
+/// Check that a peer set with only pruned peers waits and asks for archive peers while syncing.
 #[test]
-fn near_tip_block_downloads_allow_pruned_peers() {
+fn syncing_with_only_pruned_peers_waits_for_archive_peers() {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, mut handles) =
+        peer_versions.mock_peer_discovery_with_services(&[PeerServices::empty()]);
+    let (minimum_peer_version, best_tip) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+    best_tip.send_best_tip_height(Some(block::Height(2_000_000)));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD + 1));
+
+    runtime.block_on(async move {
+        let (mut peer_set, mut peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        assert!(
+            peer_set.ready().now_or_never().is_none(),
+            "peer set should wait rather than becoming ready with only pruned peers"
+        );
+        assert!(
+            handles[0]
+                .try_to_receive_outbound_client_request()
+                .is_closed(),
+            "pruned peer should be disconnected while syncing"
+        );
+        assert!(
+            peer_set_guard
+                .demand_receiver()
+                .as_mut()
+                .expect("demand receiver exists")
+                .try_next()
+                .expect("demand channel is open")
+                .is_some(),
+            "peer set should ask the crawler for an archive peer"
+        );
+    });
+}
+
+/// Check that pruned peers handle generic block downloads at or near the network tip.
+#[test]
+fn at_or_near_tip_block_downloads_allow_pruned_peers() {
     let test_hash = block::Hash([2; 32]);
     let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
@@ -860,9 +909,7 @@ fn near_tip_block_downloads_allow_pruned_peers() {
     let (minimum_peer_version, best_tip) =
         MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
     best_tip.send_best_tip_height(Some(block::Height(2_500_000)));
-    best_tip.send_estimated_distance_to_network_chain_tip(Some(
-        PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE,
-    ));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD));
 
     runtime.block_on(async move {
         let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
@@ -885,9 +932,9 @@ fn near_tip_block_downloads_allow_pruned_peers() {
     });
 }
 
-/// Check that a pruned peer can serve a block it explicitly advertised.
+/// Check that an at-tip pruned peer can serve a block it explicitly advertised.
 #[test]
-fn advertised_block_downloads_allow_pruned_peers() {
+fn at_tip_advertised_block_downloads_allow_pruned_peers() {
     let test_hash = block::Hash([3; 32]);
     let test_peer = "127.0.0.1:1".parse().expect("test peer address is valid");
     let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
@@ -903,9 +950,7 @@ fn advertised_block_downloads_allow_pruned_peers() {
     let (minimum_peer_version, best_tip) =
         MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
     best_tip.send_best_tip_height(Some(block::Height(2_000_000)));
-    best_tip.send_estimated_distance_to_network_chain_tip(Some(
-        PRUNED_PEER_BLOCK_ROUTING_MAX_TIP_DISTANCE + 1,
-    ));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(0));
 
     runtime.block_on(async move {
         let (mut peer_set, mut peer_set_guard) = PeerSetBuilder::new()

--- a/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -5,6 +5,7 @@ use std::{
     collections::HashSet,
     iter,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
     time::Duration,
 };
 
@@ -822,7 +823,16 @@ fn syncing_disconnects_pruned_peers() {
 
         let peer_ready = peer_set.ready().await.expect("peer set is ready");
         let request = Request::BlocksByHash(iter::once(test_hash).collect());
-        let _response = peer_ready.call(request.clone());
+        let response = peer_ready.call(request.clone());
+
+        // The mock client request channel has one buffered slot in addition to
+        // the first reserved send, so fill that slot before checking backpressure.
+        let peer_ready = peer_set
+            .ready()
+            .now_or_never()
+            .expect("archive peer has one remaining request slot")
+            .expect("peer set is ready");
+        let second_response = peer_ready.call(request.clone());
 
         assert!(
             peer_set.ready().now_or_never().is_none(),
@@ -842,6 +852,8 @@ fn syncing_disconnects_pruned_peers() {
                 .request,
             request
         );
+
+        std::mem::drop((response, second_response));
     });
 }
 
@@ -884,9 +896,8 @@ fn syncing_with_only_pruned_peers_waits_for_archive_peers() {
                 .demand_receiver()
                 .as_mut()
                 .expect("demand receiver exists")
-                .try_next()
-                .expect("demand channel is open")
-                .is_some(),
+                .try_recv()
+                .is_ok(),
             "peer set should ask the crawler for an archive peer"
         );
     });
@@ -1251,10 +1262,14 @@ fn find_blocks_stall_not_tracked_for_zcashd_compat() {
     let sidecar_ip = Ipv4Addr::LOCALHOST;
     let sidecar_addr: PeerSocketAddr =
         SocketAddr::new(IpAddr::V6(sidecar_ip.to_ipv6_mapped()), 1).into();
-    let (sidecar, mut sidecar_handle) = ClientTestHarness::build()
+    let (mut sidecar, mut sidecar_handle) = ClientTestHarness::build()
         .with_version(CURRENT_NETWORK_PROTOCOL_VERSION)
         .with_connected_addr(ConnectedAddr::new_inbound_direct(sidecar_addr))
         .finish();
+    Arc::get_mut(&mut sidecar.connection_info)
+        .expect("test client has unique connection info")
+        .remote
+        .services = PeerServices::NODE_NETWORK;
     let discovered_peers = stream::iter([Ok::<_, BoxError>(Change::Insert(
         sidecar_addr,
         sidecar.into(),
@@ -1526,16 +1541,24 @@ fn sidecar_and_ordinary_discovery() -> (
     let ordinary_addr: PeerSocketAddr =
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 2).into();
 
-    let (sidecar_client, sidecar_handle) = ClientTestHarness::build()
+    let (mut sidecar_client, sidecar_handle) = ClientTestHarness::build()
         .with_version(peer_version)
         .with_connected_addr(ConnectedAddr::InboundDirect { addr: sidecar_addr })
         .finish();
-    let (ordinary_client, ordinary_handle) = ClientTestHarness::build()
+    Arc::get_mut(&mut sidecar_client.connection_info)
+        .expect("test client has unique connection info")
+        .remote
+        .services = PeerServices::NODE_NETWORK;
+    let (mut ordinary_client, ordinary_handle) = ClientTestHarness::build()
         .with_version(peer_version)
         .with_connected_addr(ConnectedAddr::InboundDirect {
             addr: ordinary_addr,
         })
         .finish();
+    Arc::get_mut(&mut ordinary_client.connection_info)
+        .expect("test client has unique connection info")
+        .remote
+        .services = PeerServices::NODE_NETWORK;
 
     let discovered = stream::iter([
         Ok::<_, BoxError>(Change::Insert(

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -94,8 +94,8 @@ fn block_error_peer_label(error: &BlockDownloadVerifyError, expose_peer_addresse
 /// accountability in `zakura-network` disconnects such peers so this bound is rarely reached.
 const MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 8;
 
-/// Controls how many times the syncer retries a required block that the peer set reports as missing
-/// from *all* current peers (`NotFoundKind::Registry`) before giving up on the round.
+/// Controls how many times the syncer retries a required block that the peer set currently cannot
+/// route (`NotFoundKind::Registry`) before giving up on the round.
 ///
 /// Unlike a single-peer `notfound`, a registry-wide miss can't be resolved by routing to another
 /// currently-connected peer — it needs the peer crawler to find a peer that has the block, or the
@@ -105,7 +105,8 @@ const MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 8;
 /// temporarily unavailable. Only a genuinely stuck block (e.g. a bad tip) exhausts this and restarts.
 const MISSING_BLOCK_REGISTRY_RETRY_LIMIT: usize = 60;
 
-/// Backoff between retries of a block missing from all current peers (`NotFoundKind::Registry`).
+/// Backoff between retries of a block that the peer set currently cannot route
+/// (`NotFoundKind::Registry`).
 ///
 /// Long enough to avoid hot-looping on the synchronous `NotFoundRegistry` routing error and to let
 /// the peer crawler connect new peers / inventory marks expire, short enough that the pipeline
@@ -785,9 +786,9 @@ where
     /// `notfound` ([`NotFoundKind::Response`]). Bounded by [`MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     missing_block_retry_counts: HashMap<block::Hash, usize>,
 
-    /// Queue-level retry counts for block hashes missing from *all* current peers
-    /// ([`NotFoundKind::Registry`]). Kept separate from [`Self::missing_block_retry_counts`] so the
-    /// larger registry budget ([`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]) isn't defeated by an
+    /// Queue-level retry counts for block hashes the peer set currently cannot route
+    /// ([`NotFoundKind::Registry`]). Kept separate from [`Self::missing_block_retry_counts`] so
+    /// the larger registry budget ([`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]) isn't defeated by an
     /// occasional single-peer `notfound` for the same hash sharing the smaller budget's count.
     registry_miss_retry_counts: HashMap<block::Hash, usize>,
 
@@ -2156,14 +2157,14 @@ where
     /// rather than discarding the whole round. The requeues are bounded by
     /// [`MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     ///
-    /// A [`NotFoundKind::Registry`] miss means the peer set found that *every* ready peer is marked
-    /// missing the block, so it can't be served right now. Rather than blocking the loop on an inline
-    /// `sleep`, the hash is recorded in [`Self::registry_miss_retry`] with a backoff deadline; while
-    /// any such retry is pending, [`Self::sync_round`] gives it head-of-line priority by pausing new
-    /// speculative dispatch and re-dispatching the hash from its `select!` timer arm once the backoff
-    /// elapses. Bounded by [`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]; only a block that stays missing
-    /// for the whole budget (e.g. a bad tip) falls through to [`Self::handle_block_response`] and
-    /// restarts the round to obtain fresh tips and peers.
+    /// A [`NotFoundKind::Registry`] miss means the peer set cannot route the block right now,
+    /// because every ready peer is marked missing it or no peer is ready. Rather than blocking the
+    /// loop on an inline `sleep`, the hash is recorded in [`Self::registry_miss_retry`] with a
+    /// backoff deadline; while any such retry is pending, [`Self::sync_round`] gives it head-of-line
+    /// priority by pausing new speculative dispatch and re-dispatching the hash from its `select!`
+    /// timer arm once the backoff elapses. Bounded by [`MISSING_BLOCK_REGISTRY_RETRY_LIMIT`]; only a
+    /// block that stays unavailable for the whole budget (e.g. a bad tip) falls through to
+    /// [`Self::handle_block_response`] and restarts the round to obtain fresh tips and peers.
     async fn handle_block_response_with_missing_retry(
         &mut self,
         response: Result<(Height, block::Hash), BlockDownloadVerifyError>,

--- a/zakurad/src/components/sync/downloads.rs
+++ b/zakurad/src/components/sync/downloads.rs
@@ -212,8 +212,8 @@ impl BlockDownloadVerifyError {
         self.not_found_download().map(|(hash, _kind)| hash)
     }
 
-    /// Returns the missing block hash and the [`NotFoundKind`] for network `notfound` download
-    /// failures, or `None` for other errors.
+    /// Returns the missing block hash and the [`NotFoundKind`] for transient network download
+    /// failures that need another peer, or `None` for other errors.
     ///
     /// Uses the [`SharedPeerError`](zn::SharedPeerError) classification computed at construction
     /// rather than matching on `Debug` output, so a variant rename can't silently disable these

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -2211,6 +2211,41 @@ async fn registry_miss_schedules_backoff_retry() {
     peer_set.expect_no_requests().await;
 }
 
+/// No ready peers uses the registry backoff instead of restarting or hot-looping.
+#[tokio::test]
+async fn no_ready_peers_schedules_backoff_retry() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block_hash = block::Hash::from([0xAC; 32]);
+    let error = BlockDownloadVerifyError::DownloadFailed {
+        error: zn::SharedPeerError::from(zn::PeerError::NoReadyPeers).into(),
+        hash: block_hash,
+    };
+
+    chain_sync
+        .handle_block_response_with_missing_retry(Err(error))
+        .await
+        .expect("no ready peers should keep the current sync round alive");
+
+    assert!(
+        chain_sync.registry_miss_retry.contains_key(&block_hash),
+        "the block should wait for a peer through the backoff retry queue"
+    );
+    assert_eq!(
+        chain_sync.registry_miss_retry_counts.get(&block_hash),
+        Some(&1),
+        "the retry should be scheduled once without a hot loop"
+    );
+    peer_set.expect_no_requests().await;
+}
+
 /// A registry miss past its retry budget restarts the round and clears its retry state.
 #[tokio::test]
 async fn registry_miss_restarts_after_retry_limit() {


### PR DESCRIPTION
## Motivation

Historical legacy sync stalled after #440 because peer-set readiness counted
pruned peers, while block routing rejected them. When all archive peers were
busy, a ready pruned peer made `poll_ready` succeed and the subsequent block
request returned `NoReadyPeers`.

Restarting a sync round is intentional for structural failures such as a bad
hash chain or a block that remains unavailable. `NoReadyPeers`, however, only
means that every usable peer is busy at that instant. Classifying that transient
condition as fatal discarded the active checkpoint pipeline and made saturation
repeat as a non-converging restart cycle.

## Solution

While the local node is more than the shared at-or-near-tip threshold behind:

- disconnect peers that do not advertise `NODE_NETWORK`, including peers
  currently handling work;
- signal the crawler to find replacement peers;
- use ordinary peer-set routing and global readiness for the remaining archive
  peers, so `ready().await` parks when they are busy;
- classify `NoReadyPeers` with registry-level unavailability, using the existing
  two-second backoff and 60-retry budget while preserving downloaded blocks.

If the retry budget is exhausted, the normal fatal path still restarts the round
and obtains fresh tips. This preserves the bad-tip and incomplete-checkpoint
escape hatch.

At or near the network tip, the archive preference stops and pruned and archive
peers are retained and routed equally.

## Service-bit audit

The version decoder reads the remote service bits and the peer client checks
`NODE_NETWORK` directly. Production archive and zcashd-compatible Zakura nodes
advertise `NODE_NETWORK`; plain pruned Zakura nodes intentionally advertise no
service bits.

The managed continuous-sync and benchmark templates configure pruned nodes, so
seeing many Zakura peers classified as pruned is expected for that fleet rather
than evidence of a decoder bug. Test sidecar fixtures were updated to match the
production zcashd-compatible service advertisement.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli@0.44.0 changelog-unreleased/447.md --config .trunk/configs/.markdownlint.yaml`
- `cargo test -p zakura-network` (1,160 passed, 4 ignored; acceptance test
  passed)
- `env 'CXXFLAGS=-include cstdint' cargo test -p zakura no_ready_peers_schedules_backoff_retry`
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `env 'CXXFLAGS=-include cstdint' cargo clippy -p zakura --all-targets -- -D warnings`

The `CXXFLAGS` override works around the host RocksDB C++ header environment;
the targeted Zakura test and lint both passed.

Added coverage for:

- disconnecting pruned peers during historical sync and routing to an archive
  peer;
- waiting without a hot loop while archive peers are busy or only pruned peers
  are connected;
- scheduling `NoReadyPeers` through the backed-off retry path without restarting
  the round;
- retaining and routing to pruned peers at or near tip, including advertised
  inventory;
- matching sidecar fixtures to production archive service bits.

## Changelog

Added `changelog-unreleased/447.md`.

### Specifications & References

Regression introduced by #440
(`fix(network): avoid pruned peers during historical block sync`).

### Follow-up Work

Run a controlled legacy genesis-sync deployment to validate archive-peer
discovery and first-block progress under real mainnet peering.
