### PR TITLE
fix(network): account for queued outbound peer demand

### DIFF
--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Replenish legacy outbound peers during periodic crawls when fewer than half
+  the configured outbound connection slots are active
+  ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Replenish legacy outbound peers during periodic crawls when fewer than 30%
+- Replenish legacy outbound peers during periodic crawls when fewer than 27%
   of the configured outbound connection slots are active
   ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Replenish legacy outbound peers during periodic crawls when fewer than half
-  the configured outbound connection slots are active
+- Replenish legacy outbound peers during periodic crawls when fewer than 30%
+  of the configured outbound connection slots are active
   ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/472.md
+++ b/changelog-unreleased/472.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Prevent legacy outbound peer replenishment from over-enqueueing connection
+  attempts by accounting for queued and reserved demand
+  ([#472](https://github.com/zakura-core/zakura/pull/472)).

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -995,6 +995,27 @@ fn outbound_peer_replenishment_demand(
         .saturating_sub(active_outbound_connections)
 }
 
+/// Queue up to `connection_demand` outbound connection attempts.
+fn queue_peer_demand(
+    demand_tx: &mut futures::channel::mpsc::Sender<MorePeers>,
+    connection_demand: usize,
+) -> Result<(), BoxError> {
+    for _ in 0..connection_demand {
+        if let Err(send_error) = demand_tx.try_send(MorePeers) {
+            if send_error.is_disconnected() {
+                // Zebra is shutting down
+                return Err(send_error.into());
+            }
+
+            // Existing queued demand is already sufficient to fill the bounded
+            // channel, so additional signals are unnecessary.
+            break;
+        }
+    }
+
+    Ok(())
+}
+
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
@@ -1245,7 +1266,8 @@ where
     }
 }
 
-/// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
+/// Try to get more peers using `candidates`, then queue connection attempts
+/// using `demand_tx`.
 /// If the crawl discovers peers, queue at least one connection attempt. Also
 /// queue at least `minimum_connection_demand` attempts, unless the demand
 /// channel is already full.
@@ -1285,20 +1307,7 @@ where
     //
     // Candidate selection rate-limits outbound handshakes, and the crawler loop
     // checks the configured outbound connection limit before starting each one.
-    for _ in 0..connection_demand {
-        if let Err(send_error) = demand_tx.try_send(MorePeers) {
-            if send_error.is_disconnected() {
-                // Zebra is shutting down
-                return Err(send_error.into());
-            }
-
-            // Existing queued demand is already sufficient to fill the bounded
-            // channel, so additional signals are unnecessary.
-            break;
-        }
-    }
-
-    Ok(())
+    queue_peer_demand(&mut demand_tx, connection_demand)
 }
 
 /// Try to connect to `candidate` using `outbound_connector`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,16 +981,18 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-/// Returns `true` when the crawler should replenish outbound peers.
+/// Returns the number of outbound peers needed to reach half the configured
+/// connection limit.
 ///
-/// The threshold is strictly below half the configured outbound connection
-/// limit. Using [`usize::div_ceil`] preserves that boundary for odd limits and
-/// keeps a zero limit disabled.
-fn should_replenish_outbound_peers(
+/// Using [`usize::div_ceil`] preserves the threshold for odd limits, and
+/// [`usize::saturating_sub`] returns zero at or above the threshold.
+fn outbound_peer_replenishment_demand(
     active_outbound_connections: usize,
     outbound_connection_limit: usize,
-) -> bool {
-    active_outbound_connections < outbound_connection_limit.div_ceil(2)
+) -> usize {
+    outbound_connection_limit
+        .div_ceil(2)
+        .saturating_sub(active_outbound_connections)
 }
 
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
@@ -999,8 +1001,8 @@ fn should_replenish_outbound_peers(
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After a periodic crawl, request another outbound connection while fewer than
-/// half the configured outbound connection slots are active.
+/// After a periodic crawl, queue enough outbound connection demand to reach
+/// half the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1174,7 +1176,7 @@ where
                             // There weren't any peers, so try to get more peers.
                             debug!("demand for peers but no available candidates");
 
-                            crawl(candidates, demand_tx, false).await?;
+                            crawl(candidates, demand_tx, 0).await?;
 
                             Ok(DemandCrawlFinished)
                         }
@@ -1190,7 +1192,7 @@ where
                 let demand_tx = demand_tx.clone();
                 let active_outbound_connections = active_outbound_connections.update_count();
                 let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                let should_signal_demand = should_replenish_outbound_peers(
+                let replenishment_demand = outbound_peer_replenishment_demand(
                     active_outbound_connections,
                     outbound_connection_limit,
                 );
@@ -1201,11 +1203,11 @@ where
                             ?tick,
                             active_outbound_connections,
                             outbound_connection_limit,
-                            should_signal_demand,
+                            replenishment_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, should_signal_demand).await?;
+                        crawl(candidates, demand_tx, replenishment_demand).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1244,13 +1246,14 @@ where
 }
 
 /// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
-/// If there were no new peers and `should_signal_demand` is false, the
-/// connection attempt is skipped.
+/// If the crawl discovers peers, queue at least one connection attempt. Also
+/// queue at least `minimum_connection_demand` attempts, unless the demand
+/// channel is already full.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    should_signal_demand: bool,
+    minimum_connection_demand: usize,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1264,8 +1267,9 @@ where
         std::mem::drop(candidates);
         result
     };
-    let more_peers = match result {
-        Ok(more_peers) => more_peers.or_else(|| should_signal_demand.then_some(MorePeers)),
+    let connection_demand = match result {
+        Ok(Some(MorePeers)) => minimum_connection_demand.max(1),
+        Ok(None) => minimum_connection_demand,
         Err(e) => {
             info!(
                 ?e,
@@ -1275,22 +1279,22 @@ where
         }
     };
 
-    // If we got more peers, try to connect to a new peer on our next loop.
+    // Queue connection attempts for discovered peers or outbound replenishment.
     //
     // # Security
     //
-    // Update attempts are rate-limited by the candidate set,
-    // and we only try peers if there was actually an update.
-    //
-    // So if all peers have had a recent attempt, and there was recent update
-    // with no peers, the channel will drain. This prevents useless update attempt
-    // loops.
-    if let Some(more_peers) = more_peers {
-        if let Err(send_error) = demand_tx.try_send(more_peers) {
+    // Candidate selection rate-limits outbound handshakes, and the crawler loop
+    // checks the configured outbound connection limit before starting each one.
+    for _ in 0..connection_demand {
+        if let Err(send_error) = demand_tx.try_send(MorePeers) {
             if send_error.is_disconnected() {
                 // Zebra is shutting down
                 return Err(send_error.into());
             }
+
+            // Existing queued demand is already sufficient to fill the bounded
+            // channel, so additional signals are unnecessary.
+            break;
         }
     }
 

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,18 +981,29 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-/// Returns the number of outbound peers needed to reach half the configured
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 3;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 10;
+
+/// Returns the number of outbound peers needed to reach 30% of the configured
 /// connection limit.
 ///
-/// Using [`usize::div_ceil`] preserves the threshold for odd limits, and
-/// [`usize::saturating_sub`] returns zero at or above the threshold.
+/// The target calculation avoids overflow by applying the ratio separately to
+/// the quotient and remainder. [`usize::div_ceil`] rounds partial peers upward,
+/// and [`usize::saturating_sub`] returns zero at or above the target.
 fn outbound_peer_replenishment_demand(
     active_outbound_connections: usize,
     outbound_connection_limit: usize,
 ) -> usize {
-    outbound_connection_limit
-        .div_ceil(2)
-        .saturating_sub(active_outbound_connections)
+    let target_outbound_connections = (outbound_connection_limit
+        / OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR)
+        .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+        .saturating_add(
+            (outbound_connection_limit % OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR)
+                .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+                .div_ceil(OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR),
+        );
+
+    target_outbound_connections.saturating_sub(active_outbound_connections)
 }
 
 /// Queue up to `connection_demand` outbound connection attempts.
@@ -1023,7 +1034,7 @@ fn queue_peer_demand(
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
 /// After a periodic crawl, queue enough outbound connection demand to reach
-/// half the configured outbound connection limit.
+/// 30% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -9,7 +9,10 @@ use std::{
     convert::Infallible,
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -287,6 +290,11 @@ where
     let (mut demand_tx, demand_rx) =
         futures::channel::mpsc::channel::<MorePeers>(config.peerset_outbound_connection_limit());
 
+    // Shared count of MorePeers sitting in the demand channel. Updated by the
+    // PeerSet, crawler queueing paths, and demand drains so timer replenishment
+    // does not over-enqueue.
+    let queued_demand = Arc::new(AtomicUsize::new(0));
+
     // Create a oneshot to send background task JoinHandles to the peer set
     let (handle_tx, handle_rx) = tokio::sync::oneshot::channel();
 
@@ -296,6 +304,7 @@ where
         block_gossip_peer_ips.clone(),
         discovered_peers,
         demand_tx.clone(),
+        queued_demand.clone(),
         handle_rx,
         inv_receiver,
         bans.clone(),
@@ -363,9 +372,10 @@ where
             .peerset_initial_target_size
             .saturating_sub(active_outbound_connections.update_count());
 
-        for _ in 0..demand_count {
-            let _ = demand_tx.try_send(MorePeers);
-        }
+        // Track how many MorePeers are sitting in the demand channel so timer
+        // crawls do not enqueue a second full replenishment deficit on top.
+        // The demand channel is open during initialization; ignore a full channel.
+        let _ = queue_peer_demand(&mut demand_tx, demand_count, 0, &queued_demand);
 
         // Start the peer crawler
         let crawl_fut = crawl_and_dial(
@@ -377,15 +387,20 @@ where
             peerset_tx,
             active_outbound_connections,
             address_book_updater,
+            queued_demand,
         );
         task_handles.push(tokio::spawn(crawl_fut.in_current_span()));
     } else {
+        let queued_demand = queued_demand.clone();
         task_handles.push(tokio::spawn(
             async move {
                 let _peerset_tx = peerset_tx;
                 let mut demand_rx = demand_rx;
 
                 while let Some(MorePeers) = demand_rx.next().await {
+                    // Keep the shared counter aligned even when the legacy
+                    // crawler is not running (PeerSet may still signal demand).
+                    note_demand_dequeued(&queued_demand);
                     debug!("ignoring legacy peer demand because legacy P2P is disabled");
                 }
 
@@ -987,12 +1002,17 @@ const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 100;
 /// Returns the number of outbound peers needed to reach 27% of the configured
 /// connection limit.
 ///
+/// `queued_demand` counts pending outbound demand that should not be requested
+/// again: `MorePeers` already in the demand channel, plus timer-crawl
+/// reservations claimed before `candidates.update()` completes.
+///
 /// The target calculation avoids overflow by applying the ratio separately to
 /// the quotient and remainder. [`usize::div_ceil`] rounds partial peers upward,
 /// and [`usize::saturating_sub`] returns zero at or above the target.
 fn outbound_peer_replenishment_demand(
     active_outbound_connections: usize,
     outbound_connection_limit: usize,
+    queued_demand: usize,
 ) -> usize {
     let target_outbound_connections = (outbound_connection_limit
         / OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR)
@@ -1003,17 +1023,43 @@ fn outbound_peer_replenishment_demand(
                 .div_ceil(OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR),
         );
 
-    target_outbound_connections.saturating_sub(active_outbound_connections)
+    target_outbound_connections
+        .saturating_sub(active_outbound_connections)
+        .saturating_sub(queued_demand)
 }
 
-/// Queue up to `connection_demand` outbound connection attempts.
+/// Queue up to `desired` outbound connection attempts.
+///
+/// `already_reserved` is demand previously claimed on `queued_demand` (for
+/// example by a timer crawl before `candidates.update()` runs). This keeps the
+/// shared counter aligned with channel depth across that async gap:
+/// - adds any `desired` above the reservation before sending
+/// - releases unused reservation or failed sends when the channel is full
+///
+/// Returns the number of signals successfully placed in the channel.
 fn queue_peer_demand(
     demand_tx: &mut futures::channel::mpsc::Sender<MorePeers>,
-    connection_demand: usize,
-) -> Result<(), BoxError> {
-    for _ in 0..connection_demand {
+    desired: usize,
+    already_reserved: usize,
+    queued_demand: &AtomicUsize,
+) -> Result<usize, BoxError> {
+    if desired > already_reserved {
+        queued_demand.fetch_add(desired - already_reserved, Ordering::Relaxed);
+    } else if desired < already_reserved {
+        let _ = queued_demand.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+            Some(n.saturating_sub(already_reserved - desired))
+        });
+    }
+
+    let mut sent = 0;
+    for _ in 0..desired {
         if let Err(send_error) = demand_tx.try_send(MorePeers) {
             if send_error.is_disconnected() {
+                // Release slots claimed for signals we did not enqueue.
+                let remaining = desired.saturating_sub(sent);
+                let _ = queued_demand.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                    Some(n.saturating_sub(remaining))
+                });
                 // Zakura's peer set is shutting down.
                 return Err(send_error.into());
             }
@@ -1022,9 +1068,24 @@ fn queue_peer_demand(
             // channel, so additional signals are unnecessary.
             break;
         }
+
+        sent += 1;
     }
 
-    Ok(())
+    if sent < desired {
+        let _ = queued_demand.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+            Some(n.saturating_sub(desired - sent))
+        });
+    }
+
+    Ok(sent)
+}
+
+/// Decrements the shared queued-demand counter without underflowing.
+fn note_demand_dequeued(queued_demand: &AtomicUsize) {
+    let _ = queued_demand.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+        Some(n.saturating_sub(1))
+    });
 }
 
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
@@ -1056,6 +1117,7 @@ fn queue_peer_demand(
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
+        queued_demand,
     ),
     fields(
         new_peer_interval = ?config.crawl_new_peer_interval,
@@ -1070,6 +1132,7 @@ async fn crawl_and_dial<C, S>(
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     mut active_outbound_connections: ActiveConnectionCounter,
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
+    queued_demand: Arc<AtomicUsize>,
 ) -> Result<(), BoxError>
 where
     C: Service<
@@ -1140,6 +1203,10 @@ where
             //
             // Demand is potentially unlimited, so it must go last in a biased select!.
             next_demand = demand_rx.next() => next_demand.ok_or("demand stream closed, is Zakura shutting down?".into()).map(|MorePeers|{
+                // This signal is no longer queued; it is either dropped or turned
+                // into an active/in-flight outbound connection attempt below.
+                note_demand_dequeued(&queued_demand);
+
                 if active_outbound_connections.update_count() >= config.peerset_outbound_connection_limit() {
                     // Too many open outbound connections or pending handshakes already
                     DemandDrop
@@ -1164,6 +1231,7 @@ where
                 let peerset_tx = peerset_tx.clone();
                 let address_book_updater = address_book_updater.clone();
                 let demand_tx = demand_tx.clone();
+                let queued_demand = queued_demand.clone();
                 let expose_peer_addresses = config.expose_peer_addresses;
 
                 // Increment the connection count before we spawn the connection.
@@ -1199,6 +1267,7 @@ where
                                 peerset_tx,
                                 address_book_updater,
                                 demand_tx,
+                                queued_demand,
                                 expose_peer_addresses,
                             )
                             .await?;
@@ -1208,7 +1277,7 @@ where
                             // There weren't any peers, so try to get more peers.
                             debug!("demand for peers but no available candidates");
 
-                            crawl(candidates, demand_tx, 0).await?;
+                            crawl(candidates, demand_tx, queued_demand, 0).await?;
 
                             Ok(DemandCrawlFinished)
                         }
@@ -1222,12 +1291,22 @@ where
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
                 let demand_tx = demand_tx.clone();
+                let queued_demand = queued_demand.clone();
                 let active_outbound_connections = active_outbound_connections.update_count();
                 let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                let pending_demand = queued_demand.load(Ordering::Relaxed);
                 let replenishment_demand = outbound_peer_replenishment_demand(
                     active_outbound_connections,
                     outbound_connection_limit,
+                    pending_demand,
                 );
+
+                // Claim the deficit before spawning crawl/update so a later
+                // timer tick cannot compute the same shortfall again while
+                // candidates.update() is still running.
+                if replenishment_demand > 0 {
+                    queued_demand.fetch_add(replenishment_demand, Ordering::Relaxed);
+                }
 
                 let crawl_handle = tokio::spawn(
                     async move {
@@ -1235,11 +1314,12 @@ where
                             ?tick,
                             active_outbound_connections,
                             outbound_connection_limit,
+                            pending_demand,
                             replenishment_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, replenishment_demand).await?;
+                        crawl(candidates, demand_tx, queued_demand, replenishment_demand).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1280,13 +1360,17 @@ where
 /// Try to get more peers using `candidates`, then queue connection attempts
 /// using `demand_tx`.
 /// If the crawl discovers peers, queue at least one connection attempt. Also
-/// queue at least `minimum_connection_demand` attempts, unless the demand
-/// channel is already full.
-#[instrument(skip(candidates, demand_tx))]
+/// queue at least `pre_reserved_demand` attempts, unless the demand channel is
+/// already full.
+///
+/// `pre_reserved_demand` must already be reflected in `queued_demand` when it is
+/// non-zero (timer crawls reserve before spawning this task).
+#[instrument(skip(candidates, demand_tx, queued_demand))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    minimum_connection_demand: usize,
+    queued_demand: Arc<AtomicUsize>,
+    pre_reserved_demand: usize,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1301,9 +1385,15 @@ where
         result
     };
     let connection_demand = match result {
-        Ok(Some(MorePeers)) => minimum_connection_demand.max(1),
-        Ok(None) => minimum_connection_demand,
+        Ok(Some(MorePeers)) => pre_reserved_demand.max(1),
+        Ok(None) => pre_reserved_demand,
         Err(e) => {
+            // Release any reservation that will never be enqueued.
+            if pre_reserved_demand > 0 {
+                let _ = queued_demand.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                    Some(n.saturating_sub(pre_reserved_demand))
+                });
+            }
             info!(
                 ?e,
                 "candidate set returned an error, is Zakura shutting down?"
@@ -1318,7 +1408,13 @@ where
     //
     // Candidate selection rate-limits outbound handshakes, and the crawler loop
     // checks the configured outbound connection limit before starting each one.
-    queue_peer_demand(&mut demand_tx, connection_demand)
+    queue_peer_demand(
+        &mut demand_tx,
+        connection_demand,
+        pre_reserved_demand,
+        &queued_demand,
+    )
+    .map(|_| ())
 }
 
 /// Try to connect to `candidate` using `outbound_connector`.
@@ -1336,6 +1432,7 @@ where
     peerset_tx,
     address_book_updater,
     demand_tx,
+    queued_demand,
     expose_peer_addresses,
 ), fields(peer = %candidate.addr.addr_label(expose_peer_addresses)))]
 async fn dial<C>(
@@ -1346,6 +1443,7 @@ async fn dial<C>(
     mut peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
+    queued_demand: Arc<AtomicUsize>,
     expose_peer_addresses: bool,
 ) -> Result<(), BoxError>
 where
@@ -1418,12 +1516,7 @@ where
             // # Security
             //
             // Handshake failures are rate-limited by peer attempt timeouts.
-            if let Err(send_error) = demand_tx.try_send(MorePeers) {
-                if send_error.is_disconnected() {
-                    // Zakura's peer set is shutting down.
-                    return Err(send_error.into());
-                }
-            }
+            let _ = queue_peer_demand(&mut demand_tx, 1, 0, &queued_demand)?;
         }
     }
 

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,10 +981,10 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 3;
-const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 10;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 27;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 100;
 
-/// Returns the number of outbound peers needed to reach 30% of the configured
+/// Returns the number of outbound peers needed to reach 27% of the configured
 /// connection limit.
 ///
 /// The target calculation avoids overflow by applying the ratio separately to
@@ -1034,7 +1034,7 @@ fn queue_peer_demand(
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
 /// After a periodic crawl, queue enough outbound connection demand to reach
-/// 30% of the configured outbound connection limit.
+/// 27% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -1003,7 +1003,7 @@ fn queue_peer_demand(
     for _ in 0..connection_demand {
         if let Err(send_error) = demand_tx.try_send(MorePeers) {
             if send_error.is_disconnected() {
-                // Zebra is shutting down
+                // Zakura's peer set is shutting down.
                 return Err(send_error.into());
             }
 
@@ -1409,7 +1409,7 @@ where
             // Handshake failures are rate-limited by peer attempt timeouts.
             if let Err(send_error) = demand_tx.try_send(MorePeers) {
                 if send_error.is_disconnected() {
-                    // Zebra is shutting down
+                    // Zakura's peer set is shutting down.
                     return Err(send_error.into());
                 }
             }

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,13 +981,26 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
+/// Returns `true` when the crawler should replenish outbound peers.
+///
+/// The threshold is strictly below half the configured outbound connection
+/// limit. Using [`usize::div_ceil`] preserves that boundary for odd limits and
+/// keeps a zero limit disabled.
+fn should_replenish_outbound_peers(
+    active_outbound_connections: usize,
+    outbound_connection_limit: usize,
+) -> bool {
+    active_outbound_connections < outbound_connection_limit.div_ceil(2)
+}
+
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After crawling, try to connect to one new peer using `outbound_connector`.
+/// After a periodic crawl, request another outbound connection while fewer than
+/// half the configured outbound connection slots are active.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1175,16 +1188,24 @@ where
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
                 let demand_tx = demand_tx.clone();
-                let should_always_dial = active_outbound_connections.update_count() == 0;
+                let active_outbound_connections = active_outbound_connections.update_count();
+                let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                let should_signal_demand = should_replenish_outbound_peers(
+                    active_outbound_connections,
+                    outbound_connection_limit,
+                );
 
                 let crawl_handle = tokio::spawn(
                     async move {
                         debug!(
                             ?tick,
+                            active_outbound_connections,
+                            outbound_connection_limit,
+                            should_signal_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, should_always_dial).await?;
+                        crawl(candidates, demand_tx, should_signal_demand).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1223,12 +1244,13 @@ where
 }
 
 /// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
-/// If there were no new peers and `should_always_dial` is false, the connection attempt is skipped.
+/// If there were no new peers and `should_signal_demand` is false, the
+/// connection attempt is skipped.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    should_always_dial: bool,
+    should_signal_demand: bool,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1243,7 +1265,7 @@ where
         result
     };
     let more_peers = match result {
-        Ok(more_peers) => more_peers.or_else(|| should_always_dial.then_some(MorePeers)),
+        Ok(more_peers) => more_peers.or_else(|| should_signal_demand.then_some(MorePeers)),
         Err(e) => {
             info!(
                 ?e,

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -15,7 +15,10 @@
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -450,30 +453,37 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 #[test]
 fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     let cases = [
-        (0, 0, 0),
-        (0, 1, 1),
-        (1, 1, 0),
-        (0, 2, 1),
-        (1, 2, 0),
-        (0, 3, 1),
-        (1, 3, 0),
-        (0, 4, 2),
-        (1, 4, 1),
-        (2, 4, 0),
-        (0, 10, 3),
-        (2, 10, 1),
-        (3, 10, 0),
-        (0, 300, 81),
-        (80, 300, 1),
-        (81, 300, 0),
-        (100, 300, 0),
+        // active, limit, queued, expected
+        (0, 0, 0, 0),
+        (0, 1, 0, 1),
+        (1, 1, 0, 0),
+        (0, 2, 0, 1),
+        (1, 2, 0, 0),
+        (0, 3, 0, 1),
+        (1, 3, 0, 0),
+        (0, 4, 0, 2),
+        (1, 4, 0, 1),
+        (2, 4, 0, 0),
+        (0, 10, 0, 3),
+        (2, 10, 0, 1),
+        (3, 10, 0, 0),
+        (0, 300, 0, 81),
+        (80, 300, 0, 1),
+        (81, 300, 0, 0),
+        (100, 300, 0, 0),
+        // Queued demand already covers the deficit.
+        (0, 300, 81, 0),
+        (40, 300, 41, 0),
+        // Queued demand covers only part of the deficit.
+        (0, 300, 40, 41),
+        (40, 300, 20, 21),
     ];
 
-    for (active, limit, expected) in cases {
+    for (active, limit, queued, expected) in cases {
         assert_eq!(
-            outbound_peer_replenishment_demand(active, limit),
+            outbound_peer_replenishment_demand(active, limit, queued),
             expected,
-            "unexpected replenishment decision for {active} active peers and limit {limit}",
+            "unexpected replenishment decision for {active} active peers, limit {limit}, queued {queued}",
         );
     }
 }
@@ -483,15 +493,101 @@ fn crawler_queues_full_replenishment_demand() {
     const CONNECTION_DEMAND: usize = 81;
 
     let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
-    queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)
+    let queued_demand = AtomicUsize::new(0);
+    let sent = queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND, 0, &queued_demand)
         .expect("open demand channel accepts replenishment signals");
 
-    let mut queued_demand = 0;
+    assert_eq!(sent, CONNECTION_DEMAND);
+    assert_eq!(queued_demand.load(Ordering::Relaxed), CONNECTION_DEMAND);
+
+    let mut drained_demand = 0;
     while demand_rx.try_recv().is_ok() {
-        queued_demand += 1;
+        drained_demand += 1;
     }
 
-    assert_eq!(queued_demand, CONNECTION_DEMAND);
+    assert_eq!(drained_demand, CONNECTION_DEMAND);
+}
+
+#[test]
+fn crawler_does_not_double_count_queued_replenishment_demand() {
+    const OUTBOUND_LIMIT: usize = 300;
+    const TARGET: usize = 81;
+
+    let (mut demand_tx, mut demand_rx) = mpsc::channel(OUTBOUND_LIMIT);
+    let queued_demand = AtomicUsize::new(0);
+
+    // First crawl queues the full deficit.
+    let first = outbound_peer_replenishment_demand(0, OUTBOUND_LIMIT, queued_demand.load(Ordering::Relaxed));
+    assert_eq!(first, TARGET);
+    queue_peer_demand(&mut demand_tx, first, 0, &queued_demand)
+        .expect("open demand channel accepts first replenishment batch");
+
+    // A second crawl before the channel drains must not enqueue another full batch.
+    let second = outbound_peer_replenishment_demand(0, OUTBOUND_LIMIT, queued_demand.load(Ordering::Relaxed));
+    assert_eq!(second, 0);
+    queue_peer_demand(&mut demand_tx, second, 0, &queued_demand)
+        .expect("open demand channel accepts empty replenishment batch");
+
+    let mut drained_demand = 0;
+    while demand_rx.try_recv().is_ok() {
+        drained_demand += 1;
+    }
+
+    assert_eq!(drained_demand, TARGET);
+    assert_eq!(queued_demand.load(Ordering::Relaxed), TARGET);
+}
+
+#[test]
+fn crawler_reservation_covers_update_gap() {
+    const OUTBOUND_LIMIT: usize = 300;
+    const TARGET: usize = 81;
+
+    let (mut demand_tx, mut demand_rx) = mpsc::channel(OUTBOUND_LIMIT);
+    let queued_demand = AtomicUsize::new(0);
+
+    // Timer crawl claims the deficit before candidates.update() finishes.
+    let first = outbound_peer_replenishment_demand(0, OUTBOUND_LIMIT, queued_demand.load(Ordering::Relaxed));
+    assert_eq!(first, TARGET);
+    queued_demand.fetch_add(first, Ordering::Relaxed);
+
+    // Another timer tick during update() must see the reservation.
+    let second = outbound_peer_replenishment_demand(0, OUTBOUND_LIMIT, queued_demand.load(Ordering::Relaxed));
+    assert_eq!(second, 0);
+
+    // After update(), only the reserved batch is enqueued.
+    let sent = queue_peer_demand(&mut demand_tx, first, first, &queued_demand)
+        .expect("open demand channel accepts reserved replenishment batch");
+    assert_eq!(sent, TARGET);
+    assert_eq!(queued_demand.load(Ordering::Relaxed), TARGET);
+
+    let mut drained_demand = 0;
+    while demand_rx.try_recv().is_ok() {
+        drained_demand += 1;
+    }
+    assert_eq!(drained_demand, TARGET);
+}
+
+#[test]
+fn queue_peer_demand_releases_unused_reservation_when_channel_fills() {
+    const CAPACITY: usize = 10;
+    const RESERVED: usize = 20;
+
+    let (mut demand_tx, mut demand_rx) = mpsc::channel(CAPACITY);
+    let queued_demand = AtomicUsize::new(0);
+    queued_demand.fetch_add(RESERVED, Ordering::Relaxed);
+
+    let sent = queue_peer_demand(&mut demand_tx, RESERVED, RESERVED, &queued_demand)
+        .expect("partial enqueue is not a fatal error");
+
+    // futures::mpsc may accept slightly more than `CAPACITY` before reporting full.
+    assert!(sent < RESERVED, "channel must reject some reserved demand");
+    assert_eq!(queued_demand.load(Ordering::Relaxed), sent);
+
+    let mut drained_demand = 0;
+    while demand_rx.try_recv().is_ok() {
+        drained_demand += 1;
+    }
+    assert_eq!(drained_demand, sent);
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
@@ -2049,8 +2145,11 @@ where
     let active_outbound_connections = ActiveConnectionCounter::new_counter();
 
     // Add fake demand over the limit.
+    let queued_demand = Arc::new(AtomicUsize::new(0));
     for _ in 0..over_limit_peers {
-        let _ = demand_tx.try_send(MorePeers);
+        if demand_tx.try_send(MorePeers).is_ok() {
+            queued_demand.fetch_add(1, Ordering::Relaxed);
+        }
     }
     let mut demand_shutdown_tx = demand_tx.clone();
 
@@ -2084,6 +2183,7 @@ where
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
+        queued_demand,
     );
     let crawl_task_handle = tokio::spawn(crawl_fut);
 

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            DiscoveredPeer,
+            should_replenish_outbound_peers, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -445,6 +445,29 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
         .expect("test peer is valid for the mainnet address book");
 
     peer
+}
+
+#[test]
+fn crawler_replenishes_outbound_peers_below_half_limit() {
+    let cases = [
+        (0, 0, false),
+        (0, 1, true),
+        (1, 1, false),
+        (0, 2, true),
+        (1, 2, false),
+        (1, 3, true),
+        (2, 3, false),
+        (149, 300, true),
+        (150, 300, false),
+    ];
+
+    for (active, limit, expected) in cases {
+        assert_eq!(
+            should_replenish_outbound_peers(active, limit),
+            expected,
+            "unexpected replenishment decision for {active} active peers and limit {limit}",
+        );
+    }
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -448,19 +448,25 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 }
 
 #[test]
-fn crawler_replenishes_outbound_peers_below_half_limit() {
+fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
     let cases = [
         (0, 0, 0),
         (0, 1, 1),
         (1, 1, 0),
         (0, 2, 1),
         (1, 2, 0),
-        (0, 3, 2),
-        (1, 3, 1),
-        (2, 3, 0),
-        (100, 300, 50),
-        (149, 300, 1),
-        (150, 300, 0),
+        (0, 3, 1),
+        (1, 3, 0),
+        (0, 4, 2),
+        (1, 4, 1),
+        (2, 4, 0),
+        (0, 10, 3),
+        (2, 10, 1),
+        (3, 10, 0),
+        (0, 300, 90),
+        (89, 300, 1),
+        (90, 300, 0),
+        (100, 300, 0),
     ];
 
     for (active, limit, expected) in cases {
@@ -474,7 +480,7 @@ fn crawler_replenishes_outbound_peers_below_half_limit() {
 
 #[test]
 fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 50;
+    const CONNECTION_DEMAND: usize = 90;
 
     let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
     queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            should_replenish_outbound_peers, DiscoveredPeer,
+            outbound_peer_replenishment_demand, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -450,20 +450,22 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 #[test]
 fn crawler_replenishes_outbound_peers_below_half_limit() {
     let cases = [
-        (0, 0, false),
-        (0, 1, true),
-        (1, 1, false),
-        (0, 2, true),
-        (1, 2, false),
-        (1, 3, true),
-        (2, 3, false),
-        (149, 300, true),
-        (150, 300, false),
+        (0, 0, 0),
+        (0, 1, 1),
+        (1, 1, 0),
+        (0, 2, 1),
+        (1, 2, 0),
+        (0, 3, 2),
+        (1, 3, 1),
+        (2, 3, 0),
+        (100, 300, 50),
+        (149, 300, 1),
+        (150, 300, 0),
     ];
 
     for (active, limit, expected) in cases {
         assert_eq!(
-            should_replenish_outbound_peers(active, limit),
+            outbound_peer_replenishment_demand(active, limit),
             expected,
             "unexpected replenishment decision for {active} active peers and limit {limit}",
         );

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            outbound_peer_replenishment_demand, DiscoveredPeer,
+            outbound_peer_replenishment_demand, queue_peer_demand, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -470,6 +470,22 @@ fn crawler_replenishes_outbound_peers_below_half_limit() {
             "unexpected replenishment decision for {active} active peers and limit {limit}",
         );
     }
+}
+
+#[test]
+fn crawler_queues_full_replenishment_demand() {
+    const CONNECTION_DEMAND: usize = 50;
+
+    let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
+    queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)
+        .expect("open demand channel accepts replenishment signals");
+
+    let mut queued_demand = 0;
+    while demand_rx.try_recv().is_ok() {
+        queued_demand += 1;
+    }
+
+    assert_eq!(queued_demand, CONNECTION_DEMAND);
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -448,7 +448,7 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 }
 
 #[test]
-fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
+fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     let cases = [
         (0, 0, 0),
         (0, 1, 1),
@@ -463,9 +463,9 @@ fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
         (0, 10, 3),
         (2, 10, 1),
         (3, 10, 0),
-        (0, 300, 90),
-        (89, 300, 1),
-        (90, 300, 0),
+        (0, 300, 81),
+        (80, 300, 1),
+        (81, 300, 0),
         (100, 300, 0),
     ];
 
@@ -480,7 +480,7 @@ fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
 
 #[test]
 fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 90;
+    const CONNECTION_DEMAND: usize = 81;
 
     let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
     queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)

--- a/zakura-network/src/peer_set/set.rs
+++ b/zakura-network/src/peer_set/set.rs
@@ -100,6 +100,10 @@ use std::{
     marker::PhantomData,
     net::{IpAddr, SocketAddr},
     pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
     time::Instant,
 };
@@ -206,6 +210,10 @@ where
 
     /// A channel that asks the peer crawler task to connect to more peers.
     demand_signal: mpsc::Sender<MorePeers>,
+
+    /// Counts `MorePeers` signals that are sitting in [`Self::demand_signal`]'s
+    /// channel so the crawler does not over-enqueue replenishment demand.
+    queued_demand: Arc<AtomicUsize>,
 
     /// A shared list of banned IP addresses.
     bans: BannedIps,
@@ -350,6 +358,7 @@ where
     /// - `block_gossip_peer_ips`: inbound peer IPs that must always receive block inventory broadcasts.
     /// - `discover`: handles peer connects and disconnects;
     /// - `demand_signal`: requests more peers when all peers are busy (unready);
+    /// - `queued_demand`: shared count of pending `MorePeers` signals in `demand_signal`;
     /// - `handle_rx`: receives background task handles,
     ///   monitors them to make sure they're still running,
     ///   and shuts down all the tasks as soon as one task exits;
@@ -366,6 +375,7 @@ where
         block_gossip_peer_ips: Vec<IpAddr>,
         discover: D,
         demand_signal: mpsc::Sender<MorePeers>,
+        queued_demand: Arc<AtomicUsize>,
         handle_rx: tokio::sync::oneshot::Receiver<Vec<JoinHandle<Result<(), BoxError>>>>,
         inv_stream: broadcast::Receiver<InventoryChange>,
         bans: BannedIps,
@@ -378,6 +388,7 @@ where
             // New peers
             discover,
             demand_signal,
+            queued_demand,
             // Banned peers
             bans,
 
@@ -1670,7 +1681,14 @@ where
             // here, the crawler could deadlock sending a request to fetch more peers, because it
             // also empties the channel.
             trace!("no ready services, sending demand signal");
-            let _ = self.demand_signal.try_send(MorePeers);
+            // Increment before send so a concurrent crawler drain cannot observe
+            // an uncounted channel message. Roll back if the channel is full.
+            self.queued_demand.fetch_add(1, Ordering::Relaxed);
+            if self.demand_signal.try_send(MorePeers).is_err() {
+                let _ = self.queued_demand.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                    Some(n.saturating_sub(1))
+                });
+            }
 
             // # Correctness
             //

--- a/zakura-network/src/peer_set/set/tests.rs
+++ b/zakura-network/src/peer_set/set/tests.rs
@@ -4,7 +4,7 @@
 
 use std::{
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{atomic::AtomicUsize, Arc},
 };
 
 use futures::{channel::mpsc, stream, Stream, StreamExt};
@@ -260,6 +260,7 @@ where
             self.block_gossip_peer_ips,
             discover,
             demand_signal,
+            Arc::new(AtomicUsize::new(0)),
             handle_rx,
             inv_stream,
             bans,


### PR DESCRIPTION
## Motivation

[#462](https://github.com/zakura-core/zakura/pull/462) replenishes outbound peers toward ~27% of the outbound limit on each timer crawl. Bugbot noted that replenishment demand ignored `MorePeers` already sitting in the demand channel, so successive timer crawls could enqueue far more connection attempts than needed to reach the floor ([discussion](https://github.com/zakura-core/zakura/pull/462#discussion_r3661191058)).

Root cause: `outbound_peer_replenishment_demand` only subtracted active/in-flight connections, not pending demand signals (or reservations claimed before `candidates.update()` finished).

## Solution

- Track pending demand with a shared `Arc<AtomicUsize>` updated by crawler queue/drain paths and `PeerSet` demand signals.
- Subtract queued demand when computing replenishment.
- Reserve the replenishment deficit on the counter before spawning `crawl`, so a later timer tick cannot claim the same shortfall during `update()`.
- Release unused reservation when the channel is full or `update()` errors.
- Keep the counter aligned when legacy P2P is disabled and demand is drained without dialing.

## Testing

- `cargo test -p zakura-network --lib crawler_`
- `cargo test -p zakura-network --lib queue_peer_demand_releases`
- `cargo test -p zakura-network --lib peer_set::set::`
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli changelog-unreleased/472.md --config .trunk/configs/.markdownlint.yaml`

New coverage: queued-demand math, no double-batch after enqueue, reservation across the `update()` gap, and releasing unused reservation when the channel fills.

## Changelog

Added `changelog-unreleased/472.md` under `Fixed`.

### Specifications & References

Addresses Bugbot on #462: https://github.com/zakura-core/zakura/pull/462#discussion_r3661191058