### PR TITLE
fix(state): pin Regtest difficulty to the powLimit instead of retargeting

### DIFF
--- a/docs/changelog/unreleased/523.md
+++ b/docs/changelog/unreleased/523.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Pinned Regtest difficulty to the powLimit instead of retargeting it from height
+  18 onwards, so a following zcashd sidecar no longer rejects Zakura's Regtest
+  headers as `bad-diffbits`
+  ([#523](https://github.com/zakura-core/zakura/pull/523)).

--- a/zakura-state/src/service/check/difficulty.rs
+++ b/zakura-state/src/service/check/difficulty.rs
@@ -186,6 +186,14 @@ impl AdjustedDifficulty {
     /// Implements `ThresholdBits` from the Zcash specification, and the Testnet
     /// minimum difficulty adjustment from ZIPs 205 and 208.
     pub fn expected_difficulty_threshold(&self) -> CompactDifficulty {
+        // Regtest uses a fixed minimum difficulty with no retargeting, matching
+        // zcashd's and Bitcoin's `fPowNoRetargeting`. This keeps every Regtest
+        // block at the powLimit, so a zcashd sidecar following a Zakura Regtest
+        // chain accepts its headers instead of rejecting them as "bad-diffbits".
+        if self.network.is_regtest() {
+            return self.network.target_difficulty_limit().to_compact();
+        }
+
         if NetworkUpgrade::is_testnet_min_difficulty_block(
             &self.network,
             self.candidate_height,

--- a/zakura-state/src/service/check/tests/vectors.rs
+++ b/zakura-state/src/service/check/tests/vectors.rs
@@ -286,6 +286,51 @@ fn full_context_at_averaging_window_height_uses_pow_limit_threshold() {
     assert_eq!(expected, difficulty);
 }
 
+#[test]
+fn regtest_pins_difficulty_to_pow_limit_instead_of_retargeting() {
+    let _init_guard = zakura_test::init();
+
+    let network = Network::new_regtest(Default::default());
+    let pow_limit = network.target_difficulty_limit().to_compact();
+
+    // Past the averaging window, so `threshold_bits` runs a full retarget instead of
+    // returning the powLimit for an early-chain height.
+    let previous_block_height = block::Height(
+        u32::try_from(difficulty::POW_ADJUSTMENT_BLOCK_SPAN)
+            .expect("adjustment block span fits in u32"),
+    );
+    let candidate_height = previous_block_height
+        .next()
+        .expect("test candidate height is valid");
+    let candidate_time = DateTime::from_timestamp(10_000, 0).expect("test timestamp is in-range");
+    let target_spacing = NetworkUpgrade::target_spacing_for_height(&network, candidate_height);
+
+    // Regtest blocks are mined far faster than the target spacing, so the averaging
+    // window's actual timespan is well below the target and retargeting would raise
+    // the difficulty above the powLimit.
+    let actual_spacing = target_spacing / 4;
+    let context: Vec<_> = (0..difficulty::POW_ADJUSTMENT_BLOCK_SPAN)
+        .map(|offset| {
+            let offset = i32::try_from(offset + 1).expect("test offset fits in i32");
+            (pow_limit, candidate_time - actual_spacing * offset)
+        })
+        .collect();
+
+    let expected = difficulty::AdjustedDifficulty::new_from_header_time(
+        candidate_time,
+        previous_block_height,
+        &network,
+        context,
+    )
+    .expected_difficulty_threshold();
+
+    assert_eq!(
+        expected, pow_limit,
+        "Regtest must stay at the powLimit like zcashd's `fPowNoRetargeting`, \
+         so a following zcashd sidecar does not reject the headers as bad-diffbits"
+    );
+}
+
 fn daa_context(
     network: &Network,
     previous_block_height: block::Height,


### PR DESCRIPTION
## Motivation

`expected_difficulty_threshold` has no Regtest case: it either applies the Testnet
minimum-difficulty rule or runs a full retarget. zcashd's Regtest instead uses a
fixed minimum difficulty with no retargeting (`fPowNoRetargeting`), so the two
implementations only agree by accident.

They agree up to height 17, because `threshold_bits` returns the powLimit while
`candidate_height <= PoWAveragingWindow`. From height 18 the averaging window is
full and retargeting starts. Regtest blocks are mined far faster than the target
spacing, so the actual timespan is well below the target and the difficulty is
raised above the powLimit. A following zcashd computes the powLimit for the same
header, sees a different `nBits`, and rejects it as `bad-diffbits` — a permanent
fork at that height.

Regtest-only; there is no Mainnet or Testnet impact. It does block any Regtest
flow that mines more than ~17 blocks, such as coinbase-maturity tests that need
100+.

## Solution

Return the target difficulty limit from `expected_difficulty_threshold` on
Regtest, before the Testnet minimum-difficulty branch and the retarget path.

The fix belongs in this function specifically because both the block template and
contextual validation call it (`read/difficulty.rs` and `check.rs` respectively),
so pinning it here keeps the mined value and the expected value from drifting
apart.

To be precise about where the defect surfaces: Regtest sets `disable_pow`, and
`check.rs` relaxes the difficulty check on such networks to "must be representable
as work" rather than an equality test. So Zakura does not reject its own Regtest
blocks — the wrong `nBits` is written into the blocks it mines, and the strict
equality check is the one a following zcashd performs.

Pinning to the powLimit is what makes the headers acceptable to zcashd, because
the two limits are already the same value: Zakura's Regtest target difficulty
limit is `U256::from_big_endian(&[0x0f; 32])`, and zcashd's `CRegTestParams` sets
`consensus.powLimit` to
`uint256S("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")`.

## Testing

New unit test `regtest_pins_difficulty_to_pow_limit_instead_of_retargeting` in
`zakura-state/src/service/check/tests/vectors.rs`.

It exercises the root cause rather than just the new branch. The candidate height
is past the averaging window, so `threshold_bits` does not take the early-chain
powLimit shortcut; the context supplies a full `PoWAveragingWindow +
PoWMedianBlockSpan` of thresholds, so `mean_target_difficulty` does not fall back
to the powLimit either; and block times are spaced at a quarter of the target
spacing, which is the "mined too fast" condition that makes retargeting raise the
difficulty. The assertion is that the threshold is still the powLimit.

Negative control: with the new Regtest branch disabled, the test fails on the
difficulty value rather than erroring — it computes `CompactDifficulty(0x200ca63f)`
where the powLimit is `CompactDifficulty(0x200f0f0f)`. That is the divergence a
following zcashd reports as `bad-diffbits`. With the branch in place the test
passes and the rest of `zakura-state`'s unit tests are unaffected, so the Mainnet
and Testnet paths are unchanged.

Checks run: `cargo +nightly fmt --all -- --check`, `cargo clippy --workspace
--all-targets --features default-release-binaries`, `cargo check --locked
--all-features --all-targets`, `cargo test -p zakura-state --lib`.

Scope note: the end-to-end evidence for this bug would come from the
`zcashd-compat Regtest` suite, which is currently `workflow_dispatch`-only while
the managed download manifest is pinned to a pre-sidecar zcashd build. So the
automated coverage on this PR is the unit test above, not a sidecar run.

## Changelog

Fixed.

### Specifications & References

Closes #199.

Fixed the same way upstream in Zebra:
[ZcashFoundation/zebra#10952](https://github.com/ZcashFoundation/zebra/pull/10952),
commit
[`c7691893e`](https://github.com/ZcashFoundation/zebra/commit/c7691893e86985ee44ddc19677eb293e6641f38d),
which the issue references. That commit carries no test; this PR adds one.

zcashd pins Regtest difficulty through `consensus.fPowNoRetargeting = true` in
`CRegTestParams`, the same flag Bitcoin uses for its regtest chain.

### Follow-up Work

#200 (Regtest block time advancing ~90 minutes per block) is the other half of
the same upstream commit. It is a separate operator-visible bug with its own
reproduction, and it changes a different file, so it is left for a follow-up PR
rather than widening this one.
