### PR TITLE
fix(release): allow provenance in Docker manifest verification

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -848,7 +848,13 @@ jobs:
           docker buildx imagetools inspect "zakuracore/zakura:zcashd-compat-${image_version}" \
             --format '{{json .Manifest}}' \
             | jq -e '
-                [ .manifests[].platform | "\(.os)/\(.architecture)" ] as $platforms
+                # Buildx provenance attestations use unknown/unknown because they
+                # describe the build rather than a runnable image platform.
+                [
+                  .manifests[].platform
+                  | select(.os != "unknown" and .architecture != "unknown")
+                  | "\(.os)/\(.architecture)"
+                ] as $platforms
                 | $platforms == ["linux/amd64"]
               ' >/dev/null
 


### PR DESCRIPTION
## Motivation

The v1.1.0-rc2 zcashd compatibility manifest job published the Docker image successfully, then failed its platform assertion. Buildx attaches a provenance attestation to pushed images and represents it in the OCI index as an `unknown/unknown` manifest. The verifier treated every manifest as runnable and therefore rejected the valid index `linux/amd64, unknown/unknown`.

The attestation should remain enabled because it records build provenance and improves artifact traceability.

## Solution

Filter Buildx's non-runnable `unknown/unknown` attestation entries before comparing platforms. The assertion still requires the runnable platform list to equal exactly `linux/amd64`, so unexpected runnable architectures remain a failure while provenance metadata is accepted.

## Testing

- `actionlint .github/workflows/release-binaries.yml`
- Ran the updated `jq` assertion against the published `zakuracore/zakura:zcashd-compat-1.1.0-rc2` OCI index, which contains `linux/amd64` and the Buildx `unknown/unknown` provenance attestation.

## Changelog

Not required: this is an internal release-workflow correction and changes no Rust source or Cargo manifest.

### Specifications & References

- Failed release job: https://github.com/zakura-core/zakura/actions/runs/30977085620/job/92217511644