### PR TITLE
fix(ci): stop treating release-state PRs as the release PR

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,11 +30,19 @@ jobs:
       - name: Validate this pull request's fragment
         if: github.event_name == 'pull_request'
         env:
-          ALLOW_MISSING: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+          # Release-state PRs come from `Update Mainnet release state`. They carry `A-release`
+          # for the release CI paths, but they are not the release PR that consumes the pending
+          # fragments, and their only Rust change is the generated end-of-support floor. Treat
+          # them like Dependabot: exempt from the one-fragment rule, and not a release PR.
+          ALLOW_MISSING: >-
+            ${{ github.event.pull_request.user.login == 'dependabot[bot]'
+                || contains(github.event.pull_request.labels.*.name, 'A-release-state') }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          RELEASE_PR: ${{ contains(github.event.pull_request.labels.*.name, 'A-release') }}
+          RELEASE_PR: >-
+            ${{ contains(github.event.pull_request.labels.*.name, 'A-release')
+                && !contains(github.event.pull_request.labels.*.name, 'A-release-state') }}
         run: |
           args=(
             check-pr

--- a/.github/workflows/update-release-state.yml
+++ b/.github/workflows/update-release-state.yml
@@ -218,7 +218,12 @@ jobs:
             - Meta SHA-256: `${{ steps.import.outputs.meta_sha256 }}`
 
             The checkpoint diff is append-only over the committed list, and CI re-derives the provenance digests from the embedded data on every PR. Review before merging: checkpoints are consensus-critical, so spot-check a few new heights and the terminal hash against an independent node or explorer.
-          labels: A-release
+          # `A-release-state` marks this as an automated release-state refresh rather than the
+          # release PR itself, so the changelog gate does not require it to consume every
+          # pending fragment. `A-release` stays for the release CI paths.
+          labels: |
+            A-release
+            A-release-state
           commit-message: "chore(chain): update Mainnet checkpoints and VCT frontier"
           sign-commits: true
           draft: always-true

--- a/docs/changelog/guidelines.md
+++ b/docs/changelog/guidelines.md
@@ -59,9 +59,13 @@ exclusion with a reason:
 This PR only changes tests and has no operator-visible effect.
 ```
 
-Dependabot and release PRs are automated exceptions to the one-file check. The
-`C-exclude-from-changelog` label remains useful release metadata, but does not
-replace the explicit fragment for Rust or `Cargo.toml` PRs.
+Dependabot, release PRs, and automated release-state updates are automated
+exceptions to the one-file check. Release-state PRs (the Mainnet checkpoint and
+VCT frontier refresh) carry `A-release-state`: their only Rust change is the
+generated end-of-support floor, and unlike the release PR they do not consume
+the pending fragments. The `C-exclude-from-changelog` label remains useful
+release metadata, but does not replace the explicit fragment for Rust or
+`Cargo.toml` PRs.
 
 Run `./scripts/changelog.py check` locally. CI validates the syntax and checks
 that the fragment filename matches the PR number. The concise format reference


### PR DESCRIPTION
## Motivation

The automated Mainnet checkpoint/frontier refresh (`Update Mainnet release state`) labels its PR `A-release`. The changelog gate reads that label as "this is the release PR", so it required the PR to consume every pending fragment — which it never does. [PR #537 failed on exactly this](https://github.com/zakura-core/zakura/pull/537):

```
changelog error: release PRs must consume every fragment; remaining:
228.md, 410.md, 428.md, 486.md, 497.md, 513.md, 524.md, 525.md, 527.md, 533.md
```

A release-state refresh is not the release PR. It consumes no fragments, and its only Rust change is the generated end-of-support floor.

## Solution

`docs/changelog/guidelines.md` already frames this correctly — *"Dependabot and release PRs are automated exceptions to the one-file check"*. A release-state refresh is a third such automated PR, so this adds it as one rather than inventing new machinery:

- `update-release-state.yml` adds a dedicated `A-release-state` label. `A-release` stays, so the release CI paths it gates (`check-no-git-dependencies` in `tests-unit.yml`) still run.
- `changelog.yml` treats `A-release-state` as a Dependabot-style exemption (`--allow-missing`) and explicitly not a release PR (`A-release && !A-release-state`).
- `guidelines.md` documents the third exception.

Label created: `A-release-state` — *Automated checkpoint/frontier update PRs; exempt from the changelog fragment check*.

## Testing

Both halves of the fix are load-bearing. Verified by running `scripts/changelog.py check-pr` against PR #537's real diff (which contains `end_of_support.rs`), at merge base `5991785`:

| flags | result |
| --- | --- |
| `--release-pr` (what CI did) | `release PRs must consume every fragment` — reproduces the failure |
| no flags | `add docs/changelog/unreleased/537.md` — so dropping the release flag alone is not enough |
| `--allow-missing` (this PR) | passes |

Also: both workflow files parse as YAML with the expressions rendering as intended, and `python3 -m unittest discover -s scripts/tests` passes 42 tests.

No changelog fragment: this PR changes only `.yml` and `.md`, no Rust or `Cargo.toml`.

### Follow-up Work

PR #537 itself needs to pick this up. For `pull_request` events the workflow runs from the PR's own branch, so #537 will not see the fix until its branch is updated — simplest is to re-run `Update Mainnet release state` after this merges and let it regenerate the PR with both labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)