### PR TITLE
fix(deploy): require real height progress to clear a stalled-node alert

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -197,6 +197,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 deploy/continuous-sync/tests/test_continuous_sync.py
 
+      - name: Cluster dashboard and watchdog tests
+        if: ${{ !cancelled() }}
+        run: |
+          python3 deploy/runner/test_zakura_cluster_status.py
+          python3 deploy/runner/test_zakura_cluster_watchdog.py
+
       - name: Ensure no arbitrary or proptest dependency on default build
         if: ${{ !cancelled() }}
         run: cargo +stable tree --package zakura -e=features,no-dev | grep -Eq "arbitrary|proptest" && exit 1 || exit 0

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -361,6 +361,65 @@ class TipAgreementTests(unittest.TestCase):
             self.assertEqual(event["discarded_hash"], "a" * 64)
             self.assertEqual(event["canonical_hash"], "b" * 64)
 
+    def test_stall_timer_survives_a_collector_restart(self):
+        # A restart used to reseed last_advanced_at to "now", reporting every
+        # node as freshly advanced and clearing in-flight stall alerts.
+        with tempfile.TemporaryDirectory() as tmp:
+            state_file = Path(tmp) / "state.json"
+            first = status.ClusterCollector(
+                [node()],
+                interval=10,
+                stale_after=300,
+                upgrade_height=0,
+                target_spacing=7.5,
+                network="testnet",
+                state_file=state_file,
+            )
+            first.last_height["node-a"] = 4_129_396
+            first.last_advanced_at["node-a"] = 1_000.0
+            first.persist_state()
+
+            second = status.ClusterCollector(
+                [node()],
+                interval=10,
+                stale_after=300,
+                upgrade_height=0,
+                target_spacing=7.5,
+                network="testnet",
+                state_file=state_file,
+            )
+            self.assertEqual(second.last_advanced_at["node-a"], 1_000.0)
+            self.assertEqual(second.last_height["node-a"], 4_129_396)
+
+            # The node is still pinned at the same height long after the
+            # restart, so the row must still report a large stall age.
+            row = second.row_for(
+                node(),
+                {
+                    "height": 4_129_396,
+                    "active_state": "active",
+                    "process_running": True,
+                },
+                now=4_000.0,
+            )
+            self.assertEqual(row["seconds_since_advanced"], 3_000.0)
+            self.assertEqual(row["health"], "stale")
+
+    def test_progress_state_tolerates_a_missing_or_corrupt_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "absent.json"
+            self.assertEqual(status.load_progress(missing), {})
+            self.assertEqual(status.load_progress(None), {})
+
+            corrupt = Path(tmp) / "corrupt.json"
+            corrupt.write_text("{not json", encoding="utf-8")
+            self.assertEqual(status.load_progress(corrupt), {})
+
+            # A pre-existing file written before progress was persisted.
+            legacy = Path(tmp) / "legacy.json"
+            legacy.write_text(json.dumps({"orphan_pairs": []}), encoding="utf-8")
+            self.assertEqual(status.load_progress(legacy), {})
+
     def test_fork_depth_from_ancestor_samples(self):
         depth = status.estimate_fork_depth_from_ancestors(
             {"1": "x", "2": "y", "5": "same"},

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("zakura-cluster-watchdog.py")
+SPEC = importlib.util.spec_from_file_location("zakura_cluster_watchdog", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+watchdog = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = watchdog
+SPEC.loader.exec_module(watchdog)
+
+
+def make_args(**overrides):
+    defaults = {
+        "down_after": 600.0,
+        "stalled_after": 600.0,
+        "starting_grace": 120.0,
+        "slack_webhook": None,
+        "dry_run": True,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class StallRecoveryTests(unittest.TestCase):
+    """A stalled node must not be declared recovered at an unchanged height."""
+
+    def setUp(self):
+        self.posted: list[str] = []
+        self._real_post = watchdog.post_slack
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+
+    def tearDown(self):
+        watchdog.post_slack = self._real_post
+
+    def fire_stall(self, bucket, key="fleet/node-a", height=4129396, now=1000.0):
+        """Drive the alert past its threshold so it latches."""
+        watchdog.update_alert_state(
+            bucket, key, "stalled", now - 700.0, 600.0,
+            "STALLED", "RECOVERED", now, False, make_args(), height,
+        )
+
+    def test_stall_alert_records_the_height_it_fired_at(self):
+        bucket = {}
+        self.fire_stall(bucket)
+        self.assertEqual(len(self.posted), 1)
+        entry = bucket["fleet/node-a"]
+        self.assertTrue(entry["alerting"])
+        self.assertEqual(entry["alert_height"], 4129396)
+
+    def test_unchanged_height_does_not_clear_the_stall(self):
+        bucket = {}
+        self.fire_stall(bucket)
+        self.posted.clear()
+
+        # The dashboard restarted: its in-memory timer reset, so the condition
+        # reads "ok" again -- but the node has not moved a single block.
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 2000.0, 0.0,
+            "STALLED", "RECOVERED", 2000.0, False, make_args(), 4129396,
+        )
+        self.assertEqual(self.posted, [], "posted a recovery at an unchanged height")
+        self.assertTrue(bucket["fleet/node-a"]["alerting"], "alert should stay latched")
+        self.assertEqual(bucket["fleet/node-a"]["alert_height"], 4129396)
+
+    def test_repeated_timer_resets_never_clear_the_stall(self):
+        bucket = {}
+        self.fire_stall(bucket)
+        self.posted.clear()
+        # Five dashboard restarts, as happened on 2026-08-03.
+        for cycle in range(5):
+            watchdog.update_alert_state(
+                bucket, "fleet/node-a", "ok", 2000.0 + cycle, 0.0,
+                "STALLED", "RECOVERED", 2000.0 + cycle, False, make_args(), 4129396,
+            )
+        self.assertEqual(self.posted, [], "stall oscillated recovered/stalled")
+
+    def test_forward_progress_clears_the_stall(self):
+        bucket = {}
+        self.fire_stall(bucket)
+        self.posted.clear()
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 3000.0, 0.0,
+            "STALLED", "RECOVERED", 3000.0, False, make_args(), 4129397,
+        )
+        self.assertEqual(self.posted, ["RECOVERED"])
+        self.assertFalse(bucket["fleet/node-a"]["alerting"])
+
+    def test_missing_height_does_not_clear_the_stall(self):
+        # The "starting" grace window reports ok with no usable height.
+        bucket = {}
+        self.fire_stall(bucket)
+        self.posted.clear()
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 3000.0, 0.0,
+            "STALLED", "RECOVERED", 3000.0, False, make_args(), None,
+        )
+        self.assertEqual(self.posted, [])
+        self.assertTrue(bucket["fleet/node-a"]["alerting"])
+
+    def test_height_going_backwards_does_not_clear_the_stall(self):
+        bucket = {}
+        self.fire_stall(bucket)
+        self.posted.clear()
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 3000.0, 0.0,
+            "STALLED", "RECOVERED", 3000.0, False, make_args(), 4000000,
+        )
+        self.assertEqual(self.posted, [])
+
+    def test_down_alerts_still_recover_without_height_progress(self):
+        # Only stalls are height-gated; a restarted node legitimately recovers
+        # at whatever height it comes back on.
+        bucket = {}
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "down", 300.0, 600.0,
+            "DOWN", "RECOVERED", 1000.0, False, make_args(), None,
+        )
+        self.assertEqual(self.posted, ["DOWN"])
+        self.posted.clear()
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 2000.0, 0.0,
+            "DOWN", "RECOVERED", 2000.0, False, make_args(), 4129396,
+        )
+        self.assertEqual(self.posted, ["RECOVERED"])
+
+    def test_stall_alert_height_survives_intermediate_cycles(self):
+        bucket = {}
+        self.fire_stall(bucket)
+        self.posted.clear()
+        # Still stalled on the next poll: the anchor must not be lost.
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "stalled", 300.0, 600.0,
+            "STALLED", "RECOVERED", 1100.0, False, make_args(), 4129396,
+        )
+        self.assertEqual(bucket["fleet/node-a"]["alert_height"], 4129396)
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 2000.0, 0.0,
+            "STALLED", "RECOVERED", 2000.0, False, make_args(), 4129396,
+        )
+        self.assertEqual(self.posted, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -116,6 +116,52 @@ class StallRecoveryTests(unittest.TestCase):
         )
         self.assertEqual(self.posted, [])
 
+    def test_a_node_resynced_from_a_lower_tip_can_still_recover(self):
+        # Wiping and resyncing is a normal fix for a stuck node. Anchored at the
+        # pre-stall tip the alert would stay latched for the whole resync and no
+        # recovery would ever post, so the anchor follows the node down.
+        bucket = {}
+        self.fire_stall(bucket)
+        self.posted.clear()
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 3000.0, 0.0,
+            "STALLED", "RECOVERED", 3000.0, False, make_args(), 5_000,
+        )
+        self.assertEqual(self.posted, [], "a lower tip is not forward progress")
+        self.assertTrue(bucket["fleet/node-a"]["alerting"])
+        self.assertEqual(bucket["fleet/node-a"]["alert_height"], 5_000)
+
+        # It is now climbing again, so the recovery posts on the next sample.
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 3600.0, 0.0,
+            "STALLED", "RECOVERED", 3600.0, False, make_args(), 5_100,
+        )
+        self.assertEqual(self.posted, ["RECOVERED"])
+        self.assertFalse(bucket["fleet/node-a"]["alerting"])
+
+    def test_alert_height_is_backfilled_when_it_was_unknown_at_fire_time(self):
+        # A row can alert without a usable height. With no anchor the latch has
+        # nothing to compare against and the first reset timer clears it.
+        bucket = {}
+        self.fire_stall(bucket, height=None)
+        self.assertEqual(len(self.posted), 1)
+        self.assertIsNone(bucket["fleet/node-a"].get("alert_height"))
+        self.posted.clear()
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "stalled", 300.0, 600.0,
+            "STALLED", "RECOVERED", 1100.0, False, make_args(), 4129396,
+        )
+        self.assertEqual(bucket["fleet/node-a"]["alert_height"], 4129396)
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 2000.0, 0.0,
+            "STALLED", "RECOVERED", 2000.0, False, make_args(), 4129396,
+        )
+        self.assertEqual(self.posted, [], "cleared at an unchanged height")
+        self.assertTrue(bucket["fleet/node-a"]["alerting"])
+
     def test_down_alerts_still_recover_without_height_progress(self):
         # Only stalls are height-gated; a restarted node legitimately recovers
         # at whatever height it comes back on.

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -607,12 +607,18 @@ class ClusterCollector:
         self.state_file = state_file
         self.ironwood_activation_height = IRONWOOD_ACTIVATION_HEIGHTS[network]
         self.lock = threading.Lock()
-        self.last_height: dict[str, int | None] = {node.name: None for node in nodes}
+        restored_progress = load_progress(state_file)
+        self.last_height: dict[str, int | None] = {
+            node.name: restored_progress.get(node.name, {}).get("height") for node in nodes
+        }
         self.last_block_hash: dict[str, str | None] = {node.name: None for node in nodes}
         self.last_ancestors: dict[str, dict[str, str]] = {
             node.name: {} for node in nodes
         }
-        self.last_advanced_at: dict[str, float | None] = {node.name: None for node in nodes}
+        self.last_advanced_at: dict[str, float | None] = {
+            node.name: restored_progress.get(node.name, {}).get("last_advanced_at")
+            for node in nodes
+        }
         self.height_history: list[tuple[float, int]] = []
         self.recent_reorgs: deque[dict] = deque(
             load_orphan_pairs(state_file),
@@ -658,10 +664,31 @@ class ClusterCollector:
             self.chain = chain
             self.last_poll = now
             self.record_height_sample(now, rows)
+            snapshot = self.progress_snapshot()
+        # Snapshot under the lock, write outside it: the stall timers must
+        # survive a restart or every node reports as freshly advanced on the
+        # next process start.
+        self.persist_state(snapshot)
+
+    def progress_snapshot(self) -> dict[str, dict]:
+        return {
+            name: {
+                "height": self.last_height.get(name),
+                "last_advanced_at": self.last_advanced_at.get(name),
+            }
+            for name in self.last_advanced_at
+        }
+
+    def persist_state(self, snapshot: dict[str, dict] | None = None) -> None:
+        save_orphan_pairs(
+            self.state_file,
+            list(self.recent_reorgs),
+            self.progress_snapshot() if snapshot is None else snapshot,
+        )
 
     def record_orphan_pair(self, event: dict) -> None:
         self.recent_reorgs.appendleft(event)
-        save_orphan_pairs(self.state_file, list(self.recent_reorgs))
+        self.persist_state()
 
     def record_height_sample(self, now: float, rows: list[dict]) -> None:
         heights = [row["height"] for row in rows if row.get("height") is not None]
@@ -1071,7 +1098,11 @@ def load_orphan_pairs(path: Path | None) -> list[dict]:
     return cleaned[:RECENT_REORG_LIMIT]
 
 
-def save_orphan_pairs(path: Path | None, events: list[dict]) -> None:
+def save_orphan_pairs(
+    path: Path | None,
+    events: list[dict],
+    progress: dict[str, dict] | None = None,
+) -> None:
     if path is None:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1079,12 +1110,45 @@ def save_orphan_pairs(path: Path | None, events: list[dict]) -> None:
     payload = {
         "updated_at": time.time(),
         "orphan_pairs": list(events)[:RECENT_REORG_LIMIT],
+        "progress": progress or {},
     }
     tmp_path.write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
     tmp_path.replace(path)
+
+
+def load_progress(path: Path | None) -> dict[str, dict]:
+    """Restore per-node height/last-advanced timers written by a previous process.
+
+    Without this the stall clock restarts from zero on every dashboard restart,
+    which reports every node as freshly advanced regardless of its real height.
+    """
+    if path is None or not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    progress = payload.get("progress")
+    if not isinstance(progress, dict):
+        return {}
+    restored: dict[str, dict] = {}
+    for name, record in progress.items():
+        if not isinstance(record, dict):
+            continue
+        height = record.get("height")
+        advanced_at = record.get("last_advanced_at")
+        restored[str(name)] = {
+            "height": int(height) if isinstance(height, (int, float)) else None,
+            "last_advanced_at": (
+                float(advanced_at) if isinstance(advanced_at, (int, float)) else None
+            ),
+        }
+    return restored
 
 
 def estimate_fork_depth_from_ancestors(

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -213,6 +213,22 @@ def node_condition(
     return ("ok", now, 0)
 
 
+def stall_cleared(entry: dict[str, Any], height: float | None) -> bool:
+    """True when a stalled alert may be retired.
+
+    A stall is only over once the node is strictly higher than it was when the
+    alert fired. The dashboard's stall timer lives in memory, so any restart
+    reports every node as freshly advanced and would otherwise clear the alert
+    at an unchanged height.
+    """
+    if entry.get("condition") != "stalled":
+        return True
+    alert_height = coerce_float(entry.get("alert_height"))
+    if alert_height is None:
+        return True
+    return height is not None and height > alert_height
+
+
 def update_alert_state(
     state_bucket: dict[str, Any],
     key: str,
@@ -224,12 +240,17 @@ def update_alert_state(
     now: float,
     suppressed: bool,
     args: argparse.Namespace,
+    height: float | None = None,
 ) -> None:
     entry = state_bucket.get(key, {"condition": "ok", "alerting": False})
     was_alerting = bool(entry.get("alerting"))
 
     if condition == "ok":
         if was_alerting:
+            if not stall_cleared(entry, height):
+                # Keep the alert latched; the timer reset but the node did not move.
+                state_bucket[key] = entry
+                return
             if post_slack(recovery_text, args):
                 state_bucket[key] = {"condition": "ok", "alerting": False}
             return
@@ -251,12 +272,18 @@ def update_alert_state(
         "last_seen": now,
     }
 
+    if alerting and entry.get("alert_height") is not None:
+        next_entry["alert_height"] = entry["alert_height"]
+
     if not alerting and age >= threshold:
         if suppressed:
             print(f"suppressed alert for {key}: {condition} for {format_duration(age)}")
         elif post_slack(alert_text, args):
             next_entry["alerting"] = True
             next_entry["last_alert_at"] = now
+            if condition == "stalled" and height is not None:
+                # Anchor recovery to this height, not to the dashboard's timer.
+                next_entry["alert_height"] = height
 
     state_bucket[key] = next_entry
 
@@ -420,6 +447,7 @@ class Watchdog:
             now,
             suppressed,
             self.args,
+            coerce_float(row.get("height")),
         )
 
 

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -249,6 +249,13 @@ def update_alert_state(
         if was_alerting:
             if not stall_cleared(entry, height):
                 # Keep the alert latched; the timer reset but the node did not move.
+                anchor = coerce_float(entry.get("alert_height"))
+                if height is not None and anchor is not None and height < anchor:
+                    # The node was wiped, rolled back, or restarted onto a shorter
+                    # chain. Follow it down: anchored at the old tip the alert could
+                    # only clear once it re-synced past it, so a node that was fixed
+                    # by a resync would never post a recovery.
+                    entry = {**entry, "alert_height": height}
                 state_bucket[key] = entry
                 return
             if post_slack(recovery_text, args):
@@ -272,8 +279,15 @@ def update_alert_state(
         "last_seen": now,
     }
 
-    if alerting and entry.get("alert_height") is not None:
-        next_entry["alert_height"] = entry["alert_height"]
+    if alerting:
+        anchor = entry.get("alert_height")
+        if anchor is None and condition == "stalled":
+            # The alert fired on a sample with no usable height, so it has nothing
+            # to compare against and would clear on the first reset timer. Anchor
+            # on the first sample that does report one.
+            anchor = height
+        if anchor is not None:
+            next_entry["alert_height"] = anchor
 
     if not alerting and age >= threshold:
         if suppressed:


### PR DESCRIPTION
## Motivation

On 2026-08-03 `zakura-testnet-3` sat pinned at height **4,129,396** for 43 minutes
(19:39:40 → 20:22:58, confirmed by its own log: `chain updates have stalled ...
is_syncer_stopped=true`). The watchdog posted:

```
20:03  :white_check_mark: zakura-testnet-3 recovered from stalled
       health: healthy - height: 4129396      <-- the height it was stuck at
20:13  :rotating_light: zakura-testnet-3 stalled for 10m 23s
       health: stale - height: 4129396        <-- still not moved
```

The recovery was false. It reconciles to the second with a dashboard restart:
`zakura-testnet-dashboard.service` restarted at **20:02:37**, and the re-alert at
20:13 read "stalled for 10m 23s" — 20:13:00 − 623s = 20:02:37. The dashboard
restarted five times that day, producing one spurious recovery each.

Two defects combine:

- **`zakura-cluster-status.py`** keeps `last_advanced_at` in memory only. `--state-file`
  persists reorg pairs and nothing else, and the first poll after a start seeds the
  timer to `now` for every node regardless of height. A restart reports the whole
  fleet as freshly advanced and silently clears in-flight stall alerts — the blast
  radius is every node, not just the stalled one.
- **`zakura-cluster-watchdog.py`** cleared an alert on `condition == "ok"` alone.
  There is no height comparison anywhere on the recovery path, which is why the
  recovery message printed the stuck height.

Since nothing compares heights across a `stalled → ok` transition, a node pinned at
one height oscillates `stalled → recovered → stalled` indefinitely.

There is a second, independent height-blind path: `node_condition` returns `ok` for
`starting_grace` seconds after any dashboard bounce, and the dashboard's initial rows
are literally `health: "starting"`.

## Solution

**Watchdog (primary).** Record the height a stall alert fires at (`alert_height`) and
require the node to be strictly higher before retiring it. A reset timer, a missing
height (the `starting` window) or a height going backwards all keep the alert latched.
Only stalls are height-gated — a restarted node still recovers at whatever height it
comes back on. This closes both paths and holds even if the timer resets again, so it
does not depend on the dashboard change.

**Dashboard (complementary).** Persist per-node height and last-advanced timestamps
into the existing state file and restore them on start, so the stall clock survives a
restart instead of zeroing. Load is tolerant of a missing, corrupt, or pre-existing
file written before `progress` existed.

## Testing

- New `deploy/runner/test_zakura_cluster_watchdog.py` (8 tests): stall records its
  firing height; unchanged height does not clear it; five consecutive timer resets
  never clear it; forward progress does; missing height and backwards height stay
  latched; `down` alerts still recover without height progress; the anchor survives
  intermediate stalled cycles.
- `deploy/runner/test_zakura_cluster_status.py` 18 → 20: the stall timer survives a
  collector restart and still reports `health: stale` with the correct age, plus
  missing/corrupt/legacy state-file handling.
- Replaying the actual incident (five restarts, node never moving):

  ```
  origin/main : 6 stall alerts, 5 false recoveries
  with fix    : 1 stall alert,  0 false recoveries
  both        : genuine recovery still posted once height advances
  ```

**These tests were not running in CI at all** — `lint.yml` referenced neither runner
suite. It now runs both.

## Changelog

Deploy/monitoring tooling only; no Rust or `Cargo.toml` change, so no fragment.

### Follow-up Work

The underlying node stall was a header-sync livelock on the unmerged
`evan/header-chain-squashed` branch (staged headers hit `MAX_STAGED_HEADERS_V1` and the
target was discarded before ever committing), already fixed there by `7c283bb82`.
Neither the defect nor its fix is on `main`. This PR is only about the alerting being
truthful about it.