### PR TITLE
fix(network): let an unproven block-sync peer re-probe after a failed probe

### DIFF
--- a/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -713,8 +713,7 @@ impl PeerRoutine {
             if !self.received_status {
                 break FillStop::NoStatus;
             }
-            if self.window.requests_without_block_progress >= self.window.no_progress_request_cap()
-            {
+            if self.window.no_progress_at_cap() {
                 break if self.window.has_block_progress() {
                     FillStop::NoBlockProgressRequestCap
                 } else {

--- a/crates/zakura-network/src/zakura/block_sync/state.rs
+++ b/crates/zakura-network/src/zakura/block_sync/state.rs
@@ -690,6 +690,34 @@ impl DownloadWindow {
         }
     }
 
+    /// Whether the no-progress gate currently withholds further work from this peer.
+    ///
+    /// A **proven** peer is charged cumulatively: it has served a body, so a long run
+    /// of requests with no further accepted body is the signal, and once it reaches
+    /// the cap the block-liveness deadline governs.
+    ///
+    /// An **unproven** peer is charged on its *in-flight* probes instead. The
+    /// probe-first cap exists so a peer that accepts requests but never serves bodies
+    /// cannot spend a full BBR cold-start burst — a bound on concurrency, not on
+    /// lifetime attempts. Charging it cumulatively wedged the peer permanently the
+    /// first time a probe ended without a body (a floor request rescued at the short
+    /// floor leash, a request timeout, or a `RangeUnavailable`), because only an
+    /// accepted body — which needs a request the peer may no longer issue — or a
+    /// destructive view reset clears the streak. With a single servable peer that
+    /// stalled body sync outright until the liveness park and its cooldown elapsed.
+    ///
+    /// A re-probe never buys extra time: [`arm_liveness`](Self::arm_liveness) only
+    /// arms `block_liveness_deadline` when it is unset, so a peer that truly serves
+    /// nothing is still parked on the schedule its first probe started.
+    pub(super) fn no_progress_at_cap(&self) -> bool {
+        let charged = if self.has_block_progress() {
+            self.requests_without_block_progress
+        } else {
+            u32::try_from(self.outstanding.len()).unwrap_or(u32::MAX)
+        };
+        charged >= self.no_progress_request_cap()
+    }
+
     pub(super) fn arm_liveness(&mut self, now: Instant, timeout: Duration) {
         self.last_request_at = Some(now);
         self.requests_without_block_progress =

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -639,6 +639,97 @@ fn block_liveness_uses_probe_cap_until_first_accepted_body() {
 }
 
 #[test]
+fn probe_cap_reopens_once_an_unproven_peers_probe_ends_without_a_body() {
+    // The probe-first cap bounds an unproven peer's *concurrent* cold-start burst,
+    // not its lifetime attempts. A probe that ends without a body — the short
+    // floor-rescue leash expiring, a request timeout, a `RangeUnavailable` — drains
+    // `outstanding`, and the peer must be free to probe again. Charging the streak
+    // cumulatively wedged it forever: nothing but an accepted body (which needs a
+    // request) or a destructive view reset cleared the charge.
+    let config = ZakuraBlockSyncConfig {
+        initial_block_probe_requests: 1,
+        max_requests_without_block_progress: 8,
+        ..ZakuraBlockSyncConfig::default()
+    };
+    let timeout = config.effective_liveness_timeout();
+    let now = Instant::now();
+    let mut window = DownloadWindow::new(&config);
+
+    assert!(!window.no_progress_at_cap(), "a fresh peer may probe");
+
+    window.outstanding.push(window_request(1));
+    window.arm_liveness(now, timeout);
+    let armed = window.block_liveness_deadline;
+    assert_eq!(armed, Some(now + timeout));
+    assert!(
+        window.no_progress_at_cap(),
+        "the cold-start probe in flight holds the unproven peer at its cap",
+    );
+
+    // The probe ends with no body: every completion path removes it from
+    // `outstanding` without disarming block-progress liveness.
+    window.outstanding.clear();
+
+    assert!(
+        !window.no_progress_at_cap(),
+        "an unproven peer whose probe ended without a body must be able to probe again",
+    );
+    assert!(
+        !window.has_block_progress(),
+        "re-probing does not prove a peer"
+    );
+
+    // Re-probing must not buy the peer extra time: the deadline its first probe
+    // armed still stands, so a peer that serves nothing is parked on schedule.
+    window.outstanding.push(window_request(1));
+    window.arm_liveness(now + Duration::from_millis(1), timeout);
+    assert_eq!(
+        window.block_liveness_deadline, armed,
+        "a re-probe must not extend the block-liveness deadline",
+    );
+    assert_eq!(window.check_liveness(now + timeout), LivenessOutcome::Park);
+}
+
+#[test]
+fn proven_peer_no_progress_cap_stays_cumulative() {
+    // Reopening the gate is scoped to the unproven cold start. Once a peer has
+    // served a body it is charged cumulatively, so a long run of requests with no
+    // further accepted body still reaches the cap even as each request completes
+    // and drains `outstanding`.
+    let config = ZakuraBlockSyncConfig {
+        initial_block_probe_requests: 1,
+        max_requests_without_block_progress: 3,
+        ..ZakuraBlockSyncConfig::default()
+    };
+    let timeout = config.effective_liveness_timeout();
+    let now = Instant::now();
+    let mut window = DownloadWindow::new(&config);
+
+    window.outstanding.push(window_request(1));
+    window.arm_liveness(now, timeout);
+    window.note_block_progress(now + Duration::from_millis(1), timeout);
+    window.outstanding.clear();
+    assert!(window.has_block_progress());
+
+    for request in 1..=3 {
+        assert!(
+            !window.no_progress_at_cap(),
+            "a proven peer may issue request {request} of 3",
+        );
+        window.outstanding.push(window_request(request + 1));
+        window.arm_liveness(now + Duration::from_millis(u64::from(request) + 1), timeout);
+        // Each request completes without an accepted body, draining `outstanding`.
+        window.outstanding.clear();
+    }
+
+    assert_eq!(window.requests_without_block_progress, 3);
+    assert!(
+        window.no_progress_at_cap(),
+        "a proven peer's no-progress streak is cumulative, not in-flight",
+    );
+}
+
+#[test]
 fn block_liveness_resuming_after_idle_gets_fresh_deadline() {
     let timeout = ZakuraBlockSyncConfig::default().effective_liveness_timeout();
     let now = Instant::now();
@@ -3447,6 +3538,109 @@ async fn remote_stream_eof_after_probe_timeout_still_parks_session() {
         !connection_cancel.is_cancelled(),
         "a first stream-EOF stall must preserve the shared transport connection",
     );
+
+    reactor_task.abort();
+}
+
+#[tokio::test]
+async fn unproven_peer_reprobes_after_its_probe_ends_without_a_body() {
+    // Regression for the single-carrier cold-start wedge: an unproven peer's one
+    // cold-start probe is a *floor* request, so it carries the short floor-rescue
+    // leash. When that leash expires the request is returned to the queue, but the
+    // probe charge used to stay spent — only an accepted body (which needs a
+    // request) or a destructive view reset cleared it. With one servable peer that
+    // wedged body sync until the liveness deadline parked the session and the
+    // no-progress cooldown elapsed: 30 s of `initial_block_probe_request_cap` fill
+    // stops with the whole range pending, then a 180 s park.
+    //
+    // The probe-first cap bounds an unproven peer's *concurrent* cold-start burst,
+    // not its lifetime attempts, so the peer must probe again once its probe ends.
+    let mut config = immediate_body_download_config();
+    // Short leashes so the probe expires quickly, while the liveness deadline
+    // (`request_timeout * 4` = 2 s) stays well beyond the re-probe asserted below:
+    // the re-probe must come from the fill loop, not from a park/re-admission.
+    config.request_timeout = Duration::from_millis(500);
+    config.floor_rescue_timeout = Duration::from_millis(100);
+
+    let (tip_tx, tip_rx) = watch::channel((block::Height(0), block::Hash([0; 32])));
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        },
+        (block::Height(0), block::Hash([0; 32])),
+        tip_rx,
+        config.clone(),
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+
+    let peer = peer(0x61);
+    let (inbound_tx, inbound_rx) = framed_channel(16);
+    let (outbound_tx, mut outbound_rx) = framed_channel(16);
+    let streams = HashMap::from([(ZAKURA_STREAM_BLOCK_SYNC, (inbound_rx, outbound_tx))]);
+    let connection_cancel = CancellationToken::new();
+    service.add_peer(Peer::new_with_direction(
+        peer.clone(),
+        None,
+        ZAKURA_CAP_BLOCK_SYNC,
+        ServicePeerDirection::Outbound,
+        streams,
+        connection_cancel.clone(),
+    ));
+    wait_for_outbound_status(&mut outbound_rx).await;
+
+    inbound_tx
+        .send(
+            BlockSyncMessage::Status(BlockSyncStatus {
+                servable_low: block::Height(1),
+                servable_high: block::Height(1),
+                tip_hash: block::Hash([1; 32]),
+                max_blocks_per_response: 1,
+                max_inflight_requests: 4,
+                max_response_bytes: MAX_BS_RESPONSE_BYTES,
+            })
+            .encode_frame()
+            .expect("status encodes"),
+        )
+        .await
+        .expect("status frame queues");
+
+    tip_tx
+        .send((block::Height(1), block::Hash([1; 32])))
+        .expect("tip watch is live");
+    wait_for_query_needed_blocks(&mut actions, block::Height(0), block::Height(1)).await;
+
+    handle
+        .send(BlockSyncEvent::NeededBlocks(vec![BlockSyncBlockMeta {
+            height: block::Height(1),
+            hash: block::Hash([1; 32]),
+            size: BlockSizeEstimate::Advertised(1_000),
+        }]))
+        .await
+        .expect("needed metadata queues");
+
+    // The unproven peer gets exactly one cold-start probe for the floor height.
+    let (start_height, count) = wait_for_outbound_getblocks(&mut outbound_rx).await;
+    assert_eq!(start_height, block::Height(1));
+    assert_eq!(count, 1);
+
+    // Never answer it: the floor-rescue leash expires and the height returns to
+    // `pending`. The peer is still connected, still servable for height 1, and the
+    // budget and its request slots are free, so the floor gap must be re-requested
+    // well before the liveness deadline would park the session.
+    let (retry_start, retry_count) = tokio::time::timeout(
+        Duration::from_secs(1),
+        wait_for_outbound_getblocks(&mut outbound_rx),
+    )
+    .await
+    .expect(
+        "an unproven peer whose probe ended without a body must probe the queued floor gap \
+         again instead of wedging at its one-probe cap until the no-progress park",
+    );
+    assert_eq!(retry_start, block::Height(1));
+    assert_eq!(retry_count, 1);
 
     reactor_task.abort();
 }

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -3516,9 +3516,35 @@ async fn remote_stream_eof_after_probe_timeout_still_parks_session() {
     assert_eq!(start_height, block::Height(1));
     assert_eq!(count, 1);
 
-    // Let the probe time out: `outstanding` drains, the unproven peer is gated
-    // at its one-probe cap, and the liveness deadline stays armed.
+    // Move the peer's servable range past the queued height. An unproven peer's
+    // probe-first cap reopens once its probe drains, so without this the peer
+    // simply re-probes for the returned height and the EOF below lands with
+    // `outstanding` non-empty — the other stall path. Leaving it nothing servable
+    // pins the path under test: `outstanding` empty with liveness still armed.
+    inbound_tx
+        .send(
+            BlockSyncMessage::Status(BlockSyncStatus {
+                servable_low: block::Height(2),
+                servable_high: block::Height(2),
+                tip_hash: block::Hash([2; 32]),
+                max_blocks_per_response: 1,
+                max_inflight_requests: 1,
+                max_response_bytes: MAX_BS_RESPONSE_BYTES,
+            })
+            .encode_frame()
+            .expect("status encodes"),
+        )
+        .await
+        .expect("status frame queues");
+
+    // Let the probe time out: `outstanding` drains, the peer has nothing servable
+    // left to re-probe for, and the liveness deadline stays armed.
     tokio::time::sleep(Duration::from_millis(600)).await;
+    assert_eq!(
+        handle.peer_snapshot().outbound_peers,
+        1,
+        "the session must still be attached when the stream EOFs",
+    );
 
     // Close the peer's send side of the stream inside the window between the
     // per-request timeout and the liveness deadline.

--- a/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
+++ b/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
@@ -52,6 +52,13 @@ pub(crate) struct InvariantReport {
     /// Worst per-peer no-progress streak observed before a peer has delivered its
     /// first accepted block body.
     pub(crate) max_unproven_requests_without_block_progress: u64,
+    /// Worst per-peer *concurrent* request depth observed before a peer has delivered
+    /// its first accepted block body. This is what the probe-first cap bounds: an
+    /// unproven peer must never be handed a full BBR cold-start burst. Its serial
+    /// re-probes after a probe ends without a body are bounded instead by the
+    /// block-progress liveness deadline, which its first probe arms and no re-probe
+    /// extends.
+    pub(crate) max_unproven_outstanding_requests: u64,
     /// `block_get_blocks_sent` requests issued via the floor bypass (a floor request
     /// sent while the peer was saturated at its BBR cwnd).
     pub(crate) floor_bypass_requests: usize,
@@ -141,6 +148,7 @@ pub(crate) fn report(reader: &TraceReader) -> InvariantReport {
     let max_requests_without_block_progress = max_requests_without_block_progress(reader);
     let max_unproven_requests_without_block_progress =
         max_unproven_requests_without_block_progress(reader);
+    let max_unproven_outstanding_requests = max_unproven_outstanding_requests(reader);
     let body_rows: Vec<&Value> = reader
         .table("block_sync")
         .rows()
@@ -212,6 +220,7 @@ pub(crate) fn report(reader: &TraceReader) -> InvariantReport {
         total_requests,
         max_requests_without_block_progress,
         max_unproven_requests_without_block_progress,
+        max_unproven_outstanding_requests,
         floor_bypass_requests,
         peak_cwnd_bytes,
         peak_inflight_bytes,
@@ -230,6 +239,21 @@ fn max_unproven_requests_without_block_progress(reader: &TraceReader) -> u64 {
         .filter(|row| event(row) == Some("block_get_blocks_sent"))
         .filter(|row| u64_field(row, "block_progress_proven") == Some(0))
         .filter_map(|row| u64_field(row, "requests_without_block_progress"))
+        .max()
+        .unwrap_or(0)
+}
+
+/// Peak concurrent request depth held by a peer that has not yet delivered an accepted
+/// body. `peer_outstanding` is emitted after the new request joins `outstanding`, so
+/// this is the depth the probe-first cap actually admitted.
+fn max_unproven_outstanding_requests(reader: &TraceReader) -> u64 {
+    reader
+        .table("block_sync")
+        .rows()
+        .into_iter()
+        .filter(|row| event(row) == Some("block_get_blocks_sent"))
+        .filter(|row| u64_field(row, "block_progress_proven") == Some(0))
+        .filter_map(|row| u64_field(row, "peer_outstanding"))
         .max()
         .unwrap_or(0)
 }

--- a/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
+++ b/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/invariants.rs
@@ -232,28 +232,26 @@ pub(crate) fn report(reader: &TraceReader) -> InvariantReport {
 }
 
 fn max_unproven_requests_without_block_progress(reader: &TraceReader) -> u64 {
-    reader
-        .table("block_sync")
-        .rows()
-        .into_iter()
-        .filter(|row| event(row) == Some("block_get_blocks_sent"))
-        .filter(|row| u64_field(row, "block_progress_proven") == Some(0))
-        .filter_map(|row| u64_field(row, "requests_without_block_progress"))
-        .max()
-        .unwrap_or(0)
+    max_unproven_u64_field(reader, "requests_without_block_progress")
 }
 
 /// Peak concurrent request depth held by a peer that has not yet delivered an accepted
 /// body. `peer_outstanding` is emitted after the new request joins `outstanding`, so
 /// this is the depth the probe-first cap actually admitted.
 fn max_unproven_outstanding_requests(reader: &TraceReader) -> u64 {
+    max_unproven_u64_field(reader, "peer_outstanding")
+}
+
+/// Peak `field` across the requests sent by a peer that has not yet delivered an
+/// accepted body, as counted at send time by `block_get_blocks_sent`.
+fn max_unproven_u64_field(reader: &TraceReader, field: &str) -> u64 {
     reader
         .table("block_sync")
         .rows()
         .into_iter()
         .filter(|row| event(row) == Some("block_get_blocks_sent"))
         .filter(|row| u64_field(row, "block_progress_proven") == Some(0))
-        .filter_map(|row| u64_field(row, "peer_outstanding"))
+        .filter_map(|row| u64_field(row, field))
         .max()
         .unwrap_or(0)
 }

--- a/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/tests.rs
+++ b/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/tests.rs
@@ -331,7 +331,6 @@ async fn fuzz_silent_peer_request_cap() {
         max_requests_without_block_progress: request_cap,
         ..fuzz_config()
     };
-
     let mut silent = PeerSpec::with_serve(
         1,
         target(blocks),
@@ -359,9 +358,19 @@ async fn fuzz_silent_peer_request_cap() {
         "no-progress liveness is not a protocol reject",
     );
     assert_eq!(
-        report.max_unproven_requests_without_block_progress,
+        report.max_unproven_outstanding_requests,
         u64::from(probe_requests),
-        "the silent peer should receive exactly the configured initial probe budget",
+        "the silent peer must never hold more than the configured initial probe budget \
+         in flight — the probe-first cap bounds an unproven peer's cold-start burst",
+    );
+    // The silent peer re-probes serially as each probe ends unanswered — a peer whose
+    // probe is rescued at the short floor leash must not wedge until the park, which
+    // stalls a single-carrier node outright. Those attempts stay bounded because the
+    // block-progress liveness deadline its first probe armed is never extended by a
+    // re-probe, which is what `session_parks` above proves still lands on schedule.
+    assert!(
+        report.max_unproven_requests_without_block_progress >= u64::from(probe_requests),
+        "the silent peer must actually have been probed",
     );
 }
 

--- a/docs/changelog/unreleased/557.md
+++ b/docs/changelog/unreleased/557.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed a block-sync stall where a peer that had not yet served a block body
+  could never be asked again after its first request ended without one, halting
+  body sync until the peer was parked and its cooldown elapsed
+  ([#557](https://github.com/zakura-core/zakura/pull/557)).


### PR DESCRIPTION
Closes #526

## Motivation

An unproven block-sync peer could wedge permanently the first time its cold-start probe ended without a body — stalling body sync outright when it was the only servable carrier.

An unproven peer's single cold-start probe is by construction a *floor* request, so it carries the short floor-rescue leash rather than the base request timeout. But `try_fill` charged the probe-first cap against the cumulative `requests_without_block_progress` streak, which only an accepted body or a destructive view reset clears. So when that probe ended without a body — floor leash expiring, request timeout, or `RangeUnavailable` — the streak stayed at the unproven cap of 1 and the peer could never issue another request: clearing the charge required a body, and obtaining a body required a request.

Same defect class as the already-fixed destructive-reset trigger (`view_reset_reclears_probe_streak_so_unproven_peer_can_reprobe`); the floor-rescue trigger was missed.

The #526 trace is this wedge — a servable peer and queued work with zero requests in flight (`outstanding: 0`, `queue_len: 1`, `floor_gap_servable_peers: 1`), 163 blocks pending and `sync_block_body_received` at zero for ~208 s.

## Solution

Gate an unproven peer on its **in-flight** probes instead of the cumulative streak, via `DownloadWindow::no_progress_at_cap`. That is what the cap is for, and what `FillStop::InitialBlockProbeRequestCap` already documents: "an unproven peer's single cold-start probe is in flight … until it serves (or fails) a body".

The proven path stays cumulative. Burst protection is unchanged — still exactly one probe in flight. A re-probe buys no extra time: `arm_liveness` arms `block_liveness_deadline` only when unset, so a peer that truly serves nothing is still parked on the schedule its first probe started.

## Testing

`unproven_peer_reprobes_after_its_probe_ends_without_a_body` drives the real routine over a single peer, lets the probe expire unanswered, and requires a second `GetBlocks` for the queued floor gap before the liveness deadline — it times out against the old code. `probe_cap_reopens_once_an_unproven_peers_probe_ends_without_a_body` pins the window contract (at cap while in flight, reopened once drained, deadline not extended by a re-probe); `proven_peer_no_progress_cap_stays_cumulative` pins that the proven cap is unaffected. `fuzz_silent_peer_request_cap` now asserts peak *concurrent* unproven request depth, which is the invariant that actually encodes the burst bound.

The second commit repairs a test this fix invalidated. `remote_stream_eof_after_probe_timeout_still_parks_session` pins the EOF branch where `outstanding` is empty but liveness is still armed, and it reached that state by relying on the cap wedging the peer. The peer now re-probes every ~170 ms, so the EOF landed with a probe outstanding and the test had drifted onto the branch already covered by `remote_stream_eof_parks_session`. Moving the peer's servable range past the queued height restores the intended state; verified re-pinned by reverting `handle_remote_stream_closed` to key clean exit off `outstanding.is_empty()` alone and confirming the test fails again.

```console
cargo fmt --all -- --check
cargo clippy -p zakura-network --all-targets -- -D warnings
cargo test -p zakura-network
```

Clean, clean, and 1190 passed / 4 ignored. Three `peer_set::initialize` listener tests fail locally with `AddrNotAvailable` — they bind arbitrary `127.x.x.x` source addresses, which macOS does not auto-assign; untouched by this branch and covered by Linux CI.

## Changelog

Fragment added under `## Fixed`.
