### PR TITLE
fix(network): retry the first peer disk-cache write

### DIFF
--- a/changelog-unreleased/484.md
+++ b/changelog-unreleased/484.md
@@ -1,0 +1,6 @@
+## Changed
+
+- The first peer disk-cache write is now retried every 20 seconds until it
+  succeeds, instead of waiting the full 5-minute update interval, so a
+  cold-started node caches its peers soon after finding them
+  ([#484](https://github.com/zakura-core/zakura/pull/484)).

--- a/zakura-network/src/peer_cache_updater.rs
+++ b/zakura-network/src/peer_cache_updater.rs
@@ -27,26 +27,45 @@ pub async fn peer_cache_updater(
     //       and allow it to be set in tests
     sleep(DNS_LOOKUP_TIMEOUT * 4).await;
 
+    let mut wrote_cache = false;
+
     loop {
         // Ignore errors because updating the cache is optional.
         // Errors are already logged by the functions we're calling.
-        let _ = update_peer_cache_once(&config, &address_book).await;
+        wrote_cache |= update_peer_cache_once(&config, &address_book)
+            .await
+            .unwrap_or(false);
 
-        sleep(PEER_DISK_CACHE_UPDATE_INTERVAL).await;
+        // Right after a cold start, the address book can still be empty at the first attempt,
+        // and the cache is only written once there are cacheable peers. Retry soon until the
+        // first write, so the cache exists shortly after the node finds its first peers.
+        let interval = if wrote_cache {
+            PEER_DISK_CACHE_UPDATE_INTERVAL
+        } else {
+            DNS_LOOKUP_TIMEOUT * 4
+        };
+
+        sleep(interval).await;
     }
 }
 
 /// Caches peers from the current `address_book` to disk, based on `config`.
+///
+/// Returns `true` if the cache was written, and `false` if the cacheable peer list was empty,
+/// keeping any previous cache.
 pub async fn update_peer_cache_once(
     config: &Config,
     address_book: &Arc<Mutex<AddressBook>>,
-) -> io::Result<()> {
-    let peer_list = cacheable_peers(address_book)
+) -> io::Result<bool> {
+    let peer_list: std::collections::HashSet<_> = cacheable_peers(address_book)
         .iter()
         .map(|meta_addr| meta_addr.addr)
         .collect();
+    let has_peers = !peer_list.is_empty();
 
-    config.update_peer_cache(peer_list).await
+    config.update_peer_cache(peer_list).await?;
+
+    Ok(has_peers)
 }
 
 /// Returns a list of cacheable peers, blocking for as short a time as possible.


### PR DESCRIPTION
## Motivation

Backport of upstream Zebra [PR #11073](https://github.com/ZcashFoundation/zebra/pull/11073).

## Root cause

After a cold start, the address book is usually still empty when the peer-cache updater makes its first write attempt, and the cache is only written once there are cacheable peers. The updater then slept the full `PEER_DISK_CACHE_UPDATE_INTERVAL` (5 minutes) before retrying, so a node killed within that window restarted with no cached peers and had to rediscover the network from scratch.

## Solution

Retry every `DNS_LOOKUP_TIMEOUT * 4` (20s) until the first successful non-empty write, then fall back to the normal 5-minute interval. `update_peer_cache_once` now returns `io::Result<bool>` indicating whether the cache was written (`false` when the cacheable peer list was empty, keeping any previous cache).

## Testing

Compilation checked (`cargo build --release -p zakura-network`), including the two existing `update_peer_cache_once` test callers, which discard the return value via `.expect(...)` and are unaffected by the `()` → `bool` change. Local build evidence added below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)