### PR TITLE
ci: run checkpoint-sync bench on ephemeral DO droplets

### DIFF
--- a/.github/actions/do-droplet/action.yml
+++ b/.github/actions/do-droplet/action.yml
@@ -16,6 +16,10 @@ inputs:
   tag:
     description: "Droplet tag. Must be one the reaper sweeps, and is applied at creation so a later failure cannot leak an untagged droplet."
     required: true
+  image_id:
+    description: "Exact baked image ID. Empty resolves the newest zakura-pr-node-* image."
+    required: false
+    default: ""
   state_network:
     description: "Attach a clone of the newest zakura-pr-state-<network>-* snapshot (mainnet/testnet). Empty starts with no state volume."
     required: false
@@ -39,6 +43,9 @@ outputs:
   image_id:
     description: "Image the droplet was created from"
     value: ${{ steps.image.outputs.image_id }}
+  state_snapshot_id:
+    description: "Volume snapshot the state clone was restored from, empty when no state is requested"
+    value: ${{ steps.image.outputs.vol_snap_id }}
   volume_id:
     description: "Cloned state volume ID, empty when no state snapshot is requested"
     value: ${{ steps.create.outputs.volume_id }}
@@ -53,14 +60,19 @@ runs:
       id: image
       shell: bash
       env:
+        IMAGE_ID: ${{ inputs.image_id }}
         STATE_NETWORK: ${{ inputs.state_network }}
         STATE_SNAPSHOT_ID: ${{ inputs.state_snapshot_id }}
         VOLUME_NAME: ${{ inputs.volume_name }}
       run: |
         set -euo pipefail
-        # Image names are timestamped, so the lexical max is the newest bake.
-        IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
-          awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
+        if [ -n "${IMAGE_ID}" ]; then
+          IMAGE="${IMAGE_ID}"
+        else
+          # Image names are timestamped, so the lexical max is the newest bake.
+          IMAGE=$(doctl compute image list-user --format ID,Name --no-header | \
+            awk '$2 ~ /^zakura-pr-node-/ {print $2, $1}' | sort | tail -1 | awk '{print $2}')
+        fi
         if [ -z "${IMAGE}" ]; then
           echo "no zakura-pr-node-* image found; run the 'PR node image bake' workflow first" >&2
           exit 1

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,10 +57,10 @@ Deploys are manual, SSH-based, and run from self-hosted deployer runners; there 
 - **`zakura-pr-node-bake.yml`** — weekly bake of the golden PR-node droplet image (build deps, warm cargo cache), per-network chain-state volume snapshots, and an optional dedicated Mainnet pruned snapshot 100 blocks below the current VCT handoff. Set `rebuild_approach_from_sandblast` on a manual dispatch to build that rare fixture forward from the retained historical archive; ordinary weekly bakes leave the pinned approach snapshots in place.
 - **`zakura-pr-node-reaper.yml`** — hourly TTL cleanup backstop for PR-node resources. It keeps six Mainnet snapshot generations, two dedicated VCT approach snapshots, and dynamically pins the newest ordinary height-stamped snapshot below the current handoff as a fallback.
 - **`zakura-vct-handoff-canary.yml`** — daily, manual, and reusable Mainnet test that forces the Zakura P2P `tree_aux` path from the pinned pre-checkpoint state and exits after C is finalized and the best chain reaches C+1 with VCT fast-path activity. Failures alert `#zakura-alerts`; normal releases call it before publishing.
-- **`checkpoint-sync-bench.yml`** — manual fixed-height sync benchmark with checkpoint or semantic verification on the `zakura-bench` self-hosted runner, with a persistent metrics dashboard. See the workflow header for one-time runner setup.
+- **`checkpoint-sync-bench.yml`** — manual fixed-height sync benchmark with checkpoint or semantic verification on an ephemeral DigitalOcean droplet (baked image + Mainnet sandblast state). Uploads metrics series, bottleneck verdicts, and logs as artifacts for local dashboard replay; tears down the droplet and volume when the run ends (hourly reaper as backstop).
 - **`zakura-perf-bench.yml`** — CPU profiles mainnet workloads on ephemeral droplets. Historical mode restores `sandblast` state for fixed-height throughput and optional parallel A/B; live-head mode uses the production default P2P stack, catches up from the baked pruned tip, and requires head health throughout one observational profile window. Both produce flamegraphs, CPU counters, metrics, available traces, and block-latency digests (see `docs/cpu-profiling.md`).
 
-These workflows use the helper scripts in `.github/workflows/scripts/` (`pr-node-bake.sh`, `pr-node-run.sh`, `pr-node-monitor.py`, `perf-bench-run.sh`, `perf-bench-compare.py`).
+These workflows use the helper scripts in `.github/workflows/scripts/` (`pr-node-bake.sh`, `pr-node-run.sh`, `pr-node-monitor.py`, `perf-bench-run.sh`, `perf-bench-compare.py`, `checkpoint-sync-bench-run.sh`).
 
 After initially deploying this automation, manually dispatch the PR-node bake
 with `rebuild_approach_from_sandblast` enabled. This creates the first
@@ -70,7 +70,7 @@ that pruned state snapshots do not retain.
 Droplet lifecycle is shared, not copy-pasted, through the composite actions in `.github/actions/`:
 
 - **`do-cli`** — installs the pinned `doctl`, authenticates it for the rest of the job, and optionally writes the fleet SSH key to `/tmp/do_ssh`.
-- **`do-droplet`** — resolves the newest `zakura-pr-node-*` baked image and optionally clones either the newest network state or an exact volume snapshot, then creates the tagged droplet. Outputs `id`, `ip`, `image_id`, `volume_id`, `volume_name`.
+- **`do-droplet`** — resolves the newest `zakura-pr-node-*` baked image (or an exact `image_id`) and optionally clones either the newest network state or an exact volume snapshot, then creates the tagged droplet. Outputs `id`, `ip`, `image_id`, `state_snapshot_id`, `volume_id`, `volume_name`.
 - **`do-wait-ssh`** — polls a new droplet until it accepts SSH. Give the step an `id` if teardown needs to distinguish "unreachable" from "ran".
 - **`do-teardown`** — best-effort delete of a droplet and its volumes, recovering missing IDs from deterministic names and retrying volumes while the detach settles. Never fails a job; `enabled: false` keeps the resources and says so.
 

--- a/.github/workflows/checkpoint-sync-bench.yml
+++ b/.github/workflows/checkpoint-sync-bench.yml
@@ -1,31 +1,24 @@
 name: Checkpoint-sync benchmark
 
-# Manual, on-demand checkpoint-zone sync benchmark.
+# Manual, on-demand checkpoint-zone sync benchmark on an ephemeral DigitalOcean
+# droplet restored from the PR-node bake (image + Mainnet sandblast state).
 #
-# Picks a published release of this repo (no build in CI), runs zakurad forward from a
-# pre-synced ~1.7M mainnet state snapshot through the checkpoint zone pinned to a single
-# peer, and reports: time taken, blocks covered, blocks/s. Demonstrates the checkpoint-sync
-# throughput work (CHECKPOINT_SYNC_FINDINGS.md / PARALLEL_IDEA.md).
+# Builds or downloads a selected zakurad, hard-link-forks the baked ~1.7M state,
+# syncs through the checkpoint zone, and reports time / blocks / blocks/s plus a
+# bottleneck verdict (commit-starved / download-bound / verify-bound). Metrics
+# series and verdicts land in the GitHub Actions artifact for local dashboard
+# replay; there is no persistent host dashboard.
 #
-# Each run also records a Prometheus time series and classifies the run into a single
-# bottleneck verdict — commit-starved / download-bound / verify-bound — shown in the step
-# summary and saved as verdict-*.json. The recorded series feed an always-on dashboard
-# on the runner (scripts/zakura-dashboard.service) at http://<box>:8090/, where you can log
-# in and replay any past run's charts.
-#
-# Runs on the roman-zakura-3 self-hosted runner (label `zakura-bench`). One-time setup:
-# register the runner, set the BENCH_* repo Actions variables (see
-# scripts/checkpoint-sync-bench.sh header and the repo runbook), and install the dashboard
-# service once: `sudo cp scripts/zakura-dashboard.service /etc/systemd/system/ &&
-# sudo systemctl enable --now zakura-dashboard` (see that file's header).
+# Droplets are tagged `zakura-pr-node`, so the hourly reaper removes anything a
+# failed teardown leaves behind. Requires the same DO secrets as zakura-pr-node.yml.
 
 on:
   workflow_dispatch:
     inputs:
       build_ref:
-        description: "Git branch/tag/SHA to build on the host (cached by commit SHA). Primary mode."
+        description: "Git branch/tag/SHA to build on the droplet (cached by commit SHA). Primary mode."
         required: false
-        default: "feat/pre-release-main"
+        default: "main"
       force_rebuild:
         description: "Rebuild even if a binary for this commit SHA is already cached"
         type: boolean
@@ -45,7 +38,7 @@ on:
         required: false
         default: ""
       stop_height:
-        description: "Sync stops after committing this height (snapshot tip is 1,707,210)"
+        description: "Sync stops after committing this height (sandblast tip is 1,707,210)"
         required: true
         default: "1730000"
       wall_cap_seconds:
@@ -68,27 +61,64 @@ on:
         default: "150"
       verify_mode:
         description: "Verification mode: checkpoint, or semantic (consensus.checkpoint_sync=false; full script+proof verification past the mandatory checkpoints)"
+        type: choice
         required: false
         default: "checkpoint"
+        options:
+          - checkpoint
+          - semantic
       full_verify_concurrency_limit:
         description: "Concurrent semantic block verifications (1 approximates near-tip block-at-a-time)"
         required: false
         default: "20"
       target_p2p_stack:
         description: "Target/primary P2P stack: legacy | zakura | dual"
+        type: choice
         required: false
         default: "zakura"
+        options:
+          - legacy
+          - zakura
+          - dual
       baseline_p2p_stack:
         description: "Baseline/base P2P stack: legacy | zakura | dual"
+        type: choice
         required: false
         default: "legacy"
+        options:
+          - legacy
+          - zakura
+          - dual
       baseline_tag:
         description: "Optional (download mode): baseline release tag for a speedup comparison. Ignored when skip_baseline is true."
         required: false
         default: ""
+      droplet_size:
+        description: "Droplet size (disk must be >= the baked image's disk)"
+        type: choice
+        required: false
+        default: "g-8vcpu-32gb-intel"
+        options:
+          - g-8vcpu-32gb-intel
+          - c-8
+          - c-16
+          - c-32
+      image_id:
+        description: "Optional exact baked image ID (default: newest zakura-pr-node-*)"
+        required: false
+        default: ""
+      state_snapshot_id:
+        description: "Optional exact Mainnet state volume snapshot ID (default: newest zakura-pr-state-mainnet-*)"
+        required: false
+        default: ""
+      teardown_after_run:
+        description: "Delete the droplet + volume when the run ends (else the reaper removes them within 24h)"
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
-  group: checkpoint-sync-bench   # one bench at a time (single host, single snapshot)
+  group: checkpoint-sync-bench
   cancel-in-progress: false
 
 permissions:
@@ -97,18 +127,42 @@ permissions:
 jobs:
   bench:
     name: "checkpoint sync ${{ inputs.build_ref || inputs.release_tag }}"
-    runs-on: [self-hosted, "${{ vars.BENCH_RUNNER_LABEL || 'zakura-bench' }}"]
-    timeout-minutes: 360   # allow long self-hosted benchmark runs; WALL_CAP controls zakurad runtime
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
     steps:
-      - name: Checkout (for the bench script)
+      - name: Checkout (for the run + bench scripts)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           persist-credentials: false
 
+      - name: Install doctl and the fleet SSH key
+        uses: ./.github/actions/do-cli
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          ssh_private_key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+
+      - name: Create droplet (+ sandblast state volume)
+        id: droplet
+        uses: ./.github/actions/do-droplet
+        with:
+          name: zakura-ckpt-bench-${{ github.run_id }}
+          size: ${{ inputs.droplet_size || 'g-8vcpu-32gb-intel' }}
+          ssh_fingerprint: ${{ vars.DO_SSH_KEY_FINGERPRINT }}
+          tag: zakura-pr-node
+          image_id: ${{ inputs.image_id }}
+          state_network: mainnet
+          state_snapshot_id: ${{ inputs.state_snapshot_id }}
+          volume_name: zakura-pr-ckpt-vol-${{ github.run_id }}
+
+      - name: Wait for SSH
+        uses: ./.github/actions/do-wait-ssh
+        with:
+          ip: ${{ steps.droplet.outputs.ip }}
+
       - name: Run checkpoint-sync benchmark
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+          IP: ${{ steps.droplet.outputs.ip }}
+          GH_CLONE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_REF: ${{ inputs.build_ref }}
           BASELINE_REF: ${{ inputs.baseline_ref }}
           SKIP_BASELINE: ${{ inputs.skip_baseline && '1' || '0' }}
@@ -117,7 +171,7 @@ jobs:
           BASELINE_TAG: ${{ inputs.baseline_tag }}
           STOP_HEIGHT: ${{ inputs.stop_height }}
           WALL_CAP: ${{ inputs.wall_cap_seconds }}
-          FEED_PEER: ${{ inputs.feed_peer }}    # blank = public DNS-seeder peers
+          FEED_PEER: ${{ inputs.feed_peer }}
           PEERSET_SIZE: ${{ inputs.peerset_size }}
           CKPT_LIMIT: ${{ inputs.checkpoint_verify_concurrency_limit }}
           DL_LIMIT: ${{ inputs.download_concurrency_limit }}
@@ -125,16 +179,71 @@ jobs:
           FULL_VERIFY_LIMIT: ${{ inputs.full_verify_concurrency_limit }}
           TARGET_P2P_STACK: ${{ inputs.target_p2p_stack }}
           BASELINE_P2P_STACK: ${{ inputs.baseline_p2p_stack }}
-          SNAPSHOT_URL: ${{ vars.BENCH_SNAPSHOT_URL || 'https://zakura.valargroup.dev/mainnet/historical/zakura-mainnet-20260717T095333Z-1707210.tar.zst' }}
-          SNAPSHOT_SHA256: ${{ vars.BENCH_SNAPSHOT_SHA256 || '2bcb3786252300b4163b38a49b2d3a8015ba581d7d3efc854e6ed662a18258ac' }}
           START_HEIGHT: ${{ vars.BENCH_SNAPSHOT_START_HEIGHT || '1707210' }}
-          BENCH_HOME: ${{ vars.BENCH_HOME || '/opt/zakura-bench' }}
-          OUT_DIR: ${{ github.workspace }}/bench-out
-          # record metrics + emit the bottleneck verdict; the always-on dashboard service
-          # serves this archive dir. Disable with the BENCH_DASHBOARD repo var = '0'.
+          VOLUME_NAME: ${{ steps.droplet.outputs.volume_name }}
+          IMAGE_ID: ${{ steps.droplet.outputs.image_id }}
+          STATE_SNAPSHOT_ID: ${{ steps.droplet.outputs.state_snapshot_id }}
+          DROPLET_SIZE: ${{ inputs.droplet_size || 'g-8vcpu-32gb-intel' }}
+          DROPLET_ID: ${{ steps.droplet.outputs.id }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           DASHBOARD: ${{ vars.BENCH_DASHBOARD || '1' }}
-          DASHBOARD_ARCHIVE: ${{ vars.BENCH_DASHBOARD_ARCHIVE || '/opt/zakura-bench/dashboard/runs' }}
-        run: bash scripts/checkpoint-sync-bench.sh
+        run: |
+          set -euo pipefail
+          umask 077
+          {
+            printf 'GH_REPO=%q\n'          "${GITHUB_REPOSITORY}"
+            printf 'GH_CLONE_TOKEN=%q\n'   "${GH_CLONE_TOKEN}"
+            printf 'BUILD_REF=%q\n'        "${BUILD_REF}"
+            printf 'BASELINE_REF=%q\n'     "${BASELINE_REF}"
+            printf 'SKIP_BASELINE=%q\n'    "${SKIP_BASELINE}"
+            printf 'FORCE_REBUILD=%q\n'    "${FORCE_REBUILD}"
+            printf 'RELEASE_TAG=%q\n'      "${RELEASE_TAG}"
+            printf 'BASELINE_TAG=%q\n'     "${BASELINE_TAG}"
+            printf 'STOP_HEIGHT=%q\n'      "${STOP_HEIGHT}"
+            printf 'WALL_CAP=%q\n'         "${WALL_CAP}"
+            printf 'FEED_PEER=%q\n'        "${FEED_PEER}"
+            printf 'PEERSET_SIZE=%q\n'     "${PEERSET_SIZE}"
+            printf 'CKPT_LIMIT=%q\n'       "${CKPT_LIMIT}"
+            printf 'DL_LIMIT=%q\n'         "${DL_LIMIT}"
+            printf 'VERIFY_MODE=%q\n'      "${VERIFY_MODE}"
+            printf 'FULL_VERIFY_LIMIT=%q\n' "${FULL_VERIFY_LIMIT}"
+            printf 'TARGET_P2P_STACK=%q\n' "${TARGET_P2P_STACK}"
+            printf 'BASELINE_P2P_STACK=%q\n' "${BASELINE_P2P_STACK}"
+            printf 'START_HEIGHT=%q\n'     "${START_HEIGHT}"
+            printf 'VOLUME_NAME=%q\n'      "${VOLUME_NAME}"
+            printf 'IMAGE_ID=%q\n'         "${IMAGE_ID}"
+            printf 'STATE_SNAPSHOT_ID=%q\n' "${STATE_SNAPSHOT_ID}"
+            printf 'DROPLET_SIZE=%q\n'     "${DROPLET_SIZE}"
+            printf 'DROPLET_ID=%q\n'       "${DROPLET_ID}"
+            printf 'GITHUB_RUN_URL=%q\n'   "${GITHUB_RUN_URL}"
+            printf 'GITHUB_RUN_ID=%q\n'    "${GITHUB_RUN_ID}"
+            printf 'DASHBOARD=%q\n'        "${DASHBOARD}"
+          } > /tmp/run.env
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            /tmp/run.env \
+            .github/workflows/scripts/checkpoint-sync-bench-run.sh \
+            scripts/checkpoint-sync-bench.sh \
+            scripts/zakura-metrics-dashboard.py \
+            "root@${IP}:/root/"
+          rm -f /tmp/run.env
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=240 -i /tmp/do_ssh "root@${IP}" \
+            'set -euo pipefail; set -a; . /root/run.env; set +a; bash /root/checkpoint-sync-bench-run.sh'
+
+      - name: Collect benchmark outputs
+        if: always() && steps.droplet.outputs.ip != ''
+        env:
+          IP: ${{ steps.droplet.outputs.ip }}
+        run: |
+          set -euo pipefail
+          mkdir -p bench-out
+          scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/do_ssh \
+            "root@${IP}:/root/out/." bench-out/ || true
+          if [ -f bench-out/summary.md ]; then
+            cat bench-out/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Checkpoint-sync benchmark — no outputs collected" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Build artifact name
         id: artifact-name
@@ -153,3 +262,14 @@ jobs:
           path: bench-out/
           if-no-files-found: ignore
           retention-days: 30
+
+      - name: Teardown droplet + volume
+        if: always()
+        uses: ./.github/actions/do-teardown
+        with:
+          droplet_id: ${{ steps.droplet.outputs.id }}
+          droplet_name: zakura-ckpt-bench-${{ github.run_id }}
+          volume_ids: ${{ steps.droplet.outputs.volume_id }}
+          volume_names: ${{ steps.droplet.outputs.volume_name }}
+          # string-compare: keep teardown on when the boolean input is unset/true
+          enabled: ${{ format('{0}', inputs.teardown_after_run) == 'false' && 'false' || 'true' }}

--- a/.github/workflows/checkpoint-sync-bench.yml
+++ b/.github/workflows/checkpoint-sync-bench.yml
@@ -162,7 +162,6 @@ jobs:
       - name: Run checkpoint-sync benchmark
         env:
           IP: ${{ steps.droplet.outputs.ip }}
-          GH_CLONE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_REF: ${{ inputs.build_ref }}
           BASELINE_REF: ${{ inputs.baseline_ref }}
           SKIP_BASELINE: ${{ inputs.skip_baseline && '1' || '0' }}
@@ -192,7 +191,6 @@ jobs:
           umask 077
           {
             printf 'GH_REPO=%q\n'          "${GITHUB_REPOSITORY}"
-            printf 'GH_CLONE_TOKEN=%q\n'   "${GH_CLONE_TOKEN}"
             printf 'BUILD_REF=%q\n'        "${BUILD_REF}"
             printf 'BASELINE_REF=%q\n'     "${BASELINE_REF}"
             printf 'SKIP_BASELINE=%q\n'    "${SKIP_BASELINE}"

--- a/.github/workflows/scripts/checkpoint-sync-bench-run.sh
+++ b/.github/workflows/scripts/checkpoint-sync-bench-run.sh
@@ -25,10 +25,12 @@ log() { printf '[ckpt-bench-run %(%H:%M:%S)T] %s\n' -1 "$*" >&2; }
 die() { log "FATAL: $*"; exit 1; }
 
 scrub_secrets() {
+  local ec=$?
   git config --global --unset credential.helper 2>/dev/null || true
-  gh auth logout --hostname github.com >/dev/null 2>&1 || true
+  command -v gh >/dev/null 2>&1 && gh auth logout --hostname github.com >/dev/null 2>&1 || true
   rm -f /root/run.env
-  return 0
+  # Preserve the script's real status: EXIT-trap failures would otherwise mask it.
+  exit "$ec"
 }
 trap scrub_secrets EXIT INT TERM
 

--- a/.github/workflows/scripts/checkpoint-sync-bench-run.sh
+++ b/.github/workflows/scripts/checkpoint-sync-bench-run.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Runs ON an ephemeral checkpoint-sync-bench droplet
+# (checkpoint-sync-bench.yml). Mounts the cloned Mainnet sandblast volume,
+# validates DB format against the benched tree when building, then delegates to
+# scripts/checkpoint-sync-bench.sh with STATE_MASTER set so the historical
+# archive download is skipped.
+#
+# The volume clone is disposable and deleted with the droplet. Per-run state
+# forks stay on the volume via hard-links; builds reuse the baked
+# /root/zakura + /root/cargo-target cache.
+#
+# Config via /root/run.env (sourced by the caller before exec). Helper scripts
+# scp'd next to this one by the workflow:
+#   /root/checkpoint-sync-bench.sh
+#   /root/zakura-metrics-dashboard.py
+set -euo pipefail
+
+OUT_DIR=/root/out
+BENCH_SH=/root/checkpoint-sync-bench.sh
+DASHBOARD_PY=/root/zakura-metrics-dashboard.py
+BENCH_HOME=/root/zakura-bench
+mkdir -p "$OUT_DIR" "$BENCH_HOME"
+
+log() { printf '[ckpt-bench-run %(%H:%M:%S)T] %s\n' -1 "$*" >&2; }
+die() { log "FATAL: $*"; exit 1; }
+
+scrub_secrets() {
+  git config --global --unset credential.helper 2>/dev/null || true
+  gh auth logout --hostname github.com >/dev/null 2>&1 || true
+  rm -f /root/run.env
+  return 0
+}
+trap scrub_secrets EXIT INT TERM
+
+[[ -f "$BENCH_SH" ]] || die "missing $BENCH_SH (workflow must scp it)"
+[[ -n "${VOLUME_NAME:-}" ]] || die "VOLUME_NAME is required"
+
+cloud-init status --wait >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------- #
+# State: mount the baked sandblast tree from the cloned volume snapshot
+# ---------------------------------------------------------------------------- #
+
+DEV="/dev/disk/by-id/scsi-0DO_Volume_${VOLUME_NAME}"
+for _ in $(seq 1 30); do [ -e "$DEV" ] && break; sleep 2; done
+[ -e "$DEV" ] || die "state volume device not found: $DEV"
+mkdir -p /mnt/snapshots
+mount "$DEV" /mnt/snapshots
+STATE_MASTER="/mnt/snapshots/sandblast"
+[ -d "$STATE_MASTER/state" ] || die "no sandblast/state on the volume"
+df -h /mnt/snapshots >&2
+
+# Forks must share a filesystem with STATE_MASTER for cp -al.
+FORKS_DIR="/mnt/snapshots/forks"
+mkdir -p "$FORKS_DIR"
+
+# ---------------------------------------------------------------------------- #
+# Source: prepare the baked clone / release download tooling
+# ---------------------------------------------------------------------------- #
+
+# shellcheck source=/dev/null
+[[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+export PATH="${HOME}/.cargo/bin:${PATH}"
+export CARGO_TARGET_DIR=/root/cargo-target
+
+PRIMARY_SHA=""
+if [[ -n "${BUILD_REF:-}" ]]; then
+  [[ -d /root/zakura/.git ]] || die "baked /root/zakura clone missing"
+  cd /root/zakura
+  GIT_AUTH=$(printf 'x-access-token:%s' "${GH_CLONE_TOKEN}" | base64 -w0)
+  # Fetch every ref we may build so BUILD_REF / BASELINE_REF resolve offline later.
+  git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
+    fetch --no-tags origin "${BUILD_REF}"
+  PRIMARY_SHA=$(git rev-parse --verify 'FETCH_HEAD^{commit}')
+  if [[ -n "${BASELINE_REF:-}" && "${SKIP_BASELINE:-0}" != "1" ]]; then
+    git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
+      fetch --no-tags origin "${BASELINE_REF}"
+  fi
+  git checkout --detach "${PRIMARY_SHA}"
+
+  CODE_VER=$(grep -oE 'DATABASE_FORMAT_VERSION: .* [0-9]+' \
+    crates/zakura-state/src/constants.rs | grep -oE '[0-9]+' | tail -n1)
+  DIR_VER=$(find "$STATE_MASTER/state" -mindepth 1 -maxdepth 1 -type d -name 'v*' 2>/dev/null | \
+    sed 's#.*/v##' | sort -n | tail -1)
+  if [ -z "$DIR_VER" ]; then
+    die "no state/v* directory under $STATE_MASTER"
+  elif [ "$DIR_VER" != "$CODE_VER" ] && [ "$DIR_VER" != "$((CODE_VER - 1))" ]; then
+    die "DB format mismatch: volume is v${DIR_VER}, benched tree is v${CODE_VER}; re-bake the state snapshot"
+  fi
+  log "state DB v${DIR_VER} compatible with code v${CODE_VER}; primary=${PRIMARY_SHA}"
+
+  # Leave a short-lived credential helper so checkpoint-sync-bench.sh can fetch
+  # baseline/primary checkouts without re-exporting the token into the env file.
+  git config --global credential.helper \
+    "!f() { echo username=x-access-token; echo password=${GH_CLONE_TOKEN}; }; f"
+elif [[ -n "${RELEASE_TAG:-}" ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    log "installing GitHub CLI for release download ..."
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg status=none
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list
+    apt-get update -qq
+    apt-get install -y -qq gh
+  fi
+  echo "${GH_CLONE_TOKEN}" | gh auth login --with-token
+else
+  die "set BUILD_REF or RELEASE_TAG"
+fi
+
+rm -f /root/run.env
+# Keep the token only inside the temporary git credential helper (build mode)
+# or the gh auth session (release mode). Clear the shell copy.
+unset GH_CLONE_TOKEN GIT_AUTH
+
+# ---------------------------------------------------------------------------- #
+# Run metadata for the artifact (image / snapshot / droplet identity)
+# ---------------------------------------------------------------------------- #
+
+export PRIMARY_SHA
+python3 - <<'PY'
+import json, os
+from pathlib import Path
+meta = {
+    "droplet_id": os.environ.get("DROPLET_ID", ""),
+    "droplet_size": os.environ.get("DROPLET_SIZE", ""),
+    "image_id": os.environ.get("IMAGE_ID", ""),
+    "state_snapshot_id": os.environ.get("STATE_SNAPSHOT_ID", ""),
+    "volume_name": os.environ.get("VOLUME_NAME", ""),
+    "start_height": os.environ.get("START_HEIGHT", ""),
+    "stop_height": os.environ.get("STOP_HEIGHT", ""),
+    "verify_mode": os.environ.get("VERIFY_MODE", ""),
+    "build_ref": os.environ.get("BUILD_REF", ""),
+    "baseline_ref": os.environ.get("BASELINE_REF", ""),
+    "release_tag": os.environ.get("RELEASE_TAG", ""),
+    "primary_sha": os.environ.get("PRIMARY_SHA", ""),
+    "github_run_url": os.environ.get("GITHUB_RUN_URL", ""),
+    "github_run_id": os.environ.get("GITHUB_RUN_ID", ""),
+}
+Path("/root/out/run-meta.json").write_text(json.dumps(meta, indent=2) + "\n")
+PY
+
+# ---------------------------------------------------------------------------- #
+# Delegate to the shared bench script
+# ---------------------------------------------------------------------------- #
+
+export OUT_DIR BENCH_HOME STATE_MASTER FORKS_DIR DASHBOARD_PY
+export BUILD_SRC=/root/zakura
+export BUILD_TARGET=/root/cargo-target
+export BUILD_CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+export DASHBOARD_ARCHIVE="${OUT_DIR}/dashboard-runs"
+export GITHUB_STEP_SUMMARY="${OUT_DIR}/summary.md"
+export PRIMARY_SHA
+
+# Prefer the already-resolved SHA so the bench builds the same commit we validated.
+if [[ -n "${PRIMARY_SHA}" && -n "${BUILD_REF:-}" ]]; then
+  export BUILD_REF="${PRIMARY_SHA}"
+fi
+
+bash "$BENCH_SH"
+status=$?
+exit "$status"

--- a/.github/workflows/scripts/checkpoint-sync-bench-run.sh
+++ b/.github/workflows/scripts/checkpoint-sync-bench-run.sh
@@ -24,20 +24,6 @@ mkdir -p "$OUT_DIR" "$BENCH_HOME"
 log() { printf '[ckpt-bench-run %(%H:%M:%S)T] %s\n' -1 "$*" >&2; }
 die() { log "FATAL: $*"; exit 1; }
 
-# Invoked via trap below; shellcheck cannot see indirect calls.
-# shellcheck disable=SC2317,SC2329
-scrub_secrets() {
-  local ec=$?
-  git config --global --unset credential.helper 2>/dev/null || true
-  if command -v gh >/dev/null 2>&1; then
-    gh auth logout --hostname github.com >/dev/null 2>&1 || true
-  fi
-  rm -f /root/run.env
-  # Preserve the script's real status: EXIT-trap failures would otherwise mask it.
-  exit "$ec"
-}
-trap scrub_secrets EXIT INT TERM
-
 [[ -f "$BENCH_SH" ]] || die "missing $BENCH_SH (workflow must scp it)"
 [[ -n "${VOLUME_NAME:-}" ]] || die "VOLUME_NAME is required"
 
@@ -73,14 +59,11 @@ PRIMARY_SHA=""
 if [[ -n "${BUILD_REF:-}" ]]; then
   [[ -d /root/zakura/.git ]] || die "baked /root/zakura clone missing"
   cd /root/zakura
-  GIT_AUTH=$(printf 'x-access-token:%s' "${GH_CLONE_TOKEN}" | base64 -w0)
   # Fetch every ref we may build so BUILD_REF / BASELINE_REF resolve offline later.
-  git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
-    fetch --no-tags origin "${BUILD_REF}"
+  git fetch --no-tags origin "${BUILD_REF}"
   PRIMARY_SHA=$(git rev-parse --verify 'FETCH_HEAD^{commit}')
   if [[ -n "${BASELINE_REF:-}" && "${SKIP_BASELINE:-0}" != "1" ]]; then
-    git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
-      fetch --no-tags origin "${BASELINE_REF}"
+    git fetch --no-tags origin "${BASELINE_REF}"
   fi
   git checkout --detach "${PRIMARY_SHA}"
 
@@ -94,31 +77,11 @@ if [[ -n "${BUILD_REF:-}" ]]; then
     die "DB format mismatch: volume is v${DIR_VER}, benched tree is v${CODE_VER}; re-bake the state snapshot"
   fi
   log "state DB v${DIR_VER} compatible with code v${CODE_VER}; primary=${PRIMARY_SHA}"
-
-  # Leave a short-lived credential helper so checkpoint-sync-bench.sh can fetch
-  # baseline/primary checkouts without re-exporting the token into the env file.
-  git config --global credential.helper \
-    "!f() { echo username=x-access-token; echo password=${GH_CLONE_TOKEN}; }; f"
-elif [[ -n "${RELEASE_TAG:-}" ]]; then
-  if ! command -v gh >/dev/null 2>&1; then
-    log "installing GitHub CLI for release download ..."
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg status=none
-    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list
-    apt-get update -qq
-    apt-get install -y -qq gh
-  fi
-  echo "${GH_CLONE_TOKEN}" | gh auth login --with-token
-else
+elif [[ -z "${RELEASE_TAG:-}" ]]; then
   die "set BUILD_REF or RELEASE_TAG"
 fi
 
 rm -f /root/run.env
-# Keep the token only inside the temporary git credential helper (build mode)
-# or the gh auth session (release mode). Clear the shell copy.
-unset GH_CLONE_TOKEN GIT_AUTH
 
 # ---------------------------------------------------------------------------- #
 # Run metadata for the artifact (image / snapshot / droplet identity)

--- a/.github/workflows/scripts/checkpoint-sync-bench-run.sh
+++ b/.github/workflows/scripts/checkpoint-sync-bench-run.sh
@@ -24,10 +24,14 @@ mkdir -p "$OUT_DIR" "$BENCH_HOME"
 log() { printf '[ckpt-bench-run %(%H:%M:%S)T] %s\n' -1 "$*" >&2; }
 die() { log "FATAL: $*"; exit 1; }
 
+# Invoked via trap below; shellcheck cannot see indirect calls.
+# shellcheck disable=SC2317,SC2329
 scrub_secrets() {
   local ec=$?
   git config --global --unset credential.helper 2>/dev/null || true
-  command -v gh >/dev/null 2>&1 && gh auth logout --hostname github.com >/dev/null 2>&1 || true
+  if command -v gh >/dev/null 2>&1; then
+    gh auth logout --hostname github.com >/dev/null 2>&1 || true
+  fi
   rm -f /root/run.env
   # Preserve the script's real status: EXIT-trap failures would otherwise mask it.
   exit "$ec"

--- a/docs/cpu-profiling.md
+++ b/docs/cpu-profiling.md
@@ -62,7 +62,7 @@ macOS: `perf` does not exist; use [samply](https://github.com/mstange/samply) (`
 
 ## Related instrumentation (what this is not)
 
-- `checkpoint-sync-bench.yml` is the older fixed-host sync bench on the `zakura-bench` runner (persistent dashboard, warm caches, serialized runs); this lane is the ephemeral, parallel, profiled successor for CPU/latency questions.
+- `checkpoint-sync-bench.yml` is the fixed-height sync throughput bench on an ephemeral droplet (baked sandblast state, bottleneck verdicts, artifact replay); this lane adds CPU profiling, flamegraphs, and optional parallel A/B legs for latency questions.
 - `cargo bench` criterion microbenches (`benchmarks.yml`, `C-benchmark` PR label) time the crypto primitives in isolation; this lane shows their share of a real sync.
 - The `deploy/runner/` cohort harness (`make perf-*`) is the deterministic isolated-cohort deep-dive with per-phase commit attribution.
 - The `flamegraph` cargo feature (`tracing.flamegraph` config) renders span wall-time, not sampled CPU, and needs a special build; prefer this lane for CPU questions.

--- a/scripts/checkpoint-sync-bench.sh
+++ b/scripts/checkpoint-sync-bench.sh
@@ -293,22 +293,22 @@ ensure_snapshot() {
 # sets ZAKURAD_BIN to the zakurad binary path for $1=tag (returns via global, not
 # stdout, so no subcommand chatter can ever pollute the path)
 ensure_binary() {
-  local tag="$1" bindir="$BENCH_HOME/bins/$1" zakurad
+  local tag="$1" bindir="$BENCH_HOME/bins/$1" zakurad asset release_url
   zakurad="$bindir/zakurad"
   if [[ -x "$zakurad" ]]; then ZAKURAD_BIN="$zakurad"; return; fi
   mkdir -p "$bindir"
   log "fetching release $tag from $GH_REPO ..." >&2
   local dl="$bindir/dl"; rm -rf "$dl"; mkdir -p "$dl"
-  gh release download "$tag" -R "$GH_REPO" \
-    -p 'zakurad-*-linux-x86_64.tar.gz' -p 'zakurad-*-linux-x86_64.tar.gz' -p 'SHA256SUMS.txt' -D "$dl" \
-    || die "gh release download failed for $tag"
-  local tgz; tgz="$(find "$dl" \( -name 'zakurad-*-linux-x86_64.tar.gz' -o -name 'zakurad-*-linux-x86_64.tar.gz' \) | head -1)"
-  [[ -n "$tgz" ]] || die "no linux-x86_64 tarball asset on release $tag"
-  if [[ -f "$dl/SHA256SUMS.txt" ]]; then
-    # NB: keep all output on stderr — this function's stdout is captured as the binary path
-    ( cd "$dl" && grep "$(basename "$tgz")" SHA256SUMS.txt | sha256sum -c - ) >&2 \
-      || die "release tarball checksum mismatch for $tag"
-  fi
+  asset="zakurad-${tag}-linux-x86_64.tar.gz"
+  release_url="https://github.com/${GH_REPO}/releases/download/${tag}"
+  curl -fL --retry 3 --retry-all-errors -o "$dl/$asset" "$release_url/$asset" \
+    || die "release tarball download failed for $tag"
+  curl -fL --retry 3 --retry-all-errors -o "$dl/SHA256SUMS.txt" "$release_url/SHA256SUMS.txt" \
+    || die "release checksum download failed for $tag"
+  # NB: keep all output on stderr — this function's stdout is captured as the binary path
+  ( cd "$dl" && grep -F " ./$asset" SHA256SUMS.txt | sha256sum -c - ) >&2 \
+    || die "release tarball checksum mismatch for $tag"
+  local tgz="$dl/$asset"
   tar -xzf "$tgz" -C "$dl"
   local found; found="$(find "$dl" -type f \( -name zakurad -o -name zakurad \) | head -1)"
   [[ -n "$found" ]] || die "node binary not found in tarball for $tag"
@@ -349,11 +349,10 @@ ensure_source() {
   ensure_toolchain
   if [[ ! -d "$BUILD_SRC/.git" ]]; then
     log "cloning $GH_REPO -> $BUILD_SRC (first build only) ..." >&2
-    gh auth setup-git 2>/dev/null || true
     git clone "https://github.com/$GH_REPO.git" "$BUILD_SRC" >&2 || die "git clone failed"
   fi
-  # Ephemeral CI prefetches the needed commits; a credential helper may still be
-  # configured. Fall back to a tagged fetch for local persistent hosts.
+  # Ephemeral CI prefetches the needed commits. Fall back to a tagged fetch for
+  # local persistent hosts.
   if ! git -C "$BUILD_SRC" fetch --no-tags --force origin >&2; then
     git -C "$BUILD_SRC" fetch --tags --force origin >&2 || die "git fetch failed"
   fi

--- a/scripts/checkpoint-sync-bench.sh
+++ b/scripts/checkpoint-sync-bench.sh
@@ -168,11 +168,13 @@ fi
 
 # Always tear down a launched node + its fork, even on FATAL/interrupt, so a failed
 # run never leaves an orphan zakurad thrashing the box or a fork eating disk.
+# Each step is `|| true` so a dead PID (clean debug_stop_at_height exit) cannot
+# trip `set -e` inside the EXIT trap and flip a successful run to failure.
 CUR_PID=""; CUR_FORK=""; CUR_REC=""
 cleanup() {
-  [[ -n "$CUR_REC" ]] && kill "$CUR_REC" 2>/dev/null
-  [[ -n "$CUR_PID" ]] && kill -9 "$CUR_PID" 2>/dev/null
-  [[ -n "$CUR_FORK" ]] && rm -rf "$CUR_FORK" 2>/dev/null
+  [[ -n "$CUR_REC" ]] && kill "$CUR_REC" 2>/dev/null || true
+  [[ -n "$CUR_PID" ]] && kill -9 "$CUR_PID" 2>/dev/null || true
+  [[ -n "$CUR_FORK" ]] && rm -rf "$CUR_FORK" 2>/dev/null || true
   return 0
 }
 trap cleanup EXIT INT TERM

--- a/scripts/checkpoint-sync-bench.sh
+++ b/scripts/checkpoint-sync-bench.sh
@@ -2,13 +2,12 @@
 #
 # checkpoint-sync-bench.sh — repeatable checkpoint-zone sync benchmark.
 #
-# Downloads a pre-synced ~1.7M mainnet state snapshot once, hard-link-forks it per
-# run (cp -al), runs a prebuilt release zakurad forward through the checkpoint zone
-# pinned to a single peer, and prints: time taken, blocks covered, blocks/s.
+# Hard-link-forks a ~1.7M mainnet state master, runs zakurad forward through the
+# checkpoint zone, and prints: time taken, blocks covered, blocks/s.
 #
-# No build: the zakurad binary comes from a published GitHub release tarball.
-# Designed to run on the roman-zakura-3 self-hosted runner, but it is self-contained
-# and can be run by hand on any Linux box with enough disk.
+# Primary CI path (checkpoint-sync-bench.yml): an ephemeral DigitalOcean droplet
+# mounts a baked sandblast volume and sets STATE_MASTER so no archive download is
+# needed. Local/manual runs can still stream-download a snapshot into BENCH_HOME.
 #
 # Binary source (pick one; BUILD_REF wins):
 #   BUILD_REF             git branch/tag/SHA to build ON THIS HOST, cached by commit
@@ -32,16 +31,22 @@
 #   TARGET_P2P_STACK            legacy | zakura | dual
 #                               default: zakura
 #   BASELINE_P2P_STACK          same as TARGET_P2P_STACK for the baseline run (default: legacy)
-#   SNAPSHOT_URL          primary snapshot .tar.zst URL
+#   STATE_MASTER          pre-mounted immutable state tree (skips SNAPSHOT_URL download)
+#   FORKS_DIR             hard-link fork root (default $BENCH_HOME/forks; must share
+#                         a filesystem with STATE_MASTER / MASTER for cp -al)
+#   SNAPSHOT_URL          primary snapshot .tar.zst URL (ignored when STATE_MASTER set)
 #   SNAPSHOT_SHA256       expected sha256 of the .tar.zst
 #   START_HEIGHT          snapshot tip height                  (default 1707210)
-#   BENCH_HOME            persistent cache root                (default /opt/zakura-bench)
+#   BENCH_HOME            cache root (bins / optional master)  (default /opt/zakura-bench)
+#   BUILD_SRC             source checkout for host builds      (default $BENCH_HOME/src)
+#   BUILD_TARGET          cargo target dir                     (default $BENCH_HOME/build-target)
+#   BUILD_CARGO_HOME      cargo home                           (default $BENCH_HOME/cargo-home)
 #   GH_REPO               releases repo                        (default zakura-core/zakura)
 #   OUT_DIR               artifact output dir                  (default ./bench-out)
 #   METRICS_PORT          Prometheus port (auto-bumps if busy) (default 19999)
 #   LISTEN_PORT           P2P listen port  (auto-bumps if busy)(default 18233)
 #   DASHBOARD             1 = record metrics + emit bottleneck verdict (default 1)
-#   DASHBOARD_ARCHIVE     recorded-run dir the dashboard serves (default $BENCH_HOME/dashboard/runs)
+#   DASHBOARD_ARCHIVE     recorded-run dir for local replay    (default $OUT_DIR/dashboard-runs)
 #   BUILD_FEATURES        cargo features for host builds (default prometheus,commit-metrics)
 #
 # Ports default high and auto-skip busy ones so the bench can coexist with another
@@ -49,8 +54,8 @@
 #
 # Observability: each run records a Prometheus time series via scripts/zakura-metrics-dashboard.py
 # into DASHBOARD_ARCHIVE, classifies it into a commit/download/verify bottleneck verdict
-# (summary banner + verdict-*.json), and the always-on dashboard (scripts/zakura-dashboard.service)
-# replays every recorded run at http://<box>:8090/. See that unit file for one-time setup.
+# (summary banner + verdict-*.json), and copies the series into OUT_DIR. Replay locally with:
+#   python3 scripts/zakura-metrics-dashboard.py --archive <downloaded>/dashboard-runs --port 8090
 set -euo pipefail
 
 # ---- inputs / defaults -------------------------------------------------------
@@ -74,17 +79,18 @@ PEERSET_SIZE="${PEERSET_SIZE:-1}"   # 1 = strict single pinned peer; raise to al
 TARGET_P2P_STACK="${TARGET_P2P_STACK:-}"
 BASELINE_P2P_STACK="${BASELINE_P2P_STACK:-}"
 START_HEIGHT="${START_HEIGHT:-1707210}"
+STATE_MASTER="${STATE_MASTER:-}"
 SNAPSHOT_URL="${SNAPSHOT_URL:-https://zakura.valargroup.dev/mainnet/historical/zakura-mainnet-20260717T095333Z-1707210.tar.zst}"
 SNAPSHOT_SHA256="${SNAPSHOT_SHA256:-2bcb3786252300b4163b38a49b2d3a8015ba581d7d3efc854e6ed662a18258ac}"
 SNAPSHOT_MIRROR="${SNAPSHOT_MIRROR:-}"
 BENCH_HOME="${BENCH_HOME:-/opt/zakura-bench}"
 GH_REPO="${GH_REPO:-zakura-core/zakura}"
 OUT_DIR="${OUT_DIR:-$PWD/bench-out}"
-# Observability dashboard: record a per-run metrics time series + emit a bottleneck
-# verdict (commit / download / verify). DASHBOARD_ARCHIVE is where the always-on
-# dashboard service (scripts/zakura-dashboard.service) reads recorded runs from.
+# Observability: record a per-run metrics time series + emit a bottleneck
+# verdict (commit / download / verify). CI uploads DASHBOARD_ARCHIVE in the
+# artifact for local replay; there is no persistent host dashboard.
 DASHBOARD="${DASHBOARD:-1}"
-DASHBOARD_ARCHIVE="${DASHBOARD_ARCHIVE:-$BENCH_HOME/dashboard/runs}"
+DASHBOARD_ARCHIVE="${DASHBOARD_ARCHIVE:-$OUT_DIR/dashboard-runs}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_PY="${DASHBOARD_PY:-$SCRIPT_DIR/zakura-metrics-dashboard.py}"
 GITHUB_RUN_URL="${GITHUB_RUN_URL:-}"
@@ -92,7 +98,15 @@ if [[ -z "$GITHUB_RUN_URL" && -n "${GITHUB_RUN_ID:-}" ]]; then
   GITHUB_RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$GH_REPO}/actions/runs/$GITHUB_RUN_ID"
 fi
 
-MASTER="$BENCH_HOME/master-${START_HEIGHT}"
+if [[ -n "$STATE_MASTER" ]]; then
+  MASTER="$STATE_MASTER"
+else
+  MASTER="$BENCH_HOME/master-${START_HEIGHT}"
+fi
+FORKS_DIR="${FORKS_DIR:-$BENCH_HOME/forks}"
+BUILD_SRC="${BUILD_SRC:-$BENCH_HOME/src}"
+BUILD_TARGET="${BUILD_TARGET:-$BENCH_HOME/build-target}"
+BUILD_CARGO_HOME="${BUILD_CARGO_HOME:-$BENCH_HOME/cargo-home}"
 SAMPLE_INTERVAL=5
 ZAKURAD_BIN=""
 ZAKURA_BOOTSTRAP_PEERS=(
@@ -194,24 +208,40 @@ ensure_deps() {
 
 ensure_bench_home() {
   if [[ ! -d "$BENCH_HOME" ]]; then
-    sudo mkdir -p "$BENCH_HOME" || die "cannot create $BENCH_HOME"
-    sudo chown "$(id -u):$(id -g)" "$BENCH_HOME" || die "cannot own $BENCH_HOME"
+    mkdir -p "$BENCH_HOME" 2>/dev/null \
+      || { sudo mkdir -p "$BENCH_HOME" || die "cannot create $BENCH_HOME"
+           sudo chown "$(id -u):$(id -g)" "$BENCH_HOME" || die "cannot own $BENCH_HOME"; }
   fi
   [[ -w "$BENCH_HOME" ]] || die "$BENCH_HOME not writable"
-  mkdir -p "$BENCH_HOME/snapshots" "$BENCH_HOME/bins" "$BENCH_HOME/forks"
-  local avail_gib
-  avail_gib=$(df -B1G --output=avail "$BENCH_HOME" | tail -1 | tr -dc '0-9')
-  log "free space at $BENCH_HOME: ${avail_gib}GiB"
-  # streaming extract needs room for the ~40GiB extracted master + per-run fork divergence
-  (( avail_gib >= 45 )) || die "need >=45GiB free at $BENCH_HOME, have ${avail_gib}GiB"
+  mkdir -p "$BENCH_HOME/snapshots" "$BENCH_HOME/bins" "$FORKS_DIR"
+  local avail_gib disk_root
+  # When STATE_MASTER is set, free space for forks matters on that filesystem.
+  disk_root="$BENCH_HOME"
+  [[ -n "$STATE_MASTER" ]] && disk_root="$FORKS_DIR"
+  avail_gib=$(df -B1G --output=avail "$disk_root" | tail -1 | tr -dc '0-9')
+  log "free space at $disk_root: ${avail_gib}GiB"
+  if [[ -n "$STATE_MASTER" ]]; then
+    # baked volume already holds the master; only fork divergence needs headroom
+    (( avail_gib >= 20 )) || die "need >=20GiB free at $disk_root for forks, have ${avail_gib}GiB"
+  else
+    # streaming extract needs room for the ~40GiB extracted master + fork divergence
+    (( avail_gib >= 45 )) || die "need >=45GiB free at $BENCH_HOME, have ${avail_gib}GiB"
+  fi
 }
 
-# ---- 1. snapshot (stream download+extract once, cached) ----------------------
-# Streams the .tar.zst straight through zstd|tar so the compressed tarball is never
-# stored on disk (the box has only ~one disk and can't hold tarball + extracted state).
-# sha256 is computed over the compressed stream via tee and checked after extraction.
+# ---- 1. snapshot (pre-mounted master, or stream download+extract once) -------
+# When STATE_MASTER is set (ephemeral CI), the baked volume already holds the
+# immutable tree. Otherwise streams the .tar.zst through zstd|tar so the
+# compressed tarball is never stored on disk.
 ensure_snapshot() {
   local version_file
+  if [[ -n "$STATE_MASTER" ]]; then
+    [[ -d "$MASTER/state" ]] || die "STATE_MASTER missing state/: $MASTER"
+    version_file="$(find "$MASTER/state" -mindepth 3 -maxdepth 3 -type f -path '*/mainnet/version' -print -quit 2>/dev/null || true)"
+    [[ -n "$version_file" ]] || die "STATE_MASTER missing state/v*/mainnet/version: $MASTER"
+    log "using pre-mounted state master: $MASTER (db v$(cat "$version_file"))"
+    return
+  fi
   version_file="$(find "$MASTER/state" -mindepth 3 -maxdepth 3 -type f -path '*/mainnet/version' -print -quit 2>/dev/null || true)"
   if [[ -n "$version_file" ]]; then
     log "snapshot master present: $MASTER (db v$(cat "$version_file"))"
@@ -280,11 +310,8 @@ ensure_binary() {
 }
 
 # ---- 2b. build a git ref on this host, cached by commit SHA -------------------
-# Persistent build state lives on the bench disk so a new commit on the same branch
-# is an incremental (fast) rebuild, and a cache hit on the same SHA skips the build.
-BUILD_SRC="$BENCH_HOME/src"
-BUILD_TARGET="$BENCH_HOME/build-target"
-BUILD_CARGO_HOME="$BENCH_HOME/cargo-home"
+# Build state lives under BUILD_SRC / BUILD_TARGET (baked paths on ephemeral CI,
+# or BENCH_HOME defaults for local runs). A cache hit on the same SHA skips the build.
 
 # validate a cached binary really is the one we built for $2=sha: integrity (sha256
 # matches the stored value) AND provenance (zakurad --version embeds the git short sha).
@@ -317,7 +344,11 @@ ensure_source() {
     gh auth setup-git 2>/dev/null || true
     git clone "https://github.com/$GH_REPO.git" "$BUILD_SRC" >&2 || die "git clone failed"
   fi
-  git -C "$BUILD_SRC" fetch --tags --force origin >&2 || die "git fetch failed"
+  # Ephemeral CI prefetches the needed commits; a credential helper may still be
+  # configured. Fall back to a tagged fetch for local persistent hosts.
+  if ! git -C "$BUILD_SRC" fetch --no-tags --force origin >&2; then
+    git -C "$BUILD_SRC" fetch --tags --force origin >&2 || die "git fetch failed"
+  fi
 }
 
 # build $1=ref; sets ZAKURAD_BIN. Skips the build (with revalidation) on a SHA cache hit.
@@ -436,13 +467,14 @@ run_one() {
   resolve_binary "$tag"; local zakurad="$ZAKURAD_BIN"
   local run_id
   run_id="${prefix}-$$-$(date +%s)"
-  local fork="$BENCH_HOME/forks/$run_id"
+  local fork="$FORKS_DIR/$run_id"
   local logf="/dev/shm/zakura-bench-$run_id.log"
   local csv="$OUT_DIR/samples-$prefix.csv"
   local trace_dir="$OUT_DIR/zakura-traces-$prefix"
   local cfg="$fork.config.toml"
 
   log "fork: cp -al master -> $fork"
+  mkdir -p "$FORKS_DIR"
   rm -rf "$fork"; cp -al "$MASTER" "$fork"; CUR_FORK="$fork"
   find "$fork" -name LOCK -delete 2>/dev/null || true
   rm -rf "$trace_dir"; mkdir -p "$trace_dir"
@@ -542,9 +574,9 @@ run_one() {
     die "startup failure for $tag"
   fi
 
-  # Dashboard recorder sidecar: scrape this node's /metrics into a per-run series the
-  # always-on dashboard (scripts/zakura-dashboard.service) replays, and the classifier
-  # reads for the bottleneck verdict. Best-effort: a missing python3 never fails a bench.
+  # Dashboard recorder sidecar: scrape this node's /metrics into a per-run series
+  # copied into the CI artifact for local replay, and classified for the bottleneck
+  # verdict. Best-effort: a missing python3 never fails a bench.
   local rec_dir=""
   if [[ "$DASHBOARD" == "1" ]] && command -v python3 >/dev/null 2>&1 && [[ -f "$DASHBOARD_PY" ]]; then
     rec_dir="$DASHBOARD_ARCHIVE/$run_id"
@@ -690,6 +722,11 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-$OUT_DIR/summary.md}"
   echo "## Checkpoint-sync benchmark"
   echo ""
   echo "- binary source: $MODE \`$PRIMARY_SPEC\`"
+  if [[ -n "$STATE_MASTER" ]]; then
+    echo "- state: pre-mounted \`$STATE_MASTER\` (baked sandblast)"
+  else
+    echo "- state: downloaded snapshot master"
+  fi
   echo "- snapshot start height: **$START_HEIGHT**, stop height: **$STOP_HEIGHT**, feed: \`${FEED_PEER:-DNS seeders}\` (peerset=$PEERSET_SIZE)"
   echo "- sync knobs: checkpoint_verify=$CKPT_LIMIT, download=$DL_LIMIT, full_verify=$FULL_VERIFY_LIMIT"
   if [[ "$VERIFY_MODE" == "semantic" ]]; then

--- a/scripts/checkpoint-sync-bench.sh
+++ b/scripts/checkpoint-sync-bench.sh
@@ -172,9 +172,15 @@ fi
 # trip `set -e` inside the EXIT trap and flip a successful run to failure.
 CUR_PID=""; CUR_FORK=""; CUR_REC=""
 cleanup() {
-  [[ -n "$CUR_REC" ]] && kill "$CUR_REC" 2>/dev/null || true
-  [[ -n "$CUR_PID" ]] && kill -9 "$CUR_PID" 2>/dev/null || true
-  [[ -n "$CUR_FORK" ]] && rm -rf "$CUR_FORK" 2>/dev/null || true
+  if [[ -n "$CUR_REC" ]]; then
+    kill "$CUR_REC" 2>/dev/null || true
+  fi
+  if [[ -n "$CUR_PID" ]]; then
+    kill -9 "$CUR_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$CUR_FORK" ]]; then
+    rm -rf "$CUR_FORK" 2>/dev/null || true
+  fi
   return 0
 }
 trap cleanup EXIT INT TERM

--- a/scripts/zakura-dashboard.service
+++ b/scripts/zakura-dashboard.service
@@ -1,41 +1,36 @@
-# Always-on Zebra sync observability dashboard for the bench box.
+# Local replay helper for checkpoint-sync-bench artifacts.
 #
-# Serves http://<box>:8090/ persistently:
-#   /            live charts for any zakurad currently running on the box, plus a
-#                run selector to replay every recorded checkpoint-sync-bench run
-#   /runs        JSON index of recorded runs under the archive dir
-#   /data?run=ID replay of a recorded run (bottleneck verdict recomputed)
+# CI no longer runs a persistent host dashboard. Each benchmark uploads
+# `dashboard-runs/<run-id>/{meta.json,samples.jsonl}` in the workflow artifact.
+# Download the artifact and serve it locally:
 #
-# The checkpoint-sync benchmark (scripts/checkpoint-sync-bench.sh) records each
-# run into $BENCH_HOME/dashboard/runs/<run-id>/, which this service reads.
+#   python3 scripts/zakura-metrics-dashboard.py \
+#     --archive ./bench-out/dashboard-runs \
+#     --host 127.0.0.1 --port 8090
 #
-# The service runs the dashboard from a STABLE copy under the archive root rather
-# than the bench build clone ($BENCH_HOME/src), because the build clone is left on
-# a detached, per-commit checkout and may not hold this script between builds.
+# This unit file is optional for operators who prefer systemd. It is not
+# installed by CI and must never bind a public interface on a shared host.
 #
-# One-time install on the self-hosted runner (roman-zakura-3 / label zakura-bench),
-# which runs as root:
+# Example local install:
 #   sudo mkdir -p /opt/zakura-bench/dashboard/runs
 #   sudo cp scripts/zakura-metrics-dashboard.py /opt/zakura-bench/dashboard/
+#   # point --archive at a directory of downloaded artifact runs
 #   sudo cp scripts/zakura-dashboard.service /etc/systemd/system/
 #   sudo systemctl daemon-reload
 #   sudo systemctl enable --now zakura-dashboard
-#   # open port 8090 to whoever needs to "log in" to analyze runs
-# Refresh the dashboard code with the same `cp` of zakura-metrics-dashboard.py
-# followed by `sudo systemctl restart zakura-dashboard`.
 
 [Unit]
-Description=Zakura sync observability dashboard (live + recorded-run archive)
+Description=Zakura sync observability dashboard (local artifact replay)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
 User=root
-# Edit both paths if BENCH_HOME differs from /opt/zakura-bench.
+# Bind loopback only. Edit --archive if your downloaded runs live elsewhere.
 ExecStart=/usr/bin/python3 /opt/zakura-bench/dashboard/zakura-metrics-dashboard.py \
     --archive /opt/zakura-bench/dashboard/runs \
-    --host 0.0.0.0 --port 8090
+    --host 127.0.0.1 --port 8090
 Restart=on-failure
 RestartSec=5
 NoNewPrivileges=true


### PR DESCRIPTION
## Motivation

`checkpoint-sync-bench.yml` was pinned to the persistent `roman-zakura-3` / `zakura-bench` self-hosted runner and a host-local state/dashboard cache. That keeps a dedicated droplet online for occasional manual benchmarks and blocks retiring the host. The repo already bakes PR-node images and Mainnet sandblast state volumes for ephemeral workloads (`zakura-perf-bench`, `zakura-pr-node`).

## Solution

- Run the benchmark on `ubuntu-latest`, provisioning a tagged DigitalOcean droplet from the newest (or explicitly pinned) baked image plus a cloned Mainnet sandblast volume.
- Add `.github/workflows/scripts/checkpoint-sync-bench-run.sh` to mount state, validate DB format, reuse the warm `/root/zakura` + `/root/cargo-target` cache, and invoke `scripts/checkpoint-sync-bench.sh` with `STATE_MASTER` set so the historical archive download is skipped.
- Preserve baseline/primary semantics via hard-link forks on the volume filesystem.
- Always collect allowlisted `/root/out` (summary, logs, samples, traces, dashboard-runs, verdicts, `run-meta.json`) and upload it for 30 days; tear down droplet + volume under `if: always()` with the hourly `zakura-pr-node` reaper as backstop.
- Retire the always-on port-8090 host dashboard; artifacts are replayed locally with `zakura-metrics-dashboard.py --archive`.
- Extend `do-droplet` with optional exact `image_id` and expose resolved `state_snapshot_id`.
- Fix EXIT-trap `set -e` interaction so a clean `debug_stop_at_height` exit is not reported as workflow failure.

## Testing

Local:
- `shellcheck` on `checkpoint-sync-bench.sh` and `checkpoint-sync-bench-run.sh`
- YAML parse of the workflow and `do-droplet` action

Canaries (branch `ci/ephemeral-checkpoint-benchmark`):
- Smoke success: https://github.com/zakura-core/zakura/actions/runs/30960686103 — provisioned `g-8vcpu-32gb-intel` from image `238681123` + state snapshot `2f3e3310-8993-11f1-ab36-a28a79c8f092`, synced 1707210→1707300 (90 blocks), uploaded summary/verdict/dashboard-runs/`run-meta.json`, tore down droplet+volume (confirmed absent afterward)
- Earlier trap-bug failure that still collected full artifacts + teardown: https://github.com/zakura-core/zakura/actions/runs/30959712144 (fixed in follow-up commit)
- Failure-path teardown: https://github.com/zakura-core/zakura/actions/runs/30961664091 — volume created, droplet create 422 (size capacity), teardown step succeeded, no leftovers

## Operational retirement (post-canary)

- Disabled `valargroup/zebra` workflow `Checkpoint-sync benchmark` (`disabled_manually`)
- Deleted Zebra GitHub Actions runner registration `roman-zakura-3`
- Stopped both runner systemd units on the host
- Archived prior host dashboard runs to `~/archives/roman-zakura-3-dashboard-runs-20260804.tgz` (8 runs)
- Deleted DigitalOcean droplet `roman-zakura-3` (ID 577516149; confirmed 404)
- Follow-up for an org admin: remove the now-offline `roman-zakura-3` self-hosted runner from `zakura-core/zakura` (API returned 403 for runner admin on that repo)

## Changelog

No Rust or `Cargo.toml` changes; no changelog fragment required.

### Specifications & References

- Patterned after `.github/workflows/zakura-perf-bench.yml` and the shared `do-*` composite actions
- Baked assets: `zakura-pr-node-*` image + `zakura-pr-state-mainnet-*` volume snapshot

### Follow-up Work

- Org-admin cleanup of the offline `zakura-core/zakura` runner registration
- Optional later: durable cross-run dashboard storage beyond the 30-day artifact retention