### PR TITLE
fix(network): escape peer-provided command bytes in legacy codec logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8823,6 +8823,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-futures",
+ "tracing-subscriber",
  "zakura-chain",
  "zakura-jsonl-trace",
  "zakura-test",

--- a/changelog-unreleased/513.md
+++ b/changelog-unreleased/513.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Unknown peer message commands are now escaped before they are written to the
+  log, so control characters sent by a peer can no longer alter log output
+  ([#513](https://github.com/zakura-core/zakura/pull/513)).

--- a/zakura-network/Cargo.toml
+++ b/zakura-network/Cargo.toml
@@ -104,6 +104,7 @@ criterion = { workspace = true }
 static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "3.1.0-rc0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.0.0" }

--- a/zakura-network/src/protocol/external/codec.rs
+++ b/zakura-network/src/protocol/external/codec.rs
@@ -53,6 +53,22 @@ const MAX_HANDSHAKE_BODY_LEN: usize = 1024;
 /// The parse error returned when a legacy message body parser panics.
 const PANICKED_MESSAGE_BODY_PARSE_ERROR: &str = "panic while parsing peer message body";
 
+/// Returns the message header `command` bytes escaped as printable ASCII.
+///
+/// # Security
+///
+/// The command field is attacker-controlled, so it must be escaped before
+/// logging. Otherwise, a peer can inject newlines, ANSI escape sequences, or
+/// other control characters into log output.
+fn escape_command(command: &[u8; 12]) -> String {
+    command
+        .iter()
+        .copied()
+        .flat_map(std::ascii::escape_default)
+        .map(char::from)
+        .collect()
+}
+
 #[cfg(test)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum BodyDecodePanic {
@@ -421,12 +437,7 @@ impl Decoder for Codec {
                 trace!(
                     ?self.state,
                     ?magic,
-                    command = %String::from_utf8(
-                        command.iter()
-                            .cloned()
-                            .flat_map(std::ascii::escape_default)
-                            .collect()
-                    ).unwrap(),
+                    command = %escape_command(&command),
                     body_len,
                     ?checksum,
                     "read header from src buffer"
@@ -520,7 +531,12 @@ impl Decoder for Codec {
                         b"filteradd\0\0\0" => self.read_filteradd(&mut body_reader, body_len),
                         b"filterclear\0" => self.read_filterclear(&mut body_reader),
                         _ => {
-                            let command_string = String::from_utf8_lossy(&command);
+                            // # Security
+                            //
+                            // The command bytes are attacker-controlled, so they are
+                            // escaped before logging to stop peers injecting control
+                            // characters into log output.
+                            let command_string = escape_command(&command);
 
                             // # Security
                             //
@@ -556,8 +572,11 @@ impl Decoder for Codec {
                 match decode_result {
                     Ok(result) => result,
                     Err(_panic_payload) => {
-                        let command = String::from_utf8_lossy(&command)
-                            .trim_end_matches('\0')
+                        // Escaped for consistency with the other command logs:
+                        // reaching a body parser requires an exact known-command
+                        // match, so this is defense in depth, not a live risk.
+                        let command = escape_command(&command)
+                            .trim_end_matches(r"\x00")
                             .to_owned();
                         metrics::counter!(
                             "peer.message.parse.panics",

--- a/zakura-network/src/protocol/external/codec/tests/vectors.rs
+++ b/zakura-network/src/protocol/external/codec/tests/vectors.rs
@@ -803,3 +803,111 @@ fn message_with_wrong_network_magic_returns_error() {
         .decode(&mut bytes)
         .expect_err("decoding message with mismatching network magic should return an error");
 }
+
+/// Check that `escape_command` escapes control characters and NUL padding.
+#[test]
+fn escape_command_escapes_control_characters() {
+    // An ANSI clear-screen escape sequence and a newline, followed by
+    // printable ASCII.
+    assert_eq!(escape_command(b"\x1b[2J\nFORGED!"), r"\x1b[2J\nFORGED!");
+
+    // NUL padding in a well-formed command is escaped, not dropped.
+    assert_eq!(
+        escape_command(b"version\0\0\0\0\0"),
+        r"version\x00\x00\x00\x00\x00",
+    );
+}
+
+/// Check that an unknown command containing control characters is escaped in
+/// the "unknown message command" debug event, so a peer can't forge log lines
+/// or inject terminal escape sequences into log output.
+#[test]
+fn unknown_command_is_escaped_in_debug_log() {
+    use std::sync::{Arc, Mutex};
+
+    let _init_guard = zakura_test::init();
+
+    /// A log writer that appends formatted log bytes to a shared buffer.
+    #[derive(Clone)]
+    struct LogBuffer(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for LogBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("no code panics while holding the log buffer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // A mainnet message with an empty body, and an unknown command containing
+    // an ANSI clear-screen escape sequence and a newline.
+    let mut bytes = BytesMut::new();
+    bytes.extend_from_slice(&Network::Mainnet.magic().0);
+    bytes.extend_from_slice(b"\x1b[2J\nFORGED!");
+    bytes.extend_from_slice(&0_u32.to_le_bytes());
+    bytes.extend_from_slice(&sha256d::Checksum::from(&[][..]).0);
+
+    let log_buffer = LogBuffer(Arc::new(Mutex::new(Vec::new())));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
+        .with_writer({
+            let log_buffer = log_buffer.clone();
+            move || log_buffer.clone()
+        })
+        .finish();
+
+    let decode_result = {
+        // A test-scoped subscriber is safe here because `decode` is
+        // synchronous: its events can't be routed through another thread's
+        // subscriber, and no spans are recorded.
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        Codec::builder().finish().decode(&mut bytes)
+    };
+
+    assert!(
+        decode_result
+            .expect("unknown commands are ignored, not errors")
+            .is_none(),
+        "unknown commands should not decode to a message",
+    );
+
+    // When `debug!` events are statically disabled (for example, by zakurad's
+    // `release_max_level_info` feature in the same build), there is no log
+    // output to check.
+    if tracing::level_filters::STATIC_MAX_LEVEL < tracing::Level::DEBUG {
+        return;
+    }
+
+    let log_output = String::from_utf8(
+        log_buffer
+            .0
+            .lock()
+            .expect("no code panics while holding the log buffer lock")
+            .clone(),
+    )
+    .expect("the fmt subscriber writes valid UTF-8");
+
+    assert!(
+        log_output.contains("unknown message command from peer"),
+        "expected an unknown command debug event, got: {log_output:?}",
+    );
+    assert!(
+        log_output.contains(r"\x1b[2J\nFORGED!"),
+        "expected the escaped command string, got: {log_output:?}",
+    );
+    assert!(
+        !log_output.contains('\x1b'),
+        "raw ANSI escape bytes must not reach the log output: {log_output:?}",
+    );
+    assert!(
+        !log_output.contains("\nFORGED"),
+        "raw newlines from the command must not reach the log output: {log_output:?}",
+    );
+}


### PR DESCRIPTION
## Motivation

The legacy codec's unknown-command `debug!` event and its body-parser panic `error!` format the peer-controlled 12-byte command field with `Display` after `String::from_utf8_lossy`, so control characters in a command (newlines, ANSI escape sequences, NULs) reach log output unescaped. A peer can use this to forge apparent log lines or emit terminal escape sequences into interactively viewed logs. The header `trace!` in the same decoder already escapes the command with `ascii::escape_default`; the later events did not.

## Solution

Extract the existing escaping into a shared `escape_command` helper and use it at all three command log sites:

- the unknown-command `debug!` event — the unescaped sink,
- the body-parser panic `error!` — defense in depth only, since reaching a body parser requires an exact known-command match; the NUL-padding trim is preserved, so known commands still log as `command=tx`,
- the header `trace!` — behavior unchanged, drops an `unwrap()`.

## Testing

- New unit test for `escape_command` covering control characters and NUL padding.
- New regression test that decodes a mainnet frame whose command is `\x1b[2J\nFORGED!` through a capturing subscriber and asserts the formatted log output contains the escaped form and no raw control bytes. The log assertions are guarded on `STATIC_MAX_LEVEL` because the all-tests CI profile builds with `release_max_level_info`, which compiles `debug!` events out; the decode-returns-`Ok(None)` assertion still runs there.
- `cargo fmt --all -- --check`, `cargo clippy -p zakura-network --all-targets --release -- -D warnings`, `cargo test -p zakura-network --release` (1171 passed, 0 failed), and `cargo clippy --workspace --all-targets --release -- -D warnings`.

## Changelog

`changelog-unreleased/513.md` added under `Fixed` (873cf6a57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
