### PR TITLE
fix(rpc): apply backpressure on indexer gRPC streams instead of dropping subscriptions

### DIFF
--- a/crates/zakura-rpc/src/indexer/methods.rs
+++ b/crates/zakura-rpc/src/indexer/methods.rs
@@ -23,13 +23,13 @@ use super::{
 /// The maximum number of messages that can be queued to be streamed to a client.
 const RESPONSE_BUFFER_SIZE: usize = 64;
 
-/// How long to wait for a backpressured send to the non-finalized stream before
-/// treating the consumer as hung and dropping the subscription.
+/// How long to wait for a backpressured send before treating the consumer as hung
+/// and dropping the subscription.
 ///
-/// The non-finalized stream applies backpressure rather than dropping blocks,
-/// so a slow consumer doesn't miss blocks. Without a bound, a half-open
-/// connection could block the listener task indefinitely.
-const NON_FINALIZED_SEND_TIMEOUT: Duration = Duration::from_secs(60);
+/// All three indexer streams apply backpressure so a slow consumer doesn't miss
+/// notifications, but without a bound a consumer whose connection is half-open (dead
+/// TCP not yet detected) would block the listener task indefinitely.
+const SEND_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[tonic::async_trait]
 impl<ReadStateService, Tip> Indexer for IndexerRPC<ReadStateService, Tip>
@@ -61,17 +61,21 @@ where
                     continue;
                 };
 
-                match response_sender.try_send(Ok(BlockHashAndHeight::new(tip_hash, tip_height))) {
-                    Ok(()) => {}
-                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                let send = response_sender.send(Ok(BlockHashAndHeight::new(tip_hash, tip_height)));
+                match tokio::time::timeout(SEND_TIMEOUT, send).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(_)) => {
                         span.in_scope(|| {
                             tracing::info!("client disconnected, dropping chain_tip_change task");
                         });
                         return;
                     }
-                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    Err(_) => {
                         span.in_scope(|| {
-                            tracing::warn!("slow consumer, dropping chain_tip_change stream");
+                            tracing::warn!(
+                                "slow consumer, dropping chain_tip_change stream after \
+                                 send timed out"
+                            );
                         });
                         return;
                     }
@@ -132,14 +136,33 @@ where
 
             // Notify the client of new blocks until the channel is closed.
             //
-            // Unlike the other streams, this uses `send().await` to apply
-            // backpressure to the non-finalized state listener rather than
-            // dropping blocks for a slow consumer. A send error means the
-            // client disconnected; a timed-out send means the consumer is
-            // hung. In both cases the task ends rather than blocking forever.
-            while let Some((hash, block)) = non_finalized_state_change.recv().await {
+            // This uses `send().await` to apply backpressure to the
+            // non-finalized state listener rather than dropping blocks for a
+            // slow consumer. A send error means the client disconnected; a
+            // timed-out send means the consumer is hung. In both cases the task
+            // ends rather than blocking forever.
+            loop {
+                // A full listener buffer means the state-side task is blocked
+                // sending into it, so it may already have missed non-finalized
+                // state updates. The stream can no longer guarantee
+                // completeness, so drop the subscription instead of silently
+                // missing blocks.
+                if non_finalized_state_change.capacity() == 0 {
+                    span.in_scope(|| {
+                        tracing::warn!(
+                            "slow consumer, dropping non_finalized_state_change stream after \
+                             buffer filled"
+                        );
+                    });
+                    return;
+                }
+
+                let Some((hash, block)) = non_finalized_state_change.recv().await else {
+                    break;
+                };
+
                 let send = response_sender.send(Ok(BlockAndHash::new(hash, block)));
-                match tokio::time::timeout(NON_FINALIZED_SEND_TIMEOUT, send).await {
+                match tokio::time::timeout(SEND_TIMEOUT, send).await {
                     Ok(Ok(())) => {}
                     Ok(Err(_)) => {
                         span.in_scope(|| {
@@ -205,17 +228,21 @@ where
                             .unwrap_or_default(),
                     });
 
-                    match response_sender.try_send(msg) {
-                        Ok(()) => {}
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    let send = response_sender.send(msg);
+                    match tokio::time::timeout(SEND_TIMEOUT, send).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(_)) => {
                             span.in_scope(|| {
                                 tracing::info!("client disconnected, dropping mempool_change task");
                             });
                             return;
                         }
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        Err(_) => {
                             span.in_scope(|| {
-                                tracing::warn!("slow consumer, dropping mempool_change stream");
+                                tracing::warn!(
+                                    "slow consumer, dropping mempool_change stream after \
+                                     send timed out"
+                                );
                             });
                             return;
                         }

--- a/docs/changelog/unreleased/486.md
+++ b/docs/changelog/unreleased/486.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Indexer gRPC tip and mempool subscriptions now apply backpressure with a
+  60-second send timeout instead of being dropped the moment their buffer
+  fills, so a briefly slow consumer no longer triggers rapid re-subscribe
+  cycles ([#486](https://github.com/zakura-core/zakura/pull/486)).


### PR DESCRIPTION
## Motivation

Backport of upstream Zebra [PR #10932](https://github.com/ZcashFoundation/zebra/pull/10932).

## Root cause

The indexer gRPC `chain_tip_change` and `mempool_change` streams used `try_send` into a 64-message buffer and dropped the **entire subscription** the instant that buffer filled. A momentarily slow consumer (e.g. a wallet rescan) therefore triggered rapid re-subscribe cycles and a flood of WARN-level "slow consumer" log lines. Only the `non_finalized_state_change` stream already applied timeout-bounded backpressure.

## Solution

- Switch `chain_tip_change` and `mempool_change` to `send().await` bounded by a 60s timeout, matching the non-finalized stream, so a slow consumer gets grace instead of an instant drop. The shared timeout constant is renamed `NON_FINALIZED_SEND_TIMEOUT` → `SEND_TIMEOUT`.
- Add a completeness guard to `non_finalized_state_change`: when the listener buffer is full (`capacity() == 0`), the state-side task may already have missed non-finalized updates, so the stream can no longer guarantee completeness and drops the subscription rather than silently skipping blocks.

Zakura's `NonFinalizedBlocksListener::unwrap()` yields a plain `tokio::sync::mpsc::Receiver`, which exposes `capacity()` directly, so the guard ports without touching the listener type.

## Testing

Compilation of `zakura-rpc` checked (evidence below). No API change; slow consumers now get 60s of backpressure grace instead of an immediate drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)