### PR TITLE
ci: install build dependencies for release state checks

### DIFF
--- a/.github/workflows/update-release-state.yml
+++ b/.github/workflows/update-release-state.yml
@@ -147,6 +147,9 @@ jobs:
           toolchain: stable
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - uses: ./.github/actions/setup-zakura-build
+        if: steps.import.outputs.has_changes == 'true'
+
       - name: Re-prove the checkpoint/frontier pairing in cargo
         if: steps.import.outputs.has_changes == 'true'
         run: |


### PR DESCRIPTION
## Motivation

The `Update Mainnet release state` workflow fails before running its cargo proofs because `librocksdb-sys` invokes `clang-sys`, while the Ubuntu runner has neither `llvm-config` nor `libclang` installed.

Failing job: https://github.com/zakura-core/zakura/actions/runs/30685619155/job/91330664412

## Solution

Run the repository's existing `setup-zakura-build` action before the cargo proof step. It installs libclang and the other native Zakura build dependencies and exports the RocksDB library path.

## Testing

- `actionlint .github/workflows/update-release-state.yml`
- `git diff --check`
- Cargo tests were not run locally because this is a three-line CI configuration fix; draft CI will exercise the workflow configuration.

## Changelog

No changelog entry: CI-only change with no Rust or `Cargo.toml` modifications.

### Specifications & References

- Failed workflow job: https://github.com/zakura-core/zakura/actions/runs/30685619155/job/91330664412

### Follow-up Work

None.