### PR TITLE
fix(network): stop connection-state metrics from leaking per-peer series

### DIFF
--- a/changelog-unreleased/467.md
+++ b/changelog-unreleased/467.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed Prometheus cardinality growth for `zakura.net.connection.state` by
+  aggregating live connections by command instead of retaining historical
+  per-peer address series
+  ([#467](https://github.com/zakura-core/zakura/pull/467)).

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -163,6 +163,12 @@ Alert ownership matches the original temporary-node script:
 The status helper reports service state, metrics reachability, current block
 height, controller state, and the diagnostic paths included in Slack alerts.
 
+Down alerts fire when the controller is halted or `zakura.service` is inactive
+while a sync is expected. A metrics scrape timeout or error alone does not page
+as down while the service stays active (those are logged as
+`metrics-degraded`), because `/metrics` can grow large during long genesis
+syncs when historical per-peer series accumulate.
+
 ## Completion Criteria
 
 The controller requires several consecutive `/ready` successes before declaring

--- a/deploy/continuous-sync/alert-monitor.py
+++ b/deploy/continuous-sync/alert-monitor.py
@@ -123,6 +123,14 @@ def node_healthy(status: dict[str, Any]) -> bool:
     )
 
 
+def metrics_degraded(status: dict[str, Any]) -> bool:
+    """True when zakurad is up but /metrics could not be scraped successfully."""
+    return (
+        status.get("service_active") is True
+        and status.get("metrics_status") != "ok"
+    )
+
+
 def controller_phase(status: dict[str, Any]) -> str:
     controller_state = status.get("controller_state")
     if not isinstance(controller_state, dict):
@@ -331,9 +339,15 @@ def run_once(config: dict[str, Any]) -> int:
             if expects_node_service(status) and status.get("service_active") is not True:
                 down = True
                 reasons.append(f"{service_name} is not active")
-            if expects_node_service(status) and status.get("metrics_status") != "ok":
-                down = True
-                reasons.append(f"metrics endpoint is {status.get('metrics_status')}")
+            # Metrics scrape failures alone are not "node down": long genesis syncs
+            # can make /metrics large/slow while zakurad keeps syncing. Treat those
+            # as degraded and log them; only inactive service / controller halt page.
+            if expects_node_service(status) and metrics_degraded(status):
+                log(
+                    config,
+                    f"metrics-degraded host={name} "
+                    f"metrics={status.get('metrics_status')} service_active=True",
+                )
         node_record = state.setdefault("nodes", {}).setdefault(name, {})
         if down:
             node_record["consecutive_down_samples"] = int(

--- a/deploy/continuous-sync/alert-monitor.py
+++ b/deploy/continuous-sync/alert-monitor.py
@@ -59,7 +59,7 @@ def log(config: dict[str, Any], message: str) -> None:
         file.write(time.strftime("%Y-%m-%dT%H:%M:%S%z ") + message + "\n")
 
 
-def run_json(cmd: list[str], timeout: int = 8) -> tuple[dict[str, Any] | None, str | None]:
+def run_json(cmd: list[str], timeout: int = 20) -> tuple[dict[str, Any] | None, str | None]:
     try:
         result = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
     except Exception as exc:

--- a/deploy/continuous-sync/alert-status.py
+++ b/deploy/continuous-sync/alert-status.py
@@ -12,6 +12,11 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+# Full /metrics scrapes can exceed several MB during long syncs when historical
+# per-peer series accumulate. Prefer a generous timeout and read the whole body
+# so height gauges near the end of the exposition are still visible.
+METRICS_TIMEOUT_SECONDS = 15
+
 
 def load_config(path: Path) -> dict[str, Any]:
     with path.open("rb") as config_file:
@@ -109,8 +114,8 @@ def status(config: dict[str, Any]) -> dict[str, Any]:
     metrics_status = "unavailable"
     height = None
     try:
-        with urllib.request.urlopen(metrics_url, timeout=3) as response:
-            metrics = response.read(2_000_000).decode("utf-8", "replace")
+        with urllib.request.urlopen(metrics_url, timeout=METRICS_TIMEOUT_SECONDS) as response:
+            metrics = response.read().decode("utf-8", "replace")
         metrics_status = "ok"
         height = metric_height(metrics)
     except Exception as exc:

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -421,7 +421,7 @@ def service_active(config: Config) -> bool:
     ).returncode == 0
 
 
-def fetch_text(url: str, timeout: int = 10) -> str:
+def fetch_text(url: str, timeout: int = 15) -> str:
     with urllib.request.urlopen(url, timeout=timeout) as response:
         return response.read().decode("utf-8", errors="replace")
 

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -276,6 +276,46 @@ class ContinuousSyncTests(unittest.TestCase):
                 alert.run_once(config)
                 post_alert.assert_called_once()
 
+    def test_metrics_degraded_while_service_active_does_not_page_down(self):
+        hostname = "temp-zakura-sync-test-6"
+        status = {
+            "hostname": hostname,
+            "public_ip": "138.68.249.46",
+            "mode": "Zebra/legacy-only",
+            "service": "zakura.service",
+            "service_active": True,
+            "metrics_status": "unavailable: TimeoutError",
+            "height": None,
+            "connection": "root@138.68.249.46",
+            "alias_connection": f"ssh {hostname}",
+            "log_path": "/tmp/zebrad.log",
+            "trace_path": "/tmp/traces",
+            "monitor_log_path": "/tmp/monitor.log",
+            "controller_state": {"phase": "syncing", "failed": False},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            config = {
+                "defaults": {
+                    "alert_state_file": str(Path(tmp) / "state.json"),
+                    "monitor_log": str(Path(tmp) / "monitor.log"),
+                    "down_confirmation_samples": 2,
+                },
+                "nodes": [{"hostname": hostname}],
+            }
+            with (
+                patch.object(alert, "query_node", return_value=status),
+                patch.object(alert.socket, "gethostname", return_value=hostname),
+                patch.object(alert, "post_alert", return_value=True) as post_alert,
+            ):
+                alert.run_once(config)
+                alert.run_once(config)
+                post_alert.assert_not_called()
+
+            log_text = (Path(tmp) / "monitor.log").read_text(encoding="utf-8")
+            self.assertIn("metrics-degraded", log_text)
+            self.assertTrue(alert.metrics_degraded(status))
+            self.assertFalse(alert.node_healthy(status))
+
     def test_controller_failure_alerts_immediately(self):
         hostname = "temp-zakura-sync-test-1"
         status = {

--- a/zakura-network/src/peer/connection.rs
+++ b/zakura-network/src/peer/connection.rs
@@ -1724,6 +1724,10 @@ where
 {
     /// Update the connection state metrics for this connection,
     /// using `extra_state_info` as additional state information.
+    ///
+    /// Counts live connections by `command` only. Per-addr gauges are not used:
+    /// setting them to zero after disconnect still leaves zombie series in the
+    /// Prometheus exporter and balloons `/metrics` during long syncs.
     fn update_state_metrics(&mut self, extra_state_info: impl Into<Option<String>>) {
         let current_metrics_state = if let Some(extra_state_info) = extra_state_info.into() {
             format!("{}::{extra_state_info}", self.state.command()).into()
@@ -1737,26 +1741,24 @@ where
 
         self.erase_state_metrics();
 
-        // Set the new state
+        // Count this connection in the aggregate live-state gauge.
         metrics::gauge!(
             "zakura.net.connection.state",
             "command" => current_metrics_state.clone(),
-            "addr" => self.addr_label.clone(),
         )
         .increment(1.0);
 
         self.last_metrics_state = Some(current_metrics_state);
     }
 
-    /// Erase the connection state metrics for this connection.
+    /// Decrement the aggregate connection state gauge for this connection.
     fn erase_state_metrics(&mut self) {
         if let Some(last_metrics_state) = self.last_metrics_state.take() {
             metrics::gauge!(
                 "zakura.net.connection.state",
                 "command" => last_metrics_state,
-                "addr" => self.addr_label.clone(),
             )
-            .set(0.0);
+            .decrement(1.0);
         }
     }
 


### PR DESCRIPTION
## Motivation

Continuous-sync node `temp-zakura-sync-test-6` was flapping Slack "Zakura down" / recovered alerts while `zakura.service` stayed active and kept syncing.

Root cause: `zakura.net.connection.state` retained a Prometheus gauge series for every historical `addr` × `command` pair. Setting gauges to `0` on disconnect does not remove them from the exporter, so a long genesis sync grew `/metrics` to ~22 MB (~116k connection-state series). The alert helper's short scrape then timed out and the monitor treated that as node-down.

## Solution

- Aggregate `zakura.net.connection.state` by `command` only, using increment/decrement for live connections instead of per-`addr` zeroed gauges.
- Harden continuous-sync monitoring:
  - scrape `/metrics` with a 15s timeout and read the full body
  - when `zakura.service` is active, log metrics scrape failures as `metrics-degraded` instead of paging "down"

## Testing

- `python3 -m unittest deploy.continuous-sync.tests.test_continuous_sync`
- `cargo check -p zakura-network --locked`
- Deployed the infra scripts to `temp-zakura-sync-test-6` with `--no-start`; status now reports height correctly and services stayed active

## Changelog

- `changelog-unreleased/467.md`