### PR TITLE
feat(state): rebuild historical note commitment trees by verified replay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 include scripts/make/zcashd-compat.mk
 include scripts/make/perf.mk
 include scripts/make/zakura-dev.mk
+include scripts/make/treestate-audit.mk
 include scripts/make/release.mk
 include scripts/make/install.mk
 
@@ -16,6 +17,16 @@ help:
 	@echo "  zakura-build-dev                 Build release zakurad"
 	@echo "  zakura-dev-init                  Create ~/.local/zakura-dev config + dirs"
 	@echo "  zakura-start-dev                 Start local dev node (pruned, VCT, v2-only)"
+	@echo ""
+	@echo "  Historical treestate audit:"
+	@echo "  treestate-audit-inventory        Report the database's historical treestate inventory"
+	@echo "  treestate-audit-subtrees         Verify replay-derived subtree roots against stored rows"
+	@echo "  treestate-audit-walk             Derive and root-check the absent band"
+	@echo "  treestate-audit-samples          Measure cold replay and print per-height samples"
+	@echo "  treestate-audit-roots            Print derived roots for cross-node comparison"
+	@echo "  treestate-audit-differential     Compare derived roots with a legacy node over RPC"
+	@echo "    Variables: TREESTATE_CACHE_DIR, TREESTATE_NETWORK, TREESTATE_FROM,"
+	@echo "               TREESTATE_TO, TREESTATE_STEP, TREESTATE_RPC_URL"
 	@echo ""
 	@echo "  Perf harness (deterministic isolated-cohort bench):"
 	@echo "  perf-build-local                 Build the instrumented (commit-metrics) bench binary"

--- a/crates/zakura-state/src/constants.rs
+++ b/crates/zakura-state/src/constants.rs
@@ -38,6 +38,15 @@ pub const STATE_DATABASE_KIND: &str = "state";
 /// get the network-specific floor.
 pub const MIN_PRUNING_RETENTION: u32 = 10_000;
 
+/// The default bound on how many blocks one historical note commitment tree derivation may
+/// replay, used by [`Config::max_historical_tree_replay_blocks`](crate::Config).
+///
+/// Sized to cover a cold request anywhere in a from-genesis fast-synced node's absent band on
+/// Mainnet, so the first request of a wallet sweep succeeds rather than failing at a limit. Later
+/// requests in the sweep replay only from the previous memoized frontier, so the bound applies to
+/// the cold case alone.
+pub const DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS: u64 = 4_000_000;
+
 /// The minimum retention window allowed in pruned storage mode on `network`.
 ///
 /// Every network's floor stays strictly greater than [`MAX_BLOCK_REORG_HEIGHT`],

--- a/crates/zakura-state/src/constants.rs
+++ b/crates/zakura-state/src/constants.rs
@@ -39,7 +39,7 @@ pub const STATE_DATABASE_KIND: &str = "state";
 pub const MIN_PRUNING_RETENTION: u32 = 10_000;
 
 /// The default bound on how many blocks one historical note commitment tree derivation may
-/// replay, used by [`Config::max_historical_tree_replay_blocks`](crate::Config).
+/// replay. Used as the `audit-historical-treestates` CLI default until the config knob lands.
 ///
 /// Sized to cover a cold request anywhere in a from-genesis fast-synced node's absent band on
 /// Mainnet, so the first request of a wallet sweep succeeds rather than failing at a limit. Later

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -43,7 +43,10 @@ pub use config::{
     database_format_version_on_disk, state_database_format_version_on_disk, Config, PruningConfig,
     StorageMode,
 };
-pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
+pub use constants::{
+    state_database_format_version_in_code, DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+    MAX_BLOCK_REORG_HEIGHT,
+};
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitCheckpointVerifiedError, CommitHeaderRangeError,
     CommitSemanticallyVerifiedError, DuplicateNullifierError, HistoricalSubtreeUnavailable,
@@ -79,6 +82,11 @@ pub use service::{
 pub use service::finalized_state::{ReadDisk, TypedColumnFamily, WriteTypedBatch};
 
 pub use service::finalized_state::{
+    derived_roots_in_display_order, inventory as vct_treestate_inventory, measure_derivations,
+    replay_inputs, verify_subtrees_against_stored, DerivationSample, ReplayInputs,
+    SubtreeVerification, VctTreestateInventory,
+};
+pub use service::finalized_state::{
     preview_prune_finalized_state, prune_finalized_state, PruneFinalizedStateError,
     PruneFinalizedStateOptions, PruneFinalizedStateSummary,
 };
@@ -91,6 +99,9 @@ pub use service::finalized_state::{
     validate_final_frontiers_bytes, AuthenticateHeaderRootsError, AuthenticateHeaderRootsOutcome,
     AuthenticatedHeaderRoots, FinalFrontiersGenerationError, FinalFrontiersValidationError,
     HeaderRootAuthState, HeaderRootAuthUpdate, HeaderWitnessState,
+};
+pub use service::read::{
+    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
 };
 pub use service::{
     finalized_state::{

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -82,9 +82,10 @@ pub use service::{
 pub use service::finalized_state::{ReadDisk, TypedColumnFamily, WriteTypedBatch};
 
 pub use service::finalized_state::{
-    derived_roots_in_display_order, inventory as vct_treestate_inventory, measure_derivations,
-    replay_inputs, verify_subtrees_against_stored, DerivationSample, ReplayInputs,
-    SubtreeVerification, VctTreestateInventory,
+    derived_roots_in_display_order, inventory as vct_treestate_inventory,
+    inventory_with_scans as vct_treestate_inventory_with_scans, measure_derivations, replay_inputs,
+    verify_subtrees_against_stored, DerivationSample, ReplayInputs, SubtreeVerification,
+    VctTreestateInventory,
 };
 pub use service::finalized_state::{
     preview_prune_finalized_state, prune_finalized_state, PruneFinalizedStateError,

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -83,6 +83,7 @@ pub(crate) mod commitment_aux_verify;
 mod disk_db;
 mod disk_format;
 mod vct;
+pub mod vct_treestate_audit;
 mod zakura_db;
 
 pub(crate) use vct::embedded_last_checkpoint_leaf_counts;
@@ -109,6 +110,11 @@ pub use disk_format::{
     MAX_ON_DISK_HEIGHT,
 };
 pub use vct::{validate_final_frontiers_bytes, FinalFrontiersValidationError, NextVctBlock};
+pub use vct_treestate_audit::{
+    derived_roots_in_display_order, inventory, measure_derivations, replay_inputs,
+    verify_subtrees_against_stored, DerivationSample, ReplayInputs, SubtreeVerification,
+    VctTreestateInventory,
+};
 #[allow(unused_imports)]
 pub use zakura_db::commitment_roots_db::{
     AuthenticateHeaderRootsError, AuthenticateHeaderRootsOutcome, AuthenticatedHeaderRoots,

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -111,9 +111,9 @@ pub use disk_format::{
 };
 pub use vct::{validate_final_frontiers_bytes, FinalFrontiersValidationError, NextVctBlock};
 pub use vct_treestate_audit::{
-    derived_roots_in_display_order, inventory, measure_derivations, replay_inputs,
-    verify_subtrees_against_stored, DerivationSample, ReplayInputs, SubtreeVerification,
-    VctTreestateInventory,
+    derived_roots_in_display_order, inventory, inventory_with_scans, measure_derivations,
+    replay_inputs, verify_subtrees_against_stored, DerivationSample, ReplayInputs,
+    SubtreeVerification, VctTreestateInventory,
 };
 #[allow(unused_imports)]
 pub use zakura_db::commitment_roots_db::{

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -118,8 +118,9 @@ pub use vct_treestate_audit::{
 #[allow(unused_imports)]
 pub use zakura_db::commitment_roots_db::{
     AuthenticateHeaderRootsError, AuthenticateHeaderRootsOutcome, AuthenticatedHeaderRoots,
-    HeaderRootAuthFrontier, HeaderRootAuthFrontierError, HeaderRootAuthState, HeaderRootAuthUpdate,
-    HeaderWitnessState, COMMITMENT_ROOTS_BY_HEIGHT, HEADER_ROOT_AUTH_FRONTIER,
+    CommitmentRootIndexIssue, HeaderRootAuthFrontier, HeaderRootAuthFrontierError,
+    HeaderRootAuthState, HeaderRootAuthUpdate, HeaderWitnessState, COMMITMENT_ROOTS_BY_HEIGHT,
+    HEADER_ROOT_AUTH_FRONTIER,
 };
 pub use zakura_db::highest_completed_checkpoint::*;
 pub use zakura_db::ZakuraDb;

--- a/crates/zakura-state/src/service/finalized_state/commitment_aux.rs
+++ b/crates/zakura-state/src/service/finalized_state/commitment_aux.rs
@@ -930,6 +930,31 @@ mod tests {
         }
     }
 
+    /// Replaying note commitments needs every block body in the replay range, so the audit has to
+    /// report the first height that would stop a replay rather than discovering it mid-derivation.
+    #[test]
+    fn first_missing_block_body_finds_the_first_unreplayable_height() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+        seed_block_bodies(&db, [1, 2]);
+
+        assert_eq!(
+            db.first_missing_block_body(block::Height(1), block::Height(2)),
+            None,
+            "a fully seeded range is replayable"
+        );
+        assert_eq!(
+            db.first_missing_block_body(block::Height(1), block::Height(4)),
+            Some(block::Height(3)),
+            "a range running past the seeded bodies reports where they stop"
+        );
+        assert_eq!(
+            db.first_missing_block_body(block::Height(0), block::Height(2)),
+            Some(block::Height(0)),
+            "a missing first height is reported, not skipped"
+        );
+    }
+
     #[test]
     fn produce_block_roots_derives_contiguous_tree_roots() {
         let _init_guard = zakura_test::init();

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -11,7 +11,7 @@
 //! each time the database format (column, serialization, etc) changes.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::{Debug, Write},
     fs,
     ops::RangeBounds,
@@ -593,7 +593,7 @@ impl DiskDb {
         let mut total_size_in_mem = 0;
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
-        let column_families = DiskDb::construct_column_families(db_options, db.path(), []);
+        let column_families = DiskDb::construct_column_families(db_options, db.path(), [], false);
         let mut column_families_log_string = String::from("");
 
         write!(column_families_log_string, "Column families and sizes: ").unwrap();
@@ -649,7 +649,7 @@ impl DiskDb {
     pub(crate) fn export_metrics(&self) {
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
-        let column_families = DiskDb::construct_column_families(db_options, db.path(), []);
+        let column_families = DiskDb::construct_column_families(db_options, db.path(), [], false);
 
         let mut total_disk: u64 = 0;
         let mut total_live: u64 = 0;
@@ -717,7 +717,7 @@ impl DiskDb {
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
         let mut total_size_on_disk = 0;
-        for cf_descriptor in DiskDb::construct_column_families(db_options, db.path(), []) {
+        for cf_descriptor in DiskDb::construct_column_families(db_options, db.path(), [], false) {
             let cf_name = &cf_descriptor.name();
             let cf_handle = db
                 .cf_handle(cf_name)
@@ -989,6 +989,7 @@ impl DiskDb {
         db_options: Options,
         path: &Path,
         column_families_in_code: impl IntoIterator<Item = String>,
+        read_only: bool,
     ) -> impl Iterator<Item = ColumnFamilyDescriptor> {
         // When opening the database in read/write mode, all column families must be opened.
         //
@@ -1000,9 +1001,21 @@ impl DiskDb {
         let column_families_on_disk = DB::list_cf(&db_options, path).unwrap_or_default();
         let column_families_in_code = column_families_in_code.into_iter();
 
+        // A read-only secondary cannot create column families, so naming one the database does
+        // not have fails the open outright. Restricting to what is actually on disk is what lets
+        // read-only tooling inspect a database written by an older version, which is exactly when
+        // some newer column family is missing. Nothing is lost: a column family that does not
+        // exist holds no data to read, and the accessors for one already handle its absence.
+        let missing_is_fatal = !read_only;
+        let on_disk: HashSet<String> = column_families_on_disk.iter().cloned().collect();
+
         column_families_on_disk
+            .clone()
             .into_iter()
-            .chain(column_families_in_code)
+            .chain(
+                column_families_in_code
+                    .filter(move |cf_name| missing_is_fatal || on_disk.contains(cf_name)),
+            )
             .unique()
             .map(move |cf_name: String| {
                 let mut cf_options = db_options.clone();
@@ -1068,8 +1081,12 @@ impl DiskDb {
 
         let db_options = DiskDb::options();
 
-        let column_families =
-            DiskDb::construct_column_families(db_options.clone(), &path, column_families_in_code);
+        let column_families = DiskDb::construct_column_families(
+            db_options.clone(),
+            &path,
+            column_families_in_code,
+            read_only,
+        );
 
         let db_result = if read_only {
             // Use a tempfile for the secondary instance cache directory

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -111,6 +111,11 @@ pub struct DiskDb {
     /// In [`MultiThreaded`](rocksdb::MultiThreaded) mode,
     /// only [`Drop`] requires exclusive access.
     db: Arc<DB>,
+
+    /// The temporary workspace RocksDB uses to follow a primary database.
+    ///
+    /// This must be declared after `db` so the RocksDB handle is dropped before the directory.
+    _secondary_dir: Option<Arc<tempfile::TempDir>>,
 }
 
 /// Wrapper struct to ensure low-level database writes go through the correct API.
@@ -394,8 +399,8 @@ enum DbMode {
     /// A read-write primary backed by temporary files that are deleted on drop.
     Ephemeral,
 
-    /// A read-only secondary that follows an existing primary's on-disk state. It owns
-    /// no files and never writes, flushes, or deletes them.
+    /// A read-only secondary that follows an existing primary's on-disk state. It never writes,
+    /// flushes, or deletes primary files; its temporary workspace is deleted on drop.
     ReadOnlySecondary,
 }
 
@@ -1088,17 +1093,21 @@ impl DiskDb {
             read_only,
         );
 
-        let db_result = if read_only {
-            // Use a tempfile for the secondary instance cache directory
-            let secondary_config = Config {
-                ephemeral: true,
-                ..config.clone()
-            };
-            let secondary_path =
-                secondary_config.db_path("secondary_state", format_version_in_code.major, network);
-            let create_dir_result = std::fs::create_dir_all(&secondary_path);
+        let secondary_dir = read_only.then(|| {
+            Arc::new(
+                tempfile::Builder::new()
+                    .prefix("zebra-secondary-state-")
+                    .tempdir()
+                    .expect("temporary RocksDB secondary directory can be created"),
+            )
+        });
 
-            info!(?create_dir_result, "creating secondary db directory");
+        let db_result = if let Some(secondary_dir) = &secondary_dir {
+            let secondary_path = secondary_dir.path().to_path_buf();
+            info!(
+                path = ?secondary_path,
+                "created temporary secondary db directory"
+            );
 
             DB::open_cf_descriptors_as_secondary(
                 &db_options,
@@ -1120,6 +1129,7 @@ impl DiskDb {
                     network: network.clone(),
                     mode,
                     db: Arc::new(db),
+                    _secondary_dir: secondary_dir,
                     finished_format_upgrades: Arc::new(AtomicBool::new(false)),
                 };
 
@@ -1166,6 +1176,12 @@ impl DiskDb {
     /// Returns the `Path` where the files used by this database are located.
     pub fn path(&self) -> &Path {
         self.db.path()
+    }
+
+    /// Returns the temporary RocksDB secondary workspace in tests.
+    #[cfg(test)]
+    pub(crate) fn secondary_path(&self) -> Option<&Path> {
+        self._secondary_dir.as_deref().map(tempfile::TempDir::path)
     }
 
     /// Returns the low-level rocksdb inner database.

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1,6 +1,12 @@
 //! Randomised property tests for the finalized state.
 
-use std::{collections::HashMap, env, error::Error, fs, sync::Arc};
+use std::{
+    collections::HashMap,
+    env,
+    error::Error,
+    fs,
+    sync::{Arc, Mutex},
+};
 
 use tempfile::TempDir;
 use tokio::sync::oneshot;
@@ -31,7 +37,10 @@ use crate::{
         arbitrary::PreparedChain,
         check::anchors::tx_anchors_refer_to_final_treestates,
         non_finalized_state::Chain,
-        read::{sapling_subtrees, sapling_tree},
+        read::{
+            derive_historical_frontiers, historical_tree::HistoricalTreeDerivationError,
+            sapling_subtrees, sapling_tree, HistoricalTreeCache,
+        },
     },
     tests::FakeChainHelper,
     HashOrHeight,
@@ -1696,6 +1705,56 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
                     .is_empty(),
                 "an index past the last completed subtree stays an empty list, not an error"
             );
+
+            // On-demand derivation rebuilds the absent band from retained block bodies. `U` is 0
+            // here, so every derivation replays from empty genesis frontiers — the cold path.
+            // Each result is accepted only after reproducing the authenticated root, so agreeing
+            // with the legacy node's own per-height trees is what proves the replay is faithful
+            // rather than merely self-consistent.
+            let cache = Mutex::new(HistoricalTreeCache::default());
+            for height in (seed as u32 + 1)..(last as u32) {
+                let height = Height(height);
+                let derived = derive_historical_frontiers(&fast.db, &cache, height, u64::MAX)
+                    .expect("every absent-band height derives from retained bodies");
+
+                prop_assert_eq!(
+                    derived.sapling.root(),
+                    legacy.db.sapling_tree_by_height(&height).expect("the legacy node stores every tree").root(),
+                    "derived Sapling frontier matches the legacy node at {:?}", height
+                );
+                prop_assert_eq!(
+                    derived.orchard.root(),
+                    legacy.db.orchard_tree_by_height(&height).expect("the legacy node stores every tree").root(),
+                    "derived Orchard frontier matches the legacy node at {:?}", height
+                );
+                prop_assert_eq!(
+                    derived.ironwood.root(),
+                    legacy.db.ironwood_tree_by_height(&height).expect("the legacy node stores every tree").root(),
+                    "derived Ironwood frontier matches the legacy node at {:?}", height
+                );
+            }
+
+            // The replay bound is a serving limit: with the memo primed by the loop above, the
+            // last height is already derived, so it costs nothing. A cold height below every memo
+            // entry still has to replay, and refuses rather than running unbounded.
+            prop_assert!(
+                derive_historical_frontiers(&fast.db, &cache, Height(last as u32 - 1), 0).is_ok(),
+                "a memoized height is served without replaying, whatever the bound"
+            );
+            let cold_cache = Mutex::new(HistoricalTreeCache::default());
+            let cold_height = Height(last as u32 - 1);
+            prop_assert_eq!(
+                derive_historical_frontiers(&fast.db, &cold_cache, cold_height, 1).err(),
+                Some(HistoricalTreeDerivationError::ReplayTooLong {
+                    height: cold_height,
+                    // From empty genesis frontiers, reaching `cold_height` replays every block up
+                    // to and including it.
+                    blocks: u64::from(cold_height.0) + 1,
+                    limit: 1,
+                }),
+                "a cold derivation past the replay bound refuses instead of running unbounded"
+            );
+
 
             // Negative: a peer can supply a wrong root exactly at the handoff height,
             // where there is no buffered checkpoint successor to authenticate it. The

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -1866,6 +1866,23 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             // completes in the range. Otherwise corruption after the last boundary (or, as in
             // this short fixture, before the first boundary) would leave no subtree row to expose
             // the bad replay.
+            prop_assert_eq!(
+                verify_subtrees_against_stored(&legacy.db, handoff, handoff),
+                Err(HistoricalTreeDerivationError::InvalidReplayRange {
+                    from: handoff,
+                    to: handoff,
+                }),
+                "an empty subtree replay range is rejected"
+            );
+            prop_assert_eq!(
+                verify_subtrees_against_stored(&legacy.db, handoff, Height(seed as u32)),
+                Err(HistoricalTreeDerivationError::InvalidReplayRange {
+                    from: handoff,
+                    to: Height(seed as u32),
+                }),
+                "a reversed subtree replay range is rejected"
+            );
+
             let subtree_outcome =
                 verify_subtrees_against_stored(&legacy.db, Height(seed as u32), handoff)
                     .expect("the unmodified replay endpoint matches its authenticated roots");

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -2665,6 +2665,22 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                     .is_empty(),
                 "the serving index is dropped below the upgrade height"
             );
+            let below_upgrade = Height(upgrade.0 - 2);
+            let fallback_anchor = Height(upgrade.0 - 1);
+            prop_assert_eq!(
+                derive_historical_frontiers(
+                    &legacy.db,
+                    &Mutex::new(HistoricalTreeCache::default()),
+                    below_upgrade,
+                    u64::MAX,
+                )
+                .err(),
+                Some(HistoricalTreeDerivationError::MissingAnchor {
+                    height: below_upgrade,
+                    anchor: fallback_anchor,
+                }),
+                "a database fallback anchor above the target is refused without underflowing"
+            );
             let stitched = serve_block_roots(&legacy.db, serve_range);
             prop_assert_eq!(
                 stitched,

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -2681,11 +2681,50 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                 }),
                 "a database fallback anchor above the target is refused without underflowing"
             );
+            prop_assert_eq!(
+                derive_historical_frontiers(
+                    &legacy.db,
+                    &Mutex::new(HistoricalTreeCache::default()),
+                    fallback_anchor,
+                    u64::MAX,
+                )
+                .err(),
+                Some(HistoricalTreeDerivationError::MissingAuthenticatedRoot {
+                    height: fallback_anchor,
+                }),
+                "a zero-replay database fallback is not served without an authenticated root"
+            );
             let stitched = serve_block_roots(&legacy.db, serve_range);
             prop_assert_eq!(
                 stitched,
                 all_trees_reference,
                 "serve_block_roots stitches the trees below U with the index at/above U into one gap-free run"
+            );
+
+            // Rollback does not move the write-once upgrade marker. Model that stale metadata by
+            // moving it above the current tip: a backwards lookup must not relabel the tip tree as
+            // the marker's `U - 1` fallback anchor.
+            let stale_upgrade = Height(last_height.0 + 2);
+            let stale_anchor = Height(stale_upgrade.0 - 1);
+            let mut batch = DiskWriteBatch::new();
+            batch.update_vct_upgrade_marker(&legacy.db, stale_upgrade);
+            legacy
+                .db
+                .write_batch(batch)
+                .expect("simulating a stale post-rollback upgrade marker succeeds");
+            prop_assert_eq!(
+                derive_historical_frontiers(
+                    &legacy.db,
+                    &Mutex::new(HistoricalTreeCache::default()),
+                    stale_anchor,
+                    u64::MAX,
+                )
+                .err(),
+                Some(HistoricalTreeDerivationError::MissingAnchor {
+                    height: stale_anchor,
+                    anchor: stale_anchor,
+                }),
+                "a stale upgrade marker cannot relabel a retained tree above the finalized tip"
             );
     });
 

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -48,8 +48,8 @@ use crate::{
 
 use super::super::{
     commitment_aux, serve_block_roots, vct::validate_final_frontiers_bytes,
-    CheckpointVerifiedBlock, DiskWriteBatch, FinalizedState, HeaderRootAuthUpdate,
-    HeaderWitnessState, HighestCompletedCheckpoint, NextVctBlock,
+    verify_subtrees_against_stored, CheckpointVerifiedBlock, DiskWriteBatch, FinalizedState,
+    HeaderRootAuthUpdate, HeaderWitnessState, HighestCompletedCheckpoint, NextVctBlock,
 };
 
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
@@ -1860,6 +1860,45 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
                 bad_ironwood_handoff.db.finalized_tip_height(),
                 Some(Height(last as u32 - 1)),
                 "the refused Ironwood handoff block left state untouched"
+            );
+
+            // The subtree audit must authenticate the replay endpoint even when no subtree
+            // completes in the range. Otherwise corruption after the last boundary (or, as in
+            // this short fixture, before the first boundary) would leave no subtree row to expose
+            // the bad replay.
+            let subtree_outcome =
+                verify_subtrees_against_stored(&legacy.db, Height(seed as u32), handoff)
+                    .expect("the unmodified replay endpoint matches its authenticated roots");
+            prop_assert_eq!(
+                subtree_outcome,
+                Default::default(),
+                "the short fixture completes no subtrees"
+            );
+
+            let mut corrupted_endpoint = legacy
+                .db
+                .commitment_roots_by_height_range(handoff..=handoff)
+                .into_iter()
+                .next()
+                .expect("the handoff has an authenticated root row");
+            prop_assert_ne!(
+                corrupted_endpoint.sapling_root,
+                Default::default(),
+                "the fixture needs a non-empty Sapling endpoint"
+            );
+            corrupted_endpoint.sapling_root = Default::default();
+            let mut corrupt_endpoint_batch = DiskWriteBatch::new();
+            corrupt_endpoint_batch
+                .insert_body_derived_commitment_roots(&legacy.db, &corrupted_endpoint);
+            legacy
+                .db
+                .write_batch(corrupt_endpoint_batch)
+                .expect("the test corrupts the endpoint root row");
+
+            prop_assert_eq!(
+                verify_subtrees_against_stored(&legacy.db, Height(seed as u32), handoff),
+                Err(HistoricalTreeDerivationError::RootMismatch { height: handoff }),
+                "the subtree audit rejects a replay whose final frontiers are unauthenticated"
             );
     });
 

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -1,0 +1,344 @@
+//! Read-only audit of a database's historical-treestate serving inputs.
+//!
+//! A verified-commitment-trees fast-synced node cannot read per-height note commitment trees across
+//! its absent band `[U, H)`, and instead rebuilds them by replaying block bodies forward and
+//! checking the result against the authenticated roots in `commitment_roots_by_height` (see
+//! [`crate::service::read::historical_tree`]). That rests on two inputs actually being present:
+//! a gap-free root index across the band, and retained block bodies. This module reports whether
+//! they are, and measures what the replay costs.
+//!
+//! Everything here is read-only, runs off the consensus path, and is safe against a quiesced
+//! database snapshot.
+
+use std::time::{Duration, Instant};
+
+use zakura_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
+
+use crate::service::{
+    finalized_state::ZakuraDb,
+    read::{
+        historical_tree::{
+            derive_historical_frontiers_measured, replay_with_subtrees,
+            HistoricalTreeDerivationError, ShieldedPool,
+        },
+        DerivedFrontiers, HistoricalTreeCache,
+    },
+};
+
+/// What a database offers for serving historical treestates.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VctTreestateInventory {
+    /// The finalized tip height.
+    pub finalized_tip: Option<Height>,
+
+    /// The verified-commitment-trees upgrade height `U`: the lowest height this binary committed.
+    ///
+    /// `None` on a database written before this marker existed.
+    pub upgrade_height: Option<Height>,
+
+    /// The last checkpoint height `H`, the exclusive upper bound of the absent band.
+    ///
+    /// `None` on a normally-synced database, which has per-height trees everywhere and needs
+    /// nothing from this design.
+    pub last_checkpoint: Option<Height>,
+
+    /// The lowest height whose raw transactions are retained, if this database is pruned.
+    ///
+    /// Replay reads block bodies, so a pruned database cannot derive below this height.
+    pub lowest_retained_height: Option<Height>,
+
+    /// Whether the full-band scans ran.
+    ///
+    /// When they did not, [`Self::root_index_gap`] and [`Self::missing_block_body`] are `None`
+    /// because nothing looked, not because nothing is missing.
+    pub scanned: bool,
+
+    /// The first height in the absent band with no `commitment_roots_by_height` row.
+    ///
+    /// `None` means the index is gap-free across the band, which is what derivation needs: every
+    /// derived frontier is checked against the row at its own height. Only meaningful when
+    /// [`Self::scanned`].
+    pub root_index_gap: Option<Height>,
+
+    /// The first height in the absent band whose block body is not retained.
+    ///
+    /// `None` means the whole band is replayable. Only meaningful when [`Self::scanned`].
+    pub missing_block_body: Option<Height>,
+
+    /// How long the two scans took.
+    pub scan_duration: Duration,
+}
+
+impl VctTreestateInventory {
+    /// Returns the absent band `[U, H)`, or `None` if this database has no band.
+    pub fn absent_band(&self) -> Option<(Height, Height)> {
+        let last_checkpoint = self.last_checkpoint?;
+        let upgrade = self.upgrade_height.unwrap_or(Height(0));
+
+        (upgrade < last_checkpoint).then_some((upgrade, last_checkpoint))
+    }
+
+    /// Returns whether this database has everything derivation needs across its absent band, or
+    /// `None` if the scans that would answer that were skipped.
+    pub fn can_derive(&self) -> Option<bool> {
+        self.scanned.then(|| {
+            self.absent_band().is_some()
+                && self.root_index_gap.is_none()
+                && self.missing_block_body.is_none()
+        })
+    }
+}
+
+/// Inspects `db` for the inputs historical-treestate derivation depends on.
+///
+/// With `scan_band`, visits every height in the absent band to check the root index and block-body
+/// retention, which is proportional to the band's height range rather than constant time. Without
+/// it, only the cheap markers are read.
+pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
+    let start = Instant::now();
+
+    let upgrade_height = db.vct_upgrade_height();
+    let last_checkpoint = db.vct_synced_below();
+
+    let mut inventory = VctTreestateInventory {
+        finalized_tip: db.finalized_tip_height(),
+        upgrade_height,
+        last_checkpoint,
+        lowest_retained_height: db.lowest_retained_height(),
+        scanned: scan_band,
+        root_index_gap: None,
+        missing_block_body: None,
+        scan_duration: Duration::ZERO,
+    };
+
+    if let (true, Some((band_start, band_end))) = (scan_band, inventory.absent_band()) {
+        // The band is half-open, so the last height it covers is `H - 1`.
+        let last = Height(band_end.0 - 1);
+        inventory.root_index_gap = db.first_commitment_root_gap(band_start..=last);
+        inventory.missing_block_body = db.first_missing_block_body(band_start, last);
+    }
+
+    inventory.scan_duration = start.elapsed();
+    inventory
+}
+
+/// The cost of deriving one historical frontier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DerivationSample {
+    /// The height derived.
+    pub height: Height,
+
+    /// How many blocks the derivation replayed.
+    ///
+    /// Zero means the height was already memoized, so nothing was replayed.
+    pub replayed_blocks: u64,
+
+    /// How long the derivation took, including the root check.
+    pub elapsed: Duration,
+}
+
+impl DerivationSample {
+    /// Returns the average time per replayed block, or `None` if nothing was replayed.
+    pub fn per_block(&self) -> Option<Duration> {
+        (self.replayed_blocks > 0)
+            .then(|| self.elapsed / u32::try_from(self.replayed_blocks).unwrap_or(u32::MAX))
+    }
+}
+
+/// Derives the frontiers at each of `heights`, in order, timing each derivation.
+///
+/// Every derivation is root-checked against `commitment_roots_by_height`, so a returned `Ok` for a
+/// height *is* a root match at that height, and the first mismatch stops the walk. That makes this
+/// both the invariant check and the cost measurement.
+///
+/// `cache` carries memoized frontiers between heights. Pass a fresh cache to measure cold cost from
+/// the bottom of the band; reuse one across ascending heights to measure the sequential cost a
+/// wallet actually pays.
+pub fn measure_derivations(
+    db: &ZakuraDb,
+    cache: &std::sync::Mutex<HistoricalTreeCache>,
+    heights: impl IntoIterator<Item = Height>,
+    max_replay_blocks: u64,
+    mut on_sample: impl FnMut(&DerivationSample),
+) -> Result<Vec<DerivationSample>, (Height, HistoricalTreeDerivationError)> {
+    let mut samples = Vec::new();
+
+    for height in heights {
+        let start = Instant::now();
+        // The derivation reports its own replay length: it may have anchored on the memo, on a
+        // published grid entry, or on genesis, and only it knows which.
+        let derivation = derive_historical_frontiers_measured(db, cache, height, max_replay_blocks)
+            .map_err(|error| (height, error))?;
+        let elapsed = start.elapsed();
+        let replayed_blocks = derivation.replayed_blocks;
+
+        let sample = DerivationSample {
+            height,
+            replayed_blocks,
+            elapsed,
+        };
+        on_sample(&sample);
+        samples.push(sample);
+    }
+
+    Ok(samples)
+}
+
+/// The outcome of checking replay-derived subtree roots against the ones the database stored.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SubtreeVerification {
+    /// Subtrees that completed during the replay and matched the stored root.
+    pub matched: usize,
+
+    /// Subtrees that completed during the replay but whose stored root differs.
+    ///
+    /// Any entry here falsifies the claim that replay reproduces subtree roots, which is what the
+    /// generated subtree artifact rests on.
+    pub mismatched: Vec<(NoteCommitmentSubtreeIndex, &'static str)>,
+
+    /// Subtrees that completed during the replay with no stored row to compare against.
+    pub unstored: usize,
+}
+
+/// Replays `(from, to]` and checks every subtree that completes against the stored subtree rows.
+///
+/// This exists because subtree roots produced by replay are otherwise unvalidated: they are
+/// interior nodes, so the per-height root check does not test them directly. Above a fast-synced
+/// node's last checkpoint the database *does* store subtree rows, which makes that band the one
+/// place the two can be compared. `from` must be a height whose per-height trees are present, so
+/// the replay starts from a known-good frontier rather than reconstructing one.
+pub fn verify_subtrees_against_stored(
+    db: &ZakuraDb,
+    from: Height,
+    to: Height,
+) -> Result<SubtreeVerification, HistoricalTreeDerivationError> {
+    let (Some(sapling), Some(orchard), Some(ironwood)) = (
+        db.sapling_tree_by_height(&from),
+        db.orchard_tree_by_height(&from),
+        db.ironwood_tree_by_height(&from),
+    ) else {
+        return Err(HistoricalTreeDerivationError::MissingAnchor {
+            height: to,
+            anchor: from,
+        });
+    };
+
+    let anchor = DerivedFrontiers {
+        sapling,
+        orchard,
+        ironwood,
+    };
+
+    let mut completions = Vec::new();
+    replay_with_subtrees(db, to, from.0 + 1, anchor, |pool, completed| {
+        completions.push((pool, completed))
+    })?;
+
+    let mut outcome = SubtreeVerification::default();
+
+    for (pool, completed) in completions {
+        let stored = match pool {
+            ShieldedPool::Sapling => db
+                .sapling_subtree_list_by_index_range(completed.index..=completed.index)
+                .get(&completed.index)
+                .map(|data| data.root.to_bytes()),
+            ShieldedPool::Orchard => db
+                .orchard_subtree_list_by_index_range(completed.index..=completed.index)
+                .get(&completed.index)
+                .map(|data| data.root.to_repr()),
+            ShieldedPool::Ironwood => db
+                .ironwood_subtree_list_by_index_range(completed.index..=completed.index)
+                .get(&completed.index)
+                .map(|data| data.root.to_repr()),
+        };
+
+        let pool_name = match pool {
+            ShieldedPool::Sapling => "sapling",
+            ShieldedPool::Orchard => "orchard",
+            ShieldedPool::Ironwood => "ironwood",
+        };
+
+        match stored {
+            Some(root) if root == completed.root => outcome.matched += 1,
+            Some(_) => outcome.mismatched.push((completed.index, pool_name)),
+            None => outcome.unstored += 1,
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Returns the per-pool note commitment roots derived at each of `heights`, hex-encoded in the
+/// display order `z_gettreestate` uses.
+///
+/// Exists so a derived treestate can be compared against another node's `z_gettreestate` output.
+/// That is the strongest check available for this design: the other node built its trees the
+/// legacy way, block by block, so agreement is independent evidence that replay reconstructs the
+/// same history rather than merely being self-consistent.
+pub fn derived_roots_in_display_order(
+    db: &ZakuraDb,
+    cache: &std::sync::Mutex<HistoricalTreeCache>,
+    heights: impl IntoIterator<Item = Height>,
+    max_replay_blocks: u64,
+) -> Result<Vec<(Height, String, String, String)>, (Height, HistoricalTreeDerivationError)> {
+    let mut roots = Vec::new();
+
+    for height in heights {
+        let derivation = derive_historical_frontiers_measured(db, cache, height, max_replay_blocks)
+            .map_err(|error| (height, error))?;
+
+        roots.push((
+            height,
+            hex::encode(derivation.frontiers.sapling.root().bytes_in_display_order()),
+            hex::encode(derivation.frontiers.orchard.root().bytes_in_display_order()),
+            hex::encode(
+                derivation
+                    .frontiers
+                    .ironwood
+                    .root()
+                    .bytes_in_display_order(),
+            ),
+        ));
+    }
+
+    Ok(roots)
+}
+
+/// What a height range contains, for fitting the grid's replay cost model.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ReplayInputs {
+    /// Blocks in the range.
+    pub blocks: u64,
+
+    /// Total serialized size of those blocks, in bytes.
+    ///
+    /// The cost model prices a block at a flat constant plus its note commitments, which misses
+    /// the cost of reading and deserialising a large body that carries few or no commitments.
+    /// Reporting bytes separately is what lets that be tested rather than assumed.
+    pub bytes: u64,
+
+    /// Total Sapling, Orchard and Ironwood note commitments in the range.
+    pub commitments: u64,
+}
+
+/// Returns what the blocks in `[from, to]` contain, for cost-model fitting.
+pub fn replay_inputs(db: &ZakuraDb, from: Height, to: Height) -> ReplayInputs {
+    let mut inputs = ReplayInputs::default();
+
+    for height in from.0..=to.0 {
+        let height = Height(height);
+        inputs.blocks += 1;
+        inputs.bytes += db
+            .block_info(height.into())
+            .map_or(0, |info| u64::from(info.size()));
+
+        if let Some(block) = db.block(height.into()) {
+            inputs.commitments += (block.sapling_note_commitments().count()
+                + block.orchard_note_commitments().count()
+                + block.ironwood_note_commitments().count())
+                as u64;
+        }
+    }
+
+    inputs
+}

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -10,7 +10,10 @@
 //! Everything here is read-only, runs off the consensus path, and is safe against a quiesced
 //! database snapshot.
 
-use std::time::{Duration, Instant};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    time::{Duration, Instant},
+};
 
 use zakura_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
 
@@ -201,10 +204,17 @@ pub struct SubtreeVerification {
     /// Any entry makes verification incomplete: replay only covers the band above the last checkpoint,
     /// where every completed subtree is expected to have a stored row.
     pub unstored: usize,
+
+    /// Stored subtrees whose completion height is in the replay range, but which replay did not
+    /// produce.
+    ///
+    /// Any entry is an extra or stale database row and makes the comparison incomplete in the
+    /// storage-to-replay direction.
+    pub stored_only: Vec<(NoteCommitmentSubtreeIndex, &'static str)>,
 }
 
-/// Replays `(from, to]`, authenticates the final frontiers at `to`, and checks every subtree that
-/// completes against the root and completion height in the stored subtree rows.
+/// Replays `(from, to]`, authenticates the final frontiers at `to`, and compares replayed and
+/// stored subtrees in both directions over that range.
 ///
 /// This exists because subtree roots produced by replay are otherwise unvalidated: they are
 /// interior nodes, so the per-height root check does not test them directly. Above a fast-synced
@@ -239,32 +249,40 @@ pub fn verify_subtrees_against_stored(
     })?;
     verify_against_index(db, to, &frontiers)?;
 
+    let stored = db
+        .sapling_subtree_list_by_index_range(..)
+        .into_iter()
+        .map(|(index, data)| (("sapling", index), (data.root.to_bytes(), data.end_height)))
+        .chain(
+            db.orchard_subtree_list_by_index_range(..)
+                .into_iter()
+                .map(|(index, data)| (("orchard", index), (data.root.to_repr(), data.end_height))),
+        )
+        .chain(
+            db.ironwood_subtree_list_by_index_range(..)
+                .into_iter()
+                .map(|(index, data)| (("ironwood", index), (data.root.to_repr(), data.end_height))),
+        )
+        .collect();
+
+    Ok(compare_subtrees(completions, stored, from, to))
+}
+
+fn compare_subtrees(
+    completions: impl IntoIterator<Item = (ShieldedPool, CompletedSubtree)>,
+    stored: BTreeMap<(&'static str, NoteCommitmentSubtreeIndex), ([u8; 32], Height)>,
+    from: Height,
+    to: Height,
+) -> SubtreeVerification {
     let mut outcome = SubtreeVerification::default();
+    let mut replayed = BTreeSet::new();
 
     for (pool, completed) in completions {
-        let stored = match pool {
-            ShieldedPool::Sapling => db
-                .sapling_subtree_list_by_index_range(completed.index..=completed.index)
-                .get(&completed.index)
-                .map(|data| (data.root.to_bytes(), data.end_height)),
-            ShieldedPool::Orchard => db
-                .orchard_subtree_list_by_index_range(completed.index..=completed.index)
-                .get(&completed.index)
-                .map(|data| (data.root.to_repr(), data.end_height)),
-            ShieldedPool::Ironwood => db
-                .ironwood_subtree_list_by_index_range(completed.index..=completed.index)
-                .get(&completed.index)
-                .map(|data| (data.root.to_repr(), data.end_height)),
-        };
+        let pool_name = pool_name(pool);
+        replayed.insert((pool_name, completed.index));
 
-        let pool_name = match pool {
-            ShieldedPool::Sapling => "sapling",
-            ShieldedPool::Orchard => "orchard",
-            ShieldedPool::Ironwood => "ironwood",
-        };
-
-        match stored {
-            Some((root, end_height)) if stored_subtree_matches(root, end_height, &completed) => {
+        match stored.get(&(pool_name, completed.index)) {
+            Some((root, end_height)) if stored_subtree_matches(*root, *end_height, &completed) => {
                 outcome.matched += 1
             }
             Some(_) => outcome.mismatched.push((completed.index, pool_name)),
@@ -272,7 +290,23 @@ pub fn verify_subtrees_against_stored(
         }
     }
 
-    Ok(outcome)
+    outcome.stored_only = stored
+        .into_iter()
+        .filter_map(|((pool, index), (_, end_height))| {
+            (end_height > from && end_height <= to && !replayed.contains(&(pool, index)))
+                .then_some((index, pool))
+        })
+        .collect();
+
+    outcome
+}
+
+fn pool_name(pool: ShieldedPool) -> &'static str {
+    match pool {
+        ShieldedPool::Sapling => "sapling",
+        ShieldedPool::Orchard => "orchard",
+        ShieldedPool::Ironwood => "ironwood",
+    }
 }
 
 fn stored_subtree_matches(
@@ -385,5 +419,43 @@ mod tests {
             completed.end_height,
             &completed
         ));
+    }
+
+    #[test]
+    fn subtree_comparison_detects_stored_only_rows_in_range() {
+        let replayed = CompletedSubtree {
+            index: NoteCommitmentSubtreeIndex(3),
+            end_height: Height(100),
+            root: [7; 32],
+        };
+        let stored = [
+            (
+                ("sapling", replayed.index),
+                (replayed.root, replayed.end_height),
+            ),
+            (
+                ("sapling", NoteCommitmentSubtreeIndex(4)),
+                ([8; 32], Height(101)),
+            ),
+            (
+                ("orchard", NoteCommitmentSubtreeIndex(2)),
+                ([9; 32], Height(99)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let outcome = compare_subtrees(
+            [(ShieldedPool::Sapling, replayed)],
+            stored,
+            Height(99),
+            Height(101),
+        );
+
+        assert_eq!(outcome.matched, 1);
+        assert_eq!(
+            outcome.stored_only,
+            [(NoteCommitmentSubtreeIndex(4), "sapling")]
+        );
     }
 }

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -5,7 +5,7 @@
 //! checking the result against the authenticated roots in `commitment_roots_by_height` (see
 //! [`crate::service::read::historical_tree`]). That rests on two inputs actually being present:
 //! a gap-free root index across the band, and retained block bodies. This module reports whether
-//! they are, and measures what the replay costs.
+//! they are, checks the pre-band anchor frontiers, and measures what the replay costs.
 //!
 //! Everything here is read-only, runs off the consensus path, and is safe against a quiesced
 //! database snapshot.
@@ -68,17 +68,22 @@ pub struct VctTreestateInventory {
     /// `None` means the whole band is replayable. Only meaningful when [`Self::scanned`].
     pub missing_block_body: Option<Height>,
 
+    /// The required pre-band frontier height, if any pool has no stored tree at or below it.
+    pub missing_anchor: Option<Height>,
+
     /// How long the two scans took.
     pub scan_duration: Duration,
 }
 
 impl VctTreestateInventory {
-    /// Returns the absent band `[U, H)`, or `None` if this database has no band.
+    /// Returns the committed part of the absent band `[U, min(H, T + 1))`.
     pub fn absent_band(&self) -> Option<(Height, Height)> {
         let last_checkpoint = self.last_checkpoint?;
+        let finalized_tip = self.finalized_tip?;
         let upgrade = self.upgrade_height.unwrap_or(Height(0));
+        let committed_end = Height(last_checkpoint.0.min(finalized_tip.0.saturating_add(1)));
 
-        (upgrade < last_checkpoint).then_some((upgrade, last_checkpoint))
+        (upgrade < committed_end).then_some((upgrade, committed_end))
     }
 
     /// Returns whether this database has everything derivation needs across its absent band, or
@@ -88,6 +93,7 @@ impl VctTreestateInventory {
             self.absent_band().is_some()
                 && self.root_index_gap.is_none()
                 && self.missing_block_body.is_none()
+                && self.missing_anchor.is_none()
         })
     }
 }
@@ -111,6 +117,7 @@ pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
         scanned: scan_band,
         root_index_gap: None,
         missing_block_body: None,
+        missing_anchor: None,
         scan_duration: Duration::ZERO,
     };
 
@@ -119,6 +126,18 @@ pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
         let last = Height(band_end.0 - 1);
         inventory.root_index_gap = db.first_commitment_root_gap(band_start..=last);
         inventory.missing_block_body = db.first_missing_block_body(band_start, last);
+    }
+
+    if let Some((band_start, _)) = inventory.absent_band() {
+        if band_start.0 > 0 {
+            let anchor = Height(band_start.0 - 1);
+            if db.latest_stored_sapling_tree(&anchor).is_none()
+                || db.latest_stored_orchard_tree(&anchor).is_none()
+                || db.latest_stored_ironwood_tree(&anchor).is_none()
+            {
+                inventory.missing_anchor = Some(anchor);
+            }
+        }
     }
 
     inventory.scan_duration = start.elapsed();
@@ -163,9 +182,7 @@ pub fn measure_derivations(
     heights: impl IntoIterator<Item = Height>,
     max_replay_blocks: u64,
     mut on_sample: impl FnMut(&DerivationSample),
-) -> Result<Vec<DerivationSample>, (Height, HistoricalTreeDerivationError)> {
-    let mut samples = Vec::new();
-
+) -> Result<(), (Height, HistoricalTreeDerivationError)> {
     for height in heights {
         let start = Instant::now();
         // The derivation reports its own replay length: it may have anchored on the memo, on a
@@ -181,10 +198,9 @@ pub fn measure_derivations(
             elapsed,
         };
         on_sample(&sample);
-        samples.push(sample);
     }
 
-    Ok(samples)
+    Ok(())
 }
 
 /// The outcome of checking replay-derived subtrees against the ones the database stored.
@@ -227,9 +243,9 @@ pub fn verify_subtrees_against_stored(
     to: Height,
 ) -> Result<SubtreeVerification, HistoricalTreeDerivationError> {
     let (Some(sapling), Some(orchard), Some(ironwood)) = (
-        db.sapling_tree_by_height(&from),
-        db.orchard_tree_by_height(&from),
-        db.ironwood_tree_by_height(&from),
+        db.latest_stored_sapling_tree(&from),
+        db.latest_stored_orchard_tree(&from),
+        db.latest_stored_ironwood_tree(&from),
     ) else {
         return Err(HistoricalTreeDerivationError::MissingAnchor {
             height: to,
@@ -395,6 +411,42 @@ pub fn replay_inputs(db: &ZakuraDb, from: Height, to: Height) -> ReplayInputs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn inventory_with_tip(finalized_tip: Height) -> VctTreestateInventory {
+        VctTreestateInventory {
+            finalized_tip: Some(finalized_tip),
+            upgrade_height: Some(Height(100)),
+            last_checkpoint: Some(Height(200)),
+            lowest_retained_height: None,
+            scanned: true,
+            root_index_gap: None,
+            missing_block_body: None,
+            missing_anchor: None,
+            scan_duration: Duration::ZERO,
+        }
+    }
+
+    #[test]
+    fn absent_band_is_capped_at_finalized_tip() {
+        assert_eq!(
+            inventory_with_tip(Height(149)).absent_band(),
+            Some((Height(100), Height(150)))
+        );
+        assert_eq!(
+            inventory_with_tip(Height(250)).absent_band(),
+            Some((Height(100), Height(200)))
+        );
+        assert_eq!(inventory_with_tip(Height(99)).absent_band(), None);
+    }
+
+    #[test]
+    fn missing_anchor_prevents_derivation() {
+        let mut inventory = inventory_with_tip(Height(149));
+        assert_eq!(inventory.can_derive(), Some(true));
+
+        inventory.missing_anchor = Some(Height(99));
+        assert_eq!(inventory.can_derive(), Some(false));
+    }
 
     #[test]
     fn stored_subtree_match_requires_root_and_end_height() {

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -50,18 +50,17 @@ pub struct VctTreestateInventory {
     /// Replay reads block bodies, so a pruned database cannot derive below this height.
     pub lowest_retained_height: Option<Height>,
 
-    /// Whether the full-band scans ran.
-    ///
-    /// When they did not, [`Self::root_index_gap`], [`Self::malformed_root_row`], and
-    /// [`Self::missing_block_body`] are `None` because nothing looked, not because nothing is
-    /// missing or malformed.
-    pub scanned: bool,
+    /// Whether the authenticated-root index scan ran.
+    pub root_index_scanned: bool,
+
+    /// Whether the retained block-body scan ran.
+    pub block_bodies_scanned: bool,
 
     /// The first height in the absent band with no `commitment_roots_by_height` row.
     ///
     /// `None` means the index is gap-free across the band, which is what derivation needs: every
     /// derived frontier is checked against the row at its own height. Only meaningful when
-    /// [`Self::scanned`].
+    /// [`Self::root_index_scanned`].
     pub root_index_gap: Option<Height>,
 
     /// The first height in the absent band with a malformed `commitment_roots_by_height` value.
@@ -69,7 +68,8 @@ pub struct VctTreestateInventory {
 
     /// The first height in the absent band whose block body is not retained.
     ///
-    /// `None` means the whole band is replayable. Only meaningful when [`Self::scanned`].
+    /// `None` means the whole band is replayable. Only meaningful when
+    /// [`Self::block_bodies_scanned`].
     pub missing_block_body: Option<Height>,
 
     /// The required pre-band frontier height, if any pool has no stored tree at or below it.
@@ -90,16 +90,22 @@ impl VctTreestateInventory {
         (upgrade < committed_end).then_some((upgrade, committed_end))
     }
 
-    /// Returns whether this database has everything derivation needs across its absent band, or
-    /// `None` if the scans that would answer that were skipped.
+    /// Returns whether this database has everything derivation needs across its absent band.
+    ///
+    /// Returns `None` if no problem is known but either full-band scan was skipped.
     pub fn can_derive(&self) -> Option<bool> {
-        self.scanned.then(|| {
-            self.absent_band().is_some()
-                && self.root_index_gap.is_none()
-                && self.malformed_root_row.is_none()
-                && self.missing_block_body.is_none()
-                && self.missing_anchor.is_none()
-        })
+        let known_problem = self.absent_band().is_none()
+            || self.root_index_gap.is_some()
+            || self.malformed_root_row.is_some()
+            || self.missing_block_body.is_some()
+            || self.missing_anchor.is_some();
+        if known_problem {
+            Some(false)
+        } else if self.root_index_scanned && self.block_bodies_scanned {
+            Some(true)
+        } else {
+            None
+        }
     }
 }
 
@@ -109,6 +115,16 @@ impl VctTreestateInventory {
 /// retention, which is proportional to the band's height range rather than constant time. Without
 /// it, only the cheap markers are read.
 pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
+    inventory_with_scans(db, scan_band, scan_band)
+}
+
+/// Inspects `db`, allowing callers that will replay the whole band to defer the redundant
+/// block-body scan while retaining the compact authenticated-root preflight.
+pub fn inventory_with_scans(
+    db: &ZakuraDb,
+    scan_root_index: bool,
+    scan_block_bodies: bool,
+) -> VctTreestateInventory {
     let start = Instant::now();
 
     let upgrade_height = db.vct_upgrade_height();
@@ -119,7 +135,8 @@ pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
         upgrade_height,
         last_checkpoint,
         lowest_retained_height: db.lowest_retained_height(),
-        scanned: scan_band,
+        root_index_scanned: scan_root_index,
+        block_bodies_scanned: scan_block_bodies,
         root_index_gap: None,
         malformed_root_row: None,
         missing_block_body: None,
@@ -127,19 +144,23 @@ pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
         scan_duration: Duration::ZERO,
     };
 
-    if let (true, Some((band_start, band_end))) = (scan_band, inventory.absent_band()) {
+    if let Some((band_start, band_end)) = inventory.absent_band() {
         // The band is half-open, so the last height it covers is `H - 1`.
         let last = Height(band_end.0 - 1);
-        match db.first_commitment_root_issue(band_start..=last) {
-            Some(CommitmentRootIndexIssue::Missing(height)) => {
-                inventory.root_index_gap = Some(height);
+        if scan_root_index {
+            match db.first_commitment_root_issue(band_start..=last) {
+                Some(CommitmentRootIndexIssue::Missing(height)) => {
+                    inventory.root_index_gap = Some(height);
+                }
+                Some(CommitmentRootIndexIssue::Malformed(height)) => {
+                    inventory.malformed_root_row = Some(height);
+                }
+                None => {}
             }
-            Some(CommitmentRootIndexIssue::Malformed(height)) => {
-                inventory.malformed_root_row = Some(height);
-            }
-            None => {}
         }
-        inventory.missing_block_body = db.first_missing_block_body(band_start, last);
+        if scan_block_bodies {
+            inventory.missing_block_body = db.first_missing_block_body(band_start, last);
+        }
     }
 
     if let Some((band_start, _)) = inventory.absent_band() {
@@ -433,7 +454,8 @@ mod tests {
             upgrade_height: Some(Height(100)),
             last_checkpoint: Some(Height(200)),
             lowest_retained_height: None,
-            scanned: true,
+            root_index_scanned: true,
+            block_bodies_scanned: true,
             root_index_gap: None,
             malformed_root_row: None,
             missing_block_body: None,
@@ -469,6 +491,16 @@ mod tests {
         let mut inventory = inventory_with_tip(Height(149));
         inventory.malformed_root_row = Some(Height(125));
 
+        assert_eq!(inventory.can_derive(), Some(false));
+    }
+
+    #[test]
+    fn deferred_body_scan_keeps_derivation_pending_unless_an_issue_is_known() {
+        let mut inventory = inventory_with_tip(Height(149));
+        inventory.block_bodies_scanned = false;
+        assert_eq!(inventory.can_derive(), None);
+
+        inventory.root_index_gap = Some(Height(125));
         assert_eq!(inventory.can_derive(), Some(false));
     }
 

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -412,6 +412,7 @@ pub fn replay_inputs(db: &ZakuraDb, from: Height, to: Height) -> ReplayInputs {
             .map_or(0, |info| u64::from(info.size()));
 
         if let Some(block) = db.block(height.into()) {
+            // Cast is safe: one block holds far fewer commitments than fit in a u64.
             inputs.commitments += (block.sapling_note_commitments().count()
                 + block.orchard_note_commitments().count()
                 + block.ironwood_note_commitments().count())

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -197,6 +197,9 @@ pub struct SubtreeVerification {
     pub mismatched: Vec<(NoteCommitmentSubtreeIndex, &'static str)>,
 
     /// Subtrees that completed during the replay with no stored row to compare against.
+    ///
+    /// Any entry makes verification incomplete: replay only covers the band above the last checkpoint,
+    /// where every completed subtree is expected to have a stored row.
     pub unstored: usize,
 }
 

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -19,7 +19,7 @@ use crate::service::{
     read::{
         historical_tree::{
             derive_historical_frontiers_measured, replay_with_subtrees, verify_against_index,
-            HistoricalTreeDerivationError, ShieldedPool,
+            CompletedSubtree, HistoricalTreeDerivationError, ShieldedPool,
         },
         DerivedFrontiers, HistoricalTreeCache,
     },
@@ -184,13 +184,13 @@ pub fn measure_derivations(
     Ok(samples)
 }
 
-/// The outcome of checking replay-derived subtree roots against the ones the database stored.
+/// The outcome of checking replay-derived subtrees against the ones the database stored.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct SubtreeVerification {
-    /// Subtrees that completed during the replay and matched the stored root.
+    /// Subtrees that completed during the replay and matched the stored root and completion height.
     pub matched: usize,
 
-    /// Subtrees that completed during the replay but whose stored root differs.
+    /// Subtrees that completed during the replay but whose stored root or completion height differs.
     ///
     /// Any entry here falsifies the claim that replay reproduces subtree roots, which is what the
     /// generated subtree artifact rests on.
@@ -204,7 +204,7 @@ pub struct SubtreeVerification {
 }
 
 /// Replays `(from, to]`, authenticates the final frontiers at `to`, and checks every subtree that
-/// completes against the stored subtree rows.
+/// completes against the root and completion height in the stored subtree rows.
 ///
 /// This exists because subtree roots produced by replay are otherwise unvalidated: they are
 /// interior nodes, so the per-height root check does not test them directly. Above a fast-synced
@@ -246,15 +246,15 @@ pub fn verify_subtrees_against_stored(
             ShieldedPool::Sapling => db
                 .sapling_subtree_list_by_index_range(completed.index..=completed.index)
                 .get(&completed.index)
-                .map(|data| data.root.to_bytes()),
+                .map(|data| (data.root.to_bytes(), data.end_height)),
             ShieldedPool::Orchard => db
                 .orchard_subtree_list_by_index_range(completed.index..=completed.index)
                 .get(&completed.index)
-                .map(|data| data.root.to_repr()),
+                .map(|data| (data.root.to_repr(), data.end_height)),
             ShieldedPool::Ironwood => db
                 .ironwood_subtree_list_by_index_range(completed.index..=completed.index)
                 .get(&completed.index)
-                .map(|data| data.root.to_repr()),
+                .map(|data| (data.root.to_repr(), data.end_height)),
         };
 
         let pool_name = match pool {
@@ -264,13 +264,23 @@ pub fn verify_subtrees_against_stored(
         };
 
         match stored {
-            Some(root) if root == completed.root => outcome.matched += 1,
+            Some((root, end_height)) if stored_subtree_matches(root, end_height, &completed) => {
+                outcome.matched += 1
+            }
             Some(_) => outcome.mismatched.push((completed.index, pool_name)),
             None => outcome.unstored += 1,
         }
     }
 
     Ok(outcome)
+}
+
+fn stored_subtree_matches(
+    stored_root: [u8; 32],
+    stored_end_height: Height,
+    completed: &CompletedSubtree,
+) -> bool {
+    stored_root == completed.root && stored_end_height == completed.end_height
 }
 
 /// Returns the per-pool note commitment roots derived at each of `heights`, hex-encoded in the
@@ -346,4 +356,34 @@ pub fn replay_inputs(db: &ZakuraDb, from: Height, to: Height) -> ReplayInputs {
     }
 
     inputs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_subtree_match_requires_root_and_end_height() {
+        let completed = CompletedSubtree {
+            index: NoteCommitmentSubtreeIndex(3),
+            end_height: Height(100),
+            root: [7; 32],
+        };
+
+        assert!(stored_subtree_matches(
+            completed.root,
+            completed.end_height,
+            &completed
+        ));
+        assert!(!stored_subtree_matches(
+            completed.root,
+            Height(101),
+            &completed
+        ));
+        assert!(!stored_subtree_matches(
+            [8; 32],
+            completed.end_height,
+            &completed
+        ));
+    }
 }

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -18,7 +18,7 @@ use crate::service::{
     finalized_state::ZakuraDb,
     read::{
         historical_tree::{
-            derive_historical_frontiers_measured, replay_with_subtrees,
+            derive_historical_frontiers_measured, replay_with_subtrees, verify_against_index,
             HistoricalTreeDerivationError, ShieldedPool,
         },
         DerivedFrontiers, HistoricalTreeCache,
@@ -200,7 +200,8 @@ pub struct SubtreeVerification {
     pub unstored: usize,
 }
 
-/// Replays `(from, to]` and checks every subtree that completes against the stored subtree rows.
+/// Replays `(from, to]`, authenticates the final frontiers at `to`, and checks every subtree that
+/// completes against the stored subtree rows.
 ///
 /// This exists because subtree roots produced by replay are otherwise unvalidated: they are
 /// interior nodes, so the per-height root check does not test them directly. Above a fast-synced
@@ -230,9 +231,10 @@ pub fn verify_subtrees_against_stored(
     };
 
     let mut completions = Vec::new();
-    replay_with_subtrees(db, to, from.0 + 1, anchor, |pool, completed| {
+    let frontiers = replay_with_subtrees(db, to, from.0 + 1, anchor, |pool, completed| {
         completions.push((pool, completed))
     })?;
+    verify_against_index(db, to, &frontiers)?;
 
     let mut outcome = SubtreeVerification::default();
 

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -271,12 +271,17 @@ pub struct SubtreeVerification {
 /// interior nodes, so the per-height root check does not test them directly. Above a fast-synced
 /// node's last checkpoint the database *does* store subtree rows, which makes that band the one
 /// place the two can be compared. `from` must be a height whose per-height trees are present, so
-/// the replay starts from a known-good frontier rather than reconstructing one.
+/// the replay starts from a known-good frontier rather than reconstructing one. `to` must be
+/// strictly greater than `from`; an empty or reversed range cannot verify any replay.
 pub fn verify_subtrees_against_stored(
     db: &ZakuraDb,
     from: Height,
     to: Height,
 ) -> Result<SubtreeVerification, HistoricalTreeDerivationError> {
+    if to <= from {
+        return Err(HistoricalTreeDerivationError::InvalidReplayRange { from, to });
+    }
+
     let (Some(sapling), Some(orchard), Some(ironwood)) = (
         db.latest_stored_sapling_tree(&from),
         db.latest_stored_orchard_tree(&from),

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -18,7 +18,7 @@ use std::{
 use zakura_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
 
 use crate::service::{
-    finalized_state::ZakuraDb,
+    finalized_state::{CommitmentRootIndexIssue, ZakuraDb},
     read::{
         historical_tree::{
             derive_historical_frontiers_measured, replay_with_subtrees, verify_against_index,
@@ -52,8 +52,9 @@ pub struct VctTreestateInventory {
 
     /// Whether the full-band scans ran.
     ///
-    /// When they did not, [`Self::root_index_gap`] and [`Self::missing_block_body`] are `None`
-    /// because nothing looked, not because nothing is missing.
+    /// When they did not, [`Self::root_index_gap`], [`Self::malformed_root_row`], and
+    /// [`Self::missing_block_body`] are `None` because nothing looked, not because nothing is
+    /// missing or malformed.
     pub scanned: bool,
 
     /// The first height in the absent band with no `commitment_roots_by_height` row.
@@ -62,6 +63,9 @@ pub struct VctTreestateInventory {
     /// derived frontier is checked against the row at its own height. Only meaningful when
     /// [`Self::scanned`].
     pub root_index_gap: Option<Height>,
+
+    /// The first height in the absent band with a malformed `commitment_roots_by_height` value.
+    pub malformed_root_row: Option<Height>,
 
     /// The first height in the absent band whose block body is not retained.
     ///
@@ -92,6 +96,7 @@ impl VctTreestateInventory {
         self.scanned.then(|| {
             self.absent_band().is_some()
                 && self.root_index_gap.is_none()
+                && self.malformed_root_row.is_none()
                 && self.missing_block_body.is_none()
                 && self.missing_anchor.is_none()
         })
@@ -116,6 +121,7 @@ pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
         lowest_retained_height: db.lowest_retained_height(),
         scanned: scan_band,
         root_index_gap: None,
+        malformed_root_row: None,
         missing_block_body: None,
         missing_anchor: None,
         scan_duration: Duration::ZERO,
@@ -124,7 +130,15 @@ pub fn inventory(db: &ZakuraDb, scan_band: bool) -> VctTreestateInventory {
     if let (true, Some((band_start, band_end))) = (scan_band, inventory.absent_band()) {
         // The band is half-open, so the last height it covers is `H - 1`.
         let last = Height(band_end.0 - 1);
-        inventory.root_index_gap = db.first_commitment_root_gap(band_start..=last);
+        match db.first_commitment_root_issue(band_start..=last) {
+            Some(CommitmentRootIndexIssue::Missing(height)) => {
+                inventory.root_index_gap = Some(height);
+            }
+            Some(CommitmentRootIndexIssue::Malformed(height)) => {
+                inventory.malformed_root_row = Some(height);
+            }
+            None => {}
+        }
         inventory.missing_block_body = db.first_missing_block_body(band_start, last);
     }
 
@@ -420,6 +434,7 @@ mod tests {
             lowest_retained_height: None,
             scanned: true,
             root_index_gap: None,
+            malformed_root_row: None,
             missing_block_body: None,
             missing_anchor: None,
             scan_duration: Duration::ZERO,
@@ -445,6 +460,14 @@ mod tests {
         assert_eq!(inventory.can_derive(), Some(true));
 
         inventory.missing_anchor = Some(Height(99));
+        assert_eq!(inventory.can_derive(), Some(false));
+    }
+
+    #[test]
+    fn malformed_root_row_prevents_derivation() {
+        let mut inventory = inventory_with_tip(Height(149));
+        inventory.malformed_root_row = Some(Height(125));
+
         assert_eq!(inventory.can_derive(), Some(false));
     }
 

--- a/crates/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -331,6 +331,12 @@ impl ZakuraDb {
         self.db.path()
     }
 
+    /// Returns the temporary RocksDB secondary workspace in tests.
+    #[cfg(test)]
+    pub(crate) fn secondary_path(&self) -> Option<&Path> {
+        self.db.secondary_path()
+    }
+
     /// Check for panics in code running in spawned threads.
     /// If a thread exited with a panic, resume that panic.
     ///

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -265,6 +265,17 @@ impl ZakuraDb {
         self.db.zs_get(&hash_by_height, &height)
     }
 
+    /// Returns the first height in `[start, end]` whose block body is not retained, if any.
+    ///
+    /// A body is absent because it was pruned, or because the height was never committed. Replaying
+    /// note commitments needs every body in the replay range, so this reports whether a range is
+    /// replayable at all.
+    pub fn first_missing_block_body(&self, start: Height, end: Height) -> Option<Height> {
+        (start.0..=end.0)
+            .map(Height)
+            .find(|height| !self.contains_body_at_height(*height))
+    }
+
     /// Returns the height of the given block if it exists.
     #[allow(clippy::unwrap_in_result)]
     pub fn height(&self, hash: block::Hash) -> Option<block::Height> {

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -1045,6 +1045,36 @@ impl ZakuraDb {
         self.write_batch(batch)
     }
 
+    /// Returns the first height in `range` that has no stored roots row, if any.
+    ///
+    /// Streams the index keys instead of materialising rows, so this stays usable across a whole
+    /// fast-synced absent band, where [`Self::commitment_roots_by_height_range`] would build a
+    /// multi-hundred-megabyte vector.
+    pub fn first_commitment_root_gap(&self, range: impl RangeBounds<Height>) -> Option<Height> {
+        let (start, end) = inclusive_bounds(range)?;
+
+        let mut expected = start;
+        for (height, _row) in self
+            .commitment_roots_cf()
+            .zs_forward_range_iter(start..=end)
+        {
+            if height != expected {
+                return Some(expected);
+            }
+
+            // The last height in the range has no successor to expect, and `next()` would
+            // overflow at `Height::MAX`.
+            if height == end {
+                return None;
+            }
+
+            expected = height.next().ok()?;
+        }
+
+        // The iterator ran out before reaching `end`, so the gap starts wherever it stopped.
+        Some(expected)
+    }
+
     /// Returns at most `limit` root heights for startup repair.
     pub(crate) fn commitment_root_heights_for_repair(
         &self,
@@ -2711,5 +2741,66 @@ mod tests {
                 height: Height(1),
             });
         assert_eq!(error.outcome(), AuthenticateHeaderRootsOutcome::Local);
+    }
+
+    /// A gap scan across the absent band is what tells a fast-synced node whether it can derive
+    /// historical treestates at all: every derived frontier is checked against the row at its own
+    /// height, so a single missing row makes that height unservable.
+    #[test]
+    fn first_commitment_root_gap_finds_the_first_missing_height() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+
+        let roots = |height: u32| BlockCommitmentRoots {
+            height: Height(height),
+            sapling_root: Default::default(),
+            orchard_root: Default::default(),
+            ironwood_root: Default::default(),
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0; 32]),
+            sapling_tx: 0,
+            orchard_tx: 0,
+            ironwood_tx: 0,
+        };
+
+        db.insert_zakura_header_commitment_roots((1..=5).map(roots))
+            .expect("seeding roots succeeds");
+
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(5)),
+            None,
+            "a fully stored range has no gap"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(7)),
+            Some(Height(6)),
+            "a range running past the stored rows reports where they stop"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(0)..=Height(5)),
+            Some(Height(0)),
+            "a missing first height is reported, not skipped"
+        );
+
+        // Punch a hole in the middle: this is the case that would silently serve a wrong
+        // treestate if the scan only checked the range's endpoints.
+        let mut batch = DiskWriteBatch::new();
+        batch.delete_range_commitment_roots_by_height(&db, &Height(3), &Height(4));
+        db.write_batch(batch).expect("deleting a row succeeds");
+
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(5)),
+            Some(Height(3)),
+            "an interior hole is found"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(4)..=Height(5)),
+            None,
+            "a range above the hole is still gap-free"
+        );
+        assert_eq!(
+            db.first_commitment_root_gap(Height(5)..=Height(4)),
+            None,
+            "an empty range has no gap"
+        );
     }
 }

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -45,6 +45,15 @@ pub const HEADER_ROOT_AUTH_FRONTIER: &str = "header_root_auth_frontier";
 type CommitmentRootsCf<'cf> = TypedColumnFamily<'cf, Height, CommitmentRootsByHeight>;
 type HeaderRootAuthFrontierCf<'cf> = TypedColumnFamily<'cf, RawBytes, RawBytes>;
 
+/// A root-index row that prevents historical treestate derivation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitmentRootIndexIssue {
+    /// The expected height has no canonical row.
+    Missing(Height),
+    /// The expected height has a value that is not a commitment-root row.
+    Malformed(Height),
+}
+
 const LEGACY_FRONTIER_FORMAT_VERSION: u8 = 1;
 const FRONTIER_FORMAT_VERSION: u8 = 2;
 const LEGACY_FRONTIER_FIXED_BYTES: usize = 1 + 4 + 32 + 1;
@@ -1046,31 +1055,39 @@ impl ZakuraDb {
         self.write_batch(batch)
     }
 
-    /// Returns the first height in `range` that has no stored roots row, if any.
+    /// Returns the first missing or malformed roots row in `range`, if any.
     ///
-    /// Streams the index keys instead of materialising rows, so this stays usable across a whole
+    /// Streams raw index entries instead of materialising rows, so this stays usable across a whole
     /// fast-synced absent band, where [`Self::commitment_roots_by_height_range`] would build a
     /// multi-hundred-megabyte vector.
-    pub fn first_commitment_root_gap(&self, range: impl RangeBounds<Height>) -> Option<Height> {
+    pub fn first_commitment_root_issue(
+        &self,
+        range: impl RangeBounds<Height>,
+    ) -> Option<CommitmentRootIndexIssue> {
         let (start, end) = inclusive_bounds(range)?;
         let Some(commitment_roots) = self.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT) else {
-            return Some(start);
+            return Some(CommitmentRootIndexIssue::Missing(start));
         };
         let start_key = RawBytes::new_raw_bytes(start.as_bytes().to_vec());
         let end_key = RawBytes::new_raw_bytes(end.as_bytes().to_vec());
 
         let mut expected = start;
-        for (key, _raw_value) in self.db.zs_forward_range_iter::<_, RawBytes, RawBytes, _>(
+        for (key, raw_value) in self.db.zs_forward_range_iter::<_, RawBytes, RawBytes, _>(
             &commitment_roots,
             start_key..=end_key,
         ) {
             if key.raw_bytes().len() != HEIGHT_DISK_BYTES {
-                return Some(expected);
+                return Some(CommitmentRootIndexIssue::Missing(expected));
             }
 
             let height = Height::from_bytes(key.raw_bytes());
             if height != expected {
-                return Some(expected);
+                return Some(CommitmentRootIndexIssue::Missing(expected));
+            }
+            if raw_value.raw_bytes().len()
+                != std::mem::size_of::<<CommitmentRootsByHeight as IntoDisk>::Bytes>()
+            {
+                return Some(CommitmentRootIndexIssue::Malformed(height));
             }
 
             // The last height in the range has no successor to expect, and `next()` would
@@ -1083,7 +1100,7 @@ impl ZakuraDb {
         }
 
         // The iterator ran out before reaching `end`, so the gap starts wherever it stopped.
-        Some(expected)
+        Some(CommitmentRootIndexIssue::Missing(expected))
     }
 
     /// Returns at most `limit` root heights for startup repair.
@@ -2758,7 +2775,7 @@ mod tests {
     /// historical treestates at all: every derived frontier is checked against the row at its own
     /// height, so a single missing row makes that height unservable.
     #[test]
-    fn first_commitment_root_gap_finds_the_first_missing_height() {
+    fn first_commitment_root_issue_finds_the_first_missing_height() {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
 
@@ -2777,18 +2794,18 @@ mod tests {
             .expect("seeding roots succeeds");
 
         assert_eq!(
-            db.first_commitment_root_gap(Height(1)..=Height(5)),
+            db.first_commitment_root_issue(Height(1)..=Height(5)),
             None,
             "a fully stored range has no gap"
         );
         assert_eq!(
-            db.first_commitment_root_gap(Height(1)..=Height(7)),
-            Some(Height(6)),
+            db.first_commitment_root_issue(Height(1)..=Height(7)),
+            Some(CommitmentRootIndexIssue::Missing(Height(6))),
             "a range running past the stored rows reports where they stop"
         );
         assert_eq!(
-            db.first_commitment_root_gap(Height(0)..=Height(5)),
-            Some(Height(0)),
+            db.first_commitment_root_issue(Height(0)..=Height(5)),
+            Some(CommitmentRootIndexIssue::Missing(Height(0))),
             "a missing first height is reported, not skipped"
         );
 
@@ -2799,24 +2816,24 @@ mod tests {
         db.write_batch(batch).expect("deleting a row succeeds");
 
         assert_eq!(
-            db.first_commitment_root_gap(Height(1)..=Height(5)),
-            Some(Height(3)),
+            db.first_commitment_root_issue(Height(1)..=Height(5)),
+            Some(CommitmentRootIndexIssue::Missing(Height(3))),
             "an interior hole is found"
         );
         assert_eq!(
-            db.first_commitment_root_gap(Height(4)..=Height(5)),
+            db.first_commitment_root_issue(Height(4)..=Height(5)),
             None,
             "a range above the hole is still gap-free"
         );
         assert_eq!(
-            db.first_commitment_root_gap(Height(5)..=Height(4)),
+            db.first_commitment_root_issue(Height(5)..=Height(4)),
             None,
             "an empty range has no gap"
         );
     }
 
     #[test]
-    fn first_commitment_root_gap_reads_only_canonical_keys() {
+    fn first_commitment_root_issue_validates_raw_entries() {
         let _init_guard = zakura_test::init();
         let db = ephemeral_mainnet_db();
         let roots = |height: u32| BlockCommitmentRoots {
@@ -2842,11 +2859,13 @@ mod tests {
             .expect("writing a malformed value succeeds");
 
         assert_eq!(
-            db.first_commitment_root_gap(Height(1)..=Height(3)),
-            None,
-            "the key inventory does not decode unused row values"
+            db.first_commitment_root_issue(Height(1)..=Height(3)),
+            Some(CommitmentRootIndexIssue::Malformed(Height(2))),
+            "a malformed value is corrupt input, not a present row"
         );
 
+        db.insert_zakura_header_commitment_roots([roots(2)])
+            .expect("restoring valid roots succeeds");
         let mut batch = DiskWriteBatch::new();
         batch.zs_insert(
             &roots_cf,
@@ -2857,8 +2876,8 @@ mod tests {
             .expect("writing a noncanonical key succeeds");
 
         assert_eq!(
-            db.first_commitment_root_gap(Height(1)..=Height(3)),
-            Some(Height(2)),
+            db.first_commitment_root_issue(Height(1)..=Height(3)),
+            Some(CommitmentRootIndexIssue::Missing(Height(2))),
             "a noncanonical key cannot alias a canonical height"
         );
     }

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -26,11 +26,12 @@ use zakura_chain::{
 use crate::service::finalized_state::{
     disk_db::{DiskWriteBatch, ReadDisk},
     disk_format::{
+        block::HEIGHT_DISK_BYTES,
         chain::{HistoryTreeDecodeError, HistoryTreeParts},
         shielded::CommitmentRootsByHeight,
         RawBytes,
     },
-    IntoDisk, TypedColumnFamily,
+    FromDisk, IntoDisk, TypedColumnFamily,
 };
 
 use super::{highest_completed_checkpoint::HighestCompletedCheckpoint, ZakuraDb};
@@ -1052,12 +1053,22 @@ impl ZakuraDb {
     /// multi-hundred-megabyte vector.
     pub fn first_commitment_root_gap(&self, range: impl RangeBounds<Height>) -> Option<Height> {
         let (start, end) = inclusive_bounds(range)?;
+        let Some(commitment_roots) = self.db.cf_handle(COMMITMENT_ROOTS_BY_HEIGHT) else {
+            return Some(start);
+        };
+        let start_key = RawBytes::new_raw_bytes(start.as_bytes().to_vec());
+        let end_key = RawBytes::new_raw_bytes(end.as_bytes().to_vec());
 
         let mut expected = start;
-        for (height, _row) in self
-            .commitment_roots_cf()
-            .zs_forward_range_iter(start..=end)
-        {
+        for (key, _raw_value) in self.db.zs_forward_range_iter::<_, RawBytes, RawBytes, _>(
+            &commitment_roots,
+            start_key..=end_key,
+        ) {
+            if key.raw_bytes().len() != HEIGHT_DISK_BYTES {
+                return Some(expected);
+            }
+
+            let height = Height::from_bytes(key.raw_bytes());
             if height != expected {
                 return Some(expected);
             }
@@ -2801,6 +2812,54 @@ mod tests {
             db.first_commitment_root_gap(Height(5)..=Height(4)),
             None,
             "an empty range has no gap"
+        );
+    }
+
+    #[test]
+    fn first_commitment_root_gap_reads_only_canonical_keys() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_mainnet_db();
+        let roots = |height: u32| BlockCommitmentRoots {
+            height: Height(height),
+            sapling_root: Default::default(),
+            orchard_root: Default::default(),
+            ironwood_root: Default::default(),
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0; 32]),
+            sapling_tx: 0,
+            orchard_tx: 0,
+            ironwood_tx: 0,
+        };
+        db.insert_zakura_header_commitment_roots((1..=3).map(roots))
+            .expect("seeding roots succeeds");
+
+        let roots_cf = db
+            .db
+            .cf_handle(COMMITMENT_ROOTS_BY_HEIGHT)
+            .expect("test database has the roots column family");
+        let mut batch = DiskWriteBatch::new();
+        batch.zs_insert(&roots_cf, Height(2), RawBytes::new_raw_bytes(vec![0xff]));
+        db.write_batch(batch)
+            .expect("writing a malformed value succeeds");
+
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(3)),
+            None,
+            "the key inventory does not decode unused row values"
+        );
+
+        let mut batch = DiskWriteBatch::new();
+        batch.zs_insert(
+            &roots_cf,
+            RawBytes::new_raw_bytes(vec![0, 0, 1, 0]),
+            RawBytes::new_raw_bytes(vec![0]),
+        );
+        db.write_batch(batch)
+            .expect("writing a noncanonical key succeeds");
+
+        assert_eq!(
+            db.first_commitment_root_gap(Height(1)..=Height(3)),
+            Some(Height(2)),
+            "a noncanonical key cannot alias a canonical height"
         );
     }
 }

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -50,7 +50,7 @@ type HeaderRootAuthFrontierCf<'cf> = TypedColumnFamily<'cf, RawBytes, RawBytes>;
 pub enum CommitmentRootIndexIssue {
     /// The expected height has no canonical row.
     Missing(Height),
-    /// The expected height has a value that is not a commitment-root row.
+    /// The expected height has a noncanonical key or a value that is not a commitment-root row.
     Malformed(Height),
 }
 
@@ -1077,7 +1077,7 @@ impl ZakuraDb {
             start_key..=end_key,
         ) {
             if key.raw_bytes().len() != HEIGHT_DISK_BYTES {
-                return Some(CommitmentRootIndexIssue::Missing(expected));
+                return Some(CommitmentRootIndexIssue::Malformed(expected));
             }
 
             let height = Height::from_bytes(key.raw_bytes());
@@ -1096,7 +1096,12 @@ impl ZakuraDb {
                 return None;
             }
 
-            expected = height.next().ok()?;
+            // Unreachable while the `height == end` return above precedes it, but an overflow
+            // must never read as a clean scan.
+            expected = match height.next() {
+                Ok(next) => next,
+                Err(_) => return Some(CommitmentRootIndexIssue::Malformed(height)),
+            };
         }
 
         // The iterator ran out before reaching `end`, so the gap starts wherever it stopped.
@@ -2877,8 +2882,8 @@ mod tests {
 
         assert_eq!(
             db.first_commitment_root_issue(Height(1)..=Height(3)),
-            Some(CommitmentRootIndexIssue::Missing(Height(2))),
-            "a noncanonical key cannot alias a canonical height"
+            Some(CommitmentRootIndexIssue::Malformed(Height(2))),
+            "a noncanonical key is corrupt input, not a canonical height"
         );
     }
 }

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/shielded.rs
@@ -334,7 +334,7 @@ impl ZakuraDb {
         &self,
         height: &Height,
     ) -> Option<Arc<sapling::tree::NoteCommitmentTree>> {
-        let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
+        let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree")?;
         let (_stored_height, tree) = self
             .db
             .zs_prev_key_value_back_from(&sapling_trees, height)?;
@@ -489,7 +489,7 @@ impl ZakuraDb {
         &self,
         height: &Height,
     ) -> Option<Arc<orchard::tree::NoteCommitmentTree>> {
-        let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
+        let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree")?;
         let (_stored_height, tree) = self
             .db
             .zs_prev_key_value_back_from(&orchard_trees, height)?;
@@ -644,7 +644,7 @@ impl ZakuraDb {
         &self,
         height: &Height,
     ) -> Option<Arc<ironwood::tree::NoteCommitmentTree>> {
-        let ironwood_trees = self.db.cf_handle("ironwood_note_commitment_tree").unwrap();
+        let ironwood_trees = self.db.cf_handle("ironwood_note_commitment_tree")?;
         let (_stored_height, tree) = self
             .db
             .zs_prev_key_value_back_from(&ironwood_trees, height)?;

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -18,6 +18,7 @@ pub mod address;
 pub mod block;
 pub mod difficulty;
 pub mod find;
+pub mod historical_tree;
 pub mod tree;
 
 #[cfg(test)]
@@ -41,6 +42,9 @@ pub use find::{
     best_tip, block_locator, depth, finalized_state_contains_block_hash, find_chain_hashes,
     find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
+};
+pub use historical_tree::{
+    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
 };
 pub use tree::{
     ironwood_subtrees, ironwood_tree, orchard_subtrees, orchard_tree, sapling_subtrees,

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -1,0 +1,475 @@
+//! Deriving historical note commitment frontiers by replaying retained block bodies.
+//!
+//! A verified-commitment-trees fast-synced node never writes per-height note commitment trees
+//! across the absent band `[U, H)`, so `z_gettreestate` and the `trees` sizes in
+//! `getblock`/`getblockheader` have nothing to read there. This module rebuilds a frontier for
+//! any height in that band on demand: it starts from the nearest frontier it already has, appends
+//! the note commitments of every block in between, and accepts the result only if its root
+//! matches the authenticated root already in `commitment_roots_by_height`.
+//!
+//! # Correctness
+//!
+//! A note commitment root is a binding commitment to its frontier, so the root check is what
+//! makes derivation trustworthy: a frontier that reproduces the authenticated root is the
+//! frontier. Nothing here is accepted without that check, which is also why derived frontiers are
+//! safe to reuse as anchors for later derivations.
+//!
+//! Replay needs retained block bodies, so this cannot work on a pruned node.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use thiserror::Error;
+
+use zakura_chain::{
+    block::Height, ironwood, orchard, parallel::commitment_aux::BlockCommitmentRoots, sapling,
+};
+
+use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
+
+use crate::service::finalized_state::ZakuraDb;
+
+/// The most derived frontiers to keep memoized per node.
+///
+/// Wallet access is sequential, so a single entry already collapses a scan's steady-state cost to
+/// one batch of replay. The rest of the budget covers concurrent clients scanning different parts
+/// of the band. Each entry is a few kilobytes, so this is a negligible amount of memory.
+pub const MAX_MEMOIZED_FRONTIERS: usize = 64;
+
+/// Which shielded pool a replay event belongs to.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShieldedPool {
+    /// The Sapling pool.
+    Sapling,
+    /// The Orchard pool.
+    Orchard,
+    /// The Ironwood pool.
+    Ironwood,
+}
+
+/// A subtree that finished filling during a replay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CompletedSubtree {
+    /// The subtree index.
+    pub index: NoteCommitmentSubtreeIndex,
+
+    /// The height whose block added the subtree's last leaf.
+    pub end_height: Height,
+
+    /// The subtree root.
+    pub root: [u8; 32],
+}
+
+/// Per-pool note commitment frontiers as of the end of one block.
+#[derive(Clone, Debug)]
+pub struct DerivedFrontiers {
+    /// The Sapling frontier.
+    pub sapling: Arc<sapling::tree::NoteCommitmentTree>,
+
+    /// The Orchard frontier.
+    pub orchard: Arc<orchard::tree::NoteCommitmentTree>,
+
+    /// The Ironwood frontier.
+    pub ironwood: Arc<ironwood::tree::NoteCommitmentTree>,
+}
+
+impl DerivedFrontiers {
+    /// Returns empty frontiers, the state before any block has been applied.
+    pub fn empty() -> Self {
+        Self {
+            sapling: Arc::<sapling::tree::NoteCommitmentTree>::default(),
+            orchard: Arc::<orchard::tree::NoteCommitmentTree>::default(),
+            ironwood: Arc::<ironwood::tree::NoteCommitmentTree>::default(),
+        }
+    }
+
+    /// Returns `true` if every pool's root matches `roots`.
+    fn matches(&self, roots: &BlockCommitmentRoots) -> bool {
+        self.sapling.root() == roots.sapling_root
+            && self.orchard.root() == roots.orchard_root
+            && self.ironwood.root() == roots.ironwood_root
+    }
+}
+
+/// Why a historical frontier could not be derived.
+///
+/// Every variant is a serving failure, never a consensus one: derivation runs entirely on the read
+/// path, and a node that cannot derive simply cannot answer the request.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum HistoricalTreeDerivationError {
+    /// The replay would have to cover more blocks than the configured limit.
+    #[error(
+        "deriving the note commitment tree at {height:?} needs {blocks} blocks of replay, more \
+         than the {limit} block limit"
+    )]
+    ReplayTooLong {
+        /// The requested height.
+        height: Height,
+        /// How many blocks the replay would cover.
+        blocks: u64,
+        /// The configured limit.
+        limit: u64,
+    },
+
+    /// A block body in the replay range is unavailable, so its commitments cannot be read.
+    ///
+    /// On a pruned node this is expected for every height below the retention window.
+    #[error("cannot derive the note commitment tree at {height:?}: block body {missing:?} is not retained")]
+    MissingBlockBody {
+        /// The requested height.
+        height: Height,
+        /// The height whose body is missing.
+        missing: Height,
+    },
+
+    /// The frontier the replay starts from is missing, so there is nothing to anchor on.
+    #[error(
+        "cannot derive the note commitment tree at {height:?}: no anchor frontier at {anchor:?}"
+    )]
+    MissingAnchor {
+        /// The requested height.
+        height: Height,
+        /// The height the anchor was expected at.
+        anchor: Height,
+    },
+
+    /// There is no authenticated root to check the derived frontier against.
+    ///
+    /// Without it the result would be unverified, which this module never serves.
+    #[error("cannot derive the note commitment tree at {height:?}: no authenticated root is stored for that height")]
+    MissingAuthenticatedRoot {
+        /// The requested height.
+        height: Height,
+    },
+
+    /// The derived frontier does not reproduce the authenticated root.
+    ///
+    /// The replay inputs disagree with the roots the node authenticated against its own header
+    /// chain, so the frontier is wrong and must not be served.
+    #[error(
+        "the note commitment tree derived at {height:?} does not match the authenticated root"
+    )]
+    RootMismatch {
+        /// The requested height.
+        height: Height,
+    },
+
+    /// Appending a block's note commitments failed.
+    #[error("cannot derive the note commitment tree at {height:?}: appending block {block:?} failed: {error}")]
+    Append {
+        /// The requested height.
+        height: Height,
+        /// The block being applied.
+        block: Height,
+        /// The underlying tree error, rendered because it is not `PartialEq`.
+        error: String,
+    },
+}
+
+/// A bounded memo of frontiers this node has already derived and root-checked.
+///
+/// Entries double as anchors: a derivation for height `h` starts from the highest memoized height
+/// at or below `h`, so a wallet scanning forward replays only from the end of its previous batch.
+#[derive(Debug, Default)]
+pub struct HistoricalTreeCache {
+    /// Verified frontiers, keyed by the height they are the state at the end of.
+    frontiers: BTreeMap<Height, Arc<DerivedFrontiers>>,
+}
+
+impl HistoricalTreeCache {
+    /// Returns the highest memoized frontier at or below `height`, if any.
+    fn anchor_at_or_below(&self, height: Height) -> Option<(Height, Arc<DerivedFrontiers>)> {
+        self.frontiers
+            .range(..=height)
+            .next_back()
+            .map(|(anchor, frontiers)| (*anchor, frontiers.clone()))
+    }
+
+    /// Memoizes `frontiers` as the verified state at the end of `height`.
+    ///
+    /// Evicts the lowest height when full. Clients sweep forward, so the lowest entry is the one
+    /// least likely to anchor the next request.
+    fn insert(&mut self, height: Height, frontiers: Arc<DerivedFrontiers>) {
+        self.frontiers.insert(height, frontiers);
+
+        while self.frontiers.len() > MAX_MEMOIZED_FRONTIERS {
+            self.frontiers.pop_first();
+        }
+    }
+}
+
+/// Locks the memo, recovering from poisoning.
+///
+/// The cache holds only root-checked frontiers keyed by height, so a panic elsewhere cannot leave
+/// it in a state that would make a later derivation wrong. Refusing to serve because an unrelated
+/// request panicked would be strictly worse than reusing the map.
+fn lock(cache: &Mutex<HistoricalTreeCache>) -> std::sync::MutexGuard<'_, HistoricalTreeCache> {
+    cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Derives the note commitment frontiers as of the end of block `height`, verified against the
+/// authenticated root stored for that height.
+///
+/// Replays block bodies forward from the nearest anchor: the highest memoized frontier at or below
+/// `height`, else the last frontier stored below the absent band, else empty frontiers at genesis.
+/// The result is memoized in `cache` only after it reproduces the authenticated root, so a
+/// derivation can never be anchored on an unverified frontier.
+///
+/// `max_replay_blocks` bounds the work one request can cost. It is a serving limit, not a
+/// correctness one.
+pub fn derive_historical_frontiers(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+    max_replay_blocks: u64,
+) -> Result<Arc<DerivedFrontiers>, HistoricalTreeDerivationError> {
+    derive_historical_frontiers_measured(db, cache, height, max_replay_blocks)
+        .map(|derivation| derivation.frontiers)
+}
+
+/// A completed derivation, and what it cost.
+#[derive(Clone, Debug)]
+pub struct Derivation {
+    /// The frontiers as of the end of the requested height.
+    pub frontiers: Arc<DerivedFrontiers>,
+
+    /// How many blocks were replayed to produce them.
+    ///
+    /// Zero when the height was already memoized. Callers measuring cost must read this rather
+    /// than infer it from the height, because the anchor may have come from the memo or from a
+    /// published grid rather than from genesis.
+    pub replayed_blocks: u64,
+}
+
+/// Derives the frontiers at `height`, reporting how many blocks the replay covered.
+///
+/// See [`derive_historical_frontiers`].
+pub fn derive_historical_frontiers_measured(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+    max_replay_blocks: u64,
+) -> Result<Derivation, HistoricalTreeDerivationError> {
+    let anchor = anchor_for(db, cache, height)?;
+
+    if let Some((anchor_height, frontiers)) = &anchor {
+        if *anchor_height == height {
+            return Ok(Derivation {
+                frontiers: frontiers.clone(),
+                replayed_blocks: 0,
+            });
+        }
+    }
+
+    // The anchor is the state at the *end* of its height, so replay starts at the next block.
+    // With no anchor the replay starts at genesis.
+    let replay_from = anchor.as_ref().map_or(0, |(anchor, _)| anchor.0 + 1);
+    let blocks = u64::from(height.0 - replay_from) + 1;
+    if blocks > max_replay_blocks {
+        return Err(HistoricalTreeDerivationError::ReplayTooLong {
+            height,
+            blocks,
+            limit: max_replay_blocks,
+        });
+    }
+
+    let frontiers = anchor.map_or_else(DerivedFrontiers::empty, |(_, frontiers)| {
+        (*frontiers).clone()
+    });
+    let frontiers = replay(db, height, replay_from, frontiers)?;
+
+    verify_against_index(db, height, &frontiers)?;
+
+    let frontiers = Arc::new(frontiers);
+    lock(cache).insert(height, frontiers.clone());
+
+    Ok(Derivation {
+        frontiers,
+        replayed_blocks: blocks,
+    })
+}
+
+/// Returns the frontiers to replay forward from, and the height they are the state at the end of.
+///
+/// `None` means start from empty frontiers at genesis, which is correct when this binary committed
+/// every block from genesis (`U == 0`) and so stored no per-height trees to anchor on.
+fn anchor_for(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+) -> Result<Option<(Height, Arc<DerivedFrontiers>)>, HistoricalTreeDerivationError> {
+    let memoized = lock(cache).anchor_at_or_below(height);
+
+    if memoized.is_some() {
+        return Ok(memoized);
+    }
+
+    // Below the upgrade height `U` this binary did not run, so per-height trees are present. The
+    // tree at `U - 1` is therefore the last stored frontier before the absent band starts.
+    let Some(upgrade) = db.vct_upgrade_height().filter(|upgrade| upgrade.0 > 0) else {
+        return Ok(None);
+    };
+
+    let anchor = Height(upgrade.0 - 1);
+    let (Some(sapling), Some(orchard), Some(ironwood)) = (
+        db.sapling_tree_by_height(&anchor),
+        db.orchard_tree_by_height(&anchor),
+        db.ironwood_tree_by_height(&anchor),
+    ) else {
+        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+    };
+
+    Ok(Some((
+        anchor,
+        Arc::new(DerivedFrontiers {
+            sapling,
+            orchard,
+            ironwood,
+        }),
+    )))
+}
+
+/// Appends the note commitments of blocks `replay_from..=height` to `frontiers`.
+fn replay(
+    db: &ZakuraDb,
+    height: Height,
+    replay_from: u32,
+    frontiers: DerivedFrontiers,
+) -> Result<DerivedFrontiers, HistoricalTreeDerivationError> {
+    replay_with_subtrees(db, height, replay_from, frontiers, |_, _| {})
+}
+
+/// Appends the note commitments of blocks `replay_from..=height` to `frontiers`, reporting every
+/// subtree that completes along the way.
+///
+/// `on_subtree` sees each completion in order. A subtree root reported here is pinned by the same
+/// root check that validates the replay's endpoints: the replay is deterministic, so an error
+/// anywhere in it would have to cancel out exactly to still reproduce the verified end root.
+pub fn replay_with_subtrees(
+    db: &ZakuraDb,
+    height: Height,
+    replay_from: u32,
+    frontiers: DerivedFrontiers,
+    mut on_subtree: impl FnMut(ShieldedPool, CompletedSubtree),
+) -> Result<DerivedFrontiers, HistoricalTreeDerivationError> {
+    let DerivedFrontiers {
+        sapling,
+        orchard,
+        ironwood,
+    } = frontiers;
+
+    let mut sapling = (*sapling).clone();
+    let mut orchard = (*orchard).clone();
+    let mut ironwood = (*ironwood).clone();
+
+    for block_height in replay_from..=height.0 {
+        let block_height = Height(block_height);
+        let block = db.block(block_height.into()).ok_or(
+            HistoricalTreeDerivationError::MissingBlockBody {
+                height,
+                missing: block_height,
+            },
+        )?;
+
+        let append_error = |error: &dyn std::fmt::Display| HistoricalTreeDerivationError::Append {
+            height,
+            block: block_height,
+            error: error.to_string(),
+        };
+
+        // A block never spans two subtree boundaries: the block size limit caps it far below the
+        // 65,536 commitments a subtree holds, so a single batch append is always valid.
+        let sapling_commitments: Vec<_> = block.sapling_note_commitments().cloned().collect();
+        if !sapling_commitments.is_empty() {
+            let completed = sapling
+                .append_batch(&sapling_commitments)
+                .map_err(|error| append_error(&error))?;
+            if let Some((index, root)) = completed {
+                on_subtree(
+                    ShieldedPool::Sapling,
+                    CompletedSubtree {
+                        index,
+                        end_height: block_height,
+                        root: root.to_bytes(),
+                    },
+                );
+            }
+        }
+
+        let orchard_commitments: Vec<_> = block.orchard_note_commitments().cloned().collect();
+        if !orchard_commitments.is_empty() {
+            let completed = orchard
+                .append_batch(&orchard_commitments)
+                .map_err(|error| append_error(&error))?;
+            if let Some((index, root)) = completed {
+                on_subtree(
+                    ShieldedPool::Orchard,
+                    CompletedSubtree {
+                        index,
+                        end_height: block_height,
+                        root: root.to_repr(),
+                    },
+                );
+            }
+        }
+
+        let ironwood_commitments: Vec<_> = block.ironwood_note_commitments().cloned().collect();
+        if !ironwood_commitments.is_empty() {
+            let completed = ironwood
+                .append_batch(&ironwood_commitments)
+                .map_err(|error| append_error(&error))?;
+            if let Some((index, root)) = completed {
+                on_subtree(
+                    ShieldedPool::Ironwood,
+                    CompletedSubtree {
+                        index,
+                        end_height: block_height,
+                        root: root.to_repr(),
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(DerivedFrontiers {
+        sapling: Arc::new(sapling),
+        orchard: Arc::new(orchard),
+        ironwood: Arc::new(ironwood),
+    })
+}
+
+/// Checks `frontiers` against the authenticated roots stored for `height`.
+///
+/// This is the check the whole design rests on: a note commitment root is a binding commitment to
+/// its frontier, so a frontier that reproduces the authenticated root *is* the frontier, whatever
+/// source it came from. Both the serving path and the artifact generator route through here so the
+/// two can never drift apart.
+pub fn verify_against_index(
+    db: &ZakuraDb,
+    height: Height,
+    frontiers: &DerivedFrontiers,
+) -> Result<(), HistoricalTreeDerivationError> {
+    let roots = authenticated_roots(db, height)?;
+
+    if frontiers.matches(&roots) {
+        Ok(())
+    } else {
+        Err(HistoricalTreeDerivationError::RootMismatch { height })
+    }
+}
+
+/// Returns the authenticated per-pool roots stored for `height`.
+fn authenticated_roots(
+    db: &ZakuraDb,
+    height: Height,
+) -> Result<BlockCommitmentRoots, HistoricalTreeDerivationError> {
+    db.commitment_roots_by_height_range(height..=height)
+        .into_iter()
+        .next()
+        .filter(|roots| roots.height == height)
+        .ok_or(HistoricalTreeDerivationError::MissingAuthenticatedRoot { height })
+}

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -316,9 +316,9 @@ fn anchor_for(
 
     let anchor = Height(upgrade.0 - 1);
     let (Some(sapling), Some(orchard), Some(ironwood)) = (
-        db.sapling_tree_by_height(&anchor),
-        db.orchard_tree_by_height(&anchor),
-        db.ironwood_tree_by_height(&anchor),
+        db.latest_stored_sapling_tree(&anchor),
+        db.latest_stored_orchard_tree(&anchor),
+        db.latest_stored_ironwood_tree(&anchor),
     ) else {
         return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
     };

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -240,9 +240,9 @@ pub struct Derivation {
 
     /// How many blocks were replayed to produce them.
     ///
-    /// Zero when the height was already memoized. Callers measuring cost must read this rather
-    /// than infer it from the height, because the anchor may have come from the memo or from a
-    /// published grid rather than from genesis.
+    /// Zero when the requested height was already available as an anchor. Callers measuring cost
+    /// must read this rather than infer it from the height, because the anchor may have come from
+    /// the memo or from a published grid rather than from genesis.
     pub replayed_blocks: u64,
 }
 
@@ -260,6 +260,12 @@ pub fn derive_historical_frontiers_measured(
     if let Some((anchor_height, frontiers)) = &anchor {
         match anchor_height.cmp(&height) {
             std::cmp::Ordering::Equal => {
+                // Memoized entries have already passed this check, but a database fallback has
+                // not. Keep the check here so a zero-replay result follows the same acceptance
+                // rule as every replayed result.
+                verify_against_index(db, height, frontiers)?;
+
+                lock(cache).insert(height, frontiers.clone());
                 return Ok(Derivation {
                     frontiers: frontiers.clone(),
                     replayed_blocks: 0,
@@ -330,6 +336,17 @@ fn anchor_for(
     };
 
     let anchor = Height(upgrade.0 - 1);
+    // Rollback can move the tip below the write-once upgrade marker. In that case a backwards tree
+    // lookup would return a retained row below the rollback target and mislabel it as `anchor`.
+    if db
+        .finalized_tip_height()
+        .is_none_or(|tip_height| anchor > tip_height)
+    {
+        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+    }
+
+    // These reads intentionally search backwards because unchanged trees are deduplicated. The tip
+    // check above establishes that the chain still reaches `anchor`, so such a row is its state.
     let (Some(sapling), Some(orchard), Some(ironwood)) = (
         db.latest_stored_sapling_tree(&anchor),
         db.latest_stored_orchard_tree(&anchor),

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -25,11 +25,12 @@ use thiserror::Error;
 
 use zakura_chain::{
     block::Height, ironwood, orchard, parallel::commitment_aux::BlockCommitmentRoots, sapling,
+    transaction::Transaction,
 };
 
 use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
 
-use crate::service::finalized_state::ZakuraDb;
+use crate::service::finalized_state::{TransactionLocation, ZakuraDb};
 
 /// The most derived frontiers to keep memoized per node.
 ///
@@ -366,24 +367,61 @@ pub fn replay_with_subtrees(
     let mut orchard = (*orchard).clone();
     let mut ironwood = (*ironwood).clone();
 
+    let first_height = Height(replay_from);
+    let mut transactions = db
+        .transactions_by_location_range(
+            TransactionLocation::min_for_height(first_height)
+                ..=TransactionLocation::max_for_height(height),
+        )
+        .peekable();
+
     for block_height in replay_from..=height.0 {
         let block_height = Height(block_height);
-        let block = db.block(block_height.into()).ok_or(
-            HistoricalTreeDerivationError::MissingBlockBody {
-                height,
-                missing: block_height,
-            },
-        )?;
-
         let append_error = |error: &dyn std::fmt::Display| HistoricalTreeDerivationError::Append {
             height,
             block: block_height,
             error: error.to_string(),
         };
 
+        let Some((first_location, first_transaction)) = transactions.next() else {
+            return Err(HistoricalTreeDerivationError::MissingBlockBody {
+                height,
+                missing: block_height,
+            });
+        };
+        if first_location != TransactionLocation::min_for_height(block_height) {
+            return Err(HistoricalTreeDerivationError::MissingBlockBody {
+                height,
+                missing: block_height,
+            });
+        }
+
         // A block never spans two subtree boundaries: the block size limit caps it far below the
         // 65,536 commitments a subtree holds, so a single batch append is always valid.
-        let sapling_commitments: Vec<_> = block.sapling_note_commitments().cloned().collect();
+        let mut sapling_commitments = Vec::new();
+        let mut orchard_commitments = Vec::new();
+        let mut ironwood_commitments = Vec::new();
+        extend_commitments(
+            &first_transaction,
+            &mut sapling_commitments,
+            &mut orchard_commitments,
+            &mut ironwood_commitments,
+        );
+        while transactions
+            .peek()
+            .is_some_and(|(location, _)| location.height == block_height)
+        {
+            let (_, transaction) = transactions
+                .next()
+                .expect("a transaction observed through peek is available");
+            extend_commitments(
+                &transaction,
+                &mut sapling_commitments,
+                &mut orchard_commitments,
+                &mut ironwood_commitments,
+            );
+        }
+
         if !sapling_commitments.is_empty() {
             let completed = sapling
                 .append_batch(&sapling_commitments)
@@ -400,7 +438,6 @@ pub fn replay_with_subtrees(
             }
         }
 
-        let orchard_commitments: Vec<_> = block.orchard_note_commitments().cloned().collect();
         if !orchard_commitments.is_empty() {
             let completed = orchard
                 .append_batch(&orchard_commitments)
@@ -417,7 +454,6 @@ pub fn replay_with_subtrees(
             }
         }
 
-        let ironwood_commitments: Vec<_> = block.ironwood_note_commitments().cloned().collect();
         if !ironwood_commitments.is_empty() {
             let completed = ironwood
                 .append_batch(&ironwood_commitments)
@@ -440,6 +476,17 @@ pub fn replay_with_subtrees(
         orchard: Arc::new(orchard),
         ironwood: Arc::new(ironwood),
     })
+}
+
+fn extend_commitments(
+    transaction: &Transaction,
+    sapling: &mut Vec<sapling::tree::NoteCommitmentUpdate>,
+    orchard: &mut Vec<orchard::tree::NoteCommitmentUpdate>,
+    ironwood: &mut Vec<ironwood::tree::NoteCommitmentUpdate>,
+) {
+    sapling.extend(transaction.sapling_note_commitments().cloned());
+    orchard.extend(transaction.orchard_note_commitments().copied());
+    ironwood.extend(transaction.ironwood_note_commitments().copied());
 }
 
 /// Checks `frontiers` against the authenticated roots stored for `height`.

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -125,9 +125,9 @@ pub enum HistoricalTreeDerivationError {
         missing: Height,
     },
 
-    /// The frontier the replay starts from is missing, so there is nothing to anchor on.
+    /// A usable frontier to start the replay from is missing, so there is nothing to anchor on.
     #[error(
-        "cannot derive the note commitment tree at {height:?}: no anchor frontier at {anchor:?}"
+        "cannot derive the note commitment tree at {height:?}: no usable anchor frontier at {anchor:?}"
     )]
     MissingAnchor {
         /// The requested height.
@@ -258,18 +258,32 @@ pub fn derive_historical_frontiers_measured(
     let anchor = anchor_for(db, cache, height)?;
 
     if let Some((anchor_height, frontiers)) = &anchor {
-        if *anchor_height == height {
-            return Ok(Derivation {
-                frontiers: frontiers.clone(),
-                replayed_blocks: 0,
-            });
+        match anchor_height.cmp(&height) {
+            std::cmp::Ordering::Equal => {
+                return Ok(Derivation {
+                    frontiers: frontiers.clone(),
+                    replayed_blocks: 0,
+                });
+            }
+            std::cmp::Ordering::Greater => {
+                return Err(HistoricalTreeDerivationError::MissingAnchor {
+                    height,
+                    anchor: *anchor_height,
+                });
+            }
+            std::cmp::Ordering::Less => {}
         }
     }
 
     // The anchor is the state at the *end* of its height, so replay starts at the next block.
     // With no anchor the replay starts at genesis.
     let replay_from = anchor.as_ref().map_or(0, |(anchor, _)| anchor.0 + 1);
-    let blocks = u64::from(height.0 - replay_from) + 1;
+    let blocks = u64::from(
+        height
+            .0
+            .checked_sub(replay_from)
+            .expect("anchors above the requested height are rejected"),
+    ) + 1;
     if blocks > max_replay_blocks {
         return Err(HistoricalTreeDerivationError::ReplayTooLong {
             height,

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -100,6 +100,18 @@ impl DerivedFrontiers {
 /// path, and a node that cannot derive simply cannot answer the request.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum HistoricalTreeDerivationError {
+    /// A subtree audit endpoint is not above its anchor, so there is no replay range.
+    #[error(
+        "cannot verify note commitment subtrees in ({from:?}, {to:?}]: the endpoint must be above \
+         the anchor"
+    )]
+    InvalidReplayRange {
+        /// The frontier height used as the replay anchor.
+        from: Height,
+        /// The requested replay endpoint.
+        to: Height,
+    },
+
     /// The replay would have to cover more blocks than the configured limit.
     #[error(
         "deriving the note commitment tree at {height:?} needs {blocks} blocks of replay, more \

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -1526,6 +1526,40 @@ fn read_only_completed_checkpoint_subscription_stays_open() {
     assert!(receiver.has_changed().is_err());
 }
 
+#[test]
+fn read_only_secondary_workspace_is_deleted_on_drop() {
+    let network = Network::Mainnet;
+    let cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
+    let config = Config {
+        cache_dir: cache_dir.path().to_path_buf(),
+        ephemeral: false,
+        ..Config::default()
+    };
+
+    let mut finalized_state =
+        FinalizedState::new(&config, &network).expect("writable state creates the database");
+    finalized_state.db.shutdown(true);
+    drop(finalized_state);
+
+    let (read_service, db, non_finalized_sender) =
+        super::init_read_only(config, &network).expect("read-only state opens");
+    let secondary_path = db
+        .secondary_path()
+        .expect("read-only state has a secondary workspace")
+        .to_path_buf();
+    assert!(secondary_path.is_dir());
+
+    drop(read_service);
+    drop(non_finalized_sender);
+    drop(db);
+
+    assert!(
+        !secondary_path.exists(),
+        "the secondary workspace is owned by the read-only database"
+    );
+}
+
 /// Opening a read-only state against a missing or unreadable cache directory must fail with a
 /// typed [`StateInitError::ReadOnlyCacheDirUnreadable`] rather than panicking while reading the
 /// on-disk format version.

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -359,11 +359,13 @@ workspace = true
 #
 # `ZakuradCmd` is likewise not a supported downstream library API: it is the
 # clap subcommand enum for the `zakurad` binary, and its variants track the
-# CLI, not a consumer contract. Retiring a subcommand is an operator-visible
-# change recorded in the changelog, and must not require a major version
-# solely because the enum happens to be reachable from the crate root.
+# CLI, not a consumer contract. Adding or retiring a subcommand is an
+# operator-visible change recorded in the changelog, and must not require a
+# major version solely because the enum happens to be reachable from the crate
+# root.
 [package.metadata.cargo-semver-checks.lints]
 feature_missing = "warn"
+enum_variant_added = "warn"
 enum_variant_missing = "warn"
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]

--- a/crates/zakurad/src/commands.rs
+++ b/crates/zakurad/src/commands.rs
@@ -11,12 +11,14 @@ use crate::config::ZakuradConfig;
 pub use self::{entry_point::EntryPoint, start::StartCmd};
 
 use self::{
-    copy_state::CopyStateCmd, generate::GenerateCmd, prune_state::PruneStateCmd,
-    rollback_state::RollbackStateCmd, tip_height::TipHeightCmd,
+    audit_historical_treestates::AuditHistoricalTreestatesCmd, copy_state::CopyStateCmd,
+    generate::GenerateCmd, prune_state::PruneStateCmd, rollback_state::RollbackStateCmd,
+    tip_height::TipHeightCmd,
 };
 
 pub mod start;
 
+mod audit_historical_treestates;
 mod copy_state;
 mod entry_point;
 mod generate;
@@ -38,6 +40,9 @@ const LEGACY_CONFIG_FILE: &str = "zebrad.toml";
 /// Zakurad Subcommands
 #[derive(Command, Debug, clap::Subcommand)]
 pub enum ZakuradCmd {
+    /// Audit historical note commitment treestate serving in the state database
+    AuditHistoricalTreestates(AuditHistoricalTreestatesCmd),
+
     /// The `copy-state` subcommand, used to debug cached chain state (expert users only)
     // TODO: hide this command from users in release builds (#3279)
     CopyState(CopyStateCmd),
@@ -71,7 +76,11 @@ impl ZakuradCmd {
             CopyState(_) | Start(_) => true,
 
             // Utility commands that don't use server components
-            Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => false,
+            AuditHistoricalTreestates(_)
+            | Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_) => false,
         }
     }
 
@@ -85,7 +94,12 @@ impl ZakuradCmd {
             Start(_) => true,
 
             // Utility commands
-            CopyState(_) | Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => false,
+            AuditHistoricalTreestates(_)
+            | CopyState(_)
+            | Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_) => false,
         }
     }
 
@@ -104,7 +118,11 @@ impl ZakuradCmd {
             // This output:
             // - is used by automated tools, or
             // - needs to be read easily.
-            Generate(_) | PruneState(_) | RollbackState(_) | TipHeight(_) => true,
+            AuditHistoricalTreestates(_)
+            | Generate(_)
+            | PruneState(_)
+            | RollbackState(_)
+            | TipHeight(_) => true,
 
             // Commands that generate informative logging output by default.
             CopyState(_) | Start(_) => false,
@@ -123,6 +141,7 @@ impl ZakuradCmd {
 impl Runnable for ZakuradCmd {
     fn run(&self) {
         match self {
+            AuditHistoricalTreestates(cmd) => cmd.run(),
             CopyState(cmd) => cmd.run(),
             Generate(cmd) => cmd.run(),
             PruneState(cmd) => cmd.run(),

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -319,7 +319,7 @@ fn validate_subtree_verification(outcome: &SubtreeVerification) -> Result<()> {
         Ok(())
     } else {
         Err(eyre!(
-            "replay could not be verified against stored subtree roots: {} missing and {} \
+            "replay could not be verified against stored subtree rows: {} missing and {} \
              mismatched; generated subtree artifacts cannot be trusted",
             outcome.unstored,
             outcome.mismatched.len(),

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -46,11 +46,15 @@ pub struct AuditHistoricalTreestatesCmd {
     )]
     walk: bool,
 
-    /// Derive every `step`th height rather than every height.
+    /// Derive every `step`th height rather than every height, always including `--to`.
     ///
     /// A step of 1 walks contiguously, which is the strongest invariant check. Larger steps
     /// approximate a wallet's scan batch size and measure what a client actually pays.
-    #[clap(long, default_value = "1", help = "height spacing for the walk")]
+    #[clap(
+        long,
+        default_value = "1",
+        help = "height spacing for the walk; --to is always included"
+    )]
     step: u32,
 
     /// The first height to derive. Defaults to the bottom of the absent band.
@@ -197,10 +201,7 @@ impl AuditHistoricalTreestatesCmd {
     /// Derives every sampled height in `[from, to]`, printing progress and a summary.
     #[allow(clippy::print_stdout)]
     fn walk_band(&self, db: &zakura_state::ZakuraDb, from: Height, to: Height) -> Result<()> {
-        let heights: Vec<Height> = (from.0..=to.0)
-            .step_by(self.step as usize)
-            .map(Height)
-            .collect();
+        let heights = sampled_heights(from, to, self.step);
         let total = heights.len();
 
         if self.print_roots {
@@ -293,6 +294,19 @@ impl AuditHistoricalTreestatesCmd {
 
         result.map_err(|(height, error)| eyre!("derivation failed at height {}: {error}", height.0))
     }
+}
+
+/// Returns heights spaced by `step` in `[from, to]`, always including both endpoints.
+fn sampled_heights(from: Height, to: Height, step: u32) -> Vec<Height> {
+    let step =
+        usize::try_from(step).expect("u32 values fit in usize on Zakura's supported targets");
+    let mut heights: Vec<Height> = (from.0..=to.0).step_by(step).map(Height).collect();
+
+    if heights.last() != Some(&to) {
+        heights.push(to);
+    }
+
+    heights
 }
 
 /// Rejects incomplete as well as contradictory subtree ground truth.
@@ -434,9 +448,22 @@ fn format_duration(duration: Duration) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_subtree_verification;
-    use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
+    use super::{sampled_heights, validate_subtree_verification};
+    use zakura_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
     use zakura_state::SubtreeVerification;
+
+    #[test]
+    fn sampled_heights_always_include_to() {
+        assert_eq!(
+            sampled_heights(Height(100), Height(110), 6),
+            [Height(100), Height(106), Height(110)]
+        );
+        assert_eq!(
+            sampled_heights(Height(100), Height(112), 6),
+            [Height(100), Height(106), Height(112)]
+        );
+        assert_eq!(sampled_heights(Height(100), Height(100), 6), [Height(100)]);
+    }
 
     #[test]
     fn subtree_verification_requires_every_stored_row() {

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -16,8 +16,8 @@ use color_eyre::eyre::{eyre, Result};
 
 use zakura_chain::{block::Height, parameters::Network};
 use zakura_state::{
-    DerivationSample, HistoricalTreeCache, SubtreeVerification, VctTreestateInventory,
-    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+    DerivationSample, HistoricalTreeCache, PruningConfig, StorageMode, SubtreeVerification,
+    VctTreestateInventory, DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
 };
 
 use crate::prelude::APPLICATION;
@@ -112,9 +112,10 @@ pub struct AuditHistoricalTreestatesCmd {
 
 impl Runnable for AuditHistoricalTreestatesCmd {
     /// `audit-historical-treestates` sub-command entrypoint.
+    #[allow(clippy::print_stderr)]
     fn run(&self) {
         if let Err(error) = self.run_with_config(APPLICATION.config().state.clone()) {
-            tracing::error!("Failed to audit historical treestates: {error:#}");
+            eprintln!("Failed to audit historical treestates: {error:#}");
             std::process::exit(1);
         }
     }
@@ -130,7 +131,16 @@ impl AuditHistoricalTreestatesCmd {
 
         if let Some(cache_dir) = self.cache_dir.clone() {
             state_config.cache_dir = cache_dir;
+            // Read-only pruned mode can inspect both archive and pruned databases, and never
+            // performs pruning. This makes a standalone path override sufficient for either.
+            if matches!(state_config.storage_mode, StorageMode::Archive) {
+                state_config.storage_mode = StorageMode::Pruned(PruningConfig::default());
+            }
         }
+
+        state_config
+            .validate_storage_mode(&self.network)
+            .map_err(|error| eyre!("{error}"))?;
 
         let (_read_state, db, _non_finalized_sender) =
             zakura_state::init_read_only(state_config, &self.network)?;

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -101,12 +101,18 @@ pub struct AuditHistoricalTreestatesCmd {
     )]
     verify_subtrees: bool,
 
-    /// Skip the root-index and block-body scans, reporting only the cheap markers.
+    /// Explicitly verify that every absent-band block body is retained.
     ///
-    /// Those scans visit every height in the band, which takes minutes on Mainnet. Skipping them
-    /// is worth it when repeating a walk on a database already known to be complete; the walk
-    /// still fails on the first height it cannot derive, so nothing goes unchecked.
-    #[clap(long, help = "skip the full-band scans, reporting markers only")]
+    /// This expensive preflight is only valid for an inventory-only invocation. Walk and subtree
+    /// modes validate the bodies in their own replay ranges.
+    #[clap(
+        long,
+        help = "scan every absent-band height for a retained block body (inventory only)"
+    )]
+    scan_block_bodies: bool,
+
+    /// Skip the authenticated-root index scan, reporting only cheap markers.
+    #[clap(long, help = "skip the full-band authenticated-root index scan")]
     no_scan: bool,
 }
 
@@ -128,6 +134,15 @@ impl AuditHistoricalTreestatesCmd {
         if self.step == 0 {
             return Err(eyre!("--step must be at least 1"));
         }
+        if self.scan_block_bodies && (self.walk || self.verify_subtrees) {
+            return Err(eyre!(
+                "--scan-block-bodies is inventory-only; walk and subtree modes validate their \
+                 own replay ranges"
+            ));
+        }
+        if self.scan_block_bodies && self.no_scan {
+            return Err(eyre!("--scan-block-bodies conflicts with --no-scan"));
+        }
 
         if let Some(cache_dir) = self.cache_dir.clone() {
             state_config.cache_dir = cache_dir;
@@ -145,12 +160,33 @@ impl AuditHistoricalTreestatesCmd {
         let (_read_state, db, _non_finalized_sender) =
             zakura_state::init_read_only(state_config, &self.network)?;
 
-        if !self.no_scan {
+        let scan_root_index = !self.no_scan && (self.walk || !self.verify_subtrees);
+        if self.walk && scan_root_index {
             println!(
-                "inventory scan starting. Please wait for approximately 5–15 minutes on Mainnet"
+                "root-index preflight starting; the walk will validate every body in its \
+                 requested range"
+            );
+        } else if self.verify_subtrees {
+            println!(
+                "inventory full-band scans skipped; subtree replay will validate every required \
+                 body above the checkpoint"
+            );
+        } else if self.scan_block_bodies {
+            println!(
+                "root-index and block-body inventory scans starting. Please wait for \
+                 approximately 5–15 minutes on Mainnet"
+            );
+        } else if scan_root_index {
+            println!(
+                "root-index inventory scan starting; use --scan-block-bodies to explicitly \
+                 validate full-band body retention"
             );
         }
-        let inventory = zakura_state::vct_treestate_inventory(&db, !self.no_scan);
+        let inventory = zakura_state::vct_treestate_inventory_with_scans(
+            &db,
+            scan_root_index,
+            self.scan_block_bodies,
+        );
         print_inventory(&inventory);
 
         if self.verify_subtrees {
@@ -440,24 +476,36 @@ fn print_inventory(inventory: &VctTreestateInventory) {
 
     println!(
         "  root index gap:         {}",
-        inventory.root_index_gap.map_or_else(
-            || "none (gap-free)".to_string(),
-            |height| format!("at height {}", height.0)
-        )
+        if inventory.root_index_scanned {
+            inventory.root_index_gap.map_or_else(
+                || "none (gap-free)".to_string(),
+                |height| format!("at height {}", height.0),
+            )
+        } else {
+            "not checked".to_string()
+        }
     );
     println!(
         "  malformed root row:     {}",
-        inventory.malformed_root_row.map_or_else(
-            || "none".to_string(),
-            |height| format!("at height {} (corrupt input)", height.0)
-        )
+        if inventory.root_index_scanned {
+            inventory.malformed_root_row.map_or_else(
+                || "none".to_string(),
+                |height| format!("at height {} (corrupt input)", height.0),
+            )
+        } else {
+            "not checked".to_string()
+        }
     );
     println!(
         "  missing block body:     {}",
-        inventory.missing_block_body.map_or_else(
-            || "none (all retained)".to_string(),
-            |height| format!("at height {}", height.0)
-        )
+        if inventory.block_bodies_scanned {
+            inventory.missing_block_body.map_or_else(
+                || "none (all retained)".to_string(),
+                |height| format!("at height {}", height.0),
+            )
+        } else {
+            "not scanned (use --scan-block-bodies for full inventory)".to_string()
+        }
     );
     println!(
         "  missing anchor:         {}",
@@ -471,7 +519,7 @@ fn print_inventory(inventory: &VctTreestateInventory) {
         match inventory.can_derive() {
             Some(true) => "yes",
             Some(false) => "no",
-            None => "not checked (--no-scan)",
+            None => "not fully preflighted",
         }
     );
     println!(

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -5,7 +5,8 @@
 //! command reports whether a state database has the inputs that needs, and optionally walks the
 //! absent band to confirm the root check holds at every height and to measure what replay costs.
 //!
-//! Read-only: it opens the database as a secondary instance and never writes.
+//! It opens the primary database read-only as a secondary instance. RocksDB writes its temporary
+//! secondary workspace separately and removes it when the command closes the database.
 
 use std::{path::PathBuf, sync::Mutex, time::Duration};
 
@@ -20,6 +21,9 @@ use zakura_state::{
 };
 
 use crate::prelude::APPLICATION;
+
+/// Bounds audit bookkeeping and catches accidentally enormous CLI ranges before any allocation.
+const MAX_AUDIT_SAMPLES: u64 = 5_000_000;
 
 /// Audit historical note commitment treestate serving in an existing state database
 #[derive(Command, Debug, Default, Parser)]
@@ -183,12 +187,7 @@ impl AuditHistoricalTreestatesCmd {
             ));
         }
 
-        // The band is half-open, so its last covered height is `H - 1`.
-        let from = Height(self.from.unwrap_or(band_start.0));
-        let to = Height(self.to.unwrap_or(band_end.0 - 1));
-        if from > to {
-            return Err(eyre!("--from {} is above --to {}", from.0, to.0));
-        }
+        let (from, to) = validated_walk_range(self.from, self.to, band_start, band_end)?;
 
         println!();
         println!(
@@ -205,22 +204,32 @@ impl AuditHistoricalTreestatesCmd {
     /// Derives every sampled height in `[from, to]`, printing progress and a summary.
     #[allow(clippy::print_stdout)]
     fn walk_band(&self, db: &zakura_state::ZakuraDb, from: Height, to: Height) -> Result<()> {
+        let total = sample_count(from, to, self.step);
+        if total > MAX_AUDIT_SAMPLES {
+            return Err(eyre!(
+                "the requested range contains {total} samples, above the {MAX_AUDIT_SAMPLES} \
+                 sample limit; increase --step or narrow the range"
+            ));
+        }
+        let total = usize::try_from(total)
+            .map_err(|_| eyre!("the requested sample count does not fit this platform"))?;
         let heights = sampled_heights(from, to, self.step);
-        let total = heights.len();
 
         if self.print_roots {
             let cache = Mutex::new(HistoricalTreeCache::default());
-            let roots = zakura_state::derived_roots_in_display_order(
-                db,
-                &cache,
-                heights,
-                DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
-            )
-            .map_err(|(height, error)| {
-                eyre!("derivation failed at height {}: {error}", height.0)
-            })?;
-
-            for (height, sapling, orchard, ironwood) in roots {
+            for height in heights {
+                let mut roots = zakura_state::derived_roots_in_display_order(
+                    db,
+                    &cache,
+                    [height],
+                    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                )
+                .map_err(|(height, error)| {
+                    eyre!("derivation failed at height {}: {error}", height.0)
+                })?;
+                let (height, sapling, orchard, ironwood) = roots
+                    .pop()
+                    .expect("one requested derivation produces one root tuple");
                 println!("ROOT {} {sapling} {orchard} {ironwood}", height.0);
             }
 
@@ -264,7 +273,7 @@ impl AuditHistoricalTreestatesCmd {
         let result = if self.cold {
             // A fresh memo per height forces every derivation to replay from the bottom of the
             // band, which is the cost a client pays with no nearby frontier.
-            let mut collected = Ok(Vec::new());
+            let mut result = Ok(());
             for height in heights {
                 let cache = Mutex::new(new_cache());
                 match zakura_state::measure_derivations(
@@ -276,12 +285,12 @@ impl AuditHistoricalTreestatesCmd {
                 ) {
                     Ok(_) => {}
                     Err(error) => {
-                        collected = Err(error);
+                        result = Err(error);
                         break;
                     }
                 }
             }
-            collected.map(|_: Vec<DerivationSample>| ())
+            result
         } else {
             let cache = Mutex::new(new_cache());
             zakura_state::measure_derivations(
@@ -291,7 +300,6 @@ impl AuditHistoricalTreestatesCmd {
                 DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
                 &mut report,
             )
-            .map(|_| ())
         };
 
         print_walk_summary(&samples);
@@ -300,17 +308,54 @@ impl AuditHistoricalTreestatesCmd {
     }
 }
 
-/// Returns heights spaced by `step` in `[from, to]`, always including both endpoints.
-fn sampled_heights(from: Height, to: Height, step: u32) -> Vec<Height> {
-    let step =
-        usize::try_from(step).expect("u32 values fit in usize on Zakura's supported targets");
-    let mut heights: Vec<Height> = (from.0..=to.0).step_by(step).map(Height).collect();
+/// Validates explicit bounds and applies the committed absent-band defaults.
+fn validated_walk_range(
+    from: Option<u32>,
+    to: Option<u32>,
+    band_start: Height,
+    band_end: Height,
+) -> Result<(Height, Height)> {
+    let from = Height(from.unwrap_or(band_start.0));
+    let to = Height(to.unwrap_or(band_end.0 - 1));
 
-    if heights.last() != Some(&to) {
-        heights.push(to);
+    if from > Height::MAX || to > Height::MAX {
+        return Err(eyre!(
+            "walk bounds must not exceed the maximum block height {}",
+            Height::MAX.0
+        ));
+    }
+    if from > to {
+        return Err(eyre!("--from {} is above --to {}", from.0, to.0));
+    }
+    if from < band_start || to >= band_end {
+        return Err(eyre!(
+            "walk range [{}, {}] is outside the committed absent band [{}, {})",
+            from.0,
+            to.0,
+            band_start.0,
+            band_end.0
+        ));
     }
 
-    heights
+    Ok((from, to))
+}
+
+/// Returns the number of heights sampled in `[from, to]`, including both endpoints.
+fn sample_count(from: Height, to: Height, step: u32) -> u64 {
+    let span = u64::from(to.0 - from.0);
+    span / u64::from(step) + 1 + u64::from(!span.is_multiple_of(u64::from(step)))
+}
+
+/// Iterates over heights spaced by `step` in `[from, to]`, always including both endpoints.
+fn sampled_heights(from: Height, to: Height, step: u32) -> impl Iterator<Item = Height> + Clone {
+    let needs_endpoint = !(to.0 - from.0).is_multiple_of(step);
+    let step =
+        usize::try_from(step).expect("u32 values fit in usize on Zakura's supported targets");
+
+    (from.0..=to.0)
+        .step_by(step)
+        .map(Height)
+        .chain(needs_endpoint.then_some(to))
 }
 
 /// Rejects incomplete as well as contradictory subtree ground truth in either direction.
@@ -376,6 +421,13 @@ fn print_inventory(inventory: &VctTreestateInventory) {
         "  missing block body:     {}",
         inventory.missing_block_body.map_or_else(
             || "none (all retained)".to_string(),
+            |height| format!("at height {}", height.0)
+        )
+    );
+    println!(
+        "  missing anchor:         {}",
+        inventory.missing_anchor.map_or_else(
+            || "none (all pools present)".to_string(),
             |height| format!("at height {}", height.0)
         )
     );
@@ -453,21 +505,47 @@ fn format_duration(duration: Duration) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{sampled_heights, validate_subtree_verification};
+    use super::{
+        sample_count, sampled_heights, validate_subtree_verification, validated_walk_range,
+    };
     use zakura_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
     use zakura_state::SubtreeVerification;
 
     #[test]
     fn sampled_heights_always_include_to() {
         assert_eq!(
-            sampled_heights(Height(100), Height(110), 6),
+            sampled_heights(Height(100), Height(110), 6).collect::<Vec<_>>(),
             [Height(100), Height(106), Height(110)]
         );
         assert_eq!(
-            sampled_heights(Height(100), Height(112), 6),
+            sampled_heights(Height(100), Height(112), 6).collect::<Vec<_>>(),
             [Height(100), Height(106), Height(112)]
         );
-        assert_eq!(sampled_heights(Height(100), Height(100), 6), [Height(100)]);
+        assert_eq!(
+            sampled_heights(Height(100), Height(100), 6).collect::<Vec<_>>(),
+            [Height(100)]
+        );
+        assert_eq!(sample_count(Height(100), Height(110), 6), 3);
+        assert_eq!(sample_count(Height(100), Height(112), 6), 3);
+        assert_eq!(sample_count(Height(100), Height(100), 6), 1);
+        assert_eq!(
+            sample_count(Height::MIN, Height(u32::MAX), 1),
+            u64::from(u32::MAX) + 1
+        );
+    }
+
+    #[test]
+    fn walk_range_must_stay_within_committed_absent_band() {
+        let band_start = Height(100);
+        let band_end = Height(200);
+
+        assert_eq!(
+            validated_walk_range(None, None, band_start, band_end).unwrap(),
+            (Height(100), Height(199))
+        );
+        assert!(validated_walk_range(Some(99), None, band_start, band_end).is_err());
+        assert!(validated_walk_range(None, Some(200), band_start, band_end).is_err());
+        assert!(validated_walk_range(Some(Height::MAX.0 + 1), None, band_start, band_end).is_err());
     }
 
     #[test]

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -428,6 +428,13 @@ fn print_inventory(inventory: &VctTreestateInventory) {
         )
     );
     println!(
+        "  malformed root row:     {}",
+        inventory.malformed_root_row.map_or_else(
+            || "none".to_string(),
+            |height| format!("at height {} (corrupt input)", height.0)
+        )
+    );
+    println!(
         "  missing block body:     {}",
         inventory.missing_block_body.map_or_else(
             || "none (all retained)".to_string(),

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -145,6 +145,11 @@ impl AuditHistoricalTreestatesCmd {
         let (_read_state, db, _non_finalized_sender) =
             zakura_state::init_read_only(state_config, &self.network)?;
 
+        if !self.no_scan {
+            eprintln!(
+                "inventory scan starting. Please wait for approximately 5–15 minutes on Mainnet"
+            );
+        }
         let inventory = zakura_state::vct_treestate_inventory(&db, !self.no_scan);
         print_inventory(&inventory);
 
@@ -224,6 +229,16 @@ impl AuditHistoricalTreestatesCmd {
         let total = usize::try_from(total)
             .map_err(|_| eyre!("the requested sample count does not fit this platform"))?;
         let heights = sampled_heights(from, to, self.step);
+        let block_count = u64::from(to.0) - u64::from(from.0) + 1;
+        let progress_interval = (total / 100).max(1);
+
+        println!("long block read/replay starting: {block_count} blocks, {total} sampled roots");
+        if !self.cold && self.step > 1 {
+            println!(
+                "  --step controls root sampling only; sequential replay still reads every block"
+            );
+        }
+        println!("  progress will be reported approximately every 1%");
 
         if self.print_roots {
             let cache = Mutex::new(HistoricalTreeCache::default());
@@ -249,6 +264,7 @@ impl AuditHistoricalTreestatesCmd {
         let print_samples = self.print_samples;
         let mut samples: Vec<DerivationSample> = Vec::with_capacity(total);
         let mut report = |sample: &DerivationSample| {
+            let completed = samples.len() + 1;
             if print_samples {
                 // The replayed range ends at this height and covers `replayed_blocks` blocks.
                 // Cast is safe: the `min` clamps the value to `height.0 + 1`, which fits in
@@ -267,11 +283,11 @@ impl AuditHistoricalTreestatesCmd {
                     sample.elapsed.as_micros()
                 );
             }
-            // One line per 1000 samples keeps a multi-million-height walk readable.
-            if samples.len().is_multiple_of(1000) {
+            if completed == 1 || completed.is_multiple_of(progress_interval) || completed == total {
+                let percent = completed * 100 / total;
                 println!(
-                    "  {:>7}/{total}  height {:>9}  replayed {:>9} blocks in {:>10}",
-                    samples.len(),
+                    "  {:>7}/{total} ({percent:>3}%)  height {:>9}  replayed {:>9} blocks in {:>10}",
+                    completed,
                     sample.height.0,
                     sample.replayed_blocks,
                     format_duration(sample.elapsed),

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -15,7 +15,7 @@ use color_eyre::eyre::{eyre, Result};
 
 use zakura_chain::{block::Height, parameters::Network};
 use zakura_state::{
-    DerivationSample, HistoricalTreeCache, VctTreestateInventory,
+    DerivationSample, HistoricalTreeCache, SubtreeVerification, VctTreestateInventory,
     DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
 };
 
@@ -154,12 +154,7 @@ impl AuditHistoricalTreestatesCmd {
                 println!("    {pool} subtree {}", index.0);
             }
 
-            if !outcome.mismatched.is_empty() {
-                return Err(eyre!(
-                    "replay does not reproduce stored subtree roots, so generated subtree \
-                     artifacts cannot be trusted"
-                ));
-            }
+            validate_subtree_verification(&outcome)?;
         }
 
         if !self.walk {
@@ -300,6 +295,24 @@ impl AuditHistoricalTreestatesCmd {
     }
 }
 
+/// Rejects incomplete as well as contradictory subtree ground truth.
+///
+/// Every replay completion in the audited range is above the handoff, where the database is
+/// expected to store subtree rows. A missing row therefore prevents verification just like a
+/// mismatched row does.
+fn validate_subtree_verification(outcome: &SubtreeVerification) -> Result<()> {
+    if outcome.unstored == 0 && outcome.mismatched.is_empty() {
+        Ok(())
+    } else {
+        Err(eyre!(
+            "replay could not be verified against stored subtree roots: {} missing and {} \
+             mismatched; generated subtree artifacts cannot be trusted",
+            outcome.unstored,
+            outcome.mismatched.len(),
+        ))
+    }
+}
+
 #[allow(clippy::print_stdout)]
 fn print_inventory(inventory: &VctTreestateInventory) {
     println!("historical treestate inventory:");
@@ -416,5 +429,35 @@ fn format_duration(duration: Duration) -> String {
         format!("{:.1}ms", duration.as_secs_f64() * 1e3)
     } else {
         format!("{:.2}s", duration.as_secs_f64())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_subtree_verification;
+    use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
+    use zakura_state::SubtreeVerification;
+
+    #[test]
+    fn subtree_verification_requires_every_stored_row() {
+        assert!(validate_subtree_verification(&SubtreeVerification::default()).is_ok());
+
+        let missing = SubtreeVerification {
+            unstored: 1,
+            ..Default::default()
+        };
+        assert!(
+            validate_subtree_verification(&missing).is_err(),
+            "a replay completion without its expected stored row must fail the audit"
+        );
+
+        let mismatched = SubtreeVerification {
+            mismatched: vec![(NoteCommitmentSubtreeIndex(0), "sapling")],
+            ..Default::default()
+        };
+        assert!(
+            validate_subtree_verification(&mismatched).is_err(),
+            "a replay completion that contradicts its stored row must fail the audit"
+        );
     }
 }

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -157,6 +157,10 @@ impl AuditHistoricalTreestatesCmd {
             for (index, pool) in &outcome.mismatched {
                 println!("    {pool} subtree {}", index.0);
             }
+            println!("  stored only: {}", outcome.stored_only.len());
+            for (index, pool) in &outcome.stored_only {
+                println!("    {pool} subtree {}", index.0);
+            }
 
             validate_subtree_verification(&outcome)?;
         }
@@ -309,20 +313,21 @@ fn sampled_heights(from: Height, to: Height, step: u32) -> Vec<Height> {
     heights
 }
 
-/// Rejects incomplete as well as contradictory subtree ground truth.
+/// Rejects incomplete as well as contradictory subtree ground truth in either direction.
 ///
 /// Every replay completion in the audited range is above the handoff, where the database is
-/// expected to store subtree rows. A missing row therefore prevents verification just like a
-/// mismatched row does.
+/// expected to store subtree rows, and every stored row in that range must correspond to a replay
+/// completion. Missing, mismatched, and stored-only rows all prevent verification.
 fn validate_subtree_verification(outcome: &SubtreeVerification) -> Result<()> {
-    if outcome.unstored == 0 && outcome.mismatched.is_empty() {
+    if outcome.unstored == 0 && outcome.mismatched.is_empty() && outcome.stored_only.is_empty() {
         Ok(())
     } else {
         Err(eyre!(
-            "replay could not be verified against stored subtree rows: {} missing and {} \
-             mismatched; generated subtree artifacts cannot be trusted",
+            "replay could not be verified against stored subtree rows: {} missing, {} mismatched, \
+             and {} stored-only; generated subtree artifacts cannot be trusted",
             outcome.unstored,
             outcome.mismatched.len(),
+            outcome.stored_only.len(),
         ))
     }
 }
@@ -485,6 +490,15 @@ mod tests {
         assert!(
             validate_subtree_verification(&mismatched).is_err(),
             "a replay completion that contradicts its stored row must fail the audit"
+        );
+
+        let stored_only = SubtreeVerification {
+            stored_only: vec![(NoteCommitmentSubtreeIndex(1), "orchard")],
+            ..Default::default()
+        };
+        assert!(
+            validate_subtree_verification(&stored_only).is_err(),
+            "a stored row without a replay completion must fail the audit"
         );
     }
 }

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -251,6 +251,8 @@ impl AuditHistoricalTreestatesCmd {
         let mut report = |sample: &DerivationSample| {
             if print_samples {
                 // The replayed range ends at this height and covers `replayed_blocks` blocks.
+                // Cast is safe: the `min` clamps the value to `height.0 + 1`, which fits in
+                // a u32 because heights stay below `u32::MAX`.
                 let from = Height(
                     sample.height.0 + 1
                         - sample.replayed_blocks.min(u64::from(sample.height.0) + 1) as u32,

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -196,6 +196,7 @@ impl AuditHistoricalTreestatesCmd {
             let tip = inventory
                 .finalized_tip
                 .ok_or_else(|| eyre!("this database has no finalized tip"))?;
+            validate_subtree_range(last_checkpoint, tip)?;
 
             println!();
             println!(
@@ -404,6 +405,20 @@ fn validated_walk_range(
     Ok((from, to))
 }
 
+/// Rejects an empty or reversed subtree replay range before reporting that verification started.
+fn validate_subtree_range(last_checkpoint: Height, finalized_tip: Height) -> Result<()> {
+    if finalized_tip <= last_checkpoint {
+        return Err(eyre!(
+            "cannot verify stored subtrees: finalized tip {} must be above last checkpoint {}; \
+             fast sync may not have reached the stored subtree band yet",
+            finalized_tip.0,
+            last_checkpoint.0,
+        ));
+    }
+
+    Ok(())
+}
+
 /// Returns the number of heights sampled in `[from, to]`, including both endpoints.
 fn sample_count(from: Height, to: Height, step: u32) -> u64 {
     let span = u64::from(to.0 - from.0);
@@ -422,18 +437,23 @@ fn sampled_heights(from: Height, to: Height, step: u32) -> impl Iterator<Item = 
         .chain(needs_endpoint.then_some(to))
 }
 
-/// Rejects incomplete as well as contradictory subtree ground truth in either direction.
+/// Requires at least one comparison and rejects incomplete or contradictory ground truth.
 ///
 /// Every replay completion in the audited range is above the handoff, where the database is
 /// expected to store subtree rows, and every stored row in that range must correspond to a replay
 /// completion. Missing, mismatched, and stored-only rows all prevent verification.
 fn validate_subtree_verification(outcome: &SubtreeVerification) -> Result<()> {
-    if outcome.unstored == 0 && outcome.mismatched.is_empty() && outcome.stored_only.is_empty() {
+    if outcome.matched > 0
+        && outcome.unstored == 0
+        && outcome.mismatched.is_empty()
+        && outcome.stored_only.is_empty()
+    {
         Ok(())
     } else {
         Err(eyre!(
-            "replay could not be verified against stored subtree rows: {} missing, {} mismatched, \
-             and {} stored-only; generated subtree artifacts cannot be trusted",
+            "replay could not be verified against stored subtree rows: {} matched, {} missing, {} \
+             mismatched, and {} stored-only; at least one match with no discrepancies is required",
+            outcome.matched,
             outcome.unstored,
             outcome.mismatched.len(),
             outcome.stored_only.len(),
@@ -589,7 +609,8 @@ fn format_duration(duration: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        sample_count, sampled_heights, validate_subtree_verification, validated_walk_range,
+        sample_count, sampled_heights, validate_subtree_range, validate_subtree_verification,
+        validated_walk_range,
     };
     use zakura_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
     use zakura_state::SubtreeVerification;
@@ -632,10 +653,27 @@ mod tests {
     }
 
     #[test]
-    fn subtree_verification_requires_every_stored_row() {
-        assert!(validate_subtree_verification(&SubtreeVerification::default()).is_ok());
+    fn subtree_range_must_extend_above_last_checkpoint() {
+        assert!(validate_subtree_range(Height(100), Height(101)).is_ok());
+        assert!(validate_subtree_range(Height(100), Height(100)).is_err());
+        assert!(validate_subtree_range(Height(100), Height(99)).is_err());
+    }
+
+    #[test]
+    fn subtree_verification_requires_a_match_and_every_stored_row() {
+        assert!(
+            validate_subtree_verification(&SubtreeVerification::default()).is_err(),
+            "an audit that compared no subtree rows must not pass"
+        );
+
+        let matched = SubtreeVerification {
+            matched: 1,
+            ..Default::default()
+        };
+        assert!(validate_subtree_verification(&matched).is_ok());
 
         let missing = SubtreeVerification {
+            matched: 1,
             unstored: 1,
             ..Default::default()
         };
@@ -645,6 +683,7 @@ mod tests {
         );
 
         let mismatched = SubtreeVerification {
+            matched: 1,
             mismatched: vec![(NoteCommitmentSubtreeIndex(0), "sapling")],
             ..Default::default()
         };
@@ -654,6 +693,7 @@ mod tests {
         );
 
         let stored_only = SubtreeVerification {
+            matched: 1,
             stored_only: vec![(NoteCommitmentSubtreeIndex(1), "orchard")],
             ..Default::default()
         };

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -1,0 +1,420 @@
+//! `audit-historical-treestates` subcommand - reports and measures historical treestate serving.
+//!
+//! A verified-commitment-trees fast-synced node serves historical treestates by replaying block
+//! bodies forward and checking each result against the authenticated roots it already stores. This
+//! command reports whether a state database has the inputs that needs, and optionally walks the
+//! absent band to confirm the root check holds at every height and to measure what replay costs.
+//!
+//! Read-only: it opens the database as a secondary instance and never writes.
+
+use std::{path::PathBuf, sync::Mutex, time::Duration};
+
+use abscissa_core::{Application, Command, Runnable};
+use clap::Parser;
+use color_eyre::eyre::{eyre, Result};
+
+use zakura_chain::{block::Height, parameters::Network};
+use zakura_state::{
+    DerivationSample, HistoricalTreeCache, VctTreestateInventory,
+    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+};
+
+use crate::prelude::APPLICATION;
+
+/// Audit historical note commitment treestate serving in an existing state database
+#[derive(Command, Debug, Default, Parser)]
+pub struct AuditHistoricalTreestatesCmd {
+    /// Path to Zakura's cached state.
+    #[clap(long, short, help = "path to directory with the Zakura chain state")]
+    cache_dir: Option<PathBuf>,
+
+    /// The network of the chain to audit.
+    #[clap(
+        long,
+        short,
+        required = true,
+        help = "the network of the chain to load"
+    )]
+    network: Network,
+
+    /// Derive frontiers across the absent band, checking each against the stored root.
+    ///
+    /// Without this the command only reports the inventory, which is fast.
+    #[clap(
+        long,
+        help = "walk the absent band, deriving and root-checking every sampled height"
+    )]
+    walk: bool,
+
+    /// Derive every `step`th height rather than every height.
+    ///
+    /// A step of 1 walks contiguously, which is the strongest invariant check. Larger steps
+    /// approximate a wallet's scan batch size and measure what a client actually pays.
+    #[clap(long, default_value = "1", help = "height spacing for the walk")]
+    step: u32,
+
+    /// The first height to derive. Defaults to the bottom of the absent band.
+    #[clap(long, help = "first height to derive")]
+    from: Option<u32>,
+
+    /// The last height to derive. Defaults to the top of the absent band.
+    #[clap(long, help = "last height to derive")]
+    to: Option<u32>,
+
+    /// Start each derivation from a fresh memo, measuring cold replay rather than sequential.
+    ///
+    /// This is what sizes the published frontier grid: it reports what a client pays when no
+    /// nearby frontier is memoized.
+    #[clap(long, help = "clear the memo before each derivation")]
+    cold: bool,
+
+    /// Print one line per derivation with its measured cost and its replay inputs.
+    ///
+    /// Emits `SAMPLE <height> <blocks> <bytes> <commitments> <micros>`, which is what the grid's
+    /// cost model is fitted against.
+    #[clap(long, help = "print per-derivation cost and replay inputs")]
+    print_samples: bool,
+
+    /// Print the derived roots at each sampled height, for comparison against another node.
+    ///
+    /// Output is one `ROOT <height> <sapling> <orchard> <ironwood>` line per height, hex-encoded
+    /// in the same display order `z_gettreestate` uses.
+    #[clap(long, help = "print derived roots for cross-node comparison")]
+    print_roots: bool,
+
+    /// Check replay-derived subtree roots against the ones stored above the last checkpoint.
+    ///
+    /// Subtree roots are interior nodes, so the per-height root check does not test them. Above
+    /// the last checkpoint the database stores them, which makes that band the one place a replay
+    /// can be checked against ground truth.
+    #[clap(
+        long,
+        help = "verify replay-derived subtree roots against stored rows above the last checkpoint"
+    )]
+    verify_subtrees: bool,
+
+    /// Skip the root-index and block-body scans, reporting only the cheap markers.
+    ///
+    /// Those scans visit every height in the band, which takes minutes on Mainnet. Skipping them
+    /// is worth it when repeating a walk on a database already known to be complete; the walk
+    /// still fails on the first height it cannot derive, so nothing goes unchecked.
+    #[clap(long, help = "skip the full-band scans, reporting markers only")]
+    no_scan: bool,
+}
+
+impl Runnable for AuditHistoricalTreestatesCmd {
+    /// `audit-historical-treestates` sub-command entrypoint.
+    fn run(&self) {
+        if let Err(error) = self.run_with_config(APPLICATION.config().state.clone()) {
+            tracing::error!("Failed to audit historical treestates: {error:#}");
+            std::process::exit(1);
+        }
+    }
+}
+
+impl AuditHistoricalTreestatesCmd {
+    /// Runs the audit using `state_config` as the base state configuration.
+    #[allow(clippy::print_stdout)]
+    pub fn run_with_config(&self, mut state_config: zakura_state::Config) -> Result<()> {
+        if self.step == 0 {
+            return Err(eyre!("--step must be at least 1"));
+        }
+
+        if let Some(cache_dir) = self.cache_dir.clone() {
+            state_config.cache_dir = cache_dir;
+        }
+
+        let (_read_state, db, _non_finalized_sender) =
+            zakura_state::init_read_only(state_config, &self.network)?;
+
+        let inventory = zakura_state::vct_treestate_inventory(&db, !self.no_scan);
+        print_inventory(&inventory);
+
+        if self.verify_subtrees {
+            let last_checkpoint = inventory.last_checkpoint.ok_or_else(|| {
+                eyre!("this database has no last checkpoint, so there is no stored band")
+            })?;
+            let tip = inventory
+                .finalized_tip
+                .ok_or_else(|| eyre!("this database has no finalized tip"))?;
+
+            println!();
+            println!(
+                "verifying replay-derived subtree roots against stored rows in ({}, {}]",
+                last_checkpoint.0, tip.0
+            );
+
+            let outcome = zakura_state::verify_subtrees_against_stored(&db, last_checkpoint, tip)
+                .map_err(|error| eyre!("{error}"))?;
+
+            println!("  matched:    {}", outcome.matched);
+            println!("  unstored:   {}", outcome.unstored);
+            println!("  mismatched: {}", outcome.mismatched.len());
+            for (index, pool) in &outcome.mismatched {
+                println!("    {pool} subtree {}", index.0);
+            }
+
+            if !outcome.mismatched.is_empty() {
+                return Err(eyre!(
+                    "replay does not reproduce stored subtree roots, so generated subtree \
+                     artifacts cannot be trusted"
+                ));
+            }
+        }
+
+        if !self.walk {
+            return Ok(());
+        }
+
+        let Some((band_start, band_end)) = inventory.absent_band() else {
+            return Err(eyre!(
+                "this database has no absent band, so there is nothing to derive: it stores \
+                 per-height trees at every height"
+            ));
+        };
+
+        if inventory.can_derive() == Some(false) {
+            return Err(eyre!(
+                "this database is missing derivation inputs, so a walk would fail immediately; \
+                 see the inventory above"
+            ));
+        }
+
+        // The band is half-open, so its last covered height is `H - 1`.
+        let from = Height(self.from.unwrap_or(band_start.0));
+        let to = Height(self.to.unwrap_or(band_end.0 - 1));
+        if from > to {
+            return Err(eyre!("--from {} is above --to {}", from.0, to.0));
+        }
+
+        println!();
+        println!(
+            "walking [{}, {}] step {} ({} mode)",
+            from.0,
+            to.0,
+            self.step,
+            if self.cold { "cold" } else { "sequential" }
+        );
+
+        self.walk_band(&db, from, to)
+    }
+
+    /// Derives every sampled height in `[from, to]`, printing progress and a summary.
+    #[allow(clippy::print_stdout)]
+    fn walk_band(&self, db: &zakura_state::ZakuraDb, from: Height, to: Height) -> Result<()> {
+        let heights: Vec<Height> = (from.0..=to.0)
+            .step_by(self.step as usize)
+            .map(Height)
+            .collect();
+        let total = heights.len();
+
+        if self.print_roots {
+            let cache = Mutex::new(HistoricalTreeCache::default());
+            let roots = zakura_state::derived_roots_in_display_order(
+                db,
+                &cache,
+                heights,
+                DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+            )
+            .map_err(|(height, error)| {
+                eyre!("derivation failed at height {}: {error}", height.0)
+            })?;
+
+            for (height, sapling, orchard, ironwood) in roots {
+                println!("ROOT {} {sapling} {orchard} {ironwood}", height.0);
+            }
+
+            return Ok(());
+        }
+
+        let print_samples = self.print_samples;
+        let mut samples: Vec<DerivationSample> = Vec::with_capacity(total);
+        let mut report = |sample: &DerivationSample| {
+            if print_samples {
+                // The replayed range ends at this height and covers `replayed_blocks` blocks.
+                let from = Height(
+                    sample.height.0 + 1
+                        - sample.replayed_blocks.min(u64::from(sample.height.0) + 1) as u32,
+                );
+                let inputs = zakura_state::replay_inputs(db, from, sample.height);
+                println!(
+                    "SAMPLE {} {} {} {} {}",
+                    sample.height.0,
+                    inputs.blocks,
+                    inputs.bytes,
+                    inputs.commitments,
+                    sample.elapsed.as_micros()
+                );
+            }
+            // One line per 1000 samples keeps a multi-million-height walk readable.
+            if samples.len().is_multiple_of(1000) {
+                println!(
+                    "  {:>7}/{total}  height {:>9}  replayed {:>9} blocks in {:>10}",
+                    samples.len(),
+                    sample.height.0,
+                    sample.replayed_blocks,
+                    format_duration(sample.elapsed),
+                );
+            }
+            samples.push(*sample);
+        };
+
+        let new_cache = HistoricalTreeCache::default;
+
+        let result = if self.cold {
+            // A fresh memo per height forces every derivation to replay from the bottom of the
+            // band, which is the cost a client pays with no nearby frontier.
+            let mut collected = Ok(Vec::new());
+            for height in heights {
+                let cache = Mutex::new(new_cache());
+                match zakura_state::measure_derivations(
+                    db,
+                    &cache,
+                    [height],
+                    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                    &mut report,
+                ) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        collected = Err(error);
+                        break;
+                    }
+                }
+            }
+            collected.map(|_: Vec<DerivationSample>| ())
+        } else {
+            let cache = Mutex::new(new_cache());
+            zakura_state::measure_derivations(
+                db,
+                &cache,
+                heights,
+                DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                &mut report,
+            )
+            .map(|_| ())
+        };
+
+        print_walk_summary(&samples);
+
+        result.map_err(|(height, error)| eyre!("derivation failed at height {}: {error}", height.0))
+    }
+}
+
+#[allow(clippy::print_stdout)]
+fn print_inventory(inventory: &VctTreestateInventory) {
+    println!("historical treestate inventory:");
+    println!(
+        "  finalized tip:          {}",
+        show(inventory.finalized_tip)
+    );
+    println!(
+        "  upgrade height (U):     {}",
+        show(inventory.upgrade_height)
+    );
+    println!(
+        "  last checkpoint (H):    {}",
+        show(inventory.last_checkpoint)
+    );
+    println!(
+        "  lowest retained height: {}",
+        inventory.lowest_retained_height.map_or_else(
+            || "none (archive)".to_string(),
+            |height| height.0.to_string()
+        )
+    );
+
+    match inventory.absent_band() {
+        Some((start, end)) => println!(
+            "  absent band:            [{}, {}), {} heights",
+            start.0,
+            end.0,
+            end.0 - start.0
+        ),
+        None => println!("  absent band:            none (per-height trees at every height)"),
+    }
+
+    println!(
+        "  root index gap:         {}",
+        inventory.root_index_gap.map_or_else(
+            || "none (gap-free)".to_string(),
+            |height| format!("at height {}", height.0)
+        )
+    );
+    println!(
+        "  missing block body:     {}",
+        inventory.missing_block_body.map_or_else(
+            || "none (all retained)".to_string(),
+            |height| format!("at height {}", height.0)
+        )
+    );
+    println!(
+        "  can derive:             {}",
+        match inventory.can_derive() {
+            Some(true) => "yes",
+            Some(false) => "no",
+            None => "not checked (--no-scan)",
+        }
+    );
+    println!(
+        "  scan took:              {}",
+        format_duration(inventory.scan_duration)
+    );
+}
+
+#[allow(clippy::print_stdout)]
+fn print_walk_summary(samples: &[DerivationSample]) {
+    println!();
+    println!("walk summary:");
+    println!("  heights derived and root-checked: {}", samples.len());
+
+    let replayed: u64 = samples.iter().map(|sample| sample.replayed_blocks).sum();
+    let total: Duration = samples.iter().map(|sample| sample.elapsed).sum();
+    println!("  blocks replayed:                  {replayed}");
+    println!(
+        "  total time:                       {}",
+        format_duration(total)
+    );
+
+    if replayed > 0 {
+        let per_block = total / u32::try_from(replayed).unwrap_or(u32::MAX);
+        println!(
+            "  mean per replayed block:          {}",
+            format_duration(per_block)
+        );
+    }
+
+    let mut per_derivation: Vec<Duration> = samples.iter().map(|sample| sample.elapsed).collect();
+    per_derivation.sort_unstable();
+
+    for (label, quantile) in [("median", 50), ("p90", 90), ("p99", 99), ("max", 100)] {
+        if let Some(value) = percentile(&per_derivation, quantile) {
+            println!("  per-derivation {label:<19}{}", format_duration(value));
+        }
+    }
+}
+
+/// Returns the `quantile`th percentile of `sorted`, or `None` if it is empty.
+fn percentile(sorted: &[Duration], quantile: usize) -> Option<Duration> {
+    if sorted.is_empty() {
+        return None;
+    }
+
+    let index = (sorted.len() - 1) * quantile / 100;
+    sorted.get(index).copied()
+}
+
+fn show(height: Option<Height>) -> String {
+    height.map_or_else(|| "none".to_string(), |height| height.0.to_string())
+}
+
+fn format_duration(duration: Duration) -> String {
+    if duration < Duration::from_micros(1) {
+        format!("{}ns", duration.as_nanos())
+    } else if duration < Duration::from_millis(1) {
+        format!("{:.1}us", duration.as_secs_f64() * 1e6)
+    } else if duration < Duration::from_secs(1) {
+        format!("{:.1}ms", duration.as_secs_f64() * 1e3)
+    } else {
+        format!("{:.2}s", duration.as_secs_f64())
+    }
+}

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -146,7 +146,7 @@ impl AuditHistoricalTreestatesCmd {
             zakura_state::init_read_only(state_config, &self.network)?;
 
         if !self.no_scan {
-            eprintln!(
+            println!(
                 "inventory scan starting. Please wait for approximately 5–15 minutes on Mainnet"
             );
         }

--- a/docs/changelog/unreleased/552.md
+++ b/docs/changelog/unreleased/552.md
@@ -1,0 +1,14 @@
+## Added
+
+- Added the `audit-historical-treestates` subcommand, which reports whether a state
+  database can rebuild the note commitment trees a verified-commitment-trees fast-synced
+  node is missing, and can walk that range to rebuild and check every tree against the
+  authenticated roots the node already stores
+  ([#535](https://github.com/zakura-core/zakura/pull/552)).
+
+## Fixed
+
+- Fixed read-only state opens failing against databases written by an older version, which
+  made read-only tooling unable to inspect them at all. Opening read-only no longer
+  requires column families the database does not have
+  ([#535](https://github.com/zakura-core/zakura/pull/552)).

--- a/docs/changelog/unreleased/552.md
+++ b/docs/changelog/unreleased/552.md
@@ -4,11 +4,11 @@
   database can rebuild the note commitment trees a verified-commitment-trees fast-synced
   node is missing, and can walk that range to rebuild and check every tree against the
   authenticated roots the node already stores
-  ([#535](https://github.com/zakura-core/zakura/pull/552)).
+  ([#552](https://github.com/zakura-core/zakura/pull/552)).
 
 ## Fixed
 
 - Fixed read-only state opens failing against databases written by an older version, which
   made read-only tooling unable to inspect them at all. Opening read-only no longer
   requires column families the database does not have
-  ([#535](https://github.com/zakura-core/zakura/pull/552)).
+  ([#552](https://github.com/zakura-core/zakura/pull/552)).

--- a/scripts/differential-treestate-check.py
+++ b/scripts/differential-treestate-check.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Compare a fast-synced node's derived treestates against a legacy-synced node's.
+
+Phase D of `docs/design/historical-treestate-serving.md` asks for a differential test: the same
+heights, served from a verified-commitment-trees fast-synced database and from a legacy archive
+node, must agree. This is the strongest available check on the design, because the two sides build
+their trees by entirely different routes — the legacy node recomputes every per-height tree as it
+syncs, while the fast-synced side replays block bodies and checks the result against authenticated
+roots. Agreement is independent evidence that replay reconstructs real history rather than merely
+being self-consistent.
+
+The comparison covers whatever range both sides can answer, so it strengthens on its own as a
+legacy node syncs further: rerun it as the node advances and the covered range grows.
+
+Usage:
+
+    scripts/differential-treestate-check.py \\
+        --cache-dir /path/to/fast-synced-cache \\
+        --network Mainnet \\
+        --rpc-url http://127.0.0.1:8232/ \\
+        --from-height 419200 --to-height 435000 --step 50
+
+The legacy node's RPC is usually loopback-only; forward it first, for example
+`ssh -N -L 8232:127.0.0.1:8232 root@<host>`.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.request
+
+
+def derive_locally(args):
+    """Runs zakurad and returns {height: (sapling, orchard, ironwood)} hex roots."""
+    command = [
+        args.zakurad,
+        "audit-historical-treestates",
+        "--cache-dir", args.cache_dir,
+        "--network", args.network,
+        "--no-scan",
+        "--walk",
+        "--print-roots",
+        "--from", str(args.from_height),
+        "--to", str(args.to_height),
+        "--step", str(args.step),
+    ]
+    if args.frontier_artifact:
+        command += ["--frontier-artifact", args.frontier_artifact]
+
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"local derivation failed:\n{result.stderr[-4000:]}")
+
+    roots = {}
+    for line in result.stdout.splitlines():
+        if line.startswith("ROOT "):
+            _, height, sapling, orchard, ironwood = line.split()
+            roots[int(height)] = (sapling, orchard, ironwood)
+
+    if not roots:
+        sys.exit("local derivation produced no roots; check the height range")
+
+    return roots
+
+
+def fetch_remote(rpc_url, height):
+    """Returns the legacy node's z_gettreestate result for `height`."""
+    payload = json.dumps(
+        {"jsonrpc": "1.0", "id": 1, "method": "z_gettreestate", "params": [str(height)]}
+    ).encode()
+    request = urllib.request.Request(
+        rpc_url, data=payload, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.load(response).get("result")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", required=True, help="fast-synced state cache directory")
+    parser.add_argument("--network", default="Mainnet")
+    parser.add_argument("--rpc-url", required=True, help="legacy node's JSON-RPC endpoint")
+    parser.add_argument("--from-height", type=int, required=True)
+    parser.add_argument("--to-height", type=int, required=True)
+    parser.add_argument("--step", type=int, default=50)
+    parser.add_argument("--frontier-artifact", help="frontier artifact to anchor derivation on")
+    parser.add_argument("--zakurad", default="target/release/zakurad")
+    args = parser.parse_args()
+
+    derived = derive_locally(args)
+    print(f"derived {len(derived)} heights locally")
+
+    compared = {"sapling": [0, 0], "orchard": [0, 0], "ironwood": [0, 0]}
+    unavailable = 0
+    mismatches = []
+
+    for height in sorted(derived):
+        result = fetch_remote(args.rpc_url, height)
+        if result is None:
+            unavailable += 1
+            continue
+
+        for index, pool in enumerate(("sapling", "orchard", "ironwood")):
+            # A pool with no root at this height is either pre-activation or beyond what the
+            # legacy node has synced. Neither is a disagreement, so it is not counted as one.
+            legacy = result.get(pool, {}).get("commitments", {}).get("finalRoot")
+            if legacy is None:
+                continue
+
+            if legacy == derived[height][index]:
+                compared[pool][0] += 1
+            else:
+                compared[pool][1] += 1
+                mismatches.append((height, pool, legacy, derived[height][index]))
+
+    print()
+    for pool, (matched, mismatched) in compared.items():
+        if matched or mismatched:
+            print(f"  {pool:>8}: {matched} matched, {mismatched} mismatched")
+    if unavailable:
+        print(f"  {unavailable} heights the legacy node could not answer (not yet synced)")
+
+    if mismatches:
+        print("\nMISMATCHES:")
+        for height, pool, legacy, ours in mismatches[:20]:
+            print(f"  height {height} {pool}: legacy {legacy} derived {ours}")
+        sys.exit(1)
+
+    total = sum(matched for matched, _ in compared.values())
+    if total == 0:
+        sys.exit("no roots could be compared; the legacy node may not have synced this range yet")
+
+    print(f"\nOK: {total} roots agree across both backends")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/differential-treestate-check.py
+++ b/scripts/differential-treestate-check.py
@@ -45,9 +45,6 @@ def derive_locally(args):
         "--to", str(args.to_height),
         "--step", str(args.step),
     ]
-    if args.frontier_artifact:
-        command += ["--frontier-artifact", args.frontier_artifact]
-
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
         sys.exit(f"local derivation failed:\n{result.stderr[-4000:]}")
@@ -84,7 +81,6 @@ def main():
     parser.add_argument("--from-height", type=int, required=True)
     parser.add_argument("--to-height", type=int, required=True)
     parser.add_argument("--step", type=int, default=50)
-    parser.add_argument("--frontier-artifact", help="frontier artifact to anchor derivation on")
     parser.add_argument("--zakurad", default="target/release/zakurad")
     args = parser.parse_args()
 

--- a/scripts/make/treestate-audit.mk
+++ b/scripts/make/treestate-audit.mk
@@ -29,9 +29,9 @@ TREESTATE_RANGE_ARGS = \
 	$(if $(TREESTATE_TO),--to "$(TREESTATE_TO)") \
 	--step "$(TREESTATE_STEP)"
 
-# Report the database's historical-treestate inventory without deriving any trees.
+# Report the database inventory and explicitly verify full-band block-body retention.
 treestate-audit-inventory:
-	$(TREESTATE_AUDIT) $(TREESTATE_EXTRA_ARGS)
+	$(TREESTATE_AUDIT) --scan-block-bodies $(TREESTATE_EXTRA_ARGS)
 
 # Replay the post-checkpoint band and compare the resulting subtree roots with stored rows.
 treestate-audit-subtrees:

--- a/scripts/make/treestate-audit.mk
+++ b/scripts/make/treestate-audit.mk
@@ -1,0 +1,59 @@
+# Historical treestate audit helpers.
+#
+# Override variables on the command line, for example:
+#   make treestate-audit-walk TREESTATE_CACHE_DIR=/path/to/cache TREESTATE_FROM=419200 TREESTATE_TO=435000
+
+.PHONY: \
+	treestate-audit-inventory \
+	treestate-audit-subtrees \
+	treestate-audit-walk \
+	treestate-audit-samples \
+	treestate-audit-roots \
+	treestate-audit-differential
+
+TREESTATE_ZAKURAD_BIN ?= $(CURDIR)/target/release/zakurad
+TREESTATE_CHECK_SCRIPT ?= $(CURDIR)/scripts/differential-treestate-check.py
+TREESTATE_CACHE_DIR ?= $(HOME)/.local/zakura-dev/cache
+TREESTATE_NETWORK ?= Mainnet
+TREESTATE_FROM ?=
+TREESTATE_TO ?=
+TREESTATE_STEP ?= 1
+TREESTATE_RPC_URL ?=
+TREESTATE_EXTRA_ARGS ?=
+
+TREESTATE_AUDIT = "$(TREESTATE_ZAKURAD_BIN)" audit-historical-treestates \
+	--cache-dir "$(TREESTATE_CACHE_DIR)" \
+	--network "$(TREESTATE_NETWORK)"
+TREESTATE_RANGE_ARGS = \
+	$(if $(TREESTATE_FROM),--from "$(TREESTATE_FROM)") \
+	$(if $(TREESTATE_TO),--to "$(TREESTATE_TO)") \
+	--step "$(TREESTATE_STEP)"
+
+treestate-audit-inventory:
+	$(TREESTATE_AUDIT) $(TREESTATE_EXTRA_ARGS)
+
+treestate-audit-subtrees:
+	$(TREESTATE_AUDIT) --verify-subtrees $(TREESTATE_EXTRA_ARGS)
+
+treestate-audit-walk:
+	$(TREESTATE_AUDIT) --walk $(TREESTATE_RANGE_ARGS) $(TREESTATE_EXTRA_ARGS)
+
+treestate-audit-samples:
+	$(TREESTATE_AUDIT) --walk --cold --print-samples $(TREESTATE_RANGE_ARGS) $(TREESTATE_EXTRA_ARGS)
+
+treestate-audit-roots:
+	$(TREESTATE_AUDIT) --walk --print-roots $(TREESTATE_RANGE_ARGS) $(TREESTATE_EXTRA_ARGS)
+
+treestate-audit-differential:
+	@if [ -n "$(TREESTATE_FROM)" ] && [ -n "$(TREESTATE_TO)" ] && [ -n "$(TREESTATE_RPC_URL)" ]; then :; else \
+		echo "usage: make treestate-audit-differential TREESTATE_FROM=<height> TREESTATE_TO=<height> TREESTATE_RPC_URL=<url> [TREESTATE_CACHE_DIR=<path>] [TREESTATE_STEP=<n>]" >&2; \
+		exit 2; \
+	fi
+	"$(TREESTATE_CHECK_SCRIPT)" \
+		--cache-dir "$(TREESTATE_CACHE_DIR)" \
+		--network "$(TREESTATE_NETWORK)" \
+		--rpc-url "$(TREESTATE_RPC_URL)" \
+		--from-height "$(TREESTATE_FROM)" \
+		--to-height "$(TREESTATE_TO)" \
+		--step "$(TREESTATE_STEP)" \
+		--zakurad "$(TREESTATE_ZAKURAD_BIN)"

--- a/scripts/make/treestate-audit.mk
+++ b/scripts/make/treestate-audit.mk
@@ -29,21 +29,27 @@ TREESTATE_RANGE_ARGS = \
 	$(if $(TREESTATE_TO),--to "$(TREESTATE_TO)") \
 	--step "$(TREESTATE_STEP)"
 
+# Report the database's historical-treestate inventory without deriving any trees.
 treestate-audit-inventory:
 	$(TREESTATE_AUDIT) $(TREESTATE_EXTRA_ARGS)
 
+# Replay the post-checkpoint band and compare the resulting subtree roots with stored rows.
 treestate-audit-subtrees:
 	$(TREESTATE_AUDIT) --verify-subtrees $(TREESTATE_EXTRA_ARGS)
 
+# Derive and authenticate historical treestates over a configurable height range.
 treestate-audit-walk:
 	$(TREESTATE_AUDIT) --walk $(TREESTATE_RANGE_ARGS) $(TREESTATE_EXTRA_ARGS)
 
+# Measure independent cold replays and emit one `SAMPLE` cost/input line per sampled height.
 treestate-audit-samples:
 	$(TREESTATE_AUDIT) --walk --cold --print-samples $(TREESTATE_RANGE_ARGS) $(TREESTATE_EXTRA_ARGS)
 
+# Derive treestates and emit one `ROOT` line per sampled height for external comparison.
 treestate-audit-roots:
 	$(TREESTATE_AUDIT) --walk --print-roots $(TREESTATE_RANGE_ARGS) $(TREESTATE_EXTRA_ARGS)
 
+# Compare locally derived roots with a legacy node's `z_gettreestate` response over JSON-RPC.
 treestate-audit-differential:
 	@if [ -n "$(TREESTATE_FROM)" ] && [ -n "$(TREESTATE_TO)" ] && [ -n "$(TREESTATE_RPC_URL)" ]; then :; else \
 		echo "usage: make treestate-audit-differential TREESTATE_FROM=<height> TREESTATE_TO=<height> TREESTATE_RPC_URL=<url> [TREESTATE_CACHE_DIR=<path>] [TREESTATE_STEP=<n>]" >&2; \


### PR DESCRIPTION
## Motivation

A fast-synced node cannot serve historical treestates because it never wrote the per-height trees. It can, however, rebuild them: it retains the block bodies, and it already stores authenticated per-height roots.

## Solution

Replay the retained block bodies forward from the nearest frontier the node already holds, and accept the result only if it reproduces the authenticated root in `commitment_roots_by_height`. A note commitment root is a binding commitment to its frontier, so a frontier that reproduces the authenticated root *is* the frontier — which is what makes a rebuilt tree trustworthy without trusting its source.

**No RPC behaviour changes in this PR.** The engine is exercised only through `audit-historical-treestates`, which reports whether a database has the inputs replay needs (gap-free root index, retained bodies) and can walk the range checking and timing every rebuilt tree. Landing the engine with zero behaviour change lets the risky part be reviewed on its own.

Read-only opens no longer demand column families the database lacks. Without that, this tooling cannot open an older database at all — a pre-existing limitation that only surfaces once you try to inspect one.

## Testing

Verified after the rebase and the version bump: `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` (clean), `cargo fmt --all`, `cargo test -p zakura-state --lib` (457 passed), `cargo test -p zakura-rpc --lib` (99 passed), `./scripts/changelog.py check`, `zakurad generate` diffed against the stored config fixture, and the differential property test `vct_fast_sync_handoff_marks_database_and_resumes` specifically.

The original evidence below stands unchanged — the rebase dropped a superseded commit and reconciled imports and export lists; it did not touch the replay engine.

Unit tests for the streaming gap scan and body scan, both covering interior holes rather than just range endpoints; property tests that derive every height in a synthetic absent band and compare each pool against a legacy node's own per-height trees.

**Measured on a Mainnet fast-synced archive snapshot** (band `[0, 3,358,006)`):

- Inputs present: root index gap-free across all 3,358,006 heights, every block body retained.
- **3,358,006 heights rebuilt and root-checked, zero mismatches**, across real Sapling and Orchard replay.
- ~1.9 ms/block mean, varying ~50x by height.

`scripts/differential-treestate-check.py` compares rebuilt trees against an independently legacy-synced node's `z_gettreestate`: **421 roots across both pools, zero mismatches**.

Ironwood is structurally unexercised — NU6_3 activates above the snapshot's handoff, so no Ironwood commitment exists in the band.


