### PR TITLE
feat(rpc): serve reconstruction material for absent-band treestates

### DIFF
--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -112,7 +112,9 @@ pub(crate) mod trees;
 pub(crate) mod types;
 
 use hex_data::HexData;
-use trees::{GetSubtreesByIndexResponse, GetTreestateResponse, SubtreeRpcData};
+use trees::{
+    GetSubtreesByIndexResponse, GetTreestateAnchorResponse, GetTreestateResponse, SubtreeRpcData,
+};
 use types::{
     get_block_template::{
         constants::{
@@ -397,6 +399,36 @@ pub trait Rpc {
     /// state is available for the requested block.
     #[method(name = "z_gettreestate")]
     async fn z_get_treestate(&self, hash_or_height: String) -> Result<GetTreestateResponse>;
+
+    /// Returns the material a client needs to reconstruct a block's note commitment treestate
+    /// itself: the authenticated per-pool roots at that block, and the highest frontier at or
+    /// below it that this node has already verified against them.
+    ///
+    /// Zakura-specific; `zcashd` and `lightwalletd` have no equivalent. It exists for the height
+    /// band where a verified-commitment-trees fast-synced node stores no per-height tree and
+    /// `z_gettreestate` therefore reports the tree unavailable. A client falls back here, replays
+    /// the canonical blocks from `replayFrom` to the target, and accepts the result only if all
+    /// three target roots match — so what it ends up with is verified, not trusted.
+    ///
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Parameters
+    ///
+    /// - `hash | height`: (string, required, example="1500000") The block hash or height.
+    ///
+    /// # Notes
+    ///
+    /// This does no replay of its own, so it stays cheap however far the target is from anything
+    /// this node has derived. Replaying is the client's job, and it needs the canonical block
+    /// bodies for `replayFrom..=height` to do it — which a pruned node cannot supply.
+    ///
+    /// `anchor` is omitted when the replay must start from genesis.
+    #[method(name = "z_gettreestateanchor")]
+    async fn z_get_treestate_anchor(
+        &self,
+        hash_or_height: String,
+    ) -> Result<GetTreestateAnchorResponse>;
 
     /// Returns information about a range of shielded subtrees.
     ///
@@ -2134,6 +2166,98 @@ where
             Treestate::new(trees::Commitments::new(sapling_root, sapling_tree)),
             Treestate::new(trees::Commitments::new(orchard_root, orchard_tree)),
             ironwood,
+        ))
+    }
+
+    async fn z_get_treestate_anchor(
+        &self,
+        hash_or_height: String,
+    ) -> Result<GetTreestateAnchorResponse> {
+        let mut read_state = self.read_state.clone();
+
+        let hash_or_height =
+            HashOrHeight::new(&hash_or_height, self.latest_chain_tip.best_tip_height())
+                .map_error(server::error::LegacyCode::InvalidParameter)?;
+
+        // One state request, deliberately: the anchor and the target roots have to describe the
+        // same chain, and assembling them from separate reads would let a reorg between the two
+        // hand a client an anchor that cannot reach the target it was given.
+        let material = match read_state
+            .ready()
+            .and_then(|service| {
+                service.call(zakura_state::ReadRequest::TreestateReconstruction(
+                    hash_or_height,
+                ))
+            })
+            .await
+            .map_misc_error()?
+        {
+            zakura_state::ReadResponse::TreestateReconstruction(Some(material)) => material,
+            zakura_state::ReadResponse::TreestateReconstruction(None) => {
+                return Err("the requested block is not in the main chain")
+                    .map_error(server::error::LegacyCode::InvalidParameter);
+            }
+            _ => unreachable!("unmatched response to a treestate reconstruction request"),
+        };
+
+        // Roots only: `finalState` at the target is precisely what the client is about to derive.
+        let root_only = |root: Vec<u8>| Treestate::new(trees::Commitments::new(Some(root), None));
+
+        let target = trees::TreestateTarget::new(
+            material.target_hash,
+            material.target_height,
+            material.target_time,
+            root_only(
+                material
+                    .target_roots
+                    .sapling_root
+                    .bytes_in_display_order()
+                    .to_vec(),
+            ),
+            root_only(
+                material
+                    .target_roots
+                    .orchard_root
+                    .bytes_in_display_order()
+                    .to_vec(),
+            ),
+            root_only(
+                material
+                    .target_roots
+                    .ironwood_root
+                    .bytes_in_display_order()
+                    .to_vec(),
+            ),
+        );
+
+        let anchor = material.anchor.map(|anchor| {
+            let frontiers = &anchor.frontiers;
+            let pool = |state: Vec<u8>, root: Vec<u8>| {
+                Treestate::new(trees::Commitments::new(Some(root), Some(state)))
+            };
+
+            trees::TreestateAnchorFrontiers::new(
+                anchor.hash,
+                anchor.height,
+                pool(
+                    frontiers.sapling.to_rpc_bytes(),
+                    frontiers.sapling.root().bytes_in_display_order().to_vec(),
+                ),
+                pool(
+                    frontiers.orchard.to_rpc_bytes(),
+                    frontiers.orchard.root().bytes_in_display_order().to_vec(),
+                ),
+                pool(
+                    frontiers.ironwood.to_rpc_bytes(),
+                    frontiers.ironwood.root().bytes_in_display_order().to_vec(),
+                ),
+            )
+        });
+
+        Ok(GetTreestateAnchorResponse::new(
+            target,
+            anchor,
+            material.replay_from,
         ))
     }
 

--- a/crates/zakura-rpc/src/methods/trees.rs
+++ b/crates/zakura-rpc/src/methods/trees.rs
@@ -162,6 +162,92 @@ impl Default for GetTreestateResponse {
     }
 }
 
+/// Response to a `z_gettreestateanchor` RPC request.
+///
+/// A Zakura-specific companion to `z_gettreestate`, for the band where a fast-synced node has no
+/// stored per-height tree. Instead of the treestate itself it returns what a client needs to
+/// rebuild one: the authenticated roots at the target, and the highest frontier at or below it
+/// that this node has already checked against those roots.
+///
+/// The client replays canonical blocks from the anchor and accepts its result only if all three
+/// target roots match. That check is the whole trust story — a frontier that reproduces an
+/// authenticated root *is* the frontier — so this hands out no authority the node did not already
+/// have over the client's view of the chain.
+///
+/// `z_gettreestate`'s request and response are untouched. A client tries it first and only falls
+/// back here when it reports the historical tree unavailable.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct GetTreestateAnchorResponse {
+    /// The canonical target block and the roots the client's replay must reproduce.
+    target: TreestateTarget,
+
+    /// The verified frontier to replay forward from, or `null` to replay from genesis.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    anchor: Option<TreestateAnchorFrontiers>,
+
+    /// The first height the client has to replay.
+    #[serde(rename = "replayFrom")]
+    #[getter(copy)]
+    replay_from: Height,
+}
+
+/// The target block of a `z_gettreestateanchor` response: what the client is reconstructing, and
+/// the authenticated roots that prove it got it right.
+///
+/// The per-pool fields carry `finalRoot` only — the `finalState` is exactly what the client is
+/// asking the node to help it derive — and use the same byte order and encoding as
+/// `z_gettreestate`, so the two responses are directly comparable.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct TreestateTarget {
+    /// The canonical block hash at `height`, hex-encoded.
+    #[serde(with = "hex")]
+    #[getter(copy)]
+    hash: Hash,
+
+    /// The block height, numeric.
+    #[getter(copy)]
+    height: Height,
+
+    /// Unix time when the block was mined, so the client can build the same treestate the exact
+    /// path would have returned.
+    time: u32,
+
+    /// The authenticated Sapling root at this block.
+    sapling: Treestate,
+
+    /// The authenticated Orchard root at this block.
+    orchard: Treestate,
+
+    /// The authenticated Ironwood root at this block.
+    ironwood: Treestate,
+}
+
+/// The anchor of a `z_gettreestateanchor` response: a frontier this node has already verified,
+/// bound to the canonical block it is the state at the end of.
+///
+/// Both `finalRoot` and `finalState` are present for each pool, in `z_gettreestate`'s encoding, so
+/// a client can load the frontier with the same parser it already uses.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct TreestateAnchorFrontiers {
+    /// The canonical block hash at `height`, hex-encoded.
+    #[serde(with = "hex")]
+    #[getter(copy)]
+    hash: Hash,
+
+    /// The height the frontiers are the state at the end of, numeric.
+    #[getter(copy)]
+    height: Height,
+
+    /// The Sapling frontier and its root.
+    sapling: Treestate,
+
+    /// The Orchard frontier and its root.
+    orchard: Treestate,
+
+    /// The Ironwood frontier and its root.
+    ironwood: Treestate,
+}
+
 /// A treestate that is included in the [`z_gettreestate`][1] RPC response.
 ///
 /// [1]: https://zcash.github.io/rpc/z_gettreestate.html

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -64,7 +64,7 @@ pub use request::Spend;
 
 pub use response::{
     AnyTx, GetBlockTemplateChainInfo, KnownBlock, MinedTx, NonFinalizedBlocksListener,
-    ReadResponse, Response,
+    ReadResponse, Response, TreestateAnchor, TreestateReconstruction,
 };
 pub use service::{
     chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip, TipAction},

--- a/crates/zakura-state/src/request.rs
+++ b/crates/zakura-state/src/request.rs
@@ -1570,6 +1570,22 @@ pub enum ReadRequest {
     /// * [`ReadResponse::IronwoodTree(None)`](crate::ReadResponse::IronwoodTree) otherwise.
     IronwoodTree(HashOrHeight),
 
+    /// Gathers everything a client needs to rebuild the note commitment treestate at
+    /// `hash_or_height` for itself: the authenticated target roots, plus the highest frontier at
+    /// or below the target that this node has already verified against them.
+    ///
+    /// This is the wallet-side counterpart of the per-height tree reads above, for the band where
+    /// a fast-synced node has no stored tree. It does no replay — the client does that — so it
+    /// stays cheap even when the target is far above anything this node has derived.
+    ///
+    /// Returns
+    ///
+    /// * [`ReadResponse::TreestateReconstruction(Some(_))`](crate::ReadResponse::TreestateReconstruction)
+    ///   when the block is in the best chain and this node holds authenticated roots for it.
+    /// * [`ReadResponse::TreestateReconstruction(None)`](crate::ReadResponse::TreestateReconstruction)
+    ///   when the block is not in the best chain.
+    TreestateReconstruction(HashOrHeight),
+
     /// Returns a list of Sapling note commitment subtrees by their indexes, starting at
     /// `start_index`, and returning up to `limit` subtrees.
     ///
@@ -1749,6 +1765,7 @@ impl ReadRequest {
             ReadRequest::SaplingTree { .. } => "sapling_tree",
             ReadRequest::OrchardTree { .. } => "orchard_tree",
             ReadRequest::IronwoodTree { .. } => "ironwood_tree",
+            ReadRequest::TreestateReconstruction { .. } => "treestate_reconstruction",
             ReadRequest::SaplingSubtrees { .. } => "sapling_subtrees",
             ReadRequest::OrchardSubtrees { .. } => "orchard_subtrees",
             ReadRequest::IronwoodSubtrees { .. } => "ironwood_subtrees",

--- a/crates/zakura-state/src/response.rs
+++ b/crates/zakura-state/src/response.rs
@@ -367,6 +367,49 @@ impl PartialEq for NonFinalizedBlocksListener {
 
 impl Eq for NonFinalizedBlocksListener {}
 
+/// Everything a client needs to rebuild the note commitment treestate at one block for itself,
+/// gathered in a single state read so the anchor and the target roots can never straddle a reorg.
+///
+/// The target roots are the authenticated ones this node holds in `commitment_roots_by_height`;
+/// the anchor is a frontier this node has already checked against them. A client that replays
+/// canonical blocks from the anchor and reproduces all three target roots has the treestate, and
+/// has verified it rather than trusted it — which is what makes serving this safe on a node that
+/// cannot serve `z_gettreestate` for the height at all.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TreestateReconstruction {
+    /// The canonical height the material is for.
+    pub target_height: block::Height,
+
+    /// The canonical hash at `target_height`, so the client can pin its replay to this chain.
+    pub target_hash: block::Hash,
+
+    /// The target block's header time, carried so the client can build the same `TreeState` the
+    /// exact path would have returned.
+    pub target_time: u32,
+
+    /// The authenticated per-pool roots the client's replay must reproduce.
+    pub target_roots: zakura_chain::parallel::commitment_aux::BlockCommitmentRoots,
+
+    /// The highest verified frontier at or below the target, or `None` to replay from genesis.
+    pub anchor: Option<TreestateAnchor>,
+
+    /// The first height the client has to replay.
+    pub replay_from: block::Height,
+}
+
+/// A verified frontier the client replays forward from, bound to its canonical block hash.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TreestateAnchor {
+    /// The height the frontiers are the state at the end of.
+    pub height: block::Height,
+
+    /// The canonical hash at `height`.
+    pub hash: block::Hash,
+
+    /// The frontiers, already root-checked by this node.
+    pub frontiers: Arc<crate::service::read::DerivedFrontiers>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a read-only
 /// [`ReadStateService`](crate::service::ReadStateService)'s [`ReadRequest`].
@@ -505,6 +548,12 @@ pub enum ReadResponse {
 
     /// Response to [`ReadRequest::IronwoodTree`] with the specified Ironwood note commitment tree.
     IronwoodTree(Option<Arc<ironwood::tree::NoteCommitmentTree>>),
+
+    /// Response to [`ReadRequest::TreestateReconstruction`] with the material a client needs to
+    /// rebuild the treestate at the requested block itself.
+    ///
+    /// `None` when the requested block is not in the best chain.
+    TreestateReconstruction(Option<Box<TreestateReconstruction>>),
 
     /// Response to [`ReadRequest::SaplingSubtrees`] with the specified Sapling note commitment
     /// subtrees.
@@ -664,6 +713,7 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::SaplingTree(_)
             | ReadResponse::OrchardTree(_)
             | ReadResponse::IronwoodTree(_)
+            | ReadResponse::TreestateReconstruction(_)
             | ReadResponse::SaplingSubtrees(_)
             | ReadResponse::OrchardSubtrees(_)
             | ReadResponse::IronwoodSubtrees(_)

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -49,7 +49,7 @@ use crate::{
     },
     error::{CommitBlockError, CommitCheckpointVerifiedError, InvalidateError, ReconsiderError},
     request::TimedSpan,
-    response::NonFinalizedBlocksListener,
+    response::{NonFinalizedBlocksListener, TreestateAnchor, TreestateReconstruction},
     service::{
         block_iter::any_ancestor_blocks,
         chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
@@ -1815,6 +1815,72 @@ fn historical_frontiers(
     .map_err(BoxError::from)
 }
 
+/// Returns the material for reconstructing the treestate at `hash_or_height` on the client side.
+///
+/// Every field comes from one pass over the finalized state, so the anchor, the target roots, and
+/// the hashes they are bound to describe the same chain. A client that replays the canonical
+/// blocks between them and reproduces all three target roots ends up with a treestate it verified
+/// rather than trusted, which is what makes this servable in the band where this node has no
+/// stored tree of its own.
+///
+/// `Ok(None)` when the block is not in the finalized best chain. Non-finalized heights are
+/// deliberately not served: the absent band sits far below the reorg limit, and a request up there
+/// wants `z_gettreestate`, which works.
+fn treestate_reconstruction(
+    state: &ReadStateService,
+    hash_or_height: HashOrHeight,
+) -> Result<Option<Box<TreestateReconstruction>>, BoxError> {
+    let db = &state.db;
+
+    let Some(height) = hash_or_height.height_or_else(|hash| db.height(hash)) else {
+        return Ok(None);
+    };
+
+    // Re-resolve the hash from the height even when the caller gave one, so the response always
+    // names the block this node considers canonical at that height rather than echoing the
+    // request back.
+    let (Some(hash), Some(header)) = (db.hash(height), db.block_header(height.into())) else {
+        return Ok(None);
+    };
+
+    let material = read::reconstruction_material(db, &state.historical_trees, height)?;
+
+    let anchor = material
+        .anchor
+        .map(|anchor| {
+            db.hash(anchor.height)
+                .map(|hash| TreestateAnchor {
+                    height: anchor.height,
+                    hash,
+                    frontiers: anchor.frontiers,
+                })
+                .ok_or_else(|| {
+                    // The anchor came from this node's own verified state, so its height is
+                    // canonical by construction. A missing hash means the database is
+                    // inconsistent, and serving an anchor the client cannot pin to a block would
+                    // defeat the point of binding the material to hashes at all.
+                    BoxError::from(format!(
+                        "no canonical hash for the verified anchor at {:?}",
+                        anchor.height
+                    ))
+                })
+        })
+        .transpose()?;
+
+    Ok(Some(Box::new(TreestateReconstruction {
+        target_height: height,
+        target_hash: hash,
+        target_time: u32::try_from(header.time.timestamp()).map_err(|_| {
+            BoxError::from(format!(
+                "the header time at {height:?} does not fit in a u32"
+            ))
+        })?,
+        target_roots: material.target_roots,
+        anchor,
+        replay_from: material.replay_from,
+    })))
+}
+
 fn block_roots_by_height_range<C>(
     chain: Option<C>,
     db: &ZakuraDb,
@@ -2241,6 +2307,12 @@ impl Service<ReadRequest> for ReadStateService {
                 }
 
                 Ok(ReadResponse::IronwoodTree(tree))
+            }
+
+            ReadRequest::TreestateReconstruction(hash_or_height) => {
+                Ok(ReadResponse::TreestateReconstruction(
+                    treestate_reconstruction(&state, hash_or_height)?,
+                ))
             }
 
             ReadRequest::SaplingSubtrees { start_index, limit } => {

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -44,7 +44,8 @@ pub use find::{
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use historical_tree::{
-    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
+    derive_historical_frontiers, reconstruction_material, DerivedFrontiers, HistoricalTreeCache,
+    MAX_MEMOIZED_FRONTIERS,
 };
 pub use tree::{
     check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -66,7 +66,7 @@ pub struct CompletedSubtree {
 }
 
 /// Per-pool note commitment frontiers as of the end of one block.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DerivedFrontiers {
     /// The Sapling frontier.
     pub sapling: Arc<sapling::tree::NoteCommitmentTree>,
@@ -297,6 +297,63 @@ pub fn derive_historical_frontiers(
         .map(|derivation| derivation.frontiers)
 }
 
+/// A verified frontier a replay can start from, and the block it is the state at the end of.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedAnchor {
+    /// The height the frontiers are the state at the end of.
+    pub height: Height,
+
+    /// The frontiers themselves, already checked against this node's authenticated roots.
+    pub frontiers: Arc<DerivedFrontiers>,
+}
+
+/// Everything a client needs to rebuild the treestate at a target height for itself.
+///
+/// This is the wallet-side counterpart of [`derive_historical_frontiers`]: instead of replaying to
+/// the target here, the node hands over the nearest verified anchor and the authenticated roots
+/// the client must reproduce. The roots are what make that safe — a frontier that reproduces them
+/// *is* the frontier, wherever the replay ran — so a wallet accepting a reconstruction under this
+/// check extends the node no more trust than it already extends its own header chain.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReconstructionMaterial {
+    /// The authenticated per-pool roots at the target height.
+    pub target_roots: BlockCommitmentRoots,
+
+    /// The highest verified anchor at or below the target, or `None` to replay from genesis.
+    pub anchor: Option<VerifiedAnchor>,
+
+    /// The first height the client has to replay.
+    pub replay_from: Height,
+}
+
+/// Returns the material for reconstructing the treestate at `height` on the client side.
+///
+/// Does no replay: the anchor is whatever this node already holds verified, so the cost is one
+/// root lookup plus, at most, one root check of a published grid entry.
+pub fn reconstruction_material(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+) -> Result<ReconstructionMaterial, HistoricalTreeDerivationError> {
+    // Read the roots first. Without them there is nothing for the client to verify against, and
+    // serving an anchor it could not check would be exactly the silent-corruption path this whole
+    // design exists to close.
+    let target_roots = authenticated_roots(db, height)?;
+
+    let anchor = highest_verified_anchor(db, cache, height)?
+        .map(|(height, frontiers)| VerifiedAnchor { height, frontiers });
+
+    // The anchor is the state at the *end* of its height, so the client replays from the next
+    // block. With no anchor it replays from genesis.
+    let replay_from = Height(anchor.as_ref().map_or(0, |anchor| anchor.height.0 + 1));
+
+    Ok(ReconstructionMaterial {
+        target_roots,
+        anchor,
+        replay_from,
+    })
+}
+
 /// A completed derivation, and what it cost.
 #[derive(Clone, Debug)]
 pub struct Derivation {
@@ -320,7 +377,7 @@ pub fn derive_historical_frontiers_measured(
     height: Height,
     max_replay_blocks: u64,
 ) -> Result<Derivation, HistoricalTreeDerivationError> {
-    let anchor = anchor_for(db, cache, height)?;
+    let anchor = highest_verified_anchor(db, cache, height)?;
 
     if let Some((anchor_height, frontiers)) = &anchor {
         if *anchor_height == height {
@@ -359,36 +416,48 @@ pub fn derive_historical_frontiers_measured(
     })
 }
 
-/// Returns the frontiers to replay forward from, and the height they are the state at the end of.
+/// Returns the highest verified frontier at or below `height`, and the height it is the state at
+/// the end of.
+///
+/// Three sources can supply one: the memo of frontiers this node already derived, the published
+/// grid, and the last per-height tree stored below the upgrade height `U`. The *highest* of them
+/// wins rather than the first, because the only thing an anchor's provenance changes is how much
+/// replay is left — all three are equally verified once accepted, and picking a lower one just
+/// costs blocks.
 ///
 /// `None` means start from empty frontiers at genesis, which is correct when this binary committed
 /// every block from genesis (`U == 0`) and so stored no per-height trees to anchor on.
-fn anchor_for(
+fn highest_verified_anchor(
     db: &ZakuraDb,
     cache: &Mutex<HistoricalTreeCache>,
     height: Height,
 ) -> Result<Option<(Height, Arc<DerivedFrontiers>)>, HistoricalTreeDerivationError> {
-    let memoized = lock(cache).anchor_at_or_below(height);
+    let mut best = lock(cache).anchor_at_or_below(height);
 
-    if memoized.is_some() {
-        return Ok(memoized);
-    }
+    let improves = |best: &Option<(Height, Arc<DerivedFrontiers>)>, candidate: Height| {
+        best.as_ref().is_none_or(|(best, _)| candidate > *best)
+    };
 
-    // Fall back to the published grid. The entry is checked against this node's own authenticated
-    // root before it anchors anything, so a wrong or hostile artifact cannot steer a derivation.
+    // The published grid. The entry is checked against this node's own authenticated root before
+    // it anchors anything, so a wrong or hostile artifact cannot steer a derivation.
     //
     // A failed check is deliberately *not* fatal: the artifact is an optimization with no trust
     // weight, so a bad entry is ignored and the derivation falls back to replaying further. Making
     // it fatal would hand anyone who can supply a corrupt artifact a denial of service over a
     // node that is perfectly capable of answering without one.
-    let published = lock(cache).artifact_anchor_at_or_below(height);
+    //
+    // The check costs three root computations, so it only runs when the entry would actually beat
+    // what the memo already holds.
+    let published = lock(cache)
+        .artifact_anchor_at_or_below(height)
+        .filter(|(anchor_height, _)| improves(&best, *anchor_height));
     if let Some((anchor_height, frontiers)) = published {
         match verify_against_index(db, anchor_height, &frontiers) {
             Ok(()) => {
                 let frontiers = Arc::new(frontiers);
                 lock(cache).insert(anchor_height, frontiers.clone());
 
-                return Ok(Some((anchor_height, frontiers)));
+                best = Some((anchor_height, frontiers));
             }
             Err(error) => {
                 tracing::warn!(
@@ -404,16 +473,26 @@ fn anchor_for(
     // Below the upgrade height `U` this binary did not run, so per-height trees are present. The
     // tree at `U - 1` is therefore the last stored frontier before the absent band starts.
     let Some(upgrade) = db.vct_upgrade_height().filter(|upgrade| upgrade.0 > 0) else {
-        return Ok(None);
+        return Ok(best);
     };
 
     let anchor = Height(upgrade.0 - 1);
+    if anchor > height || !improves(&best, anchor) {
+        return Ok(best);
+    }
+
     let (Some(sapling), Some(orchard), Some(ironwood)) = (
         db.sapling_tree_by_height(&anchor),
         db.orchard_tree_by_height(&anchor),
         db.ironwood_tree_by_height(&anchor),
     ) else {
-        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+        // Only fatal when nothing else can anchor the replay. A node whose memo or grid already
+        // covers `height` does not care that the band's lower edge is unreadable.
+        if best.is_none() {
+            return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+        }
+
+        return Ok(best);
     };
 
     Ok(Some((

--- a/docs/changelog/unreleased/550.md
+++ b/docs/changelog/unreleased/550.md
@@ -1,0 +1,20 @@
+## Added
+
+- Added `z_gettreestateanchor`, which returns the material a client needs to rebuild a
+  historical treestate itself: the canonical target block with its authenticated per-pool
+  note commitment roots, the highest frontier at or below it that this node has already
+  verified, and the first height to replay from. A client replays the canonical blocks and
+  accepts the result only if it reproduces all three roots, so what it ends up with is
+  verified rather than trusted, and this node does no replay of its own. Intended as the
+  fallback for the height band where a fast-synced node reports the historical tree
+  unavailable; `z_gettreestate` is unchanged
+  ([#550](https://github.com/zakura-core/zakura/pull/550)).
+
+## Changed
+
+- Changed historical note commitment tree derivation to anchor on the highest verified
+  frontier available, rather than the first source that has one. The memo, the published
+  frontier grid, and the last stored tree below the upgrade height are all equally
+  verified once accepted, so preferring a lower anchor only made a derivation replay more
+  blocks than it needed to
+  ([#550](https://github.com/zakura-core/zakura/pull/550)).

--- a/docs/design/historical-treestate-serving.md
+++ b/docs/design/historical-treestate-serving.md
@@ -323,7 +323,7 @@ The trade-off to weigh: the node's sizes currently act as a loose cross-check on
 client's tree position. It is a weak check, since those sizes are unauthenticated on every
 backend, but dropping it should be a deliberate decision rather than a silent side effect.
 
-**Prototyped (2026-08-05).** zecd derives sizes locally *only* inside the band — that is, only
+**Prototyped (2026-08-05).** zecd derives sizes locally _only_ inside the band — that is, only
 when the node cannot serve the tree state just below a scan range, which is exactly when its
 per-block `trees` query would fail anyway. Everywhere else the node's sizes are still used, so the
 cross-check is kept where it costs nothing and dropped only where it does not exist.
@@ -350,7 +350,7 @@ only if all three roots match. **This is the same check as §4.2, run on the oth
 so it carries the same weight: a frontier that reproduces an authenticated root is the frontier,
 and a wrong or stale anchor cannot survive it. The trust boundary therefore does not move. The
 node's roots are authenticated against its own header chain and the client already relies on that
-node for its view of the chain; what it does *not* have to do is believe an unverified frontier.
+node for its view of the chain; what it does _not_ have to do is believe an unverified frontier.
 
 Three properties follow, and they are why this is worth having alongside §4.3 rather than instead
 of it:
@@ -360,7 +360,7 @@ of it:
    apply, so an operator can serve the band without a replay budget or an RPC-timeout risk.
 2. **The client's cache is self-invalidating.** A wallet memoizes each verified end state and
    anchors the next batch on it. A stale entry — from an abandoned fork, or from before a reorg —
-   cannot corrupt anything, because it would have to replay into the *new* chain's authenticated
+   cannot corrupt anything, because it would have to replay into the _new_ chain's authenticated
    roots. It can only make a request fail, never succeed wrongly. No explicit reorg invalidation is
    needed.
 3. **It composes with the anchor grid.** The client's anchor is whichever is higher: its own
@@ -368,7 +368,7 @@ of it:
    the common case, so grid spacing again only costs the first request of a sweep.
 
 The cost the client pays is the replay itself, and the block bodies it needs for it. A pruned node
-still cannot supply those, so this widens *who can serve* the band but not *which nodes* can.
+still cannot supply those, so this widens _who can serve_ the band but not _which nodes_ can.
 Subtree roots (§4.6) are unaffected: they cannot be checked this way on either side, so they still
 ship as a reviewed artifact.
 

--- a/docs/design/historical-treestate-serving.md
+++ b/docs/design/historical-treestate-serving.md
@@ -207,7 +207,8 @@ pass and no follower lane.
 
 ### 4.4 Serving the three RPCs
 
-- **`z_gettreestate`** is served directly by §4.3.
+- **`z_gettreestate`** is served directly by §4.3, or reconstructed client-side from
+  `z_gettreestateanchor` (§6a) on a node that would rather not replay.
 - **`z_getsubtreesbyindex`** is served from the embedded subtree-root artifact (§4.6),
   never by replay. Replay is the wrong tool here: wallets doing spend-before-sync fetch
   the full subtree list in one request at startup, from index 0 to the tip, so a
@@ -321,6 +322,55 @@ cheapest first step.
 The trade-off to weigh: the node's sizes currently act as a loose cross-check on the
 client's tree position. It is a weak check, since those sizes are unauthenticated on every
 backend, but dropping it should be a deliberate decision rather than a silent side effect.
+
+**Prototyped (2026-08-05).** zecd derives sizes locally *only* inside the band — that is, only
+when the node cannot serve the tree state just below a scan range, which is exactly when its
+per-block `trees` query would fail anyway. Everywhere else the node's sizes are still used, so the
+cross-check is kept where it costs nothing and dropped only where it does not exist.
+
+## 6a. Wallet-side reconstruction
+
+A second consumer of §4.2's verification property, and the one that makes the absent band
+serviceable without the node paying for §4.3 at all: **the client can run the replay.**
+
+The node exposes a Zakura-specific `z_gettreestateanchor(hash | height)` returning, in one state
+read so the pieces cannot straddle a reorg:
+
+- the canonical target height and hash, its header time, and the three authenticated roots;
+- the highest frontier at or below the target that the node has already verified — from its
+  memo, from the published grid, or from the last stored tree below `U` — with its own canonical
+  hash and `finalState` in `z_gettreestate`'s encoding;
+- `replayFrom`, the first height the client must replay.
+
+`z_gettreestate` is untouched: same response, same errors, same codes. A client tries it first and
+falls back here only on the typed historical-tree-unavailable message from §4.5.
+
+The client then replays the canonical blocks from `replayFrom` to the target and accepts the result
+only if all three roots match. **This is the same check as §4.2, run on the other side of the RPC**,
+so it carries the same weight: a frontier that reproduces an authenticated root is the frontier,
+and a wrong or stale anchor cannot survive it. The trust boundary therefore does not move. The
+node's roots are authenticated against its own header chain and the client already relies on that
+node for its view of the chain; what it does *not* have to do is believe an unverified frontier.
+
+Three properties follow, and they are why this is worth having alongside §4.3 rather than instead
+of it:
+
+1. **The node does no replay.** Answering costs one root lookup plus, at most, one root check of a
+   published grid entry. The measured per-request cost of §4.3 (median 1.07 s, p90 2.50 s) does not
+   apply, so an operator can serve the band without a replay budget or an RPC-timeout risk.
+2. **The client's cache is self-invalidating.** A wallet memoizes each verified end state and
+   anchors the next batch on it. A stale entry — from an abandoned fork, or from before a reorg —
+   cannot corrupt anything, because it would have to replay into the *new* chain's authenticated
+   roots. It can only make a request fail, never succeed wrongly. No explicit reorg invalidation is
+   needed.
+3. **It composes with the anchor grid.** The client's anchor is whichever is higher: its own
+   previous batch end, or whatever the node offers. Sequential wallet access (§4.3) makes the first
+   the common case, so grid spacing again only costs the first request of a sweep.
+
+The cost the client pays is the replay itself, and the block bodies it needs for it. A pruned node
+still cannot supply those, so this widens *who can serve* the band but not *which nodes* can.
+Subtree roots (§4.6) are unaffected: they cannot be checked this way on either side, so they still
+ship as a reviewed artifact.
 
 ## 7. Open questions
 

--- a/docs/design/historical-treestate-serving.md
+++ b/docs/design/historical-treestate-serving.md
@@ -194,8 +194,8 @@ Two properties make a coarse grid viable:
 
 **Wallet access is sequential.** Scan batches are contiguous: a wallet's next request is
 for the block immediately preceding the range it just finished, which is the block it just
-scanned to. A node that memoizes its most recently derived frontier replays *forward by
-one batch*, not from a distant grid point.
+scanned to. A node that memoizes its most recently derived frontier replays _forward by
+one batch_, not from a distant grid point.
 
 **Therefore spacing only costs the first request of a sweep.** Steady-state replay cost is
 bounded by the client's batch size, independent of grid spacing. This is why the


### PR DESCRIPTION
## Motivation

A verified-commitment-trees fast-synced node stores no per-height note commitment tree across the absent band, so `z_gettreestate` there reports the tree unavailable. Today the node's only way to answer is to replay the band itself ([design §4.3](../blob/feat/wallet-side-treestate-reconstruction/docs/design/historical-treestate-serving.md)), which the 2026-08-03 measurements put at a median 1.07 s and p90 2.50 s per cold request even on the cost-weighted grid. That is a real serving budget for every operator, and it exists only because the replay happens on the wrong side of the RPC.

It does not have to. The verification property in §4.2 — a frontier that reproduces an authenticated root *is* the frontier — does not care which machine runs the replay.

## Solution

Add a Zakura-specific `z_gettreestateanchor(hash | height)` that hands a client the material to reconstruct the treestate itself:

- the canonical target height and hash, its header time, and the three authenticated per-pool roots;
- the highest frontier at or below the target this node has already verified — from its memo, the published grid, or the last stored tree below `U` — with its own canonical hash and `finalState` in `z_gettreestate`'s encoding;
- `replayFrom`, the first height the client must replay.

The client replays the canonical blocks and accepts the result only if all three roots match. That is the same check §4.2 already applies node-side, so **the trust boundary does not move**: the client still relies on this node for its view of the chain, but it no longer has to believe an unverified frontier. What changes is the cost — answering is one root lookup plus, at most, one root check of a published grid entry. No replay.

`z_gettreestate` is untouched: same request, same response shape, same error codes. The new method is a fallback a client reaches only on the typed historical-tree-unavailable error.

Two details worth review attention:

- **One state read.** `ReadRequest::TreestateReconstruction` gathers the anchor and the target roots in a single pass so they cannot straddle a reorg, and binds both to canonical block hashes so a client can pin its replay to this chain. Assembling them from separate reads would let a reorg between the two hand out an anchor that cannot reach its own target.
- **Anchor selection now takes the maximum**, not the first hit. `anchor_for` preferred memo, then grid, then the stored tree below `U`; `highest_verified_anchor` takes the highest across all three. Provenance only changes how much replay is left — all three are equally verified once accepted — so preferring a lower one just costs blocks. This improves the existing node-side derivation path too. The grid entry's root check still runs only when that entry would actually beat the memo, so the steady state costs no extra hashing.

Failure policy is unchanged and fail-closed: a missing authenticated root is an error, an anchor above the target is rejected, a grid entry that fails its root check is ignored rather than fatal (it carries no trust, so making it fatal would hand a DoS to anyone who can supply a corrupt artifact), and an anchor whose height has no canonical hash is an error rather than an unbound response.

Design doc gains §6a describing the wallet-side path, the trust argument, and the client-cache property that falls out of it: a stale or forked cached anchor can only make a request *fail*, never succeed wrongly, because it would have to replay into the new chain's authenticated roots. That is why no explicit reorg invalidation is needed client-side.

## Testing

- `cargo test -p zakura-state --lib` — 480 passed, 0 failed.
- `cargo test -p zakura-rpc --lib` — 96 passed, 0 failed. Includes the existing `rpc_z_get_treestate_absent_band_is_an_error` golden, which is what holds `z_gettreestate`'s error contract unchanged.
- `cargo clippy -p zakura-state -p zakura-rpc --all-targets` — clean.
- `cargo fmt --all --check` — clean.
- `./scripts/changelog.py check` — 9 fragments validated.
- markdownlint **not run**: no node/npm in this environment. The `docs-check` workflow covers it here. The emphasis added to the design doc was converted to underscores by hand to match MD049's configured style.

**Not covered, and the reason this is a draft.** There are no new unit tests for anchor selection itself — the max-across-sources choice, the genesis case, an anchor rejected for sitting above the target, a corrupt grid entry being skipped rather than fatal, and the canonical height/hash binding. Those need a populated-database fixture I have not built here, and they are the tests that would actually pin this behavior. Treat the anchor-selection rewrite as unverified beyond compilation and the existing derivation tests that route through it.

## Changelog

`docs/changelog/unreleased/550.md` — one Added entry for `z_gettreestateanchor`, one Changed entry for the anchor-selection rewrite.

### Specifications & References

- `docs/design/historical-treestate-serving.md` §4.2 (the verification property this rests on), §4.3 (the node-side replay this is an alternative to), §4.5 (the typed error that triggers the fallback), and the new §6a.
- Prototyped end to end against a zecd client (separate repo): exact-first resolution, three-pool replay, root verification, a self-invalidating verified-state cache, and locally derived `chain_metadata` sizes inside the band. Not part of this PR.

### Known CI failure (inherited, not from this PR)

`semver (zakura)` fails on `enum_variant_added` for `ZakuradCmd::AuditHistoricalTreestates` and `ZakuradCmd::ExportHistoricalTreestates`. Both variants come from `feat/historical-treestate-serving`, this PR's base; nothing here touches `crates/zakurad/src/commands.rs` or adds a variant to any `zakura`-public enum. semver-checks compares against the crates.io baseline rather than the base branch, so it will fail on every PR in this stack until the base bumps `zakura` past `1.1.0-rc1` to a major version. Fixing it belongs there, not here.

### Follow-up Work

- Unit tests for anchor selection across all three sources, genesis handling, activation boundaries, root byte order, and canonical height/hash binding.
- Regtest absent-band end-to-end wallet scan, and the differential test against a legacy archive node — the phase D items, and the ones that would actually prove the design.
- This branch stacks on `feat/historical-treestate-serving`; merging toward `feat/vct-verified-replay` needs that branch to pick up the artifact machinery and the read-service cache seam first.
