### PR TITLE
ci(release): parallelize public API verification

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -162,11 +162,10 @@ jobs:
           restore-keys: prepare-release-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       # Deliberately unpinned (like semver-checks.yml): cargo-semver-checks
-      # must track new stable rustdoc formats. cargo-public-api supplies
-      # independent API-diff evidence for each changed published library.
+      # must track new stable rustdoc formats.
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
         with:
-          tool: cargo-release,cargo-semver-checks,cargo-public-api
+          tool: cargo-release,cargo-semver-checks
 
       - uses: ./.github/actions/setup-zakura-build
 
@@ -241,37 +240,6 @@ jobs:
         continue-on-error: true
         run: cargo fmt --all -- --check
 
-      - name: Record public API diffs
-        id: verify-public-api
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          packages="$(
-            jq -r '
-              .crates[]
-              | select(.level != "manual" and .target != null and .target != "")
-              | .name
-            ' \
-              "$RUNNER_TEMP/prep-summary.json"
-          )"
-          if [ -z "$packages" ]; then
-            echo "No changed library crates are being published."
-            exit 0
-          fi
-          # cargo-public-api builds rustdoc JSON with nightly even when the
-          # workspace itself is built and verified with stable. Keep setup in
-          # this continue-on-error step so a toolchain outage is recorded in
-          # the generated draft PR instead of preventing PR creation.
-          rustup toolchain install nightly --profile minimal
-          while IFS= read -r package; do
-            [ -n "$package" ] || continue
-            echo "::group::cargo public-api diff latest -p ${package}"
-            # Public API evidence must build both current and previously
-            # published crates; nightly-only warnings are not a lint gate.
-            RUSTFLAGS='' cargo public-api diff latest -p "$package" -sss
-            echo "::endgroup::"
-          done <<<"$packages"
-
       - name: Write the PR body
         id: body
         env:
@@ -280,7 +248,6 @@ jobs:
           VERIFY_PRERELEASE: ${{ steps.verify-prerelease.outcome }}
           VERIFY_CONFIG: ${{ steps.verify-config.outcome }}
           VERIFY_FMT: ${{ steps.verify-fmt.outcome }}
-          VERIFY_PUBLIC_API: ${{ steps.verify-public-api.outcome }}
         run: |
           python3 - "$RUNNER_TEMP/prep-summary.json" > "$RUNNER_TEMP/pr-body.md" <<'PY'
           import json, os, sys
@@ -377,11 +344,13 @@ jobs:
               ("cargo test -p zakura --test acceptance config_tests -- --exact",
                os.environ["VERIFY_CONFIG"]),
               ("cargo fmt --all -- --check", os.environ["VERIFY_FMT"]),
-              ("cargo public-api diff latest for changed published libraries",
-               os.environ["VERIFY_PUBLIC_API"]),
           ]
           lines += ["", "## Verification", ""]
           lines += [f"- [{mark(o)}] `{cmd}`" for cmd, o in checks]
+          lines.append(
+              "- ⏳ `cargo public-api diff latest` for changed published "
+              "libraries runs in the parallel release-PR CI matrix."
+          )
           if any(o != "success" for _, o in checks):
               lines += [
                   "",
@@ -482,8 +451,7 @@ jobs:
         if: >-
           steps.verify-prerelease.outcome == 'failure' ||
           steps.verify-config.outcome == 'failure' ||
-          steps.verify-fmt.outcome == 'failure' ||
-          steps.verify-public-api.outcome == 'failure'
+          steps.verify-fmt.outcome == 'failure'
         run: |
           echo "Release preparation verification failed; see the step logs above." >&2
           exit 1

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -60,6 +60,8 @@ jobs:
       has_packages: ${{ steps.affected.outputs.has_packages }}
       packages: ${{ steps.affected.outputs.packages }}
       packages_json: ${{ steps.affected.outputs.packages_json }}
+      public_api_packages_json: ${{ steps.affected.outputs.public_api_packages_json }}
+      has_public_api_packages: ${{ steps.affected.outputs.has_public_api_packages }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
@@ -93,14 +95,25 @@ jobs:
               | jq --raw-input --slurp --compact-output \
                 'split("\n") | map(select(length > 0))'
           )"
+          # The release preparation has always limited the independent
+          # public-API evidence to library crates in its crate bump plan;
+          # `zakura` is versioned separately from that plan.
+          public_api_packages_json="$(
+            jq --compact-output 'map(select(. != "zakura"))' <<<"$packages_json"
+          )"
+          has_public_api_packages="$(
+            jq --raw-output 'length > 0' <<<"$public_api_packages_json"
+          )"
 
           {
             echo "baseline_tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
             echo "has_packages=$([[ -n "$packages" ]] && echo true || echo false)"
+            echo "has_public_api_packages=$has_public_api_packages"
             echo "packages<<EOF"
             echo "$packages"
             echo "EOF"
             echo "packages_json=$packages_json"
+            echo "public_api_packages_json=$public_api_packages_json"
           } >> "$GITHUB_OUTPUT"
 
           if [[ -n "$packages" ]]; then
@@ -178,6 +191,46 @@ jobs:
           checklist ("Update Crate Versions").
           EOF
 
+  public-api-diff:
+    name: public API (${{ matrix.package }})
+    if: >-
+      github.event_name == 'pull_request'
+      && startsWith(github.head_ref, 'release/v')
+      && needs.select-packages.outputs.has_public_api_packages == 'true'
+    needs: select-packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.select-packages.outputs.public_api_packages_json) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+          cache: false
+
+      - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
+        with:
+          tool: cargo-public-api
+
+      - uses: ./.github/actions/setup-zakura-build
+
+      - name: Install nightly rustdoc toolchain
+        run: rustup toolchain install nightly --profile minimal
+
+      - name: Diff against the latest published API
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          # cargo-public-api builds both the current and published crate with
+          # nightly. Nightly-only warnings are evidence, not the lint gate.
+          RUSTFLAGS='' cargo public-api diff latest -p "$PACKAGE" -sss
+
   warm-baselines:
     name: Warm semver baselines
     if: >-
@@ -240,7 +293,7 @@ jobs:
   semver-checks:
     name: semver-checks
     if: always()
-    needs: [select-packages, check-package, warm-baselines]
+    needs: [select-packages, check-package, public-api-diff, warm-baselines]
     runs-on: ubuntu-latest
     steps:
       - name: Check semver job results
@@ -248,6 +301,9 @@ jobs:
           CHECK_RESULT: ${{ needs.check-package.result }}
           EVENT_NAME: ${{ github.event_name }}
           HAS_PACKAGES: ${{ needs.select-packages.outputs.has_packages }}
+          HAS_PUBLIC_API_PACKAGES: ${{ needs.select-packages.outputs.has_public_api_packages }}
+          PUBLIC_API_RESULT: ${{ needs.public-api-diff.result }}
+          RELEASE_PR: ${{ startsWith(github.head_ref, 'release/v') }}
           SELECT_RESULT: ${{ needs.select-packages.result }}
           WARM_RESULT: ${{ needs.warm-baselines.result }}
         run: |
@@ -259,6 +315,11 @@ jobs:
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             if [[ "$HAS_PACKAGES" == "true" && "$CHECK_RESULT" != "success" ]]; then
               echo "Package checks failed: $CHECK_RESULT" >&2
+              exit 1
+            fi
+            if [[ "$RELEASE_PR" == "true" && "$HAS_PUBLIC_API_PACKAGES" == "true" \
+              && "$PUBLIC_API_RESULT" != "success" ]]; then
+              echo "Public API diffs failed: $PUBLIC_API_RESULT" >&2
               exit 1
             fi
           elif [[ "$WARM_RESULT" != "success" ]]; then


### PR DESCRIPTION
## Motivation

The successful v1.1.0-rc2 preparation took 35m47s. Its independent public-API diffs ran serially for 11m15s, making them the largest safely parallelizable stage: `zakura-rpc` took 3m19s, `zakura-network` 1m57s, and `zakura-consensus` 1m16s.

## Solution

Move `cargo public-api diff latest` from the serial preparation job into the existing per-package release-PR matrix. Each changed published library now runs on its own runner after the draft opens, and the required `semver-checks` aggregate fails if any API diff fails.

Preserve the existing scope by excluding the separately versioned `zakura` package. Ordinary PRs and main pushes do not run the new matrix; it is limited to `release/v*` pull requests.

The generated release PR records that API evidence is delegated to parallel PR CI rather than claiming it already passed.

## Testing

- `actionlint .github/workflows/prepare-release-pr.yml .github/workflows/semver-checks.yml`
- `python3 .github/workflows/scripts/test_affected_semver_packages.py`
- `git diff --check`

The matrix itself requires a generated `release/v*` PR and therefore cannot execute on this non-release draft. After merge, rerun release preparation and compare the preparation duration plus the parallel API job durations against the baseline run.

## Changelog

No fragment required: this changes internal release CI without modifying Rust sources or Cargo manifests.

### Specifications & References

- Timing baseline: https://github.com/zakura-core/zakura/actions/runs/30966042771
- Generated release PR: https://github.com/zakura-core/zakura/pull/547

### Follow-up Work

Measure the first post-merge release run. The serial 11m15s stage should be replaced by the slowest per-package matrix path plus runner setup, while preserving all API-diff evidence.