### PR TITLE
fix(deploy): bound broadcast gateway request lifetimes and concurrency

### DIFF
--- a/deploy/gateway/README.md
+++ b/deploy/gateway/README.md
@@ -33,6 +33,8 @@ Submit-only JSON-RPC reverse proxy for Vizor and other clients that need
 | Redirects | none (HTTP returns `400 HTTPS required`) |
 | Body logging | never |
 | Rate limit | 30 req/min/client IP |
+| Concurrency | 64 in-flight requests total, 8 per client IP |
+| Read timeouts | headers 10 s, body 30 s (enforced by both Caddy and the gateway) |
 
 ### Mainnet
 

--- a/deploy/gateway/broadcast.py
+++ b/deploy/gateway/broadcast.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Public Zakura JSON-RPC broadcast gateway.
 
-Accepts only `sendrawtransaction`, rate-limits by client IP, and load-balances
+Accepts only `sendrawtransaction`, rate-limits by client IP, caps concurrent
+requests globally and per client, bounds body-read time, and load-balances
 across healthy Zakura backends. Request bodies are never logged.
 
 Only the Python stdlib is used.
@@ -34,6 +35,10 @@ DEFAULT_MAX_BODY_BYTES = 1 * 1024 * 1024
 DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024
 DEFAULT_BACKEND_TIMEOUT = 10.0
 DEFAULT_HEALTH_INTERVAL = 15.0
+DEFAULT_SOCKET_TIMEOUT = 30.0
+DEFAULT_BODY_READ_TIMEOUT = 30.0
+DEFAULT_MAX_INFLIGHT_TOTAL = 64
+DEFAULT_MAX_INFLIGHT_PER_CLIENT = 8
 HEALTH_METHOD = "getblockchaininfo"
 
 LOGGER = logging.getLogger("zakura-broadcast-gateway")
@@ -80,6 +85,49 @@ class RateLimiter:
                 return False
             events.append(now)
             return True
+
+
+class InflightLimiter:
+    """Global and per-client caps on requests currently being served.
+
+    The fixed-window RateLimiter alone cannot stop slow uploads from piling
+    up: a request still blocked reading its body stops counting against the
+    window once the window expires. An in-flight slot is held for the whole
+    request, however slow, so stalled uploads cannot accumulate handler
+    threads across rate windows.
+    """
+
+    def __init__(
+        self,
+        total_limit: int = DEFAULT_MAX_INFLIGHT_TOTAL,
+        client_limit: int = DEFAULT_MAX_INFLIGHT_PER_CLIENT,
+    ):
+        self.total_limit = total_limit
+        self.client_limit = client_limit
+        self.lock = threading.Lock()
+        self.total = 0
+        # Bounded by total_limit entries: every key holds at least one slot.
+        self.per_client: dict[str, int] = {}
+
+    def acquire(self, client: str) -> str | None:
+        """Take a slot; returns None on success or the exhausted scope."""
+        with self.lock:
+            if self.total >= self.total_limit:
+                return "total"
+            if self.per_client.get(client, 0) >= self.client_limit:
+                return "client"
+            self.total += 1
+            self.per_client[client] = self.per_client.get(client, 0) + 1
+            return None
+
+    def release(self, client: str) -> None:
+        with self.lock:
+            self.total = max(0, self.total - 1)
+            remaining = self.per_client.get(client, 0) - 1
+            if remaining > 0:
+                self.per_client[client] = remaining
+            else:
+                self.per_client.pop(client, None)
 
 
 class BackendPool:
@@ -249,8 +297,10 @@ class BackendPool:
 
 GATEWAY: BackendPool | None = None
 RATE_LIMITER = RateLimiter()
+INFLIGHT_LIMITER = InflightLimiter()
 MAX_BODY_BYTES = DEFAULT_MAX_BODY_BYTES
 RATE_WINDOW = DEFAULT_RATE_WINDOW
+BODY_READ_TIMEOUT = DEFAULT_BODY_READ_TIMEOUT
 
 
 def load_backends(path: Path) -> list[Backend]:
@@ -290,6 +340,9 @@ def jsonrpc_error(req_id: Any, code: int, message: str) -> bytes:
 class SubmitHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
     server_version = "zakura-broadcast-gateway/1.0"
+    # Per-recv socket timeout: a peer that stops sending is disconnected
+    # instead of pinning this handler thread forever.
+    timeout = DEFAULT_SOCKET_TIMEOUT
 
     def log_message(self, fmt: str, *args: Any) -> None:
         # Replace BaseHTTPRequestHandler's stderr logger; never include bodies.
@@ -302,7 +355,10 @@ class SubmitHandler(BaseHTTPRequestHandler):
         except ValueError:
             return peer
 
-        forwarded_for = self.headers.get("X-Forwarded-For")
+        # headers is unset when logging a timeout that fired before a
+        # request line was ever parsed on this connection.
+        headers = getattr(self, "headers", None)
+        forwarded_for = headers.get("X-Forwarded-For") if headers is not None else None
         if peer_address.is_loopback and forwarded_for:
             candidate = forwarded_for.rsplit(",", 1)[-1].strip()
             try:
@@ -351,36 +407,111 @@ class SubmitHandler(BaseHTTPRequestHandler):
     def do_HEAD(self) -> None:
         self.do_GET()
 
+    def read_body_with_deadline(self, length: int) -> bytes | None:
+        """Read exactly `length` body bytes within BODY_READ_TIMEOUT seconds.
+
+        Enforces a wall-clock deadline rather than a per-recv timeout, so a
+        client dripping one byte per timeout cannot hold this thread open
+        indefinitely. Raises TimeoutError when the deadline expires; returns
+        None if the client disconnects first. Either way the body was not
+        consumed, so the caller must close the connection.
+        """
+        deadline = time.monotonic() + BODY_READ_TIMEOUT
+        chunks: list[bytes] = []
+        outstanding = length
+        try:
+            while outstanding > 0:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("body read deadline exceeded")
+                self.connection.settimeout(remaining)
+                # read1 issues at most one recv, so the deadline is
+                # re-checked at least once per received chunk.
+                chunk = self.rfile.read1(min(outstanding, 65536))
+                if not chunk:
+                    return None
+                chunks.append(chunk)
+                outstanding -= len(chunk)
+        finally:
+            self.connection.settimeout(self.timeout)
+        return b"".join(chunks)
+
     def do_POST(self) -> None:
         parsed = urllib.parse.urlparse(self.path)
         if parsed.path not in {"", "/"}:
-            return self.send_bytes(404, b"not found\n", "text/plain; charset=utf-8")
+            # The body was not read; close so leftover bytes cannot desync
+            # a reused keep-alive connection.
+            return self.send_bytes(
+                404,
+                b"not found\n",
+                "text/plain; charset=utf-8",
+                {"Connection": "close"},
+            )
 
         client = self.rate_limit_client()
+        exhausted = INFLIGHT_LIMITER.acquire(client)
+        if exhausted == "client":
+            body = jsonrpc_error(None, -32029, "Too many concurrent requests")
+            return self.send_bytes(
+                429,
+                body,
+                "application/json; charset=utf-8",
+                {"Retry-After": "1", "Connection": "close"},
+            )
+        if exhausted is not None:
+            body = jsonrpc_error(None, -32000, "Gateway is at capacity")
+            return self.send_bytes(
+                503,
+                body,
+                "application/json; charset=utf-8",
+                {"Retry-After": "1", "Connection": "close"},
+            )
+        try:
+            self.handle_submit(client)
+        finally:
+            INFLIGHT_LIMITER.release(client)
+
+    def handle_submit(self, client: str) -> None:
         if not RATE_LIMITER.allow(client):
             body = jsonrpc_error(None, -32029, "Request rate limit exceeded")
             return self.send_bytes(
                 429,
                 body,
                 "application/json; charset=utf-8",
-                {"Retry-After": str(int(RATE_WINDOW))},
+                {"Retry-After": str(int(RATE_WINDOW)), "Connection": "close"},
             )
 
         length_header = self.headers.get("Content-Length")
         if length_header is None:
             body = jsonrpc_error(None, -32700, "Content-Length required")
-            return self.send_bytes(411, body, "application/json; charset=utf-8")
+            return self.send_bytes(
+                411, body, "application/json; charset=utf-8", {"Connection": "close"}
+            )
         try:
             length = int(length_header)
         except ValueError:
             body = jsonrpc_error(None, -32700, "Invalid Content-Length")
-            return self.send_bytes(400, body, "application/json; charset=utf-8")
+            return self.send_bytes(
+                400, body, "application/json; charset=utf-8", {"Connection": "close"}
+            )
         if length < 0 or length > MAX_BODY_BYTES:
             body = jsonrpc_error(None, -32600, "Request body too large")
-            return self.send_bytes(413, body, "application/json; charset=utf-8")
+            return self.send_bytes(
+                413, body, "application/json; charset=utf-8", {"Connection": "close"}
+            )
 
         # Read exactly the declared body; do not retain it beyond this request.
-        raw = self.rfile.read(length)
+        try:
+            raw = self.read_body_with_deadline(length)
+        except TimeoutError:
+            body = jsonrpc_error(None, -32000, "Timed out reading request body")
+            return self.send_bytes(
+                408, body, "application/json; charset=utf-8", {"Connection": "close"}
+            )
+        if raw is None:
+            # Client disconnected mid-upload; there is nobody to answer.
+            self.close_connection = True
+            return
         try:
             payload = json.loads(raw.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
@@ -429,7 +560,8 @@ class SubmitHandler(BaseHTTPRequestHandler):
 
 
 def main() -> None:
-    global GATEWAY, RATE_LIMITER, MAX_BODY_BYTES, RATE_WINDOW
+    global GATEWAY, RATE_LIMITER, INFLIGHT_LIMITER, MAX_BODY_BYTES, RATE_WINDOW
+    global BODY_READ_TIMEOUT
 
     parser = argparse.ArgumentParser(description="Serve a Zakura broadcast-only JSON-RPC gateway.")
     parser.add_argument("--backends", required=True, type=Path, help="path to backends TOML")
@@ -440,6 +572,24 @@ def main() -> None:
     parser.add_argument("--max-body-bytes", default=DEFAULT_MAX_BODY_BYTES, type=int)
     parser.add_argument("--backend-timeout", default=DEFAULT_BACKEND_TIMEOUT, type=float)
     parser.add_argument("--health-interval", default=DEFAULT_HEALTH_INTERVAL, type=float)
+    parser.add_argument(
+        "--body-read-timeout",
+        default=DEFAULT_BODY_READ_TIMEOUT,
+        type=float,
+        help="wall-clock seconds allowed to upload a request body",
+    )
+    parser.add_argument(
+        "--max-inflight",
+        default=DEFAULT_MAX_INFLIGHT_TOTAL,
+        type=int,
+        help="total concurrent requests served at once",
+    )
+    parser.add_argument(
+        "--max-inflight-per-client",
+        default=DEFAULT_MAX_INFLIGHT_PER_CLIENT,
+        type=int,
+        help="concurrent requests served at once per client IP",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -449,7 +599,12 @@ def main() -> None:
 
     MAX_BODY_BYTES = args.max_body_bytes
     RATE_WINDOW = args.rate_window
+    BODY_READ_TIMEOUT = args.body_read_timeout
     RATE_LIMITER = RateLimiter(limit=args.rate_limit, window=args.rate_window)
+    INFLIGHT_LIMITER = InflightLimiter(
+        total_limit=args.max_inflight,
+        client_limit=args.max_inflight_per_client,
+    )
     backends = load_backends(args.backends)
     GATEWAY = BackendPool(
         backends,
@@ -460,12 +615,15 @@ def main() -> None:
 
     server = ThreadingHTTPServer((args.host, args.port), SubmitHandler)
     LOGGER.info(
-        "listening on http://%s:%s backends=%s rate=%s/%ss",
+        "listening on http://%s:%s backends=%s rate=%s/%ss inflight=%s/%s body_timeout=%ss",
         args.host,
         args.port,
         len(backends),
         args.rate_limit,
         args.rate_window,
+        args.max_inflight,
+        args.max_inflight_per_client,
+        args.body_read_timeout,
     )
     try:
         server.serve_forever()

--- a/deploy/gateway/mainnet/Caddyfile
+++ b/deploy/gateway/mainnet/Caddyfile
@@ -2,6 +2,17 @@
 # Source: deploy/gateway/mainnet/Caddyfile
 # Installs via zakura-mainnet-deploy.yml; do not hand-edit on the host.
 
+{
+	servers {
+		# Caddy defaults to no read timeouts; bound them so a client that
+		# stalls its headers or body cannot hold connections open forever.
+		timeouts {
+			read_header 10s
+			read_body 30s
+		}
+	}
+}
+
 status.mainnet.zakura.valargroup.dev {
 	reverse_proxy 127.0.0.1:8090
 }

--- a/deploy/gateway/test_broadcast.py
+++ b/deploy/gateway/test_broadcast.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import socket
 import sys
 import threading
+import time
 import unittest
 import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import Any, Callable
 
 
 SCRIPT_PATH = Path(__file__).with_name("broadcast.py")
@@ -91,6 +93,25 @@ class RateLimiterTest(unittest.TestCase):
         self.assertTrue(limiter.allow("2.2.2.2", now=100.2))
 
 
+class InflightLimiterTest(unittest.TestCase):
+    def test_total_and_client_caps(self) -> None:
+        limiter = gateway.InflightLimiter(total_limit=3, client_limit=2)
+        self.assertIsNone(limiter.acquire("a"))
+        self.assertIsNone(limiter.acquire("a"))
+        self.assertEqual(limiter.acquire("a"), "client")
+        self.assertIsNone(limiter.acquire("b"))
+        self.assertEqual(limiter.acquire("c"), "total")
+        limiter.release("b")
+        self.assertIsNone(limiter.acquire("c"))
+
+    def test_release_clears_client_state(self) -> None:
+        limiter = gateway.InflightLimiter(total_limit=2, client_limit=1)
+        self.assertIsNone(limiter.acquire("a"))
+        limiter.release("a")
+        self.assertEqual(limiter.per_client, {})
+        self.assertEqual(limiter.total, 0)
+
+
 class BackendPoolTest(unittest.TestCase):
     def test_fails_over_from_unreachable_backend(self) -> None:
         good_payload = {
@@ -164,6 +185,8 @@ class HandlerTest(unittest.TestCase):
         pool.refresh_health()
         gateway.GATEWAY = pool
         gateway.RATE_LIMITER = gateway.RateLimiter(limit=100, window=60.0)
+        gateway.INFLIGHT_LIMITER = gateway.InflightLimiter()
+        gateway.BODY_READ_TIMEOUT = gateway.DEFAULT_BODY_READ_TIMEOUT
         gateway.MAX_BODY_BYTES = 1024
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), gateway.SubmitHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
@@ -218,6 +241,169 @@ class HandlerTest(unittest.TestCase):
         with urllib.request.urlopen(self.base + "/healthz", timeout=3) as resp:
             self.assertEqual(resp.status, 200)
             self.assertEqual(resp.read(), b"ok\n")
+
+
+def wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+class SlowBodyTest(unittest.TestCase):
+    """Slow and incomplete uploads: in-flight caps and body-read deadlines."""
+
+    def setUp(self) -> None:
+        health_ok = {
+            "jsonrpc": "2.0",
+            "id": "health",
+            "result": {"blocks": 1},
+        }
+        submit_ok = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": "ab" * 32,
+        }
+        self.backend, backend_url = start_fake_backend(
+            {
+                "getblockchaininfo": (200, health_ok),
+                "sendrawtransaction": (200, submit_ok),
+            }
+        )
+        pool = gateway.BackendPool(
+            [gateway.Backend("local", backend_url)],
+            timeout=2.0,
+            health_interval=60.0,
+        )
+        pool.refresh_health()
+        gateway.GATEWAY = pool
+        gateway.RATE_LIMITER = gateway.RateLimiter(limit=100, window=60.0)
+        gateway.INFLIGHT_LIMITER = gateway.InflightLimiter(total_limit=8, client_limit=2)
+        gateway.BODY_READ_TIMEOUT = 30.0
+        gateway.MAX_BODY_BYTES = 1024
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), gateway.SubmitHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.host, self.port = self.server.server_address
+        self.sockets: list[socket.socket] = []
+
+    def tearDown(self) -> None:
+        for sock in self.sockets:
+            try:
+                sock.close()
+            except OSError:
+                pass
+        # Closed uploads unblock their handler threads and free their slots.
+        wait_until(lambda: gateway.INFLIGHT_LIMITER.total == 0)
+        self.server.shutdown()
+        self.backend.shutdown()
+        gateway.GATEWAY = None
+        gateway.INFLIGHT_LIMITER = gateway.InflightLimiter()
+        gateway.BODY_READ_TIMEOUT = gateway.DEFAULT_BODY_READ_TIMEOUT
+
+    def open_incomplete_post(self, forwarded_for: str, length: int = 64) -> socket.socket:
+        """Send headers plus one body byte, then withhold the rest."""
+        sock = socket.create_connection((self.host, self.port), timeout=5)
+        self.sockets.append(sock)
+        request = (
+            "POST / HTTP/1.1\r\n"
+            f"Host: {self.host}\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {length}\r\n"
+            f"X-Forwarded-For: {forwarded_for}\r\n"
+            "\r\n"
+            "{"
+        )
+        sock.sendall(request.encode())
+        return sock
+
+    def read_status(self, sock: socket.socket, timeout: float = 5.0) -> int:
+        sock.settimeout(timeout)
+        data = b""
+        while b"\r\n" not in data:
+            chunk = sock.recv(1024)
+            if not chunk:
+                break
+            data += chunk
+        status_line = data.split(b"\r\n", 1)[0].decode()
+        return int(status_line.split(" ")[1])
+
+    def test_rate_window_expiry_does_not_admit_more_slow_uploads(self) -> None:
+        # Regression for the slow-body DoS: stalled uploads stop counting
+        # against the fixed rate window once it expires, so only the
+        # in-flight cap prevents one client from accumulating blocked
+        # handler threads across windows.
+        gateway.RATE_LIMITER = gateway.RateLimiter(limit=2, window=0.2)
+        self.open_incomplete_post("9.9.9.9")
+        self.open_incomplete_post("9.9.9.9")
+        self.assertTrue(wait_until(lambda: gateway.INFLIGHT_LIMITER.total == 2))
+        # Let the rate window expire while both uploads stay blocked; the
+        # limiter has forgotten them, so only the in-flight cap now stands
+        # between this client and a third blocked body read.
+        time.sleep(0.4)
+        third = self.open_incomplete_post("9.9.9.9")
+        self.assertEqual(self.read_status(third), 429)
+        self.assertEqual(gateway.INFLIGHT_LIMITER.total, 2)
+        # Other clients are unaffected by the stalled client's slots.
+        self.open_incomplete_post("8.8.8.8")
+        self.assertTrue(wait_until(lambda: gateway.INFLIGHT_LIMITER.total == 3))
+
+    def test_global_inflight_cap_rejects_when_saturated(self) -> None:
+        gateway.INFLIGHT_LIMITER = gateway.InflightLimiter(total_limit=2, client_limit=2)
+        self.open_incomplete_post("1.1.1.1")
+        self.open_incomplete_post("2.2.2.2")
+        self.assertTrue(wait_until(lambda: gateway.INFLIGHT_LIMITER.total == 2))
+        rejected = self.open_incomplete_post("3.3.3.3")
+        self.assertEqual(self.read_status(rejected), 503)
+        self.assertEqual(gateway.INFLIGHT_LIMITER.total, 2)
+
+    def test_stalled_body_read_returns_408_and_frees_slot(self) -> None:
+        gateway.BODY_READ_TIMEOUT = 0.4
+        sock = self.open_incomplete_post("7.7.7.7")
+        self.assertEqual(self.read_status(sock), 408)
+        self.assertTrue(wait_until(lambda: gateway.INFLIGHT_LIMITER.total == 0))
+
+    def test_dripped_body_hits_wall_clock_deadline(self) -> None:
+        # Feeding bytes faster than any per-recv timeout must not extend
+        # the overall body deadline.
+        gateway.BODY_READ_TIMEOUT = 0.5
+        sock = self.open_incomplete_post("6.6.6.6")
+
+        def drip() -> None:
+            try:
+                for _ in range(20):
+                    sock.sendall(b"x")
+                    time.sleep(0.1)
+            except OSError:
+                pass
+
+        threading.Thread(target=drip, daemon=True).start()
+        self.assertEqual(self.read_status(sock), 408)
+
+    def test_complete_upload_succeeds_and_releases_slot(self) -> None:
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "sendrawtransaction",
+                "params": ["00"],
+            }
+        ).encode()
+        sock = socket.create_connection((self.host, self.port), timeout=5)
+        self.sockets.append(sock)
+        request = (
+            "POST / HTTP/1.1\r\n"
+            f"Host: {self.host}\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {len(payload)}\r\n"
+            "X-Forwarded-For: 4.4.4.4\r\n"
+            "\r\n"
+        ).encode() + payload
+        sock.sendall(request)
+        self.assertEqual(self.read_status(sock), 200)
+        self.assertTrue(wait_until(lambda: gateway.INFLIGHT_LIMITER.total == 0))
 
 
 if __name__ == "__main__":

--- a/deploy/gateway/testnet/Caddyfile
+++ b/deploy/gateway/testnet/Caddyfile
@@ -2,6 +2,17 @@
 # Source: deploy/gateway/testnet/Caddyfile
 # Installs via zakura-testnet-deploy.yml; do not hand-edit on the host.
 
+{
+	servers {
+		# Caddy defaults to no read timeouts; bound them so a client that
+		# stalls its headers or body cannot hold connections open forever.
+		timeouts {
+			read_header 10s
+			read_body 30s
+		}
+	}
+}
+
 ironwood.zakura.valargroup.dev {
 	reverse_proxy 127.0.0.1:8091
 }


### PR DESCRIPTION
## Motivation

The broadcast gateway reads request bodies with no time bound: a request that
declares a `Content-Length` and then stalls its upload blocks its handler
thread in `rfile.read()` indefinitely. The fixed-window rate limiter only
records request timestamps, so a stalled request stops counting against its
client once the window expires, and `ThreadingHTTPServer` is
thread-per-request, so slow uploads can accumulate blocked handler threads,
file descriptors, and proxy connections without bound. The checked-in
Caddyfiles also set no `read_header`/`read_body` timeouts, which Caddy
defaults to unlimited.

## Solution

Bound every phase of a request, at both layers:

- Caddy edge (both gateway Caddyfiles): global `read_header 10s` /
  `read_body 30s` server timeouts.
- `broadcast.py`:
  - a per-recv socket timeout (30 s) on handler connections, so peers that go
    silent are disconnected instead of pinning a thread;
  - a wall-clock body-read deadline (`--body-read-timeout`, default 30 s)
    enforced with `read1()` chunks so trickling bytes cannot extend it;
    expiry returns 408 and closes the connection;
  - a new `InflightLimiter` capping concurrent requests globally
    (`--max-inflight`, default 64) and per client IP
    (`--max-inflight-per-client`, default 8), separate from the fixed-window
    rate limiter: a slot is held for the whole request, however slow, so
    stalled uploads keep counting across rate windows (429/503 with
    `Retry-After` when exhausted);
  - responses sent before the body is consumed now include
    `Connection: close`, so unread body bytes cannot desync a reused
    keep-alive connection (pre-existing issue on the 429 path).

## Testing

- `python3 deploy/gateway/test_broadcast.py` — 13 tests pass (6 pre-existing,
  7 new).
- The main regression test exercises the root cause directly: two stalled
  uploads hold their in-flight slots, the rate window expires, and a third
  stalled upload from the same client is rejected immediately instead of
  acquiring another blocked body read, while a different client is
  unaffected.
- Additional tests cover global-cap saturation (503), a stalled body
  returning 408 and freeing its slot, a trickled body hitting the wall-clock
  deadline despite steady per-recv progress, completed uploads releasing
  their slots, and `InflightLimiter` unit behavior.
- Markdown lint (`markdownlint-cli2` with the repo config) passes on the
  changed README.
- Not run locally: `caddy validate` (no caddy binary on this machine); the
  global-options block matches the documented Caddyfile syntax.

## Changelog

No Rust or `Cargo.toml` changes; deploy-only, so no changelog fragment is
required.

### Follow-up Work

- Overlaps textually with #495, which also modifies
  `deploy/gateway/broadcast.py` and its tests; whichever lands second needs a
  rebase. #495 also raises the backend timeout to 100 s, which lengthens how
  long legitimate in-flight slots are held — worth rechecking the cap sizing
  at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
