### PR TITLE
ci: harden release readiness automation

### DIFF
--- a/.agents/skills/release-zakura/SKILL.md
+++ b/.agents/skills/release-zakura/SKILL.md
@@ -185,7 +185,8 @@ watches to the approval gate, and verifies the published release; it is
 resumable and re-runs skip completed steps:
 
 ```bash
-./scripts/release-t0.sh publish --tag <tag> --mode main --head-sha <merged-commit>
+./scripts/release-t0.sh publish --tag <tag> --mode main \
+  --head-sha <merged-commit> --expected-tag-delay-days <days>
 ```
 
 Raw dispatch fallback:

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -261,7 +261,7 @@ date, and updates `ESTIMATED_RELEASE_HEIGHT` when needed:
 
 ```sh
 ./scripts/release-t0.sh publish --tag v<version> --mode main \
-    --head-sha <merged-main-commit>
+    --head-sha <merged-main-commit> --expected-tag-delay-days <days>
 ```
 
 Manual fallback: run the

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -88,6 +88,9 @@ fastmod --fixed-strings '1.58' '1.65'
       `hotfix/v*` — that namespace is reserved for the
       [hotfix release process](https://github.com/zakura-core/zakura/blob/main/docs/security-hotfix-release.md)).
 - [ ] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/zakura-core/zakura/compare/release/v1.0.0?expand=1&template=release-checklist.md)).
+- [ ] Complete every generated manual-judgment checkbox before marking the PR
+      ready; the release-readiness workflow returns incomplete `release/v*`
+      PRs to draft.
 - [ ] Freeze the [`batched` queue](https://dashboard.mergify.com/github/valargroup/repo/zakura/queues) using Mergify.
 - [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
 - [ ] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
@@ -104,10 +107,12 @@ This check runs automatically on pull requests with the `A-release` label. It mu
 > **Automation**: the
 > [Prepare release PR workflow](https://github.com/zakura-core/zakura/actions/workflows/prepare-release-pr.yml)
 > performs the mechanical steps in this section (crate and zakura version
-> bumps, lockfile, stored config, changelog assembly, end-of-support floor)
-> and opens a draft PR. The judgment items remain manual either way: review
-> the chosen bump levels, curate the assembled changelog, and set the
-> authoritative end-of-support height below.
+> bumps, lockfile, stored config, changelog assembly, release-level validation,
+> public-API reports, and a projected end-of-support height from the latest
+> verified release-state bundle) and opens a draft PR. It also refuses stale
+> committed release state unless an urgent-RC waiver reason is supplied. The
+> remaining judgment items are changelog curation and confirmation that no
+> release hold is active.
 
 ## Update Zakura Version
 
@@ -131,6 +136,12 @@ version.
 ```sh
 cargo release version --verbose --execute --allow-branch '*' -p zakura patch # [ major | minor ]
 ```
+
+The preparation workflow rejects a requested tag below the conservative
+release level implied by the pending changelog: `Added`, `Changed`,
+`Deprecated`, or `Removed` entries require at least a minor release; a
+Mainnet network upgrade requires a major release; otherwise the floor is a
+patch release. It never silently changes the requested tag.
 
 - [ ] Generate and commit the stored config for the new version — the
       `last_config_is_stored` acceptance test derives the expected filename
@@ -166,7 +177,8 @@ Check that the release will work:
       a package version bump. This warning is local-only and advisory; unchanged
       crates are not bumped or published.
 - [ ] Update (or install) `semver-checks`: `cargo +stable install cargo-semver-checks --locked`
-- [ ] Update (or install) `public-api`: `cargo +stable install cargo-public-api --locked`
+- [ ] Confirm the preparation workflow's `cargo public-api diff latest` reports
+      completed successfully for every changed library being published.
 - [ ] For each crate that requires a release:
   - [ ] Determine which type of release to make. Run `semver-checks` to list API
         changes: `cargo semver-checks -p <crate> --default-features`. If there are
@@ -210,12 +222,17 @@ make prepare-release-changelog RELEASE_TAG=v<version>
       For example:
       `make pre-release RELEASE_TAG=v1.0.3 BASE_TAG=v1.0.2`.
 
-## Update End of Support
+## Verify End of Support
 
-The end of support height is calculated from the current blockchain height:
+The preparation workflow calculates the release height from a fresh,
+digest-verified Mainnet release-state bundle, projects it to the expected tag
+date, and updates `ESTIMATED_RELEASE_HEIGHT` when needed:
 
-- [ ] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
-- [ ] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/zakura-core/zakura/blob/main/zakurad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged. (The release-state PR floors this value near its bundle height, but this manual estimate is authoritative — with an 18-day support window, days matter.)
+- [ ] Review the bundle height, generation time, expected tag delay, and
+      resulting `ESTIMATED_RELEASE_HEIGHT` recorded in the release PR.
+- [ ] If tagging is delayed, re-run preparation with the new expected delay;
+      `Create release` currently warns when the estimate is below its freshly
+      resolved projection.
 
 <details>
 
@@ -242,16 +259,17 @@ The end of support height is calculated from the current blockchain height:
       published tag, release, and assets (resumable — re-runs skip
       completed steps):
 
-      ```sh
-      ./scripts/release-t0.sh publish --tag v<version> --mode main \
-          --head-sha <merged-main-commit>
-      ```
+```sh
+./scripts/release-t0.sh publish --tag v<version> --mode main \
+    --head-sha <merged-main-commit>
+```
 
-      Manual fallback: run the
-      [Create release workflow](https://github.com/zakura-core/zakura/actions/workflows/create-release.yml)
-      from `main`, entering the exact version tag, for example `v1.0.0-rc2`.
-      The workflow verifies that the tag matches the `zakura` package version,
-      then builds and verifies the assets without creating a tag.
+Manual fallback: run the
+[Create release workflow](https://github.com/zakura-core/zakura/actions/workflows/create-release.yml)
+from `main`, entering the exact version tag, for example `v1.0.0-rc2`.
+The workflow verifies that the tag matches the `zakura` package version,
+then builds and verifies the assets without creating a tag.
+
 - [ ] Wait for the build and no-push Docker checks to pass, then approve the
       `release` environment deployment when the script announces it. The
       workflow publishes a complete pre-release and creates the protected

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,6 +25,15 @@ on:
         required: false
         default: false
         type: boolean
+      expected_tag_delay_days:
+        description: "Expected days before tagging; used to validate ESTIMATED_RELEASE_HEIGHT"
+        required: false
+        default: 0
+        type: number
+      release_state_waiver:
+        description: "Urgent RC only: reason for releasing behind the latest verified Mainnet release-state bundle"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -45,6 +54,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
+          fetch-depth: 0
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
@@ -87,6 +97,97 @@ jobs:
 
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Check release readiness advisories
+        env:
+          EXPECTED_TAG_DELAY_DAYS: ${{ inputs.expected_tag_delay_days }}
+          LATEST_URL: ${{ vars.MAINNET_RELEASE_STATE_LATEST_URL }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_STATE_WAIVER: ${{ inputs.release_state_waiver }}
+        run: |
+          advisory_exit() {
+            status=$?
+            trap - EXIT
+            if [ "$status" -ne 0 ]; then
+              echo "::warning title=Release readiness advisory unavailable::An unexpected readiness-check failure occurred (exit ${status}); continuing temporarily."
+            fi
+            exit 0
+          }
+          # These checks are intentionally advisory. Convert any unanticipated
+          # shell, parsing, or data error into a warning as a final safeguard.
+          trap advisory_exit EXIT
+          set -euo pipefail
+          if [ -z "$LATEST_URL" ]; then
+            echo "::warning title=Release-state advisory unavailable::Set the MAINNET_RELEASE_STATE_LATEST_URL repository variable."
+            exit 0
+          fi
+          if [ -n "$RELEASE_STATE_WAIVER" ] && [[ "$RELEASE_TAG" != *-rc* ]]; then
+            echo "::warning title=Ignored release-state waiver::release_state_waiver is only valid for urgent release candidates."
+            RELEASE_STATE_WAIVER=""
+          fi
+          if ! python3 .github/scripts/fetch-release-state.py --self-test \
+            || ! python3 scripts/release-readiness.py self-test; then
+            echo "::warning title=Release readiness advisory unavailable::A release-readiness self-test failed; continuing without these advisory checks."
+            exit 0
+          fi
+          base_tag="$(git describe --tags --match 'v*' --abbrev=0 HEAD)"
+          base_version="$(
+            git show "${base_tag}:zakurad/Cargo.toml" \
+              | awk -F ' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }'
+          )"
+          version_report=""
+          if ! version_report="$(
+            python3 scripts/release-readiness.py version \
+              --base-version "$base_version" \
+              --release-tag "$RELEASE_TAG"
+          )"; then
+            echo "::warning title=Release level advisory::The requested tag is below the changelog-derived release level; continuing temporarily."
+          fi
+          if ! python3 .github/scripts/fetch-release-state.py \
+            --latest-url "$LATEST_URL" \
+            --output-dir "$RUNNER_TEMP/release-state-bundle" \
+            --metadata-out "$RUNNER_TEMP/release-state-resolution.json" \
+            --max-age-hours 48; then
+            echo "::warning title=Release-state advisory unavailable::The latest Mainnet release-state bundle could not be verified; continuing temporarily."
+            exit 0
+          fi
+          report=""
+          if ! report="$(
+            python3 scripts/release-readiness.py height \
+              --resolution "$RUNNER_TEMP/release-state-resolution.json" \
+              --expected-tag-delay-days "$EXPECTED_TAG_DELAY_DAYS"
+          )"; then
+            echo "::warning title=Support-height advisory unavailable::The projected release height could not be calculated; continuing temporarily."
+            exit 0
+          fi
+          latest_height="$(jq -r '.bundle_height' <<<"$report")"
+          estimated_height="$(jq -r '.estimated_release_height' <<<"$report")"
+          committed_height="$(
+            jq -r '.finalized_height' \
+              zakura-state/src/service/finalized_state/vct/mainnet-frontier.json
+          )"
+          configured_height="$(
+            grep -oE 'ESTIMATED_RELEASE_HEIGHT: u32 = [0-9_]+' \
+              zakurad/src/components/sync/end_of_support.rs \
+              | grep -oE '[0-9_]+$' | tr -d '_'
+          )"
+          minimum_height=$((committed_height + 3456))
+          if [ "$estimated_height" -gt "$minimum_height" ]; then
+            minimum_height="$estimated_height"
+          fi
+
+          if [ "$latest_height" -gt "$committed_height" ]; then
+            if [ -z "$RELEASE_STATE_WAIVER" ]; then
+              echo "::warning title=Stale committed release state::Committed height ${committed_height} trails verified bundle ${latest_height}; update the release state before the next release."
+            else
+              echo "::warning title=Release-state waiver::${RELEASE_STATE_WAIVER}"
+            fi
+          fi
+          if [ "$configured_height" -lt "$minimum_height" ]; then
+            echo "::warning title=Stale support height::ESTIMATED_RELEASE_HEIGHT ${configured_height} trails the projected floor ${minimum_height}; re-run release preparation."
+          fi
+          [ -z "$version_report" ] || jq . <<<"$version_report" >> "$GITHUB_STEP_SUMMARY"
+          jq . <<<"$report" >> "$GITHUB_STEP_SUMMARY"
 
   handoff-canary:
     name: Verify VCT handoff crossing

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -1,8 +1,9 @@
 # Prepare a release PR mechanically and open it as a draft for human review.
 #
 # Runs scripts/prepare-release.sh on a fresh checkout of main (crate bumps via
-# cargo-semver-checks, zakura version, lockfile, config fixture, README tag,
-# end-of-support floor, changelog assembly), verifies the result with
+# cargo-semver-checks, Zakura release-level validation, lockfile, config
+# fixture, README tag, projected end-of-support height, release-state freshness,
+# and changelog assembly), verifies the result with
 # `make pre-release`, and opens or updates a draft PR through the release
 # GitHub App. Nothing merges, tags, or publishes from this workflow: the PR is
 # always a draft, judgment items (bump-level review, authoritative
@@ -38,6 +39,15 @@ on:
         required: false
         type: boolean
         default: false
+      expected_tag_delay_days:
+        description: "Expected days between preparation and tagging; used to project ESTIMATED_RELEASE_HEIGHT"
+        required: false
+        type: number
+        default: 0
+      release_state_waiver:
+        description: "Urgent RC only: reason for releasing behind the latest verified Mainnet release-state bundle"
+        required: false
+        type: string
 
 permissions: {}
 
@@ -102,6 +112,36 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Preparing ${RELEASE_TAG} from ${BASE_TAG} (rc: ${IS_RC}, flags: '${NO_CRATES_FLAG}')"
 
+      - name: Resolve the latest verified Mainnet release state
+        id: release-state
+        env:
+          EXPECTED_TAG_DELAY_DAYS: ${{ inputs.expected_tag_delay_days }}
+          LATEST_URL: ${{ vars.MAINNET_RELEASE_STATE_LATEST_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$LATEST_URL" ]; then
+            echo "Set the MAINNET_RELEASE_STATE_LATEST_URL repository variable." >&2
+            exit 1
+          fi
+          python3 .github/scripts/fetch-release-state.py --self-test
+          python3 scripts/release-readiness.py self-test
+          python3 .github/scripts/fetch-release-state.py \
+            --latest-url "$LATEST_URL" \
+            --output-dir "$RUNNER_TEMP/release-state-bundle" \
+            --metadata-out "$RUNNER_TEMP/release-state-resolution.json" \
+            --max-age-hours 48
+          report="$(
+            python3 scripts/release-readiness.py height \
+              --resolution "$RUNNER_TEMP/release-state-resolution.json" \
+              --expected-tag-delay-days "$EXPECTED_TAG_DELAY_DAYS"
+          )"
+          {
+            echo "bundle_height=$(jq -r '.bundle_height' <<<"$report")"
+            echo "estimated_release_height=$(jq -r '.estimated_release_height' <<<"$report")"
+            echo "generated_at=$(jq -r '.generated_at' <<<"$report")"
+          } >> "$GITHUB_OUTPUT"
+          jq . <<<"$report" >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         id: toolchain
         with:
@@ -122,10 +162,11 @@ jobs:
           restore-keys: prepare-release-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       # Deliberately unpinned (like semver-checks.yml): cargo-semver-checks
-      # must track new stable rustdoc formats.
+      # must track new stable rustdoc formats. cargo-public-api supplies
+      # independent API-diff evidence for each changed published library.
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
         with:
-          tool: cargo-release,cargo-semver-checks
+          tool: cargo-release,cargo-semver-checks,cargo-public-api
 
       - uses: ./.github/actions/setup-zakura-build
 
@@ -135,13 +176,21 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
           BASE_TAG: ${{ steps.params.outputs.base_tag }}
           NO_CRATES_FLAG: ${{ steps.params.outputs.no_crates_flag }}
+          ESTIMATED_RELEASE_HEIGHT: ${{ steps.release-state.outputs.estimated_release_height }}
+          LATEST_RELEASE_STATE_HEIGHT: ${{ steps.release-state.outputs.bundle_height }}
+          RELEASE_STATE_WAIVER: ${{ inputs.release_state_waiver }}
         run: |
-          # shellcheck disable=SC2086 # NO_CRATES_FLAG is deliberately unquoted
-          scripts/prepare-release.sh \
-            --release-tag "$RELEASE_TAG" \
-            --base-tag "$BASE_TAG" \
-            $NO_CRATES_FLAG \
+          args=(
+            --release-tag "$RELEASE_TAG"
+            --base-tag "$BASE_TAG"
+            --estimated-release-height "$ESTIMATED_RELEASE_HEIGHT"
+            --latest-release-state-height "$LATEST_RELEASE_STATE_HEIGHT"
             --summary-json "$RUNNER_TEMP/prep-summary.json"
+          )
+          [ -z "$NO_CRATES_FLAG" ] || args+=("$NO_CRATES_FLAG")
+          [ -z "$RELEASE_STATE_WAIVER" ] \
+            || args+=(--release-state-waiver "$RELEASE_STATE_WAIVER")
+          scripts/prepare-release.sh "${args[@]}"
 
       - name: Save baseline rustdoc cache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
@@ -192,6 +241,30 @@ jobs:
         continue-on-error: true
         run: cargo fmt --all -- --check
 
+      - name: Record public API diffs
+        id: verify-public-api
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          packages="$(
+            jq -r '
+              .crates[]
+              | select(.level != "manual" and .target != null and .target != "")
+              | .name
+            ' \
+              "$RUNNER_TEMP/prep-summary.json"
+          )"
+          if [ -z "$packages" ]; then
+            echo "No changed library crates are being published."
+            exit 0
+          fi
+          while IFS= read -r package; do
+            [ -n "$package" ] || continue
+            echo "::group::cargo public-api diff latest -p ${package}"
+            cargo public-api diff latest -p "$package" -sss
+            echo "::endgroup::"
+          done <<<"$packages"
+
       - name: Write the PR body
         id: body
         env:
@@ -200,6 +273,7 @@ jobs:
           VERIFY_PRERELEASE: ${{ steps.verify-prerelease.outcome }}
           VERIFY_CONFIG: ${{ steps.verify-config.outcome }}
           VERIFY_FMT: ${{ steps.verify-fmt.outcome }}
+          VERIFY_PUBLIC_API: ${{ steps.verify-public-api.outcome }}
         run: |
           python3 - "$RUNNER_TEMP/prep-summary.json" > "$RUNNER_TEMP/pr-body.md" <<'PY'
           import json, os, sys
@@ -209,6 +283,8 @@ jobs:
           base = summary["base_tag"]
           zakura = summary["zakura"]
           eos = summary["eos"]
+          release_state = summary["release_state"]
+          version_readiness = summary["version_readiness"]
 
           def mark(outcome):
               return "x" if outcome == "success" else " "
@@ -239,6 +315,10 @@ jobs:
               "Bump policy: breaking → major; any other change → minor. Patch is",
               "never auto-selected — downgrade during review where warranted.",
               "",
+              f"Zakura release-level gate: **{version_readiness['minimum_level']}** "
+              f"(minimum `{version_readiness['minimum_version']}` from "
+              f"{', '.join(version_readiness['categories']) or 'no user-visible categories'}).",
+              "",
               "## Also updated",
               "",
               f"- Config fixture regenerated: `{summary['fixture']}` "
@@ -246,13 +326,23 @@ jobs:
           ]
           if eos["floored"]:
               lines.append(
-                  f"- `ESTIMATED_RELEASE_HEIGHT` floored: {eos['old']} → {eos['floor']} "
-                  "(committed checkpoint height + 3456)."
+                  f"- `ESTIMATED_RELEASE_HEIGHT` updated: {eos['old']} → "
+                  f"{eos['target']} ({eos['basis']})."
               )
           else:
               lines.append(
                   f"- `ESTIMATED_RELEASE_HEIGHT` kept at {eos['old']} "
-                  f"(already at or above the {eos['floor']} floor)."
+                  f"(already at or above {eos['target']}, {eos['basis']})."
+              )
+          lines.append(
+              f"- Mainnet release state: committed "
+              f"{release_state['committed_height']}, latest verified "
+              f"{release_state['latest_verified_height']}."
+          )
+          if release_state["waiver"]:
+              lines.append(
+                  f"- ⚠️ Rapid-RC release-state waiver: "
+                  f"{release_state['waiver']}"
               )
           lines.append(
               f"- README install tag updated to {tag}." if summary["readme_updated"]
@@ -268,6 +358,8 @@ jobs:
               ("cargo test -p zakura --test acceptance config_tests -- --exact",
                os.environ["VERIFY_CONFIG"]),
               ("cargo fmt --all -- --check", os.environ["VERIFY_FMT"]),
+              ("cargo public-api diff latest for changed published libraries",
+               os.environ["VERIFY_PUBLIC_API"]),
           ]
           lines += ["", "## Verification", ""]
           lines += [f"- [{mark(o)}] `{cmd}`" for cmd, o in checks]
@@ -283,15 +375,28 @@ jobs:
               "",
               "## Remaining manual judgment (before undrafting)",
               "",
-              "- [ ] Set the authoritative `ESTIMATED_RELEASE_HEIGHT` from the "
-              "current Mainnet tip and expected tag date (the automated value "
-              "is only a staleness floor).",
-              "- [ ] Curate the assembled changelog (dedupe, trim trivial "
-              "entries, check categories).",
-              "- [ ] Review semver bump levels; downgrade minor → patch where "
-              "appropriate; choose initial versions for any new crates.",
-              "- [ ] Confirm no release hold is in effect (an embargoed hotfix "
-              "may be in flight for the same version).",
+              "- [ ] <!-- release-judgment:changelog --> Curate the assembled "
+              "changelog (dedupe, trim trivial entries, check categories).",
+          ]
+          manual_crates = [
+              crate["name"] for crate in summary["crates"]
+              if crate["level"] == "manual"
+          ]
+          if manual_crates:
+              lines.append(
+                  "- [ ] <!-- release-judgment:new-crate-versions --> Choose "
+                  "initial publish versions for new crates: "
+                  + ", ".join(manual_crates) + "."
+              )
+          else:
+              lines.append(
+                  "- [x] <!-- release-judgment:new-crate-versions --> No new "
+                  "crates require initial publish versions."
+              )
+          lines += [
+              "- [ ] <!-- release-judgment:release-hold --> Confirm no release "
+              "hold is in effect (an embargoed hotfix may be in flight for "
+              "the same version).",
               "",
               "### AI Disclosure",
               "",
@@ -358,7 +463,8 @@ jobs:
         if: >-
           steps.verify-prerelease.outcome == 'failure' ||
           steps.verify-config.outcome == 'failure' ||
-          steps.verify-fmt.outcome == 'failure'
+          steps.verify-fmt.outcome == 'failure' ||
+          steps.verify-public-api.outcome == 'failure'
         run: |
           echo "Release preparation verification failed; see the step logs above." >&2
           exit 1

--- a/.github/workflows/release-pr-readiness.yml
+++ b/.github/workflows/release-pr-readiness.yml
@@ -1,0 +1,79 @@
+name: Release PR readiness
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  manual-judgment:
+    name: Release PR manual judgment
+    if: startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check release preparation attestations
+        id: attestations
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+
+          body = os.environ.get("PR_BODY", "")
+          manual_heading = "## Remaining manual judgment (before undrafting)"
+          required = {
+              "changelog",
+              "new-crate-versions",
+              "release-hold",
+          }
+
+          if manual_heading not in body:
+              raise SystemExit(
+                  "Release PR body lacks the manual judgment checklist."
+              )
+          section = body.split(manual_heading, 1)[1]
+          section = re.split(r"^## ", section, maxsplit=1, flags=re.MULTILINE)[0]
+          markers = re.findall(
+              r"^- \[([ xX])\] <!-- release-judgment:([a-z0-9-]+) -->",
+              section,
+              re.MULTILINE,
+          )
+          found = [marker for _, marker in markers]
+          duplicates = sorted(
+              marker for marker in set(found) if found.count(marker) > 1
+          )
+          if duplicates:
+              raise SystemExit(
+                  "Release PR has duplicate judgment markers: "
+                  + ", ".join(duplicates)
+              )
+          missing = sorted(required - set(found))
+          unexpected = sorted(set(found) - required)
+          if missing or unexpected:
+              details = []
+              if missing:
+                  details.append("missing: " + ", ".join(missing))
+              if unexpected:
+                  details.append("unexpected: " + ", ".join(unexpected))
+              raise SystemExit(
+                  "Release PR judgment markers are invalid (" + "; ".join(details) + ")."
+              )
+          unchecked = sorted(marker for state, marker in markers if state == " ")
+          if unchecked:
+              raise SystemExit(
+                  "Release PR still has unchecked judgment items: "
+                  + ", ".join(unchecked)
+              )
+          PY
+
+      - name: Return an incomplete release PR to draft
+        if: failure() && !github.event.pull_request.draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr ready "$PR_URL" --undo

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -58,9 +58,14 @@ ruleset administration must remain limited.
 
 1. Merge the release version bump into `main`.
 2. Open **Actions > Create release > Run workflow**.
-3. Select the `main` branch and enter the exact release tag.
-4. Wait for the workflow to build and verify the release assets and no-push
-   Docker builds. Nothing is tagged or published during this stage.
+3. Select the `main` branch, enter the exact release tag, and set the expected
+   tag delay. Dispatching the workflow acknowledges that no release hold is
+   active.
+4. The workflow resolves the latest digest-verified Mainnet release-state
+   bundle and warns about release-level, committed-state, or
+   `ESTIMATED_RELEASE_HEIGHT` readiness problems. Then wait for it to build and
+   verify the release assets and no-push Docker builds. Nothing is tagged or
+   published during this stage.
 5. Approve the `release` environment deployment. The workflow publishes the
    complete pre-release, creating the protected tag as its final step.
 6. Confirm that `Release binaries` starts from the new tag, skips rebuilding

--- a/make/release.mk
+++ b/make/release.mk
@@ -4,18 +4,23 @@
 
 PRE_RELEASE_WARN_CRATE_VERSION_BUMPS ?= $(if $(CI),0,1)
 CRATE_PACKAGING_VERIFY ?= 0
+TAG_REMOTE ?= https://github.com/zakura-core/zakura.git
 
 prepare-release:
 	@test -n "$(RELEASE_TAG)" || { echo "RELEASE_TAG is required, e.g. make prepare-release RELEASE_TAG=v1.0.0" >&2; exit 1; }
 	./scripts/prepare-release.sh --release-tag "$(RELEASE_TAG)" \
 		$(if $(BASE_TAG),--base-tag "$(BASE_TAG)") \
+		--tag-remote "$(TAG_REMOTE)" \
 		$(if $(filter 1,$(NO_CRATES)),--no-crates) \
 		$(if $(filter 1,$(DRY_RUN)),--dry-run)
 
 prepare-release-changelog:
 	@test -n "$(RELEASE_TAG)" || { echo "RELEASE_TAG is required, e.g. make prepare-release-changelog RELEASE_TAG=v1.0.0" >&2; exit 1; }
 	./scripts/check-release-version.sh "$(RELEASE_TAG)"
-	./scripts/changelog.py release "$(RELEASE_TAG)" $(if $(CHANGELOG_DATE),--date "$(CHANGELOG_DATE)")
+	./scripts/changelog.py release "$(RELEASE_TAG)" \
+		$(if $(CHANGELOG_DATE),--date "$(CHANGELOG_DATE)") \
+		--tag-remote "$(TAG_REMOTE)" \
+		$(if $(filter 1,$(RETARGET_UNPUBLISHED)),--retarget-unpublished)
 
 pre-release:
 	@test -n "$(RELEASE_TAG)" || { echo "RELEASE_TAG is required, e.g. make pre-release RELEASE_TAG=v1.0.0" >&2; exit 1; }

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -16,6 +16,7 @@ from pathlib import Path
 FRAGMENT_DIRECTORY = "changelog-unreleased"
 NO_CHANGELOG_MARKER = "<!-- changelog: none -->"
 ROOT_CHANGELOG = "CHANGELOG.md"
+CANONICAL_TAG_REMOTE = "https://github.com/zakura-core/zakura.git"
 STANDARD_CATEGORIES = (
     "Added",
     "Changed",
@@ -277,7 +278,11 @@ def render_release(
 
 
 def release_plan(
-    repo_root: Path, release_tag: str, release_date: str
+    repo_root: Path,
+    release_tag: str,
+    release_date: str,
+    retarget_latest: bool = False,
+    tag_remote: str = CANONICAL_TAG_REMOTE,
 ) -> tuple[dict[Path, str], list[Path]]:
     tag_match = RELEASE_TAG.match(release_tag)
     if not tag_match:
@@ -326,11 +331,24 @@ def release_plan(
         rendered = render_unreleased(prefix, body, suffix)
     else:
         if not body:
-            raise ChangelogError(
-                f"{path}: release version is {root_version}, latest changelog "
-                f"version is {latest}, but Unreleased is empty"
+            if not retarget_latest:
+                raise ChangelogError(
+                    f"{path}: release version is {root_version}, latest changelog "
+                    f"version is {latest}, but Unreleased is empty"
+                )
+            ensure_retargetable(repo_root, latest, tag_remote)
+            latest_heading = VERSION_HEADING.search(suffix)
+            if latest_heading is None or latest_heading.group(1) != latest:
+                raise ChangelogError(f"{path}: could not retarget latest release {latest}")
+            replacement = f"## [{root_version}] - {release_date}"
+            suffix = (
+                suffix[: latest_heading.start()]
+                + replacement
+                + suffix[latest_heading.end() :]
             )
-        rendered = render_release(prefix, body, suffix, root_version, release_date)
+            rendered = render_unreleased(prefix, body, suffix)
+        else:
+            rendered = render_release(prefix, body, suffix, root_version, release_date)
 
     writes = {path: rendered} if rendered != original else {}
 
@@ -348,6 +366,45 @@ def run_git(repo_root: Path, arguments: list[str]) -> str:
     if result.returncode:
         raise ChangelogError(result.stderr.strip() or "git command failed")
     return result.stdout
+
+
+def git_ref_exists(repo_root: Path, ref: str) -> bool:
+    result = subprocess.run(
+        ["git", "show-ref", "--verify", "--quiet", ref],
+        cwd=repo_root,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise ChangelogError(f"git could not check {ref}")
+    return result.returncode == 0
+
+
+def git_remote_ref_exists(repo_root: Path, remote: str, ref: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "--refs", remote, ref],
+        cwd=repo_root,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 2:
+        return False
+    raise ChangelogError(
+        result.stderr.strip() or f"git could not check {ref} on remote {remote}"
+    )
+
+
+def ensure_retargetable(repo_root: Path, version: str, remote: str) -> None:
+    shallow = run_git(repo_root, ["rev-parse", "--is-shallow-repository"]).strip()
+    if shallow != "false":
+        raise ChangelogError(
+            "cannot retarget an unpublished release from a shallow repository"
+        )
+    ref = f"refs/tags/v{version}"
+    if git_ref_exists(repo_root, ref) or git_remote_ref_exists(repo_root, remote, ref):
+        raise ChangelogError(f"cannot retarget {version}: git tag v{version} exists")
 
 
 def check_pull_request(
@@ -421,6 +478,19 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="fail if release assembly would change tracked files",
     )
+    release.add_argument(
+        "--retarget-unpublished",
+        action="store_true",
+        help=(
+            "rename the latest changelog section if it has no git tag "
+            "and there are no new changes"
+        ),
+    )
+    release.add_argument(
+        "--tag-remote",
+        default=CANONICAL_TAG_REMOTE,
+        help="canonical remote URL checked before retargeting",
+    )
     return parser.parse_args()
 
 
@@ -442,7 +512,13 @@ def main() -> int:
             )
             print("pull request changelog fragment is valid")
         elif args.command == "release":
-            writes, removals = release_plan(repo_root, args.release_tag, args.date)
+            writes, removals = release_plan(
+                repo_root,
+                args.release_tag,
+                args.date,
+                retarget_latest=args.retarget_unpublished,
+                tag_remote=args.tag_remote,
+            )
             if args.check:
                 if writes or removals:
                     changed = [str(path.relative_to(repo_root)) for path in writes]

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -7,20 +7,27 @@
 #   3. Refresh Cargo.lock.
 #   4. Regenerate the stored config fixture for the new version.
 #   5. Update the README install tag (stable releases only).
-#   6. Floor ESTIMATED_RELEASE_HEIGHT from the committed checkpoint list.
-#   7. Assemble the changelog from pending fragments.
+#   6. Validate the requested Zakura release level from the changelog.
+#   7. Update ESTIMATED_RELEASE_HEIGHT from a verified release-state projection.
+#   8. Require the committed release state to match the latest verified bundle.
+#   9. Assemble the changelog from pending fragments.
 #
-# Judgment calls stay with the reviewer: minor is never downgraded to patch,
-# new crates are reported but not versioned, and the authoritative
-# end-of-support estimate still comes from the release checklist. The
-# "Prepare release PR" workflow runs this script and opens a draft PR; it is
-# equally runnable locally.
+# Judgment calls stay with the reviewer where they cannot be derived safely:
+# minor is never downgraded to patch for library crates, new crates are
+# reported but not versioned, and changelog wording still needs review. The
+# "Prepare release PR" workflow supplies verified release-state inputs; local
+# callers without them retain the committed-checkpoint floor.
 #
 # Usage:
 #   ./scripts/prepare-release.sh --release-tag v1.2.3-rc0 [--base-tag v1.2.2]
+#       [--estimated-release-height HEIGHT]
+#       [--latest-release-state-height HEIGHT]
+#       [--release-state-waiver REASON]
+#       [--tag-remote URL]
 #       [--no-crates] [--dry-run] [--summary-json PATH]
 #
 #   --base-tag      defaults to the most recent v* tag reachable from HEAD
+#   --tag-remote    canonical tag source checked before retargeting
 #   --no-crates     GitHub-only release candidate: bump only the zakura package
 #   --dry-run       print the bump plan and intended edits; modify nothing
 #   --summary-json  write a machine-readable summary (used for the PR body)
@@ -34,9 +41,13 @@ base_tag=""
 no_crates=0
 dry_run=0
 summary_json=""
+estimated_release_height=""
+latest_release_state_height=""
+release_state_waiver=""
+tag_remote="https://github.com/zakura-core/zakura.git"
 
 usage() {
-  sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -44,6 +55,10 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --release-tag) release_tag="${2:?--release-tag needs a value}"; shift 2 ;;
     --base-tag) base_tag="${2:?--base-tag needs a value}"; shift 2 ;;
+    --estimated-release-height) estimated_release_height="${2:?--estimated-release-height needs a value}"; shift 2 ;;
+    --latest-release-state-height) latest_release_state_height="${2:?--latest-release-state-height needs a value}"; shift 2 ;;
+    --release-state-waiver) release_state_waiver="${2:?--release-state-waiver needs a value}"; shift 2 ;;
+    --tag-remote) tag_remote="${2:?--tag-remote needs a value}"; shift 2 ;;
     --no-crates) no_crates=1; shift ;;
     --dry-run) dry_run=1; shift ;;
     --summary-json) summary_json="${2:?--summary-json needs a value}"; shift 2 ;;
@@ -70,8 +85,12 @@ if [ "$no_crates" = 1 ] && [ -z "$suffix" ]; then
   echo "ERROR: --no-crates is only valid for release candidates; stable releases always version the full crate graph." >&2
   exit 1
 fi
+if [ -n "$release_state_waiver" ] && [ -z "$suffix" ]; then
+  echo "ERROR: --release-state-waiver is only valid for urgent release candidates." >&2
+  exit 1
+fi
 
-for cmd in cargo git jq awk perl; do
+for cmd in cargo git jq awk perl python3; do
   command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd" >&2; exit 1; }
 done
 cargo release --version >/dev/null 2>&1 \
@@ -97,6 +116,14 @@ if ! git merge-base --is-ancestor "$base_tag" HEAD; then
   echo "ERROR: base tag '${base_tag}' is not an ancestor of HEAD." >&2
   exit 1
 fi
+
+for height_arg in "$estimated_release_height" "$latest_release_state_height"; do
+  if [ -n "$height_arg" ] && ! [[ "$height_arg" =~ ^[0-9]+$ ]] \
+    || [ -n "$height_arg" ] && { [ "$height_arg" -le 0 ] || [ "$height_arg" -ge 4294967296 ]; }; then
+    echo "ERROR: release-state heights must be positive u32 integers, got '${height_arg}'." >&2
+    exit 1
+  fi
+done
 
 if [ "$dry_run" = 0 ] && [ -n "$(git status --porcelain --untracked-files=normal)" ]; then
   echo "ERROR: the working tree is not clean; commit or stash before preparing a release." >&2
@@ -160,6 +187,66 @@ plan_currents=()
 plan_manifests=()
 
 metadata="$(cargo metadata --format-version 1 --no-deps)"
+zakura_old="$(
+  jq -r '.packages[] | select(.name == "zakura") | .version' <<<"$metadata"
+)"
+
+base_zakura_version="$(
+  git show "${base_tag}:zakurad/Cargo.toml" \
+    | awk -F ' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }'
+)"
+if [ -z "$base_zakura_version" ]; then
+  echo "ERROR: could not read the zakura package version at ${base_tag}." >&2
+  exit 1
+fi
+version_readiness="$(
+  python3 scripts/release-readiness.py version \
+    --repo-root "$repo_root" \
+    --base-version "$base_zakura_version" \
+    --release-tag "$release_tag"
+)"
+echo "Zakura release level: $(jq -r \
+  '"target \(.target), minimum \(.minimum_version) (\(.minimum_level)); categories: \(.categories | join(", "))"' \
+  <<<"$version_readiness")"
+
+retarget_unpublished=0
+latest_changelog_version="$(jq -r '.changelog.latest_version' <<<"$version_readiness")"
+pending_fragments="$(jq -r '.changelog.pending_fragments' <<<"$version_readiness")"
+unreleased_category_count="$(
+  jq -r '.changelog.unreleased_categories | length' <<<"$version_readiness"
+)"
+if [ -n "$suffix" ] \
+  && [ "$zakura_old" != "$version" ] \
+  && [ "$latest_changelog_version" = "$zakura_old" ] \
+  && [ "$pending_fragments" -eq 0 ] \
+  && [ "$unreleased_category_count" -eq 0 ]; then
+  old_tag_ref="refs/tags/v${zakura_old}"
+  if git show-ref --verify --quiet "$old_tag_ref"; then
+    echo "ERROR: cannot retarget v${zakura_old}; the local tag exists." >&2
+    exit 1
+  fi
+  if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+    echo "ERROR: cannot retarget an unpublished release from a shallow repository." >&2
+    exit 1
+  fi
+  remote_tag_status=0
+  git ls-remote --exit-code --refs "$tag_remote" "$old_tag_ref" >/dev/null 2>&1 \
+    || remote_tag_status=$?
+  case "$remote_tag_status" in
+    0)
+      echo "ERROR: cannot retarget v${zakura_old}; the tag exists on ${tag_remote}." >&2
+      exit 1
+      ;;
+    2)
+      retarget_unpublished=1
+      echo "Retargeting unpublished release preparation v${zakura_old} to ${release_tag}."
+      ;;
+    *)
+      echo "ERROR: could not verify ${old_tag_ref} against ${tag_remote}." >&2
+      exit 1
+      ;;
+  esac
+fi
 
 add_to_plan() {
   # add_to_plan name target current manifest_rel
@@ -210,6 +297,13 @@ if [ "$no_crates" = 0 ]; then
     if [ -z "$base_version" ]; then
       echo "ERROR: could not read ${crate}'s package version at ${base_tag}." >&2
       exit 1
+    fi
+
+    if [ "$retarget_unpublished" = 1 ] \
+      && [ "$current_version" = "$base_version" ]; then
+      add_crate_row "$crate" "$base_version" "$current_version" "$current_version" \
+        "kept" "unchanged in the existing unpublished release preparation"
+      continue
     fi
 
     if [ "$current_version" != "$base_version" ]; then
@@ -284,24 +378,39 @@ if [ "$no_crates" = 0 ]; then
   )
 fi
 
-zakura_old="$(
-  cargo metadata --format-version 1 --no-deps \
-    | jq -r '.packages[] | select(.name == "zakura") | .version'
-)"
-
-# End-of-support floor: committed checkpoint height plus ~3 days of blocks.
-# The release checklist's manual estimate from the live chain tip stays
-# authoritative; this only keeps a skipped step from shipping a stale value.
+# The workflow projects the release height from a fresh, digest-verified
+# release-state bundle. Local callers retain the committed checkpoint plus
+# three days as a fail-safe floor.
 eos_file="zakurad/src/components/sync/end_of_support.rs"
 checkpoint_file="zakura-chain/src/parameters/checkpoint/main-checkpoints.txt"
 committed_height="$(tail -1 "$checkpoint_file" | cut -d' ' -f1)"
 eos_floor=$((committed_height + 3456))
+if [ -n "$latest_release_state_height" ] \
+  && [ "$latest_release_state_height" -gt "$committed_height" ] \
+  && [ -z "$release_state_waiver" ]; then
+  cat >&2 <<EOF
+ERROR: committed Mainnet release state ends at ${committed_height}, but the
+latest verified bundle ends at ${latest_release_state_height}.
+
+Run the Update Mainnet release state workflow, review and merge its PR, then
+retry release preparation. For an urgent release candidate only, pass a
+non-empty --release-state-waiver reason so the exception is recorded.
+EOF
+  exit 1
+fi
 eos_old="$(
   grep -oE 'ESTIMATED_RELEASE_HEIGHT: u32 = [0-9_]+' "$eos_file" \
     | grep -oE '[0-9_]+$' | tr -d '_'
 )"
+eos_target="$eos_floor"
+eos_basis="committed checkpoint ${committed_height} + 3456"
+if [ -n "$estimated_release_height" ] \
+  && [ "$estimated_release_height" -gt "$eos_target" ]; then
+  eos_target="$estimated_release_height"
+  eos_basis="fresh verified release-state projection"
+fi
 eos_floored=0
-[ "$eos_old" -lt "$eos_floor" ] && eos_floored=1
+[ "$eos_old" -lt "$eos_target" ] && eos_floored=1
 
 fragment_count="$(find changelog-unreleased -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')"
 
@@ -314,9 +423,15 @@ jq -r '.[] | "  \(.name): \(.base // "-") -> \(.target // "?") [\(.level)] (\(.r
 [ "$(jq 'length' <<<"$crates_json")" != 0 ] || echo "  (no publishable crate changes)"
 echo "  zakura: ${zakura_old} -> ${version} (release tag)"
 if [ "$eos_floored" = 1 ]; then
-  echo "  ESTIMATED_RELEASE_HEIGHT: ${eos_old} -> ${eos_floor} (checkpoint ${committed_height} + 3456)"
+  echo "  ESTIMATED_RELEASE_HEIGHT: ${eos_old} -> ${eos_target} (${eos_basis})"
 else
-  echo "  ESTIMATED_RELEASE_HEIGHT: ${eos_old} already at or above the ${eos_floor} floor"
+  echo "  ESTIMATED_RELEASE_HEIGHT: ${eos_old} already at or above ${eos_target} (${eos_basis})"
+fi
+if [ -n "$latest_release_state_height" ]; then
+  echo "  Release state: committed ${committed_height}, latest verified ${latest_release_state_height}"
+fi
+if [ -n "$release_state_waiver" ]; then
+  echo "  Release-state waiver: ${release_state_waiver}"
 fi
 echo "  Changelog fragments to consume: ${fragment_count}"
 if [ -z "$suffix" ]; then
@@ -333,17 +448,31 @@ write_summary() {
     --argjson no_crates "$([ "$no_crates" = 1 ] && echo true || echo false)" \
     --argjson dry_run "$([ "$dry_run" = 1 ] && echo true || echo false)" \
     --argjson crates "$crates_json" \
+    --argjson version_readiness "$version_readiness" \
     --arg zakura_old "$zakura_old" \
     --arg zakura_new "$version" \
     --argjson eos_old "$eos_old" \
-    --argjson eos_floor "$eos_floor" \
+    --argjson eos_target "$eos_target" \
+    --arg eos_basis "$eos_basis" \
     --argjson eos_floored "$([ "$eos_floored" = 1 ] && echo true || echo false)" \
+    --argjson committed_release_state_height "$committed_height" \
+    --argjson latest_release_state_height "${latest_release_state_height:-$committed_height}" \
+    --arg release_state_waiver "$release_state_waiver" \
+    --argjson retargeted_unpublished "$([ "$retarget_unpublished" = 1 ] && echo true || echo false)" \
     --argjson readme_updated "$([ -z "$suffix" ] && echo true || echo false)" \
     --argjson fragments_consumed "$fragment_count" \
     '{release_tag: $release_tag, base_tag: $base_tag, no_crates: $no_crates,
       dry_run: $dry_run, crates: $crates,
+      version_readiness: $version_readiness,
+      retargeted_unpublished: $retargeted_unpublished,
       zakura: {old: $zakura_old, new: $zakura_new},
-      eos: {old: $eos_old, floor: $eos_floor, floored: $eos_floored},
+      eos: {old: $eos_old, target: $eos_target, basis: $eos_basis,
+            floored: $eos_floored},
+      release_state: {
+        committed_height: $committed_release_state_height,
+        latest_verified_height: $latest_release_state_height,
+        waiver: $release_state_waiver
+      },
       fixture: ("zakurad/tests/common/configs/v" + $zakura_new + ".toml"),
       readme_updated: $readme_updated,
       fragments_consumed: $fragments_consumed}' \
@@ -443,8 +572,8 @@ fi
 
 if [ "$eos_floored" = 1 ]; then
   echo
-  echo "==> Flooring ESTIMATED_RELEASE_HEIGHT at ${eos_floor}"
-  formatted="$(echo "$eos_floor" | awk '{n=$0; r=""; for(i=length(n);i>0;i--) { r=substr(n,i,1) r; if((length(n)-i)%3==2 && i>1) r="_" r }; print r}')"
+  echo "==> Updating ESTIMATED_RELEASE_HEIGHT to ${eos_target}"
+  formatted="$(echo "$eos_target" | awk '{n=$0; r=""; for(i=length(n);i>0;i--) { r=substr(n,i,1) r; if((length(n)-i)%3==2 && i>1) r="_" r }; print r}')"
   # sed -i needs a suffix argument on macOS; keep the script runnable locally.
   sed -i.prepare-release.bak \
     "s/ESTIMATED_RELEASE_HEIGHT: u32 = [0-9_]*/ESTIMATED_RELEASE_HEIGHT: u32 = ${formatted}/" \
@@ -454,7 +583,10 @@ fi
 
 echo
 echo "==> Assembling the changelog"
-make prepare-release-changelog RELEASE_TAG="$release_tag"
+make prepare-release-changelog \
+  RELEASE_TAG="$release_tag" \
+  RETARGET_UNPUBLISHED="$retarget_unpublished" \
+  TAG_REMOTE="$tag_remote"
 
 echo
 echo "Release preparation for ${release_tag} is complete; review with 'git diff'."

--- a/scripts/release-readiness.py
+++ b/scripts/release-readiness.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Compute release-version and Mainnet-height readiness values."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import changelog
+
+BLOCKS_PER_DAY = 1152
+MINOR_CATEGORIES = {"Added", "Changed", "Deprecated", "Removed"}
+NETWORK_UPGRADE = re.compile(r"\b(?:mainnet\s+)?network upgrade\b", re.IGNORECASE)
+VERSION = re.compile(
+    r"^(?P<major>0|[1-9][0-9]*)\."
+    r"(?P<minor>0|[1-9][0-9]*)\."
+    r"(?P<patch>0|[1-9][0-9]*)"
+    r"(?P<prerelease>-rc(?P<rc>[0-9]+))?$"
+)
+
+
+class ReadinessError(RuntimeError):
+    """A release-readiness input or invariant is invalid."""
+
+
+@dataclass(frozen=True, order=True)
+class CoreVersion:
+    major: int
+    minor: int
+    patch: int
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(frozen=True)
+class Version:
+    core: CoreVersion
+    rc: int | None
+
+
+def parse_version(value: str) -> Version:
+    match = VERSION.fullmatch(value)
+    if match is None:
+        raise ReadinessError(f"invalid version {value!r}; expected X.Y.Z or X.Y.Z-rcN")
+    return Version(
+        CoreVersion(
+            int(match.group("major")),
+            int(match.group("minor")),
+            int(match.group("patch")),
+        ),
+        int(match.group("rc")) if match.group("rc") is not None else None,
+    )
+
+
+def changelog_context(
+    repo_root: Path, base_version: str
+) -> tuple[dict[str, list[str]], dict[str, object]]:
+    root_path = repo_root / changelog.ROOT_CHANGELOG
+    _, unreleased, suffix = changelog.split_unreleased(
+        root_path.read_text(), root_path
+    )
+    unreleased_entries = changelog.parse_unreleased_body(unreleased, root_path)
+    fragments = changelog.load_fragments(repo_root)
+    entries: dict[str, list[str]] = {
+        category: [body]
+        for category, body in unreleased_entries.items()
+    }
+    for fragment in fragments:
+        for category, body in fragment.entries.items():
+            entries.setdefault(category, []).append(body)
+
+    # Include assembled-but-untagged release sections. This matters when a
+    # prepared release PR was merged but publication was stopped: a retry must
+    # still see the entries that justified its release level.
+    matches = list(changelog.VERSION_HEADING.finditer(suffix))
+    found_base = False
+    for index, match in enumerate(matches):
+        version = match.group(1)
+        if version == base_version:
+            found_base = True
+            break
+        section_end = (
+            matches[index + 1].start() if index + 1 < len(matches) else len(suffix)
+        )
+        body = suffix[match.end() : section_end].strip()
+        for category, category_body in changelog.parse_category_body(
+            body, root_path, f"release {version}"
+        ).items():
+            entries.setdefault(category, []).append(category_body)
+    if not found_base:
+        raise ReadinessError(
+            f"root changelog has no section for base version {base_version}"
+        )
+    return entries, {
+        "latest_version": changelog.latest_changelog_version(suffix, root_path),
+        "unreleased_categories": sorted(unreleased_entries),
+        "pending_fragments": len(fragments),
+    }
+
+
+def release_entries(repo_root: Path, base_version: str) -> dict[str, list[str]]:
+    entries, _ = changelog_context(repo_root, base_version)
+    return entries
+
+
+def minimum_release(
+    base: Version, target: Version, entries: dict[str, list[str]]
+) -> tuple[str, CoreVersion, list[str]]:
+    categories = sorted(entries)
+    combined = "\n".join(body for bodies in entries.values() for body in bodies)
+
+    # Later candidates and the stable release keep the core chosen by the
+    # first candidate. New entries during the candidate cycle are folded into
+    # that pending release rather than forcing another bump.
+    if base.rc is not None and target.core == base.core:
+        if target.rc is not None and target.rc <= base.rc:
+            raise ReadinessError(
+                f"target rc{target.rc} must advance from base rc{base.rc}"
+            )
+        return "continuation", base.core, categories
+
+    if NETWORK_UPGRADE.search(combined):
+        level = "major"
+        minimum = CoreVersion(base.core.major + 1, 0, 0)
+    elif MINOR_CATEGORIES.intersection(entries):
+        level = "minor"
+        minimum = CoreVersion(base.core.major, base.core.minor + 1, 0)
+    else:
+        level = "patch"
+        minimum = CoreVersion(base.core.major, base.core.minor, base.core.patch + 1)
+
+    if target.core < minimum:
+        raise ReadinessError(
+            f"target {target.core} is below the {minimum} {level} floor "
+            f"required by changelog categories: {', '.join(categories) or 'none'}"
+        )
+    if target.core <= base.core:
+        raise ReadinessError(
+            f"target {target.core} must advance from released version {base.core}"
+        )
+
+    return level, minimum, categories
+
+
+def version_report(repo_root: Path, base_version: str, release_tag: str) -> dict[str, object]:
+    if not release_tag.startswith("v"):
+        raise ReadinessError("release tag must start with 'v'")
+    base = parse_version(base_version)
+    target = parse_version(release_tag.removeprefix("v"))
+    entries, context = changelog_context(repo_root, base_version)
+    level, minimum, categories = minimum_release(base, target, entries)
+    return {
+        "base": base_version,
+        "target": release_tag.removeprefix("v"),
+        "minimum_level": level,
+        "minimum_version": str(minimum),
+        "categories": categories,
+        "changelog": context,
+    }
+
+
+def parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ReadinessError("generated_at must be an RFC 3339 timestamp") from error
+    if parsed.tzinfo is None:
+        raise ReadinessError("generated_at must include a timezone")
+    return parsed
+
+
+def estimated_height(
+    bundle_height: int,
+    generated_at: datetime,
+    now: datetime,
+    delay_days: int,
+) -> int:
+    if bundle_height <= 0 or bundle_height >= 2**32:
+        raise ReadinessError("bundle height is outside the u32 block-height range")
+    if delay_days < 0 or delay_days > 30:
+        raise ReadinessError("expected tag delay must be between 0 and 30 days")
+    if generated_at > now + timedelta(minutes=10):
+        raise ReadinessError("bundle generation time is unexpectedly in the future")
+
+    elapsed = max(timedelta(), now - generated_at) + timedelta(days=delay_days)
+    projected_blocks = math.ceil(elapsed.total_seconds() * BLOCKS_PER_DAY / 86400)
+    projected = bundle_height + projected_blocks
+    if projected >= 2**32:
+        raise ReadinessError("projected release height exceeds the u32 range")
+    return projected
+
+
+def height_report(
+    resolution_path: Path,
+    delay_days: int,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    try:
+        resolution = json.loads(resolution_path.read_text())
+        bundle_height = resolution["height"]
+        generated_at_text = resolution["generated_at"]
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        raise ReadinessError(f"cannot read release-state resolution: {error}") from error
+    if isinstance(bundle_height, bool) or not isinstance(bundle_height, int):
+        raise ReadinessError("release-state resolution height must be an integer")
+    generated_at = parse_timestamp(generated_at_text)
+    now = now or datetime.now(timezone.utc)
+    return {
+        "bundle_height": bundle_height,
+        "generated_at": generated_at_text,
+        "expected_tag_delay_days": delay_days,
+        "estimated_release_height": estimated_height(
+            bundle_height, generated_at, now, delay_days
+        ),
+    }
+
+
+class SelfTests(unittest.TestCase):
+    def test_assembled_untagged_section_still_sets_release_floor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "changelog-unreleased").mkdir()
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [1.0.6-rc0] - 2026-08-01\n\n"
+                "### Added\n\n"
+                "- Added an RPC.\n\n"
+                "## [1.0.5] - 2026-07-27\n\n"
+                "### Fixed\n\n"
+                "- Fixed an older bug.\n"
+            )
+            entries, context = changelog_context(root, "1.0.5")
+            self.assertEqual(sorted(entries), ["Added"])
+            self.assertEqual(context["latest_version"], "1.0.6-rc0")
+            self.assertEqual(context["unreleased_categories"], [])
+            self.assertEqual(context["pending_fragments"], 0)
+            with self.assertRaisesRegex(ReadinessError, "minor floor"):
+                minimum_release(
+                    parse_version("1.0.5"),
+                    parse_version("1.0.6-rc0"),
+                    entries,
+                )
+
+    def test_minor_category_rejects_patch_target(self) -> None:
+        with self.assertRaisesRegex(ReadinessError, "minor floor"):
+            minimum_release(
+                parse_version("1.0.5"),
+                parse_version("1.0.6-rc0"),
+                {"Added": ["- Added an RPC."]},
+            )
+
+    def test_fixed_category_allows_patch_target(self) -> None:
+        level, minimum, _ = minimum_release(
+            parse_version("1.0.5"),
+            parse_version("1.0.6-rc0"),
+            {"Fixed": ["- Fixed a bug."]},
+        )
+        self.assertEqual((level, str(minimum)), ("patch", "1.0.6"))
+
+    def test_network_upgrade_requires_major_target(self) -> None:
+        with self.assertRaisesRegex(ReadinessError, "major floor"):
+            minimum_release(
+                parse_version("1.4.2"),
+                parse_version("1.5.0-rc0"),
+                {"Added": ["- Added the Mainnet Network Upgrade."]},
+            )
+
+    def test_release_candidate_continuation_keeps_core(self) -> None:
+        level, minimum, _ = minimum_release(
+            parse_version("1.1.0-rc0"),
+            parse_version("1.1.0-rc1"),
+            {},
+        )
+        self.assertEqual((level, str(minimum)), ("continuation", "1.1.0"))
+
+    def test_stable_release_continues_release_candidate_core(self) -> None:
+        level, minimum, _ = minimum_release(
+            parse_version("1.1.0-rc1"),
+            parse_version("1.1.0"),
+            {},
+        )
+        self.assertEqual((level, str(minimum)), ("continuation", "1.1.0"))
+
+    def test_release_candidate_cannot_repeat(self) -> None:
+        with self.assertRaisesRegex(ReadinessError, "must advance"):
+            minimum_release(
+                parse_version("1.1.0-rc1"),
+                parse_version("1.1.0-rc1"),
+                {},
+            )
+
+    def test_release_candidate_cannot_decrease(self) -> None:
+        with self.assertRaisesRegex(ReadinessError, "must advance"):
+            minimum_release(
+                parse_version("1.1.0-rc2"),
+                parse_version("1.1.0-rc1"),
+                {},
+            )
+
+    def test_height_projection_includes_delay(self) -> None:
+        generated = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        now = generated + timedelta(hours=12)
+        self.assertEqual(estimated_height(3_400_000, generated, now, 1), 3_401_728)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    version_parser = subparsers.add_parser("version")
+    version_parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    version_parser.add_argument("--base-version", required=True)
+    version_parser.add_argument("--release-tag", required=True)
+
+    height_parser = subparsers.add_parser("height")
+    height_parser.add_argument("--resolution", type=Path, required=True)
+    height_parser.add_argument("--expected-tag-delay-days", type=int, default=0)
+
+    subparsers.add_parser("self-test")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "version":
+            report = version_report(args.repo_root, args.base_version, args.release_tag)
+        elif args.command == "height":
+            report = height_report(
+                args.resolution,
+                args.expected_tag_delay_days,
+            )
+        else:
+            suite = unittest.defaultTestLoader.loadTestsFromTestCase(SelfTests)
+            return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+    except (ReadinessError, changelog.ChangelogError) as error:
+        print(f"release readiness failed: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release-t0.sh
+++ b/scripts/release-t0.sh
@@ -42,6 +42,8 @@
 #                      publish; pins merge, push, and dispatch verification)
 #   --source-first     Mode B: pass source_first_release=true to the workflow
 #   --allow-bootstrap-release-state  pass the emergency workflow input through
+#   --release-state-waiver REASON  urgent RC only: record why the committed
+#                      release state may trail the latest verified bundle
 #   --repo OWNER/NAME  default zakura-core/zakura (or $REPOSITORY); any other
 #                      value needs --allow-nondefault-repo (staging drills)
 #   --allow-nondefault-repo  explicit staging-repo override
@@ -65,6 +67,7 @@ PR_NUM=""
 HEAD_SHA=""
 SOURCE_FIRST=0
 ALLOW_BOOTSTRAP=0
+RELEASE_STATE_WAIVER=""
 ALLOW_NONDEFAULT_REPO=0
 RUN_ID_ARG=""
 DRY_RUN=0
@@ -521,9 +524,10 @@ step_merge_or_push() {
   local merge_args=(gh pr merge "$PR_NUM" --repo "$REPO" --squash
     --match-head-commit "$HEAD_SHA")
   if ! act "squash-merging PR #${PR_NUM}" "${merge_args[@]}"; then
-    warn "plain squash-merge refused (review requirements?)"
-    confirm "Retry with --admin (bypasses review requirements)?"
-    act "squash-merging PR #${PR_NUM} with --admin" "${merge_args[@]}" --admin
+    die "$step" "gh pr merge ${PR_NUM}" "refused by repository rules" \
+      "all release-readiness, review, and merge requirements satisfied" \
+      "inspect the PR's failed or pending checks and unresolved review requirements;" \
+      "do not bypass release readiness with an admin merge"
   fi
   [ "$DRY_RUN" = 1 ] && { MERGE_SHA="$HEAD_SHA"; return 0; }
 
@@ -575,6 +579,8 @@ step_dispatch() {
     --ref "$dispatch_ref" -f "release_tag=${TAG}")
   [ "$SOURCE_FIRST" = 1 ] && dispatch_args+=(-f source_first_release=true)
   [ "$ALLOW_BOOTSTRAP" = 1 ] && dispatch_args+=(-f allow_bootstrap_release_state=true)
+  [ -z "$RELEASE_STATE_WAIVER" ] \
+    || dispatch_args+=(-f "release_state_waiver=${RELEASE_STATE_WAIVER}")
   act "dispatching Create release for ${TAG} from ${dispatch_ref}" "${dispatch_args[@]}"
   [ "$DRY_RUN" = 1 ] && return 0
 
@@ -909,6 +915,7 @@ main() {
       --head-sha) HEAD_SHA="$2"; shift 2 ;;
       --source-first) SOURCE_FIRST=1; shift ;;
       --allow-bootstrap-release-state) ALLOW_BOOTSTRAP=1; shift ;;
+      --release-state-waiver) RELEASE_STATE_WAIVER="$2"; shift 2 ;;
       --repo) REPO="$2"; shift 2 ;;
       --allow-nondefault-repo) ALLOW_NONDEFAULT_REPO=1; shift ;;
       --run-id) RUN_ID_ARG="$2"; shift 2 ;;

--- a/scripts/release-t0.sh
+++ b/scripts/release-t0.sh
@@ -44,6 +44,8 @@
 #   --allow-bootstrap-release-state  pass the emergency workflow input through
 #   --release-state-waiver REASON  urgent RC only: record why the committed
 #                      release state may trail the latest verified bundle
+#   --expected-tag-delay-days DAYS  expected preparation-to-tag delay, 0–30
+#                      (must match the Prepare release PR input; default 0)
 #   --repo OWNER/NAME  default zakura-core/zakura (or $REPOSITORY); any other
 #                      value needs --allow-nondefault-repo (staging drills)
 #   --allow-nondefault-repo  explicit staging-repo override
@@ -68,6 +70,7 @@ HEAD_SHA=""
 SOURCE_FIRST=0
 ALLOW_BOOTSTRAP=0
 RELEASE_STATE_WAIVER=""
+EXPECTED_TAG_DELAY_DAYS=0
 ALLOW_NONDEFAULT_REPO=0
 RUN_ID_ARG=""
 DRY_RUN=0
@@ -78,7 +81,7 @@ ALLOW_SQUASH=0
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
-usage() { sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,59p' "$0" | sed 's/^# \{0,1\}//'; }
 
 # --- output helpers ---------------------------------------------------------
 
@@ -204,6 +207,10 @@ check_globals() {
   [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] \
     || die "arguments" "--tag shape" "$TAG" "v<major>.<minor>.<patch>[-pre]" \
         "pass a tag like v1.0.4 or v1.0.4-rc0"
+  [[ "$EXPECTED_TAG_DELAY_DAYS" =~ ^([0-9]|[12][0-9]|30)$ ]] \
+    || die "arguments" "--expected-tag-delay-days" "$EXPECTED_TAG_DELAY_DAYS" \
+        "an integer from 0 through 30" \
+        "pass the same expected tag delay used by Prepare release PR"
 
   # Never trust local tags: warn when one shadows or diverges from the remote.
   local local_commit remote_commit=""
@@ -576,7 +583,8 @@ step_dispatch() {
     --limit 1 --json databaseId --jq '.[0].databaseId // 0')
 
   local dispatch_args=(gh workflow run create-release.yml --repo "$REPO"
-    --ref "$dispatch_ref" -f "release_tag=${TAG}")
+    --ref "$dispatch_ref" -f "release_tag=${TAG}"
+    -f "expected_tag_delay_days=${EXPECTED_TAG_DELAY_DAYS}")
   [ "$SOURCE_FIRST" = 1 ] && dispatch_args+=(-f source_first_release=true)
   [ "$ALLOW_BOOTSTRAP" = 1 ] && dispatch_args+=(-f allow_bootstrap_release_state=true)
   [ -z "$RELEASE_STATE_WAIVER" ] \
@@ -916,6 +924,7 @@ main() {
       --source-first) SOURCE_FIRST=1; shift ;;
       --allow-bootstrap-release-state) ALLOW_BOOTSTRAP=1; shift ;;
       --release-state-waiver) RELEASE_STATE_WAIVER="$2"; shift 2 ;;
+      --expected-tag-delay-days) EXPECTED_TAG_DELAY_DAYS="$2"; shift 2 ;;
       --repo) REPO="$2"; shift 2 ;;
       --allow-nondefault-repo) ALLOW_NONDEFAULT_REPO=1; shift ;;
       --run-id) RUN_ID_ARG="$2"; shift 2 ;;
@@ -935,10 +944,10 @@ main() {
       printf '\npreflight complete. Execution plan for publish:\n'
       if [ "$MODE" = "branch" ]; then
         printf '  1. git push origin %s:refs/heads/hotfix/%s\n' "${HEAD_SHA:0:9}" "$TAG"
-        printf '  2. gh workflow run create-release.yml --repo %s --ref hotfix/%s -f release_tag=%s\n' "$REPO" "$TAG" "$TAG"
+        printf '  2. gh workflow run create-release.yml --repo %s --ref hotfix/%s -f release_tag=%s -f expected_tag_delay_days=%s\n' "$REPO" "$TAG" "$TAG" "$EXPECTED_TAG_DELAY_DAYS"
       else
         printf '  1. gh pr merge %s --repo %s --squash --match-head-commit %s\n' "${PR_NUM:-<N>}" "$REPO" "$HEAD_SHA"
-        printf '  2. gh workflow run create-release.yml --repo %s --ref main -f release_tag=%s\n' "$REPO" "$TAG"
+        printf '  2. gh workflow run create-release.yml --repo %s --ref main -f release_tag=%s -f expected_tag_delay_days=%s\n' "$REPO" "$TAG" "$EXPECTED_TAG_DELAY_DAYS"
       fi
       printf '  3. watch to the release-environment gate; YOU approve\n'
       printf '  4. verify tag + release + assets\n'

--- a/scripts/tests/test_changelog.py
+++ b/scripts/tests/test_changelog.py
@@ -166,6 +166,50 @@ class ChangelogTests(unittest.TestCase):
         with self.assertRaisesRegex(changelog.ChangelogError, "Unreleased is empty"):
             changelog.release_plan(self.root, "v1.1.0", "2026-07-21")
 
+    def test_release_retargets_unpublished_version_without_new_entries(self):
+        with mock.patch.object(changelog, "ensure_retargetable") as safety_check:
+            writes, removals = changelog.release_plan(
+                self.root,
+                "v1.1.0-rc0",
+                "2026-07-21",
+                retarget_latest=True,
+            )
+
+        rendered = writes[self.root / "CHANGELOG.md"]
+        safety_check.assert_called_once_with(
+            self.root,
+            "1.0.0",
+            changelog.CANONICAL_TAG_REMOTE,
+        )
+        self.assertIn("## [1.1.0-rc0] - 2026-07-21", rendered)
+        self.assertNotIn("## [1.0.0]", rendered)
+        self.assertIn("- Previous release.", rendered)
+        self.assertEqual(removals, [])
+
+    def test_retarget_rejects_shallow_repository(self):
+        with mock.patch.object(changelog, "run_git", return_value="true\n"):
+            with self.assertRaisesRegex(changelog.ChangelogError, "shallow"):
+                changelog.ensure_retargetable(self.root, "1.0.0", "origin")
+
+    def test_retarget_rejects_remote_tag(self):
+        with (
+            mock.patch.object(changelog, "run_git", return_value="false\n"),
+            mock.patch.object(changelog, "git_ref_exists", return_value=False),
+            mock.patch.object(changelog, "git_remote_ref_exists", return_value=True),
+        ):
+            with self.assertRaisesRegex(changelog.ChangelogError, "tag .* exists"):
+                changelog.ensure_retargetable(self.root, "1.0.0", "origin")
+
+    def test_retarget_rejects_local_tag(self):
+        with (
+            mock.patch.object(changelog, "run_git", return_value="false\n"),
+            mock.patch.object(changelog, "git_ref_exists", return_value=True),
+            mock.patch.object(changelog, "git_remote_ref_exists") as remote_check,
+        ):
+            with self.assertRaisesRegex(changelog.ChangelogError, "tag .* exists"):
+                changelog.ensure_retargetable(self.root, "1.0.0", "origin")
+        remote_check.assert_not_called()
+
     def test_stable_release_combines_and_removes_release_candidates(self):
         first = self.root / "changelog-unreleased" / "101.md"
         first.write_text("## Added\n\n- Added the first feature.\n")


### PR DESCRIPTION
## Motivation

Release preparation accepted an undersized `v1.0.6-rc0` target, relied on a stale end-of-support floor, and failed when a prepared but untagged release needed to be retargeted with no new changelog entries. Several release checklist requirements were manual and could be missed between preparation and publication.

## Solution

- Derive the minimum Zakura release level from pending and assembled-but-untagged changelog entries, including strict forward-only RC progression.
- Resolve a fresh digest-verified Mainnet release-state bundle during preparation, project the expected tagging height, update `ESTIMATED_RELEASE_HEIGHT`, and block stale committed state unless an urgent RC waiver is recorded.
- Re-run release-level, state-freshness, and support-height checks as non-blocking advisories during `Create release`.
- Record `cargo public-api diff latest` evidence for changed published libraries while excluding new crates without a published baseline.
- Safely retarget an unpublished prepared changelog section when there are no new entries, rejecting shallow repositories and checking both local tags and the explicit canonical Zakura tag source.
- Require stable hidden judgment markers before a release PR can leave draft, so checklist items cannot be bypassed by deleting their text.
- Forward the preparation-to-tag delay through the T-0 orchestrator, remove its admin merge bypass, and keep repository review requirements authoritative.
- Update the release checklist and tag-protection documentation for the automated checks and remaining human judgments.

The unrelated unattended auto-prepare/auto-merge behavior from #500 is not included; release preparation remains a human-reviewed draft PR flow.

## Testing

- `actionlint .github/workflows/create-release.yml .github/workflows/prepare-release-pr.yml .github/workflows/release-pr-readiness.yml`
- `shellcheck scripts/prepare-release.sh scripts/release-t0.sh`
- `python3 -m unittest scripts/tests/test_changelog.py` (20 tests)
- `python3 scripts/release-readiness.py self-test` (9 tests)
- `python3 -m py_compile scripts/changelog.py scripts/release-readiness.py`
- `npx --yes markdownlint-cli2 --config .trunk/configs/.markdownlint.yaml .github/PULL_REQUEST_TEMPLATE/release-checklist.md docs/release-tag-protection.md`
- `git diff --check`
- Targeted advisory failure, judgment-marker, public-API filter, and canonical tag-source propagation scenarios

## Changelog

No fragment: this PR changes CI, release tooling, tests, and documentation only; it does not change Rust source or `Cargo.toml`.

### Specifications & References

- #500 — explicitly excluded unattended auto-merge implementation
- Failed release preparation run: https://github.com/zakura-core/zakura/actions/runs/30684626108/job/91327930303

### Follow-up Work

- Keep the new `Create release` readiness checks advisory until maintainers choose to make them blocking.