### PR TITLE
feat(deploy): track fleet tip agreement and redesign the cluster dashboard

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -373,7 +373,7 @@ jobs:
           [Service]
           Type=simple
           WorkingDirectory=/opt/zakura-mainnet-dashboard
-          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --upgrade-height 3428143 --target-spacing 75
+          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --upgrade-height 3428143 --target-spacing 75 --state-file /var/lib/zakura-mainnet-dashboard/orphan-pairs.json
           Restart=always
           RestartSec=5
 

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -302,7 +302,7 @@ jobs:
           [Service]
           Type=simple
           WorkingDirectory=/opt/zakura-testnet-dashboard
-          ExecStart=/usr/bin/python3 /opt/zakura-testnet-dashboard/zakura-cluster-status.py --config /opt/zakura-testnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network testnet --interval 10 --stale-after 300 --upgrade-height 4134000 --target-spacing 7.5
+          ExecStart=/usr/bin/python3 /opt/zakura-testnet-dashboard/zakura-cluster-status.py --config /opt/zakura-testnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network testnet --interval 10 --stale-after 300 --upgrade-height 4134000 --target-spacing 7.5 --state-file /var/lib/zakura-testnet-dashboard/orphan-pairs.json
           Restart=always
           RestartSec=5
 

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -20,6 +20,21 @@ the most recent complete observation is more than 120 seconds old. The endpoint
 is rate-limited and permits cross-origin reads from `https://zakura.com`.
 Testnet additionally permits the two development origins on port `1111`.
 
+### Tip Agreement and Orphan Pairs
+
+Each poll groups the fleet by `(height, tip hash)`. A single group means the
+nodes agree; several groups at the leading height mean a split, and the
+dashboard labels each node `majority`, `fork`, `ahead`, or `behind`. Fork depth
+between two tips at the same height is estimated from best-chain ancestor
+hashes sampled at 1, 2, 5, 10, and 32 blocks back, so an unresolved fork reports
+`> 32 or unknown` rather than a wrong number.
+
+A node whose height drops or whose tip hash changes at the same height records
+an orphan pair: the discarded hash, the new canonical hash, and the depth. Pass
+`--state-file` to persist that history across restarts; the deploy workflows
+point it at `/var/lib/zakura-<network>-dashboard/orphan-pairs.json`. Without the
+flag the history is in-memory only and is lost on every restart.
+
 ## Fleet Slack Watchdog
 
 `zakura-cluster-watchdog.py` is a small stdlib-only Python service that polls the

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import tempfile
 import threading
 import time
 import unittest
@@ -83,6 +84,9 @@ class IronwoodStatusTests(unittest.TestCase):
         compile(status.REMOTE_PROBE, "<remote-probe>", "exec")
         self.assertIn('rpc_call("getblockchaininfo")', status.REMOTE_PROBE)
         self.assertIn('rpc_call("getinfo")', status.REMOTE_PROBE)
+        self.assertIn('blockchain_info.get("headers")', status.REMOTE_PROBE)
+        self.assertIn('"getblockhash"', status.REMOTE_PROBE)
+        self.assertIn('rpc_call("getblockheader"', status.REMOTE_PROBE)
 
     def test_success_response_has_the_stable_public_shape(self):
         subject = collector()
@@ -182,6 +186,214 @@ class IronwoodStatusTests(unittest.TestCase):
         payload = subject.snapshot()
 
         self.assertEqual(payload["rows"][0]["ssh"], "root@192.0.2.1")
+        self.assertIn("chain", payload)
+        self.assertEqual(payload["chain"]["status"], "unknown")
+
+
+class TipAgreementTests(unittest.TestCase):
+    def test_classify_tip_event_detects_reorg_signals(self):
+        self.assertEqual(
+            status.classify_tip_event(None, None, 10, "a" * 64),
+            "initial",
+        )
+        self.assertEqual(
+            status.classify_tip_event(10, "a" * 64, 11, "b" * 64),
+            "advanced",
+        )
+        self.assertEqual(
+            status.classify_tip_event(10, "a" * 64, 10, "a" * 64),
+            "unchanged",
+        )
+        self.assertEqual(
+            status.classify_tip_event(10, "a" * 64, 10, "b" * 64),
+            "tip_switch",
+        )
+        self.assertEqual(
+            status.classify_tip_event(10, "a" * 64, 8, "c" * 64),
+            "reorg_height_drop",
+        )
+
+    def test_chain_summary_agreed_lagging_and_split(self):
+        agreed = status.compute_chain_summary(
+            [
+                {"name": "a", "height": 100, "block_hash": "aa", "client_name": "zakurad"},
+                {"name": "b", "height": 100, "block_hash": "aa", "client_name": "zakurad"},
+            ]
+        )
+        self.assertEqual(agreed["status"], "agreed")
+        self.assertFalse(agreed["split"])
+        self.assertEqual(agreed["majority_height"], 100)
+
+        lagging = status.compute_chain_summary(
+            [
+                {"name": "a", "height": 100, "block_hash": "aa", "client_name": "zakurad"},
+                {"name": "b", "height": 99, "block_hash": "bb", "client_name": "zakurad"},
+            ]
+        )
+        self.assertEqual(lagging["status"], "lagging")
+        self.assertFalse(lagging["split"])
+
+        split = status.compute_chain_summary(
+            [
+                {"name": "a", "height": 100, "block_hash": "aa", "client_name": "zakurad"},
+                {"name": "b", "height": 100, "block_hash": "bb", "client_name": "zcashd"},
+            ]
+        )
+        self.assertEqual(split["status"], "split")
+        self.assertTrue(split["split"])
+        self.assertTrue(split["compat_split"])
+
+    def test_enrich_chain_roles(self):
+        rows = [
+            {"name": "a", "height": 100, "block_hash": "aa"},
+            {"name": "b", "height": 100, "block_hash": "aa"},
+            {"name": "c", "height": 100, "block_hash": "ff"},
+            {"name": "d", "height": 99, "block_hash": "dd"},
+            {"name": "e", "height": None, "block_hash": ""},
+        ]
+        chain = status.compute_chain_summary(rows)
+        status.enrich_chain_roles(rows, chain)
+
+        roles = {row["name"]: row["chain_role"] for row in rows}
+        self.assertEqual(chain["status"], "split")
+        self.assertEqual(roles["a"], "majority")
+        self.assertEqual(roles["b"], "majority")
+        self.assertEqual(roles["c"], "fork")
+        self.assertEqual(roles["d"], "behind")
+        self.assertEqual(roles["e"], "unknown")
+
+        ahead_rows = [
+            {"name": "a", "height": 100, "block_hash": "aa"},
+            {"name": "b", "height": 100, "block_hash": "aa"},
+            {"name": "c", "height": 101, "block_hash": "cc"},
+        ]
+        ahead_chain = status.compute_chain_summary(ahead_rows)
+        status.enrich_chain_roles(ahead_rows, ahead_chain)
+        self.assertEqual(ahead_chain["status"], "lagging")
+        self.assertEqual(
+            {row["name"]: row["chain_role"] for row in ahead_rows},
+            {"a": "majority", "b": "majority", "c": "ahead"},
+        )
+
+    def test_row_for_records_reorg_and_headers(self):
+        subject = collector()
+        subject.last_height["node-a"] = 100
+        subject.last_block_hash["node-a"] = "a" * 64
+        subject.last_advanced_at["node-a"] = 1_000.0
+
+        row = subject.row_for(
+            node(),
+            {
+                "height": 98,
+                "headers": 101,
+                "block_hash": "b" * 64,
+                "active_state": "active",
+                "process_running": True,
+                "client_name": "zakurad",
+                "client_version": "v1",
+            },
+            now=1_100.0,
+        )
+
+        self.assertEqual(row["tip_event"], "reorg_height_drop")
+        self.assertEqual(row["headers"], 101)
+        self.assertEqual(row["header_lag"], 3)
+        self.assertEqual(len(subject.recent_reorgs), 1)
+        self.assertEqual(subject.recent_reorgs[0]["kind"], "reorg_height_drop")
+
+        subject.rows = [row]
+        subject.chain = status.compute_chain_summary(
+            subject.rows,
+            list(subject.recent_reorgs),
+        )
+        status.enrich_chain_roles(subject.rows, subject.chain)
+        snapshot = subject.snapshot()
+        self.assertEqual(snapshot["chain"]["recent_reorgs"][0]["node"], "node-a")
+        self.assertIn("height dropped", snapshot["rows"][0]["detail"])
+        self.assertEqual(snapshot["chain"]["recent_reorgs"][0]["depth"], 2)
+        self.assertEqual(
+            snapshot["chain"]["recent_reorgs"][0]["discarded_hash"],
+            "a" * 64,
+        )
+
+    def test_orphan_pairs_persist_across_collector_restarts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_file = Path(tmp) / "orphan-pairs.json"
+            first = status.ClusterCollector(
+                [node()],
+                interval=10,
+                stale_after=300,
+                upgrade_height=0,
+                target_spacing=7.5,
+                network="testnet",
+                state_file=state_file,
+            )
+            first.last_height["node-a"] = 100
+            first.last_block_hash["node-a"] = "a" * 64
+            first.last_ancestors["node-a"] = {"1": "p" * 64}
+            first.last_advanced_at["node-a"] = 1_000.0
+            first.row_for(
+                node(),
+                {
+                    "height": 100,
+                    "block_hash": "b" * 64,
+                    "ancestor_hashes": {"1": "p" * 64},
+                    "active_state": "active",
+                    "process_running": True,
+                },
+                now=1_100.0,
+            )
+            self.assertTrue(state_file.exists())
+
+            second = status.ClusterCollector(
+                [node()],
+                interval=10,
+                stale_after=300,
+                upgrade_height=0,
+                target_spacing=7.5,
+                network="testnet",
+                state_file=state_file,
+            )
+            self.assertEqual(len(second.recent_reorgs), 1)
+            event = second.recent_reorgs[0]
+            self.assertEqual(event["kind"], "tip_switch")
+            self.assertEqual(event["depth"], 1)
+            self.assertEqual(event["discarded_hash"], "a" * 64)
+            self.assertEqual(event["canonical_hash"], "b" * 64)
+
+    def test_fork_depth_from_ancestor_samples(self):
+        depth = status.estimate_fork_depth_from_ancestors(
+            {"1": "x", "2": "y", "5": "same"},
+            {"1": "a", "2": "b", "5": "same"},
+        )
+        self.assertEqual(depth["depth"], 5)
+        self.assertEqual(depth["label"], "depth 5")
+
+        split = status.compute_chain_summary(
+            [
+                {
+                    "name": "a",
+                    "height": 100,
+                    "block_hash": "aa",
+                    "ancestor_hashes": {"1": "p1", "2": "shared"},
+                    "client_name": "zakurad",
+                },
+                {
+                    "name": "b",
+                    "height": 100,
+                    "block_hash": "bb",
+                    "ancestor_hashes": {"1": "q1", "2": "shared"},
+                    "client_name": "zakurad",
+                },
+            ]
+        )
+        other = next(
+            group
+            for group in split["tip_groups"]
+            if group["block_hash"] != split["majority_hash"]
+        )
+        self.assertEqual(other["fork_depth"], 2)
+        self.assertEqual(other["fork_depth_label"], "depth 2")
 
 
 class RateLimiterTests(unittest.TestCase):

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -3,8 +3,9 @@
 
 Reads a deploy/deployer nodes TOML, polls each node over SSH, and serves a small
 HTML dashboard showing the running commit, Zakura node ID, restart time, current
-height, latest block hash, and whether the node has advanced recently. It also
-serves a deliberately small public Ironwood status response for zakura.com.
+height, latest block hash, tip agreement across the fleet, per-node reorg
+candidates, and whether the node has advanced recently. It also serves a
+deliberately small public Ironwood status response for zakura.com.
 
 Only the Python stdlib is used.
 """
@@ -58,6 +59,9 @@ MIN_OBSERVED_BLOCKS = 3
 MIN_OBSERVED_SECONDS = 120
 MIN_SECONDS_PER_BLOCK = 1.0
 MAX_SECONDS_PER_BLOCK = 10 * 60.0
+RECENT_REORG_LIMIT = 40
+# Sampled best-chain ancestor offsets used to estimate fork depth between tips.
+ANCESTOR_DEPTHS = (1, 2, 5, 10, 32)
 
 SSH_COMMON_OPTS = [
     "-o", "BatchMode=yes",
@@ -307,12 +311,12 @@ def rpc_headers():
         headers["Authorization"] = f"Basic {token}"
     return headers
 
-def rpc_call(method):
+def rpc_call(method, params=None):
     body = json.dumps({
         "jsonrpc": "2.0",
         "id": "zakura-cluster-status",
         "method": method,
-        "params": [],
+        "params": list(params or []),
     }).encode()
     request = urllib.request.Request(
         rpc_url,
@@ -439,8 +443,34 @@ if rpc_url:
             raise RuntimeError("getblockchaininfo returned a non-object result")
 
         out["height"] = blockchain_info.get("blocks")
+        out["headers"] = blockchain_info.get("headers")
         out["block_hash"] = blockchain_info.get("bestblockhash")
         out["rpc_chain"] = blockchain_info.get("chain")
+
+        ancestor_hashes = {}
+        try:
+            tip_height = int(blockchain_info.get("blocks"))
+        except (TypeError, ValueError):
+            tip_height = None
+        if tip_height is not None:
+            for depth in (1, 2, 5, 10, 32):
+                if tip_height >= depth:
+                    try:
+                        ancestor_hashes[str(depth)] = rpc_call(
+                            "getblockhash", [tip_height - depth]
+                        )
+                    except Exception:
+                        pass
+        out["ancestor_hashes"] = ancestor_hashes
+
+        best_hash = out.get("block_hash")
+        if best_hash:
+            try:
+                header = rpc_call("getblockheader", [best_hash, True])
+                if isinstance(header, dict):
+                    out["previous_hash"] = header.get("previousblockhash") or ""
+            except Exception as error:
+                out["previous_hash_error"] = str(error)
 
         value_pools = blockchain_info.get("valuePools")
         if not isinstance(value_pools, list):
@@ -566,6 +596,7 @@ class ClusterCollector:
         upgrade_height: int,
         target_spacing: float,
         network: str,
+        state_file: Path | None = None,
     ):
         self.nodes = nodes
         self.interval = interval
@@ -573,11 +604,21 @@ class ClusterCollector:
         self.upgrade_height = upgrade_height
         self.target_spacing = target_spacing
         self.network = network
+        self.state_file = state_file
         self.ironwood_activation_height = IRONWOOD_ACTIVATION_HEIGHTS[network]
         self.lock = threading.Lock()
         self.last_height: dict[str, int | None] = {node.name: None for node in nodes}
+        self.last_block_hash: dict[str, str | None] = {node.name: None for node in nodes}
+        self.last_ancestors: dict[str, dict[str, str]] = {
+            node.name: {} for node in nodes
+        }
         self.last_advanced_at: dict[str, float | None] = {node.name: None for node in nodes}
         self.height_history: list[tuple[float, int]] = []
+        self.recent_reorgs: deque[dict] = deque(
+            load_orphan_pairs(state_file),
+            maxlen=RECENT_REORG_LIMIT,
+        )
+        self.chain: dict = empty_chain_summary()
         self.rows: list[dict] = [
             {
                 "name": node.name,
@@ -610,9 +651,17 @@ class ClusterCollector:
         rows.sort(key=lambda row: row["name"])
         now = time.time()
         with self.lock:
+            recent_reorgs = list(self.recent_reorgs)
+            chain = compute_chain_summary(rows, recent_reorgs)
+            enrich_chain_roles(rows, chain)
             self.rows = rows
+            self.chain = chain
             self.last_poll = now
             self.record_height_sample(now, rows)
+
+    def record_orphan_pair(self, event: dict) -> None:
+        self.recent_reorgs.appendleft(event)
+        save_orphan_pairs(self.state_file, list(self.recent_reorgs))
 
     def record_height_sample(self, now: float, rows: list[dict]) -> None:
         heights = [row["height"] for row in rows if row.get("height") is not None]
@@ -633,16 +682,57 @@ class ClusterCollector:
 
     def row_for(self, node: Node, probe: dict, now: float) -> dict:
         previous_height = self.last_height.get(node.name)
+        previous_hash = self.last_block_hash.get(node.name)
+        previous_ancestors = dict(self.last_ancestors.get(node.name) or {})
         height = coerce_int(probe.get("height"))
+        headers = coerce_int(probe.get("headers"))
+        block_hash = str(probe.get("block_hash") or "")
+        ancestor_hashes = normalize_ancestor_hashes(probe.get("ancestor_hashes"))
+        previous_block_hash = str(probe.get("previous_hash") or "")
 
         advanced = False
+        tip_event = None
         if height is not None:
+            tip_event = classify_tip_event(
+                previous_height,
+                previous_hash,
+                height,
+                block_hash or None,
+            )
             if previous_height is None and self.last_advanced_at.get(node.name) is None:
                 self.last_advanced_at[node.name] = now
             elif previous_height is not None and height > previous_height:
                 self.last_advanced_at[node.name] = now
                 advanced = True
             self.last_height[node.name] = height
+            if block_hash:
+                self.last_block_hash[node.name] = block_hash
+            self.last_ancestors[node.name] = ancestor_hashes
+            if tip_event in ("reorg_height_drop", "tip_switch"):
+                depth_info = estimate_reorg_depth(
+                    tip_event,
+                    previous_height,
+                    height,
+                    previous_ancestors,
+                    ancestor_hashes,
+                )
+                self.record_orphan_pair(
+                    {
+                        "node": node.name,
+                        "kind": tip_event,
+                        "from_height": previous_height,
+                        "from_hash": previous_hash or "",
+                        "to_height": height,
+                        "to_hash": block_hash,
+                        "discarded_hash": previous_hash or "",
+                        "canonical_hash": block_hash,
+                        "depth": depth_info.get("depth"),
+                        "depth_label": depth_info.get("label") or "unknown",
+                        "durable": True,
+                        "demo": False,
+                        "at": now,
+                    }
+                )
 
         last_advanced_at = self.last_advanced_at.get(node.name)
         seconds_since_advanced = (
@@ -678,6 +768,21 @@ class ClusterCollector:
             health = "healthy"
             detail = "advanced this poll" if advanced else "height recently advanced"
 
+        if tip_event == "reorg_height_drop":
+            detail = (
+                f"height dropped {previous_height} → {height} "
+                f"(possible reorg); {detail}"
+            )
+        elif tip_event == "tip_switch":
+            detail = (
+                f"tip hash changed at height {height} "
+                f"(possible reorg); {detail}"
+            )
+
+        header_lag = None
+        if headers is not None and height is not None:
+            header_lag = headers - height
+
         return {
             "name": node.name,
             "ssh": node.ssh_string,
@@ -685,11 +790,17 @@ class ClusterCollector:
             "health": health,
             "detail": detail,
             "commit": probe.get("commit") or "",
-            "block_hash": probe.get("block_hash") or "",
+            "block_hash": block_hash,
+            "previous_hash": previous_block_hash,
+            "ancestor_hashes": ancestor_hashes,
             "node_id": node.node_id or probe.get("node_id") or "",
             "version": probe.get("version") or "",
             "last_restarted": probe.get("last_restarted") or "",
             "height": height,
+            "headers": headers,
+            "header_lag": header_lag,
+            "tip_event": tip_event,
+            "chain_role": "unknown",
             "active_state": active_state,
             "rpc_ok": rpc_ok,
             "last_seen_at": now,
@@ -711,6 +822,11 @@ class ClusterCollector:
             rows = [dict(row) for row in self.rows]
             last_poll = self.last_poll
             upgrade = self.upgrade_estimate(time.time())
+            chain = dict(self.chain)
+            chain["tip_groups"] = [dict(group) for group in chain.get("tip_groups", [])]
+            chain["recent_reorgs"] = [
+                dict(event) for event in chain.get("recent_reorgs", [])
+            ]
         healthy = sum(1 for row in rows if row.get("healthy"))
         return {
             "generated_at": time.time(),
@@ -720,6 +836,7 @@ class ClusterCollector:
             "healthy": healthy,
             "total": len(rows),
             "upgrade": upgrade,
+            "chain": chain,
             "rows": rows,
         }
 
@@ -910,6 +1027,278 @@ def coerce_int(value) -> int | None:
         return None
 
 
+def empty_chain_summary() -> dict:
+    return {
+        "status": "unknown",
+        "split": False,
+        "compat_split": False,
+        "majority_height": None,
+        "majority_hash": "",
+        "max_height": None,
+        "observed_tips": 0,
+        "tip_groups": [],
+        "recent_reorgs": [],
+    }
+
+
+def normalize_ancestor_hashes(value) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    out = {}
+    for key, hash_value in value.items():
+        if hash_value:
+            out[str(key)] = str(hash_value)
+    return out
+
+
+def load_orphan_pairs(path: Path | None) -> list[dict]:
+    if path is None or not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(payload, dict):
+        events = payload.get("orphan_pairs") or payload.get("recent_reorgs") or []
+    else:
+        events = payload
+    if not isinstance(events, list):
+        return []
+    cleaned = []
+    for event in events:
+        if isinstance(event, dict):
+            cleaned.append(dict(event))
+    return cleaned[:RECENT_REORG_LIMIT]
+
+
+def save_orphan_pairs(path: Path | None, events: list[dict]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    payload = {
+        "updated_at": time.time(),
+        "orphan_pairs": list(events)[:RECENT_REORG_LIMIT],
+    }
+    tmp_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+
+
+def estimate_fork_depth_from_ancestors(
+    left: dict[str, str] | None,
+    right: dict[str, str] | None,
+    sampled_depths: tuple[int, ...] = ANCESTOR_DEPTHS,
+) -> dict:
+    """Estimate fork depth from sampled best-chain ancestor hashes.
+
+    Returns the smallest sampled depth where both tips share the same ancestor.
+    """
+    left = left or {}
+    right = right or {}
+    for depth in sampled_depths:
+        key = str(depth)
+        left_hash = left.get(key)
+        right_hash = right.get(key)
+        if left_hash and right_hash and left_hash == right_hash:
+            return {
+                "depth": depth,
+                "exact": True,
+                "label": f"depth {depth}",
+            }
+    if left and right:
+        ceiling = max(sampled_depths)
+        return {
+            "depth": None,
+            "exact": False,
+            "label": f"> {ceiling} or unknown",
+        }
+    return {"depth": None, "exact": False, "label": "unknown"}
+
+
+def estimate_reorg_depth(
+    kind: str,
+    from_height: int | None,
+    to_height: int | None,
+    previous_ancestors: dict[str, str] | None,
+    current_ancestors: dict[str, str] | None,
+) -> dict:
+    if (
+        kind == "reorg_height_drop"
+        and from_height is not None
+        and to_height is not None
+        and from_height > to_height
+    ):
+        depth = from_height - to_height
+        return {"depth": depth, "exact": True, "label": f"depth {depth}"}
+    if kind == "tip_switch":
+        estimated = estimate_fork_depth_from_ancestors(
+            previous_ancestors,
+            current_ancestors,
+        )
+        if estimated.get("depth") is not None or estimated.get("label") != "unknown":
+            return estimated
+        return {"depth": 1, "exact": False, "label": "depth ~1"}
+    return {"depth": None, "exact": False, "label": "unknown"}
+
+
+def classify_tip_event(
+    previous_height: int | None,
+    previous_hash: str | None,
+    height: int,
+    block_hash: str | None,
+) -> str | None:
+    """Classify a tip change relative to the previous poll for one node."""
+    if previous_height is None:
+        return "initial"
+    if height < previous_height:
+        return "reorg_height_drop"
+    if (
+        block_hash
+        and previous_hash
+        and height == previous_height
+        and block_hash != previous_hash
+    ):
+        return "tip_switch"
+    if height > previous_height:
+        return "advanced"
+    return "unchanged"
+
+
+def tipped_rows(rows: list[dict]) -> list[dict]:
+    return [
+        row
+        for row in rows
+        if row.get("height") is not None and row.get("block_hash")
+    ]
+
+
+def best_tip_row(rows: list[dict], client_name: str | None = None) -> dict | None:
+    candidates = tipped_rows(rows)
+    if client_name is not None:
+        candidates = [
+            row for row in candidates if row.get("client_name") == client_name
+        ]
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda row: (row["height"], row.get("block_hash") or ""),
+    )
+
+
+def compute_chain_summary(
+    rows: list[dict],
+    recent_reorgs: list[dict] | None = None,
+) -> dict:
+    """Summarize tip agreement and recent reorg candidates across the fleet."""
+    tipped = tipped_rows(rows)
+    groups: dict[tuple[int, str], list[str]] = defaultdict(list)
+    representatives: dict[tuple[int, str], dict] = {}
+    for row in tipped:
+        key = (row["height"], row["block_hash"])
+        groups[key].append(row["name"])
+        representatives.setdefault(key, row)
+
+    tip_groups = [
+        {
+            "height": height,
+            "block_hash": block_hash,
+            "nodes": sorted(names),
+            "count": len(names),
+            "ancestor_hashes": normalize_ancestor_hashes(
+                representatives[(height, block_hash)].get("ancestor_hashes")
+            ),
+            "fork_depth": None,
+            "fork_depth_label": "",
+        }
+        for (height, block_hash), names in groups.items()
+    ]
+    tip_groups.sort(
+        key=lambda group: (group["count"], group["height"], group["block_hash"]),
+        reverse=True,
+    )
+
+    majority = tip_groups[0] if tip_groups else None
+    max_height = max((group["height"] for group in tip_groups), default=None)
+    at_tip = (
+        [group for group in tip_groups if group["height"] == max_height]
+        if max_height is not None
+        else []
+    )
+    split = len(at_tip) > 1
+
+    if not tip_groups:
+        status = "unknown"
+    elif split:
+        status = "split"
+    elif len(tip_groups) > 1:
+        status = "lagging"
+    else:
+        status = "agreed"
+
+    if majority is not None:
+        majority["fork_depth"] = 0
+        majority["fork_depth_label"] = "majority"
+        for group in tip_groups[1:]:
+            if group["height"] == majority["height"]:
+                depth_info = estimate_fork_depth_from_ancestors(
+                    majority.get("ancestor_hashes"),
+                    group.get("ancestor_hashes"),
+                )
+                group["fork_depth"] = depth_info.get("depth")
+                group["fork_depth_label"] = depth_info.get("label") or "unknown"
+            else:
+                behind = majority["height"] - group["height"]
+                group["fork_depth"] = behind
+                group["fork_depth_label"] = f"{behind} behind"
+
+    zakurad_tip = best_tip_row(rows, "zakurad")
+    zcashd_tip = best_tip_row(rows, "zcashd")
+    compat_split = bool(
+        zakurad_tip
+        and zcashd_tip
+        and (
+            zakurad_tip["height"] != zcashd_tip["height"]
+            or zakurad_tip["block_hash"] != zcashd_tip["block_hash"]
+        )
+    )
+
+    return {
+        "status": status,
+        "split": split,
+        "compat_split": compat_split,
+        "majority_height": majority["height"] if majority else None,
+        "majority_hash": majority["block_hash"] if majority else "",
+        "max_height": max_height,
+        "observed_tips": len(tipped),
+        "tip_groups": tip_groups,
+        "recent_reorgs": list(recent_reorgs or []),
+    }
+
+
+def enrich_chain_roles(rows: list[dict], chain: dict) -> None:
+    majority_height = chain.get("majority_height")
+    majority_hash = chain.get("majority_hash") or ""
+    for row in rows:
+        height = row.get("height")
+        block_hash = row.get("block_hash") or ""
+        if height is None or not block_hash:
+            row["chain_role"] = "unknown"
+        elif majority_height is None:
+            row["chain_role"] = "unknown"
+        elif height == majority_height and block_hash == majority_hash:
+            row["chain_role"] = "majority"
+        elif height == majority_height:
+            row["chain_role"] = "fork"
+        elif height > majority_height:
+            row["chain_role"] = "ahead"
+        else:
+            row["chain_role"] = "behind"
+
+
 def public_error(network: str, code: str) -> dict:
     return {
         "schema_version": PUBLIC_SCHEMA_VERSION,
@@ -940,22 +1329,32 @@ PAGE = r"""<!doctype html>
 <style>
 :root {
   color-scheme: dark;
-  --void: #080610;
-  --base: #0e0c18;
-  --surface: #131120;
-  --overlay: #1a1728;
-  --line: #221f32;
-  --line-hi: #2e2a42;
-  --ink: #e2dff0;
-  --muted: #7a7494;
-  --dim: #3f3a56;
+  --void: #07060e;
+  --base: #0d0b16;
+  --surface: #12101d;
+  --raised: #191627;
+  --line: #221f33;
+  --line-hi: #322d49;
+  --ink: #ebe8f7;
+  --ink-2: #b6b0d0;
+  --muted: #837ca0;
+  --dim: #4f4870;
   --pink: #c2457a;
-  --pink-hi: #e0609a;
-  --pink-soft: rgba(194, 69, 122, 0.10);
-  --green: #7ecfb0;
-  --yellow: #e3b341;
-  --red: #ff7b72;
-  --r: 14px;
+  --pink-hi: #e8709f;
+  --pink-soft: rgba(194, 69, 122, 0.12);
+  --ok: #5fd7a6;
+  --ok-soft: rgba(95, 215, 166, 0.10);
+  --ok-line: rgba(95, 215, 166, 0.32);
+  --warn: #efc255;
+  --warn-soft: rgba(239, 194, 85, 0.10);
+  --warn-line: rgba(239, 194, 85, 0.32);
+  --bad: #ff7b72;
+  --bad-soft: rgba(255, 123, 114, 0.10);
+  --bad-line: rgba(255, 123, 114, 0.32);
+  --r-lg: 16px;
+  --r-md: 12px;
+  --r-sm: 8px;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 * { box-sizing: border-box; }
 body {
@@ -963,360 +1362,746 @@ body {
   min-height: 100vh;
   color: var(--ink);
   background:
-    radial-gradient(circle at top left, rgba(194, 69, 122, 0.12), transparent 32rem),
+    radial-gradient(1100px 520px at 12% -8%, rgba(194, 69, 122, 0.14), transparent 70%),
+    radial-gradient(900px 480px at 92% 0%, rgba(88, 74, 173, 0.12), transparent 70%),
     var(--void);
-  font: 15px/1.65 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  background-attachment: fixed;
+  font: 15px/1.6 'Inter', ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
 }
-h1, h2, p { margin: 0; }
-h1 {
-  color: var(--ink);
-  font-size: clamp(1.45rem, 3.5vw, 2.45rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.1;
-}
-h2 {
-  color: var(--ink);
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
+h1, h2, h3, p { margin: 0; }
+a { color: var(--pink-hi); }
+button { font: inherit; }
+
+/* ---------- primitives ---------- */
 .shell {
-  width: min(1120px, calc(100% - 32px));
+  width: min(100% - 40px, 1560px);
   margin: 0 auto;
-  padding: 36px 0 80px;
+  padding: 24px 0 56px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
+.panel {
+  min-width: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.022), transparent 120px), var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+}
+.pad { padding: 20px 22px; }
+.eyebrow {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 650;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+}
+.label {
+  color: var(--muted);
+  font-size: 0.66rem;
+  font-weight: 650;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+.mono { font-family: var(--mono); font-variant-ligatures: none; }
+.num { font-variant-numeric: tabular-nums; }
+.muted { color: var(--muted); }
+.dim { color: var(--dim); }
+
+/* ---------- header ---------- */
 .topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
-  padding: 22px 26px;
-  background: var(--surface);
-  border: 1px solid var(--line-hi);
-  border-radius: var(--r);
-  box-shadow:
-    0 0 0 1px rgba(194, 69, 122, 0.08),
-    0 8px 48px rgba(0, 0, 0, 0.55),
-    0 1px 0 rgba(255, 255, 255, 0.03) inset;
+  gap: 20px;
+  flex-wrap: wrap;
+  padding: 16px 22px;
 }
-.brand {
+.brand { display: flex; align-items: center; gap: 14px; min-width: 0; }
+.brand img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(194, 69, 122, 0.55);
+  box-shadow: 0 0 0 4px var(--pink-soft);
+  flex-shrink: 0;
+}
+.brand h1 {
+  font-size: clamp(1.15rem, 2.2vw, 1.5rem);
+  font-weight: 680;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+.brand .eyebrow { display: flex; align-items: center; gap: 8px; }
+.chip {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 7px;
+  border: 1px solid var(--line-hi);
+  border-radius: 5px;
+  background: var(--base);
+  color: var(--ink-2);
+  font-size: 0.62rem;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.header-right {
   display: flex;
   align-items: center;
-  gap: 16px;
-  min-width: 0;
+  gap: 10px;
+  flex-wrap: wrap;
 }
-.brand-icon {
-  width: 46px;
-  height: 46px;
-  border: 2px solid var(--pink);
-  border-radius: 50%;
-  box-shadow: 0 0 0 4px var(--pink-soft), 0 4px 20px rgba(0, 0, 0, 0.5);
-  flex-shrink: 0;
-  object-fit: cover;
-}
-.brand-wordmark {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  min-width: 0;
-}
-.eyebrow {
-  color: var(--muted);
+.state-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 15px;
+  border-radius: 999px;
+  border: 1px solid var(--line-hi);
+  background: var(--base);
+  color: var(--ink-2);
   font-size: 0.72rem;
-  font-weight: 500;
-  letter-spacing: 0.03em;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
-.status {
+.state-pill::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 9px currentColor;
+  animation: pulse 2.6s ease-in-out infinite;
+}
+.state-pill.is-ok { border-color: var(--ok-line); background: var(--ok-soft); color: var(--ok); }
+.state-pill.is-warn { border-color: var(--warn-line); background: var(--warn-soft); color: var(--warn); }
+.state-pill.is-bad { border-color: var(--bad-line); background: var(--bad-soft); color: var(--bad); }
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+.ghost-button {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  min-height: 32px;
-  padding: 0 14px;
-  border: 1px solid rgba(194, 69, 122, 0.35);
+  height: 34px;
+  padding: 0 13px;
+  border: 1px solid var(--line-hi);
   border-radius: 999px;
-  background: var(--pink-soft);
-  color: var(--pink-hi);
-  font-size: 0.73rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  background: var(--base);
+  color: var(--ink-2);
+  font-size: 0.76rem;
+  font-weight: 550;
+  text-decoration: none;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
   white-space: nowrap;
 }
-.status::before {
-  content: '';
-  display: block;
-  width: 6px;
-  height: 6px;
-  background: var(--pink-hi);
-  border-radius: 50%;
-  box-shadow: 0 0 8px var(--pink-hi);
-  animation: bloom 2.8s ease-in-out infinite;
-}
-@keyframes bloom {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.3; transform: scale(0.7); }
-}
-.grid {
+.ghost-button:hover { border-color: var(--pink); color: var(--pink-hi); background: var(--pink-soft); }
+.ghost-button.is-on { border-color: var(--warn-line); background: var(--warn-soft); color: var(--warn); }
+.freshness { font-size: 0.76rem; color: var(--muted); white-space: nowrap; }
+.freshness b { color: var(--ink-2); font-weight: 600; }
+
+/* ---------- hero ---------- */
+.hero {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
   gap: 16px;
-  margin-top: 16px;
 }
-.panel {
-  min-width: 0;
-  padding: 24px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: var(--r);
-  overflow: hidden;
-  position: relative;
-  transition: border-color 0.2s;
-}
-.panel:hover { border-color: var(--line-hi); }
-.panel-full { grid-column: 1 / -1; }
-.panel-header {
+.hero.is-single { grid-template-columns: minmax(0, 1fr); }
+.hero-head {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 14px;
+  gap: 14px;
   flex-wrap: wrap;
+  margin-bottom: 14px;
 }
-.body-copy {
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-.summary-card {
-  padding: 12px;
-  background: var(--base);
-  border: 1px solid var(--line);
-  border-radius: 10px;
-}
-.summary-card span {
-  display: block;
-  color: var(--muted);
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.summary-card strong {
-  display: block;
-  margin-top: 3px;
-  color: var(--ink);
-  font-size: 0.95rem;
-  overflow-wrap: anywhere;
-}
-.summary-card small {
-  display: block;
-  margin-top: 2px;
-  color: var(--dim);
-  font-size: 0.76rem;
-}
-.table-wrap {
-  margin-top: 16px;
-  overflow-x: auto;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--overlay);
-}
-table {
-  width: 100%;
-  min-width: 1040px;
-  border-collapse: collapse;
-}
-th, td {
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--line);
-  text-align: left;
-  font-size: 0.86rem;
-  vertical-align: top;
-}
-th {
-  background: var(--base);
-  color: var(--muted);
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-tr:last-child td { border-bottom: 0; }
-tbody tr:hover td { background: rgba(46, 42, 66, 0.35); }
-.num {
-  text-align: right;
+.big-value {
+  font-size: clamp(2rem, 4.6vw, 3rem);
+  font-weight: 690;
+  letter-spacing: -0.035em;
+  line-height: 1;
   font-variant-numeric: tabular-nums;
 }
+.big-sub { margin-top: 7px; color: var(--muted); font-size: 0.86rem; }
+.progress {
+  margin-top: 18px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--base);
+  border: 1px solid var(--line);
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  width: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #8b3f8f, var(--pink-hi));
+  transition: width 0.6s ease;
+}
+.progress-legend {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 7px;
+  font-size: 0.72rem;
+  color: var(--dim);
+}
+.facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+  gap: 10px;
+  margin-top: 18px;
+}
+.fact {
+  padding: 11px 13px;
+  min-width: 0;
+  background: var(--base);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+}
+.fact strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.94rem;
+  font-weight: 620;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+.fact small { display: block; margin-top: 2px; color: var(--dim); font-size: 0.7rem; }
+
+/* fleet card */
+.donut-row { display: flex; align-items: center; gap: 18px; }
+.health-bar {
+  display: flex;
+  gap: 3px;
+  margin-top: 16px;
+  height: 10px;
+}
+.health-bar span {
+  border-radius: 3px;
+  min-width: 4px;
+  transition: flex-grow 0.4s ease;
+}
+.seg-ok { background: var(--ok); }
+.seg-warn { background: var(--warn); }
+.seg-bad { background: var(--bad); }
+.seg-neutral { background: var(--dim); }
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin-top: 12px;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+.legend span { display: inline-flex; align-items: center; }
+.legend i {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  margin-right: 7px;
+  font-style: normal;
+}
+.legend b { color: var(--ink); font-weight: 620; font-variant-numeric: tabular-nums; }
+
+/* ---------- stat strip ---------- */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 12px;
+}
+.stat {
+  padding: 13px 15px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  min-width: 0;
+}
+.stat-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+}
+.stat-value > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.stat small { display: block; margin-top: 3px; color: var(--dim); font-size: 0.74rem; }
+
+/* ---------- badges ---------- */
 .badge {
   display: inline-flex;
   align-items: center;
-  min-height: 22px;
-  padding: 0 9px;
-  border-radius: 999px;
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
+  height: 21px;
+  padding: 0 8px;
+  border-radius: 6px;
+  border: 1px solid var(--line-hi);
+  background: var(--base);
+  color: var(--ink-2);
+  font-size: 0.66rem;
+  font-weight: 680;
+  letter-spacing: 0.045em;
   text-transform: uppercase;
   white-space: nowrap;
 }
-.healthy {
-  border: 1px solid rgba(126, 207, 176, 0.35);
-  background: rgba(126, 207, 176, 0.08);
-  color: var(--green);
+.badge.tone-ok { border-color: var(--ok-line); background: var(--ok-soft); color: var(--ok); }
+.badge.tone-warn { border-color: var(--warn-line); background: var(--warn-soft); color: var(--warn); }
+.badge.tone-bad { border-color: var(--bad-line); background: var(--bad-soft); color: var(--bad); }
+.badge.tone-info { border-color: rgba(194, 69, 122, 0.32); background: var(--pink-soft); color: var(--pink-hi); }
+
+/* ---------- section header ---------- */
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
 }
-.stale {
-  border: 1px solid rgba(227, 179, 65, 0.35);
-  background: rgba(227, 179, 65, 0.08);
-  color: var(--yellow);
-}
-.down, .rpc_error {
-  border: 1px solid rgba(255, 123, 114, 0.35);
-  background: rgba(255, 123, 114, 0.08);
-  color: var(--red);
-}
-.starting {
-  border: 1px solid var(--line-hi);
+.section-head h2 { font-size: 1rem; font-weight: 640; letter-spacing: -0.01em; margin-top: 3px; }
+.section-note { color: var(--muted); font-size: 0.83rem; }
+
+/* ---------- tip groups ---------- */
+.tip-groups { display: grid; gap: 10px; }
+.tip-group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px 16px;
+  padding: 13px 15px;
   background: var(--base);
-  color: var(--muted);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--dim);
+  border-radius: var(--r-md);
 }
-.muted { color: var(--muted); }
-.mono {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  font-size: 0.82rem;
-}
-.details {
-  max-width: 280px;
-  color: var(--muted);
-}
-.wide-mono {
-  max-width: 260px;
+.tip-group.is-majority { border-left-color: var(--ok); }
+.tip-group.is-fork { border-left-color: var(--bad); }
+.tip-group-top { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.tip-group-top .height { font-weight: 640; font-variant-numeric: tabular-nums; }
+.tip-group-count { color: var(--muted); font-size: 0.8rem; white-space: nowrap; text-align: right; }
+.tip-group-nodes {
+  grid-column: 1 / -1;
+  color: var(--ink-2);
+  font-size: 0.79rem;
+  line-height: 1.5;
   overflow-wrap: anywhere;
 }
-.copyable-value {
-  display: inline-flex;
+.subhead {
+  display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
+  margin: 22px 0 10px;
 }
+.subhead::after { content: ''; flex: 1; height: 1px; background: var(--line); }
+.reorg-list { display: grid; gap: 8px; }
+.reorg-item {
+  padding: 11px 14px;
+  background: var(--base);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--warn);
+  border-radius: var(--r-md);
+  font-size: 0.82rem;
+  color: var(--ink-2);
+}
+.reorg-top { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.reorg-detail { margin-top: 5px; color: var(--muted); font-size: 0.78rem; overflow-wrap: anywhere; }
+.empty {
+  padding: 18px;
+  border: 1px dashed var(--line-hi);
+  border-radius: var(--r-md);
+  color: var(--muted);
+  font-size: 0.84rem;
+  text-align: center;
+}
+
+/* ---------- toolbar ---------- */
+.toolbar { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--line-hi);
+  border-radius: 999px;
+  background: var(--base);
+}
+.search:focus-within { border-color: var(--pink); }
+.search svg { width: 14px; height: 14px; stroke: var(--muted); fill: none; stroke-width: 2; }
+.search input {
+  width: 190px;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  font-size: 0.82rem;
+  outline: none;
+}
+.search input::placeholder { color: var(--dim); }
+
+/* ---------- table ---------- */
+.table-wrap {
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--base);
+  overflow: auto;
+  max-height: 78vh;
+}
+table { width: 100%; min-width: 1080px; border-collapse: separate; border-spacing: 0; }
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 9px 10px;
+  background: var(--raised);
+  border-bottom: 1px solid var(--line-hi);
+  color: var(--muted);
+  font-size: 0.63rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: left;
+  white-space: nowrap;
+  user-select: none;
+}
+thead th.sortable { cursor: pointer; }
+thead th.sortable:hover { color: var(--ink-2); }
+thead th .arrow { margin-left: 4px; opacity: 0.35; }
+thead th.is-sorted { color: var(--pink-hi); }
+thead th.is-sorted .arrow { opacity: 1; }
+tbody td {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.79rem;
+  vertical-align: middle;
+}
+tbody tr.node-row { cursor: pointer; }
+tbody tr.node-row:hover td { background: rgba(50, 45, 73, 0.28); }
+tbody tr.is-open td { background: rgba(50, 45, 73, 0.34); }
+tbody tr.row-warn td:first-child { box-shadow: inset 3px 0 0 var(--warn); }
+tbody tr.row-bad td:first-child { box-shadow: inset 3px 0 0 var(--bad); }
+th.col-num, td.col-num { text-align: right; }
+.col-node { width: 16%; }
+.col-health { width: 7.5%; }
+.col-chain { width: 9%; }
+.col-height { width: 10%; }
+.col-hdr { width: 4.5%; }
+.col-adv { width: 5%; }
+.col-commit { width: 9%; }
+.col-tip { width: 11%; }
+.col-restarted { width: 9%; }
+.col-detail { width: auto; }
+.node-cell { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.twisty {
+  flex-shrink: 0;
+  width: 12px;
+  color: var(--dim);
+  font-size: 0.6rem;
+  transition: transform 0.15s;
+}
+tr.is-open .twisty { transform: rotate(90deg); color: var(--pink-hi); }
+.node-name { font-weight: 620; font-size: 0.82rem; overflow-wrap: anywhere; }
+.node-sub { color: var(--dim); font-size: 0.68rem; font-family: var(--mono); }
+.stack { display: flex; flex-direction: column; align-items: flex-start; gap: 3px; min-width: 0; }
+.col-num .stack { align-items: flex-end; }
+.delta { font-size: 0.68rem; color: var(--muted); font-variant-numeric: tabular-nums; }
+.detail-text {
+  color: var(--muted);
+  font-size: 0.74rem;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+tbody tr.drawer > td { padding: 0; border-bottom: 1px solid var(--line); background: var(--surface); }
+.drawer-inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 12px 22px;
+  padding: 16px 18px 18px 30px;
+}
+.field { min-width: 0; }
+.field .label { font-size: 0.61rem; }
+.field-value {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-top: 3px;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+.field-value.is-bad { color: var(--bad); }
+.drawer-inner .full { grid-column: 1 / -1; }
+.ancestors { display: grid; gap: 3px; margin-top: 4px; }
+.ancestors div { display: flex; gap: 8px; font-size: 0.73rem; font-family: var(--mono); color: var(--ink-2); }
+.ancestors span:first-child { color: var(--dim); min-width: 3.2rem; }
+
+/* ---------- copy ---------- */
+.copyable { display: inline-flex; align-items: center; gap: 5px; min-width: 0; white-space: nowrap; }
 .copy-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
   padding: 0;
   border: 0;
-  border-radius: 6px;
+  border-radius: 5px;
   background: transparent;
   color: var(--dim);
   cursor: pointer;
 }
-.copy-button:hover {
-  background: var(--pink-soft);
-  color: var(--pink-hi);
-}
+.copy-button:hover { background: var(--pink-soft); color: var(--pink-hi); }
+.copy-button.is-done { color: var(--ok); }
 .copy-button svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.8;
+  stroke-width: 1.9;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
-@media (max-width: 900px) {
-  .grid { grid-template-columns: 1fr; }
+.banner {
+  padding: 11px 16px;
+  border: 1px solid var(--bad-line);
+  border-radius: var(--r-md);
+  background: var(--bad-soft);
+  color: var(--bad);
+  font-size: 0.84rem;
 }
-@media (max-width: 760px) {
-  .shell {
-    width: min(100% - 20px, 1120px);
-    padding-top: 16px;
-  }
-  .topbar {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .panel { padding: 18px; }
+.banner[hidden] { display: none; }
+footer {
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-align: center;
+  padding-top: 6px;
+}
+
+@media (max-width: 1100px) {
+  .hero { grid-template-columns: 1fr; }
+}
+@media (max-width: 720px) {
+  .shell { width: calc(100% - 22px); padding-top: 16px; }
+  .pad { padding: 16px; }
+  .topbar { align-items: flex-start; }
+  .search input { width: 130px; }
 }
 </style>
 </head>
 <body>
 <main class="shell">
-  <section class="topbar" aria-label="Page header">
+  <header class="panel topbar">
     <div class="brand">
-      <img src="https://avatars.githubusercontent.com/u/272444516?s=200&v=4" alt="Valar Group" class="brand-icon" width="44" height="44">
-      <div class="brand-wordmark">
-        <p class="eyebrow" id="network-eyebrow">Zakura Ironwood observability</p>
+      <img src="https://avatars.githubusercontent.com/u/272444516?s=200&v=4" alt="Valar Group" width="40" height="40">
+      <div>
+        <p class="eyebrow"><span id="network-chip" class="chip">mainnet</span> Ironwood observability</p>
         <h1>Zakura Cluster Status</h1>
       </div>
     </div>
-    <div class="status" id="status">Connecting</div>
-  </section>
+    <div class="header-right">
+      <span class="freshness" id="freshness">connecting...</span>
+      <span class="state-pill" id="state-pill">Connecting</span>
+    </div>
+  </header>
 
-  <section class="grid" aria-label="Cluster summary">
-    <article class="summary-card">
-      <span>Healthy nodes</span>
-      <strong id="healthy-count">...</strong>
-    </article>
-    <article class="summary-card">
-      <span>Last poll</span>
-      <strong id="last-poll">...</strong>
-    </article>
-    <article class="summary-card">
-      <span>Stale window</span>
-      <strong id="stale-window">...</strong>
-    </article>
-    <article class="summary-card upgrade-card">
-      <span>Upgrade height</span>
-      <strong id="upgrade-height">...</strong>
-    </article>
-    <article class="summary-card upgrade-card">
-      <span>Blocks remaining</span>
-      <strong id="blocks-remaining">...</strong>
-    </article>
-    <article class="summary-card upgrade-card">
-      <span>Upgrade ETA</span>
-      <strong id="upgrade-eta">...</strong>
-    </article>
-    <article class="summary-card upgrade-card">
-      <span>Block time</span>
-      <strong id="block-time">...</strong>
-      <small id="block-time-source">...</small>
-    </article>
-  </section>
+  <div class="banner" id="banner" hidden></div>
 
-  <section class="panel panel-full" style="margin-top:16px;">
-    <div class="panel-header">
-      <div>
-        <p class="eyebrow">Fleet health</p>
-        <h2>Live node status</h2>
+  <section class="hero">
+    <article class="panel pad" id="activation-panel">
+      <div class="hero-head">
+        <div>
+          <p class="eyebrow">Network upgrade</p>
+          <h2 id="activation-title">Ironwood activation</h2>
+        </div>
+        <span class="badge" id="activation-badge">pending</span>
       </div>
-      <p class="body-copy" id="summary">Waiting for first poll...</p>
+      <div class="big-value" id="activation-countdown">...</div>
+      <p class="big-sub" id="activation-eta">waiting for the first poll</p>
+      <div class="progress"><div class="progress-fill" id="activation-progress"></div></div>
+      <div class="progress-legend">
+        <span id="progress-from">...</span>
+        <span id="progress-to">...</span>
+      </div>
+      <div class="facts">
+        <div class="fact">
+          <span class="label">Current height</span>
+          <strong id="current-height">...</strong>
+        </div>
+        <div class="fact">
+          <span class="label">Target height</span>
+          <strong id="upgrade-height">...</strong>
+        </div>
+        <div class="fact">
+          <span class="label">Blocks left</span>
+          <strong id="blocks-remaining">...</strong>
+        </div>
+        <div class="fact">
+          <span class="label">Block time</span>
+          <strong id="block-time">...</strong>
+          <small id="block-time-source">...</small>
+        </div>
+      </div>
+    </article>
+
+    <article class="panel pad">
+      <div class="hero-head">
+        <div>
+          <p class="eyebrow">Fleet health</p>
+          <h2>Nodes reporting</h2>
+        </div>
+        <span class="badge" id="client-mix">...</span>
+      </div>
+      <div class="big-value" id="healthy-count">...</div>
+      <p class="big-sub" id="healthy-sub">waiting for the first poll</p>
+      <div class="health-bar" id="health-bar"></div>
+      <div class="legend" id="health-legend"></div>
+      <div class="facts">
+        <div class="fact">
+          <span class="label">Leading height</span>
+          <strong id="fleet-max-height">...</strong>
+          <small id="fleet-spread">...</small>
+        </div>
+        <div class="fact">
+          <span class="label">Slowest advance</span>
+          <strong id="fleet-slowest">...</strong>
+          <small id="fleet-slowest-node">...</small>
+        </div>
+        <div class="fact">
+          <span class="label">Max header lag</span>
+          <strong id="fleet-max-lag">...</strong>
+          <small id="fleet-max-lag-node">...</small>
+        </div>
+      </div>
+    </article>
+  </section>
+
+  <section class="stats">
+    <div class="stat">
+      <span class="label">Tip agreement</span>
+      <div class="stat-value" id="tip-agreement">...</div>
+      <small id="tip-agreement-detail">...</small>
+    </div>
+    <div class="stat">
+      <span class="label">Majority tip</span>
+      <div class="stat-value mono" id="majority-tip">...</div>
+      <small id="majority-height">...</small>
+    </div>
+    <div class="stat">
+      <span class="label">Recorded reorgs</span>
+      <div class="stat-value" id="reorg-count">...</div>
+      <small id="reorg-latest">...</small>
+    </div>
+    <div class="stat">
+      <span class="label">zakurad vs zcashd</span>
+      <div class="stat-value" id="compat-split">...</div>
+      <small id="compat-detail">...</small>
+    </div>
+    <div class="stat">
+      <span class="label">Last poll</span>
+      <div class="stat-value" id="last-poll">...</div>
+      <small id="stale-window">...</small>
+    </div>
+  </section>
+
+  <section class="panel pad">
+    <div class="section-head">
+      <div>
+        <p class="eyebrow">Chain tips</p>
+        <h2>Tip agreement across the fleet</h2>
+      </div>
+      <p class="section-note" id="chain-summary">Waiting for first poll...</p>
+    </div>
+    <div class="tip-groups" id="tip-groups"></div>
+    <div class="subhead"><p class="eyebrow">Orphan pairs</p></div>
+    <div class="reorg-list" id="reorg-list"></div>
+  </section>
+
+  <section class="panel pad">
+    <div class="section-head">
+      <div>
+        <p class="eyebrow">Live node status</p>
+        <h2 id="table-title">Fleet</h2>
+      </div>
+      <div class="toolbar">
+        <label class="search">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.6-3.6"></path></svg>
+          <input id="filter-input" type="search" placeholder="Filter node, commit, hash, detail" autocomplete="off" spellcheck="false">
+        </label>
+        <button class="ghost-button" id="issues-toggle" type="button">Issues only</button>
+        <button class="ghost-button" id="expand-toggle" type="button">Expand all</button>
+      </div>
     </div>
     <div class="table-wrap">
       <table>
         <thead>
           <tr>
-            <th>Node</th>
-            <th>Health</th>
-            <th>Commit</th>
-            <th>Latest block commit hash</th>
-            <th>Last restarted</th>
-            <th class="num">Height</th>
-            <th>Last advanced</th>
-            <th>Details</th>
+            <th class="col-node sortable" data-sort="name">Node<span class="arrow"></span></th>
+            <th class="col-health sortable" data-sort="health">Health<span class="arrow"></span></th>
+            <th class="col-chain sortable" data-sort="chain_role">Chain<span class="arrow"></span></th>
+            <th class="col-height col-num sortable" data-sort="height">Height<span class="arrow"></span></th>
+            <th class="col-hdr col-num sortable" data-sort="header_lag" title="headers minus blocks">Hdr<span class="arrow"></span></th>
+            <th class="col-adv col-num sortable" data-sort="seconds_since_advanced" title="time since the tip last advanced">Adv<span class="arrow"></span></th>
+            <th class="col-commit sortable" data-sort="commit">Commit<span class="arrow"></span></th>
+            <th class="col-tip">Tip</th>
+            <th class="col-restarted sortable" data-sort="last_restarted">Restarted<span class="arrow"></span></th>
+            <th class="col-detail">Details</th>
           </tr>
         </thead>
         <tbody id="rows"></tbody>
       </table>
     </div>
   </section>
+
+  <footer>For snapshots and install instructions, see
+    <a href="https://zakura.com/snapshots/" target="_blank" rel="noopener">https://zakura.com/snapshots/</a>
+  </footer>
 </main>
 <script>
+const REFRESH_MS = 10000;
+// The progress bar shows the run-in to activation, not all of chain history.
+const PROGRESS_WINDOW = 10000;
+
+const state = {
+  data: null,
+  query: '',
+  issuesOnly: false,
+  sortKey: 'name',
+  sortDir: 1,
+  expanded: new Set(),
+  expandAll: false,
+  fetchedAt: null,
+  error: '',
+};
+
+const el = (id) => document.getElementById(id);
+
+/* ---------- formatting ---------- */
+function esc(value) {
+  return String(value == null ? '' : value).replace(/[&<>"']/g, (match) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[match]));
+}
+function num(value) {
+  return value == null ? '—' : Number(value).toLocaleString('en-US');
+}
 function age(seconds) {
-  if (seconds == null) return 'never observed';
-  if (seconds < 60) return Math.round(seconds) + 's ago';
-  if (seconds < 3600) return Math.round(seconds / 60) + 'm ago';
-  return Math.round(seconds / 3600) + 'h ago';
+  if (seconds == null) return '—';
+  if (seconds < 60) return Math.round(seconds) + 's';
+  if (seconds < 3600) return Math.round(seconds / 60) + 'm';
+  if (seconds < 86400) return Math.round(seconds / 3600) + 'h';
+  return Math.round(seconds / 86400) + 'd';
 }
 function countdown(seconds) {
   if (seconds == null) return 'waiting for height';
@@ -1328,113 +2113,574 @@ function countdown(seconds) {
   if (hours > 0) return hours + 'h ' + minutes + 'm';
   return Math.max(1, minutes) + 'm';
 }
-function formatNumber(value) {
-  return value == null ? '...' : Number(value).toLocaleString();
+function blockTime(seconds) {
+  if (seconds == null) return '—';
+  return (seconds < 10 ? Number(seconds).toFixed(1) : Math.round(seconds)) + 's';
 }
-function formatBlockTime(seconds) {
-  if (seconds == null) return '...';
-  if (seconds < 10) return Number(seconds).toFixed(1) + 's/block';
-  return Math.round(seconds) + 's/block';
+function clockTime(epochSeconds) {
+  if (!epochSeconds) return '—';
+  return new Date(epochSeconds * 1000).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  });
 }
-const copyIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="10" height="10" rx="1"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
-const checkIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"></path></svg>';
-function middleHash(value, left = 8, right = 8) {
-  if (!value) return 'unknown';
-  if (value.length <= left + right + 4) return value;
-  return value.slice(0, left) + '....' + value.slice(-right);
+function middleHash(value, left, right) {
+  if (!value) return '—';
+  if (value.length <= left + right + 2) return value;
+  return value.slice(0, left) + '…' + value.slice(-right);
 }
-function shortCommit(commit) { return middleHash(commit, 8, 8); }
 function shortHash(hash) { return middleHash(hash, 8, 8); }
-function esc(value) {
-  return String(value == null ? '' : value).replace(/[&<>"']/g, (match) => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;'
-  }[match]));
-}
-async function copyValue(button) {
-  const value = button.dataset.copyValue || '';
-  if (!value) return;
-
-  if (navigator.clipboard && window.isSecureContext) {
-    await navigator.clipboard.writeText(value);
-  } else {
-    const textarea = document.createElement('textarea');
-    textarea.value = value;
-    textarea.setAttribute('readonly', '');
-    textarea.style.cssText = 'position:fixed;top:-1000px;left:-1000px';
-    document.body.appendChild(textarea);
-    textarea.focus();
-    textarea.select();
-    try { document.execCommand('copy'); }
-    finally { textarea.remove(); }
+function tinyHash(hash) { return middleHash(hash, 6, 6); }
+function shortCommit(commit) { return commit ? commit.slice(0, 9) : '—'; }
+function formatRestarted(value) {
+  if (!value) return '—';
+  const raw = String(value).trim();
+  // ISO / docker: 2026-07-28T01:33:37.986819514Z
+  let match = raw.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::\d{2})?(?:\.\d+)?Z?$/);
+  if (match) return match[2] + '-' + match[3] + ' ' + match[4] + ':' + match[5];
+  // systemctl: Tue 2026-07-28 01:20:42 UTC
+  match = raw.match(/^[A-Za-z]{3}\s+(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2})(?::\d{2})?\s+UTC$/);
+  if (match) return match[2] + '-' + match[3] + ' ' + match[4] + ':' + match[5];
+  // ps / zcashd: Tue Jul 28 01:33:18 2026
+  match = raw.match(/^[A-Za-z]{3}\s+([A-Za-z]{3})\s+(\d{1,2})\s+(\d{2}):(\d{2})(?::\d{2})?\s+(\d{4})$/);
+  if (match) {
+    const months = {
+      Jan: '01', Feb: '02', Mar: '03', Apr: '04', May: '05', Jun: '06',
+      Jul: '07', Aug: '08', Sep: '09', Oct: '10', Nov: '11', Dec: '12',
+    };
+    const month = months[match[1]] || match[1];
+    return month + '-' + String(match[2]).padStart(2, '0') + ' ' + match[3] + ':' + match[4];
   }
-
-  button.innerHTML = checkIcon;
-  setTimeout(() => { button.innerHTML = copyIcon; }, 1400);
+  return raw;
 }
+
+/* ---------- tone mapping ---------- */
+const HEALTH_TONE = {
+  healthy: 'ok', stale: 'warn', rpc_error: 'bad', down: 'bad', starting: 'neutral',
+};
+const CHAIN_TONE = {
+  majority: 'ok', behind: 'warn', ahead: 'warn', fork: 'bad', unknown: 'neutral',
+};
+const STATUS_TONE = { agreed: 'ok', lagging: 'warn', split: 'bad', unknown: 'neutral' };
+const HEALTH_LABEL = { rpc_error: 'rpc error' };
+function tone(map, value) { return map[value] || 'neutral'; }
+function badge(text, toneName) {
+  const cls = toneName && toneName !== 'neutral' ? ' tone-' + toneName : '';
+  return '<span class="badge' + cls + '">' + esc(text) + '</span>';
+}
+function tipEventLabel(event) {
+  if (event === 'reorg_height_drop') return 'height drop';
+  if (event === 'tip_switch') return 'tip switch';
+  return '';
+}
+function chainStatusLabel(status) {
+  return { agreed: 'Agreed', lagging: 'Lagging', split: 'Split' }[status] || 'Unknown';
+}
+
+/* ---------- copy to clipboard ---------- */
+const copyIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+const checkIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"></path></svg>';
 function copyButton(value, label) {
   if (!value) return '';
-  return `<button class="copy-button" type="button" data-copy-value="${esc(value)}" aria-label="${esc(label)}" title="${esc(label)}">${copyIcon}</button>`;
+  return '<button class="copy-button" type="button" data-copy="' + esc(value) + '"'
+    + ' aria-label="' + esc(label) + '" title="' + esc(label) + '">' + copyIcon + '</button>';
 }
-async function tick() {
-  let data;
+async function copyValue(button) {
+  const value = button.dataset.copy || '';
+  if (!value) return;
   try {
-    const response = await fetch('/data', { cache: 'no-store' });
-    data = await response.json();
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(value);
+    } else {
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.setAttribute('readonly', '');
+      textarea.style.cssText = 'position:fixed;top:-1000px;left:-1000px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try { document.execCommand('copy'); } finally { textarea.remove(); }
+    }
+    button.classList.add('is-done');
+    button.innerHTML = checkIcon;
   } catch (error) {
-    document.getElementById('status').textContent = 'Unreachable';
-    document.getElementById('summary').textContent = 'Dashboard data endpoint is unreachable.';
+    button.innerHTML = '!';
+  }
+  setTimeout(() => {
+    button.classList.remove('is-done');
+    button.innerHTML = copyIcon;
+  }, 1400);
+}
+function copyCell(value, shortened, label) {
+  if (!value) return '<span class="dim">—</span>';
+  return '<span class="copyable"><span title="' + esc(value) + '">' + esc(shortened) + '</span>'
+    + copyButton(value, label) + '</span>';
+}
+
+/* ---------- rendering ---------- */
+function renderHeader(data) {
+  const chain = data.chain || {};
+  const network = data.network || 'mainnet';
+  el('network-chip').textContent = network;
+  document.title = 'Zakura ' + network + ' cluster status';
+
+  let label = 'Healthy';
+  let toneName = 'ok';
+  if (chain.status === 'split') {
+    label = 'Tip split';
+    toneName = 'bad';
+  } else if (data.healthy !== data.total) {
+    label = 'Degraded';
+    toneName = data.healthy === 0 ? 'bad' : 'warn';
+  } else if (chain.status === 'lagging') {
+    label = 'Lagging';
+    toneName = 'warn';
+  }
+  const pill = el('state-pill');
+  pill.textContent = label;
+  pill.className = 'state-pill is-' + toneName;
+}
+function renderFreshness() {
+  const node = el('freshness');
+  if (state.error) {
+    node.innerHTML = '<b>offline</b>';
     return;
   }
-  const poll = data.last_poll ? new Date(data.last_poll * 1000).toLocaleString() : 'not yet polled';
-  document.getElementById('status').textContent = data.healthy === data.total ? 'Healthy' : 'Degraded';
-  document.getElementById('healthy-count').textContent = data.healthy + ' / ' + data.total;
-  document.getElementById('last-poll').textContent = poll;
-  document.getElementById('stale-window').textContent = Math.round(data.stale_after) + 's';
-  if (data.network) {
-    document.getElementById('network-eyebrow').textContent =
-      'Zakura Ironwood ' + data.network + ' observability';
+  if (!state.fetchedAt) {
+    node.textContent = 'connecting...';
+    return;
   }
-  const upgrade = data.upgrade || {};
-  const upgradeEnabled = upgrade.enabled !== false;
-  document.querySelectorAll('.upgrade-card').forEach((card) => {
-    card.style.display = upgradeEnabled ? '' : 'none';
-  });
-  if (upgradeEnabled) {
-    const etaAt = upgrade.eta_at ? new Date(upgrade.eta_at * 1000).toLocaleString() : 'waiting for block movement';
-    document.getElementById('upgrade-height').textContent = formatNumber(upgrade.height);
-    document.getElementById('blocks-remaining').textContent = upgrade.activated ? 'activated' : formatNumber(upgrade.blocks_remaining);
-    document.getElementById('upgrade-eta').textContent = upgrade.activated ? 'activated' : countdown(upgrade.eta_seconds) + ' / ' + etaAt;
-    document.getElementById('block-time').textContent = formatBlockTime(upgrade.seconds_per_block);
-    document.getElementById('block-time-source').textContent = upgrade.source === 'observed'
-      ? 'recent average'
-      : 'default estimate';
-  }
-  document.getElementById('summary').textContent = data.healthy + ' / ' + data.total + ' nodes healthy';
-  const body = document.getElementById('rows');
-  body.innerHTML = data.rows.map((row) => `
-    <tr>
-      <td><div>${esc(row.name)}</div><div class="muted mono wide-mono">${esc(row.node_id || 'node ID unknown')}</div></td>
-      <td><span class="badge ${esc(row.health)}">${esc(row.health)}</span></td>
-      <td class="mono" title="${esc(row.commit)}"><span class="copyable-value"><span>${esc(shortCommit(row.commit))}</span>${copyButton(row.commit, 'Copy full commit hash')}</span></td>
-      <td class="mono wide-mono" title="${esc(row.block_hash)}"><span class="copyable-value"><span>${esc(shortHash(row.block_hash))}</span>${copyButton(row.block_hash, 'Copy full latest block commit hash')}</span></td>
-      <td>${esc(row.last_restarted || 'unknown')}</td>
-      <td class="num mono">${row.height == null ? '--' : esc(row.height)}</td>
-      <td>${esc(age(row.seconds_since_advanced))}</td>
-      <td class="details">${esc(row.detail || '')}</td>
-    </tr>`).join('');
-  for (const button of body.querySelectorAll('[data-copy-value]')) {
-    button.addEventListener('click', () => copyValue(button).catch(() => {
-      button.textContent = '!';
-      setTimeout(() => { button.innerHTML = copyIcon; }, 1400);
-    }));
-  }
+  const seconds = Math.max(0, Math.round((Date.now() - state.fetchedAt) / 1000));
+  const next = Math.max(0, Math.ceil(REFRESH_MS / 1000) - seconds);
+  node.innerHTML = 'updated <b>' + seconds + 's</b> ago &middot; next in ' + next + 's';
 }
+function renderActivation(data) {
+  const upgrade = data.upgrade || {};
+  const panel = el('activation-panel');
+  const enabled = upgrade.enabled !== false;
+  panel.hidden = !enabled;
+  document.querySelector('.hero').classList.toggle('is-single', !enabled);
+  if (!enabled) return;
+
+  const badgeNode = el('activation-badge');
+  if (upgrade.activated) {
+    badgeNode.textContent = 'activated';
+    badgeNode.className = 'badge tone-ok';
+  } else {
+    badgeNode.textContent = 'pending';
+    badgeNode.className = 'badge tone-info';
+  }
+  el('activation-countdown').textContent = upgrade.activated
+    ? 'Activated'
+    : countdown(upgrade.eta_seconds);
+  el('activation-eta').textContent = upgrade.activated
+    ? 'The upgrade height has been reached.'
+    : (upgrade.eta_at
+      ? 'estimated ' + new Date(upgrade.eta_at * 1000).toLocaleString()
+      : 'waiting for block movement');
+
+  const remaining = upgrade.blocks_remaining;
+  const done = remaining == null
+    ? 0
+    : Math.min(1, Math.max(0, (PROGRESS_WINDOW - remaining) / PROGRESS_WINDOW));
+  el('activation-progress').style.width = (done * 100).toFixed(2) + '%';
+  el('progress-from').textContent = 'final ' + num(PROGRESS_WINDOW) + ' blocks';
+  el('progress-to').textContent = remaining == null
+    ? '—'
+    : (done * 100).toFixed(1) + '% complete';
+
+  el('current-height').textContent = num(upgrade.current_height);
+  el('upgrade-height').textContent = num(upgrade.height);
+  el('blocks-remaining').textContent = upgrade.activated ? '0' : num(remaining);
+  el('block-time').textContent = blockTime(upgrade.seconds_per_block);
+  el('block-time-source').textContent = upgrade.source === 'observed'
+    ? 'observed average'
+    : 'target spacing fallback';
+}
+function renderFleet(data) {
+  const rows = data.rows || [];
+  const counts = {};
+  for (const row of rows) {
+    const health = row.health || 'unknown';
+    counts[health] = (counts[health] || 0) + 1;
+  }
+  el('healthy-count').textContent = data.healthy + ' / ' + data.total;
+  const unhealthy = data.total - data.healthy;
+  el('healthy-sub').textContent = unhealthy === 0
+    ? 'every node is active, serving RPC, and advancing'
+    : unhealthy + ' node' + (unhealthy === 1 ? '' : 's') + ' need attention';
+
+  const order = ['healthy', 'stale', 'rpc_error', 'down', 'starting'];
+  const present = order.filter((key) => counts[key]);
+  for (const key of Object.keys(counts)) {
+    if (!present.includes(key)) present.push(key);
+  }
+  el('health-bar').innerHTML = present.map((key) =>
+    '<span class="seg-' + tone(HEALTH_TONE, key) + '" style="flex-grow:' + counts[key] + '"'
+    + ' title="' + esc(key + ': ' + counts[key]) + '"></span>'
+  ).join('');
+  el('health-legend').innerHTML = present.map((key) =>
+    '<span><i class="seg-' + tone(HEALTH_TONE, key) + '"></i>'
+    + '<b>' + counts[key] + '</b>&nbsp;' + esc(HEALTH_LABEL[key] || key) + '</span>'
+  ).join('');
+
+  const clients = {};
+  for (const row of rows) {
+    const client = row.client_name || 'unknown';
+    clients[client] = (clients[client] || 0) + 1;
+  }
+  el('client-mix').textContent = Object.keys(clients).sort()
+    .map((client) => clients[client] + ' ' + client).join(' · ') || 'no clients';
+
+  const heights = rows.map((row) => row.height).filter((height) => height != null);
+  el('fleet-max-height').textContent = heights.length ? num(Math.max(...heights)) : '—';
+  el('fleet-spread').textContent = heights.length
+    ? (Math.max(...heights) - Math.min(...heights)) + ' block spread'
+    : 'no heights reported';
+
+  const slowest = pickWorst(rows, (row) => row.seconds_since_advanced);
+  el('fleet-slowest').textContent = slowest ? age(slowest.seconds_since_advanced) : '—';
+  el('fleet-slowest-node').textContent = slowest ? slowest.name : 'no node advancing yet';
+
+  const laggiest = pickWorst(rows, (row) => row.header_lag);
+  el('fleet-max-lag').textContent = laggiest ? num(laggiest.header_lag) : '—';
+  el('fleet-max-lag-node').textContent = laggiest
+    ? (laggiest.header_lag ? laggiest.name : 'every node has caught up')
+    : 'no headers reported';
+}
+function pickWorst(rows, pick) {
+  let worst = null;
+  for (const row of rows) {
+    const value = pick(row);
+    if (typeof value !== 'number') continue;
+    if (worst === null || value > pick(worst)) worst = row;
+  }
+  return worst;
+}
+function renderStats(data) {
+  const chain = data.chain || {};
+  const status = chain.status || 'unknown';
+  const tipGroups = chain.tip_groups || [];
+  const reorgs = chain.recent_reorgs || [];
+
+  el('tip-agreement').innerHTML = badge(chainStatusLabel(status), tone(STATUS_TONE, status));
+  el('tip-agreement-detail').textContent =
+    tipGroups.length + ' tip group' + (tipGroups.length === 1 ? '' : 's')
+    + ' · ' + (chain.observed_tips || 0) + ' node' + (chain.observed_tips === 1 ? '' : 's') + ' observed';
+
+  el('majority-tip').innerHTML = copyCell(
+    chain.majority_hash, shortHash(chain.majority_hash), 'Copy majority tip hash');
+  el('majority-height').textContent = chain.majority_height == null
+    ? 'no tip yet'
+    : 'height ' + num(chain.majority_height);
+
+  el('reorg-count').textContent = String(reorgs.length);
+  el('reorg-latest').textContent = reorgs.length
+    ? 'latest ' + clockTime(reorgs[0].at)
+    : 'none recorded';
+
+  el('compat-split').innerHTML = chain.compat_split
+    ? badge('diverged', 'bad')
+    : badge('aligned', 'ok');
+  el('compat-detail').textContent = chain.compat_split
+    ? 'best zakurad and zcashd tips differ'
+    : 'best zakurad and zcashd tips match';
+
+  el('last-poll').textContent = data.last_poll
+    ? new Date(data.last_poll * 1000).toLocaleTimeString()
+    : 'not yet polled';
+  el('stale-window').textContent =
+    'stale after ' + Math.round(data.stale_after) + 's without a new block';
+}
+function renderChain(data) {
+  const chain = data.chain || {};
+  const status = chain.status || 'unknown';
+  const tipGroups = chain.tip_groups || [];
+  const reorgs = chain.recent_reorgs || [];
+
+  el('chain-summary').textContent = {
+    split: 'Nodes disagree on the tip hash at the leading height.',
+    lagging: 'One tip hash leads; some nodes are behind.',
+    agreed: 'All observed nodes share the same tip.',
+  }[status] || 'Waiting for tip observations.';
+
+  el('tip-groups').innerHTML = tipGroups.length
+    ? tipGroups.map((group) => {
+      const isMajority = group.height === chain.majority_height
+        && group.block_hash === chain.majority_hash;
+      const depth = group.fork_depth_label && !isMajority
+        ? badge(group.fork_depth_label, 'warn')
+        : '';
+      return '<div class="tip-group ' + (isMajority ? 'is-majority' : 'is-fork') + '">'
+        + '<div class="tip-group-top">'
+        + badge(isMajority ? 'majority' : 'fork', isMajority ? 'ok' : 'bad')
+        + '<span class="height num">height ' + num(group.height) + '</span>'
+        + '<span class="mono muted" style="font-size:0.78rem">'
+        + copyCell(group.block_hash, shortHash(group.block_hash), 'Copy tip hash') + '</span>'
+        + depth
+        + '</div>'
+        + '<div class="tip-group-count">' + group.count
+        + ' node' + (group.count === 1 ? '' : 's') + '</div>'
+        + '<div class="tip-group-nodes">' + esc((group.nodes || []).join(', ')) + '</div>'
+        + '</div>';
+    }).join('')
+    : '<div class="empty">No tip hashes observed yet.</div>';
+
+  el('reorg-list').innerHTML = reorgs.length
+    ? reorgs.slice(0, 12).map((event) => {
+      const discarded = event.discarded_hash || event.from_hash || '';
+      const canonical = event.canonical_hash || event.to_hash || '';
+      const depth = event.depth_label
+        || (event.depth != null ? 'depth ' + event.depth : 'depth unknown');
+      return '<div class="reorg-item">'
+        + '<div class="reorg-top">'
+        + '<strong>' + esc(event.node) + '</strong>'
+        + badge(tipEventLabel(event.kind) || event.kind, 'warn')
+        + badge(depth, 'neutral')
+        + (event.demo ? badge('demo', 'info') : '')
+        + '<span class="muted num" style="font-size:0.78rem">' + num(event.from_height)
+        + ' → ' + num(event.to_height) + '</span>'
+        + '</div>'
+        + '<div class="reorg-detail mono">orphan ' + esc(tinyHash(discarded))
+        + ' → tip ' + esc(tinyHash(canonical))
+        + '<span class="dim"> · ' + esc(clockTime(event.at)) + '</span></div>'
+        + '</div>';
+    }).join('')
+    : '<div class="empty">No orphan pairs yet. Height drops and tip switches are'
+      + ' recorded here and survive dashboard restarts.</div>';
+}
+
+function matchesQuery(row, query) {
+  if (!query) return true;
+  return [
+    row.name, row.commit, row.node_id, row.block_hash, row.detail,
+    row.ssh, row.version, row.health, row.chain_role, row.client_name,
+  ].some((value) => String(value || '').toLowerCase().includes(query));
+}
+function sortRows(rows) {
+  const key = state.sortKey;
+  const dir = state.sortDir;
+  return rows.slice().sort((left, right) => {
+    const a = left[key];
+    const b = right[key];
+    if (a == null && b == null) return left.name.localeCompare(right.name);
+    if (a == null) return 1;
+    if (b == null) return -1;
+    if (typeof a === 'number' && typeof b === 'number') {
+      return a === b ? left.name.localeCompare(right.name) : (a - b) * dir;
+    }
+    const compared = String(a).localeCompare(String(b));
+    return compared === 0 ? left.name.localeCompare(right.name) : compared * dir;
+  });
+}
+function fieldHtml(label, value, options) {
+  const settings = options || {};
+  if (value == null || value === '') return '';
+  const text = settings.short ? settings.short : String(value);
+  const copy = settings.copy ? copyButton(String(value), 'Copy ' + label.toLowerCase()) : '';
+  const cls = 'field-value' + (settings.bad ? ' is-bad' : '') + (settings.mono ? ' mono' : '');
+  return '<div class="field' + (settings.full ? ' full' : '') + '">'
+    + '<span class="label">' + esc(label) + '</span>'
+    + '<div class="' + cls + '"><span>' + esc(text) + '</span>' + copy + '</div>'
+    + '</div>';
+}
+function drawerHtml(row) {
+  const ancestors = row.ancestor_hashes || {};
+  const depths = Object.keys(ancestors).sort((a, b) => Number(a) - Number(b));
+  const ancestorHtml = depths.length
+    ? '<div class="field full"><span class="label">Sampled best-chain ancestors</span>'
+      + '<div class="ancestors">' + depths.map((depth) =>
+        '<div><span>-' + esc(depth) + '</span><span>' + esc(ancestors[depth]) + '</span></div>'
+      ).join('') + '</div></div>'
+    : '';
+  return '<div class="drawer-inner">'
+    + fieldHtml('SSH target', row.ssh, { mono: true, copy: true })
+    + fieldHtml('Client', (row.client_name || 'unknown') + ' ' + (row.client_version || ''))
+    + fieldHtml('Version banner', row.version, { mono: true })
+    + fieldHtml('Service state', row.active_state)
+    + fieldHtml('RPC chain', String(row.rpc_chain || 'unknown')
+      + (row.rpc_testnet ? ' (testnet)' : ''))
+    + fieldHtml('Headers / blocks', num(row.headers) + ' / ' + num(row.height))
+    + fieldHtml('Commit', row.commit, { mono: true, copy: true })
+    + fieldHtml('Tip event', tipEventLabel(row.tip_event) || row.tip_event)
+    + fieldHtml('Tip last advanced', row.last_advanced_at
+      ? new Date(row.last_advanced_at * 1000).toLocaleString() : '')
+    + fieldHtml('Last probed', row.last_seen_at
+      ? new Date(row.last_seen_at * 1000).toLocaleString() : '')
+    + fieldHtml('Restarted', row.last_restarted)
+    + fieldHtml('Ironwood pool (zat)', row.ironwood_chain_balance_zat, { mono: true })
+    + fieldHtml('Node ID', row.node_id, { mono: true, copy: true, full: true })
+    + fieldHtml('Tip hash', row.block_hash, { mono: true, copy: true, full: true })
+    + fieldHtml('Parent hash', row.previous_hash, { mono: true, copy: true, full: true })
+    + ancestorHtml
+    + fieldHtml('Detail', row.detail, { full: true })
+    + fieldHtml('Ironwood pool error', row.ironwood_pool_error, { bad: true, full: true })
+    + fieldHtml('RPC metadata error', row.rpc_metadata_error, { bad: true, full: true })
+    + '</div>';
+}
+function renderTable(data) {
+  const chain = data.chain || {};
+  const majorityHeight = chain.majority_height;
+  const all = data.rows || [];
+  const visible = sortRows(all.filter((row) =>
+    (!state.issuesOnly || !row.healthy) && matchesQuery(row, state.query)));
+
+  el('table-title').textContent = visible.length === all.length
+    ? all.length + ' nodes'
+    : visible.length + ' of ' + all.length + ' nodes';
+
+  for (const th of document.querySelectorAll('thead th[data-sort]')) {
+    const active = th.dataset.sort === state.sortKey;
+    th.classList.toggle('is-sorted', active);
+    th.querySelector('.arrow').textContent = active ? (state.sortDir === 1 ? '↑' : '↓') : '';
+  }
+
+  if (!visible.length) {
+    el('rows').innerHTML = '<tr><td colspan="10"><div class="empty">'
+      + (all.length ? 'No nodes match the current filter.' : 'Waiting for the first poll.')
+      + '</div></td></tr>';
+    return;
+  }
+
+  el('rows').innerHTML = visible.map((row) => {
+    const healthTone = tone(HEALTH_TONE, row.health);
+    const chainTone = tone(CHAIN_TONE, row.chain_role);
+    const open = state.expandAll || state.expanded.has(row.name);
+    const tipLabel = tipEventLabel(row.tip_event);
+    const behind = (majorityHeight != null && row.height != null)
+      ? row.height - majorityHeight
+      : null;
+    const deltaHtml = behind
+      ? '<span class="delta">' + (behind > 0 ? '+' : '') + behind + ' vs majority</span>'
+      : '';
+    const rowTone = healthTone === 'bad' || chainTone === 'bad'
+      ? 'row-bad'
+      : (healthTone === 'warn' || chainTone === 'warn' ? 'row-warn' : '');
+    const lag = row.header_lag;
+    const lagHtml = lag == null
+      ? '<span class="dim">—</span>'
+      : (lag > 0 ? '<span style="color:var(--warn)">' + num(lag) + '</span>' : '0');
+
+    return '<tr class="node-row ' + rowTone + (open ? ' is-open' : '') + '"'
+      + ' data-node="' + esc(row.name) + '">'
+      + '<td class="col-node"><div class="node-cell"><span class="twisty">&#9654;</span>'
+      + '<div class="stack"><span class="node-name">' + esc(row.name) + '</span>'
+      + '<span class="node-sub" title="' + esc(row.node_id || '') + '">'
+      + esc(row.node_id ? tinyHash(row.node_id) : 'node id unknown') + '</span></div></div></td>'
+      + '<td class="col-health">' + badge(HEALTH_LABEL[row.health] || row.health, healthTone) + '</td>'
+      + '<td class="col-chain"><div class="stack">'
+      + badge(row.chain_role || 'unknown', chainTone)
+      + (tipLabel ? badge(tipLabel, 'bad') : '') + '</div></td>'
+      + '<td class="col-height col-num mono"><div class="stack">'
+      + '<span>' + num(row.height) + '</span>' + deltaHtml + '</div></td>'
+      + '<td class="col-hdr col-num mono">' + lagHtml + '</td>'
+      + '<td class="col-adv col-num mono" title="'
+      + esc(row.seconds_since_advanced == null ? 'never' : row.seconds_since_advanced + 's') + '">'
+      + esc(age(row.seconds_since_advanced)) + '</td>'
+      + '<td class="col-commit mono">'
+      + copyCell(row.commit, shortCommit(row.commit), 'Copy full commit hash') + '</td>'
+      + '<td class="col-tip mono">'
+      + copyCell(row.block_hash, tinyHash(row.block_hash), 'Copy full tip hash') + '</td>'
+      + '<td class="col-restarted mono num" title="' + esc(row.last_restarted || '') + '">'
+      + esc(formatRestarted(row.last_restarted)) + '</td>'
+      + '<td class="col-detail"><div class="detail-text" title="' + esc(row.detail || '') + '">'
+      + esc(row.detail || '') + '</div></td>'
+      + '</tr>'
+      + (open
+        ? '<tr class="drawer"><td colspan="10">' + drawerHtml(row) + '</td></tr>'
+        : '');
+  }).join('');
+}
+function render() {
+  if (!state.data) return;
+  renderHeader(state.data);
+  renderActivation(state.data);
+  renderFleet(state.data);
+  renderStats(state.data);
+  renderChain(state.data);
+  renderTable(state.data);
+  renderFreshness();
+}
+
+/* ---------- data ---------- */
+async function tick() {
+  try {
+    const response = await fetch('/data', { cache: 'no-store' });
+    if (!response.ok) throw new Error('HTTP ' + response.status);
+    state.data = await response.json();
+    state.fetchedAt = Date.now();
+    state.error = '';
+    el('banner').hidden = true;
+  } catch (error) {
+    state.error = String(error);
+    const banner = el('banner');
+    banner.hidden = false;
+    banner.textContent = 'Dashboard data endpoint is unreachable (' + state.error + '). '
+      + (state.data ? 'Showing the last successful poll.' : 'No poll has succeeded yet.');
+    const pill = el('state-pill');
+    pill.textContent = 'Unreachable';
+    pill.className = 'state-pill is-bad';
+    renderFreshness();
+    return;
+  }
+  render();
+}
+
+/* ---------- interaction ---------- */
+document.addEventListener('click', (event) => {
+  const copy = event.target.closest('[data-copy]');
+  if (copy) {
+    event.stopPropagation();
+    copyValue(copy);
+    return;
+  }
+  const header = event.target.closest('thead th[data-sort]');
+  if (header) {
+    const key = header.dataset.sort;
+    if (state.sortKey === key) {
+      state.sortDir = -state.sortDir;
+    } else {
+      state.sortKey = key;
+      state.sortDir = 1;
+    }
+    if (state.data) renderTable(state.data);
+    return;
+  }
+  const row = event.target.closest('tr.node-row');
+  if (row) {
+    const name = row.dataset.node;
+    if (state.expandAll) {
+      // Leaving expand-all: keep every row open except the one just clicked.
+      state.expandAll = false;
+      el('expand-toggle').classList.remove('is-on');
+      el('expand-toggle').textContent = 'Expand all';
+      state.expanded = new Set((state.data.rows || []).map((each) => each.name));
+      state.expanded.delete(name);
+    } else if (state.expanded.has(name)) {
+      state.expanded.delete(name);
+    } else {
+      state.expanded.add(name);
+    }
+    if (state.data) renderTable(state.data);
+  }
+});
+el('filter-input').addEventListener('input', (event) => {
+  state.query = event.target.value.trim().toLowerCase();
+  if (state.data) renderTable(state.data);
+});
+el('issues-toggle').addEventListener('click', (event) => {
+  state.issuesOnly = !state.issuesOnly;
+  event.currentTarget.classList.toggle('is-on', state.issuesOnly);
+  if (state.data) renderTable(state.data);
+});
+el('expand-toggle').addEventListener('click', (event) => {
+  state.expandAll = !state.expandAll;
+  if (!state.expandAll) state.expanded.clear();
+  event.currentTarget.classList.toggle('is-on', state.expandAll);
+  event.currentTarget.textContent = state.expandAll ? 'Collapse all' : 'Expand all';
+  if (state.data) renderTable(state.data);
+});
 tick();
-setInterval(tick, 10000);
+setInterval(tick, REFRESH_MS);
+setInterval(renderFreshness, 1000);
 </script>
 </body>
 </html>"""
@@ -1607,9 +2853,15 @@ def main() -> None:
         default=DEFAULT_TARGET_SPACING,
         help="fallback seconds per block before enough live samples are observed",
     )
+    parser.add_argument(
+        "--state-file",
+        default="",
+        help="optional JSON path for durable orphan-pair history",
+    )
     args = parser.parse_args()
 
     nodes = load_nodes(Path(args.config))
+    state_file = Path(args.state_file) if args.state_file else None
     COLLECTOR = ClusterCollector(
         nodes,
         args.interval,
@@ -1617,12 +2869,14 @@ def main() -> None:
         args.upgrade_height,
         args.target_spacing,
         args.network,
+        state_file=state_file,
     )
     threading.Thread(target=COLLECTOR.loop, daemon=True).start()
 
     print(
         f"cluster status dashboard bound on {args.host}:{args.port}; "
         f"polling {len(nodes)} node(s) every {args.interval}s"
+        + (f"; state {state_file}" if state_file else "")
     )
     ThreadingHTTPServer((args.host, args.port), Handler).serve_forever()
 


### PR DESCRIPTION
## Motivation

The mainnet cluster dashboard reported per-node height, commit, and liveness,
but nothing about whether the fleet agreed on a chain tip. A split or a reorg
was only visible by comparing heights by eye across thirteen rows, and a tip
switch at an unchanged height was invisible. The page itself had no hierarchy:
ten identical summary cards in a ragged four-column grid, and a table whose
64-character node ids wrapped over three lines while the Ironwood countdown sat
in a card the same size as everything else.

## Solution

**Tip agreement.** Each poll groups nodes by `(height, tip hash)`. One group
means agreement; several groups at the leading height mean a split. Nodes are
labelled `majority`, `fork`, `ahead`, or `behind`. Fork depth between two tips
at the same height is estimated from best-chain ancestor hashes sampled at 1,
2, 5, 10, and 32 blocks back, so an unresolved fork reports `> 32 or unknown`
rather than a wrong number.

**Orphan pairs.** A height drop or a tip switch at the same height records the
discarded hash, the new canonical hash, and the depth. `--state-file` persists
that history across restarts. Both deploy workflows now pass the flag, pointed
at `/var/lib/zakura-<network>-dashboard/orphan-pairs.json`; without it the
history was in-memory only and lost on every restart, which would have made the
feature inert in production.

**Page rebuild.** An Ironwood activation panel (countdown, ETA, progress over
the final 10,000 blocks) and a fleet health panel (healthy count, health
segments, leading height, slowest advance, max header lag) lead the page. The
node table is filterable and sortable, colours rows by severity, shows each
node's delta against the majority tip, and expands every row into the full
probe output: ssh target, client and version, service state, RPC chain, node
id, tip and parent hashes, sampled ancestors, and any RPC or pool errors.
Badge tone is now mapped explicitly instead of interpolating server-supplied
values into CSS class names.

`/data`, `/healthz`, and `/ironwood-status.json` are unchanged. The public
Ironwood response shape and its verification rules are untouched.

## Testing

- `python3 -m unittest discover -s deploy/runner -p test_zakura_cluster_status.py`
  — 18 tests pass. New cases cover tip event classification, agreed/lagging/
  split summaries, chain role enrichment, header lag, fork depth from ancestor
  samples, and orphan pairs surviving a collector restart through the state
  file.
- `npx markdownlint-cli2 deploy/runner/README.md` — clean.
- `./scripts/changelog.py check` — clean.
- Rendered the page against a captured snapshot of the live 13-node mainnet
  fleet and against a synthetic degraded fleet (down, stale, rpc_error, and
  ahead nodes plus a two-way tip split) to exercise the failure styling, the
  split tip group, and the unreachable-endpoint banner. Also checked the
  narrow-viewport layout and confirmed the document does not overflow.
- Deployed to `us-east-0` and verified live: 13/13 healthy, tip groups and row
  drawers populated, and a real one-block propagation lag correctly surfaced as
  `Lagging` with a second tip group labelled `1 behind`.

## Changelog

No fragment: this PR changes no Rust source and no `Cargo.toml`. It touches
only the deploy runner dashboard, its tests, and the two deploy workflows.

### Follow-up Work

- The `--state-file` addition means the next mainnet deploy will create
  `/var/lib/zakura-mainnet-dashboard/orphan-pairs.json` on the runner. The
  directory is created by the writer, so no provisioning step is needed.
- The public DNS record for `status.mainnet.zakura.valargroup.dev` resolves to
  `18.204.152.241`, which does not answer for that name; the working hostname is
  `status-mainnet.valargroup.dev`. Unrelated to this PR, but worth fixing.