### PR TITLE
ci(release): make preparation caches read-only

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -148,18 +148,9 @@ jobs:
           toolchain: stable
           cache-key: prepare-release
           cache-on-failure: true
-          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      # Separate cache for baseline rustdoc JSON, mirroring semver-checks.yml:
-      # rust-cache's target-dir cleaner would delete target/semver-checks
-      # before saving. Distinct key because --baseline-rev baselines differ
-      # from crates.io ones.
-      - name: Restore baseline rustdoc cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
-        with:
-          path: target/semver-checks/cache
-          key: prepare-release-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ github.run_id }}
-          restore-keys: prepare-release-baselines-${{ steps.toolchain.outputs.cachekey }}-
+          # Release preparation consumes existing build caches without
+          # replacing caches warmed by regular CI.
+          cache-save-if: false
 
       # Deliberately unpinned (like semver-checks.yml): cargo-semver-checks
       # must track new stable rustdoc formats.
@@ -190,12 +181,6 @@ jobs:
           [ -z "$RELEASE_STATE_WAIVER" ] \
             || args+=(--release-state-waiver "$RELEASE_STATE_WAIVER")
           scripts/prepare-release.sh "${args[@]}"
-
-      - name: Save baseline rustdoc cache
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
-        with:
-          path: target/semver-checks/cache
-          key: prepare-release-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ github.run_id }}
 
       # cargo package (run by the packaging check) refuses a dirty tree, so
       # verification runs on a temporary local commit; it is soft-reset away


### PR DESCRIPTION
## Motivation

The release-preparation workflow is a manually dispatched consumer of build
caches, but it was configured to save the shared Rust cache after runs on
`main`. It also maintained a release-specific semver baseline cache whose save
path does not exist after `cargo semver-checks --baseline-rev` completes. In
[run 30964249950](https://github.com/zakura-core/zakura/actions/runs/30964249950/job/92174650233),
the baseline restore missed and the subsequent save was a no-op because the
path was absent.

Release preparation should not create cache entries, consume cache quota, or
contribute to eviction of caches warmed by regular CI.

## Solution

Make the workflow cache-read-only by:

- setting the shared Rust cache's `cache-save-if` input to `false`, while
  retaining cache restoration; and
- removing the ineffective release-specific semver cache restore and save
  steps.

The dedicated semver workflow remains responsible for warming reusable semver
baselines.

## Testing

- Parsed `.github/workflows/prepare-release-pr.yml` with Ruby's YAML parser.
- `git diff --check`
- Confirmed the workflow no longer references `actions/cache`,
  `prepare-release-baselines`, or any enabled cache-save condition.

## Changelog

No changelog fragment is required because this only changes internal release
CI and does not modify Rust sources or Cargo manifests.

### Specifications & References

- [Observed release-preparation run](https://github.com/zakura-core/zakura/actions/runs/30964249950/job/92174650233)

### Follow-up Work

If release preparation can consume the normal semver workflow's baseline
format without weakening comparison against the exact base tag, that reuse can
be added separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow cache behavior; no Rust sources, manifests, or release logic changes.
> 
> **Overview**
> The **Prepare release PR** workflow no longer writes GitHub Actions caches. The shared Rust toolchain step still restores caches but sets **`cache-save-if: false`**, so manual release prep only consumes caches warmed by regular CI instead of saving on `main` and competing for quota.
> 
> The workflow also **drops** the dedicated **`prepare-release-baselines`** restore/save pair for `target/semver-checks/cache`. That path was ineffective after `cargo semver-checks --baseline-rev` (restore could miss and save was a no-op). Semver baseline warming stays with the dedicated semver workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2276efa833259c385bc02f78c6ee14589f7c4feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->