### PR TITLE
fix(rpc): report pruned storage mode and add pruneheight to getblockchaininfo

### DIFF
--- a/changelog-unreleased/470.md
+++ b/changelog-unreleased/470.md
@@ -1,0 +1,29 @@
+## Added
+
+- Added the `pruneheight` field to `getblockchaininfo`, reporting the lowest
+  height at and above which every block body is retained. As in `zcashd`, it is
+  only present when `pruned` is true. Zakura prunes raw transaction data rather
+  than whole blocks, so blocks below this height keep their headers, transaction
+  IDs, and consensus state, and the genesis block is never pruned
+  ([#470](https://github.com/zakura-core/zakura/pull/470)).
+
+## Changed
+
+- Changed the read-request metric label `is_pruned` to `pruning_info`, because
+  the request now reports the prune height alongside the pruned flag. Dashboards
+  and alerts keyed on the old label need updating
+  ([#470](https://github.com/zakura-core/zakura/pull/470)).
+- Changed the public `GetBlockchainInfoResponse::new()` in `zakura-rpc` to take
+  a `prune_height` argument, so that downstream callers can set the new field.
+  This breaks existing callers of that constructor
+  ([#470](https://github.com/zakura-core/zakura/pull/470)).
+
+## Fixed
+
+- Fixed `getblockchaininfo` reporting `pruned: false` on a node configured with
+  `storage_mode.pruned` until it first deleted block data, which took at least
+  10,000 blocks on Mainnet and Testnet and longer when pruning was enabled on an
+  existing archive database. As in `zcashd`, the field now reports whether blocks
+  are subject to pruning, not whether any block has been deleted yet. Databases
+  that had already pruned were unaffected
+  ([#470](https://github.com/zakura-core/zakura/pull/470)).

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -1018,26 +1018,37 @@ where
         let debug_force_finished_sync = self.debug_force_finished_sync;
         let network = &self.network;
 
-        let (usage_info_rsp, is_pruned_rsp, tip_pool_values_rsp, chain_tip_difficulty) = {
+        let (usage_info_rsp, pruning_info_rsp, tip_pool_values_rsp, chain_tip_difficulty) = {
             use zakura_state::ReadRequest::*;
             let state_call = |request| self.read_state.clone().oneshot(request);
             tokio::join!(
                 state_call(UsageInfo),
-                state_call(IsPruned),
+                state_call(PruningInfo),
                 state_call(TipPoolValues),
                 chain_tip_difficulty(network.clone(), self.read_state.clone(), true)
             )
         };
 
-        let (size_on_disk, is_pruned, (tip_height, tip_hash), value_balance, difficulty) = {
+        let (
+            size_on_disk,
+            is_pruned,
+            prune_height,
+            (tip_height, tip_hash),
+            value_balance,
+            difficulty,
+        ) = {
             use zakura_state::ReadResponse::*;
 
             let UsageInfo(size_on_disk) = usage_info_rsp.map_misc_error()? else {
                 unreachable!("unmatched response to a UsageInfo request")
             };
 
-            let IsPruned(is_pruned) = is_pruned_rsp.map_misc_error()? else {
-                unreachable!("unmatched response to an IsPruned request")
+            let PruningInfo {
+                pruned: is_pruned,
+                prune_height,
+            } = pruning_info_rsp.map_misc_error()?
+            else {
+                unreachable!("unmatched response to a PruningInfo request")
             };
 
             let (tip, value_balance) = match tip_pool_values_rsp {
@@ -1053,7 +1064,14 @@ where
             let difficulty = chain_tip_difficulty
                 .expect("should always be Ok when `should_use_default` is true");
 
-            (size_on_disk, is_pruned, tip, value_balance, difficulty)
+            (
+                size_on_disk,
+                is_pruned,
+                prune_height,
+                tip,
+                value_balance,
+                difficulty,
+            )
         };
 
         let now = Utc::now();
@@ -1143,6 +1161,7 @@ where
             // TODO: store work in the finalized state for each height (#7109)
             chain_work: 0,
             pruned: is_pruned,
+            prune_height,
             size_on_disk,
             // TODO: Investigate whether this needs to be implemented (it's sprout-only in zcashd)
             commitments: 0,
@@ -3539,6 +3558,21 @@ pub struct GetBlockchainInfoResponse {
     /// runs in pruned storage mode or has already pruned historical data.
     pruned: bool,
 
+    /// The lowest height whose block body this node still stores, omitted when
+    /// [`pruned`](Self::pruned) is false.
+    ///
+    /// Zakura prunes raw transaction data, so blocks below this height still
+    /// have their headers, transaction IDs, and consensus state — only their
+    /// bodies cannot be served. The genesis block is never pruned, so its body
+    /// is available below this height too.
+    #[serde(
+        default,
+        rename = "pruneheight",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[getter(copy)]
+    prune_height: Option<Height>,
+
     /// The estimated size of the block and undo files on disk
     size_on_disk: u64,
 
@@ -3593,6 +3627,7 @@ impl Default for GetBlockchainInfoResponse {
             verification_progress: 0.0,
             chain_work: 0,
             pruned: false,
+            prune_height: None,
             size_on_disk: 0,
             commitments: 0,
         }
@@ -3618,6 +3653,7 @@ impl GetBlockchainInfoResponse {
         verification_progress: f64,
         chain_work: u64,
         pruned: bool,
+        prune_height: Option<Height>,
         size_on_disk: u64,
         commitments: u64,
     ) -> Self {
@@ -3635,6 +3671,7 @@ impl GetBlockchainInfoResponse {
             verification_progress,
             chain_work,
             pruned,
+            prune_height,
             size_on_disk,
             commitments,
         }

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -3535,7 +3535,8 @@ pub struct GetBlockchainInfoResponse {
     #[serde(rename = "chainwork")]
     chain_work: u64,
 
-    /// Whether this node is pruned, currently always false in Zebra.
+    /// Whether this node's blocks are subject to pruning, that is, whether it
+    /// runs in pruned storage mode or has already pruned historical data.
     pruned: bool,
 
     /// The estimated size of the block and undo files on disk

--- a/zakura-rpc/src/methods/tests/prop.rs
+++ b/zakura-rpc/src/methods/tests/prop.rs
@@ -395,10 +395,13 @@ proptest! {
                         .respond(zakura_state::ReadResponse::UsageInfo(0));
 
                     state
-                        .expect_request(zakura_state::ReadRequest::IsPruned)
+                        .expect_request(zakura_state::ReadRequest::PruningInfo)
                         .await
                         .expect("getblockchaininfo should call mock state service with correct request")
-                        .respond(zakura_state::ReadResponse::IsPruned(false));
+                        .respond(zakura_state::ReadResponse::PruningInfo {
+                            pruned: false,
+                            prune_height: None,
+                        });
 
                     state
                         .expect_request(zakura_state::ReadRequest::TipPoolValues)
@@ -458,6 +461,7 @@ proptest! {
         let block_hash = block.hash();
         let expected_size_on_disk = 1_000;
         let expected_is_pruned = true;
+        let expected_prune_height = Some(Height(1_000));
 
         // check no requests were made during this test
         runtime.block_on(async move {
@@ -472,10 +476,13 @@ proptest! {
                         .respond(zakura_state::ReadResponse::UsageInfo(expected_size_on_disk));
 
                     state
-                        .expect_request(zakura_state::ReadRequest::IsPruned)
+                        .expect_request(zakura_state::ReadRequest::PruningInfo)
                         .await
                         .expect("getblockchaininfo should call mock state service with correct request")
-                        .respond(zakura_state::ReadResponse::IsPruned(expected_is_pruned));
+                        .respond(zakura_state::ReadResponse::PruningInfo {
+                            pruned: expected_is_pruned,
+                            prune_height: expected_prune_height,
+                        });
 
                     state
                         .expect_request(zakura_state::ReadRequest::TipPoolValues)
@@ -513,6 +520,7 @@ proptest! {
                     prop_assert_eq!(info.best_block_hash, block_hash);
                     prop_assert_eq!(info.size_on_disk, expected_size_on_disk);
                     prop_assert_eq!(info.pruned, expected_is_pruned);
+                    prop_assert_eq!(info.prune_height, expected_prune_height);
                     prop_assert!(info.estimated_height < Height::MAX);
 
                     prop_assert_eq!(
@@ -589,10 +597,13 @@ proptest! {
                     .respond(zakura_state::ReadResponse::UsageInfo(expected_size_on_disk));
 
                 state
-                    .expect_request(zakura_state::ReadRequest::IsPruned)
+                    .expect_request(zakura_state::ReadRequest::PruningInfo)
                     .await
                     .expect("getblockchaininfo should call mock state service with correct request")
-                    .respond(zakura_state::ReadResponse::IsPruned(false));
+                    .respond(zakura_state::ReadResponse::PruningInfo {
+                            pruned: false,
+                            prune_height: None,
+                        });
 
                 state.expect_request(zakura_state::ReadRequest::TipPoolValues)
                     .await

--- a/zakura-rpc/tests/serialization_tests.rs
+++ b/zakura-rpc/tests/serialization_tests.rs
@@ -121,6 +121,7 @@ fn test_get_blockchain_info() -> Result<(), Box<dyn std::error::Error>> {
     let verification_progress = obj.verification_progress();
     let chain_work = obj.chain_work();
     let pruned = obj.pruned();
+    let prune_height = obj.prune_height();
     let size_on_disk = obj.size_on_disk();
     let commitments = obj.commitments();
     let best_block_hash = obj.best_block_hash();
@@ -144,6 +145,7 @@ fn test_get_blockchain_info() -> Result<(), Box<dyn std::error::Error>> {
         verification_progress,
         chain_work,
         pruned,
+        prune_height,
         size_on_disk,
         commitments,
     );

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -1289,11 +1289,10 @@ pub enum ReadRequest {
     /// with the current disk space usage in bytes.
     UsageInfo,
 
-    /// Returns [`ReadResponse::IsPruned(bool)`](ReadResponse::IsPruned)
-    /// with whether this node's block data is subject to pruning, because
-    /// pruned storage mode is configured or historical data has already been
-    /// pruned.
-    IsPruned,
+    /// Returns [`ReadResponse::PruningInfo`](ReadResponse::PruningInfo) with
+    /// whether this node's block data is subject to pruning, and the lowest
+    /// height at and above which every block body is retained.
+    PruningInfo,
 
     /// Returns [`ReadResponse::Tip(Option<(Height, block::Hash)>)`](ReadResponse::Tip)
     /// with the current best chain tip.
@@ -1721,7 +1720,7 @@ impl ReadRequest {
     pub fn variant_name(&self) -> &'static str {
         match self {
             ReadRequest::UsageInfo => "usage_info",
-            ReadRequest::IsPruned => "is_pruned",
+            ReadRequest::PruningInfo => "pruning_info",
             ReadRequest::Tip => "tip",
             ReadRequest::FinalizedTip => "finalized_tip",
             ReadRequest::TipPoolValues => "tip_pool_values",

--- a/zakura-state/src/request.rs
+++ b/zakura-state/src/request.rs
@@ -1290,7 +1290,9 @@ pub enum ReadRequest {
     UsageInfo,
 
     /// Returns [`ReadResponse::IsPruned(bool)`](ReadResponse::IsPruned)
-    /// with whether the database has pruned historical data.
+    /// with whether this node's block data is subject to pruning, because
+    /// pruned storage mode is configured or historical data has already been
+    /// pruned.
     IsPruned,
 
     /// Returns [`ReadResponse::Tip(Option<(Height, block::Hash)>)`](ReadResponse::Tip)

--- a/zakura-state/src/response.rs
+++ b/zakura-state/src/response.rs
@@ -374,10 +374,21 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::UsageInfo`] with the current best chain tip.
     UsageInfo(u64),
 
-    /// Response to [`ReadRequest::IsPruned`] with whether this node's block data
-    /// is subject to pruning, because pruned storage mode is configured or
-    /// historical data has already been pruned.
-    IsPruned(bool),
+    /// Response to [`ReadRequest::PruningInfo`] with this node's pruning status.
+    PruningInfo {
+        /// Whether this node's block data is subject to pruning, because pruned
+        /// storage mode is configured or historical data has already been
+        /// pruned.
+        pruned: bool,
+
+        /// The lowest height at and above which every block body is retained,
+        /// or `None` when this node does not prune.
+        ///
+        /// This is [`Height::MIN`](block::Height::MIN) while a pruning node has
+        /// not deleted anything yet. The genesis block is never pruned, so its
+        /// body is available even when this is a higher height.
+        prune_height: Option<block::Height>,
+    },
 
     /// Response to [`ReadRequest::BlockRoots`] with the per-block commitment roots
     /// this node holds for the requested range, in ascending height order.
@@ -644,7 +655,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::ValidBestChainTipNullifiersAndAnchors => Ok(Response::ValidBestChainTipNullifiersAndAnchors),
 
             ReadResponse::UsageInfo(_)
-            | ReadResponse::IsPruned(_)
+            | ReadResponse::PruningInfo { .. }
             | ReadResponse::BlockRoots(_)
             | ReadResponse::TipPoolValues { .. }
             | ReadResponse::BlockInfo(_)

--- a/zakura-state/src/response.rs
+++ b/zakura-state/src/response.rs
@@ -374,8 +374,9 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::UsageInfo`] with the current best chain tip.
     UsageInfo(u64),
 
-    /// Response to [`ReadRequest::IsPruned`] with whether the database has
-    /// pruned historical data.
+    /// Response to [`ReadRequest::IsPruned`] with whether this node's block data
+    /// is subject to pruning, because pruned storage mode is configured or
+    /// historical data has already been pruned.
     IsPruned(bool),
 
     /// Response to [`ReadRequest::BlockRoots`] with the per-block commitment roots

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -1821,7 +1821,7 @@ impl Service<ReadRequest> for ReadStateService {
             ReadRequest::UsageInfo => Ok(ReadResponse::UsageInfo(state.db.size())),
 
             // Used by the `getblockchaininfo` RPC.
-            ReadRequest::IsPruned => Ok(ReadResponse::IsPruned(state.db.is_pruned())),
+            ReadRequest::IsPruned => Ok(ReadResponse::IsPruned(state.db.prunes_historical_data())),
 
             // Used by the StateService.
             ReadRequest::Tip => Ok(ReadResponse::Tip(read::tip(

--- a/zakura-state/src/service.rs
+++ b/zakura-state/src/service.rs
@@ -1821,7 +1821,10 @@ impl Service<ReadRequest> for ReadStateService {
             ReadRequest::UsageInfo => Ok(ReadResponse::UsageInfo(state.db.size())),
 
             // Used by the `getblockchaininfo` RPC.
-            ReadRequest::IsPruned => Ok(ReadResponse::IsPruned(state.db.prunes_historical_data())),
+            ReadRequest::PruningInfo => Ok(ReadResponse::PruningInfo {
+                pruned: state.db.prunes_historical_data(),
+                prune_height: state.db.prune_height(),
+            }),
 
             // Used by the StateService.
             ReadRequest::Tip => Ok(ReadResponse::Tip(read::tip(

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -883,7 +883,12 @@ impl ZakuraDb {
     ///
     /// This is what `getblockchaininfo.pruned` reports, matching `zcashd`, which
     /// returns its prune-mode setting rather than whether any block has actually
-    /// been deleted yet. A node configured with
+    /// been deleted yet:
+    /// <https://github.com/zcash/zcash/blob/v6.3.0/src/rpc/blockchain.cpp>
+    ///
+    ///     obj.pushKV("pruned", fPruneMode);
+    ///
+    /// A node configured with
     /// [`StorageMode::Pruned`](crate::StorageMode::Pruned) prunes nothing until
     /// its tip rises above the retention window, but it is still a pruned node,
     /// and clients must not assume it can serve arbitrary historical blocks.
@@ -892,6 +897,23 @@ impl ZakuraDb {
     /// that decides whether a database may be reopened in archive mode.
     pub fn prunes_historical_data(&self) -> bool {
         self.config().pruning_config().is_some() || self.is_pruned()
+    }
+
+    /// Returns the lowest height at and above which every block body is
+    /// retained, or `None` if this node does not prune.
+    ///
+    /// A pruning node that has not deleted anything yet still retains every
+    /// body, so this is [`Height::MIN`] until the first prune. The genesis
+    /// block is never pruned, so its body is available even when this returns a
+    /// higher height.
+    ///
+    /// This is what `getblockchaininfo.pruneheight` reports. `zcashd` emits that
+    /// field only when `pruned` is true, and reports the lowest height whose
+    /// full block it still stores:
+    /// <https://github.com/zcash/zcash/blob/v6.3.0/src/rpc/blockchain.cpp>
+    pub fn prune_height(&self) -> Option<Height> {
+        self.prunes_historical_data()
+            .then(|| self.lowest_retained_height().unwrap_or(Height::MIN))
     }
 
     // Verified-commitment-trees fast-sync methods

--- a/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -877,6 +877,23 @@ impl ZakuraDb {
         self.lowest_retained_height().is_some()
     }
 
+    /// Returns `true` if this node's block data is subject to pruning: either
+    /// pruned storage mode is configured, or the database has already pruned
+    /// historical data.
+    ///
+    /// This is what `getblockchaininfo.pruned` reports, matching `zcashd`, which
+    /// returns its prune-mode setting rather than whether any block has actually
+    /// been deleted yet. A node configured with
+    /// [`StorageMode::Pruned`](crate::StorageMode::Pruned) prunes nothing until
+    /// its tip rises above the retention window, but it is still a pruned node,
+    /// and clients must not assume it can serve arbitrary historical blocks.
+    ///
+    /// Use [`is_pruned`](Self::is_pruned) instead for the one-way on-disk state
+    /// that decides whether a database may be reopened in archive mode.
+    pub fn prunes_historical_data(&self) -> bool {
+        self.config().pruning_config().is_some() || self.is_pruned()
+    }
+
     // Verified-commitment-trees fast-sync methods
 
     /// Returns the checkpoint handoff height `H` of a verified-commitment-trees fast-synced

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -1115,6 +1115,11 @@ fn pruned_mode_reports_pruned_before_anything_is_pruned() {
         "a node configured in pruned storage mode is a pruned node from the start, \
          even before its tip rises above the retention window"
     );
+    assert_eq!(
+        state.db.prune_height(),
+        Some(Height::MIN),
+        "every block body from genesis upwards is still retained"
+    );
 }
 
 #[test]
@@ -1128,6 +1133,11 @@ fn archive_mode_never_reports_pruned() {
     assert!(
         !state.db.prunes_historical_data(),
         "an archive node's blocks are not subject to pruning"
+    );
+    assert_eq!(
+        state.db.prune_height(),
+        None,
+        "an archive node reports no prune height"
     );
 }
 
@@ -1160,6 +1170,11 @@ fn reopened_pruned_database_reports_pruned_before_committing_a_block() {
 
     assert!(reopened.db.is_pruned());
     assert!(reopened.db.prunes_historical_data());
+    assert_eq!(
+        reopened.db.prune_height(),
+        Some(Height(4)),
+        "the prune height tracks the marker once bodies have been deleted"
+    );
 }
 
 #[test]

--- a/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -1099,6 +1099,70 @@ fn prepare_prune_batch_deletes_history_and_keeps_consensus_state() {
 }
 
 #[test]
+fn pruned_mode_reports_pruned_before_anything_is_pruned() {
+    let _init_guard = zakura_test::init();
+    let network = Mainnet;
+
+    // The tip is far below the retention window, so nothing has been pruned yet.
+    let state = new_state_with_blocks(&pruned_config(), &network);
+
+    assert!(
+        !state.db.is_pruned(),
+        "no raw transaction data has been deleted, so the one-way marker is unset"
+    );
+    assert!(
+        state.db.prunes_historical_data(),
+        "a node configured in pruned storage mode is a pruned node from the start, \
+         even before its tip rises above the retention window"
+    );
+}
+
+#[test]
+fn archive_mode_never_reports_pruned() {
+    let _init_guard = zakura_test::init();
+    let network = Mainnet;
+
+    let state = new_state_with_blocks(&Config::ephemeral(), &network);
+
+    assert!(!state.db.is_pruned());
+    assert!(
+        !state.db.prunes_historical_data(),
+        "an archive node's blocks are not subject to pruning"
+    );
+}
+
+#[test]
+fn reopened_pruned_database_reports_pruned_before_committing_a_block() {
+    let _init_guard = zakura_test::init();
+    let network = Mainnet;
+
+    let dir = tempfile::tempdir().expect("temp dir is created");
+    let config = Config {
+        cache_dir: dir.path().to_path_buf(),
+        ephemeral: false,
+        storage_mode: StorageMode::Pruned(PruningConfig {
+            tx_retention: MIN_PRUNING_RETENTION,
+        }),
+        ..Config::default()
+    };
+
+    // Prune some raw transaction data, then drop the handle to release the lock.
+    {
+        let state = new_state_with_blocks(&config, &network);
+        let mut batch = DiskWriteBatch::new();
+        batch.prepare_prune_batch(&state.db, Height(1), Height(4));
+        state.db.write_batch(batch).expect("prune batch writes");
+    }
+
+    // The durable marker makes the reopened database report pruned immediately,
+    // without waiting for a block commit to prune anything.
+    let reopened = FinalizedState::new(&config, &network).expect("reopening the database succeeds");
+
+    assert!(reopened.db.is_pruned());
+    assert!(reopened.db.prunes_historical_data());
+}
+
+#[test]
 fn pruned_block_bodies_stop_tree_derived_root_serving() {
     let _init_guard = zakura_test::init();
     let network = Mainnet;


### PR DESCRIPTION
RPC consumers like Zaino and Lightwalletd should be able to know if Zakura is running pruned mode.

## Motivation

`getblockchaininfo.pruned` was sourced from `ZakuraDb::is_pruned()`, which reports
whether the durable `pruning_metadata` marker has been written. That marker is only
written by a commit that actually deletes raw transaction data, so a node configured
with `storage_mode.pruned` reported `pruned: false` until its tip rose above the
retention window — at least 10,000 blocks on Mainnet and Testnet, and longer when
pruning is first enabled on an existing archive database.

zcashd reports `fPruneMode`: whether blocks are *subject to* pruning, not whether any
block has been deleted yet.

```c
obj.pushKV("pruned", fPruneMode);
```

zcashd also emits `pruneheight` whenever `pruned` is true, so a client can learn where
the servable range starts. Zakura omitted that field entirely, leaving `pruned: true`
with no way to tell which bodies are still available.

Reopening an already-pruned database was never affected: the marker is durable, so it
reports pruned before any block is committed. `FinalizedState::new` relies on exactly
that to refuse an archive-mode open of a pruned database.

## Solution

Add `ZakuraDb::prunes_historical_data()` — true when pruned storage mode is configured
or the database has already pruned — and serve the RPC from it.

Add `ZakuraDb::prune_height()`: the lowest height at and above which every block body is
retained. It is `Height::MIN` for a pruning node that has not deleted anything yet,
because such a node still retains every body, and `None` for an archive node. It is
serialized as the optional `pruneheight` field, omitted when `pruned` is false.

`is_pruned()` keeps its "has actually pruned" meaning for the one-way archive reopen
guard and the subtree upgrade check, which need the on-disk fact rather than the
configured mode.

Zakura prunes raw transaction data rather than whole blocks, so blocks below
`pruneheight` keep their headers, transaction IDs, and consensus state, and the genesis
block is never pruned. Both departures from zcashd's "lowest-height complete block
stored" are documented on the field.

`ReadRequest::IsPruned` becomes `ReadRequest::PruningInfo` and its response carries both
values, so `getblockchaininfo` still makes one state call.

## Testing

`zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs`:

- `pruned_mode_reports_pruned_before_anything_is_pruned` — asserts both `!is_pruned()`
  and `prunes_historical_data()` on a pruned-mode database whose tip is far below the
  retention window, pinning the old bug and the new behavior in one test, plus
  `prune_height() == Some(Height::MIN)`.
- `archive_mode_never_reports_pruned` — archive nodes report neither.
- `reopened_pruned_database_reports_pruned_before_committing_a_block` — a reopened
  pruned database reports pruned and `prune_height() == Some(Height(4))` before any
  block is committed, covering the case that was already correct so it stays that way.

`zakura-rpc/src/methods/tests/prop.rs` covers the pass-through of both fields to the RPC
response.

Run locally: `cargo test -p zakura-state --lib` (459 passed), `cargo test -p zakura-rpc`
(90 + 33 passed), `cargo clippy --all-targets -- -D warnings` on both crates,
`cargo fmt --all -- --check`, `cargo doc -p zakura-state`.

## Changelog

Fragment added as `changelog-unreleased/<PR-number>.md`.

Two compatibility breaks are called out there:

- `GetBlockchainInfoResponse::new()` gained a `prune_height` argument. It is a public fn
  in a published crate; the in-workspace caller is updated, but downstream callers break.
- The read-request metric label changed from `is_pruned` to `pruning_info`, which
  affects any dashboard or alert keyed on the old name.

### Specifications & References

- zcashd `getblockchaininfo`, `pruned` and `pruneheight`:
  https://github.com/zcash/zcash/blob/v6.3.0/src/rpc/blockchain.cpp

### Follow-up Work

- **`getblock` pruned-vs-unknown errors** — `getblock` maps every missing body to
  "Block not found" (-8), which a client cannot tell apart from an unknown hash. zcashd
  reports `RPC_INTERNAL_ERROR` with "Block not available (pruned data)". Branch is ready
  and rebased onto `main`; it is a distinct change to RPC error semantics, so it gets its
  own PR and its own review.
- **`getrawtransaction`** — same pruned-vs-unknown gap for transactions. Pruning retains
  `tx_loc_by_hash`, so the information exists, but no read request exposes it; fixing
  this needs a new one.
- **`z_gettreestate` on VCT fast-synced nodes** — for a height in the `[U, H)` absent
  band the RPC returns 200 with null tree fields, indistinguishable from "this pool was
  not active yet". `ZakuraDb::vct_historical_tree_unavailable()` exists for exactly this
  check and currently has no production caller.

  Worth deciding with that change: `pruneheight` tells a client which *bodies* are
  missing, but nothing tells it that historical *treestates* are missing. Those are two
  different limits on what a node can serve, so the VCT work may want its own field
  rather than overloading this one.
