### PR TITLE
fix(ci): install nightly for release API diffs

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -241,6 +241,11 @@ jobs:
         continue-on-error: true
         run: cargo fmt --all -- --check
 
+      # cargo-public-api builds rustdoc JSON with nightly even when the
+      # workspace itself is built and verified with stable.
+      - name: Install nightly for public API diffs
+        run: rustup toolchain install nightly --profile minimal
+
       - name: Record public API diffs
         id: verify-public-api
         continue-on-error: true


### PR DESCRIPTION
## Motivation

The release preparation workflow added `cargo public-api diff latest` in #511, but only provisioned the stable Rust toolchain. `cargo-public-api` requires nightly to build rustdoc JSON, so preparation failed after all other verification passed in [run 30734596608](https://github.com/zakura-core/zakura/actions/runs/30734596608).

## Solution

Install the minimal nightly toolchain immediately before public API verification. Stable remains the workspace's active toolchain for preparation, packaging, tests, and formatting; nightly is available only when `cargo-public-api` requests it.

## Testing

- `actionlint .github/workflows/prepare-release-pr.yml`
- `git diff --check`
- IDE diagnostics: no errors

## Changelog

No fragment: this changes CI release tooling only and does not modify Rust source or `Cargo.toml`.

### Specifications & References

- #511
- [Failed release preparation run](https://github.com/zakura-core/zakura/actions/runs/30734596608)