### PR TITLE
fix(network): preserve configured user agent

### DIFF
--- a/docs/changelog/unreleased/524.md
+++ b/docs/changelog/unreleased/524.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed Zakura's P2P user agent so every transport mode advertises the
+  `zakurad` release version without an internal networking crate version
+  ([#524](https://github.com/zakura-core/zakura/pull/524)).

--- a/zakura-network/src/peer/handshake.rs
+++ b/zakura-network/src/peer/handshake.rs
@@ -613,7 +613,7 @@ where
             tx
         });
         let nonces = Arc::new(futures::lock::Mutex::new(IndexSet::new()));
-        let user_agent = configured_user_agent(&config, self.user_agent.unwrap_or_default());
+        let user_agent = self.user_agent.unwrap_or_default();
         let our_services = configured_advertised_services(
             &config,
             self.our_services.unwrap_or_else(PeerServices::empty),
@@ -673,29 +673,6 @@ fn configured_advertised_services(config: &Config, mut services: PeerServices) -
     }
 
     services
-}
-
-/// Return the user-agent Zakura should advertise for this handshake.
-fn configured_user_agent(config: &Config, user_agent: String) -> String {
-    if !config.v2_p2p() {
-        return user_agent;
-    }
-
-    let zakura_token = format!("Zakura:{}", env!("CARGO_PKG_VERSION"));
-    let trimmed_user_agent = user_agent.trim_matches('/');
-
-    if trimmed_user_agent.is_empty() {
-        format!("/{zakura_token}/")
-    } else if trimmed_user_agent
-        .split('/')
-        .any(|token| token == zakura_token)
-    {
-        // The default user agent already carries the Zakura token, so
-        // prepending it again would advertise `/Zakura:x/Zakura:x/`.
-        format!("/{trimmed_user_agent}/")
-    } else {
-        format!("/{zakura_token}/{trimmed_user_agent}/")
-    }
 }
 
 /// Returns true when the legacy handshake should try to route this peer to Zakura P2P v2.

--- a/zakura-network/src/peer/handshake/tests.rs
+++ b/zakura-network/src/peer/handshake/tests.rs
@@ -26,6 +26,9 @@ use zakura_chain::{block, chain_tip::NoChainTip};
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
 static TEST_ZAKURA_SECRET_KEY_COUNTER: AtomicUsize = AtomicUsize::new(1);
+const TEST_HANDSHAKE_USER_AGENT: &str = "/Zebra:handshake-test/";
+const TEST_LOCAL_USER_AGENT: &str = "/Zebra:local-test/";
+const TEST_REMOTE_USER_AGENT: &str = "/Zebra:remote-test/";
 
 impl<S, C> Handshake<S, C>
 where
@@ -96,9 +99,8 @@ async fn negotiate_test_pair(
     let local_services = configured_advertised_services(&local_config, PeerServices::NODE_NETWORK);
     let remote_services =
         configured_advertised_services(&remote_config, PeerServices::NODE_NETWORK);
-    let local_user_agent = configured_user_agent(&local_config, "/Zebra:local-test/".to_string());
-    let remote_user_agent =
-        configured_user_agent(&remote_config, "/Zebra:remote-test/".to_string());
+    let local_user_agent = TEST_LOCAL_USER_AGENT.to_string();
+    let remote_user_agent = TEST_REMOTE_USER_AGENT.to_string();
 
     let local_task = tokio::spawn(async move {
         negotiate_version(
@@ -150,7 +152,7 @@ fn test_handshake(
         .with_inbound_service(inbound_service)
         .with_address_book_updater(address_book_updater)
         .with_advertised_services(PeerServices::NODE_NETWORK)
-        .with_user_agent("/Zebra:handshake-test/".to_string())
+        .with_user_agent(TEST_HANDSHAKE_USER_AGENT.to_string())
         .with_zakura_handshake_connector(crate::zakura::ZakuraHandshakeConnector::for_test(
             calls, outcome,
         ))
@@ -171,7 +173,7 @@ fn test_handshake_without_zakura_connector(
         .with_inbound_service(inbound_service)
         .with_address_book_updater(address_book_updater)
         .with_advertised_services(PeerServices::NODE_NETWORK)
-        .with_user_agent("/Zebra:handshake-test/".to_string())
+        .with_user_agent(TEST_HANDSHAKE_USER_AGENT.to_string())
         .want_transactions(true)
         .finish()
         .unwrap()
@@ -190,7 +192,7 @@ fn test_handshake_with_connector(
         .with_inbound_service(inbound_service)
         .with_address_book_updater(address_book_updater)
         .with_advertised_services(PeerServices::NODE_NETWORK)
-        .with_user_agent("/Zebra:handshake-test/".to_string())
+        .with_user_agent(TEST_HANDSHAKE_USER_AGENT.to_string())
         .with_zakura_handshake_connector(connector)
         .want_transactions(true)
         .finish()
@@ -599,7 +601,7 @@ async fn initiator_upgrade_disconnects_on_malformed_prelude() {
 }
 
 #[tokio::test]
-async fn p2p_v2_service_bit_advertisement_follows_config() {
+async fn p2p_v2_service_bit_advertisement_preserves_user_agent() {
     let _init_guard = zakura_test::init();
 
     assert!(!configured_advertised_services(
@@ -620,6 +622,10 @@ async fn p2p_v2_service_bit_advertisement_follows_config() {
         .address_from
         .untrusted_services()
         .contains(PeerServices::NODE_P2P_V2));
+    assert_eq!(
+        disabled_peer_seen_by_enabled.remote.user_agent,
+        TEST_REMOTE_USER_AGENT
+    );
 
     assert!(enabled_peer_seen_by_disabled
         .remote
@@ -630,56 +636,25 @@ async fn p2p_v2_service_bit_advertisement_follows_config() {
         .address_from
         .untrusted_services()
         .contains(PeerServices::NODE_P2P_V2));
-    assert!(enabled_peer_seen_by_disabled
-        .remote
-        .user_agent
-        .starts_with("/Zakura:"));
-    assert!(enabled_peer_seen_by_disabled
-        .remote
-        .user_agent
-        .contains("/Zebra:local-test/"));
+    assert_eq!(
+        enabled_peer_seen_by_disabled.remote.user_agent,
+        TEST_LOCAL_USER_AGENT
+    );
 }
 
-/// The Zakura token is prepended for the v2 stack, but never doubled when the
-/// user agent (like zakurad's default) already carries it.
 #[test]
-fn configured_user_agent_deduplicates_zakura_token() {
+fn handshake_preserves_configured_user_agent_for_every_stack() {
     let _init_guard = zakura_test::init();
+    let (address_book_tx, _address_book_rx) = tokio::sync::mpsc::channel(8);
 
-    let zakura_token = format!("Zakura:{}", env!("CARGO_PKG_VERSION"));
-    let default_user_agent = format!("/{zakura_token}/");
+    for p2p_stack in [P2pStack::Legacy, P2pStack::Dual, P2pStack::Zakura] {
+        let handshake = test_handshake_without_zakura_connector(
+            test_config(p2p_stack),
+            address_book_tx.clone(),
+        );
 
-    // The legacy stack passes the configured user agent through unchanged.
-    assert_eq!(
-        configured_user_agent(&test_config(P2pStack::Legacy), default_user_agent.clone()),
-        default_user_agent,
-    );
-
-    // The v2 stack advertises the token on its own or before a foreign agent.
-    assert_eq!(
-        configured_user_agent(&test_config(P2pStack::Dual), String::new()),
-        default_user_agent,
-    );
-    assert_eq!(
-        configured_user_agent(
-            &test_config(P2pStack::Dual),
-            "/MagicBean:6.3.0/".to_string()
-        ),
-        format!("/{zakura_token}/MagicBean:6.3.0/"),
-    );
-
-    // A user agent that already carries the token is not doubled.
-    assert_eq!(
-        configured_user_agent(&test_config(P2pStack::Dual), default_user_agent.clone()),
-        default_user_agent,
-    );
-    assert_eq!(
-        configured_user_agent(
-            &test_config(P2pStack::Dual),
-            format!("/{zakura_token}/MagicBean:6.3.0/"),
-        ),
-        format!("/{zakura_token}/MagicBean:6.3.0/"),
-    );
+        assert_eq!(handshake.user_agent, TEST_HANDSHAKE_USER_AGENT);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

When P2P v2 was enabled, the network handshake rewrote the configured BIP14 user agent by prepending a Zakura token built from the internal zakura-network crate version. Because that crate is versioned independently from the zakurad binary, Zakura v1.0.5 advertised the misleading composite /Zakura:5.0.1/Zakura:1.0.5/ string on dual-stack networks.

## Solution

Advertise the exact user agent supplied through Builder::with_user_agent on every P2P stack. The NODE_P2P_V2 service bit continues to advertise v2 capability, so transport selection does not need to be encoded in the user-agent string.

Tests cover both builder state and on-wire version negotiation for legacy, dual, and Zakura-only configurations.

## Testing

- cargo fmt --all -- --check
- cargo test -p zakura-network user_agent -- --nocapture (3 passed)
- cargo test -p zakura-network peer::handshake::tests -- --nocapture (15 passed)
- cargo clippy -p zakura-network --lib -- -D warnings
- ./scripts/changelog.py check
- markdownlint-cli docs/changelog/unreleased/524.md

## Changelog

The operator-visible fix is documented in docs/changelog/unreleased/524.md.

### Specifications & References

- [BIP 14: Protocol Version and User Agent](https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small handshake behavior change limited to version-message metadata; P2P upgrade routing still uses service bits, with added regression tests.
> 
> **Overview**
> Stops rewriting the BIP14 user agent when P2P v2 is enabled. The handshake no longer prepends a `Zakura:` token derived from the **zakura-network** crate version; it advertises exactly what `Handshake::builder().with_user_agent(...)` supplies on legacy, dual, and Zakura-only stacks.
> 
> **NODE_P2P_V2** service-bit handling is unchanged—v2 capability is still signaled via services, not the user-agent string. Tests now assert on-wire and builder user agents stay intact across stack modes instead of expecting injected or deduplicated Zakura tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8424754d1f01844c5ad351d4a181be09279c46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->