### PR TITLE
fix(state): correct dequeue_children by_height index handling

### DIFF
--- a/changelog-unreleased/483.md
+++ b/changelog-unreleased/483.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed a queued-block index leak where dequeuing one fork sibling un-indexed
+  another block at the same height, preventing it from being pruned and leaking
+  entries in the block queue and its known-UTXO cache
+  ([#483](https://github.com/zakura-core/zakura/pull/483)).

--- a/zakura-state/src/service/queued_blocks.rs
+++ b/zakura-state/src/service/queued_blocks.rs
@@ -107,7 +107,14 @@ impl QueuedBlocks {
             .collect::<Vec<_>>();
 
         for queued in &queued_children {
-            self.by_height.remove(&queued.0.height);
+            if let Some(hashes) = self.by_height.get_mut(&queued.0.height) {
+                hashes.remove(&queued.0.hash);
+
+                if hashes.is_empty() {
+                    self.by_height.remove(&queued.0.height);
+                }
+            }
+
             // TODO: only remove UTXOs if there are no queued blocks with that UTXO
             //       (known_utxos is best-effort, so this is ok for now)
             for outpoint in queued.0.new_outputs.keys() {

--- a/zakura-state/src/service/queued_blocks/tests/vectors.rs
+++ b/zakura-state/src/service/queued_blocks/tests/vectors.rs
@@ -197,3 +197,51 @@ fn sent_hashes_remove_drops_rejected_hash_and_utxos() -> Result<()> {
 
     Ok(())
 }
+
+// Ensures `dequeue_children` does not remove same-height sibling blocks from other forks.
+#[test]
+fn dequeue_children_preserves_same_height_siblings() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    let root_block: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+
+    let left_child: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
+    let left_grandchild = left_child.make_fake_child();
+
+    let right_child = root_block.make_fake_child();
+    let right_grandchild = right_child.make_fake_child();
+
+    let mut queue = QueuedBlocks::default();
+    queue.queue(left_grandchild.clone().into_queued());
+    queue.queue(right_grandchild.clone().into_queued());
+
+    let height = left_grandchild.coinbase_height().unwrap();
+
+    // Sanity check: both entries are indexed under the same height bucket
+    assert_eq!(
+        queue.by_height.get(&height).unwrap().len(),
+        2,
+        "expected both fork grandchildren to be in the same height bucket"
+    );
+
+    // Dequeue only one branch
+    queue.dequeue_children(left_child.hash());
+
+    assert!(
+        queue.blocks.contains_key(&right_grandchild.hash()),
+        "sibling block must remain in queue after unrelated dequeue"
+    );
+
+    assert!(
+        queue
+            .by_height
+            .get(&height)
+            .unwrap()
+            .contains(&right_grandchild.hash()),
+        "sibling must remain indexed by height after unrelated dequeue"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Backport of upstream Zebra [PR #10604](https://github.com/ZcashFoundation/zebra/pull/10604).

## Root cause

`QueuedBlocks::dequeue_children` removed the entire `by_height` entry for a dequeued child's height (`self.by_height.remove(&queued.0.height)`) instead of removing just that child's hash. `by_height` is a `BTreeMap<Height, HashSet<Hash>>`, so when two queued blocks share a height — fork siblings with different parents — dequeuing one un-indexed the other. Because `prune_by_height` walks `by_height` to clean up, the un-indexed sibling could never be pruned, leaking entries in `blocks`, `by_parent`, and `known_utxos`. Leaked `known_utxos` are worse than a memory leak: a stale UTXO can answer a pending-UTXO (`AwaitUtxo`) request.

## Solution

Remove only the specific hash from the height bucket, and drop the height entry only once its set becomes empty.

## Testing

Added `dequeue_children_preserves_same_height_siblings`: queues two same-height fork grandchildren, dequeues one branch, and asserts the other branch's block survives in both `blocks` and `by_height`. Local test evidence added below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)