### PR TITLE
fix(zakura-utils): stop zakurad-log-filter executing log text as shell

### DIFF
--- a/changelog-unreleased/481.md
+++ b/changelog-unreleased/481.md
@@ -1,0 +1,12 @@
+## Security
+
+- `zakurad-log-filter` no longer runs log text as a shell command. Previously a
+  log line containing a single quote could execute arbitrary commands as the
+  user running the filter
+  ([#481](https://github.com/zakura-core/zakura/pull/481)).
+
+## Changed
+
+- `zakurad-log-filter` no longer requires GNU sed, and no longer reads the
+  `GNU_SED` environment variable. Backslashes in log lines are now printed
+  as-is ([#481](https://github.com/zakura-core/zakura/pull/481)).

--- a/zakura-utils/zakurad-log-filter
+++ b/zakura-utils/zakurad-log-filter
@@ -10,22 +10,18 @@ set -euo pipefail
 #   zakurad start | zakurad-log-filter
 #   ZCASH_CLI="zcash-cli -testnet" zakurad start | zakurad-log-filter
 
-# Find GNU sed
-if command -v gsed > /dev/null; then
-    GNU_SED=${GNU_SED:-gsed}
-else
-    # Just assume it's GNU sed
-    GNU_SED=${GNU_SED:-sed}
-fi
+HASH_REGEX='[0-9a-f]{64}'
 
-while read line; do
-    # Put each hash on a separate line, then expand them
-    echo "$line" | \
-        $GNU_SED -r \
-            's/([0-9a-f]{64})/\n\1/g' | \
-        $GNU_SED -r \
-            's/(.*)([0-9a-f]{64})(.*)/ \
-                echo -n '\''\1'\''; \
-                echo '\''\2'\'' | zakurad-hash-lookup; \
-                echo -n '\''\3'\''; /e'
+while IFS= read -r line; do
+    # Expand each hash in place, leaving the surrounding log text untouched
+    while [[ $line =~ $HASH_REGEX ]]; do
+        hash=${BASH_REMATCH[0]}
+
+        printf '%s\n' "${line%%"$hash"*}"
+        printf '%s\n' "$hash" | zakurad-hash-lookup
+
+        line=${line#*"$hash"}
+    done
+
+    printf '%s\n' "$line"
 done < "${1:-/dev/stdin}"


### PR DESCRIPTION
## Motivation

Backport of upstream Zebra [PR #11050](https://github.com/ZcashFoundation/zebra/pull/11050). The `zakurad-log-filter` helper script was carried over from upstream (renamed `zebrad`→`zakurad`) but never received upstream's fix, so it still contains the shell-injection bug.

## Root cause

The filter interpolated log-line capture groups into a GNU `sed` command that used the `/e` execute flag. A log line containing a single quote could break out of the quoting and run arbitrary commands as the operator running the filter.

## Solution

Do the substitution in pure bash: match the 64-hex hash with `[[ =~ ]]`, split the line with parameter expansion, and `printf` the surrounding text around the `zakurad-hash-lookup` output. Nothing derived from a log line ever reaches a shell. This also drops the GNU `sed` dependency and preserves backslashes in log lines.

## Testing

Manually exercised the rewritten script with a stubbed `zakurad-hash-lookup`:
- A line containing `'$(touch /tmp/PWNED)'` plus two hashes: the payload is printed literally (no file created), and both hashes are expanded in place.
- Backslashes in log text (`C:\Users`) are preserved verbatim.
- `bash -n` passes.

This is a shell script (no Rust source or `Cargo.toml`), but a `Security` changelog fragment is included since the fix is operator-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)