### PR TITLE
fix(state): classify frontier errors as local

### DIFF
--- a/changelog-unreleased/499.md
+++ b/changelog-unreleased/499.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+Internal error-classification fix only: header-root authentication frontier
+failures are local state errors and do not change operator-visible behavior.

--- a/zakura-state/src/error.rs
+++ b/zakura-state/src/error.rs
@@ -918,6 +918,7 @@ impl ValidateContextError {
             | ValidateContextError::UnknownIronwoodAnchor { .. } => 100,
 
             ValidateContextError::MissingSproutTipTree(_)
+            | ValidateContextError::HeaderRootAuthFrontier { .. }
             | ValidateContextError::BlockPreviouslyInvalidated { .. }
             | ValidateContextError::NotReadyToBeCommitted
             | ValidateContextError::InvalidAncestorBlock(_)
@@ -1159,6 +1160,13 @@ mod tests {
                 finalized_tip_height: height,
             }));
         assert_eq!(stale_fork_error.misbehavior_score(), 0);
+
+        let local_frontier_error = CommitBlockError::ValidateContextError(Box::new(
+            ValidateContextError::HeaderRootAuthFrontier {
+                reason: "test frontier failure".to_string(),
+            },
+        ));
+        assert_eq!(local_frontier_error.misbehavior_score(), 0);
 
         let dup_err = CommitBlockError::Duplicate {
             hash_or_height: None,


### PR DESCRIPTION
## Motivation

The merged release-preparation workflow dry run failed while compiling `zakura-state` because `ValidateContextError::HeaderRootAuthFrontier` was missing from the exhaustive peer-misbehavior scoring match. This local state failure must not be attributed to a peer.

## Solution

Classify `HeaderRootAuthFrontier` with the zero-score local/transient errors and add regression coverage asserting that classification.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `markdownlint changelog-unreleased/499.md --config .trunk/configs/.markdownlint.yaml`
- The targeted `zakura-state` test was attempted locally, but the RocksDB build requires a locally unavailable `libclang.dylib`; draft CI provides compilation and test coverage.
- Reproduced by the [Prepare release PR dry run](https://github.com/zakura-core/zakura/actions/runs/30680027581), which reaches the exact omitted match arm.

## Changelog

`changelog-unreleased/499.md` records this as an internal-only fix.

### Specifications & References

- Unblocks the first post-merge dry-run test of #418.

### Follow-up Work

- Merge this fix, then rerun the release-preparation workflow with `v1.0.6-rc0`, base `v1.0.5`, and `dry_run: true`.