### PR TITLE
fix(consensus): grace early NU6.3 branch IDs before activation

### DIFF
--- a/changelog-unreleased/482.md
+++ b/changelog-unreleased/482.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Extended the NU6.3 mempool branch-ID grace period to cover honest peers that
+  relay NU6.3 transactions in the 40 blocks before activation, so they are no
+  longer scored as misbehaving and banned during the activation transition
+  ([#482](https://github.com/zakura-core/zakura/pull/482)).

--- a/zakura-consensus/src/error.rs
+++ b/zakura-consensus/src/error.rs
@@ -265,7 +265,7 @@ pub enum TransactionError {
     WrongConsensusBranchId,
 
     #[error(
-        "mempool transaction uses the NU6.2 consensus branch id during the NU6.3 grace period"
+        "mempool transaction uses a mismatched NU6.2/NU6.3 consensus branch id during the NU6.3 grace period"
     )]
     WrongConsensusBranchIdNu6_3GracePeriod,
 

--- a/zakura-consensus/src/transaction.rs
+++ b/zakura-consensus/src/transaction.rs
@@ -78,25 +78,49 @@ const MEMPOOL_OUTPUT_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::
 /// response from the transaction verifier.
 const POLL_MEMPOOL_DELAY: std::time::Duration = Duration::from_millis(50);
 
-/// Number of blocks after NU6.3 activation during which a NU6.2 branch ID
-/// does not count as peer misbehavior.
+/// Number of blocks on either side of NU6.3 activation during which a mismatched
+/// NU6.2/NU6.3 branch ID does not count as peer misbehavior.
 const NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS: i64 = 40;
 
-/// Returns whether a mempool transaction with a NU6.2 branch ID is within the
-/// NU6.3 peer-misbehavior grace period.
+/// Returns whether a mempool transaction whose consensus branch ID mismatches the
+/// expected network upgrade is within the NU6.3 activation grace period.
+///
+/// Around NU6.3 activation, honest peers whose chain tips are a few blocks apart relay
+/// transactions signed for the branch ID on their side of the boundary, and neither
+/// direction is misbehavior:
+///
+/// * a peer still behind activation keeps relaying NU6.2 transactions after we cross it,
+///   graced for the first [`NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS`] blocks from
+///   activation onward, and
+/// * a peer already past activation relays NU6.3 transactions while we are still up to
+///   [`NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS`] blocks behind activation.
 fn is_nu6_3_branch_id_misbehavior_grace_period(
     tx: &Transaction,
     height: block::Height,
     network: &Network,
 ) -> bool {
-    tx.network_upgrade() == Some(NetworkUpgrade::Nu6_2)
-        && NetworkUpgrade::current(network, height) == NetworkUpgrade::Nu6_3
-        && NetworkUpgrade::Nu6_3
-            .activation_height(network)
-            .and_then(|activation_height| {
-                activation_height + NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS
-            })
-            .is_some_and(|grace_period_end| height < grace_period_end)
+    let Some(activation_height) = NetworkUpgrade::Nu6_3.activation_height(network) else {
+        return false;
+    };
+
+    // `Height - Height` yields an `i64` `HeightDiff` and is always exact, so the signed
+    // distance from activation cannot overflow.
+    let height_offset = height - activation_height;
+
+    match (
+        tx.network_upgrade(),
+        NetworkUpgrade::current(network, height),
+    ) {
+        // Stale NU6.2 transaction relayed after we crossed activation.
+        (Some(NetworkUpgrade::Nu6_2), NetworkUpgrade::Nu6_3) => {
+            (0..NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS).contains(&height_offset)
+        }
+        // Early NU6.3 transaction relayed while we are still behind activation.
+        (Some(NetworkUpgrade::Nu6_3), NetworkUpgrade::Nu6_2) => {
+            (-NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS..0).contains(&height_offset)
+        }
+        _ => false,
+    }
 }
 
 /// Asynchronous transaction verification.

--- a/zakura-consensus/src/transaction/tests.rs
+++ b/zakura-consensus/src/transaction/tests.rs
@@ -4265,6 +4265,24 @@ fn public_nu6_3_consensus_branch_id_boundary() {
             Ok(()),
         );
 
+        // Early direction: a peer already past activation relays NU6.3 transactions while
+        // we are still behind. These are graced for the 40 blocks before activation.
+        assert!(super::is_nu6_3_branch_id_misbehavior_grace_period(
+            &tx,
+            (activation_height - 1).expect("NU6.3 is not genesis"),
+            &network,
+        ));
+        assert!(super::is_nu6_3_branch_id_misbehavior_grace_period(
+            &tx,
+            (activation_height - 40).expect("NU6.3 activates well above the grace window"),
+            &network,
+        ));
+        assert!(!super::is_nu6_3_branch_id_misbehavior_grace_period(
+            &tx,
+            (activation_height - 41).expect("NU6.3 activates well above the grace window"),
+            &network,
+        ));
+
         tx.update_network_upgrade(NetworkUpgrade::Nu6_2)
             .expect("V5 transactions support the NU6.2 branch ID");
     }


### PR DESCRIPTION
## Motivation

Backport of the early-direction half of upstream Zebra [PR #11113](https://github.com/ZcashFoundation/zebra/pull/11113). Time-sensitive ahead of mainnet Ironwood (NU6.3) activation. edit: lol!

## Root cause

Zakura's NU6.3 mempool branch-ID grace period (`is_nu6_3_branch_id_misbehavior_grace_period`) only suppressed the peer misbehavior score for **stale NU6.2** transactions relayed *after* our node crosses the activation height. The reverse direction was unhandled: when a peer is already past activation and relays **NU6.3** transactions while our node is still up to 40 blocks *behind* activation, `check::consensus_branch_id` returns `WrongConsensusBranchId`, which scores 100 and bans the peer — even though the peer is honest and its chain tip is simply a few blocks ahead of ours.

This is the direction that fires *first* during an activation transition, because a node one step behind sees NU6.3 traffic before it crosses the boundary itself.

## Solution

Extend `is_nu6_3_branch_id_misbehavior_grace_period` to grace both directions within `NU6_3_BRANCH_ID_MISBEHAVIOR_GRACE_BLOCKS` (40) of the NU6.3 activation height, keyed on the signed height offset from activation (`Height - Height` yields an exact `i64` `HeightDiff`):

- `(Nu6_2 tx, current Nu6_3)` with offset `0..40` — unchanged (stale-after-activation), and
- `(Nu6_3 tx, current Nu6_2)` with offset `-40..0` — new (early-before-activation).

The existing call site maps a graced `WrongConsensusBranchId` to `WrongConsensusBranchIdNu6_3GracePeriod` (score 0), so no call-site change is needed — the transaction is still rejected, only the ban score is suppressed. This is not consensus-critical: it affects mempool peer-scoring policy only.

This keeps Zakura's error-variant approach rather than adopting upstream's `transaction_upgrade`/`verification_height` fields on the download-verify error.

## Testing

Extended `public_nu6_3_consensus_branch_id_boundary` with early-direction assertions: an NU6.3 transaction is graced at `activation - 1` and `activation - 40`, and not graced at `activation - 41`. Verified the NU6.2→NU6.3 gap on both public networks (63,543 and 82,000 blocks) is far wider than the 40-block window, so the test heights land in the NU6.2 epoch. Local test evidence added below once run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)