### PR TITLE
feat(rpc)!: expose end-of-support information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8844,7 +8844,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/changelog-unreleased/470.md
+++ b/changelog-unreleased/470.md
@@ -17,6 +17,11 @@
   a `prune_height` argument, so that downstream callers can set the new field.
   This breaks existing callers of that constructor
   ([#470](https://github.com/zakura-core/zakura/pull/470)).
+- Replaced the public `ReadRequest::IsPruned` and
+  `ReadResponse::IsPruned(bool)` variants in `zakura-state` with
+  `ReadRequest::PruningInfo` and a structured `ReadResponse::PruningInfo`.
+  Downstream callers must update their request and response matching
+  ([#470](https://github.com/zakura-core/zakura/pull/470)).
 
 ## Fixed
 

--- a/changelog-unreleased/470.md
+++ b/changelog-unreleased/470.md
@@ -17,11 +17,6 @@
   a `prune_height` argument, so that downstream callers can set the new field.
   This breaks existing callers of that constructor
   ([#470](https://github.com/zakura-core/zakura/pull/470)).
-- Replaced the public `ReadRequest::IsPruned` and
-  `ReadResponse::IsPruned(bool)` variants in `zakura-state` with
-  `ReadRequest::PruningInfo` and a structured `ReadResponse::PruningInfo`.
-  Downstream callers must update their request and response matching
-  ([#470](https://github.com/zakura-core/zakura/pull/470)).
 
 ## Fixed
 

--- a/changelog-unreleased/494.md
+++ b/changelog-unreleased/494.md
@@ -1,0 +1,14 @@
+## Added
+
+- Added the `getdeprecationinfo` RPC, which reports Zakura's Mainnet
+  end-of-support height and an estimated halt time with a 24-hour safety
+  margin. When the chain tip is unavailable, the estimate starts from the
+  latest network checkpoint
+  ([#494](https://github.com/zakura-core/zakura/pull/494)).
+
+## Changed
+
+- Raised `zakura-rpc` to 6.0.0 for its breaking public API changes, including
+  the new required `Rpc::get_deprecation_info` trait method and the
+  `GetBlockchainInfoResponse::new` signature change from #470
+  ([#494](https://github.com/zakura-core/zakura/pull/494)).

--- a/changelog-unreleased/494.md
+++ b/changelog-unreleased/494.md
@@ -12,3 +12,8 @@
   the new required `Rpc::get_deprecation_info` trait method and the
   `GetBlockchainInfoResponse::new` signature change from #470
   ([#494](https://github.com/zakura-core/zakura/pull/494)).
+- Documented the public `zakura-state` pruning API changes from #470:
+  `ReadRequest::IsPruned` and `ReadResponse::IsPruned(bool)` were replaced by
+  `ReadRequest::PruningInfo` and a structured `ReadResponse::PruningInfo`.
+  Downstream callers must update their request and response matching
+  ([#494](https://github.com/zakura-core/zakura/pull/494)).

--- a/zakura-rpc/Cargo.toml
+++ b/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "5.0.0"
+version = "6.0.0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/zakura-rpc/src/client.rs
+++ b/zakura-rpc/src/client.rs
@@ -37,12 +37,12 @@ pub use crate::methods::{
         validate_address::ValidateAddressResponse,
         z_validate_address::{ZValidateAddressResponse, ZValidateAddressType},
     },
-    AddressStrings, BlockHeaderObject, BlockObject, GetAddressBalanceRequest,
+    AddressStrings, BlockHeaderObject, BlockObject, EndOfService, GetAddressBalanceRequest,
     GetAddressBalanceResponse, GetAddressTxIdsRequest, GetAddressUtxosResponse,
     GetAddressUtxosResponseObject, GetBlockHashResponse, GetBlockHeaderResponse,
     GetBlockHeightAndHashResponse, GetBlockResponse, GetBlockTransaction, GetBlockTrees,
-    GetBlockchainInfoResponse, GetInfoResponse, GetRawTransactionResponse, Hash,
-    SendRawTransactionResponse, Utxo,
+    GetBlockchainInfoResponse, GetDeprecationInfoResponse, GetInfoResponse,
+    GetRawTransactionResponse, Hash, SendRawTransactionResponse, Utxo,
 };
 
 /// Constants needed by clients of Zebra's RPC server

--- a/zakura-rpc/src/methods.rs
+++ b/zakura-rpc/src/methods.rs
@@ -68,7 +68,8 @@ use zakura_chain::{
             block_subsidy, founders_reward, funding_stream_values, miner_subsidy,
             FundingStreamReceiver,
         },
-        ConsensusBranchId, Network, NetworkUpgrade, POW_AVERAGING_WINDOW,
+        ConsensusBranchId, Network, NetworkUpgrade, POST_BLOSSOM_POW_TARGET_SPACING,
+        POW_AVERAGING_WINDOW,
     },
     serialization::{BytesInDisplayOrder, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
     subtree::NoteCommitmentSubtreeIndex,
@@ -193,6 +194,31 @@ pub trait Rpc {
     /// [required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L91-L95)
     #[method(name = "getinfo")]
     async fn get_info(&self) -> Result<GetInfoResponse>;
+
+    /// Returns end-of-support information for this node release, as a
+    /// [`GetDeprecationInfoResponse`] JSON struct.
+    ///
+    /// zcashd reference:
+    /// [`getdeprecationinfo`](https://zcash.github.io/rpc/getdeprecationinfo.html)
+    /// method: post
+    /// tags: network
+    ///
+    /// # Notes
+    ///
+    /// As in zcashd, the `end_of_service` object is only present on Mainnet,
+    /// where end of support is enforced. Zakura reports the estimated last
+    /// height this release supports in `end_of_service.block_height`; the node
+    /// halts when the tip goes past it.
+    ///
+    /// Some fields from the zcashd response are missing from Zakura's response:
+    /// `version` and `subversion` are available from `getinfo`,
+    /// `deprecationheight` is deprecated in zcashd, and Zakura does not have
+    /// zcashd's feature deprecation framework.
+    ///
+    /// The estimate assumes the node is synced to the network tip; during
+    /// initial sync it is significantly overestimated.
+    #[method(name = "getdeprecationinfo")]
+    async fn get_deprecation_info(&self) -> Result<GetDeprecationInfoResponse>;
 
     /// Returns blockchain state information, as a [`GetBlockchainInfoResponse`] JSON struct.
     ///
@@ -810,6 +836,9 @@ where
     /// no matter what the estimated height or local clock is.
     debug_force_finished_sync: bool,
 
+    /// The estimated last height this release supports, if enforced.
+    end_of_support_height: Option<Height>,
+
     // Services
     //
     /// A handle to the mempool service.
@@ -924,6 +953,7 @@ where
             user_agent,
             network: network.clone(),
             debug_force_finished_sync,
+            end_of_support_height: None,
             mempool: mempool.clone(),
             state: state.clone(),
             read_state: read_state.clone(),
@@ -947,6 +977,14 @@ where
     /// Returns a reference to the configured network.
     pub fn network(&self) -> &Network {
         &self.network
+    }
+
+    /// Sets the end-of-support height reported by `getdeprecationinfo`.
+    ///
+    /// When unset, or set to `None`, the RPC omits `end_of_service`.
+    pub fn with_end_of_support_height(mut self, end_of_support_height: Option<Height>) -> Self {
+        self.end_of_support_height = end_of_support_height;
+        self
     }
 }
 
@@ -1011,6 +1049,37 @@ where
         };
 
         Ok(response)
+    }
+
+    async fn get_deprecation_info(&self) -> Result<GetDeprecationInfoResponse> {
+        let end_of_service = self
+            .end_of_support_height
+            // End of support is only enforced on Mainnet. Match zcashd by
+            // omitting `end_of_service` on other networks.
+            .filter(|_| self.network == Network::Mainnet)
+            .map(|end_of_support_height| {
+                // If the tip is unavailable, use the latest checkpoint so the
+                // estimate remains useful during startup.
+                let tip_height = self
+                    .latest_chain_tip
+                    .best_tip_height()
+                    .unwrap_or_else(|| self.network.checkpoint_list().max_height());
+                let remaining_blocks = i64::from(end_of_support_height.0) - i64::from(tip_height.0);
+                let estimated_time = Utc::now()
+                    .timestamp()
+                    .saturating_add(
+                        remaining_blocks.saturating_mul(i64::from(POST_BLOSSOM_POW_TARGET_SPACING)),
+                    )
+                    .saturating_sub(END_OF_SERVICE_ESTIMATE_SAFETY_MARGIN)
+                    .max(0);
+
+                EndOfService {
+                    block_height: end_of_support_height.0,
+                    estimated_time,
+                }
+            });
+
+        Ok(GetDeprecationInfoResponse { end_of_service })
     }
 
     #[allow(clippy::unwrap_in_result)]
@@ -3473,6 +3542,39 @@ impl GetInfoResponse {
 
         Some(version_number)
     }
+}
+
+/// Seconds subtracted from `getdeprecationinfo`'s estimated halt time.
+///
+/// Block times vary, so the halt can happen earlier than a spacing-based
+/// estimate. Reporting it a day early gives consumers time to act.
+const END_OF_SERVICE_ESTIMATE_SAFETY_MARGIN: i64 = 24 * 60 * 60;
+
+/// Response to a `getdeprecationinfo` RPC request.
+///
+/// See the notes for [`Rpc::get_deprecation_info`].
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct GetDeprecationInfoResponse {
+    /// End-of-service information, only present on Mainnet.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_of_service: Option<EndOfService>,
+}
+
+/// The `end_of_service` object in a [`GetDeprecationInfoResponse`].
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct EndOfService {
+    /// The estimated last height this server version supports.
+    ///
+    /// The node halts when the chain tip goes past this height.
+    #[getter(copy)]
+    block_height: u32,
+
+    /// Approximate halt time in seconds since the Unix epoch.
+    ///
+    /// This is reported 24 hours earlier than the spacing-based estimate, so
+    /// consumers are warned early when block times vary.
+    #[getter(copy)]
+    estimated_time: i64,
 }
 
 /// Type alias for the array of `GetBlockchainInfoBalance` objects

--- a/zakura-rpc/src/methods/tests/vectors.rs
+++ b/zakura-rpc/src/methods/tests/vectors.rs
@@ -20,7 +20,7 @@ use zakura_chain::{
     parameters::{
         testnet::{self, Parameters},
         Network::*,
-        NetworkKind,
+        NetworkKind, POST_BLOSSOM_POW_TARGET_SPACING,
     },
     serialization::{DateTime32, ZcashDeserializeInto, ZcashSerialize},
     transaction::{zip317, UnminedTxId, VerifiedUnminedTx},
@@ -113,6 +113,189 @@ async fn rpc_getinfo() {
     // The queue task should continue without errors or panics
     let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
     assert!(rpc_tx_queue_task_result.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo_uses_latest_checkpoint_without_tip() {
+    let _init_guard = zakura_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let deprecation_info = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed");
+    assert_eq!(deprecation_info.end_of_service, None);
+
+    let checkpoint_height = Mainnet.checkpoint_list().max_height();
+    let end_of_support_height = Height(
+        checkpoint_height
+            .0
+            .checked_add(100_000)
+            .expect("test checkpoint height is far below the maximum height"),
+    );
+    let rpc = rpc.with_end_of_support_height(Some(end_of_support_height));
+    let remaining_blocks = i64::from(end_of_support_height.0) - i64::from(checkpoint_height.0);
+    let expected_offset = remaining_blocks * i64::from(POST_BLOSSOM_POW_TARGET_SPACING)
+        - END_OF_SERVICE_ESTIMATE_SAFETY_MARGIN;
+
+    let before = Utc::now().timestamp();
+    let end_of_service = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed")
+        .end_of_service
+        .expect("end_of_service should be present when a height is set");
+    let after = Utc::now().timestamp();
+
+    assert_eq!(end_of_service.block_height, end_of_support_height.0);
+    assert!(end_of_service.estimated_time >= before + expected_offset);
+    assert!(end_of_service.estimated_time <= after + expected_offset);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo_estimates_time_from_tip_with_safety_margin() {
+    let _init_guard = zakura_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (latest_chain_tip, latest_chain_tip_sender) = MockChainTip::new();
+    let tip_height = Height(3_000_000);
+    latest_chain_tip_sender.send_best_tip_height(tip_height);
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        latest_chain_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let end_of_support_height = Height(3_546_440);
+    let rpc = rpc.with_end_of_support_height(Some(end_of_support_height));
+    let remaining_blocks = i64::from(end_of_support_height.0 - tip_height.0);
+    let expected_offset = remaining_blocks * i64::from(POST_BLOSSOM_POW_TARGET_SPACING)
+        - END_OF_SERVICE_ESTIMATE_SAFETY_MARGIN;
+
+    let before = Utc::now().timestamp();
+    let end_of_service = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed")
+        .end_of_service
+        .expect("end_of_service should be present when a height is set");
+    let after = Utc::now().timestamp();
+
+    assert_eq!(end_of_service.block_height, end_of_support_height.0);
+    assert!(end_of_service.estimated_time >= before + expected_offset);
+    assert!(end_of_service.estimated_time <= after + expected_offset);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo_omits_end_of_service_off_mainnet() {
+    let _init_guard = zakura_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Network::new_default_testnet(),
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let rpc = rpc.with_end_of_support_height(Some(Height(100)));
+    let deprecation_info = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed");
+    assert_eq!(deprecation_info.end_of_service, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo_estimated_time_is_never_negative() {
+    let _init_guard = zakura_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (latest_chain_tip, latest_chain_tip_sender) = MockChainTip::new();
+    latest_chain_tip_sender.send_best_tip_height(Height::MAX);
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        latest_chain_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+    let rpc = rpc.with_end_of_support_height(Some(Height(1)));
+
+    let end_of_service = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed")
+        .end_of_service
+        .expect("end_of_service should be present when a height is set");
+
+    assert_eq!(end_of_service.block_height, 1);
+    assert_eq!(end_of_service.estimated_time, 0);
 }
 
 // Helper function that returns the nonce, final sapling root and

--- a/zakura-rpc/tests/serialization_tests.rs
+++ b/zakura-rpc/tests/serialization_tests.rs
@@ -23,14 +23,14 @@ use zakura_rpc::client::zakura_chain::{
     work::difficulty::{CompactDifficulty, ExpandedDifficulty},
 };
 use zakura_rpc::client::{
-    BlockHeaderObject, BlockObject, BlockTemplateResponse, Commitments, DefaultRoots,
+    BlockHeaderObject, BlockObject, BlockTemplateResponse, Commitments, DefaultRoots, EndOfService,
     FundingStream, GetAddressBalanceRequest, GetAddressBalanceResponse, GetAddressTxIdsRequest,
     GetAddressUtxosResponse, GetAddressUtxosResponseObject, GetBlockHashResponse,
     GetBlockHeaderResponse, GetBlockHeightAndHashResponse, GetBlockResponse,
     GetBlockSubsidyResponse, GetBlockTemplateParameters, GetBlockTemplateRequestMode,
     GetBlockTemplateResponse, GetBlockTransaction, GetBlockTrees, GetBlockchainInfoBalance,
-    GetBlockchainInfoResponse, GetInfoResponse, GetMiningInfoResponse, GetNetworkInfoResponse,
-    GetPeerInfoResponse, GetRawMempoolResponse, GetRawTransactionResponse,
+    GetBlockchainInfoResponse, GetDeprecationInfoResponse, GetInfoResponse, GetMiningInfoResponse,
+    GetNetworkInfoResponse, GetPeerInfoResponse, GetRawMempoolResponse, GetRawTransactionResponse,
     GetSubtreesByIndexResponse, GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject,
     Orchard, OrchardAction, OrchardFlags, Output, PeerInfo, ScriptPubKey, ScriptSig,
     SendRawTransactionResponse, ShieldedOutput, ShieldedSpend, SubmitBlockErrorResponse,
@@ -104,6 +104,41 @@ fn test_get_info() -> Result<(), Box<dyn std::error::Error>> {
         errors_timestamp,
     );
 
+    assert_eq!(obj, new_obj);
+
+    Ok(())
+}
+
+#[test]
+fn test_get_deprecation_info() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"
+{
+  "end_of_service": {
+    "block_height": 3546440,
+    "estimated_time": 1769900000
+  }
+}"#;
+    let obj: GetDeprecationInfoResponse = serde_json::from_str(json)?;
+
+    let end_of_service = obj
+        .end_of_service()
+        .clone()
+        .expect("end_of_service is present in the JSON");
+    let block_height = end_of_service.block_height();
+    let estimated_time = end_of_service.estimated_time();
+
+    assert_eq!(block_height, 3_546_440);
+    assert_eq!(estimated_time, 1_769_900_000);
+
+    let new_obj =
+        GetDeprecationInfoResponse::new(Some(EndOfService::new(block_height, estimated_time)));
+    assert_eq!(obj, new_obj);
+
+    let obj: GetDeprecationInfoResponse = serde_json::from_str("{}")?;
+    assert_eq!(*obj.end_of_service(), None);
+    assert_eq!(serde_json::to_string(&obj)?, "{}");
+
+    let new_obj = GetDeprecationInfoResponse::new(None);
     assert_eq!(obj, new_obj);
 
     Ok(())

--- a/zakurad/Cargo.toml
+++ b/zakurad/Cargo.toml
@@ -173,7 +173,7 @@ zakura-consensus = { path = "../zakura-consensus", version = "5.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.0.1" }
 zakura-network = { path = "../zakura-network", version = "5.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.0.0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "5.0.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "6.0.0" }
 zakura-state = { path = "../zakura-state", version = "6.0.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of

--- a/zakurad/src/commands/start.rs
+++ b/zakurad/src/commands/start.rs
@@ -643,6 +643,9 @@ impl StartCmd {
             LAST_WARN_ERROR_LOG_SENDER.subscribe(),
             Some(submit_block_channel.sender()),
         );
+        let rpc_impl = rpc_impl.with_end_of_support_height(
+            sync::end_of_support::end_of_support_height(&config.network.network),
+        );
 
         let rpc_task_handle = if config.rpc.listen_addr.is_some() {
             RpcServer::start(rpc_impl.clone(), config.rpc.clone())

--- a/zakurad/src/components/sync/end_of_support.rs
+++ b/zakurad/src/components/sync/end_of_support.rs
@@ -7,13 +7,19 @@ use color_eyre::Report;
 use zakura_chain::{
     block::Height,
     chain_tip::ChainTip,
-    parameters::{Network, NetworkUpgrade},
+    parameters::{Network, POST_BLOSSOM_POW_TARGET_SPACING},
 };
 
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
 pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_428_500;
+
+/// The estimated number of blocks per day after Blossom.
+///
+/// All Zakura releases ship after Blossom, so this matches the spacing seen at
+/// every reachable tip height.
+pub const ESTIMATED_BLOCKS_PER_DAY: u32 = 24 * 60 * 60 / POST_BLOSSOM_POW_TARGET_SPACING;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -65,22 +71,26 @@ pub async fn start(
     }
 }
 
+/// Returns the last supported height, or `None` when support is not enforced.
+///
+/// The node runs at this height and halts when the tip goes past it. This
+/// matches zcashd's `end_of_service.block_height` threshold semantics.
+pub fn end_of_support_height(network: &Network) -> Option<Height> {
+    (network == &Network::Mainnet).then_some(Height(
+        ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY),
+    ))
+}
+
 /// Check if the current release is too old and panic if so.
 pub fn check(tip_height: Height, network: &Network) {
     info!("Checking if Zakura release is inside support range ...");
 
-    // Get the current block spacing
-    let target_block_spacing = NetworkUpgrade::target_spacing_for_height(network, tip_height);
-
-    // Get the number of blocks per day
-    let estimated_blocks_per_day =
-        u32::try_from(chrono::Duration::days(1).num_seconds() / target_block_spacing.num_seconds())
-            .expect("number is always small enough to fit");
-
-    let panic_height =
-        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * estimated_blocks_per_day));
+    let Some(panic_height) = end_of_support_height(network) else {
+        info!("Release always valid outside Mainnet");
+        return;
+    };
     let warn_height =
-        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_WARN_AFTER * estimated_blocks_per_day));
+        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_WARN_AFTER * ESTIMATED_BLOCKS_PER_DAY));
 
     if tip_height > panic_height {
         panic!(

--- a/zakurad/tests/end_of_support.rs
+++ b/zakurad/tests/end_of_support.rs
@@ -8,11 +8,9 @@ use color_eyre::eyre::Result;
 
 use zakura_chain::{block::Height, chain_tip::mock::MockChainTip, parameters::Network};
 use zakurad::components::sync::end_of_support::{
-    self, EOS_PANIC_AFTER, EOS_WARN_AFTER, EOS_WARN_MESSAGE_HEADER, ESTIMATED_RELEASE_HEIGHT,
+    self, EOS_PANIC_AFTER, EOS_WARN_AFTER, EOS_WARN_MESSAGE_HEADER, ESTIMATED_BLOCKS_PER_DAY,
+    ESTIMATED_RELEASE_HEIGHT,
 };
-
-// Estimated blocks per day with the current 75 seconds block spacing.
-const ESTIMATED_BLOCKS_PER_DAY: u32 = 1152;
 
 /// Test that the `end_of_support` function is working as expected.
 #[test]
@@ -50,6 +48,22 @@ fn end_of_support_function() {
     ));
 
     // Panic is tested in `end_of_support_panic`
+}
+
+/// Test that end of support is only reported and enforced on Mainnet.
+#[test]
+fn end_of_support_height_per_network() {
+    let last_supported_height =
+        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY));
+    assert_eq!(
+        end_of_support::end_of_support_height(&Network::Mainnet),
+        Some(last_supported_height)
+    );
+    end_of_support::check(last_supported_height, &Network::Mainnet);
+
+    let testnet = Network::new_default_testnet();
+    assert_eq!(end_of_support::end_of_support_height(&testnet), None);
+    end_of_support::check(Height::MAX, &testnet);
 }
 
 /// Test that we are never in end of support warning or panic.


### PR DESCRIPTION
## Motivation

PR #470 introduced breaking public API changes without bumping
`zakura-rpc`, causing the Semver check to fail. Its changelog fragment also
omitted the public `zakura-state` pruning request and response changes.

Operators additionally need a machine-readable way to monitor the node's
end-of-support height.

## Solution

- Bump `zakura-rpc` to 6.0.0 and update the `zakura` dependency and lockfile.
- Document the `ReadRequest::PruningInfo` and
  `ReadResponse::PruningInfo` compatibility changes omitted by #470.
- Port ZcashFoundation/zebra#11097 as a zcashd-compatible
  `getdeprecationinfo` RPC.
- Report the shared Mainnet end-of-support threshold and estimate its time
  from the current tip, with a 24-hour safety margin.
- Use the latest network checkpoint when the chain tip is unavailable.

## Testing

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1 --locked`
- `./scripts/changelog.py check`
- `./scripts/changelog.py check-pr --base <main> --head HEAD --pr 494`
- `npx --yes markdownlint-cli changelog-unreleased/494.md --config .trunk/configs/.markdownlint.yaml`
- `cargo test -p zakura-rpc getdeprecationinfo`
- `cargo test -p zakura-rpc --test serialization_tests test_get_deprecation_info -- --exact`
- `cargo test -p zakura --test end_of_support`
- `cargo clippy -p zakura-rpc -p zakura --all-targets -- -D warnings`
- `cargo semver-checks --package zakura-rpc --default-features`

## Changelog

`changelog-unreleased/494.md` documents the RPC, the major version bump, and
the public pruning API changes omitted from #470's fragment.

### Specifications & References

- Follow-up to #470
- Ports ZcashFoundation/zebra#11097
- <https://zcash.github.io/rpc/getdeprecationinfo.html>

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking `zakura-rpc` semver and a new required RPC trait method affect downstream crates; behavior is informational on Mainnet and aligned with existing halt logic rather than new enforcement paths.
> 
> **Overview**
> Adds a zcashd-compatible **`getdeprecationinfo`** RPC so operators can monitor when this release stops being supported. On **Mainnet** it returns an optional **`end_of_service`** object with the last supported block height and an estimated halt time (post-Blossom block spacing, minus a **24-hour** safety margin). Without a chain tip, the time estimate uses the latest network checkpoint. Other networks omit **`end_of_service`**, matching zcashd.
> 
> **`zakura-rpc` is bumped to 6.0.0** (breaking: new required **`Rpc::get_deprecation_info`** and related public types exported from the client). Node startup wires the RPC via **`with_end_of_support_height`** using a new shared **`end_of_support_height()`** in the sync end-of-support module; panic/warn thresholds now use a fixed post-Blossom blocks-per-day constant instead of tip-dependent spacing.
> 
> Changelog also records **`zakura-state`** pruning API changes from #470 that were missing from the prior release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d4275734a64fdc2841495ef1fe7641fb54d175e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->