### PR TITLE
chore(lint): replace clippy.toml with crate-level type_complexity allows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ zakurad (CLI orchestration)
 
 - Rust 2021 conventions and `rustfmt` defaults apply across the workspace (4-space indentation).
 - Naming: `snake_case` for functions/modules/files, `CamelCase` for types/traits, `SCREAMING_SNAKE_CASE` for constants.
-- Respect workspace lint policy in `.cargo/config.toml` and crate-specific lint config in `clippy.toml`.
+- Respect workspace lint policy in `.cargo/config.toml` and the crate-level lint attributes at the top of each crate's `lib.rs`.
 - Keep dependencies flowing downward across crates; maintain `zakura-chain` as sync-only.
 
 ## Code Patterns

--- a/changelog-unreleased/509.md
+++ b/changelog-unreleased/509.md
@@ -1,0 +1,5 @@
+<!-- changelog: none -->
+
+This PR only changes lint configuration (crate-level `clippy::type_complexity`
+allows replacing `clippy.toml`) and agent documentation. It has no operator- or
+crate-consumer-visible effect.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-type-complexity-threshold = 999999

--- a/zakura-chain/src/lib.rs
+++ b/zakura-chain/src/lib.rs
@@ -8,6 +8,9 @@
 #![doc(html_root_url = "https://docs.rs/zakura_chain")]
 // Required by bitvec! macro
 #![recursion_limit = "256"]
+// Long tuple and result types are routine in this crate, and factoring them
+// into type aliases would not make the code clearer.
+#![allow(clippy::type_complexity)]
 
 #[macro_use]
 extern crate bitflags;

--- a/zakura-consensus/src/lib.rs
+++ b/zakura-consensus/src/lib.rs
@@ -33,6 +33,9 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_consensus")]
+// Long Tower service and future types are routine in this crate, and factoring
+// them into type aliases would not make the code clearer.
+#![allow(clippy::type_complexity)]
 
 mod block;
 mod checkpoint;

--- a/zakura-network/src/lib.rs
+++ b/zakura-network/src/lib.rs
@@ -132,6 +132,9 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_network")]
+// Long Tower service and future types are routine in this crate, and factoring
+// them into type aliases would not make the code clearer.
+#![allow(clippy::type_complexity)]
 
 #[macro_use]
 extern crate pin_project;

--- a/zakura-rpc/src/lib.rs
+++ b/zakura-rpc/src/lib.rs
@@ -3,6 +3,9 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_rpc")]
+// Long Tower service and future types are routine in this crate, and factoring
+// them into type aliases would not make the code clearer.
+#![allow(clippy::type_complexity)]
 
 pub mod client;
 pub mod config;

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -14,6 +14,9 @@
 // Remove if possible if MSRV is increased
 #![allow(unknown_lints)]
 #![allow(clippy::manual_is_multiple_of)]
+// Long Tower service and future types are routine in this crate, and factoring
+// them into type aliases would not make the code clearer.
+#![allow(clippy::type_complexity)]
 
 #[macro_use]
 extern crate tracing;

--- a/zakura-state/src/service/finalized_state/vct.rs
+++ b/zakura-state/src/service/finalized_state/vct.rs
@@ -237,7 +237,6 @@ impl VctState {
 
     /// The verified `(sapling, orchard, sprout, ironwood)` frontiers to write as the tip
     /// treestate, when `height` is the checkpoint handoff height.
-    #[allow(clippy::type_complexity)]
     pub(super) fn final_frontiers_for_last_checkpoint(
         &self,
         height: block::Height,

--- a/zakura-state/src/service/finalized_state/vct/artifact.rs
+++ b/zakura-state/src/service/finalized_state/vct/artifact.rs
@@ -110,7 +110,6 @@ fn read_exact(reader: &mut impl Read, bytes: &mut [u8]) -> Result<(), Error> {
     })
 }
 
-#[allow(clippy::type_complexity)]
 #[allow(clippy::unwrap_in_result)]
 fn decode_header(
     bytes: &[u8; HEADER_LEN],

--- a/zakurad/src/lib.rs
+++ b/zakurad/src/lib.rs
@@ -121,6 +121,9 @@
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]
+// Long Tower service and future types are routine in this crate, and factoring
+// them into type aliases would not make the code clearer.
+#![allow(clippy::type_complexity)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
## Motivation

`clippy.toml` contained a single line, `type-complexity-threshold = 999999` — a hack inherited from upstream Zebra (2020) whose only effect is to disable `clippy::type_complexity`. Removing the file cleans up the repository, but restores the default threshold, which fires at 57 sites across six crates and fails the CI clippy run.

## Solution

Allow the lint at the crate root of the six affected crates (`zakura-chain`, `zakura-consensus`, `zakura-network`, `zakura-state`, `zakura-rpc`, `zakurad`) with a short why-comment, matching the existing crate-level lint idiom (`cognitive_complexity` in `zakurad`, `manual_is_multiple_of` in `zakura-state`).

The flagged types are routine for this codebase — Tower service stacks, boxed verifier futures, multi-value `Result` tuples — and most sites are upstream-inherited, so refactoring them into aliases would add churn and permanent backport conflicts without making the code clearer. Per-site allows would be 57 attributes of noise.

Also removes the two per-site `type_complexity` allows in `zakura-state` made redundant by the crate-level attribute, and updates the stale `clippy.toml` reference in `AGENTS.md`.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (previously 57 `type_complexity` warnings without `clippy.toml`)
- `markdownlint AGENTS.md --config .trunk/configs/.markdownlint.yaml` — clean

No behavior change; lint-config and attribute-only.

## Changelog

Internal-only change; no-changelog fragment added after the draft PR number was assigned.

### Follow-up Work

The `clippy.toml` entries in CI path filters (`lint.yml`, `test-crates.yml`, `status-checks.patch.yml`) are now vestigial but harmless; left untouched to keep the patch-workflow mirror sets in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)