### PR TITLE
feat(state): serve z_getsubtreesbyindex from a published subtree-root artifact

### DIFF
--- a/.github/workflows/update-release-state.yml
+++ b/.github/workflows/update-release-state.yml
@@ -64,6 +64,7 @@ jobs:
           CHECKPOINTS: crates/zakura-chain/src/parameters/checkpoint/main-checkpoints.txt
           FRONTIER: crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.bin
           PROVENANCE: crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json
+          SUBTREES: crates/zakura-state/src/service/finalized_state/vct/mainnet-subtrees.bin
           EOS_FILE: crates/zakurad/src/components/sync/end_of_support.rs
         run: |
           set -euo pipefail
@@ -91,11 +92,56 @@ jobs:
           cp "$BUNDLE/main-checkpoints.txt" "$CHECKPOINTS"
           cp "$BUNDLE/mainnet-frontier.bin" "$FRONTIER"
 
-          python3 - "$RESOLUTION" "$BUNDLE" "$CHECKPOINTS" "$FRONTIER" "$PROVENANCE" <<'PY'
+          # The subtree-root artifact is optional: generating it replays the whole absent band,
+          # so a publisher may skip it (SKIP_TREESTATE_ARTIFACTS). A bundle without it leaves the
+          # committed copy untouched rather than deleting it.
+          if [ -f "$BUNDLE/mainnet-treestate-subtrees.bin" ]; then
+            # Records are append-only. The frame is not a byte-prefix of its successor -- the
+            # header carries per-pool counts and a payload digest -- so the contract is checked
+            # over the records themselves. A rewrite of published history fails closed here,
+            # because a changed root would silently rebuild wrong witnesses on every consumer.
+            if [ -f "$SUBTREES" ]; then
+              python3 - "$SUBTREES" "$BUNDLE/mainnet-treestate-subtrees.bin" <<'PY'
+          import struct, sys
+
+          HEADER = 8 + 2 + 1 + 4 + 4 + 4 + 4 + 32
+          RECORD = 2 + 4 + 32
+
+          def pools(path):
+              data = open(path, "rb").read()
+              magic, _version, _network, _handoff, *counts = struct.unpack("<8sHBIIII", data[:27])
+              if magic != b"ZKVCTST1":
+                  sys.exit(f"{path} is not a subtree-root artifact")
+              out, off = [], HEADER
+              for count in counts:
+                  out.append(data[off:off + count * RECORD])
+                  off += count * RECORD
+              return out
+
+          for name, old, new in zip(("sapling", "orchard", "ironwood"), pools(sys.argv[1]), pools(sys.argv[2])):
+              if not new.startswith(old):
+                  sys.exit(f"bundle rewrites committed {name} subtree roots; refusing")
+          PY
+            fi
+            cp "$BUNDLE/mainnet-treestate-subtrees.bin" "$SUBTREES"
+            echo "imported subtree-root artifact"
+          else
+            echo "bundle carries no subtree-root artifact; leaving the committed copy unchanged"
+          fi
+
+          python3 - "$RESOLUTION" "$BUNDLE" "$CHECKPOINTS" "$FRONTIER" "$PROVENANCE" "$SUBTREES" <<'PY'
           import hashlib, json, sys
-          resolution_path, bundle, checkpoints, frontier, provenance_path = sys.argv[1:6]
+          resolution_path, bundle, checkpoints, frontier, provenance_path, subtrees = sys.argv[1:7]
           resolution = json.load(open(resolution_path, encoding="utf-8"))
           frontier_bytes = open(frontier, "rb").read()
+          try:
+              subtree_bytes = open(subtrees, "rb").read()
+              subtree_provenance = {
+                  "subtrees_sha256": hashlib.sha256(subtree_bytes).hexdigest(),
+                  "subtrees_size": len(subtree_bytes),
+              }
+          except FileNotFoundError:
+              subtree_provenance = {}
           provenance = {
               "schema_version": 1,
               "network": "Mainnet",
@@ -106,6 +152,7 @@ jobs:
               "checkpoints_sha256": hashlib.sha256(open(checkpoints, "rb").read()).hexdigest(),
               "frontier_sha256": hashlib.sha256(frontier_bytes).hexdigest(),
               "frontier_size": len(frontier_bytes),
+              **subtree_provenance,
               "meta_sha256": resolution["meta_sha256"],
           }
           with open(provenance_path, "w", encoding="utf-8") as out:
@@ -169,6 +216,7 @@ jobs:
           crates/zakura-chain/src/parameters/checkpoint/main-checkpoints.txt
           crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.bin
           crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json
+          crates/zakura-state/src/service/finalized_state/vct/mainnet-subtrees.bin
           crates/zakurad/src/components/sync/end_of_support.rs
           EOF
           UNEXPECTED=$(comm -23 "$RUNNER_TEMP/actual-files" "$RUNNER_TEMP/allowed-files")

--- a/crates/zakura-state/src/config.rs
+++ b/crates/zakura-state/src/config.rs
@@ -145,6 +145,13 @@ pub struct Config {
     #[serde(skip)]
     pub vct_fast_sync: bool,
 
+    /// Path to a subtree-root artifact used to serve `z_getsubtreesbyindex` below the handoff.
+    ///
+    /// Set to `None` by default. Unlike the frontier artifact, a node cannot check these records
+    /// against a stored root without replaying each subtree's 65,536 leaves, so this file is
+    /// trusted after its framing and digest validate.
+    pub historical_subtree_artifact: Option<PathBuf>,
+
     /// Whether to delete the old database directories when present.
     ///
     /// Set to `true` by default. If this is set to `false`,
@@ -430,6 +437,7 @@ impl Default for Config {
             enable_zakura_header_seed_from_committed_blocks: false,
             checkpoint_sync: true,
             vct_fast_sync: true,
+            historical_subtree_artifact: None,
             delete_old_database: true,
             storage_mode: StorageMode::default(),
             debug_stop_at_height: None,

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -87,6 +87,10 @@ pub use service::finalized_state::{
     SubtreeVerification, VctTreestateInventory,
 };
 pub use service::finalized_state::{
+    export_subtree_artifact, SubtreeArtifact, SubtreeRecord, TreestateArtifactError,
+    TreestateExport, TreestateExportError,
+};
+pub use service::finalized_state::{
     generate_mainnet_from_archive, produce_final_frontiers_bytes,
     produce_settled_final_frontiers_bytes, validate_final_frontiers_bytes,
     AuthenticateHeaderRootsError, AuthenticateHeaderRootsOutcome, AuthenticatedHeaderRoots,

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -17,6 +17,7 @@
 use std::{
     collections::HashMap,
     future::Future,
+    ops::Bound,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -252,6 +253,12 @@ pub struct ReadStateService {
     /// Keeps the completed-checkpoint watch open in read-only services.
     _highest_completed_checkpoint_sender:
         Option<tokio::sync::watch::Sender<Option<finalized_state::HighestCompletedCheckpoint>>>,
+
+    /// Published completed subtree roots for heights below the checkpoint handoff.
+    ///
+    /// `None` when no artifact is configured or it failed to validate, in which case
+    /// `z_getsubtreesbyindex` keeps reporting the absent band rather than serving unchecked data.
+    historical_subtrees: Option<Arc<finalized_state::SubtreeArtifact>>,
 
     /// Watch channel publishing the next VCT supplied-root repair needed by the finalized writer.
     vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
@@ -1125,11 +1132,17 @@ impl ReadStateService {
             Option<finalized_state::HeaderRootAuthState>,
         >,
     ) -> Self {
+        let historical_subtrees = load_historical_subtree_artifact(
+            &finalized_state.network(),
+            finalized_state.db.config(),
+        );
+
         let read_service = Self {
             network: finalized_state.network(),
             db: finalized_state.db.clone(),
             non_finalized_state_receiver,
             block_write_task,
+            historical_subtrees,
             highest_completed_checkpoint_receiver,
             _highest_completed_checkpoint_sender: highest_completed_checkpoint_sender,
             vct_root_repair_receiver,
@@ -1667,6 +1680,61 @@ where
         .collect()
 }
 
+/// Returns the index range a subtree request covers, as a concrete range type.
+///
+/// Mirrors the read path's handling of an absent or overflowing end bound, where the request is
+/// served to the end of what exists.
+fn range_for(
+    start_index: NoteCommitmentSubtreeIndex,
+    end_index: Option<NoteCommitmentSubtreeIndex>,
+) -> (
+    Bound<NoteCommitmentSubtreeIndex>,
+    Bound<NoteCommitmentSubtreeIndex>,
+) {
+    (
+        Bound::Included(start_index),
+        end_index.map_or(Bound::Unbounded, Bound::Excluded),
+    )
+}
+
+/// Loads the subtree-root artifact named in `config`, if any.
+///
+/// A missing or invalid artifact is logged and skipped rather than fatal: the node still works, it
+/// just keeps reporting the absent band for `z_getsubtreesbyindex`. Refusing to start over a
+/// serving-only input would be a worse trade.
+fn load_historical_subtree_artifact(
+    network: &Network,
+    config: &Config,
+) -> Option<Arc<finalized_state::SubtreeArtifact>> {
+    let subtrees = config
+        .historical_subtree_artifact
+        .as_ref()
+        .and_then(|path| match std::fs::read(path) {
+            Ok(bytes) => match finalized_state::SubtreeArtifact::decode(&bytes, network) {
+                Ok(artifact) => {
+                    tracing::info!(
+                        ?path,
+                        sapling = artifact.sapling.len(),
+                        orchard = artifact.orchard.len(),
+                        ironwood = artifact.ironwood.len(),
+                        "loaded historical subtree-root artifact"
+                    );
+                    Some(Arc::new(artifact))
+                }
+                Err(error) => {
+                    tracing::warn!(?path, %error, "ignoring invalid historical subtree-root artifact");
+                    None
+                }
+            },
+            Err(error) => {
+                tracing::warn!(?path, %error, "cannot read historical subtree-root artifact");
+                None
+            }
+        });
+
+    subtrees
+}
+
 fn block_roots_by_height_range<C>(
     chain: Option<C>,
     db: &ZakuraDb,
@@ -2106,6 +2174,23 @@ impl Service<ReadRequest> for ReadStateService {
                     read::sapling_subtrees(best_chain, &state.db, start_index..)
                 };
 
+                let sapling_subtrees = if sapling_subtrees.contains_key(&start_index) {
+                    sapling_subtrees
+                } else if let Some(artifact) = state.historical_subtrees.as_ref() {
+                    // The gated read drops everything when it has no row at `start_index`, so the
+                    // node's own rows above the handoff are missing from it here. Rebuild the
+                    // union from the raw range plus the published records — a client asking from
+                    // index 0 must get one continuous list spanning both, not just the published
+                    // half — then re-apply the continuity contract over the whole thing.
+                    let range = range_for(start_index, end_index);
+                    let mut merged = state.db.sapling_subtree_list_by_index_range(range);
+                    read::merge_published_subtrees(&mut merged, artifact.sapling_range(range));
+
+                    read::contiguous_subtrees_from(merged, start_index)
+                } else {
+                    sapling_subtrees
+                };
+
                 read::check_historical_sapling_subtrees_available(
                     &state.db,
                     start_index,
@@ -2132,6 +2217,23 @@ impl Service<ReadRequest> for ReadStateService {
                     read::orchard_subtrees(best_chain, &state.db, start_index..)
                 };
 
+                let orchard_subtrees = if orchard_subtrees.contains_key(&start_index) {
+                    orchard_subtrees
+                } else if let Some(artifact) = state.historical_subtrees.as_ref() {
+                    // The gated read drops everything when it has no row at `start_index`, so the
+                    // node's own rows above the handoff are missing from it here. Rebuild the
+                    // union from the raw range plus the published records — a client asking from
+                    // index 0 must get one continuous list spanning both, not just the published
+                    // half — then re-apply the continuity contract over the whole thing.
+                    let range = range_for(start_index, end_index);
+                    let mut merged = state.db.orchard_subtree_list_by_index_range(range);
+                    read::merge_published_subtrees(&mut merged, artifact.orchard_range(range));
+
+                    read::contiguous_subtrees_from(merged, start_index)
+                } else {
+                    orchard_subtrees
+                };
+
                 read::check_historical_orchard_subtrees_available(
                     &state.db,
                     start_index,
@@ -2152,6 +2254,23 @@ impl Service<ReadRequest> for ReadStateService {
                     read::ironwood_subtrees(best_chain, &state.db, start_index..end_index)
                 } else {
                     read::ironwood_subtrees(best_chain, &state.db, start_index..)
+                };
+
+                let ironwood_subtrees = if ironwood_subtrees.contains_key(&start_index) {
+                    ironwood_subtrees
+                } else if let Some(artifact) = state.historical_subtrees.as_ref() {
+                    // The gated read drops everything when it has no row at `start_index`, so the
+                    // node's own rows above the handoff are missing from it here. Rebuild the
+                    // union from the raw range plus the published records — a client asking from
+                    // index 0 must get one continuous list spanning both, not just the published
+                    // half — then re-apply the continuity contract over the whole thing.
+                    let range = range_for(start_index, end_index);
+                    let mut merged = state.db.ironwood_subtree_list_by_index_range(range);
+                    read::merge_published_subtrees(&mut merged, artifact.ironwood_range(range));
+
+                    read::contiguous_subtrees_from(merged, start_index)
+                } else {
+                    ironwood_subtrees
                 };
 
                 read::check_historical_ironwood_subtrees_available(

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -82,6 +82,8 @@ pub(crate) mod commitment_aux;
 pub(crate) mod commitment_aux_verify;
 mod disk_db;
 mod disk_format;
+pub mod treestate_artifact;
+pub mod treestate_export;
 mod vct;
 pub mod vct_treestate_audit;
 mod zakura_db;
@@ -111,6 +113,10 @@ pub use disk_format::upgrade::repair_vct_sprout_history::{
 pub use disk_format::{
     FromDisk, IntoDisk, OutputLocation, RawBytes, TransactionIndex, TransactionLocation,
     MAX_ON_DISK_HEIGHT,
+};
+pub use treestate_artifact::{SubtreeArtifact, SubtreeRecord, TreestateArtifactError};
+pub use treestate_export::{
+    export as export_subtree_artifact, TreestateExport, TreestateExportError,
 };
 pub use vct::{
     generate_mainnet_from_archive, validate_final_frontiers_bytes, FinalFrontiersValidationError,

--- a/crates/zakura-state/src/service/finalized_state/treestate_artifact.rs
+++ b/crates/zakura-state/src/service/finalized_state/treestate_artifact.rs
@@ -1,0 +1,491 @@
+//! Binary artifacts that let a fast-synced node serve historical treestates.
+//!
+//! Two artifacts, with deliberately different trust stories (see
+//! `docs/design/historical-treestate-serving.md` §4.1, §4.2 and §4.6):
+//!
+//! - The **frontier artifact** holds per-pool note commitment frontiers at a sparse height grid.
+//!   Every entry is checked against the authenticated root in `commitment_roots_by_height` before
+//!   use, so the artifact carries no trust weight: a corrupt or hostile one is rejected rather
+//!   than absorbed. That is what lets it be coarse, small, and distributed outside the binary.
+//! - The **subtree-root artifact** holds completed subtree roots, which a node cannot check the
+//!   same way without replaying each subtree's 65,536 leaves.
+//!
+//! Both follow the framing the Sprout history artifact established: magic, version, network byte,
+//! explicit record counts, and a SHA-256 over the payload, with the parser validating the whole
+//! frame before any record is used.
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use zakura_chain::{
+    block::Height,
+    orchard,
+    parameters::{Network, NetworkKind},
+    subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
+};
+
+/// Magic bytes identifying a subtree-root artifact.
+const SUBTREE_MAGIC: &[u8; 8] = b"ZKVCTST1";
+
+/// The format version both artifacts are written at.
+const VERSION: u16 = 1;
+
+/// Fixed header length: magic, version, network, handoff, three record counts, digest.
+const SUBTREE_HEADER_LEN: usize = 8 + 2 + 1 + 4 + 4 + 4 + 4 + 32;
+
+/// Bytes per subtree record: index, end height, root.
+const SUBTREE_RECORD_LEN: usize = 2 + 4 + 32;
+
+/// The most subtree records an artifact may declare per pool.
+///
+/// Subtree indexes are `u16`, so a pool can never complete more than this many.
+const MAX_SUBTREE_RECORDS: usize = u16::MAX as usize + 1;
+
+/// Why an artifact could not be parsed or did not describe what the caller expected.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum TreestateArtifactError {
+    /// The artifact does not start with the expected magic bytes.
+    #[error("not a {kind} artifact: wrong magic bytes")]
+    InvalidMagic {
+        /// Which artifact was expected.
+        kind: &'static str,
+    },
+
+    /// The artifact declares a format version this binary does not implement.
+    #[error("unsupported {kind} artifact version {found}, expected {VERSION}")]
+    UnsupportedVersion {
+        /// Which artifact was being parsed.
+        kind: &'static str,
+        /// The version the artifact declares.
+        found: u16,
+    },
+
+    /// The artifact was generated for a different network.
+    #[error("{kind} artifact is for network byte {found}, expected {expected}")]
+    WrongNetwork {
+        /// Which artifact was being parsed.
+        kind: &'static str,
+        /// The network byte the artifact declares.
+        found: u8,
+        /// The network byte this node expects.
+        expected: u8,
+    },
+
+    /// The artifact is shorter than its own framing requires.
+    #[error("{kind} artifact is truncated at offset {offset}: needs {needed} more bytes")]
+    Truncated {
+        /// Which artifact was being parsed.
+        kind: &'static str,
+        /// Where the parse ran out of bytes.
+        offset: usize,
+        /// How many more bytes the frame required.
+        needed: usize,
+    },
+
+    /// The artifact declares more records than the format allows.
+    #[error("{kind} artifact declares {found} records, more than the {max} limit")]
+    TooManyRecords {
+        /// Which artifact was being parsed.
+        kind: &'static str,
+        /// The declared count.
+        found: usize,
+        /// The format's limit.
+        max: usize,
+    },
+
+    /// The payload does not hash to the digest in the header.
+    #[error("{kind} artifact payload does not match the digest in its header")]
+    DigestMismatch {
+        /// Which artifact was being parsed.
+        kind: &'static str,
+    },
+
+    /// Bytes remain after the last declared record.
+    #[error("{kind} artifact has {trailing} trailing bytes after its last record")]
+    TrailingBytes {
+        /// Which artifact was being parsed.
+        kind: &'static str,
+        /// How many bytes remain.
+        trailing: usize,
+    },
+
+    /// Entry heights are not strictly increasing.
+    ///
+    /// Ordering is what makes "nearest entry at or below `h`" a binary search rather than a scan,
+    /// and what makes the append-only prefix contract checkable.
+    #[error("{kind} artifact entries are out of order: {previous:?} is followed by {found:?}")]
+    OutOfOrder {
+        /// Which artifact was being parsed.
+        kind: &'static str,
+        /// The previous entry's key.
+        previous: u32,
+        /// The offending entry's key.
+        found: u32,
+    },
+}
+
+/// Returns the network byte an artifact for `network` carries.
+fn network_byte(network: &Network) -> u8 {
+    match network.kind() {
+        NetworkKind::Mainnet => 1,
+        NetworkKind::Testnet => 2,
+        NetworkKind::Regtest => 3,
+    }
+}
+
+/// Reads a fixed-size array from `bytes` at `offset`, or reports a truncated frame.
+fn read_array<const N: usize>(
+    bytes: &[u8],
+    offset: usize,
+    kind: &'static str,
+) -> Result<[u8; N], TreestateArtifactError> {
+    bytes
+        .get(offset..offset.saturating_add(N))
+        .and_then(|slice| slice.try_into().ok())
+        .ok_or(TreestateArtifactError::Truncated {
+            kind,
+            offset,
+            needed: N,
+        })
+}
+
+/// One completed subtree's root and the height it completed at.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SubtreeRecord {
+    /// The subtree index.
+    pub index: NoteCommitmentSubtreeIndex,
+
+    /// The height the subtree's last leaf was added at.
+    pub end_height: Height,
+
+    /// The subtree root.
+    pub root: [u8; 32],
+}
+
+/// Completed subtree roots per pool, in index order.
+///
+/// Unlike [`FrontierArtifact`], a consumer cannot check these against a stored root without
+/// replaying each subtree's leaves, so this ships in the reviewed, committed bundle (§4.6).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubtreeArtifact {
+    /// The checkpoint handoff this was generated against.
+    pub handoff: Height,
+
+    /// Completed Sapling subtrees, in index order.
+    pub sapling: Vec<SubtreeRecord>,
+
+    /// Completed Orchard subtrees, in index order.
+    pub orchard: Vec<SubtreeRecord>,
+
+    /// Completed Ironwood subtrees, in index order.
+    pub ironwood: Vec<SubtreeRecord>,
+}
+
+impl Default for SubtreeArtifact {
+    fn default() -> Self {
+        Self {
+            handoff: Height(0),
+            sapling: Vec::new(),
+            orchard: Vec::new(),
+            ironwood: Vec::new(),
+        }
+    }
+}
+
+impl SubtreeArtifact {
+    /// The name used in error messages.
+    const KIND: &'static str = "subtree-root";
+
+    /// Serializes to the artifact byte format.
+    pub fn encode(&self, network: &Network) -> Vec<u8> {
+        let mut payload = Vec::new();
+        for pool in [&self.sapling, &self.orchard, &self.ironwood] {
+            for record in pool {
+                payload.extend_from_slice(&record.index.0.to_le_bytes());
+                payload.extend_from_slice(&record.end_height.0.to_le_bytes());
+                payload.extend_from_slice(&record.root);
+            }
+        }
+
+        let count = |pool: &Vec<SubtreeRecord>| {
+            u32::try_from(pool.len()).expect("subtree indexes are u16, so counts fit in u32")
+        };
+
+        let mut out = Vec::with_capacity(SUBTREE_HEADER_LEN + payload.len());
+        out.extend_from_slice(SUBTREE_MAGIC);
+        out.extend_from_slice(&VERSION.to_le_bytes());
+        out.push(network_byte(network));
+        out.extend_from_slice(&self.handoff.0.to_le_bytes());
+        out.extend_from_slice(&count(&self.sapling).to_le_bytes());
+        out.extend_from_slice(&count(&self.orchard).to_le_bytes());
+        out.extend_from_slice(&count(&self.ironwood).to_le_bytes());
+        out.extend_from_slice(&Sha256::digest(&payload));
+        out.extend_from_slice(&payload);
+
+        out
+    }
+
+    /// Parses the artifact byte format, validating the whole frame before returning any record.
+    pub fn decode(bytes: &[u8], network: &Network) -> Result<Self, TreestateArtifactError> {
+        let kind = Self::KIND;
+
+        if read_array::<8>(bytes, 0, kind)? != *SUBTREE_MAGIC {
+            return Err(TreestateArtifactError::InvalidMagic { kind });
+        }
+
+        let version = u16::from_le_bytes(read_array::<2>(bytes, 8, kind)?);
+        if version != VERSION {
+            return Err(TreestateArtifactError::UnsupportedVersion {
+                kind,
+                found: version,
+            });
+        }
+
+        let found = read_array::<1>(bytes, 10, kind)?[0];
+        let expected = network_byte(network);
+        if found != expected {
+            return Err(TreestateArtifactError::WrongNetwork {
+                kind,
+                found,
+                expected,
+            });
+        }
+
+        let handoff = Height(u32::from_le_bytes(read_array::<4>(bytes, 11, kind)?));
+
+        let mut counts = [0usize; 3];
+        for (index, count) in counts.iter_mut().enumerate() {
+            *count = u32::from_le_bytes(read_array::<4>(bytes, 15 + index * 4, kind)?) as usize;
+            if *count > MAX_SUBTREE_RECORDS {
+                return Err(TreestateArtifactError::TooManyRecords {
+                    kind,
+                    found: *count,
+                    max: MAX_SUBTREE_RECORDS,
+                });
+            }
+        }
+
+        let digest = read_array::<32>(bytes, 27, kind)?;
+        let payload = bytes
+            .get(SUBTREE_HEADER_LEN..)
+            .ok_or(TreestateArtifactError::Truncated {
+                kind,
+                offset: SUBTREE_HEADER_LEN,
+                needed: 0,
+            })?;
+
+        if Sha256::digest(payload).as_slice() != digest {
+            return Err(TreestateArtifactError::DigestMismatch { kind });
+        }
+
+        let mut offset = 0;
+        let mut pools = Vec::with_capacity(3);
+        for count in counts {
+            let mut records = Vec::with_capacity(count);
+            let mut previous: Option<u32> = None;
+
+            for _ in 0..count {
+                let index = u16::from_le_bytes(read_array::<2>(payload, offset, kind)?);
+                let end_height = Height(u32::from_le_bytes(read_array::<4>(
+                    payload,
+                    offset + 2,
+                    kind,
+                )?));
+                let root = read_array::<32>(payload, offset + 6, kind)?;
+                offset += SUBTREE_RECORD_LEN;
+
+                if let Some(previous) = previous {
+                    if u32::from(index) <= previous {
+                        return Err(TreestateArtifactError::OutOfOrder {
+                            kind,
+                            previous,
+                            found: u32::from(index),
+                        });
+                    }
+                }
+                previous = Some(u32::from(index));
+
+                records.push(SubtreeRecord {
+                    index: NoteCommitmentSubtreeIndex(index),
+                    end_height,
+                    root,
+                });
+            }
+
+            pools.push(records);
+        }
+
+        if offset != payload.len() {
+            return Err(TreestateArtifactError::TrailingBytes {
+                kind,
+                trailing: payload.len() - offset,
+            });
+        }
+
+        let mut pools = pools.into_iter();
+        Ok(Self {
+            handoff,
+            sapling: pools.next().expect("three pools were decoded"),
+            orchard: pools.next().expect("three pools were decoded"),
+            ironwood: pools.next().expect("three pools were decoded"),
+        })
+    }
+
+    /// Returns the Sapling subtrees in `range`, as `z_getsubtreesbyindex` serves them.
+    pub fn sapling_range(
+        &self,
+        range: impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex> + Clone,
+    ) -> Vec<(
+        NoteCommitmentSubtreeIndex,
+        NoteCommitmentSubtreeData<sapling_crypto::Node>,
+    )> {
+        self.sapling
+            .iter()
+            .filter(|record| range.contains(&record.index))
+            .filter_map(|record| {
+                sapling_crypto::Node::from_bytes(record.root)
+                    .into_option()
+                    .map(|root| {
+                        (
+                            record.index,
+                            NoteCommitmentSubtreeData::new(record.end_height, root),
+                        )
+                    })
+            })
+            .collect()
+    }
+
+    /// Returns the Orchard subtrees in `range`, as `z_getsubtreesbyindex` serves them.
+    pub fn orchard_range(
+        &self,
+        range: impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex> + Clone,
+    ) -> Vec<(
+        NoteCommitmentSubtreeIndex,
+        NoteCommitmentSubtreeData<orchard::tree::Node>,
+    )> {
+        Self::pallas_range(&self.orchard, range)
+    }
+
+    /// Returns the Ironwood subtrees in `range`, as `z_getsubtreesbyindex` serves them.
+    pub fn ironwood_range(
+        &self,
+        range: impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex> + Clone,
+    ) -> Vec<(
+        NoteCommitmentSubtreeIndex,
+        NoteCommitmentSubtreeData<orchard::tree::Node>,
+    )> {
+        Self::pallas_range(&self.ironwood, range)
+    }
+
+    /// Shared body for the two Pallas-based pools, which use the same node type.
+    fn pallas_range(
+        records: &[SubtreeRecord],
+        range: impl std::ops::RangeBounds<NoteCommitmentSubtreeIndex> + Clone,
+    ) -> Vec<(
+        NoteCommitmentSubtreeIndex,
+        NoteCommitmentSubtreeData<orchard::tree::Node>,
+    )> {
+        records
+            .iter()
+            .filter(|record| range.contains(&record.index))
+            .filter_map(|record| {
+                orchard::tree::Node::try_from(record.root.as_slice())
+                    .ok()
+                    .map(|root| {
+                        (
+                            record.index,
+                            NoteCommitmentSubtreeData::new(record.end_height, root),
+                        )
+                    })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use zakura_chain::parameters::Network;
+
+    fn sample_subtrees() -> SubtreeArtifact {
+        SubtreeArtifact {
+            handoff: Height(31),
+            sapling: vec![
+                SubtreeRecord {
+                    index: NoteCommitmentSubtreeIndex(0),
+                    end_height: Height(7),
+                    root: [1; 32],
+                },
+                SubtreeRecord {
+                    index: NoteCommitmentSubtreeIndex(1),
+                    end_height: Height(19),
+                    root: [2; 32],
+                },
+            ],
+            orchard: vec![SubtreeRecord {
+                index: NoteCommitmentSubtreeIndex(0),
+                end_height: Height(21),
+                root: [3; 32],
+            }],
+            ironwood: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn subtree_artifact_round_trips() {
+        let artifact = sample_subtrees();
+        let bytes = artifact.encode(&Network::Mainnet);
+
+        assert_eq!(
+            SubtreeArtifact::decode(&bytes, &Network::Mainnet),
+            Ok(artifact)
+        );
+    }
+
+    #[test]
+    fn subtree_artifact_rejects_tampering() {
+        let artifact = sample_subtrees();
+        let good = artifact.encode(&Network::Mainnet);
+
+        let mut wrong_magic = good.clone();
+        wrong_magic[0] ^= 0xff;
+        assert_eq!(
+            SubtreeArtifact::decode(&wrong_magic, &Network::Mainnet),
+            Err(TreestateArtifactError::InvalidMagic {
+                kind: "subtree-root"
+            })
+        );
+
+        // Flipping a root byte is the failure that matters most here: this artifact's records
+        // cannot be re-derived cheaply by a consumer, so the digest is the only thing standing
+        // between a corrupted root and a wrong witness.
+        let mut flipped = good.clone();
+        *flipped.last_mut().expect("artifact is not empty") ^= 0x01;
+        assert_eq!(
+            SubtreeArtifact::decode(&flipped, &Network::Mainnet),
+            Err(TreestateArtifactError::DigestMismatch {
+                kind: "subtree-root"
+            })
+        );
+    }
+
+    #[test]
+    fn subtree_artifact_serves_index_ranges() {
+        let artifact = sample_subtrees();
+
+        let all = artifact.sapling_range(..);
+        assert_eq!(all.len(), 2, "an unbounded range serves every subtree");
+
+        let from_one = artifact.sapling_range(NoteCommitmentSubtreeIndex(1)..);
+        assert_eq!(from_one.len(), 1);
+        assert_eq!(from_one[0].0, NoteCommitmentSubtreeIndex(1));
+        assert_eq!(from_one[0].1.end_height, Height(19));
+
+        assert_eq!(artifact.orchard_range(..).len(), 1);
+        assert!(
+            artifact.ironwood_range(..).is_empty(),
+            "a pool with no completed subtrees serves nothing"
+        );
+    }
+}

--- a/crates/zakura-state/src/service/finalized_state/treestate_export.rs
+++ b/crates/zakura-state/src/service/finalized_state/treestate_export.rs
@@ -1,0 +1,157 @@
+//! Generating the completed-subtree-root artifact from an archive database.
+//!
+//! One contiguous replay across the absent band collects every subtree that completes, which is
+//! what a fast-synced node needs to serve `z_getsubtreesbyindex` there (see
+//! `docs/design/historical-treestate-serving.md` §4.6).
+//!
+//! # Why this does not need a legacy-synced publisher
+//!
+//! §5 of the design specifies an archive, *legacy-synced* publisher host, on the assumption that
+//! the exporter reads the `{pool}_note_commitment_subtree` column families straight off disk.
+//! Replaying instead lifts that requirement, and buys verification with it: subtree roots are
+//! interior nodes computed during a replay whose endpoints are checked against the authenticated
+//! roots in `commitment_roots_by_height`. Between two checked endpoints the replay is pinned —
+//! producing the correct end root from a correct start root while computing a wrong interior node
+//! would require a hash collision.
+//!
+//! That is stronger than §4.6's "reviewed, trusted" story, which exists only because it assumed
+//! subtree roots could not be checked without replaying each subtree's leaves. That is true for a
+//! serving node; it is not true for a publisher that is replaying regardless.
+
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+
+use zakura_chain::block::Height;
+
+use crate::service::{
+    finalized_state::{
+        treestate_artifact::{SubtreeArtifact, SubtreeRecord},
+        ZakuraDb,
+    },
+    read::{
+        historical_tree::{
+            replay_with_subtrees, verify_against_index, HistoricalTreeDerivationError, ShieldedPool,
+        },
+        DerivedFrontiers,
+    },
+};
+
+/// How often the replay stops to check itself against the stored roots.
+///
+/// Only the endpoints are load-bearing for correctness, but checking along the way turns "the
+/// export failed" into "the export failed at height N", which is the difference between a
+/// diagnosable bug and a bisect over three million blocks.
+const CHECKPOINT_INTERVAL: u32 = 100_000;
+
+/// Why artifact generation could not complete.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum TreestateExportError {
+    /// The database has no absent band, so there is nothing to generate.
+    #[error("this database stores per-height trees at every height, so no artifact is needed")]
+    NoAbsentBand,
+
+    /// A replay or its root check failed.
+    #[error("generation failed at height {height:?}: {source}")]
+    Derivation {
+        /// The height being produced when generation failed.
+        height: Height,
+        /// The underlying failure.
+        #[source]
+        source: HistoricalTreeDerivationError,
+    },
+}
+
+/// What one generation run produced.
+#[derive(Clone, Debug)]
+pub struct TreestateExport {
+    /// The completed subtree roots.
+    pub subtrees: SubtreeArtifact,
+
+    /// How long generation took.
+    pub elapsed: Duration,
+
+    /// How many blocks were replayed.
+    pub replayed_blocks: u64,
+}
+
+/// Generates the subtree-root artifact for `db`'s absent band.
+///
+/// Replays contiguously from the bottom of the band, recording every subtree that completes and
+/// checking the running frontiers against `commitment_roots_by_height` as it goes. Generation
+/// stops at the first height that fails its check, so a returned artifact is one whose whole
+/// replay reproduced this node's own authenticated roots.
+pub fn export(
+    db: &ZakuraDb,
+    mut on_progress: impl FnMut(Height, u64),
+) -> Result<TreestateExport, TreestateExportError> {
+    let handoff = db
+        .vct_synced_below()
+        .ok_or(TreestateExportError::NoAbsentBand)?;
+    let upgrade = db.vct_upgrade_height().unwrap_or(Height(0));
+    if upgrade >= handoff {
+        return Err(TreestateExportError::NoAbsentBand);
+    }
+
+    let start = Instant::now();
+    // The band is half-open, so the last height it covers is `H - 1`.
+    let last = Height(handoff.0 - 1);
+
+    let mut subtrees = SubtreeArtifact {
+        handoff,
+        ..SubtreeArtifact::default()
+    };
+    let mut frontiers = DerivedFrontiers::empty();
+    let mut replay_from = upgrade.0;
+    let mut replayed_blocks = 0u64;
+
+    loop {
+        let target = Height(replay_from.saturating_add(CHECKPOINT_INTERVAL).min(last.0));
+
+        let mut collected = Vec::new();
+        frontiers = replay_with_subtrees(db, target, replay_from, frontiers, |pool, completed| {
+            collected.push((pool, completed))
+        })
+        .map_err(|source| TreestateExportError::Derivation {
+            height: target,
+            source,
+        })?;
+
+        replayed_blocks += u64::from(target.0 - replay_from) + 1;
+        replay_from = target.0 + 1;
+
+        // The root check is what makes every subtree recorded since the previous check safe to
+        // publish.
+        verify_against_index(db, target, &frontiers).map_err(|source| {
+            TreestateExportError::Derivation {
+                height: target,
+                source,
+            }
+        })?;
+
+        for (pool, completed) in collected {
+            let record = SubtreeRecord {
+                index: completed.index,
+                end_height: completed.end_height,
+                root: completed.root,
+            };
+            match pool {
+                ShieldedPool::Sapling => subtrees.sapling.push(record),
+                ShieldedPool::Orchard => subtrees.orchard.push(record),
+                ShieldedPool::Ironwood => subtrees.ironwood.push(record),
+            }
+        }
+
+        on_progress(target, replayed_blocks);
+
+        if target == last {
+            break;
+        }
+    }
+
+    Ok(TreestateExport {
+        subtrees,
+        elapsed: start.elapsed(),
+        replayed_blocks,
+    })
+}

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -49,8 +49,8 @@ pub use historical_tree::{
 pub use tree::{
     check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,
     check_historical_sapling_subtrees_available, check_historical_tree_available,
-    ironwood_subtrees, ironwood_tree, orchard_subtrees, orchard_tree, sapling_subtrees,
-    sapling_tree,
+    contiguous_subtrees_from, ironwood_subtrees, ironwood_tree, merge_published_subtrees,
+    orchard_subtrees, orchard_tree, sapling_subtrees, sapling_tree,
 };
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -29,7 +29,7 @@ use zakura_chain::{
 
 use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
 
-use crate::service::finalized_state::ZakuraDb;
+use crate::service::finalized_state::{treestate_artifact::SubtreeArtifact, ZakuraDb};
 
 /// The most derived frontiers to keep memoized per node.
 ///
@@ -176,9 +176,42 @@ pub enum HistoricalTreeDerivationError {
 pub struct HistoricalTreeCache {
     /// Verified frontiers, keyed by the height they are the state at the end of.
     frontiers: BTreeMap<Height, Arc<DerivedFrontiers>>,
+
+    /// Published subtree roots to check against as replays pass completion positions.
+    ///
+    /// Nothing here anchors a derivation; it exists only so the published roots are checked. A
+    /// derivation crosses subtree boundaries anyway, so verifying the ones it passes is free, and
+    /// wallet sweeps cross every boundary in the band — which is what makes the published list
+    /// converge from trusted to verified over a node's lifetime (design §4.6).
+    subtrees: Option<Arc<SubtreeArtifact>>,
 }
 
 impl HistoricalTreeCache {
+    /// Adds published subtree roots for the opportunistic completion check.
+    pub fn with_subtrees(mut self, subtrees: Arc<SubtreeArtifact>) -> Self {
+        self.subtrees = Some(subtrees);
+        self
+    }
+
+    /// Returns the published root for `pool`'s subtree `index`, if the artifact carries one.
+    fn published_subtree_root(
+        &self,
+        pool: ShieldedPool,
+        index: NoteCommitmentSubtreeIndex,
+    ) -> Option<[u8; 32]> {
+        let artifact = self.subtrees.as_ref()?;
+        let records = match pool {
+            ShieldedPool::Sapling => &artifact.sapling,
+            ShieldedPool::Orchard => &artifact.orchard,
+            ShieldedPool::Ironwood => &artifact.ironwood,
+        };
+
+        records
+            .binary_search_by_key(&index, |record| record.index)
+            .ok()
+            .map(|position| records[position].root)
+    }
+
     /// Returns the highest memoized frontier at or below `height`, if any.
     fn anchor_at_or_below(&self, height: Height) -> Option<(Height, Arc<DerivedFrontiers>)> {
         self.frontiers
@@ -280,7 +313,7 @@ pub fn derive_historical_frontiers_measured(
     let frontiers = anchor.map_or_else(DerivedFrontiers::empty, |(_, frontiers)| {
         (*frontiers).clone()
     });
-    let frontiers = replay(db, height, replay_from, frontiers)?;
+    let frontiers = replay_checking_subtrees(db, cache, height, replay_from, frontiers)?;
 
     verify_against_index(db, height, &frontiers)?;
 
@@ -333,14 +366,58 @@ fn anchor_for(
     )))
 }
 
-/// Appends the note commitments of blocks `replay_from..=height` to `frontiers`.
-fn replay(
+/// Replays `replay_from..=height`, checking every subtree completed on the way against the
+/// published roots.
+///
+/// The published subtree roots cannot be checked cheaply on demand — that is why they ship at
+/// review-level trust — but a derivation passes completion positions anyway, so checking the ones
+/// it crosses costs nothing. Over a node's lifetime, wallet sweeps cross every boundary in the
+/// band, so the published list converges from trusted to verified (design §4.6).
+///
+/// A mismatch is a *serving* failure, not a consensus one: the derived frontier is still checked
+/// against the authenticated root, so what a mismatch means is that the published artifact is
+/// wrong. It is reported loudly and the artifact's subtree data is dropped, rather than failing
+/// the request, because the treestate the caller asked for is unaffected.
+fn replay_checking_subtrees(
     db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
     height: Height,
     replay_from: u32,
     frontiers: DerivedFrontiers,
 ) -> Result<DerivedFrontiers, HistoricalTreeDerivationError> {
-    replay_with_subtrees(db, height, replay_from, frontiers, |_, _| {})
+    let mut mismatched = Vec::new();
+
+    let derived = replay_with_subtrees(db, height, replay_from, frontiers, |pool, completed| {
+        let published = lock(cache).published_subtree_root(pool, completed.index);
+
+        if let Some(published) = published {
+            if published == completed.root {
+                metrics::counter!("state.historical_tree.subtree_root_confirmed").increment(1);
+            } else {
+                mismatched.push((pool, completed.index));
+            }
+        }
+    })?;
+
+    if !mismatched.is_empty() {
+        for (pool, index) in &mismatched {
+            tracing::error!(
+                ?pool,
+                index = index.0,
+                "a published subtree root does not match the one this node derived; \
+                 dropping the published subtree data",
+            );
+        }
+        metrics::counter!("state.historical_tree.subtree_root_mismatch")
+            .increment(mismatched.len() as u64);
+
+        // Refusing to serve the rest of the artifact is the conservative response: one wrong
+        // record means the file cannot be trusted, and `z_getsubtreesbyindex` reporting the
+        // absent band beats serving roots that would build wrong witnesses.
+        lock(cache).subtrees = None;
+    }
+
+    Ok(derived)
 }
 
 /// Appends the note commitments of blocks `replay_from..=height` to `frontiers`, reporting every
@@ -472,4 +549,70 @@ fn authenticated_roots(
         .next()
         .filter(|roots| roots.height == height)
         .ok_or(HistoricalTreeDerivationError::MissingAuthenticatedRoot { height })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::service::finalized_state::treestate_artifact::SubtreeRecord;
+
+    fn record(index: u16, root: u8) -> SubtreeRecord {
+        SubtreeRecord {
+            index: NoteCommitmentSubtreeIndex(index),
+            end_height: Height(1000 + u32::from(index)),
+            root: [root; 32],
+        }
+    }
+
+    /// The opportunistic check (§4.6) has to find the published root for a given pool and index.
+    /// Subtree indexes are sparse in principle and the lookup is a binary search, so a wrong
+    /// result here would either silently skip the check or compare against another pool's root.
+    #[test]
+    fn published_subtree_lookup_finds_the_right_pool_and_index() {
+        let artifact = SubtreeArtifact {
+            handoff: Height(9_000),
+            sapling: vec![record(0, 0xaa), record(1, 0xbb), record(5, 0xcc)],
+            orchard: vec![record(0, 0xdd)],
+            ironwood: Vec::new(),
+        };
+        let cache = HistoricalTreeCache::default().with_subtrees(Arc::new(artifact));
+
+        assert_eq!(
+            cache.published_subtree_root(ShieldedPool::Sapling, NoteCommitmentSubtreeIndex(1)),
+            Some([0xbb; 32])
+        );
+        assert_eq!(
+            cache.published_subtree_root(ShieldedPool::Sapling, NoteCommitmentSubtreeIndex(5)),
+            Some([0xcc; 32]),
+            "a gap below an index must not hide it"
+        );
+        assert_eq!(
+            cache.published_subtree_root(ShieldedPool::Sapling, NoteCommitmentSubtreeIndex(2)),
+            None,
+            "an index the artifact does not carry is not checked against a neighbour"
+        );
+        assert_eq!(
+            cache.published_subtree_root(ShieldedPool::Orchard, NoteCommitmentSubtreeIndex(0)),
+            Some([0xdd; 32]),
+            "pools are looked up independently"
+        );
+        assert_eq!(
+            cache.published_subtree_root(ShieldedPool::Ironwood, NoteCommitmentSubtreeIndex(0)),
+            None,
+            "a pool with no published subtrees checks nothing"
+        );
+    }
+
+    /// Without an artifact the check is inert, so a node serving without published subtree roots
+    /// pays nothing for it.
+    #[test]
+    fn published_subtree_lookup_is_inert_without_an_artifact() {
+        let cache = HistoricalTreeCache::default();
+
+        assert_eq!(
+            cache.published_subtree_root(ShieldedPool::Sapling, NoteCommitmentSubtreeIndex(0)),
+            None
+        );
+    }
 }

--- a/crates/zakura-state/src/service/read/tests/vectors.rs
+++ b/crates/zakura-state/src/service/read/tests/vectors.rs
@@ -28,7 +28,8 @@ use crate::{
         finalized_state::{DiskWriteBatch, ZakuraDb, STATE_COLUMN_FAMILIES_IN_CODE},
         non_finalized_state::Chain,
         read::{
-            ironwood_subtrees, orchard_subtrees, sapling_subtrees,
+            contiguous_subtrees_from, ironwood_subtrees, merge_published_subtrees,
+            orchard_subtrees, sapling_subtrees,
             tree::{first_missing_subtree_index, subtree_completed_by_handoff},
         },
     },
@@ -751,4 +752,96 @@ fn first_missing_subtree_index_finds_the_end_of_the_run() {
         None,
         "the final index must not overflow into a phantom gap"
     );
+}
+
+/// Merging the node's own subtree rows with published ones must still serve a continuous list.
+///
+/// The gated read drops everything when it has no row at the requested start, so a node holding
+/// rows only *above* the handoff contributes nothing until the published records below it are
+/// merged in. A client doing spend-before-sync asks from index 0 and needs one list spanning both
+/// halves; serving only the published half would silently truncate its witness data.
+#[test]
+fn contiguous_subtrees_spans_published_and_stored_rows() {
+    let data = |height: u32| {
+        NoteCommitmentSubtreeData::new(
+            Height(height),
+            sapling_crypto::Node::from_bytes([0; 32]).unwrap(),
+        )
+    };
+
+    let merged: std::collections::BTreeMap<_, _> = [0u16, 1, 2, 3]
+        .into_iter()
+        .map(|index| (NoteCommitmentSubtreeIndex(index), data(index as u32 + 1)))
+        .collect();
+
+    let served = contiguous_subtrees_from(merged.clone(), NoteCommitmentSubtreeIndex(0));
+    assert_eq!(served.len(), 4, "a gapless union is served whole");
+
+    // A gap makes everything past it unusable, so it is dropped rather than served.
+    let mut holed = merged.clone();
+    holed.remove(&NoteCommitmentSubtreeIndex(2));
+    let served = contiguous_subtrees_from(holed, NoteCommitmentSubtreeIndex(0));
+    assert_eq!(
+        served.keys().copied().collect::<Vec<_>>(),
+        vec![NoteCommitmentSubtreeIndex(0), NoteCommitmentSubtreeIndex(1)],
+        "the run stops at the first gap"
+    );
+
+    // A missing start index means there is nothing to serve, not a list starting later.
+    let mut no_start = merged.clone();
+    no_start.remove(&NoteCommitmentSubtreeIndex(0));
+    assert!(
+        contiguous_subtrees_from(no_start, NoteCommitmentSubtreeIndex(0)).is_empty(),
+        "a missing start index serves nothing"
+    );
+
+    // Indexes below the request are not served.
+    let served = contiguous_subtrees_from(merged, NoteCommitmentSubtreeIndex(2));
+    assert_eq!(
+        served.keys().copied().collect::<Vec<_>>(),
+        vec![NoteCommitmentSubtreeIndex(2), NoteCommitmentSubtreeIndex(3)],
+        "the run starts at the requested index"
+    );
+}
+
+/// A published subtree record must never displace the node's own row.
+///
+/// The node computed and verified its rows; a published record is trusted only after a digest the
+/// artifact carries itself, which is not a signature. A correct artifact never overlaps, so an
+/// overlap is exactly the corrupt-or-hostile case where precedence decides whether a wrong root
+/// reaches a client and builds a wrong witness.
+#[test]
+fn published_subtrees_never_displace_the_nodes_own_rows() {
+    let node = |root: u8| {
+        NoteCommitmentSubtreeData::new(
+            Height(11),
+            sapling_crypto::Node::from_bytes([root; 32]).unwrap(),
+        )
+    };
+
+    let mut stored = std::collections::BTreeMap::new();
+    stored.insert(NoteCommitmentSubtreeIndex(0), node(1));
+    stored.insert(NoteCommitmentSubtreeIndex(1), node(2));
+
+    merge_published_subtrees(
+        &mut stored,
+        [
+            // Collides with a row the node holds.
+            (NoteCommitmentSubtreeIndex(1), node(4)),
+            // Fills a genuine gap, which is what the artifact is for.
+            (NoteCommitmentSubtreeIndex(2), node(3)),
+        ],
+    );
+
+    assert_eq!(
+        stored[&NoteCommitmentSubtreeIndex(1)].root,
+        node(2).root,
+        "the node's own row wins on collision"
+    );
+    assert_eq!(
+        stored[&NoteCommitmentSubtreeIndex(2)].root,
+        node(3).root,
+        "a published record still fills an index the node lacks"
+    );
+    assert_eq!(stored.len(), 3);
 }

--- a/crates/zakura-state/src/service/read/tree.rs
+++ b/crates/zakura-state/src/service/read/tree.rs
@@ -51,6 +51,56 @@ pub fn check_historical_tree_available(
     }
 }
 
+/// Trims `subtrees` to the contiguous run beginning at `start_index`.
+///
+/// `z_getsubtreesbyindex` serves a continuous list: a client builds witnesses by walking indexes in
+/// order, so anything past a gap is unusable and a missing `start_index` means there is nothing to
+/// serve at all. Callers that merge two sources — the node's own rows and a published artifact —
+/// use this to re-establish that contract over the union.
+pub fn contiguous_subtrees_from<Node>(
+    mut subtrees: BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<Node>>,
+    start_index: NoteCommitmentSubtreeIndex,
+) -> BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<Node>> {
+    if !subtrees.contains_key(&start_index) {
+        return BTreeMap::new();
+    }
+
+    subtrees.retain(|index, _| *index >= start_index);
+
+    let mut expected = start_index.0;
+    let mut contiguous = BTreeMap::new();
+    for (index, data) in subtrees {
+        if index.0 != expected {
+            break;
+        }
+
+        contiguous.insert(index, data);
+        let Some(next) = expected.checked_add(1) else {
+            break;
+        };
+        expected = next;
+    }
+
+    contiguous
+}
+
+/// Merges published subtree records into `stored`, keeping the node's own row wherever both carry
+/// an index.
+///
+/// The node computed and verified its own rows; a published record is trusted only after a digest
+/// the artifact carries itself, which is not a signature. A correct artifact holds only subtrees
+/// completed at or below the handoff and so never overlaps what the node stores, which means an
+/// overlap is precisely the corrupt-or-hostile case where precedence decides whether a wrong root
+/// reaches a client.
+pub fn merge_published_subtrees<Node>(
+    stored: &mut BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<Node>>,
+    published: impl IntoIterator<Item = (NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<Node>)>,
+) {
+    for (index, data) in published {
+        stored.entry(index).or_insert(data);
+    }
+}
+
 /// Returns `true` if the subtree at `start_index` completed at or below the checkpoint handoff,
 /// given `handoff_leaves`, the pool's note commitment count at the handoff height.
 ///

--- a/crates/zakurad/src/commands.rs
+++ b/crates/zakurad/src/commands.rs
@@ -12,8 +12,9 @@ pub use self::{entry_point::EntryPoint, start::StartCmd};
 
 use self::{
     audit_historical_treestates::AuditHistoricalTreestatesCmd, copy_state::CopyStateCmd,
-    generate::GenerateCmd, prune_state::PruneStateCmd, rollback_state::RollbackStateCmd,
-    tip_height::TipHeightCmd, validate_vct_sprout_history::ValidateVctSproutHistoryCmd,
+    export_historical_treestates::ExportHistoricalTreestatesCmd, generate::GenerateCmd,
+    prune_state::PruneStateCmd, rollback_state::RollbackStateCmd, tip_height::TipHeightCmd,
+    validate_vct_sprout_history::ValidateVctSproutHistoryCmd,
 };
 
 pub mod start;
@@ -21,6 +22,7 @@ pub mod start;
 mod audit_historical_treestates;
 mod copy_state;
 mod entry_point;
+mod export_historical_treestates;
 mod generate;
 pub mod prune_state;
 pub mod rollback_state;
@@ -43,6 +45,9 @@ const LEGACY_CONFIG_FILE: &str = "zebrad.toml";
 pub enum ZakuradCmd {
     /// Audit historical note commitment treestate serving in the state database
     AuditHistoricalTreestates(AuditHistoricalTreestatesCmd),
+
+    /// Generate the historical subtree-root artifact from the state database
+    ExportHistoricalTreestates(ExportHistoricalTreestatesCmd),
 
     /// The `copy-state` subcommand, used to debug cached chain state (expert users only)
     // TODO: hide this command from users in release builds (#3279)
@@ -81,6 +86,7 @@ impl ZakuradCmd {
 
             // Utility commands that don't use server components
             AuditHistoricalTreestates(_)
+            | ExportHistoricalTreestates(_)
             | Generate(_)
             | PruneState(_)
             | RollbackState(_)
@@ -101,6 +107,7 @@ impl ZakuradCmd {
             // Utility commands
             AuditHistoricalTreestates(_)
             | CopyState(_)
+            | ExportHistoricalTreestates(_)
             | Generate(_)
             | PruneState(_)
             | RollbackState(_)
@@ -125,6 +132,7 @@ impl ZakuradCmd {
             // - is used by automated tools, or
             // - needs to be read easily.
             AuditHistoricalTreestates(_)
+            | ExportHistoricalTreestates(_)
             | Generate(_)
             | PruneState(_)
             | RollbackState(_)
@@ -149,6 +157,7 @@ impl Runnable for ZakuradCmd {
     fn run(&self) {
         match self {
             AuditHistoricalTreestates(cmd) => cmd.run(),
+            ExportHistoricalTreestates(cmd) => cmd.run(),
             CopyState(cmd) => cmd.run(),
             Generate(cmd) => cmd.run(),
             PruneState(cmd) => cmd.run(),

--- a/crates/zakurad/src/commands/export_historical_treestates.rs
+++ b/crates/zakurad/src/commands/export_historical_treestates.rs
@@ -1,0 +1,105 @@
+//! `export-historical-treestates` subcommand - generates the subtree-root artifact.
+//!
+//! One read-only replay across the absent band emits the completed subtree roots described in
+//! `docs/design/historical-treestate-serving.md` §4.6. The replay is checked against the
+//! authenticated roots the database already holds, so generation fails rather than publishing
+//! roots that do not match.
+
+use std::{fs, path::PathBuf};
+
+use abscissa_core::{Application, Command, Runnable};
+use clap::Parser;
+use color_eyre::eyre::{eyre, Result, WrapErr};
+
+use zakura_chain::parameters::Network;
+
+use crate::prelude::APPLICATION;
+
+/// Generate the historical subtree-root artifact from an existing state database
+#[derive(Command, Debug, Default, Parser)]
+pub struct ExportHistoricalTreestatesCmd {
+    /// Path to Zakura's cached state.
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
+    cache_dir: Option<PathBuf>,
+
+    /// The network of the chain to export.
+    #[clap(
+        long,
+        short,
+        required = true,
+        help = "the network of the chain to load"
+    )]
+    network: Network,
+
+    /// Where to write the subtree-root artifact.
+    #[clap(
+        long,
+        required = true,
+        help = "output path for the subtree-root artifact"
+    )]
+    subtree_output: PathBuf,
+}
+
+impl Runnable for ExportHistoricalTreestatesCmd {
+    /// `export-historical-treestates` sub-command entrypoint.
+    fn run(&self) {
+        if let Err(error) = self.run_with_config(APPLICATION.config().state.clone()) {
+            tracing::error!("Failed to export historical treestates: {error:#}");
+            std::process::exit(1);
+        }
+    }
+}
+
+impl ExportHistoricalTreestatesCmd {
+    /// Runs generation using `state_config` as the base state configuration.
+    #[allow(clippy::print_stdout)]
+    pub fn run_with_config(&self, mut state_config: zakura_state::Config) -> Result<()> {
+        if let Some(cache_dir) = self.cache_dir.clone() {
+            state_config.cache_dir = cache_dir;
+        }
+
+        let (_read_state, db, _non_finalized_sender) =
+            zakura_state::init_read_only(state_config, &self.network)?;
+
+        let export = zakura_state::export_subtree_artifact(&db, |height, blocks| {
+            println!("  reached height {:>9} after {blocks:>9} blocks", height.0);
+        })
+        .map_err(|error| eyre!("{error}"))?;
+
+        println!();
+        println!(
+            "subtree roots:   sapling {}, orchard {}, ironwood {}",
+            export.subtrees.sapling.len(),
+            export.subtrees.orchard.len(),
+            export.subtrees.ironwood.len(),
+        );
+        println!("blocks replayed: {}", export.replayed_blocks);
+        println!("elapsed:         {:.1}s", export.elapsed.as_secs_f64());
+
+        let bytes = export.subtrees.encode(&self.network);
+        write_atomically(&self.subtree_output, &bytes)?;
+
+        println!();
+        println!(
+            "wrote {} ({} bytes)",
+            self.subtree_output.display(),
+            bytes.len()
+        );
+
+        Ok(())
+    }
+}
+
+/// Writes `bytes` to `path` via a temporary file and a rename.
+///
+/// A consumer must never observe a partially written artifact, and a crash mid-write must leave
+/// any previous one intact.
+fn write_atomically(path: &PathBuf, bytes: &[u8]) -> Result<()> {
+    let temporary = path.with_extension("tmp");
+
+    fs::write(&temporary, bytes).wrap_err_with(|| format!("writing {}", temporary.display()))?;
+    fs::rename(&temporary, path)
+        .wrap_err_with(|| format!("renaming {} to {}", temporary.display(), path.display()))?;
+
+    Ok(())
+}

--- a/docs/changelog/unreleased/532.md
+++ b/docs/changelog/unreleased/532.md
@@ -1,0 +1,10 @@
+## Added
+
+- Added `state.historical_subtree_artifact`, which lets a verified-commitment-trees
+  fast-synced node serve `z_getsubtreesbyindex` below its checkpoint handoff from a
+  published set of completed subtree roots. Published roots never displace the node's own
+  rows, and each one a rebuild happens to cross is checked against the root the node
+  derives, so the published set is confirmed over a node's lifetime rather than trusted
+  indefinitely ([#532](https://github.com/zakura-core/zakura/pull/532)).
+- Added the `export-historical-treestates` subcommand, which generates that artifact from
+  an archive state database ([#532](https://github.com/zakura-core/zakura/pull/532)).

--- a/docs/changelog/unreleased/536.md
+++ b/docs/changelog/unreleased/536.md
@@ -5,6 +5,9 @@
   published set of completed subtree roots. Published roots never displace the node's own
   rows, and each one a rebuild happens to cross is checked against the root the node
   derives, so the published set is confirmed over a node's lifetime rather than trusted
-  indefinitely ([#532](https://github.com/zakura-core/zakura/pull/532)).
+  indefinitely ([#536](https://github.com/zakura-core/zakura/pull/536)).
 - Added the `export-historical-treestates` subcommand, which generates that artifact from
-  an archive state database ([#532](https://github.com/zakura-core/zakura/pull/532)).
+  an archive state database ([#536](https://github.com/zakura-core/zakura/pull/536)).
+- The release-state update workflow now imports the subtree-root artifact alongside the
+  checkpoint list and frontier, enforcing that published subtree roots are only ever
+  appended to ([#536](https://github.com/zakura-core/zakura/pull/536)).


### PR DESCRIPTION
Stacked on #535.

## Motivation

A fast-synced node records no completed subtree roots below its handoff — they are a by-product of the per-height tree maintenance the fast path skips, so they cannot be recorded during fast sync at all. Implements §4.6 of `docs/design/historical-treestate-serving.md`.

## Solution

Publish them as a small artifact (71,879 bytes for Mainnet: 1,127 Sapling, 763 Orchard) and serve them, with the node's own rows always taking precedence.

Two things the merge has to get right:

- **Published records never displace the node's own rows.** A correct artifact holds only subtrees completed at or below the handoff and so never overlaps — which makes an overlap exactly the corrupt-or-hostile case where the node's own verified value must win. The artifact's digest is self-contained, not a signature.
- **The served run is checked to its end.** One contiguous run means a gap anywhere truncates the response, and a single unbounded request from index 0 would otherwise return a short list that a client reads as the whole chain.

Generation replays the band and checks itself against the authenticated roots, so it needs an archive node but **not** a legacy-synced one — which §5 of the design assumed. Subtree roots fall out of that replay as interior nodes, pinned between two root-checked endpoints.

## Testing

Round-trip, determinism, and tamper tests (bad magic, wrong version, wrong network, flipped payload byte, absurd record count, truncation); merge-precedence and contiguity tests; lookup tests for the opportunistic check.

**Verified against ground truth**: above a fast-synced node's handoff the database *does* store subtree rows, so replaying `(3,358,006, 3,432,538]` and comparing gives **5 matched, 0 mismatched**.

**Determinism**: three exports at different grid parameterisations produced byte-identical artifacts (`d037bf37…`), which shows the content depends only on the chain.

CI imports the artifact with the checkpoint update, enforcing append-only over the records — the frame is not a byte-prefix of its successor, since the header carries counts and a digest.