### PR TITLE
build: update rocksdb to 0.24 and bump zakura-state to 6.0.0

### DIFF
--- a/.github/actions/setup-zakura-build/action.yml
+++ b/.github/actions/setup-zakura-build/action.yml
@@ -1,15 +1,18 @@
 name: 'Setup Zakura Build Environment'
-description: 'Install protoc and RocksDB as system libraries'
+description: 'Install libclang, protoc, and RocksDB as system libraries'
 runs:
   using: 'composite'
   steps:
-    - name: Install protoc and librocksdb-dev on Ubuntu
+    - name: Install libclang, protoc, and librocksdb-dev on Ubuntu
       if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo rm -f /etc/apt/sources.list.d/{microsoft-prod,azure-cli}.{list,sources}
         sudo apt-get -qq update
-        sudo apt-get -qq install -y --no-install-recommends protobuf-compiler librocksdb-dev
+        # libclang is needed at build time: librocksdb-sys always runs bindgen
+        # (via clang-sys) to generate FFI bindings, even when linking the system
+        # RocksDB via ROCKSDB_LIB_DIR.
+        sudo apt-get -qq install -y --no-install-recommends clang libclang-dev protobuf-compiler librocksdb-dev
         echo "ROCKSDB_LIB_DIR=/usr/lib/" >> $GITHUB_ENV
 
     - name: Install protoc and RocksDB on macOS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,26 +452,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.13.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -483,7 +463,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -3268,7 +3248,7 @@ dependencies = [
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "pin-project-lite",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.18",
@@ -3287,7 +3267,7 @@ dependencies = [
  "getrandom 0.2.17",
  "rand 0.8.6",
  "ring",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3383,15 +3363,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3528,7 +3499,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "rand 0.8.6",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3636,12 +3607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3686,14 +3651,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -3717,7 +3681,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8ce05b56f3cbc65ec7d0908adb308ed91281e022f61c8c3a0c9388b5380b17"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "thiserror 2.0.18",
  "tracing",
@@ -5381,7 +5345,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.4",
  "thiserror 2.0.18",
@@ -5403,7 +5367,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5852,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5895,12 +5859,6 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -6963,7 +6921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8974,7 +8932,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "5.0.1"
+version = "6.0.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ regex = "1.11"
 reqwest = { version = "0.12", default-features = false }
 ripemd = "0.1"
 rlimit = "0.10"
-rocksdb = { version = "0.22", default-features = false }
+rocksdb = { version = "0.24", default-features = false }
 secp256k1 = "0.29"
 semver = "1.0.26"
 sentry = { version = "0.47", default-features = false }

--- a/README.md
+++ b/README.md
@@ -96,12 +96,7 @@ compiler. Below are quick summaries for installing these dependencies.
 sudo pacman -S rust clang protobuf
 ```
 
-Note that the package `clang` includes `libclang` as well. The GCC version on
-Arch Linux has a broken build script in a `rocksdb` dependency. A workaround is:
-
-```sh
-export CXXFLAGS="$CXXFLAGS -include cstdint"
-```
+Note that the package `clang` includes `libclang` as well.
 
 </details>
 

--- a/changelog-unreleased/480.md
+++ b/changelog-unreleased/480.md
@@ -1,0 +1,11 @@
+## Changed
+
+- Updated `rocksdb` to 0.24 (RocksDB 10.4.2), porting
+  [ZcashFoundation/zebra#10922](https://github.com/ZcashFoundation/zebra/pull/10922).
+  Zakura now builds with GCC 15/16 without the `CXXFLAGS="-include cstdint"`
+  workaround. The bundled `librocksdb-sys` now always runs `bindgen` to
+  generate its FFI bindings, so **`libclang` is required at build time** (in
+  addition to `protoc` and a C++ compiler) even when linking a system RocksDB
+  via `ROCKSDB_LIB_DIR`. Install `libclang-dev` (Debian/Ubuntu), `clang`
+  (Arch), or the equivalent for your platform
+  ([#480](https://github.com/zakura-core/zakura/pull/480)).

--- a/deny.toml
+++ b/deny.toml
@@ -121,9 +121,6 @@ skip-tree = [
     # wait for structopt-derive to update heck
     { name = "heck", version = "=0.3.3" },
 
-    # wait for librocksdb-sys to update bindgen
-    { name = "bindgen", version = "=0.69.5" },
-
     # wait for halo2_gadgets and primitive-types to update uint
     { name = "uint", version = "=0.9.5" },
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1141,10 +1141,6 @@ criteria = "safe-to-deploy"
 version = "0.2.19"
 criteria = "safe-to-deploy"
 
-[[exemptions.lazycell]]
-version = "1.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.libc]]
 version = "0.2.186"
 criteria = "safe-to-deploy"
@@ -1166,7 +1162,7 @@ version = "0.1.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.librocksdb-sys]]
-version = "0.16.0+8.10.0"
+version = "0.17.3+10.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.libz-sys]]
@@ -1828,7 +1824,7 @@ version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rocksdb]]
-version = "0.22.0"
+version = "0.24.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ron]]

--- a/zakura-consensus/Cargo.toml
+++ b/zakura-consensus/Cargo.toml
@@ -69,7 +69,7 @@ tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.1.0" }
 
 zakura-script = { path = "../zakura-script", version = "3.0.0" }
-zakura-state = { path = "../zakura-state", version = "5.0.0" }
+zakura-state = { path = "../zakura-state", version = "6.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.0.0" }
 zakura-chain = { path = "../zakura-chain", version = "3.0.0" }
 
@@ -96,7 +96,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-state = { path = "../zakura-state", version = "5.0.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "6.0.0", features = ["proptest-impl"] }
 zakura-chain = { path = "../zakura-chain", version = "3.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.0.0" }
 

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -118,7 +118,7 @@ zakura-node-services = { path = "../zakura-node-services", version = "3.0.0", fe
     "rpc-client",
 ] }
 zakura-script = { path = "../zakura-script", version = "3.0.0" }
-zakura-state = { path = "../zakura-state", version = "5.0.0" }
+zakura-state = { path = "../zakura-state", version = "6.0.0" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
 rustls-pemfile = "2.2.0"
@@ -149,7 +149,7 @@ zakura-consensus = { path = "../zakura-consensus", version = "5.0.0", features =
 zakura-network = { path = "../zakura-network", version = "5.0.0", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "5.0.0", features = [
+zakura-state = { path = "../zakura-state", version = "6.0.0", features = [
     "proptest-impl",
 ] }
 

--- a/zakura-state/Cargo.toml
+++ b/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "5.0.1"
+version = "6.0.0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-utils/Cargo.toml
+++ b/zakura-utils/Cargo.toml
@@ -70,7 +70,7 @@ zakura-chain = { path = "../zakura-chain", version = "3.0.0" }
 itertools = { workspace = true, optional = true }
 
 # This crate is needed for the zakura-checkpoints offline export mode
-zakura-state = { path = "../zakura-state", version = "5.0.0", optional = true }
+zakura-state = { path = "../zakura-state", version = "6.0.0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
 tokio = { workspace = true, features = ["full"], optional = true }

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -174,7 +174,7 @@ zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.1" }
 zakura-network = { path = "../zakura-network", version = "5.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.0.0", features = ["rpc-client"] }
 zakura-rpc = { path = "../zakura-rpc", version = "5.0.0" }
-zakura-state = { path = "../zakura-state", version = "5.0.0" }
+zakura-state = { path = "../zakura-state", version = "6.0.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -325,7 +325,7 @@ color-eyre = { workspace = true }
 zakura-chain = { path = "../zakura-chain", version = "3.0.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "5.0.0", features = ["proptest-impl"] }
 zakura-network = { path = "../zakura-network", version = "5.0.0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "5.0.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "6.0.0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "2.0.0" }
 


### PR DESCRIPTION
## Motivation

The GCC version on Arch Linux (GCC 15/16) fails to compile the RocksDB 8.10.0 sources bundled by `rocksdb` 0.22: headers such as `include/rocksdb/trace_record.h` are missing `#include <cstdint>`, which newer libstdc++ no longer provides transitively. Building Zakura on Arch currently requires the `CXXFLAGS="-include cstdint"` workaround documented in the README.

## Solution

Ports upstream Zebra's rocksdb upgrade ([ZcashFoundation/zebra#10922](https://github.com/ZcashFoundation/zebra/pull/10922)) — credit to the Zebra team for the patch:

- Update `rocksdb` 0.22 → 0.24 (`librocksdb-sys` 0.16.0+8.10.0 → 0.17.3+10.4.2). RocksDB 10.4.2 includes the upstream `<cstdint>` fixes, so no compiler flags are needed. No Rust code changes are required.
- Remove the now-unnecessary Arch workaround from the README.
- `librocksdb-sys` 0.17 always runs `bindgen`, so libclang is required at build time even when linking a system RocksDB via `ROCKSDB_LIB_DIR`; install `clang`/`libclang-dev` in the Ubuntu CI setup action (mirrors the upstream action change).
- Drop the stale `bindgen 0.69.5` skip-tree entry from `deny.toml` and refresh `supply-chain/config.toml` exemptions (`cargo vet --locked` passes; the removed `lazycell` exemption left the dependency tree).
- Bump `zakura-state` 5.0.1 → 6.0.0 and dependent version requirements: rocksdb types (`rocksdb::Error`, `DBWithThreadMode`, `ColumnFamilyRef`) appear in `zakura-state`'s public API, so the dependency major bump is semver-major. 5.0.1 is published on crates.io, so a new version is required.

### Tests

All run on Arch Linux with GCC 16.1.1 and **no** `CXXFLAGS` workaround:

- `cargo build --release --all` passes (previously failed with `uint64_t does not name a type` in `librocksdb-sys`).
- `cargo test -p zakura-state --release` passes.
- `cargo clippy -p zakura-state --all-targets --release` is clean (no new deprecation warnings from rocksdb 0.24).
- `cargo vet --locked` passes.
- On-disk compatibility smoke test: a database written by RocksDB 8.10 opens, reads, and writes under 10.4, and a database created by 10.4 opens, reads, and writes under 8.10 (rollback-safe).
- `markdownlint` passes for the changed README.

## Changelog

Added `changelog-unreleased/480.md` with the operator-visible entry (rocksdb 0.24 update and the new libclang build-time requirement). `./scripts/changelog.py check` passes.

### Specifications & References

- Upstream patch: [ZcashFoundation/zebra#10922](https://github.com/ZcashFoundation/zebra/pull/10922)
- RocksDB `<cstdint>` fixes shipped in RocksDB 9.x/10.x

### AI Disclosure

This PR was prepared with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
