### PR TITLE
fix(release): preserve crate identity across moves

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -63,5 +63,7 @@ jobs:
         run: ./scripts/changelog.py check
 
       - name: Run scripts/tests unit tests
-        # covers the changelog tool and the bench digest helper (both stdlib-only)
-        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+        # These tests use only Python's stdlib and standard shell/git tools.
+        run: |
+          python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+          bash scripts/tests/test_release_packages.sh

--- a/scripts/lib/release-packages.sh
+++ b/scripts/lib/release-packages.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Print package name, version, and manifest path for every package at a git
+# revision. Package identity is independent of repository layout.
+list_release_packages_at() {
+  local revision="$1"
+  local manifest_rel package
+
+  while IFS= read -r manifest_rel; do
+    case "$manifest_rel" in
+      Cargo.toml|*/Cargo.toml) ;;
+      *) continue ;;
+    esac
+
+    package="$(
+      git show "${revision}:${manifest_rel}" \
+        | awk -F ' *= *' '
+            $0 == "[package]" { in_package = 1; next }
+            in_package && /^\[/ { exit }
+            in_package && $1 == "name" {
+              gsub(/"/, "", $2)
+              name = $2
+            }
+            in_package && $1 == "version" {
+              gsub(/"/, "", $2)
+              version = $2
+            }
+            END {
+              if (name != "" && version != "") {
+                print name "\t" version
+              }
+            }
+          '
+    )"
+    [ -n "$package" ] || continue
+    printf '%s\t%s\n' "$package" "$manifest_rel"
+  done < <(git ls-tree -r --name-only "$revision")
+}

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -46,6 +46,8 @@ cd "$repo_root"
 # The library is linted as a standalone shellcheck input in lint.yml.
 # shellcheck source=scripts/lib/crates-index.sh disable=SC1091
 . "${repo_root}/scripts/lib/crates-index.sh"
+# shellcheck source=scripts/lib/release-packages.sh disable=SC1091
+. "${repo_root}/scripts/lib/release-packages.sh"
 
 release_tag=""
 base_tag=""
@@ -261,6 +263,21 @@ zakura_old="$(
   jq -r '.packages[] | select(.name == "zakura") | .version' <<<"$metadata"
 )"
 
+# Match base-tag packages by Cargo package name rather than their current
+# manifest path. Repository-only moves must not make existing published crates
+# look new to the release planner.
+declare -A base_manifest_by_crate=()
+declare -A base_version_by_crate=()
+while IFS=$'\t' read -r base_crate base_version base_manifest_rel; do
+  [ -n "$base_crate" ] || continue
+  if [ -n "${base_manifest_by_crate[$base_crate]:-}" ]; then
+    echo "ERROR: duplicate package '${base_crate}' at ${base_tag}." >&2
+    exit 1
+  fi
+  base_manifest_by_crate["$base_crate"]="$base_manifest_rel"
+  base_version_by_crate["$base_crate"]="$base_version"
+done < <(list_release_packages_at "$base_tag")
+
 base_zakura_version="$(
   # Transition fallback: tags created before the crates/ move keep
   # zakurad/Cargo.toml at the repo root; remove once a post-move tag exists.
@@ -349,8 +366,9 @@ if [ "$no_crates" = 0 ]; then
 
     manifest_rel="${manifest_path#"$repo_root"/}"
     crate_dir="$(dirname "$manifest_rel")"
+    base_manifest_rel="${base_manifest_by_crate[$crate]:-}"
 
-    if ! git cat-file -e "${base_tag}:${manifest_rel}" 2>/dev/null; then
+    if [ -z "$base_manifest_rel" ]; then
       if ! git diff --quiet "$base_tag" -- "$crate_dir"; then
         echo "NOTICE: ${crate} is new since ${base_tag}; choose its initial publish version manually." >&2
         add_crate_row "$crate" "" "$current_version" "" "manual" \
@@ -359,16 +377,14 @@ if [ "$no_crates" = 0 ]; then
       continue
     fi
 
-    if git diff --quiet "$base_tag" -- "$crate_dir"; then
+    base_crate_dir="$(dirname "$base_manifest_rel")"
+    if git diff --quiet "$base_tag" -- "$base_crate_dir" "$crate_dir"; then
       continue
     fi
 
     # Assumes [package] has a literal version before any other version key;
     # manifests using version.workspace = true would need different parsing.
-    base_version="$(
-      git show "${base_tag}:${manifest_rel}" \
-        | awk -F ' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }'
-    )"
+    base_version="${base_version_by_crate[$crate]:-}"
     if [ -z "$base_version" ]; then
       echo "ERROR: could not read ${crate}'s package version at ${base_tag}." >&2
       exit 1

--- a/scripts/tests/test_release_packages.sh
+++ b/scripts/tests/test_release_packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=scripts/lib/release-packages.sh
+. "${repo_root}/scripts/lib/release-packages.sh"
+
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+cd "$fixture"
+
+git init --quiet
+git config user.name "Release Test"
+git config user.email "release-test@example.com"
+mkdir -p old/demo
+cat > old/demo/Cargo.toml <<'EOF'
+[package]
+name = "demo-crate"
+version = "1.2.3"
+edition = "2021"
+EOF
+git add .
+git commit --quiet -m "add package"
+git tag base
+
+mkdir crates
+git mv old/demo crates/demo
+git commit --quiet -m "move package"
+
+expected=$'demo-crate\t1.2.3\told/demo/Cargo.toml'
+actual="$(list_release_packages_at base)"
+if [ "$actual" != "$expected" ]; then
+  printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+printf 'release package identity survives manifest moves\n'


### PR DESCRIPTION
## Motivation

The automated v1.1.0-rc2 preparation treated every crate moved under `crates/` after v1.1.0-rc1 as a new package. Because the planner matched base-tag crates by their current manifest paths, it emitted manual rows instead of the required version and cascade bumps, and the publish-graph verification failed.

## Solution

Resolve packages at the base tag by Cargo package name, version, and historical manifest path. The release planner now compares both the historical and current crate directories, preserving package identity across repository-only moves while retaining the manual gate for genuinely new crates.

Add a focused git-fixture regression test that tags a package before moving its manifest and verifies that its original identity and version are still discovered. Run that test in the existing scripts test job.

## Testing

- `bash scripts/tests/test_release_packages.sh`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
- `bash -n scripts/prepare-release.sh scripts/lib/release-packages.sh scripts/tests/test_release_packages.sh`
- `shellcheck scripts/prepare-release.sh scripts/lib/release-packages.sh scripts/tests/test_release_packages.sh`
- `actionlint .github/workflows/changelog.yml`
- Verified `list_release_packages_at v1.1.0-rc1` discovers the pre-move manifests and versions.
- Full `prepare-release.sh` dry run not run locally: macOS ships Bash 3, while this existing script requires Bash 4 associative arrays. The draft CI runs on Linux.

## Changelog

No fragment required: this changes internal release tooling without modifying Rust sources or Cargo manifests.

### Specifications & References

- Failed preparation: https://github.com/zakura-core/zakura/actions/runs/30957674595
- Generated release PR: https://github.com/zakura-core/zakura/pull/540
- Crate layout move: https://github.com/zakura-core/zakura/pull/525

### Follow-up Work

After this fix merges, rerun the v1.1.0-rc2 preparation workflow so it replaces the incomplete draft release branch with a correctly bumped crate graph.