### PR TITLE
test(network): verify ban metrics publication

### DIFF
--- a/changelog-unreleased/453.md
+++ b/changelog-unreleased/453.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes tests and has no operator- or crate-consumer-visible
+effect.

--- a/zakura-network/src/address_book/tests/vectors.rs
+++ b/zakura-network/src/address_book/tests/vectors.rs
@@ -104,6 +104,8 @@ fn misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one() {
     assert!(address_book.get(other_port_same_ip).is_some());
 
     let bans = address_book.bans();
+    let mut address_metrics = address_book.address_metrics_watcher();
+    assert_eq!(address_metrics.borrow().num_addresses, 3);
 
     address_book.update(MetaAddrChange::UpdateMisbehavior {
         addr: banned_addr,
@@ -126,6 +128,15 @@ fn misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one() {
     assert!(
         address_book.get(unrelated_addr).is_some(),
         "unrelated IP entries should remain after banning a different IP"
+    );
+    assert!(
+        address_metrics.has_changed().unwrap(),
+        "the ban should publish updated address metrics"
+    );
+    assert_eq!(
+        address_metrics.borrow_and_update().num_addresses,
+        1,
+        "published metrics should exclude all addresses on the banned IP"
     );
 }
 

--- a/zakura-network/src/address_book/tests/vectors.rs
+++ b/zakura-network/src/address_book/tests/vectors.rs
@@ -80,6 +80,7 @@ fn misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one() {
 
     let mut address_book =
         AddressBook::new("0.0.0.0:0".parse().unwrap(), &Mainnet, 2, Span::current());
+    let mut address_metrics = address_book.address_metrics_watcher();
 
     // Seed two entries on the soon-to-be-banned IP plus an unrelated entry,
     // so the ban path's per-IP cleanup has visible work to do.
@@ -104,8 +105,7 @@ fn misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one() {
     assert!(address_book.get(other_port_same_ip).is_some());
 
     let bans = address_book.bans();
-    let mut address_metrics = address_book.address_metrics_watcher();
-    assert_eq!(address_metrics.borrow().num_addresses, 3);
+    assert_eq!(address_metrics.borrow_and_update().num_addresses, 3);
 
     address_book.update(MetaAddrChange::UpdateMisbehavior {
         addr: banned_addr,


### PR DESCRIPTION
## Motivation

PR #451 fixed address metrics publication after banning an IP, but the existing
ban regression test only checked the address-book contents and ban list.

## Solution

Extend the ban regression test with a metrics watcher. Verify that the watcher
contains three addresses before the ban, observes an immediate publication,
and contains only the unrelated address afterward.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p zakura-network --lib
  misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one`
  (1 passed)
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/453.md --config
  .trunk/configs/.markdownlint.yaml`

## Changelog

`changelog-unreleased/453.md` marks this test-only change as having no
operator- or crate-consumer-visible effect.

### Specifications & References

Follow-up test coverage for #451.

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and changelog metadata; no production behavior is modified.
> 
> **Overview**
> Adds regression coverage for **address metrics publication** when a misbehavior ban removes all peers on an IP (follow-up to #451).
> 
> The existing `misbehavior_ban_does_not_panic_with_max_connections_per_ip_above_one` test now subscribes via `address_metrics_watcher()` and checks that `num_addresses` is **3** before the ban, that the watcher **signals an update** after the ban, and that the published count drops to **1** (only the unrelated IP remains). A changelog entry records that the change is test-only with no operator or crate-consumer impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f88ef3efd56eaed21aaffe47e18d12d807c1b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->