### PR TITLE
fix(sync): gate unanchored findblocks singletons

### DIFF
--- a/changelog-unreleased/457.md
+++ b/changelog-unreleased/457.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Prevented ambiguous one-hash legacy block discovery responses from
+  downloading far-ahead blocks and penalizing unrelated serving peers
+  ([#457](https://github.com/zakura-core/zakura/pull/457)).

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -31,7 +31,8 @@ use tower::{
 
 use zakura_chain::{
     block::{self, Height, HeightDiff},
-    chain_tip::ChainTip,
+    chain_tip::{ChainTip, AT_OR_NEAR_TIP_THRESHOLD},
+    parameters::Network,
 };
 use zakura_network::{self as zn, PeerSocketAddr};
 use zakura_state as zs;
@@ -725,6 +726,9 @@ where
     /// The genesis hash for the configured network
     genesis_hash: block::Hash,
 
+    /// The configured network, used for local chain-tip distance estimates.
+    network: Network,
+
     /// The largest block height for the checkpoint verifier, based on the current config.
     max_checkpoint_height: Height,
 
@@ -933,6 +937,7 @@ where
 
         let new_syncer = Self {
             genesis_hash: config.network.network.genesis_hash(),
+            network: config.network.network.clone(),
             max_checkpoint_height,
             checkpoint_verify_concurrency_limit,
             full_verify_concurrency_limit,
@@ -1547,6 +1552,23 @@ where
         Ok(first_unknown)
     }
 
+    /// Returns whether an unanchored singleton response is plausible near the
+    /// committed chain tip.
+    fn should_accept_unanchored_singleton(&self) -> bool {
+        if self.is_regtest {
+            return true;
+        }
+
+        matches!(
+            self.latest_chain_tip
+                .estimate_distance_to_network_chain_tip(&self.network),
+            Some((distance, tip_height))
+                if tip_height >= self.max_checkpoint_height
+                    && (-AT_OR_NEAR_TIP_THRESHOLD..=AT_OR_NEAR_TIP_THRESHOLD)
+                        .contains(&distance)
+        )
+    }
+
     async fn validate_extend_find_blocks_response<'a>(
         state: &mut ZS,
         hashes: &'a [block::Hash],
@@ -1635,6 +1657,10 @@ where
             "got block locator and trying to obtain new chain tips"
         );
 
+        // Snapshot this local-only estimate before issuing the fanout so every
+        // response in the round uses the same eligibility decision.
+        let accept_unanchored_singletons = self.should_accept_unanchored_singleton();
+
         let mut requests = FuturesUnordered::new();
         for attempt in 0..FANOUT {
             if attempt > 0 {
@@ -1675,6 +1701,22 @@ where
                     let hashes = hashes.as_slice();
                     if hashes.is_empty() {
                         continue;
+                    }
+
+                    if let [hash] = hashes {
+                        if !accept_unanchored_singletons {
+                            debug!(
+                                ?hash,
+                                "ignoring unanchored singleton FindBlocks response while the \
+                                 committed chain is not known to be near the network tip"
+                            );
+                            metrics::counter!(
+                                "sync.obtain.unanchored_singleton.count",
+                                "action" => "ignored"
+                            )
+                            .increment(1);
+                            continue;
+                        }
                     }
 
                     if !has_valid_tips_response_hash_count(hashes) {
@@ -2062,13 +2104,6 @@ where
                     .try_send((advertiser_addr, error.misbehavior_score()));
             }
 
-            Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
-                advertiser_addr: Some(advertiser_addr),
-                ..
-            }) => {
-                let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
-            }
-
             Err(BlockDownloadVerifyError::InvalidHeight {
                 advertiser_addr: Some(advertiser_addr),
                 ..
@@ -2076,6 +2111,9 @@ where
                 let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
             }
 
+            // `AboveLookaheadHeightLimit` carries the peer that served the
+            // requested block, not the peer that supplied its discovery hash.
+            // Keep dropping the block, but do not score an unattributable peer.
             Err(_) => {}
         };
 

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -17,8 +17,11 @@ use futures::{Future, FutureExt, StreamExt};
 use tower::timeout::Timeout;
 
 use zakura_chain::{
-    block::{self, Block, Height},
-    chain_tip::mock::{MockChainTip, MockChainTipSender},
+    block::{self, Block, Height, HeightDiff},
+    chain_tip::{
+        mock::{MockChainTip, MockChainTipSender},
+        AT_OR_NEAR_TIP_THRESHOLD,
+    },
     serialization::ZcashDeserializeInto,
 };
 use zakura_consensus::{
@@ -1449,10 +1452,10 @@ async fn above_lookahead_does_not_restart_sync() {
     );
 }
 
-/// Verifies fix for GHSA-gvjc-3w7c-92jx: `AboveLookaheadHeightLimit` now
-/// carries `advertiser_addr` so the offending peer can be scored.
+/// `AboveLookaheadHeightLimit` retains the serving peer address for
+/// diagnostics.
 #[tokio::test]
-async fn above_lookahead_has_peer_attribution() {
+async fn above_lookahead_retains_serving_peer_diagnostics() {
     let addr: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
     let err = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
         height: block::Height(60_000),
@@ -1463,8 +1466,50 @@ async fn above_lookahead_has_peer_attribution() {
     assert_eq!(
         err.advertiser_addr(),
         Some(addr),
-        "AboveLookaheadHeightLimit should carry advertiser_addr for peer scoring \
-         (GHSA-gvjc-3w7c-92jx fix)"
+        "AboveLookaheadHeightLimit should retain its serving peer address"
+    );
+}
+
+#[tokio::test]
+async fn above_lookahead_does_not_score_serving_peer() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        _peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+    let (misbehavior_sender, mut misbehavior_receiver) = tokio::sync::mpsc::channel(1);
+    chain_sync.misbehavior_sender = misbehavior_sender;
+
+    let addr: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+    let hash = block::Hash::from([0xCC; 32]);
+    chain_sync
+        .handle_block_response(Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
+            height: block::Height(60_000),
+            hash,
+            advertiser_addr: Some(addr),
+        }))
+        .expect("above-lookahead blocks are dropped without restarting sync");
+
+    assert_eq!(
+        misbehavior_receiver.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty),
+        "the serving peer did not necessarily advertise the discovery hash"
+    );
+
+    chain_sync
+        .handle_block_response(Err(BlockDownloadVerifyError::InvalidHeight {
+            hash,
+            advertiser_addr: Some(addr),
+        }))
+        .expect("invalid-height blocks are dropped without restarting sync");
+
+    assert_eq!(
+        misbehavior_receiver.try_recv(),
+        Ok((addr, 100)),
+        "independently invalid block data should still be scored"
     );
 }
 
@@ -1745,16 +1790,57 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
     Ok(())
 }
 
+#[test]
+fn unanchored_singleton_requires_a_committed_near_tip() {
+    let (
+        chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        _peer_set,
+        _state_service,
+        mock_chain_tip_sender,
+    ) = setup_chain_sync_with_options(Height(10), MAX_SERVICE_REQUEST_DELAY);
+
+    assert!(!chain_sync.should_accept_unanchored_singleton());
+
+    mock_chain_tip_sender.send_best_tip_height(Height(9));
+    mock_chain_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+    assert!(!chain_sync.should_accept_unanchored_singleton());
+
+    mock_chain_tip_sender.send_best_tip_height(Height(10));
+    assert!(chain_sync.should_accept_unanchored_singleton());
+
+    mock_chain_tip_sender
+        .send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD));
+    assert!(chain_sync.should_accept_unanchored_singleton());
+
+    mock_chain_tip_sender
+        .send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD + 1));
+    assert!(!chain_sync.should_accept_unanchored_singleton());
+
+    mock_chain_tip_sender
+        .send_estimated_distance_to_network_chain_tip(Some(-AT_OR_NEAR_TIP_THRESHOLD));
+    assert!(chain_sync.should_accept_unanchored_singleton());
+
+    mock_chain_tip_sender
+        .send_estimated_distance_to_network_chain_tip(Some(-AT_OR_NEAR_TIP_THRESHOLD - 1));
+    assert!(!chain_sync.should_accept_unanchored_singleton());
+}
+
 #[tokio::test]
-async fn obtain_tips_downloads_single_hash() -> Result<(), crate::BoxError> {
+async fn obtain_tips_downloads_single_hash_when_near_tip() -> Result<(), crate::BoxError> {
     let (
         mut chain_sync,
         _sync_status,
         mut block_verifier_router,
         mut peer_set,
         mut state_service,
-        _mock_chain_tip_sender,
+        mock_chain_tip_sender,
     ) = setup_chain_sync();
+
+    mock_chain_tip_sender.send_best_tip_height(Height(1));
+    mock_chain_tip_sender
+        .send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD));
 
     let locator = block::Hash::from([0x01; 32]);
     let unknown = block::Hash::from([0x02; 32]);
@@ -1812,6 +1898,81 @@ async fn obtain_tips_downloads_single_hash() -> Result<(), crate::BoxError> {
     state_service.expect_no_requests().await;
 
     Ok(())
+}
+
+async fn assert_obtain_tips_ignores_singleton(
+    estimated_distance: Option<HeightDiff>,
+) -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    if let Some(estimated_distance) = estimated_distance {
+        mock_chain_tip_sender.send_best_tip_height(Height(1));
+        mock_chain_tip_sender
+            .send_estimated_distance_to_network_chain_tip(Some(estimated_distance));
+    }
+
+    let locator = block::Hash::from([0x01; 32]);
+    let unknown = block::Hash::from([0x02; 32]);
+
+    // Run two rounds so the first round's zero-length legacy sync-status
+    // update cannot unlock singleton processing in the second round.
+    for _ in 0..2 {
+        let respond_to_requests = async {
+            state_service
+                .expect_request(zs::Request::BlockLocator)
+                .await
+                .respond(zs::Response::BlockLocator(vec![locator]));
+
+            peer_set
+                .expect_request(zn::Request::FindBlocks {
+                    known_blocks: vec![locator],
+                    stop: None,
+                })
+                .await
+                .respond(zn::Response::BlockHashes(vec![unknown]));
+
+            for _ in 0..(sync::FANOUT - 1) {
+                peer_set
+                    .expect_request(zn::Request::FindBlocks {
+                        known_blocks: vec![locator],
+                        stop: None,
+                    })
+                    .await
+                    .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+            }
+
+            Ok::<_, crate::BoxError>(())
+        };
+
+        let (extra_hashes, responded) =
+            futures::join!(chain_sync.obtain_tips(), respond_to_requests);
+        responded?;
+        assert!(extra_hashes?.is_empty());
+        assert!(chain_sync.prospective_tips.is_empty());
+
+        peer_set.expect_no_requests().await;
+        block_verifier_router.expect_no_requests().await;
+        state_service.expect_no_requests().await;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn obtain_tips_ignores_single_hash_when_tip_is_unknown() -> Result<(), crate::BoxError> {
+    assert_obtain_tips_ignores_singleton(None).await
+}
+
+#[tokio::test]
+async fn obtain_tips_ignores_single_hash_when_far_from_tip() -> Result<(), crate::BoxError> {
+    assert_obtain_tips_ignores_singleton(Some(AT_OR_NEAR_TIP_THRESHOLD + 1)).await
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

PR #452 removed the retired zcashd trailing-hash workaround and retained
one-entry `FindBlocks` responses so nodes can discover the final block at the
chain head.

Legacy block inventory messages do not identify whether they are a
`FindBlocks` response or an unrelated tip announcement. While a node is far
behind, a one-entry announcement can therefore race a pending request and
cause the node to download a block more than 50,000 heights ahead. The
resulting penalty is attributed to the peer that later serves the block, which
is not necessarily the peer that supplied the discovery hash.

## Solution

Treat raw one-entry initial `FindBlocks` responses as unanchored:

- accept them only when the committed tip is at or above the final checkpoint
  and its local network-tip distance estimate is within the shared five-block
  near-tip threshold;
- preserve regtest behavior, multi-hash initial responses, and anchored
  extension responses;
- continue dropping blocks above the 50,000-block lookahead limit, but do not
  score the later serving peer for that unattributable height error;
- retain penalties for independently invalid block heights and consensus
  failures.

The near-tip decision is snapshotted before each fanout so every response in a
round receives the same treatment.

## Testing

- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/457.md --config
  .trunk/configs/.markdownlint.yaml`
- `cargo clippy -p zakura --all-targets --locked -- -D warnings`
- `cargo test -p zakura --lib --locked components::sync::tests::vectors`
  (37 passed)
- `cargo test -p zakura --lib --locked` (329 passed)

The new tests cover the committed-tip/checkpoint boundary, near-tip singleton
acceptance, repeated far/unknown singleton rejection, and preservation of
invalid-block scoring while above-lookahead serving peers remain unscored.
Existing anchored-extension tests remain unchanged.

## Changelog

Added `changelog-unreleased/457.md` under Fixed.

### Specifications & References

- Follow-up to #452
- [GHSA-gvjc-3w7c-92jx](https://github.com/advisories/GHSA-gvjc-3w7c-92jx)

### Follow-up Work

Carry authenticated discovery provenance or validated parent-chain anchors
through the legacy sync pipeline before restoring any discovery-based peer
penalty.
