### PR TITLE
fix(ci): make release API diff verification reliable

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -241,11 +241,6 @@ jobs:
         continue-on-error: true
         run: cargo fmt --all -- --check
 
-      # cargo-public-api builds rustdoc JSON with nightly even when the
-      # workspace itself is built and verified with stable.
-      - name: Install nightly for public API diffs
-        run: rustup toolchain install nightly --profile minimal
-
       - name: Record public API diffs
         id: verify-public-api
         continue-on-error: true
@@ -263,6 +258,11 @@ jobs:
             echo "No changed library crates are being published."
             exit 0
           fi
+          # cargo-public-api builds rustdoc JSON with nightly even when the
+          # workspace itself is built and verified with stable. Keep setup in
+          # this continue-on-error step so a toolchain outage is recorded in
+          # the generated draft PR instead of preventing PR creation.
+          rustup toolchain install nightly --profile minimal
           while IFS= read -r package; do
             [ -n "$package" ] || continue
             echo "::group::cargo public-api diff latest -p ${package}"

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -266,7 +266,9 @@ jobs:
           while IFS= read -r package; do
             [ -n "$package" ] || continue
             echo "::group::cargo public-api diff latest -p ${package}"
-            cargo public-api diff latest -p "$package" -sss
+            # Public API evidence must build both current and previously
+            # published crates; nightly-only warnings are not a lint gate.
+            RUSTFLAGS='' cargo public-api diff latest -p "$package" -sss
             echo "::endgroup::"
           done <<<"$packages"
 


### PR DESCRIPTION
## Motivation

Follow up #519 and the subsequent [release preparation failure](https://github.com/zakura-core/zakura/actions/runs/30736190306). Public API verification had two reliability problems:

- a nightly installation outage would abort before creating the diagnostic draft release PR;
- the workflow-wide `RUSTFLAGS=-D warnings` turned nightly-only deprecations into build errors while generating rustdoc JSON.

## Solution

- Move nightly provisioning into the existing fallible `Record public API diffs` step, preserving draft creation when setup fails and skipping installation when no API diffs are needed.
- Clear `RUSTFLAGS` only for `cargo public-api diff`. API comparison must build both current and previously published crates and should not double as a nightly lint gate.

Stable remains the active toolchain and warning policy for the workflow's actual release verification.

## Testing

- `actionlint .github/workflows/prepare-release-pr.yml`
- `git diff --check`
- IDE diagnostics: no errors

## Changelog

No fragment: this changes CI release tooling only and does not modify Rust source or `Cargo.toml`.

### Specifications & References

- #519
- [Missing-nightly failure](https://github.com/zakura-core/zakura/actions/runs/30734596608)
- [Nightly-deprecation failure](https://github.com/zakura-core/zakura/actions/runs/30736190306)