### PR TITLE
chore(headersync): add release and rollout support

### DIFF
--- a/.agents/skills/deploy-specific/SKILL.md
+++ b/.agents/skills/deploy-specific/SKILL.md
@@ -23,6 +23,8 @@ Require or confirm:
 - `nodes`: one or more exact names from the inventories below.
 - `force_rebuild`: optional; defaults to `false`.
 - `no_restart`: optional; defaults to `false`.
+- `p2p_stack`: optional testnet override; defaults to `auto`, which preserves
+  the inventory's dual-stack role.
 
 For any mainnet node, confirm the `ref` and complete node list explicitly with
 the user immediately before dispatch.
@@ -112,11 +114,16 @@ Append these workflow fields only when requested:
 -f no_restart=true
 ```
 
+Do not override `p2p_stack` merely because a node is being redeployed. Let
+`auto` preserve its inventory role unless the user explicitly requests a
+topology experiment.
+
 ## Verification
 
 - Confirm every workflow run succeeded and its final node status is healthy.
 - Confirm each node reports the expected commit/version.
 - For restarted nodes, confirm RPC height is current and advances.
+- Confirm the configured P2P role after an explicit testnet stack override.
 - For mainnet `zakura-compat`, confirm both Zakura and zcashd remain healthy.
 - Stop on failure; do not continue to additional requested nodes.
 - Report each requested node and its workflow run URL.
@@ -126,6 +133,8 @@ Append these workflow fields only when requested:
 - Never dispatch with an empty `node` input.
 - Never add unrequested nodes to the deployment.
 - Do not change cache, state, identity, or node configuration paths.
+- Preserve the node-specific P2P role unless the user explicitly requests an
+  override.
 - Only one deploy per network runs at a time (`cancel-in-progress: false`).
 
 ## References

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -326,7 +326,7 @@ from publication until deletion.
       have been changed, but keep their overall order:
 
 ```
-for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakura-tower-batch-control zakura-node-services zakura-script zakura-state zakura-consensus zakura-network zakura-rpc zakura-utils zakura; do cargo release publish --verbose --execute -p $c; done
+for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakura-header-chain zakura-tower-batch-control zakura-node-services zakura-script zakura-state zakura-consensus zakura-network zakura-rpc zakura-utils zakura; do cargo release publish --verbose --execute -p $c; done
 ```
 
 - [ ] Check that Zakura can be installed from `crates.io`:

--- a/.github/workflows/header-fuzz.yml
+++ b/.github/workflows/header-fuzz.yml
@@ -1,0 +1,102 @@
+name: Header-chain fuzzing
+
+on:
+  # Run the normative budgets Monday through Saturday and a longer campaign on Sunday.
+  schedule:
+    - cron: "13 5 * * 1-6"
+    - cron: "13 5 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_FUZZ_VERSION: 0.13.2
+  HEADER_FUZZ_NIGHTLY: nightly-2026-07-15
+  RUST_BACKTRACE: 1
+  CXXFLAGS: -include cstdint
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: fork_transitions
+            seconds: 1800
+            weekly_seconds: 7200
+            rss_mb: 4096
+            max_len: 512
+            detect_leaks: 1
+          - target: header_codec
+            seconds: 900
+            weekly_seconds: 3600
+            rss_mb: 2048
+            max_len: 2097152
+            detect_leaks: 1
+          - target: header_pursuit
+            seconds: 900
+            weekly_seconds: 3600
+            rss_mb: 2048
+            max_len: 512
+            detect_leaks: 1
+          - target: recovery_rows
+            seconds: 900
+            weekly_seconds: 3600
+            rss_mb: 4096
+            max_len: 256
+            # RocksDB retains process-global allocations after each temporary database closes.
+            # AddressSanitizer remains enabled for the recovery target, but its exit-time leak
+            # detector cannot distinguish those allocations from harness leaks.
+            detect_leaks: 0
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: ${{ env.HEADER_FUZZ_NIGHTLY }}
+          cache: true
+          cache-on-failure: true
+      - uses: ./.github/actions/setup-zakura-build
+      - name: Install pinned cargo-fuzz
+        run: cargo install cargo-fuzz --version "${CARGO_FUZZ_VERSION}" --locked
+      - name: Run bounded campaign
+        working-directory: fuzz/header-chain
+        env:
+          NORMAL_SECONDS: ${{ matrix.seconds }}
+          WEEKLY_SECONDS: ${{ matrix.weekly_seconds }}
+          SCHEDULE: ${{ github.event.schedule }}
+          TARGET: ${{ matrix.target }}
+          RSS_MB: ${{ matrix.rss_mb }}
+          MAX_LEN: ${{ matrix.max_len }}
+          DETECT_LEAKS: ${{ matrix.detect_leaks }}
+          ASAN_OPTIONS: detect_leaks=${{ matrix.detect_leaks }}
+        run: |
+          seconds="${NORMAL_SECONDS}"
+          if [ "${SCHEDULE}" = "13 5 * * 0" ]; then
+            seconds="${WEEKLY_SECONDS}"
+          fi
+          cargo fuzz run "${TARGET}" -- \
+            -max_total_time="${seconds}" \
+            -rss_limit_mb="${RSS_MB}" \
+            -max_len="${MAX_LEN}" \
+            -detect_leaks="${DETECT_LEAKS}"
+      - name: Upload crash artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: header-fuzz-${{ matrix.target }}-${{ github.run_id }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: fuzz/header-chain/artifacts/${{ matrix.target }}

--- a/.github/workflows/header-fuzz.yml
+++ b/.github/workflows/header-fuzz.yml
@@ -1,7 +1,8 @@
 name: Header-chain fuzzing
 
 on:
-  # Run the normative budgets Monday through Saturday and a longer campaign on Sunday.
+  # Run the normative budgets Monday through Saturday.
+  # Run the longer campaign on Sunday.
   schedule:
     - cron: "13 5 * * 1-6"
     - cron: "13 5 * * 0"
@@ -55,8 +56,8 @@ jobs:
             rss_mb: 4096
             max_len: 256
             # RocksDB retains process-global allocations after each temporary database closes.
-            # AddressSanitizer remains enabled for the recovery target, but its exit-time leak
-            # detector cannot distinguish those allocations from harness leaks.
+            # AddressSanitizer remains enabled for the recovery target.
+            # Its exit-time leak detector cannot distinguish those allocations from harness leaks.
             detect_leaks: 0
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,10 @@ on:
       - "**/Cargo.lock"
       - .cargo/config.toml
       - .github/workflows/lint.yml
+      - docs/specs/fork-aware-header-chain-engine.md
       - qa/supply-chain/**
       - "scripts/**.sh"
+      - crates/zakura-header-chain/conformance.toml
       - ".github/workflows/scripts/**"
       - ".github/actions/**"
       # ci-python-tests covers these suites, so changes to them must trigger it.
@@ -25,8 +27,10 @@ on:
       - "**/Cargo.lock"
       - .cargo/config.toml
       - .github/workflows/lint.yml
+      - docs/specs/fork-aware-header-chain-engine.md
       - qa/supply-chain/**
       - "scripts/**.sh"
+      - crates/zakura-header-chain/conformance.toml
       - ".github/workflows/scripts/**"
       - ".github/actions/**"
       # ci-python-tests covers these suites, so changes to them must trigger it.
@@ -206,6 +210,24 @@ jobs:
       - name: Ensure no arbitrary or proptest dependency on default build
         if: ${{ !cancelled() }}
         run: cargo +stable tree --package zakura -e=features,no-dev | grep -Eq "arbitrary|proptest" && exit 1 || exit 0
+
+  header-conformance:
+    name: header conformance
+    permissions:
+      contents: read
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+          cache: false
+      - name: Validate header-chain conformance manifest
+        run: cargo xtask header-conformance
 
   unused-deps:
     name: unused-deps

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -13,6 +13,8 @@ on:
       - crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json
       - .config/nextest.toml
       - .github/workflows/tests-unit.yml
+      - docs/specs/fork-aware-header-chain-engine.md
+      - crates/zakura-header-chain/conformance.toml
 
   push:
     branches: [main]
@@ -25,6 +27,8 @@ on:
       - crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json
       - .config/nextest.toml
       - .github/workflows/tests-unit.yml
+      - docs/specs/fork-aware-header-chain-engine.md
+      - crates/zakura-header-chain/conformance.toml
 
   # Run the full unit-test suite when a PR is queued so the merge queue validates
   # the merged result against the latest `main`. `merge_group` ignores path

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -25,6 +25,17 @@ on:
         type: boolean
         required: false
         default: false
+      p2p_stack:
+        description: "P2P stack override; auto preserves each node's fleet role"
+        type: choice
+        required: false
+        options: [auto, dual, zakura, legacy]
+        default: auto
+      header_sync_trace:
+        description: "Write structured header/block-sync traces to the data volume"
+        type: boolean
+        required: false
+        default: false
       node:
         description: "Optional single deployer node name; blank deploys the whole fleet"
         required: false
@@ -111,6 +122,28 @@ jobs:
         run: |
           set -euo pipefail
 
+          requested_p2p_stack="${{ inputs.p2p_stack }}"
+          default_p2p_stack="dual"
+
+          if [ "$requested_p2p_stack" != "auto" ]; then
+            if [ -z "${{ inputs.node }}" ]; then
+              echo "p2p_stack overrides require one explicit node" >&2
+              exit 1
+            fi
+            default_p2p_stack="$requested_p2p_stack"
+          fi
+
+          if [ "${{ inputs.header_sync_trace }}" = "true" ] \
+            && [ -z "${{ inputs.node }}" ]; then
+            echo "header_sync_trace requires one explicit node" >&2
+            exit 1
+          fi
+
+          zakura_trace_line=""
+          if [ "${{ inputs.header_sync_trace }}" = "true" ]; then
+            zakura_trace_line='trace_dir = "/mnt/data/traces/header-chain-canary"'
+          fi
+
           cat > nodes.ci.toml <<EOF
           [defaults]
           service_name    = "zakurad"
@@ -121,7 +154,7 @@ jobs:
           rpc_listen_addr = "0.0.0.0:18232"
           rpc_enable_cookie_auth = false
           storage_mode    = "archive"
-          p2p_stack       = "dual"
+          p2p_stack       = "${default_p2p_stack}"
           metrics_endpoint = "127.0.0.1:9999"
           tracing_filter  = "info,zakura_network::zakura=info"
           checkpoint_sync = false
@@ -129,6 +162,7 @@ jobs:
 
           [defaults.zakura]
           listen_addr = "0.0.0.0:8234"
+          ${zakura_trace_line}
           bootstrap_peers = [
               "57ad39fad4f0bca46cf1ea831772a99d5027b372fef2be5a0ea68e1b5bb4da49@167.99.103.111:8234",
               "2bbb907b5d90598ef49f2e637066586b311a64587479be6ed43e8388587fcd2a@164.92.209.78:8234",

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -85,12 +85,20 @@ The workflow is manual (`workflow_dispatch`). Inputs:
 - `ref` — branch, tag, or SHA to build and deploy, default `main`.
 - `force_rebuild` — pass `--force` to rebuild the cached binary.
 - `no_restart` — stage binary/config/unit without restarting, default `false`.
+- `p2p_stack` — optionally override the selected node with `dual`, `zakura`, or
+  `legacy`. The default `auto` preserves the fleet's dual-stack role.
+- `header_sync_trace` — write structured canary traces under
+  `/mnt/data/traces/header-chain-canary`; defaults to `false`.
 - `node` — optional deployer node name; blank deploys the whole fleet.
+
+Explicit `p2p_stack` overrides and `header_sync_trace = true` require an
+explicit `node`, preventing canary settings from being applied fleet-wide.
 
 The generated CI config uses Testnet ports, public RPC at `0.0.0.0:18232`, and
 explicitly sets `vct_fast_sync = false`, which keeps checkpoint sync available
 while forcing the legacy non-VCT path. Fleet nodes use `p2p_stack = "dual"`.
-It also writes `/etc/zakura/zakura.toml` and uses each node's existing
+Explicit per-node overrides remain available for staged experiments. The
+workflow also writes `/etc/zakura/zakura.toml` and uses each node's existing
 `/mnt/data/zakura-cache` snapshot directory, so CI restarts the current
 `zakurad.service` against the existing state instead of creating a fresh
 database. Volume-backed fleet hosts mount their attached DigitalOcean block

--- a/docs/changelog/unreleased/532.md
+++ b/docs/changelog/unreleased/532.md
@@ -1,0 +1,34 @@
+## Added
+
+- Added fork-aware, bounded header and block synchronization with crash-atomic
+  header-chain persistence, contextual validation, and resumable startup
+  reconstruction
+  ([#532](https://github.com/zakura-core/zakura/pull/532)).
+
+## Changed
+
+- Changed native/legacy sync handoff, header capability readiness, and ordered
+  service demand to use one explicit lifecycle coordinator, preventing legacy
+  fallback from applying blocks while an accepted native apply is still live
+  ([#532](https://github.com/zakura-core/zakura/pull/532)).
+
+## Fixed
+
+- Fixed header-sync work and memory retention across body commits, finality
+  advances, peer terminal paths, process restarts, and committed resource-limit
+  refusals
+  ([#532](https://github.com/zakura-core/zakura/pull/532)).
+- Fixed native scratch-sync commit throughput by caching immutable trust-anchor
+  digests, using ordered trust-pin lookups, borrowing immutable writer
+  configuration, and reading VCT auxiliary windows and continuation locators
+  from the already-audited committed engine projection instead of repeatedly
+  cloning or walking immutable state for every block; header projection and
+  eligibility updates now use bounded exact keys instead of rescanning RocksDB
+  ranges on every commit, and finalized validation-context windows update only
+  their changed predecessor rows; independent header hashing, proof-of-work,
+  commitment, target, time, and work checks run in parallel while ordered link
+  and contextual-difficulty checks remain deterministic; integrated sync now
+  refills its bounded header window at half capacity so header proof validation
+  overlaps body application instead of starving at the old checkpoint low-water
+  boundary
+  ([#532](https://github.com/zakura-core/zakura/pull/532)).

--- a/scripts/check-crate-packaging.sh
+++ b/scripts/check-crate-packaging.sh
@@ -53,6 +53,7 @@ PUBLISH_ORDER=(
   zakura-tower-fallback
   zakura-jsonl-trace
   zakura-chain
+  zakura-header-chain
   zakura-tower-batch-control
   zakura-node-services
   zakura-script


### PR DESCRIPTION
> Stack layer **8/8**. Parent: #572. Review bottom-to-top beginning with #586.

## Motivation

The feature needs CI enforcement, packaging/release awareness, rollout support, and one user-visible changelog entry without mixing repository automation into production review.

## Stack map

1. #586 — `2be164ceb97ae51b2de91cb5ac02ab1315f50d5c` — engine implementation, deterministic tests, replay adapter, and bottom-boundary Docker mount
2. #587 — `91379561b76eff5a8967225bb5dd5ed8e6b35b4e` — typed service and authority contracts
3. #563 — `768941d527ce9fe1fe92a6d093e4e6062b613f0d` — durable state production
4. #588 — `53aa22af61e19f037fd86f4f5bd7b8e102107b75` — state durability and recovery tests
5. #569 — `f9fbde47d2c2a6ee125020a39d203ab91ab08866` — network, consensus/RPC, and node runtime integration
6. #571 — `5221e94155ab43f0113461d897670206d26383e9` — fuzzing
7. #572 — `6a4f48d7fd61dfda6eda61114b061f37830cc13d` — conformance and migration documentation
8. #532 — `e59614be62320b871befe8788e876b4f7577338c` — repository/release support

The stack contains exactly 16 focused commits over frozen `main` `87479333cd670791eca801b8083fbc1b19a835e2`. The final rebase onto that main was conflict-free, and `git range-diff` marks every commit patch-identical to the fully validated corrected series. Subjects, production ownership, and all eight commit boundaries are unchanged. The cumulative published tree is `746e87878caf3379f2c983b4bfbfeb46789382c9`. The previously published top remains archived at `evan/header-chain-v12-publish-pre-remaining-20260807`.

## V12 audit corrections

All 28 V12 findings outside #586 have final dispositions: the 16 state findings from run 6095 were already corrected, and this publication adds the accepted fixes and regressions for the remaining 12 findings across #587, #563/#588, #569, and #572. Run 6102 on #571 produced no findings; #532 had no V12 audit comment.

## Testing

Passed at the cumulative head:

- formatting, locked all-feature/all-target workspace check, and strict workspace clippy
- header-chain tests — 126 passed, 1 ignored
- state tests — 417 passed, 3 ignored
- network library tests — 1,048 passed, 3 ignored
- focused `zakurad` sync tests — 80 passed
- consensus routing tests — 6 passed; RPC tests — 101 passed, 1 ignored
- DB-lock acceptance regression
- isolated fuzz-manifest check, all four pinned-nightly builds, and 100 bounded iterations per target
- `cargo xtask header-conformance` — 110 rules, 0 unimplemented, 16 unique audit IDs
- changelog validation — 10 fragments including the new `main` fragment
- affected-semver tests — 5 passed
- CI-equivalent #586 runtime Docker image build, `actionlint`, packaging/regtest script syntax, `git diff --check`, and 16-commit range-diff review

Markdown/codespell/link checks passed in documentation CI. No nodes, SSH, release, or deployment operation was run.

## Changelog

`docs/changelog/unreleased/532.md` contains the single user-visible header-sync entry.

### Landing contract

- #586 must be green against `main`; after its squash merge, restack/rebase #587 onto updated `main`, retarget it, and require a green exact head.
- #563 and #588 remain separate review layers but are not independent landing units. Fold them into #569 and require full exact-head `main` CI before merging that combined state/runtime change.
- After that merge, restack/rebase and retarget #571, #572, and #532 one at a time to `main`; wait for each exact-head required CI before merging.
- Never merge a red commit or use atomic stack merge without exact-head checks for every landing layer. Ready-for-review authorization was received on 2026-08-07; the two intentionally red review-only state layers remain draft until folded into the green #569 landing unit.