### PR TITLE
fix(network): stop dialing and caching inbound peer addresses

### DIFF
--- a/crates/zakura-network/src/address_book.rs
+++ b/crates/zakura-network/src/address_book.rs
@@ -601,6 +601,21 @@ impl AddressBook {
             return false;
         };
 
+        // # Correctness
+        //
+        // This cache exists to space out our own outbound connections to one IP, and
+        // `Config::max_connections_per_ip` is only enforced when we accept inbound
+        // connections, never when we dial. An inbound peer refreshes its entry with
+        // every message it sends, so it would hold its IP's slot for as long as it
+        // stays connected, and the address we would refuse to dial is a different
+        // address on that IP: the peer's own listener, which is the address we want.
+        // Recording inbound entries here stops us dialing exactly the peers that are
+        // most active on the network, and the more inbound connections we accept, the
+        // fewer peers we are able to reach.
+        if updated.is_inbound() {
+            return false;
+        }
+
         if let Some(previous) = most_recent_by_ip.get(&updated.addr.ip()) {
             updated.last_connection_state == PeerAddrState::Responded
                 && updated.last_response() > previous.last_response()
@@ -869,6 +884,12 @@ impl AddressBook {
             // If there's no entry for this IP, any connection is allowed
             return true;
         };
+        if same_ip_peer.is_inbound() {
+            // An address can become inbound after it is recorded here, because
+            // `is_inbound` is sticky. Ignore it once it does, for the reasons in
+            // `should_update_most_recent_by_ip`.
+            return true;
+        }
         !same_ip_peer.has_connection_recently_responded(chrono_now)
     }
 

--- a/crates/zakura-network/src/address_book.rs
+++ b/crates/zakura-network/src/address_book.rs
@@ -553,6 +553,14 @@ impl AddressBook {
             // This prevents Zebra from caching nodes that are likely unreachable,
             // which improves startup time and reliability.
             .filter(|addr| addr.is_active_for_gossip(now))
+            // # Security
+            //
+            // Remove addresses learned from inbound connections, whose ports are
+            // the peer's ephemeral source port rather than its listener. They
+            // are connected right now, so they rank as maximally active and
+            // would otherwise dominate the cache, leaving a restarted node with
+            // mostly undialable candidates.
+            .filter(|addr| !addr.is_inbound())
             .cloned()
             .collect()
     }

--- a/crates/zakura-network/src/address_book.rs
+++ b/crates/zakura-network/src/address_book.rs
@@ -561,6 +561,17 @@ impl AddressBook {
             // would otherwise dominate the cache, leaving a restarted node with
             // mostly undialable candidates.
             .filter(|addr| !addr.is_inbound())
+            // # Security
+            //
+            // Only cache addresses that have answered one of our own connections.
+            // The cache file stores bare socket addresses, so nothing else in this
+            // entry survives a restart: an address we cache on someone else's word
+            // is re-read as an ordinary initial peer, with no record of where it
+            // came from. Requiring a response of our own means an undialable
+            // address can never enter the cache, however it reached the address
+            // book — gossip, a hand-edited cache file, or an earlier cache written
+            // by a release without this filter.
+            .filter(|addr| addr.has_ever_responded())
             .cloned()
             .collect()
     }

--- a/crates/zakura-network/src/address_book/tests/vectors.rs
+++ b/crates/zakura-network/src/address_book/tests/vectors.rs
@@ -11,7 +11,10 @@ use zakura_chain::{
 };
 
 use crate::{
-    constants::{DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK, MAX_PEER_MISBEHAVIOR_SCORE},
+    constants::{
+        DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK, MAX_PEER_MISBEHAVIOR_SCORE,
+        MIN_PEER_RECONNECTION_DELAY,
+    },
     meta_addr::{MetaAddr, MetaAddrChange},
     protocol::external::types::PeerServices,
     AddressBook,
@@ -300,4 +303,59 @@ fn test_reconnection_peers_skips_recently_updated_ip<
     } else {
         assert_ne!(next_reconnection_peer, None,);
     }
+}
+
+/// Peers learned from inbound connections are neither dialed nor cached.
+///
+/// Their port is the peer's ephemeral source port rather than a listener, so
+/// dialing them wastes the crawler's connection budget. They are also connected
+/// right now, which makes them rank as maximally active — without the filter
+/// they crowd dialable peers out of the disk cache and a restarted node comes
+/// back with mostly undialable candidates.
+#[test]
+fn inbound_peers_are_not_reconnection_or_cache_candidates() {
+    let inbound_addr = "127.0.0.1:54321".parse().unwrap();
+    let outbound_addr = "127.0.0.2:8233".parse().unwrap();
+
+    let instant_now = Instant::now();
+    let chrono_now = Utc::now();
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+
+    let inbound_peer = MetaAddr::new_connected(inbound_addr, &PeerServices::NODE_NETWORK, true)
+        .into_new_meta_addr(instant_now, local_now);
+    let outbound_peer = MetaAddr::new_connected(outbound_addr, &PeerServices::NODE_NETWORK, false)
+        .into_new_meta_addr(instant_now, local_now);
+
+    let address_book = AddressBook::new_with_addrs(
+        "0.0.0.0:0".parse().unwrap(),
+        &Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
+        MAX_ADDRS_IN_ADDRESS_BOOK,
+        Span::current(),
+        vec![inbound_peer, outbound_peer],
+    );
+
+    // Both peers are active for gossip, so activity is not what separates them.
+    assert!(inbound_peer.is_active_for_gossip(chrono_now));
+    assert!(outbound_peer.is_active_for_gossip(chrono_now));
+
+    // Look at the book after the reconnection delay, so neither peer is held
+    // back by `was_recently_updated`.
+    let later_instant = instant_now + MIN_PEER_RECONNECTION_DELAY * 2;
+    let later_chrono = chrono_now
+        + chrono::Duration::from_std(MIN_PEER_RECONNECTION_DELAY * 2)
+            .expect("test reconnection delay fits in chrono");
+
+    let reconnection_addrs: Vec<_> = address_book
+        .reconnection_peers(later_instant, later_chrono)
+        .map(|peer| peer.addr())
+        .collect();
+    assert_eq!(reconnection_addrs, vec![outbound_addr]);
+
+    let cacheable_addrs: Vec<_> = address_book
+        .cacheable(chrono_now)
+        .into_iter()
+        .map(|peer| peer.addr())
+        .collect();
+    assert_eq!(cacheable_addrs, vec![outbound_addr]);
 }

--- a/crates/zakura-network/src/address_book/tests/vectors.rs
+++ b/crates/zakura-network/src/address_book/tests/vectors.rs
@@ -360,6 +360,65 @@ fn inbound_peers_are_not_reconnection_or_cache_candidates() {
     assert_eq!(cacheable_addrs, vec![outbound_addr]);
 }
 
+/// An inbound connection does not stop us dialing the same peer's listener.
+///
+/// `most_recent_by_ip` spaces out our own outbound connections to one IP, but it does
+/// not record which direction the connection came from. An inbound peer refreshes its
+/// entry with every message it sends, so it holds its IP's slot for as long as it stays
+/// connected — and the address that slot bars us from dialing is a different address on
+/// that IP, the peer's listener. Peers that connect to us are the ones most active on
+/// the network, so this silently removes the best dial candidates, in proportion to how
+/// many inbound connections we accept.
+#[test]
+fn inbound_connections_do_not_block_dialing_the_same_ip() {
+    // The peer's ephemeral source port, and the listener it is really reachable on.
+    let inbound_addr = "127.0.0.1:54321".parse().unwrap();
+    let listener_addr = "127.0.0.1:8233".parse().unwrap();
+    // A peer we dialed ourselves, and another address at that same IP.
+    let outbound_addr = "127.0.0.2:8233".parse().unwrap();
+    let same_ip_as_outbound = "127.0.0.2:8234".parse().unwrap();
+
+    let instant_now = Instant::now();
+    let chrono_now = Utc::now();
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+
+    let inbound_peer = MetaAddr::new_connected(inbound_addr, &PeerServices::NODE_NETWORK, true)
+        .into_new_meta_addr(instant_now, local_now);
+    let outbound_peer = MetaAddr::new_connected(outbound_addr, &PeerServices::NODE_NETWORK, false)
+        .into_new_meta_addr(instant_now, local_now);
+    let gossiped = |addr| {
+        MetaAddr::new_gossiped_meta_addr(addr, PeerServices::NODE_NETWORK, local_now)
+            .new_gossiped_change()
+            .expect("recently gossiped peer creates an address book change")
+            .into_new_meta_addr(instant_now, local_now)
+    };
+
+    let address_book = AddressBook::new_with_addrs(
+        "0.0.0.0:0".parse().unwrap(),
+        &Mainnet,
+        // Only a limit of one enables the per-IP cache under test.
+        DEFAULT_MAX_CONNS_PER_IP,
+        MAX_ADDRS_IN_ADDRESS_BOOK,
+        Span::current(),
+        vec![
+            inbound_peer,
+            gossiped(listener_addr),
+            outbound_peer,
+            gossiped(same_ip_as_outbound),
+        ],
+    );
+
+    let reconnection_addrs: Vec<_> = address_book
+        .reconnection_peers(instant_now, chrono_now)
+        .map(|peer| peer.addr())
+        .collect();
+
+    // The listener is dialable even though its IP holds a live inbound connection,
+    // while the address sharing an IP with a peer we dialed ourselves is still spaced
+    // out, which is what this cache is for.
+    assert_eq!(reconnection_addrs, vec![listener_addr]);
+}
+
 /// Addresses we have never connected to ourselves are not written to the disk cache.
 ///
 /// The cache file stores bare socket addresses, so an entry read back from disk has

--- a/crates/zakura-network/src/address_book/tests/vectors.rs
+++ b/crates/zakura-network/src/address_book/tests/vectors.rs
@@ -359,3 +359,52 @@ fn inbound_peers_are_not_reconnection_or_cache_candidates() {
         .collect();
     assert_eq!(cacheable_addrs, vec![outbound_addr]);
 }
+
+/// Addresses we have never connected to ourselves are not written to the disk cache.
+///
+/// The cache file stores bare socket addresses, so an entry read back from disk has
+/// no record of where it came from: it is re-added as an ordinary initial peer, with
+/// no inbound flag. Caching an address on another peer's word therefore launders it,
+/// and the ephemeral source ports that inbound peers gossip around the network
+/// survive every restart. Requiring a response of our own is the only property that
+/// outlives the round trip through the cache file.
+#[test]
+fn peers_we_have_never_connected_to_are_not_cached() {
+    let gossiped_addr = "127.0.0.1:54321".parse().unwrap();
+    let connected_addr = "127.0.0.2:8233".parse().unwrap();
+
+    let instant_now = Instant::now();
+    let chrono_now = Utc::now();
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+
+    let gossiped_peer =
+        MetaAddr::new_gossiped_meta_addr(gossiped_addr, PeerServices::NODE_NETWORK, local_now)
+            .new_gossiped_change()
+            .expect("recently gossiped peer creates an address book change")
+            .into_new_meta_addr(instant_now, local_now);
+    let connected_peer =
+        MetaAddr::new_connected(connected_addr, &PeerServices::NODE_NETWORK, false)
+            .into_new_meta_addr(instant_now, local_now);
+
+    let address_book = AddressBook::new_with_addrs(
+        "0.0.0.0:0".parse().unwrap(),
+        &Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
+        MAX_ADDRS_IN_ADDRESS_BOOK,
+        Span::current(),
+        vec![gossiped_peer, connected_peer],
+    );
+
+    // The gossiped peer passes every other cache filter: it is not inbound, and its
+    // gossiped last seen time makes it active for gossip.
+    assert!(!gossiped_peer.is_inbound());
+    assert!(gossiped_peer.is_active_for_gossip(chrono_now));
+    assert!(!gossiped_peer.has_ever_responded());
+
+    let cacheable_addrs: Vec<_> = address_book
+        .cacheable(chrono_now)
+        .into_iter()
+        .map(|peer| peer.addr())
+        .collect();
+    assert_eq!(cacheable_addrs, vec![connected_addr]);
+}

--- a/crates/zakura-network/src/config.rs
+++ b/crates/zakura-network/src/config.rs
@@ -33,8 +33,9 @@ use zakura_chain::{
 use crate::{
     constants::{
         DEFAULT_CRAWL_NEW_PEER_INTERVAL, DEFAULT_MAX_CONNS_PER_IP,
-        DEFAULT_PEERSET_INITIAL_TARGET_SIZE, DNS_LOOKUP_TIMEOUT, INBOUND_PEER_LIMIT_MULTIPLIER,
-        MAX_PEER_DISK_CACHE_SIZE, OUTBOUND_PEER_LIMIT_DIVISOR, OUTBOUND_PEER_LIMIT_MULTIPLIER,
+        DEFAULT_PEERSET_INITIAL_TARGET_SIZE, DNS_LOOKUP_TIMEOUT, EPHEMERAL_PORT_FLOOR,
+        INBOUND_PEER_LIMIT_MULTIPLIER, MAX_PEER_DISK_CACHE_SIZE, OUTBOUND_PEER_LIMIT_DIVISOR,
+        OUTBOUND_PEER_LIMIT_MULTIPLIER,
     },
     protocol::external::{canonical_peer_addr, canonical_socket_addr},
     zakura::ZakuraConfig,
@@ -608,7 +609,7 @@ impl Config {
         let peer_list: HashSet<PeerSocketAddr> = peer_list
             .lines()
             .filter_map(|peer| {
-                peer.parse()
+                peer.parse::<PeerSocketAddr>()
                     .map_err(|peer_parse_error| {
                         info!(
                             ?peer_parse_error,
@@ -620,16 +621,40 @@ impl Config {
             })
             .collect();
 
+        // # Security
+        //
+        // Cached addresses become initial peers, which are dialed directly and enter
+        // the address book as if we had chosen them ourselves. The cache file holds
+        // bare socket addresses, so the port is all we know about them, and an entry
+        // in the ephemeral range is the source port of a past inbound connection
+        // rather than a listener we reached. Dropping them here stops a cache written
+        // by an older release — or edited by hand — from refilling the address book
+        // with addresses that can never be connected to.
+        //
+        // Requiring the network's default port instead would be a mistake: about one
+        // in six of a node's outbound peers listens on a non-default port, and those
+        // are peers we have already handshaked with.
+        let parsed_ip_count = peer_list.len();
+        let peer_list: HashSet<PeerSocketAddr> = peer_list
+            .into_iter()
+            .filter(|peer| peer.port() != 0 && peer.port() < EPHEMERAL_PORT_FLOOR)
+            .collect();
+        let skipped_ip_count = parsed_ip_count - peer_list.len();
+
         // This log is needed for user debugging, but it's annoying during tests.
         #[cfg(not(test))]
         info!(
             cached_ip_count = ?peer_list.len(),
+            ?skipped_ip_count,
+            ephemeral_port_floor = ?EPHEMERAL_PORT_FLOOR,
             ?peer_cache_file,
             "loaded cached peer IP addresses"
         );
         #[cfg(test)]
         debug!(
             cached_ip_count = ?peer_list.len(),
+            ?skipped_ip_count,
+            ephemeral_port_floor = ?EPHEMERAL_PORT_FLOOR,
             ?peer_cache_file,
             "loaded cached peer IP addresses"
         );

--- a/crates/zakura-network/src/config/tests/vectors.rs
+++ b/crates/zakura-network/src/config/tests/vectors.rs
@@ -128,6 +128,70 @@ async fn empty_peer_cache_update_preserves_existing_cache() {
     );
 }
 
+/// Cached addresses in the ephemeral port range are dropped when the cache is read,
+/// and listeners on non-default ports are kept.
+///
+/// Releases before this filter cached the ephemeral source ports of inbound peers, and
+/// those addresses are still gossiped by peers running older code. They are re-read as
+/// ordinary initial peers and dialed directly at startup, so a node that restarts on a
+/// polluted cache spends its whole initial peer budget on addresses nothing listens on.
+///
+/// Filtering on the network's default port instead would also discard reachable peers:
+/// about one in six of a mainnet node's outbound peers listens on another port, and
+/// those have already completed a handshake with us.
+#[tokio::test]
+async fn cached_peers_on_ephemeral_ports_are_not_loaded() {
+    let _init_guard = zakura_test::init();
+
+    let cache_dir = tempfile::tempdir().expect("temporary peer cache directory creation failed");
+    let config = Config {
+        cache_dir: CacheDir::custom_path(cache_dir.path()),
+        ..Config::default()
+    };
+    let peer_cache_file = config
+        .cache_dir
+        .peer_cache_file_path(&config.network)
+        .expect("test cache directory enables the peer cache");
+    fs::create_dir_all(
+        peer_cache_file
+            .parent()
+            .expect("peer cache file has a parent directory"),
+    )
+    .expect("peer cache directory should be creatable");
+    // A listener on the network's port, listeners on non-default ports observed on the
+    // mainnet fleet, an unusable port 0, and three ephemeral source ports belonging to
+    // the same inbound peer. Only the ephemeral ones and port 0 may be dropped.
+    fs::write(
+        &peer_cache_file,
+        "127.0.0.1:8233\n\
+         127.0.0.3:8235\n\
+         127.0.0.4:21099\n\
+         127.0.0.5:28233\n\
+         127.0.0.6:0\n\
+         127.0.0.2:34138\n\
+         127.0.0.2:38788\n\
+         127.0.0.2:48150\n",
+    )
+    .expect("pre-seeded peer cache should be writable");
+
+    let cached_peers = config
+        .load_peer_cache()
+        .await
+        .expect("pre-seeded peer cache should load");
+
+    assert_eq!(
+        cached_peers,
+        HashSet::from([
+            "127.0.0.1:8233".parse().expect("valid test peer address"),
+            "127.0.0.3:8235".parse().expect("valid test peer address"),
+            "127.0.0.4:21099".parse().expect("valid test peer address"),
+            "127.0.0.5:28233".parse().expect("valid test peer address"),
+        ]),
+        "the peer cache must drop ephemeral source ports and port 0, and keep every \
+         listener below the ephemeral floor whatever port it uses",
+    );
+}
+
 #[test]
 fn testnet_params_serialization_roundtrip() {
     let _init_guard = zakura_test::init();

--- a/crates/zakura-network/src/constants.rs
+++ b/crates/zakura-network/src/constants.rs
@@ -189,6 +189,25 @@ pub const PEER_DISK_CACHE_UPDATE_INTERVAL: Duration = Duration::from_secs(5 * 60
 /// It is a tradeoff between fingerprinting attacks, DNS pollution risk, and cache pollution risk.
 pub const MAX_PEER_DISK_CACHE_SIZE: usize = 300;
 
+/// The lowest port number an operating system assigns as an ephemeral source port.
+///
+/// A peer that connects to us is recorded at the remote end of *its* socket, so its
+/// port is the source port its kernel picked, not a listener we can dial. The peer
+/// disk cache stores bare socket addresses, so the port is the only evidence a cached
+/// entry carries about which of the two it is.
+///
+/// Linux's default `net.ipv4.ip_local_port_range` is `32768 60999`, and other
+/// platforms allocate from `49152-65535`, so this is the inclusive lower bound across
+/// both. It separates every address observed on the mainnet fleet: legitimate peer
+/// listeners appeared on 7952, 8131, 8231, 8233, 8234, 8235, 8236, 8243, 8433, 9058,
+/// 9222, 9533, 18233, 21099, and 28233, while every inbound source port recorded as a
+/// cache entry was above this floor.
+///
+/// This is deliberately weaker than requiring the network's default port: roughly one
+/// in six of a node's outbound peers listens on a non-default port, and those are
+/// reachable peers we want to keep.
+pub const EPHEMERAL_PORT_FLOOR: u16 = 32768;
+
 /// The maximum duration since a peer was last seen to consider it reachable.
 ///
 /// This is used to prevent Zebra from gossiping addresses that are likely unreachable. Peers that

--- a/crates/zakura-network/src/meta_addr.rs
+++ b/crates/zakura-network/src/meta_addr.rs
@@ -508,6 +508,14 @@ impl MetaAddr {
         self.is_inbound
     }
 
+    /// Returns whether we have ever received a message from a peer at this address.
+    ///
+    /// Unlike [`MetaAddr::last_seen`], this ignores the last seen time gossiped by
+    /// other peers, so it is only true for addresses we have connected to ourselves.
+    pub fn has_ever_responded(&self) -> bool {
+        self.last_response.is_some()
+    }
+
     /// Returns the round-trip time (RTT) for this peer, if available.
     pub fn rtt(&self) -> Option<Duration> {
         self.rtt

--- a/crates/zakura-network/src/meta_addr.rs
+++ b/crates/zakura-network/src/meta_addr.rs
@@ -652,13 +652,23 @@ impl MetaAddr {
     }
 
     /// Is this address ready for a new outbound connection attempt?
+    ///
+    /// # Security
+    ///
+    /// Addresses learned from inbound connections are excluded. An inbound
+    /// peer's address is the remote end of *its* connection to us, so its port
+    /// is an ephemeral source port rather than a listener we can dial. Dialing
+    /// those addresses spends the crawler's connection budget on attempts that
+    /// can never succeed, and leaves the address book full of permanently
+    /// failing entries that crowd out reachable candidates.
     pub fn is_ready_for_connection_attempt(
         &self,
         instant_now: Instant,
         chrono_now: chrono::DateTime<Utc>,
         network: &Network,
     ) -> bool {
-        self.last_known_info_is_valid_for_outbound(network)
+        !self.is_inbound
+            && self.last_known_info_is_valid_for_outbound(network)
             && !self.was_recently_updated(instant_now, chrono_now)
             && self.is_probably_reachable(chrono_now)
     }

--- a/crates/zakura-network/src/meta_addr/tests/vectors.rs
+++ b/crates/zakura-network/src/meta_addr/tests/vectors.rs
@@ -13,7 +13,9 @@ use zakura_chain::{
 };
 
 use crate::{
-    constants::{CONCURRENT_ADDRESS_CHANGE_PERIOD, MAX_PEER_ACTIVE_FOR_GOSSIP},
+    constants::{
+        CONCURRENT_ADDRESS_CHANGE_PERIOD, MAX_PEER_ACTIVE_FOR_GOSSIP, MIN_PEER_RECONNECTION_DELAY,
+    },
     meta_addr::MetaAddrChange,
     protocol::{external::canonical_peer_addr, types::PeerServices},
     PeerSocketAddr,
@@ -568,4 +570,84 @@ fn new_misbehavior_canonicalizes_ipv4_mapped_addr() {
 
     assert_eq!(updated.addr(), canonical_addr);
     assert_eq!(updated.misbehavior(), 100);
+}
+
+/// An address learned from an inbound connection is never a dial candidate.
+///
+/// The port on such an address is the peer's ephemeral source port, so dialing
+/// it can only fail. Everything else about the two peers in this test is
+/// identical, so the inbound flag is the only thing that can separate them.
+#[test]
+fn inbound_addresses_are_not_ready_for_connection_attempts() {
+    let _init_guard = zakura_test::init();
+
+    let instant_now = Instant::now();
+    let chrono_now = Utc::now();
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+
+    let address = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
+
+    // Look at the peers well after the reconnection delay has elapsed, so
+    // `was_recently_updated` cannot be what holds either of them back.
+    let elapsed = MIN_PEER_RECONNECTION_DELAY * 2;
+    let later_instant = instant_now + elapsed;
+    let later_chrono = chrono_now
+        + chrono::Duration::from_std(elapsed).expect("test reconnection delay fits in chrono");
+
+    for is_inbound in [false, true] {
+        let peer = MetaAddr::new_connected(address, &PeerServices::NODE_NETWORK, is_inbound)
+            .into_new_meta_addr(instant_now, local_now);
+
+        assert_eq!(peer.is_inbound(), is_inbound);
+        assert_eq!(
+            peer.is_ready_for_connection_attempt(later_instant, later_chrono, &Mainnet),
+            !is_inbound,
+            "unexpected dial readiness for a peer with is_inbound: {is_inbound}",
+        );
+    }
+}
+
+/// The inbound flag is sticky, so a later change cannot make an address that was
+/// once inbound dialable again.
+///
+/// This is deliberate. The alternative — letting a subsequent outbound-shaped
+/// change clear the flag — would let an ephemeral source port back into the dial
+/// candidate set. The cost is that a peer which dialed us from its own listener
+/// port is only reachable through a separate address book entry, learned from
+/// gossip or a DNS seeder.
+#[test]
+fn inbound_flag_keeps_an_address_out_of_dial_candidates() {
+    let _init_guard = zakura_test::init();
+
+    let instant_now = Instant::now();
+    let chrono_now = Utc::now();
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+
+    let address = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
+
+    let inbound_peer = MetaAddr::new_connected(address, &PeerServices::NODE_NETWORK, true)
+        .into_new_meta_addr(instant_now, local_now);
+
+    // A response arriving over the same inbound connection is the change most
+    // likely to look like fresh evidence that the address is good. Apply it
+    // well after the connection, so it is not treated as a concurrent change.
+    let response_delay = MIN_PEER_RECONNECTION_DELAY;
+    let response_chrono =
+        chrono_now + chrono::Duration::from_std(response_delay).expect("test delay fits in chrono");
+    let updated = MetaAddr::new_responded(address, None)
+        .apply_to_meta_addr(inbound_peer, instant_now + response_delay, response_chrono)
+        .expect("a later response applies to a connected peer");
+
+    // Look at the peer after the reconnection delay has elapsed since the
+    // response, so `was_recently_updated` cannot be what holds it back.
+    let elapsed = response_delay * 3;
+    let later_chrono = chrono_now
+        + chrono::Duration::from_std(elapsed).expect("test reconnection delay fits in chrono");
+
+    assert!(updated.is_inbound());
+    assert!(!updated.is_ready_for_connection_attempt(
+        instant_now + elapsed,
+        later_chrono,
+        &Mainnet
+    ));
 }

--- a/crates/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/crates/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -510,10 +510,9 @@ async fn written_peer_cache_is_automatically_read_on_startup() {
 /// Adds a recent gossiped peer that is eligible for the disk cache.
 fn add_cacheable_peer(address_book: &Arc<std::sync::Mutex<AddressBook>>) -> PeerSocketAddr {
     let peer = "127.0.0.1:8233".parse().expect("valid test peer address");
-    let change =
-        MetaAddr::new_gossiped_meta_addr(peer, PeerServices::NODE_NETWORK, DateTime32::now())
-            .new_gossiped_change()
-            .expect("recent gossiped peer creates an address book change");
+    // Only peers that have answered one of our own outbound connections are cached,
+    // so a gossiped address is not enough to make this peer cacheable.
+    let change = MetaAddr::new_connected(peer, &PeerServices::NODE_NETWORK, false);
 
     address_book
         .lock()

--- a/docs/changelog/unreleased/507.md
+++ b/docs/changelog/unreleased/507.md
@@ -1,0 +1,8 @@
+## Fixed
+
+- Stopped dialing and caching the addresses of inbound peers. An inbound peer's
+  address book entry records its ephemeral source port rather than a listener,
+  so those addresses could never be connected to. They made up 79% of the peer
+  disk cache on an affected node, holding the handshake success rate near 20%
+  and crowding reachable peers out of the cache on restart
+  ([#507](https://github.com/zakura-core/zakura/pull/507)).

--- a/docs/changelog/unreleased/507.md
+++ b/docs/changelog/unreleased/507.md
@@ -6,3 +6,12 @@
   disk cache on an affected node, holding the handshake success rate near 20%
   and crowding reachable peers out of the cache on restart
   ([#507](https://github.com/zakura-core/zakura/pull/507)).
+- Restricted the peer disk cache to addresses that have answered one of our own
+  outbound connections, and dropped cached addresses in the ephemeral port range
+  when the cache is read. The cache file stores bare socket addresses, so an
+  entry read back from disk is indistinguishable from a peer we chose ourselves.
+  Without these checks, undialable addresses that reach the address book by
+  gossip are cached, reloaded as initial peers, dialed directly, and cached
+  again, so they survive every restart. Listeners on non-default ports are kept:
+  about one in six of a node's outbound peers uses one
+  ([#507](https://github.com/zakura-core/zakura/pull/507)).

--- a/docs/changelog/unreleased/507.md
+++ b/docs/changelog/unreleased/507.md
@@ -15,3 +15,12 @@
   again, so they survive every restart. Listeners on non-default ports are kept:
   about one in six of a node's outbound peers uses one
   ([#507](https://github.com/zakura-core/zakura/pull/507)).
+- Stopped inbound connections from blocking outbound connection attempts to the
+  same IP address. The cache that spaces out our own outbound connections per IP
+  did not record the connection's direction, so a peer connecting to us held its
+  IP's entry for as long as it stayed connected, and we would not dial that
+  peer's listener. Peers that connect to us are the most active on the network,
+  so a node lost dial candidates in proportion to the inbound connections it
+  accepted: one mainnet node held 300 inbound connections and 9 outbound, and
+  made no connection attempts at all against a replenishment target of 80
+  ([#507](https://github.com/zakura-core/zakura/pull/507)).


### PR DESCRIPTION
## Motivation

Nodes on the CI fleet hold a fraction of their configured outbound peer set, and
the peer disk cache explains most of it. Of the 206 entries in
`/var/lib/zakura/network/mainnet.peers` on `temp-zakura-sync-test-6`, only
**43 (20.9%) are on port 8233**. The rest look like this:

```text
100.36.20.73:60642
104.199.175.115:34448
104.199.175.115:35822
104.199.175.115:38290
```

One IP with several different high ports is unmistakable: those are the *source*
ports of inbound TCP connections, stored as though they were dialable listen
addresses. That node's lifetime handshake success rate was 20.7%.

They enter the address book because `ConnectedAddr::get_address_book_addr()`
returns the inbound socket's remote address, which becomes a `MetaAddr` with
`is_inbound = true`. The flag is set correctly; it is just not honoured anywhere
that matters. This is inherited from upstream, not a recent regression —
`get_address_book_addr()` is byte-identical in `zebra-upstream/main`.

Three separate mechanisms turn that into undialable peers, and fixing only the
first is not enough unfortunatley

## Solution

Four commits, each with its own failure mode and its own tests.

### 1. Honour `is_inbound` on the dial and cache paths

`is_ready_for_connection_attempt()` and `AddressBook::cacheable()` both ignored
the flag, while `MetaAddr::sanitize()` honoured it. Inbound peers are connected
*right now*, so they score as maximally active and dominate cache ordering.

### 2. Only cache addresses that answered one of our own connections

**This is what actually cleaned the cache, and the reason commit 1 alone was not
enough.** The `is_inbound` flag lives on the address book entry, and *nothing on
that entry survives the disk cache* — the file holds bare socket addresses.
`Config::initial_peers()` chains them with the DNS seeds, so a cached address is
re-added through `MetaAddr::new_initial_peer()` with no inbound flag, no
services, and no history, then dialed directly at startup.

Worse, the same junk arrives by **gossip** with `is_inbound == false`, so neither
guard from commit 1 ever sees it. Measured on a node running commit 1 only: the
cache was wiped to 0 and refilled to **82% ephemeral (88/107) within one
minute**.

`cacheable()` now also requires `MetaAddr::has_ever_responded()`, and
`load_peer_cache()` drops entries in the ephemeral port range, using a new
`EPHEMERAL_PORT_FLOOR` of 32768.

#### Why the floor, and not the network's default port

An earlier revision of this branch filtered the cache on
`port == network.default_port()`. That is wrong, and the fleet says so. Counting
`zakurad`'s own established outbound connections — peers it dialed and
handshaked, so unambiguously real listeners:

| node | on :8233 | on other ports | non-default share |
| --- | ---: | ---: | ---: |
| canada-0 | 95 | 16 | 14.4% |
| us-east-0 | 81 | 16 | 16.5% |
| us-0 | 73 | 17 | ~16% |

Ports observed carrying real peers: 7952, 8131, 8231, 8234, 8235, 8236, 8243,
8433, 9058, 9222, 9533, 18233, 21099, 28233. A default-port filter would drop
about one in six good peers from the bootstrap path — and worse, it would be
asymmetric with `cacheable()`, which has no port check, so the node would keep
writing those peers to the cache for the next startup to discard.

The ephemeral floor separates the two populations cleanly on live data: every
port above carries a real listener and is below 32768, while every inbound source
port found in a cache (57266, 55224, 44330, 43546, 37336, …) is above it. Linux
defaults `net.ipv4.ip_local_port_range` to `32768 60999` and other platforms
allocate from `49152-65535`, so 32768 is the inclusive lower bound across both.
Port 0 is rejected separately.

### 3. Stop inbound connections from blocking dials to the same IP

`AddressBook::most_recent_by_ip` records the responded address with the newest
`last_response` per IP, and `reconnection_peers()` refuses to dial any address
whose IP has a recent entry there. The entry does not record direction.

An inbound peer's entry is refreshed by every message it sends, so it holds its
IP's slot for the whole life of the connection — and the address it blocks is a
*different* address on that IP: the peer's listener, which is exactly what we
want to dial. Peers that connect to us are the most active on the network, so
this removes the best candidates, and removes more of them the more inbound
connections we accept. #478 raised `INBOUND_PEER_LIMIT_MULTIPLIER` from 1 to 3,
tripling the number of IPs a node bars itself from.

The cache exists to space out *our own* outbound connections to one IP, and
`max_connections_per_ip` is only enforced in `accept_inbound_connections()`,
never on the dial path — so an inbound connection was suppressing dials to
enforce a limit that would not have rejected them.

Measured before this commit: 300 inbound connections, 9 outbound, a
replenishment demand of 70, and **zero connection attempts over 20 minutes**.
The crawler was not failing to dial; it had no candidate left to dial.

## Correcting an earlier claim in this PR

An earlier revision of this description said existing polluted entries need no
migration because "the cache is rewritten without them within
`PEER_DISK_CACHE_UPDATE_INTERVAL`". **That was wrong**, and the fleet showed it:
because `load_peer_cache()` returns bare addresses with no flags, a polluted
cache launders itself clean across every restart. Commit 2's port filter on load
is what makes the claim true.

### Reviewer's attention: the flag is sticky

`MetaAddrChange` merges OR `is_inbound` with the previous value, so an address
that was ever inbound is never dialed again on that entry. A peer that dialed us
*from its own listener port* would not be dialed back on that entry. Outbound
connections use ephemeral source ports — zcashd and Zebra both do — and the same
IP on its real listener port is a *separate* address book key. Commit 3 relies on
this stickiness deliberately, and both behaviours are pinned by tests.

`maybe_connected_peers()` is defined as the complement of
`is_ready_for_connection_attempt()`, so inbound peers now fall into it. That
reads correctly — they are connected — and the method has no callers in the
workspace.

## Testing

- `cargo test -p zakura-network --lib` — 1197 passed, 0 failed.
- `cargo clippy -p zakura-network --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

New tests, each verified to fail with its own source change reverted:

- `inbound_addresses_are_not_ready_for_connection_attempts` — two peers differing
  only in the `is_inbound` argument, checked past `MIN_PEER_RECONNECTION_DELAY`
  so `was_recently_updated` cannot be what separates them.
- `inbound_flag_keeps_an_address_out_of_dial_candidates` — applies a later
  `new_responded` change, the update most likely to look like fresh evidence the
  address is good, and asserts it stays out of the candidate set.
- `inbound_peers_are_not_reconnection_or_cache_candidates` — asserts both peers
  are `is_active_for_gossip` first, so the existing filter is not what does the
  work.
- `inbound_connections_do_not_block_dialing_the_same_ip` — puts a live inbound
  connection and its peer's listener on one IP, plus an address sharing an IP
  with a peer we dialed ourselves, and asserts only the listener is a
  reconnection candidate.
- `cached_peers_on_ephemeral_ports_are_not_loaded` seeds a cache with listeners
  on 8233, 8235, 21099 and 28233, a port 0 entry, and three ephemeral source
  ports from one IP, then asserts only the last four are dropped. It fails under
  the default-port predicate, so it pins the choice above rather than just the
  ephemeral filtering.

`address_book/tests/prop.rs` asserts every peer from `reconnection_peers` is
`is_probably_reachable`; this change only narrows that set.

## Fleet verification

Deployed as `test/combined-506-507` on two mainnet nodes (`asia-0`,
`europe-central-0`) against seven controls on `1.0.5`, sustained over three days:

| | cache entries | on :8233 | ephemeral |
| --- | ---: | ---: | ---: |
| patched (asia-0) | 38 | 28 | **0** |
| patched (europe-central-0) | 33 | 26 | **0** |
| controls | 74 | 22-27 | **33-44** |

The cache hygiene goal is met. Outbound peer count did **not** recover — it sits
at 32-39 against a target of 80 — but that is now bound by the supply of
reachable peers rather than by address hygiene: the recent handshake failure mix
on asia-0 is 138 timeout / 90 peer-closed / 43 refused / 36 reset against 77
obsolete-version. See the follow-up note below.

## Changelog

Fragment at `docs/changelog/unreleased/507.md`. No tunable parameter changed, so
`docs/changelog/params.md` is untouched.

### Follow-up Work

Deliberately out of scope:

1. **Stop recording the inbound socket address at all** — returning `None` for
   `InboundDirect` in `get_address_book_addr()`, or recording the peer's
   advertised listener from its `version` message. That is the root fix, but
   `book_addr` also keys `new_responded` / `new_errored` / `new_shutdown` and
   misbehavior tracking.
2. **`is_probably_reachable()` keeping failed addresses alive.** The same pattern
   can still hold a repeatedly-failing gossiped address in the retry pool.
3. **Post-NU6.3 outbound supply.** Nodes that restarted after Ironwood activation
   (2026-07-28T14:07:23Z) converge to ~35-40 outbound because established
   connections are never re-version-checked, so long-lived nodes keep peers they
   could not re-establish today. This is not an address-hygiene problem and needs
   its own investigation.
4. **Address book dial-candidate tracing**, which produced the measurements
   above, is split into its own PR stacked on this one.

Related: #506 fixes the crawler's replenishment budget, an independent cause of
the same symptom.
