### PR TITLE
fix(deploy): wait for broadcast gateway readiness

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -415,7 +415,8 @@ jobs:
           sudo systemctl enable zakura-broadcast-mainnet.service
           sudo systemctl restart zakura-broadcast-mainnet.service
           sudo systemctl --no-pager --full status zakura-broadcast-mainnet.service || true
-          curl -fsS "http://127.0.0.1:8092/healthz"
+          curl --retry 10 --retry-delay 1 --retry-connrefused \
+            --max-time 2 -fsS "http://127.0.0.1:8092/healthz"
           echo
 
       - name: Install fleet watchdog

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -375,7 +375,8 @@ jobs:
           sudo systemctl enable zakura-broadcast-testnet.service
           sudo systemctl restart zakura-broadcast-testnet.service
           sudo systemctl --no-pager --full status zakura-broadcast-testnet.service || true
-          curl -fsS "http://127.0.0.1:8092/healthz"
+          curl --retry 10 --retry-delay 1 --retry-connrefused \
+            --max-time 2 -fsS "http://127.0.0.1:8092/healthz"
           echo
 
       - name: Fetch recent logs on failure


### PR DESCRIPTION
## Motivation

Single-node testnet and mainnet deployments restart the public broadcast gateway and immediately probe its health endpoint. The Python service can still be starting, causing a connection-refused failure even though systemd reports it active and the node deployment succeeded.

## Solution

Retry connection-refused gateway health probes for up to ten seconds on both deployment workflows. The probe still fails the workflow if the gateway does not become healthy within the bounded retry window.

## Testing

- [x] `actionlint .github/workflows/zakura-testnet-deploy.yml .github/workflows/zakura-mainnet-deploy.yml`
- [x] IDE workflow diagnostics report no errors
- [ ] Required GitHub checks
- [ ] Validate with the interrupted testnet rollout after merge

## Changelog

Not required: this changes deployment workflow behavior only and does not modify Rust source or Cargo manifests.