### PR TITLE
feat(deploy): add public Zakura broadcast JSON-RPC gateways

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -386,6 +386,38 @@ jobs:
           sudo systemctl restart zakura-mainnet-dashboard.service
           sudo systemctl --no-pager --full status zakura-mainnet-dashboard.service || true
 
+      - name: Install public broadcast gateway
+        if: always()
+        run: |
+          set -euo pipefail
+
+          gateway_dir="/opt/zakura-gateway-mainnet"
+          sudo install -d -m 755 "$gateway_dir"
+          sudo install -m 755 deploy/gateway/broadcast.py "$gateway_dir/broadcast.py"
+          sudo install -m 644 deploy/gateway/mainnet/backends.toml \
+            "$gateway_dir/backends.toml"
+          sudo install -m 644 deploy/gateway/mainnet/broadcast.service \
+            /etc/systemd/system/zakura-broadcast-mainnet.service
+
+          # Keep status hosts and the broadcast TLS front door in sync.
+          sudo install -m 644 deploy/gateway/mainnet/Caddyfile /etc/caddy/Caddyfile
+          sudo caddy validate --config /etc/caddy/Caddyfile
+          sudo systemctl reload caddy.service
+
+          # Remove transitional install paths if present.
+          if systemctl list-unit-files zakura-submit-gateway.service >/dev/null 2>&1; then
+            sudo systemctl disable --now zakura-submit-gateway.service || true
+            sudo rm -f /etc/systemd/system/zakura-submit-gateway.service
+          fi
+          sudo rm -rf /opt/zakura-submit-gateway /opt/zakura-broadcast-mainnet
+
+          sudo systemctl daemon-reload
+          sudo systemctl enable zakura-broadcast-mainnet.service
+          sudo systemctl restart zakura-broadcast-mainnet.service
+          sudo systemctl --no-pager --full status zakura-broadcast-mainnet.service || true
+          curl -fsS "http://127.0.0.1:8092/healthz"
+          echo
+
       - name: Install fleet watchdog
         if: always()
         env:

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -351,6 +351,33 @@ jobs:
           sudo systemctl restart zakura-testnet-snapshots.service
           sudo systemctl --no-pager --full status zakura-testnet-snapshots.service || true
 
+      - name: Install public broadcast gateway
+        if: always()
+        run: |
+          set -euo pipefail
+
+          gateway_dir="/opt/zakura-gateway-testnet"
+          sudo install -d -m 755 "$gateway_dir"
+          sudo install -m 755 deploy/gateway/broadcast.py "$gateway_dir/broadcast.py"
+          sudo install -m 644 deploy/gateway/testnet/backends.toml \
+            "$gateway_dir/backends.toml"
+          sudo install -m 644 deploy/gateway/testnet/broadcast.service \
+            /etc/systemd/system/zakura-broadcast-testnet.service
+
+          # Keep ironwood/status hosts and the broadcast TLS front door in sync.
+          sudo install -m 644 deploy/gateway/testnet/Caddyfile /etc/caddy/Caddyfile
+          sudo caddy validate --config /etc/caddy/Caddyfile
+          sudo systemctl reload caddy.service
+
+          sudo rm -rf /opt/zakura-broadcast-testnet
+
+          sudo systemctl daemon-reload
+          sudo systemctl enable zakura-broadcast-testnet.service
+          sudo systemctl restart zakura-broadcast-testnet.service
+          sudo systemctl --no-pager --full status zakura-broadcast-testnet.service || true
+          curl -fsS "http://127.0.0.1:8092/healthz"
+          echo
+
       - name: Fetch recent logs on failure
         if: failure()
         working-directory: deploy/deployer

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -129,6 +129,19 @@ selects one healthy node from the highest agreed tip and contains only the
 network, Ironwood activation and balance data, observation time, and source
 client metadata. It never proxies caller-supplied RPC requests.
 
+It also installs the public broadcast-only JSON-RPC gateway on
+`zakura-testnet-1` (see `deploy/gateway/`):
+
+- service: `zakura-broadcast-testnet.service`
+- public URL: `https://zakura-broadcast.testnet.valargroup.dev/`
+- origin: `http://127.0.0.1:8092/`
+- install dir: `/opt/zakura-gateway-testnet`
+- TLS front door: `/etc/caddy/Caddyfile` from `deploy/gateway/testnet/Caddyfile`
+
+The gateway allowlists `sendrawtransaction`, rate-limits at 30 req/min/IP, and
+load-balances across the testnet `:18232` backends listed in
+`deploy/gateway/testnet/backends.toml`.
+
 The workflow also refreshes a static Zakura Ironwood testnet snapshots website on
 `zakura-testnet-1`:
 
@@ -217,6 +230,19 @@ The workflow refreshes a fleet status dashboard on `us-east-0`:
 - service: `zakura-mainnet-dashboard.service`
 - URL: `http://159.65.183.89:8090/`
 - install dir: `/opt/zakura-mainnet-dashboard`
+
+It also installs the public broadcast-only JSON-RPC gateway on the same host
+(see `deploy/gateway/`):
+
+- service: `zakura-broadcast-mainnet.service`
+- public URL: `https://zakura-broadcast.valargroup.dev/`
+- origin: `http://127.0.0.1:8092/`
+- install dir: `/opt/zakura-gateway-mainnet`
+- TLS front door: `/etc/caddy/Caddyfile` from `deploy/gateway/mainnet/Caddyfile`
+
+The gateway allowlists `sendrawtransaction`, rate-limits at 30 req/min/IP, and
+load-balances across the mainnet `:8232` backends listed in
+`deploy/gateway/mainnet/backends.toml`.
 
 It is the same `zakura-cluster-status.py` as testnet, launched with
 `--upgrade-height 3428143` for the Ironwood mainnet activation height. The ETA

--- a/deploy/gateway/README.md
+++ b/deploy/gateway/README.md
@@ -1,0 +1,69 @@
+# Zakura public edge gateway
+
+TLS front doors, allowlisted proxies, and related edge services for Zakura
+fleets. Network-specific config lives under `mainnet/` and `testnet/`.
+
+## Layout
+
+```text
+deploy/gateway/
+  broadcast.py            # sendrawtransaction-only JSON-RPC proxy
+  test_broadcast.py
+  README.md
+  mainnet/
+    backends.toml
+    Caddyfile             # us-east-0 edge (status + broadcast)
+    broadcast.service
+  testnet/
+    backends.toml
+    Caddyfile             # zakura-testnet-1 edge (ironwood + status + broadcast)
+    broadcast.service
+```
+
+## Broadcast service
+
+Submit-only JSON-RPC reverse proxy for Vizor and other clients that need
+`sendrawtransaction` without exposing full node RPC.
+
+| Item | Value |
+| --- | --- |
+| Method | JSON-RPC 2.0 `sendrawtransaction` only |
+| Auth | none |
+| Success | HTTP 2xx; `result` = 64-char hex txid |
+| Redirects | none (HTTP returns `400 HTTPS required`) |
+| Body logging | never |
+| Rate limit | 30 req/min/client IP |
+
+### Mainnet
+
+- Public URL: `https://zakura-broadcast.valargroup.dev/`
+- Origin host: `us-east-0` (`127.0.0.1:8092`)
+- Install dir: `/opt/zakura-gateway-mainnet`
+- Service: `zakura-broadcast-mainnet.service`
+- Installed by `.github/workflows/zakura-mainnet-deploy.yml`
+
+```bash
+python3 deploy/gateway/test_broadcast.py
+
+curl -fsS --max-redirs 0 https://zakura-broadcast.valargroup.dev/healthz
+```
+
+```text
+VIZOR_ZCASH_TRANSACTION_RELAY_URL_MAIN=https://zakura-broadcast.valargroup.dev/
+```
+
+### Testnet
+
+- Public URL: `https://zakura-broadcast.testnet.valargroup.dev/`
+- Origin host: `zakura-testnet-1` (`127.0.0.1:8092`)
+- Install dir: `/opt/zakura-gateway-testnet`
+- Service: `zakura-broadcast-testnet.service`
+- Installed by `.github/workflows/zakura-testnet-deploy.yml`
+
+```bash
+curl -fsS --max-redirs 0 https://zakura-broadcast.testnet.valargroup.dev/healthz
+```
+
+```text
+VIZOR_ZCASH_TRANSACTION_RELAY_URL_TEST=https://zakura-broadcast.testnet.valargroup.dev/
+```

--- a/deploy/gateway/broadcast.py
+++ b/deploy/gateway/broadcast.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Public Zakura JSON-RPC broadcast gateway.
+
+Accepts only `sendrawtransaction`, rate-limits by client IP, and load-balances
+across healthy Zakura backends. Request bodies are never logged.
+
+Only the Python stdlib is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import logging
+import threading
+import time
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import deque
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_METHOD = "sendrawtransaction"
+DEFAULT_RATE_LIMIT = 30
+DEFAULT_RATE_WINDOW = 60.0
+DEFAULT_RATE_CLIENT_LIMIT = 4_096
+DEFAULT_MAX_BODY_BYTES = 1 * 1024 * 1024
+DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024
+DEFAULT_BACKEND_TIMEOUT = 10.0
+DEFAULT_HEALTH_INTERVAL = 15.0
+HEALTH_METHOD = "getblockchaininfo"
+
+LOGGER = logging.getLogger("zakura-broadcast-gateway")
+
+
+@dataclass(frozen=True)
+class Backend:
+    name: str
+    url: str
+
+
+class RateLimiter:
+    """Per-client fixed-window limiter (same shape as the status dashboard)."""
+
+    def __init__(
+        self,
+        limit: int = DEFAULT_RATE_LIMIT,
+        window: float = DEFAULT_RATE_WINDOW,
+        client_limit: int = DEFAULT_RATE_CLIENT_LIMIT,
+    ):
+        self.limit = limit
+        self.window = window
+        self.client_limit = client_limit
+        self.lock = threading.Lock()
+        self.events: dict[str, deque[float]] = {}
+
+    def allow(self, client: str, now: float | None = None) -> bool:
+        now = time.time() if now is None else now
+        cutoff = now - self.window
+        with self.lock:
+            if client not in self.events and len(self.events) >= self.client_limit:
+                self.events = {
+                    key: events
+                    for key, events in self.events.items()
+                    if events and events[-1] > cutoff
+                }
+                if len(self.events) >= self.client_limit:
+                    return False
+
+            events = self.events.setdefault(client, deque())
+            while events and events[0] <= cutoff:
+                events.popleft()
+            if len(events) >= self.limit:
+                return False
+            events.append(now)
+            return True
+
+
+class BackendPool:
+    """Round-robin pool that skips backends failing cheap liveness checks."""
+
+    def __init__(
+        self,
+        backends: list[Backend],
+        *,
+        timeout: float = DEFAULT_BACKEND_TIMEOUT,
+        health_interval: float = DEFAULT_HEALTH_INTERVAL,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    ):
+        if not backends:
+            raise ValueError("at least one backend is required")
+        self.backends = backends
+        self.timeout = timeout
+        self.health_interval = health_interval
+        self.max_response_bytes = max_response_bytes
+        self.lock = threading.Lock()
+        self.next_index = 0
+        self.healthy = {backend.name: True for backend in backends}
+        self._stop = threading.Event()
+        self._health_thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self.refresh_health()
+        self._health_thread = threading.Thread(
+            target=self._health_loop,
+            name="broadcast-gateway-health",
+            daemon=True,
+        )
+        self._health_thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._health_thread is not None:
+            self._health_thread.join(timeout=2.0)
+
+    def _health_loop(self) -> None:
+        while not self._stop.wait(self.health_interval):
+            try:
+                self.refresh_health()
+            except Exception:
+                LOGGER.exception("backend health refresh failed")
+
+    def refresh_health(self) -> None:
+        for backend in self.backends:
+            ok = self._probe(backend)
+            with self.lock:
+                previous = self.healthy.get(backend.name, True)
+                self.healthy[backend.name] = ok
+            if ok != previous:
+                LOGGER.info(
+                    "backend health changed name=%s healthy=%s",
+                    backend.name,
+                    ok,
+                )
+
+    def _probe(self, backend: Backend) -> bool:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "health",
+            "method": HEALTH_METHOD,
+            "params": [],
+        }
+        try:
+            status, body = self._post(backend, payload)
+        except Exception:
+            return False
+        if status != 200:
+            return False
+        try:
+            decoded = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return False
+        return isinstance(decoded, dict) and "result" in decoded and "error" not in decoded
+
+    def snapshot(self) -> dict[str, Any]:
+        with self.lock:
+            return {
+                "backends": [
+                    {
+                        "name": backend.name,
+                        "url": backend.url,
+                        "healthy": self.healthy.get(backend.name, False),
+                    }
+                    for backend in self.backends
+                ],
+                "healthy_count": sum(
+                    1 for backend in self.backends if self.healthy.get(backend.name, False)
+                ),
+            }
+
+    def _ordered_candidates(self) -> list[Backend]:
+        with self.lock:
+            start = self.next_index % len(self.backends)
+            self.next_index = (start + 1) % len(self.backends)
+            ordered = self.backends[start:] + self.backends[:start]
+            healthy = [b for b in ordered if self.healthy.get(b.name, False)]
+            if healthy:
+                return healthy
+            # All marked unhealthy: still try everyone once so the gateway can recover.
+            return ordered
+
+    def mark_unhealthy(self, backend: Backend) -> None:
+        with self.lock:
+            self.healthy[backend.name] = False
+
+    def forward(self, payload: dict[str, Any]) -> tuple[int, bytes, str]:
+        errors: list[str] = []
+        for backend in self._ordered_candidates():
+            try:
+                status, body = self._post(backend, payload)
+            except Exception as exc:
+                self.mark_unhealthy(backend)
+                errors.append(f"{backend.name}: {exc}")
+                LOGGER.warning(
+                    "backend request failed name=%s error=%s",
+                    backend.name,
+                    type(exc).__name__,
+                )
+                continue
+            if status >= 500:
+                self.mark_unhealthy(backend)
+                errors.append(f"{backend.name}: HTTP {status}")
+                continue
+            return status, body, backend.name
+        detail = "; ".join(errors) if errors else "no backends available"
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": payload.get("id"),
+                "error": {
+                    "code": -32000,
+                    "message": f"All submit backends unavailable: {detail}",
+                },
+            },
+            separators=(",", ":"),
+        ).encode()
+        return 502, body, ""
+
+    def _post(self, backend: Backend, payload: dict[str, Any]) -> tuple[int, bytes]:
+        data = json.dumps(payload, separators=(",", ":")).encode()
+        request = urllib.request.Request(
+            backend.url,
+            data=data,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "zakura-broadcast-gateway/1.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                body = response.read(self.max_response_bytes + 1)
+                if len(body) > self.max_response_bytes:
+                    raise ValueError("backend response exceeds size limit")
+                return int(response.status), body
+        except urllib.error.HTTPError as exc:
+            body = exc.read(self.max_response_bytes + 1)
+            if len(body) > self.max_response_bytes:
+                raise ValueError("backend response exceeds size limit") from exc
+            return int(exc.code), body
+
+
+GATEWAY: BackendPool | None = None
+RATE_LIMITER = RateLimiter()
+MAX_BODY_BYTES = DEFAULT_MAX_BODY_BYTES
+RATE_WINDOW = DEFAULT_RATE_WINDOW
+
+
+def load_backends(path: Path) -> list[Backend]:
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+    backends = data.get("backends")
+    if not isinstance(backends, list) or not backends:
+        raise ValueError(f"{path}: expected non-empty [[backends]] list")
+    loaded: list[Backend] = []
+    for index, entry in enumerate(backends):
+        if not isinstance(entry, dict):
+            raise ValueError(f"{path}: backends[{index}] must be a table")
+        name = entry.get("name")
+        url = entry.get("url")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{path}: backends[{index}].name is required")
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError(f"{path}: backends[{index}].url is required")
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"{path}: backends[{index}].url must be http(s)")
+        loaded.append(Backend(name=name.strip(), url=url.strip()))
+    return loaded
+
+
+def jsonrpc_error(req_id: Any, code: int, message: str) -> bytes:
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": code, "message": message},
+        },
+        separators=(",", ":"),
+    ).encode()
+
+
+class SubmitHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "zakura-broadcast-gateway/1.0"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Replace BaseHTTPRequestHandler's stderr logger; never include bodies.
+        LOGGER.info("http client=%s %s", self.rate_limit_client(), fmt % args)
+
+    def rate_limit_client(self) -> str:
+        peer = self.client_address[0]
+        try:
+            peer_address = ipaddress.ip_address(peer)
+        except ValueError:
+            return peer
+
+        forwarded_for = self.headers.get("X-Forwarded-For")
+        if peer_address.is_loopback and forwarded_for:
+            candidate = forwarded_for.rsplit(",", 1)[-1].strip()
+            try:
+                return str(ipaddress.ip_address(candidate))
+            except ValueError:
+                pass
+        return str(peer_address)
+
+    def send_bytes(
+        self,
+        status: int,
+        body: bytes,
+        content_type: str,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        if headers:
+            for key, value in headers.items():
+                self.send_header(key, value)
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == "/healthz":
+            assert GATEWAY is not None
+            snap = GATEWAY.snapshot()
+            if snap["healthy_count"] <= 0:
+                return self.send_bytes(
+                    503,
+                    b"no healthy backends\n",
+                    "text/plain; charset=utf-8",
+                )
+            return self.send_bytes(200, b"ok\n", "text/plain; charset=utf-8")
+        if parsed.path == "/backends":
+            assert GATEWAY is not None
+            body = json.dumps(GATEWAY.snapshot(), separators=(",", ":")).encode()
+            return self.send_bytes(200, body, "application/json; charset=utf-8")
+        return self.send_bytes(404, b"not found\n", "text/plain; charset=utf-8")
+
+    def do_HEAD(self) -> None:
+        self.do_GET()
+
+    def do_POST(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path not in {"", "/"}:
+            return self.send_bytes(404, b"not found\n", "text/plain; charset=utf-8")
+
+        client = self.rate_limit_client()
+        if not RATE_LIMITER.allow(client):
+            body = jsonrpc_error(None, -32029, "Request rate limit exceeded")
+            return self.send_bytes(
+                429,
+                body,
+                "application/json; charset=utf-8",
+                {"Retry-After": str(int(RATE_WINDOW))},
+            )
+
+        length_header = self.headers.get("Content-Length")
+        if length_header is None:
+            body = jsonrpc_error(None, -32700, "Content-Length required")
+            return self.send_bytes(411, body, "application/json; charset=utf-8")
+        try:
+            length = int(length_header)
+        except ValueError:
+            body = jsonrpc_error(None, -32700, "Invalid Content-Length")
+            return self.send_bytes(400, body, "application/json; charset=utf-8")
+        if length < 0 or length > MAX_BODY_BYTES:
+            body = jsonrpc_error(None, -32600, "Request body too large")
+            return self.send_bytes(413, body, "application/json; charset=utf-8")
+
+        # Read exactly the declared body; do not retain it beyond this request.
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            body = jsonrpc_error(None, -32700, "Parse error")
+            return self.send_bytes(400, body, "application/json; charset=utf-8")
+        finally:
+            del raw
+
+        if not isinstance(payload, dict):
+            body = jsonrpc_error(None, -32600, "Invalid Request")
+            return self.send_bytes(400, body, "application/json; charset=utf-8")
+
+        req_id = payload.get("id")
+        method = payload.get("method")
+        if method != ALLOWED_METHOD:
+            LOGGER.info(
+                "rejected method client=%s method=%r",
+                client,
+                method if isinstance(method, str) else type(method).__name__,
+            )
+            body = jsonrpc_error(req_id, -32601, "Method not allowed")
+            return self.send_bytes(200, body, "application/json; charset=utf-8")
+
+        params = payload.get("params")
+        if not isinstance(params, list) or len(params) < 1 or not isinstance(params[0], str):
+            body = jsonrpc_error(
+                req_id,
+                -32602,
+                "Invalid params: expected [hex_tx, ...]",
+            )
+            return self.send_bytes(200, body, "application/json; charset=utf-8")
+
+        assert GATEWAY is not None
+        started = time.monotonic()
+        status, body, backend_name = GATEWAY.forward(payload)
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        LOGGER.info(
+            "submit client=%s backend=%s status=%s bytes=%s elapsed_ms=%s",
+            client,
+            backend_name or "-",
+            status,
+            len(body),
+            elapsed_ms,
+        )
+        return self.send_bytes(status, body, "application/json; charset=utf-8")
+
+
+def main() -> None:
+    global GATEWAY, RATE_LIMITER, MAX_BODY_BYTES, RATE_WINDOW
+
+    parser = argparse.ArgumentParser(description="Serve a Zakura broadcast-only JSON-RPC gateway.")
+    parser.add_argument("--backends", required=True, type=Path, help="path to backends TOML")
+    parser.add_argument("--host", default="127.0.0.1", help="bind host")
+    parser.add_argument("--port", default=8092, type=int, help="bind port")
+    parser.add_argument("--rate-limit", default=DEFAULT_RATE_LIMIT, type=int)
+    parser.add_argument("--rate-window", default=DEFAULT_RATE_WINDOW, type=float)
+    parser.add_argument("--max-body-bytes", default=DEFAULT_MAX_BODY_BYTES, type=int)
+    parser.add_argument("--backend-timeout", default=DEFAULT_BACKEND_TIMEOUT, type=float)
+    parser.add_argument("--health-interval", default=DEFAULT_HEALTH_INTERVAL, type=float)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    MAX_BODY_BYTES = args.max_body_bytes
+    RATE_WINDOW = args.rate_window
+    RATE_LIMITER = RateLimiter(limit=args.rate_limit, window=args.rate_window)
+    backends = load_backends(args.backends)
+    GATEWAY = BackendPool(
+        backends,
+        timeout=args.backend_timeout,
+        health_interval=args.health_interval,
+    )
+    GATEWAY.start()
+
+    server = ThreadingHTTPServer((args.host, args.port), SubmitHandler)
+    LOGGER.info(
+        "listening on http://%s:%s backends=%s rate=%s/%ss",
+        args.host,
+        args.port,
+        len(backends),
+        args.rate_limit,
+        args.rate_window,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        GATEWAY.stop()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/gateway/mainnet/Caddyfile
+++ b/deploy/gateway/mainnet/Caddyfile
@@ -1,0 +1,28 @@
+# Managed Caddyfile for us-east-0 (zakura mainnet runner).
+# Source: deploy/gateway/mainnet/Caddyfile
+# Installs via zakura-mainnet-deploy.yml; do not hand-edit on the host.
+
+status.mainnet.zakura.valargroup.dev {
+	reverse_proxy 127.0.0.1:8090
+}
+
+status-mainnet.valargroup.dev {
+	reverse_proxy 127.0.0.1:8090
+}
+
+# HTTPS-only public submit endpoint. Explicit HTTP block avoids an
+# HTTP→HTTPS redirect that Vizor (redirect policy: none) cannot follow.
+http://zakura-broadcast.valargroup.dev {
+	respond "HTTPS required" 400
+}
+
+zakura-broadcast.valargroup.dev {
+	# Do not expose internal /backends inventory on the public hostname.
+	@public path / /healthz
+	handle @public {
+		reverse_proxy 127.0.0.1:8092
+	}
+	handle {
+		respond "not found" 404
+	}
+}

--- a/deploy/gateway/mainnet/backends.toml
+++ b/deploy/gateway/mainnet/backends.toml
@@ -1,0 +1,18 @@
+# Mainnet Zakura JSON-RPC backends for the public broadcast gateway.
+# North America only — reachable :8232 from us-east-0.
+
+[[backends]]
+name = "us-east-0"
+url = "http://127.0.0.1:8232/"
+
+[[backends]]
+name = "us-0"
+url = "http://104.131.184.123:8232/"
+
+[[backends]]
+name = "us-west-0"
+url = "http://143.244.184.176:8232/"
+
+[[backends]]
+name = "canada-0"
+url = "http://159.203.38.10:8232/"

--- a/deploy/gateway/mainnet/broadcast.service
+++ b/deploy/gateway/mainnet/broadcast.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Zakura mainnet public JSON-RPC broadcast gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/zakura-gateway-mainnet
+ExecStart=/usr/bin/python3 /opt/zakura-gateway-mainnet/broadcast.py \
+  --backends /opt/zakura-gateway-mainnet/backends.toml \
+  --host 127.0.0.1 \
+  --port 8092
+Restart=always
+RestartSec=5
+# Never inherit a shell that might dump request bodies into the journal.
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/gateway/test_broadcast.py
+++ b/deploy/gateway/test_broadcast.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Tests for the Zakura public submit gateway."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+
+SCRIPT_PATH = Path(__file__).with_name("broadcast.py")
+SPEC = importlib.util.spec_from_file_location("zakura_broadcast_gateway", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+gateway = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = gateway
+SPEC.loader.exec_module(gateway)
+
+
+def make_fake_backend_handler(
+    responses: dict[str, tuple[int, dict[str, Any]]],
+) -> type[BaseHTTPRequestHandler]:
+    class FakeBackendHandler(BaseHTTPRequestHandler):
+        def log_message(self, fmt: str, *args: Any) -> None:
+            return
+
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length)
+            payload = json.loads(raw.decode())
+            method = payload["method"]
+            status, body = responses.get(
+                method,
+                (
+                    200,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": payload.get("id"),
+                        "error": {"code": -32601, "message": "unknown"},
+                    },
+                ),
+            )
+            encoded = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    return FakeBackendHandler
+
+
+def start_fake_backend(
+    responses: dict[str, tuple[int, dict[str, Any]]],
+) -> tuple[ThreadingHTTPServer, str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), make_fake_backend_handler(responses))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    return server, f"http://{host}:{port}/"
+
+
+class LoadBackendsTest(unittest.TestCase):
+    def test_loads_backends_toml(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "backends.toml"
+            path.write_text(
+                '[[backends]]\nname = "a"\nurl = "http://127.0.0.1:8232/"\n',
+                encoding="utf-8",
+            )
+            backends = gateway.load_backends(path)
+            self.assertEqual(
+                backends,
+                [gateway.Backend(name="a", url="http://127.0.0.1:8232/")],
+            )
+
+
+class RateLimiterTest(unittest.TestCase):
+    def test_limits_per_client(self) -> None:
+        limiter = gateway.RateLimiter(limit=2, window=60.0)
+        self.assertTrue(limiter.allow("1.1.1.1", now=100.0))
+        self.assertTrue(limiter.allow("1.1.1.1", now=100.1))
+        self.assertFalse(limiter.allow("1.1.1.1", now=100.2))
+        self.assertTrue(limiter.allow("2.2.2.2", now=100.2))
+
+
+class BackendPoolTest(unittest.TestCase):
+    def test_fails_over_from_unreachable_backend(self) -> None:
+        good_payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": "abcd" * 16,
+        }
+        health_ok = {
+            "jsonrpc": "2.0",
+            "id": "health",
+            "result": {"blocks": 1},
+        }
+        server_good, url_good = start_fake_backend(
+            {
+                "getblockchaininfo": (200, health_ok),
+                "sendrawtransaction": (200, good_payload),
+            }
+        )
+        try:
+            pool = gateway.BackendPool(
+                [
+                    # Reserved port with nothing listening.
+                    gateway.Backend("bad", "http://127.0.0.1:1/"),
+                    gateway.Backend("good", url_good),
+                ],
+                timeout=1.0,
+                health_interval=60.0,
+            )
+            # Pretend both were healthy so forward() still tries bad first.
+            with pool.lock:
+                pool.healthy = {"bad": True, "good": True}
+                pool.next_index = 0
+            status, body, name = pool.forward(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "sendrawtransaction",
+                    "params": ["00"],
+                }
+            )
+            self.assertEqual(status, 200)
+            self.assertEqual(name, "good")
+            self.assertEqual(json.loads(body)["result"], "abcd" * 16)
+        finally:
+            server_good.shutdown()
+
+
+class HandlerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        health_ok = {
+            "jsonrpc": "2.0",
+            "id": "health",
+            "result": {"blocks": 1},
+        }
+        submit_ok = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": "ab" * 32,
+        }
+        self.backend, backend_url = start_fake_backend(
+            {
+                "getblockchaininfo": (200, health_ok),
+                "sendrawtransaction": (200, submit_ok),
+            }
+        )
+        pool = gateway.BackendPool(
+            [gateway.Backend("local", backend_url)],
+            timeout=2.0,
+            health_interval=60.0,
+        )
+        pool.refresh_health()
+        gateway.GATEWAY = pool
+        gateway.RATE_LIMITER = gateway.RateLimiter(limit=100, window=60.0)
+        gateway.MAX_BODY_BYTES = 1024
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), gateway.SubmitHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        host, port = self.server.server_address
+        self.base = f"http://{host}:{port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.backend.shutdown()
+        gateway.GATEWAY = None
+
+    def _post(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            self.base + "/",
+            data=data,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=3) as resp:
+                return int(resp.status), json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            return int(exc.code), json.loads(exc.read().decode())
+
+    def test_allowlists_sendrawtransaction(self) -> None:
+        status, body = self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": gateway.ALLOWED_METHOD,
+                "params": ["00"],
+            }
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(body["result"], "ab" * 32)
+
+    def test_rejects_other_methods(self) -> None:
+        status, body = self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getblockchaininfo",
+                "params": [],
+            }
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(body["error"]["code"], -32601)
+
+    def test_healthz(self) -> None:
+        with urllib.request.urlopen(self.base + "/healthz", timeout=3) as resp:
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(resp.read(), b"ok\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/gateway/testnet/Caddyfile
+++ b/deploy/gateway/testnet/Caddyfile
@@ -1,0 +1,36 @@
+# Managed Caddyfile for zakura-testnet-1.
+# Source: deploy/gateway/testnet/Caddyfile
+# Installs via zakura-testnet-deploy.yml; do not hand-edit on the host.
+
+ironwood.zakura.valargroup.dev {
+	reverse_proxy 127.0.0.1:8091
+}
+
+ironwood-testnet.valargroup.dev {
+	reverse_proxy 127.0.0.1:8091
+}
+
+status.testnet.zakura.valargroup.dev {
+	reverse_proxy 127.0.0.1:8090
+}
+
+status-testnet.valargroup.dev {
+	reverse_proxy 127.0.0.1:8090
+}
+
+# HTTPS-only public submit endpoint. Explicit HTTP block avoids an
+# HTTP→HTTPS redirect that Vizor (redirect policy: none) cannot follow.
+http://zakura-broadcast.testnet.valargroup.dev {
+	respond "HTTPS required" 400
+}
+
+zakura-broadcast.testnet.valargroup.dev {
+	# Do not expose internal /backends inventory on the public hostname.
+	@public path / /healthz
+	handle @public {
+		reverse_proxy 127.0.0.1:8092
+	}
+	handle {
+		respond "not found" 404
+	}
+}

--- a/deploy/gateway/testnet/backends.toml
+++ b/deploy/gateway/testnet/backends.toml
@@ -1,0 +1,14 @@
+# Testnet Zakura JSON-RPC backends for the public broadcast gateway.
+# Reachable :18232 from zakura-testnet-1.
+
+[[backends]]
+name = "zakura-testnet-1"
+url = "http://127.0.0.1:18232/"
+
+[[backends]]
+name = "zakura-testnet-2"
+url = "http://167.99.110.145:18232/"
+
+[[backends]]
+name = "zakura-testnet-3"
+url = "http://138.68.229.254:18232/"

--- a/deploy/gateway/testnet/broadcast.service
+++ b/deploy/gateway/testnet/broadcast.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Zakura testnet public JSON-RPC broadcast gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/zakura-gateway-testnet
+ExecStart=/usr/bin/python3 /opt/zakura-gateway-testnet/broadcast.py \
+  --backends /opt/zakura-gateway-testnet/backends.toml \
+  --host 127.0.0.1 \
+  --port 8092
+Restart=always
+RestartSec=5
+# Never inherit a shell that might dump request bodies into the journal.
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -4,6 +4,9 @@ This directory contains helper services and scripts that run on Zakura deploy or
 benchmark hosts. The deploy workflows copy the tracked service files here onto
 the self-hosted runners.
 
+The public `sendrawtransaction` broadcast gateway lives under
+[`deploy/gateway/`](../gateway/README.md).
+
 ## Cluster Status and Public Ironwood API
 
 `zakura-cluster-status.py` polls authenticated node RPC endpoints over SSH and


### PR DESCRIPTION
## Motivation

Vizor needs an official HTTPS `sendrawtransaction` relay so Ironwood denomination-prep txs do not go through the user's lightwalletd, and so temporary plaintext Zakura `:8232` IPs in vizor-wallet#381 can be removed.

## Solution

- Add `deploy/gateway/` with a shared submit-only JSON-RPC proxy (`broadcast.py`): allowlists `sendrawtransaction`, rate-limits at 30 req/min/IP, load-balances across healthy backends, never logs request bodies.
- Mainnet edge on `us-east-0`: `https://zakura-broadcast.valargroup.dev/` → NA backends.
- Testnet edge on `zakura-testnet-1`: `https://zakura-broadcast.testnet.valargroup.dev/` → testnet-1/2/3.
- Caddy terminates TLS with no HTTP→HTTPS redirect on the broadcast hostnames (Vizor uses `reqwest` redirect policy `none`).
- Wire install/reload into `zakura-mainnet-deploy.yml` and `zakura-testnet-deploy.yml`.

## Testing

- `python3 deploy/gateway/test_broadcast.py` (unit tests for allowlist, rate limit, failover, healthz).
- Manual against live endpoints:
  - `/healthz` → `ok`
  - invalid `sendrawtransaction` → JSON-RPC error (HTTP 200)
  - `getblockchaininfo` → `Method not allowed`
  - plain HTTP → `400 HTTPS required` (no `Location`)

## Changelog

Deploy/docs/CI only — no Rust or `Cargo.toml` changes; no changelog fragment.

### Specifications & References

- Vizor client contract: vizor-wallet#381 (`TransactionRelayClient`)
- Live URLs:
  - `VIZOR_ZCASH_TRANSACTION_RELAY_URL_MAIN=https://zakura-broadcast.valargroup.dev/`
  - `VIZOR_ZCASH_TRANSACTION_RELAY_URL_TEST=https://zakura-broadcast.testnet.valargroup.dev/`

### Follow-up Work

- After Vizor ships the dart-defines, lock public fleet `:8232` / `:18232` to gateway-only (or localhost).
- Optional later: multi-origin Cloudflare geo LB in front of regional gateways.