### PR TITLE
feat(deploy): show Ironwood ETA on mainnet dashboard

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -373,7 +373,7 @@ jobs:
           [Service]
           Type=simple
           WorkingDirectory=/opt/zakura-mainnet-dashboard
-          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --upgrade-height 0
+          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --upgrade-height 3428143 --target-spacing 75
           Restart=always
           RestartSec=5
 

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -219,8 +219,10 @@ The workflow refreshes a fleet status dashboard on `us-east-0`:
 - install dir: `/opt/zakura-mainnet-dashboard`
 
 It is the same `zakura-cluster-status.py` as testnet, launched with
-`--upgrade-height 0`, which hides the upgrade-ETA cards (mainnet has no pending
-Zakura activation to count down to). Manual run:
+`--upgrade-height 3428143` for the Ironwood mainnet activation height. The ETA
+uses observed cluster block movement when enough samples are available,
+otherwise it falls back to `--target-spacing 75` (post-Blossom mainnet spacing).
+Manual run:
 
 ```bash
 python3 deploy/runner/zakura-cluster-status.py \
@@ -228,7 +230,8 @@ python3 deploy/runner/zakura-cluster-status.py \
   --host 0.0.0.0 \
   --port 8090 \
   --network mainnet \
-  --upgrade-height 0
+  --upgrade-height 3428143 \
+  --target-spacing 75
 ```
 
 The mainnet workflow also installs a Slack watchdog on `us-east-0`:

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -716,6 +716,7 @@ class ClusterCollector:
             "generated_at": time.time(),
             "last_poll": last_poll,
             "stale_after": self.stale_after,
+            "network": self.network,
             "healthy": healthy,
             "total": len(rows),
             "upgrade": upgrade,
@@ -848,7 +849,7 @@ class ClusterCollector:
 
     def upgrade_estimate(self, now: float) -> dict:
         # A non-positive upgrade height means there is no pending activation to
-        # count down to (e.g. mainnet); the dashboard hides the upgrade cards.
+        # count down to; the dashboard hides the upgrade cards.
         if self.upgrade_height <= 0:
             return {"enabled": False}
 
@@ -933,7 +934,7 @@ PAGE = r"""<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="Zakura Ironwood testnet cluster status">
+<meta name="description" content="Zakura Ironwood cluster status">
 <title>Zakura cluster status</title>
 <link rel="icon" href="https://avatars.githubusercontent.com/u/272444516?s=200&v=4" type="image/png">
 <style>
@@ -1244,7 +1245,7 @@ tbody tr:hover td { background: rgba(46, 42, 66, 0.35); }
     <div class="brand">
       <img src="https://avatars.githubusercontent.com/u/272444516?s=200&v=4" alt="Valar Group" class="brand-icon" width="44" height="44">
       <div class="brand-wordmark">
-        <p class="eyebrow">Zakura Ironwood testnet observability</p>
+        <p class="eyebrow" id="network-eyebrow">Zakura Ironwood observability</p>
         <h1>Zakura Cluster Status</h1>
       </div>
     </div>
@@ -1393,6 +1394,10 @@ async function tick() {
   document.getElementById('healthy-count').textContent = data.healthy + ' / ' + data.total;
   document.getElementById('last-poll').textContent = poll;
   document.getElementById('stale-window').textContent = Math.round(data.stale_after) + 's';
+  if (data.network) {
+    document.getElementById('network-eyebrow').textContent =
+      'Zakura Ironwood ' + data.network + ' observability';
+  }
   const upgrade = data.upgrade || {};
   const upgradeEnabled = upgrade.enabled !== false;
   document.querySelectorAll('.upgrade-card').forEach((card) => {
@@ -1594,7 +1599,7 @@ def main() -> None:
         "--upgrade-height",
         type=int,
         default=DEFAULT_UPGRADE_HEIGHT,
-        help="upgrade activation height to estimate; 0 hides the upgrade cards (e.g. mainnet)",
+        help="upgrade activation height to estimate; 0 hides the upgrade cards",
     )
     parser.add_argument(
         "--target-spacing",


### PR DESCRIPTION
## Motivation

The mainnet cluster status dashboard was started with `--upgrade-height 0`, which hid the upgrade height / blocks remaining / ETA / block-time cards that testnet already shows. With Ironwood mainnet activation approaching at height `3428143`, operators need the same countdown.

## Solution

- Launch the mainnet dashboard with `--upgrade-height 3428143` and `--target-spacing 75` (post-Blossom mainnet spacing).
- Document the new flags in the deployer README.
- Make the dashboard eyebrow network-aware (`mainnet` / `testnet`) instead of hardcoding testnet.

ETA still uses observed tip movement once enough samples exist (≥3 blocks and ≥120s); until then it falls back to the 75s target spacing.

## Testing

- `python3 -m unittest deploy.runner.test_zakura_cluster_status`
- Manually updated `us-east-0` dashboard unit and verified https://status.mainnet.zakura.valargroup.dev/data returns `upgrade.enabled: true` with height `3428143`
- Low-risk deploy/config change; skipped workspace Rust compilation (rely on draft CI)

## Changelog

No Rust or `Cargo.toml` changes; no changelog fragment required.

### Specifications & References

- Ironwood / NU6.3 mainnet height: `3_428_143` (`zakura-chain` constants)
- Live: https://status.mainnet.zakura.valargroup.dev/
- Testnet reference: https://status.testnet.zakura.valargroup.dev/