### PR TITLE
fix(network): replenish depleted outbound peers

### DIFF
--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Replenish legacy outbound peers during periodic crawls when fewer than half
+  the configured outbound connection slots are active
+  ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Replenish legacy outbound peers during periodic crawls when fewer than 30%
+- Replenish legacy outbound peers during periodic crawls when fewer than 27%
   of the configured outbound connection slots are active
   ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Replenish legacy outbound peers during periodic crawls when fewer than half
-  the configured outbound connection slots are active
+- Replenish legacy outbound peers during periodic crawls when fewer than 30%
+  of the configured outbound connection slots are active
   ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -995,6 +995,27 @@ fn outbound_peer_replenishment_demand(
         .saturating_sub(active_outbound_connections)
 }
 
+/// Queue up to `connection_demand` outbound connection attempts.
+fn queue_peer_demand(
+    demand_tx: &mut futures::channel::mpsc::Sender<MorePeers>,
+    connection_demand: usize,
+) -> Result<(), BoxError> {
+    for _ in 0..connection_demand {
+        if let Err(send_error) = demand_tx.try_send(MorePeers) {
+            if send_error.is_disconnected() {
+                // Zebra is shutting down
+                return Err(send_error.into());
+            }
+
+            // Existing queued demand is already sufficient to fill the bounded
+            // channel, so additional signals are unnecessary.
+            break;
+        }
+    }
+
+    Ok(())
+}
+
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
@@ -1245,7 +1266,8 @@ where
     }
 }
 
-/// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
+/// Try to get more peers using `candidates`, then queue connection attempts
+/// using `demand_tx`.
 /// If the crawl discovers peers, queue at least one connection attempt. Also
 /// queue at least `minimum_connection_demand` attempts, unless the demand
 /// channel is already full.
@@ -1285,20 +1307,7 @@ where
     //
     // Candidate selection rate-limits outbound handshakes, and the crawler loop
     // checks the configured outbound connection limit before starting each one.
-    for _ in 0..connection_demand {
-        if let Err(send_error) = demand_tx.try_send(MorePeers) {
-            if send_error.is_disconnected() {
-                // Zebra is shutting down
-                return Err(send_error.into());
-            }
-
-            // Existing queued demand is already sufficient to fill the bounded
-            // channel, so additional signals are unnecessary.
-            break;
-        }
-    }
-
-    Ok(())
+    queue_peer_demand(&mut demand_tx, connection_demand)
 }
 
 /// Try to connect to `candidate` using `outbound_connector`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -965,8 +965,6 @@ where
 
 /// An action that the peer crawler can take.
 enum CrawlerAction {
-    /// Drop the demand signal because there are too many pending handshakes.
-    DemandDrop,
     /// Initiate a handshake to the next candidate peer in response to demand.
     ///
     /// If there are no available candidates, crawl existing peers.
@@ -1006,34 +1004,13 @@ fn outbound_peer_replenishment_demand(
     target_outbound_connections.saturating_sub(active_outbound_connections)
 }
 
-/// Queue up to `connection_demand` outbound connection attempts.
-fn queue_peer_demand(
-    demand_tx: &mut futures::channel::mpsc::Sender<MorePeers>,
-    connection_demand: usize,
-) -> Result<(), BoxError> {
-    for _ in 0..connection_demand {
-        if let Err(send_error) = demand_tx.try_send(MorePeers) {
-            if send_error.is_disconnected() {
-                // Zakura's peer set is shutting down.
-                return Err(send_error.into());
-            }
-
-            // Existing queued demand is already sufficient to fill the bounded
-            // channel, so additional signals are unnecessary.
-            break;
-        }
-    }
-
-    Ok(())
-}
-
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After a periodic crawl, queue enough outbound connection demand to reach
+/// After a periodic crawl, start enough outbound connection attempts to reach
 /// 27% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
@@ -1113,6 +1090,12 @@ where
 
     let mut crawl_timer = IntervalStream::new(crawl_timer).map(|tick| TimerCrawl { tick });
 
+    // This task is the only `demand_rx` consumer and the only owner of periodic
+    // replenishment demand. Existing queued demand is processed first and
+    // consumes this count, so timer crawls do not duplicate connection attempts
+    // that are already waiting in `demand_rx`.
+    let mut remaining_replenishment_demand: usize = 0;
+
     // # Concurrency
     //
     // To avoid hangs and starvation, the crawler must spawn a separate task for each crawl
@@ -1134,112 +1117,108 @@ where
             ),
             // The timer is rate-limited
             next_timer = crawl_timer.next() => Ok(next_timer.expect("timers never terminate")),
-            // Turn any new demand into an action, based on the crawler's current state.
-            //
-            // # Concurrency
-            //
-            // Demand is potentially unlimited, so it must go last in a biased select!.
-            next_demand = demand_rx.next() => next_demand.ok_or("demand stream closed, is Zakura shutting down?".into()).map(|MorePeers|{
-                if active_outbound_connections.update_count() >= config.peerset_outbound_connection_limit() {
-                    // Too many open outbound connections or pending handshakes already
-                    DemandDrop
-                } else {
-                    DemandHandshakeOrCrawl
-                }
-            })
+            // External demand is potentially unlimited, so it goes after the
+            // rate-limited timer in this biased select.
+            next_demand = demand_rx.next() => next_demand
+                .ok_or("demand stream closed, is Zakura shutting down?".into())
+                .map(|MorePeers| DemandHandshakeOrCrawl),
+            // Existing channel demand gets priority over local replenishment.
+            // Each action consumes one unit of replenishment demand below.
+            _ = future::ready(()), if remaining_replenishment_demand > 0 => {
+                Ok(DemandHandshakeOrCrawl)
+            }
         };
 
         match crawler_action {
-            // Dummy actions
-            Ok(DemandDrop) => {
-                // This is set to trace level because when the peerset is
-                // congested it can generate a lot of demand signal very rapidly.
-                trace!("too many open connections or in-flight handshakes, dropping demand signal");
-            }
-
             // Spawned tasks
             Ok(DemandHandshakeOrCrawl) => {
-                let candidates = candidates.clone();
-                let outbound_connector = outbound_connector.clone();
-                let peerset_tx = peerset_tx.clone();
-                let address_book_updater = address_book_updater.clone();
-                let demand_tx = demand_tx.clone();
-                let expose_peer_addresses = config.expose_peer_addresses;
+                remaining_replenishment_demand = remaining_replenishment_demand.saturating_sub(1);
 
-                // Increment the connection count before we spawn the connection.
-                let outbound_connection_tracker = active_outbound_connections.track_connection();
-                let outbound_connections = active_outbound_connections.update_count();
-                debug!(?outbound_connections, "opening an outbound peer connection");
+                if active_outbound_connections.update_count()
+                    >= config.peerset_outbound_connection_limit()
+                {
+                    remaining_replenishment_demand = 0;
 
-                // Spawn each handshake or crawl into an independent task, so handshakes can make
-                // progress while crawls are running.
-                //
-                // # Concurrency
-                //
-                // The peer crawler must be able to make progress even if some handshakes are
-                // rate-limited. So the async mutex and next peer timeout are awaited inside the
-                // spawned task.
-                let handshake_or_crawl_handle = tokio::spawn(
-                    async move {
-                        // Try to get the next available peer for a handshake.
-                        //
-                        // candidates.next() has a short timeout, and briefly holds the address
-                        // book lock, so it shouldn't hang.
-                        //
-                        // Hold the lock for as short a time as possible.
-                        let candidate = { candidates.lock().await.next().await };
+                    // This is set to trace level because when the peer set is
+                    // congested it can generate a lot of demand signals.
+                    trace!(
+                        "too many open connections or in-flight handshakes, dropping demand signal"
+                    );
+                } else {
+                    let candidates = candidates.clone();
+                    let outbound_connector = outbound_connector.clone();
+                    let peerset_tx = peerset_tx.clone();
+                    let address_book_updater = address_book_updater.clone();
+                    let demand_tx = demand_tx.clone();
+                    let expose_peer_addresses = config.expose_peer_addresses;
 
-                        if let Some(candidate) = candidate {
-                            // we don't need to spawn here, because there's nothing running concurrently
-                            dial(
-                                candidate,
-                                outbound_connector,
-                                outbound_connection_tracker,
-                                outbound_connections,
-                                peerset_tx,
-                                address_book_updater,
-                                demand_tx,
-                                expose_peer_addresses,
-                            )
-                            .await?;
+                    // Increment the connection count before we spawn the connection.
+                    let outbound_connection_tracker =
+                        active_outbound_connections.track_connection();
+                    let outbound_connections = active_outbound_connections.update_count();
+                    debug!(?outbound_connections, "opening an outbound peer connection");
 
-                            Ok(HandshakeFinished)
-                        } else {
-                            // There weren't any peers, so try to get more peers.
-                            debug!("demand for peers but no available candidates");
+                    // Spawn each handshake or crawl into an independent task, so handshakes can
+                    // make progress while crawls are running.
+                    //
+                    // # Concurrency
+                    //
+                    // The peer crawler must be able to make progress even if some handshakes are
+                    // rate-limited. So the async mutex and next peer timeout are awaited inside the
+                    // spawned task.
+                    let handshake_or_crawl_handle = tokio::spawn(
+                        async move {
+                            // Try to get the next available peer for a handshake.
+                            //
+                            // candidates.next() has a short timeout, and briefly holds the address
+                            // book lock, so it shouldn't hang.
+                            //
+                            // Hold the lock for as short a time as possible.
+                            let candidate = { candidates.lock().await.next().await };
 
-                            crawl(candidates, demand_tx, 0).await?;
+                            if let Some(candidate) = candidate {
+                                // we don't need to spawn here, because there's nothing running concurrently
+                                dial(
+                                    candidate,
+                                    outbound_connector,
+                                    outbound_connection_tracker,
+                                    outbound_connections,
+                                    peerset_tx,
+                                    address_book_updater,
+                                    demand_tx,
+                                    expose_peer_addresses,
+                                )
+                                .await?;
 
-                            Ok(DemandCrawlFinished)
+                                Ok(HandshakeFinished)
+                            } else {
+                                // There weren't any peers, so try to get more peers.
+                                debug!("demand for peers but no available candidates");
+
+                                crawl(candidates, demand_tx).await?;
+
+                                Ok(DemandCrawlFinished)
+                            }
                         }
-                    }
-                    .in_current_span(),
-                )
-                .wait_for_panics();
+                        .in_current_span(),
+                    )
+                    .wait_for_panics();
 
-                handshakes.push(handshake_or_crawl_handle);
+                    handshakes.push(handshake_or_crawl_handle);
+                }
             }
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
                 let demand_tx = demand_tx.clone();
-                let active_outbound_connections = active_outbound_connections.update_count();
-                let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                let replenishment_demand = outbound_peer_replenishment_demand(
-                    active_outbound_connections,
-                    outbound_connection_limit,
-                );
 
                 let crawl_handle = tokio::spawn(
                     async move {
                         debug!(
                             ?tick,
-                            active_outbound_connections,
-                            outbound_connection_limit,
-                            replenishment_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, replenishment_demand).await?;
+                        crawl(candidates, demand_tx).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1260,7 +1239,19 @@ where
                 trace!("demand-based crawl finished");
             }
             Ok(TimerCrawlFinished) => {
-                debug!("timer-based crawl finished");
+                let active_outbound_connections = active_outbound_connections.update_count();
+                let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                remaining_replenishment_demand = outbound_peer_replenishment_demand(
+                    active_outbound_connections,
+                    outbound_connection_limit,
+                );
+
+                debug!(
+                    active_outbound_connections,
+                    outbound_connection_limit,
+                    remaining_replenishment_demand,
+                    "timer-based crawl finished"
+                );
             }
 
             // Fatal errors and shutdowns
@@ -1277,16 +1268,12 @@ where
     }
 }
 
-/// Try to get more peers using `candidates`, then queue connection attempts
-/// using `demand_tx`.
-/// If the crawl discovers peers, queue at least one connection attempt. Also
-/// queue at least `minimum_connection_demand` attempts, unless the demand
-/// channel is already full.
+/// Try to get more peers using `candidates`, then queue a connection attempt
+/// using `demand_tx` if the crawl discovers peers.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    minimum_connection_demand: usize,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1300,9 +1287,8 @@ where
         std::mem::drop(candidates);
         result
     };
-    let connection_demand = match result {
-        Ok(Some(MorePeers)) => minimum_connection_demand.max(1),
-        Ok(None) => minimum_connection_demand,
+    let more_peers = match result {
+        Ok(more_peers) => more_peers,
         Err(e) => {
             info!(
                 ?e,
@@ -1312,13 +1298,22 @@ where
         }
     };
 
-    // Queue connection attempts for discovered peers or outbound replenishment.
+    // Queue a connection attempt for discovered peers.
     //
     // # Security
     //
-    // Candidate selection rate-limits outbound handshakes, and the crawler loop
-    // checks the configured outbound connection limit before starting each one.
-    queue_peer_demand(&mut demand_tx, connection_demand)
+    // Update attempts are rate-limited by the candidate set, and we only try
+    // peers if there was actually an update.
+    if let Some(more_peers) = more_peers {
+        if let Err(send_error) = demand_tx.try_send(more_peers) {
+            if send_error.is_disconnected() {
+                // Zakura's peer set is shutting down.
+                return Err(send_error.into());
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Try to connect to `candidate` using `outbound_connector`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,16 +981,18 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-/// Returns `true` when the crawler should replenish outbound peers.
+/// Returns the number of outbound peers needed to reach half the configured
+/// connection limit.
 ///
-/// The threshold is strictly below half the configured outbound connection
-/// limit. Using [`usize::div_ceil`] preserves that boundary for odd limits and
-/// keeps a zero limit disabled.
-fn should_replenish_outbound_peers(
+/// Using [`usize::div_ceil`] preserves the threshold for odd limits, and
+/// [`usize::saturating_sub`] returns zero at or above the threshold.
+fn outbound_peer_replenishment_demand(
     active_outbound_connections: usize,
     outbound_connection_limit: usize,
-) -> bool {
-    active_outbound_connections < outbound_connection_limit.div_ceil(2)
+) -> usize {
+    outbound_connection_limit
+        .div_ceil(2)
+        .saturating_sub(active_outbound_connections)
 }
 
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
@@ -999,8 +1001,8 @@ fn should_replenish_outbound_peers(
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After a periodic crawl, request another outbound connection while fewer than
-/// half the configured outbound connection slots are active.
+/// After a periodic crawl, queue enough outbound connection demand to reach
+/// half the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1174,7 +1176,7 @@ where
                             // There weren't any peers, so try to get more peers.
                             debug!("demand for peers but no available candidates");
 
-                            crawl(candidates, demand_tx, false).await?;
+                            crawl(candidates, demand_tx, 0).await?;
 
                             Ok(DemandCrawlFinished)
                         }
@@ -1190,7 +1192,7 @@ where
                 let demand_tx = demand_tx.clone();
                 let active_outbound_connections = active_outbound_connections.update_count();
                 let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                let should_signal_demand = should_replenish_outbound_peers(
+                let replenishment_demand = outbound_peer_replenishment_demand(
                     active_outbound_connections,
                     outbound_connection_limit,
                 );
@@ -1201,11 +1203,11 @@ where
                             ?tick,
                             active_outbound_connections,
                             outbound_connection_limit,
-                            should_signal_demand,
+                            replenishment_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, should_signal_demand).await?;
+                        crawl(candidates, demand_tx, replenishment_demand).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1244,13 +1246,14 @@ where
 }
 
 /// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
-/// If there were no new peers and `should_signal_demand` is false, the
-/// connection attempt is skipped.
+/// If the crawl discovers peers, queue at least one connection attempt. Also
+/// queue at least `minimum_connection_demand` attempts, unless the demand
+/// channel is already full.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    should_signal_demand: bool,
+    minimum_connection_demand: usize,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1264,8 +1267,9 @@ where
         std::mem::drop(candidates);
         result
     };
-    let more_peers = match result {
-        Ok(more_peers) => more_peers.or_else(|| should_signal_demand.then_some(MorePeers)),
+    let connection_demand = match result {
+        Ok(Some(MorePeers)) => minimum_connection_demand.max(1),
+        Ok(None) => minimum_connection_demand,
         Err(e) => {
             info!(
                 ?e,
@@ -1275,22 +1279,22 @@ where
         }
     };
 
-    // If we got more peers, try to connect to a new peer on our next loop.
+    // Queue connection attempts for discovered peers or outbound replenishment.
     //
     // # Security
     //
-    // Update attempts are rate-limited by the candidate set,
-    // and we only try peers if there was actually an update.
-    //
-    // So if all peers have had a recent attempt, and there was recent update
-    // with no peers, the channel will drain. This prevents useless update attempt
-    // loops.
-    if let Some(more_peers) = more_peers {
-        if let Err(send_error) = demand_tx.try_send(more_peers) {
+    // Candidate selection rate-limits outbound handshakes, and the crawler loop
+    // checks the configured outbound connection limit before starting each one.
+    for _ in 0..connection_demand {
+        if let Err(send_error) = demand_tx.try_send(MorePeers) {
             if send_error.is_disconnected() {
                 // Zebra is shutting down
                 return Err(send_error.into());
             }
+
+            // Existing queued demand is already sufficient to fill the bounded
+            // channel, so additional signals are unnecessary.
+            break;
         }
     }
 

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,18 +981,29 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-/// Returns the number of outbound peers needed to reach half the configured
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 3;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 10;
+
+/// Returns the number of outbound peers needed to reach 30% of the configured
 /// connection limit.
 ///
-/// Using [`usize::div_ceil`] preserves the threshold for odd limits, and
-/// [`usize::saturating_sub`] returns zero at or above the threshold.
+/// The target calculation avoids overflow by applying the ratio separately to
+/// the quotient and remainder. [`usize::div_ceil`] rounds partial peers upward,
+/// and [`usize::saturating_sub`] returns zero at or above the target.
 fn outbound_peer_replenishment_demand(
     active_outbound_connections: usize,
     outbound_connection_limit: usize,
 ) -> usize {
-    outbound_connection_limit
-        .div_ceil(2)
-        .saturating_sub(active_outbound_connections)
+    let target_outbound_connections = (outbound_connection_limit
+        / OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR)
+        .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+        .saturating_add(
+            (outbound_connection_limit % OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR)
+                .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+                .div_ceil(OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR),
+        );
+
+    target_outbound_connections.saturating_sub(active_outbound_connections)
 }
 
 /// Queue up to `connection_demand` outbound connection attempts.
@@ -1023,7 +1034,7 @@ fn queue_peer_demand(
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
 /// After a periodic crawl, queue enough outbound connection demand to reach
-/// half the configured outbound connection limit.
+/// 30% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,10 +981,10 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 3;
-const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 10;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 27;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 100;
 
-/// Returns the number of outbound peers needed to reach 30% of the configured
+/// Returns the number of outbound peers needed to reach 27% of the configured
 /// connection limit.
 ///
 /// The target calculation avoids overflow by applying the ratio separately to
@@ -1034,7 +1034,7 @@ fn queue_peer_demand(
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
 /// After a periodic crawl, queue enough outbound connection demand to reach
-/// 30% of the configured outbound connection limit.
+/// 27% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -1003,7 +1003,7 @@ fn queue_peer_demand(
     for _ in 0..connection_demand {
         if let Err(send_error) = demand_tx.try_send(MorePeers) {
             if send_error.is_disconnected() {
-                // Zebra is shutting down
+                // Zakura's peer set is shutting down.
                 return Err(send_error.into());
             }
 
@@ -1409,7 +1409,7 @@ where
             // Handshake failures are rate-limited by peer attempt timeouts.
             if let Err(send_error) = demand_tx.try_send(MorePeers) {
                 if send_error.is_disconnected() {
-                    // Zebra is shutting down
+                    // Zakura's peer set is shutting down.
                     return Err(send_error.into());
                 }
             }

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,13 +981,26 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
+/// Returns `true` when the crawler should replenish outbound peers.
+///
+/// The threshold is strictly below half the configured outbound connection
+/// limit. Using [`usize::div_ceil`] preserves that boundary for odd limits and
+/// keeps a zero limit disabled.
+fn should_replenish_outbound_peers(
+    active_outbound_connections: usize,
+    outbound_connection_limit: usize,
+) -> bool {
+    active_outbound_connections < outbound_connection_limit.div_ceil(2)
+}
+
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After crawling, try to connect to one new peer using `outbound_connector`.
+/// After a periodic crawl, request another outbound connection while fewer than
+/// half the configured outbound connection slots are active.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1175,16 +1188,24 @@ where
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
                 let demand_tx = demand_tx.clone();
-                let should_always_dial = active_outbound_connections.update_count() == 0;
+                let active_outbound_connections = active_outbound_connections.update_count();
+                let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                let should_signal_demand = should_replenish_outbound_peers(
+                    active_outbound_connections,
+                    outbound_connection_limit,
+                );
 
                 let crawl_handle = tokio::spawn(
                     async move {
                         debug!(
                             ?tick,
+                            active_outbound_connections,
+                            outbound_connection_limit,
+                            should_signal_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, should_always_dial).await?;
+                        crawl(candidates, demand_tx, should_signal_demand).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1223,12 +1244,13 @@ where
 }
 
 /// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
-/// If there were no new peers and `should_always_dial` is false, the connection attempt is skipped.
+/// If there were no new peers and `should_signal_demand` is false, the
+/// connection attempt is skipped.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    should_always_dial: bool,
+    should_signal_demand: bool,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1243,7 +1265,7 @@ where
         result
     };
     let more_peers = match result {
-        Ok(more_peers) => more_peers.or_else(|| should_always_dial.then_some(MorePeers)),
+        Ok(more_peers) => more_peers.or_else(|| should_signal_demand.then_some(MorePeers)),
         Err(e) => {
             info!(
                 ?e,

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -968,15 +968,105 @@ enum CrawlerAction {
     /// Initiate a handshake to the next candidate peer in response to demand.
     ///
     /// If there are no available candidates, crawl existing peers.
-    DemandHandshakeOrCrawl,
+    DemandHandshakeOrCrawl { source: DemandSource },
     /// Crawl existing peers for more peers in response to a timer `tick`.
     TimerCrawl { tick: Instant },
     /// Clear a finished handshake.
-    HandshakeFinished,
+    HandshakeFinished {
+        resume_replenishment_demand: bool,
+        restore_replenishment_demand: bool,
+    },
     /// Clear a finished demand crawl (DemandHandshakeOrCrawl with no peers).
-    DemandCrawlFinished,
+    DemandCrawlFinished { restore_replenishment_demand: bool },
     /// Clear a finished TimerCrawl.
     TimerCrawlFinished,
+}
+
+/// The source of an outbound connection demand action.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum DemandSource {
+    /// Demand received from the peer set or another crawler task.
+    Queued,
+    /// Demand generated locally after a periodic crawl.
+    Replenishment,
+}
+
+/// The result of an outbound dial attempt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum DialOutcome {
+    /// The connection was sent to the peer set.
+    Connected,
+    /// The connection failed.
+    Failed,
+}
+
+/// Locally generated outbound connection demand.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+struct ReplenishmentDemand {
+    remaining: usize,
+    paused: bool,
+}
+
+impl ReplenishmentDemand {
+    /// Replace local demand with a fresh periodic-crawl deficit.
+    fn replace(&mut self, demand: usize) {
+        self.remaining = demand;
+        self.paused = false;
+    }
+
+    /// Resume local demand, clamping stale demand to the current deficit.
+    fn resume(&mut self, current_deficit: usize) {
+        self.clamp(current_deficit);
+        self.paused = false;
+    }
+
+    /// Clamp stale local demand to the current deficit.
+    fn clamp(&mut self, current_deficit: usize) {
+        self.remaining = self.remaining.min(current_deficit);
+    }
+
+    /// Tentatively consume one local demand unit.
+    fn take(&mut self) -> bool {
+        if self.remaining == 0 {
+            false
+        } else {
+            self.remaining -= 1;
+            true
+        }
+    }
+
+    /// Restore tentatively consumed demand after a failed dial.
+    fn restore(&mut self, current_deficit: usize) {
+        self.remaining = self.remaining.saturating_add(1).min(current_deficit);
+    }
+
+    /// Restore tentatively consumed demand when no candidate was available.
+    ///
+    /// Pausing prevents a hot retry loop against an empty candidate set.
+    fn restore_and_pause(&mut self, current_deficit: usize) {
+        self.restore(current_deficit);
+        self.paused = true;
+    }
+
+    /// Pause local demand without discarding it.
+    fn pause(&mut self) {
+        self.paused = true;
+    }
+
+    /// Returns `true` if local demand is ready to be processed.
+    fn is_ready(&self) -> bool {
+        self.remaining > 0 && !self.paused
+    }
+
+    /// Returns `true` if local demand is paused.
+    fn is_paused(&self) -> bool {
+        self.paused
+    }
+
+    /// Returns the number of remaining local demand units.
+    fn remaining(&self) -> usize {
+        self.remaining
+    }
 }
 
 const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 27;
@@ -1094,7 +1184,7 @@ where
     // replenishment demand. Existing queued demand is processed first and
     // consumes this count, so timer crawls do not duplicate connection attempts
     // that are already waiting in `demand_rx`.
-    let mut remaining_replenishment_demand: usize = 0;
+    let mut replenishment_demand = ReplenishmentDemand::default();
 
     // # Concurrency
     //
@@ -1121,23 +1211,26 @@ where
             // rate-limited timer in this biased select.
             next_demand = demand_rx.next() => next_demand
                 .ok_or("demand stream closed, is Zakura shutting down?".into())
-                .map(|MorePeers| DemandHandshakeOrCrawl),
+                .map(|MorePeers| DemandHandshakeOrCrawl {
+                    source: DemandSource::Queued,
+                }),
             // Existing channel demand gets priority over local replenishment.
-            // Each action consumes one unit of replenishment demand below.
-            _ = future::ready(()), if remaining_replenishment_demand > 0 => {
-                Ok(DemandHandshakeOrCrawl)
+            // Each scheduled action tentatively consumes one local demand unit.
+            _ = future::ready(()), if replenishment_demand.is_ready() => {
+                Ok(DemandHandshakeOrCrawl {
+                    source: DemandSource::Replenishment,
+                })
             }
         };
 
         match crawler_action {
             // Spawned tasks
-            Ok(DemandHandshakeOrCrawl) => {
-                remaining_replenishment_demand = remaining_replenishment_demand.saturating_sub(1);
+            Ok(DemandHandshakeOrCrawl { source }) => {
+                let outbound_connection_count = active_outbound_connections.update_count();
+                let outbound_connection_limit = config.peerset_outbound_connection_limit();
 
-                if active_outbound_connections.update_count()
-                    >= config.peerset_outbound_connection_limit()
-                {
-                    remaining_replenishment_demand = 0;
+                if outbound_connection_count >= outbound_connection_limit {
+                    replenishment_demand.pause();
 
                     // This is set to trace level because when the peer set is
                     // congested it can generate a lot of demand signals.
@@ -1151,6 +1244,16 @@ where
                     let address_book_updater = address_book_updater.clone();
                     let demand_tx = demand_tx.clone();
                     let expose_peer_addresses = config.expose_peer_addresses;
+                    if source == DemandSource::Queued {
+                        let current_deficit = outbound_peer_replenishment_demand(
+                            outbound_connection_count,
+                            outbound_connection_limit,
+                        );
+                        replenishment_demand.clamp(current_deficit);
+                    }
+                    let resume_replenishment_demand =
+                        source == DemandSource::Queued && replenishment_demand.is_paused();
+                    let restore_replenishment_demand = replenishment_demand.take();
 
                     // Increment the connection count before we spawn the connection.
                     let outbound_connection_tracker =
@@ -1178,7 +1281,7 @@ where
 
                             if let Some(candidate) = candidate {
                                 // we don't need to spawn here, because there's nothing running concurrently
-                                dial(
+                                let dial_outcome = dial(
                                     candidate,
                                     outbound_connector,
                                     outbound_connection_tracker,
@@ -1190,14 +1293,22 @@ where
                                 )
                                 .await?;
 
-                                Ok(HandshakeFinished)
+                                Ok(HandshakeFinished {
+                                    resume_replenishment_demand,
+                                    restore_replenishment_demand: restore_replenishment_demand
+                                        && dial_outcome == DialOutcome::Failed,
+                                })
                             } else {
                                 // There weren't any peers, so try to get more peers.
                                 debug!("demand for peers but no available candidates");
 
+                                // Release the reserved outbound slot before crawling.
+                                std::mem::drop(outbound_connection_tracker);
                                 crawl(candidates, demand_tx).await?;
 
-                                Ok(DemandCrawlFinished)
+                                Ok(DemandCrawlFinished {
+                                    restore_replenishment_demand,
+                                })
                             }
                         }
                         .in_current_span(),
@@ -1230,10 +1341,40 @@ where
             }
 
             // Completed spawned tasks
-            Ok(HandshakeFinished) => {
+            Ok(HandshakeFinished {
+                resume_replenishment_demand,
+                restore_replenishment_demand,
+            }) => {
+                if resume_replenishment_demand || restore_replenishment_demand {
+                    let active_outbound_connections = active_outbound_connections.update_count();
+                    let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                    let current_deficit = outbound_peer_replenishment_demand(
+                        active_outbound_connections,
+                        outbound_connection_limit,
+                    );
+                    if restore_replenishment_demand {
+                        replenishment_demand.restore(current_deficit);
+                    }
+                    if resume_replenishment_demand {
+                        replenishment_demand.resume(current_deficit);
+                    }
+                }
+
                 // Already logged in dial()
             }
-            Ok(DemandCrawlFinished) => {
+            Ok(DemandCrawlFinished {
+                restore_replenishment_demand,
+            }) => {
+                if restore_replenishment_demand {
+                    let active_outbound_connections = active_outbound_connections.update_count();
+                    let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                    let current_deficit = outbound_peer_replenishment_demand(
+                        active_outbound_connections,
+                        outbound_connection_limit,
+                    );
+                    replenishment_demand.restore_and_pause(current_deficit);
+                }
+
                 // This is set to trace level because when the peerset is
                 // congested it can generate a lot of demand signal very rapidly.
                 trace!("demand-based crawl finished");
@@ -1241,15 +1382,16 @@ where
             Ok(TimerCrawlFinished) => {
                 let active_outbound_connections = active_outbound_connections.update_count();
                 let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                remaining_replenishment_demand = outbound_peer_replenishment_demand(
+                let replenishment_deficit = outbound_peer_replenishment_demand(
                     active_outbound_connections,
                     outbound_connection_limit,
                 );
+                replenishment_demand.replace(replenishment_deficit);
 
                 debug!(
                     active_outbound_connections,
                     outbound_connection_limit,
-                    remaining_replenishment_demand,
+                    remaining_replenishment_demand = replenishment_demand.remaining(),
                     "timer-based crawl finished"
                 );
             }
@@ -1342,7 +1484,7 @@ async fn dial<C>(
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
     expose_peer_addresses: bool,
-) -> Result<(), BoxError>
+) -> Result<DialOutcome, BoxError>
 where
     C: Service<
             OutboundConnectorRequest,
@@ -1377,12 +1519,14 @@ where
     // the handshake has timeouts, so it shouldn't hang
     let handshake_result = outbound_connector.call(req).map(Into::into).await;
 
-    match handshake_result {
+    let dial_outcome = match handshake_result {
         Ok((address, client)) => {
             debug!(peer = %addr_label, "successfully dialed new peer");
 
             // The connection limit makes sure this send doesn't block.
             peerset_tx.send((address, client)).await?;
+
+            DialOutcome::Connected
         }
         // The connection was never opened, or it failed the handshake and was dropped.
         Err(error) => {
@@ -1419,10 +1563,12 @@ where
                     return Err(send_error.into());
                 }
             }
-        }
-    }
 
-    Ok(())
+            DialOutcome::Failed
+        }
+    };
+
+    Ok(dial_outcome)
 }
 
 /// Mark `addr` as a failed peer to `address_book_updater`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -9,7 +9,10 @@ use std::{
     convert::Infallible,
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -965,108 +968,20 @@ where
 
 /// An action that the peer crawler can take.
 enum CrawlerAction {
+    /// Drop the demand signal because there are too many pending handshakes.
+    DemandDrop,
     /// Initiate a handshake to the next candidate peer in response to demand.
     ///
     /// If there are no available candidates, crawl existing peers.
-    DemandHandshakeOrCrawl { source: DemandSource },
+    DemandHandshakeOrCrawl,
     /// Crawl existing peers for more peers in response to a timer `tick`.
     TimerCrawl { tick: Instant },
     /// Clear a finished handshake.
-    HandshakeFinished {
-        resume_replenishment_demand: bool,
-        restore_replenishment_demand: bool,
-    },
+    HandshakeFinished,
     /// Clear a finished demand crawl (DemandHandshakeOrCrawl with no peers).
-    DemandCrawlFinished { restore_replenishment_demand: bool },
+    DemandCrawlFinished,
     /// Clear a finished TimerCrawl.
     TimerCrawlFinished,
-}
-
-/// The source of an outbound connection demand action.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum DemandSource {
-    /// Demand received from the peer set or another crawler task.
-    Queued,
-    /// Demand generated locally after a periodic crawl.
-    Replenishment,
-}
-
-/// The result of an outbound dial attempt.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum DialOutcome {
-    /// The connection was sent to the peer set.
-    Connected,
-    /// The connection failed.
-    Failed,
-}
-
-/// Locally generated outbound connection demand.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-struct ReplenishmentDemand {
-    remaining: usize,
-    paused: bool,
-}
-
-impl ReplenishmentDemand {
-    /// Replace local demand with a fresh periodic-crawl deficit.
-    fn replace(&mut self, demand: usize) {
-        self.remaining = demand;
-        self.paused = false;
-    }
-
-    /// Resume local demand, clamping stale demand to the current deficit.
-    fn resume(&mut self, current_deficit: usize) {
-        self.clamp(current_deficit);
-        self.paused = false;
-    }
-
-    /// Clamp stale local demand to the current deficit.
-    fn clamp(&mut self, current_deficit: usize) {
-        self.remaining = self.remaining.min(current_deficit);
-    }
-
-    /// Tentatively consume one local demand unit.
-    fn take(&mut self) -> bool {
-        if self.remaining == 0 {
-            false
-        } else {
-            self.remaining -= 1;
-            true
-        }
-    }
-
-    /// Restore tentatively consumed demand after a failed dial.
-    fn restore(&mut self, current_deficit: usize) {
-        self.remaining = self.remaining.saturating_add(1).min(current_deficit);
-    }
-
-    /// Restore tentatively consumed demand when no candidate was available.
-    ///
-    /// Pausing prevents a hot retry loop against an empty candidate set.
-    fn restore_and_pause(&mut self, current_deficit: usize) {
-        self.restore(current_deficit);
-        self.paused = true;
-    }
-
-    /// Pause local demand without discarding it.
-    fn pause(&mut self) {
-        self.paused = true;
-    }
-
-    /// Returns `true` if local demand is ready to be processed.
-    fn is_ready(&self) -> bool {
-        self.remaining > 0 && !self.paused
-    }
-
-    /// Returns `true` if local demand is paused.
-    fn is_paused(&self) -> bool {
-        self.paused
-    }
-
-    /// Returns the number of remaining local demand units.
-    fn remaining(&self) -> usize {
-        self.remaining
-    }
 }
 
 const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 27;
@@ -1100,8 +1015,8 @@ fn outbound_peer_replenishment_demand(
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After a periodic crawl, start enough outbound connection attempts to reach
-/// 27% of the configured outbound connection limit.
+/// After a periodic crawl, refresh the connection demand needed to reach 27%
+/// of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1180,11 +1095,10 @@ where
 
     let mut crawl_timer = IntervalStream::new(crawl_timer).map(|tick| TimerCrawl { tick });
 
-    // This task is the only `demand_rx` consumer and the only owner of periodic
-    // replenishment demand. Existing queued demand is processed first and
-    // consumes this count, so timer crawls do not duplicate connection attempts
-    // that are already waiting in `demand_rx`.
-    let mut replenishment_demand = ReplenishmentDemand::default();
+    // Periodic replenishment is best-effort. Every consumed demand action
+    // decrements this counter, even if it crawls instead of dialing. The next
+    // periodic crawl refreshes any remaining deficit.
+    let remaining_replenishment_demand = AtomicUsize::new(0);
 
     // # Concurrency
     //
@@ -1211,112 +1125,105 @@ where
             // rate-limited timer in this biased select.
             next_demand = demand_rx.next() => next_demand
                 .ok_or("demand stream closed, is Zakura shutting down?".into())
-                .map(|MorePeers| DemandHandshakeOrCrawl {
-                    source: DemandSource::Queued,
-                }),
+                .map(|MorePeers| DemandHandshakeOrCrawl),
             // Existing channel demand gets priority over local replenishment.
-            // Each scheduled action tentatively consumes one local demand unit.
-            _ = future::ready(()), if replenishment_demand.is_ready() => {
-                Ok(DemandHandshakeOrCrawl {
-                    source: DemandSource::Replenishment,
-                })
+            // Each action consumes one unit of replenishment demand below.
+            _ = future::ready(()),
+                if remaining_replenishment_demand.load(Ordering::Relaxed) > 0 =>
+            {
+                Ok(DemandHandshakeOrCrawl)
             }
         };
 
-        match crawler_action {
-            // Spawned tasks
-            Ok(DemandHandshakeOrCrawl { source }) => {
-                let outbound_connection_count = active_outbound_connections.update_count();
-                let outbound_connection_limit = config.peerset_outbound_connection_limit();
+        let crawler_action = match crawler_action {
+            Ok(DemandHandshakeOrCrawl) => {
+                let _ = remaining_replenishment_demand.fetch_update(
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                    |demand| Some(demand.saturating_sub(1)),
+                );
 
-                if outbound_connection_count >= outbound_connection_limit {
-                    replenishment_demand.pause();
-
-                    // This is set to trace level because when the peer set is
-                    // congested it can generate a lot of demand signals.
-                    trace!(
-                        "too many open connections or in-flight handshakes, dropping demand signal"
-                    );
+                if active_outbound_connections.update_count()
+                    >= config.peerset_outbound_connection_limit()
+                {
+                    remaining_replenishment_demand.store(0, Ordering::Relaxed);
+                    Ok(DemandDrop)
                 } else {
-                    let candidates = candidates.clone();
-                    let outbound_connector = outbound_connector.clone();
-                    let peerset_tx = peerset_tx.clone();
-                    let address_book_updater = address_book_updater.clone();
-                    let demand_tx = demand_tx.clone();
-                    let expose_peer_addresses = config.expose_peer_addresses;
-                    if source == DemandSource::Queued {
-                        let current_deficit = outbound_peer_replenishment_demand(
-                            outbound_connection_count,
-                            outbound_connection_limit,
-                        );
-                        replenishment_demand.clamp(current_deficit);
-                    }
-                    let resume_replenishment_demand =
-                        source == DemandSource::Queued && replenishment_demand.is_paused();
-                    let restore_replenishment_demand = replenishment_demand.take();
-
-                    // Increment the connection count before we spawn the connection.
-                    let outbound_connection_tracker =
-                        active_outbound_connections.track_connection();
-                    let outbound_connections = active_outbound_connections.update_count();
-                    debug!(?outbound_connections, "opening an outbound peer connection");
-
-                    // Spawn each handshake or crawl into an independent task, so handshakes can
-                    // make progress while crawls are running.
-                    //
-                    // # Concurrency
-                    //
-                    // The peer crawler must be able to make progress even if some handshakes are
-                    // rate-limited. So the async mutex and next peer timeout are awaited inside the
-                    // spawned task.
-                    let handshake_or_crawl_handle = tokio::spawn(
-                        async move {
-                            // Try to get the next available peer for a handshake.
-                            //
-                            // candidates.next() has a short timeout, and briefly holds the address
-                            // book lock, so it shouldn't hang.
-                            //
-                            // Hold the lock for as short a time as possible.
-                            let candidate = { candidates.lock().await.next().await };
-
-                            if let Some(candidate) = candidate {
-                                // we don't need to spawn here, because there's nothing running concurrently
-                                let dial_outcome = dial(
-                                    candidate,
-                                    outbound_connector,
-                                    outbound_connection_tracker,
-                                    outbound_connections,
-                                    peerset_tx,
-                                    address_book_updater,
-                                    demand_tx,
-                                    expose_peer_addresses,
-                                )
-                                .await?;
-
-                                Ok(HandshakeFinished {
-                                    resume_replenishment_demand,
-                                    restore_replenishment_demand: restore_replenishment_demand
-                                        && dial_outcome == DialOutcome::Failed,
-                                })
-                            } else {
-                                // There weren't any peers, so try to get more peers.
-                                debug!("demand for peers but no available candidates");
-
-                                // Release the reserved outbound slot before crawling.
-                                std::mem::drop(outbound_connection_tracker);
-                                crawl(candidates, demand_tx).await?;
-
-                                Ok(DemandCrawlFinished {
-                                    restore_replenishment_demand,
-                                })
-                            }
-                        }
-                        .in_current_span(),
-                    )
-                    .wait_for_panics();
-
-                    handshakes.push(handshake_or_crawl_handle);
+                    Ok(DemandHandshakeOrCrawl)
                 }
+            }
+            crawler_action => crawler_action,
+        };
+
+        match crawler_action {
+            // Dummy actions
+            Ok(DemandDrop) => {
+                // This is set to trace level because when the peer set is
+                // congested it can generate a lot of demand signals.
+                trace!("too many open connections or in-flight handshakes, dropping demand signal");
+            }
+
+            // Spawned tasks
+            Ok(DemandHandshakeOrCrawl) => {
+                let candidates = candidates.clone();
+                let outbound_connector = outbound_connector.clone();
+                let peerset_tx = peerset_tx.clone();
+                let address_book_updater = address_book_updater.clone();
+                let demand_tx = demand_tx.clone();
+                let expose_peer_addresses = config.expose_peer_addresses;
+
+                // Increment the connection count before we spawn the connection.
+                let outbound_connection_tracker = active_outbound_connections.track_connection();
+                let outbound_connections = active_outbound_connections.update_count();
+                debug!(?outbound_connections, "opening an outbound peer connection");
+
+                // Spawn each handshake or crawl into an independent task, so handshakes can
+                // make progress while crawls are running.
+                //
+                // # Concurrency
+                //
+                // The peer crawler must be able to make progress even if some handshakes are
+                // rate-limited. So the async mutex and next peer timeout are awaited inside the
+                // spawned task.
+                let handshake_or_crawl_handle = tokio::spawn(
+                    async move {
+                        // Try to get the next available peer for a handshake.
+                        //
+                        // candidates.next() has a short timeout, and briefly holds the address
+                        // book lock, so it shouldn't hang.
+                        //
+                        // Hold the lock for as short a time as possible.
+                        let candidate = { candidates.lock().await.next().await };
+
+                        if let Some(candidate) = candidate {
+                            // we don't need to spawn here, because there's nothing running concurrently
+                            dial(
+                                candidate,
+                                outbound_connector,
+                                outbound_connection_tracker,
+                                outbound_connections,
+                                peerset_tx,
+                                address_book_updater,
+                                demand_tx,
+                                expose_peer_addresses,
+                            )
+                            .await?;
+
+                            Ok(HandshakeFinished)
+                        } else {
+                            // There weren't any peers, so try to get more peers.
+                            debug!("demand for peers but no available candidates");
+
+                            crawl(candidates, demand_tx).await?;
+
+                            Ok(DemandCrawlFinished)
+                        }
+                    }
+                    .in_current_span(),
+                )
+                .wait_for_panics();
+
+                handshakes.push(handshake_or_crawl_handle);
             }
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
@@ -1341,40 +1248,10 @@ where
             }
 
             // Completed spawned tasks
-            Ok(HandshakeFinished {
-                resume_replenishment_demand,
-                restore_replenishment_demand,
-            }) => {
-                if resume_replenishment_demand || restore_replenishment_demand {
-                    let active_outbound_connections = active_outbound_connections.update_count();
-                    let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                    let current_deficit = outbound_peer_replenishment_demand(
-                        active_outbound_connections,
-                        outbound_connection_limit,
-                    );
-                    if restore_replenishment_demand {
-                        replenishment_demand.restore(current_deficit);
-                    }
-                    if resume_replenishment_demand {
-                        replenishment_demand.resume(current_deficit);
-                    }
-                }
-
+            Ok(HandshakeFinished) => {
                 // Already logged in dial()
             }
-            Ok(DemandCrawlFinished {
-                restore_replenishment_demand,
-            }) => {
-                if restore_replenishment_demand {
-                    let active_outbound_connections = active_outbound_connections.update_count();
-                    let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                    let current_deficit = outbound_peer_replenishment_demand(
-                        active_outbound_connections,
-                        outbound_connection_limit,
-                    );
-                    replenishment_demand.restore_and_pause(current_deficit);
-                }
-
+            Ok(DemandCrawlFinished) => {
                 // This is set to trace level because when the peerset is
                 // congested it can generate a lot of demand signal very rapidly.
                 trace!("demand-based crawl finished");
@@ -1382,16 +1259,16 @@ where
             Ok(TimerCrawlFinished) => {
                 let active_outbound_connections = active_outbound_connections.update_count();
                 let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                let replenishment_deficit = outbound_peer_replenishment_demand(
+                let replenishment_demand = outbound_peer_replenishment_demand(
                     active_outbound_connections,
                     outbound_connection_limit,
                 );
-                replenishment_demand.replace(replenishment_deficit);
+                remaining_replenishment_demand.store(replenishment_demand, Ordering::Relaxed);
 
                 debug!(
                     active_outbound_connections,
                     outbound_connection_limit,
-                    remaining_replenishment_demand = replenishment_demand.remaining(),
+                    remaining_replenishment_demand = replenishment_demand,
                     "timer-based crawl finished"
                 );
             }
@@ -1484,7 +1361,7 @@ async fn dial<C>(
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
     expose_peer_addresses: bool,
-) -> Result<DialOutcome, BoxError>
+) -> Result<(), BoxError>
 where
     C: Service<
             OutboundConnectorRequest,
@@ -1519,14 +1396,12 @@ where
     // the handshake has timeouts, so it shouldn't hang
     let handshake_result = outbound_connector.call(req).map(Into::into).await;
 
-    let dial_outcome = match handshake_result {
+    match handshake_result {
         Ok((address, client)) => {
             debug!(peer = %addr_label, "successfully dialed new peer");
 
             // The connection limit makes sure this send doesn't block.
             peerset_tx.send((address, client)).await?;
-
-            DialOutcome::Connected
         }
         // The connection was never opened, or it failed the handshake and was dropped.
         Err(error) => {
@@ -1563,12 +1438,10 @@ where
                     return Err(send_error.into());
                 }
             }
-
-            DialOutcome::Failed
         }
-    };
+    }
 
-    Ok(dial_outcome)
+    Ok(())
 }
 
 /// Mark `addr` as a failed peer to `address_book_updater`.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,9 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            outbound_peer_replenishment_demand, queue_peer_demand, DiscoveredPeer,
+            outbound_peer_replenishment_demand, DiscoveredPeer,
+            OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR,
+            OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -61,6 +63,19 @@ const PEER_CACHE_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// A crawler peer limit large enough to exercise multi-peer behavior without
 /// flooding the test runtime with hundreds of immediate fake handshakes.
 const CRAWLER_MANY_PEER_LIMIT_FOR_TESTS: usize = 15;
+
+/// A small peer target that keeps replenishment race tests fast.
+const CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS: usize = 10;
+
+/// The outbound connection limit used by replenishment race tests.
+const CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS: usize =
+    CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS * constants::OUTBOUND_PEER_LIMIT_MULTIPLIER;
+
+/// The outbound connection target used by replenishment race tests.
+const CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS: usize =
+    CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS
+        .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+        .div_ceil(OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR);
 
 /// The maximum time to wait for the listener tests to make expected progress.
 const LISTENER_TEST_DURATION: Duration = Duration::from_secs(10);
@@ -478,20 +493,95 @@ fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     }
 }
 
-#[test]
-fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 81;
+#[tokio::test(start_paused = true)]
+async fn crawler_startup_demand_satisfies_replenishment() {
+    let mut harness = spawn_replenishment_crawler(
+        0,
+        CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+    )
+    .await;
 
-    let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
-    queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)
-        .expect("open demand channel accepts replenishment signals");
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS)
+        .await;
+}
 
-    let mut queued_demand = 0;
-    while demand_rx.try_recv().is_ok() {
-        queued_demand += 1;
-    }
+#[tokio::test(start_paused = true)]
+async fn crawler_partial_queued_demand_is_completed_to_target() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 3, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
 
-    assert_eq!(queued_demand, CONNECTION_DEMAND);
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_demand_arriving_during_crawl_counts_toward_target() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 0, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
+
+    harness.wait_for_crawl_start().await;
+    harness.queue_demand(4);
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_disconnects_during_crawl_are_replenished() {
+    let mut harness = spawn_replenishment_crawler(
+        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.drop_initial_connections(4);
+    harness.release_crawl();
+    harness.assert_connection_attempts(4).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_overlapping_timer_crawls_do_not_duplicate_replenishment() {
+    let mut harness = spawn_replenishment_crawler(0, 0, Duration::from_secs(1)).await;
+
+    harness.wait_for_crawl_start().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_excess_queued_demand_is_preserved() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 12, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness.assert_connection_attempts(12).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_replenishment_respects_hard_outbound_limit() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 40, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS)
+        .await;
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
@@ -1906,6 +1996,248 @@ where
     .await;
 
     address_book
+}
+
+struct ReplenishmentCrawlerTestHarness {
+    config: Config,
+    demand_tx: mpsc::Sender<MorePeers>,
+    crawl_started_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+    crawl_release_tx: tokio::sync::watch::Sender<bool>,
+    connection_tracker_rx: tokio::sync::mpsc::UnboundedReceiver<ConnectionTracker>,
+    crawl_task_handle: JoinHandle<Result<(), BoxError>>,
+    address_book_updater_guard: JoinHandle<Result<(), BoxError>>,
+    _peerset_rx: mpsc::Receiver<DiscoveredPeer>,
+    initial_connection_trackers: Vec<ConnectionTracker>,
+}
+
+impl ReplenishmentCrawlerTestHarness {
+    async fn wait_for_crawl_start(&mut self) {
+        wait_for_crawler_events(
+            &mut self.crawl_started_rx,
+            1,
+            "periodic peer crawl should start before the timeout",
+        )
+        .await;
+    }
+
+    fn release_crawl(&self) {
+        self.crawl_release_tx
+            .send(true)
+            .expect("controlled crawl receiver remains open");
+    }
+
+    fn queue_demand(&mut self, demand_count: usize) {
+        for _ in 0..demand_count {
+            self.demand_tx
+                .try_send(MorePeers)
+                .expect("replenishment test demand channel has capacity");
+        }
+    }
+
+    fn drop_initial_connections(&mut self, connection_count: usize) {
+        assert!(
+            connection_count <= self.initial_connection_trackers.len(),
+            "cannot drop more initial connections than the harness holds"
+        );
+
+        let keep_count = self.initial_connection_trackers.len() - connection_count;
+        let dropped_connections = self.initial_connection_trackers.split_off(keep_count);
+        std::mem::drop(dropped_connections);
+    }
+
+    async fn assert_connection_attempts(mut self, expected_connection_attempts: usize) {
+        let mut connection_trackers = wait_for_crawler_events(
+            &mut self.connection_tracker_rx,
+            expected_connection_attempts,
+            "crawler should start the expected replenishment attempts",
+        )
+        .await;
+
+        self.demand_tx.close_channel();
+
+        let shutdown_deadline = Instant::now() + CRAWLER_TEST_TIMEOUT;
+        while !self.crawl_task_handle.is_finished() {
+            assert!(
+                Instant::now() < shutdown_deadline,
+                "crawler should shut down after its demand channel closes"
+            );
+            tokio::task::spawn_blocking(|| {})
+                .await
+                .expect("crawler test blocking-task synchronization should not panic");
+            tokio::task::yield_now().await;
+        }
+
+        let crawl_result = self.crawl_task_handle.await;
+        match crawl_result {
+            Ok(Err(error)) => assert!(
+                error.to_string().contains("demand stream closed"),
+                "unexpected peer crawler shutdown error: {error:?}"
+            ),
+            other => panic!("unexpected peer crawler shutdown result: {other:?}"),
+        }
+
+        let connection_deadline = Instant::now() + CRAWLER_TEST_TIMEOUT;
+        loop {
+            while let Ok(connection_tracker) = self.connection_tracker_rx.try_recv() {
+                connection_trackers.push(connection_tracker);
+            }
+
+            if self.connection_tracker_rx.is_closed() {
+                break;
+            }
+
+            assert!(
+                Instant::now() < connection_deadline,
+                "all spawned connection attempts should finish before the timeout"
+            );
+            tokio::time::advance(constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL).await;
+            tokio::task::spawn_blocking(|| {})
+                .await
+                .expect("crawler test blocking-task synchronization should not panic");
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            connection_trackers.len(),
+            expected_connection_attempts,
+            "crawler started an unexpected number of connection attempts"
+        );
+        assert!(
+            connection_trackers.len() <= self.config.peerset_outbound_connection_limit(),
+            "crawler exceeded the hard outbound connection limit"
+        );
+
+        self.address_book_updater_guard.abort();
+    }
+}
+
+async fn spawn_replenishment_crawler(
+    initial_connection_count: usize,
+    initial_demand_count: usize,
+    crawl_new_peer_interval: Duration,
+) -> ReplenishmentCrawlerTestHarness {
+    let config = Config {
+        peerset_initial_target_size: CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
+        crawl_new_peer_interval,
+        ..Config::default()
+    };
+    let outbound_connection_limit = config.peerset_outbound_connection_limit();
+
+    assert!(initial_connection_count <= outbound_connection_limit);
+
+    let (
+        address_book,
+        _bans_receiver,
+        address_book_updater,
+        _address_metrics,
+        address_book_updater_guard,
+    ) = AddressBookUpdater::spawn(&config, config.listen_addr, PeerServices::NODE_NETWORK);
+
+    let candidate_count = outbound_connection_limit
+        .saturating_mul(2)
+        .saturating_add(1);
+    for address_number in 0..candidate_count {
+        let address_number =
+            u32::try_from(address_number).expect("small replenishment test address count fits u32");
+        let ip =
+            Ipv4Addr::from(u32::from(Ipv4Addr::new(127, 2, 0, 0)).saturating_add(address_number));
+        let addr = MetaAddr::new_gossiped_meta_addr(
+            SocketAddr::new(ip.into(), 8233).into(),
+            PeerServices::NODE_NETWORK,
+            DateTime32::now(),
+        )
+        .new_gossiped_change()
+        .expect("replenishment test peer has valid gossiped address fields");
+
+        address_book
+            .lock()
+            .expect("previous test thread panicked while holding the address book")
+            .update(addr)
+            .expect("replenishment test peer is valid");
+    }
+
+    let (crawl_started_tx, crawl_started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (crawl_release_tx, crawl_release_rx) = tokio::sync::watch::channel(false);
+    let controlled_peer_set = service_fn(move |request| {
+        let crawl_started_tx = crawl_started_tx.clone();
+        let mut crawl_release_rx = crawl_release_rx.clone();
+
+        async move {
+            assert!(
+                matches!(request, Request::Peers),
+                "crawler should only request peer addresses"
+            );
+            crawl_started_tx
+                .send(())
+                .expect("replenishment test crawl observer remains open");
+            crawl_release_rx
+                .wait_for(|crawl_released| *crawl_released)
+                .await
+                .expect("replenishment test crawl controller remains open");
+
+            Err::<Response, BoxError>("controlled peer crawl returns no addresses".into())
+        }
+    });
+    let candidates = CandidateSet::new(address_book, controlled_peer_set);
+
+    let channel_capacity = candidate_count.max(initial_demand_count);
+    let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(channel_capacity);
+    let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(channel_capacity);
+    for _ in 0..initial_demand_count {
+        demand_tx
+            .try_send(MorePeers)
+            .expect("initial replenishment test demand channel has capacity");
+    }
+
+    let mut active_outbound_connections = ActiveConnectionCounter::new_counter_with(
+        outbound_connection_limit,
+        "Replenishment Test Outbound Connections",
+    );
+    let initial_connection_trackers = (0..initial_connection_count)
+        .map(|_| active_outbound_connections.track_connection())
+        .collect();
+
+    let (connection_tracker_tx, connection_tracker_rx) = tokio::sync::mpsc::unbounded_channel();
+    let outbound_connector = service_fn(move |request: OutboundConnectorRequest| {
+        let connection_tracker_tx = connection_tracker_tx.clone();
+
+        async move {
+            let OutboundConnectorRequest {
+                addr,
+                connection_tracker,
+            } = request;
+            let (fake_client, _harness) = ClientTestHarness::build().finish();
+
+            connection_tracker_tx
+                .send(connection_tracker)
+                .expect("replenishment connection observer remains open");
+
+            Ok((addr, fake_client))
+        }
+    });
+
+    let crawl_task_handle = tokio::spawn(crawl_and_dial(
+        config.clone(),
+        demand_tx.clone(),
+        demand_rx,
+        candidates,
+        outbound_connector,
+        peerset_tx,
+        active_outbound_connections,
+        address_book_updater,
+    ));
+
+    ReplenishmentCrawlerTestHarness {
+        config,
+        demand_tx,
+        crawl_started_rx,
+        crawl_release_tx,
+        connection_tracker_rx,
+        crawl_task_handle,
+        address_book_updater_guard,
+        _peerset_rx: peerset_rx,
+        initial_connection_trackers,
+    }
 }
 
 /// The number of connector calls a crawler peer-limit test expects to observe.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            DiscoveredPeer,
+            should_replenish_outbound_peers, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -445,6 +445,29 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
         .expect("test peer is valid for the mainnet address book");
 
     peer
+}
+
+#[test]
+fn crawler_replenishes_outbound_peers_below_half_limit() {
+    let cases = [
+        (0, 0, false),
+        (0, 1, true),
+        (1, 1, false),
+        (0, 2, true),
+        (1, 2, false),
+        (1, 3, true),
+        (2, 3, false),
+        (149, 300, true),
+        (150, 300, false),
+    ];
+
+    for (active, limit, expected) in cases {
+        assert_eq!(
+            should_replenish_outbound_peers(active, limit),
+            expected,
+            "unexpected replenishment decision for {active} active peers and limit {limit}",
+        );
+    }
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -448,19 +448,25 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 }
 
 #[test]
-fn crawler_replenishes_outbound_peers_below_half_limit() {
+fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
     let cases = [
         (0, 0, 0),
         (0, 1, 1),
         (1, 1, 0),
         (0, 2, 1),
         (1, 2, 0),
-        (0, 3, 2),
-        (1, 3, 1),
-        (2, 3, 0),
-        (100, 300, 50),
-        (149, 300, 1),
-        (150, 300, 0),
+        (0, 3, 1),
+        (1, 3, 0),
+        (0, 4, 2),
+        (1, 4, 1),
+        (2, 4, 0),
+        (0, 10, 3),
+        (2, 10, 1),
+        (3, 10, 0),
+        (0, 300, 90),
+        (89, 300, 1),
+        (90, 300, 0),
+        (100, 300, 0),
     ];
 
     for (active, limit, expected) in cases {
@@ -474,7 +480,7 @@ fn crawler_replenishes_outbound_peers_below_half_limit() {
 
 #[test]
 fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 50;
+    const CONNECTION_DEMAND: usize = 90;
 
     let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
     queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            should_replenish_outbound_peers, DiscoveredPeer,
+            outbound_peer_replenishment_demand, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -450,20 +450,22 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 #[test]
 fn crawler_replenishes_outbound_peers_below_half_limit() {
     let cases = [
-        (0, 0, false),
-        (0, 1, true),
-        (1, 1, false),
-        (0, 2, true),
-        (1, 2, false),
-        (1, 3, true),
-        (2, 3, false),
-        (149, 300, true),
-        (150, 300, false),
+        (0, 0, 0),
+        (0, 1, 1),
+        (1, 1, 0),
+        (0, 2, 1),
+        (1, 2, 0),
+        (0, 3, 2),
+        (1, 3, 1),
+        (2, 3, 0),
+        (100, 300, 50),
+        (149, 300, 1),
+        (150, 300, 0),
     ];
 
     for (active, limit, expected) in cases {
         assert_eq!(
-            should_replenish_outbound_peers(active, limit),
+            outbound_peer_replenishment_demand(active, limit),
             expected,
             "unexpected replenishment decision for {active} active peers and limit {limit}",
         );

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            outbound_peer_replenishment_demand, DiscoveredPeer,
+            outbound_peer_replenishment_demand, queue_peer_demand, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -470,6 +470,22 @@ fn crawler_replenishes_outbound_peers_below_half_limit() {
             "unexpected replenishment decision for {active} active peers and limit {limit}",
         );
     }
+}
+
+#[test]
+fn crawler_queues_full_replenishment_demand() {
+    const CONNECTION_DEMAND: usize = 50;
+
+    let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
+    queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)
+        .expect("open demand channel accepts replenishment signals");
+
+    let mut queued_demand = 0;
+    while demand_rx.try_recv().is_ok() {
+        queued_demand += 1;
+    }
+
+    assert_eq!(queued_demand, CONNECTION_DEMAND);
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -448,7 +448,7 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 }
 
 #[test]
-fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
+fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     let cases = [
         (0, 0, 0),
         (0, 1, 1),
@@ -463,9 +463,9 @@ fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
         (0, 10, 3),
         (2, 10, 1),
         (3, 10, 0),
-        (0, 300, 90),
-        (89, 300, 1),
-        (90, 300, 0),
+        (0, 300, 81),
+        (80, 300, 1),
+        (81, 300, 0),
         (100, 300, 0),
     ];
 
@@ -480,7 +480,7 @@ fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
 
 #[test]
 fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 90;
+    const CONNECTION_DEMAND: usize = 81;
 
     let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
     queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            outbound_peer_replenishment_demand, DiscoveredPeer,
+            outbound_peer_replenishment_demand, DiscoveredPeer, ReplenishmentDemand,
             OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR,
             OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR,
         },
@@ -493,6 +493,57 @@ fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     }
 }
 
+#[test]
+fn crawler_replenishment_pauses_without_discarding_demand_at_limit() {
+    let mut replenishment_demand = ReplenishmentDemand::default();
+    replenishment_demand.replace(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
+
+    replenishment_demand.pause();
+
+    assert_eq!(
+        replenishment_demand.remaining(),
+        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS
+    );
+    assert!(!replenishment_demand.is_ready());
+
+    replenishment_demand.resume(4);
+
+    assert_eq!(replenishment_demand.remaining(), 4);
+    assert!(replenishment_demand.is_ready());
+}
+
+#[test]
+fn crawler_replenishment_restores_no_candidate_demand() {
+    let mut replenishment_demand = ReplenishmentDemand::default();
+    replenishment_demand.replace(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
+
+    assert!(replenishment_demand.take());
+    assert_eq!(
+        replenishment_demand.remaining(),
+        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS - 1
+    );
+
+    replenishment_demand.restore_and_pause(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
+
+    assert_eq!(
+        replenishment_demand.remaining(),
+        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS
+    );
+    assert!(!replenishment_demand.is_ready());
+}
+
+#[test]
+fn crawler_replenishment_restores_failed_dial_demand() {
+    let mut replenishment_demand = ReplenishmentDemand::default();
+    replenishment_demand.replace(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
+
+    assert!(replenishment_demand.take());
+    replenishment_demand.restore(3);
+
+    assert_eq!(replenishment_demand.remaining(), 3);
+    assert!(replenishment_demand.is_ready());
+}
+
 #[tokio::test(start_paused = true)]
 async fn crawler_startup_demand_satisfies_replenishment() {
     let mut harness = spawn_replenishment_crawler(
@@ -529,6 +580,26 @@ async fn crawler_demand_arriving_during_crawl_counts_toward_target() {
     harness.wait_for_crawl_start().await;
     harness.queue_demand(4);
     harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_no_candidate_does_not_spend_replenishment_demand() {
+    let mut harness = spawn_replenishment_crawler_with_candidates(
+        0,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+        false,
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness.wait_for_no_candidate_replenishment_pause().await;
+    harness.add_candidates(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
+    harness.queue_demand(1);
     harness
         .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
         .await;
@@ -2008,6 +2079,8 @@ struct ReplenishmentCrawlerTestHarness {
     address_book_updater_guard: JoinHandle<Result<(), BoxError>>,
     _peerset_rx: mpsc::Receiver<DiscoveredPeer>,
     initial_connection_trackers: Vec<ConnectionTracker>,
+    address_book: Arc<std::sync::Mutex<AddressBook>>,
+    next_candidate_address: usize,
 }
 
 impl ReplenishmentCrawlerTestHarness {
@@ -2032,6 +2105,32 @@ impl ReplenishmentCrawlerTestHarness {
                 .try_send(MorePeers)
                 .expect("replenishment test demand channel has capacity");
         }
+    }
+
+    fn add_candidates(&mut self, candidate_count: usize) {
+        add_replenishment_candidates(
+            &self.address_book,
+            self.next_candidate_address,
+            candidate_count,
+        );
+        self.next_candidate_address = self
+            .next_candidate_address
+            .checked_add(candidate_count)
+            .expect("small replenishment test candidate count does not overflow");
+    }
+
+    async fn wait_for_no_candidate_replenishment_pause(&mut self) {
+        for _ in 0..CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS {
+            tokio::task::spawn_blocking(|| {})
+                .await
+                .expect("crawler test blocking-task synchronization should not panic");
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            self.connection_tracker_rx.try_recv().is_err(),
+            "crawler should not dial when the candidate set is empty"
+        );
     }
 
     fn drop_initial_connections(&mut self, connection_count: usize) {
@@ -2116,6 +2215,21 @@ async fn spawn_replenishment_crawler(
     initial_demand_count: usize,
     crawl_new_peer_interval: Duration,
 ) -> ReplenishmentCrawlerTestHarness {
+    spawn_replenishment_crawler_with_candidates(
+        initial_connection_count,
+        initial_demand_count,
+        crawl_new_peer_interval,
+        true,
+    )
+    .await
+}
+
+async fn spawn_replenishment_crawler_with_candidates(
+    initial_connection_count: usize,
+    initial_demand_count: usize,
+    crawl_new_peer_interval: Duration,
+    add_initial_candidates: bool,
+) -> ReplenishmentCrawlerTestHarness {
     let config = Config {
         peerset_initial_target_size: CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
         crawl_new_peer_interval,
@@ -2132,29 +2246,6 @@ async fn spawn_replenishment_crawler(
         _address_metrics,
         address_book_updater_guard,
     ) = AddressBookUpdater::spawn(&config, config.listen_addr, PeerServices::NODE_NETWORK);
-
-    let candidate_count = outbound_connection_limit
-        .saturating_mul(2)
-        .saturating_add(1);
-    for address_number in 0..candidate_count {
-        let address_number =
-            u32::try_from(address_number).expect("small replenishment test address count fits u32");
-        let ip =
-            Ipv4Addr::from(u32::from(Ipv4Addr::new(127, 2, 0, 0)).saturating_add(address_number));
-        let addr = MetaAddr::new_gossiped_meta_addr(
-            SocketAddr::new(ip.into(), 8233).into(),
-            PeerServices::NODE_NETWORK,
-            DateTime32::now(),
-        )
-        .new_gossiped_change()
-        .expect("replenishment test peer has valid gossiped address fields");
-
-        address_book
-            .lock()
-            .expect("previous test thread panicked while holding the address book")
-            .update(addr)
-            .expect("replenishment test peer is valid");
-    }
 
     let (crawl_started_tx, crawl_started_rx) = tokio::sync::mpsc::unbounded_channel();
     let (crawl_release_tx, crawl_release_rx) = tokio::sync::watch::channel(false);
@@ -2178,7 +2269,18 @@ async fn spawn_replenishment_crawler(
             Err::<Response, BoxError>("controlled peer crawl returns no addresses".into())
         }
     });
-    let candidates = CandidateSet::new(address_book, controlled_peer_set);
+
+    let candidate_count = outbound_connection_limit
+        .saturating_mul(2)
+        .saturating_add(1);
+    let initial_candidate_count = if add_initial_candidates {
+        candidate_count
+    } else {
+        0
+    };
+    add_replenishment_candidates(&address_book, 0, initial_candidate_count);
+
+    let candidates = CandidateSet::new(address_book.clone(), controlled_peer_set);
 
     let channel_capacity = candidate_count.max(initial_demand_count);
     let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(channel_capacity);
@@ -2237,6 +2339,38 @@ async fn spawn_replenishment_crawler(
         address_book_updater_guard,
         _peerset_rx: peerset_rx,
         initial_connection_trackers,
+        address_book,
+        next_candidate_address: initial_candidate_count,
+    }
+}
+
+fn add_replenishment_candidates(
+    address_book: &Arc<std::sync::Mutex<AddressBook>>,
+    first_candidate_address: usize,
+    candidate_count: usize,
+) {
+    let last_candidate_address = first_candidate_address
+        .checked_add(candidate_count)
+        .expect("small replenishment test candidate count does not overflow");
+
+    for address_number in first_candidate_address..last_candidate_address {
+        let address_number =
+            u32::try_from(address_number).expect("small replenishment test address count fits u32");
+        let ip =
+            Ipv4Addr::from(u32::from(Ipv4Addr::new(127, 2, 0, 0)).saturating_add(address_number));
+        let addr = MetaAddr::new_gossiped_meta_addr(
+            SocketAddr::new(ip.into(), 8233).into(),
+            PeerServices::NODE_NETWORK,
+            DateTime32::now(),
+        )
+        .new_gossiped_change()
+        .expect("replenishment test peer has valid gossiped address fields");
+
+        address_book
+            .lock()
+            .expect("previous test thread panicked while holding the address book")
+            .update(addr)
+            .expect("replenishment test peer is valid");
     }
 }
 

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            outbound_peer_replenishment_demand, DiscoveredPeer, ReplenishmentDemand,
+            outbound_peer_replenishment_demand, DiscoveredPeer,
             OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR,
             OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR,
         },
@@ -493,57 +493,6 @@ fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     }
 }
 
-#[test]
-fn crawler_replenishment_pauses_without_discarding_demand_at_limit() {
-    let mut replenishment_demand = ReplenishmentDemand::default();
-    replenishment_demand.replace(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
-
-    replenishment_demand.pause();
-
-    assert_eq!(
-        replenishment_demand.remaining(),
-        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS
-    );
-    assert!(!replenishment_demand.is_ready());
-
-    replenishment_demand.resume(4);
-
-    assert_eq!(replenishment_demand.remaining(), 4);
-    assert!(replenishment_demand.is_ready());
-}
-
-#[test]
-fn crawler_replenishment_restores_no_candidate_demand() {
-    let mut replenishment_demand = ReplenishmentDemand::default();
-    replenishment_demand.replace(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
-
-    assert!(replenishment_demand.take());
-    assert_eq!(
-        replenishment_demand.remaining(),
-        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS - 1
-    );
-
-    replenishment_demand.restore_and_pause(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
-
-    assert_eq!(
-        replenishment_demand.remaining(),
-        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS
-    );
-    assert!(!replenishment_demand.is_ready());
-}
-
-#[test]
-fn crawler_replenishment_restores_failed_dial_demand() {
-    let mut replenishment_demand = ReplenishmentDemand::default();
-    replenishment_demand.replace(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
-
-    assert!(replenishment_demand.take());
-    replenishment_demand.restore(3);
-
-    assert_eq!(replenishment_demand.remaining(), 3);
-    assert!(replenishment_demand.is_ready());
-}
-
 #[tokio::test(start_paused = true)]
 async fn crawler_startup_demand_satisfies_replenishment() {
     let mut harness = spawn_replenishment_crawler(
@@ -580,26 +529,6 @@ async fn crawler_demand_arriving_during_crawl_counts_toward_target() {
     harness.wait_for_crawl_start().await;
     harness.queue_demand(4);
     harness.release_crawl();
-    harness
-        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
-        .await;
-}
-
-#[tokio::test(start_paused = true)]
-async fn crawler_no_candidate_does_not_spend_replenishment_demand() {
-    let mut harness = spawn_replenishment_crawler_with_candidates(
-        0,
-        0,
-        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
-        false,
-    )
-    .await;
-
-    harness.wait_for_crawl_start().await;
-    harness.release_crawl();
-    harness.wait_for_no_candidate_replenishment_pause().await;
-    harness.add_candidates(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS);
-    harness.queue_demand(1);
     harness
         .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
         .await;
@@ -2079,8 +2008,6 @@ struct ReplenishmentCrawlerTestHarness {
     address_book_updater_guard: JoinHandle<Result<(), BoxError>>,
     _peerset_rx: mpsc::Receiver<DiscoveredPeer>,
     initial_connection_trackers: Vec<ConnectionTracker>,
-    address_book: Arc<std::sync::Mutex<AddressBook>>,
-    next_candidate_address: usize,
 }
 
 impl ReplenishmentCrawlerTestHarness {
@@ -2105,32 +2032,6 @@ impl ReplenishmentCrawlerTestHarness {
                 .try_send(MorePeers)
                 .expect("replenishment test demand channel has capacity");
         }
-    }
-
-    fn add_candidates(&mut self, candidate_count: usize) {
-        add_replenishment_candidates(
-            &self.address_book,
-            self.next_candidate_address,
-            candidate_count,
-        );
-        self.next_candidate_address = self
-            .next_candidate_address
-            .checked_add(candidate_count)
-            .expect("small replenishment test candidate count does not overflow");
-    }
-
-    async fn wait_for_no_candidate_replenishment_pause(&mut self) {
-        for _ in 0..CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS {
-            tokio::task::spawn_blocking(|| {})
-                .await
-                .expect("crawler test blocking-task synchronization should not panic");
-            tokio::task::yield_now().await;
-        }
-
-        assert!(
-            self.connection_tracker_rx.try_recv().is_err(),
-            "crawler should not dial when the candidate set is empty"
-        );
     }
 
     fn drop_initial_connections(&mut self, connection_count: usize) {
@@ -2215,21 +2116,6 @@ async fn spawn_replenishment_crawler(
     initial_demand_count: usize,
     crawl_new_peer_interval: Duration,
 ) -> ReplenishmentCrawlerTestHarness {
-    spawn_replenishment_crawler_with_candidates(
-        initial_connection_count,
-        initial_demand_count,
-        crawl_new_peer_interval,
-        true,
-    )
-    .await
-}
-
-async fn spawn_replenishment_crawler_with_candidates(
-    initial_connection_count: usize,
-    initial_demand_count: usize,
-    crawl_new_peer_interval: Duration,
-    add_initial_candidates: bool,
-) -> ReplenishmentCrawlerTestHarness {
     let config = Config {
         peerset_initial_target_size: CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
         crawl_new_peer_interval,
@@ -2246,6 +2132,29 @@ async fn spawn_replenishment_crawler_with_candidates(
         _address_metrics,
         address_book_updater_guard,
     ) = AddressBookUpdater::spawn(&config, config.listen_addr, PeerServices::NODE_NETWORK);
+
+    let candidate_count = outbound_connection_limit
+        .saturating_mul(2)
+        .saturating_add(1);
+    for address_number in 0..candidate_count {
+        let address_number =
+            u32::try_from(address_number).expect("small replenishment test address count fits u32");
+        let ip =
+            Ipv4Addr::from(u32::from(Ipv4Addr::new(127, 2, 0, 0)).saturating_add(address_number));
+        let addr = MetaAddr::new_gossiped_meta_addr(
+            SocketAddr::new(ip.into(), 8233).into(),
+            PeerServices::NODE_NETWORK,
+            DateTime32::now(),
+        )
+        .new_gossiped_change()
+        .expect("replenishment test peer has valid gossiped address fields");
+
+        address_book
+            .lock()
+            .expect("previous test thread panicked while holding the address book")
+            .update(addr)
+            .expect("replenishment test peer is valid");
+    }
 
     let (crawl_started_tx, crawl_started_rx) = tokio::sync::mpsc::unbounded_channel();
     let (crawl_release_tx, crawl_release_rx) = tokio::sync::watch::channel(false);
@@ -2269,18 +2178,7 @@ async fn spawn_replenishment_crawler_with_candidates(
             Err::<Response, BoxError>("controlled peer crawl returns no addresses".into())
         }
     });
-
-    let candidate_count = outbound_connection_limit
-        .saturating_mul(2)
-        .saturating_add(1);
-    let initial_candidate_count = if add_initial_candidates {
-        candidate_count
-    } else {
-        0
-    };
-    add_replenishment_candidates(&address_book, 0, initial_candidate_count);
-
-    let candidates = CandidateSet::new(address_book.clone(), controlled_peer_set);
+    let candidates = CandidateSet::new(address_book, controlled_peer_set);
 
     let channel_capacity = candidate_count.max(initial_demand_count);
     let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(channel_capacity);
@@ -2339,38 +2237,6 @@ async fn spawn_replenishment_crawler_with_candidates(
         address_book_updater_guard,
         _peerset_rx: peerset_rx,
         initial_connection_trackers,
-        address_book,
-        next_candidate_address: initial_candidate_count,
-    }
-}
-
-fn add_replenishment_candidates(
-    address_book: &Arc<std::sync::Mutex<AddressBook>>,
-    first_candidate_address: usize,
-    candidate_count: usize,
-) {
-    let last_candidate_address = first_candidate_address
-        .checked_add(candidate_count)
-        .expect("small replenishment test candidate count does not overflow");
-
-    for address_number in first_candidate_address..last_candidate_address {
-        let address_number =
-            u32::try_from(address_number).expect("small replenishment test address count fits u32");
-        let ip =
-            Ipv4Addr::from(u32::from(Ipv4Addr::new(127, 2, 0, 0)).saturating_add(address_number));
-        let addr = MetaAddr::new_gossiped_meta_addr(
-            SocketAddr::new(ip.into(), 8233).into(),
-            PeerServices::NODE_NETWORK,
-            DateTime32::now(),
-        )
-        .new_gossiped_change()
-        .expect("replenishment test peer has valid gossiped address fields");
-
-        address_book
-            .lock()
-            .expect("previous test thread panicked while holding the address book")
-            .update(addr)
-            .expect("replenishment test peer is valid");
     }
 }
 


### PR DESCRIPTION
## Motivation

The periodic peer crawler only forced a new outbound connection attempt when
every outbound connection was gone. After stalled or otherwise unhealthy peers
disconnected, a node could retain a small nonzero peer set indefinitely because
losing a slot did not itself create crawler demand.

## Solution

After each periodic crawl completes, recompute the outbound peer deficit to 27%
of the configured connection limit. For the default 300-peer outbound limit, a
node with no active or pending outbound connections starts 81 connection
attempts instead of recovering one peer per 61-second tick.

The crawler uses a best-effort atomic demand counter. Each completed periodic
crawl replaces the counter with the freshly observed deficit. Existing queued
demand has priority, and every consumed demand action saturating-decrements the
counter, including actions that crawl instead of dialing. A later periodic
crawl refreshes any demand lost to candidate misses or failed attempts.

The loop rechecks the active-plus-reserved count and reserves each slot
synchronously before spawning its handshake. Reaching the hard outbound limit
clears the best-effort replenishment counter.

Candidate selection continues to serialize and pace outbound handshakes at
100 ms intervals, and the existing hard outbound limit remains authoritative.

The threshold calculation rounds partial peers upward without overflowing and
preserves a zero connection limit.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network crawler_ -- --nocapture` (15 tests)
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/462.md --config .trunk/configs/.markdownlint.yaml`

The unrestricted full crate run passed 1,161 tests. Three unrelated
zcashd-compat listener tests could not bind their alternate loopback source
addresses on the local macOS host (`AddrNotAvailable`).

## Changelog

Added `changelog-unreleased/462.md` under `Fixed`.

### Specifications & References

This addresses peer-set depletion after crawler-managed connections disconnect.
