### PR TITLE
fix(state): serve embedded VCT frontier roots at handoff

### DIFF
--- a/changelog-unreleased/464.md
+++ b/changelog-unreleased/464.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed Mainnet genesis VCT sync failing closed at the handoff height by serving
+  embedded frontier roots from `PeerSource` when no authenticated DB root exists
+  at that height
+  ([#464](https://github.com/zakura-core/zakura/pull/464)).

--- a/zakura-state/src/service/finalized_state/commitment_aux.rs
+++ b/zakura-state/src/service/finalized_state/commitment_aux.rs
@@ -439,6 +439,12 @@ impl CommitmentRootSource for FixtureSource {
 /// immutably here and never fetched over the network — a peer source always has one,
 /// because peer mode is only selected on networks with an embedded frontier. Committed
 /// rows are cleaned up by the database's own retention, not through this seam.
+///
+/// At the handoff height itself the header-root lane never promotes a peer row: checkpoint
+/// header `C` is only the final pinned witness for `C - 1`, and no later configured
+/// checkpoint can authenticate a successor at `C + 1`. [`Self::vct_root`] therefore returns
+/// the embedded frontier roots at `C` so the handoff commit can verify the block commitment
+/// against that reviewed frontier (design §13.2) instead of stalling on a missing DB row.
 #[derive(Debug)]
 pub(super) struct PeerSource {
     db: ZakuraDb,
@@ -462,6 +468,16 @@ impl CommitmentRootSource for PeerSource {
         orchard::tree::Root,
         ironwood::tree::Root,
     )> {
+        // Header-root authentication promotes through C-1 only. Serve the embedded
+        // handoff frontier roots at C so body commit can finish the fast sync.
+        if height == self.frontiers.height {
+            return Some((
+                self.frontiers.sapling.root(),
+                self.frontiers.orchard.root(),
+                self.frontiers.ironwood.root(),
+            ));
+        }
+
         self.db
             .commitment_roots_by_height_range(height..=height)
             .into_iter()
@@ -1484,6 +1500,42 @@ mod tests {
                 ironwood::tree::NoteCommitmentTree::default().root(),
             )),
             "a re-read returns the same authenticated row below the frontier"
+        );
+    }
+
+    /// The header-root lane never writes an authenticated row at the handoff height, so
+    /// [`PeerSource`] must still expose the embedded frontier roots there for commit.
+    #[test]
+    fn peer_source_serves_embedded_frontier_roots_at_handoff() {
+        let db = ephemeral_mainnet_db();
+
+        let handoff = block::Height(50);
+        let frontiers = FinalFrontiers {
+            height: handoff,
+            sapling: Arc::new(Default::default()),
+            orchard: Arc::new(Default::default()),
+            sprout: Arc::new(Default::default()),
+            ironwood: Arc::new(Default::default()),
+        };
+        let expected = (
+            frontiers.sapling.root(),
+            frontiers.orchard.root(),
+            frontiers.ironwood.root(),
+        );
+        let source = PeerSource::new(db, frontiers);
+
+        assert!(
+            source.vct_root(block::Height(49)).is_none(),
+            "heights below the handoff still require an authenticated DB row"
+        );
+        assert_eq!(
+            source.vct_root(handoff),
+            Some(expected),
+            "handoff height is served from the embedded frontiers without a DB row"
+        );
+        assert!(
+            source.vct_root(block::Height(51)).is_none(),
+            "heights above the handoff are never served by PeerSource"
         );
     }
 }

--- a/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -2612,3 +2612,125 @@ fn vct_peer_source_filled_incrementally_drives_byte_identical_state() -> Result<
 
     Ok(())
 }
+
+/// Production PeerSource never receives an authenticated DB row at the handoff height
+/// (header-root auth promotes through C-1 only). Committing the handoff must still
+/// succeed by reading the embedded frontier roots from [`commitment_aux::PeerSource`].
+#[test]
+#[allow(clippy::needless_range_loop)] // the loops index blocks[i+1] and by height
+fn vct_peer_source_handoff_without_db_root_at_c() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    let network = early_upgrade_network();
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 activation height is configured");
+    // Handoff at NU5 + 3, plus one trailing block for below-handoff successor witnesses.
+    let tested_block_count =
+        usize::try_from(nu5_height.0 + 5).expect("test activation height fits in usize");
+    let ledger_strategy =
+        LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
+
+    proptest!(ProptestConfig::with_cases(1),
+        |((chain, network) in super::valid_commitment_chain(ledger_strategy, tested_block_count).no_shrink())| {
+
+            let blocks: Vec<_> = chain.iter().collect();
+            let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0;
+            let heartwood = NetworkUpgrade::Heartwood.activation_height(&network).unwrap().0;
+            let last = (nu5 + 3) as usize;
+            prop_assert!(blocks.len() > last + 1, "generated chain unexpectedly short");
+            let seed = (heartwood - 1) as usize;
+            let handoff = Height(last as u32);
+
+            let mut legacy = FinalizedState::new(&Config::ephemeral(), &network)
+                .expect("opening an ephemeral database should succeed");
+            let mut handoff_trees = None;
+            for i in 0..=last {
+                let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
+                let (_h, trees) = legacy
+                    .commit_finalized_direct(cv.into(), None, None, "vct peer handoff legacy")
+                    .unwrap();
+                if i == last {
+                    handoff_trees = Some(trees);
+                }
+            }
+            let handoff_trees = handoff_trees.expect("committed the handoff block");
+            let golden_anchors = legacy.db.vct_anchor_digest();
+            let golden_history = legacy.db.history_tree().hash();
+            let golden_tip = legacy.db.note_commitment_trees_for_tip().unwrap();
+
+            // Authenticated roots through C-1 only — the production header-root lane
+            // never promotes a row at C.
+            let below_handoff_roots = commitment_aux::produce_block_roots(
+                &legacy.db,
+                Height((seed + 1) as u32)..=Height((last as u32) - 1),
+            );
+            prop_assert!(
+                !below_handoff_roots.iter().any(|root| root.height == handoff),
+                "the fixture must omit the handoff root from the authenticated index"
+            );
+
+            let mut fast = FinalizedState::new(&Config::ephemeral(), &network)
+                .expect("opening an ephemeral database should succeed");
+            fast.db
+                .insert_zakura_header_commitment_roots(below_handoff_roots)
+                .expect("writing below-handoff header-sync roots succeeds");
+            let peer_source = commitment_aux::PeerSource::new(
+                fast.db.clone(),
+                commitment_aux::FinalFrontiers {
+                    height: handoff,
+                    sapling: handoff_trees.sapling.clone(),
+                    orchard: handoff_trees.orchard.clone(),
+                    sprout: handoff_trees.sprout.clone(),
+                    ironwood: handoff_trees.ironwood.clone(),
+                },
+            );
+            fast.enable_vct_fast_source(Box::new(peer_source), true);
+
+            for i in 0..=last {
+                let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
+                let next = (i < last).then(|| vct_successor_header(blocks[i + 1].block.clone()));
+                fast.commit_finalized_direct(
+                    cv.into(),
+                    None,
+                    next,
+                    "vct peer handoff without DB root at C",
+                )
+                .expect("handoff commit must succeed from embedded frontier roots");
+            }
+
+            prop_assert_eq!(
+                fast.vct_fast_synced_below(),
+                Some(handoff),
+                "fast-sync marker is set to the handoff height"
+            );
+            prop_assert_eq!(
+                fast.db.vct_anchor_digest(),
+                golden_anchors,
+                "fast anchors must match legacy after a PeerSource handoff"
+            );
+            prop_assert_eq!(
+                fast.db.history_tree().hash(),
+                golden_history,
+                "fast history must match legacy after a PeerSource handoff"
+            );
+            let fast_tip = fast.db.note_commitment_trees_for_tip().unwrap();
+            prop_assert_eq!(
+                fast_tip.sapling.root(),
+                golden_tip.sapling.root(),
+                "tip sapling frontier must match legacy"
+            );
+            prop_assert_eq!(
+                fast_tip.orchard.root(),
+                golden_tip.orchard.root(),
+                "tip orchard frontier must match legacy"
+            );
+            prop_assert_eq!(
+                fast_tip.sprout.root(),
+                golden_tip.sprout.root(),
+                "tip sprout frontier must match legacy"
+            );
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Genesis VCT sync fail-closed at Mainnet handoff height `C = 3418406`, leaving the tip stuck at `3418405`. Observed on continuous-sync node `temp-zakura-sync-test-7` (dual-stack): after ~10 minutes of

```text
VCT: no verifiable supplied root for a frozen-frontier height; refusing to recompute (retryable) height=Height(3418406)
```

the controller halted the run for stall, and the Slack monitor later posted a DOWN alert because `zakura.service` was already stopped.

### How we regressed

This worked before header-root authentication ([#352](https://github.com/zakura-core/zakura/pull/352)) and broke when that PR landed.

**Before #352**, header sync wrote peer `tree_aux` roots into the DB as provisional rows ahead of body commit, including at handoff height `C`. `PeerSource::vct_root` was a plain DB lookup, so commit of `C` found a row and finished. Handoff “worked” because a provisional peer write papered over `C` — not because handoff was specially handled.

**#352** correctly stopped promoting unauthenticated peer roots past `C - 1`: there is no later configured checkpoint to witness a successor at `C + 1`, so the authenticated index never gets a row at `C` (design §13.2). `PeerSource` still only read DB rows and was never taught to fall back to the embedded frontier at `C`.

So the same commit path that used to see a provisional row at `C` now sees `None`, fail-closes, and retries forever. Last successful continuous-sync on this host was Jul 22; #352 merged Jul 23; this stall reproduced Jul 26.

## Solution

At the VCT handoff height, `PeerSource::vct_root` returns the embedded frontier roots instead of requiring a DB row that header-root auth never writes at `C`. Heights below `C` still require authenticated DB rows; heights above `C` are unchanged.

## Testing

- Unit test `peer_source_serves_embedded_frontier_roots_at_handoff` in `commitment_aux.rs`
- Property test `vct_peer_source_handoff_without_db_root_at_c` in `prop.rs` (authenticated roots through `C - 1` only; handoff commit must still succeed and match legacy)
- Manual validation: fixed binary on `temp-zakura-sync-test-7` advanced tip past `3418406`

## Changelog

- `changelog-unreleased/464.md` — user-visible Fixed entry

### Specifications & References

- `docs/design/header-sync-vct-root-authentication.md` §13.2 (handoff at the last checkpoint with embedded frontier)
- Regression introduced by [#352](https://github.com/zakura-core/zakura/pull/352)

### Follow-up Work

- CI gate that syncs through the VCT handoff (e.g. revive pre-checkpoint PR-node mode from [#310](https://github.com/zakura-core/zakura/pull/310)) so this seam cannot land again without a real crossing