### PR TITLE
fix(network): credit replenishment budget on failed dials

### DIFF
--- a/changelog-unreleased/474.md
+++ b/changelog-unreleased/474.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Credit outbound peer replenishment demand when a failed dial restores
+  channel demand, so poor connectivity does not double-spend the timer budget
+  ([#474](https://github.com/zakura-core/zakura/pull/474)).

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -10,7 +10,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -380,6 +380,7 @@ where
             peerset_tx,
             active_outbound_connections,
             address_book_updater,
+            Arc::new(AtomicBool::new(false)),
         );
         task_handles.push(tokio::spawn(crawl_fut.in_current_span()));
     } else {
@@ -984,11 +985,12 @@ enum CrawlerAction {
     TimerCrawl { tick: Instant },
     /// Clear a finished successful handshake.
     HandshakeFinished,
-    /// Clear a finished failed handshake that restored demand to the channel.
+    /// Clear a finished failed handshake.
     ///
     /// When `restore_replenishment_demand` is set, credits one unit of remaining
-    /// replenishment demand so a restored `MorePeers` message does not
-    /// permanently consume the timer-based budget.
+    /// replenishment demand. That flag is only set when this attempt both spent
+    /// timer budget and successfully restored `MorePeers` to the demand channel,
+    /// so a full channel cannot credit budget without a matching later decrement.
     HandshakeFailed {
         restore_replenishment_demand: bool,
     },
@@ -1033,9 +1035,10 @@ fn outbound_peer_replenishment_demand(
 /// of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
-/// `demand_tx`, and credit one unit of remaining replenishment demand when that
-/// attempt consumed timer budget so the restored signal does not permanently
-/// double-spend the budget.
+/// `demand_tx`. When that restore succeeds and the attempt consumed timer
+/// budget, credit one replenishment unit so the restored signal does not
+/// permanently double-spend the budget. A full demand channel does not credit,
+/// because there will be no later channel-driven decrement.
 ///
 /// The crawler terminates when `candidates.update()` or `peerset_tx` returns a
 /// permanent internal error. Transient errors and individual peer errors should
@@ -1054,6 +1057,7 @@ fn outbound_peer_replenishment_demand(
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
+        force_failed_dial_demand_restore_full,
     ),
     fields(
         new_peer_interval = ?config.crawl_new_peer_interval,
@@ -1068,6 +1072,9 @@ async fn crawl_and_dial<C, S>(
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     mut active_outbound_connections: ActiveConnectionCounter,
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
+    // When true, failed dials report a full demand channel so tests can cover
+    // unrestored-demand credit gating without racing the crawler select loop.
+    force_failed_dial_demand_restore_full: Arc<AtomicBool>,
 ) -> Result<(), BoxError>
 where
     C: Service<
@@ -1201,6 +1208,8 @@ where
                 let address_book_updater = address_book_updater.clone();
                 let demand_tx = demand_tx.clone();
                 let expose_peer_addresses = config.expose_peer_addresses;
+                let force_failed_dial_demand_restore_full =
+                    force_failed_dial_demand_restore_full.clone();
 
                 // Increment the connection count before we spawn the connection.
                 let outbound_connection_tracker = active_outbound_connections.track_connection();
@@ -1236,12 +1245,14 @@ where
                                 address_book_updater,
                                 demand_tx,
                                 expose_peer_addresses,
+                                force_failed_dial_demand_restore_full,
                             )
                             .await?
                             {
                                 DialOutcome::Connected => Ok(HandshakeFinished),
-                                DialOutcome::Failed => Ok(HandshakeFailed {
-                                    restore_replenishment_demand,
+                                DialOutcome::Failed { demand_restored } => Ok(HandshakeFailed {
+                                    restore_replenishment_demand: restore_replenishment_demand
+                                        && demand_restored,
                                 }),
                             }
                         } else {
@@ -1288,8 +1299,9 @@ where
             Ok(HandshakeFailed {
                 restore_replenishment_demand,
             }) => {
-                // dial() restored MorePeers to demand_rx when possible. Credit
-                // only when this attempt consumed timer replenishment demand.
+                // Credit only when this attempt spent timer budget and dial()
+                // successfully restored MorePeers. A full channel must not
+                // credit, or remaining would rise without a matching decrement.
                 if restore_replenishment_demand {
                     let _ = remaining_replenishment_demand.fetch_add(1, Ordering::Relaxed);
                 }
@@ -1382,8 +1394,31 @@ where
 enum DialOutcome {
     /// The handshake succeeded and the peer was sent to the peer set.
     Connected,
-    /// The handshake failed; demand was restored to `demand_tx` when possible.
-    Failed,
+    /// The handshake failed.
+    ///
+    /// `demand_restored` is true only when `MorePeers` was successfully
+    /// re-queued on the demand channel.
+    Failed { demand_restored: bool },
+}
+
+/// Try to restore demand after a failed dial.
+///
+/// Returns whether `MorePeers` was queued. A full channel returns `Ok(false)`
+/// so callers do not credit replenishment budget without a later decrement.
+fn try_restore_demand_after_failed_dial(
+    demand_tx: &mut futures::channel::mpsc::Sender<MorePeers>,
+    force_failed_dial_demand_restore_full: &AtomicBool,
+) -> Result<bool, BoxError> {
+    // Tests can force a full-channel outcome without racing the crawler select.
+    if force_failed_dial_demand_restore_full.load(Ordering::Relaxed) {
+        return Ok(false);
+    }
+
+    match demand_tx.try_send(MorePeers) {
+        Ok(()) => Ok(true),
+        Err(send_error) if send_error.is_disconnected() => Err(send_error.into()),
+        Err(_) => Ok(false),
+    }
 }
 
 /// Try to connect to `candidate` using `outbound_connector`.
@@ -1391,7 +1426,7 @@ enum DialOutcome {
 ///
 /// On success, sends peers to `peerset_tx`.
 /// On failure, marks the peer as failed in the address book,
-/// then re-adds demand to `demand_tx`.
+/// then re-adds demand to `demand_tx` when the channel has capacity.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(
     candidate,
@@ -1402,6 +1437,7 @@ enum DialOutcome {
     address_book_updater,
     demand_tx,
     expose_peer_addresses,
+    force_failed_dial_demand_restore_full,
 ), fields(peer = %candidate.addr.addr_label(expose_peer_addresses)))]
 async fn dial<C>(
     candidate: MetaAddr,
@@ -1412,6 +1448,7 @@ async fn dial<C>(
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
     expose_peer_addresses: bool,
+    force_failed_dial_demand_restore_full: Arc<AtomicBool>,
 ) -> Result<DialOutcome, BoxError>
 where
     C: Service<
@@ -1480,19 +1517,17 @@ where
             }
 
             // The demand signal that was taken out of the queue to attempt to connect to the
-            // failed candidate never turned into a connection, so add it back.
+            // failed candidate never turned into a connection, so add it back when possible.
             //
             // # Security
             //
             // Handshake failures are rate-limited by peer attempt timeouts.
-            if let Err(send_error) = demand_tx.try_send(MorePeers) {
-                if send_error.is_disconnected() {
-                    // Zakura's peer set is shutting down.
-                    return Err(send_error.into());
-                }
-            }
+            let demand_restored = try_restore_demand_after_failed_dial(
+                &mut demand_tx,
+                &force_failed_dial_demand_restore_full,
+            )?;
 
-            Ok(DialOutcome::Failed)
+            Ok(DialOutcome::Failed { demand_restored })
         }
     }
 }

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -973,11 +973,25 @@ enum CrawlerAction {
     /// Initiate a handshake to the next candidate peer in response to demand.
     ///
     /// If there are no available candidates, crawl existing peers.
-    DemandHandshakeOrCrawl,
+    ///
+    /// `restore_replenishment_demand` is set when this action consumed a unit of
+    /// timer replenishment demand. Failed dials that restore `MorePeers` must
+    /// credit that unit so the retry does not permanently double-spend the budget.
+    DemandHandshakeOrCrawl {
+        restore_replenishment_demand: bool,
+    },
     /// Crawl existing peers for more peers in response to a timer `tick`.
     TimerCrawl { tick: Instant },
-    /// Clear a finished handshake.
+    /// Clear a finished successful handshake.
     HandshakeFinished,
+    /// Clear a finished failed handshake that restored demand to the channel.
+    ///
+    /// When `restore_replenishment_demand` is set, credits one unit of remaining
+    /// replenishment demand so a restored `MorePeers` message does not
+    /// permanently consume the timer-based budget.
+    HandshakeFailed {
+        restore_replenishment_demand: bool,
+    },
     /// Clear a finished demand crawl (DemandHandshakeOrCrawl with no peers).
     DemandCrawlFinished,
     /// Clear a finished TimerCrawl.
@@ -1019,7 +1033,9 @@ fn outbound_peer_replenishment_demand(
 /// of the configured outbound connection limit.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
-/// `demand_tx`.
+/// `demand_tx`, and credit one unit of remaining replenishment demand when that
+/// attempt consumed timer budget so the restored signal does not permanently
+/// double-spend the budget.
 ///
 /// The crawler terminates when `candidates.update()` or `peerset_tx` returns a
 /// permanent internal error. Transient errors and individual peer errors should
@@ -1125,18 +1141,28 @@ where
             // rate-limited timer in this biased select.
             next_demand = demand_rx.next() => next_demand
                 .ok_or("demand stream closed, is Zakura shutting down?".into())
-                .map(|MorePeers| DemandHandshakeOrCrawl),
+                // Placeholder flag; replaced below after checking the live counter.
+                .map(|MorePeers| DemandHandshakeOrCrawl {
+                    restore_replenishment_demand: false,
+                }),
             // Existing channel demand gets priority over local replenishment.
             // Each action consumes one unit of replenishment demand below.
             _ = future::ready(()),
                 if remaining_replenishment_demand.load(Ordering::Relaxed) > 0 =>
             {
-                Ok(DemandHandshakeOrCrawl)
+                Ok(DemandHandshakeOrCrawl {
+                    restore_replenishment_demand: false,
+                })
             }
         };
 
         let crawler_action = match crawler_action {
-            Ok(DemandHandshakeOrCrawl) => {
+            Ok(DemandHandshakeOrCrawl { .. }) => {
+                // Only credit later if this action actually consumed a timer
+                // replenishment unit. Channel demand with remaining == 0 must
+                // not invent local budget on failure.
+                let restore_replenishment_demand =
+                    remaining_replenishment_demand.load(Ordering::Relaxed) > 0;
                 let _ = remaining_replenishment_demand.fetch_update(
                     Ordering::Relaxed,
                     Ordering::Relaxed,
@@ -1149,7 +1175,9 @@ where
                     remaining_replenishment_demand.store(0, Ordering::Relaxed);
                     Ok(DemandDrop)
                 } else {
-                    Ok(DemandHandshakeOrCrawl)
+                    Ok(DemandHandshakeOrCrawl {
+                        restore_replenishment_demand,
+                    })
                 }
             }
             crawler_action => crawler_action,
@@ -1164,7 +1192,9 @@ where
             }
 
             // Spawned tasks
-            Ok(DemandHandshakeOrCrawl) => {
+            Ok(DemandHandshakeOrCrawl {
+                restore_replenishment_demand,
+            }) => {
                 let candidates = candidates.clone();
                 let outbound_connector = outbound_connector.clone();
                 let peerset_tx = peerset_tx.clone();
@@ -1197,7 +1227,7 @@ where
 
                         if let Some(candidate) = candidate {
                             // we don't need to spawn here, because there's nothing running concurrently
-                            dial(
+                            match dial(
                                 candidate,
                                 outbound_connector,
                                 outbound_connection_tracker,
@@ -1207,9 +1237,13 @@ where
                                 demand_tx,
                                 expose_peer_addresses,
                             )
-                            .await?;
-
-                            Ok(HandshakeFinished)
+                            .await?
+                            {
+                                DialOutcome::Connected => Ok(HandshakeFinished),
+                                DialOutcome::Failed => Ok(HandshakeFailed {
+                                    restore_replenishment_demand,
+                                }),
+                            }
                         } else {
                             // There weren't any peers, so try to get more peers.
                             debug!("demand for peers but no available candidates");
@@ -1250,6 +1284,15 @@ where
             // Completed spawned tasks
             Ok(HandshakeFinished) => {
                 // Already logged in dial()
+            }
+            Ok(HandshakeFailed {
+                restore_replenishment_demand,
+            }) => {
+                // dial() restored MorePeers to demand_rx when possible. Credit
+                // only when this attempt consumed timer replenishment demand.
+                if restore_replenishment_demand {
+                    let _ = remaining_replenishment_demand.fetch_add(1, Ordering::Relaxed);
+                }
             }
             Ok(DemandCrawlFinished) => {
                 // This is set to trace level because when the peerset is
@@ -1335,6 +1378,14 @@ where
     Ok(())
 }
 
+/// Outcome of an outbound dial for crawler replenishment bookkeeping.
+enum DialOutcome {
+    /// The handshake succeeded and the peer was sent to the peer set.
+    Connected,
+    /// The handshake failed; demand was restored to `demand_tx` when possible.
+    Failed,
+}
+
 /// Try to connect to `candidate` using `outbound_connector`.
 /// Uses `outbound_connection_tracker` to track the active connection count.
 ///
@@ -1361,7 +1412,7 @@ async fn dial<C>(
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
     expose_peer_addresses: bool,
-) -> Result<(), BoxError>
+) -> Result<DialOutcome, BoxError>
 where
     C: Service<
             OutboundConnectorRequest,
@@ -1402,6 +1453,8 @@ where
 
             // The connection limit makes sure this send doesn't block.
             peerset_tx.send((address, client)).await?;
+
+            Ok(DialOutcome::Connected)
         }
         // The connection was never opened, or it failed the handshake and was dropped.
         Err(error) => {
@@ -1438,10 +1491,10 @@ where
                     return Err(send_error.into());
                 }
             }
+
+            Ok(DialOutcome::Failed)
         }
     }
-
-    Ok(())
 }
 
 /// Mark `addr` as a failed peer to `address_book_updater`.

--- a/zakura-network/src/peer_set/initialize.rs
+++ b/zakura-network/src/peer_set/initialize.rs
@@ -978,9 +978,7 @@ enum CrawlerAction {
     /// `restore_replenishment_demand` is set when this action consumed a unit of
     /// timer replenishment demand. Failed dials that restore `MorePeers` must
     /// credit that unit so the retry does not permanently double-spend the budget.
-    DemandHandshakeOrCrawl {
-        restore_replenishment_demand: bool,
-    },
+    DemandHandshakeOrCrawl { restore_replenishment_demand: bool },
     /// Crawl existing peers for more peers in response to a timer `tick`.
     TimerCrawl { tick: Instant },
     /// Clear a finished successful handshake.
@@ -991,9 +989,7 @@ enum CrawlerAction {
     /// replenishment demand. That flag is only set when this attempt both spent
     /// timer budget and successfully restored `MorePeers` to the demand channel,
     /// so a full channel cannot credit budget without a matching later decrement.
-    HandshakeFailed {
-        restore_replenishment_demand: bool,
-    },
+    HandshakeFailed { restore_replenishment_demand: bool },
     /// Clear a finished demand crawl (DemandHandshakeOrCrawl with no peers).
     DemandCrawlFinished,
     /// Clear a finished TimerCrawl.

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -646,11 +646,9 @@ fn try_restore_demand_after_failed_dial_reports_full_channel() {
         .try_send(MorePeers)
         .expect("test demand channel accepts the sender's reserved slot");
 
-    let demand_restored = super::super::try_restore_demand_after_failed_dial(
-        &mut demand_tx,
-        &AtomicBool::new(false),
-    )
-    .expect("full channel is not a fatal restore error");
+    let demand_restored =
+        super::super::try_restore_demand_after_failed_dial(&mut demand_tx, &AtomicBool::new(false))
+            .expect("full channel is not a fatal restore error");
     assert!(
         !demand_restored,
         "a full demand channel must not report a successful restore"
@@ -663,11 +661,9 @@ fn try_restore_demand_after_failed_dial_reports_full_channel() {
 fn try_restore_demand_after_failed_dial_reports_success() {
     let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(1);
 
-    let demand_restored = super::super::try_restore_demand_after_failed_dial(
-        &mut demand_tx,
-        &AtomicBool::new(false),
-    )
-    .expect("empty channel accepts restored demand");
+    let demand_restored =
+        super::super::try_restore_demand_after_failed_dial(&mut demand_tx, &AtomicBool::new(false))
+            .expect("empty channel accepts restored demand");
     assert!(
         demand_restored,
         "an empty demand channel must report a successful restore"
@@ -680,11 +676,9 @@ fn try_restore_demand_after_failed_dial_reports_success() {
 fn try_restore_demand_after_failed_dial_honors_force_full() {
     let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(1);
 
-    let demand_restored = super::super::try_restore_demand_after_failed_dial(
-        &mut demand_tx,
-        &AtomicBool::new(true),
-    )
-    .expect("forced full channel is not a fatal restore error");
+    let demand_restored =
+        super::super::try_restore_demand_after_failed_dial(&mut demand_tx, &AtomicBool::new(true))
+            .expect("forced full channel is not a fatal restore error");
     assert!(
         !demand_restored,
         "forced full-channel mode must not report a successful restore"
@@ -2374,7 +2368,9 @@ async fn spawn_replenishment_crawler_with(
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
-        Arc::new(AtomicBool::new(options.force_failed_dial_demand_restore_full)),
+        Arc::new(AtomicBool::new(
+            options.force_failed_dial_demand_restore_full,
+        )),
     ));
 
     ReplenishmentCrawlerTestHarness {

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -16,7 +16,7 @@
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::{Duration, Instant},
@@ -600,6 +600,7 @@ async fn crawler_failed_dials_do_not_shrink_replenishment_budget() {
         constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
         ReplenishmentCrawlerOptions {
             fail_first_dials: FAILED_DIALS,
+            ..ReplenishmentCrawlerOptions::default()
         },
     )
     .await;
@@ -611,6 +612,85 @@ async fn crawler_failed_dials_do_not_shrink_replenishment_budget() {
             CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS + FAILED_DIALS,
         )
         .await;
+}
+
+/// When demand cannot be restored (full channel), failed dials must not credit
+/// replenishment budget. Crediting without a queued `MorePeers` would leave
+/// `remaining` unchanged and keep local replenishment dialing past the target.
+#[tokio::test(start_paused = true)]
+async fn crawler_unrestored_failed_dials_do_not_credit_replenishment() {
+    let mut harness = spawn_replenishment_crawler_with(
+        0,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+        ReplenishmentCrawlerOptions {
+            fail_first_dials: CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS,
+            force_failed_dial_demand_restore_full: true,
+        },
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .await;
+}
+
+#[test]
+fn try_restore_demand_after_failed_dial_reports_full_channel() {
+    // futures::mpsc capacity is buffer + number of senders, so buffer 0 still
+    // has one sender slot. Filling that slot makes the next try_send Full.
+    let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(0);
+    demand_tx
+        .try_send(MorePeers)
+        .expect("test demand channel accepts the sender's reserved slot");
+
+    let demand_restored = super::super::try_restore_demand_after_failed_dial(
+        &mut demand_tx,
+        &AtomicBool::new(false),
+    )
+    .expect("full channel is not a fatal restore error");
+    assert!(
+        !demand_restored,
+        "a full demand channel must not report a successful restore"
+    );
+
+    std::mem::drop(demand_rx);
+}
+
+#[test]
+fn try_restore_demand_after_failed_dial_reports_success() {
+    let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(1);
+
+    let demand_restored = super::super::try_restore_demand_after_failed_dial(
+        &mut demand_tx,
+        &AtomicBool::new(false),
+    )
+    .expect("empty channel accepts restored demand");
+    assert!(
+        demand_restored,
+        "an empty demand channel must report a successful restore"
+    );
+
+    std::mem::drop(demand_rx);
+}
+
+#[test]
+fn try_restore_demand_after_failed_dial_honors_force_full() {
+    let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(1);
+
+    let demand_restored = super::super::try_restore_demand_after_failed_dial(
+        &mut demand_tx,
+        &AtomicBool::new(true),
+    )
+    .expect("forced full channel is not a fatal restore error");
+    assert!(
+        !demand_restored,
+        "forced full-channel mode must not report a successful restore"
+    );
+
+    std::mem::drop(demand_rx);
 }
 
 /// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
@@ -2145,6 +2225,8 @@ impl ReplenishmentCrawlerTestHarness {
 struct ReplenishmentCrawlerOptions {
     /// Fail the first N outbound dials before succeeding.
     fail_first_dials: usize,
+    /// Report failed-dial demand restores as full-channel misses.
+    force_failed_dial_demand_restore_full: bool,
 }
 
 async fn spawn_replenishment_crawler(
@@ -2292,6 +2374,7 @@ async fn spawn_replenishment_crawler_with(
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
+        Arc::new(AtomicBool::new(options.force_failed_dial_demand_restore_full)),
     ));
 
     ReplenishmentCrawlerTestHarness {
@@ -2483,6 +2566,7 @@ where
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
+        Arc::new(AtomicBool::new(false)),
     );
     let crawl_task_handle = tokio::spawn(crawl_fut);
 

--- a/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -15,7 +15,10 @@
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -581,6 +584,32 @@ async fn crawler_replenishment_respects_hard_outbound_limit() {
     harness.release_crawl();
     harness
         .assert_connection_attempts(CRAWLER_REPLENISHMENT_OUTBOUND_LIMIT_FOR_TESTS)
+        .await;
+}
+
+/// Failed dials restore channel demand and must not permanently consume the
+/// timer replenishment budget. Without crediting, `failed_dials` attempts would
+/// shrink the successful connection count below the target.
+#[tokio::test(start_paused = true)]
+async fn crawler_failed_dials_do_not_shrink_replenishment_budget() {
+    const FAILED_DIALS: usize = 3;
+
+    let mut harness = spawn_replenishment_crawler_with(
+        0,
+        0,
+        constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+        ReplenishmentCrawlerOptions {
+            fail_first_dials: FAILED_DIALS,
+        },
+    )
+    .await;
+
+    harness.wait_for_crawl_start().await;
+    harness.release_crawl();
+    harness
+        .assert_connection_attempts(
+            CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS + FAILED_DIALS,
+        )
         .await;
 }
 
@@ -2111,10 +2140,32 @@ impl ReplenishmentCrawlerTestHarness {
     }
 }
 
+/// Options for [`spawn_replenishment_crawler_with`].
+#[derive(Clone, Debug, Default)]
+struct ReplenishmentCrawlerOptions {
+    /// Fail the first N outbound dials before succeeding.
+    fail_first_dials: usize,
+}
+
 async fn spawn_replenishment_crawler(
     initial_connection_count: usize,
     initial_demand_count: usize,
     crawl_new_peer_interval: Duration,
+) -> ReplenishmentCrawlerTestHarness {
+    spawn_replenishment_crawler_with(
+        initial_connection_count,
+        initial_demand_count,
+        crawl_new_peer_interval,
+        ReplenishmentCrawlerOptions::default(),
+    )
+    .await
+}
+
+async fn spawn_replenishment_crawler_with(
+    initial_connection_count: usize,
+    initial_demand_count: usize,
+    crawl_new_peer_interval: Duration,
+    options: ReplenishmentCrawlerOptions,
 ) -> ReplenishmentCrawlerTestHarness {
     let config = Config {
         peerset_initial_target_size: CRAWLER_REPLENISHMENT_TARGET_SIZE_FOR_TESTS,
@@ -2180,7 +2231,12 @@ async fn spawn_replenishment_crawler(
     });
     let candidates = CandidateSet::new(address_book, controlled_peer_set);
 
-    let channel_capacity = candidate_count.max(initial_demand_count);
+    // Include room for failed-dial demand requeues plus the successful retries.
+    let channel_capacity = candidate_count
+        .max(initial_demand_count)
+        .saturating_add(options.fail_first_dials)
+        .saturating_add(CRAWLER_REPLENISHMENT_CONNECTION_TARGET_FOR_TESTS)
+        .max(1);
     let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(channel_capacity);
     let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(channel_capacity);
     for _ in 0..initial_demand_count {
@@ -2198,20 +2254,31 @@ async fn spawn_replenishment_crawler(
         .collect();
 
     let (connection_tracker_tx, connection_tracker_rx) = tokio::sync::mpsc::unbounded_channel();
+    let remaining_failures = Arc::new(AtomicUsize::new(options.fail_first_dials));
     let outbound_connector = service_fn(move |request: OutboundConnectorRequest| {
         let connection_tracker_tx = connection_tracker_tx.clone();
+        let remaining_failures = remaining_failures.clone();
 
         async move {
             let OutboundConnectorRequest {
                 addr,
                 connection_tracker,
             } = request;
-            let (fake_client, _harness) = ClientTestHarness::build().finish();
 
             connection_tracker_tx
                 .send(connection_tracker)
                 .expect("replenishment connection observer remains open");
 
+            if remaining_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |failures| {
+                    failures.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err("controlled replenishment dial failure".into());
+            }
+
+            let (fake_client, _harness) = ClientTestHarness::build().finish();
             Ok((addr, fake_client))
         }
     });


### PR DESCRIPTION
## Motivation

[#462](https://github.com/zakura-core/zakura/pull/462) replenishes outbound peers toward 27% of the configured limit via a local `remaining_replenishment_demand` counter. Each attempt decrements that counter, but `dial` still re-queues `MorePeers` on handshake failure. The restored channel demand runs through the same handler and decrements again, so one failed attempt can consume two replenishment units.

Under poor connectivity, that double-spend exhausts the timer budget faster than useful dials succeed, so the peer set can stop short of the 27% target until the next crawl.

## Solution

When a `DemandHandshakeOrCrawl` action consumes timer replenishment demand and the dial fails (restoring `MorePeers`), credit one unit back on `HandshakeFailed`. Channel demand that did not spend timer budget is unchanged and still must not invent local budget on failure.

This is intentionally narrower than crediting empty-candidate crawls or adding a local-replenishment pause.

## Testing

- `cargo test -p zakura-network crawler_ -- --nocapture` (16 tests)
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- New `crawler_failed_dials_do_not_shrink_replenishment_budget` covers three controlled failures still reaching the 27% target (`target + failed_dials` attempts)

## Changelog

Added `changelog-unreleased/474.md` under `Fixed`.

### Specifications & References

Addresses the Bugbot finding on [#462](https://github.com/zakura-core/zakura/pull/462#discussion_r3661578417).

### Follow-up Work

Empty-candidate crawls that spend replenishment without dialing are still uncredited; handle separately if needed (see also draft [#473](https://github.com/zakura-core/zakura/pull/473)).