### PR TITLE
Expand the legacy peer cache

### DIFF
--- a/zakura-network/src/address_book.rs
+++ b/zakura-network/src/address_book.rs
@@ -541,8 +541,8 @@ impl AddressBook {
 
         let peers = self.peers.clone();
 
-        // Get peers in preferred order, then keep the recently active ones
-        peers
+        // Get peers in preferred order, then keep the recently active ones.
+        let mut peers: Vec<_> = peers
             .ordered_values()
             // # Security
             //
@@ -554,7 +554,13 @@ impl AddressBook {
             // which improves startup time and reliability.
             .filter(|addr| addr.is_active_for_gossip(now))
             .cloned()
-            .collect()
+            .collect();
+
+        // Prefer direct local evidence over unverified gossiped timestamps,
+        // while preserving the existing order within each group.
+        peers.sort_by_key(|peer| peer.last_response().is_none());
+
+        peers
     }
 
     /// Look up `addr` in the address book, and return its [`MetaAddr`].

--- a/zakura-network/src/address_book/tests/vectors.rs
+++ b/zakura-network/src/address_book/tests/vectors.rs
@@ -260,6 +260,40 @@ fn reconnection_peers_skips_recently_updated_ip() {
     });
 }
 
+/// Check that the cache prefers locally observed peers over gossiped peers.
+#[test]
+fn cacheable_prefers_locally_observed_peers() {
+    let locally_observed_addr = "127.0.0.1:1".parse().unwrap();
+    let gossiped_addr = "127.0.0.2:1".parse().unwrap();
+    let now = Utc::now();
+
+    let locally_observed = MetaAddr::new_responded(locally_observed_addr, None)
+        .into_new_meta_addr(Instant::now(), now.try_into().unwrap());
+    let gossiped = MetaAddr::new_gossiped_meta_addr(
+        gossiped_addr,
+        PeerServices::NODE_NETWORK,
+        now.try_into().unwrap(),
+    );
+    let mut address_book = AddressBook::new_with_addrs(
+        "0.0.0.0:0".parse().unwrap(),
+        &Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
+        MAX_ADDRS_IN_ADDRESS_BOOK,
+        Span::current(),
+        [locally_observed, gossiped],
+    );
+
+    // A later failure does not erase the stronger evidence that this peer
+    // responded to us.
+    address_book.update(MetaAddr::new_errored(locally_observed_addr, None));
+
+    let cacheable = address_book.cacheable(Utc::now());
+
+    assert_eq!(cacheable.len(), 2);
+    assert_eq!(cacheable[0].addr, locally_observed_addr);
+    assert_eq!(cacheable[1].addr, gossiped_addr);
+}
+
 fn test_reconnection_peers_skips_recently_updated_ip<
     M: Fn(crate::PeerSocketAddr) -> crate::meta_addr::MetaAddrChange,
 >(

--- a/zakura-network/src/constants.rs
+++ b/zakura-network/src/constants.rs
@@ -170,10 +170,12 @@ pub const PEER_DISK_CACHE_UPDATE_INTERVAL: Duration = Duration::from_secs(5 * 60
 
 /// The maximum number of addresses in the peer disk cache.
 ///
-/// This is chosen to be less than the number of active peers,
-/// and approximately the same as the number of seed peers returned by DNS.
-/// It is a tradeoff between fingerprinting attacks, DNS pollution risk, and cache pollution risk.
-pub const MAX_PEER_DISK_CACHE_SIZE: usize = 75;
+/// This is less than the default hard outbound limit of
+/// [`DEFAULT_PEERSET_INITIAL_TARGET_SIZE`] * [`OUTBOUND_PEER_LIMIT_MULTIPLIER`]
+/// (300). Loading the cache does not open every entry; the connection limit is
+/// independently enforced. The cache size is a tradeoff between fingerprinting
+/// attacks, DNS pollution risk, and cache pollution risk.
+pub const MAX_PEER_DISK_CACHE_SIZE: usize = 125;
 
 /// The maximum duration since a peer was last seen to consider it reachable.
 ///

--- a/zakura-network/src/peer_cache_updater.rs
+++ b/zakura-network/src/peer_cache_updater.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use tokio::time::sleep;
 
 use crate::{
-    constants::{DNS_LOOKUP_TIMEOUT, PEER_DISK_CACHE_UPDATE_INTERVAL},
+    constants::{DNS_LOOKUP_TIMEOUT, MAX_PEER_DISK_CACHE_SIZE, PEER_DISK_CACHE_UPDATE_INTERVAL},
     meta_addr::MetaAddr,
     AddressBook, BoxError, Config,
 };
@@ -42,7 +42,8 @@ pub async fn update_peer_cache_once(
     address_book: &Arc<Mutex<AddressBook>>,
 ) -> io::Result<()> {
     let peer_list = cacheable_peers(address_book)
-        .iter()
+        .into_iter()
+        .take(MAX_PEER_DISK_CACHE_SIZE)
         .map(|meta_addr| meta_addr.addr)
         .collect();
 

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -75,7 +75,7 @@
 //! to isolated peers and increases the chance of an eclipse attack on some peers of the network.
 //!
 //! Zebra does not gradually migrate its peers as it approaches an activation height. This is
-//! because Zebra by default can connect to up to 75 peers, as can be seen in [`Config::default`].
+//! because Zebra by default can connect to up to 300 peers, as can be seen in [`Config::default`].
 //! Since this is a lot larger than the 8 peers Zcashd connects to, an eclipse attack becomes a lot
 //! more costly to execute, and the probability of an abrupt network partition that isolates peers
 //! is lower.


### PR DESCRIPTION
## Summary

- increase the legacy peer disk cache from 75 to 125 addresses
- prefer recently active peers that have responded locally over peers known only through gossip
- select the preferred subset before converting it to a `HashSet`
- retain the final lexicographic file sort so cache ordering does not expose selection priority or connection timing
- correct stale rustdoc that described the default hard outbound limit as 75 rather than 300

## Why this is safe

The default legacy peer target is 100 and the hard outbound multiplier is 3, so the current default hard outbound limit is 300. A 125-address disk cache remains well below that limit.

Loading the cache does not dial every cached address. Startup connection attempts remain capped by the existing target, and all later connections remain subject to the independently enforced outbound limit. The existing three-hour activity filter is unchanged.

Prioritizing peers with `last_response.is_some()` uses stronger local evidence than an unverified gossiped timestamp. A peer remains in that preferred group if it responded previously and a later connection attempt failed.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network cacheable_prefers_locally_observed_peers`
- `cargo test -p zakura-network peer_cache`
- `git diff --check`

## API surface

- changes the public `MAX_PEER_DISK_CACHE_SIZE` constant value from 75 to 125
- no function signatures, visibility, traits, enum variants, constructors, or type aliases change