### PR TITLE
fix(network): credit replenishment budget on empty crawls and failed dials

### DIFF
--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Replenish legacy outbound peers during periodic crawls when fewer than half
+  the configured outbound connection slots are active
+  ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Replenish legacy outbound peers during periodic crawls when fewer than 30%
+- Replenish legacy outbound peers during periodic crawls when fewer than 27%
   of the configured outbound connection slots are active
   ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/462.md
+++ b/changelog-unreleased/462.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Replenish legacy outbound peers during periodic crawls when fewer than half
-  the configured outbound connection slots are active
+- Replenish legacy outbound peers during periodic crawls when fewer than 30%
+  of the configured outbound connection slots are active
   ([#462](https://github.com/zakura-core/zakura/pull/462)).

--- a/changelog-unreleased/473.md
+++ b/changelog-unreleased/473.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Preserve outbound peer replenishment progress across failed dials and empty
+  candidate crawls
+  ([#473](https://github.com/zakura-core/zakura/pull/473)).

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -995,6 +995,27 @@ fn outbound_peer_replenishment_demand(
         .saturating_sub(active_outbound_connections)
 }
 
+/// Queue up to `connection_demand` outbound connection attempts.
+fn queue_peer_demand(
+    demand_tx: &mut futures::channel::mpsc::Sender<MorePeers>,
+    connection_demand: usize,
+) -> Result<(), BoxError> {
+    for _ in 0..connection_demand {
+        if let Err(send_error) = demand_tx.try_send(MorePeers) {
+            if send_error.is_disconnected() {
+                // Zebra is shutting down
+                return Err(send_error.into());
+            }
+
+            // Existing queued demand is already sufficient to fill the bounded
+            // channel, so additional signals are unnecessary.
+            break;
+        }
+    }
+
+    Ok(())
+}
+
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
@@ -1245,7 +1266,8 @@ where
     }
 }
 
-/// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
+/// Try to get more peers using `candidates`, then queue connection attempts
+/// using `demand_tx`.
 /// If the crawl discovers peers, queue at least one connection attempt. Also
 /// queue at least `minimum_connection_demand` attempts, unless the demand
 /// channel is already full.
@@ -1285,20 +1307,7 @@ where
     //
     // Candidate selection rate-limits outbound handshakes, and the crawler loop
     // checks the configured outbound connection limit before starting each one.
-    for _ in 0..connection_demand {
-        if let Err(send_error) = demand_tx.try_send(MorePeers) {
-            if send_error.is_disconnected() {
-                // Zebra is shutting down
-                return Err(send_error.into());
-            }
-
-            // Existing queued demand is already sufficient to fill the bounded
-            // channel, so additional signals are unnecessary.
-            break;
-        }
-    }
-
-    Ok(())
+    queue_peer_demand(&mut demand_tx, connection_demand)
 }
 
 /// Try to connect to `candidate` using `outbound_connector`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -965,8 +965,6 @@ where
 
 /// An action that the peer crawler can take.
 enum CrawlerAction {
-    /// Drop the demand signal because there are too many pending handshakes.
-    DemandDrop,
     /// Initiate a handshake to the next candidate peer in response to demand.
     ///
     /// If there are no available candidates, crawl existing peers.
@@ -1006,34 +1004,13 @@ fn outbound_peer_replenishment_demand(
     target_outbound_connections.saturating_sub(active_outbound_connections)
 }
 
-/// Queue up to `connection_demand` outbound connection attempts.
-fn queue_peer_demand(
-    demand_tx: &mut futures::channel::mpsc::Sender<MorePeers>,
-    connection_demand: usize,
-) -> Result<(), BoxError> {
-    for _ in 0..connection_demand {
-        if let Err(send_error) = demand_tx.try_send(MorePeers) {
-            if send_error.is_disconnected() {
-                // Zakura's peer set is shutting down.
-                return Err(send_error.into());
-            }
-
-            // Existing queued demand is already sufficient to fill the bounded
-            // channel, so additional signals are unnecessary.
-            break;
-        }
-    }
-
-    Ok(())
-}
-
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After a periodic crawl, queue enough outbound connection demand to reach
+/// After a periodic crawl, start enough outbound connection attempts to reach
 /// 27% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
@@ -1113,6 +1090,12 @@ where
 
     let mut crawl_timer = IntervalStream::new(crawl_timer).map(|tick| TimerCrawl { tick });
 
+    // This task is the only `demand_rx` consumer and the only owner of periodic
+    // replenishment demand. Existing queued demand is processed first and
+    // consumes this count, so timer crawls do not duplicate connection attempts
+    // that are already waiting in `demand_rx`.
+    let mut remaining_replenishment_demand: usize = 0;
+
     // # Concurrency
     //
     // To avoid hangs and starvation, the crawler must spawn a separate task for each crawl
@@ -1134,112 +1117,108 @@ where
             ),
             // The timer is rate-limited
             next_timer = crawl_timer.next() => Ok(next_timer.expect("timers never terminate")),
-            // Turn any new demand into an action, based on the crawler's current state.
-            //
-            // # Concurrency
-            //
-            // Demand is potentially unlimited, so it must go last in a biased select!.
-            next_demand = demand_rx.next() => next_demand.ok_or("demand stream closed, is Zakura shutting down?".into()).map(|MorePeers|{
-                if active_outbound_connections.update_count() >= config.peerset_outbound_connection_limit() {
-                    // Too many open outbound connections or pending handshakes already
-                    DemandDrop
-                } else {
-                    DemandHandshakeOrCrawl
-                }
-            })
+            // External demand is potentially unlimited, so it goes after the
+            // rate-limited timer in this biased select.
+            next_demand = demand_rx.next() => next_demand
+                .ok_or("demand stream closed, is Zakura shutting down?".into())
+                .map(|MorePeers| DemandHandshakeOrCrawl),
+            // Existing channel demand gets priority over local replenishment.
+            // Each action consumes one unit of replenishment demand below.
+            _ = future::ready(()), if remaining_replenishment_demand > 0 => {
+                Ok(DemandHandshakeOrCrawl)
+            }
         };
 
         match crawler_action {
-            // Dummy actions
-            Ok(DemandDrop) => {
-                // This is set to trace level because when the peerset is
-                // congested it can generate a lot of demand signal very rapidly.
-                trace!("too many open connections or in-flight handshakes, dropping demand signal");
-            }
-
             // Spawned tasks
             Ok(DemandHandshakeOrCrawl) => {
-                let candidates = candidates.clone();
-                let outbound_connector = outbound_connector.clone();
-                let peerset_tx = peerset_tx.clone();
-                let address_book_updater = address_book_updater.clone();
-                let demand_tx = demand_tx.clone();
-                let expose_peer_addresses = config.expose_peer_addresses;
+                remaining_replenishment_demand = remaining_replenishment_demand.saturating_sub(1);
 
-                // Increment the connection count before we spawn the connection.
-                let outbound_connection_tracker = active_outbound_connections.track_connection();
-                let outbound_connections = active_outbound_connections.update_count();
-                debug!(?outbound_connections, "opening an outbound peer connection");
+                if active_outbound_connections.update_count()
+                    >= config.peerset_outbound_connection_limit()
+                {
+                    remaining_replenishment_demand = 0;
 
-                // Spawn each handshake or crawl into an independent task, so handshakes can make
-                // progress while crawls are running.
-                //
-                // # Concurrency
-                //
-                // The peer crawler must be able to make progress even if some handshakes are
-                // rate-limited. So the async mutex and next peer timeout are awaited inside the
-                // spawned task.
-                let handshake_or_crawl_handle = tokio::spawn(
-                    async move {
-                        // Try to get the next available peer for a handshake.
-                        //
-                        // candidates.next() has a short timeout, and briefly holds the address
-                        // book lock, so it shouldn't hang.
-                        //
-                        // Hold the lock for as short a time as possible.
-                        let candidate = { candidates.lock().await.next().await };
+                    // This is set to trace level because when the peer set is
+                    // congested it can generate a lot of demand signals.
+                    trace!(
+                        "too many open connections or in-flight handshakes, dropping demand signal"
+                    );
+                } else {
+                    let candidates = candidates.clone();
+                    let outbound_connector = outbound_connector.clone();
+                    let peerset_tx = peerset_tx.clone();
+                    let address_book_updater = address_book_updater.clone();
+                    let demand_tx = demand_tx.clone();
+                    let expose_peer_addresses = config.expose_peer_addresses;
 
-                        if let Some(candidate) = candidate {
-                            // we don't need to spawn here, because there's nothing running concurrently
-                            dial(
-                                candidate,
-                                outbound_connector,
-                                outbound_connection_tracker,
-                                outbound_connections,
-                                peerset_tx,
-                                address_book_updater,
-                                demand_tx,
-                                expose_peer_addresses,
-                            )
-                            .await?;
+                    // Increment the connection count before we spawn the connection.
+                    let outbound_connection_tracker =
+                        active_outbound_connections.track_connection();
+                    let outbound_connections = active_outbound_connections.update_count();
+                    debug!(?outbound_connections, "opening an outbound peer connection");
 
-                            Ok(HandshakeFinished)
-                        } else {
-                            // There weren't any peers, so try to get more peers.
-                            debug!("demand for peers but no available candidates");
+                    // Spawn each handshake or crawl into an independent task, so handshakes can
+                    // make progress while crawls are running.
+                    //
+                    // # Concurrency
+                    //
+                    // The peer crawler must be able to make progress even if some handshakes are
+                    // rate-limited. So the async mutex and next peer timeout are awaited inside the
+                    // spawned task.
+                    let handshake_or_crawl_handle = tokio::spawn(
+                        async move {
+                            // Try to get the next available peer for a handshake.
+                            //
+                            // candidates.next() has a short timeout, and briefly holds the address
+                            // book lock, so it shouldn't hang.
+                            //
+                            // Hold the lock for as short a time as possible.
+                            let candidate = { candidates.lock().await.next().await };
 
-                            crawl(candidates, demand_tx, 0).await?;
+                            if let Some(candidate) = candidate {
+                                // we don't need to spawn here, because there's nothing running concurrently
+                                dial(
+                                    candidate,
+                                    outbound_connector,
+                                    outbound_connection_tracker,
+                                    outbound_connections,
+                                    peerset_tx,
+                                    address_book_updater,
+                                    demand_tx,
+                                    expose_peer_addresses,
+                                )
+                                .await?;
 
-                            Ok(DemandCrawlFinished)
+                                Ok(HandshakeFinished)
+                            } else {
+                                // There weren't any peers, so try to get more peers.
+                                debug!("demand for peers but no available candidates");
+
+                                crawl(candidates, demand_tx).await?;
+
+                                Ok(DemandCrawlFinished)
+                            }
                         }
-                    }
-                    .in_current_span(),
-                )
-                .wait_for_panics();
+                        .in_current_span(),
+                    )
+                    .wait_for_panics();
 
-                handshakes.push(handshake_or_crawl_handle);
+                    handshakes.push(handshake_or_crawl_handle);
+                }
             }
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
                 let demand_tx = demand_tx.clone();
-                let active_outbound_connections = active_outbound_connections.update_count();
-                let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                let replenishment_demand = outbound_peer_replenishment_demand(
-                    active_outbound_connections,
-                    outbound_connection_limit,
-                );
 
                 let crawl_handle = tokio::spawn(
                     async move {
                         debug!(
                             ?tick,
-                            active_outbound_connections,
-                            outbound_connection_limit,
-                            replenishment_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, replenishment_demand).await?;
+                        crawl(candidates, demand_tx).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1260,7 +1239,19 @@ where
                 trace!("demand-based crawl finished");
             }
             Ok(TimerCrawlFinished) => {
-                debug!("timer-based crawl finished");
+                let active_outbound_connections = active_outbound_connections.update_count();
+                let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                remaining_replenishment_demand = outbound_peer_replenishment_demand(
+                    active_outbound_connections,
+                    outbound_connection_limit,
+                );
+
+                debug!(
+                    active_outbound_connections,
+                    outbound_connection_limit,
+                    remaining_replenishment_demand,
+                    "timer-based crawl finished"
+                );
             }
 
             // Fatal errors and shutdowns
@@ -1277,16 +1268,12 @@ where
     }
 }
 
-/// Try to get more peers using `candidates`, then queue connection attempts
-/// using `demand_tx`.
-/// If the crawl discovers peers, queue at least one connection attempt. Also
-/// queue at least `minimum_connection_demand` attempts, unless the demand
-/// channel is already full.
+/// Try to get more peers using `candidates`, then queue a connection attempt
+/// using `demand_tx` if the crawl discovers peers.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    minimum_connection_demand: usize,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1300,9 +1287,8 @@ where
         std::mem::drop(candidates);
         result
     };
-    let connection_demand = match result {
-        Ok(Some(MorePeers)) => minimum_connection_demand.max(1),
-        Ok(None) => minimum_connection_demand,
+    let more_peers = match result {
+        Ok(more_peers) => more_peers,
         Err(e) => {
             info!(
                 ?e,
@@ -1312,13 +1298,22 @@ where
         }
     };
 
-    // Queue connection attempts for discovered peers or outbound replenishment.
+    // Queue a connection attempt for discovered peers.
     //
     // # Security
     //
-    // Candidate selection rate-limits outbound handshakes, and the crawler loop
-    // checks the configured outbound connection limit before starting each one.
-    queue_peer_demand(&mut demand_tx, connection_demand)
+    // Update attempts are rate-limited by the candidate set, and we only try
+    // peers if there was actually an update.
+    if let Some(more_peers) = more_peers {
+        if let Err(send_error) = demand_tx.try_send(more_peers) {
+            if send_error.is_disconnected() {
+                // Zakura's peer set is shutting down.
+                return Err(send_error.into());
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Try to connect to `candidate` using `outbound_connector`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,16 +981,18 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-/// Returns `true` when the crawler should replenish outbound peers.
+/// Returns the number of outbound peers needed to reach half the configured
+/// connection limit.
 ///
-/// The threshold is strictly below half the configured outbound connection
-/// limit. Using [`usize::div_ceil`] preserves that boundary for odd limits and
-/// keeps a zero limit disabled.
-fn should_replenish_outbound_peers(
+/// Using [`usize::div_ceil`] preserves the threshold for odd limits, and
+/// [`usize::saturating_sub`] returns zero at or above the threshold.
+fn outbound_peer_replenishment_demand(
     active_outbound_connections: usize,
     outbound_connection_limit: usize,
-) -> bool {
-    active_outbound_connections < outbound_connection_limit.div_ceil(2)
+) -> usize {
+    outbound_connection_limit
+        .div_ceil(2)
+        .saturating_sub(active_outbound_connections)
 }
 
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
@@ -999,8 +1001,8 @@ fn should_replenish_outbound_peers(
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After a periodic crawl, request another outbound connection while fewer than
-/// half the configured outbound connection slots are active.
+/// After a periodic crawl, queue enough outbound connection demand to reach
+/// half the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1174,7 +1176,7 @@ where
                             // There weren't any peers, so try to get more peers.
                             debug!("demand for peers but no available candidates");
 
-                            crawl(candidates, demand_tx, false).await?;
+                            crawl(candidates, demand_tx, 0).await?;
 
                             Ok(DemandCrawlFinished)
                         }
@@ -1190,7 +1192,7 @@ where
                 let demand_tx = demand_tx.clone();
                 let active_outbound_connections = active_outbound_connections.update_count();
                 let outbound_connection_limit = config.peerset_outbound_connection_limit();
-                let should_signal_demand = should_replenish_outbound_peers(
+                let replenishment_demand = outbound_peer_replenishment_demand(
                     active_outbound_connections,
                     outbound_connection_limit,
                 );
@@ -1201,11 +1203,11 @@ where
                             ?tick,
                             active_outbound_connections,
                             outbound_connection_limit,
-                            should_signal_demand,
+                            replenishment_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, should_signal_demand).await?;
+                        crawl(candidates, demand_tx, replenishment_demand).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1244,13 +1246,14 @@ where
 }
 
 /// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
-/// If there were no new peers and `should_signal_demand` is false, the
-/// connection attempt is skipped.
+/// If the crawl discovers peers, queue at least one connection attempt. Also
+/// queue at least `minimum_connection_demand` attempts, unless the demand
+/// channel is already full.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    should_signal_demand: bool,
+    minimum_connection_demand: usize,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1264,8 +1267,9 @@ where
         std::mem::drop(candidates);
         result
     };
-    let more_peers = match result {
-        Ok(more_peers) => more_peers.or_else(|| should_signal_demand.then_some(MorePeers)),
+    let connection_demand = match result {
+        Ok(Some(MorePeers)) => minimum_connection_demand.max(1),
+        Ok(None) => minimum_connection_demand,
         Err(e) => {
             info!(
                 ?e,
@@ -1275,22 +1279,22 @@ where
         }
     };
 
-    // If we got more peers, try to connect to a new peer on our next loop.
+    // Queue connection attempts for discovered peers or outbound replenishment.
     //
     // # Security
     //
-    // Update attempts are rate-limited by the candidate set,
-    // and we only try peers if there was actually an update.
-    //
-    // So if all peers have had a recent attempt, and there was recent update
-    // with no peers, the channel will drain. This prevents useless update attempt
-    // loops.
-    if let Some(more_peers) = more_peers {
-        if let Err(send_error) = demand_tx.try_send(more_peers) {
+    // Candidate selection rate-limits outbound handshakes, and the crawler loop
+    // checks the configured outbound connection limit before starting each one.
+    for _ in 0..connection_demand {
+        if let Err(send_error) = demand_tx.try_send(MorePeers) {
             if send_error.is_disconnected() {
                 // Zebra is shutting down
                 return Err(send_error.into());
             }
+
+            // Existing queued demand is already sufficient to fill the bounded
+            // channel, so additional signals are unnecessary.
+            break;
         }
     }
 

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -975,16 +975,16 @@ enum CrawlerAction {
     HandshakeFinished,
     /// Clear a finished failed handshake that restored demand to the channel.
     ///
-    /// Credits one unit of remaining replenishment demand so the restored
-    /// `MorePeers` message can be processed without permanently consuming the
-    /// timer-based replenishment budget.
-    HandshakeFailed,
+    /// When `restore_replenishment_demand` is set, credits one unit of remaining
+    /// replenishment demand so a restored `MorePeers` message does not
+    /// permanently consume the timer-based budget.
+    HandshakeFailed { restore_replenishment_demand: bool },
     /// Clear a finished demand crawl (DemandHandshakeOrCrawl with no peers).
     ///
-    /// Credits one unit of remaining replenishment demand because the attempt
-    /// did not consume a candidate or open a connection, and pauses further
-    /// local replenishment until timer or channel demand.
-    DemandCrawlFinished,
+    /// When `restore_replenishment_demand` is set, credits one unit of remaining
+    /// replenishment demand. Always pauses further local replenishment until
+    /// timer or channel demand so crediting cannot busy-loop empty crawls.
+    DemandCrawlFinished { restore_replenishment_demand: bool },
     /// Clear a finished TimerCrawl.
     TimerCrawlFinished,
 }
@@ -1159,6 +1159,10 @@ where
         match crawler_action {
             // Spawned tasks
             Ok(DemandHandshakeOrCrawl) => {
+                // Only credit later if this action actually consumed a timer
+                // replenishment unit. Channel demand with remaining == 0 must
+                // not invent local budget on failure or empty candidate crawls.
+                let restore_replenishment_demand = remaining_replenishment_demand > 0;
                 remaining_replenishment_demand = remaining_replenishment_demand.saturating_sub(1);
 
                 if active_outbound_connections.update_count()
@@ -1218,15 +1222,21 @@ where
                                 .await?
                                 {
                                     DialOutcome::Connected => Ok(HandshakeFinished),
-                                    DialOutcome::Failed => Ok(HandshakeFailed),
+                                    DialOutcome::Failed => Ok(HandshakeFailed {
+                                        restore_replenishment_demand,
+                                    }),
                                 }
                             } else {
                                 // There weren't any peers, so try to get more peers.
                                 debug!("demand for peers but no available candidates");
 
+                                // Release the reserved outbound slot before crawling.
+                                std::mem::drop(outbound_connection_tracker);
                                 crawl(candidates, demand_tx).await?;
 
-                                Ok(DemandCrawlFinished)
+                                Ok(DemandCrawlFinished {
+                                    restore_replenishment_demand,
+                                })
                             }
                         }
                         .in_current_span(),
@@ -1262,20 +1272,27 @@ where
             Ok(HandshakeFinished) => {
                 // Already logged in dial()
             }
-            Ok(HandshakeFailed) => {
+            Ok(HandshakeFailed {
+                restore_replenishment_demand,
+            }) => {
                 // dial() restored MorePeers to demand_rx when possible. Credit
-                // the unit spent when spawning this attempt so a restored
-                // message (or a local retry if the channel was full) does not
-                // permanently shrink the replenishment budget.
-                remaining_replenishment_demand = remaining_replenishment_demand.saturating_add(1);
-                pause_local_replenishment = false;
+                // only when this attempt consumed timer replenishment demand.
+                if restore_replenishment_demand {
+                    remaining_replenishment_demand =
+                        remaining_replenishment_demand.saturating_add(1);
+                    pause_local_replenishment = false;
+                }
             }
-            Ok(DemandCrawlFinished) => {
-                // No candidate was dialed, so credit the unit spent for this
-                // demand action. Pause local replenishment so crediting does
-                // not busy-loop empty crawls; the next timer or channel demand
-                // clears the pause and can spend the preserved budget.
-                remaining_replenishment_demand = remaining_replenishment_demand.saturating_add(1);
+            Ok(DemandCrawlFinished {
+                restore_replenishment_demand,
+            }) => {
+                // No candidate was dialed. Credit only when this attempt
+                // consumed timer replenishment demand, and always pause local
+                // replenishment so empty candidate sets cannot busy-loop.
+                if restore_replenishment_demand {
+                    remaining_replenishment_demand =
+                        remaining_replenishment_demand.saturating_add(1);
+                }
                 pause_local_replenishment = true;
 
                 // This is set to trace level because when the peerset is

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,18 +981,29 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-/// Returns the number of outbound peers needed to reach half the configured
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 3;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 10;
+
+/// Returns the number of outbound peers needed to reach 30% of the configured
 /// connection limit.
 ///
-/// Using [`usize::div_ceil`] preserves the threshold for odd limits, and
-/// [`usize::saturating_sub`] returns zero at or above the threshold.
+/// The target calculation avoids overflow by applying the ratio separately to
+/// the quotient and remainder. [`usize::div_ceil`] rounds partial peers upward,
+/// and [`usize::saturating_sub`] returns zero at or above the target.
 fn outbound_peer_replenishment_demand(
     active_outbound_connections: usize,
     outbound_connection_limit: usize,
 ) -> usize {
-    outbound_connection_limit
-        .div_ceil(2)
-        .saturating_sub(active_outbound_connections)
+    let target_outbound_connections = (outbound_connection_limit
+        / OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR)
+        .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+        .saturating_add(
+            (outbound_connection_limit % OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR)
+                .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+                .div_ceil(OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR),
+        );
+
+    target_outbound_connections.saturating_sub(active_outbound_connections)
 }
 
 /// Queue up to `connection_demand` outbound connection attempts.
@@ -1023,7 +1034,7 @@ fn queue_peer_demand(
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
 /// After a periodic crawl, queue enough outbound connection demand to reach
-/// half the configured outbound connection limit.
+/// 30% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,10 +981,10 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
-const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 3;
-const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 10;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR: usize = 27;
+const OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR: usize = 100;
 
-/// Returns the number of outbound peers needed to reach 30% of the configured
+/// Returns the number of outbound peers needed to reach 27% of the configured
 /// connection limit.
 ///
 /// The target calculation avoids overflow by applying the ratio separately to
@@ -1034,7 +1034,7 @@ fn queue_peer_demand(
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
 /// After a periodic crawl, queue enough outbound connection demand to reach
-/// 30% of the configured outbound connection limit.
+/// 27% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -1003,7 +1003,7 @@ fn queue_peer_demand(
     for _ in 0..connection_demand {
         if let Err(send_error) = demand_tx.try_send(MorePeers) {
             if send_error.is_disconnected() {
-                // Zebra is shutting down
+                // Zakura's peer set is shutting down.
                 return Err(send_error.into());
             }
 
@@ -1409,7 +1409,7 @@ where
             // Handshake failures are rate-limited by peer attempt timeouts.
             if let Err(send_error) = demand_tx.try_send(MorePeers) {
                 if send_error.is_disconnected() {
-                    // Zebra is shutting down
+                    // Zakura's peer set is shutting down.
                     return Err(send_error.into());
                 }
             }

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -971,9 +971,19 @@ enum CrawlerAction {
     DemandHandshakeOrCrawl,
     /// Crawl existing peers for more peers in response to a timer `tick`.
     TimerCrawl { tick: Instant },
-    /// Clear a finished handshake.
+    /// Clear a finished successful handshake.
     HandshakeFinished,
+    /// Clear a finished failed handshake that restored demand to the channel.
+    ///
+    /// Credits one unit of remaining replenishment demand so the restored
+    /// `MorePeers` message can be processed without permanently consuming the
+    /// timer-based replenishment budget.
+    HandshakeFailed,
     /// Clear a finished demand crawl (DemandHandshakeOrCrawl with no peers).
+    ///
+    /// Credits one unit of remaining replenishment demand because the attempt
+    /// did not consume a candidate or open a connection, and pauses further
+    /// local replenishment until timer or channel demand.
     DemandCrawlFinished,
     /// Clear a finished TimerCrawl.
     TimerCrawlFinished,
@@ -1014,7 +1024,11 @@ fn outbound_peer_replenishment_demand(
 /// 27% of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
-/// `demand_tx`.
+/// `demand_tx`, and credit one unit of remaining replenishment demand so the
+/// restored signal does not permanently consume the timer-based budget.
+///
+/// If demand arrives with no candidates, crawl for peers and credit the same
+/// replenishment unit so empty candidate sets do not under-replenish.
 ///
 /// The crawler terminates when `candidates.update()` or `peerset_tx` returns a
 /// permanent internal error. Transient errors and individual peer errors should
@@ -1096,6 +1110,12 @@ where
     // that are already waiting in `demand_rx`.
     let mut remaining_replenishment_demand: usize = 0;
 
+    // When demand finds no candidates, credit the spent replenishment unit but
+    // pause further *local* attempts. Otherwise crediting would busy-loop empty
+    // crawls while `remaining_replenishment_demand > 0`. Channel demand (PeerSet
+    // or a crawl that discovered peers) and the next timer clear the pause.
+    let mut pause_local_replenishment = false;
+
     // # Concurrency
     //
     // To avoid hangs and starvation, the crawler must spawn a separate task for each crawl
@@ -1119,12 +1139,19 @@ where
             next_timer = crawl_timer.next() => Ok(next_timer.expect("timers never terminate")),
             // External demand is potentially unlimited, so it goes after the
             // rate-limited timer in this biased select.
-            next_demand = demand_rx.next() => next_demand
-                .ok_or("demand stream closed, is Zakura shutting down?".into())
-                .map(|MorePeers| DemandHandshakeOrCrawl),
+            next_demand = demand_rx.next() => {
+                // New channel demand means candidates or PeerSet pressure may
+                // have changed; allow local replenishment again after this try.
+                pause_local_replenishment = false;
+                next_demand
+                    .ok_or("demand stream closed, is Zakura shutting down?".into())
+                    .map(|MorePeers| DemandHandshakeOrCrawl)
+            },
             // Existing channel demand gets priority over local replenishment.
             // Each action consumes one unit of replenishment demand below.
-            _ = future::ready(()), if remaining_replenishment_demand > 0 => {
+            _ = future::ready(()),
+                if remaining_replenishment_demand > 0 && !pause_local_replenishment =>
+            {
                 Ok(DemandHandshakeOrCrawl)
             }
         };
@@ -1178,7 +1205,7 @@ where
 
                             if let Some(candidate) = candidate {
                                 // we don't need to spawn here, because there's nothing running concurrently
-                                dial(
+                                match dial(
                                     candidate,
                                     outbound_connector,
                                     outbound_connection_tracker,
@@ -1188,9 +1215,11 @@ where
                                     demand_tx,
                                     expose_peer_addresses,
                                 )
-                                .await?;
-
-                                Ok(HandshakeFinished)
+                                .await?
+                                {
+                                    DialOutcome::Connected => Ok(HandshakeFinished),
+                                    DialOutcome::Failed => Ok(HandshakeFailed),
+                                }
                             } else {
                                 // There weren't any peers, so try to get more peers.
                                 debug!("demand for peers but no available candidates");
@@ -1233,7 +1262,22 @@ where
             Ok(HandshakeFinished) => {
                 // Already logged in dial()
             }
+            Ok(HandshakeFailed) => {
+                // dial() restored MorePeers to demand_rx when possible. Credit
+                // the unit spent when spawning this attempt so a restored
+                // message (or a local retry if the channel was full) does not
+                // permanently shrink the replenishment budget.
+                remaining_replenishment_demand = remaining_replenishment_demand.saturating_add(1);
+                pause_local_replenishment = false;
+            }
             Ok(DemandCrawlFinished) => {
+                // No candidate was dialed, so credit the unit spent for this
+                // demand action. Pause local replenishment so crediting does
+                // not busy-loop empty crawls; the next timer or channel demand
+                // clears the pause and can spend the preserved budget.
+                remaining_replenishment_demand = remaining_replenishment_demand.saturating_add(1);
+                pause_local_replenishment = true;
+
                 // This is set to trace level because when the peerset is
                 // congested it can generate a lot of demand signal very rapidly.
                 trace!("demand-based crawl finished");
@@ -1245,6 +1289,7 @@ where
                     active_outbound_connections,
                     outbound_connection_limit,
                 );
+                pause_local_replenishment = false;
 
                 debug!(
                     active_outbound_connections,
@@ -1316,6 +1361,14 @@ where
     Ok(())
 }
 
+/// Outcome of an outbound dial for crawler replenishment bookkeeping.
+enum DialOutcome {
+    /// The handshake succeeded and the peer was sent to the peer set.
+    Connected,
+    /// The handshake failed; demand was restored to `demand_tx` when possible.
+    Failed,
+}
+
 /// Try to connect to `candidate` using `outbound_connector`.
 /// Uses `outbound_connection_tracker` to track the active connection count.
 ///
@@ -1342,7 +1395,7 @@ async fn dial<C>(
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
     expose_peer_addresses: bool,
-) -> Result<(), BoxError>
+) -> Result<DialOutcome, BoxError>
 where
     C: Service<
             OutboundConnectorRequest,
@@ -1383,6 +1436,8 @@ where
 
             // The connection limit makes sure this send doesn't block.
             peerset_tx.send((address, client)).await?;
+
+            Ok(DialOutcome::Connected)
         }
         // The connection was never opened, or it failed the handshake and was dropped.
         Err(error) => {
@@ -1419,10 +1474,10 @@ where
                     return Err(send_error.into());
                 }
             }
+
+            Ok(DialOutcome::Failed)
         }
     }
-
-    Ok(())
 }
 
 /// Mark `addr` as a failed peer to `address_book_updater`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -981,13 +981,26 @@ enum CrawlerAction {
     TimerCrawlFinished,
 }
 
+/// Returns `true` when the crawler should replenish outbound peers.
+///
+/// The threshold is strictly below half the configured outbound connection
+/// limit. Using [`usize::div_ceil`] preserves that boundary for odd limits and
+/// keeps a zero limit disabled.
+fn should_replenish_outbound_peers(
+    active_outbound_connections: usize,
+    outbound_connection_limit: usize,
+) -> bool {
+    active_outbound_connections < outbound_connection_limit.div_ceil(2)
+}
+
 /// Given a channel `demand_rx` that signals a need for new peers, try to find
 /// and connect to new peers, and send the resulting `peer::Client`s through the
 /// `peerset_tx` channel.
 ///
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
-/// After crawling, try to connect to one new peer using `outbound_connector`.
+/// After a periodic crawl, request another outbound connection while fewer than
+/// half the configured outbound connection slots are active.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1175,16 +1188,24 @@ where
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
                 let demand_tx = demand_tx.clone();
-                let should_always_dial = active_outbound_connections.update_count() == 0;
+                let active_outbound_connections = active_outbound_connections.update_count();
+                let outbound_connection_limit = config.peerset_outbound_connection_limit();
+                let should_signal_demand = should_replenish_outbound_peers(
+                    active_outbound_connections,
+                    outbound_connection_limit,
+                );
 
                 let crawl_handle = tokio::spawn(
                     async move {
                         debug!(
                             ?tick,
+                            active_outbound_connections,
+                            outbound_connection_limit,
+                            should_signal_demand,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, should_always_dial).await?;
+                        crawl(candidates, demand_tx, should_signal_demand).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1223,12 +1244,13 @@ where
 }
 
 /// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
-/// If there were no new peers and `should_always_dial` is false, the connection attempt is skipped.
+/// If there were no new peers and `should_signal_demand` is false, the
+/// connection attempt is skipped.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    should_always_dial: bool,
+    should_signal_demand: bool,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1243,7 +1265,7 @@ where
         result
     };
     let more_peers = match result {
-        Ok(more_peers) => more_peers.or_else(|| should_always_dial.then_some(MorePeers)),
+        Ok(more_peers) => more_peers.or_else(|| should_signal_demand.then_some(MorePeers)),
         Err(e) => {
             info!(
                 ?e,

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,9 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            outbound_peer_replenishment_demand, queue_peer_demand, DiscoveredPeer,
+            outbound_peer_replenishment_demand, DiscoveredPeer,
+            OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR,
+            OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -61,6 +63,19 @@ const PEER_CACHE_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// A crawler peer limit large enough to exercise multi-peer behavior without
 /// flooding the test runtime with hundreds of immediate fake handshakes.
 const CRAWLER_MANY_PEER_LIMIT_FOR_TESTS: usize = 15;
+
+/// A small peer target that keeps replenishment race tests fast.
+const CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS: usize = 10;
+
+/// The outbound connection limit used by replenishment race tests.
+const CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS: usize =
+    CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS * constants::OUTBOUND_PEER_LIMIT_MULTIPLIER;
+
+/// The outbound connection target used by replenishment race tests.
+const CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS: usize =
+    CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS
+        .saturating_mul(OUTBOUND_PEER_REPLENISHMENT_TARGET_NUMERATOR)
+        .div_ceil(OUTBOUND_PEER_REPLENISHMENT_TARGET_DENOMINATOR);
 
 /// The maximum time to wait for the listener tests to make expected progress.
 const LISTENER_TEST_DURATION: Duration = Duration::from_secs(10);
@@ -478,20 +493,95 @@ fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     }
 }
 
-#[test]
-fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 81;
+#[tokio::test(start_paused = true)]
+async fn crawler_startup_demand_satisfies_replenishment() {
+    let mut harness = spawn_replenishment_crawler(
+        0,
+        CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+    )
+    .await;
 
-    let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
-    queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)
-        .expect("open demand channel accepts replenishment signals");
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS)
+        .await;
+}
 
-    let mut queued_demand = 0;
-    while demand_rx.try_recv().is_ok() {
-        queued_demand += 1;
-    }
+#[tokio::test(start_paused = true)]
+async fn crawler_partial_queued_demand_is_completed_to_target() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 3, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
 
-    assert_eq!(queued_demand, CONNECTION_DEMAND);
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_demand_arriving_during_crawl_counts_toward_target() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 0, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
+
+    harness.wait_for_crawl_start().await;
+    harness.queue_demand(4);
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_disconnects_during_crawl_are_replenished() {
+    let mut harness = spawn_replenishment_crawler(
+        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.drop_initial_connections(4);
+    harness.release_crawl();
+    harness.assert_connection_attempts(4).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_overlapping_timer_crawls_do_not_duplicate_replenishment() {
+    let mut harness = spawn_replenishment_crawler(0, 0, Duration::from_secs(1)).await;
+
+    harness.wait_for_crawl_start().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_excess_queued_demand_is_preserved() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 12, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness.assert_connection_attempts(12).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn crawler_replenishment_respects_hard_outbound_limit() {
+    let mut harness =
+        spawn_replenishment_crawler(0, 40, constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL).await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS)
+        .await;
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
@@ -1906,6 +1996,248 @@ where
     .await;
 
     address_book
+}
+
+struct ReplenishmentCrawlerTestHarness {
+    config: Config,
+    demand_tx: mpsc::Sender<MorePeers>,
+    crawl_started_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+    crawl_release_tx: tokio::sync::watch::Sender<bool>,
+    connection_tracker_rx: tokio::sync::mpsc::UnboundedReceiver<ConnectionTracker>,
+    crawl_task_handle: JoinHandle<Result<(), BoxError>>,
+    address_book_updater_guard: JoinHandle<Result<(), BoxError>>,
+    _peerset_rx: mpsc::Receiver<DiscoveredPeer>,
+    initial_connection_trackers: Vec<ConnectionTracker>,
+}
+
+impl ReplenishmentCrawlerTestHarness {
+    async fn wait_for_crawl_start(&mut self) {
+        wait_for_crawler_events(
+            &mut self.crawl_started_rx,
+            1,
+            "periodic peer crawl should start before the timeout",
+        )
+        .await;
+    }
+
+    fn release_crawl(&self) {
+        self.crawl_release_tx
+            .send(true)
+            .expect("controlled crawl receiver remains open");
+    }
+
+    fn queue_demand(&mut self, demand_count: usize) {
+        for _ in 0..demand_count {
+            self.demand_tx
+                .try_send(MorePeers)
+                .expect("replenishment test demand channel has capacity");
+        }
+    }
+
+    fn drop_initial_connections(&mut self, connection_count: usize) {
+        assert!(
+            connection_count <= self.initial_connection_trackers.len(),
+            "cannot drop more initial connections than the harness holds"
+        );
+
+        let keep_count = self.initial_connection_trackers.len() - connection_count;
+        let dropped_connections = self.initial_connection_trackers.split_off(keep_count);
+        std::mem::drop(dropped_connections);
+    }
+
+    async fn assert_connection_attempts(mut self, expected_connection_attempts: usize) {
+        let mut connection_trackers = wait_for_crawler_events(
+            &mut self.connection_tracker_rx,
+            expected_connection_attempts,
+            "crawler should start the expected replenishment attempts",
+        )
+        .await;
+
+        self.demand_tx.close_channel();
+
+        let shutdown_deadline = Instant::now() + CRAWLER_TEST_TIMEOUT;
+        while !self.crawl_task_handle.is_finished() {
+            assert!(
+                Instant::now() < shutdown_deadline,
+                "crawler should shut down after its demand channel closes"
+            );
+            tokio::task::spawn_blocking(|| {})
+                .await
+                .expect("crawler test blocking-task synchronization should not panic");
+            tokio::task::yield_now().await;
+        }
+
+        let crawl_result = self.crawl_task_handle.await;
+        match crawl_result {
+            Ok(Err(error)) => assert!(
+                error.to_string().contains("demand stream closed"),
+                "unexpected peer crawler shutdown error: {error:?}"
+            ),
+            other => panic!("unexpected peer crawler shutdown result: {other:?}"),
+        }
+
+        let connection_deadline = Instant::now() + CRAWLER_TEST_TIMEOUT;
+        loop {
+            while let Ok(connection_tracker) = self.connection_tracker_rx.try_recv() {
+                connection_trackers.push(connection_tracker);
+            }
+
+            if self.connection_tracker_rx.is_closed() {
+                break;
+            }
+
+            assert!(
+                Instant::now() < connection_deadline,
+                "all spawned connection attempts should finish before the timeout"
+            );
+            tokio::time::advance(constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL).await;
+            tokio::task::spawn_blocking(|| {})
+                .await
+                .expect("crawler test blocking-task synchronization should not panic");
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            connection_trackers.len(),
+            expected_connection_attempts,
+            "crawler started an unexpected number of connection attempts"
+        );
+        assert!(
+            connection_trackers.len() <= self.config.peerset_outbound_connection_limit(),
+            "crawler exceeded the hard outbound connection limit"
+        );
+
+        self.address_book_updater_guard.abort();
+    }
+}
+
+async fn spawn_replenishment_crawler(
+    initial_connection_count: usize,
+    initial_demand_count: usize,
+    crawl_new_peer_interval: Duration,
+) -> ReplenishmentCrawlerTestHarness {
+    let config = Config {
+        peerset_initial_target_size: CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
+        crawl_new_peer_interval,
+        ..Config::default()
+    };
+    let outbound_connection_limit = config.peerset_outbound_connection_limit();
+
+    assert!(initial_connection_count <= outbound_connection_limit);
+
+    let (
+        address_book,
+        _bans_receiver,
+        address_book_updater,
+        _address_metrics,
+        address_book_updater_guard,
+    ) = AddressBookUpdater::spawn(&config, config.listen_addr, PeerServices::NODE_NETWORK);
+
+    let candidate_count = outbound_connection_limit
+        .saturating_mul(2)
+        .saturating_add(1);
+    for address_number in 0..candidate_count {
+        let address_number =
+            u32::try_from(address_number).expect("small replenishment test address count fits u32");
+        let ip =
+            Ipv4Addr::from(u32::from(Ipv4Addr::new(127, 2, 0, 0)).saturating_add(address_number));
+        let addr = MetaAddr::new_gossiped_meta_addr(
+            SocketAddr::new(ip.into(), 8233).into(),
+            PeerServices::NODE_NETWORK,
+            DateTime32::now(),
+        )
+        .new_gossiped_change()
+        .expect("replenishment test peer has valid gossiped address fields");
+
+        address_book
+            .lock()
+            .expect("previous test thread panicked while holding the address book")
+            .update(addr)
+            .expect("replenishment test peer is valid");
+    }
+
+    let (crawl_started_tx, crawl_started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (crawl_release_tx, crawl_release_rx) = tokio::sync::watch::channel(false);
+    let controlled_peer_set = service_fn(move |request| {
+        let crawl_started_tx = crawl_started_tx.clone();
+        let mut crawl_release_rx = crawl_release_rx.clone();
+
+        async move {
+            assert!(
+                matches!(request, Request::Peers),
+                "crawler should only request peer addresses"
+            );
+            crawl_started_tx
+                .send(())
+                .expect("replenishment test crawl observer remains open");
+            crawl_release_rx
+                .wait_for(|crawl_released| *crawl_released)
+                .await
+                .expect("replenishment test crawl controller remains open");
+
+            Err::<Response, BoxError>("controlled peer crawl returns no addresses".into())
+        }
+    });
+    let candidates = CandidateSet::new(address_book, controlled_peer_set);
+
+    let channel_capacity = candidate_count.max(initial_demand_count);
+    let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(channel_capacity);
+    let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(channel_capacity);
+    for _ in 0..initial_demand_count {
+        demand_tx
+            .try_send(MorePeers)
+            .expect("initial replenishment test demand channel has capacity");
+    }
+
+    let mut active_outbound_connections = ActiveConnectionCounter::new_counter_with(
+        outbound_connection_limit,
+        "Replenishment Test Outbound Connections",
+    );
+    let initial_connection_trackers = (0..initial_connection_count)
+        .map(|_| active_outbound_connections.track_connection())
+        .collect();
+
+    let (connection_tracker_tx, connection_tracker_rx) = tokio::sync::mpsc::unbounded_channel();
+    let outbound_connector = service_fn(move |request: OutboundConnectorRequest| {
+        let connection_tracker_tx = connection_tracker_tx.clone();
+
+        async move {
+            let OutboundConnectorRequest {
+                addr,
+                connection_tracker,
+            } = request;
+            let (fake_client, _harness) = ClientTestHarness::build().finish();
+
+            connection_tracker_tx
+                .send(connection_tracker)
+                .expect("replenishment connection observer remains open");
+
+            Ok((addr, fake_client))
+        }
+    });
+
+    let crawl_task_handle = tokio::spawn(crawl_and_dial(
+        config.clone(),
+        demand_tx.clone(),
+        demand_rx,
+        candidates,
+        outbound_connector,
+        peerset_tx,
+        active_outbound_connections,
+        address_book_updater,
+    ));
+
+    ReplenishmentCrawlerTestHarness {
+        config,
+        demand_tx,
+        crawl_started_rx,
+        crawl_release_tx,
+        connection_tracker_rx,
+        crawl_task_handle,
+        address_book_updater_guard,
+        _peerset_rx: peerset_rx,
+        initial_connection_trackers,
+    }
 }
 
 /// The number of connector calls a crawler peer-limit test expects to observe.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            DiscoveredPeer,
+            should_replenish_outbound_peers, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -445,6 +445,29 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
         .expect("test peer is valid for the mainnet address book");
 
     peer
+}
+
+#[test]
+fn crawler_replenishes_outbound_peers_below_half_limit() {
+    let cases = [
+        (0, 0, false),
+        (0, 1, true),
+        (1, 1, false),
+        (0, 2, true),
+        (1, 2, false),
+        (1, 3, true),
+        (2, 3, false),
+        (149, 300, true),
+        (150, 300, false),
+    ];
+
+    for (active, limit, expected) in cases {
+        assert_eq!(
+            should_replenish_outbound_peers(active, limit),
+            expected,
+            "unexpected replenishment decision for {active} active peers and limit {limit}",
+        );
+    }
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -448,19 +448,25 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 }
 
 #[test]
-fn crawler_replenishes_outbound_peers_below_half_limit() {
+fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
     let cases = [
         (0, 0, 0),
         (0, 1, 1),
         (1, 1, 0),
         (0, 2, 1),
         (1, 2, 0),
-        (0, 3, 2),
-        (1, 3, 1),
-        (2, 3, 0),
-        (100, 300, 50),
-        (149, 300, 1),
-        (150, 300, 0),
+        (0, 3, 1),
+        (1, 3, 0),
+        (0, 4, 2),
+        (1, 4, 1),
+        (2, 4, 0),
+        (0, 10, 3),
+        (2, 10, 1),
+        (3, 10, 0),
+        (0, 300, 90),
+        (89, 300, 1),
+        (90, 300, 0),
+        (100, 300, 0),
     ];
 
     for (active, limit, expected) in cases {
@@ -474,7 +480,7 @@ fn crawler_replenishes_outbound_peers_below_half_limit() {
 
 #[test]
 fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 50;
+    const CONNECTION_DEMAND: usize = 90;
 
     let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
     queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -656,6 +656,32 @@ async fn crawler_empty_candidates_pause_local_replenishment() {
     harness.assert_connection_attempts(0).await;
 }
 
+/// Channel demand at the replenishment target must not mint local budget when
+/// dials fail. Unconditional credits would leave `remaining > 0` after the
+/// successful retry and overshoot the 27% target.
+#[tokio::test(start_paused = true)]
+async fn crawler_channel_demand_failures_do_not_invent_replenishment_budget() {
+    const FAILED_DIALS: usize = 3;
+
+    let mut harness = spawn_replenishment_crawler_with(
+        CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+        ReplenishmentCrawlerOptions {
+            fail_first_dials: FAILED_DIALS,
+            ..ReplenishmentCrawlerOptions::default()
+        },
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness.queue_demand(1);
+    harness
+        .assert_connection_attempts(FAILED_DIALS.saturating_add(1))
+        .await;
+}
+
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
 #[tokio::test(start_paused = true)]
 async fn crawler_peer_limit_zero_connect_panic() {

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            should_replenish_outbound_peers, DiscoveredPeer,
+            outbound_peer_replenishment_demand, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -450,20 +450,22 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 #[test]
 fn crawler_replenishes_outbound_peers_below_half_limit() {
     let cases = [
-        (0, 0, false),
-        (0, 1, true),
-        (1, 1, false),
-        (0, 2, true),
-        (1, 2, false),
-        (1, 3, true),
-        (2, 3, false),
-        (149, 300, true),
-        (150, 300, false),
+        (0, 0, 0),
+        (0, 1, 1),
+        (1, 1, 0),
+        (0, 2, 1),
+        (1, 2, 0),
+        (0, 3, 2),
+        (1, 3, 1),
+        (2, 3, 0),
+        (100, 300, 50),
+        (149, 300, 1),
+        (150, 300, 0),
     ];
 
     for (active, limit, expected) in cases {
         assert_eq!(
-            should_replenish_outbound_peers(active, limit),
+            outbound_peer_replenishment_demand(active, limit),
             expected,
             "unexpected replenishment decision for {active} active peers and limit {limit}",
         );

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -15,7 +15,10 @@
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -582,6 +585,75 @@ async fn crawler_replenishment_respects_hard_outbound_limit() {
     harness
         .assert_connection_attempts(CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS)
         .await;
+}
+
+/// Failed dials restore channel demand and must not permanently consume the
+/// timer replenishment budget. Without crediting, `failed_dials` attempts would
+/// shrink the successful connection count below the target.
+#[tokio::test(start_paused = true)]
+async fn crawler_failed_dials_do_not_shrink_replenishment_budget() {
+    const FAILED_DIALS: usize = 3;
+
+    let mut harness = spawn_replenishment_crawler_with(
+        0,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+        ReplenishmentCrawlerOptions {
+            fail_first_dials: FAILED_DIALS,
+            ..ReplenishmentCrawlerOptions::default()
+        },
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(
+            CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS + FAILED_DIALS,
+        )
+        .await;
+}
+
+/// Empty candidate sets must credit spent replenishment demand without
+/// busy-looping local attempts. After one empty demand crawl, local
+/// replenishment pauses until the next timer or channel demand.
+#[tokio::test(start_paused = true)]
+async fn crawler_empty_candidates_pause_local_replenishment() {
+    let mut harness = spawn_replenishment_crawler_with(
+        0,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+        ReplenishmentCrawlerOptions {
+            candidate_count: Some(0),
+            ..ReplenishmentCrawlerOptions::default()
+        },
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+
+    // Give a buggy busy-loop plenty of mocked time to spawn extra crawls.
+    for _ in 0..100 {
+        tokio::time::advance(constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL).await;
+        tokio::task::spawn_blocking(|| {})
+            .await
+            .expect("crawler test blocking-task synchronization should not panic");
+        tokio::task::yield_now().await;
+    }
+
+    let mut crawl_count: usize = 1;
+    while harness.crawl_started_rx.try_recv().is_ok() {
+        crawl_count = crawl_count.saturating_add(1);
+    }
+
+    assert!(
+        crawl_count <= 3,
+        "empty candidates should pause local replenishment after one demand crawl, \
+         but observed {crawl_count} crawls"
+    );
+
+    harness.assert_connection_attempts(0).await;
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
@@ -2111,10 +2183,45 @@ impl ReplenishmentCrawlerTestHarness {
     }
 }
 
+/// Options for [`spawn_replenishment_crawler_with`].
+#[derive(Clone, Debug)]
+struct ReplenishmentCrawlerOptions {
+    /// Number of address-book candidates to seed.
+    ///
+    /// `None` seeds enough candidates for the default replenishment race tests.
+    candidate_count: Option<usize>,
+    /// Fail the first N outbound dials before succeeding.
+    fail_first_dials: usize,
+}
+
+impl Default for ReplenishmentCrawlerOptions {
+    fn default() -> Self {
+        Self {
+            candidate_count: None,
+            fail_first_dials: 0,
+        }
+    }
+}
+
 async fn spawn_replenishment_crawler(
     initial_connection_count: usize,
     initial_demand_count: usize,
     crawl_new_peer_interval: Duration,
+) -> ReplenishmentCrawlerTestHarness {
+    spawn_replenishment_crawler_with(
+        initial_connection_count,
+        initial_demand_count,
+        crawl_new_peer_interval,
+        ReplenishmentCrawlerOptions::default(),
+    )
+    .await
+}
+
+async fn spawn_replenishment_crawler_with(
+    initial_connection_count: usize,
+    initial_demand_count: usize,
+    crawl_new_peer_interval: Duration,
+    options: ReplenishmentCrawlerOptions,
 ) -> ReplenishmentCrawlerTestHarness {
     let config = Config {
         peerset_initial_target_size: CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
@@ -2133,9 +2240,11 @@ async fn spawn_replenishment_crawler(
         address_book_updater_guard,
     ) = AddressBookUpdater::spawn(&config, config.listen_addr, PeerServices::NODE_NETWORK);
 
-    let candidate_count = outbound_connection_limit
-        .saturating_mul(2)
-        .saturating_add(1);
+    let candidate_count = options.candidate_count.unwrap_or_else(|| {
+        outbound_connection_limit
+            .saturating_mul(2)
+            .saturating_add(1)
+    });
     for address_number in 0..candidate_count {
         let address_number =
             u32::try_from(address_number).expect("small replenishment test address count fits u32");
@@ -2180,7 +2289,12 @@ async fn spawn_replenishment_crawler(
     });
     let candidates = CandidateSet::new(address_book, controlled_peer_set);
 
-    let channel_capacity = candidate_count.max(initial_demand_count);
+    // Include room for failed-dial demand requeues plus the successful retries.
+    let channel_capacity = candidate_count
+        .max(initial_demand_count)
+        .saturating_add(options.fail_first_dials)
+        .saturating_add(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .max(1);
     let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(channel_capacity);
     let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(channel_capacity);
     for _ in 0..initial_demand_count {
@@ -2198,20 +2312,31 @@ async fn spawn_replenishment_crawler(
         .collect();
 
     let (connection_tracker_tx, connection_tracker_rx) = tokio::sync::mpsc::unbounded_channel();
+    let remaining_failures = Arc::new(AtomicUsize::new(options.fail_first_dials));
     let outbound_connector = service_fn(move |request: OutboundConnectorRequest| {
         let connection_tracker_tx = connection_tracker_tx.clone();
+        let remaining_failures = remaining_failures.clone();
 
         async move {
             let OutboundConnectorRequest {
                 addr,
                 connection_tracker,
             } = request;
-            let (fake_client, _harness) = ClientTestHarness::build().finish();
 
             connection_tracker_tx
                 .send(connection_tracker)
                 .expect("replenishment connection observer remains open");
 
+            if remaining_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |failures| {
+                    failures.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err("controlled replenishment dial failure".into());
+            }
+
+            let (fake_client, _harness) = ClientTestHarness::build().finish();
             Ok((addr, fake_client))
         }
     });

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -41,7 +41,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            outbound_peer_replenishment_demand, DiscoveredPeer,
+            outbound_peer_replenishment_demand, queue_peer_demand, DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet, ConnectionTracker,
@@ -470,6 +470,22 @@ fn crawler_replenishes_outbound_peers_below_half_limit() {
             "unexpected replenishment decision for {active} active peers and limit {limit}",
         );
     }
+}
+
+#[test]
+fn crawler_queues_full_replenishment_demand() {
+    const CONNECTION_DEMAND: usize = 50;
+
+    let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
+    queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)
+        .expect("open demand channel accepts replenishment signals");
+
+    let mut queued_demand = 0;
+    while demand_rx.try_recv().is_ok() {
+        queued_demand += 1;
+    }
+
+    assert_eq!(queued_demand, CONNECTION_DEMAND);
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -448,7 +448,7 @@ fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> Peer
 }
 
 #[test]
-fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
+fn crawler_replenishes_outbound_peers_below_twenty_seven_percent_limit() {
     let cases = [
         (0, 0, 0),
         (0, 1, 1),
@@ -463,9 +463,9 @@ fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
         (0, 10, 3),
         (2, 10, 1),
         (3, 10, 0),
-        (0, 300, 90),
-        (89, 300, 1),
-        (90, 300, 0),
+        (0, 300, 81),
+        (80, 300, 1),
+        (81, 300, 0),
         (100, 300, 0),
     ];
 
@@ -480,7 +480,7 @@ fn crawler_replenishes_outbound_peers_below_thirty_percent_limit() {
 
 #[test]
 fn crawler_queues_full_replenishment_demand() {
-    const CONNECTION_DEMAND: usize = 90;
+    const CONNECTION_DEMAND: usize = 81;
 
     let (mut demand_tx, mut demand_rx) = mpsc::channel(CONNECTION_DEMAND);
     queue_peer_demand(&mut demand_tx, CONNECTION_DEMAND)


### PR DESCRIPTION
## Motivation

PR #462 replenishes outbound peers toward 27% of the configured limit via a local `remaining_replenishment_demand` counter. Two paths permanently consumed that budget without producing a useful dial:

1. **Failed handshake** — `dial` re-queues `MorePeers`, but the crawler had already decremented `remaining`, so the restored demand double-spent the timer budget.
2. **No candidate** — `DemandCrawlFinished` burned a replenishment unit even though no connection was attempted, under-replenishing until the next crawl timer.

## Solution

- Return `DialOutcome` from `dial` and credit one unit of `remaining_replenishment_demand` on `HandshakeFailed`.
- Credit one unit on `DemandCrawlFinished`, and set `pause_local_replenishment` so crediting cannot busy-loop empty crawls.
- Clear the pause on channel demand, timer crawl completion, or failed-dial credit.

## Testing

- `cargo test -p zakura-network -- crawler_failed_dials_do_not_shrink_replenishment_budget crawler_empty_candidates_pause_local_replenishment crawler_partial_queued_demand crawler_startup_demand crawler_overlapping_timer crawler_disconnects_during_crawl crawler_demand_arriving crawler_excess_queued crawler_replenishment_respects`
  - 9 related replenishment crawler tests passed, including the two new coverage cases above.
- `./scripts/changelog.py check` passed.

## Changelog

- `changelog-unreleased/473.md`

### Specifications & References

- Parent: #462 (`agent/refill-outbound-peers`)
- Bugbot follow-ups on failed-dial / empty-candidate budget spending

### Follow-up Work

- None planned for this hardening; hard-limit remaining clear remains intentional.