### PR TITLE
docs: point rustdoc logo and favicon at zakura.com assets

### DIFF
--- a/changelog-unreleased/510.md
+++ b/changelog-unreleased/510.md
@@ -1,0 +1,5 @@
+## Changed
+
+- Rustdoc pages for the library crates now show the Zakura logo and favicon
+  instead of upstream Zebra branding
+  ([#510](https://github.com/zakura-core/zakura/pull/510)).

--- a/zakura-chain/src/lib.rs
+++ b/zakura-chain/src/lib.rs
@@ -3,8 +3,8 @@
 //! This crate provides definitions of core data structures for Zcash, such as
 //! blocks, transactions, addresses, etc.
 
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_chain")]
 // Required by bitvec! macro
 #![recursion_limit = "256"]

--- a/zakura-consensus/src/lib.rs
+++ b/zakura-consensus/src/lib.rs
@@ -30,8 +30,8 @@
 //! code in this crate.  *Contextual validity* is enforced in
 //! `zakura-state` when objects are committed to the chain state.
 
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_consensus")]
 
 mod block;

--- a/zakura-network/src/lib.rs
+++ b/zakura-network/src/lib.rs
@@ -129,8 +129,8 @@
 //!
 //! [1]: protocol::external::Message
 
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_network")]
 
 #[macro_use]

--- a/zakura-rpc/src/lib.rs
+++ b/zakura-rpc/src/lib.rs
@@ -1,7 +1,7 @@
 //! The Zakura node's Remote Procedure Call (RPC) interface
 
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_rpc")]
 
 pub mod client;

--- a/zakura-script/src/lib.rs
+++ b/zakura-script/src/lib.rs
@@ -1,6 +1,6 @@
 //! Zakura script verification wrapping zcashd's zcash_script library
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_script")]
 // We allow unsafe code, so we can call zcash_script
 #![allow(unsafe_code)]

--- a/zakura-state/src/lib.rs
+++ b/zakura-state/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! Otherwise, verification of out-of-order and invalid blocks can hang indefinitely.
 
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_state")]
 // Remove if possible if MSRV is increased
 #![allow(unknown_lints)]

--- a/zakura-test/src/lib.rs
+++ b/zakura-test/src/lib.rs
@@ -1,6 +1,6 @@
 //! Miscellaneous test code for the Zakura node.
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_test")]
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "512"]

--- a/zakura-utils/src/lib.rs
+++ b/zakura-utils/src/lib.rs
@@ -1,6 +1,6 @@
 //! Utilities for Zakura development, not for library or application users.
-#![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
-#![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
+#![doc(html_favicon_url = "https://zakura.com/assets/rustdoc/zakura-favicon-128.png")]
+#![doc(html_logo_url = "https://zakura.com/assets/rustdoc/zakura-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zakura_utils")]
 
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};


### PR DESCRIPTION
## Motivation

The library crates' rustdoc pages still carry upstream Zebra branding: `html_logo_url` and `html_favicon_url` point at the zebra icon and favicon hosted on zfnd.org.

## Solution

Point both doc attributes in all eight library crates at the Zakura assets now published at https://zakura.com/assets/rustdoc/ (`zakura-icon.png`, `zakura-favicon-128.png`), rendered from the canonical logo SVG in zakura-core/assets.

## Testing

Both URLs verified live (HTTP 200, `image/png`). Attribute string literals only — no behavior change; `cargo fmt --all -- --check` passes.

## Changelog

`changelog-unreleased/510.md` — `Changed` entry; validated with `./scripts/changelog.py check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)