### PR TITLE
revert(sync): restore legacy FindBlocks handling

### DIFF
--- a/changelog-unreleased/452.md
+++ b/changelog-unreleased/452.md
@@ -1,5 +1,0 @@
-## Fixed
-
-- Fixed legacy block sync stalling when a peer advertises only one new block
-  at the chain head
-  ([#452](https://github.com/zakura-core/zakura/pull/452)).

--- a/changelog-unreleased/452.md
+++ b/changelog-unreleased/452.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed legacy block sync stalling when a peer advertises only one new block
+  at the chain head
+  ([#452](https://github.com/zakura-core/zakura/pull/452)).

--- a/changelog-unreleased/459.md
+++ b/changelog-unreleased/459.md
@@ -1,0 +1,5 @@
+## Changed
+
+- Restored the legacy `FindBlocks` compatibility behavior while additional
+  peer-response and chain-head edge cases are validated
+  ([#459](https://github.com/zakura-core/zakura/pull/459)).

--- a/zakurad/src/components/sync.rs
+++ b/zakurad/src/components/sync.rs
@@ -165,6 +165,12 @@ pub const MAX_TIPS_RESPONSE_HASH_COUNT: usize = 500;
 
 /// Returns true if a `FindBlocks` hash list has the protocol maximum number of
 /// block hashes or fewer.
+///
+/// Callers that discard zcashd's extra trailing hash must apply this check to
+/// the hashes that remain after stripping. That way a 501-hash zcashd response
+/// (500 chain hashes plus one appended hash) is accepted as 500 usable hashes,
+/// while larger responses are still rejected before they can inflate the
+/// syncer's discovered-hash reserve.
 fn has_valid_tips_response_hash_count(hashes: &[block::Hash]) -> bool {
     hashes.len() <= MAX_TIPS_RESPONSE_HASH_COUNT
 }
@@ -284,9 +290,10 @@ const REGTEST_SYNC_RESTART_DELAY: Duration = Duration::from_secs(2);
 ///
 /// When there are no hashes left to discover but blocks are still in flight, those blocks can be
 /// waiting on hashes we haven't discovered yet: the checkpoint verifier holds every block in a
-/// range until the whole range up to the next checkpoint has arrived. Waiting for the downloads to
-/// drain would therefore wait forever. This interval bounds how often the syncer re-runs
-/// [`ChainSync::obtain_tips`] while it waits.
+/// range until the whole range up to the next checkpoint has arrived, and the trailing hash of
+/// each `FindBlocks` response is discarded on the promise that a later fanout re-discovers it. So
+/// waiting for the downloads to drain would wait forever. This interval bounds how often the
+/// syncer re-runs [`ChainSync::obtain_tips`] while it waits.
 const TIP_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Controls how long we wait to retry a failed attempt to download
@@ -1553,35 +1560,56 @@ where
         locator: block::Hash,
         expected_next: block::Hash,
     ) -> Result<Option<&'a [block::Hash]>, Report> {
+        let matched_hashes = match hashes {
+            [expected_hash, _rest @ ..] if *expected_hash == expected_next => hashes,
+            [first_hash, expected_hash, _rest @ ..] if *expected_hash == expected_next => {
+                debug!(?first_hash, ?expected_next, ?locator, "unexpected first hash, but the second matches: using the hashes after the match");
+                &hashes[1..]
+            }
+            [] => return Ok(None),
+            [single_hash] => {
+                debug!(
+                    ?single_hash,
+                    ?expected_next,
+                    ?locator,
+                    "discarding response containing a single unexpected hash"
+                );
+                return Ok(None);
+            }
+            [first_hash, second_hash, rest @ ..] => {
+                debug!(?first_hash, ?second_hash, rest_len = ?rest.len(), ?expected_next, ?locator, "discarding response that starts with two unexpected hashes");
+                return Ok(None);
+            }
+        };
+
+        // We use the last hash for the tip, and we want to avoid bad tips.
+        // So we discard the last hash before checking duplicates or known hashes.
+        let matched_hashes = match matched_hashes {
+            [] => unreachable!("matched FindBlocks response contains the expected hash"),
+            [rest @ .., _last] => rest,
+        };
+
+        let unknown_hashes = match matched_hashes {
+            [expected_hash, rest @ ..] if *expected_hash == expected_next => rest,
+            [] => return Ok(Some(&[])),
+            _ => unreachable!("matched FindBlocks response starts with the expected hash"),
+        };
+
         // Apply the count guard before scanning peer-controlled hashes or
         // querying state, so oversized responses cannot amplify state work.
-        if !has_valid_tips_response_hash_count(hashes) {
+        if !has_valid_tips_response_hash_count(unknown_hashes) {
             debug!(
-                hashes.len = hashes.len(),
+                hashes.len = unknown_hashes.len(),
                 max_hashes = MAX_TIPS_RESPONSE_HASH_COUNT,
                 "discarding oversized FindBlocks response"
             );
             return Ok(None);
         }
 
-        let Some((&first_hash, unknown_hashes)) = hashes.split_first() else {
-            return Ok(None);
-        };
-
-        if first_hash != expected_next {
-            debug!(
-                ?first_hash,
-                ?expected_next,
-                ?locator,
-                "discarding FindBlocks response that does not start with the expected hash"
-            );
-            return Ok(None);
-        }
-
         let mut seen = HashSet::new();
-        if hashes.iter().any(|hash| !seen.insert(*hash)) {
+        if matched_hashes.iter().any(|hash| !seen.insert(*hash)) {
             debug!(
-                ?hashes,
+                ?matched_hashes,
                 "discarding FindBlocks extension response with duplicate hash"
             );
             return Ok(None);
@@ -1672,11 +1700,40 @@ where
                 Ok(zn::Response::BlockHashes(hashes)) => {
                     trace!(?hashes);
 
-                    let hashes = hashes.as_slice();
+                    // zcashd sometimes appends an unrelated hash at the start
+                    // or end of its response.
+                    //
+                    // We can't discard the first hash, because it might be a
+                    // block we want to download. So we just accept any
+                    // out-of-order first hashes.
+
+                    // We use the last hash for the tip, and we want to avoid bad
+                    // tips from zcashd's quirk of appending an unrelated hash.
+                    // So we discard the last hash on mainnet/testnet.
+                    // (We don't need to worry about missed downloads, because we
+                    // will pick them up again in ExtendTips.)
+                    //
+                    // In regtest we only connect to Zebra nodes, not zcashd,
+                    // so we trust all hashes in the response and keep them all.
+                    // This is necessary when there are only a small number of
+                    // blocks to sync (e.g. 2 new blocks), where stripping the
+                    // last hash leaves only 1 unknown hash and rchunks_exact(2)
+                    // would discard the entire response.
+                    let hashes = if self.is_regtest {
+                        hashes.as_slice()
+                    } else {
+                        match hashes.as_slice() {
+                            [] => continue,
+                            [rest @ .., _last] => rest,
+                        }
+                    };
                     if hashes.is_empty() {
                         continue;
                     }
 
+                    // Apply the count guard after stripping zcashd's trailing
+                    // hash so a full 500-hash chain plus one appended hash is
+                    // still usable.
                     if !has_valid_tips_response_hash_count(hashes) {
                         debug!(
                             hashes.len = hashes.len(),
@@ -1698,26 +1755,29 @@ where
 
                     trace!(?unknown_hashes);
 
-                    if let Some(end) = unknown_hashes.rchunks_exact(2).next() {
-                        let new_tip = CheckedTip {
+                    let new_tip = if let Some(end) = unknown_hashes.rchunks_exact(2).next() {
+                        CheckedTip {
                             tip: end[0],
                             expected_next: end[1],
-                        };
-
-                        // Make sure we get the same tips, regardless of the
-                        // order of peer responses
-                        if !download_set.contains(&new_tip.expected_next) {
-                            debug!(?new_tip,
-                                            "adding new prospective tip, and removing existing tips in the new block hash list");
-                            self.prospective_tips
-                                .retain(|t| !unknown_hashes.contains(&t.expected_next));
-                            self.prospective_tips.insert(new_tip);
-                        } else {
-                            debug!(
-                                ?new_tip,
-                                "discarding prospective tip: already in download set"
-                            );
                         }
+                    } else {
+                        debug!("discarding response that extends only one block");
+                        continue;
+                    };
+
+                    // Make sure we get the same tips, regardless of the
+                    // order of peer responses
+                    if !download_set.contains(&new_tip.expected_next) {
+                        debug!(?new_tip,
+                                        "adding new prospective tip, and removing existing tips in the new block hash list");
+                        self.prospective_tips
+                            .retain(|t| !unknown_hashes.contains(&t.expected_next));
+                        self.prospective_tips.insert(new_tip);
+                    } else {
+                        debug!(
+                            ?new_tip,
+                            "discarding prospective tip: already in download set"
+                        );
                     }
 
                     // security: the first response determines our download order
@@ -1810,6 +1870,9 @@ where
                         debug!(first = ?hashes.first(), len = ?hashes.len());
                         trace!(?hashes);
 
+                        // zcashd sometimes appends an unrelated hash at the
+                        // start or end of its response. Check the first hash
+                        // against the previous response, and discard mismatches.
                         let Some(unknown_hashes) = Self::validate_extend_find_blocks_response(
                             &mut state,
                             hashes.as_slice(),
@@ -1821,29 +1884,31 @@ where
                             continue;
                         };
 
-                        if let Some(end) = unknown_hashes.rchunks_exact(2).next() {
-                            let new_tip = CheckedTip {
+                        let new_tip = if let Some(end) = unknown_hashes.rchunks_exact(2).next() {
+                            CheckedTip {
                                 tip: end[0],
                                 expected_next: end[1],
-                            };
-
-                            // Make sure we get the same tips, regardless of the
-                            // order of peer responses
-                            if !download_set.contains(&new_tip.expected_next) {
-                                debug!(?new_tip,
-                                                "adding new prospective tip, and removing any existing tips in the new block hash list");
-                                prospective_tips
-                                    .retain(|t| !unknown_hashes.contains(&t.expected_next));
-                                prospective_tips.insert(new_tip);
-                            } else {
-                                debug!(
-                                    ?new_tip,
-                                    "discarding prospective tip: already in download set"
-                                );
                             }
-                        }
+                        } else {
+                            debug!("discarding response that extends only one block");
+                            continue;
+                        };
 
                         trace!(?unknown_hashes);
+
+                        // Make sure we get the same tips, regardless of the
+                        // order of peer responses
+                        if !download_set.contains(&new_tip.expected_next) {
+                            debug!(?new_tip,
+                                            "adding new prospective tip, and removing any existing tips in the new block hash list");
+                            prospective_tips.retain(|t| !unknown_hashes.contains(&t.expected_next));
+                            prospective_tips.insert(new_tip);
+                        } else {
+                            debug!(
+                                ?new_tip,
+                                "discarding prospective tip: already in download set"
+                            );
+                        }
 
                         // security: the first response determines our download order
                         //

--- a/zakurad/src/components/sync/tests/vectors.rs
+++ b/zakurad/src/components/sync/tests/vectors.rs
@@ -72,6 +72,8 @@ const STALLED_SERVICE_REQUEST_DELAY: Duration = Duration::from_secs(30 * 60);
 fn oversized_find_blocks_response_is_rejected() {
     let hash = block::Hash([0; 32]);
 
+    // The guard is applied after ObtainTips/ExtendTips strip zcashd's extra
+    // trailing hash, so 500 remaining hashes are accepted and 501 are not.
     assert!(sync::has_valid_tips_response_hash_count(&vec![
         hash;
         sync::MAX_TIPS_RESPONSE_HASH_COUNT
@@ -81,6 +83,13 @@ fn oversized_find_blocks_response_is_rejected() {
         sync::MAX_TIPS_RESPONSE_HASH_COUNT
             + 1
     ]));
+
+    // A zcashd response with 500 chain hashes plus one appended hash must remain
+    // usable after the trailing hash is discarded.
+    let raw = vec![hash; sync::MAX_TIPS_RESPONSE_HASH_COUNT + 1];
+    let stripped = &raw[..raw.len() - 1];
+    assert_eq!(stripped.len(), sync::MAX_TIPS_RESPONSE_HASH_COUNT);
+    assert!(sync::has_valid_tips_response_hash_count(stripped));
 }
 
 /// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips.
@@ -118,6 +127,10 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     let block4: Arc<Block> =
         zakura_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?;
     let block4_hash = block4.hash();
+
+    let block5: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?;
+    let block5_hash = block5.hash();
 
     // Start the syncer
     let chain_sync_task_handle = tokio::spawn(chain_sync_future);
@@ -173,6 +186,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
         .respond(zn::Response::BlockHashes(vec![
             block1_hash, // tip
             block2_hash, // expected_next
+            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for each candidate hash before it is queued.
@@ -259,9 +273,10 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
         })
         .await
         .respond(zn::Response::BlockHashes(vec![
-            block2_hash, // expected_next (match anchor, already fetched)
-            block3_hash, // tip
-            block4_hash, // expected_next
+            block2_hash, // tip (discarded - already fetched)
+            block3_hash, // expected_next
+            block4_hash,
+            block5_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     for hash in [block3_hash, block4_hash] {
@@ -339,15 +354,18 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 /// This scales the production failure at checkpoints 400 and 800 down to a four-block checkpoint
 /// range. Every peer response here is one a real peer would send:
 ///
-/// - the peer initially has blocks 1-2, so `FindBlocks` from genesis answers `[1, 2]`.
-/// - extending that tip answers `[2]`, so the response extends by nothing and the prospective tip
-///   set empties.
+/// - the peer's tip is block 3, so `FindBlocks` from genesis answers `[1, 2, 3]`. `obtain_tips`
+///   discards the trailing hash for zcashd's quirk of appending an unrelated one, leaving blocks
+///   1-2 to download.
+/// - extending that tip answers `[2, 3]`, and the same trailing-hash rule discards block 3, so the
+///   response extends by nothing and the prospective tip set empties. The peer did extend the tip;
+///   the workaround is what drops the block, on the promise that a later fanout re-discovers it.
 /// - blocks 1-2 are now parked in the checkpoint verifier, which cannot verify *any* block in a
 ///   range until the whole range up to checkpoint 4 has arrived. So they stay in flight forever.
 ///
 /// Discovering the rest of the range is the only way out, and only a fresh fanout can do it. The
 /// syncer must therefore keep discovering hashes while blocks are parked, rather than waiting for
-/// the download queue to drain first — that wait cannot terminate. The chain grows to block 4, a
+/// the download queue to drain first — that wait cannot terminate. The chain grows to block 5, a
 /// refreshed fanout picks up blocks 3-4, and the range verifies.
 ///
 /// Time is paused, so a syncer that instead waits out [`sync::BLOCK_VERIFY_TIMEOUT`] and restarts
@@ -371,6 +389,7 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
         zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?,
         zakura_test::vectors::BLOCK_MAINNET_3_BYTES.zcash_deserialize_into()?,
         zakura_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?,
+        zakura_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?,
     ];
     let hashes: Vec<_> = blocks.iter().map(|block| block.hash()).collect();
 
@@ -381,7 +400,8 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
         .await
         .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
 
-    // The peer's tip is block 2, which is only half of the checkpoint range ending at block 4.
+    // The peer's tip is block 3. The trailing hash is discarded, leaving blocks 1-2 to download,
+    // which is only half of the checkpoint range ending at block 4.
     state_service
         .expect_request(zs::Request::BlockLocator)
         .await
@@ -392,7 +412,9 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![hashes[1], hashes[2]]));
+        .respond(zn::Response::BlockHashes(vec![
+            hashes[1], hashes[2], hashes[3],
+        ]));
     state_service
         .expect_request(zs::Request::KnownBlock(hashes[1]))
         .await
@@ -438,14 +460,15 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
     }
     assert!(expected_verifications.is_empty());
 
-    // The peer has not extended the tip, so the prospective tip set empties.
+    // The peer extends the tip with block 3, but the trailing-hash workaround discards it, so the
+    // response extends by nothing and the prospective tip set empties.
     peer_set
         .expect_request(zn::Request::FindBlocks {
             known_blocks: vec![hashes[1]],
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![hashes[2]]));
+        .respond(zn::Response::BlockHashes(vec![hashes[2], hashes[3]]));
     for _ in 0..(sync::FANOUT - 1) {
         peer_set
             .expect_request(zn::Request::FindBlocks {
@@ -472,7 +495,7 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
          verifier: waiting out BLOCK_VERIFY_TIMEOUT and restarting discards the partial range",
     );
 
-    // The chain has grown to block 4, so the refreshed fanout covers the rest of the range. Blocks
+    // The chain has grown to block 5, so the refreshed fanout covers the rest of the range. Blocks
     // 1-2 are still in flight, so they are re-dispatched as duplicates and not downloaded again.
     refreshed_locator.respond(zs::Response::BlockLocator(vec![hashes[0]]));
     peer_set
@@ -482,7 +505,7 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
         })
         .await
         .respond(zn::Response::BlockHashes(vec![
-            hashes[1], hashes[2], hashes[3], hashes[4],
+            hashes[1], hashes[2], hashes[3], hashes[4], hashes[5],
         ]));
     state_service
         .expect_request(zs::Request::KnownBlock(hashes[1]))
@@ -527,14 +550,15 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
     }
     assert!(expected_verifications.is_empty());
 
-    // Extending the refreshed tip finds no new blocks. The checkpoint range is already complete.
+    // Extending the refreshed tip discards block 5 by the same trailing-hash rule, so this response
+    // extends by nothing. The checkpoint range is already complete, so that no longer matters.
     peer_set
         .expect_request(zn::Request::FindBlocks {
             known_blocks: vec![hashes[3]],
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![hashes[4]]));
+        .respond(zn::Response::BlockHashes(vec![hashes[4], hashes[5]]));
     for _ in 0..(sync::FANOUT - 1) {
         peer_set
             .expect_request(zn::Request::FindBlocks {
@@ -566,11 +590,12 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
     Ok(())
 }
 
-/// Test that the syncer downloads a single newly advertised block from an extended tip.
+/// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips,
+/// with unrelated trailing hashes that are discarded.
 ///
 /// This test also makes sure that the syncer downloads blocks in order.
 #[tokio::test(start_paused = true)]
-async fn sync_blocks_single_hash_extension_ok() -> Result<(), crate::BoxError> {
+async fn sync_blocks_trailing_hashes_ok() -> Result<(), crate::BoxError> {
     // Get services
     let (
         chain_sync_future,
@@ -597,6 +622,14 @@ async fn sync_blocks_single_hash_extension_ok() -> Result<(), crate::BoxError> {
     let block3: Arc<Block> =
         zakura_test::vectors::BLOCK_MAINNET_3_BYTES.zcash_deserialize_into()?;
     let block3_hash = block3.hash();
+
+    let block4: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?;
+    let block4_hash = block4.hash();
+
+    let block5: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?;
+    let block5_hash = block5.hash();
 
     // Start the syncer
     let chain_sync_task_handle = tokio::spawn(chain_sync_future);
@@ -652,6 +685,7 @@ async fn sync_blocks_single_hash_extension_ok() -> Result<(), crate::BoxError> {
         .respond(zn::Response::BlockHashes(vec![
             block1_hash, // tip
             block2_hash, // expected_next
+            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for each candidate hash before it is queued.
@@ -738,14 +772,18 @@ async fn sync_blocks_single_hash_extension_ok() -> Result<(), crate::BoxError> {
         })
         .await
         .respond(zn::Response::BlockHashes(vec![
-            block2_hash, // expected_next (match anchor, already fetched)
-            block3_hash, // single newly advertised hash
+            block2_hash, // tip (discarded - already fetched)
+            block3_hash, // expected_next
+            block4_hash,
+            block5_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
-    state_service
-        .expect_request(zs::Request::KnownBlock(block3_hash))
-        .await
-        .respond(zs::Response::KnownBlock(None));
+    for hash in [block3_hash, block4_hash] {
+        state_service
+            .expect_request(zs::Request::KnownBlock(hash))
+            .await
+            .respond(zs::Response::KnownBlock(None));
+    }
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -762,7 +800,7 @@ async fn sync_blocks_single_hash_extension_ok() -> Result<(), crate::BoxError> {
     block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
-    // The single extension hash is fetched and verified.
+    // Blocks 3 & 4 are fetched in order, then verified concurrently
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block3_hash).collect()))
         .await
@@ -770,10 +808,32 @@ async fn sync_blocks_single_hash_extension_ok() -> Result<(), crate::BoxError> {
             block3.clone(),
             None,
         ))]));
-    block_verifier_router
-        .expect_request(zakura_consensus::Request::Commit(block3))
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block4_hash).collect()))
         .await
-        .respond(block3_hash);
+        .respond(zn::Response::Blocks(vec![Available((
+            block4.clone(),
+            None,
+        ))]));
+
+    // We can't guarantee the verification request order
+    let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
+        [(block3_hash, block3), (block4_hash, block4)]
+            .iter()
+            .cloned()
+            .collect();
+
+    for _ in 3..=4 {
+        block_verifier_router
+            .expect_request_that(|req| remaining_blocks.remove(&req.block().hash()).is_some())
+            .await
+            .respond_with(|req| req.block().hash());
+    }
+    assert_eq!(
+        remaining_blocks,
+        HashMap::new(),
+        "expected all non-tip blocks to be verified by extend tips"
+    );
 
     // Check that nothing unexpected happened.
     block_verifier_router.expect_no_requests().await;
@@ -872,6 +932,10 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
         zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
     let block2_hash = block2.hash();
 
+    let block3: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_3_BYTES.zcash_deserialize_into()?;
+    let block3_hash = block3.hash();
+
     // Also get a block that is a long way away from genesis
     let block982k: Arc<Block> =
         zakura_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?;
@@ -932,6 +996,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
             block982k_hash,
             block1_hash, // tip
             block2_hash, // expected_next
+            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for each candidate hash before it is queued.
@@ -1053,6 +1118,10 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
         zakura_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?;
     let block4_hash = block4.hash();
 
+    let block5: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?;
+    let block5_hash = block5.hash();
+
     // Also get a block that is a long way away from genesis
     let block982k: Arc<Block> =
         zakura_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?;
@@ -1112,6 +1181,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
         .respond(zn::Response::BlockHashes(vec![
             block1_hash, // tip
             block2_hash, // expected_next
+            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for each candidate hash before it is queued.
@@ -1198,10 +1268,11 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
         })
         .await
         .respond(zn::Response::BlockHashes(vec![
-            block2_hash, // expected_next (match anchor, already fetched)
-            block3_hash,
+            block2_hash, // tip (discarded - already fetched)
+            block3_hash, // expected_next
             block4_hash,
             block982k_hash,
+            block5_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     for hash in [block3_hash, block4_hash, block982k_hash] {
@@ -1678,8 +1749,8 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
         tips,
     ));
 
-    // One peer extends the tip. The response starts with the expected hash, which is the match
-    // anchor and is not downloaded.
+    // One peer extends the tip. The response starts with the expected hash (the match anchor) and
+    // ends with a possibly-incorrect trailing hash that the syncer discards.
     peer_set
         .expect_request(zn::Request::FindBlocks {
             known_blocks: vec![block1_hash],
@@ -1690,10 +1761,10 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
             block2_hash, // expected_next (match anchor, not downloaded)
             block3_hash,
             block4_hash,
-            block5_hash,
+            block5_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
-    for hash in [block3_hash, block4_hash, block5_hash] {
+    for hash in [block3_hash, block4_hash] {
         state_service
             .expect_request(zs::Request::KnownBlock(hash))
             .await
@@ -1715,21 +1786,22 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
         .await
         .expect("build_extend task should not panic")?;
 
-    // Discovery: blocks 3-5 are queued for download in response order. Block 2 is the match anchor.
+    // Discovery: blocks 3 & 4 are queued for download, in response order. Block 2 is the match
+    // anchor and block 5 is the discarded trailing hash, so neither is downloaded.
     assert_eq!(
         download_set.into_iter().collect::<Vec<_>>(),
-        vec![block3_hash, block4_hash, block5_hash],
-        "build_extend should discover every hash after the match anchor",
+        vec![block3_hash, block4_hash],
+        "build_extend should discover the inner hashes in response order",
     );
     assert_eq!(
-        discovered, 3,
+        discovered, 2,
         "discovered count should match the download set length",
     );
 
-    // The new prospective tip extends from block4, expecting block5 next.
+    // The new prospective tip extends from block3, expecting block4 next.
     let expected_tip = sync::CheckedTip {
-        tip: block4_hash,
-        expected_next: block5_hash,
+        tip: block3_hash,
+        expected_next: block4_hash,
     };
     assert_eq!(
         prospective_tips,
@@ -1741,75 +1813,6 @@ async fn build_extend_discovers_hashes_without_dispatching() -> Result<(), crate
     // fan-out was sent — no `BlocksByHash`, no verifier requests.
     peer_set.expect_no_requests().await;
     block_verifier_router.expect_no_requests().await;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn obtain_tips_downloads_single_hash() -> Result<(), crate::BoxError> {
-    let (
-        mut chain_sync,
-        _sync_status,
-        mut block_verifier_router,
-        mut peer_set,
-        mut state_service,
-        _mock_chain_tip_sender,
-    ) = setup_chain_sync();
-
-    let locator = block::Hash::from([0x01; 32]);
-    let unknown = block::Hash::from([0x02; 32]);
-
-    let respond_to_requests = async {
-        state_service
-            .expect_request(zs::Request::BlockLocator)
-            .await
-            .respond(zs::Response::BlockLocator(vec![locator]));
-
-        peer_set
-            .expect_request(zn::Request::FindBlocks {
-                known_blocks: vec![locator],
-                stop: None,
-            })
-            .await
-            .respond(zn::Response::BlockHashes(vec![unknown]));
-
-        state_service
-            .expect_request(zs::Request::KnownBlock(unknown))
-            .await
-            .respond(zs::Response::KnownBlock(None));
-
-        for _ in 0..(sync::FANOUT - 1) {
-            peer_set
-                .expect_request(zn::Request::FindBlocks {
-                    known_blocks: vec![locator],
-                    stop: None,
-                })
-                .await
-                .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
-        }
-
-        state_service
-            .expect_request(zs::Request::KnownBlock(unknown))
-            .await
-            .respond(zs::Response::KnownBlock(None));
-
-        // End the background download without invoking the verifier.
-        peer_set
-            .expect_request(zn::Request::BlocksByHash(iter::once(unknown).collect()))
-            .await
-            .respond(zn::Response::Blocks(Vec::new()));
-
-        Ok::<_, crate::BoxError>(())
-    };
-
-    let (extra_hashes, responded) = futures::join!(chain_sync.obtain_tips(), respond_to_requests);
-    responded?;
-    assert!(extra_hashes?.is_empty());
-    assert!(chain_sync.prospective_tips.is_empty());
-
-    peer_set.expect_no_requests().await;
-    block_verifier_router.expect_no_requests().await;
-    state_service.expect_no_requests().await;
 
     Ok(())
 }
@@ -1946,11 +1949,7 @@ async fn build_extend_ignores_malformed_find_blocks_responses() -> Result<(), cr
             stop: None,
         })
         .await
-        .respond(zn::Response::BlockHashes(vec![
-            random,
-            expected_next,
-            unknown,
-        ]));
+        .respond(zn::Response::BlockHashes(vec![random]));
 
     let (download_set, prospective_tips, discovered) = extend_handle
         .await
@@ -1980,7 +1979,8 @@ async fn build_extend_rejects_oversized_response_before_state_queries(
 
     let tip = block::Hash::from([0x20; 32]);
     let expected_next = block::Hash::from([0x21; 32]);
-    let unknown_hashes = (0..sync::MAX_TIPS_RESPONSE_HASH_COUNT).map(|index| {
+    let trailing = block::Hash::from([0x22; 32]);
+    let unknown_hashes = (0..=sync::MAX_TIPS_RESPONSE_HASH_COUNT).map(|index| {
         let index = u64::try_from(index).expect("test hash count fits in u64");
         let mut bytes = [0; 32];
         bytes[..8].copy_from_slice(&index.to_le_bytes());
@@ -1988,6 +1988,7 @@ async fn build_extend_rejects_oversized_response_before_state_queries(
     });
     let response_hashes = std::iter::once(expected_next)
         .chain(unknown_hashes)
+        .chain(std::iter::once(trailing))
         .collect();
 
     let tips = HashSet::from([sync::CheckedTip { tip, expected_next }]);
@@ -2091,7 +2092,7 @@ async fn build_extend_rejects_locator_echo_before_state_queries() -> Result<(), 
 }
 
 #[tokio::test]
-async fn build_extend_rejects_known_hash_in_advertised_suffix() -> Result<(), crate::BoxError> {
+async fn build_extend_ignores_known_trailing_find_blocks_hash() -> Result<(), crate::BoxError> {
     let (
         _chain_sync,
         _sync_status,
@@ -2105,7 +2106,6 @@ async fn build_extend_rejects_known_hash_in_advertised_suffix() -> Result<(), cr
     let expected_next = block::Hash::from([0x21; 32]);
     let unknown_a = block::Hash::from([0x22; 32]);
     let unknown_b = block::Hash::from([0x23; 32]);
-    let known_suffix = block::Hash::from([0x24; 32]);
 
     let tips = HashSet::from([sync::CheckedTip { tip, expected_next }]);
     let extend_handle = tokio::spawn(TestChainSync::build_extend(
@@ -2124,7 +2124,7 @@ async fn build_extend_rejects_known_hash_in_advertised_suffix() -> Result<(), cr
             expected_next,
             unknown_a,
             unknown_b,
-            known_suffix,
+            tip, // zcashd can append an unrelated known hash here.
         ]));
 
     for hash in [unknown_a, unknown_b] {
@@ -2133,10 +2133,6 @@ async fn build_extend_rejects_known_hash_in_advertised_suffix() -> Result<(), cr
             .await
             .respond(zs::Response::KnownBlock(None));
     }
-    state_service
-        .expect_request(zs::Request::KnownBlock(known_suffix))
-        .await
-        .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
 
     for _ in 0..(sync::FANOUT - 1) {
         peer_set
@@ -2152,9 +2148,19 @@ async fn build_extend_rejects_known_hash_in_advertised_suffix() -> Result<(), cr
         .await
         .expect("build_extend task should not panic")?;
 
-    assert!(download_set.is_empty());
-    assert_eq!(discovered, 0);
-    assert!(prospective_tips.is_empty());
+    assert_eq!(
+        download_set.into_iter().collect::<Vec<_>>(),
+        vec![unknown_a, unknown_b],
+        "build_extend should keep valid inner hashes and discard the trailing known hash",
+    );
+    assert_eq!(discovered, 2);
+    assert_eq!(
+        prospective_tips,
+        HashSet::from([sync::CheckedTip {
+            tip: unknown_a,
+            expected_next: unknown_b,
+        }]),
+    );
 
     peer_set.expect_no_requests().await;
     block_verifier_router.expect_no_requests().await;


### PR DESCRIPTION
## Motivation

We want to keep `main` ready to release at all times right now. PR #452 changed legacy `FindBlocks` response handling shortly before release, and we are not yet confident that all required peer-response and chain-head edge cases are understood well enough to ship that behavior.

## Solution

Revert #452 and restore the previous zcashd-compatible `FindBlocks` handling and its test expectations. This is a risk-reduction step for release readiness, not a conclusion that the prior behavior is the final long-term design.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura --lib --locked` (324 passed)
- `cargo clippy -p zakura --all-targets --locked -- -D warnings`
- `npx --yes markdownlint-cli changelog-unreleased/459.md --config .trunk/configs/.markdownlint.yaml`
- `./scripts/changelog.py check`

Draft CI will provide the remaining validation.

## Changelog

Added `changelog-unreleased/459.md` under Changed.

### Specifications & References

- Reverts #452.

### Follow-up Work

Revisit the complete-response behavior after the required compatibility, malformed-response, short-response, chain-head, checkpoint, and mixed-peer edge cases are covered with enough confidence to ship.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live in the critical initial-sync path (`obtain_tips` / `extend_tips`) and deliberately accept looser peer responses than #452, so incorrect stripping or matching could stall sync or miss blocks until a later fanout.
> 
> **Overview**
> **Reverts #452** and brings back the previous **zcashd-compatible `FindBlocks`** behavior in legacy `ChainSync` so release risk stays low while more peer/chain-head edge cases are validated.
> 
> On **mainnet/testnet**, `obtain_tips` again **drops the last hash** in each response (zcashd’s extra trailing hash) and applies the **500-hash cap after stripping**, so a 501-hash reply (500 chain + 1 appended) still counts as valid. **Regtest** keeps all hashes so short chains are not wiped out by `rchunks_exact(2)`.
> 
> **Extend tips** again uses **`validate_extend_find_blocks_response`**: tolerate a wrong first hash when the second matches `expected_next`, strip the trailing hash before duplicate/state checks, and reject responses that extend by only one block. Comments on tip refresh and hash-count guards document that discarded trailing hashes are expected to be **re-discovered** on later fanout.
> 
> **Tests** are aligned with trailing-hash vectors, oversized-response checks after strip, and checkpoint stall scenarios; a test that assumed single-hash obtain behavior was removed in favor of **`sync_blocks_trailing_hashes_ok`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00c14d003c079b798d0ef68ecb19feda5f8c2c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->