### PR TITLE
fix(network): gate singleton findblocks replies near tip

### DIFF
--- a/changelog-unreleased/456.md
+++ b/changelog-unreleased/456.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Prevented unsolicited single-block announcements from interrupting legacy block discovery while syncing
+  ([#456](https://github.com/zakura-core/zakura/pull/456)).

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -47,6 +47,8 @@ mod peer_tx;
 #[cfg(test)]
 mod tests;
 
+type IsAtOrNearNetworkTip = Box<dyn Fn() -> bool + Send>;
+
 #[derive(Debug)]
 pub(super) enum Handler {
     /// Indicates that the handler has finished processing the request.
@@ -57,7 +59,9 @@ pub(super) enum Handler {
         ping_sent_at: Instant,
     },
     Peers,
-    FindBlocks,
+    FindBlocks {
+        accept_singleton_response: bool,
+    },
     FindHeaders,
     BlocksByHash {
         pending_hashes: HashSet<block::Hash>,
@@ -79,7 +83,7 @@ impl fmt::Display for Handler {
             Handler::Ping { .. } => "Ping".to_string(),
             Handler::Peers => "Peers".to_string(),
 
-            Handler::FindBlocks => "FindBlocks".to_string(),
+            Handler::FindBlocks { .. } => "FindBlocks".to_string(),
             Handler::FindHeaders => "FindHeaders".to_string(),
             Handler::BlocksByHash {
                 pending_hashes,
@@ -113,7 +117,7 @@ impl Handler {
             Handler::Ping { .. } => "Ping".into(),
             Handler::Peers => "Peers".into(),
 
-            Handler::FindBlocks => "FindBlocks".into(),
+            Handler::FindBlocks { .. } => "FindBlocks".into(),
             Handler::FindHeaders => "FindHeaders".into(),
 
             Handler::BlocksByHash { .. } => "BlocksByHash".into(),
@@ -399,10 +403,16 @@ impl Handler {
 
             // TODO:
             // - use `any(inv)` rather than `all(inv)`?
-            (Handler::FindBlocks, Message::Inv(items))
-                if items
-                    .iter()
-                    .all(|item| matches!(item, InventoryHash::Block(_))) =>
+            (
+                Handler::FindBlocks {
+                    accept_singleton_response,
+                },
+                Message::Inv(items),
+            ) if items
+                .iter()
+                .all(|item| matches!(item, InventoryHash::Block(_)))
+                // A singleton can be an unsolicited tip announcement.
+                && (items.len() != 1 || accept_singleton_response) =>
             {
                 Handler::Finished(Ok(Response::BlockHashes(
                     block_hashes(&items[..]).collect(),
@@ -607,6 +617,9 @@ where
     /// The configured log and metrics label for this peer. Usually the remote IP and port.
     pub(super) addr_label: String,
 
+    /// Reports whether the locally committed chain is at or near the estimated network tip.
+    is_at_or_near_network_tip: IsAtOrNearNetworkTip,
+
     /// The state for this peer, when the metrics were last updated.
     pub(super) last_metrics_state: Option<Cow<'static, str>>,
 
@@ -650,6 +663,7 @@ where
         connection_info: Arc<ConnectionInfo>,
         addr_label: String,
         initial_cached_addrs: Vec<MetaAddr>,
+        is_at_or_near_network_tip: IsAtOrNearNetworkTip,
     ) -> Self {
         Connection {
             connection_info,
@@ -662,6 +676,7 @@ where
             peer_tx: peer_tx.into(),
             connection_tracker,
             addr_label,
+            is_at_or_near_network_tip,
             last_metrics_state: None,
             last_overload_time: None,
         }
@@ -1086,13 +1101,14 @@ where
             }
 
             (AwaitingRequest, FindBlocks { known_blocks, stop }) => {
+                let accept_singleton_response = (self.is_at_or_near_network_tip)();
                 self
                     .peer_tx
                     .send(Message::GetBlocks { known_blocks, stop })
                     .await
-                    .map(|()|
-                         Handler::FindBlocks
-                    )
+                    .map(|()| Handler::FindBlocks {
+                        accept_singleton_response,
+                    })
             }
             (AwaitingRequest, FindHeaders { known_blocks, stop }) => {
                 self

--- a/zakura-network/src/peer/connection/tests.rs
+++ b/zakura-network/src/peer/connection/tests.rs
@@ -82,7 +82,23 @@ fn new_test_connection<A>() -> (
     mpsc::Receiver<Message>,
     ErrorSlot,
 ) {
-    new_test_connection_with_protection(false)
+    new_test_connection_with_options(false, true)
+}
+
+/// Creates a new [`Connection`] with a fixed local near-tip estimate.
+fn new_test_connection_with_tip_status<A>(
+    is_at_or_near_network_tip: bool,
+) -> (
+    Connection<
+        MockService<Request, Response, A>,
+        SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, A>,
+    mpsc::Receiver<Message>,
+    ErrorSlot,
+) {
+    new_test_connection_with_options(false, is_at_or_near_network_tip)
 }
 
 /// Creates a new [`Connection`] marked as an operator-configured protected peer
@@ -97,13 +113,13 @@ fn new_protected_test_connection<A>() -> (
     mpsc::Receiver<Message>,
     ErrorSlot,
 ) {
-    new_test_connection_with_protection(true)
+    new_test_connection_with_options(true, true)
 }
 
-/// Creates a new [`Connection`] instance for testing, setting whether it is an
-/// operator-configured protected peer.
-fn new_test_connection_with_protection<A>(
+/// Creates a new [`Connection`] instance with the requested test behavior.
+fn new_test_connection_with_options<A>(
     is_protected_peer: bool,
+    is_at_or_near_network_tip: bool,
 ) -> (
     Connection<
         MockService<Request, Response, A>,
@@ -170,6 +186,7 @@ fn new_test_connection_with_protection<A>(
         Arc::new(connection_info),
         addr_label,
         Vec::new(),
+        Box::new(move || is_at_or_near_network_tip),
     );
 
     (
@@ -225,6 +242,7 @@ fn new_never_closing_test_connection<A>(
         Arc::new(connection_info),
         addr_label,
         Vec::new(),
+        Box::new(|| true),
     );
 
     (connection, client_tx, shared_error_slot)

--- a/zakura-network/src/peer/connection/tests/vectors.rs
+++ b/zakura-network/src/peer/connection/tests/vectors.rs
@@ -238,6 +238,134 @@ async fn connection_run_loop_message_ok() {
     assert_eq!(outbound_message, None);
 }
 
+/// A singleton `inv` completes `FindBlocks` when the committed chain is near tip.
+#[tokio::test]
+async fn find_blocks_accepts_singleton_response_near_tip() {
+    let _init_guard = zakura_test::init();
+
+    let (mut peer_tx, peer_rx) = mpsc::channel(1);
+    let (
+        connection,
+        mut client_tx,
+        mut inbound_service,
+        mut peer_outbound_messages,
+        shared_error_slot,
+    ) = super::new_test_connection_with_tip_status::<PanicAssertion>(true);
+    let connection_join_handle = tokio::spawn(connection.run(peer_rx));
+
+    let locator = block::Hash::from([0x11; 32]);
+    let response_hash = block::Hash::from([0x22; 32]);
+    let (request_tx, request_rx) = oneshot::channel();
+    client_tx
+        .try_send(ClientRequest {
+            request: Request::FindBlocks {
+                known_blocks: vec![locator],
+                stop: None,
+            },
+            tx: request_tx,
+            inv_collector: None,
+            transient_addr: None,
+            span: Span::current(),
+        })
+        .expect("internal request channel should accept the request");
+
+    assert_eq!(
+        peer_outbound_messages.next().await,
+        Some(Message::GetBlocks {
+            known_blocks: vec![locator],
+            stop: None,
+        })
+    );
+
+    peer_tx
+        .try_send(Ok(Message::Inv(vec![response_hash.into()])))
+        .expect("peer response channel should accept the response");
+
+    assert_eq!(
+        request_rx
+            .await
+            .expect("connection should send a response")
+            .expect("singleton should produce a successful response"),
+        Response::BlockHashes(vec![response_hash])
+    );
+    inbound_service.expect_no_requests().await;
+    assert!(shared_error_slot.try_get_error().is_none());
+
+    connection_join_handle.abort();
+}
+
+/// A singleton `inv` is gossip, not a `FindBlocks` response, while far from tip.
+#[tokio::test]
+async fn find_blocks_routes_singleton_as_gossip_while_far_from_tip() {
+    let _init_guard = zakura_test::init();
+
+    let (mut peer_tx, peer_rx) = mpsc::channel(2);
+    let (
+        connection,
+        mut client_tx,
+        mut inbound_service,
+        mut peer_outbound_messages,
+        shared_error_slot,
+    ) = super::new_test_connection_with_tip_status::<PanicAssertion>(false);
+    let connection_join_handle = tokio::spawn(connection.run(peer_rx));
+
+    let locator = block::Hash::from([0x31; 32]);
+    let announced_tip = block::Hash::from([0x32; 32]);
+    let response_hashes = [block::Hash::from([0x33; 32]), block::Hash::from([0x34; 32])];
+    let (request_tx, mut request_rx) = oneshot::channel();
+    client_tx
+        .try_send(ClientRequest {
+            request: Request::FindBlocks {
+                known_blocks: vec![locator],
+                stop: None,
+            },
+            tx: request_tx,
+            inv_collector: None,
+            transient_addr: None,
+            span: Span::current(),
+        })
+        .expect("internal request channel should accept the request");
+
+    assert_eq!(
+        peer_outbound_messages.next().await,
+        Some(Message::GetBlocks {
+            known_blocks: vec![locator],
+            stop: None,
+        })
+    );
+
+    peer_tx
+        .try_send(Ok(Message::Inv(vec![announced_tip.into()])))
+        .expect("peer response channel should accept the announcement");
+    inbound_service
+        .expect_request(Request::AdvertiseBlock(announced_tip, None))
+        .await
+        .respond(Response::Nil);
+
+    tokio::task::yield_now().await;
+    assert!(
+        matches!(request_rx.try_recv(), Ok(None)),
+        "block gossip must not complete the FindBlocks request while far from tip"
+    );
+
+    peer_tx
+        .try_send(Ok(Message::Inv(
+            response_hashes.iter().copied().map(Into::into).collect(),
+        )))
+        .expect("peer response channel should accept the response");
+
+    assert_eq!(
+        request_rx
+            .await
+            .expect("connection should send a response")
+            .expect("multi-hash inventory should produce a successful response"),
+        Response::BlockHashes(response_hashes.to_vec())
+    );
+    assert!(shared_error_slot.try_get_error().is_none());
+
+    connection_join_handle.abort();
+}
+
 /// Test that the connection run loop fails correctly when dropped
 #[tokio::test]
 async fn connection_run_loop_future_drop() {

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -1486,6 +1486,7 @@ where
         let our_services = self.our_services;
         let relay = self.relay;
         let minimum_peer_version = self.minimum_peer_version.clone();
+        let latest_chain_tip = self.minimum_peer_version.chain_tip().clone();
         let zakura_handshake_connector = self.zakura_handshake_connector.clone();
 
         // Whether this peer is exempt from the inbound-overload connection drop.
@@ -1763,6 +1764,10 @@ where
                     )
                 });
 
+            let network = config.network.clone();
+            let is_at_or_near_network_tip =
+                Box::new(move || latest_chain_tip.is_at_or_near_network_tip(&network));
+
             let server = Connection::new(
                 inbound_service,
                 server_rx,
@@ -1772,6 +1777,7 @@ where
                 connection_info.clone(),
                 addr_label,
                 alternate_addrs.collect(),
+                is_at_or_near_network_tip,
             );
 
             let connection_task = tokio::spawn(

--- a/zakura-network/src/protocol/internal/request.rs
+++ b/zakura-network/src/protocol/internal/request.rs
@@ -152,10 +152,10 @@ pub enum Request {
     /// subsequent blocks. However, Bitcoin nodes *also* send `inv` messages
     /// unsolicited in order to gossip new blocks to their peers. These gossip
     /// messages can race with the response to a `getblocks` request, and there
-    /// is no way for the network layer to distinguish them. For this reason, the
-    /// response may occasionally contain a single hash of a new chain tip rather
-    /// than a list of hashes of subsequent blocks. We believe that unsolicited
-    /// `inv` messages will always have exactly one block hash.
+    /// is no way for the network layer to distinguish them. Legacy connections
+    /// accept a singleton `inv` as the response only when the locally committed
+    /// chain is estimated to be at or near the network tip. Otherwise, they treat
+    /// it as block gossip and keep waiting for a multi-hash response.
     FindBlocks {
         /// Hashes of known blocks, ordered from highest height to lowest height.
         //


### PR DESCRIPTION
## Motivation

Legacy getblocks uses untagged inv messages for both solicited responses and unsolicited tip gossip. While Zakura is syncing, a one-block tip announcement can arrive before the real multi-hash response and be mistaken for that response. Discovery then discards the useful reply and stalls until it retries.

## Solution

Use the existing committed-chain timestamp estimate when a legacy getblocks request is sent. That estimate treats the node as near tip when its estimated distance is at most five blocks. Near the estimated network tip, retain singleton response handling. While far from tip or when tip proximity is unknown, route a singleton inv through the normal block-gossip path and keep waiting for a multi-hash response. Native Zakura connections are unchanged.

This is the heuristic alternative to changing discovery to getheaders. It avoids the additional header download and deserialization cost. The intentional tradeoff is that a genuine singleton reply from a stale peer may wait for the request timeout while the local estimate says far from tip or unknown.

## Testing

- cargo test -p zakura-network find_blocks_ -- --nocapture
- cargo clippy -p zakura-network --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo test -p zakura-network ran 1,162 library tests: 1,155 passed, 3 failed, and 4 were ignored. The three failures are listener tests whose configured loopback source addresses could not be bound on this macOS host.

## Changelog

Added changelog-unreleased/456.md.