### PR TITLE
test(e2e): stabilize restart catch-up validation

### DIFF
--- a/docker/zakura-regtest-e2e/run.sh
+++ b/docker/zakura-regtest-e2e/run.sh
@@ -238,6 +238,7 @@ log "using zakurad binary: ${ZAKURAD_BIN}"
 log "writing Zakura traces under: ${ZAKURA_E2E_TRACE_DIR}"
 
 ORACLE_RAN=0
+OPTIONAL_NODE4_QUIESCED=0
 
 trace_dir_has_jsonl() {
   [[ -d "${ZAKURA_E2E_TRACE_DIR}" ]] \
@@ -567,6 +568,34 @@ block_count() { rpc "$1" getblockcount | jq -r '.result // 0'; }
 block_hash() { rpc "$1" getblockhash "[$2]" | jq -r '.result // empty'; }
 strict_upgrade() { [[ "${ZAKURA_REGTEST_E2E_STRICT_UPGRADE:-0}" == "1" ]]; }
 
+# The restart matrix only stresses node2. Stop the known-optional upgraded peer
+# at a verified idle trace boundary so its unrelated catch-up cannot outlive it.
+quiesce_optional_node4_for_restart_matrix() {
+  [[ "${ZAKURA_E2E_MODE}" == "restart-matrix" ]] || return 0
+  strict_upgrade && return 0
+
+  log "quiescing optional node4 before the node2 restart matrix"
+  wait_metric_zero 19004 sync_block_budget_reserved_bytes "node4 pre-matrix budget"
+  wait_metric_zero 19004 sync_block_reorder_buffered_bytes "node4 pre-matrix reorder"
+  wait_metric_zero 19004 sync_block_applying "node4 pre-matrix applying"
+  wait_metric_zero 19004 sync_block_outstanding "node4 pre-matrix outstanding"
+  wait_for_commit_trace_balance node4 "node4 pre-matrix"
+  wait_for_trace_flush
+
+  local file="${ZAKURA_E2E_TRACE_DIR}/node4/block_sync.jsonl" last leak
+  last=$(grep 'block_sync_state' "${file}" 2>/dev/null | tail -1 || true)
+  [[ -n "${last}" ]] || fail "node4 pre-matrix block-sync trace is missing"
+  leak=$(printf '%s' "${last}" \
+    | jq -er '[(.applying//0),(.budget_reserved//0),(.reorder//0),(.outstanding//0)]|add') \
+    || fail "could not read node4 pre-matrix block-sync trace"
+  [[ "${leak}" == "0" ]] \
+    || fail "node4 pre-matrix block-sync trace is not drained (total ${leak})"
+
+  docker compose -f "${COMPOSE_FILE}" stop zakura-node-4 \
+    || fail "could not stop optional node4 before the restart matrix"
+  OPTIONAL_NODE4_QUIESCED=1
+}
+
 invalidate_block_if_present() {
   local port="$1" height="$2" hash="$3" label="$4"
   local current_height current_hash
@@ -636,6 +665,8 @@ wait_zakura_body_frontiers_at_tip() {
   wait_zakura_body_frontier_at_tip 19002 18332 "${target}" "node2 ${phase}"
   if strict_upgrade; then
     wait_zakura_body_frontier_at_tip 19004 18532 "${target}" "node4 ${phase}"
+  elif [[ "${OPTIONAL_NODE4_QUIESCED}" == "1" ]]; then
+    printf '  node4 %s quiesced after upgrade smoke coverage\n' "${phase}"
   else
     h4=$(block_count 18532)
     header4=$(metric 19004 sync_block_best_header_tip_height)
@@ -660,6 +691,8 @@ assert_block_sync_budget_empty() {
     wait_metric_zero 19004 sync_block_reorder_buffered_bytes "node4 ${phase} reorder"
     wait_metric_zero 19004 sync_block_applying "node4 ${phase} applying"
     wait_metric_zero 19004 sync_block_outstanding "node4 ${phase} outstanding"
+  elif [[ "${OPTIONAL_NODE4_QUIESCED}" == "1" ]]; then
+    printf '  node4 %s quiesced after upgrade smoke coverage\n' "${phase}"
   else
     printf '  node4 %s optional budget=%s reorder=%s applying=%s outstanding=%s\n' \
       "${phase}" \
@@ -890,6 +923,7 @@ log "asserting Zakura body frontier reached the header tip after gossip propagat
 wait_zakura_body_frontiers_at_tip "${target}" "post-generate"
 assert_block_sync_budget_empty "post-generate"
 snapshot_timeline "post-generate"
+quiesce_optional_node4_for_restart_matrix
 
 log "stopping pure-Zakura node2 before the from-scratch catch-up setup"
 wait_for_commit_trace_balance node2 "node2 pre-reset"
@@ -1026,7 +1060,11 @@ old_tip_hash=$(block_hash 18232 "${target}")
 invalidate_block_if_present 18232 "${target}" "${old_tip_hash}" node1
 invalidate_block_if_present 18332 "${target}" "${old_tip_hash}" node2
 invalidate_block_if_present 18432 "${target}" "${old_tip_hash}" node3
-invalidate_block_if_present 18532 "${target}" "${old_tip_hash}" node4
+if [[ "${OPTIONAL_NODE4_QUIESCED}" == "1" ]]; then
+  printf '  node4 skipping invalidate: quiesced after upgrade smoke coverage\n'
+else
+  invalidate_block_if_present 18532 "${target}" "${old_tip_hash}" node4
+fi
 reorg_base=$((target - 1))
 wait_block_count_equal 18232 "${reorg_base}" node1
 wait_block_count_equal 18332 "${reorg_base}" node2

--- a/docker/zakura-regtest-e2e/run.sh
+++ b/docker/zakura-regtest-e2e/run.sh
@@ -319,6 +319,24 @@ wait_for_trace_flush() {
   log "trace flush wait timed out after ${TRACE_FLUSH_TIMEOUT}s; running oracle anyway"
 }
 
+wait_for_commit_trace_balance() {
+  local node="$1" label="$2"
+  local file="${ZAKURA_E2E_TRACE_DIR}/${node}/commit_state.jsonl"
+  local deadline=$((SECONDS + TRACE_FLUSH_TIMEOUT)) starts finishes
+
+  [[ -s "${file}" ]] || fail "${label} commit trace is missing"
+  log "waiting for ${label} commit trace to flush before reset"
+  while (( SECONDS < deadline )); do
+    starts=$(grep -c 'commit_start' "${file}" 2>/dev/null || true)
+    finishes=$(grep -c 'commit_finish' "${file}" 2>/dev/null || true)
+    printf '  %s commit_state starts=%s finishes=%s\n' \
+      "${label}" "${starts}" "${finishes}"
+    (( starts == finishes )) && return 0
+    sleep 3
+  done
+  fail "${label} commit trace did not balance within ${TRACE_FLUSH_TIMEOUT}s"
+}
+
 run_trace_oracle() {
   trace_dir_has_jsonl || return 0
   ORACLE_RAN=1
@@ -507,13 +525,19 @@ wait_ready() {
   fail "${name} RPC did not become ready within ${READY_TIMEOUT}s"
 }
 
-reset_node2_from_scratch() {
+stop_node2_for_reset() {
   local label="$1"
   docker compose -f "${COMPOSE_FILE}" stop zakura-node-2 \
     || fail "could not stop node2 for ${label}"
   if [[ "${ZAKURA_E2E_RESTART_MATRIX}" == "1" ]]; then
     docker compose -f "${COMPOSE_FILE}" rm -f zakura-node-2 \
       || fail "could not remove node2 container for ${label}"
+  fi
+}
+
+start_node2_after_reset() {
+  local label="$1"
+  if [[ "${ZAKURA_E2E_RESTART_MATRIX}" == "1" ]]; then
     docker compose -f "${COMPOSE_FILE}" up -d zakura-node-2 \
       || fail "could not recreate node2 for ${label}"
   else
@@ -521,6 +545,12 @@ reset_node2_from_scratch() {
       || fail "could not restart node2 for ${label}"
   fi
   wait_ready 18332 "node2 (${label})"
+}
+
+reset_node2_from_scratch() {
+  local label="$1"
+  stop_node2_for_reset "${label}"
+  start_node2_after_reset "${label}"
 }
 
 restart_node2_preserving_state() {
@@ -861,6 +891,10 @@ wait_zakura_body_frontiers_at_tip "${target}" "post-generate"
 assert_block_sync_budget_empty "post-generate"
 snapshot_timeline "post-generate"
 
+log "stopping pure-Zakura node2 before the from-scratch catch-up setup"
+wait_for_commit_trace_balance node2 "node2 pre-reset"
+stop_node2_for_reset "post-reset catch-up"
+
 # ---------------------------------------------------------------------------
 # Deepen the chain before the from-scratch reset so the kind-6 catch-up below
 # re-downloads many bodies in a burst. Crossing hundreds of blocks is what fills
@@ -868,8 +902,7 @@ snapshot_timeline "post-generate"
 # wedged in production (a full queue silently dropping solicited bodies, then a
 # checkpoint-range commit waiting forever on the gap). A 3-block catch-up never
 # fills that queue, so the earlier topology could not reproduce the stall. node2
-# is still connected and tracks these via gossip, but it is wiped by the reset
-# below, forcing a real kind-6 re-download of the whole deepened chain.
+# is stopped before this deepening, so it cannot prefetch any of these bodies.
 if (( CATCHUP_BLOCKS > 0 )); then
   log "deepening node1 chain by ${CATCHUP_BLOCKS} block(s) before the reset catch-up"
   remaining=${CATCHUP_BLOCKS}
@@ -896,16 +929,12 @@ fi
 # ---------------------------------------------------------------------------
 # Exercise kind-6 block sync via a from-scratch reset of the pure-Zakura node.
 #
-# Above, node2 reached the tip while connected — but it got there through inbound
-# gossip (advertisement -> download), not kind-6 block sync: in this tiny topology
-# gossip delivers every body the instant it is mined, so no body gap ever forms.
-# The only way to force kind-6 is to remove gossip as a source. node2 has ephemeral
-# state, so stopping its container discards its chain; node1 keeps the chain and
-# mines nothing more. On reconnect node2 has a real, gossip-unfillable gap (node1
-# re-advertises nothing), so it must re-download every existing block over the
-# dedicated block-sync stream. This is the production Mainnet-from-0 /
-# restart-catch-up path.
-log "resetting pure-Zakura node2 to force a from-scratch kind-6 catch-up"
+# Above, node2 reached the initial tip through inbound gossip, then was stopped
+# and its state discarded before node1 deepened the chain. On reconnect node2
+# has a real, gossip-unfillable gap (node1 re-advertises nothing), so it must
+# re-download every existing block over the dedicated block-sync stream. This
+# is the production Mainnet-from-0 / restart-catch-up path.
+log "starting pure-Zakura node2 for a from-scratch kind-6 catch-up"
 catchup_target=$(block_count 18232)
 [[ "${catchup_target}" -ge 1 ]] || fail \
   "node1 has no chain for node2 to catch up to (height ${catchup_target})"
@@ -965,7 +994,7 @@ else
   log "chain too short (tip ${catchup_target}, interval ${CHECKPOINT_INTERVAL}); node2 catches up with the genesis-only checkpoint list"
 fi
 
-reset_node2_from_scratch "post-reset catch-up"
+start_node2_after_reset "post-reset catch-up"
 snapshot_timeline "post-reset-catch-up-started"
 
 # node2's own counters restart from zero, so assert absolute kind-6 activity, not a

--- a/docker/zakura-regtest-e2e/trace_oracle.py
+++ b/docker/zakura-regtest-e2e/trace_oracle.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import sys
 import tempfile
+from bisect import bisect_left, bisect_right
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -76,6 +77,87 @@ class TraceRow:
     @property
     def ts(self) -> int | None:
         return int_field(self.row, "ts")
+
+
+@dataclass(frozen=True)
+class TraceActivityIndex:
+    """Index timestamp windows while preserving the event-index fallback."""
+
+    rows: tuple[TraceRow, ...]
+    timestamped_rows: tuple[TraceRow, ...]
+    timestamps: tuple[int, ...]
+
+    @classmethod
+    def build(cls, rows: Iterable[TraceRow]) -> TraceActivityIndex:
+        ordered_rows = tuple(sorted(rows, key=sort_key))
+        timestamped = tuple((row.ts, row) for row in ordered_rows if row.ts is not None)
+        return cls(
+            rows=ordered_rows,
+            timestamped_rows=tuple(row for _, row in timestamped),
+            timestamps=tuple(ts for ts, _ in timestamped if ts is not None),
+        )
+
+    def near_count(self, state: TraceRow, options: OracleOptions) -> int:
+        if state.ts is None:
+            return sum(1 for _ in self._rows_near_event_index(state))
+
+        lower, upper = self._timestamp_bounds(state.ts, options.persistent_lag_micros)
+        return upper - lower
+
+    def near_tail(
+        self,
+        state: TraceRow,
+        options: OracleOptions,
+        limit: int,
+    ) -> list[TraceRow]:
+        if limit <= 0:
+            return []
+        if state.ts is None:
+            return list(self._rows_near_event_index(state))[-limit:]
+
+        lower, upper = self._timestamp_bounds(state.ts, options.persistent_lag_micros)
+        return list(self.timestamped_rows[max(lower, upper - limit) : upper])
+
+    def has_near(self, state: TraceRow, options: OracleOptions) -> bool:
+        if state.ts is None:
+            return any(self._rows_near_event_index(state))
+
+        lower, upper = self._timestamp_bounds(state.ts, options.persistent_lag_micros)
+        return lower < upper
+
+    def has_forward(self, state: TraceRow, options: OracleOptions) -> bool:
+        if state.ts is None:
+            return any(
+                row.table != state.table
+                or state.index <= row.index <= state.index + RECENT_ACTIVITY_EVENTS
+                for row in self.rows
+            )
+        if options.persistent_lag_micros < 0:
+            return False
+
+        lower = bisect_left(self.timestamps, state.ts)
+        upper = bisect_right(
+            self.timestamps,
+            state.ts + options.persistent_lag_micros,
+        )
+        return lower < upper
+
+    def _rows_near_event_index(self, state: TraceRow) -> Iterable[TraceRow]:
+        lower = max(0, state.index - RECENT_ACTIVITY_EVENTS)
+        upper = state.index + RECENT_ACTIVITY_EVENTS
+        return (
+            row
+            for row in self.rows
+            if row.table != state.table or lower <= row.index <= upper
+        )
+
+    def _timestamp_bounds(self, state_ts: int, window: int) -> tuple[int, int]:
+        if window < 0:
+            return (0, 0)
+        return (
+            bisect_left(self.timestamps, state_ts - window),
+            bisect_right(self.timestamps, state_ts + window),
+        )
 
 
 @dataclass
@@ -450,17 +532,16 @@ def check_frontiers(node: NodeTrace) -> list[Failure]:
 def check_block_sync_activity(node: NodeTrace, options: OracleOptions) -> list[Failure]:
     failures: list[Failure] = []
     states = node.events("block_sync", BLOCK_SYNC_STATE)
-    real_activity = sorted(
+    real_activity = TraceActivityIndex.build(
         [row for row in node.table("block_sync") if row.event in BODY_PROGRESS_EVENTS]
-        + [row for row in node.table("commit_state") if commit_state_row_is_body_progress(row)],
-        key=sort_key,
+        + [row for row in node.table("commit_state") if commit_state_row_is_body_progress(row)]
     )
-    query_rows = [
+    query_rows = TraceActivityIndex.build(
         row
         for row in node.table("commit_state")
         if row.row.get("action") == QUERY_NEEDED_BLOCKS
         and row.event in {"state_read_start", "state_read_success", "state_read_error", "state_read_timeout"}
-    ]
+    )
 
     if node.node not in options.optional_lag_nodes:
         for state in states:
@@ -469,9 +550,9 @@ def check_block_sync_activity(node: NodeTrace, options: OracleOptions) -> list[F
             if best is None or verified is None or best <= verified:
                 continue
 
-            has_real_activity = has_near_activity(state, real_activity, options)
+            has_real_activity = real_activity.has_near(state, options)
             if not has_real_activity:
-                recent_query_count = len(rows_near(state, query_rows, options))
+                recent_query_count = query_rows.near_count(state, options)
                 invariant = (
                     "lagging_body_sync_not_query_spin"
                     if recent_query_count > 0
@@ -486,13 +567,16 @@ def check_block_sync_activity(node: NodeTrace, options: OracleOptions) -> list[F
                             "best_header_tip": best,
                             "verified_block_tip": verified,
                             "recent_query_needed_blocks": recent_query_count,
-                            "nearby_real_activity": [compact_row(row) for row in rows_near(state, real_activity, options)[-5:]],
+                            "nearby_real_activity": [
+                                compact_row(row)
+                                for row in real_activity.near_tail(state, options, 5)
+                            ],
                         },
                     )
                 )
                 break
 
-            if body_sync_has_pinned_queue(state) and not has_forward_activity(state, real_activity, options):
+            if body_sync_has_pinned_queue(state) and not real_activity.has_forward(state, options):
                 failures.append(
                     failure(
                         node,
@@ -540,38 +624,6 @@ def commit_state_row_is_body_progress(row: TraceRow) -> bool:
     if row.event == COMMIT_FINISH and row.row.get("source") == "block_sync_driver":
         return True
     return False
-
-
-def rows_near(state: TraceRow, activity: list[TraceRow], options: OracleOptions) -> list[TraceRow]:
-    state_ts = state.ts
-    if state_ts is None:
-        lower = max(0, state.index - RECENT_ACTIVITY_EVENTS)
-        upper = state.index + RECENT_ACTIVITY_EVENTS
-        return [row for row in activity if row.table != state.table or lower <= row.index <= upper]
-
-    return [
-        row
-        for row in activity
-        if row.ts is not None and abs(row.ts - state_ts) <= options.persistent_lag_micros
-    ]
-
-
-def has_near_activity(state: TraceRow, activity: list[TraceRow], options: OracleOptions) -> bool:
-    return bool(rows_near(state, activity, options))
-
-
-def has_forward_activity(state: TraceRow, activity: list[TraceRow], options: OracleOptions) -> bool:
-    state_ts = state.ts
-    if state_ts is None:
-        return any(
-            row.table != state.table or state.index <= row.index <= state.index + RECENT_ACTIVITY_EVENTS
-            for row in activity
-        )
-    return any(
-        row.ts is not None
-        and state_ts <= row.ts <= state_ts + options.persistent_lag_micros
-        for row in activity
-    )
 
 
 def body_sync_has_pinned_queue(state: TraceRow) -> bool:
@@ -887,6 +939,35 @@ def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
 
 
 def run_self_test() -> None:
+    state = TraceRow("node1", "block_sync", 50, {"ts": 100})
+    activity = TraceActivityIndex.build(
+        TraceRow("node1", "block_sync", index, {"ts": ts})
+        for index, ts in enumerate((89, 90, 100, 110, 111), start=1)
+    )
+    window = OracleOptions(persistent_lag_micros=10)
+    assert activity.near_count(state, window) == 3
+    assert [row.ts for row in activity.near_tail(state, window, 2)] == [100, 110]
+    assert activity.has_near(state, window)
+    assert activity.has_forward(state, window)
+
+    past_activity = TraceActivityIndex.build(
+        [TraceRow("node1", "block_sync", 1, {"ts": 90})]
+    )
+    assert past_activity.has_near(state, window)
+    assert not past_activity.has_forward(state, window)
+
+    unclocked_state = TraceRow("node1", "block_sync", 2_500, {})
+    unclocked_activity = TraceActivityIndex.build(
+        [TraceRow("node1", "block_sync", 1_000, {})]
+    )
+    assert unclocked_activity.near_count(unclocked_state, window) == 1
+    assert not unclocked_activity.has_forward(unclocked_state, window)
+    cross_table_activity = TraceActivityIndex.build(
+        [TraceRow("node1", "commit_state", 10_000, {})]
+    )
+    assert cross_table_activity.near_count(unclocked_state, window) == 1
+    assert cross_table_activity.has_forward(unclocked_state, window)
+
     with tempfile.TemporaryDirectory(prefix="zakura-trace-oracle.") as tmp:
         root = Path(tmp)
 


### PR DESCRIPTION
## Motivation

The restart-matrix harness had three independent CI problems. It could stop node2 while a deepening commit was still in flight, leaving a persisted `commit_start` without a matching `commit_finish` even though functional catch-up passed. Large successful traces also made the trace oracle scan every activity row for every block-sync state, so completed scenarios could spend hours in post-run validation.

After those fixes, the faster node2 matrix exposed a separate lifecycle issue. The known-optional upgraded node4 remained active during the node2-only restart stress and could still be catching up when the oracle took its final snapshot.

## Solution

Stop node2 at the already verified initial tip, require its persisted commit trace to be balanced, and keep it offline while node1 deepens the chain. Then restart node2 from empty state for the same kind-6 catch-up.

For the non-strict restart-matrix mode, verify that optional node4 has a balanced, resource-free trace after its upgrade and propagation smoke coverage, then stop it before the node2 restart stress. Strict-upgrade mode keeps node4 running and fully enforced.

Keep every oracle invariant and time-window boundary unchanged, but index timestamped activity rows and use binary search for each window. Rows without timestamps retain the existing event-index fallback. The broader trace process-epoch model remains out of scope.

## Testing

- `bash -n docker/zakura-regtest-e2e/run.sh`
- `shellcheck -e SC2015 docker/zakura-regtest-e2e/run.sh`
- `python3 -m py_compile docker/zakura-regtest-e2e/trace_oracle.py`
- `python3 docker/zakura-regtest-e2e/trace_oracle.py --self-test`
- 500 randomized cases matched the previous window and forward-activity semantics
- The exact canceled PR restart artifact passes all invariants in 22.4 seconds
- The known-bad main artifact still reports `node2 / block_sync_queue_lag_makes_progress` in 13.9 seconds
- The latest failed artifact still reports the strict `node4 / final_block_sync_state_has_no_leaks` invariant when left unmodified
- Replaying that artifact with node4 ending at the proposed idle boundary passes every oracle invariant with node4 at body/header height 3 and all resource counters zero
- A clean PR-gate run reached height 164, recorded 171 matched node2 commit starts and finishes, and passed the trace oracle

## Changelog

Internal shell and Python test harness only; no changelog fragment is required.

## AI Disclosure

Used Codex to investigate the CI artifacts, adjust the E2E lifecycle, optimize the trace oracle, and run the targeted validation.