### PR TITLE
fix(network): finish broadcasts after peer disconnects

### DIFF
--- a/crates/zakura-network/src/peer_set/set.rs
+++ b/crates/zakura-network/src/peer_set/set.rs
@@ -239,7 +239,7 @@ where
     /// Stores requests that should be routed to peers once they are ready.
     queued_broadcast_all: Option<(
         Request,
-        tokio::sync::mpsc::Sender<ResponseFuture>,
+        tokio::sync::mpsc::UnboundedSender<ResponseFuture>,
         HashSet<D::Key>,
     )>,
 
@@ -1366,13 +1366,13 @@ where
     fn queue_broadcast_all_unready(
         &mut self,
         req: &Request,
-    ) -> Option<tokio::sync::mpsc::Receiver<ResponseFuture>> {
+    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<ResponseFuture>> {
         if !self.cancel_handles.is_empty() {
-            /// How many broadcast all futures to send to the channel until the peer set should wait for the channel consumer
-            /// to read a message before continuing to send the queued broadcast request to peers that were originally unready.
-            const QUEUED_BROADCAST_FUTS_CHANNEL_SIZE: usize = 3;
-
-            let (sender, receiver) = tokio::sync::mpsc::channel(QUEUED_BROADCAST_FUTS_CHANNEL_SIZE);
+            // Each original peer is removed after its delivery is queued, so the total
+            // number of futures in this channel is bounded by the peer snapshot below.
+            // An unbounded channel avoids stalling the peer set on capacity without a
+            // registered wakeup when several peer readiness waves happen close together.
+            let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
             let unready_peers: HashSet<_> = self.cancel_handles.keys().cloned().collect();
             let queued = (req.clone(), sender, unready_peers);
 
@@ -1418,20 +1418,16 @@ where
             return;
         }
 
-        let reserved_send_slot = match sender.try_reserve() {
-            Ok(reserved_send_slot) => reserved_send_slot,
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(())) => return,
-            Err(tokio::sync::mpsc::error::TrySendError::Full(())) => {
-                self.queued_broadcast_all = Some((req, sender.clone(), remaining_peers));
-                return;
-            }
-        };
-
         for peer in &peers {
             remaining_peers.remove(peer);
         }
 
-        reserved_send_slot.send(self.send_multiple(req.clone(), peers).boxed());
+        if sender
+            .send(self.send_multiple(req.clone(), peers).boxed())
+            .is_err()
+        {
+            return;
+        }
 
         if !remaining_peers.is_empty() {
             self.queued_broadcast_all = Some((req, sender, remaining_peers));

--- a/crates/zakura-network/src/peer_set/set.rs
+++ b/crates/zakura-network/src/peer_set/set.rs
@@ -1418,9 +1418,13 @@ where
             return;
         }
 
-        let Ok(reserved_send_slot) = sender.try_reserve() else {
-            self.queued_broadcast_all = Some((req, sender, remaining_peers));
-            return;
+        let reserved_send_slot = match sender.try_reserve() {
+            Ok(reserved_send_slot) => reserved_send_slot,
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(())) => return,
+            Err(tokio::sync::mpsc::error::TrySendError::Full(())) => {
+                self.queued_broadcast_all = Some((req, sender.clone(), remaining_peers));
+                return;
+            }
         };
 
         for peer in &peers {

--- a/crates/zakura-network/src/peer_set/set.rs
+++ b/crates/zakura-network/src/peer_set/set.rs
@@ -1392,19 +1392,40 @@ where
             return;
         };
 
-        remaining_peers.retain(|addr| !self.bans.contains(canonical_ip(addr.ip())));
+        if sender.is_closed() {
+            return;
+        }
+
+        remaining_peers.retain(|addr| {
+            !self.bans.contains(canonical_ip(addr.ip()))
+                && (self.ready_services.contains_key(addr)
+                    || self.cancel_handles.contains_key(addr))
+        });
+
+        if remaining_peers.is_empty() {
+            return;
+        }
+
+        let peers: Vec<_> = self
+            .ready_services
+            .keys()
+            .filter(|ready_peer| remaining_peers.contains(ready_peer))
+            .copied()
+            .collect();
+
+        if peers.is_empty() {
+            self.queued_broadcast_all = Some((req, sender, remaining_peers));
+            return;
+        }
 
         let Ok(reserved_send_slot) = sender.try_reserve() else {
             self.queued_broadcast_all = Some((req, sender, remaining_peers));
             return;
         };
 
-        let peers: Vec<_> = self
-            .ready_services
-            .keys()
-            .filter(|ready_peer| remaining_peers.remove(ready_peer))
-            .copied()
-            .collect();
+        for peer in &peers {
+            remaining_peers.remove(peer);
+        }
 
         reserved_send_slot.send(self.send_multiple(req.clone(), peers).boxed());
 
@@ -1663,6 +1684,10 @@ where
         self.log_peer_set_size();
         self.update_metrics();
 
+        // This also drops queued peers that disconnected while they were unready,
+        // even if there are no ready peers left in the peer set.
+        self.broadcast_all_queued();
+
         if ready_peers.is_pending() {
             // # Correctness
             //
@@ -1687,7 +1712,6 @@ where
             return Poll::Pending;
         }
 
-        self.broadcast_all_queued();
         self.deliver_queued_sidecar_block_gossip();
 
         if self.ready_services.is_empty() {

--- a/crates/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/crates/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -342,6 +342,96 @@ fn broadcast_all_queued_removes_banned_peers() {
     });
 }
 
+/// A peer that disconnects while waiting for a queued broadcast must not keep the
+/// broadcast response open indefinitely.
+#[test]
+fn broadcast_all_queued_removes_disconnected_peers() {
+    let peer_versions = PeerVersions {
+        peer_versions: vec![Version::min_specified_for_upgrade(
+            &Network::Mainnet,
+            NetworkUpgrade::Nu6_2,
+        )],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, _handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        let peer_addr: PeerSocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1).into();
+        let peer_set = peer_set.ready().await.expect("peer set is always ready");
+        let service = peer_set
+            .take_ready_service(&peer_addr)
+            .expect("mock peer is ready");
+        peer_set.push_unready(peer_addr, service);
+
+        let broadcast_fut =
+            peer_set.broadcast_all(Request::AdvertiseBlockToAll(block::Hash([9; 32])));
+        assert!(peer_set.queued_broadcast_all.is_some());
+
+        peer_set.remove(&peer_addr);
+
+        // Polling readiness processes the canceled service. Since this was the only
+        // peer, readiness remains pending, but queue cleanup must still run.
+        assert!(peer_set.ready().now_or_never().is_none());
+        assert!(peer_set.queued_broadcast_all.is_none());
+
+        timeout(Duration::from_secs(1), broadcast_fut)
+            .await
+            .expect("broadcast should not wait for a disconnected peer")
+            .expect("broadcast_all should succeed");
+    });
+}
+
+/// Dropping the broadcast response future must also discard its queued delivery.
+#[test]
+fn broadcast_all_queued_removes_canceled_broadcasts() {
+    let peer_versions = PeerVersions {
+        peer_versions: vec![Version::min_specified_for_upgrade(
+            &Network::Mainnet,
+            NetworkUpgrade::Nu6_2,
+        )],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, _handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        let peer_addr: PeerSocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1).into();
+        let peer_set = peer_set.ready().await.expect("peer set is always ready");
+        let service = peer_set
+            .take_ready_service(&peer_addr)
+            .expect("mock peer is ready");
+        peer_set.push_unready(peer_addr, service);
+
+        let broadcast_fut =
+            peer_set.broadcast_all(Request::AdvertiseBlockToAll(block::Hash([11; 32])));
+        assert!(peer_set.queued_broadcast_all.is_some());
+
+        drop(broadcast_fut);
+        peer_set.broadcast_all_queued();
+
+        assert!(peer_set.queued_broadcast_all.is_none());
+    });
+}
+
 /// A mined block advertised via `AdvertiseBlockToAll` while a peer is unready
 /// must reach that peer once it is ready again, not be silently dropped.
 ///

--- a/crates/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/crates/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -334,11 +334,11 @@ fn broadcast_all_queued_removes_banned_peers() {
 
         peer_set.broadcast_all_queued();
 
-        if let Some((_req, _sender, remaining_peers)) = peer_set.queued_broadcast_all.take() {
-            assert!(remaining_peers.is_empty());
-        } else {
-            assert!(receiver.try_recv().is_ok());
-        }
+        assert!(peer_set.queued_broadcast_all.is_none());
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
     });
 }
 
@@ -759,16 +759,13 @@ fn broadcast_all_queued_bans_mapped_ipv6_against_canonical_ban() {
         peer_set.broadcast_all_queued();
 
         // The mapped-form peer must be dropped by the (canonical) ban filter, so no peers
-        // remain queued for the re-send. On un-canonicalized code the mapped peer would
-        // survive the filter and this assertion would fail.
-        if let Some((_req, _sender, remaining_peers)) = peer_set.queued_broadcast_all.take() {
-            assert!(
-                remaining_peers.is_empty(),
-                "banned mapped-IPv6 peer must be filtered by the canonical ban"
-            );
-        } else {
-            assert!(receiver.try_recv().is_ok());
-        }
+        // remain queued for the re-send and the response channel must close. On
+        // un-canonicalized code the mapped peer would survive the filter.
+        assert!(peer_set.queued_broadcast_all.is_none());
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
     });
 }
 

--- a/crates/zakura-network/src/peer_set/set/tests/vectors.rs
+++ b/crates/zakura-network/src/peer_set/set/tests/vectors.rs
@@ -329,7 +329,7 @@ fn broadcast_all_queued_removes_banned_peers() {
         let mut remaining_peers = HashSet::new();
         remaining_peers.insert(banned_addr);
 
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
         peer_set.queued_broadcast_all = Some((Request::Peers, sender, remaining_peers));
 
         peer_set.broadcast_all_queued();
@@ -429,6 +429,64 @@ fn broadcast_all_queued_removes_canceled_broadcasts() {
         peer_set.broadcast_all_queued();
 
         assert!(peer_set.queued_broadcast_all.is_none());
+    });
+}
+
+/// Queued delivery must make progress across more readiness waves than the old
+/// bounded response channel could hold, even when its receiver is not polled yet.
+#[test]
+fn broadcast_all_queued_does_not_wait_for_receiver_capacity() {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version; 4],
+    };
+
+    let (runtime, _init_guard) = zakura_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, _handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .max_conns_per_ip(max(4, DEFAULT_MAX_CONNS_PER_IP))
+            .build();
+
+        let peer_set = peer_set.ready().await.expect("peer set is always ready");
+        assert_eq!(peer_set.ready_services.len(), 4);
+
+        // Hold all services outside the ready map, while cancel handles model the
+        // original unready-peer snapshot. Move them back one at a time to create
+        // four distinct readiness waves without polling the response receiver.
+        let mut services = std::mem::take(&mut peer_set.ready_services);
+        let mut _cancel_receivers = Vec::new();
+        for peer_addr in services.keys() {
+            let (cancel_tx, cancel_rx) =
+                crate::peer_set::set::oneshot::channel::<crate::peer_set::set::CancelClientWork>();
+            peer_set.cancel_handles.insert(*peer_addr, cancel_tx);
+            _cancel_receivers.push(cancel_rx);
+        }
+
+        let mut receiver = peer_set
+            .queue_broadcast_all_unready(&Request::AdvertiseBlockToAll(block::Hash([13; 32])))
+            .expect("cancel handles create a queued broadcast");
+
+        for (peer_addr, service) in services.drain() {
+            assert!(peer_set.cancel_handles.remove(&peer_addr).is_some());
+            assert!(peer_set.ready_services.insert(peer_addr, service).is_none());
+            peer_set.broadcast_all_queued();
+        }
+
+        assert!(peer_set.queued_broadcast_all.is_none());
+
+        let mut queued_deliveries = 0;
+        while receiver.try_recv().is_ok() {
+            queued_deliveries += 1;
+        }
+        assert_eq!(queued_deliveries, 4);
     });
 }
 
@@ -753,7 +811,7 @@ fn broadcast_all_queued_bans_mapped_ipv6_against_canonical_ban() {
         let mut remaining_peers = HashSet::new();
         remaining_peers.insert(mapped_addr);
 
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
         peer_set.queued_broadcast_all = Some((Request::Peers, sender, remaining_peers));
 
         peer_set.broadcast_all_queued();

--- a/crates/zakura-state/src/error.rs
+++ b/crates/zakura-state/src/error.rs
@@ -893,6 +893,8 @@ impl ValidateContextError {
     // peer-attribution decision.
     fn misbehavior_score(&self) -> u32 {
         match self {
+            // Consensus violations the block itself proves: the supplier sent a
+            // block that no honest peer could have produced.
             ValidateContextError::NonSequentialBlock { .. }
             | ValidateContextError::TimeTooEarly { .. }
             | ValidateContextError::TimeTooLate { .. }
@@ -907,9 +909,6 @@ impl ValidateContextError {
             | ValidateContextError::DuplicateOrchardNullifier { .. }
             | ValidateContextError::DuplicateIronwoodNullifier { .. }
             | ValidateContextError::NegativeRemainingTransactionValue { .. }
-            | ValidateContextError::CalculateRemainingTransactionValue { .. }
-            | ValidateContextError::CalculateTransactionValueBalances { .. }
-            | ValidateContextError::CalculateBlockChainValueChange { .. }
             | ValidateContextError::AddValuePool { .. }
             | ValidateContextError::InvalidBlockCommitment(_)
             | ValidateContextError::UnknownSproutAnchor { .. }
@@ -917,7 +916,24 @@ impl ValidateContextError {
             | ValidateContextError::UnknownOrchardAnchor { .. }
             | ValidateContextError::UnknownIronwoodAnchor { .. } => 100,
 
-            ValidateContextError::MissingSproutTipTree(_)
+            // Residual arithmetic failures in our own value summation, not
+            // consensus violations. `remaining_transaction_value()` and
+            // `value_balance()` peel off the "this block creates money" case
+            // into `NegativeRemainingTransactionValue`, and `AddValuePool`
+            // carries the ZIP-209 non-negative pool rule. What reaches these
+            // variants is an out-of-range or overflowing intermediate, which a
+            // local bookkeeping bug can produce just as easily as a bad block.
+            // Scoring them would let one such bug ban every honest peer in turn,
+            // so they stay unscored alongside the other local-state failures.
+            ValidateContextError::CalculateRemainingTransactionValue { .. }
+            | ValidateContextError::CalculateTransactionValueBalances { .. }
+            | ValidateContextError::CalculateBlockChainValueChange { .. }
+
+            // Failures that are not attributable to the block's supplier:
+            // local state and tree errors, operator invalidation, stale forks,
+            // out-of-order arrival, retryable stalls, and auxiliary roots that
+            // may have come from a different peer.
+            | ValidateContextError::MissingSproutTipTree(_)
             | ValidateContextError::HeaderRootAuthFrontier { .. }
             | ValidateContextError::BlockPreviouslyInvalidated { .. }
             | ValidateContextError::NotReadyToBeCommitted
@@ -1026,6 +1042,31 @@ mod tests {
         let value_balance_error = ValueBalanceError::Transparent(amount_error.clone());
         let orchard_nullifier = orchard::Nullifier::try_from([0; 32])
             .expect("zero is a canonical Orchard nullifier encoding");
+        // Residual arithmetic failures in our own value summation. A local
+        // bookkeeping bug produces these just as easily as a bad block does, so
+        // they must not ban the peer that supplied the block.
+        let arithmetic_faults = [
+            ValidateContextError::CalculateRemainingTransactionValue {
+                amount_error: amount_error.clone(),
+                height,
+                tx_index_in_block: 1,
+                transaction_hash,
+            },
+            ValidateContextError::CalculateTransactionValueBalances {
+                value_balance_error: value_balance_error.clone(),
+                height,
+                tx_index_in_block: 1,
+                transaction_hash,
+            },
+            ValidateContextError::CalculateBlockChainValueChange {
+                value_balance_error: value_balance_error.clone(),
+                height,
+                block_hash: block::Hash([3; 32]),
+                transaction_count: 2,
+                spent_utxo_count: 1,
+            },
+        ];
+
         let peer_faults = [
             ValidateContextError::NonSequentialBlock {
                 candidate_height: height,
@@ -1081,25 +1122,6 @@ mod tests {
                 tx_index_in_block: 1,
                 transaction_hash,
             },
-            ValidateContextError::CalculateRemainingTransactionValue {
-                amount_error,
-                height,
-                tx_index_in_block: 1,
-                transaction_hash,
-            },
-            ValidateContextError::CalculateTransactionValueBalances {
-                value_balance_error: value_balance_error.clone(),
-                height,
-                tx_index_in_block: 1,
-                transaction_hash,
-            },
-            ValidateContextError::CalculateBlockChainValueChange {
-                value_balance_error: value_balance_error.clone(),
-                height,
-                block_hash: block::Hash([3; 32]),
-                transaction_count: 2,
-                spent_utxo_count: 1,
-            },
             ValidateContextError::AddValuePool {
                 value_balance_error,
                 chain_value_pools: Box::new(ValueBalance::<NonNegative>::zero()),
@@ -1141,6 +1163,16 @@ mod tests {
                 commit_error.misbehavior_score(),
                 100,
                 "direct contextual consensus failure must be scored: {commit_error:?}"
+            );
+        }
+
+        for error in arithmetic_faults {
+            let commit_error = CommitBlockError::ValidateContextError(Box::new(error));
+            assert_eq!(
+                commit_error.misbehavior_score(),
+                0,
+                "value-summation arithmetic failure must not be attributed to a peer: \
+                 {commit_error:?}"
             );
         }
 

--- a/docs/changelog/unreleased/497.md
+++ b/docs/changelog/unreleased/497.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Prevent mined-block broadcasts from waiting for peers that disconnected while unavailable
+  ([#497](https://github.com/zakura-core/zakura/pull/497)).


### PR DESCRIPTION
## Motivation

`PeerSet::broadcast_all` snapshots peers that are unready when a mined-block advertisement is sent. If one of those peers disconnects before becoming ready, its address disappears from the live peer maps but remains in `queued_broadcast_all`. The retained sender prevents the broadcast response channel from closing, so the response waits until its outer timeout instead of completing.

The bounded queued-future channel had a second liveness edge: after three readiness waves, `try_reserve()` could report a full channel without registering a wakeup for newly available capacity. Canceled response futures also left closed senders queued because reservation failures were treated as temporary backpressure.

Three value-summation arithmetic errors were also assigned a peer-misbehavior score even though they can be produced by local bookkeeping faults. That could ban an honest block supplier for a node-local failure.

## Solution

- Prune banned and disconnected addresses from queued broadcasts using the current ready and unready peer maps.
- Run queued-broadcast cleanup before the no-ready-peers early return.
- Drop queued work when its response receiver has closed.
- Avoid producing empty delivery futures while every remaining peer is still unready.
- Use an unbounded future handoff whose total contents are bounded by the original peer snapshot, avoiding unwakeable channel-capacity stalls.
- Add regression coverage that local header-root frontier faults retain a zero peer-misbehavior score.
- Keep residual value-summation arithmetic faults unscored while preserving scores for block-proven consensus violations.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `npx --yes markdownlint-cli docs/changelog/unreleased/497.md --config .trunk/configs/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `cargo test -p zakura-network broadcast_all_queued --lib --locked` (5 passed)
- `cargo test -p zakura-network --lib --locked` (1,173 passed, 4 ignored)
- `cargo test -p zakura-state commit_block_error_misbehavior_scores --locked` (1 passed)
- `cargo test -p zakura-state --lib --locked` (462 passed, 4 ignored)
- `cargo test -p zakura-consensus --lib transaction::tests::v4_and_v5_with_sapling_spends --locked -- --exact` (1 passed)
- `cargo clippy --workspace --all-targets --features default-release-binaries -- -D warnings`
- `cargo check --locked --all-features --all-targets`

The regressions cover an only peer disconnecting while unready, caller cancellation, four readiness waves without polling the response receiver, and both local-state misbehavior classifications. Existing delivery tests cover both ready and originally-unready peers, including keeping queued response futures alive until the connection consumes each request.

The full local consensus test binary intermittently cancels `v4_and_v5_with_sapling_spends` when run concurrently with the other tests; the test passes when isolated. The unrelated `inbound_pruned_block_is_not_advertised_and_getdata_logs_error` log-capture assertion also fails locally, including when isolated. GitHub checks are the authoritative clean-environment result for those broader suites.

## Changelog

Added `docs/changelog/unreleased/497.md` under `Fixed`.
