### PR TITLE
fix(ci): avoid forwarding GitHub token to benchmark host

### DIFF
--- a/.github/workflows/checkpoint-sync-bench.yml
+++ b/.github/workflows/checkpoint-sync-bench.yml
@@ -162,7 +162,6 @@ jobs:
       - name: Run checkpoint-sync benchmark
         env:
           IP: ${{ steps.droplet.outputs.ip }}
-          GH_CLONE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_REF: ${{ inputs.build_ref }}
           BASELINE_REF: ${{ inputs.baseline_ref }}
           SKIP_BASELINE: ${{ inputs.skip_baseline && '1' || '0' }}
@@ -192,7 +191,6 @@ jobs:
           umask 077
           {
             printf 'GH_REPO=%q\n'          "${GITHUB_REPOSITORY}"
-            printf 'GH_CLONE_TOKEN=%q\n'   "${GH_CLONE_TOKEN}"
             printf 'BUILD_REF=%q\n'        "${BUILD_REF}"
             printf 'BASELINE_REF=%q\n'     "${BASELINE_REF}"
             printf 'SKIP_BASELINE=%q\n'    "${SKIP_BASELINE}"

--- a/.github/workflows/scripts/checkpoint-sync-bench-run.sh
+++ b/.github/workflows/scripts/checkpoint-sync-bench-run.sh
@@ -24,20 +24,6 @@ mkdir -p "$OUT_DIR" "$BENCH_HOME"
 log() { printf '[ckpt-bench-run %(%H:%M:%S)T] %s\n' -1 "$*" >&2; }
 die() { log "FATAL: $*"; exit 1; }
 
-# Invoked via trap below; shellcheck cannot see indirect calls.
-# shellcheck disable=SC2317,SC2329
-scrub_secrets() {
-  local ec=$?
-  git config --global --unset credential.helper 2>/dev/null || true
-  if command -v gh >/dev/null 2>&1; then
-    gh auth logout --hostname github.com >/dev/null 2>&1 || true
-  fi
-  rm -f /root/run.env
-  # Preserve the script's real status: EXIT-trap failures would otherwise mask it.
-  exit "$ec"
-}
-trap scrub_secrets EXIT INT TERM
-
 [[ -f "$BENCH_SH" ]] || die "missing $BENCH_SH (workflow must scp it)"
 [[ -n "${VOLUME_NAME:-}" ]] || die "VOLUME_NAME is required"
 
@@ -73,14 +59,11 @@ PRIMARY_SHA=""
 if [[ -n "${BUILD_REF:-}" ]]; then
   [[ -d /root/zakura/.git ]] || die "baked /root/zakura clone missing"
   cd /root/zakura
-  GIT_AUTH=$(printf 'x-access-token:%s' "${GH_CLONE_TOKEN}" | base64 -w0)
   # Fetch every ref we may build so BUILD_REF / BASELINE_REF resolve offline later.
-  git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
-    fetch --no-tags origin "${BUILD_REF}"
+  git fetch --no-tags origin "${BUILD_REF}"
   PRIMARY_SHA=$(git rev-parse --verify 'FETCH_HEAD^{commit}')
   if [[ -n "${BASELINE_REF:-}" && "${SKIP_BASELINE:-0}" != "1" ]]; then
-    git -c http.extraheader="AUTHORIZATION: basic ${GIT_AUTH}" \
-      fetch --no-tags origin "${BASELINE_REF}"
+    git fetch --no-tags origin "${BASELINE_REF}"
   fi
   git checkout --detach "${PRIMARY_SHA}"
 
@@ -94,31 +77,11 @@ if [[ -n "${BUILD_REF:-}" ]]; then
     die "DB format mismatch: volume is v${DIR_VER}, benched tree is v${CODE_VER}; re-bake the state snapshot"
   fi
   log "state DB v${DIR_VER} compatible with code v${CODE_VER}; primary=${PRIMARY_SHA}"
-
-  # Leave a short-lived credential helper so checkpoint-sync-bench.sh can fetch
-  # baseline/primary checkouts without re-exporting the token into the env file.
-  git config --global credential.helper \
-    "!f() { echo username=x-access-token; echo password=${GH_CLONE_TOKEN}; }; f"
-elif [[ -n "${RELEASE_TAG:-}" ]]; then
-  if ! command -v gh >/dev/null 2>&1; then
-    log "installing GitHub CLI for release download ..."
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg status=none
-    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list
-    apt-get update -qq
-    apt-get install -y -qq gh
-  fi
-  echo "${GH_CLONE_TOKEN}" | gh auth login --with-token
-else
+elif [[ -z "${RELEASE_TAG:-}" ]]; then
   die "set BUILD_REF or RELEASE_TAG"
 fi
 
 rm -f /root/run.env
-# Keep the token only inside the temporary git credential helper (build mode)
-# or the gh auth session (release mode). Clear the shell copy.
-unset GH_CLONE_TOKEN GIT_AUTH
 
 # ---------------------------------------------------------------------------- #
 # Run metadata for the artifact (image / snapshot / droplet identity)

--- a/scripts/checkpoint-sync-bench.sh
+++ b/scripts/checkpoint-sync-bench.sh
@@ -293,22 +293,22 @@ ensure_snapshot() {
 # sets ZAKURAD_BIN to the zakurad binary path for $1=tag (returns via global, not
 # stdout, so no subcommand chatter can ever pollute the path)
 ensure_binary() {
-  local tag="$1" bindir="$BENCH_HOME/bins/$1" zakurad
+  local tag="$1" bindir="$BENCH_HOME/bins/$1" zakurad asset release_url
   zakurad="$bindir/zakurad"
   if [[ -x "$zakurad" ]]; then ZAKURAD_BIN="$zakurad"; return; fi
   mkdir -p "$bindir"
   log "fetching release $tag from $GH_REPO ..." >&2
   local dl="$bindir/dl"; rm -rf "$dl"; mkdir -p "$dl"
-  gh release download "$tag" -R "$GH_REPO" \
-    -p 'zakurad-*-linux-x86_64.tar.gz' -p 'zakurad-*-linux-x86_64.tar.gz' -p 'SHA256SUMS.txt' -D "$dl" \
-    || die "gh release download failed for $tag"
-  local tgz; tgz="$(find "$dl" \( -name 'zakurad-*-linux-x86_64.tar.gz' -o -name 'zakurad-*-linux-x86_64.tar.gz' \) | head -1)"
-  [[ -n "$tgz" ]] || die "no linux-x86_64 tarball asset on release $tag"
-  if [[ -f "$dl/SHA256SUMS.txt" ]]; then
-    # NB: keep all output on stderr — this function's stdout is captured as the binary path
-    ( cd "$dl" && grep "$(basename "$tgz")" SHA256SUMS.txt | sha256sum -c - ) >&2 \
-      || die "release tarball checksum mismatch for $tag"
-  fi
+  asset="zakurad-${tag}-linux-x86_64.tar.gz"
+  release_url="https://github.com/${GH_REPO}/releases/download/${tag}"
+  curl -fL --retry 3 --retry-all-errors -o "$dl/$asset" "$release_url/$asset" \
+    || die "release tarball download failed for $tag"
+  curl -fL --retry 3 --retry-all-errors -o "$dl/SHA256SUMS.txt" "$release_url/SHA256SUMS.txt" \
+    || die "release checksum download failed for $tag"
+  # NB: keep all output on stderr — this function's stdout is captured as the binary path
+  ( cd "$dl" && grep -F " ./$asset" SHA256SUMS.txt | sha256sum -c - ) >&2 \
+    || die "release tarball checksum mismatch for $tag"
+  local tgz="$dl/$asset"
   tar -xzf "$tgz" -C "$dl"
   local found; found="$(find "$dl" -type f \( -name zakurad -o -name zakurad \) | head -1)"
   [[ -n "$found" ]] || die "node binary not found in tarball for $tag"
@@ -349,11 +349,10 @@ ensure_source() {
   ensure_toolchain
   if [[ ! -d "$BUILD_SRC/.git" ]]; then
     log "cloning $GH_REPO -> $BUILD_SRC (first build only) ..." >&2
-    gh auth setup-git 2>/dev/null || true
     git clone "https://github.com/$GH_REPO.git" "$BUILD_SRC" >&2 || die "git clone failed"
   fi
-  # Ephemeral CI prefetches the needed commits; a credential helper may still be
-  # configured. Fall back to a tagged fetch for local persistent hosts.
+  # Ephemeral CI prefetches the needed commits. Fall back to a tagged fetch for
+  # local persistent hosts.
   if ! git -C "$BUILD_SRC" fetch --no-tags --force origin >&2; then
     git -C "$BUILD_SRC" fetch --tags --force origin >&2 || die "git fetch failed"
   fi


### PR DESCRIPTION
## Motivation

The ephemeral checkpoint benchmark copied the job-scoped GitHub token to the DigitalOcean droplet even though Zakura source refs and release assets are public. Scrubbing reduced persistence, but the credential was still exposed to the remote host while the benchmark ran.

## Solution

- Fetch build and baseline refs anonymously over HTTPS.
- Download public release tarballs and checksums directly from GitHub release URLs using `curl`.
- Stop copying `GITHUB_TOKEN` to the droplet and remove the now-unneeded credential helper, GitHub CLI login, and secret-scrubbing trap.
- Continue verifying downloaded release assets against the published `SHA256SUMS.txt` before extraction.

## Testing

- `shellcheck .github/workflows/scripts/checkpoint-sync-bench-run.sh scripts/checkpoint-sync-bench.sh`
- `actionlint .github/workflows/checkpoint-sync-bench.yml`
- Parsed `.github/workflows/checkpoint-sync-bench.yml` with Ruby YAML.
- With `GH_TOKEN`, `GITHUB_TOKEN`, and Git credential config disabled, anonymously resolved `ci/ephemeral-checkpoint-benchmark` using `git ls-remote`.
- With GitHub token variables unset, downloaded the public v1.0.5 Linux x86_64 release tarball and `SHA256SUMS.txt`, verified the SHA-256 checksum, and listed the archive successfully.
- Real droplet canary: https://github.com/zakura-core/zakura/actions/runs/30963664942 — anonymously fetched the source ref, completed the 90-block smoke benchmark, uploaded the benchmark artifact, and successfully tore down the droplet and volume.

These checks exercise both credential-free paths used by the workflow and the complete ephemeral droplet lifecycle.

## Changelog

No Rust source or `Cargo.toml` changes; no changelog fragment required.

### Specifications & References

- Follow-up to #541.