### PR TITLE
feat(state): rebuild historical note commitment trees by verified replay

### DIFF
--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -1154,6 +1154,150 @@ async fn rpc_getblock_missing_error() {
     assert!(rpc_tx_queue_task_result.is_none());
 }
 
+/// A `z_gettreestate` inside a fast-synced node's absent band must fail loudly.
+///
+/// Before this, an absent per-height tree became a JSON `null` treestate. Clients following
+/// the lightwalletd contract read that as the *empty* tree and derive a wallet birthday anchor
+/// asserting an empty commitment tree deep in the chain, with no error at the point of
+/// corruption. The read handler now returns [`zakura_state::HistoricalTreeUnavailable`], which
+/// the RPC surfaces as an error.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_z_get_treestate_absent_band_is_an_error() {
+    let _init_guard = zakura_test::init();
+
+    let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let block_hash = block.hash();
+
+    // Sapling is active here and NU5 is not, so the Sapling tree is the only tree requested.
+    let height = Height(1_000_000);
+    let handoff = Height(3_418_406);
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let treestate_future =
+        tokio::spawn(async move { rpc.z_get_treestate(height.0.to_string()).await });
+
+    read_state
+        .expect_request(ReadRequest::Block(height.into()))
+        .await
+        .respond(ReadResponse::Block(Some(block)));
+
+    read_state
+        .expect_request(ReadRequest::SaplingTree(block_hash.into()))
+        .await
+        .respond_error(Box::new(zakura_state::HistoricalTreeUnavailable {
+            hash_or_height: block_hash.into(),
+            handoff,
+        }));
+
+    let treestate_response = treestate_future
+        .await
+        .expect("treestate future should not panic")
+        .expect_err("an absent-band treestate must be an error, not a null treestate");
+
+    assert_eq!(treestate_response.code(), ErrorCode::ServerError(-1).code());
+    assert!(
+        treestate_response.message().contains("fast-synced"),
+        "the error must name the cause, got: {}",
+        treestate_response.message()
+    );
+
+    read_state.expect_no_requests().await;
+
+    let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
+    assert!(rpc_tx_queue_task_result.is_none());
+}
+
+/// A `z_getsubtreesbyindex` inside a fast-synced node's absent band must fail loudly.
+///
+/// The subtree read path returns an empty list when the starting index is absent, which is
+/// indistinguishable from "this chain has no subtrees there". A client seeds nothing and fails
+/// later without a clear cause, so the read handler returns
+/// [`zakura_state::HistoricalSubtreeUnavailable`] instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_z_get_subtrees_by_index_absent_band_is_an_error() {
+    let _init_guard = zakura_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let start_index = NoteCommitmentSubtreeIndex(0);
+    let subtrees_future = tokio::spawn(async move {
+        rpc.z_get_subtrees_by_index("sapling".to_string(), start_index, Some(1u16.into()))
+            .await
+    });
+
+    read_state
+        .expect_request(ReadRequest::SaplingSubtrees {
+            start_index,
+            limit: Some(1u16.into()),
+        })
+        .await
+        .respond_error(Box::new(zakura_state::HistoricalSubtreeUnavailable {
+            pool: "sapling",
+            index: start_index,
+            handoff: Height(3_418_406),
+        }));
+
+    let subtrees_response = subtrees_future
+        .await
+        .expect("subtrees future should not panic")
+        .expect_err("an absent-band subtree list must be an error, not an empty list");
+
+    assert_eq!(subtrees_response.code(), ErrorCode::ServerError(-1).code());
+    assert!(
+        subtrees_response.message().contains("fast-synced"),
+        "the error must name the cause, got: {}",
+        subtrees_response.message()
+    );
+
+    read_state.expect_no_requests().await;
+
+    let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
+    assert!(rpc_tx_queue_task_result.is_none());
+}
+
 /// Regression test for GHSA-x6v8-c2xp-928m — panics (aborts) before the fix.
 ///
 /// When `Depth` returns `None` (side-chain block), `get_block_header` sets

--- a/crates/zakura-state/src/constants.rs
+++ b/crates/zakura-state/src/constants.rs
@@ -38,6 +38,15 @@ pub const STATE_DATABASE_KIND: &str = "state";
 /// get the network-specific floor.
 pub const MIN_PRUNING_RETENTION: u32 = 10_000;
 
+/// The default bound on how many blocks one historical note commitment tree derivation may
+/// replay, used by [`Config::max_historical_tree_replay_blocks`](crate::Config).
+///
+/// Sized to cover a cold request anywhere in a from-genesis fast-synced node's absent band on
+/// Mainnet, so the first request of a wallet sweep succeeds rather than failing at a limit. Later
+/// requests in the sweep replay only from the previous memoized frontier, so the bound applies to
+/// the cold case alone.
+pub const DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS: u64 = 4_000_000;
+
 /// The minimum retention window allowed in pruned storage mode on `network`.
 ///
 /// Every network's floor stays strictly greater than [`MAX_BLOCK_REORG_HEIGHT`],

--- a/crates/zakura-state/src/error.rs
+++ b/crates/zakura-state/src/error.rs
@@ -10,7 +10,9 @@ use zakura_chain::{
     amount::{self, NegativeAllowed, NonNegative},
     block,
     history_tree::HistoryTreeError,
-    ironwood, orchard, sapling, sprout, transaction, transparent,
+    ironwood, orchard, sapling, sprout,
+    subtree::NoteCommitmentSubtreeIndex,
+    transaction, transparent,
     value_balance::{ValueBalance, ValueBalanceError},
     work::difficulty::CompactDifficulty,
 };
@@ -51,6 +53,53 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub struct MissingSproutTipTree {
     /// The finalized tip whose Sprout frontier is missing.
     pub tip: block::Height,
+}
+
+/// The per-height note commitment tree for a historical block was never written, because this
+/// database was built by the verified-commitment-trees fast-sync path.
+///
+/// Fast sync skips per-height trees across the half-open band `[U, H)`, where `U` is the first
+/// height this binary committed and `H` is the checkpoint handoff. Read handlers return this
+/// instead of an absent tree so the RPC boundary reports a diagnosable archive-mode failure:
+/// clients following the lightwalletd contract read an absent treestate as the *empty* tree, and
+/// would silently derive a wallet birthday anchor asserting an empty commitment tree deep in the
+/// chain.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error(
+    "historical note commitment tree at {hash_or_height} is unavailable: this node was fast-synced \
+     with verified commitment trees, so per-height trees below the checkpoint handoff {handoff:?} \
+     were never written"
+)]
+pub struct HistoricalTreeUnavailable {
+    /// The block whose per-height tree was requested.
+    pub hash_or_height: HashOrHeight,
+
+    /// The checkpoint handoff height `H`: the exclusive upper bound of the absent band.
+    pub handoff: block::Height,
+}
+
+/// A completed note commitment subtree root was never recorded, because this database was built
+/// by the verified-commitment-trees fast-sync path.
+///
+/// Subtree roots are a by-product of the per-height tree maintenance the fast path skips, so
+/// every subtree that completed at or below the checkpoint handoff is missing. Read handlers
+/// return this instead of an empty subtree list, which a client would otherwise read as "this
+/// chain has no subtrees here" and seed nothing, failing later without a clear cause.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error(
+    "historical {pool} note commitment subtree {index:?} is unavailable: this node was fast-synced \
+     with verified commitment trees, so subtrees completed at or below the checkpoint handoff \
+     {handoff:?} were never recorded"
+)]
+pub struct HistoricalSubtreeUnavailable {
+    /// The shielded pool whose subtree was requested, in `z_getsubtreesbyindex` spelling.
+    pub pool: &'static str,
+
+    /// The requested starting subtree index.
+    pub index: NoteCommitmentSubtreeIndex,
+
+    /// The checkpoint handoff height `H`, below which no subtree roots were recorded.
+    pub handoff: block::Height,
 }
 
 /// An error describing why opening the finalized state database failed.

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -46,8 +46,9 @@ pub use config::{
 pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitCheckpointVerifiedError, CommitHeaderRangeError,
-    CommitSemanticallyVerifiedError, DuplicateNullifierError, MissingSproutTipTree, StateInitError,
-    StoreIncoherentError, ValidateContextError,
+    CommitSemanticallyVerifiedError, DuplicateNullifierError, HistoricalSubtreeUnavailable,
+    HistoricalTreeUnavailable, MissingSproutTipTree, StateInitError, StoreIncoherentError,
+    ValidateContextError,
 };
 pub use request::{
     AuthenticateHeaderRootsRequest, CheckpointVerifiedBlock,

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -43,7 +43,10 @@ pub use config::{
     database_format_version_on_disk, state_database_format_version_on_disk, Config, PruningConfig,
     StorageMode,
 };
-pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
+pub use constants::{
+    state_database_format_version_in_code, DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+    MAX_BLOCK_REORG_HEIGHT,
+};
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitCheckpointVerifiedError, CommitHeaderRangeError,
     CommitSemanticallyVerifiedError, DuplicateNullifierError, HistoricalSubtreeUnavailable,
@@ -79,6 +82,11 @@ pub use service::{
 pub use service::finalized_state::{ReadDisk, TypedColumnFamily, WriteTypedBatch};
 
 pub use service::finalized_state::{
+    derived_roots_in_display_order, inventory as vct_treestate_inventory, measure_derivations,
+    replay_inputs, verify_subtrees_against_stored, DerivationSample, ReplayInputs,
+    SubtreeVerification, VctTreestateInventory,
+};
+pub use service::finalized_state::{
     generate_mainnet_from_archive, produce_final_frontiers_bytes,
     produce_settled_final_frontiers_bytes, validate_final_frontiers_bytes,
     AuthenticateHeaderRootsError, AuthenticateHeaderRootsOutcome, AuthenticatedHeaderRoots,
@@ -95,6 +103,9 @@ pub use service::finalized_state::{
 };
 pub use service::finalized_state::{
     VctSproutHistoryValidationError, VctSproutHistoryValidationSummary,
+};
+pub use service::read::{
+    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
 };
 pub use service::{
     finalized_state::{

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -2062,17 +2062,33 @@ impl Service<ReadRequest> for ReadStateService {
                 Ok(ReadResponse::Blocks(blocks))
             }
 
-            ReadRequest::SaplingTree(hash_or_height) => Ok(ReadResponse::SaplingTree(
-                read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height),
-            )),
+            ReadRequest::SaplingTree(hash_or_height) => {
+                let tree = read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height);
+                if tree.is_none() {
+                    read::check_historical_tree_available(&state.db, hash_or_height)?;
+                }
 
-            ReadRequest::OrchardTree(hash_or_height) => Ok(ReadResponse::OrchardTree(
-                read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height),
-            )),
+                Ok(ReadResponse::SaplingTree(tree))
+            }
 
-            ReadRequest::IronwoodTree(hash_or_height) => Ok(ReadResponse::IronwoodTree(
-                read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height),
-            )),
+            ReadRequest::OrchardTree(hash_or_height) => {
+                let tree = read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height);
+                if tree.is_none() {
+                    read::check_historical_tree_available(&state.db, hash_or_height)?;
+                }
+
+                Ok(ReadResponse::OrchardTree(tree))
+            }
+
+            ReadRequest::IronwoodTree(hash_or_height) => {
+                let tree =
+                    read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height);
+                if tree.is_none() {
+                    read::check_historical_tree_available(&state.db, hash_or_height)?;
+                }
+
+                Ok(ReadResponse::IronwoodTree(tree))
+            }
 
             ReadRequest::SaplingSubtrees { start_index, limit } => {
                 let end_index = limit
@@ -2089,6 +2105,13 @@ impl Service<ReadRequest> for ReadStateService {
                     // the trees run out.)
                     read::sapling_subtrees(best_chain, &state.db, start_index..)
                 };
+
+                read::check_historical_sapling_subtrees_available(
+                    &state.db,
+                    start_index,
+                    end_index,
+                    &sapling_subtrees,
+                )?;
 
                 Ok(ReadResponse::SaplingSubtrees(sapling_subtrees))
             }
@@ -2109,6 +2132,13 @@ impl Service<ReadRequest> for ReadStateService {
                     read::orchard_subtrees(best_chain, &state.db, start_index..)
                 };
 
+                read::check_historical_orchard_subtrees_available(
+                    &state.db,
+                    start_index,
+                    end_index,
+                    &orchard_subtrees,
+                )?;
+
                 Ok(ReadResponse::OrchardSubtrees(orchard_subtrees))
             }
 
@@ -2123,6 +2153,13 @@ impl Service<ReadRequest> for ReadStateService {
                 } else {
                     read::ironwood_subtrees(best_chain, &state.db, start_index..)
                 };
+
+                read::check_historical_ironwood_subtrees_available(
+                    &state.db,
+                    start_index,
+                    end_index,
+                    &ironwood_subtrees,
+                )?;
 
                 Ok(ReadResponse::IronwoodSubtrees(ironwood_subtrees))
             }

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -83,6 +83,7 @@ pub(crate) mod commitment_aux_verify;
 mod disk_db;
 mod disk_format;
 mod vct;
+pub mod vct_treestate_audit;
 mod zakura_db;
 
 use vct::{VctCommitState, VctState, VctWriteData};
@@ -114,6 +115,11 @@ pub use disk_format::{
 pub use vct::{
     generate_mainnet_from_archive, validate_final_frontiers_bytes, FinalFrontiersValidationError,
     GeneratorError, NextVctBlock,
+};
+pub use vct_treestate_audit::{
+    derived_roots_in_display_order, inventory, measure_derivations, replay_inputs,
+    verify_subtrees_against_stored, DerivationSample, ReplayInputs, SubtreeVerification,
+    VctTreestateInventory,
 };
 #[allow(unused_imports)]
 pub use zakura_db::commitment_roots_db::{

--- a/crates/zakura-state/src/service/finalized_state/commitment_aux.rs
+++ b/crates/zakura-state/src/service/finalized_state/commitment_aux.rs
@@ -930,6 +930,31 @@ mod tests {
         }
     }
 
+    /// Replaying note commitments needs every block body in the replay range, so the audit has to
+    /// report the first height that would stop a replay rather than discovering it mid-derivation.
+    #[test]
+    fn first_missing_block_body_finds_the_first_unreplayable_height() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+        seed_block_bodies(&db, [1, 2]);
+
+        assert_eq!(
+            db.first_missing_block_body(block::Height(1), block::Height(2)),
+            None,
+            "a fully seeded range is replayable"
+        );
+        assert_eq!(
+            db.first_missing_block_body(block::Height(1), block::Height(4)),
+            Some(block::Height(3)),
+            "a range running past the seeded bodies reports where they stop"
+        );
+        assert_eq!(
+            db.first_missing_block_body(block::Height(0), block::Height(2)),
+            Some(block::Height(0)),
+            "a missing first height is reported, not skipped"
+        );
+    }
+
     #[test]
     fn produce_block_roots_derives_contiguous_tree_roots() {
         let _init_guard = zakura_test::init();

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -11,7 +11,7 @@
 //! each time the database format (column, serialization, etc) changes.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::{Debug, Write},
     fs,
     ops::RangeBounds,
@@ -593,7 +593,7 @@ impl DiskDb {
         let mut total_size_in_mem = 0;
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
-        let column_families = DiskDb::construct_column_families(db_options, db.path(), []);
+        let column_families = DiskDb::construct_column_families(db_options, db.path(), [], false);
         let mut column_families_log_string = String::from("");
 
         write!(column_families_log_string, "Column families and sizes: ").unwrap();
@@ -649,7 +649,7 @@ impl DiskDb {
     pub(crate) fn export_metrics(&self) {
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
-        let column_families = DiskDb::construct_column_families(db_options, db.path(), []);
+        let column_families = DiskDb::construct_column_families(db_options, db.path(), [], false);
 
         let mut total_disk: u64 = 0;
         let mut total_live: u64 = 0;
@@ -717,7 +717,7 @@ impl DiskDb {
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
         let mut total_size_on_disk = 0;
-        for cf_descriptor in DiskDb::construct_column_families(db_options, db.path(), []) {
+        for cf_descriptor in DiskDb::construct_column_families(db_options, db.path(), [], false) {
             let cf_name = &cf_descriptor.name();
             let cf_handle = db
                 .cf_handle(cf_name)
@@ -989,6 +989,7 @@ impl DiskDb {
         db_options: Options,
         path: &Path,
         column_families_in_code: impl IntoIterator<Item = String>,
+        read_only: bool,
     ) -> impl Iterator<Item = ColumnFamilyDescriptor> {
         // When opening the database in read/write mode, all column families must be opened.
         //
@@ -1000,9 +1001,21 @@ impl DiskDb {
         let column_families_on_disk = DB::list_cf(&db_options, path).unwrap_or_default();
         let column_families_in_code = column_families_in_code.into_iter();
 
+        // A read-only secondary cannot create column families, so naming one the database does
+        // not have fails the open outright. Restricting to what is actually on disk is what lets
+        // read-only tooling inspect a database written by an older version, which is exactly when
+        // some newer column family is missing. Nothing is lost: a column family that does not
+        // exist holds no data to read, and the accessors for one already handle its absence.
+        let missing_is_fatal = !read_only;
+        let on_disk: HashSet<String> = column_families_on_disk.iter().cloned().collect();
+
         column_families_on_disk
+            .clone()
             .into_iter()
-            .chain(column_families_in_code)
+            .chain(
+                column_families_in_code
+                    .filter(move |cf_name| missing_is_fatal || on_disk.contains(cf_name)),
+            )
             .unique()
             .map(move |cf_name: String| {
                 let mut cf_options = db_options.clone();
@@ -1068,8 +1081,12 @@ impl DiskDb {
 
         let db_options = DiskDb::options();
 
-        let column_families =
-            DiskDb::construct_column_families(db_options.clone(), &path, column_families_in_code);
+        let column_families = DiskDb::construct_column_families(
+            db_options.clone(),
+            &path,
+            column_families_in_code,
+            read_only,
+        );
 
         let db_result = if read_only {
             // Use a tempfile for the secondary instance cache directory

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1,6 +1,12 @@
 //! Randomised property tests for the finalized state.
 
-use std::{collections::HashMap, env, error::Error, fs, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    env,
+    error::Error,
+    fs,
+    sync::Arc,
+};
 
 use tempfile::TempDir;
 use tokio::sync::oneshot;
@@ -25,7 +31,12 @@ use zakura_test::prelude::*;
 
 use crate::{
     config::Config,
-    service::{arbitrary::PreparedChain, check::anchors::tx_anchors_refer_to_final_treestates},
+    error::HistoricalTreeUnavailable,
+    service::{
+        arbitrary::PreparedChain,
+        check::anchors::tx_anchors_refer_to_final_treestates,
+        read::{check_historical_sapling_subtrees_available, check_historical_tree_available},
+    },
     tests::FakeChainHelper,
     HashOrHeight,
 };
@@ -1652,6 +1663,38 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             // handoff height itself is available.
             prop_assert!(fast.db.vct_historical_tree_unavailable(HashOrHeight::Height(Height(last as u32 - 1))), "RPC gate: below-handoff treestate is unavailable");
             prop_assert!(!fast.db.vct_historical_tree_unavailable(HashOrHeight::Height(handoff)), "RPC gate: handoff treestate is available");
+
+            // The read handlers turn that predicate into the typed archive-mode error the
+            // RPC boundary reports, carrying the handoff so the failure is diagnosable.
+            // Without it, a below-handoff `z_gettreestate` returns a JSON `null`, which
+            // lightwalletd-style clients read as the *empty* tree.
+            let below_handoff_height = HashOrHeight::Height(Height(last as u32 - 1));
+            prop_assert_eq!(
+                check_historical_tree_available(&fast.db, below_handoff_height),
+                Err(HistoricalTreeUnavailable { hash_or_height: below_handoff_height, handoff }),
+                "a below-handoff tree read is a typed archive-mode error, not an absent tree"
+            );
+            prop_assert_eq!(
+                check_historical_tree_available(&fast.db, HashOrHeight::Height(handoff)),
+                Ok(()),
+                "the handoff height itself is served normally"
+            );
+            // A legacy node never reports the archive-mode error, whatever the height.
+            prop_assert_eq!(
+                check_historical_tree_available(&legacy.db, below_handoff_height),
+                Ok(()),
+                "a legacy-synced node has the tree and must not report an absent band"
+            );
+
+            // The subtree gate must not fire just because a node is fast-synced. This chain is
+            // far too short to complete a subtree, so `z_getsubtreesbyindex` at index 0 is an
+            // ordinary "nothing here yet" empty list, exactly as on a legacy node.
+            prop_assert_eq!(
+                check_historical_sapling_subtrees_available(&fast.db, 0.into(), None, &BTreeMap::new()),
+                Ok(()),
+                "an index past the last completed subtree stays an empty list, not an error"
+            );
+
 
             // Negative: a peer can supply a wrong root exactly at the handoff height,
             // where there is no buffered checkpoint successor to authenticate it. The

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -5,7 +5,7 @@ use std::{
     env,
     error::Error,
     fs,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use tempfile::TempDir;
@@ -35,7 +35,11 @@ use crate::{
     service::{
         arbitrary::PreparedChain,
         check::anchors::tx_anchors_refer_to_final_treestates,
-        read::{check_historical_sapling_subtrees_available, check_historical_tree_available},
+        read::{
+            check_historical_sapling_subtrees_available, check_historical_tree_available,
+            derive_historical_frontiers, historical_tree::HistoricalTreeDerivationError,
+            HistoricalTreeCache,
+        },
     },
     tests::FakeChainHelper,
     HashOrHeight,
@@ -1693,6 +1697,55 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
                 check_historical_sapling_subtrees_available(&fast.db, 0.into(), None, &BTreeMap::new()),
                 Ok(()),
                 "an index past the last completed subtree stays an empty list, not an error"
+            );
+
+            // On-demand derivation rebuilds the absent band from retained block bodies. `U` is 0
+            // here, so every derivation replays from empty genesis frontiers — the cold path.
+            // Each result is accepted only after reproducing the authenticated root, so agreeing
+            // with the legacy node's own per-height trees is what proves the replay is faithful
+            // rather than merely self-consistent.
+            let cache = Mutex::new(HistoricalTreeCache::default());
+            for height in (seed as u32 + 1)..(last as u32) {
+                let height = Height(height);
+                let derived = derive_historical_frontiers(&fast.db, &cache, height, u64::MAX)
+                    .expect("every absent-band height derives from retained bodies");
+
+                prop_assert_eq!(
+                    derived.sapling.root(),
+                    legacy.db.sapling_tree_by_height(&height).expect("the legacy node stores every tree").root(),
+                    "derived Sapling frontier matches the legacy node at {:?}", height
+                );
+                prop_assert_eq!(
+                    derived.orchard.root(),
+                    legacy.db.orchard_tree_by_height(&height).expect("the legacy node stores every tree").root(),
+                    "derived Orchard frontier matches the legacy node at {:?}", height
+                );
+                prop_assert_eq!(
+                    derived.ironwood.root(),
+                    legacy.db.ironwood_tree_by_height(&height).expect("the legacy node stores every tree").root(),
+                    "derived Ironwood frontier matches the legacy node at {:?}", height
+                );
+            }
+
+            // The replay bound is a serving limit: with the memo primed by the loop above, the
+            // last height is already derived, so it costs nothing. A cold height below every memo
+            // entry still has to replay, and refuses rather than running unbounded.
+            prop_assert!(
+                derive_historical_frontiers(&fast.db, &cache, Height(last as u32 - 1), 0).is_ok(),
+                "a memoized height is served without replaying, whatever the bound"
+            );
+            let cold_cache = Mutex::new(HistoricalTreeCache::default());
+            let cold_height = Height(last as u32 - 1);
+            prop_assert_eq!(
+                derive_historical_frontiers(&fast.db, &cold_cache, cold_height, 1).err(),
+                Some(HistoricalTreeDerivationError::ReplayTooLong {
+                    height: cold_height,
+                    // From empty genesis frontiers, reaching `cold_height` replays every block up
+                    // to and including it.
+                    blocks: u64::from(cold_height.0) + 1,
+                    limit: 1,
+                }),
+                "a cold derivation past the replay bound refuses instead of running unbounded"
             );
 
 

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -1,0 +1,344 @@
+//! Read-only audit of a database's historical-treestate serving inputs.
+//!
+//! A verified-commitment-trees fast-synced node cannot read per-height note commitment trees across
+//! its absent band `[U, H)`, and instead rebuilds them by replaying block bodies forward and
+//! checking the result against the authenticated roots in `commitment_roots_by_height` (see
+//! [`crate::service::read::historical_tree`]). That rests on two inputs actually being present:
+//! a gap-free root index across the band, and retained block bodies. This module reports whether
+//! they are, and measures what the replay costs.
+//!
+//! Everything here is read-only, runs off the consensus path, and is safe against a quiesced
+//! database snapshot.
+
+use std::time::{Duration, Instant};
+
+use zakura_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
+
+use crate::service::{
+    finalized_state::ZakuraDb,
+    read::{
+        historical_tree::{
+            derive_historical_frontiers_measured, replay_with_subtrees,
+            HistoricalTreeDerivationError, ShieldedPool,
+        },
+        DerivedFrontiers, HistoricalTreeCache,
+    },
+};
+
+/// What a database offers for serving historical treestates.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VctTreestateInventory {
+    /// The finalized tip height.
+    pub finalized_tip: Option<Height>,
+
+    /// The verified-commitment-trees upgrade height `U`: the lowest height this binary committed.
+    ///
+    /// `None` on a database written before this marker existed.
+    pub upgrade_height: Option<Height>,
+
+    /// The checkpoint handoff height `H`, the exclusive upper bound of the absent band.
+    ///
+    /// `None` on a normally-synced database, which has per-height trees everywhere and needs
+    /// nothing from this design.
+    pub handoff_height: Option<Height>,
+
+    /// The lowest height whose raw transactions are retained, if this database is pruned.
+    ///
+    /// Replay reads block bodies, so a pruned database cannot derive below this height.
+    pub lowest_retained_height: Option<Height>,
+
+    /// Whether the full-band scans ran.
+    ///
+    /// When they did not, [`Self::root_index_gap`] and [`Self::missing_block_body`] are `None`
+    /// because nothing looked, not because nothing is missing.
+    pub scanned: bool,
+
+    /// The first height in the absent band with no `commitment_roots_by_height` row.
+    ///
+    /// `None` means the index is gap-free across the band, which is what derivation needs: every
+    /// derived frontier is checked against the row at its own height. Only meaningful when
+    /// [`Self::scanned`].
+    pub root_index_gap: Option<Height>,
+
+    /// The first height in the absent band whose block body is not retained.
+    ///
+    /// `None` means the whole band is replayable. Only meaningful when [`Self::scanned`].
+    pub missing_block_body: Option<Height>,
+
+    /// How long the two scans took.
+    pub scan_duration: Duration,
+}
+
+impl VctTreestateInventory {
+    /// Returns the absent band `[U, H)`, or `None` if this database has no band.
+    pub fn absent_band(&self) -> Option<(Height, Height)> {
+        let handoff = self.handoff_height?;
+        let upgrade = self.upgrade_height.unwrap_or(Height(0));
+
+        (upgrade < handoff).then_some((upgrade, handoff))
+    }
+
+    /// Returns whether this database has everything derivation needs across its absent band, or
+    /// `None` if the scans that would answer that were skipped.
+    pub fn can_derive(&self) -> Option<bool> {
+        self.scanned.then(|| {
+            self.absent_band().is_some()
+                && self.root_index_gap.is_none()
+                && self.missing_block_body.is_none()
+        })
+    }
+}
+
+/// Inspects `db` for the inputs historical-treestate derivation depends on.
+///
+/// With `scan_band`, visits every height in the absent band to check the root index and block-body
+/// retention, which is proportional to the band's height range rather than constant time. Without
+/// it, only the cheap markers are read.
+pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
+    let start = Instant::now();
+
+    let upgrade_height = db.vct_upgrade_height();
+    let handoff_height = db.vct_synced_below();
+
+    let mut inventory = VctTreestateInventory {
+        finalized_tip: db.finalized_tip_height(),
+        upgrade_height,
+        handoff_height,
+        lowest_retained_height: db.lowest_retained_height(),
+        scanned: scan_band,
+        root_index_gap: None,
+        missing_block_body: None,
+        scan_duration: Duration::ZERO,
+    };
+
+    if let (true, Some((band_start, band_end))) = (scan_band, inventory.absent_band()) {
+        // The band is half-open, so the last height it covers is `H - 1`.
+        let last = Height(band_end.0 - 1);
+        inventory.root_index_gap = db.first_commitment_root_gap(band_start..=last);
+        inventory.missing_block_body = db.first_missing_block_body(band_start, last);
+    }
+
+    inventory.scan_duration = start.elapsed();
+    inventory
+}
+
+/// The cost of deriving one historical frontier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DerivationSample {
+    /// The height derived.
+    pub height: Height,
+
+    /// How many blocks the derivation replayed.
+    ///
+    /// Zero means the height was already memoized, so nothing was replayed.
+    pub replayed_blocks: u64,
+
+    /// How long the derivation took, including the root check.
+    pub elapsed: Duration,
+}
+
+impl DerivationSample {
+    /// Returns the average time per replayed block, or `None` if nothing was replayed.
+    pub fn per_block(&self) -> Option<Duration> {
+        (self.replayed_blocks > 0)
+            .then(|| self.elapsed / u32::try_from(self.replayed_blocks).unwrap_or(u32::MAX))
+    }
+}
+
+/// Derives the frontiers at each of `heights`, in order, timing each derivation.
+///
+/// Every derivation is root-checked against `commitment_roots_by_height`, so a returned `Ok` for a
+/// height *is* a root match at that height, and the first mismatch stops the walk. That makes this
+/// both the invariant check and the cost measurement.
+///
+/// `cache` carries memoized frontiers between heights. Pass a fresh cache to measure cold cost from
+/// the bottom of the band; reuse one across ascending heights to measure the sequential cost a
+/// wallet actually pays.
+pub fn measure_derivations(
+    db: &ZakuraDb,
+    cache: &std::sync::Mutex<HistoricalTreeCache>,
+    heights: impl IntoIterator<Item = Height>,
+    max_replay_blocks: u64,
+    mut on_sample: impl FnMut(&DerivationSample),
+) -> Result<Vec<DerivationSample>, (Height, HistoricalTreeDerivationError)> {
+    let mut samples = Vec::new();
+
+    for height in heights {
+        let start = Instant::now();
+        // The derivation reports its own replay length: it may have anchored on the memo, on a
+        // published grid entry, or on genesis, and only it knows which.
+        let derivation = derive_historical_frontiers_measured(db, cache, height, max_replay_blocks)
+            .map_err(|error| (height, error))?;
+        let elapsed = start.elapsed();
+        let replayed_blocks = derivation.replayed_blocks;
+
+        let sample = DerivationSample {
+            height,
+            replayed_blocks,
+            elapsed,
+        };
+        on_sample(&sample);
+        samples.push(sample);
+    }
+
+    Ok(samples)
+}
+
+/// The outcome of checking replay-derived subtree roots against the ones the database stored.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SubtreeVerification {
+    /// Subtrees that completed during the replay and matched the stored root.
+    pub matched: usize,
+
+    /// Subtrees that completed during the replay but whose stored root differs.
+    ///
+    /// Any entry here falsifies the claim that replay reproduces subtree roots, which is what the
+    /// generated subtree artifact rests on.
+    pub mismatched: Vec<(NoteCommitmentSubtreeIndex, &'static str)>,
+
+    /// Subtrees that completed during the replay with no stored row to compare against.
+    pub unstored: usize,
+}
+
+/// Replays `(from, to]` and checks every subtree that completes against the stored subtree rows.
+///
+/// This exists because subtree roots produced by replay are otherwise unvalidated: they are
+/// interior nodes, so the per-height root check does not test them directly. Above a fast-synced
+/// node's handoff the database *does* store subtree rows, which makes that band the one place the
+/// two can be compared. `from` must be a height whose per-height trees are present, so the replay
+/// starts from a known-good frontier rather than reconstructing one.
+pub fn verify_subtrees_against_stored(
+    db: &ZakuraDb,
+    from: Height,
+    to: Height,
+) -> Result<SubtreeVerification, HistoricalTreeDerivationError> {
+    let (Some(sapling), Some(orchard), Some(ironwood)) = (
+        db.sapling_tree_by_height(&from),
+        db.orchard_tree_by_height(&from),
+        db.ironwood_tree_by_height(&from),
+    ) else {
+        return Err(HistoricalTreeDerivationError::MissingAnchor {
+            height: to,
+            anchor: from,
+        });
+    };
+
+    let anchor = DerivedFrontiers {
+        sapling,
+        orchard,
+        ironwood,
+    };
+
+    let mut completions = Vec::new();
+    replay_with_subtrees(db, to, from.0 + 1, anchor, |pool, completed| {
+        completions.push((pool, completed))
+    })?;
+
+    let mut outcome = SubtreeVerification::default();
+
+    for (pool, completed) in completions {
+        let stored = match pool {
+            ShieldedPool::Sapling => db
+                .sapling_subtree_list_by_index_range(completed.index..=completed.index)
+                .get(&completed.index)
+                .map(|data| data.root.to_bytes()),
+            ShieldedPool::Orchard => db
+                .orchard_subtree_list_by_index_range(completed.index..=completed.index)
+                .get(&completed.index)
+                .map(|data| data.root.to_repr()),
+            ShieldedPool::Ironwood => db
+                .ironwood_subtree_list_by_index_range(completed.index..=completed.index)
+                .get(&completed.index)
+                .map(|data| data.root.to_repr()),
+        };
+
+        let pool_name = match pool {
+            ShieldedPool::Sapling => "sapling",
+            ShieldedPool::Orchard => "orchard",
+            ShieldedPool::Ironwood => "ironwood",
+        };
+
+        match stored {
+            Some(root) if root == completed.root => outcome.matched += 1,
+            Some(_) => outcome.mismatched.push((completed.index, pool_name)),
+            None => outcome.unstored += 1,
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Returns the per-pool note commitment roots derived at each of `heights`, hex-encoded in the
+/// display order `z_gettreestate` uses.
+///
+/// Exists so a derived treestate can be compared against another node's `z_gettreestate` output.
+/// That is the strongest check available for this design: the other node built its trees the
+/// legacy way, block by block, so agreement is independent evidence that replay reconstructs the
+/// same history rather than merely being self-consistent.
+pub fn derived_roots_in_display_order(
+    db: &ZakuraDb,
+    cache: &std::sync::Mutex<HistoricalTreeCache>,
+    heights: impl IntoIterator<Item = Height>,
+    max_replay_blocks: u64,
+) -> Result<Vec<(Height, String, String, String)>, (Height, HistoricalTreeDerivationError)> {
+    let mut roots = Vec::new();
+
+    for height in heights {
+        let derivation = derive_historical_frontiers_measured(db, cache, height, max_replay_blocks)
+            .map_err(|error| (height, error))?;
+
+        roots.push((
+            height,
+            hex::encode(derivation.frontiers.sapling.root().bytes_in_display_order()),
+            hex::encode(derivation.frontiers.orchard.root().bytes_in_display_order()),
+            hex::encode(
+                derivation
+                    .frontiers
+                    .ironwood
+                    .root()
+                    .bytes_in_display_order(),
+            ),
+        ));
+    }
+
+    Ok(roots)
+}
+
+/// What a height range contains, for fitting the grid's replay cost model.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ReplayInputs {
+    /// Blocks in the range.
+    pub blocks: u64,
+
+    /// Total serialized size of those blocks, in bytes.
+    ///
+    /// The cost model prices a block at a flat constant plus its note commitments, which misses
+    /// the cost of reading and deserialising a large body that carries few or no commitments.
+    /// Reporting bytes separately is what lets that be tested rather than assumed.
+    pub bytes: u64,
+
+    /// Total Sapling, Orchard and Ironwood note commitments in the range.
+    pub commitments: u64,
+}
+
+/// Returns what the blocks in `[from, to]` contain, for cost-model fitting.
+pub fn replay_inputs(db: &ZakuraDb, from: Height, to: Height) -> ReplayInputs {
+    let mut inputs = ReplayInputs::default();
+
+    for height in from.0..=to.0 {
+        let height = Height(height);
+        inputs.blocks += 1;
+        inputs.bytes += db
+            .block_info(height.into())
+            .map_or(0, |info| u64::from(info.size()));
+
+        if let Some(block) = db.block(height.into()) {
+            inputs.commitments += (block.sapling_note_commitments().count()
+                + block.orchard_note_commitments().count()
+                + block.ironwood_note_commitments().count())
+                as u64;
+        }
+    }
+
+    inputs
+}

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -265,6 +265,17 @@ impl ZakuraDb {
         self.db.zs_get(&hash_by_height, &height)
     }
 
+    /// Returns the first height in `[start, end]` whose block body is not retained, if any.
+    ///
+    /// A body is absent because it was pruned, or because the height was never committed. Replaying
+    /// note commitments needs every body in the replay range, so this reports whether a range is
+    /// replayable at all.
+    pub fn first_missing_block_body(&self, start: Height, end: Height) -> Option<Height> {
+        (start.0..=end.0)
+            .map(Height)
+            .find(|height| !self.contains_body_at_height(*height))
+    }
+
     /// Returns the height of the given block if it exists.
     #[allow(clippy::unwrap_in_result)]
     pub fn height(&self, hash: block::Hash) -> Option<block::Height> {

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -1045,6 +1045,36 @@ impl ZakuraDb {
         self.write_batch(batch)
     }
 
+    /// Returns the first height in `range` that has no stored roots row, if any.
+    ///
+    /// Streams the index keys instead of materialising rows, so this stays usable across a whole
+    /// fast-synced absent band, where [`Self::commitment_roots_by_height_range`] would build a
+    /// multi-hundred-megabyte vector.
+    pub fn first_commitment_root_gap(&self, range: impl RangeBounds<Height>) -> Option<Height> {
+        let (start, end) = inclusive_bounds(range)?;
+
+        let mut expected = start;
+        for (height, _row) in self
+            .commitment_roots_cf()
+            .zs_forward_range_iter(start..=end)
+        {
+            if height != expected {
+                return Some(expected);
+            }
+
+            // The last height in the range has no successor to expect, and `next()` would
+            // overflow at `Height::MAX`.
+            if height == end {
+                return None;
+            }
+
+            expected = height.next().ok()?;
+        }
+
+        // The iterator ran out before reaching `end`, so the gap starts wherever it stopped.
+        Some(expected)
+    }
+
     /// Returns at most `limit` root heights for startup repair.
     pub(crate) fn commitment_root_heights_for_repair(
         &self,
@@ -2711,5 +2741,66 @@ mod tests {
                 height: Height(1),
             });
         assert_eq!(error.outcome(), AuthenticateHeaderRootsOutcome::Local);
+    }
+
+    /// A gap scan across the absent band is what tells a fast-synced node whether it can derive
+    /// historical treestates at all: every derived frontier is checked against the row at its own
+    /// height, so a single missing row makes that height unservable.
+    #[test]
+    fn first_commitment_root_gap_finds_the_first_missing_height() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+
+        let roots = |height: u32| BlockCommitmentRoots {
+            height: Height(height),
+            sapling_root: Default::default(),
+            orchard_root: Default::default(),
+            ironwood_root: Default::default(),
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0; 32]),
+            sapling_tx: 0,
+            orchard_tx: 0,
+            ironwood_tx: 0,
+        };
+
+        db.insert_zakura_header_commitment_roots((1..=5).map(roots))
+            .expect("seeding roots succeeds");
+
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(5)),
+            None,
+            "a fully stored range has no gap"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(7)),
+            Some(Height(6)),
+            "a range running past the stored rows reports where they stop"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(0)..=Height(5)),
+            Some(Height(0)),
+            "a missing first height is reported, not skipped"
+        );
+
+        // Punch a hole in the middle: this is the case that would silently serve a wrong
+        // treestate if the scan only checked the range's endpoints.
+        let mut batch = DiskWriteBatch::new();
+        batch.delete_range_commitment_roots_by_height(&db, &Height(3), &Height(4));
+        db.write_batch(batch).expect("deleting a row succeeds");
+
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(5)),
+            Some(Height(3)),
+            "an interior hole is found"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(4)..=Height(5)),
+            None,
+            "a range above the hole is still gap-free"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(5)..=Height(4)),
+            None,
+            "an empty range has no gap"
+        );
     }
 }

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -18,6 +18,7 @@ pub mod address;
 pub mod block;
 pub mod difficulty;
 pub mod find;
+pub mod historical_tree;
 pub mod tree;
 
 #[cfg(test)]
@@ -41,6 +42,9 @@ pub use find::{
     best_tip, block_locator, depth, finalized_state_contains_block_hash, find_chain_hashes,
     find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
+};
+pub use historical_tree::{
+    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
 };
 pub use tree::{
     check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -43,6 +43,8 @@ pub use find::{
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use tree::{
+    check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,
+    check_historical_sapling_subtrees_available, check_historical_tree_available,
     ironwood_subtrees, ironwood_tree, orchard_subtrees, orchard_tree, sapling_subtrees,
     sapling_tree,
 };

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -1,0 +1,475 @@
+//! Deriving historical note commitment frontiers by replaying retained block bodies.
+//!
+//! A verified-commitment-trees fast-synced node never writes per-height note commitment trees
+//! across the absent band `[U, H)`, so `z_gettreestate` and the `trees` sizes in
+//! `getblock`/`getblockheader` have nothing to read there. This module rebuilds a frontier for
+//! any height in that band on demand: it starts from the nearest frontier it already has, appends
+//! the note commitments of every block in between, and accepts the result only if its root
+//! matches the authenticated root already in `commitment_roots_by_height`.
+//!
+//! # Correctness
+//!
+//! A note commitment root is a binding commitment to its frontier, so the root check is what
+//! makes derivation trustworthy: a frontier that reproduces the authenticated root is the
+//! frontier. Nothing here is accepted without that check, which is also why derived frontiers are
+//! safe to reuse as anchors for later derivations.
+//!
+//! Replay needs retained block bodies, so this cannot work on a pruned node.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use thiserror::Error;
+
+use zakura_chain::{
+    block::Height, ironwood, orchard, parallel::commitment_aux::BlockCommitmentRoots, sapling,
+};
+
+use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
+
+use crate::service::finalized_state::ZakuraDb;
+
+/// The most derived frontiers to keep memoized per node.
+///
+/// Wallet access is sequential, so a single entry already collapses a scan's steady-state cost to
+/// one batch of replay. The rest of the budget covers concurrent clients scanning different parts
+/// of the band. Each entry is a few kilobytes, so this is a negligible amount of memory.
+pub const MAX_MEMOIZED_FRONTIERS: usize = 64;
+
+/// Which shielded pool a replay event belongs to.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShieldedPool {
+    /// The Sapling pool.
+    Sapling,
+    /// The Orchard pool.
+    Orchard,
+    /// The Ironwood pool.
+    Ironwood,
+}
+
+/// A subtree that finished filling during a replay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CompletedSubtree {
+    /// The subtree index.
+    pub index: NoteCommitmentSubtreeIndex,
+
+    /// The height whose block added the subtree's last leaf.
+    pub end_height: Height,
+
+    /// The subtree root.
+    pub root: [u8; 32],
+}
+
+/// Per-pool note commitment frontiers as of the end of one block.
+#[derive(Clone, Debug)]
+pub struct DerivedFrontiers {
+    /// The Sapling frontier.
+    pub sapling: Arc<sapling::tree::NoteCommitmentTree>,
+
+    /// The Orchard frontier.
+    pub orchard: Arc<orchard::tree::NoteCommitmentTree>,
+
+    /// The Ironwood frontier.
+    pub ironwood: Arc<ironwood::tree::NoteCommitmentTree>,
+}
+
+impl DerivedFrontiers {
+    /// Returns empty frontiers, the state before any block has been applied.
+    pub fn empty() -> Self {
+        Self {
+            sapling: Arc::<sapling::tree::NoteCommitmentTree>::default(),
+            orchard: Arc::<orchard::tree::NoteCommitmentTree>::default(),
+            ironwood: Arc::<ironwood::tree::NoteCommitmentTree>::default(),
+        }
+    }
+
+    /// Returns `true` if every pool's root matches `roots`.
+    fn matches(&self, roots: &BlockCommitmentRoots) -> bool {
+        self.sapling.root() == roots.sapling_root
+            && self.orchard.root() == roots.orchard_root
+            && self.ironwood.root() == roots.ironwood_root
+    }
+}
+
+/// Why a historical frontier could not be derived.
+///
+/// Every variant is a serving failure, never a consensus one: derivation runs entirely on the read
+/// path, and a node that cannot derive simply cannot answer the request.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum HistoricalTreeDerivationError {
+    /// The replay would have to cover more blocks than the configured limit.
+    #[error(
+        "deriving the note commitment tree at {height:?} needs {blocks} blocks of replay, more \
+         than the {limit} block limit"
+    )]
+    ReplayTooLong {
+        /// The requested height.
+        height: Height,
+        /// How many blocks the replay would cover.
+        blocks: u64,
+        /// The configured limit.
+        limit: u64,
+    },
+
+    /// A block body in the replay range is unavailable, so its commitments cannot be read.
+    ///
+    /// On a pruned node this is expected for every height below the retention window.
+    #[error("cannot derive the note commitment tree at {height:?}: block body {missing:?} is not retained")]
+    MissingBlockBody {
+        /// The requested height.
+        height: Height,
+        /// The height whose body is missing.
+        missing: Height,
+    },
+
+    /// The frontier the replay starts from is missing, so there is nothing to anchor on.
+    #[error(
+        "cannot derive the note commitment tree at {height:?}: no anchor frontier at {anchor:?}"
+    )]
+    MissingAnchor {
+        /// The requested height.
+        height: Height,
+        /// The height the anchor was expected at.
+        anchor: Height,
+    },
+
+    /// There is no authenticated root to check the derived frontier against.
+    ///
+    /// Without it the result would be unverified, which this module never serves.
+    #[error("cannot derive the note commitment tree at {height:?}: no authenticated root is stored for that height")]
+    MissingAuthenticatedRoot {
+        /// The requested height.
+        height: Height,
+    },
+
+    /// The derived frontier does not reproduce the authenticated root.
+    ///
+    /// The replay inputs disagree with the roots the node authenticated against its own header
+    /// chain, so the frontier is wrong and must not be served.
+    #[error(
+        "the note commitment tree derived at {height:?} does not match the authenticated root"
+    )]
+    RootMismatch {
+        /// The requested height.
+        height: Height,
+    },
+
+    /// Appending a block's note commitments failed.
+    #[error("cannot derive the note commitment tree at {height:?}: appending block {block:?} failed: {error}")]
+    Append {
+        /// The requested height.
+        height: Height,
+        /// The block being applied.
+        block: Height,
+        /// The underlying tree error, rendered because it is not `PartialEq`.
+        error: String,
+    },
+}
+
+/// A bounded memo of frontiers this node has already derived and root-checked.
+///
+/// Entries double as anchors: a derivation for height `h` starts from the highest memoized height
+/// at or below `h`, so a wallet scanning forward replays only from the end of its previous batch.
+#[derive(Debug, Default)]
+pub struct HistoricalTreeCache {
+    /// Verified frontiers, keyed by the height they are the state at the end of.
+    frontiers: BTreeMap<Height, Arc<DerivedFrontiers>>,
+}
+
+impl HistoricalTreeCache {
+    /// Returns the highest memoized frontier at or below `height`, if any.
+    fn anchor_at_or_below(&self, height: Height) -> Option<(Height, Arc<DerivedFrontiers>)> {
+        self.frontiers
+            .range(..=height)
+            .next_back()
+            .map(|(anchor, frontiers)| (*anchor, frontiers.clone()))
+    }
+
+    /// Memoizes `frontiers` as the verified state at the end of `height`.
+    ///
+    /// Evicts the lowest height when full. Clients sweep forward, so the lowest entry is the one
+    /// least likely to anchor the next request.
+    fn insert(&mut self, height: Height, frontiers: Arc<DerivedFrontiers>) {
+        self.frontiers.insert(height, frontiers);
+
+        while self.frontiers.len() > MAX_MEMOIZED_FRONTIERS {
+            self.frontiers.pop_first();
+        }
+    }
+}
+
+/// Locks the memo, recovering from poisoning.
+///
+/// The cache holds only root-checked frontiers keyed by height, so a panic elsewhere cannot leave
+/// it in a state that would make a later derivation wrong. Refusing to serve because an unrelated
+/// request panicked would be strictly worse than reusing the map.
+fn lock(cache: &Mutex<HistoricalTreeCache>) -> std::sync::MutexGuard<'_, HistoricalTreeCache> {
+    cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Derives the note commitment frontiers as of the end of block `height`, verified against the
+/// authenticated root stored for that height.
+///
+/// Replays block bodies forward from the nearest anchor: the highest memoized frontier at or below
+/// `height`, else the last frontier stored below the absent band, else empty frontiers at genesis.
+/// The result is memoized in `cache` only after it reproduces the authenticated root, so a
+/// derivation can never be anchored on an unverified frontier.
+///
+/// `max_replay_blocks` bounds the work one request can cost. It is a serving limit, not a
+/// correctness one.
+pub fn derive_historical_frontiers(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+    max_replay_blocks: u64,
+) -> Result<Arc<DerivedFrontiers>, HistoricalTreeDerivationError> {
+    derive_historical_frontiers_measured(db, cache, height, max_replay_blocks)
+        .map(|derivation| derivation.frontiers)
+}
+
+/// A completed derivation, and what it cost.
+#[derive(Clone, Debug)]
+pub struct Derivation {
+    /// The frontiers as of the end of the requested height.
+    pub frontiers: Arc<DerivedFrontiers>,
+
+    /// How many blocks were replayed to produce them.
+    ///
+    /// Zero when the height was already memoized. Callers measuring cost must read this rather
+    /// than infer it from the height, because the anchor may have come from the memo or from a
+    /// published grid rather than from genesis.
+    pub replayed_blocks: u64,
+}
+
+/// Derives the frontiers at `height`, reporting how many blocks the replay covered.
+///
+/// See [`derive_historical_frontiers`].
+pub fn derive_historical_frontiers_measured(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+    max_replay_blocks: u64,
+) -> Result<Derivation, HistoricalTreeDerivationError> {
+    let anchor = anchor_for(db, cache, height)?;
+
+    if let Some((anchor_height, frontiers)) = &anchor {
+        if *anchor_height == height {
+            return Ok(Derivation {
+                frontiers: frontiers.clone(),
+                replayed_blocks: 0,
+            });
+        }
+    }
+
+    // The anchor is the state at the *end* of its height, so replay starts at the next block.
+    // With no anchor the replay starts at genesis.
+    let replay_from = anchor.as_ref().map_or(0, |(anchor, _)| anchor.0 + 1);
+    let blocks = u64::from(height.0 - replay_from) + 1;
+    if blocks > max_replay_blocks {
+        return Err(HistoricalTreeDerivationError::ReplayTooLong {
+            height,
+            blocks,
+            limit: max_replay_blocks,
+        });
+    }
+
+    let frontiers = anchor.map_or_else(DerivedFrontiers::empty, |(_, frontiers)| {
+        (*frontiers).clone()
+    });
+    let frontiers = replay(db, height, replay_from, frontiers)?;
+
+    verify_against_index(db, height, &frontiers)?;
+
+    let frontiers = Arc::new(frontiers);
+    lock(cache).insert(height, frontiers.clone());
+
+    Ok(Derivation {
+        frontiers,
+        replayed_blocks: blocks,
+    })
+}
+
+/// Returns the frontiers to replay forward from, and the height they are the state at the end of.
+///
+/// `None` means start from empty frontiers at genesis, which is correct when this binary committed
+/// every block from genesis (`U == 0`) and so stored no per-height trees to anchor on.
+fn anchor_for(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+) -> Result<Option<(Height, Arc<DerivedFrontiers>)>, HistoricalTreeDerivationError> {
+    let memoized = lock(cache).anchor_at_or_below(height);
+
+    if memoized.is_some() {
+        return Ok(memoized);
+    }
+
+    // Below the upgrade height `U` this binary did not run, so per-height trees are present. The
+    // tree at `U - 1` is therefore the last stored frontier before the absent band starts.
+    let Some(upgrade) = db.vct_upgrade_height().filter(|upgrade| upgrade.0 > 0) else {
+        return Ok(None);
+    };
+
+    let anchor = Height(upgrade.0 - 1);
+    let (Some(sapling), Some(orchard), Some(ironwood)) = (
+        db.sapling_tree_by_height(&anchor),
+        db.orchard_tree_by_height(&anchor),
+        db.ironwood_tree_by_height(&anchor),
+    ) else {
+        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+    };
+
+    Ok(Some((
+        anchor,
+        Arc::new(DerivedFrontiers {
+            sapling,
+            orchard,
+            ironwood,
+        }),
+    )))
+}
+
+/// Appends the note commitments of blocks `replay_from..=height` to `frontiers`.
+fn replay(
+    db: &ZakuraDb,
+    height: Height,
+    replay_from: u32,
+    frontiers: DerivedFrontiers,
+) -> Result<DerivedFrontiers, HistoricalTreeDerivationError> {
+    replay_with_subtrees(db, height, replay_from, frontiers, |_, _| {})
+}
+
+/// Appends the note commitments of blocks `replay_from..=height` to `frontiers`, reporting every
+/// subtree that completes along the way.
+///
+/// `on_subtree` sees each completion in order. A subtree root reported here is pinned by the same
+/// root check that validates the replay's endpoints: the replay is deterministic, so an error
+/// anywhere in it would have to cancel out exactly to still reproduce the verified end root.
+pub fn replay_with_subtrees(
+    db: &ZakuraDb,
+    height: Height,
+    replay_from: u32,
+    frontiers: DerivedFrontiers,
+    mut on_subtree: impl FnMut(ShieldedPool, CompletedSubtree),
+) -> Result<DerivedFrontiers, HistoricalTreeDerivationError> {
+    let DerivedFrontiers {
+        sapling,
+        orchard,
+        ironwood,
+    } = frontiers;
+
+    let mut sapling = (*sapling).clone();
+    let mut orchard = (*orchard).clone();
+    let mut ironwood = (*ironwood).clone();
+
+    for block_height in replay_from..=height.0 {
+        let block_height = Height(block_height);
+        let block = db.block(block_height.into()).ok_or(
+            HistoricalTreeDerivationError::MissingBlockBody {
+                height,
+                missing: block_height,
+            },
+        )?;
+
+        let append_error = |error: &dyn std::fmt::Display| HistoricalTreeDerivationError::Append {
+            height,
+            block: block_height,
+            error: error.to_string(),
+        };
+
+        // A block never spans two subtree boundaries: the block size limit caps it far below the
+        // 65,536 commitments a subtree holds, so a single batch append is always valid.
+        let sapling_commitments: Vec<_> = block.sapling_note_commitments().cloned().collect();
+        if !sapling_commitments.is_empty() {
+            let completed = sapling
+                .append_batch(&sapling_commitments)
+                .map_err(|error| append_error(&error))?;
+            if let Some((index, root)) = completed {
+                on_subtree(
+                    ShieldedPool::Sapling,
+                    CompletedSubtree {
+                        index,
+                        end_height: block_height,
+                        root: root.to_bytes(),
+                    },
+                );
+            }
+        }
+
+        let orchard_commitments: Vec<_> = block.orchard_note_commitments().cloned().collect();
+        if !orchard_commitments.is_empty() {
+            let completed = orchard
+                .append_batch(&orchard_commitments)
+                .map_err(|error| append_error(&error))?;
+            if let Some((index, root)) = completed {
+                on_subtree(
+                    ShieldedPool::Orchard,
+                    CompletedSubtree {
+                        index,
+                        end_height: block_height,
+                        root: root.to_repr(),
+                    },
+                );
+            }
+        }
+
+        let ironwood_commitments: Vec<_> = block.ironwood_note_commitments().cloned().collect();
+        if !ironwood_commitments.is_empty() {
+            let completed = ironwood
+                .append_batch(&ironwood_commitments)
+                .map_err(|error| append_error(&error))?;
+            if let Some((index, root)) = completed {
+                on_subtree(
+                    ShieldedPool::Ironwood,
+                    CompletedSubtree {
+                        index,
+                        end_height: block_height,
+                        root: root.to_repr(),
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(DerivedFrontiers {
+        sapling: Arc::new(sapling),
+        orchard: Arc::new(orchard),
+        ironwood: Arc::new(ironwood),
+    })
+}
+
+/// Checks `frontiers` against the authenticated roots stored for `height`.
+///
+/// This is the check the whole design rests on: a note commitment root is a binding commitment to
+/// its frontier, so a frontier that reproduces the authenticated root *is* the frontier, whatever
+/// source it came from. Both the serving path and the artifact generator route through here so the
+/// two can never drift apart.
+pub fn verify_against_index(
+    db: &ZakuraDb,
+    height: Height,
+    frontiers: &DerivedFrontiers,
+) -> Result<(), HistoricalTreeDerivationError> {
+    let roots = authenticated_roots(db, height)?;
+
+    if frontiers.matches(&roots) {
+        Ok(())
+    } else {
+        Err(HistoricalTreeDerivationError::RootMismatch { height })
+    }
+}
+
+/// Returns the authenticated per-pool roots stored for `height`.
+fn authenticated_roots(
+    db: &ZakuraDb,
+    height: Height,
+) -> Result<BlockCommitmentRoots, HistoricalTreeDerivationError> {
+    db.commitment_roots_by_height_range(height..=height)
+        .into_iter()
+        .next()
+        .filter(|roots| roots.height == height)
+        .ok_or(HistoricalTreeDerivationError::MissingAuthenticatedRoot { height })
+}

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -8,7 +8,10 @@ use zakura_chain::{
     ironwood, orchard,
     parameters::Network::*,
     serialization::ZcashDeserializeInto,
-    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
+    subtree::{
+        NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex,
+        TRACKED_SUBTREE_HEIGHT,
+    },
     transaction,
 };
 
@@ -24,7 +27,10 @@ use crate::{
     service::{
         finalized_state::{DiskWriteBatch, ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
         non_finalized_state::Chain,
-        read::{ironwood_subtrees, orchard_subtrees, sapling_subtrees},
+        read::{
+            ironwood_subtrees, orchard_subtrees, sapling_subtrees,
+            tree::{first_missing_subtree_index, subtree_completed_by_handoff},
+        },
     },
     Config, ReadRequest, ReadResponse,
 };
@@ -636,4 +642,113 @@ async fn any_chain_block_finds_side_chain_blocks() -> Result<()> {
     assert_eq!(found.unwrap().hash(), best_hash);
 
     Ok(())
+}
+
+/// The absent-band subtree bound must cover exactly the subtrees the fast path skipped.
+///
+/// The bound is what keeps [`crate::HistoricalSubtreeUnavailable`] from firing on an ordinary
+/// "you asked past the tip" query: only indices that completed at or below the handoff were
+/// skipped, everything at or above that is genuinely absent on any node.
+#[test]
+fn subtree_absent_band_bound_is_exact() {
+    const LEAVES_PER_SUBTREE: u64 = 1 << TRACKED_SUBTREE_HEIGHT;
+
+    // No subtree has completed yet, so no index is in the band, whatever the client asks for.
+    for leaves in [0, 1, LEAVES_PER_SUBTREE - 1] {
+        assert!(
+            !subtree_completed_by_handoff(0.into(), leaves),
+            "no subtree completes before {LEAVES_PER_SUBTREE} leaves, but {leaves} claimed one"
+        );
+    }
+
+    // Exactly one subtree (index 0) completed. Index 1 has not, so it stays an empty list.
+    assert!(subtree_completed_by_handoff(0.into(), LEAVES_PER_SUBTREE));
+    assert!(!subtree_completed_by_handoff(1.into(), LEAVES_PER_SUBTREE));
+
+    // A partly-filled second subtree does not count as completed.
+    assert!(subtree_completed_by_handoff(
+        0.into(),
+        LEAVES_PER_SUBTREE + 1
+    ));
+    assert!(!subtree_completed_by_handoff(
+        1.into(),
+        LEAVES_PER_SUBTREE + 1
+    ));
+
+    // Mainnet-scale: 73,934,658 Sapling commitments at the handoff is 1,128 completed subtrees,
+    // indexes 0..=1127. Index 1128 is the one still filling.
+    let sapling_leaves_at_handoff = 73_934_658;
+    assert!(subtree_completed_by_handoff(
+        1127.into(),
+        sapling_leaves_at_handoff
+    ));
+    assert!(!subtree_completed_by_handoff(
+        1128.into(),
+        sapling_leaves_at_handoff
+    ));
+}
+
+/// The served run must be checked to its end, not just at its start.
+///
+/// `z_getsubtreesbyindex` returns one contiguous run, so a gap anywhere truncates the response.
+/// A single unbounded request from index 0 against a truncated artifact would otherwise return a
+/// short list with no error, which a client reads as "that is every subtree on this chain" — the
+/// same silent-truncation failure the typed errors exist to remove.
+#[test]
+fn first_missing_subtree_index_finds_the_end_of_the_run() {
+    let data = || {
+        NoteCommitmentSubtreeData::new(
+            Height(1),
+            sapling_crypto::Node::from_bytes([0; 32]).unwrap(),
+        )
+    };
+    let map = |indexes: &[u16]| {
+        indexes
+            .iter()
+            .map(|i| (NoteCommitmentSubtreeIndex(*i), data()))
+            .collect::<std::collections::BTreeMap<_, _>>()
+    };
+
+    // A run that stops early reports the index just past its end, not "nothing missing".
+    assert_eq!(
+        first_missing_subtree_index(&map(&[0, 1, 2]), NoteCommitmentSubtreeIndex(0), None),
+        Some(NoteCommitmentSubtreeIndex(3))
+    );
+
+    // Nothing served at all: the requested start is the first missing index.
+    assert_eq!(
+        first_missing_subtree_index(&map(&[]), NoteCommitmentSubtreeIndex(7), None),
+        Some(NoteCommitmentSubtreeIndex(7))
+    );
+
+    // An index the client did not ask for is not missing from its answer.
+    assert_eq!(
+        first_missing_subtree_index(
+            &map(&[0, 1, 2]),
+            NoteCommitmentSubtreeIndex(0),
+            Some(NoteCommitmentSubtreeIndex(3))
+        ),
+        None,
+        "a fully satisfied bounded request has no gap"
+    );
+    assert_eq!(
+        first_missing_subtree_index(
+            &map(&[0, 1]),
+            NoteCommitmentSubtreeIndex(0),
+            Some(NoteCommitmentSubtreeIndex(5))
+        ),
+        Some(NoteCommitmentSubtreeIndex(2)),
+        "a bounded request served short still reports the gap"
+    );
+
+    // `u16::MAX` is the last index that can exist, so a run reaching it has no successor.
+    assert_eq!(
+        first_missing_subtree_index(
+            &map(&[u16::MAX]),
+            NoteCommitmentSubtreeIndex(u16::MAX),
+            None
+        ),
+        None,
+        "the final index must not overflow into a phantom gap"
+    );
 }

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -14,11 +14,12 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use zakura_chain::{
-    ironwood, orchard, sapling,
-    subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
+    block, ironwood, orchard, sapling,
+    subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex, TRACKED_SUBTREE_HEIGHT},
 };
 
 use crate::{
+    error::{HistoricalSubtreeUnavailable, HistoricalTreeUnavailable},
     service::{finalized_state::ZakuraDb, non_finalized_state::Chain},
     HashOrHeight,
 };
@@ -26,6 +27,190 @@ use crate::{
 // Doc-only items
 #[allow(unused_imports)]
 use zakura_chain::subtree::NoteCommitmentSubtree;
+
+/// Returns an error if the per-height note commitment tree for `hash_or_height` was never
+/// written, because `db` was built by the verified-commitment-trees fast-sync path and
+/// `hash_or_height` falls in the absent band `[U, H)`.
+///
+/// Read handlers call this only after a tree read came back empty, so a tree that is present
+/// (below `U`, or at or above the handoff) is never rejected. Distinguishing the absent band
+/// from an ordinary miss is what stops a client from reading the miss as the empty tree; see
+/// [`HistoricalTreeUnavailable`].
+pub fn check_historical_tree_available(
+    db: &ZakuraDb,
+    hash_or_height: HashOrHeight,
+) -> Result<(), HistoricalTreeUnavailable> {
+    match db.vct_synced_below() {
+        Some(handoff) if db.vct_historical_tree_unavailable(hash_or_height) => {
+            Err(HistoricalTreeUnavailable {
+                hash_or_height,
+                handoff,
+            })
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Returns `true` if the subtree at `start_index` completed at or below the checkpoint handoff,
+/// given `handoff_leaves`, the pool's note commitment count at the handoff height.
+///
+/// Subtrees complete at every multiple of `1 << TRACKED_SUBTREE_HEIGHT` leaves, so the leaf
+/// count floor-divides to the number of subtrees completed by then, and index `i` is one of
+/// them exactly when `i` is below that count.
+pub(crate) fn subtree_completed_by_handoff(
+    start_index: NoteCommitmentSubtreeIndex,
+    handoff_leaves: u64,
+) -> bool {
+    u64::from(start_index) < (handoff_leaves >> TRACKED_SUBTREE_HEIGHT)
+}
+
+/// Returns an error if the served run stops short of a subtree that exists on this chain but
+/// this node cannot supply.
+///
+/// `first_missing` is the lowest index the served run does not cover: `start_index` when nothing
+/// was served, otherwise one past the end of the contiguous run. `handoff_leaves` reads the pool's
+/// commitment count at the handoff, which bounds the indexes the fast path could have skipped:
+/// anything at or above it completed after the handoff and is genuinely absent on any node, so a
+/// client asking past the tip still gets today's empty list.
+///
+/// # Correctness
+///
+/// Checking only that `start_index` was served is not enough. `z_getsubtreesbyindex` returns one
+/// contiguous run, so a gap anywhere in it truncates the response — and a single unbounded request
+/// from index 0 would then return a short list with no error, which a client reads as "that is
+/// every subtree on this chain". That is the same silent-truncation failure the typed errors exist
+/// to remove, just arriving through a truncated artifact instead of an absent one.
+fn check_historical_subtree_available(
+    db: &ZakuraDb,
+    pool: &'static str,
+    first_missing: Option<NoteCommitmentSubtreeIndex>,
+    handoff_leaves: impl FnOnce(&ZakuraDb, block::Height) -> Option<u64>,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    // No gap: either the run covered everything asked for, or it ran past the last possible index.
+    let Some(first_missing) = first_missing else {
+        return Ok(());
+    };
+
+    let Some(handoff) = db.vct_synced_below() else {
+        return Ok(());
+    };
+
+    // Without the handoff leaf count there is no way to tell a skipped subtree from one that
+    // never existed, so fail closed. Reporting the archive-mode error for a subtree that was
+    // genuinely never completed is a visible, diagnosable wrong answer; serving a truncated list
+    // is the silent one this whole path exists to remove. The tree at the handoff is outside the
+    // absent band and at or below the tip, so this is not expected to happen — but "not expected"
+    // is the wrong thing to lean on when the failure is silent.
+    let Some(leaves) = handoff_leaves(db, handoff) else {
+        tracing::error!(
+            pool,
+            ?handoff,
+            "no note commitment tree at the checkpoint handoff, so completed subtrees cannot be \
+             distinguished from absent ones; refusing to serve",
+        );
+        metrics::counter!("state.historical_tree.handoff_tree_missing").increment(1);
+
+        return Err(HistoricalSubtreeUnavailable {
+            pool,
+            index: first_missing,
+            handoff,
+        });
+    };
+
+    if subtree_completed_by_handoff(first_missing, leaves) {
+        Err(HistoricalSubtreeUnavailable {
+            pool,
+            index: first_missing,
+            handoff,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Returns the lowest index in `[start_index, end_index)` that `subtrees` does not serve, or
+/// `None` when the run covers the whole request.
+///
+/// `subtrees` is contiguous from `start_index` by the time this runs, so the first index it fails
+/// to cover is one past its last key.
+pub(crate) fn first_missing_subtree_index<Node>(
+    subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<Node>>,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+) -> Option<NoteCommitmentSubtreeIndex> {
+    let first_missing = match subtrees.keys().next_back() {
+        // `u16::MAX` is the last index that can exist, so a run reaching it has no successor to
+        // be missing.
+        Some(last) => NoteCommitmentSubtreeIndex(last.0.checked_add(1)?),
+        None => start_index,
+    };
+
+    // An index the client did not ask for is not missing from its answer.
+    match end_index {
+        Some(end) if first_missing >= end => None,
+        _ => Some(first_missing),
+    }
+}
+
+/// Returns an error if the Sapling subtree list `subtrees` is missing `start_index` because it
+/// completed inside the verified-commitment-trees absent band.
+///
+/// See [`check_historical_subtree_available`].
+pub fn check_historical_sapling_subtrees_available(
+    db: &ZakuraDb,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+    subtrees: &BTreeMap<
+        NoteCommitmentSubtreeIndex,
+        NoteCommitmentSubtreeData<sapling_crypto::Node>,
+    >,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    check_historical_subtree_available(
+        db,
+        "sapling",
+        first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| db.sapling_tree_by_height(&handoff).map(|tree| tree.count()),
+    )
+}
+
+/// Returns an error if the Orchard subtree list `subtrees` is missing `start_index` because it
+/// completed inside the verified-commitment-trees absent band.
+///
+/// See [`check_historical_subtree_available`].
+pub fn check_historical_orchard_subtrees_available(
+    db: &ZakuraDb,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+    subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    check_historical_subtree_available(
+        db,
+        "orchard",
+        first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| db.orchard_tree_by_height(&handoff).map(|tree| tree.count()),
+    )
+}
+
+/// Returns an error if the Ironwood subtree list `subtrees` is missing `start_index` because it
+/// completed inside the verified-commitment-trees absent band.
+///
+/// See [`check_historical_subtree_available`].
+pub fn check_historical_ironwood_subtrees_available(
+    db: &ZakuraDb,
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+    subtrees: &BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>,
+) -> Result<(), HistoricalSubtreeUnavailable> {
+    check_historical_subtree_available(
+        db,
+        "ironwood",
+        first_missing_subtree_index(subtrees, start_index, end_index),
+        |db, handoff| {
+            db.ironwood_tree_by_height(&handoff)
+                .map(|tree| tree.count())
+        },
+    )
+}
 
 /// Returns the Sapling
 /// [`NoteCommitmentTree`](sapling::tree::NoteCommitmentTree) specified by a

--- a/crates/zakurad/src/commands.rs
+++ b/crates/zakurad/src/commands.rs
@@ -11,13 +11,14 @@ use crate::config::ZakuradConfig;
 pub use self::{entry_point::EntryPoint, start::StartCmd};
 
 use self::{
-    copy_state::CopyStateCmd, generate::GenerateCmd, prune_state::PruneStateCmd,
-    rollback_state::RollbackStateCmd, tip_height::TipHeightCmd,
-    validate_vct_sprout_history::ValidateVctSproutHistoryCmd,
+    audit_historical_treestates::AuditHistoricalTreestatesCmd, copy_state::CopyStateCmd,
+    generate::GenerateCmd, prune_state::PruneStateCmd, rollback_state::RollbackStateCmd,
+    tip_height::TipHeightCmd, validate_vct_sprout_history::ValidateVctSproutHistoryCmd,
 };
 
 pub mod start;
 
+mod audit_historical_treestates;
 mod copy_state;
 mod entry_point;
 mod generate;
@@ -40,6 +41,9 @@ const LEGACY_CONFIG_FILE: &str = "zebrad.toml";
 /// Zakurad Subcommands
 #[derive(Command, Debug, clap::Subcommand)]
 pub enum ZakuradCmd {
+    /// Audit historical note commitment treestate serving in the state database
+    AuditHistoricalTreestates(AuditHistoricalTreestatesCmd),
+
     /// The `copy-state` subcommand, used to debug cached chain state (expert users only)
     // TODO: hide this command from users in release builds (#3279)
     CopyState(CopyStateCmd),
@@ -76,7 +80,8 @@ impl ZakuradCmd {
             CopyState(_) | Start(_) => true,
 
             // Utility commands that don't use server components
-            Generate(_)
+            AuditHistoricalTreestates(_)
+            | Generate(_)
             | PruneState(_)
             | RollbackState(_)
             | TipHeight(_)
@@ -94,7 +99,8 @@ impl ZakuradCmd {
             Start(_) => true,
 
             // Utility commands
-            CopyState(_)
+            AuditHistoricalTreestates(_)
+            | CopyState(_)
             | Generate(_)
             | PruneState(_)
             | RollbackState(_)
@@ -118,7 +124,8 @@ impl ZakuradCmd {
             // This output:
             // - is used by automated tools, or
             // - needs to be read easily.
-            Generate(_)
+            AuditHistoricalTreestates(_)
+            | Generate(_)
             | PruneState(_)
             | RollbackState(_)
             | TipHeight(_)
@@ -141,6 +148,7 @@ impl ZakuradCmd {
 impl Runnable for ZakuradCmd {
     fn run(&self) {
         match self {
+            AuditHistoricalTreestates(cmd) => cmd.run(),
             CopyState(cmd) => cmd.run(),
             Generate(cmd) => cmd.run(),
             PruneState(cmd) => cmd.run(),

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -1,0 +1,420 @@
+//! `audit-historical-treestates` subcommand - reports and measures historical treestate serving.
+//!
+//! A verified-commitment-trees fast-synced node serves historical treestates by replaying block
+//! bodies forward and checking each result against the authenticated roots it already stores. This
+//! command reports whether a state database has the inputs that needs, and optionally walks the
+//! absent band to confirm the root check holds at every height and to measure what replay costs.
+//!
+//! Read-only: it opens the database as a secondary instance and never writes.
+
+use std::{path::PathBuf, sync::Mutex, time::Duration};
+
+use abscissa_core::{Application, Command, Runnable};
+use clap::Parser;
+use color_eyre::eyre::{eyre, Result};
+
+use zakura_chain::{block::Height, parameters::Network};
+use zakura_state::{
+    DerivationSample, HistoricalTreeCache, VctTreestateInventory,
+    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+};
+
+use crate::prelude::APPLICATION;
+
+/// Audit historical note commitment treestate serving in an existing state database
+#[derive(Command, Debug, Default, Parser)]
+pub struct AuditHistoricalTreestatesCmd {
+    /// Path to Zakura's cached state.
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
+    cache_dir: Option<PathBuf>,
+
+    /// The network of the chain to audit.
+    #[clap(
+        long,
+        short,
+        required = true,
+        help = "the network of the chain to load"
+    )]
+    network: Network,
+
+    /// Derive frontiers across the absent band, checking each against the stored root.
+    ///
+    /// Without this the command only reports the inventory, which is fast.
+    #[clap(
+        long,
+        help = "walk the absent band, deriving and root-checking every sampled height"
+    )]
+    walk: bool,
+
+    /// Derive every `step`th height rather than every height.
+    ///
+    /// A step of 1 walks contiguously, which is the strongest invariant check. Larger steps
+    /// approximate a wallet's scan batch size and measure what a client actually pays.
+    #[clap(long, default_value = "1", help = "height spacing for the walk")]
+    step: u32,
+
+    /// The first height to derive. Defaults to the bottom of the absent band.
+    #[clap(long, help = "first height to derive")]
+    from: Option<u32>,
+
+    /// The last height to derive. Defaults to the top of the absent band.
+    #[clap(long, help = "last height to derive")]
+    to: Option<u32>,
+
+    /// Start each derivation from a fresh memo, measuring cold replay rather than sequential.
+    ///
+    /// This is what sizes the published frontier grid: it reports what a client pays when no
+    /// nearby frontier is memoized.
+    #[clap(long, help = "clear the memo before each derivation")]
+    cold: bool,
+
+    /// Print one line per derivation with its measured cost and its replay inputs.
+    ///
+    /// Emits `SAMPLE <height> <blocks> <bytes> <commitments> <micros>`, which is what the grid's
+    /// cost model is fitted against.
+    #[clap(long, help = "print per-derivation cost and replay inputs")]
+    print_samples: bool,
+
+    /// Print the derived roots at each sampled height, for comparison against another node.
+    ///
+    /// Output is one `ROOT <height> <sapling> <orchard> <ironwood>` line per height, hex-encoded
+    /// in the same display order `z_gettreestate` uses.
+    #[clap(long, help = "print derived roots for cross-node comparison")]
+    print_roots: bool,
+
+    /// Check replay-derived subtree roots against the ones stored above the handoff.
+    ///
+    /// Subtree roots are interior nodes, so the per-height root check does not test them. Above
+    /// the handoff the database stores them, which makes that band the one place a replay can be
+    /// checked against ground truth.
+    #[clap(
+        long,
+        help = "verify replay-derived subtree roots against stored rows above the handoff"
+    )]
+    verify_subtrees: bool,
+
+    /// Skip the root-index and block-body scans, reporting only the cheap markers.
+    ///
+    /// Those scans visit every height in the band, which takes minutes on Mainnet. Skipping them
+    /// is worth it when repeating a walk on a database already known to be complete; the walk
+    /// still fails on the first height it cannot derive, so nothing goes unchecked.
+    #[clap(long, help = "skip the full-band scans, reporting markers only")]
+    no_scan: bool,
+}
+
+impl Runnable for AuditHistoricalTreestatesCmd {
+    /// `audit-historical-treestates` sub-command entrypoint.
+    fn run(&self) {
+        if let Err(error) = self.run_with_config(APPLICATION.config().state.clone()) {
+            tracing::error!("Failed to audit historical treestates: {error:#}");
+            std::process::exit(1);
+        }
+    }
+}
+
+impl AuditHistoricalTreestatesCmd {
+    /// Runs the audit using `state_config` as the base state configuration.
+    #[allow(clippy::print_stdout)]
+    pub fn run_with_config(&self, mut state_config: zakura_state::Config) -> Result<()> {
+        if self.step == 0 {
+            return Err(eyre!("--step must be at least 1"));
+        }
+
+        if let Some(cache_dir) = self.cache_dir.clone() {
+            state_config.cache_dir = cache_dir;
+        }
+
+        let (_read_state, db, _non_finalized_sender) =
+            zakura_state::init_read_only(state_config, &self.network)?;
+
+        let inventory = zakura_state::vct_treestate_inventory(&db, !self.no_scan);
+        print_inventory(&inventory);
+
+        if self.verify_subtrees {
+            let handoff = inventory
+                .handoff_height
+                .ok_or_else(|| eyre!("this database has no handoff, so there is no stored band"))?;
+            let tip = inventory
+                .finalized_tip
+                .ok_or_else(|| eyre!("this database has no finalized tip"))?;
+
+            println!();
+            println!(
+                "verifying replay-derived subtree roots against stored rows in ({}, {}]",
+                handoff.0, tip.0
+            );
+
+            let outcome = zakura_state::verify_subtrees_against_stored(&db, handoff, tip)
+                .map_err(|error| eyre!("{error}"))?;
+
+            println!("  matched:    {}", outcome.matched);
+            println!("  unstored:   {}", outcome.unstored);
+            println!("  mismatched: {}", outcome.mismatched.len());
+            for (index, pool) in &outcome.mismatched {
+                println!("    {pool} subtree {}", index.0);
+            }
+
+            if !outcome.mismatched.is_empty() {
+                return Err(eyre!(
+                    "replay does not reproduce stored subtree roots, so generated subtree \
+                     artifacts cannot be trusted"
+                ));
+            }
+        }
+
+        if !self.walk {
+            return Ok(());
+        }
+
+        let Some((band_start, band_end)) = inventory.absent_band() else {
+            return Err(eyre!(
+                "this database has no absent band, so there is nothing to derive: it stores \
+                 per-height trees at every height"
+            ));
+        };
+
+        if inventory.can_derive() == Some(false) {
+            return Err(eyre!(
+                "this database is missing derivation inputs, so a walk would fail immediately; \
+                 see the inventory above"
+            ));
+        }
+
+        // The band is half-open, so its last covered height is `H - 1`.
+        let from = Height(self.from.unwrap_or(band_start.0));
+        let to = Height(self.to.unwrap_or(band_end.0 - 1));
+        if from > to {
+            return Err(eyre!("--from {} is above --to {}", from.0, to.0));
+        }
+
+        println!();
+        println!(
+            "walking [{}, {}] step {} ({} mode)",
+            from.0,
+            to.0,
+            self.step,
+            if self.cold { "cold" } else { "sequential" }
+        );
+
+        self.walk_band(&db, from, to)
+    }
+
+    /// Derives every sampled height in `[from, to]`, printing progress and a summary.
+    #[allow(clippy::print_stdout)]
+    fn walk_band(&self, db: &zakura_state::ZakuraDb, from: Height, to: Height) -> Result<()> {
+        let heights: Vec<Height> = (from.0..=to.0)
+            .step_by(self.step as usize)
+            .map(Height)
+            .collect();
+        let total = heights.len();
+
+        if self.print_roots {
+            let cache = Mutex::new(HistoricalTreeCache::default());
+            let roots = zakura_state::derived_roots_in_display_order(
+                db,
+                &cache,
+                heights,
+                DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+            )
+            .map_err(|(height, error)| {
+                eyre!("derivation failed at height {}: {error}", height.0)
+            })?;
+
+            for (height, sapling, orchard, ironwood) in roots {
+                println!("ROOT {} {sapling} {orchard} {ironwood}", height.0);
+            }
+
+            return Ok(());
+        }
+
+        let print_samples = self.print_samples;
+        let mut samples: Vec<DerivationSample> = Vec::with_capacity(total);
+        let mut report = |sample: &DerivationSample| {
+            if print_samples {
+                // The replayed range ends at this height and covers `replayed_blocks` blocks.
+                let from = Height(
+                    sample.height.0 + 1
+                        - sample.replayed_blocks.min(u64::from(sample.height.0) + 1) as u32,
+                );
+                let inputs = zakura_state::replay_inputs(db, from, sample.height);
+                println!(
+                    "SAMPLE {} {} {} {} {}",
+                    sample.height.0,
+                    inputs.blocks,
+                    inputs.bytes,
+                    inputs.commitments,
+                    sample.elapsed.as_micros()
+                );
+            }
+            // One line per 1000 samples keeps a multi-million-height walk readable.
+            if samples.len().is_multiple_of(1000) {
+                println!(
+                    "  {:>7}/{total}  height {:>9}  replayed {:>9} blocks in {:>10}",
+                    samples.len(),
+                    sample.height.0,
+                    sample.replayed_blocks,
+                    format_duration(sample.elapsed),
+                );
+            }
+            samples.push(*sample);
+        };
+
+        let new_cache = HistoricalTreeCache::default;
+
+        let result = if self.cold {
+            // A fresh memo per height forces every derivation to replay from the bottom of the
+            // band, which is the cost a client pays with no nearby frontier.
+            let mut collected = Ok(Vec::new());
+            for height in heights {
+                let cache = Mutex::new(new_cache());
+                match zakura_state::measure_derivations(
+                    db,
+                    &cache,
+                    [height],
+                    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                    &mut report,
+                ) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        collected = Err(error);
+                        break;
+                    }
+                }
+            }
+            collected.map(|_: Vec<DerivationSample>| ())
+        } else {
+            let cache = Mutex::new(new_cache());
+            zakura_state::measure_derivations(
+                db,
+                &cache,
+                heights,
+                DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                &mut report,
+            )
+            .map(|_| ())
+        };
+
+        print_walk_summary(&samples);
+
+        result.map_err(|(height, error)| eyre!("derivation failed at height {}: {error}", height.0))
+    }
+}
+
+#[allow(clippy::print_stdout)]
+fn print_inventory(inventory: &VctTreestateInventory) {
+    println!("historical treestate inventory:");
+    println!(
+        "  finalized tip:          {}",
+        show(inventory.finalized_tip)
+    );
+    println!(
+        "  upgrade height (U):     {}",
+        show(inventory.upgrade_height)
+    );
+    println!(
+        "  handoff height (H):     {}",
+        show(inventory.handoff_height)
+    );
+    println!(
+        "  lowest retained height: {}",
+        inventory.lowest_retained_height.map_or_else(
+            || "none (archive)".to_string(),
+            |height| height.0.to_string()
+        )
+    );
+
+    match inventory.absent_band() {
+        Some((start, end)) => println!(
+            "  absent band:            [{}, {}), {} heights",
+            start.0,
+            end.0,
+            end.0 - start.0
+        ),
+        None => println!("  absent band:            none (per-height trees at every height)"),
+    }
+
+    println!(
+        "  root index gap:         {}",
+        inventory.root_index_gap.map_or_else(
+            || "none (gap-free)".to_string(),
+            |height| format!("at height {}", height.0)
+        )
+    );
+    println!(
+        "  missing block body:     {}",
+        inventory.missing_block_body.map_or_else(
+            || "none (all retained)".to_string(),
+            |height| format!("at height {}", height.0)
+        )
+    );
+    println!(
+        "  can derive:             {}",
+        match inventory.can_derive() {
+            Some(true) => "yes",
+            Some(false) => "no",
+            None => "not checked (--no-scan)",
+        }
+    );
+    println!(
+        "  scan took:              {}",
+        format_duration(inventory.scan_duration)
+    );
+}
+
+#[allow(clippy::print_stdout)]
+fn print_walk_summary(samples: &[DerivationSample]) {
+    println!();
+    println!("walk summary:");
+    println!("  heights derived and root-checked: {}", samples.len());
+
+    let replayed: u64 = samples.iter().map(|sample| sample.replayed_blocks).sum();
+    let total: Duration = samples.iter().map(|sample| sample.elapsed).sum();
+    println!("  blocks replayed:                  {replayed}");
+    println!(
+        "  total time:                       {}",
+        format_duration(total)
+    );
+
+    if replayed > 0 {
+        let per_block = total / u32::try_from(replayed).unwrap_or(u32::MAX);
+        println!(
+            "  mean per replayed block:          {}",
+            format_duration(per_block)
+        );
+    }
+
+    let mut per_derivation: Vec<Duration> = samples.iter().map(|sample| sample.elapsed).collect();
+    per_derivation.sort_unstable();
+
+    for (label, quantile) in [("median", 50), ("p90", 90), ("p99", 99), ("max", 100)] {
+        if let Some(value) = percentile(&per_derivation, quantile) {
+            println!("  per-derivation {label:<19}{}", format_duration(value));
+        }
+    }
+}
+
+/// Returns the `quantile`th percentile of `sorted`, or `None` if it is empty.
+fn percentile(sorted: &[Duration], quantile: usize) -> Option<Duration> {
+    if sorted.is_empty() {
+        return None;
+    }
+
+    let index = (sorted.len() - 1) * quantile / 100;
+    sorted.get(index).copied()
+}
+
+fn show(height: Option<Height>) -> String {
+    height.map_or_else(|| "none".to_string(), |height| height.0.to_string())
+}
+
+fn format_duration(duration: Duration) -> String {
+    if duration < Duration::from_micros(1) {
+        format!("{}ns", duration.as_nanos())
+    } else if duration < Duration::from_millis(1) {
+        format!("{:.1}us", duration.as_secs_f64() * 1e6)
+    } else if duration < Duration::from_secs(1) {
+        format!("{:.1}ms", duration.as_secs_f64() * 1e3)
+    } else {
+        format!("{:.2}s", duration.as_secs_f64())
+    }
+}

--- a/docs/changelog/unreleased/534.md
+++ b/docs/changelog/unreleased/534.md
@@ -1,0 +1,10 @@
+## Fixed
+
+- Fixed `z_gettreestate` returning a JSON `null` treestate, and `z_getsubtreesbyindex`
+  returning an empty list, for heights a verified-commitment-trees fast-synced node has no
+  data for. Clients following the lightwalletd contract read an absent treestate as the
+  _empty_ tree, so a wallet could derive a birthday anchor asserting an empty commitment
+  tree deep in the chain with no error raised. Both now return a typed archive-mode error,
+  and `getblock`/`getblockheader` explain why the tree is missing rather than reporting a
+  bare "missing Sapling tree"
+  ([#534](https://github.com/zakura-core/zakura/pull/534)).

--- a/docs/changelog/unreleased/535.md
+++ b/docs/changelog/unreleased/535.md
@@ -1,0 +1,14 @@
+## Added
+
+- Added the `audit-historical-treestates` subcommand, which reports whether a state
+  database can rebuild the note commitment trees a verified-commitment-trees fast-synced
+  node is missing, and can walk that range to rebuild and check every tree against the
+  authenticated roots the node already stores
+  ([#535](https://github.com/zakura-core/zakura/pull/535)).
+
+## Fixed
+
+- Fixed read-only state opens failing against databases written by an older version, which
+  made read-only tooling unable to inspect them at all. Opening read-only no longer
+  requires column families the database does not have
+  ([#535](https://github.com/zakura-core/zakura/pull/535)).

--- a/scripts/differential-treestate-check.py
+++ b/scripts/differential-treestate-check.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Compare a fast-synced node's derived treestates against a legacy-synced node's.
+
+Phase D of `docs/design/historical-treestate-serving.md` asks for a differential test: the same
+heights, served from a verified-commitment-trees fast-synced database and from a legacy archive
+node, must agree. This is the strongest available check on the design, because the two sides build
+their trees by entirely different routes — the legacy node recomputes every per-height tree as it
+syncs, while the fast-synced side replays block bodies and checks the result against authenticated
+roots. Agreement is independent evidence that replay reconstructs real history rather than merely
+being self-consistent.
+
+The comparison covers whatever range both sides can answer, so it strengthens on its own as a
+legacy node syncs further: rerun it as the node advances and the covered range grows.
+
+Usage:
+
+    scripts/differential-treestate-check.py \\
+        --cache-dir /path/to/fast-synced-cache \\
+        --network Mainnet \\
+        --rpc-url http://127.0.0.1:8232/ \\
+        --from-height 419200 --to-height 435000 --step 50
+
+The legacy node's RPC is usually loopback-only; forward it first, for example
+`ssh -N -L 8232:127.0.0.1:8232 root@<host>`.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.request
+
+
+def derive_locally(args):
+    """Runs zakurad and returns {height: (sapling, orchard, ironwood)} hex roots."""
+    command = [
+        args.zakurad,
+        "audit-historical-treestates",
+        "--cache-dir", args.cache_dir,
+        "--network", args.network,
+        "--no-scan",
+        "--walk",
+        "--print-roots",
+        "--from", str(args.from_height),
+        "--to", str(args.to_height),
+        "--step", str(args.step),
+    ]
+    if args.frontier_artifact:
+        command += ["--frontier-artifact", args.frontier_artifact]
+
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"local derivation failed:\n{result.stderr[-4000:]}")
+
+    roots = {}
+    for line in result.stdout.splitlines():
+        if line.startswith("ROOT "):
+            _, height, sapling, orchard, ironwood = line.split()
+            roots[int(height)] = (sapling, orchard, ironwood)
+
+    if not roots:
+        sys.exit("local derivation produced no roots; check the height range")
+
+    return roots
+
+
+def fetch_remote(rpc_url, height):
+    """Returns the legacy node's z_gettreestate result for `height`."""
+    payload = json.dumps(
+        {"jsonrpc": "1.0", "id": 1, "method": "z_gettreestate", "params": [str(height)]}
+    ).encode()
+    request = urllib.request.Request(
+        rpc_url, data=payload, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.load(response).get("result")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", required=True, help="fast-synced state cache directory")
+    parser.add_argument("--network", default="Mainnet")
+    parser.add_argument("--rpc-url", required=True, help="legacy node's JSON-RPC endpoint")
+    parser.add_argument("--from-height", type=int, required=True)
+    parser.add_argument("--to-height", type=int, required=True)
+    parser.add_argument("--step", type=int, default=50)
+    parser.add_argument("--frontier-artifact", help="frontier artifact to anchor derivation on")
+    parser.add_argument("--zakurad", default="target/release/zakurad")
+    args = parser.parse_args()
+
+    derived = derive_locally(args)
+    print(f"derived {len(derived)} heights locally")
+
+    compared = {"sapling": [0, 0], "orchard": [0, 0], "ironwood": [0, 0]}
+    unavailable = 0
+    mismatches = []
+
+    for height in sorted(derived):
+        result = fetch_remote(args.rpc_url, height)
+        if result is None:
+            unavailable += 1
+            continue
+
+        for index, pool in enumerate(("sapling", "orchard", "ironwood")):
+            # A pool with no root at this height is either pre-activation or beyond what the
+            # legacy node has synced. Neither is a disagreement, so it is not counted as one.
+            legacy = result.get(pool, {}).get("commitments", {}).get("finalRoot")
+            if legacy is None:
+                continue
+
+            if legacy == derived[height][index]:
+                compared[pool][0] += 1
+            else:
+                compared[pool][1] += 1
+                mismatches.append((height, pool, legacy, derived[height][index]))
+
+    print()
+    for pool, (matched, mismatched) in compared.items():
+        if matched or mismatched:
+            print(f"  {pool:>8}: {matched} matched, {mismatched} mismatched")
+    if unavailable:
+        print(f"  {unavailable} heights the legacy node could not answer (not yet synced)")
+
+    if mismatches:
+        print("\nMISMATCHES:")
+        for height, pool, legacy, ours in mismatches[:20]:
+            print(f"  height {height} {pool}: legacy {legacy} derived {ours}")
+        sys.exit(1)
+
+    total = sum(matched for matched, _ in compared.values())
+    if total == 0:
+        sys.exit("no roots could be compared; the legacy node may not have synced this range yet")
+
+    print(f"\nOK: {total} roots agree across both backends")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked on #534.

## Motivation

A fast-synced node cannot serve historical treestates because it never wrote the per-height trees. It can, however, rebuild them: it retains the block bodies, and it already stores authenticated per-height roots.

Implements the verification property in §4.2 and the replay in §4.3 of `docs/design/historical-treestate-serving.md`, plus the phase A tooling in §8.1.

## Solution

Replay the retained block bodies forward from the nearest frontier the node already holds, and accept the result only if it reproduces the authenticated root in `commitment_roots_by_height`. A note commitment root is a binding commitment to its frontier, so a frontier that reproduces the authenticated root *is* the frontier — which is what makes a rebuilt tree trustworthy without trusting its source.

**No RPC behaviour changes in this PR.** The engine is exercised only through `audit-historical-treestates`, which reports whether a database has the inputs replay needs (gap-free root index, retained bodies) and can walk the range checking and timing every rebuilt tree. Landing the engine with zero behaviour change lets the risky part be reviewed on its own.

Read-only opens no longer demand column families the database lacks. Without that, this tooling cannot open an older database at all — a pre-existing limitation that only surfaces once you try to inspect one.

## Testing

Unit tests for the streaming gap scan and body scan, both covering interior holes rather than just range endpoints; property tests that derive every height in a synthetic absent band and compare each pool against a legacy node's own per-height trees.

**Measured on a Mainnet fast-synced archive snapshot** (band `[0, 3,358,006)`):

- Inputs present: root index gap-free across all 3,358,006 heights, every block body retained.
- **3,358,006 heights rebuilt and root-checked, zero mismatches**, across real Sapling and Orchard replay.
- ~1.9 ms/block mean, varying ~50x by height.

`scripts/differential-treestate-check.py` compares rebuilt trees against an independently legacy-synced node's `z_gettreestate`: **421 roots across both pools, zero mismatches**.

Ironwood is structurally unexercised — NU6_3 activates above the snapshot's handoff, so no Ironwood commitment exists in the band.