### PR TITLE
ci: warm semver baseline cache on main

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -48,14 +48,18 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  semver-checks:
-    name: semver-checks
+  select-packages:
+    name: Select semver packages
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    outputs:
+      baseline_tag: ${{ steps.affected.outputs.baseline_tag }}
+      has_packages: ${{ steps.affected.outputs.has_packages }}
+      packages: ${{ steps.affected.outputs.packages }}
+      packages_json: ${{ steps.affected.outputs.packages_json }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
@@ -84,10 +88,19 @@ jobs:
             )"
           fi
 
+          packages_json="$(
+            printf '%s\n' "$packages" \
+              | jq --raw-input --slurp --compact-output \
+                'split("\n") | map(select(length > 0))'
+          )"
+
           {
+            echo "baseline_tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
+            echo "has_packages=$([[ -n "$packages" ]] && echo true || echo false)"
             echo "packages<<EOF"
             echo "$packages"
             echo "EOF"
+            echo "packages_json=$packages_json"
           } >> "$GITHUB_OUTPUT"
 
           if [[ -n "$packages" ]]; then
@@ -97,14 +110,30 @@ jobs:
             echo "No publishable crates need semver checks."
           fi
 
+  check-package:
+    name: semver (${{ matrix.package }})
+    if: >-
+      github.event_name == 'pull_request'
+      && needs.select-packages.outputs.has_packages == 'true'
+    needs: select-packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.select-packages.outputs.packages_json) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
-        if: steps.affected.outputs.packages != ''
         id: toolchain
         with:
           toolchain: stable
           # cargo-semver-checks removes its temporary build directories after
-          # producing rustdoc JSON. Cache that small final output below rather
-          # than retaining unrelated Cargo registry and target artifacts.
+          # producing rustdoc JSON. Cache that small final output rather than
+          # retaining unrelated Cargo registry and target artifacts.
           cache: false
 
       # cargo-semver-checks reuses generated baseline rustdoc JSON from
@@ -113,52 +142,25 @@ jobs:
       # rustc version because the rustdoc JSON format rotates with the
       # toolchain, and on the last release tag because published baselines
       # remain immutable until the next release.
-      - name: Find latest release tag
-        if: steps.affected.outputs.packages != ''
-        id: baseline
-        run: |
-          tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "Using $tag for the baseline cache."
-
       - name: Restore baseline rustdoc cache
-        if: steps.affected.outputs.packages != ''
-        id: baseline-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ steps.baseline.outputs.tag }}
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
           restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       # Deliberately unpinned (like cargo-hack): cargo-semver-checks must
       # track new stable rustdoc formats; pin only if a regression forces it.
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
-        if: steps.affected.outputs.packages != ''
         with:
           tool: cargo-semver-checks
 
       - uses: ./.github/actions/setup-zakura-build
-        if: steps.affected.outputs.packages != ''
 
-      - name: Check affected crates against stable crates.io baselines
-        if: steps.affected.outputs.packages != ''
+      - name: Check package against its stable crates.io baseline
         env:
-          PACKAGES: ${{ steps.affected.outputs.packages }}
-        run: |
-          while IFS= read -r package; do
-            [[ -n "$package" ]] || continue
-            cargo semver-checks --package "$package" --default-features
-          done <<< "$PACKAGES"
-
-      - name: Save baseline rustdoc cache
-        if: >-
-          github.ref == 'refs/heads/main'
-          && steps.affected.outputs.packages != ''
-          && steps.baseline-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
-        with:
-          path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ steps.baseline.outputs.tag }}
+          PACKAGE: ${{ matrix.package }}
+        run: cargo semver-checks --package "$PACKAGE" --default-features
 
       - name: Explain the failure
         if: failure()
@@ -175,3 +177,91 @@ jobs:
           CHANGELOG_GUIDELINES.md ("Library crates") and the release
           checklist ("Update Crate Versions").
           EOF
+
+  warm-baselines:
+    name: Warm semver baselines
+    if: >-
+      github.event_name != 'pull_request'
+      && needs.select-packages.outputs.has_packages == 'true'
+    needs: select-packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        id: toolchain
+        with:
+          toolchain: stable
+          cache: false
+
+      - name: Restore baseline rustdoc cache
+        id: baseline-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: target/semver-checks/cache
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
+          restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
+
+      - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
+        with:
+          tool: cargo-semver-checks
+
+      - uses: ./.github/actions/setup-zakura-build
+
+      - name: Check all crates against stable crates.io baselines
+        env:
+          PACKAGES: ${{ needs.select-packages.outputs.packages }}
+        run: |
+          while IFS= read -r package; do
+            [[ -n "$package" ]] || continue
+            cargo semver-checks --package "$package" --default-features
+          done <<< "$PACKAGES"
+
+      - name: Save baseline rustdoc cache
+        if: >-
+          github.ref == 'refs/heads/main'
+          && steps.baseline-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: target/semver-checks/cache
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
+
+      - name: Explain the failure
+        if: failure()
+        run: |
+          cat >&2 <<'EOF'
+          cargo-semver-checks failed while warming the latest release
+          baselines. Review the package report above before retrying.
+          EOF
+
+  semver-checks:
+    name: semver-checks
+    if: always()
+    needs: [select-packages, check-package, warm-baselines]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check semver job results
+        env:
+          CHECK_RESULT: ${{ needs.check-package.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          HAS_PACKAGES: ${{ needs.select-packages.outputs.has_packages }}
+          SELECT_RESULT: ${{ needs.select-packages.result }}
+          WARM_RESULT: ${{ needs.warm-baselines.result }}
+        run: |
+          if [[ "$SELECT_RESULT" != "success" ]]; then
+            echo "Package selection failed: $SELECT_RESULT" >&2
+            exit 1
+          fi
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$HAS_PACKAGES" == "true" && "$CHECK_RESULT" != "success" ]]; then
+              echo "Package checks failed: $CHECK_RESULT" >&2
+              exit 1
+            fi
+          elif [[ "$WARM_RESULT" != "success" ]]; then
+            echo "Baseline warmer failed: $WARM_RESULT" >&2
+            exit 1
+          fi

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -111,14 +111,23 @@ jobs:
       # target/semver-checks/cache (~1-2 MB per crate baseline; a hit skips
       # that baseline's download and rustdoc build entirely). Keyed on the
       # rustc version because the rustdoc JSON format rotates with the
-      # toolchain. The run_id suffix makes every trusted main run save a fresh
-      # entry; PRs restore-prefix-match the newest one.
+      # toolchain, and on the last release tag because published baselines
+      # remain immutable until the next release.
+      - name: Find latest release tag
+        if: steps.affected.outputs.packages != ''
+        id: baseline
+        run: |
+          tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Using $tag for the baseline cache."
+
       - name: Restore baseline rustdoc cache
         if: steps.affected.outputs.packages != ''
+        id: baseline-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ github.run_id }}
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ steps.baseline.outputs.tag }}
           restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       # Deliberately unpinned (like cargo-hack): cargo-semver-checks must
@@ -142,11 +151,14 @@ jobs:
           done <<< "$PACKAGES"
 
       - name: Save baseline rustdoc cache
-        if: github.ref == 'refs/heads/main' && steps.affected.outputs.packages != ''
+        if: >-
+          github.ref == 'refs/heads/main'
+          && steps.affected.outputs.packages != ''
+          && steps.baseline-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ github.run_id }}
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ steps.baseline.outputs.tag }}
 
       - name: Explain the failure
         if: failure()

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -33,6 +33,15 @@ on:
       - .github/workflows/semver-checks.yml
       - .github/workflows/scripts/affected_semver_packages.py
       - .github/workflows/scripts/test_affected_semver_packages.py
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - .github/workflows/semver-checks.yml
+      - .github/workflows/scripts/affected_semver_packages.py
+      - .github/workflows/scripts/test_affected_semver_packages.py
   workflow_dispatch:
 
 permissions:
@@ -60,15 +69,18 @@ jobs:
         run: |
           python3 .github/workflows/scripts/test_affected_semver_packages.py
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            packages="$(
-              python3 .github/workflows/scripts/affected_semver_packages.py --all
-            )"
-          else
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             packages="$(
               python3 .github/workflows/scripts/affected_semver_packages.py \
                 --base "$BASE_SHA" \
                 --head "$GITHUB_SHA"
+            )"
+          else
+            # Trusted main runs populate reusable rustdoc JSON for the latest
+            # stable crates.io baselines. Check every publishable crate so one
+            # cache entry can warm any package selected by a later PR.
+            packages="$(
+              python3 .github/workflows/scripts/affected_semver_packages.py --all
             )"
           fi
 
@@ -90,18 +102,17 @@ jobs:
         id: toolchain
         with:
           toolchain: stable
-          cache-key: semver-checks
-          cache-on-failure: true
-          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+          # cargo-semver-checks removes its temporary build directories after
+          # producing rustdoc JSON. Cache that small final output below rather
+          # than retaining unrelated Cargo registry and target artifacts.
+          cache: false
 
       # cargo-semver-checks reuses generated baseline rustdoc JSON from
       # target/semver-checks/cache (~1-2 MB per crate baseline; a hit skips
-      # that baseline's download and rustdoc build entirely). rust-cache's
-      # target-dir cleaner deletes unrecognized target/ entries before
-      # saving, so this cache needs its own steps. Keyed on the rustc
-      # version: the rustdoc JSON format (and the tool's own invalidation)
-      # rotates with the toolchain. The run_id suffix makes every manual main
-      # run save a fresh entry; restores prefix-match the newest one.
+      # that baseline's download and rustdoc build entirely). Keyed on the
+      # rustc version because the rustdoc JSON format rotates with the
+      # toolchain. The run_id suffix makes every trusted main run save a fresh
+      # entry; PRs restore-prefix-match the newest one.
       - name: Restore baseline rustdoc cache
         if: steps.affected.outputs.packages != ''
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0


### PR DESCRIPTION
## Motivation

Semver checks rebuild every crates.io baseline on cold PR runners. The observed release job spent about 8 minutes compiling immutable baseline rustdoc JSON, then checked affected packages serially even though their rustdoc generations are independent.

The workflow also assigned every main push a unique concurrency group, so superseded baseline warmers could run simultaneously instead of being cancelled.

## Solution

Run the workflow for relevant pushes to `main` and check every publishable crate there. Successful trusted main runs save the complete `target/semver-checks/cache`, and later PRs restore it before checking their affected package closure.

Key the baseline cache by the stable Rust compiler identity and the latest reachable `v*` release tag. A new release tag therefore creates one new immutable baseline cache; repeated main runs reuse the exact tag cache instead of uploading duplicates.

For pull requests, convert only the selector output into a dynamic matrix and run one read-only semver job per affected publishable package. Keep trusted main warming serial so one job owns the complete cache write, then preserve the required `semver-checks` status with a final aggregate job.

Use the branch or ref as the concurrency group so a newer commit cancels an obsolete PR check or main warmer. Disable the generic Cargo target and registry cache so this workflow stores only cargo-semver-checks rustdoc JSON and validation metadata.

## Testing

- `python3 .github/workflows/scripts/test_affected_semver_packages.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/semver-checks.yml`
- Parsed `.github/workflows/semver-checks.yml` with Ruby YAML
- `git diff --check`
- Confirmed `--all` converts to the expected JSON package matrix
- Confirmed latest reachable release-tag resolution returns `v1.0.5`

The draft CI run validates the GitHub-hosted selection and aggregate paths. This workflow-only PR intentionally selects no package matrix jobs; the affected-package selector itself remains covered by its unit tests.

## Changelog

Not required: this PR changes only CI configuration.

### Specifications & References

- Slow job: https://github.com/zakura-core/zakura/actions/runs/30316984824/job/90144551640

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; semver enforcement behavior on PRs is preserved via the aggregate job, with faster parallel checks and shared baseline caching.
> 
> **Overview**
> **Semver CI** is split into a package selector, per-crate PR matrix jobs, a **main-only baseline warmer**, and a final **`semver-checks` aggregate** so the required status name stays stable.
> 
> On **`main` pushes** (same path filters as PRs), the workflow now runs **`--all` publishable crates** serially in `warm-baselines` and **saves** `target/semver-checks/cache` when there is no cache hit. **PRs** only run **`check-package`** jobs in parallel (one `cargo semver-checks` per affected crate) and **restore** that cache before checking.
> 
> **Baseline rustdoc cache keys** switch from `github.run_id` to **`rustc` + latest `v*` release tag** (`baseline_tag` from `git describe`), so repeated main runs reuse one entry per release instead of uploading duplicates. **Concurrency** uses `head_ref || ref` instead of `run_id`, so newer commits cancel stale PR or main warmers. **Cargo’s generic target/registry cache is disabled** (`cache: false`) so only semver rustdoc JSON is cached.
> 
> The selector now emits **`packages_json`** for the matrix, plus **`has_packages`** and **`baseline_tag`**. Failure hints differ: PR matrix jobs keep the version-bump guidance; the warmer uses a shorter baseline-failure message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc38e24d22530704c5f2d2d8ec4e507c4961f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->