### PR TITLE
fix(network): separate findblocks responses from block gossip

### DIFF
--- a/changelog-unreleased/455.md
+++ b/changelog-unreleased/455.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Fixed legacy peer block discovery so unsolicited block announcements cannot be mistaken for discovery responses
+  ([#455](https://github.com/zakura-core/zakura/pull/455)).

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -397,15 +397,12 @@ impl Handler {
                 }
             }
 
-            // TODO:
-            // - use `any(inv)` rather than `all(inv)`?
-            (Handler::FindBlocks, Message::Inv(items))
-                if items
-                    .iter()
-                    .all(|item| matches!(item, InventoryHash::Block(_))) =>
-            {
+            (Handler::FindBlocks, Message::Headers(headers)) => {
                 Handler::Finished(Ok(Response::BlockHashes(
-                    block_hashes(&items[..]).collect(),
+                    headers
+                        .into_iter()
+                        .map(|counted_header| counted_header.header.hash())
+                        .collect(),
                 )))
             }
             (Handler::FindHeaders, Message::Headers(headers)) => {
@@ -1086,9 +1083,11 @@ where
             }
 
             (AwaitingRequest, FindBlocks { known_blocks, stop }) => {
+                // `getblocks` responses and block announcements are both `inv` messages.
+                // Use `getheaders` so tip gossip cannot be mistaken for this response.
                 self
                     .peer_tx
-                    .send(Message::GetBlocks { known_blocks, stop })
+                    .send(Message::GetHeaders { known_blocks, stop })
                     .await
                     .map(|()|
                          Handler::FindBlocks

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::HashSet,
+    sync::Arc,
     task::Poll,
     time::{Duration, Instant},
 };
@@ -18,7 +19,10 @@ use futures::{
 use tower::load_shed::error::Overloaded;
 use tracing::Span;
 
-use zakura_chain::{block, serialization::SerializationError};
+use zakura_chain::{
+    block,
+    serialization::{SerializationError, ZcashDeserializeInto},
+};
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
@@ -236,6 +240,85 @@ async fn connection_run_loop_message_ok() {
     connection_join_handle.abort();
     let outbound_message = peer_outbound_messages.next().await;
     assert_eq!(outbound_message, None);
+}
+
+/// A block announcement must not satisfy an in-flight block hash discovery request.
+#[tokio::test]
+async fn find_blocks_ignores_block_gossip_before_response() {
+    let _init_guard = zakura_test::init();
+
+    let (mut peer_tx, peer_rx) = mpsc::channel(2);
+    let (
+        connection,
+        mut client_tx,
+        mut inbound_service,
+        mut peer_outbound_messages,
+        shared_error_slot,
+    ) = new_test_connection();
+    let connection_join_handle = tokio::spawn(connection.run(peer_rx));
+
+    let locator = block::Hash::from([0x11; 32]);
+    let announced_tip = block::Hash::from([0x22; 32]);
+    let header: block::Header = zakura_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let response_hash = header.hash();
+
+    let (request_tx, mut request_rx) = oneshot::channel();
+    client_tx
+        .try_send(ClientRequest {
+            request: Request::FindBlocks {
+                known_blocks: vec![locator],
+                stop: None,
+            },
+            tx: request_tx,
+            inv_collector: None,
+            transient_addr: None,
+            span: Span::current(),
+        })
+        .expect("internal request channel should accept the request");
+
+    assert_eq!(
+        peer_outbound_messages.next().await,
+        Some(Message::GetHeaders {
+            known_blocks: vec![locator],
+            stop: None,
+        })
+    );
+
+    peer_tx
+        .try_send(Ok(Message::Inv(vec![announced_tip.into()])))
+        .expect("peer response channel should accept the announcement");
+    inbound_service
+        .expect_request(Request::AdvertiseBlock(announced_tip, None))
+        .await
+        .respond(Response::Nil);
+
+    tokio::task::yield_now().await;
+    assert!(
+        matches!(request_rx.try_recv(), Ok(None)),
+        "block gossip must not complete the FindBlocks request"
+    );
+
+    peer_tx
+        .try_send(Ok(Message::Headers(vec![block::CountedHeader {
+            header: Arc::new(header),
+        }])))
+        .expect("peer response channel should accept the headers response");
+
+    assert_eq!(
+        request_rx
+            .await
+            .expect("connection should send a response")
+            .expect("headers should produce a successful response"),
+        Response::BlockHashes(vec![response_hash])
+    );
+    assert!(
+        shared_error_slot.try_get_error().is_none(),
+        "the connection should remain healthy"
+    );
+
+    connection_join_handle.abort();
 }
 
 /// Test that the connection run loop fails correctly when dropped

--- a/zakura-network/src/protocol/internal/request.rs
+++ b/zakura-network/src/protocol/internal/request.rs
@@ -145,17 +145,9 @@ pub enum Request {
     /// Returns
     /// [`Response::BlockHashes`](super::Response::BlockHashes).
     ///
-    /// # Warning
-    ///
-    /// This is implemented by sending a `getblocks` message. Bitcoin nodes
-    /// respond to `getblocks` with an `inv` message containing a list of the
-    /// subsequent blocks. However, Bitcoin nodes *also* send `inv` messages
-    /// unsolicited in order to gossip new blocks to their peers. These gossip
-    /// messages can race with the response to a `getblocks` request, and there
-    /// is no way for the network layer to distinguish them. For this reason, the
-    /// response may occasionally contain a single hash of a new chain tip rather
-    /// than a list of hashes of subsequent blocks. We believe that unsolicited
-    /// `inv` messages will always have exactly one block hash.
+    /// Outbound legacy TCP requests use `getheaders` and return up to 160 hashes
+    /// from the `headers` response. This keeps the response distinct from
+    /// unsolicited block announcements, which use `inv` messages.
     FindBlocks {
         /// Hashes of known blocks, ordered from highest height to lowest height.
         //


### PR DESCRIPTION
## Motivation

Legacy TCP uses `inv` for both `getblocks` responses and unsolicited block announcements. Because those messages carry no request ID, a tip announcement can arrive first and incorrectly complete an in-flight `FindBlocks` request; the real response then arrives after the handler has moved on.

## Solution

Send outbound legacy TCP `FindBlocks` requests as `getheaders`, then convert the distinct `headers` response into ordered block hashes. Unsolicited `inv` messages continue through the normal block-advertisement path without completing the request. Native Zakura transport and inbound `getblocks` handling are unchanged.

This deliberately changes the legacy discovery batch limit from 500 hashes to 160 headers. The sync loop already requests another batch whenever its reserve is below 500, so discovery continues immediately rather than stalling at 160.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network find_blocks_ignores_block_gossip_before_response --locked`
- `cargo clippy -p zakura-network --all-targets --locked -- -D warnings`
- Serialized `zakura-network` library suite: 1,154 passed, with only three macOS-incompatible source-address binding tests skipped
- `cargo test -p zakura --lib --locked`: 325 passed
- `cargo clippy -p zakura --all-targets --locked -- -D warnings`

The regression test reproduces the ordering race by delivering singleton block gossip before the actual response. It verifies that gossip is advertised normally, the discovery request remains pending, and the later headers response completes it with the expected hash.

## Changelog

Added `changelog-unreleased/455.md` under `Fixed`.
