### PR TITLE
perf(network): batch address metrics updates

### DIFF
--- a/changelog-unreleased/451.md
+++ b/changelog-unreleased/451.md
@@ -1,0 +1,5 @@
+## Changed
+
+- Improved address-book metric collection performance, which was surprisingly
+  active in CPU profiles
+  ([#451](https://github.com/zakura-core/zakura/pull/451)).

--- a/zakura-network/benches/address_book.rs
+++ b/zakura-network/benches/address_book.rs
@@ -10,7 +10,10 @@ use tracing::Span;
 
 use zakura_chain::parameters::Network::Mainnet;
 use zakura_network::{
-    constants::{DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK, MAX_PEER_MISBEHAVIOR_SCORE},
+    constants::{
+        DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK, MAX_ADDRS_IN_MESSAGE,
+        MAX_PEER_MISBEHAVIOR_SCORE,
+    },
     types::MetaAddr,
     AddressBook, PeerSocketAddr,
 };
@@ -72,9 +75,15 @@ fn address_book(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
 
     for size in [SMALL_ADDRESS_BOOK_SIZE, MAX_ADDRS_IN_ADDRESS_BOOK] {
+        group.throughput(Throughput::Elements(1));
+
         let address_book = populated_address_book(size);
         let existing_addr = peer_addr(SAME_IP_ADDRESS_COUNT - 1);
         let new_addr = unique_ip_addr(size);
+        let batch_size = size.min(MAX_ADDRS_IN_MESSAGE);
+        let batch_updates: Vec<_> = (0..batch_size)
+            .map(|index| MetaAddr::new_misbehavior(peer_addr(index), 1))
+            .collect();
 
         let mut update_check = address_book.clone();
         let update_change = MetaAddr::new_misbehavior(existing_addr, 1);
@@ -93,6 +102,10 @@ fn address_book(c: &mut Criterion) {
         assert!(ban_check.update(ban_change).is_none());
         assert_eq!(ban_check.len(), size - SAME_IP_ADDRESS_COUNT);
         assert!(ban_check.bans().contains(existing_addr.ip()));
+
+        let mut batch_check = address_book.clone();
+        batch_check.extend(batch_updates.iter().copied());
+        assert_eq!(batch_check.len(), size);
 
         group.bench_with_input(
             BenchmarkId::new("clone_and_drop", size),
@@ -162,6 +175,20 @@ fn address_book(c: &mut Criterion) {
                 );
             },
         );
+
+        group.throughput(Throughput::Elements(
+            u64::try_from(batch_size).expect("address batch size fits in u64"),
+        ));
+        group.bench_with_input(BenchmarkId::new("update_batch", size), &size, |b, _size| {
+            b.iter_batched_ref(
+                || address_book.clone(),
+                |address_book| {
+                    address_book.extend(batch_updates.iter().copied());
+                    black_box(address_book);
+                },
+                BatchSize::PerIteration,
+            );
+        });
     }
 
     group.finish();

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -625,7 +625,7 @@ impl AddressBook {
     /// peers.
     pub fn update(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         let updated = self.update_inner(change);
-        self.update_metrics_if_dirty();
+        self.publish_metrics();
         updated
     }
 
@@ -806,7 +806,7 @@ impl AddressBook {
             }
 
             std::mem::drop(_guard);
-            self.update_metrics_if_dirty();
+            self.publish_metrics();
             Some(entry)
         } else {
             None
@@ -970,7 +970,7 @@ impl AddressBook {
     }
 
     /// Publish metrics if the address book changed since the previous update.
-    fn update_metrics_if_dirty(&mut self) {
+    fn publish_metrics(&mut self) {
         if !self.address_metrics_dirty {
             return;
         }
@@ -1097,7 +1097,7 @@ impl Extend<MetaAddrChange> for AddressBook {
             self.update_inner(change);
         }
 
-        self.update_metrics_if_dirty();
+        self.publish_metrics();
     }
 }
 

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -623,7 +623,6 @@ impl AddressBook {
     /// As an exception, this function can ignore all changes for specific
     /// [`PeerSocketAddr`]s. Ignored addresses will never be used to connect to
     /// peers.
-    #[allow(clippy::unwrap_in_result)]
     pub fn update(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         let updated = self.update_inner(change);
         self.update_metrics_if_dirty();
@@ -631,6 +630,7 @@ impl AddressBook {
     }
 
     /// Apply `change` without immediately publishing address book metrics.
+    #[allow(clippy::unwrap_in_result)]
     fn update_inner(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         let addr_label = change.addr().addr_label(self.expose_peer_addresses);
 
@@ -1091,6 +1091,8 @@ impl Extend<MetaAddrChange> for AddressBook {
     where
         T: IntoIterator<Item = MetaAddrChange>,
     {
+        // Publish once after the full batch instead of scanning the address
+        // book after every accepted change.
         for change in iter.into_iter() {
             self.update_inner(change);
         }

--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -292,6 +292,12 @@ pub struct AddressBook {
     /// A channel used to send the latest address book metrics.
     address_metrics_tx: watch::Sender<AddressMetrics>,
 
+    /// Whether the address book changed since metrics were last published.
+    address_metrics_dirty: bool,
+
+    #[cfg(test)]
+    address_metrics_update_count: usize,
+
     /// The last time we logged a message about the address metrics.
     last_address_log: Option<Instant>,
 }
@@ -358,6 +364,9 @@ impl AddressBook {
             span,
             expose_peer_addresses: false,
             address_metrics_tx,
+            address_metrics_dirty: false,
+            #[cfg(test)]
+            address_metrics_update_count: 0,
             last_address_log: None,
             most_recent_by_ip: should_limit_outbound_conns_per_ip.then(HashMap::new),
             bans_by_ip: Default::default(),
@@ -616,6 +625,13 @@ impl AddressBook {
     /// peers.
     #[allow(clippy::unwrap_in_result)]
     pub fn update(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
+        let updated = self.update_inner(change);
+        self.update_metrics_if_dirty();
+        updated
+    }
+
+    /// Apply `change` without immediately publishing address book metrics.
+    fn update_inner(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         let addr_label = change.addr().addr_label(self.expose_peer_addresses);
 
         if self.bans_by_ip.contains(change.addr().ip()) {
@@ -669,6 +685,7 @@ impl AddressBook {
                 }
 
                 self.peers.remove_ip(banned_ip);
+                self.address_metrics_dirty = true;
 
                 warn!(
                     peer = %addr_label,
@@ -699,6 +716,7 @@ impl AddressBook {
             }
 
             self.peers.insert(updated);
+            self.address_metrics_dirty = true;
 
             // Add the address to `most_recent_by_ip` if it sent the most recent
             // response Zebra has received from this IP.
@@ -753,9 +771,6 @@ impl AddressBook {
             }
 
             assert!(self.len() <= self.addr_limit);
-
-            std::mem::drop(_guard);
-            self.update_metrics(instant_now, chrono_now);
         }
 
         updated
@@ -771,7 +786,6 @@ impl AddressBook {
     fn take(&mut self, removed_addr: PeerSocketAddr) -> Option<MetaAddr> {
         let _guard = self.span.enter();
 
-        let instant_now = Instant::now();
         let chrono_now = Utc::now();
 
         trace!(
@@ -781,6 +795,8 @@ impl AddressBook {
         );
 
         if let Some(entry) = self.peers.remove(&removed_addr) {
+            self.address_metrics_dirty = true;
+
             // Check if this surplus peer's addr matches that in `most_recent_by_ip`
             // for this the surplus peer's ip to remove it there as well.
             if self.should_remove_most_recent_by_ip(entry.addr) {
@@ -790,7 +806,7 @@ impl AddressBook {
             }
 
             std::mem::drop(_guard);
-            self.update_metrics(instant_now, chrono_now);
+            self.update_metrics_if_dirty();
             Some(entry)
         } else {
             None
@@ -953,9 +969,24 @@ impl AddressBook {
         }
     }
 
+    /// Publish metrics if the address book changed since the previous update.
+    fn update_metrics_if_dirty(&mut self) {
+        if !self.address_metrics_dirty {
+            return;
+        }
+
+        self.address_metrics_dirty = false;
+        self.update_metrics(Instant::now(), Utc::now());
+    }
+
     /// Update the metrics for this address book.
     fn update_metrics(&mut self, instant_now: Instant, chrono_now: chrono::DateTime<Utc>) {
         let _guard = self.span.enter();
+
+        #[cfg(test)]
+        {
+            self.address_metrics_update_count += 1;
+        }
 
         let m = self.address_metrics_internal(chrono_now);
 
@@ -1061,8 +1092,10 @@ impl Extend<MetaAddrChange> for AddressBook {
         T: IntoIterator<Item = MetaAddrChange>,
     {
         for change in iter.into_iter() {
-            self.update(change);
+            self.update_inner(change);
         }
+
+        self.update_metrics_if_dirty();
     }
 }
 
@@ -1087,6 +1120,9 @@ impl Clone for AddressBook {
             span: self.span.clone(),
             expose_peer_addresses: self.expose_peer_addresses,
             address_metrics_tx,
+            address_metrics_dirty: false,
+            #[cfg(test)]
+            address_metrics_update_count: 0,
             last_address_log: None,
             most_recent_by_ip: self.most_recent_by_ip.clone(),
             bans_by_ip: self.bans_by_ip.clone(),

--- a/zakura-network/src/address_book/tests.rs
+++ b/zakura-network/src/address_book/tests.rs
@@ -4,9 +4,16 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 
-use crate::constants::MAX_BANNED_IPS;
+use chrono::Utc;
+use tracing::Span;
+use zakura_chain::parameters::Network::Mainnet;
 
-use super::{BanList, BannedIps};
+use crate::{
+    constants::{DEFAULT_MAX_CONNS_PER_IP, MAX_BANNED_IPS},
+    types::MetaAddr,
+};
+
+use super::{AddressBook, BanList, BannedIps};
 
 mod prop;
 mod vectors;
@@ -36,4 +43,39 @@ fn banned_ips_match_ipv4_and_ipv4_mapped_ipv6() {
 
     assert!(BannedIps::with_banned_ip(ipv4).contains(ipv4_mapped));
     assert!(BannedIps::with_banned_ip(ipv4_mapped).contains(ipv4));
+}
+
+#[test]
+fn address_metrics_are_updated_once_per_batch() {
+    let mut address_book = AddressBook::new(
+        "0.0.0.0:0".parse().unwrap(),
+        &Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
+        Span::none(),
+    );
+    let mut address_metrics = address_book.address_metrics_watcher();
+    let initial_update_count = address_book.address_metrics_update_count;
+    let peers = [
+        "11.1.1.1:8233".parse().unwrap(),
+        "11.1.1.2:8233".parse().unwrap(),
+        "11.1.1.3:8233".parse().unwrap(),
+        "11.1.1.4:8233".parse().unwrap(),
+    ]
+    .map(MetaAddr::new_initial_peer);
+
+    address_book.extend(peers);
+
+    assert_eq!(
+        address_book.address_metrics_update_count,
+        initial_update_count + 1
+    );
+    assert!(address_metrics.has_changed().unwrap());
+    assert_eq!(
+        address_metrics.borrow_and_update().num_addresses,
+        peers.len()
+    );
+    assert_eq!(
+        address_book.address_metrics(Utc::now()),
+        *address_metrics.borrow()
+    );
 }


### PR DESCRIPTION
## Motivation

Peer address crawls can apply up to 1,000 address changes as one batch.
`AddressBook::extend` previously published address metrics after every accepted
change, repeatedly scanning the address book while holding its mutex.

This supersedes #437, whose CPU measurements predated the indexed address book
from #431.

## Solution

Track whether an address-book mutation made the metrics dirty. Individual
updates continue to publish immediately, while `AddressBook::extend` applies
the complete batch and publishes once afterward.

The batch still publishes its final metrics before releasing the address-book
lock, including when a ban removes addresses.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p zakura-network --lib address_book` (12 passed)
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/451.md --config
  .trunk/configs/.markdownlint.yaml`

The new unit test applies four address changes through `extend`, verifies that
metrics are published once, and checks that both the watch snapshot and a
fresh calculation contain the final batch state.

## Benchmarks

The `update_batch` Criterion case applies accepted changes to existing peers.
Both revisions used the same release-profile benchmark source:

| Address book | Changes | Before | After | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 16 | 16 | 12.227 µs | 9.404 µs | 1.30× |
| 5,000 | 1,000 | 91.758 ms | 1.073 ms | 85.5× |

Command:

```sh
cargo bench -p zakura-network --features internal-bench \
  --bench address_book -- update_batch --noplot
```

## Changelog

`changelog-unreleased/451.md` records the address-book metric collection
performance improvement.

### Specifications & References

No protocol behavior changes.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactor of metrics publishing; peer address semantics and batch application paths are unchanged aside from fewer intermediate metric snapshots during `extend`.
> 
> **Overview**
> **Address-book metric publishing is deferred during batch updates** so peer crawls that apply up to ~1,000 changes no longer rescan the full book and push Prometheus/watch metrics after every accepted entry.
> 
> `AddressBook` now tracks an `address_metrics_dirty` flag and routes mutations through `update_inner`, with `publish_metrics` doing the expensive `address_metrics_internal` scan only when needed. **`update` still publishes immediately** for single changes; **`Extend::extend`** (used from `candidate_set` for gossip batches) applies the whole iterator via `update_inner` and publishes **once** at the end, still before releasing the mutex.
> 
> Adds a unit test that `extend` triggers a single metrics update, plus a Criterion **`update_batch`** benchmark and changelog entry **451**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b9a3cd3f25bd73c6dac72483823c14afb2d474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->