### PR TITLE
fix(state): report a typed error for absent historical treestates

### DIFF
--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -1154,6 +1154,150 @@ async fn rpc_getblock_missing_error() {
     assert!(rpc_tx_queue_task_result.is_none());
 }
 
+/// A `z_gettreestate` inside a fast-synced node's absent band must fail loudly.
+///
+/// Before this, an absent per-height tree became a JSON `null` treestate. Clients following
+/// the lightwalletd contract read that as the *empty* tree and derive a wallet birthday anchor
+/// asserting an empty commitment tree deep in the chain, with no error at the point of
+/// corruption. The read handler now returns [`zakura_state::HistoricalTreeUnavailable`], which
+/// the RPC surfaces as an error.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_z_get_treestate_absent_band_is_an_error() {
+    let _init_guard = zakura_test::init();
+
+    let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let block_hash = block.hash();
+
+    // Sapling is active here and NU5 is not, so the Sapling tree is the only tree requested.
+    let height = Height(1_000_000);
+    let handoff = Height(3_418_406);
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let treestate_future =
+        tokio::spawn(async move { rpc.z_get_treestate(height.0.to_string()).await });
+
+    read_state
+        .expect_request(ReadRequest::Block(height.into()))
+        .await
+        .respond(ReadResponse::Block(Some(block)));
+
+    read_state
+        .expect_request(ReadRequest::SaplingTree(block_hash.into()))
+        .await
+        .respond_error(Box::new(zakura_state::HistoricalTreeUnavailable {
+            hash_or_height: block_hash.into(),
+            handoff,
+        }));
+
+    let treestate_response = treestate_future
+        .await
+        .expect("treestate future should not panic")
+        .expect_err("an absent-band treestate must be an error, not a null treestate");
+
+    assert_eq!(treestate_response.code(), ErrorCode::ServerError(-1).code());
+    assert!(
+        treestate_response.message().contains("fast-synced"),
+        "the error must name the cause, got: {}",
+        treestate_response.message()
+    );
+
+    read_state.expect_no_requests().await;
+
+    let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
+    assert!(rpc_tx_queue_task_result.is_none());
+}
+
+/// A `z_getsubtreesbyindex` inside a fast-synced node's absent band must fail loudly.
+///
+/// The subtree read path returns an empty list when the starting index is absent, which is
+/// indistinguishable from "this chain has no subtrees there". A client seeds nothing and fails
+/// later without a clear cause, so the read handler returns
+/// [`zakura_state::HistoricalSubtreeUnavailable`] instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
+    let _init_guard = zakura_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let start_index = NoteCommitmentSubtreeIndex(0);
+    let subtrees_future = tokio::spawn(async move {
+        rpc.z_get_subtrees_by_index("sapling".to_string(), start_index, Some(1u16.into()))
+            .await
+    });
+
+    read_state
+        .expect_request(ReadRequest::SaplingSubtrees {
+            start_index,
+            limit: Some(1u16.into()),
+        })
+        .await
+        .respond_error(Box::new(zakura_state::HistoricalSubtreeUnavailable {
+            pool: "sapling",
+            index: start_index,
+            handoff: Height(3_418_406),
+        }));
+
+    let subtrees_response = subtrees_future
+        .await
+        .expect("subtrees future should not panic")
+        .expect_err("an absent-band subtree list must be an error, not an empty list");
+
+    assert_eq!(subtrees_response.code(), ErrorCode::ServerError(-1).code());
+    assert!(
+        subtrees_response.message().contains("fast-synced"),
+        "the error must name the cause, got: {}",
+        subtrees_response.message()
+    );
+
+    read_state.expect_no_requests().await;
+
+    let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
+    assert!(rpc_tx_queue_task_result.is_none());
+}
+
 /// Regression test for GHSA-x6v8-c2xp-928m — panics (aborts) before the fix.
 ///
 /// When `Depth` returns `None` (side-chain block), `get_block_header` sets

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -1217,6 +1217,123 @@ async fn rpc_getblockheader_preserves_historical_tree_error() {
     assert!(rpc_tx_queue.now_or_never().is_none());
 }
 
+/// Verbose `getblock` must serve a pre-activation block from the empty frontier.
+///
+/// Below a pool's activation height the note commitment tree is the consensus-defined empty
+/// frontier, so a fast-synced node's absent per-height tree is not missing history: the read
+/// handler answers with the empty tree rather than the archive-mode error, exactly as a
+/// legacy node answers from its backward tree search. This pins the reported values, because
+/// the claim this behaviour rests on is equivalence with a legacy node, not merely "no error".
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getblock_serves_pre_activation_empty_trees() {
+    let _init_guard = zakura_test::init();
+    let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let hash = block.hash();
+    let height = Height(0);
+    let tx_hashes = block
+        .transactions
+        .iter()
+        .map(|transaction| transaction.hash())
+        .collect::<Vec<_>>();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool, 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state.clone(), 8),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let block_future =
+        tokio::spawn(async move { rpc.get_block(height.0.to_string(), Some(1)).await });
+
+    read_state
+        .expect_request(ReadRequest::BlockHeader(height.into()))
+        .await
+        .respond(ReadResponse::BlockHeader {
+            header: block.header.clone(),
+            hash,
+            height,
+            next_block_hash: None,
+        });
+    // Genesis is below Sapling and NU5 activation, so both reads resolve to the empty frontier
+    // on a fast-synced node instead of returning the absent-band error.
+    read_state
+        .expect_request(ReadRequest::SaplingTree(hash.into()))
+        .await
+        .respond(ReadResponse::SaplingTree(Some(Arc::new(
+            zakura_chain::sapling::tree::NoteCommitmentTree::default(),
+        ))));
+    read_state
+        .expect_request(ReadRequest::Depth(hash))
+        .await
+        .respond(ReadResponse::Depth(Some(0)));
+    read_state
+        .expect_request(ReadRequest::TransactionIdsForBlock(hash.into()))
+        .await
+        .respond(ReadResponse::TransactionIdsForBlock(Some(Arc::from(
+            tx_hashes.into_boxed_slice(),
+        ))));
+    read_state
+        .expect_request(ReadRequest::OrchardTree(hash.into()))
+        .await
+        .respond(ReadResponse::OrchardTree(Some(Arc::new(
+            zakura_chain::orchard::tree::NoteCommitmentTree::default(),
+        ))));
+    read_state
+        .expect_request(ReadRequest::BlockInfo(
+            block.header.previous_block_hash.into(),
+        ))
+        .await
+        .respond(ReadResponse::BlockInfo(None));
+    read_state
+        .expect_request(ReadRequest::BlockInfo(hash.into()))
+        .await
+        .respond(ReadResponse::BlockInfo(None));
+
+    let response = block_future
+        .await
+        .expect("getblock future should not panic")
+        .expect("a pre-activation block is served, not reported as missing history");
+
+    let GetBlockResponse::Object(block_object) = response else {
+        panic!("verbosity 1 returns a block object");
+    };
+
+    let trees = block_object.trees;
+    assert_eq!(
+        trees.sapling(),
+        0,
+        "an empty Sapling frontier has no commitments"
+    );
+    assert_eq!(
+        trees.orchard(),
+        0,
+        "an empty Orchard frontier has no commitments"
+    );
+    // NU5 is inactive at genesis, so `getblock` omits the final Orchard root entirely rather
+    // than reporting the empty tree's root.
+    assert_eq!(block_object.final_orchard_root, None);
+
+    read_state.expect_no_requests().await;
+    assert!(rpc_tx_queue.now_or_never().is_none());
+}
+
 /// Verbose `getblock` must preserve the typed Orchard-tree error from state.
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_getblock_preserves_historical_tree_error() {
@@ -1469,23 +1586,35 @@ async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
             pool: "sapling",
             index: start_index,
             handoff: Height(3_418_406),
-            reason: zakura_state::HistoricalSubtreeUnavailableReason::Syncing,
+            reason: zakura_state::HistoricalSubtreeUnavailableReason::Indeterminate,
         }));
 
-    let syncing_response = subtrees_future
+    let indeterminate_response = subtrees_future
         .await
         .expect("subtrees future should not panic")
         .expect_err("a subtree missing during sync must be an error, not an empty list");
 
-    assert_eq!(syncing_response.code(), ErrorCode::ServerError(-1).code());
-    assert!(
-        syncing_response
-            .message()
-            .contains("retry after sync advances"),
-        "the error must identify the failure as transient, got: {}",
-        syncing_response.message()
+    assert_eq!(
+        indeterminate_response.code(),
+        ErrorCode::ServerError(-1).code()
     );
-    assert_ne!(subtrees_response.message(), syncing_response.message());
+    assert!(
+        indeterminate_response
+            .message()
+            .contains("cannot yet tell whether the subtree was skipped"),
+        "the error must identify the availability as undecided, got: {}",
+        indeterminate_response.message()
+    );
+    assert!(
+        !indeterminate_response.message().contains("retry"),
+        "a subtree skipped below the handoff never arrives, so the error must not advise a \
+         retry, got: {}",
+        indeterminate_response.message()
+    );
+    assert_ne!(
+        subtrees_response.message(),
+        indeterminate_response.message()
+    );
 
     read_state.expect_no_requests().await;
 

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -1163,7 +1163,7 @@ async fn rpc_getblockheader_preserves_historical_tree_error() {
         .unwrap();
     let hash = block.hash();
     let height = Height(0);
-    let handoff = Height(3_418_406);
+    let last_checkpoint = Height(3_418_406);
 
     let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
@@ -1203,7 +1203,7 @@ async fn rpc_getblockheader_preserves_historical_tree_error() {
         .await
         .respond_error(Box::new(zakura_state::HistoricalTreeUnavailable {
             hash_or_height: hash.into(),
-            handoff,
+            last_checkpoint,
         }));
 
     let error = header_future
@@ -1343,7 +1343,7 @@ async fn rpc_getblock_preserves_historical_tree_error() {
         .unwrap();
     let hash = block.hash();
     let height = Height(0);
-    let handoff = Height(3_418_406);
+    let last_checkpoint = Height(3_418_406);
     let tx_hashes = block
         .transactions
         .iter()
@@ -1404,7 +1404,7 @@ async fn rpc_getblock_preserves_historical_tree_error() {
         .await
         .respond_error(Box::new(zakura_state::HistoricalTreeUnavailable {
             hash_or_height: hash.into(),
-            handoff,
+            last_checkpoint,
         }));
     read_state
         .expect_request(ReadRequest::BlockInfo(
@@ -1446,7 +1446,7 @@ async fn rpc_z_get_treestate_absent_band_is_an_error() {
 
     // Sapling is active here and NU5 is not, so the Sapling tree is the only tree requested.
     let height = Height(1_000_000);
-    let handoff = Height(3_418_406);
+    let last_checkpoint = Height(3_418_406);
 
     let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
@@ -1483,7 +1483,7 @@ async fn rpc_z_get_treestate_absent_band_is_an_error() {
         .await
         .respond_error(Box::new(zakura_state::HistoricalTreeUnavailable {
             hash_or_height: block_hash.into(),
-            handoff,
+            last_checkpoint,
         }));
 
     let treestate_response = treestate_future
@@ -1553,7 +1553,7 @@ async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
         .respond_error(Box::new(zakura_state::HistoricalSubtreeUnavailable {
             pool: "sapling",
             index: start_index,
-            handoff: Height(3_418_406),
+            last_checkpoint: Height(3_418_406),
             reason: zakura_state::HistoricalSubtreeUnavailableReason::NotStored,
         }));
 
@@ -1585,7 +1585,7 @@ async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
         .respond_error(Box::new(zakura_state::HistoricalSubtreeUnavailable {
             pool: "sapling",
             index: start_index,
-            handoff: Height(3_418_406),
+            last_checkpoint: Height(3_418_406),
             reason: zakura_state::HistoricalSubtreeUnavailableReason::Indeterminate,
         }));
 
@@ -1607,7 +1607,7 @@ async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
     );
     assert!(
         !indeterminate_response.message().contains("retry"),
-        "a subtree skipped below the handoff never arrives, so the error must not advise a \
+        "a subtree skipped below the last checkpoint never arrives, so the error must not advise a \
          retry, got: {}",
         indeterminate_response.message()
     );

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -1420,6 +1420,40 @@ async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
     );
 
     let start_index = NoteCommitmentSubtreeIndex(0);
+    let subtrees_rpc = rpc.clone();
+    let subtrees_future = tokio::spawn(async move {
+        subtrees_rpc
+            .z_get_subtrees_by_index("sapling".to_string(), start_index, Some(1u16.into()))
+            .await
+    });
+
+    read_state
+        .expect_request(ReadRequest::SaplingSubtrees {
+            start_index,
+            limit: Some(1u16.into()),
+        })
+        .await
+        .respond_error(Box::new(zakura_state::HistoricalSubtreeUnavailable {
+            pool: "sapling",
+            index: start_index,
+            handoff: Height(3_418_406),
+            reason: zakura_state::HistoricalSubtreeUnavailableReason::NotStored,
+        }));
+
+    let subtrees_response = subtrees_future
+        .await
+        .expect("subtrees future should not panic")
+        .expect_err("an absent-band subtree list must be an error, not an empty list");
+
+    assert_eq!(subtrees_response.code(), ErrorCode::ServerError(-1).code());
+    assert!(
+        subtrees_response
+            .message()
+            .contains("continuing synchronization will not restore it"),
+        "the error must identify the failure as permanent, got: {}",
+        subtrees_response.message()
+    );
+
     let subtrees_future = tokio::spawn(async move {
         rpc.z_get_subtrees_by_index("sapling".to_string(), start_index, Some(1u16.into()))
             .await
@@ -1435,19 +1469,23 @@ async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
             pool: "sapling",
             index: start_index,
             handoff: Height(3_418_406),
+            reason: zakura_state::HistoricalSubtreeUnavailableReason::Syncing,
         }));
 
-    let subtrees_response = subtrees_future
+    let syncing_response = subtrees_future
         .await
         .expect("subtrees future should not panic")
-        .expect_err("an absent-band subtree list must be an error, not an empty list");
+        .expect_err("a subtree missing during sync must be an error, not an empty list");
 
-    assert_eq!(subtrees_response.code(), ErrorCode::ServerError(-1).code());
+    assert_eq!(syncing_response.code(), ErrorCode::ServerError(-1).code());
     assert!(
-        subtrees_response.message().contains("fast-synced"),
-        "the error must name the cause, got: {}",
-        subtrees_response.message()
+        syncing_response
+            .message()
+            .contains("retry after sync advances"),
+        "the error must identify the failure as transient, got: {}",
+        syncing_response.message()
     );
+    assert_ne!(subtrees_response.message(), syncing_response.message());
 
     read_state.expect_no_requests().await;
 

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -1154,6 +1154,163 @@ async fn rpc_getblock_missing_error() {
     assert!(rpc_tx_queue_task_result.is_none());
 }
 
+/// Verbose `getblockheader` must preserve the typed historical-tree error from state.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getblockheader_preserves_historical_tree_error() {
+    let _init_guard = zakura_test::init();
+    let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let hash = block.hash();
+    let height = Height(0);
+    let handoff = Height(3_418_406);
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool, 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state.clone(), 2),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let header_future =
+        tokio::spawn(async move { rpc.get_block_header(height.0.to_string(), Some(true)).await });
+
+    read_state
+        .expect_request(ReadRequest::BlockHeader(height.into()))
+        .await
+        .respond(ReadResponse::BlockHeader {
+            header: block.header.clone(),
+            hash,
+            height,
+            next_block_hash: None,
+        });
+    read_state
+        .expect_request(ReadRequest::SaplingTree(hash.into()))
+        .await
+        .respond_error(Box::new(zakura_state::HistoricalTreeUnavailable {
+            hash_or_height: hash.into(),
+            handoff,
+        }));
+
+    let error = header_future
+        .await
+        .expect("getblockheader future should not panic")
+        .expect_err("an absent historical tree must fail getblockheader");
+    assert!(error.message().contains("historical note commitment tree"));
+    assert!(!error.message().contains("missing Sapling tree"));
+
+    read_state.expect_no_requests().await;
+    assert!(rpc_tx_queue.now_or_never().is_none());
+}
+
+/// Verbose `getblock` must preserve the typed Orchard-tree error from state.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getblock_preserves_historical_tree_error() {
+    let _init_guard = zakura_test::init();
+    let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let hash = block.hash();
+    let height = Height(0);
+    let handoff = Height(3_418_406);
+    let tx_hashes = block
+        .transactions
+        .iter()
+        .map(|transaction| transaction.hash())
+        .collect::<Vec<_>>();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool, 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state.clone(), 8),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let block_future =
+        tokio::spawn(async move { rpc.get_block(height.0.to_string(), Some(1)).await });
+
+    read_state
+        .expect_request(ReadRequest::BlockHeader(height.into()))
+        .await
+        .respond(ReadResponse::BlockHeader {
+            header: block.header.clone(),
+            hash,
+            height,
+            next_block_hash: None,
+        });
+    read_state
+        .expect_request(ReadRequest::SaplingTree(hash.into()))
+        .await
+        .respond(ReadResponse::SaplingTree(Some(Arc::new(
+            zakura_chain::sapling::tree::NoteCommitmentTree::default(),
+        ))));
+    read_state
+        .expect_request(ReadRequest::Depth(hash))
+        .await
+        .respond(ReadResponse::Depth(Some(0)));
+    read_state
+        .expect_request(ReadRequest::TransactionIdsForBlock(hash.into()))
+        .await
+        .respond(ReadResponse::TransactionIdsForBlock(Some(Arc::from(
+            tx_hashes.into_boxed_slice(),
+        ))));
+    read_state
+        .expect_request(ReadRequest::OrchardTree(hash.into()))
+        .await
+        .respond_error(Box::new(zakura_state::HistoricalTreeUnavailable {
+            hash_or_height: hash.into(),
+            handoff,
+        }));
+    read_state
+        .expect_request(ReadRequest::BlockInfo(
+            block.header.previous_block_hash.into(),
+        ))
+        .await
+        .respond(ReadResponse::BlockInfo(None));
+    read_state
+        .expect_request(ReadRequest::BlockInfo(hash.into()))
+        .await
+        .respond(ReadResponse::BlockInfo(None));
+
+    let error = block_future
+        .await
+        .expect("getblock future should not panic")
+        .expect_err("an absent historical tree must fail getblock");
+    assert!(error.message().contains("historical note commitment tree"));
+    assert!(!error.message().contains("missing Orchard tree"));
+
+    read_state.expect_no_requests().await;
+    assert!(rpc_tx_queue.now_or_never().is_none());
+}
+
 /// A `z_gettreestate` inside a fast-synced node's absent band must fail loudly.
 ///
 /// Before this, an absent per-height tree became a JSON `null` treestate. Clients following

--- a/crates/zakura-state/src/error.rs
+++ b/crates/zakura-state/src/error.rs
@@ -10,7 +10,9 @@ use zakura_chain::{
     amount::{self, NegativeAllowed, NonNegative},
     block,
     history_tree::HistoryTreeError,
-    ironwood, orchard, sapling, sprout, transaction, transparent,
+    ironwood, orchard, sapling, sprout,
+    subtree::NoteCommitmentSubtreeIndex,
+    transaction, transparent,
     value_balance::{ValueBalance, ValueBalanceError},
     work::difficulty::CompactDifficulty,
 };
@@ -51,6 +53,53 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub struct MissingSproutTipTree {
     /// The finalized tip whose Sprout frontier is missing.
     pub tip: block::Height,
+}
+
+/// The per-height note commitment tree for a historical block was never written, because this
+/// database was built by the verified-commitment-trees fast-sync path.
+///
+/// Fast sync skips per-height trees across the half-open band `[U, H)`, where `U` is the first
+/// height this binary committed and `H` is the checkpoint handoff. Read handlers return this
+/// instead of an absent tree so the RPC boundary reports a diagnosable archive-mode failure:
+/// clients following the lightwalletd contract read an absent treestate as the *empty* tree, and
+/// would silently derive a wallet birthday anchor asserting an empty commitment tree deep in the
+/// chain.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error(
+    "historical note commitment tree at {hash_or_height} is unavailable: this node was fast-synced \
+     with verified commitment trees, so per-height trees below the checkpoint handoff {handoff:?} \
+     were never written"
+)]
+pub struct HistoricalTreeUnavailable {
+    /// The block whose per-height tree was requested.
+    pub hash_or_height: HashOrHeight,
+
+    /// The checkpoint handoff height `H`: the exclusive upper bound of the absent band.
+    pub handoff: block::Height,
+}
+
+/// A completed note commitment subtree root was never recorded, because this database was built
+/// by the verified-commitment-trees fast-sync path.
+///
+/// Subtree roots are a by-product of the per-height tree maintenance the fast path skips, so
+/// every subtree that completed at or below the checkpoint handoff is missing. Read handlers
+/// return this instead of an empty subtree list, which a client would otherwise read as "this
+/// chain has no subtrees here" and seed nothing, failing later without a clear cause.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error(
+    "historical {pool} note commitment subtree {index:?} is unavailable: this node was fast-synced \
+     with verified commitment trees, so subtrees completed at or below the checkpoint handoff \
+     {handoff:?} were never recorded"
+)]
+pub struct HistoricalSubtreeUnavailable {
+    /// The shielded pool whose subtree was requested, in `z_getsubtreesbyindex` spelling.
+    pub pool: &'static str,
+
+    /// The requested starting subtree index.
+    pub index: NoteCommitmentSubtreeIndex,
+
+    /// The checkpoint handoff height `H`, below which no subtree roots were recorded.
+    pub handoff: block::Height,
 }
 
 /// An error describing why opening the finalized state database failed.

--- a/crates/zakura-state/src/error.rs
+++ b/crates/zakura-state/src/error.rs
@@ -59,7 +59,7 @@ pub struct MissingSproutTipTree {
 /// database was built by the verified-commitment-trees fast-sync path.
 ///
 /// Fast sync skips per-height trees across the half-open band `[U, H)`, where `U` is the first
-/// height this binary committed and `H` is the checkpoint handoff. Read handlers return this
+/// height this binary committed and `H` is the last checkpoint. Read handlers return this
 /// instead of an absent tree so the RPC boundary reports a diagnosable archive-mode failure:
 /// clients following the lightwalletd contract read an absent treestate as the *empty* tree, and
 /// would silently derive a wallet birthday anchor asserting an empty commitment tree deep in the
@@ -67,28 +67,29 @@ pub struct MissingSproutTipTree {
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 #[error(
     "historical note commitment tree at {hash_or_height} is unavailable: this node was fast-synced \
-     with verified commitment trees, so per-height trees below the checkpoint handoff {handoff:?} \
+     with verified commitment trees, so per-height trees below the last checkpoint \
+     {last_checkpoint:?} \
      were never written"
 )]
 pub struct HistoricalTreeUnavailable {
     /// The block whose per-height tree was requested.
     pub hash_or_height: HashOrHeight,
 
-    /// The checkpoint handoff height `H`: the exclusive upper bound of the absent band.
-    pub handoff: block::Height,
+    /// The last checkpoint height `H`: the exclusive upper bound of the absent band.
+    pub last_checkpoint: block::Height,
 }
 
 /// A completed note commitment subtree root was never recorded, because this database was built
 /// by the verified-commitment-trees fast-sync path.
 ///
 /// Subtree roots are a by-product of the per-height tree maintenance the fast path skips, so
-/// every subtree that completed at or below the checkpoint handoff is missing. Read handlers
+/// every subtree that completed at or below the last checkpoint is missing. Read handlers
 /// return this instead of an empty subtree list, which a client would otherwise read as "this
 /// chain has no subtrees here" and seed nothing, failing later without a clear cause.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 #[error(
-    "historical {pool} note commitment subtree {index:?} is unavailable at checkpoint handoff \
-     {handoff:?}: {reason}"
+    "historical {pool} note commitment subtree {index:?} is unavailable at last checkpoint \
+     {last_checkpoint:?}: {reason}"
 )]
 pub struct HistoricalSubtreeUnavailable {
     /// The shielded pool whose subtree was requested, in `z_getsubtreesbyindex` spelling.
@@ -97,8 +98,8 @@ pub struct HistoricalSubtreeUnavailable {
     /// The requested starting subtree index.
     pub index: NoteCommitmentSubtreeIndex,
 
-    /// The checkpoint handoff height `H`, below which no subtree roots were recorded.
-    pub handoff: block::Height,
+    /// The last checkpoint height `H`, below which no subtree roots were recorded.
+    pub last_checkpoint: block::Height,
 
     /// What this node knows about the subtree's availability.
     pub reason: HistoricalSubtreeUnavailableReason,
@@ -107,19 +108,19 @@ pub struct HistoricalSubtreeUnavailable {
 /// Why a requested historical subtree is currently unavailable.
 #[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
 pub enum HistoricalSubtreeUnavailableReason {
-    /// The node has not reached the fast-sync checkpoint handoff, so it cannot yet tell a
+    /// The node has not reached the fast-sync last checkpoint, so it cannot yet tell a
     /// subtree the fast path skipped from one the chain has not reached.
     ///
     /// This is not a promise of recovery. Deciding between the two needs the pool's leaf count
-    /// at the handoff, which only exists once sync gets there; every subtree that completed
-    /// below the handoff is skipped, and turns into [`Self::NotStored`] rather than appearing.
+    /// at the last checkpoint, which only exists once sync gets there; every subtree that completed
+    /// below the last checkpoint is skipped, and turns into [`Self::NotStored`] rather than appearing.
     #[error(
-        "this node has not reached the checkpoint handoff, so it cannot yet tell whether the \
-         subtree was skipped; subtrees completed below the handoff are never recorded"
+        "this node has not reached the last checkpoint, so it cannot yet tell whether the \
+         subtree was skipped; subtrees completed below the last checkpoint are never recorded"
     )]
     Indeterminate,
 
-    /// The node has passed the handoff without recording the requested subtree.
+    /// The node has passed the last checkpoint without recording the requested subtree.
     #[error(
         "this node did not record the subtree and continuing synchronization will not restore it; \
          use another node"

--- a/crates/zakura-state/src/error.rs
+++ b/crates/zakura-state/src/error.rs
@@ -100,16 +100,24 @@ pub struct HistoricalSubtreeUnavailable {
     /// The checkpoint handoff height `H`, below which no subtree roots were recorded.
     pub handoff: block::Height,
 
-    /// Whether the subtree can become available as this node continues syncing.
+    /// What this node knows about the subtree's availability.
     pub reason: HistoricalSubtreeUnavailableReason,
 }
 
 /// Why a requested historical subtree is currently unavailable.
 #[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
 pub enum HistoricalSubtreeUnavailableReason {
-    /// The node has not reached the fast-sync checkpoint handoff yet.
-    #[error("this node is still syncing toward the checkpoint handoff; retry after sync advances")]
-    Syncing,
+    /// The node has not reached the fast-sync checkpoint handoff, so it cannot yet tell a
+    /// subtree the fast path skipped from one the chain has not reached.
+    ///
+    /// This is not a promise of recovery. Deciding between the two needs the pool's leaf count
+    /// at the handoff, which only exists once sync gets there; every subtree that completed
+    /// below the handoff is skipped, and turns into [`Self::NotStored`] rather than appearing.
+    #[error(
+        "this node has not reached the checkpoint handoff, so it cannot yet tell whether the \
+         subtree was skipped; subtrees completed below the handoff are never recorded"
+    )]
+    Indeterminate,
 
     /// The node has passed the handoff without recording the requested subtree.
     #[error(

--- a/crates/zakura-state/src/error.rs
+++ b/crates/zakura-state/src/error.rs
@@ -87,9 +87,8 @@ pub struct HistoricalTreeUnavailable {
 /// chain has no subtrees here" and seed nothing, failing later without a clear cause.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 #[error(
-    "historical {pool} note commitment subtree {index:?} is unavailable: this node was fast-synced \
-     with verified commitment trees, so subtrees completed at or below the checkpoint handoff \
-     {handoff:?} were never recorded"
+    "historical {pool} note commitment subtree {index:?} is unavailable at checkpoint handoff \
+     {handoff:?}: {reason}"
 )]
 pub struct HistoricalSubtreeUnavailable {
     /// The shielded pool whose subtree was requested, in `z_getsubtreesbyindex` spelling.
@@ -100,6 +99,24 @@ pub struct HistoricalSubtreeUnavailable {
 
     /// The checkpoint handoff height `H`, below which no subtree roots were recorded.
     pub handoff: block::Height,
+
+    /// Whether the subtree can become available as this node continues syncing.
+    pub reason: HistoricalSubtreeUnavailableReason,
+}
+
+/// Why a requested historical subtree is currently unavailable.
+#[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
+pub enum HistoricalSubtreeUnavailableReason {
+    /// The node has not reached the fast-sync checkpoint handoff yet.
+    #[error("this node is still syncing toward the checkpoint handoff; retry after sync advances")]
+    Syncing,
+
+    /// The node has passed the handoff without recording the requested subtree.
+    #[error(
+        "this node did not record the subtree and continuing synchronization will not restore it; \
+         use another node"
+    )]
+    NotStored,
 }
 
 /// An error describing why opening the finalized state database failed.

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -46,8 +46,9 @@ pub use config::{
 pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitCheckpointVerifiedError, CommitHeaderRangeError,
-    CommitSemanticallyVerifiedError, DuplicateNullifierError, MissingSproutTipTree, StateInitError,
-    StoreIncoherentError, ValidateContextError,
+    CommitSemanticallyVerifiedError, DuplicateNullifierError, HistoricalSubtreeUnavailable,
+    HistoricalTreeUnavailable, MissingSproutTipTree, StateInitError, StoreIncoherentError,
+    ValidateContextError,
 };
 pub use request::{
     AuthenticateHeaderRootsRequest, CheckpointVerifiedBlock,

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -47,8 +47,8 @@ pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGH
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitCheckpointVerifiedError, CommitHeaderRangeError,
     CommitSemanticallyVerifiedError, DuplicateNullifierError, HistoricalSubtreeUnavailable,
-    HistoricalTreeUnavailable, MissingSproutTipTree, StateInitError, StoreIncoherentError,
-    ValidateContextError,
+    HistoricalSubtreeUnavailableReason, HistoricalTreeUnavailable, MissingSproutTipTree,
+    StateInitError, StoreIncoherentError, ValidateContextError,
 };
 pub use request::{
     AuthenticateHeaderRootsRequest, CheckpointVerifiedBlock,

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -2062,17 +2062,33 @@ impl Service<ReadRequest> for ReadStateService {
                 Ok(ReadResponse::Blocks(blocks))
             }
 
-            ReadRequest::SaplingTree(hash_or_height) => Ok(ReadResponse::SaplingTree(
-                read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height),
-            )),
+            ReadRequest::SaplingTree(hash_or_height) => {
+                let tree = read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height);
+                if tree.is_none() {
+                    read::check_historical_tree_available(&state.db, hash_or_height)?;
+                }
 
-            ReadRequest::OrchardTree(hash_or_height) => Ok(ReadResponse::OrchardTree(
-                read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height),
-            )),
+                Ok(ReadResponse::SaplingTree(tree))
+            }
 
-            ReadRequest::IronwoodTree(hash_or_height) => Ok(ReadResponse::IronwoodTree(
-                read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height),
-            )),
+            ReadRequest::OrchardTree(hash_or_height) => {
+                let tree = read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height);
+                if tree.is_none() {
+                    read::check_historical_tree_available(&state.db, hash_or_height)?;
+                }
+
+                Ok(ReadResponse::OrchardTree(tree))
+            }
+
+            ReadRequest::IronwoodTree(hash_or_height) => {
+                let tree =
+                    read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height);
+                if tree.is_none() {
+                    read::check_historical_tree_available(&state.db, hash_or_height)?;
+                }
+
+                Ok(ReadResponse::IronwoodTree(tree))
+            }
 
             ReadRequest::SaplingSubtrees { start_index, limit } => {
                 let end_index = limit
@@ -2089,6 +2105,13 @@ impl Service<ReadRequest> for ReadStateService {
                     // the trees run out.)
                     read::sapling_subtrees(best_chain, &state.db, start_index..)
                 };
+
+                read::check_historical_sapling_subtrees_available(
+                    &state.db,
+                    start_index,
+                    end_index,
+                    &sapling_subtrees,
+                )?;
 
                 Ok(ReadResponse::SaplingSubtrees(sapling_subtrees))
             }
@@ -2109,6 +2132,13 @@ impl Service<ReadRequest> for ReadStateService {
                     read::orchard_subtrees(best_chain, &state.db, start_index..)
                 };
 
+                read::check_historical_orchard_subtrees_available(
+                    &state.db,
+                    start_index,
+                    end_index,
+                    &orchard_subtrees,
+                )?;
+
                 Ok(ReadResponse::OrchardSubtrees(orchard_subtrees))
             }
 
@@ -2123,6 +2153,13 @@ impl Service<ReadRequest> for ReadStateService {
                 } else {
                     read::ironwood_subtrees(best_chain, &state.db, start_index..)
                 };
+
+                read::check_historical_ironwood_subtrees_available(
+                    &state.db,
+                    start_index,
+                    end_index,
+                    &ironwood_subtrees,
+                )?;
 
                 Ok(ReadResponse::IronwoodSubtrees(ironwood_subtrees))
             }

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -2063,30 +2063,20 @@ impl Service<ReadRequest> for ReadStateService {
             }
 
             ReadRequest::SaplingTree(hash_or_height) => {
-                let tree = read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height);
-                if tree.is_none() {
-                    read::check_historical_tree_available(&state.db, hash_or_height)?;
-                }
-
+                let tree =
+                    read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height)?;
                 Ok(ReadResponse::SaplingTree(tree))
             }
 
             ReadRequest::OrchardTree(hash_or_height) => {
-                let tree = read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height);
-                if tree.is_none() {
-                    read::check_historical_tree_available(&state.db, hash_or_height)?;
-                }
-
+                let tree =
+                    read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height)?;
                 Ok(ReadResponse::OrchardTree(tree))
             }
 
             ReadRequest::IronwoodTree(hash_or_height) => {
                 let tree =
-                    read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height);
-                if tree.is_none() {
-                    read::check_historical_tree_available(&state.db, hash_or_height)?;
-                }
-
+                    read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height)?;
                 Ok(ReadResponse::IronwoodTree(tree))
             }
 
@@ -2104,14 +2094,7 @@ impl Service<ReadRequest> for ReadStateService {
                     // `zcashd` does. (It never calculates an end bound, so it just keeps iterating until
                     // the trees run out.)
                     read::sapling_subtrees(best_chain, &state.db, start_index..)
-                };
-
-                read::check_historical_sapling_subtrees_available(
-                    &state.db,
-                    start_index,
-                    end_index,
-                    &sapling_subtrees,
-                )?;
+                }?;
 
                 Ok(ReadResponse::SaplingSubtrees(sapling_subtrees))
             }
@@ -2130,14 +2113,7 @@ impl Service<ReadRequest> for ReadStateService {
                     // `zcashd` does. (It never calculates an end bound, so it just keeps iterating until
                     // the trees run out.)
                     read::orchard_subtrees(best_chain, &state.db, start_index..)
-                };
-
-                read::check_historical_orchard_subtrees_available(
-                    &state.db,
-                    start_index,
-                    end_index,
-                    &orchard_subtrees,
-                )?;
+                }?;
 
                 Ok(ReadResponse::OrchardSubtrees(orchard_subtrees))
             }
@@ -2152,14 +2128,7 @@ impl Service<ReadRequest> for ReadStateService {
                     read::ironwood_subtrees(best_chain, &state.db, start_index..end_index)
                 } else {
                     read::ironwood_subtrees(best_chain, &state.db, start_index..)
-                };
-
-                read::check_historical_ironwood_subtrees_available(
-                    &state.db,
-                    start_index,
-                    end_index,
-                    &ironwood_subtrees,
-                )?;
+                }?;
 
                 Ok(ReadResponse::IronwoodSubtrees(ironwood_subtrees))
             }

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -85,7 +85,7 @@ mod disk_format;
 mod vct;
 mod zakura_db;
 
-pub(crate) use vct::embedded_handoff_leaf_counts;
+pub(crate) use vct::embedded_last_checkpoint_leaf_counts;
 use vct::{VctCommitState, VctState, VctWriteData};
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -85,6 +85,7 @@ mod disk_format;
 mod vct;
 mod zakura_db;
 
+pub(crate) use vct::embedded_handoff_leaf_counts;
 use vct::{VctCommitState, VctState, VctWriteData};
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1,6 +1,12 @@
 //! Randomised property tests for the finalized state.
 
-use std::{collections::HashMap, env, error::Error, fs, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    env,
+    error::Error,
+    fs,
+    sync::Arc,
+};
 
 use tempfile::TempDir;
 use tokio::sync::oneshot;
@@ -25,7 +31,12 @@ use zakura_test::prelude::*;
 
 use crate::{
     config::Config,
-    service::{arbitrary::PreparedChain, check::anchors::tx_anchors_refer_to_final_treestates},
+    error::HistoricalTreeUnavailable,
+    service::{
+        arbitrary::PreparedChain,
+        check::anchors::tx_anchors_refer_to_final_treestates,
+        read::{check_historical_sapling_subtrees_available, check_historical_tree_available},
+    },
     tests::FakeChainHelper,
     HashOrHeight,
 };
@@ -1652,6 +1663,38 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             // handoff height itself is available.
             prop_assert!(fast.db.vct_historical_tree_unavailable(HashOrHeight::Height(Height(last as u32 - 1))), "RPC gate: below-handoff treestate is unavailable");
             prop_assert!(!fast.db.vct_historical_tree_unavailable(HashOrHeight::Height(handoff)), "RPC gate: handoff treestate is available");
+
+            // The read handlers turn that predicate into the typed archive-mode error the
+            // RPC boundary reports, carrying the handoff so the failure is diagnosable.
+            // Without it, a below-handoff `z_gettreestate` returns a JSON `null`, which
+            // lightwalletd-style clients read as the *empty* tree.
+            let below_handoff_height = HashOrHeight::Height(Height(last as u32 - 1));
+            prop_assert_eq!(
+                check_historical_tree_available(&fast.db, below_handoff_height),
+                Err(HistoricalTreeUnavailable { hash_or_height: below_handoff_height, handoff }),
+                "a below-handoff tree read is a typed archive-mode error, not an absent tree"
+            );
+            prop_assert_eq!(
+                check_historical_tree_available(&fast.db, HashOrHeight::Height(handoff)),
+                Ok(()),
+                "the handoff height itself is served normally"
+            );
+            // A legacy node never reports the archive-mode error, whatever the height.
+            prop_assert_eq!(
+                check_historical_tree_available(&legacy.db, below_handoff_height),
+                Ok(()),
+                "a legacy-synced node has the tree and must not report an absent band"
+            );
+
+            // The subtree gate must not fire just because a node is fast-synced. This chain is
+            // far too short to complete a subtree, so `z_getsubtreesbyindex` at index 0 is an
+            // ordinary "nothing here yet" empty list, exactly as on a legacy node.
+            prop_assert_eq!(
+                check_historical_sapling_subtrees_available(&fast.db, 0.into(), None, &BTreeMap::new()),
+                Ok(()),
+                "an index past the last completed subtree stays an empty list, not an error"
+            );
+
 
             // Negative: a peer can supply a wrong root exactly at the handoff height,
             // where there is no buffered checkpoint successor to authenticate it. The

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1,12 +1,6 @@
 //! Randomised property tests for the finalized state.
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    env,
-    error::Error,
-    fs,
-    sync::Arc,
-};
+use std::{collections::HashMap, env, error::Error, fs, sync::Arc};
 
 use tempfile::TempDir;
 use tokio::sync::oneshot;
@@ -24,6 +18,7 @@ use zakura_chain::{
     primitives::Groth16Proof,
     serialization::{BytesInDisplayOrder, ZcashDeserializeInto},
     sprout::JoinSplit,
+    subtree::NoteCommitmentSubtreeIndex,
     transaction::{JoinSplitData, LockTime, Transaction, UnminedTx},
     LedgerState,
 };
@@ -35,7 +30,8 @@ use crate::{
     service::{
         arbitrary::PreparedChain,
         check::anchors::tx_anchors_refer_to_final_treestates,
-        read::{check_historical_sapling_subtrees_available, check_historical_tree_available},
+        non_finalized_state::Chain,
+        read::{sapling_subtrees, sapling_tree},
     },
     tests::FakeChainHelper,
     HashOrHeight,
@@ -1670,28 +1666,31 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             // lightwalletd-style clients read as the *empty* tree.
             let below_handoff_height = HashOrHeight::Height(Height(last as u32 - 1));
             prop_assert_eq!(
-                check_historical_tree_available(&fast.db, below_handoff_height),
+                sapling_tree(None::<Arc<Chain>>, &fast.db, below_handoff_height),
                 Err(HistoricalTreeUnavailable { hash_or_height: below_handoff_height, handoff }),
                 "a below-handoff tree read is a typed archive-mode error, not an absent tree"
             );
-            prop_assert_eq!(
-                check_historical_tree_available(&fast.db, HashOrHeight::Height(handoff)),
-                Ok(()),
+            prop_assert!(
+                sapling_tree(None::<Arc<Chain>>, &fast.db, HashOrHeight::Height(handoff))
+                    .expect("the handoff tree is available")
+                    .is_some(),
                 "the handoff height itself is served normally"
             );
             // A legacy node never reports the archive-mode error, whatever the height.
-            prop_assert_eq!(
-                check_historical_tree_available(&legacy.db, below_handoff_height),
-                Ok(()),
+            prop_assert!(
+                sapling_tree(None::<Arc<Chain>>, &legacy.db, below_handoff_height)
+                    .expect("legacy tree reads do not report an absent band")
+                    .is_some(),
                 "a legacy-synced node has the tree and must not report an absent band"
             );
 
             // The subtree gate must not fire just because a node is fast-synced. This chain is
             // far too short to complete a subtree, so `z_getsubtreesbyindex` at index 0 is an
             // ordinary "nothing here yet" empty list, exactly as on a legacy node.
-            prop_assert_eq!(
-                check_historical_sapling_subtrees_available(&fast.db, 0.into(), None, &BTreeMap::new()),
-                Ok(()),
+            prop_assert!(
+                sapling_subtrees(None::<Arc<Chain>>, &fast.db, NoteCommitmentSubtreeIndex(0)..)
+                    .expect("an index past the last completed subtree is available")
+                    .is_empty(),
                 "an index past the last completed subtree stays an empty list, not an error"
             );
 

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1657,8 +1657,8 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             // The `z_gettreestate` RPC gate predicate matches the read guard: a
             // below-handoff height is unavailable (typed archive-mode error), while the
             // handoff height itself is available.
-            prop_assert!(fast.db.vct_historical_tree_unavailable(HashOrHeight::Height(Height(last as u32 - 1))), "RPC gate: below-handoff treestate is unavailable");
-            prop_assert!(!fast.db.vct_historical_tree_unavailable(HashOrHeight::Height(handoff)), "RPC gate: handoff treestate is available");
+            prop_assert!(fast.db.vct_tree_absent(Height(last as u32 - 1)), "RPC gate: below-handoff treestate is unavailable");
+            prop_assert!(!fast.db.vct_tree_absent(handoff), "RPC gate: handoff treestate is available");
 
             // The read handlers turn that predicate into the typed archive-mode error the
             // RPC boundary reports, carrying the handoff so the failure is diagnosable.

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1667,7 +1667,10 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             let below_handoff_height = HashOrHeight::Height(Height(last as u32 - 1));
             prop_assert_eq!(
                 sapling_tree(None::<Arc<Chain>>, &fast.db, below_handoff_height),
-                Err(HistoricalTreeUnavailable { hash_or_height: below_handoff_height, handoff }),
+                Err(HistoricalTreeUnavailable {
+                    hash_or_height: below_handoff_height,
+                    last_checkpoint: handoff,
+                }),
                 "a below-handoff tree read is a typed archive-mode error, not an absent tree"
             );
             prop_assert!(

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1694,7 +1694,6 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
                 "an index past the last completed subtree stays an empty list, not an error"
             );
 
-
             // Negative: a peer can supply a wrong root exactly at the handoff height,
             // where there is no buffered checkpoint successor to authenticate it. The
             // final embedded frontier still binds the expected root, so the committer

--- a/crates/zakura-state/src/service/finalized_state/vct.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct.rs
@@ -481,6 +481,22 @@ pub(super) fn embedded_final_frontiers(network: &Network) -> Option<FinalFrontie
     }
 }
 
+/// Returns the verified Sapling, Orchard, and Ironwood leaf counts at `handoff`, when the
+/// configured network has a matching embedded final frontier.
+pub(crate) fn embedded_handoff_leaf_counts(
+    network: &Network,
+    handoff: block::Height,
+) -> Option<(u64, u64, u64)> {
+    let frontiers = embedded_final_frontiers(network)?;
+    (frontiers.height == handoff).then(|| {
+        (
+            frontiers.sapling.count(),
+            frontiers.orchard.count(),
+            frontiers.ironwood.count(),
+        )
+    })
+}
+
 /// Parse the Mainnet frontier without panicking, for fallible startup validation.
 pub(super) fn embedded_mainnet_final_frontiers(
 ) -> Result<FinalFrontiers, FinalFrontiersValidationError> {

--- a/crates/zakura-state/src/service/finalized_state/vct.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct.rs
@@ -481,14 +481,14 @@ pub(super) fn embedded_final_frontiers(network: &Network) -> Option<FinalFrontie
     }
 }
 
-/// Returns the verified Sapling, Orchard, and Ironwood leaf counts at `handoff`, when the
+/// Returns the verified Sapling, Orchard, and Ironwood leaf counts at `last_checkpoint`, when the
 /// configured network has a matching embedded final frontier.
-pub(crate) fn embedded_handoff_leaf_counts(
+pub(crate) fn embedded_last_checkpoint_leaf_counts(
     network: &Network,
-    handoff: block::Height,
+    last_checkpoint: block::Height,
 ) -> Option<(u64, u64, u64)> {
     let frontiers = embedded_final_frontiers(network)?;
-    (frontiers.height == handoff).then(|| {
+    (frontiers.height == last_checkpoint).then(|| {
         (
             frontiers.sapling.count(),
             frontiers.orchard.count(),

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -971,17 +971,6 @@ impl ZakuraDb {
         upgrade <= height && height < handoff
     }
 
-    /// Returns `true` if `hash_or_height` resolves to a non-tip historical height
-    /// whose per-height note-commitment tree is unavailable because this is a
-    /// vct-synced database (the tree within the `[U, H)` absent band was never
-    /// written). Read-request handlers use this to return an archive-mode error
-    /// instead of a misleading "not found".
-    pub fn vct_historical_tree_unavailable(&self, hash_or_height: HashOrHeight) -> bool {
-        hash_or_height
-            .height_or_else(|hash| self.height(hash))
-            .is_some_and(|height| self.vct_tree_absent(height))
-    }
-
     /// Returns the half-open range of block heights `[from, until)` whose raw
     /// transaction data should be pruned when committing a block at `new_tip`,
     /// given the configured `retention` window. Returns `None` if there is

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
@@ -328,8 +328,9 @@ impl ZakuraDb {
         Some(Arc::new(tree))
     }
 
+    /// Returns the latest stored Sapling tree at or below `height`, without asserting its presence.
     #[allow(clippy::unwrap_in_result)]
-    fn latest_stored_sapling_tree(
+    pub(crate) fn latest_stored_sapling_tree(
         &self,
         height: &Height,
     ) -> Option<Arc<sapling::tree::NoteCommitmentTree>> {
@@ -482,8 +483,9 @@ impl ZakuraDb {
         Some(Arc::new(tree))
     }
 
+    /// Returns the latest stored Orchard tree at or below `height`, without asserting its presence.
     #[allow(clippy::unwrap_in_result)]
-    fn latest_stored_orchard_tree(
+    pub(crate) fn latest_stored_orchard_tree(
         &self,
         height: &Height,
     ) -> Option<Arc<orchard::tree::NoteCommitmentTree>> {
@@ -636,8 +638,9 @@ impl ZakuraDb {
         Some(Arc::new(tree))
     }
 
+    /// Returns the latest stored Ironwood tree at or below `height`, without asserting its presence.
     #[allow(clippy::unwrap_in_result)]
-    fn latest_stored_ironwood_tree(
+    pub(crate) fn latest_stored_ironwood_tree(
         &self,
         height: &Height,
     ) -> Option<Arc<ironwood::tree::NoteCommitmentTree>> {

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -43,6 +43,8 @@ pub use find::{
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use tree::{
+    check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,
+    check_historical_sapling_subtrees_available, check_historical_tree_available,
     ironwood_subtrees, ironwood_tree, orchard_subtrees, orchard_tree, sapling_subtrees,
     sapling_tree,
 };

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -43,8 +43,6 @@ pub use find::{
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use tree::{
-    check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,
-    check_historical_sapling_subtrees_available, check_historical_tree_available,
     ironwood_subtrees, ironwood_tree, orchard_subtrees, orchard_tree, sapling_subtrees,
     sapling_tree,
 };

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -8,7 +8,10 @@ use zakura_chain::{
     ironwood, orchard,
     parameters::Network::*,
     serialization::ZcashDeserializeInto,
-    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
+    subtree::{
+        NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex,
+        TRACKED_SUBTREE_HEIGHT,
+    },
     transaction,
 };
 
@@ -24,7 +27,10 @@ use crate::{
     service::{
         finalized_state::{DiskWriteBatch, ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
         non_finalized_state::Chain,
-        read::{ironwood_subtrees, orchard_subtrees, sapling_subtrees},
+        read::{
+            ironwood_subtrees, orchard_subtrees, sapling_subtrees,
+            tree::{first_missing_subtree_index, subtree_completed_by_handoff},
+        },
     },
     Config, ReadRequest, ReadResponse,
 };
@@ -636,4 +642,113 @@ async fn any_chain_block_finds_side_chain_blocks() -> Result<()> {
     assert_eq!(found.unwrap().hash(), best_hash);
 
     Ok(())
+}
+
+/// The absent-band subtree bound must cover exactly the subtrees the fast path skipped.
+///
+/// The bound is what keeps [`crate::HistoricalSubtreeUnavailable`] from firing on an ordinary
+/// "you asked past the tip" query: only indices that completed at or below the handoff were
+/// skipped, everything at or above that is genuinely absent on any node.
+#[test]
+fn subtree_absent_band_bound_is_exact() {
+    const LEAVES_PER_SUBTREE: u64 = 1 << TRACKED_SUBTREE_HEIGHT;
+
+    // No subtree has completed yet, so no index is in the band, whatever the client asks for.
+    for leaves in [0, 1, LEAVES_PER_SUBTREE - 1] {
+        assert!(
+            !subtree_completed_by_handoff(0.into(), leaves),
+            "no subtree completes before {LEAVES_PER_SUBTREE} leaves, but {leaves} claimed one"
+        );
+    }
+
+    // Exactly one subtree (index 0) completed. Index 1 has not, so it stays an empty list.
+    assert!(subtree_completed_by_handoff(0.into(), LEAVES_PER_SUBTREE));
+    assert!(!subtree_completed_by_handoff(1.into(), LEAVES_PER_SUBTREE));
+
+    // A partly-filled second subtree does not count as completed.
+    assert!(subtree_completed_by_handoff(
+        0.into(),
+        LEAVES_PER_SUBTREE + 1
+    ));
+    assert!(!subtree_completed_by_handoff(
+        1.into(),
+        LEAVES_PER_SUBTREE + 1
+    ));
+
+    // Mainnet-scale: 73,934,658 Sapling commitments at the handoff is 1,128 completed subtrees,
+    // indexes 0..=1127. Index 1128 is the one still filling.
+    let sapling_leaves_at_handoff = 73_934_658;
+    assert!(subtree_completed_by_handoff(
+        1127.into(),
+        sapling_leaves_at_handoff
+    ));
+    assert!(!subtree_completed_by_handoff(
+        1128.into(),
+        sapling_leaves_at_handoff
+    ));
+}
+
+/// The served run must be checked to its end, not just at its start.
+///
+/// `z_getsubtreesbyindex` returns one contiguous run, so a gap anywhere truncates the response.
+/// A single unbounded request from index 0 against a truncated artifact would otherwise return a
+/// short list with no error, which a client reads as "that is every subtree on this chain" — the
+/// same silent-truncation failure the typed errors exist to remove.
+#[test]
+fn first_missing_subtree_index_finds_the_end_of_the_run() {
+    let data = || {
+        NoteCommitmentSubtreeData::new(
+            Height(1),
+            sapling_crypto::Node::from_bytes([0; 32]).unwrap(),
+        )
+    };
+    let map = |indexes: &[u16]| {
+        indexes
+            .iter()
+            .map(|i| (NoteCommitmentSubtreeIndex(*i), data()))
+            .collect::<std::collections::BTreeMap<_, _>>()
+    };
+
+    // A run that stops early reports the index just past its end, not "nothing missing".
+    assert_eq!(
+        first_missing_subtree_index(&map(&[0, 1, 2]), NoteCommitmentSubtreeIndex(0), None),
+        Some(NoteCommitmentSubtreeIndex(3))
+    );
+
+    // Nothing served at all: the requested start is the first missing index.
+    assert_eq!(
+        first_missing_subtree_index(&map(&[]), NoteCommitmentSubtreeIndex(7), None),
+        Some(NoteCommitmentSubtreeIndex(7))
+    );
+
+    // An index the client did not ask for is not missing from its answer.
+    assert_eq!(
+        first_missing_subtree_index(
+            &map(&[0, 1, 2]),
+            NoteCommitmentSubtreeIndex(0),
+            Some(NoteCommitmentSubtreeIndex(3))
+        ),
+        None,
+        "a fully satisfied bounded request has no gap"
+    );
+    assert_eq!(
+        first_missing_subtree_index(
+            &map(&[0, 1]),
+            NoteCommitmentSubtreeIndex(0),
+            Some(NoteCommitmentSubtreeIndex(5))
+        ),
+        Some(NoteCommitmentSubtreeIndex(2)),
+        "a bounded request served short still reports the gap"
+    );
+
+    // `u16::MAX` is the last index that can exist, so a run reaching it has no successor.
+    assert_eq!(
+        first_missing_subtree_index(
+            &map(&[u16::MAX]),
+            NoteCommitmentSubtreeIndex(u16::MAX),
+            None
+        ),
+        None,
+        "the final index must not overflow into a phantom gap"
+    );
 }

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -752,6 +752,42 @@ async fn missing_subtree_before_handoff_reports_indeterminate_reason() {
     );
 }
 
+/// A subtree that the authenticated handoff frontier proves was not completed is an ordinary
+/// empty result, even while the finalized tip is below the handoff.
+#[tokio::test]
+async fn incomplete_ironwood_subtree_before_mainnet_handoff_is_empty() {
+    let _init_guard = zakura_test::init();
+    let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .values()
+        .take(2)
+        .map(|block_bytes| block_bytes.zcash_deserialize_into().unwrap())
+        .collect();
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
+        populated_state(blocks, &Mainnet).await;
+    let handoff = Mainnet.checkpoint_list().max_height();
+
+    assert!(
+        read_state.db.finalized_tip_height() < Some(handoff),
+        "the regression requires a finalized tip below the Mainnet handoff"
+    );
+
+    let mut batch = DiskWriteBatch::new();
+    batch.update_vct_sync_marker(&read_state.db, handoff);
+    read_state
+        .db
+        .write_batch(batch)
+        .expect("seeding the Mainnet VCT handoff succeeds");
+
+    let subtrees = ironwood_subtrees(
+        None::<Arc<Chain>>,
+        &read_state.db,
+        NoteCommitmentSubtreeIndex(0)..1.into(),
+    )
+    .expect("the authenticated handoff proves Ironwood subtree zero was not completed");
+
+    assert!(subtrees.is_empty());
+}
+
 /// A missing handoff tree is an error once the finalized tip has reached the handoff.
 #[tokio::test]
 async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -744,6 +744,55 @@ async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {
     assert_eq!(error.handoff, handoff);
 }
 
+/// Missing pre-activation trees are consensus-defined empty frontiers, not unavailable history.
+#[tokio::test]
+async fn pre_activation_tree_requests_do_not_report_archive_errors() {
+    let _init_guard = zakura_test::init();
+    let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .values()
+        .take(2)
+        .map(|block_bytes| block_bytes.zcash_deserialize_into().unwrap())
+        .collect();
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
+        populated_state(blocks, &Mainnet).await;
+    let requested_height = Height::MIN;
+    let handoff = Height(10);
+
+    let mut batch = DiskWriteBatch::new();
+    batch.update_vct_sync_marker(&read_state.db, handoff);
+    batch.delete_sapling_tree(&read_state.db, &requested_height);
+    batch.delete_orchard_tree(&read_state.db, &requested_height);
+    batch.delete_ironwood_tree(&read_state.db, &requested_height);
+    read_state
+        .db
+        .write_batch(batch)
+        .expect("seeding missing pre-activation trees succeeds");
+
+    assert_eq!(
+        read_state
+            .clone()
+            .oneshot(ReadRequest::SaplingTree(requested_height.into()))
+            .await
+            .expect("pre-activation Sapling tree request succeeds"),
+        ReadResponse::SaplingTree(None)
+    );
+    assert_eq!(
+        read_state
+            .clone()
+            .oneshot(ReadRequest::OrchardTree(requested_height.into()))
+            .await
+            .expect("pre-activation Orchard tree request succeeds"),
+        ReadResponse::OrchardTree(None)
+    );
+    assert_eq!(
+        read_state
+            .oneshot(ReadRequest::IronwoodTree(requested_height.into()))
+            .await
+            .expect("pre-activation Ironwood tree request succeeds"),
+        ReadResponse::IronwoodTree(None)
+    );
+}
+
 /// The served run must be checked to its end, not just at its start.
 ///
 /// `z_getsubtreesbyindex` returns one contiguous run, so a gap anywhere truncates the response.

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -793,13 +793,10 @@ async fn pre_activation_tree_requests_return_empty_frontiers() {
 
     let mut batch = DiskWriteBatch::new();
     batch.update_vct_sync_marker(&read_state.db, handoff);
-    batch.delete_sapling_tree(&read_state.db, &requested_height);
-    batch.delete_orchard_tree(&read_state.db, &requested_height);
-    batch.delete_ironwood_tree(&read_state.db, &requested_height);
     read_state
         .db
         .write_batch(batch)
-        .expect("seeding missing pre-activation trees succeeds");
+        .expect("seeding the VCT absent band succeeds");
 
     assert_eq!(
         read_state

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -31,7 +31,7 @@ use crate::{
             ironwood_subtrees, orchard_subtrees, sapling_subtrees,
             tree::{
                 first_missing_subtree_index, is_syncing_below_last_checkpoint,
-                subtree_completed_by_handoff,
+                subtree_completed_by_last_checkpoint,
             },
         },
     },
@@ -652,7 +652,7 @@ async fn any_chain_block_finds_side_chain_blocks() -> Result<()> {
 /// The absent-band subtree bound must cover exactly the subtrees the fast path skipped.
 ///
 /// The bound is what keeps [`crate::HistoricalSubtreeUnavailable`] from firing on an ordinary
-/// "you asked past the tip" query: only indices that completed at or below the handoff were
+/// "you asked past the tip" query: only indices that completed at or below the last checkpoint were
 /// skipped, everything at or above that is genuinely absent on any node.
 #[test]
 fn subtree_absent_band_bound_is_exact() {
@@ -661,59 +661,74 @@ fn subtree_absent_band_bound_is_exact() {
     // No subtree has completed yet, so no index is in the band, whatever the client asks for.
     for leaves in [0, 1, LEAVES_PER_SUBTREE - 1] {
         assert!(
-            !subtree_completed_by_handoff(0.into(), leaves),
+            !subtree_completed_by_last_checkpoint(0.into(), leaves),
             "no subtree completes before {LEAVES_PER_SUBTREE} leaves, but {leaves} claimed one"
         );
     }
 
     // Exactly one subtree (index 0) completed. Index 1 has not, so it stays an empty list.
-    assert!(subtree_completed_by_handoff(0.into(), LEAVES_PER_SUBTREE));
-    assert!(!subtree_completed_by_handoff(1.into(), LEAVES_PER_SUBTREE));
+    assert!(subtree_completed_by_last_checkpoint(
+        0.into(),
+        LEAVES_PER_SUBTREE
+    ));
+    assert!(!subtree_completed_by_last_checkpoint(
+        1.into(),
+        LEAVES_PER_SUBTREE
+    ));
 
     // A partly-filled second subtree does not count as completed.
-    assert!(subtree_completed_by_handoff(
+    assert!(subtree_completed_by_last_checkpoint(
         0.into(),
         LEAVES_PER_SUBTREE + 1
     ));
-    assert!(!subtree_completed_by_handoff(
+    assert!(!subtree_completed_by_last_checkpoint(
         1.into(),
         LEAVES_PER_SUBTREE + 1
     ));
 
-    // Mainnet-scale: 73,934,658 Sapling commitments at the handoff is 1,128 completed subtrees,
-    // indexes 0..=1127. Index 1128 is the one still filling.
-    let sapling_leaves_at_handoff = 73_934_658;
-    assert!(subtree_completed_by_handoff(
+    // Mainnet-scale: 73,934,658 Sapling commitments at the last checkpoint is 1,128 completed
+    // subtrees, indexes 0..=1127. Index 1128 is the one still filling.
+    let sapling_leaves_at_last_checkpoint = 73_934_658;
+    assert!(subtree_completed_by_last_checkpoint(
         1127.into(),
-        sapling_leaves_at_handoff
+        sapling_leaves_at_last_checkpoint
     ));
-    assert!(!subtree_completed_by_handoff(
+    assert!(!subtree_completed_by_last_checkpoint(
         1128.into(),
-        sapling_leaves_at_handoff
+        sapling_leaves_at_last_checkpoint
     ));
 }
 
-/// A persisted handoff marker does not mean the handoff tree should exist before sync reaches it.
+/// A persisted last-checkpoint marker does not mean the tree should exist before sync reaches it.
 #[test]
-fn handoff_tree_is_only_expected_after_sync_reaches_handoff() {
-    let handoff = Height(10);
+fn last_checkpoint_tree_is_only_expected_after_sync_reaches_last_checkpoint() {
+    let last_checkpoint = Height(10);
 
-    assert!(is_syncing_below_last_checkpoint(Some(Height(9)), handoff));
-    assert!(!is_syncing_below_last_checkpoint(Some(handoff), handoff));
-    assert!(!is_syncing_below_last_checkpoint(Some(Height(11)), handoff));
+    assert!(is_syncing_below_last_checkpoint(
+        Some(Height(9)),
+        last_checkpoint
+    ));
+    assert!(!is_syncing_below_last_checkpoint(
+        Some(last_checkpoint),
+        last_checkpoint
+    ));
+    assert!(!is_syncing_below_last_checkpoint(
+        Some(Height(11)),
+        last_checkpoint
+    ));
 
     // A marker without any finalized block cannot be produced by the atomic commit path, so keep
     // treating that state as an invariant failure rather than ordinary sync progress.
-    assert!(!is_syncing_below_last_checkpoint(None, handoff));
+    assert!(!is_syncing_below_last_checkpoint(None, last_checkpoint));
 }
 
-/// A missing subtree's availability is undecided while the finalized tip is below the handoff.
+/// A missing subtree's availability is undecided while the finalized tip is below the last checkpoint.
 ///
 /// The node cannot tell a skipped subtree from one the chain has not reached until it has the
-/// pool's leaf count at the handoff, so the error must not advise a retry: every subtree that
-/// completed below the handoff is skipped, and this node never records it.
+/// pool's leaf count at the last checkpoint, so the error must not advise a retry: every subtree
+/// that completed below the last checkpoint is skipped, and this node never records it.
 #[tokio::test]
-async fn missing_subtree_before_handoff_reports_indeterminate_reason() {
+async fn missing_subtree_before_last_checkpoint_reports_indeterminate_reason() {
     let _init_guard = zakura_test::init();
     let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
         .values()
@@ -722,21 +737,21 @@ async fn missing_subtree_before_handoff_reports_indeterminate_reason() {
         .collect();
     let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
         populated_state(blocks, &Mainnet).await;
-    let handoff = Height(10);
+    let last_checkpoint = Height(10);
 
     let mut batch = DiskWriteBatch::new();
-    batch.update_vct_sync_marker(&read_state.db, handoff);
+    batch.update_vct_sync_marker(&read_state.db, last_checkpoint);
     read_state
         .db
         .write_batch(batch)
-        .expect("seeding a future handoff succeeds");
+        .expect("seeding a future last checkpoint succeeds");
 
     let error = sapling_subtrees(
         None::<Arc<Chain>>,
         &read_state.db,
         NoteCommitmentSubtreeIndex(0)..1.into(),
     )
-    .expect_err("a subtree below an unreached handoff must fail closed");
+    .expect_err("a subtree below an unreached last checkpoint must fail closed");
 
     assert_eq!(
         error.reason,
@@ -747,15 +762,15 @@ async fn missing_subtree_before_handoff_reports_indeterminate_reason() {
         .contains("cannot yet tell whether the subtree was skipped"));
     assert!(
         !error.to_string().contains("retry"),
-        "a subtree skipped below the handoff never arrives, so the error must not advise a \
+        "a subtree skipped below the last checkpoint never arrives, so the error must not advise a \
          retry, got: {error}"
     );
 }
 
-/// A subtree that the authenticated handoff frontier proves was not completed is an ordinary
-/// empty result, even while the finalized tip is below the handoff.
+/// A subtree that the authenticated last-checkpoint frontier proves was not completed is an
+/// ordinary empty result, even while the finalized tip is below the last checkpoint.
 #[tokio::test]
-async fn incomplete_ironwood_subtree_before_mainnet_handoff_is_empty() {
+async fn incomplete_ironwood_subtree_before_mainnet_last_checkpoint_is_empty() {
     let _init_guard = zakura_test::init();
     let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
         .values()
@@ -764,33 +779,33 @@ async fn incomplete_ironwood_subtree_before_mainnet_handoff_is_empty() {
         .collect();
     let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
         populated_state(blocks, &Mainnet).await;
-    let handoff = Mainnet.checkpoint_list().max_height();
+    let last_checkpoint = Mainnet.checkpoint_list().max_height();
 
     assert!(
-        read_state.db.finalized_tip_height() < Some(handoff),
-        "the regression requires a finalized tip below the Mainnet handoff"
+        read_state.db.finalized_tip_height() < Some(last_checkpoint),
+        "the regression requires a finalized tip below the Mainnet last checkpoint"
     );
 
     let mut batch = DiskWriteBatch::new();
-    batch.update_vct_sync_marker(&read_state.db, handoff);
+    batch.update_vct_sync_marker(&read_state.db, last_checkpoint);
     read_state
         .db
         .write_batch(batch)
-        .expect("seeding the Mainnet VCT handoff succeeds");
+        .expect("seeding the Mainnet VCT last checkpoint succeeds");
 
     let subtrees = ironwood_subtrees(
         None::<Arc<Chain>>,
         &read_state.db,
         NoteCommitmentSubtreeIndex(0)..1.into(),
     )
-    .expect("the authenticated handoff proves Ironwood subtree zero was not completed");
+    .expect("the authenticated last checkpoint proves Ironwood subtree zero was not completed");
 
     assert!(subtrees.is_empty());
 }
 
-/// A missing handoff tree is an error once the finalized tip has reached the handoff.
+/// A missing last-checkpoint tree is an error once the finalized tip has reached the checkpoint.
 #[tokio::test]
-async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {
+async fn missing_last_checkpoint_tree_fails_closed_after_sync_reaches_last_checkpoint() {
     let _init_guard = zakura_test::init();
     let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
         .values()
@@ -799,30 +814,30 @@ async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {
         .collect();
     let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
         populated_state(blocks, &Mainnet).await;
-    let handoff = read_state
+    let last_checkpoint = read_state
         .db
         .finalized_tip_height()
         .expect("the populated state has a finalized tip");
 
     let mut batch = DiskWriteBatch::new();
-    batch.update_vct_sync_marker(&read_state.db, handoff);
-    batch.delete_range_sapling_tree(&read_state.db, &Height::MIN, &handoff);
-    batch.delete_sapling_tree(&read_state.db, &handoff);
+    batch.update_vct_sync_marker(&read_state.db, last_checkpoint);
+    batch.delete_range_sapling_tree(&read_state.db, &Height::MIN, &last_checkpoint);
+    batch.delete_sapling_tree(&read_state.db, &last_checkpoint);
     read_state
         .db
         .write_batch(batch)
-        .expect("seeding a missing handoff tree succeeds");
+        .expect("seeding a missing last-checkpoint tree succeeds");
 
     let error = sapling_subtrees(
         None::<Arc<Chain>>,
         &read_state.db,
         NoteCommitmentSubtreeIndex(0)..1.into(),
     )
-    .expect_err("a reached handoff without its tree must fail closed");
+    .expect_err("a reached last checkpoint without its tree must fail closed");
 
     assert_eq!(error.pool, "sapling");
     assert_eq!(error.index, NoteCommitmentSubtreeIndex(0));
-    assert_eq!(error.handoff, handoff);
+    assert_eq!(error.last_checkpoint, last_checkpoint);
     assert_eq!(error.reason, HistoricalSubtreeUnavailableReason::NotStored);
     assert!(error.to_string().contains("use another node"));
 }
@@ -839,10 +854,10 @@ async fn pre_activation_tree_requests_return_empty_frontiers() {
     let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
         populated_state(blocks, &Mainnet).await;
     let requested_height = Height::MIN;
-    let handoff = Height(10);
+    let last_checkpoint = Height(10);
 
     let mut batch = DiskWriteBatch::new();
-    batch.update_vct_sync_marker(&read_state.db, handoff);
+    batch.update_vct_sync_marker(&read_state.db, last_checkpoint);
     read_state
         .db
         .write_batch(batch)
@@ -874,7 +889,7 @@ async fn pre_activation_tree_requests_return_empty_frontiers() {
     );
     assert_eq!(
         read_state
-            .oneshot(ReadRequest::SaplingTree(handoff.into()))
+            .oneshot(ReadRequest::SaplingTree(last_checkpoint.into()))
             .await
             .expect("missing pre-activation block request succeeds"),
         ReadResponse::SaplingTree(None),
@@ -909,7 +924,7 @@ fn first_missing_subtree_index_finds_the_end_of_the_run() {
         Some(NoteCommitmentSubtreeIndex(3))
     );
 
-    // An upgraded database can contain a pre-U row and a post-handoff row around a subtree
+    // An upgraded database can contain a pre-U row and a post-checkpoint row around a subtree
     // skipped by VCT fast sync. The later row must not hide the internal gap.
     assert_eq!(
         first_missing_subtree_index(&map(&[0, 2]), NoteCommitmentSubtreeIndex(0), None),

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -707,9 +707,13 @@ fn handoff_tree_is_only_expected_after_sync_reaches_handoff() {
     assert!(!is_syncing_below_last_checkpoint(None, handoff));
 }
 
-/// A missing subtree is transient while the finalized tip is still below the handoff.
+/// A missing subtree's availability is undecided while the finalized tip is below the handoff.
+///
+/// The node cannot tell a skipped subtree from one the chain has not reached until it has the
+/// pool's leaf count at the handoff, so the error must not advise a retry: every subtree that
+/// completed below the handoff is skipped, and this node never records it.
 #[tokio::test]
-async fn missing_subtree_while_syncing_reports_transient_reason() {
+async fn missing_subtree_before_handoff_reports_indeterminate_reason() {
     let _init_guard = zakura_test::init();
     let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
         .values()
@@ -734,8 +738,18 @@ async fn missing_subtree_while_syncing_reports_transient_reason() {
     )
     .expect_err("a subtree below an unreached handoff must fail closed");
 
-    assert_eq!(error.reason, HistoricalSubtreeUnavailableReason::Syncing);
-    assert!(error.to_string().contains("retry after sync advances"));
+    assert_eq!(
+        error.reason,
+        HistoricalSubtreeUnavailableReason::Indeterminate
+    );
+    assert!(error
+        .to_string()
+        .contains("cannot yet tell whether the subtree was skipped"));
+    assert!(
+        !error.to_string().contains("retry"),
+        "a subtree skipped below the handoff never arrives, so the error must not advise a \
+         retry, got: {error}"
+    );
 }
 
 /// A missing handoff tree is an error once the finalized tip has reached the handoff.

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -715,6 +715,14 @@ fn first_missing_subtree_index_finds_the_end_of_the_run() {
         Some(NoteCommitmentSubtreeIndex(3))
     );
 
+    // An upgraded database can contain a pre-U row and a post-handoff row around a subtree
+    // skipped by VCT fast sync. The later row must not hide the internal gap.
+    assert_eq!(
+        first_missing_subtree_index(&map(&[0, 2]), NoteCommitmentSubtreeIndex(0), None),
+        Some(NoteCommitmentSubtreeIndex(1)),
+        "the first internal gap must be reported instead of one past the last key"
+    );
+
     // Nothing served at all: the requested start is the first missing index.
     assert_eq!(
         first_missing_subtree_index(&map(&[]), NoteCommitmentSubtreeIndex(7), None),

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -169,7 +169,7 @@ async fn test_read_subtrees() -> Result<()> {
     // There should be 10 entries in db and 2 in chain with no overlap
 
     // Unbounded range should start at 0
-    let all_subtrees = sapling_subtrees(Some(chain.clone()), &db, ..);
+    let all_subtrees = sapling_subtrees(Some(chain.clone()), &db, ..)?;
     assert_eq!(all_subtrees.len(), 12, "should have 12 subtrees in state");
 
     // Add a subtree to `chain` that overlaps and is not consistent with the db subtrees
@@ -178,14 +178,14 @@ async fn test_read_subtrees() -> Result<()> {
     let modified_chain = modify_chain(&chain, first_chain_index, end_height.0);
 
     // The inconsistent entry and any later entries should be omitted
-    let all_subtrees = sapling_subtrees(modified_chain.clone(), &db, ..);
+    let all_subtrees = sapling_subtrees(modified_chain.clone(), &db, ..)?;
     assert_eq!(all_subtrees.len(), 10, "should have 10 subtrees in state");
 
     let first_chain_index =
         NoteCommitmentSubtreeIndex(u16::try_from(first_chain_index).expect("should fit in u16"));
 
     // Entries should be returned without reading from disk if the chain contains the first subtree index in the range
-    let mut chain_subtrees = sapling_subtrees(modified_chain, &db, first_chain_index..);
+    let mut chain_subtrees = sapling_subtrees(modified_chain, &db, first_chain_index..)?;
     assert_eq!(chain_subtrees.len(), 3, "should have 3 subtrees in chain");
 
     let (index, subtree) = chain_subtrees
@@ -201,7 +201,7 @@ async fn test_read_subtrees() -> Result<()> {
 
     let start = 0.into();
     let range = (Excluded(start), Unbounded);
-    let subtrees = sapling_subtrees(Some(chain), &db, range);
+    let subtrees = sapling_subtrees(Some(chain), &db, range)?;
     assert_eq!(subtrees.len(), 11);
     assert!(
         !subtrees.contains_key(&start),
@@ -236,40 +236,40 @@ async fn test_sapling_subtrees() -> Result<()> {
     // the non-finalized state.
 
     // Retrieve only the first subtree and check its properties.
-    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into());
+    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
 
     // Retrieve both subtrees using a limit and check their properties.
-    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into());
+    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 2);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve both subtrees without using a limit and check their properties.
-    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..);
+    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..)?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 2);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree and check its properties.
-    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into());
+    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree, using a limit that would allow for more trees if they were
     // present, and check its properties.
-    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into());
+    let subtrees = sapling_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree, without using any limit, and check its properties.
-    let subtrees = sapling_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..);
+    let subtrees = sapling_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..)?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
@@ -302,40 +302,40 @@ async fn test_orchard_subtrees() -> Result<()> {
     // the non-finalized state.
 
     // Retrieve only the first subtree and check its properties.
-    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into());
+    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
 
     // Retrieve both subtrees using a limit and check their properties.
-    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into());
+    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 2);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve both subtrees without using a limit and check their properties.
-    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..);
+    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..)?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 2);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree and check its properties.
-    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into());
+    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree, using a limit that would allow for more trees if they were
     // present, and check its properties.
-    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into());
+    let subtrees = orchard_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree, without using any limit, and check its properties.
-    let subtrees = orchard_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..);
+    let subtrees = orchard_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..)?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
@@ -368,40 +368,40 @@ async fn test_ironwood_subtrees() -> Result<()> {
     // the non-finalized state.
 
     // Retrieve only the first subtree and check its properties.
-    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into());
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..1.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
 
     // Retrieve both subtrees using a limit and check their properties.
-    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into());
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..2.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 2);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve both subtrees without using a limit and check their properties.
-    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..);
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(0)..)?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 2);
     assert!(subtrees_eq(subtrees.next().unwrap(), &db_subtree));
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree and check its properties.
-    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into());
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..2.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree, using a limit that would allow for more trees if they were
     // present, and check its properties.
-    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into());
+    let subtrees = ironwood_subtrees(chain.clone(), &db, NoteCommitmentSubtreeIndex(1)..3.into())?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
 
     // Retrieve only the second subtree, without using any limit, and check its properties.
-    let subtrees = ironwood_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..);
+    let subtrees = ironwood_subtrees(chain, &db, NoteCommitmentSubtreeIndex(1)..)?;
     let mut subtrees = subtrees.iter();
     assert_eq!(subtrees.len(), 1);
     assert!(subtrees_eq(subtrees.next().unwrap(), &chain_subtree));
@@ -417,7 +417,9 @@ fn excluded_max_subtree_range_is_empty() {
     let no_chain = Option::<Arc<Chain>>::None;
     let range = (Excluded(NoteCommitmentSubtreeIndex(u16::MAX)), Unbounded);
 
-    assert!(sapling_subtrees(no_chain, &db, range).is_empty());
+    assert!(sapling_subtrees(no_chain, &db, range)
+        .expect("an empty range is available")
+        .is_empty());
 }
 
 /// Returns test cases for the empty state and missing blocks.

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -744,9 +744,9 @@ async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {
     assert_eq!(error.handoff, handoff);
 }
 
-/// Missing pre-activation trees are consensus-defined empty frontiers, not unavailable history.
+/// Missing pre-activation trees are returned as consensus-defined empty frontiers.
 #[tokio::test]
-async fn pre_activation_tree_requests_do_not_report_archive_errors() {
+async fn pre_activation_tree_requests_return_empty_frontiers() {
     let _init_guard = zakura_test::init();
     let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
         .values()
@@ -774,7 +774,7 @@ async fn pre_activation_tree_requests_do_not_report_archive_errors() {
             .oneshot(ReadRequest::SaplingTree(requested_height.into()))
             .await
             .expect("pre-activation Sapling tree request succeeds"),
-        ReadResponse::SaplingTree(None)
+        ReadResponse::SaplingTree(Some(Default::default()))
     );
     assert_eq!(
         read_state
@@ -782,14 +782,23 @@ async fn pre_activation_tree_requests_do_not_report_archive_errors() {
             .oneshot(ReadRequest::OrchardTree(requested_height.into()))
             .await
             .expect("pre-activation Orchard tree request succeeds"),
-        ReadResponse::OrchardTree(None)
+        ReadResponse::OrchardTree(Some(Default::default()))
     );
     assert_eq!(
         read_state
+            .clone()
             .oneshot(ReadRequest::IronwoodTree(requested_height.into()))
             .await
             .expect("pre-activation Ironwood tree request succeeds"),
-        ReadResponse::IronwoodTree(None)
+        ReadResponse::IronwoodTree(Some(Default::default()))
+    );
+    assert_eq!(
+        read_state
+            .oneshot(ReadRequest::SaplingTree(handoff.into()))
+            .await
+            .expect("missing pre-activation block request succeeds"),
+        ReadResponse::SaplingTree(None),
+        "an empty frontier is only returned for a block that exists"
     );
 }
 

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -29,7 +29,10 @@ use crate::{
         non_finalized_state::Chain,
         read::{
             ironwood_subtrees, orchard_subtrees, sapling_subtrees,
-            tree::{first_missing_subtree_index, subtree_completed_by_handoff},
+            tree::{
+                first_missing_subtree_index, is_syncing_below_last_checkpoint,
+                subtree_completed_by_handoff,
+            },
         },
     },
     Config, ReadRequest, ReadResponse,
@@ -686,6 +689,20 @@ fn subtree_absent_band_bound_is_exact() {
         1128.into(),
         sapling_leaves_at_handoff
     ));
+}
+
+/// A persisted handoff marker does not mean the handoff tree should exist before sync reaches it.
+#[test]
+fn handoff_tree_is_only_expected_after_sync_reaches_handoff() {
+    let handoff = Height(10);
+
+    assert!(is_syncing_below_last_checkpoint(Some(Height(9)), handoff));
+    assert!(!is_syncing_below_last_checkpoint(Some(handoff), handoff));
+    assert!(!is_syncing_below_last_checkpoint(Some(Height(11)), handoff));
+
+    // A marker without any finalized block cannot be produced by the atomic commit path, so keep
+    // treating that state as an invariant failure rather than ordinary sync progress.
+    assert!(!is_syncing_below_last_checkpoint(None, handoff));
 }
 
 /// The served run must be checked to its end, not just at its start.

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -35,7 +35,7 @@ use crate::{
             },
         },
     },
-    Config, ReadRequest, ReadResponse,
+    Config, HistoricalSubtreeUnavailableReason, ReadRequest, ReadResponse,
 };
 
 /// Test that ReadStateService responds correctly when empty.
@@ -707,6 +707,37 @@ fn handoff_tree_is_only_expected_after_sync_reaches_handoff() {
     assert!(!is_syncing_below_last_checkpoint(None, handoff));
 }
 
+/// A missing subtree is transient while the finalized tip is still below the handoff.
+#[tokio::test]
+async fn missing_subtree_while_syncing_reports_transient_reason() {
+    let _init_guard = zakura_test::init();
+    let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .values()
+        .take(2)
+        .map(|block_bytes| block_bytes.zcash_deserialize_into().unwrap())
+        .collect();
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
+        populated_state(blocks, &Mainnet).await;
+    let handoff = Height(10);
+
+    let mut batch = DiskWriteBatch::new();
+    batch.update_vct_sync_marker(&read_state.db, handoff);
+    read_state
+        .db
+        .write_batch(batch)
+        .expect("seeding a future handoff succeeds");
+
+    let error = sapling_subtrees(
+        None::<Arc<Chain>>,
+        &read_state.db,
+        NoteCommitmentSubtreeIndex(0)..1.into(),
+    )
+    .expect_err("a subtree below an unreached handoff must fail closed");
+
+    assert_eq!(error.reason, HistoricalSubtreeUnavailableReason::Syncing);
+    assert!(error.to_string().contains("retry after sync advances"));
+}
+
 /// A missing handoff tree is an error once the finalized tip has reached the handoff.
 #[tokio::test]
 async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {
@@ -742,6 +773,8 @@ async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {
     assert_eq!(error.pool, "sapling");
     assert_eq!(error.index, NoteCommitmentSubtreeIndex(0));
     assert_eq!(error.handoff, handoff);
+    assert_eq!(error.reason, HistoricalSubtreeUnavailableReason::NotStored);
+    assert!(error.to_string().contains("use another node"));
 }
 
 /// Missing pre-activation trees are returned as consensus-defined empty frontiers.

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -707,6 +707,43 @@ fn handoff_tree_is_only_expected_after_sync_reaches_handoff() {
     assert!(!is_syncing_below_last_checkpoint(None, handoff));
 }
 
+/// A missing handoff tree is an error once the finalized tip has reached the handoff.
+#[tokio::test]
+async fn missing_handoff_tree_fails_closed_after_sync_reaches_handoff() {
+    let _init_guard = zakura_test::init();
+    let blocks: Vec<Arc<Block>> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .values()
+        .take(2)
+        .map(|block_bytes| block_bytes.zcash_deserialize_into().unwrap())
+        .collect();
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
+        populated_state(blocks, &Mainnet).await;
+    let handoff = read_state
+        .db
+        .finalized_tip_height()
+        .expect("the populated state has a finalized tip");
+
+    let mut batch = DiskWriteBatch::new();
+    batch.update_vct_sync_marker(&read_state.db, handoff);
+    batch.delete_range_sapling_tree(&read_state.db, &Height::MIN, &handoff);
+    batch.delete_sapling_tree(&read_state.db, &handoff);
+    read_state
+        .db
+        .write_batch(batch)
+        .expect("seeding a missing handoff tree succeeds");
+
+    let error = sapling_subtrees(
+        None::<Arc<Chain>>,
+        &read_state.db,
+        NoteCommitmentSubtreeIndex(0)..1.into(),
+    )
+    .expect_err("a reached handoff without its tree must fail closed");
+
+    assert_eq!(error.pool, "sapling");
+    assert_eq!(error.index, NoteCommitmentSubtreeIndex(0));
+    assert_eq!(error.handoff, handoff);
+}
+
 /// The served run must be checked to its end, not just at its start.
 ///
 /// `z_getsubtreesbyindex` returns one contiguous run, so a gap anywhere truncates the response.

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -14,11 +14,12 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use zakura_chain::{
-    ironwood, orchard, sapling,
-    subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
+    block, ironwood, orchard, sapling,
+    subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex, TRACKED_SUBTREE_HEIGHT},
 };
 
 use crate::{
+    error::{HistoricalSubtreeUnavailable, HistoricalTreeUnavailable},
     service::{finalized_state::ZakuraDb, non_finalized_state::Chain},
     HashOrHeight,
 };
@@ -26,6 +27,190 @@ use crate::{
 // Doc-only items
 #[allow(unused_imports)]
 use zakura_chain::subtree::NoteCommitmentSubtree;
+
+/// Returns an error if the per-height note commitment tree for `hash_or_height` was never
+/// written, because `db` was built by the verified-commitment-trees fast-sync path and
+/// `hash_or_height` falls in the absent band `[U, H)`.
+///
+/// Read handlers call this only after a tree read came back empty, so a tree that is present
+/// (below `U`, or at or above the handoff) is never rejected. Distinguishing the absent band
+/// from an ordinary miss is what stops a client from reading the miss as the empty tree; see
+/// [`HistoricalTreeUnavailable`].
+pub fn check_historical_tree_available(
+    db: &ZakuraDb,
+    hash_or_height: HashOrHeight,
+) -> Result<(), HistoricalTreeUnavailable> {
+    match db.vct_synced_below() {
+        Some(handoff) if db.vct_historical_tree_unavailable(hash_or_height) => {
+            Err(HistoricalTreeUnavailable {
+                hash_or_height,
+                handoff,
+            })
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Returns `true` if the subtree at `start_index` completed at or below the checkpoint handoff,
+/// given `handoff_leaves`, the pool's note commitment count at the handoff height.
+///
+/// Subtrees complete at every multiple of `1 << TRACKED_SUBTREE_HEIGHT` leaves, so the leaf
+/// count floor-divides to the number of subtrees completed by then, and index `i` is one of
+/// them exactly when `i` is below that count.
+pub(crate) fn subtree_completed_by_handoff(
+    start_index: NoteCommitmentSubtreeIndex,
+    handoff_leaves: u64,
+) -> bool {
+    u64::from(start_index) < (handoff_leaves >> TRACKED_SUBTREE_HEIGHT)
+}
+
+/// Returns an error if the served run stops short of a subtree that exists on this chain but
+/// this node cannot supply.
+///
+/// `first_missing` is the lowest index the served run does not cover: `start_index` when nothing
+/// was served, otherwise one past the end of the contiguous run. `handoff_leaves` reads the pool's
+/// commitment count at the handoff, which bounds the indexes the fast path could have skipped:
+/// anything at or above it completed after the handoff and is genuinely absent on any node, so a
+/// client asking past the tip still gets today's empty list.
+///
+/// # Correctness
+///
+/// Checking only that `start_index` was served is not enough. `z_getsubtreesbyindex` returns one
+/// contiguous run, so a gap anywhere in it truncates the response — and a single unbounded request
+/// from index 0 would then return a short list with no error, which a client reads as "that is
+/// every subtree on this chain". That is the same silent-truncation failure the typed errors exist
+/// to remove, just arriving through a truncated artifact instead of an absent one.
+fn check_historical_subtree_available(
+    db: &ZakuraDb,
+    pool: &'static str,
+    first_missing: Option<NoteCommitmentSubtreeIndex>,
+    handoff_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    // No gap: either the run covered everything asked for, or it ran past the last possible index.
+    let Some(first_missing) = first_missing else {
+        return Ok(());
+    };
+
+    let Some(handoff) = db.vct_synced_below() else {
+        return Ok(());
+    };
+
+    // Without the handoff leaf count there is no way to tell a skipped subtree from one that
+    // never existed, so fail closed. Reporting the archive-mode error for a subtree that was
+    // genuinely never completed is a visible, diagnosable wrong answer; serving a truncated list
+    // is the silent one this whole path exists to remove. The tree at the handoff is outside the
+    // absent band and at or below the tip, so this is not expected to happen — but "not expected"
+    // is the wrong thing to lean on when the failure is silent.
+    let Some(leaves) = handoff_leaves(db, handoff) else {
+        tracing::error!(
+            pool,
+            ?handoff,
+            "no note commitment tree at the checkpoint handoff, so completed subtrees cannot be \
+             distinguished from absent ones; refusing to serve",
+        );
+        metrics::counter!("state.historical_tree.handoff_tree_missing").increment(1);
+
+        return Err(HistoricalSubtreeUnavailable {
+            pool,
+            index: first_missing,
+            handoff,
+        });
+    };
+
+    if subtree_completed_by_handoff(first_missing, leaves) {
+        Err(HistoricalSubtreeUnavailable {
+            pool,
+            index: first_missing,
+            handoff,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Returns the lowest index in `[start_index, end_index)` that `subtrees` does not serve, or
+/// `None` when the run covers the whole request.
+///
+/// `subtrees` is contiguous from `start_index` by the time this runs, so the first index it fails
+/// to cover is one past its last key.
+pub(crate) fn first_missing_subtree_index<Node>(
+    subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<Node>>,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+) -> Option<NoteCommitmentSubtreeIndex> {
+    let first_missing = match subtrees.keys().next_back() {
+        // `u16::MAX` is the last index that can exist, so a run reaching it has no successor to
+        // be missing.
+        Some(last) => NoteCommitmentSubtreeIndex(last.0.checked_add(1)?),
+        None => start_index,
+    };
+
+    // An index the client did not ask for is not missing from its answer.
+    match end_index {
+        Some(end) if first_missing >= end => None,
+        _ => Some(first_missing),
+    }
+}
+
+/// Returns an error if the Sapling subtree list `subtrees` is missing `start_index` because it
+/// completed inside the verified-commitment-trees absent band.
+///
+/// See [`check_historical_subtree_available`].
+pub fn check_historical_sapling_subtrees_available(
+    db: &ZakuraDb,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+    subtrees: &BTreeMap<
+        NoteCommitmentSubtreeIndex,
+        NoteCommitmentSubtreeData<sapling_crypto::Node>,
+    >,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    check_historical_subtree_available(
+        db,
+        "sapling",
+        first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| db.sapling_tree_by_height(&handoff).map(|tree| tree.count()),
+    )
+}
+
+/// Returns an error if the Orchard subtree list `subtrees` is missing `start_index` because it
+/// completed inside the verified-commitment-trees absent band.
+///
+/// See [`check_historical_subtree_available`].
+pub fn check_historical_orchard_subtrees_available(
+    db: &ZakuraDb,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+    subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    check_historical_subtree_available(
+        db,
+        "orchard",
+        first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| db.orchard_tree_by_height(&handoff).map(|tree| tree.count()),
+    )
+}
+
+/// Returns an error if the Ironwood subtree list `subtrees` is missing `start_index` because it
+/// completed inside the verified-commitment-trees absent band.
+///
+/// See [`check_historical_subtree_available`].
+pub fn check_historical_ironwood_subtrees_available(
+    db: &ZakuraDb,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+    subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    check_historical_subtree_available(
+        db,
+        "ironwood",
+        first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| {
+            db.ironwood_tree_by_height(&handoff)
+                .map(|tree| tree.count())
+        },
+    )
+}
 
 /// Returns the Sapling
 /// [`NoteCommitmentTree`](sapling::tree::NoteCommitmentTree) specified by a

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -24,7 +24,10 @@ use crate::{
     error::{
         HistoricalSubtreeUnavailable, HistoricalSubtreeUnavailableReason, HistoricalTreeUnavailable,
     },
-    service::{finalized_state::ZakuraDb, non_finalized_state::Chain},
+    service::{
+        finalized_state::{embedded_handoff_leaf_counts, ZakuraDb},
+        non_finalized_state::Chain,
+    },
     HashOrHeight,
 };
 
@@ -115,6 +118,7 @@ fn check_historical_subtree_available(
     db: &ZakuraDb,
     pool: &'static str,
     first_missing: Option<NoteCommitmentSubtreeIndex>,
+    authenticated_handoff_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
     handoff_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
 ) -> Result<(), HistoricalSubtreeUnavailable> {
     // No gap: either the run covered everything asked for, or it ran past the last possible index.
@@ -126,10 +130,25 @@ fn check_historical_subtree_available(
         return Ok(());
     };
 
+    // The embedded final frontier is authenticated before fast sync begins, so its leaf count can
+    // bound skipped subtrees even while the finalized tip is still below the handoff.
+    if let Some(leaves) = authenticated_handoff_leaves(db, handoff) {
+        return if subtree_completed_by_handoff(first_missing, leaves) {
+            Err(HistoricalSubtreeUnavailable {
+                pool,
+                index: first_missing,
+                handoff,
+                reason: HistoricalSubtreeUnavailableReason::NotStored,
+            })
+        } else {
+            Ok(())
+        };
+    }
+
     // The durable handoff marker is written by the first fast-path commit, so it exists throughout
-    // an ordinary fast sync even though the handoff height is still above the finalized tip. Keep
-    // this guard before `handoff_leaves`: its backward search has no tip guard and can return a row
-    // below the unreached handoff.
+    // an ordinary fast sync even though the handoff height is still above the finalized tip. If no
+    // matching authenticated frontier is available, do not run `handoff_leaves`: its backward
+    // search has no tip guard and can return a row below the unreached handoff.
     if is_syncing_below_last_checkpoint(db.finalized_tip_height(), handoff) {
         tracing::debug!(
             pool,
@@ -226,6 +245,9 @@ fn check_historical_sapling_subtrees_available(
         "sapling",
         first_missing_subtree_index(subtrees, start_index, end_index),
         |db, handoff| {
+            embedded_handoff_leaf_counts(&db.network(), handoff).map(|(sapling, _, _)| sapling)
+        },
+        |db, handoff| {
             // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
             db.latest_stored_sapling_tree(&handoff)
                 .map(|tree| tree.count())
@@ -247,6 +269,9 @@ fn check_historical_orchard_subtrees_available(
         db,
         "orchard",
         first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| {
+            embedded_handoff_leaf_counts(&db.network(), handoff).map(|(_, orchard, _)| orchard)
+        },
         |db, handoff| {
             // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
             db.latest_stored_orchard_tree(&handoff)
@@ -272,6 +297,9 @@ fn check_historical_ironwood_subtrees_available(
         db,
         "ironwood",
         first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| {
+            embedded_handoff_leaf_counts(&db.network(), handoff).map(|(_, _, ironwood)| ironwood)
+        },
         |db, handoff| {
             // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
             db.latest_stored_ironwood_tree(&handoff)

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -64,6 +64,14 @@ pub(crate) fn subtree_completed_by_handoff(
     u64::from(start_index) < (handoff_leaves >> TRACKED_SUBTREE_HEIGHT)
 }
 
+/// Returns `true` while the finalized tip has not reached the checkpoint handoff.
+pub(crate) fn is_syncing_below_last_checkpoint(
+    finalized_tip: Option<block::Height>,
+    handoff: block::Height,
+) -> bool {
+    finalized_tip.is_some_and(|tip| tip < handoff)
+}
+
 /// Returns an error if the served run stops short of a subtree that exists on this chain but
 /// this node cannot supply.
 ///
@@ -95,12 +103,29 @@ fn check_historical_subtree_available(
         return Ok(());
     };
 
+    // The durable handoff marker is written by the first fast-path commit, so it exists throughout
+    // an ordinary fast sync even though the handoff height is still above the finalized tip. The
+    // tree lookup necessarily returns `None` in that state; refuse the incomplete response without
+    // reporting a database invariant failure.
+    if is_syncing_below_last_checkpoint(db.finalized_tip_height(), handoff) {
+        tracing::debug!(
+            pool,
+            ?handoff,
+            "checkpoint handoff has not been reached; refusing to serve incomplete subtrees",
+        );
+
+        return Err(HistoricalSubtreeUnavailable {
+            pool,
+            index: first_missing,
+            handoff,
+        });
+    }
+
     // Without the handoff leaf count there is no way to tell a skipped subtree from one that
     // never existed, so fail closed. Reporting the archive-mode error for a subtree that was
     // genuinely never completed is a visible, diagnosable wrong answer; serving a truncated list
-    // is the silent one this whole path exists to remove. The tree at the handoff is outside the
-    // absent band and at or below the tip, so this is not expected to happen — but "not expected"
-    // is the wrong thing to lean on when the failure is silent.
+    // is the silent one this whole path exists to remove. Once the tip reaches the handoff, its
+    // tree is outside the absent band and must be present.
     let Some(leaves) = handoff_leaves(db, handoff) else {
         tracing::error!(
             pool,

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -199,7 +199,10 @@ fn check_historical_sapling_subtrees_available(
         db,
         "sapling",
         first_missing_subtree_index(subtrees, start_index, end_index),
-        |db, handoff| db.sapling_tree_by_height(&handoff).map(|tree| tree.count()),
+        |db, handoff| {
+            db.latest_stored_sapling_tree(&handoff)
+                .map(|tree| tree.count())
+        },
     )
 }
 
@@ -217,7 +220,10 @@ fn check_historical_orchard_subtrees_available(
         db,
         "orchard",
         first_missing_subtree_index(subtrees, start_index, end_index),
-        |db, handoff| db.orchard_tree_by_height(&handoff).map(|tree| tree.count()),
+        |db, handoff| {
+            db.latest_stored_orchard_tree(&handoff)
+                .map(|tree| tree.count())
+        },
     )
 }
 
@@ -236,7 +242,7 @@ fn check_historical_ironwood_subtrees_available(
         "ironwood",
         first_missing_subtree_index(subtrees, start_index, end_index),
         |db, handoff| {
-            db.ironwood_tree_by_height(&handoff)
+            db.latest_stored_ironwood_tree(&handoff)
                 .map(|tree| tree.count())
         },
     )

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -30,31 +30,32 @@ use crate::{
 #[allow(unused_imports)]
 use zakura_chain::subtree::NoteCommitmentSubtree;
 
-/// Returns an error if the per-height note commitment tree for `hash_or_height` was never
-/// written, because `db` was built by the verified-commitment-trees fast-sync path and
-/// `hash_or_height` falls in the absent band `[U, H)`.
+/// Returns `tree` if it exists, or the consensus-defined empty frontier before `pool_activation`.
 ///
-/// Read handlers call this only after a tree read came back empty, so a tree that is present
-/// (below `U`, or at or above the handoff) is never rejected. Distinguishing the absent band
-/// from an ordinary miss is what stops a client from reading the miss as the empty tree; see
-/// [`HistoricalTreeUnavailable`].
-///
-/// A missing tree before `pool_activation` is the consensus-defined empty frontier, so it is not
-/// historical data that the fast-sync path failed to store.
-fn check_historical_tree_available(
+/// Returns an error if the tree was never written because `db` was built by the
+/// verified-commitment-trees fast-sync path and `hash_or_height` falls in the absent band `[U, H)`.
+fn resolve_historical_tree<Tree: Default>(
     db: &ZakuraDb,
     hash_or_height: HashOrHeight,
     pool_activation: NetworkUpgrade,
-) -> Result<(), HistoricalTreeUnavailable> {
-    let Some(height) = hash_or_height.height_or_else(|hash| db.height(hash)) else {
-        return Ok(());
+    tree: Option<Tree>,
+) -> Result<Option<Tree>, HistoricalTreeUnavailable> {
+    if tree.is_some() {
+        return Ok(tree);
+    }
+
+    let Some(height) = hash_or_height
+        .hash_or_else(|height| db.hash(height))
+        .and_then(|hash| db.height(hash))
+    else {
+        return Ok(None);
     };
 
     if pool_activation
         .activation_height(&db.network())
         .is_none_or(|activation| height < activation)
     {
-        return Ok(());
+        return Ok(Some(Default::default()));
     }
 
     match db.vct_synced_below() {
@@ -64,7 +65,7 @@ fn check_historical_tree_available(
                 handoff,
             })
         }
-        _ => Ok(()),
+        _ => Ok(None),
     }
 }
 
@@ -285,11 +286,7 @@ where
         .and_then(|chain| chain.as_ref().sapling_tree(hash_or_height))
         .or_else(|| db.sapling_tree_by_hash_or_height(hash_or_height));
 
-    if tree.is_none() {
-        check_historical_tree_available(db, hash_or_height, NetworkUpgrade::Sapling)?;
-    }
-
-    Ok(tree)
+    resolve_historical_tree(db, hash_or_height, NetworkUpgrade::Sapling, tree)
 }
 
 /// Returns a list of Sapling [`NoteCommitmentSubtree`]s with indexes in the provided range.
@@ -344,11 +341,7 @@ where
         .and_then(|chain| chain.as_ref().orchard_tree(hash_or_height))
         .or_else(|| db.orchard_tree_by_hash_or_height(hash_or_height));
 
-    if tree.is_none() {
-        check_historical_tree_available(db, hash_or_height, NetworkUpgrade::Nu5)?;
-    }
-
-    Ok(tree)
+    resolve_historical_tree(db, hash_or_height, NetworkUpgrade::Nu5, tree)
 }
 
 /// Returns a list of Orchard [`NoteCommitmentSubtree`]s with indexes in the provided range.
@@ -398,11 +391,7 @@ where
         .and_then(|chain| chain.as_ref().ironwood_tree(hash_or_height))
         .or_else(|| db.ironwood_tree_by_hash_or_height(hash_or_height));
 
-    if tree.is_none() {
-        check_historical_tree_available(db, hash_or_height, NetworkUpgrade::Nu6_3)?;
-    }
-
-    Ok(tree)
+    resolve_historical_tree(db, hash_or_height, NetworkUpgrade::Nu6_3, tree)
 }
 
 /// Returns a list of Ironwood [`NoteCommitmentSubtree`]s with indexes in the

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -131,19 +131,24 @@ fn check_historical_subtree_available(
 /// Returns the lowest index in `[start_index, end_index)` that `subtrees` does not serve, or
 /// `None` when the run covers the whole request.
 ///
-/// `subtrees` is contiguous from `start_index` by the time this runs, so the first index it fails
-/// to cover is one past its last key.
+/// Scans the returned keys in order so an internal gap is detected even when later subtrees are
+/// present.
 pub(crate) fn first_missing_subtree_index<Node>(
     subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<Node>>,
     start_index: NoteCommitmentSubtreeIndex,
     end_index: Option<NoteCommitmentSubtreeIndex>,
 ) -> Option<NoteCommitmentSubtreeIndex> {
-    let first_missing = match subtrees.keys().next_back() {
+    let mut first_missing = start_index;
+
+    for index in subtrees.keys() {
+        if *index != first_missing {
+            break;
+        }
+
         // `u16::MAX` is the last index that can exist, so a run reaching it has no successor to
         // be missing.
-        Some(last) => NoteCommitmentSubtreeIndex(last.0.checked_add(1)?),
-        None => start_index,
-    };
+        first_missing = NoteCommitmentSubtreeIndex(first_missing.0.checked_add(1)?);
+    }
 
     // An index the client did not ask for is not missing from its answer.
     match end_index {

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -46,9 +46,14 @@ fn resolve_historical_tree<Tree: Default>(
         return Ok(tree);
     }
 
+    // An empty frontier is only an answer for a block this node has. Both arms resolve through an
+    // index column family (`height_by_hash` and `hash_by_height`), which pruning retains — it
+    // removes only the `tx_by_loc` bodies. Keep it that way: a body-backed probe such as
+    // `contains_body_at_height` would report every pruned block as absent, silently turning a
+    // pre-activation empty frontier back into a "missing tree" error in pruned storage mode.
     let Some(height) = (match hash_or_height {
         HashOrHeight::Hash(hash) => db.height(hash),
-        HashOrHeight::Height(height) => db.hash(height).map(|_| height),
+        HashOrHeight::Height(height) => db.contains_height(height).then_some(height),
     }) else {
         return Ok(None);
     };
@@ -136,7 +141,7 @@ fn check_historical_subtree_available(
             pool,
             index: first_missing,
             handoff,
-            reason: HistoricalSubtreeUnavailableReason::Syncing,
+            reason: HistoricalSubtreeUnavailableReason::Indeterminate,
         });
     }
 

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -36,7 +36,7 @@ use zakura_chain::subtree::NoteCommitmentSubtree;
 /// (below `U`, or at or above the handoff) is never rejected. Distinguishing the absent band
 /// from an ordinary miss is what stops a client from reading the miss as the empty tree; see
 /// [`HistoricalTreeUnavailable`].
-pub fn check_historical_tree_available(
+fn check_historical_tree_available(
     db: &ZakuraDb,
     hash_or_height: HashOrHeight,
 ) -> Result<(), HistoricalTreeUnavailable> {
@@ -186,7 +186,7 @@ pub(crate) fn first_missing_subtree_index<Node>(
 /// completed inside the verified-commitment-trees absent band.
 ///
 /// See [`check_historical_subtree_available`].
-pub fn check_historical_sapling_subtrees_available(
+fn check_historical_sapling_subtrees_available(
     db: &ZakuraDb,
     start_index: NoteCommitmentSubtreeIndex,
     end_index: Option<NoteCommitmentSubtreeIndex>,
@@ -207,7 +207,7 @@ pub fn check_historical_sapling_subtrees_available(
 /// completed inside the verified-commitment-trees absent band.
 ///
 /// See [`check_historical_subtree_available`].
-pub fn check_historical_orchard_subtrees_available(
+fn check_historical_orchard_subtrees_available(
     db: &ZakuraDb,
     start_index: NoteCommitmentSubtreeIndex,
     end_index: Option<NoteCommitmentSubtreeIndex>,
@@ -225,7 +225,7 @@ pub fn check_historical_orchard_subtrees_available(
 /// completed inside the verified-commitment-trees absent band.
 ///
 /// See [`check_historical_subtree_available`].
-pub fn check_historical_ironwood_subtrees_available(
+fn check_historical_ironwood_subtrees_available(
     db: &ZakuraDb,
     start_index: NoteCommitmentSubtreeIndex,
     end_index: Option<NoteCommitmentSubtreeIndex>,
@@ -249,7 +249,7 @@ pub fn sapling_tree<C>(
     chain: Option<C>,
     db: &ZakuraDb,
     hash_or_height: HashOrHeight,
-) -> Option<Arc<sapling::tree::NoteCommitmentTree>>
+) -> Result<Option<Arc<sapling::tree::NoteCommitmentTree>>, HistoricalTreeUnavailable>
 where
     C: AsRef<Chain>,
 {
@@ -258,9 +258,15 @@ where
     // Since sapling treestates are the same in the finalized and non-finalized
     // state, we check the most efficient alternative first. (`chain` is always
     // in memory, but `db` stores blocks on disk, with a memory cache.)
-    chain
+    let tree = chain
         .and_then(|chain| chain.as_ref().sapling_tree(hash_or_height))
-        .or_else(|| db.sapling_tree_by_hash_or_height(hash_or_height))
+        .or_else(|| db.sapling_tree_by_hash_or_height(hash_or_height));
+
+    if tree.is_none() {
+        check_historical_tree_available(db, hash_or_height)?;
+    }
+
+    Ok(tree)
 }
 
 /// Returns a list of Sapling [`NoteCommitmentSubtree`]s with indexes in the provided range.
@@ -273,16 +279,26 @@ pub fn sapling_subtrees<C>(
     chain: Option<C>,
     db: &ZakuraDb,
     range: impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex> + Clone,
-) -> BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<sapling_crypto::Node>>
+) -> Result<
+    BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<sapling_crypto::Node>>,
+    HistoricalSubtreeUnavailable,
+>
 where
     C: AsRef<Chain>,
 {
-    subtrees(
+    let (start_index, end_index) = subtree_range_bounds(&range);
+    let subtrees = subtrees(
         chain,
         range,
         |chain, range| chain.sapling_subtrees_in_range(range),
         |range| db.sapling_subtree_list_by_index_range(range),
-    )
+    );
+
+    if let Some(start_index) = start_index {
+        check_historical_sapling_subtrees_available(db, start_index, end_index, &subtrees)?;
+    }
+
+    Ok(subtrees)
 }
 
 /// Returns the Orchard
@@ -292,7 +308,7 @@ pub fn orchard_tree<C>(
     chain: Option<C>,
     db: &ZakuraDb,
     hash_or_height: HashOrHeight,
-) -> Option<Arc<orchard::tree::NoteCommitmentTree>>
+) -> Result<Option<Arc<orchard::tree::NoteCommitmentTree>>, HistoricalTreeUnavailable>
 where
     C: AsRef<Chain>,
 {
@@ -301,9 +317,15 @@ where
     // Since orchard treestates are the same in the finalized and non-finalized
     // state, we check the most efficient alternative first. (`chain` is always
     // in memory, but `db` stores blocks on disk, with a memory cache.)
-    chain
+    let tree = chain
         .and_then(|chain| chain.as_ref().orchard_tree(hash_or_height))
-        .or_else(|| db.orchard_tree_by_hash_or_height(hash_or_height))
+        .or_else(|| db.orchard_tree_by_hash_or_height(hash_or_height));
+
+    if tree.is_none() {
+        check_historical_tree_available(db, hash_or_height)?;
+    }
+
+    Ok(tree)
 }
 
 /// Returns a list of Orchard [`NoteCommitmentSubtree`]s with indexes in the provided range.
@@ -316,16 +338,26 @@ pub fn orchard_subtrees<C>(
     chain: Option<C>,
     db: &ZakuraDb,
     range: impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex> + Clone,
-) -> BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>
+) -> Result<
+    BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>,
+    HistoricalSubtreeUnavailable,
+>
 where
     C: AsRef<Chain>,
 {
-    subtrees(
+    let (start_index, end_index) = subtree_range_bounds(&range);
+    let subtrees = subtrees(
         chain,
         range,
         |chain, range| chain.orchard_subtrees_in_range(range),
         |range| db.orchard_subtree_list_by_index_range(range),
-    )
+    );
+
+    if let Some(start_index) = start_index {
+        check_historical_orchard_subtrees_available(db, start_index, end_index, &subtrees)?;
+    }
+
+    Ok(subtrees)
 }
 
 /// Returns the Ironwood
@@ -335,13 +367,19 @@ pub fn ironwood_tree<C>(
     chain: Option<C>,
     db: &ZakuraDb,
     hash_or_height: HashOrHeight,
-) -> Option<Arc<ironwood::tree::NoteCommitmentTree>>
+) -> Result<Option<Arc<ironwood::tree::NoteCommitmentTree>>, HistoricalTreeUnavailable>
 where
     C: AsRef<Chain>,
 {
-    chain
+    let tree = chain
         .and_then(|chain| chain.as_ref().ironwood_tree(hash_or_height))
-        .or_else(|| db.ironwood_tree_by_hash_or_height(hash_or_height))
+        .or_else(|| db.ironwood_tree_by_hash_or_height(hash_or_height));
+
+    if tree.is_none() {
+        check_historical_tree_available(db, hash_or_height)?;
+    }
+
+    Ok(tree)
 }
 
 /// Returns a list of Ironwood [`NoteCommitmentSubtree`]s with indexes in the
@@ -355,16 +393,49 @@ pub fn ironwood_subtrees<C>(
     chain: Option<C>,
     db: &ZakuraDb,
     range: impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex> + Clone,
-) -> BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<ironwood::tree::Node>>
+) -> Result<
+    BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<ironwood::tree::Node>>,
+    HistoricalSubtreeUnavailable,
+>
 where
     C: AsRef<Chain>,
 {
-    subtrees(
+    let (start_index, end_index) = subtree_range_bounds(&range);
+    let subtrees = subtrees(
         chain,
         range,
         |chain, range| chain.ironwood_subtrees_in_range(range),
         |range| db.ironwood_subtree_list_by_index_range(range),
-    )
+    );
+
+    if let Some(start_index) = start_index {
+        check_historical_ironwood_subtrees_available(db, start_index, end_index, &subtrees)?;
+    }
+
+    Ok(subtrees)
+}
+
+/// Returns the first requested subtree index and the exclusive end bound.
+fn subtree_range_bounds(
+    range: &impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex>,
+) -> (
+    Option<NoteCommitmentSubtreeIndex>,
+    Option<NoteCommitmentSubtreeIndex>,
+) {
+    use std::ops::Bound::*;
+
+    let start = match range.start_bound().cloned() {
+        Included(start) => Some(start),
+        Excluded(start) => start.0.checked_add(1).map(Into::into),
+        Unbounded => Some(0.into()),
+    };
+    let end = match range.end_bound().cloned() {
+        Included(end) => end.0.checked_add(1).map(Into::into),
+        Excluded(end) => Some(end),
+        Unbounded => None,
+    };
+
+    (start, end)
 }
 
 /// Returns a list of [`NoteCommitmentSubtree`]s in the provided range.

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -21,7 +21,9 @@ use zakura_chain::{
 };
 
 use crate::{
-    error::{HistoricalSubtreeUnavailable, HistoricalTreeUnavailable},
+    error::{
+        HistoricalSubtreeUnavailable, HistoricalSubtreeUnavailableReason, HistoricalTreeUnavailable,
+    },
     service::{finalized_state::ZakuraDb, non_finalized_state::Chain},
     HashOrHeight,
 };
@@ -136,6 +138,7 @@ fn check_historical_subtree_available(
             pool,
             index: first_missing,
             handoff,
+            reason: HistoricalSubtreeUnavailableReason::Syncing,
         });
     }
 
@@ -157,6 +160,7 @@ fn check_historical_subtree_available(
             pool,
             index: first_missing,
             handoff,
+            reason: HistoricalSubtreeUnavailableReason::NotStored,
         });
     };
 
@@ -165,6 +169,7 @@ fn check_historical_subtree_available(
             pool,
             index: first_missing,
             handoff,
+            reason: HistoricalSubtreeUnavailableReason::NotStored,
         })
     } else {
         Ok(())

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -14,7 +14,9 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use zakura_chain::{
-    block, ironwood, orchard, sapling,
+    block, ironwood, orchard,
+    parameters::NetworkUpgrade,
+    sapling,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex, TRACKED_SUBTREE_HEIGHT},
 };
 
@@ -36,10 +38,25 @@ use zakura_chain::subtree::NoteCommitmentSubtree;
 /// (below `U`, or at or above the handoff) is never rejected. Distinguishing the absent band
 /// from an ordinary miss is what stops a client from reading the miss as the empty tree; see
 /// [`HistoricalTreeUnavailable`].
+///
+/// A missing tree before `pool_activation` is the consensus-defined empty frontier, so it is not
+/// historical data that the fast-sync path failed to store.
 fn check_historical_tree_available(
     db: &ZakuraDb,
     hash_or_height: HashOrHeight,
+    pool_activation: NetworkUpgrade,
 ) -> Result<(), HistoricalTreeUnavailable> {
+    let Some(height) = hash_or_height.height_or_else(|hash| db.height(hash)) else {
+        return Ok(());
+    };
+
+    if pool_activation
+        .activation_height(&db.network())
+        .is_none_or(|activation| height < activation)
+    {
+        return Ok(());
+    }
+
     match db.vct_synced_below() {
         Some(handoff) if db.vct_historical_tree_unavailable(hash_or_height) => {
             Err(HistoricalTreeUnavailable {
@@ -269,7 +286,7 @@ where
         .or_else(|| db.sapling_tree_by_hash_or_height(hash_or_height));
 
     if tree.is_none() {
-        check_historical_tree_available(db, hash_or_height)?;
+        check_historical_tree_available(db, hash_or_height, NetworkUpgrade::Sapling)?;
     }
 
     Ok(tree)
@@ -328,7 +345,7 @@ where
         .or_else(|| db.orchard_tree_by_hash_or_height(hash_or_height));
 
     if tree.is_none() {
-        check_historical_tree_available(db, hash_or_height)?;
+        check_historical_tree_available(db, hash_or_height, NetworkUpgrade::Nu5)?;
     }
 
     Ok(tree)
@@ -382,7 +399,7 @@ where
         .or_else(|| db.ironwood_tree_by_hash_or_height(hash_or_height));
 
     if tree.is_none() {
-        check_historical_tree_available(db, hash_or_height)?;
+        check_historical_tree_available(db, hash_or_height, NetworkUpgrade::Nu6_3)?;
     }
 
     Ok(tree)

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -25,7 +25,7 @@ use crate::{
         HistoricalSubtreeUnavailable, HistoricalSubtreeUnavailableReason, HistoricalTreeUnavailable,
     },
     service::{
-        finalized_state::{embedded_handoff_leaf_counts, ZakuraDb},
+        finalized_state::{embedded_last_checkpoint_leaf_counts, ZakuraDb},
         non_finalized_state::Chain,
     },
     HashOrHeight,
@@ -69,43 +69,43 @@ fn resolve_historical_tree<Tree: Default>(
     }
 
     match db.vct_synced_below() {
-        Some(handoff) if db.vct_tree_absent(height) => Err(HistoricalTreeUnavailable {
+        Some(last_checkpoint) if db.vct_tree_absent(height) => Err(HistoricalTreeUnavailable {
             hash_or_height,
-            handoff,
+            last_checkpoint,
         }),
         _ => Ok(None),
     }
 }
 
-/// Returns `true` if the subtree at `start_index` completed at or below the checkpoint handoff,
-/// given `handoff_leaves`, the pool's note commitment count at the handoff height.
+/// Returns `true` if the subtree at `start_index` completed at or below the last checkpoint,
+/// given `last_checkpoint_leaves`, the pool's note commitment count at the last checkpoint height.
 ///
 /// Subtrees complete at every multiple of `1 << TRACKED_SUBTREE_HEIGHT` leaves, so the leaf
 /// count floor-divides to the number of subtrees completed by then, and index `i` is one of
 /// them exactly when `i` is below that count.
-pub(crate) fn subtree_completed_by_handoff(
+pub(crate) fn subtree_completed_by_last_checkpoint(
     start_index: NoteCommitmentSubtreeIndex,
-    handoff_leaves: u64,
+    last_checkpoint_leaves: u64,
 ) -> bool {
-    u64::from(start_index) < (handoff_leaves >> TRACKED_SUBTREE_HEIGHT)
+    u64::from(start_index) < (last_checkpoint_leaves >> TRACKED_SUBTREE_HEIGHT)
 }
 
-/// Returns `true` while the finalized tip has not reached the checkpoint handoff.
+/// Returns `true` while the finalized tip has not reached the last checkpoint.
 pub(crate) fn is_syncing_below_last_checkpoint(
     finalized_tip: Option<block::Height>,
-    handoff: block::Height,
+    last_checkpoint: block::Height,
 ) -> bool {
-    finalized_tip.is_some_and(|tip| tip < handoff)
+    finalized_tip.is_some_and(|tip| tip < last_checkpoint)
 }
 
 /// Returns an error if the served run stops short of a subtree that exists on this chain but
 /// this node cannot supply.
 ///
 /// `first_missing` is the lowest index the served run does not cover: `start_index` when nothing
-/// was served, otherwise one past the end of the contiguous run. `handoff_leaves` reads the pool's
-/// commitment count at the handoff, which bounds the indexes the fast path could have skipped:
-/// anything at or above it completed after the handoff and is genuinely absent on any node, so a
-/// client asking past the tip still gets today's empty list.
+/// was served, otherwise one past the end of the contiguous run. `last_checkpoint_leaves` reads
+/// the pool's commitment count at the last checkpoint, which bounds the indexes the fast path
+/// could have skipped: anything at or above it completed after the last checkpoint and is
+/// genuinely absent on any node, so a client asking past the tip still gets today's empty list.
 ///
 /// # Correctness
 ///
@@ -118,26 +118,26 @@ fn check_historical_subtree_available(
     db: &ZakuraDb,
     pool: &'static str,
     first_missing: Option<NoteCommitmentSubtreeIndex>,
-    authenticated_handoff_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
-    handoff_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
+    authenticated_last_checkpoint_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
+    last_checkpoint_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
 ) -> Result<(), HistoricalSubtreeUnavailable> {
     // No gap: either the run covered everything asked for, or it ran past the last possible index.
     let Some(first_missing) = first_missing else {
         return Ok(());
     };
 
-    let Some(handoff) = db.vct_synced_below() else {
+    let Some(last_checkpoint) = db.vct_synced_below() else {
         return Ok(());
     };
 
     // The embedded final frontier is authenticated before fast sync begins, so its leaf count can
-    // bound skipped subtrees even while the finalized tip is still below the handoff.
-    if let Some(leaves) = authenticated_handoff_leaves(db, handoff) {
-        return if subtree_completed_by_handoff(first_missing, leaves) {
+    // bound skipped subtrees even while the finalized tip is still below the last checkpoint.
+    if let Some(leaves) = authenticated_last_checkpoint_leaves(db, last_checkpoint) {
+        return if subtree_completed_by_last_checkpoint(first_missing, leaves) {
             Err(HistoricalSubtreeUnavailable {
                 pool,
                 index: first_missing,
-                handoff,
+                last_checkpoint,
                 reason: HistoricalSubtreeUnavailableReason::NotStored,
             })
         } else {
@@ -145,52 +145,53 @@ fn check_historical_subtree_available(
         };
     }
 
-    // The durable handoff marker is written by the first fast-path commit, so it exists throughout
-    // an ordinary fast sync even though the handoff height is still above the finalized tip. If no
-    // matching authenticated frontier is available, do not run `handoff_leaves`: its backward
-    // search has no tip guard and can return a row below the unreached handoff.
-    if is_syncing_below_last_checkpoint(db.finalized_tip_height(), handoff) {
+    // The durable last-checkpoint marker is written by the first fast-path commit, so it exists
+    // throughout an ordinary fast sync even though the last checkpoint height is still above the
+    // finalized tip. If no matching authenticated frontier is available, do not run
+    // `last_checkpoint_leaves`: its backward search has no tip guard and can return a row below the
+    // unreached last checkpoint.
+    if is_syncing_below_last_checkpoint(db.finalized_tip_height(), last_checkpoint) {
         tracing::debug!(
             pool,
-            ?handoff,
-            "checkpoint handoff has not been reached; refusing to serve incomplete subtrees",
+            ?last_checkpoint,
+            "last checkpoint has not been reached; refusing to serve incomplete subtrees",
         );
 
         return Err(HistoricalSubtreeUnavailable {
             pool,
             index: first_missing,
-            handoff,
+            last_checkpoint,
             reason: HistoricalSubtreeUnavailableReason::Indeterminate,
         });
     }
 
-    // Without the handoff leaf count there is no way to tell a skipped subtree from one that
+    // Without the last checkpoint leaf count there is no way to tell a skipped subtree from one that
     // never existed, so fail closed. Reporting the archive-mode error for a subtree that was
     // genuinely never completed is a visible, diagnosable wrong answer; serving a truncated list
-    // is the silent one this whole path exists to remove. Once the tip reaches the handoff, its
-    // tree is outside the absent band and must be present.
-    let Some(leaves) = handoff_leaves(db, handoff) else {
+    // is the silent one this whole path exists to remove. Once the tip reaches the last checkpoint,
+    // its tree is outside the absent band and must be present.
+    let Some(leaves) = last_checkpoint_leaves(db, last_checkpoint) else {
         tracing::error!(
             pool,
-            ?handoff,
-            "no note commitment tree at the checkpoint handoff, so completed subtrees cannot be \
+            ?last_checkpoint,
+            "no note commitment tree at the last checkpoint, so completed subtrees cannot be \
              distinguished from absent ones; refusing to serve",
         );
-        metrics::counter!("state.historical_tree.handoff_tree_missing").increment(1);
+        metrics::counter!("state.historical_tree.last_checkpoint_tree_missing").increment(1);
 
         return Err(HistoricalSubtreeUnavailable {
             pool,
             index: first_missing,
-            handoff,
+            last_checkpoint,
             reason: HistoricalSubtreeUnavailableReason::NotStored,
         });
     };
 
-    if subtree_completed_by_handoff(first_missing, leaves) {
+    if subtree_completed_by_last_checkpoint(first_missing, leaves) {
         Err(HistoricalSubtreeUnavailable {
             pool,
             index: first_missing,
-            handoff,
+            last_checkpoint,
             reason: HistoricalSubtreeUnavailableReason::NotStored,
         })
     } else {
@@ -244,12 +245,13 @@ fn check_historical_sapling_subtrees_available(
         db,
         "sapling",
         first_missing_subtree_index(subtrees, start_index, end_index),
-        |db, handoff| {
-            embedded_handoff_leaf_counts(&db.network(), handoff).map(|(sapling, _, _)| sapling)
+        |db, last_checkpoint| {
+            embedded_last_checkpoint_leaf_counts(&db.network(), last_checkpoint)
+                .map(|(sapling, _, _)| sapling)
         },
-        |db, handoff| {
-            // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
-            db.latest_stored_sapling_tree(&handoff)
+        |db, last_checkpoint| {
+            // Sparse-tree dedup only omits the last checkpoint row when an older frontier is identical.
+            db.latest_stored_sapling_tree(&last_checkpoint)
                 .map(|tree| tree.count())
         },
     )
@@ -269,12 +271,13 @@ fn check_historical_orchard_subtrees_available(
         db,
         "orchard",
         first_missing_subtree_index(subtrees, start_index, end_index),
-        |db, handoff| {
-            embedded_handoff_leaf_counts(&db.network(), handoff).map(|(_, orchard, _)| orchard)
+        |db, last_checkpoint| {
+            embedded_last_checkpoint_leaf_counts(&db.network(), last_checkpoint)
+                .map(|(_, orchard, _)| orchard)
         },
-        |db, handoff| {
-            // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
-            db.latest_stored_orchard_tree(&handoff)
+        |db, last_checkpoint| {
+            // Sparse-tree dedup only omits the last checkpoint row when an older frontier is identical.
+            db.latest_stored_orchard_tree(&last_checkpoint)
                 .map(|tree| tree.count())
         },
     )
@@ -297,12 +300,13 @@ fn check_historical_ironwood_subtrees_available(
         db,
         "ironwood",
         first_missing_subtree_index(subtrees, start_index, end_index),
-        |db, handoff| {
-            embedded_handoff_leaf_counts(&db.network(), handoff).map(|(_, _, ironwood)| ironwood)
+        |db, last_checkpoint| {
+            embedded_last_checkpoint_leaf_counts(&db.network(), last_checkpoint)
+                .map(|(_, _, ironwood)| ironwood)
         },
-        |db, handoff| {
-            // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
-            db.latest_stored_ironwood_tree(&handoff)
+        |db, last_checkpoint| {
+            // Sparse-tree dedup only omits the last checkpoint row when an older frontier is identical.
+            db.latest_stored_ironwood_tree(&last_checkpoint)
                 .map(|tree| tree.count())
         },
     )

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -46,10 +46,10 @@ fn resolve_historical_tree<Tree: Default>(
         return Ok(tree);
     }
 
-    let Some(height) = hash_or_height
-        .hash_or_else(|height| db.hash(height))
-        .and_then(|hash| db.height(hash))
-    else {
+    let Some(height) = (match hash_or_height {
+        HashOrHeight::Hash(hash) => db.height(hash),
+        HashOrHeight::Height(height) => db.hash(height).map(|_| height),
+    }) else {
         return Ok(None);
     };
 
@@ -61,12 +61,10 @@ fn resolve_historical_tree<Tree: Default>(
     }
 
     match db.vct_synced_below() {
-        Some(handoff) if db.vct_historical_tree_unavailable(hash_or_height) => {
-            Err(HistoricalTreeUnavailable {
-                hash_or_height,
-                handoff,
-            })
-        }
+        Some(handoff) if db.vct_tree_absent(height) => Err(HistoricalTreeUnavailable {
+            hash_or_height,
+            handoff,
+        }),
         _ => Ok(None),
     }
 }
@@ -124,9 +122,9 @@ fn check_historical_subtree_available(
     };
 
     // The durable handoff marker is written by the first fast-path commit, so it exists throughout
-    // an ordinary fast sync even though the handoff height is still above the finalized tip. The
-    // tree lookup necessarily returns `None` in that state; refuse the incomplete response without
-    // reporting a database invariant failure.
+    // an ordinary fast sync even though the handoff height is still above the finalized tip. Keep
+    // this guard before `handoff_leaves`: its backward search has no tip guard and can return a row
+    // below the unreached handoff.
     if is_syncing_below_last_checkpoint(db.finalized_tip_height(), handoff) {
         tracing::debug!(
             pool,
@@ -223,6 +221,7 @@ fn check_historical_sapling_subtrees_available(
         "sapling",
         first_missing_subtree_index(subtrees, start_index, end_index),
         |db, handoff| {
+            // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
             db.latest_stored_sapling_tree(&handoff)
                 .map(|tree| tree.count())
         },
@@ -244,6 +243,7 @@ fn check_historical_orchard_subtrees_available(
         "orchard",
         first_missing_subtree_index(subtrees, start_index, end_index),
         |db, handoff| {
+            // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
             db.latest_stored_orchard_tree(&handoff)
                 .map(|tree| tree.count())
         },
@@ -258,13 +258,17 @@ fn check_historical_ironwood_subtrees_available(
     db: &ZakuraDb,
     start_index: NoteCommitmentSubtreeIndex,
     end_index: Option<NoteCommitmentSubtreeIndex>,
-    subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>,
+    subtrees: &BTreeMap<
+        NoteCommitmentSubtreeIndex,
+        NoteCommitmentSubtreeData<ironwood::tree::Node>,
+    >,
 ) -> Result<(), HistoricalSubtreeUnavailable> {
     check_historical_subtree_available(
         db,
         "ironwood",
         first_missing_subtree_index(subtrees, start_index, end_index),
         |db, handoff| {
+            // Sparse-tree dedup only omits the handoff row when an older frontier is identical.
             db.latest_stored_ironwood_tree(&handoff)
                 .map(|tree| tree.count())
         },

--- a/docs/changelog/unreleased/534.md
+++ b/docs/changelog/unreleased/534.md
@@ -1,0 +1,10 @@
+## Fixed
+
+- Fixed `z_gettreestate` returning a JSON `null` treestate, and `z_getsubtreesbyindex`
+  returning an empty list, for heights a verified-commitment-trees fast-synced node has no
+  data for. Clients following the lightwalletd contract read an absent treestate as the
+  _empty_ tree, so a wallet could derive a birthday anchor asserting an empty commitment
+  tree deep in the chain with no error raised. Both now return a typed archive-mode error,
+  and `getblock`/`getblockheader` explain why the tree is missing rather than reporting a
+  bare "missing Sapling tree"
+  ([#534](https://github.com/zakura-core/zakura/pull/534)).

--- a/docs/changelog/unreleased/534.md
+++ b/docs/changelog/unreleased/534.md
@@ -6,5 +6,6 @@
   _empty_ tree, so a wallet could derive a birthday anchor asserting an empty commitment
   tree deep in the chain with no error raised. Both now return a typed archive-mode error,
   and verbose `getblock`/`getblockheader` preserve that explanation rather than reporting
-  bare "missing Orchard tree" and "missing Sapling tree" errors, respectively
+  bare "missing Orchard tree" and "missing Sapling tree" errors, respectively. Subtree errors
+  also distinguish a transient incomplete sync from data this node will never recover
   ([#534](https://github.com/zakura-core/zakura/pull/534)).

--- a/docs/changelog/unreleased/534.md
+++ b/docs/changelog/unreleased/534.md
@@ -7,5 +7,6 @@
   tree deep in the chain with no error raised. Both now return a typed archive-mode error,
   and verbose `getblock`/`getblockheader` preserve that explanation rather than reporting
   bare "missing Orchard tree" and "missing Sapling tree" errors, respectively. Subtree errors
-  also distinguish a transient incomplete sync from data this node will never recover
+  also report whether this node has determined that it will never hold the data, or has not yet
+  reached the handoff needed to decide
   ([#534](https://github.com/zakura-core/zakura/pull/534)).

--- a/docs/changelog/unreleased/534.md
+++ b/docs/changelog/unreleased/534.md
@@ -5,6 +5,6 @@
   data for. Clients following the lightwalletd contract read an absent treestate as the
   _empty_ tree, so a wallet could derive a birthday anchor asserting an empty commitment
   tree deep in the chain with no error raised. Both now return a typed archive-mode error,
-  and `getblock`/`getblockheader` explain why the tree is missing rather than reporting a
-  bare "missing Sapling tree"
+  and verbose `getblock`/`getblockheader` preserve that explanation rather than reporting
+  bare "missing Orchard tree" and "missing Sapling tree" errors, respectively
   ([#534](https://github.com/zakura-core/zakura/pull/534)).


### PR DESCRIPTION
## Motivation

A verified-commitment-trees fast-synced node has no per-height note commitment trees below its checkpoint handoff. `z_gettreestate` maps that to a JSON `null` and `z_getsubtreesbyindex` to an empty list — both of which a lightwalletd-contract client reads as real data. An absent treestate becomes the *empty* tree, so a wallet derives a birthday anchor asserting an empty commitment tree deep in the chain, with no error at the point of corruption.

Implements §4.5 of `docs/design/historical-treestate-serving.md`, which says to wire this up regardless of whether the rest of the design proceeds.

## Solution

Two typed errors, returned by the tree and subtree read APIs instead of an absent tree or an empty list. Because availability checks are part of those APIs' `Result` values, callers cannot accidentally omit them. The checks run only after a read comes back empty, so nothing present is ever rejected.

The subtree gate needs a bound or it fires on ordinary queries: it compares the requested index against the pool's leaf count at the handoff, so only subtrees the fast path actually skipped are reported, and an index past the tip still returns today's empty list. The served run is checked to its end rather than only its start, because `z_getsubtreesbyindex` returns one contiguous run and a gap anywhere truncates the response.

Verbose `getblockheader` previously replaced the state error with a bare "missing Sapling tree" error, while verbose `getblock` could replace it with "missing Orchard tree". Both now preserve the typed state error and explain why the historical tree is unavailable.

## Testing

Unit tests cover the completion bound and gap finder, including bounded requests, gaps, and the `u16::MAX` edge. State tests cover ordinary mid-sync unavailability and the fail-closed missing-handoff-tree branch. RPC tests verify that `z_gettreestate`, `z_getsubtreesbyindex`, verbose `getblock`, and verbose `getblockheader` surface the typed errors rather than null, empty, or generic missing-tree responses. Property-test assertions verify that the gate matches the read guard.

## Note for reviewers

This will look like a regression to anyone whose client "works" today by treating `null` as the empty tree. That client was silently corrupting; it now fails loudly. **This PR does not unblock a wallet** — it makes the existing breakage diagnosable. Serving is restored in the follow-ups.

### Follow-up Work

Stacked: replay engine (#531), subtree artifact (#532), then treestate serving and the frontier grid.