### PR TITLE
ci(chain): allow the non-local variant of the semicolon-in-expressions lint in u256

### DIFF
--- a/changelog-unreleased/488.md
+++ b/changelog-unreleased/488.md
@@ -1,0 +1,6 @@
+<!-- changelog: none -->
+
+Internal lint-attribute change only: `u256.rs` now allows both the old and
+renamed `semicolon_in_expressions_from(_non_local)_macros` lint names so it
+builds warning-free across toolchains. No operator- or crate-consumer-visible
+effect.

--- a/zakura-chain/src/work/u256.rs
+++ b/zakura-chain/src/work/u256.rs
@@ -4,7 +4,10 @@
 #![allow(clippy::all)]
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::fallible_impl_from)]
+// `uint`'s macro expansion trips this lint, and each toolchain knows only one of its two names: https://github.com/rust-lang/rust/issues/79813
+#![allow(unknown_lints)]
 #![allow(semicolon_in_expressions_from_macros)]
+#![allow(semicolon_in_expressions_from_non_local_macros)]
 #![allow(missing_docs)]
 
 use uint::construct_uint;


### PR DESCRIPTION
## Motivation

Backport of upstream Zebra [PR #11131](https://github.com/ZcashFoundation/zebra/pull/11131).

## Root cause

Newer Rust toolchains renamed the `semicolon_in_expressions_from_macros` lint to `semicolon_in_expressions_from_non_local_macros`. The vendored `uint` crate's `construct_uint!` macro expansion trips whichever name the active toolchain knows, so `u256.rs` warns on one toolchain or the other.

## Solution

Add `#![allow(unknown_lints)]` (so allowing the name the toolchain doesn't recognize is itself not a warning) plus the new lint name alongside the old one, so `u256.rs` builds warning-free on both old and new toolchains.

## Testing

Compilation of `zakura-chain` checked (evidence below). Lint-attribute-only change with no behavior effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)