### PR TITLE
feat(header-chain): add the fork-aware graph model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8357,7 +8357,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "4.0.0-rc2"
+version = "4.0.0"
 dependencies = [
  "bech32",
  "bitflags",
@@ -8476,6 +8476,16 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+]
+
+[[package]]
+name = "zakura-header-chain"
+version = "1.0.0-rc0"
+dependencies = [
+ "chrono",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "zakura-chain",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
         "crates/zakurad",
         "crates/zakura-chain",
+        "crates/zakura-header-chain",
         "crates/zakura-network",
         "crates/zakura-state",
         "crates/zakura-script",

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "4.0.0-rc2"
+version = "4.0.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/src/block.rs
+++ b/crates/zakura-chain/src/block.rs
@@ -44,6 +44,14 @@ pub use header::{BlockTimeError, CountedHeader, Header, ZCASH_BLOCK_VERSION};
 pub use height::{Height, HeightDiff, TryIntoHeight};
 pub use serialize::{SerializedBlock, MAX_BLOCK_BYTES};
 
+/// Re-assert the signed Zcash block-header version rule on an in-memory header.
+///
+/// Canonical deserialization already applies this check. Observable header
+/// validators call it again so locally constructed headers use the same rule.
+pub fn validate_header_version(version: u32) -> Result<(), &'static str> {
+    serialize::validate_header_version(version)
+}
+
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use arbitrary::LedgerState;
 

--- a/crates/zakura-chain/src/block/header.rs
+++ b/crates/zakura-chain/src/block/header.rs
@@ -101,8 +101,7 @@ pub enum BlockTimeError {
 }
 
 impl Header {
-    /// TODO: Inline this function into zakura_consensus::block::check::time_is_valid_at.
-    /// See <https://github.com/ZcashFoundation/zebra/issues/1021> for more details.
+    /// Shared observable-header validation delegates to this canonical time calculation.
     #[allow(clippy::unwrap_in_result)]
     pub fn time_is_valid_at(
         &self,

--- a/crates/zakura-chain/src/block/serialize.rs
+++ b/crates/zakura-chain/src/block/serialize.rs
@@ -33,7 +33,7 @@ pub const MAX_BLOCK_BYTES: u64 = 2_000_000;
 ///
 /// All other blocks are deserialized when we receive them, and never modified,
 /// so the deserialisation would pick up any errors.
-fn check_version(version: u32) -> Result<(), &'static str> {
+pub(crate) fn validate_header_version(version: u32) -> Result<(), &'static str> {
     match version {
         // The Zcash specification says that:
         // "The current and only defined block version number for Zcash is 4."
@@ -64,7 +64,7 @@ fn check_version(version: u32) -> Result<(), &'static str> {
 impl ZcashSerialize for Header {
     #[allow(clippy::unwrap_in_result)]
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
-        check_version(self.version).map_err(io::Error::other)?;
+        validate_header_version(self.version).map_err(io::Error::other)?;
 
         writer.write_u32::<LittleEndian>(self.version)?;
         self.previous_block_hash.zcash_serialize(&mut writer)?;
@@ -86,7 +86,7 @@ impl ZcashSerialize for Header {
 impl ZcashDeserialize for Header {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         let version = reader.read_u32::<LittleEndian>()?;
-        check_version(version).map_err(SerializationError::Parse)?;
+        validate_header_version(version).map_err(SerializationError::Parse)?;
 
         Ok(Header {
             version,

--- a/crates/zakura-chain/src/parameters.rs
+++ b/crates/zakura-chain/src/parameters.rs
@@ -27,5 +27,7 @@ pub use network::{magic::Magic, subsidy, testnet, Network, NetworkKind};
 pub use network_upgrade::*;
 pub use transaction::*;
 
+pub use constants::MAX_NON_FINALIZED_CHAIN_FORKS;
+
 #[cfg(test)]
 mod tests;

--- a/crates/zakura-chain/src/parameters/constants.rs
+++ b/crates/zakura-chain/src/parameters/constants.rs
@@ -29,6 +29,17 @@ pub const SLOW_START_SHIFT: Height = Height(SLOW_START_INTERVAL.0 / 2);
 // TODO: change to HeightDiff
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = 1000;
 
+/// The maximum number of non-finalized chain forks Zakura will track.
+/// When this limit is reached, we drop the chain with the lowest work.
+///
+/// When the network is under heavy transaction load, there are around 5 active forks in the last
+/// 100 blocks. (1 fork per 20 blocks.) When block propagation is efficient, there is around
+/// 1 fork per 300 blocks.
+///
+/// This limits non-finalized chain memory, in the worst case, to around:
+/// `10 forks * 1000 blocks * 2 MB per block = 20 GB`
+pub const MAX_NON_FINALIZED_CHAIN_FORKS: usize = 10;
+
 /// Magic numbers used to identify different Zcash networks.
 pub mod magics {
     use crate::parameters::network::magic::Magic;

--- a/crates/zakura-chain/src/parameters/network.rs
+++ b/crates/zakura-chain/src/parameters/network.rs
@@ -232,17 +232,15 @@ impl Network {
 
     /// Returns true if the maximum block time rule is active for `network` and `height`.
     ///
-    /// Always returns true if `network` is the Mainnet.
-    /// If `network` is the Testnet, the `height` should be at least
-    /// TESTNET_MAX_TIME_START_HEIGHT to return true.
-    /// Returns false otherwise.
+    /// Mainnet returns true; its height-1 exception is applied by validation.
+    /// Public Testnet activates at its historical consensus height. Configured
+    /// networks and Regtest use their authenticated local parameter.
     ///
     /// Part of the consensus rules at <https://zips.z.cash/protocol/protocol.pdf#blockheader>
     pub fn is_max_block_time_enforced(&self, height: block::Height) -> bool {
         match self {
             Network::Mainnet => true,
-            // TODO: Move `TESTNET_MAX_TIME_START_HEIGHT` to a field on testnet::Parameters (#8364)
-            Network::Testnet(_params) => height >= super::TESTNET_MAX_TIME_START_HEIGHT,
+            Network::Testnet(params) => height >= params.max_block_time_start_height(),
         }
     }
 

--- a/crates/zakura-chain/src/parameters/network/testnet.rs
+++ b/crates/zakura-chain/src/parameters/network/testnet.rs
@@ -9,7 +9,7 @@ use crate::{
         checkpoint::list::{CheckpointList, TESTNET_CHECKPOINT_LIST},
         constants::{magics, SLOW_START_INTERVAL, SLOW_START_SHIFT},
         network::error::ParametersBuilderError,
-        network_upgrade::TESTNET_ACTIVATION_HEIGHTS,
+        network_upgrade::{TESTNET_ACTIVATION_HEIGHTS, TESTNET_MAX_TIME_START_HEIGHT},
         subsidy::{
             constants::mainnet,
             constants::testnet,
@@ -475,6 +475,8 @@ pub struct ParametersBuilder {
     target_difficulty_limit: ExpandedDifficulty,
     /// A flag for disabling proof-of-work checks when Zebra is validating blocks
     disable_pow: bool,
+    /// Optional local activation height for the MTP-plus-90-minutes rule.
+    max_block_time_start_height: Option<Height>,
     /// Whether to allow transactions with transparent outputs to spend coinbase outputs,
     /// similar to `fCoinbaseMustBeShielded` in zcashd.
     should_allow_unshielded_coinbase_spends: bool,
@@ -514,6 +516,7 @@ impl Default for ParametersBuilder {
                 .to_expanded()
                 .expect("difficulty limits are valid expanded values"),
             disable_pow: false,
+            max_block_time_start_height: None,
             funding_streams: testnet::FUNDING_STREAMS.clone(),
             should_lock_funding_stream_address_period: false,
             pre_blossom_halving_interval: PRE_BLOSSOM_HALVING_INTERVAL,
@@ -751,6 +754,12 @@ impl ParametersBuilder {
         self
     }
 
+    /// Sets the local activation height for the MTP-plus-90-minutes rule.
+    pub fn with_max_block_time_start_height(mut self, height: Height) -> Self {
+        self.max_block_time_start_height = Some(height);
+        self
+    }
+
     /// Sets the `disable_pow` flag to be used in the [`Parameters`] being built.
     pub fn with_unshielded_coinbase_spends(
         mut self,
@@ -843,6 +852,7 @@ impl ParametersBuilder {
 
     /// Converts the builder to a [`Parameters`] struct
     fn finish(self) -> Parameters {
+        let max_block_time_start_height = self.max_block_time_start_height.unwrap_or(Height(2));
         let Self {
             network_name,
             network_magic,
@@ -853,6 +863,7 @@ impl ParametersBuilder {
             should_lock_funding_stream_address_period: _,
             target_difficulty_limit,
             disable_pow,
+            max_block_time_start_height: _,
             should_allow_unshielded_coinbase_spends,
             pre_blossom_halving_interval,
             post_blossom_halving_interval,
@@ -870,6 +881,7 @@ impl ParametersBuilder {
             funding_streams,
             target_difficulty_limit,
             disable_pow,
+            max_block_time_start_height,
             should_allow_unshielded_coinbase_spends,
             pre_blossom_halving_interval,
             post_blossom_halving_interval,
@@ -907,6 +919,13 @@ impl ParametersBuilder {
 
     /// Returns true if these [`Parameters`] should be compatible with the default Testnet parameters.
     pub fn is_compatible_with_default_parameters(&self) -> bool {
+        let max_block_time_start_height = self.max_block_time_start_height.unwrap_or_else(|| {
+            if self == &Self::default() {
+                TESTNET_MAX_TIME_START_HEIGHT
+            } else {
+                Height(2)
+            }
+        });
         let Self {
             network_name: _,
             network_magic,
@@ -917,6 +936,7 @@ impl ParametersBuilder {
             should_lock_funding_stream_address_period: _,
             target_difficulty_limit,
             disable_pow,
+            max_block_time_start_height: _,
             should_allow_unshielded_coinbase_spends,
             pre_blossom_halving_interval,
             post_blossom_halving_interval,
@@ -932,6 +952,7 @@ impl ParametersBuilder {
             && self.funding_streams == funding_streams
             && self.target_difficulty_limit == target_difficulty_limit
             && self.disable_pow == disable_pow
+            && max_block_time_start_height == TESTNET_MAX_TIME_START_HEIGHT
             && self.should_allow_unshielded_coinbase_spends
                 == should_allow_unshielded_coinbase_spends
             && self.pre_blossom_halving_interval == pre_blossom_halving_interval
@@ -951,6 +972,8 @@ pub struct RegtestParameters {
     pub lockbox_disbursements: Option<Vec<ConfiguredLockboxDisbursement>>,
     /// Configured checkpointed block heights and hashes.
     pub checkpoints: Option<ConfiguredCheckpoints>,
+    /// Local activation height for the MTP-plus-90-minutes rule.
+    pub max_block_time_start_height: Option<Height>,
     /// Whether funding stream addresses should be repeated to fill all required funding stream periods.
     pub extend_funding_stream_addresses_as_required: Option<bool>,
 }
@@ -985,6 +1008,8 @@ pub struct Parameters {
     target_difficulty_limit: ExpandedDifficulty,
     /// A flag for disabling proof-of-work checks when Zebra is validating blocks
     disable_pow: bool,
+    /// Activation height for the MTP-plus-90-minutes rule.
+    max_block_time_start_height: Height,
     /// Whether to allow transactions with transparent outputs to spend coinbase outputs,
     /// similar to `fCoinbaseMustBeShielded` in zcashd.
     should_allow_unshielded_coinbase_spends: bool,
@@ -1005,6 +1030,7 @@ impl Default for Parameters {
     fn default() -> Self {
         Self {
             network_name: "Testnet".to_string(),
+            max_block_time_start_height: TESTNET_MAX_TIME_START_HEIGHT,
             ..Self::build().finish()
         }
     }
@@ -1026,6 +1052,7 @@ impl Parameters {
             lockbox_disbursements,
             checkpoints,
             extend_funding_stream_addresses_as_required,
+            max_block_time_start_height,
         }: RegtestParameters,
     ) -> Result<Self, ParametersBuilderError> {
         let mut parameters = Self::build()
@@ -1045,6 +1072,10 @@ impl Parameters {
             .with_funding_streams(funding_streams.unwrap_or_default())
             .with_lockbox_disbursements(lockbox_disbursements.unwrap_or_default())
             .with_checkpoints(checkpoints.unwrap_or_default())?;
+
+        if let Some(height) = max_block_time_start_height {
+            parameters = parameters.with_max_block_time_start_height(height);
+        }
 
         if Some(true) == extend_funding_stream_addresses_as_required {
             parameters = parameters.extend_funding_streams();
@@ -1080,6 +1111,7 @@ impl Parameters {
             funding_streams: _,
             target_difficulty_limit,
             disable_pow,
+            max_block_time_start_height,
             should_allow_unshielded_coinbase_spends,
             pre_blossom_halving_interval,
             post_blossom_halving_interval,
@@ -1094,6 +1126,7 @@ impl Parameters {
             && self.slow_start_shift == slow_start_shift
             && self.target_difficulty_limit == target_difficulty_limit
             && self.disable_pow == disable_pow
+            && self.max_block_time_start_height == max_block_time_start_height
             && self.should_allow_unshielded_coinbase_spends
                 == should_allow_unshielded_coinbase_spends
             && self.pre_blossom_halving_interval == pre_blossom_halving_interval
@@ -1143,6 +1176,11 @@ impl Parameters {
     /// Returns true if proof-of-work validation should be disabled for this network
     pub fn disable_pow(&self) -> bool {
         self.disable_pow
+    }
+
+    /// Returns the local activation height for the MTP-plus-90-minutes rule.
+    pub fn max_block_time_start_height(&self) -> Height {
+        self.max_block_time_start_height
     }
 
     /// Returns true if this network should allow transactions with transparent outputs

--- a/crates/zakura-chain/src/primitives/zcash_history.rs
+++ b/crates/zakura-chain/src/primitives/zcash_history.rs
@@ -403,8 +403,7 @@ impl Version for zcash_history::V1 {
             .difficulty_threshold
             .to_work()
             .expect("work must be valid during contextual verification");
-        // There is no direct `std::primitive::u128` to `bigint::U256` conversion
-        let work = primitive_types::U256::from_big_endian(&work.as_u128().to_be_bytes());
+        let work = primitive_types::U256::from_big_endian(&work.as_u256().to_big_endian());
 
         match network_upgrade {
             NetworkUpgrade::Genesis

--- a/crates/zakura-chain/src/work/difficulty.rs
+++ b/crates/zakura-chain/src/work/difficulty.rs
@@ -103,7 +103,7 @@ pub const INVALID_COMPACT_DIFFICULTY: CompactDifficulty = CompactDifficulty(u32:
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ExpandedDifficulty(U256);
 
-/// A 128-bit unsigned "Work" value.
+/// A 256-bit unsigned "Work" value.
 ///
 /// Used to calculate the total work for each chain of blocks.
 ///
@@ -113,11 +113,8 @@ pub struct ExpandedDifficulty(U256);
 /// choose the best chain. But its precise value and bit pattern are not
 /// consensus-critical.
 ///
-/// We calculate work values according to the Zcash specification, but store
-/// them as u128, rather than the implied u256. We don't expect the total chain
-/// work to ever exceed 2^128. The current total chain work for Zcash is 2^58,
-/// and Bitcoin adds around 2^91 work per year. (Each extra bit represents twice
-/// as much work.)
+/// Work is kept at its exact 256-bit width so valid hard targets are not
+/// rejected or narrowed before cumulative-work comparisons.
 ///
 /// > a node chooses the “best” block chain visible to it by finding the chain of valid blocks
 /// > with the greatest total work. The work of a block with value nBits for the nBits field in
@@ -127,16 +124,16 @@ pub struct ExpandedDifficulty(U256);
 ///
 /// [section 7.7.5]: https://zips.z.cash/protocol/protocol.pdf#workdef
 #[derive(Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Work(u128);
+pub struct Work(U256);
 
 impl Work {
     /// Returns a value representing no work.
     pub fn zero() -> Self {
-        Self(0)
+        Self(U256::zero())
     }
 
-    /// Return the inner `u128` value.
-    pub fn as_u128(self) -> u128 {
+    /// Returns the exact inner 256-bit value.
+    pub fn as_u256(self) -> U256 {
         self.0
     }
 }
@@ -151,12 +148,22 @@ impl fmt::Debug for Work {
             // Use decimal, to compare with zcashd
             .field(&format_args!("{}", self.0))
             // Use log2, to compare with zcashd
-            .field(&format_args!("{:.5}", (self.0 as f64).log2()))
+            .field(&format_args!("{:.5}", u256_to_f64(self.0).log2()))
             .finish()
     }
 }
 
 impl CompactDifficulty {
+    /// Return the exact four-byte little-endian consensus representation.
+    pub const fn to_le_bytes(self) -> [u8; 4] {
+        self.0.to_le_bytes()
+    }
+
+    /// Construct from the exact four-byte little-endian consensus representation.
+    pub const fn from_le_bytes(bytes: [u8; 4]) -> Self {
+        Self(u32::from_le_bytes(bytes))
+    }
+
     /// CompactDifficulty exponent base.
     const BASE: u32 = 256;
 
@@ -254,8 +261,6 @@ impl CompactDifficulty {
     /// `GetBlockProof()` in zcashd.
     ///
     /// Returns None if the corresponding ExpandedDifficulty is None.
-    /// Also returns None on Work overflow, which should be impossible on a
-    /// valid chain.
     ///
     /// [Zcash Specification]: https://zips.z.cash/protocol/protocol.pdf#workdef
     pub fn to_work(self) -> Option<Work> {
@@ -398,12 +403,18 @@ impl TryFrom<ExpandedDifficulty> for Work {
         // 2^256, as it's too large for a u256. However, as 2^256 is at least as
         // large as `expanded + 1`, it is equal to
         // `((2^256 - expanded - 1) / (expanded + 1)) + 1`, or
-        let result = (!expanded.0 / (expanded.0 + 1)) + 1;
-        if result <= u128::MAX.into() {
-            Ok(Work(result.as_u128()))
-        } else {
-            Err(())
+        if expanded.0.is_zero() {
+            // A zero target has work 2^256, which is outside U256.
+            return Err(());
         }
+
+        if expanded.0 == U256::MAX {
+            // The mathematical denominator is 2^256, so the floor is one.
+            return Ok(Work(U256::one()));
+        }
+
+        let result = (!expanded.0 / (expanded.0 + 1)) + 1;
+        Ok(Work(result))
     }
 }
 
@@ -666,17 +677,27 @@ impl std::ops::Add for Work {
 ///
 /// See [`Work`] for details.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PartialCumulativeWork(u128);
+pub struct PartialCumulativeWork(U256);
 
 impl PartialCumulativeWork {
     /// Returns a value representing no work.
     pub fn zero() -> Self {
-        Self(0)
+        Self(U256::zero())
     }
 
-    /// Return the inner `u128` value.
-    pub fn as_u128(self) -> u128 {
+    /// Returns the exact inner 256-bit value.
+    pub fn as_u256(self) -> U256 {
         self.0
+    }
+
+    /// Adds exact per-block work, returning `None` at the 2^256 boundary.
+    pub fn checked_add(self, rhs: Work) -> Option<Self> {
+        self.0.checked_add(rhs.0).map(Self)
+    }
+
+    /// Subtracts exact per-block work, returning `None` on underflow.
+    pub fn checked_sub(self, rhs: Work) -> Option<Self> {
+        self.0.checked_sub(rhs.0).map(Self)
     }
 
     /// Returns a floating-point work multiplier that can be used for display.
@@ -690,9 +711,8 @@ impl PartialCumulativeWork {
             .to_work()
             .expect("target difficult limit is valid work");
 
-        // Convert to u128 then f64.
-        let pow_limit = pow_limit.as_u128() as f64;
-        let work = self.as_u128() as f64;
+        let pow_limit = u256_to_f64(pow_limit.as_u256());
+        let work = u256_to_f64(self.as_u256());
 
         work / pow_limit
     }
@@ -702,8 +722,7 @@ impl PartialCumulativeWork {
     pub fn difficulty_bits_for_display(&self) -> f64 {
         // This calculation is similar to `zcashd`'s bits display in its logs.
 
-        // Convert to u128 then f64.
-        let work = self.as_u128() as f64;
+        let work = u256_to_f64(self.as_u256());
 
         work.log2()
     }
@@ -751,16 +770,25 @@ impl From<Work> for PartialCumulativeWork {
     }
 }
 
+impl From<Work> for U256 {
+    fn from(work: Work) -> Self {
+        work.0
+    }
+}
+
+impl From<PartialCumulativeWork> for U256 {
+    fn from(work: PartialCumulativeWork) -> Self {
+        work.0
+    }
+}
+
 impl std::ops::Add<Work> for PartialCumulativeWork {
     type Output = PartialCumulativeWork;
 
     fn add(self, rhs: Work) -> Self::Output {
-        let result = self
-            .0
-            .checked_add(rhs.0)
-            .expect("Work values do not overflow");
-
-        PartialCumulativeWork(result)
+        self.checked_add(rhs).expect(
+            "cumulative work fits in 256 bits under the chain-work representation invariant",
+        )
     }
 }
 
@@ -774,11 +802,8 @@ impl std::ops::Sub<Work> for PartialCumulativeWork {
     type Output = PartialCumulativeWork;
 
     fn sub(self, rhs: Work) -> Self::Output {
-        let result = self.0
-            .checked_sub(rhs.0)
-            .expect("PartialCumulativeWork values do not underflow: all subtracted Work values must have been previously added to the PartialCumulativeWork");
-
-        PartialCumulativeWork(result)
+        self.checked_sub(rhs)
+            .expect("subtracted block work was previously included in cumulative work")
     }
 }
 
@@ -786,4 +811,19 @@ impl std::ops::SubAssign<Work> for PartialCumulativeWork {
     fn sub_assign(&mut self, rhs: Work) {
         *self = *self - rhs;
     }
+}
+
+fn u256_to_f64(value: U256) -> f64 {
+    let bits = value.bits();
+    let mantissa_bits = usize::try_from(f64::MANTISSA_DIGITS)
+        .expect("the f64 mantissa width fits in usize on every supported target");
+    if bits <= mantissa_bits {
+        // Values with at most 53 bits are represented exactly by f64.
+        return value.as_u64() as f64;
+    }
+
+    let shift = bits - mantissa_bits;
+    let significant = (value >> shift).as_u64();
+    // `significant` has exactly the 53 high bits, so this conversion is exact.
+    significant as f64 * 2.0_f64.powi(i32::try_from(shift).expect("a U256 shift fits in i32"))
 }

--- a/crates/zakura-chain/src/work/equihash.rs
+++ b/crates/zakura-chain/src/work/equihash.rs
@@ -99,27 +99,39 @@ impl Solution {
     /// proof-of-work parameters by choosing the on-wire solution length.
     #[allow(clippy::unwrap_in_result)]
     pub fn check(&self, header: &Header, network: &Network) -> Result<(), Error> {
+        self.validate_shape(network)?;
+
         // TODO:
         // - Add Equihash parameters field to `testnet::Parameters`
         // - Update `Solution::Regtest` variant to hold a `Vec` to support arbitrary parameters - rename to `Other`
-        let (n, k) = match (network.is_regtest(), self) {
+        let (n, k) = if network.is_regtest() {
+            (REGTEST_N, REGTEST_K)
+        } else {
+            (200, 9)
+        };
+
+        self.check_equihash(header, n, k)
+    }
+
+    /// Validate that this solution's encoded shape matches the authenticated network parameters,
+    /// without verifying the Equihash proof.
+    pub fn validate_shape(&self, network: &Network) -> Result<(), Error> {
+        match (network.is_regtest(), self) {
             // Mainnet and Testnet require the memory-hard (200, 9) parameters,
             // encoded as a 1344-byte `Common` solution.
-            (false, Solution::Common(_)) => (200, 9),
+            (false, Solution::Common(_)) => Ok(()),
             // Regtest requires the toy (48, 5) parameters used by zcashd.
-            (true, Solution::Regtest(_)) => (REGTEST_N, REGTEST_K),
+            (true, Solution::Regtest(_)) => Ok(()),
             // Reject a solution variant that does not match the active
             // network before selecting parameters. Otherwise the
             // attacker-controlled solution length could change the PoW
             // parameter set.
             (false, Solution::Regtest(_)) | (true, Solution::Common(_)) => {
-                return Err(Error::InvalidSolutionSize {
+                Err(Error::InvalidSolutionSize {
                     network: network.clone(),
                 })
             }
-        };
-
-        self.check_equihash(header, n, k)
+        }
     }
 
     /// Returns `Ok(())` if this solution is valid for `header` under the given

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "zakura-header-chain"
+version = "1.0.0-rc0"
+authors.workspace = true
+description = "Fork-aware header-chain domain types and transition engine for Zakura"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories = ["cryptography::cryptocurrencies"]
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+chrono = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+zakura-chain = { path = "../zakura-chain", version = "4.0.0" }
+
+[lints]
+workspace = true

--- a/crates/zakura-header-chain/src/config.rs
+++ b/crates/zakura-header-chain/src/config.rs
@@ -1,0 +1,317 @@
+//! Versioned engine resource limits.
+
+use std::{
+    collections::BTreeMap,
+    num::{NonZeroU32, NonZeroUsize},
+    str::FromStr,
+    sync::Arc,
+};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use zakura_chain::{
+    block,
+    parameters::{
+        constants::MAX_BLOCK_REORG_HEIGHT, Network, NetworkKind, NetworkUpgrade,
+        MAX_NON_FINALIZED_CHAIN_FORKS,
+    },
+};
+
+use crate::Frontier;
+
+/// Exact v1 maximum number of retained non-finalized header nodes.
+pub const MAX_NON_FINALIZED_NODES_V1: usize = 65_536;
+/// Exact v1 maximum number of staged unknown targets across all peers.
+pub const MAX_STAGED_TARGETS_V1: usize = 16;
+/// Exact v1 maximum number of candidate tips.
+pub const MAX_CANDIDATE_TIPS_V1: usize = MAX_NON_FINALIZED_CHAIN_FORKS;
+
+/// Header-engine integration and finality mode.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum EngineMode {
+    /// Full state is the only authority allowed to advance finality.
+    Integrated,
+    /// A selected header 1,000 blocks deep becomes a disclosed local trust pin.
+    HeadersOnly,
+}
+
+/// Exact trusted bootstrap header and its hash-qualified height.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrustedAnchor {
+    /// Exact configured frontier.
+    pub frontier: Frontier,
+    /// Canonical anchor header, still subject to observable validation.
+    pub header: Arc<block::Header>,
+}
+
+/// Authenticated local checkpoint map; height-only or hash-only entries are impossible.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CheckpointSet(BTreeMap<block::Height, block::Hash>);
+
+impl CheckpointSet {
+    /// Construct a checkpoint set, rejecting conflicting duplicates.
+    pub fn new(checkpoints: impl IntoIterator<Item = Frontier>) -> Result<Self, EngineConfigError> {
+        let mut result = BTreeMap::new();
+        for checkpoint in checkpoints {
+            if result
+                .insert(checkpoint.height, checkpoint.hash)
+                .is_some_and(|old| old != checkpoint.hash)
+            {
+                return Err(EngineConfigError::ConflictingCheckpoint(checkpoint.height));
+            }
+        }
+        Ok(Self(result))
+    }
+
+    /// Return the configured hash at `height`.
+    pub fn hash(&self, height: block::Height) -> Option<block::Hash> {
+        self.0.get(&height).copied()
+    }
+
+    /// Iterate checkpoints in ascending height order.
+    pub fn iter(&self) -> impl Iterator<Item = Frontier> + '_ {
+        self.0
+            .iter()
+            .map(|(height, hash)| Frontier::new(*height, *hash))
+    }
+}
+
+/// One release-authenticated settled network-upgrade pin.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SettledUpgradePin {
+    /// Production network identity.
+    pub network: NetworkKind,
+    /// Settled upgrade identity.
+    pub upgrade: NetworkUpgrade,
+    /// Exact activation frontier.
+    pub activation: Frontier,
+}
+
+/// Immutable settled pins compiled into this release.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SettledUpgradeManifest {
+    pins: Vec<SettledUpgradePin>,
+    digest: [u8; 32],
+}
+
+impl SettledUpgradeManifest {
+    /// Construct and validate the exact specification-v1.3 release manifest.
+    pub fn for_release() -> Result<Self, EngineConfigError> {
+        let pins = vec![
+            SettledUpgradePin {
+                network: NetworkKind::Mainnet,
+                upgrade: NetworkUpgrade::Nu6_2,
+                activation: Frontier::new(
+                    block::Height(3_364_600),
+                    block::Hash::from_str(
+                        "0000000000806344c408a4cfdf472f4132c632edbdc24cf2f3f672061da8b865",
+                    )
+                    .map_err(|_| EngineConfigError::MalformedSettledPin(NetworkKind::Mainnet))?,
+                ),
+            },
+            SettledUpgradePin {
+                network: NetworkKind::Testnet,
+                upgrade: NetworkUpgrade::Nu6_2,
+                activation: Frontier::new(
+                    block::Height(4_052_000),
+                    block::Hash::from_str(
+                        "0010cb912b0188da5bc055ee67e3f77d30cd27611369d865974a5bf0b1ec2912",
+                    )
+                    .map_err(|_| EngineConfigError::MalformedSettledPin(NetworkKind::Testnet))?,
+                ),
+            },
+        ];
+        Self::new(pins)
+    }
+
+    fn new(mut pins: Vec<SettledUpgradePin>) -> Result<Self, EngineConfigError> {
+        pins.sort_unstable_by_key(|pin| match pin.network {
+            NetworkKind::Mainnet => 0_u8,
+            NetworkKind::Testnet => 1_u8,
+            NetworkKind::Regtest => 2_u8,
+        });
+        if pins.iter().any(|pin| pin.network == NetworkKind::Regtest) {
+            return Err(EngineConfigError::InvalidSettledNetwork);
+        }
+        if pins
+            .windows(2)
+            .any(|pair| pair[0].network == pair[1].network)
+        {
+            return Err(EngineConfigError::DuplicateSettledPin);
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(b"zakura-settled-upgrade-manifest-v1");
+        for pin in &pins {
+            hasher.update(match pin.network {
+                NetworkKind::Mainnet => b"mainnet".as_slice(),
+                NetworkKind::Testnet => b"testnet".as_slice(),
+                NetworkKind::Regtest => b"regtest".as_slice(),
+            });
+            hasher.update(b"nu6.2");
+            hasher.update(pin.activation.height.0.to_le_bytes());
+            hasher.update(pin.activation.hash.0);
+        }
+        Ok(Self {
+            pins,
+            digest: hasher.finalize().into(),
+        })
+    }
+
+    /// Return the immutable manifest digest stored with engine metadata.
+    pub const fn digest(&self) -> [u8; 32] {
+        self.digest
+    }
+
+    /// Return the mandatory pin for a production network; custom networks have none.
+    pub fn pin_for_network(&self, network: &Network) -> Option<SettledUpgradePin> {
+        let production_kind = match network {
+            Network::Mainnet => Some(NetworkKind::Mainnet),
+            Network::Testnet(_) if network.is_default_testnet() => Some(NetworkKind::Testnet),
+            Network::Testnet(_) => None,
+        }?;
+        self.pins
+            .iter()
+            .find(|pin| pin.network == production_kind)
+            .copied()
+    }
+
+    /// Iterate every release-authenticated production pin.
+    pub fn iter(&self) -> impl Iterator<Item = SettledUpgradePin> + '_ {
+        self.pins.iter().copied()
+    }
+}
+
+/// Immutable pure-engine configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EngineConfig {
+    /// Finality authority mode.
+    pub mode: EngineMode,
+    /// Authenticated network parameters.
+    pub network: Network,
+    /// Exact trusted bootstrap anchor.
+    pub bootstrap_anchor: TrustedAnchor,
+    /// Optional authenticated local checkpoints.
+    pub local_checkpoints: CheckpointSet,
+    /// Mandatory release-authenticated settled pins.
+    pub settled_manifest: SettledUpgradeManifest,
+    /// Frozen engine resource limits.
+    pub limits: EngineLimits,
+}
+
+impl EngineConfig {
+    /// Construct a configuration with the mandatory compiled settled manifest.
+    pub fn new(
+        mode: EngineMode,
+        network: Network,
+        bootstrap_anchor: TrustedAnchor,
+        local_checkpoints: CheckpointSet,
+    ) -> Result<Self, EngineConfigError> {
+        let actual_anchor = crate::validation::validate_trusted_anchor_observables(
+            &bootstrap_anchor.header,
+            &network,
+            bootstrap_anchor.frontier.height,
+        )
+        .map_err(EngineConfigError::InvalidTrustedAnchor)?;
+        if actual_anchor != bootstrap_anchor.frontier.hash {
+            return Err(EngineConfigError::AnchorHashMismatch {
+                expected: bootstrap_anchor.frontier.hash,
+                actual: actual_anchor,
+            });
+        }
+        let settled_manifest = SettledUpgradeManifest::for_release()?;
+        if matches!(network, Network::Mainnet) || network.is_default_testnet() {
+            settled_manifest
+                .pin_for_network(&network)
+                .ok_or(EngineConfigError::MissingSettledPin(network.kind()))?;
+        }
+        Ok(Self {
+            mode,
+            network,
+            bootstrap_anchor,
+            local_checkpoints,
+            settled_manifest,
+            limits: EngineLimits::v1(),
+        })
+    }
+
+    /// Digest binding every absolute trust anchor used by validation and startup.
+    pub fn trust_anchor_digest(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(b"zakura-header-chain-trust-anchors-v1");
+        hasher.update(self.settled_manifest.digest());
+        hasher.update(self.bootstrap_anchor.frontier.height.0.to_le_bytes());
+        hasher.update(self.bootstrap_anchor.frontier.hash.0);
+        for checkpoint in self.local_checkpoints.iter() {
+            hasher.update(checkpoint.height.0.to_le_bytes());
+            hasher.update(checkpoint.hash.0);
+        }
+        hasher.finalize().into()
+    }
+}
+
+/// Invalid immutable engine or trust-anchor configuration.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum EngineConfigError {
+    /// A supplied trusted header failed a directly observable validation rule.
+    #[error("trusted anchor failed {0}")]
+    InvalidTrustedAnchor(&'static str),
+    /// The canonical trusted header did not match its configured hash.
+    #[error("trusted anchor header hashes to {actual:?}, expected {expected:?}")]
+    AnchorHashMismatch {
+        /// Configured hash.
+        expected: block::Hash,
+        /// Locally computed hash.
+        actual: block::Hash,
+    },
+    /// Two local checkpoints name different hashes at one height.
+    #[error("conflicting local checkpoint at {0:?}")]
+    ConflictingCheckpoint(block::Height),
+    /// A compiled settled hash failed canonical parsing.
+    #[error("malformed compiled settled pin for {0:?}")]
+    MalformedSettledPin(NetworkKind),
+    /// A manifest contains more than one pin for a production identity.
+    #[error("duplicate settled-upgrade production identity")]
+    DuplicateSettledPin,
+    /// Settled production pins cannot use the Regtest identity.
+    #[error("settled-upgrade manifest cannot contain a Regtest pin")]
+    InvalidSettledNetwork,
+    /// A production configuration has no mandatory settled pin.
+    #[error("missing mandatory settled pin for {0:?}")]
+    MissingSettledPin(NetworkKind),
+}
+
+/// Immutable resource bounds for one header-chain engine version.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct EngineLimits {
+    /// Irreversible local finality depth.
+    pub local_finality_depth: NonZeroU32,
+    /// Maximum retained eligible and ineligible candidate tips.
+    pub max_candidate_tips: NonZeroUsize,
+    /// Maximum retained non-finalized DAG nodes.
+    pub max_non_finalized_nodes: NonZeroUsize,
+}
+
+impl EngineLimits {
+    /// Return the exact limits frozen by specification version 1.3.
+    pub fn v1() -> Self {
+        Self {
+            local_finality_depth: NonZeroU32::new(MAX_BLOCK_REORG_HEIGHT)
+                .expect("the v1 local finality depth is nonzero"),
+            max_candidate_tips: NonZeroUsize::new(MAX_CANDIDATE_TIPS_V1)
+                .expect("the v1 candidate-tip limit is nonzero"),
+            max_non_finalized_nodes: NonZeroUsize::new(MAX_NON_FINALIZED_NODES_V1)
+                .expect("the v1 node limit is nonzero"),
+        }
+    }
+}
+
+impl Default for EngineLimits {
+    fn default() -> Self {
+        Self::v1()
+    }
+}
+
+const _: () = assert!(MAX_BLOCK_REORG_HEIGHT == 1_000);
+const _: () = assert!(MAX_CANDIDATE_TIPS_V1 == 10);
+const _: () = assert!(MAX_NON_FINALIZED_NODES_V1 == 65_536);
+const _: () = assert!(MAX_STAGED_TARGETS_V1 == 16);

--- a/crates/zakura-header-chain/src/error.rs
+++ b/crates/zakura-header-chain/src/error.rs
@@ -1,0 +1,292 @@
+//! Stable error categories and peer-attribution boundaries.
+
+use std::{error::Error as StdError, fmt, num::NonZeroU64};
+
+use zakura_chain::BoxError;
+
+use crate::{BodyPayloadMismatch, BranchId, ConsensusBodyInvalid, EvidenceId, HeaderId, SourceId};
+
+/// Stable normative rule identifier attached to a failure.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RuleId(&'static str);
+
+impl RuleId {
+    /// Construct a rule ID from a checked-in stable identifier.
+    pub const fn new(id: &'static str) -> Self {
+        Self(id)
+    }
+
+    /// Return the stable identifier.
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+/// Exact subject of a header-chain operation or failure.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum ErrorSubject {
+    /// One hash-qualified header.
+    Header(HeaderId),
+    /// One exact anchor/target branch.
+    Branch(BranchId),
+    /// One correlated peer request.
+    Request {
+        /// Stable peer/session source.
+        source: SourceId,
+        /// Nonzero request ID.
+        request_id: NonZeroU64,
+    },
+    /// A named local subsystem invariant or resource.
+    Local(&'static str),
+}
+
+/// Stable category preserved across service, driver, reactor, and metrics boundaries.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum ErrorCategory {
+    /// Structurally invalid peer protocol data.
+    MalformedProtocol,
+    /// A deterministically invalid network header.
+    InvalidHeader,
+    /// A valid but non-selected fork.
+    ValidLosingFork,
+    /// A header deferred only by an injected-clock rule.
+    DeferredHeader,
+    /// A body payload did not match its requested header.
+    BodyPayloadMismatch,
+    /// A matching body failed consensus validation.
+    ConsensusBodyInvalid,
+    /// Local operator policy made a header ineligible.
+    OperatorIneligible,
+    /// Completion belongs to a stale target, version, or generation.
+    StaleTargetOrGeneration,
+    /// A local anchor, retained path, or durable invariant is incoherent.
+    LocalAnchorOrIncoherence,
+    /// A local resource, storage, or transient execution failure.
+    LocalResourceOrStorage,
+}
+
+impl ErrorCategory {
+    /// Stable low-cardinality label for metrics and traces.
+    pub const fn metrics_label(self) -> &'static str {
+        match self {
+            Self::MalformedProtocol => "malformed_protocol",
+            Self::InvalidHeader => "invalid_header",
+            Self::ValidLosingFork => "valid_losing_fork",
+            Self::DeferredHeader => "deferred_header",
+            Self::BodyPayloadMismatch => "body_payload_mismatch",
+            Self::ConsensusBodyInvalid => "consensus_body_invalid",
+            Self::OperatorIneligible => "operator_ineligible",
+            Self::StaleTargetOrGeneration => "stale_target_or_generation",
+            Self::LocalAnchorOrIncoherence => "local_anchor_or_incoherence",
+            Self::LocalResourceOrStorage => "local_resource_or_storage",
+        }
+    }
+}
+
+/// Explicit source attribution for evidence and peer scoring.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Attribution {
+    /// No peer is responsible.
+    None,
+    /// Header-delivery peer is responsible.
+    HeaderPeer(SourceId),
+    /// Body-delivery peer is responsible.
+    BodyPeer(SourceId),
+    /// Auxiliary-metadata peer is responsible.
+    AuxPeer(SourceId),
+}
+
+impl Attribution {
+    /// Stable low-cardinality label for metrics and traces.
+    pub const fn metrics_label(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::HeaderPeer(_) => "header_peer",
+            Self::BodyPeer(_) => "body_peer",
+            Self::AuxPeer(_) => "aux_peer",
+        }
+    }
+}
+
+/// Complete typed header-chain failure record.
+pub struct HeaderChainError {
+    /// Stable error category.
+    pub category: ErrorCategory,
+    /// Exact affected object or local subsystem.
+    pub subject: ErrorSubject,
+    /// Normative rule that failed, when applicable.
+    pub rule: Option<RuleId>,
+    /// Stable evidence record, when one was retained.
+    pub evidence: Option<EvidenceId>,
+    /// Explicit peer attribution boundary.
+    pub attribution: Attribution,
+    /// Original typed error, retained without recategorization.
+    pub source: Option<BoxError>,
+}
+
+impl HeaderChainError {
+    /// Construct a category-preserving error with explicit attribution.
+    pub fn new(
+        category: ErrorCategory,
+        subject: ErrorSubject,
+        rule: Option<RuleId>,
+        evidence: Option<EvidenceId>,
+        attribution: Attribution,
+        source: Option<BoxError>,
+    ) -> Self {
+        Self {
+            category,
+            subject,
+            rule,
+            evidence,
+            attribution,
+            source,
+        }
+    }
+
+    /// Construct malformed-protocol evidence attributed to its header peer.
+    pub fn malformed_protocol(
+        subject: ErrorSubject,
+        rule: RuleId,
+        source_id: SourceId,
+        source: Option<BoxError>,
+    ) -> Self {
+        Self::new(
+            ErrorCategory::MalformedProtocol,
+            subject,
+            Some(rule),
+            None,
+            Attribution::HeaderPeer(source_id),
+            source,
+        )
+    }
+
+    /// Construct invalid-header evidence attributed to its header peer.
+    pub fn invalid_header(
+        subject: ErrorSubject,
+        rule: RuleId,
+        evidence: EvidenceId,
+        source_id: SourceId,
+        source: Option<BoxError>,
+    ) -> Self {
+        Self::new(
+            ErrorCategory::InvalidHeader,
+            subject,
+            Some(rule),
+            Some(evidence),
+            Attribution::HeaderPeer(source_id),
+            source,
+        )
+    }
+
+    /// Construct mismatched-body evidence attributed only to its body supplier.
+    pub fn body_payload_mismatch(evidence: BodyPayloadMismatch) -> Self {
+        Self::new(
+            ErrorCategory::BodyPayloadMismatch,
+            ErrorSubject::Header(HeaderId::new(evidence.requested)),
+            None,
+            Some(evidence.evidence),
+            Attribution::BodyPeer(evidence.source),
+            None,
+        )
+    }
+
+    /// Construct deterministic invalid-body evidence attributed only to its body supplier.
+    pub fn consensus_body_invalid(evidence: &ConsensusBodyInvalid) -> Self {
+        Self::new(
+            ErrorCategory::ConsensusBodyInvalid,
+            ErrorSubject::Header(HeaderId::new(evidence.hash)),
+            None,
+            Some(evidence.evidence),
+            Attribution::BodyPeer(evidence.source),
+            None,
+        )
+    }
+
+    /// Construct a local unknown-anchor or retained-path incoherence.
+    pub fn unknown_anchor(subject: ErrorSubject, source: Option<BoxError>) -> Self {
+        Self::new(
+            ErrorCategory::LocalAnchorOrIncoherence,
+            subject,
+            None,
+            None,
+            Attribution::None,
+            source,
+        )
+    }
+
+    /// Construct a stale target, version, generation, or validation owner.
+    pub fn stale_target(subject: ErrorSubject) -> Self {
+        Self::new(
+            ErrorCategory::StaleTargetOrGeneration,
+            subject,
+            None,
+            None,
+            Attribution::None,
+            None,
+        )
+    }
+
+    /// Construct a local resource, task, service, or storage failure.
+    pub fn local_resource(subject: ErrorSubject, source: Option<BoxError>) -> Self {
+        Self::new(
+            ErrorCategory::LocalResourceOrStorage,
+            subject,
+            None,
+            None,
+            Attribution::None,
+            source,
+        )
+    }
+
+    /// Return true only for categories that automatically justify header-peer scoring.
+    pub fn is_automatic_header_peer_fault(&self) -> bool {
+        matches!(
+            (&self.category, &self.attribution),
+            (
+                ErrorCategory::MalformedProtocol | ErrorCategory::InvalidHeader,
+                Attribution::HeaderPeer(_)
+            )
+        )
+    }
+
+    /// Return true only for evidence-bearing body failures attributed to their supplier.
+    pub fn is_automatic_body_peer_fault(&self) -> bool {
+        self.evidence.is_some()
+            && matches!(
+                (&self.category, &self.attribution),
+                (
+                    ErrorCategory::BodyPayloadMismatch | ErrorCategory::ConsensusBodyInvalid,
+                    Attribution::BodyPeer(_)
+                )
+            )
+    }
+}
+
+impl fmt::Debug for HeaderChainError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HeaderChainError")
+            .field("category", &self.category)
+            .field("subject", &self.subject)
+            .field("rule", &self.rule)
+            .field("evidence", &self.evidence)
+            .field("attribution", &self.attribution)
+            .field("source", &self.source.as_ref().map(ToString::to_string))
+            .finish()
+    }
+}
+
+impl fmt::Display for HeaderChainError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:?} for {:?}", self.category, self.subject)
+    }
+}
+
+impl StdError for HeaderChainError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| -> &(dyn StdError + 'static) { source })
+    }
+}

--- a/crates/zakura-header-chain/src/frontier.rs
+++ b/crates/zakura-header-chain/src/frontier.rs
@@ -1,0 +1,170 @@
+//! Hash-qualified frontiers and exact chain-work ordering.
+
+use std::cmp::Ordering;
+
+use thiserror::Error;
+use zakura_chain::{
+    block,
+    work::difficulty::{Work, U256},
+};
+
+/// One exact height/hash frontier.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Frontier {
+    /// Frontier height.
+    pub height: block::Height,
+    /// Exact block hash at `height`.
+    pub hash: block::Hash,
+}
+
+impl Frontier {
+    /// Construct a hash-qualified frontier.
+    pub const fn new(height: block::Height, hash: block::Hash) -> Self {
+        Self { height, hash }
+    }
+}
+
+/// The three independently meaningful durable engine frontiers.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct FrontierSet {
+    /// Irreversible local finality frontier.
+    pub finalized: Frontier,
+    /// Best locally header-valid frontier.
+    pub header_best: Frontier,
+    /// Best body-verified frontier on the selected path.
+    pub verified_best: Frontier,
+}
+
+/// Exact cumulative work of a suffix after one shared anchor.
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SuffixWork(U256);
+
+impl SuffixWork {
+    /// Construct exact suffix work from its 256-bit integer representation.
+    pub const fn new(work: U256) -> Self {
+        Self(work)
+    }
+
+    /// Return a value representing no suffix work.
+    pub fn zero() -> Self {
+        Self(U256::zero())
+    }
+
+    /// Return the exact 256-bit integer representation.
+    pub const fn as_u256(self) -> U256 {
+        self.0
+    }
+
+    /// Add exact per-block work, failing closed at the 2^256 boundary.
+    pub fn checked_add(self, work: Work) -> Option<Self> {
+        self.0.checked_add(work.as_u256()).map(Self)
+    }
+}
+
+impl From<U256> for SuffixWork {
+    fn from(work: U256) -> Self {
+        Self::new(work)
+    }
+}
+
+/// The only fork-selection score: exact suffix work, then raw internal tip hash.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ChainScore {
+    /// Exact cumulative work after the shared comparison anchor.
+    pub suffix_work: SuffixWork,
+    /// Raw internal hash of the candidate tip.
+    pub tip_hash: block::Hash,
+}
+
+impl ChainScore {
+    /// Construct a score whose work is already rebased to a shared anchor.
+    pub const fn new(suffix_work: SuffixWork, tip_hash: block::Hash) -> Self {
+        Self {
+            suffix_work,
+            tip_hash,
+        }
+    }
+}
+
+impl Ord for ChainScore {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.suffix_work
+            .cmp(&other.suffix_work)
+            .then_with(|| self.tip_hash.0.cmp(&other.tip_hash.0))
+    }
+}
+
+impl PartialOrd for ChainScore {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Checked cumulative work from one immutable bootstrap origin.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct WorkCoordinate {
+    origin_hash: block::Hash,
+    cumulative: U256,
+}
+
+impl WorkCoordinate {
+    /// Construct a coordinate from a trusted origin and exact cumulative work.
+    pub const fn new(origin_hash: block::Hash, cumulative: U256) -> Self {
+        Self {
+            origin_hash,
+            cumulative,
+        }
+    }
+
+    /// Return the immutable work origin hash.
+    pub const fn origin_hash(self) -> block::Hash {
+        self.origin_hash
+    }
+
+    /// Return the exact cumulative work from the immutable origin.
+    pub const fn cumulative_work(self) -> U256 {
+        self.cumulative
+    }
+
+    /// Add one block's exact work, failing closed on overflow.
+    pub fn checked_add(self, work: Work) -> Result<Self, WorkCoordinateError> {
+        let cumulative = self
+            .cumulative
+            .checked_add(work.as_u256())
+            .ok_or(WorkCoordinateError::Overflow)?;
+        Ok(Self { cumulative, ..self })
+    }
+
+    /// Subtract an ancestor coordinate to produce comparable suffix work.
+    pub fn suffix_after(self, anchor: Self) -> Result<SuffixWork, WorkCoordinateError> {
+        if self.origin_hash != anchor.origin_hash {
+            return Err(WorkCoordinateError::OriginMismatch {
+                anchor: anchor.origin_hash,
+                tip: self.origin_hash,
+            });
+        }
+        self.cumulative
+            .checked_sub(anchor.cumulative)
+            .map(SuffixWork)
+            .ok_or(WorkCoordinateError::Underflow)
+    }
+}
+
+/// Failure to maintain or compare exact work coordinates.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum WorkCoordinateError {
+    /// Coordinates name different immutable bootstrap origins.
+    #[error("work-coordinate origin mismatch: anchor {anchor:?}, tip {tip:?}")]
+    OriginMismatch {
+        /// Anchor coordinate origin.
+        anchor: block::Hash,
+        /// Tip coordinate origin.
+        tip: block::Hash,
+    },
+    /// Exact work accumulation crossed the 2^256 boundary.
+    #[error("work-coordinate accumulation overflow")]
+    Overflow,
+    /// An alleged descendant had less cumulative work than its anchor.
+    #[error("work-coordinate suffix subtraction underflow")]
+    Underflow,
+}

--- a/crates/zakura-header-chain/src/graph.rs
+++ b/crates/zakura-header-chain/src/graph.rs
@@ -1,0 +1,1037 @@
+//! Pure in-memory header DAG queries, eligibility propagation, and selection.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    sync::Arc,
+};
+
+use thiserror::Error;
+use zakura_chain::{
+    block,
+    work::difficulty::{Work, U256},
+};
+
+use crate::{
+    BodyRuleId, BodyValidationState, ChainScore, EligibilityReason, EligibilityState, EvidenceId,
+    Frontier, HeaderNode, HeaderValidationState, OperatorInvalidationId, WorkCoordinate,
+    WorkCoordinateError,
+};
+
+mod overlay;
+pub(crate) use overlay::{GraphDelta, GraphOverlay};
+
+pub(crate) trait HeaderGraphView {
+    fn view_finalized(&self) -> Frontier;
+    fn view_node_count(&self) -> usize;
+    fn view_node(&self, hash: block::Hash) -> Option<&HeaderNode>;
+    fn view_nodes(&self) -> Vec<&HeaderNode>;
+    fn view_retained_hashes(&self) -> Vec<block::Hash>;
+    fn view_hashes_at_height(&self, height: block::Height) -> Vec<block::Hash>;
+    fn view_children(&self, parent: block::Hash) -> Vec<block::Hash>;
+    fn view_eligible_tips(&self) -> Vec<Frontier>;
+    fn view_select_header_best(&self) -> Result<(Frontier, ChainScore), GraphError>;
+    fn view_score(&self, hash: block::Hash) -> Result<ChainScore, GraphError>;
+    fn view_ancestor(
+        &self,
+        descendant: block::Hash,
+        height: block::Height,
+    ) -> Result<Option<Frontier>, GraphError>;
+}
+
+pub(crate) trait HeaderGraphEdit: HeaderGraphView {
+    fn edit_node_mut(&mut self, hash: block::Hash) -> Result<&mut HeaderNode, GraphError>;
+    fn edit_insert(
+        &mut self,
+        header: Arc<block::Header>,
+        block_work: Work,
+        validation: HeaderValidationState,
+        direct_reasons: Vec<EligibilityReason>,
+        body: BodyValidationState,
+    ) -> Result<InsertResult, GraphError>;
+    fn edit_add_reason(
+        &mut self,
+        hash: block::Hash,
+        reason: EligibilityReason,
+    ) -> Result<bool, GraphError>;
+    fn edit_remove_operator_invalidation(
+        &mut self,
+        hash: block::Hash,
+        id: OperatorInvalidationId,
+    ) -> Result<bool, GraphError>;
+    fn edit_set_consensus_body_invalid(
+        &mut self,
+        hash: block::Hash,
+        evidence: EvidenceId,
+        rule: BodyRuleId,
+    ) -> Result<bool, GraphError>;
+    fn edit_set_body_state(
+        &mut self,
+        hash: block::Hash,
+        body: BodyValidationState,
+    ) -> Result<bool, GraphError>;
+    fn edit_set_validation(
+        &mut self,
+        hash: block::Hash,
+        validation: HeaderValidationState,
+    ) -> Result<bool, GraphError>;
+    fn edit_advance_finalized(
+        &mut self,
+        finalized: Frontier,
+    ) -> Result<Vec<block::Hash>, GraphError>;
+    fn edit_remove_leaf(&mut self, hash: block::Hash) -> Result<(), GraphError>;
+}
+
+/// Failure to construct or query a coherent in-memory header DAG.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum GraphError {
+    /// The supplied trusted anchor header does not hash to its frontier.
+    #[error("trusted anchor header hashes to {actual:?}, expected {expected:?}")]
+    AnchorHashMismatch {
+        /// Expected configured anchor hash.
+        expected: block::Hash,
+        /// Locally computed header hash.
+        actual: block::Hash,
+    },
+    /// A durable insertion attempted to reference an unknown parent.
+    #[error("header {header:?} has unknown parent {parent:?}")]
+    UnknownParent {
+        /// Candidate header hash.
+        header: block::Hash,
+        /// Missing parent hash.
+        parent: block::Hash,
+    },
+    /// The inferred child height crossed the supported range.
+    #[error("child of {parent:?} exceeds the supported height range")]
+    HeightOverflow {
+        /// Parent hash at maximum height.
+        parent: block::Hash,
+    },
+    /// The exact header hash is already retained with different contents.
+    #[error("conflicting duplicate header {0:?}")]
+    ConflictingDuplicate(block::Hash),
+    /// A requested retained node does not exist.
+    #[error("unknown retained header {0:?}")]
+    UnknownNode(block::Hash),
+    /// Finality attempted to root the graph at an ineligible header.
+    #[error("cannot finalize ineligible retained header {0:?}")]
+    IneligibleFinalized(block::Hash),
+    /// Retention attempted to remove a node that still has retained children.
+    #[error("cannot remove non-leaf header {0:?}")]
+    NodeHasChildren(block::Hash),
+    /// Body-invalid state and its exact durable eligibility reason disagreed.
+    #[error("body-invalid state and eligibility evidence disagree for {0:?}")]
+    BodyEligibilityMismatch(block::Hash),
+    /// A requested ancestor height is above its descendant.
+    #[error("ancestor height {ancestor:?} exceeds descendant height {descendant:?}")]
+    InvalidAncestorHeight {
+        /// Requested ancestor height.
+        ancestor: block::Height,
+        /// Descendant height.
+        descendant: block::Height,
+    },
+    /// Exact work accumulation or rebasing failed closed.
+    #[error(transparent)]
+    Work(#[from] WorkCoordinateError),
+}
+
+/// Result of an idempotent DAG insertion.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum InsertResult {
+    /// A new node and all reconstructible indexes were inserted.
+    Inserted(Frontier),
+    /// The exact same node was already retained.
+    AlreadyPresent(Frontier),
+}
+
+/// Pure hash-keyed in-memory implementation of the header DAG contract.
+#[derive(Clone, Debug)]
+pub struct MemHeaderStore {
+    finalized: Frontier,
+    nodes: HashMap<block::Hash, HeaderNode>,
+    children: HashMap<block::Hash, HashSet<block::Hash>>,
+    heights: HashMap<block::Height, HashSet<block::Hash>>,
+    eligible_tips: HashSet<block::Hash>,
+}
+
+impl MemHeaderStore {
+    /// Construct a store rooted at one trusted, already-validated work origin.
+    pub fn new(
+        finalized: Frontier,
+        header: Arc<block::Header>,
+        block_work: Work,
+        cumulative_work: U256,
+    ) -> Result<Self, GraphError> {
+        let actual = header.hash();
+        if actual != finalized.hash {
+            return Err(GraphError::AnchorHashMismatch {
+                expected: finalized.hash,
+                actual,
+            });
+        }
+        let anchor = HeaderNode {
+            parent_hash: header.previous_block_hash,
+            header,
+            hash: finalized.hash,
+            height: finalized.height,
+            block_work,
+            work_coordinate: WorkCoordinate::new(finalized.hash, cumulative_work),
+            validation: HeaderValidationState::Valid,
+            eligibility: EligibilityState::default(),
+            body: BodyValidationState::Unknown,
+            aux_delivery_ids: Vec::new(),
+        };
+        let mut nodes = HashMap::new();
+        nodes.insert(finalized.hash, anchor);
+        let mut heights = HashMap::new();
+        heights.insert(finalized.height, HashSet::from([finalized.hash]));
+        Ok(Self {
+            finalized,
+            nodes,
+            children: HashMap::new(),
+            heights,
+            eligible_tips: HashSet::from([finalized.hash]),
+        })
+    }
+
+    /// Return the immutable finalized root of every eligible path.
+    pub const fn finalized(&self) -> Frontier {
+        self.finalized
+    }
+
+    /// Return the number of retained nodes, including the finalized anchor.
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Read one retained node by exact consensus hash.
+    pub fn node(&self, hash: block::Hash) -> Option<&HeaderNode> {
+        self.nodes.get(&hash)
+    }
+
+    /// Return every retained hash at a height, ordered by raw internal bytes.
+    pub fn hashes_at_height(&self, height: block::Height) -> Vec<block::Hash> {
+        let mut hashes: Vec<_> = self
+            .heights
+            .get(&height)
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect();
+        hashes.sort_unstable_by_key(|hash| hash.0);
+        hashes
+    }
+
+    /// Return direct children ordered by raw internal bytes.
+    pub fn children(&self, parent: block::Hash) -> Vec<block::Hash> {
+        let mut children: Vec<_> = self
+            .children
+            .get(&parent)
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect();
+        children.sort_unstable_by_key(|hash| hash.0);
+        children
+    }
+
+    /// Insert one admitted header after its exact parent is retained.
+    pub(crate) fn insert(
+        &mut self,
+        header: Arc<block::Header>,
+        block_work: Work,
+        validation: HeaderValidationState,
+        direct_reasons: impl IntoIterator<Item = EligibilityReason>,
+        body: BodyValidationState,
+    ) -> Result<InsertResult, GraphError> {
+        let hash = header.hash();
+        if let Some(existing) = self.nodes.get(&hash) {
+            if existing.header == header {
+                return Ok(InsertResult::AlreadyPresent(Frontier::new(
+                    existing.height,
+                    hash,
+                )));
+            }
+            return Err(GraphError::ConflictingDuplicate(hash));
+        }
+        let parent_hash = header.previous_block_hash;
+        let parent = self
+            .nodes
+            .get(&parent_hash)
+            .ok_or(GraphError::UnknownParent {
+                header: hash,
+                parent: parent_hash,
+            })?;
+        let height = parent
+            .height
+            .next()
+            .map_err(|_| GraphError::HeightOverflow {
+                parent: parent_hash,
+            })?;
+        let inherited_from = (!parent.is_eligible()).then_some(parent_hash);
+        let direct_reasons: BTreeSet<EligibilityReason> = direct_reasons.into_iter().collect();
+        let body_reason = match &body {
+            BodyValidationState::ConsensusInvalid { evidence, rule } => {
+                Some(EligibilityReason::ConsensusBodyInvalid {
+                    evidence: *evidence,
+                    rule: rule.clone(),
+                })
+            }
+            _ => None,
+        };
+        let recorded_body_reasons = direct_reasons
+            .iter()
+            .filter(|reason| matches!(reason, EligibilityReason::ConsensusBodyInvalid { .. }))
+            .count();
+        if body_reason
+            .as_ref()
+            .is_some_and(|reason| !direct_reasons.contains(reason))
+            || (body_reason.is_none() && recorded_body_reasons != 0)
+            || recorded_body_reasons > 1
+        {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let node = HeaderNode {
+            header,
+            hash,
+            parent_hash,
+            height,
+            block_work,
+            work_coordinate: parent.work_coordinate().checked_add(block_work)?,
+            validation,
+            eligibility: EligibilityState {
+                direct_reasons,
+                inherited_from,
+            },
+            body,
+            aux_delivery_ids: Vec::new(),
+        };
+        self.nodes.insert(hash, node);
+        self.children.entry(parent_hash).or_default().insert(hash);
+        self.heights.entry(height).or_default().insert(hash);
+        if self
+            .nodes
+            .get(&hash)
+            .expect("the inserted node is present")
+            .is_eligible()
+        {
+            self.eligible_tips.remove(&parent_hash);
+            self.eligible_tips.insert(hash);
+        }
+        Ok(InsertResult::Inserted(Frontier::new(height, hash)))
+    }
+
+    /// Add one independent direct reason, then recompute the affected subtree cache.
+    pub(crate) fn add_reason(
+        &mut self,
+        hash: block::Hash,
+        reason: EligibilityReason,
+    ) -> Result<bool, GraphError> {
+        if matches!(reason, EligibilityReason::ConsensusBodyInvalid { .. }) {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let changed = self
+            .nodes
+            .get_mut(&hash)
+            .ok_or(GraphError::UnknownNode(hash))?
+            .eligibility
+            .direct_reasons
+            .insert(reason);
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    /// Remove exactly one operator invalidation, preserving every unrelated reason.
+    pub(crate) fn remove_operator_invalidation(
+        &mut self,
+        hash: block::Hash,
+        id: OperatorInvalidationId,
+    ) -> Result<bool, GraphError> {
+        let reason = EligibilityReason::OperatorInvalid { id };
+        let changed = self
+            .nodes
+            .get_mut(&hash)
+            .ok_or(GraphError::UnknownNode(hash))?
+            .eligibility
+            .direct_reasons
+            .remove(&reason);
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    /// Atomically record one commitment-matching deterministic body failure.
+    pub(crate) fn set_consensus_body_invalid(
+        &mut self,
+        hash: block::Hash,
+        evidence: EvidenceId,
+        rule: BodyRuleId,
+    ) -> Result<bool, GraphError> {
+        let node = self
+            .nodes
+            .get_mut(&hash)
+            .ok_or(GraphError::UnknownNode(hash))?;
+        let body = BodyValidationState::ConsensusInvalid {
+            evidence,
+            rule: rule.clone(),
+        };
+        let reason = EligibilityReason::ConsensusBodyInvalid { evidence, rule };
+        if node.eligibility.direct_reasons.iter().any(|existing| {
+            matches!(existing, EligibilityReason::ConsensusBodyInvalid { .. })
+                && *existing != reason
+        }) || matches!(node.body, BodyValidationState::ConsensusInvalid { .. })
+            && node.body != body
+        {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let changed = node.body != body || !node.eligibility.direct_reasons.contains(&reason);
+        node.body = body;
+        node.eligibility.direct_reasons.insert(reason);
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    /// Update body availability or verification without changing fork choice eligibility.
+    pub(crate) fn set_body_state(
+        &mut self,
+        hash: block::Hash,
+        body: BodyValidationState,
+    ) -> Result<bool, GraphError> {
+        if matches!(body, BodyValidationState::ConsensusInvalid { .. }) {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let node = self
+            .nodes
+            .get_mut(&hash)
+            .ok_or(GraphError::UnknownNode(hash))?;
+        if node
+            .eligibility
+            .direct_reasons
+            .iter()
+            .any(|reason| matches!(reason, EligibilityReason::ConsensusBodyInvalid { .. }))
+        {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let changed = node.body != body;
+        node.body = body;
+        Ok(changed)
+    }
+
+    /// Update local-time validation state and recompute descendant eligibility.
+    pub(crate) fn set_validation(
+        &mut self,
+        hash: block::Hash,
+        validation: HeaderValidationState,
+    ) -> Result<bool, GraphError> {
+        let node = self
+            .nodes
+            .get_mut(&hash)
+            .ok_or(GraphError::UnknownNode(hash))?;
+        let changed = node.validation != validation;
+        node.validation = validation;
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    /// Return the exact ancestor at `height`, if the retained path reaches it.
+    pub fn ancestor(
+        &self,
+        descendant: block::Hash,
+        height: block::Height,
+    ) -> Result<Option<Frontier>, GraphError> {
+        let mut node = self
+            .nodes
+            .get(&descendant)
+            .ok_or(GraphError::UnknownNode(descendant))?;
+        if height > node.height {
+            return Err(GraphError::InvalidAncestorHeight {
+                ancestor: height,
+                descendant: node.height,
+            });
+        }
+        while node.height > height {
+            let Some(parent) = self.nodes.get(&node.parent_hash) else {
+                return Ok(None);
+            };
+            node = parent;
+        }
+        Ok(Some(Frontier::new(node.height, node.hash)))
+    }
+
+    /// Return all currently maximal eligible nodes in deterministic hash order.
+    pub fn eligible_tips(&self) -> Vec<Frontier> {
+        let mut tips: Vec<_> = self
+            .eligible_tips
+            .iter()
+            .filter_map(|hash| self.nodes.get(hash))
+            .map(|node| Frontier::new(node.height, node.hash))
+            .collect();
+        tips.sort_unstable_by_key(|tip| tip.hash.0);
+        tips
+    }
+
+    /// Select the deterministic greatest-work eligible tip after the finalized anchor.
+    pub fn select_header_best(&self) -> Result<(Frontier, ChainScore), GraphError> {
+        let anchor = self
+            .nodes
+            .get(&self.finalized.hash)
+            .ok_or(GraphError::UnknownNode(self.finalized.hash))?;
+        let mut best = None;
+        for hash in &self.eligible_tips {
+            let node = self
+                .nodes
+                .get(hash)
+                .expect("eligible tips are derived from retained nodes");
+            let tip = Frontier::new(node.height, node.hash);
+            let score = ChainScore::new(
+                node.work_coordinate()
+                    .suffix_after(anchor.work_coordinate())?,
+                tip.hash,
+            );
+            if best.is_none_or(|(_, best_score)| score > best_score) {
+                best = Some((tip, score));
+            }
+        }
+        best.ok_or(GraphError::UnknownNode(self.finalized.hash))
+    }
+
+    /// Return the selection score of one retained descendant of the finalized anchor.
+    pub fn score(&self, hash: block::Hash) -> Result<ChainScore, GraphError> {
+        let anchor = self
+            .nodes
+            .get(&self.finalized.hash)
+            .ok_or(GraphError::UnknownNode(self.finalized.hash))?;
+        let node = self.nodes.get(&hash).ok_or(GraphError::UnknownNode(hash))?;
+        Ok(ChainScore::new(
+            node.work_coordinate()
+                .suffix_after(anchor.work_coordinate())?,
+            hash,
+        ))
+    }
+
+    pub(crate) fn from_nodes(
+        finalized: Frontier,
+        nodes: impl IntoIterator<Item = HeaderNode>,
+    ) -> Result<Self, GraphError> {
+        let mut node_map = HashMap::new();
+        let mut children: HashMap<_, HashSet<_>> = HashMap::new();
+        let mut heights: HashMap<_, HashSet<_>> = HashMap::new();
+        for node in nodes {
+            heights.entry(node.height).or_default().insert(node.hash);
+            children
+                .entry(node.parent_hash)
+                .or_default()
+                .insert(node.hash);
+            node_map.insert(node.hash, node);
+        }
+        if !node_map.contains_key(&finalized.hash) {
+            return Err(GraphError::UnknownNode(finalized.hash));
+        }
+        children.remove(
+            &node_map
+                .get(&finalized.hash)
+                .expect("the finalized node was checked above")
+                .parent_hash,
+        );
+        let mut store = Self {
+            finalized,
+            nodes: node_map,
+            children,
+            heights,
+            eligible_tips: HashSet::new(),
+        };
+        store.rebuild_eligible_tips();
+        Ok(store)
+    }
+
+    /// Rebuild all in-memory indexes from nodes returned by an exhaustive store audit.
+    pub fn from_audited_nodes(
+        finalized: Frontier,
+        nodes: impl IntoIterator<Item = HeaderNode>,
+    ) -> Result<Self, GraphError> {
+        Self::from_nodes(finalized, nodes)
+    }
+
+    pub(crate) fn nodes(&self) -> impl Iterator<Item = &HeaderNode> {
+        self.nodes.values()
+    }
+
+    pub(crate) fn node_mut(&mut self, hash: block::Hash) -> Result<&mut HeaderNode, GraphError> {
+        self.nodes
+            .get_mut(&hash)
+            .ok_or(GraphError::UnknownNode(hash))
+    }
+
+    pub(crate) fn recompute_all_eligibility(&mut self) -> Result<(), GraphError> {
+        let mut frontiers: Vec<_> = self
+            .nodes
+            .values()
+            .map(|node| Frontier::new(node.height, node.hash))
+            .collect();
+        frontiers.sort_unstable_by_key(|frontier| (frontier.height, frontier.hash.0));
+        for frontier in frontiers {
+            if frontier == self.finalized {
+                self.node_mut(frontier.hash)?.eligibility.inherited_from = None;
+                continue;
+            }
+            let parent_hash = self
+                .node(frontier.hash)
+                .expect("frontier came from nodes")
+                .parent_hash;
+            let parent = self.node(parent_hash).ok_or(GraphError::UnknownParent {
+                header: frontier.hash,
+                parent: parent_hash,
+            })?;
+            let inherited_from = (!parent.is_eligible()).then_some(parent_hash);
+            self.node_mut(frontier.hash)?.eligibility.inherited_from = inherited_from;
+        }
+        self.rebuild_eligible_tips();
+        Ok(())
+    }
+
+    pub(crate) fn advance_finalized(
+        &mut self,
+        finalized: Frontier,
+    ) -> Result<Vec<block::Hash>, GraphError> {
+        let node = self
+            .node(finalized.hash)
+            .ok_or(GraphError::UnknownNode(finalized.hash))?;
+        if node.height != finalized.height {
+            return Err(GraphError::UnknownNode(finalized.hash));
+        }
+        if !node.is_eligible() {
+            return Err(GraphError::IneligibleFinalized(finalized.hash));
+        }
+        let mut retained = HashSet::new();
+        let mut pending = vec![finalized.hash];
+        while let Some(hash) = pending.pop() {
+            if retained.insert(hash) {
+                pending.extend(self.children(hash));
+            }
+        }
+        let mut deleted: Vec<_> = self
+            .nodes
+            .keys()
+            .copied()
+            .filter(|hash| !retained.contains(hash))
+            .collect();
+        deleted.sort_unstable_by_key(|hash| hash.0);
+        for hash in &deleted {
+            let node = self
+                .nodes
+                .remove(hash)
+                .expect("the deletion set came from retained graph nodes");
+            self.children.remove(hash);
+            self.eligible_tips.remove(hash);
+            if let Some(hashes) = self.heights.get_mut(&node.height) {
+                hashes.remove(hash);
+                if hashes.is_empty() {
+                    self.heights.remove(&node.height);
+                }
+            }
+        }
+        self.finalized = finalized;
+        self.nodes
+            .get_mut(&finalized.hash)
+            .expect("the new finalized root is retained")
+            .eligibility
+            .inherited_from = None;
+        self.refresh_eligible_tip(finalized.hash);
+        Ok(deleted)
+    }
+
+    pub(crate) fn retained_hashes(&self) -> impl Iterator<Item = block::Hash> + '_ {
+        self.nodes.keys().copied()
+    }
+
+    pub(crate) fn remove_leaf(&mut self, hash: block::Hash) -> Result<(), GraphError> {
+        let node = self.nodes.get(&hash).ok_or(GraphError::UnknownNode(hash))?;
+        if self
+            .children
+            .get(&hash)
+            .is_some_and(|children| !children.is_empty())
+        {
+            return Err(GraphError::NodeHasChildren(hash));
+        }
+        let parent_hash = node.parent_hash;
+        let height = node.height;
+        self.eligible_tips.remove(&hash);
+        self.nodes.remove(&hash);
+        self.children.remove(&hash);
+        if let Some(children) = self.children.get_mut(&parent_hash) {
+            children.remove(&hash);
+            if children.is_empty() {
+                self.children.remove(&parent_hash);
+            }
+        }
+        if let Some(hashes) = self.heights.get_mut(&height) {
+            hashes.remove(&hash);
+            if hashes.is_empty() {
+                self.heights.remove(&height);
+            }
+        }
+        self.refresh_eligible_tip(parent_hash);
+        Ok(())
+    }
+
+    fn recompute_descendant_eligibility(&mut self, root: block::Hash) -> Result<(), GraphError> {
+        let mut affected = HashSet::from([root]);
+        let mut queue = VecDeque::from(self.children(root));
+        while let Some(hash) = queue.pop_front() {
+            affected.insert(hash);
+            let parent_hash = self
+                .nodes
+                .get(&hash)
+                .ok_or(GraphError::UnknownNode(hash))?
+                .parent_hash;
+            let parent = self
+                .nodes
+                .get(&parent_hash)
+                .ok_or(GraphError::UnknownNode(parent_hash))?;
+            let inherited_from = (!parent.is_eligible()).then_some(parent_hash);
+            self.nodes
+                .get_mut(&hash)
+                .expect("the queued child was read from the retained node map")
+                .eligibility
+                .inherited_from = inherited_from;
+            queue.extend(self.children(hash));
+        }
+        let parents: Vec<_> = affected
+            .iter()
+            .filter_map(|hash| self.nodes.get(hash).map(|node| node.parent_hash))
+            .collect();
+        affected.extend(parents);
+        for hash in affected {
+            self.refresh_eligible_tip(hash);
+        }
+        Ok(())
+    }
+
+    fn has_eligible_child(&self, hash: block::Hash) -> bool {
+        self.children.get(&hash).is_some_and(|children| {
+            children
+                .iter()
+                .any(|child| self.nodes.get(child).is_some_and(HeaderNode::is_eligible))
+        })
+    }
+
+    fn refresh_eligible_tip(&mut self, hash: block::Hash) {
+        self.eligible_tips.remove(&hash);
+        if self
+            .nodes
+            .get(&hash)
+            .is_some_and(|node| node.is_eligible() && !self.has_eligible_child(hash))
+        {
+            self.eligible_tips.insert(hash);
+        }
+    }
+
+    fn rebuild_eligible_tips(&mut self) {
+        self.eligible_tips = self
+            .nodes
+            .values()
+            .filter(|node| node.is_eligible() && !self.has_eligible_child(node.hash))
+            .map(|node| node.hash)
+            .collect();
+    }
+
+    pub(crate) fn apply_delta(&mut self, delta: &GraphDelta) -> Result<(), GraphError> {
+        for hash in &delta.delete_nodes {
+            if !self.nodes.contains_key(hash) {
+                return Err(GraphError::UnknownNode(*hash));
+            }
+        }
+        for node in &delta.put_nodes {
+            if delta.delete_nodes.contains(&node.hash) {
+                return Err(GraphError::ConflictingDuplicate(node.hash));
+            }
+        }
+
+        for hash in &delta.delete_nodes {
+            let node = self
+                .nodes
+                .remove(hash)
+                .expect("delta deletions were validated before mutation");
+            self.children.remove(hash);
+            if let Some(hashes) = self.heights.get_mut(&node.height) {
+                hashes.remove(hash);
+                if hashes.is_empty() {
+                    self.heights.remove(&node.height);
+                }
+            }
+        }
+        for node in &delta.put_nodes {
+            let old = self.nodes.insert(node.hash, node.clone());
+            if old.is_none() {
+                self.heights
+                    .entry(node.height)
+                    .or_default()
+                    .insert(node.hash);
+            }
+        }
+        for (parent, child) in &delta.remove_children {
+            if let Some(children) = self.children.get_mut(parent) {
+                children.remove(child);
+                if children.is_empty() {
+                    self.children.remove(parent);
+                }
+            }
+        }
+        for (parent, child) in &delta.add_children {
+            self.children.entry(*parent).or_default().insert(*child);
+        }
+        for hash in &delta.remove_eligible_tips {
+            self.eligible_tips.remove(hash);
+        }
+        self.eligible_tips
+            .extend(delta.add_eligible_tips.iter().copied());
+        if let Some(finalized) = delta.finalized {
+            self.finalized = finalized;
+        }
+        Ok(())
+    }
+}
+
+impl HeaderGraphView for MemHeaderStore {
+    fn view_finalized(&self) -> Frontier {
+        self.finalized()
+    }
+
+    fn view_node_count(&self) -> usize {
+        self.node_count()
+    }
+
+    fn view_node(&self, hash: block::Hash) -> Option<&HeaderNode> {
+        self.node(hash)
+    }
+
+    fn view_nodes(&self) -> Vec<&HeaderNode> {
+        self.nodes().collect()
+    }
+
+    fn view_retained_hashes(&self) -> Vec<block::Hash> {
+        self.retained_hashes().collect()
+    }
+
+    fn view_hashes_at_height(&self, height: block::Height) -> Vec<block::Hash> {
+        self.hashes_at_height(height)
+    }
+
+    fn view_children(&self, parent: block::Hash) -> Vec<block::Hash> {
+        self.children(parent)
+    }
+
+    fn view_eligible_tips(&self) -> Vec<Frontier> {
+        self.eligible_tips()
+    }
+
+    fn view_select_header_best(&self) -> Result<(Frontier, ChainScore), GraphError> {
+        self.select_header_best()
+    }
+
+    fn view_score(&self, hash: block::Hash) -> Result<ChainScore, GraphError> {
+        self.score(hash)
+    }
+
+    fn view_ancestor(
+        &self,
+        descendant: block::Hash,
+        height: block::Height,
+    ) -> Result<Option<Frontier>, GraphError> {
+        self.ancestor(descendant, height)
+    }
+}
+
+impl HeaderGraphEdit for MemHeaderStore {
+    fn edit_node_mut(&mut self, hash: block::Hash) -> Result<&mut HeaderNode, GraphError> {
+        self.node_mut(hash)
+    }
+
+    fn edit_insert(
+        &mut self,
+        header: Arc<block::Header>,
+        block_work: Work,
+        validation: HeaderValidationState,
+        direct_reasons: Vec<EligibilityReason>,
+        body: BodyValidationState,
+    ) -> Result<InsertResult, GraphError> {
+        self.insert(header, block_work, validation, direct_reasons, body)
+    }
+
+    fn edit_add_reason(
+        &mut self,
+        hash: block::Hash,
+        reason: EligibilityReason,
+    ) -> Result<bool, GraphError> {
+        self.add_reason(hash, reason)
+    }
+
+    fn edit_remove_operator_invalidation(
+        &mut self,
+        hash: block::Hash,
+        id: OperatorInvalidationId,
+    ) -> Result<bool, GraphError> {
+        self.remove_operator_invalidation(hash, id)
+    }
+
+    fn edit_set_consensus_body_invalid(
+        &mut self,
+        hash: block::Hash,
+        evidence: EvidenceId,
+        rule: BodyRuleId,
+    ) -> Result<bool, GraphError> {
+        self.set_consensus_body_invalid(hash, evidence, rule)
+    }
+
+    fn edit_set_body_state(
+        &mut self,
+        hash: block::Hash,
+        body: BodyValidationState,
+    ) -> Result<bool, GraphError> {
+        self.set_body_state(hash, body)
+    }
+
+    fn edit_set_validation(
+        &mut self,
+        hash: block::Hash,
+        validation: HeaderValidationState,
+    ) -> Result<bool, GraphError> {
+        self.set_validation(hash, validation)
+    }
+
+    fn edit_advance_finalized(
+        &mut self,
+        finalized: Frontier,
+    ) -> Result<Vec<block::Hash>, GraphError> {
+        self.advance_finalized(finalized)
+    }
+
+    fn edit_remove_leaf(&mut self, hash: block::Hash) -> Result<(), GraphError> {
+        self.remove_leaf(hash)
+    }
+}
+
+impl HeaderGraphView for GraphOverlay<'_> {
+    fn view_finalized(&self) -> Frontier {
+        self.finalized()
+    }
+
+    fn view_node_count(&self) -> usize {
+        self.node_count()
+    }
+
+    fn view_node(&self, hash: block::Hash) -> Option<&HeaderNode> {
+        self.node(hash)
+    }
+
+    fn view_nodes(&self) -> Vec<&HeaderNode> {
+        self.nodes().collect()
+    }
+
+    fn view_retained_hashes(&self) -> Vec<block::Hash> {
+        self.retained_hashes().collect()
+    }
+
+    fn view_hashes_at_height(&self, height: block::Height) -> Vec<block::Hash> {
+        self.hashes_at_height(height)
+    }
+
+    fn view_children(&self, parent: block::Hash) -> Vec<block::Hash> {
+        self.children(parent)
+    }
+
+    fn view_eligible_tips(&self) -> Vec<Frontier> {
+        self.eligible_tips()
+    }
+
+    fn view_select_header_best(&self) -> Result<(Frontier, ChainScore), GraphError> {
+        self.select_header_best()
+    }
+
+    fn view_score(&self, hash: block::Hash) -> Result<ChainScore, GraphError> {
+        self.score(hash)
+    }
+
+    fn view_ancestor(
+        &self,
+        descendant: block::Hash,
+        height: block::Height,
+    ) -> Result<Option<Frontier>, GraphError> {
+        self.ancestor(descendant, height)
+    }
+}
+
+impl HeaderGraphEdit for GraphOverlay<'_> {
+    fn edit_node_mut(&mut self, hash: block::Hash) -> Result<&mut HeaderNode, GraphError> {
+        self.node_mut(hash)
+    }
+
+    fn edit_insert(
+        &mut self,
+        header: Arc<block::Header>,
+        block_work: Work,
+        validation: HeaderValidationState,
+        direct_reasons: Vec<EligibilityReason>,
+        body: BodyValidationState,
+    ) -> Result<InsertResult, GraphError> {
+        self.insert(header, block_work, validation, direct_reasons, body)
+    }
+
+    fn edit_add_reason(
+        &mut self,
+        hash: block::Hash,
+        reason: EligibilityReason,
+    ) -> Result<bool, GraphError> {
+        self.add_reason(hash, reason)
+    }
+
+    fn edit_remove_operator_invalidation(
+        &mut self,
+        hash: block::Hash,
+        id: OperatorInvalidationId,
+    ) -> Result<bool, GraphError> {
+        self.remove_operator_invalidation(hash, id)
+    }
+
+    fn edit_set_consensus_body_invalid(
+        &mut self,
+        hash: block::Hash,
+        evidence: EvidenceId,
+        rule: BodyRuleId,
+    ) -> Result<bool, GraphError> {
+        self.set_consensus_body_invalid(hash, evidence, rule)
+    }
+
+    fn edit_set_body_state(
+        &mut self,
+        hash: block::Hash,
+        body: BodyValidationState,
+    ) -> Result<bool, GraphError> {
+        self.set_body_state(hash, body)
+    }
+
+    fn edit_set_validation(
+        &mut self,
+        hash: block::Hash,
+        validation: HeaderValidationState,
+    ) -> Result<bool, GraphError> {
+        self.set_validation(hash, validation)
+    }
+
+    fn edit_advance_finalized(
+        &mut self,
+        finalized: Frontier,
+    ) -> Result<Vec<block::Hash>, GraphError> {
+        self.advance_finalized(finalized)
+    }
+
+    fn edit_remove_leaf(&mut self, hash: block::Hash) -> Result<(), GraphError> {
+        self.remove_leaf(hash)
+    }
+}

--- a/crates/zakura-header-chain/src/graph/overlay.rs
+++ b/crates/zakura-header-chain/src/graph/overlay.rs
@@ -1,0 +1,933 @@
+#[cfg(test)]
+use std::cell::Cell;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use zakura_chain::{block, work::difficulty::Work};
+
+use super::{GraphError, InsertResult, MemHeaderStore};
+use crate::{
+    BodyRuleId, BodyValidationState, ChainScore, EligibilityReason, EligibilityState, EvidenceId,
+    Frontier, HeaderNode, HeaderValidationState, OperatorInvalidationId,
+};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct GraphDelta {
+    pub(crate) finalized: Option<Frontier>,
+    pub(crate) put_nodes: Vec<HeaderNode>,
+    pub(crate) delete_nodes: Vec<block::Hash>,
+    pub(crate) add_children: Vec<(block::Hash, block::Hash)>,
+    pub(crate) remove_children: Vec<(block::Hash, block::Hash)>,
+    pub(crate) add_eligible_tips: Vec<block::Hash>,
+    pub(crate) remove_eligible_tips: Vec<block::Hash>,
+}
+
+pub(crate) struct GraphOverlay<'a> {
+    base: &'a MemHeaderStore,
+    finalized: Frontier,
+    puts: HashMap<block::Hash, HeaderNode>,
+    deletes: HashSet<block::Hash>,
+    add_children: HashMap<block::Hash, HashSet<block::Hash>>,
+    remove_children: HashMap<block::Hash, HashSet<block::Hash>>,
+    eligible_tips: HashSet<block::Hash>,
+    node_count: usize,
+    #[cfg(test)]
+    base_nodes_cloned: Cell<usize>,
+    #[cfg(test)]
+    eligibility_nodes_visited: Cell<usize>,
+}
+
+impl<'a> GraphOverlay<'a> {
+    pub(crate) fn new(base: &'a MemHeaderStore) -> Self {
+        Self {
+            base,
+            finalized: base.finalized,
+            puts: HashMap::new(),
+            deletes: HashSet::new(),
+            add_children: HashMap::new(),
+            remove_children: HashMap::new(),
+            eligible_tips: base.eligible_tips.clone(),
+            node_count: base.nodes.len(),
+            #[cfg(test)]
+            base_nodes_cloned: Cell::new(0),
+            #[cfg(test)]
+            eligibility_nodes_visited: Cell::new(0),
+        }
+    }
+
+    pub(crate) fn from_delta(base: &'a MemHeaderStore, delta: &GraphDelta) -> Self {
+        let puts = delta
+            .put_nodes
+            .iter()
+            .cloned()
+            .map(|node| (node.hash, node))
+            .collect();
+        let deletes = delta.delete_nodes.iter().copied().collect();
+        let mut add_children: HashMap<_, HashSet<_>> = HashMap::new();
+        let mut remove_children: HashMap<_, HashSet<_>> = HashMap::new();
+        for (parent, child) in &delta.add_children {
+            add_children.entry(*parent).or_default().insert(*child);
+        }
+        for (parent, child) in &delta.remove_children {
+            remove_children.entry(*parent).or_default().insert(*child);
+        }
+        let mut eligible_tips = base.eligible_tips.clone();
+        for hash in &delta.remove_eligible_tips {
+            eligible_tips.remove(hash);
+        }
+        eligible_tips.extend(delta.add_eligible_tips.iter().copied());
+        Self {
+            base,
+            finalized: delta.finalized.unwrap_or(base.finalized),
+            puts,
+            deletes,
+            add_children,
+            remove_children,
+            eligible_tips,
+            node_count: base
+                .nodes
+                .len()
+                .saturating_add(
+                    delta
+                        .put_nodes
+                        .iter()
+                        .filter(|node| !base.nodes.contains_key(&node.hash))
+                        .count(),
+                )
+                .saturating_sub(delta.delete_nodes.len()),
+            #[cfg(test)]
+            base_nodes_cloned: Cell::new(0),
+            #[cfg(test)]
+            eligibility_nodes_visited: Cell::new(0),
+        }
+    }
+
+    pub(crate) const fn finalized(&self) -> Frontier {
+        self.finalized
+    }
+
+    pub(crate) const fn node_count(&self) -> usize {
+        self.node_count
+    }
+
+    pub(crate) fn node(&self, hash: block::Hash) -> Option<&HeaderNode> {
+        if self.deletes.contains(&hash) {
+            return None;
+        }
+        self.puts.get(&hash).or_else(|| self.base.nodes.get(&hash))
+    }
+
+    pub(crate) fn node_mut(&mut self, hash: block::Hash) -> Result<&mut HeaderNode, GraphError> {
+        if self.deletes.contains(&hash) {
+            return Err(GraphError::UnknownNode(hash));
+        }
+        if !self.puts.contains_key(&hash) {
+            let node = self
+                .base
+                .nodes
+                .get(&hash)
+                .cloned()
+                .ok_or(GraphError::UnknownNode(hash))?;
+            #[cfg(test)]
+            self.base_nodes_cloned
+                .set(self.base_nodes_cloned.get().saturating_add(1));
+            self.puts.insert(hash, node);
+        }
+        self.puts
+            .get_mut(&hash)
+            .ok_or(GraphError::UnknownNode(hash))
+    }
+
+    pub(crate) fn nodes(&self) -> impl Iterator<Item = &HeaderNode> {
+        self.base
+            .nodes
+            .values()
+            .filter(|node| {
+                !self.deletes.contains(&node.hash) && !self.puts.contains_key(&node.hash)
+            })
+            .chain(
+                self.puts
+                    .values()
+                    .filter(|node| !self.deletes.contains(&node.hash)),
+            )
+    }
+
+    pub(crate) fn retained_hashes(&self) -> impl Iterator<Item = block::Hash> + '_ {
+        self.nodes().map(|node| node.hash)
+    }
+
+    pub(crate) fn hashes_at_height(&self, height: block::Height) -> Vec<block::Hash> {
+        let mut hashes: HashSet<_> = self
+            .base
+            .heights
+            .get(&height)
+            .into_iter()
+            .flatten()
+            .filter(|hash| !self.deletes.contains(hash) && !self.puts.contains_key(hash))
+            .copied()
+            .collect();
+        hashes.extend(
+            self.puts
+                .values()
+                .filter(|node| node.height == height && !self.deletes.contains(&node.hash))
+                .map(|node| node.hash),
+        );
+        let mut hashes: Vec<_> = hashes.into_iter().collect();
+        hashes.sort_unstable_by_key(|hash| hash.0);
+        hashes
+    }
+
+    pub(crate) fn children(&self, parent: block::Hash) -> Vec<block::Hash> {
+        if self.node(parent).is_none() {
+            return Vec::new();
+        }
+        let removed = self.remove_children.get(&parent);
+        let mut children: HashSet<_> = self
+            .base
+            .children
+            .get(&parent)
+            .into_iter()
+            .flatten()
+            .filter(|child| {
+                !self.deletes.contains(child)
+                    && removed.is_none_or(|removed| !removed.contains(child))
+            })
+            .copied()
+            .collect();
+        children.extend(
+            self.add_children
+                .get(&parent)
+                .into_iter()
+                .flatten()
+                .filter(|child| !self.deletes.contains(child))
+                .copied(),
+        );
+        let mut children: Vec<_> = children.into_iter().collect();
+        children.sort_unstable_by_key(|hash| hash.0);
+        children
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        header: Arc<block::Header>,
+        block_work: Work,
+        validation: HeaderValidationState,
+        direct_reasons: impl IntoIterator<Item = EligibilityReason>,
+        body: BodyValidationState,
+    ) -> Result<InsertResult, GraphError> {
+        let hash = header.hash();
+        if let Some(existing) = self.node(hash) {
+            if existing.header == header {
+                return Ok(InsertResult::AlreadyPresent(Frontier::new(
+                    existing.height,
+                    hash,
+                )));
+            }
+            return Err(GraphError::ConflictingDuplicate(hash));
+        }
+        let parent_hash = header.previous_block_hash;
+        let parent = self.node(parent_hash).ok_or(GraphError::UnknownParent {
+            header: hash,
+            parent: parent_hash,
+        })?;
+        let height = parent
+            .height
+            .next()
+            .map_err(|_| GraphError::HeightOverflow {
+                parent: parent_hash,
+            })?;
+        let inherited_from = (!parent.is_eligible()).then_some(parent_hash);
+        let work_coordinate = parent.work_coordinate().checked_add(block_work)?;
+        let direct_reasons: BTreeSet<_> = direct_reasons.into_iter().collect();
+        let body_reason = match &body {
+            BodyValidationState::ConsensusInvalid { evidence, rule } => {
+                Some(EligibilityReason::ConsensusBodyInvalid {
+                    evidence: *evidence,
+                    rule: rule.clone(),
+                })
+            }
+            _ => None,
+        };
+        let recorded_body_reasons = direct_reasons
+            .iter()
+            .filter(|reason| matches!(reason, EligibilityReason::ConsensusBodyInvalid { .. }))
+            .count();
+        if body_reason
+            .as_ref()
+            .is_some_and(|reason| !direct_reasons.contains(reason))
+            || (body_reason.is_none() && recorded_body_reasons != 0)
+            || recorded_body_reasons > 1
+        {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let eligible = validation == HeaderValidationState::Valid
+            && direct_reasons.is_empty()
+            && inherited_from.is_none();
+        self.puts.insert(
+            hash,
+            HeaderNode {
+                header,
+                hash,
+                parent_hash,
+                height,
+                block_work,
+                work_coordinate,
+                validation,
+                eligibility: EligibilityState {
+                    direct_reasons,
+                    inherited_from,
+                },
+                body,
+                aux_delivery_ids: Vec::new(),
+            },
+        );
+        self.deletes.remove(&hash);
+        self.record_child_add(parent_hash, hash);
+        self.node_count = self.node_count.saturating_add(1);
+        if eligible {
+            self.eligible_tips.remove(&parent_hash);
+            self.eligible_tips.insert(hash);
+        }
+        Ok(InsertResult::Inserted(Frontier::new(height, hash)))
+    }
+
+    pub(crate) fn add_reason(
+        &mut self,
+        hash: block::Hash,
+        reason: EligibilityReason,
+    ) -> Result<bool, GraphError> {
+        if matches!(reason, EligibilityReason::ConsensusBodyInvalid { .. }) {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let changed = self
+            .node_mut(hash)?
+            .eligibility
+            .direct_reasons
+            .insert(reason);
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    pub(crate) fn remove_operator_invalidation(
+        &mut self,
+        hash: block::Hash,
+        id: OperatorInvalidationId,
+    ) -> Result<bool, GraphError> {
+        let changed = self
+            .node_mut(hash)?
+            .eligibility
+            .direct_reasons
+            .remove(&EligibilityReason::OperatorInvalid { id });
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    pub(crate) fn set_consensus_body_invalid(
+        &mut self,
+        hash: block::Hash,
+        evidence: EvidenceId,
+        rule: BodyRuleId,
+    ) -> Result<bool, GraphError> {
+        let node = self.node_mut(hash)?;
+        let body = BodyValidationState::ConsensusInvalid {
+            evidence,
+            rule: rule.clone(),
+        };
+        let reason = EligibilityReason::ConsensusBodyInvalid { evidence, rule };
+        if node.eligibility.direct_reasons.iter().any(|existing| {
+            matches!(existing, EligibilityReason::ConsensusBodyInvalid { .. })
+                && *existing != reason
+        }) || matches!(node.body, BodyValidationState::ConsensusInvalid { .. })
+            && node.body != body
+        {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let changed = node.body != body || !node.eligibility.direct_reasons.contains(&reason);
+        node.body = body;
+        node.eligibility.direct_reasons.insert(reason);
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    pub(crate) fn set_body_state(
+        &mut self,
+        hash: block::Hash,
+        body: BodyValidationState,
+    ) -> Result<bool, GraphError> {
+        if matches!(body, BodyValidationState::ConsensusInvalid { .. }) {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let node = self.node_mut(hash)?;
+        if node
+            .eligibility
+            .direct_reasons
+            .iter()
+            .any(|reason| matches!(reason, EligibilityReason::ConsensusBodyInvalid { .. }))
+        {
+            return Err(GraphError::BodyEligibilityMismatch(hash));
+        }
+        let changed = node.body != body;
+        node.body = body;
+        Ok(changed)
+    }
+
+    pub(crate) fn set_validation(
+        &mut self,
+        hash: block::Hash,
+        validation: HeaderValidationState,
+    ) -> Result<bool, GraphError> {
+        let node = self.node_mut(hash)?;
+        let changed = node.validation != validation;
+        node.validation = validation;
+        if changed {
+            self.recompute_descendant_eligibility(hash)?;
+        }
+        Ok(changed)
+    }
+
+    pub(crate) fn ancestor(
+        &self,
+        descendant: block::Hash,
+        height: block::Height,
+    ) -> Result<Option<Frontier>, GraphError> {
+        let mut node = self
+            .node(descendant)
+            .ok_or(GraphError::UnknownNode(descendant))?;
+        if height > node.height {
+            return Err(GraphError::InvalidAncestorHeight {
+                ancestor: height,
+                descendant: node.height,
+            });
+        }
+        while node.height > height {
+            let Some(parent) = self.node(node.parent_hash) else {
+                return Ok(None);
+            };
+            node = parent;
+        }
+        Ok(Some(Frontier::new(node.height, node.hash)))
+    }
+
+    pub(crate) fn eligible_tips(&self) -> Vec<Frontier> {
+        let mut tips: Vec<_> = self
+            .eligible_tips
+            .iter()
+            .filter_map(|hash| self.node(*hash))
+            .map(|node| Frontier::new(node.height, node.hash))
+            .collect();
+        tips.sort_unstable_by_key(|tip| tip.hash.0);
+        tips
+    }
+
+    pub(crate) fn select_header_best(&self) -> Result<(Frontier, ChainScore), GraphError> {
+        let anchor = self
+            .node(self.finalized.hash)
+            .ok_or(GraphError::UnknownNode(self.finalized.hash))?;
+        let mut best = None;
+        for hash in &self.eligible_tips {
+            let node = self
+                .node(*hash)
+                .expect("overlay eligible tips are retained nodes");
+            let tip = Frontier::new(node.height, node.hash);
+            let score = ChainScore::new(
+                node.work_coordinate()
+                    .suffix_after(anchor.work_coordinate())?,
+                tip.hash,
+            );
+            if best.is_none_or(|(_, best_score)| score > best_score) {
+                best = Some((tip, score));
+            }
+        }
+        best.ok_or(GraphError::UnknownNode(self.finalized.hash))
+    }
+
+    pub(crate) fn score(&self, hash: block::Hash) -> Result<ChainScore, GraphError> {
+        let anchor = self
+            .node(self.finalized.hash)
+            .ok_or(GraphError::UnknownNode(self.finalized.hash))?;
+        let node = self.node(hash).ok_or(GraphError::UnknownNode(hash))?;
+        Ok(ChainScore::new(
+            node.work_coordinate()
+                .suffix_after(anchor.work_coordinate())?,
+            hash,
+        ))
+    }
+
+    pub(crate) fn advance_finalized(
+        &mut self,
+        finalized: Frontier,
+    ) -> Result<Vec<block::Hash>, GraphError> {
+        let node = self
+            .node(finalized.hash)
+            .ok_or(GraphError::UnknownNode(finalized.hash))?;
+        if node.height != finalized.height {
+            return Err(GraphError::UnknownNode(finalized.hash));
+        }
+        if !node.is_eligible() {
+            return Err(GraphError::IneligibleFinalized(finalized.hash));
+        }
+        let mut retained = HashSet::new();
+        let mut pending = vec![finalized.hash];
+        while let Some(hash) = pending.pop() {
+            if retained.insert(hash) {
+                pending.extend(self.children(hash));
+            }
+        }
+        let mut deleted: Vec<_> = self
+            .retained_hashes()
+            .filter(|hash| !retained.contains(hash))
+            .collect();
+        deleted.sort_unstable_by_key(|hash| hash.0);
+        for hash in &deleted {
+            self.delete_node(*hash)?;
+        }
+        self.finalized = finalized;
+        self.node_mut(finalized.hash)?.eligibility.inherited_from = None;
+        self.refresh_eligible_tip(finalized.hash);
+        Ok(deleted)
+    }
+
+    pub(crate) fn remove_leaf(&mut self, hash: block::Hash) -> Result<(), GraphError> {
+        if !self.children(hash).is_empty() {
+            return Err(GraphError::NodeHasChildren(hash));
+        }
+        self.delete_node(hash)
+    }
+
+    pub(crate) fn delta(&self) -> GraphDelta {
+        let mut put_nodes: Vec<_> = self
+            .puts
+            .values()
+            .filter(|node| {
+                !self.deletes.contains(&node.hash) && self.base.nodes.get(&node.hash) != Some(*node)
+            })
+            .cloned()
+            .collect();
+        put_nodes.sort_unstable_by_key(|node| (node.height, node.hash.0));
+        let mut delete_nodes: Vec<_> = self.deletes.iter().copied().collect();
+        delete_nodes.sort_unstable_by_key(|hash| hash.0);
+        let mut add_children = flatten_edges(&self.add_children);
+        let mut remove_children = flatten_edges(&self.remove_children);
+        add_children.sort_unstable_by_key(|(parent, child)| (parent.0, child.0));
+        remove_children.sort_unstable_by_key(|(parent, child)| (parent.0, child.0));
+        let mut add_eligible_tips: Vec<_> = self
+            .eligible_tips
+            .difference(&self.base.eligible_tips)
+            .copied()
+            .collect();
+        let mut remove_eligible_tips: Vec<_> = self
+            .base
+            .eligible_tips
+            .difference(&self.eligible_tips)
+            .copied()
+            .collect();
+        add_eligible_tips.sort_unstable_by_key(|hash| hash.0);
+        remove_eligible_tips.sort_unstable_by_key(|hash| hash.0);
+        GraphDelta {
+            finalized: (self.finalized != self.base.finalized).then_some(self.finalized),
+            put_nodes,
+            delete_nodes,
+            add_children,
+            remove_children,
+            add_eligible_tips,
+            remove_eligible_tips,
+        }
+    }
+
+    fn delete_node(&mut self, hash: block::Hash) -> Result<(), GraphError> {
+        let node = self
+            .node(hash)
+            .cloned()
+            .ok_or(GraphError::UnknownNode(hash))?;
+        self.puts.remove(&hash);
+        if self.base.nodes.contains_key(&hash) {
+            self.deletes.insert(hash);
+        }
+        self.record_child_remove(node.parent_hash, hash);
+        self.eligible_tips.remove(&hash);
+        self.node_count = self.node_count.saturating_sub(1);
+        self.refresh_eligible_tip(node.parent_hash);
+        Ok(())
+    }
+
+    fn recompute_descendant_eligibility(&mut self, root: block::Hash) -> Result<(), GraphError> {
+        let mut affected = HashSet::from([root]);
+        let mut queue = VecDeque::from(self.children(root));
+        while let Some(hash) = queue.pop_front() {
+            #[cfg(test)]
+            self.eligibility_nodes_visited
+                .set(self.eligibility_nodes_visited.get().saturating_add(1));
+            let parent_hash = self
+                .node(hash)
+                .ok_or(GraphError::UnknownNode(hash))?
+                .parent_hash;
+            let inherited_from = (!self
+                .node(parent_hash)
+                .ok_or(GraphError::UnknownNode(parent_hash))?
+                .is_eligible())
+            .then_some(parent_hash);
+            if self
+                .node(hash)
+                .is_some_and(|node| node.eligibility.inherited_from == inherited_from)
+            {
+                continue;
+            }
+            self.node_mut(hash)?.eligibility.inherited_from = inherited_from;
+            affected.insert(hash);
+            queue.extend(self.children(hash));
+        }
+        let parents: Vec<_> = affected
+            .iter()
+            .filter_map(|hash| self.node(*hash).map(|node| node.parent_hash))
+            .collect();
+        affected.extend(parents);
+        for hash in affected {
+            self.refresh_eligible_tip(hash);
+        }
+        Ok(())
+    }
+
+    fn has_eligible_child(&self, hash: block::Hash) -> bool {
+        self.children(hash)
+            .into_iter()
+            .any(|child| self.node(child).is_some_and(HeaderNode::is_eligible))
+    }
+
+    fn refresh_eligible_tip(&mut self, hash: block::Hash) {
+        self.eligible_tips.remove(&hash);
+        if self
+            .node(hash)
+            .is_some_and(|node| node.is_eligible() && !self.has_eligible_child(hash))
+        {
+            self.eligible_tips.insert(hash);
+        }
+    }
+
+    fn record_child_add(&mut self, parent: block::Hash, child: block::Hash) {
+        if self
+            .remove_children
+            .get_mut(&parent)
+            .is_some_and(|removed| removed.remove(&child))
+        {
+            return;
+        }
+        self.add_children.entry(parent).or_default().insert(child);
+    }
+
+    fn record_child_remove(&mut self, parent: block::Hash, child: block::Hash) {
+        if self
+            .add_children
+            .get_mut(&parent)
+            .is_some_and(|added| added.remove(&child))
+        {
+            return;
+        }
+        if self
+            .base
+            .children
+            .get(&parent)
+            .is_some_and(|children| children.contains(&child))
+        {
+            self.remove_children
+                .entry(parent)
+                .or_default()
+                .insert(child);
+        }
+    }
+
+    #[cfg(test)]
+    fn operation_counts(&self) -> (usize, usize, usize) {
+        (
+            self.base_nodes_cloned.get(),
+            self.puts.len().saturating_add(self.deletes.len()),
+            self.eligibility_nodes_visited.get(),
+        )
+    }
+}
+
+fn flatten_edges(
+    edges: &HashMap<block::Hash, HashSet<block::Hash>>,
+) -> Vec<(block::Hash, block::Hash)> {
+    edges
+        .iter()
+        .flat_map(|(parent, children)| children.iter().map(|child| (*parent, *child)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zakura_chain::block::genesis::regtest_genesis_block;
+
+    fn store() -> MemHeaderStore {
+        let block = regtest_genesis_block();
+        let work = block
+            .header
+            .difficulty_threshold
+            .to_work()
+            .expect("the regtest target has valid work");
+        MemHeaderStore::new(
+            Frontier::new(block::Height(0), block.hash()),
+            block.header.clone(),
+            work,
+            work.as_u256(),
+        )
+        .expect("the anchor is coherent")
+    }
+
+    fn header(parent: block::Hash, marker: u8) -> Arc<block::Header> {
+        let mut header = *regtest_genesis_block().header;
+        header.previous_block_hash = parent;
+        header.nonce = [marker; 32].into();
+        Arc::new(header)
+    }
+
+    #[test]
+    fn overlay_tracks_only_changed_nodes_edges_and_tips() {
+        let base = store();
+        let anchor = base.finalized();
+        let mut overlay = GraphOverlay::new(&base);
+        let child_header = header(anchor.hash, 1);
+        let work = child_header
+            .difficulty_threshold
+            .to_work()
+            .expect("the child target has valid work");
+        let child = match overlay
+            .insert(
+                child_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the overlay child inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        let delta = overlay.delta();
+        assert_eq!(delta.put_nodes.len(), 1);
+        assert_eq!(delta.put_nodes[0].hash, child.hash);
+        assert_eq!(delta.delete_nodes, Vec::<block::Hash>::new());
+        assert_eq!(delta.add_children, vec![(anchor.hash, child.hash)]);
+        assert_eq!(delta.remove_eligible_tips, vec![anchor.hash]);
+        assert_eq!(delta.add_eligible_tips, vec![child.hash]);
+        assert_eq!(overlay.node_count(), base.node_count().saturating_add(1));
+    }
+
+    #[test]
+    fn applying_delta_matches_the_complete_overlay_projection() {
+        let mut base = store();
+        let anchor = base.finalized();
+        let first_header = header(anchor.hash, 1);
+        let work = first_header
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture target has valid work");
+        let first = match base
+            .insert(
+                first_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the first base child inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        let second_header = header(first.hash, 2);
+        let second = match base
+            .insert(
+                second_header.clone(),
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the second base child inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        let fork_header = header(anchor.hash, 3);
+        let fork = match base
+            .insert(
+                fork_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the base fork inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+
+        let mut overlay = GraphOverlay::new(&base);
+        let operator = OperatorInvalidationId::new([9; 16]);
+        overlay
+            .add_reason(
+                first.hash,
+                EligibilityReason::OperatorInvalid { id: operator },
+            )
+            .expect("operator invalidation propagates");
+        overlay
+            .remove_operator_invalidation(first.hash, operator)
+            .expect("operator reconsideration propagates");
+        overlay
+            .set_body_state(second.hash, BodyValidationState::CommitmentMatched)
+            .expect("body knowledge changes");
+        let third_header = header(second.hash, 4);
+        let third = match overlay
+            .insert(
+                third_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the overlay extension inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        overlay
+            .remove_leaf(fork.hash)
+            .expect("the unselected fork is removable");
+        overlay
+            .advance_finalized(first)
+            .expect("the eligible descendant becomes the new anchor");
+
+        let delta = overlay.delta();
+        let projected = MemHeaderStore::from_nodes(first, overlay.nodes().cloned())
+            .expect("the overlay materializes as a coherent graph");
+        let mut applied = base.clone();
+        applied
+            .apply_delta(&delta)
+            .expect("the verified delta applies to its base");
+
+        assert_eq!(applied.finalized, projected.finalized);
+        assert_eq!(applied.nodes, projected.nodes);
+        assert_eq!(applied.children, projected.children);
+        assert_eq!(applied.heights, projected.heights);
+        assert_eq!(applied.eligible_tips, projected.eligible_tips);
+        assert_eq!(applied.select_header_best(), projected.select_header_best());
+        assert_eq!(applied.finalized(), first);
+        assert!(applied.node(anchor.hash).is_none());
+        assert!(applied.node(fork.hash).is_none());
+        assert_eq!(
+            applied.node(third.hash).map(|node| node.parent_hash),
+            Some(second.hash)
+        );
+    }
+
+    #[test]
+    fn insertion_clones_no_base_nodes_and_eligibility_skips_unaffected_branches() {
+        let mut base = store();
+        let anchor = base.finalized();
+        let work = base
+            .node(anchor.hash)
+            .expect("the anchor is retained")
+            .block_work;
+        let left_header = header(anchor.hash, 1);
+        let left = match base
+            .insert(
+                left_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the left branch inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        let right_header = header(anchor.hash, 2);
+        let right = match base
+            .insert(
+                right_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the right branch inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        let right_child_header = header(right.hash, 3);
+        let right_child = match base
+            .insert(
+                right_child_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the unrelated descendant inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        let left_child_header = header(left.hash, 4);
+        let left_child = match base
+            .insert(
+                left_child_header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the affected descendant inserts")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+
+        let mut insertion = GraphOverlay::new(&base);
+        insertion
+            .insert(
+                header(left_child.hash, 5),
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the overlay insertion succeeds");
+        assert_eq!(insertion.operation_counts(), (0, 1, 0));
+
+        let mut eligibility = GraphOverlay::new(&base);
+        eligibility
+            .add_reason(
+                left.hash,
+                EligibilityReason::OperatorInvalid {
+                    id: OperatorInvalidationId::new([5; 16]),
+                },
+            )
+            .expect("the local invalidation propagates");
+        let (base_clones, changed_nodes, eligibility_visits) = eligibility.operation_counts();
+        assert_eq!(base_clones, 2);
+        assert_eq!(changed_nodes, 2);
+        assert_eq!(eligibility_visits, 1);
+        assert!(!eligibility
+            .node(left_child.hash)
+            .is_some_and(HeaderNode::is_eligible));
+        assert!(eligibility
+            .node(right.hash)
+            .is_some_and(HeaderNode::is_eligible));
+        assert!(eligibility
+            .node(right_child.hash)
+            .is_some_and(HeaderNode::is_eligible));
+    }
+
+    #[test]
+    fn production_planner_has_no_full_graph_clone_or_node_map_diff() {
+        let planner = include_str!("../transition/planner.rs");
+        assert!(!planner.contains("let mut graph = engine.graph().clone()"));
+        assert!(!planner.contains("fn node_map"));
+        assert!(!planner.contains("old_nodes"));
+        assert!(!planner.contains("new_nodes"));
+    }
+}

--- a/crates/zakura-header-chain/src/ids.rs
+++ b/crates/zakura-header-chain/src/ids.rs
@@ -1,0 +1,393 @@
+//! Stable identities and generation counters.
+
+use std::{fmt, num::NonZeroU64};
+
+use thiserror::Error;
+use zakura_chain::block;
+
+/// A version or generation counter reached `u64::MAX`.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[error("header-chain {counter} counter is exhausted at u64::MAX")]
+pub struct CounterExhausted {
+    counter: &'static str,
+}
+
+macro_rules! counter_type {
+    ($name:ident, $label:literal, $docs:literal) => {
+        #[doc = $docs]
+        #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        pub struct $name(u64);
+
+        impl $name {
+            /// Construct a counter from its durable integer representation.
+            pub const fn new(value: u64) -> Self {
+                Self(value)
+            }
+
+            /// Return the durable integer representation.
+            pub const fn get(self) -> u64 {
+                self.0
+            }
+
+            /// Return the next counter value, failing closed at `u64::MAX`.
+            pub fn checked_next(self) -> Result<Self, CounterExhausted> {
+                self.0
+                    .checked_add(1)
+                    .map(Self)
+                    .ok_or(CounterExhausted { counter: $label })
+            }
+        }
+    };
+}
+
+counter_type!(
+    StateVersion,
+    "state version",
+    "Monotonic version of the complete durable header-chain state."
+);
+counter_type!(
+    HeaderGeneration,
+    "header generation",
+    "Generation that owns selected-header forward work."
+);
+counter_type!(
+    VerifiedGeneration,
+    "verified generation",
+    "Generation that owns verified-body forward work."
+);
+counter_type!(
+    FinalityEpoch,
+    "finality epoch",
+    "Monotonic epoch of irreversible finality changes."
+);
+
+/// Hash-qualified identity of one admitted header.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct HeaderId(block::Hash);
+
+impl HeaderId {
+    /// Construct an identity from the header's raw internal hash.
+    pub const fn new(hash: block::Hash) -> Self {
+        Self(hash)
+    }
+
+    /// Return the identified header hash.
+    pub const fn hash(self) -> block::Hash {
+        self.0
+    }
+}
+
+impl From<block::Hash> for HeaderId {
+    fn from(hash: block::Hash) -> Self {
+        Self::new(hash)
+    }
+}
+
+/// Stable identifier for deduplicated validation or operator evidence.
+#[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct EvidenceId([u8; 32]);
+
+impl EvidenceId {
+    /// Construct an ID from a domain-separated evidence digest.
+    pub const fn from_digest(digest: [u8; 32]) -> Self {
+        Self(digest)
+    }
+
+    /// Return the opaque digest bytes.
+    pub const fn digest(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl fmt::Debug for EvidenceId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("EvidenceId").field(&self.0).finish()
+    }
+}
+
+/// Stable identifier for one independently removable operator invalidation.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct OperatorInvalidationId([u8; 16]);
+
+impl OperatorInvalidationId {
+    /// Construct an ID from its stable opaque bytes.
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the stable opaque bytes.
+    pub const fn bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+/// Opaque stable digest of a peer identity and connection domain.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SourceId([u8; 32]);
+
+impl SourceId {
+    /// Construct a source ID from its stable digest.
+    pub const fn from_digest(digest: [u8; 32]) -> Self {
+        Self(digest)
+    }
+
+    /// Return the opaque digest bytes.
+    pub const fn digest(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// Exact branch identity, qualified by both anchor and target hashes.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BranchId {
+    /// Immutable branch anchor hash.
+    pub anchor_hash: block::Hash,
+    /// Exact target tip hash.
+    pub target_tip_hash: block::Hash,
+}
+
+impl BranchId {
+    /// Construct an exact branch identity.
+    pub const fn new(anchor_hash: block::Hash, target_tip_hash: block::Hash) -> Self {
+        Self {
+            anchor_hash,
+            target_tip_hash,
+        }
+    }
+}
+
+/// Header-generation and branch authority captured before asynchronous header work.
+///
+/// Global state versions and verified-body generations are deliberately absent:
+/// neither can authorize or stale pure header work.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct HeaderWorkAuthority {
+    /// Selected-header generation that scheduled the work.
+    pub header_generation: HeaderGeneration,
+    /// Exact anchor/target branch identity.
+    pub branch: BranchId,
+}
+
+impl HeaderWorkAuthority {
+    /// Capture authority for one exact advertised header target.
+    pub fn for_target(snapshot: &crate::EngineSnapshot, target_tip_hash: block::Hash) -> Self {
+        Self {
+            header_generation: snapshot.header_generation,
+            branch: BranchId::new(snapshot.frontiers.finalized.hash, target_tip_hash),
+        }
+    }
+
+    /// Bind this authority to the exact transport session and request.
+    pub const fn bind(self, session_id: u64, request_id: NonZeroU64) -> HeaderWorkOwner {
+        HeaderWorkOwner {
+            authority: self,
+            session_id,
+            request_id,
+        }
+    }
+}
+
+/// Header authority plus the verified generation required by body-affecting work.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BodyWorkAuthority {
+    /// Header branch on which the body work is valid.
+    pub header: HeaderWorkAuthority,
+    /// Verified-body generation that scheduled the work.
+    pub verified_generation: VerifiedGeneration,
+}
+
+impl BodyWorkAuthority {
+    /// Capture body-affecting authority from one atomic committed snapshot.
+    pub fn for_snapshot(snapshot: &crate::EngineSnapshot) -> Self {
+        Self {
+            header: HeaderWorkAuthority {
+                header_generation: snapshot.header_generation,
+                branch: BranchId::new(
+                    snapshot.frontiers.finalized.hash,
+                    snapshot.frontiers.header_best.hash,
+                ),
+            },
+            verified_generation: snapshot.verified_generation,
+        }
+    }
+
+    /// Bind this authority to the exact transport session and request.
+    pub const fn bind(self, session_id: u64, request_id: NonZeroU64) -> BodyWorkOwner {
+        BodyWorkOwner {
+            authority: self,
+            session_id,
+            request_id,
+        }
+    }
+}
+
+/// Exact owner of pure header work.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct HeaderWorkOwner {
+    /// Durable authority for this attempt.
+    pub authority: HeaderWorkAuthority,
+    /// Transport session that owns the work.
+    pub session_id: u64,
+    /// Nonzero request identifier within that session.
+    pub request_id: NonZeroU64,
+}
+
+impl HeaderWorkOwner {
+    /// Return the durable authority shared by every item in this request.
+    pub const fn authority(self) -> HeaderWorkAuthority {
+        self.authority
+    }
+
+    /// Return the exact transport session.
+    pub const fn session_id(self) -> u64 {
+        self.session_id
+    }
+
+    /// Return the exact request identity.
+    pub const fn request_id(self) -> NonZeroU64 {
+        self.request_id
+    }
+}
+
+impl std::ops::Deref for HeaderWorkOwner {
+    type Target = HeaderWorkAuthority;
+
+    fn deref(&self) -> &Self::Target {
+        &self.authority
+    }
+}
+
+/// Exact owner of body-affecting work.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BodyWorkOwner {
+    /// Durable authority for this attempt.
+    pub authority: BodyWorkAuthority,
+    /// Transport session that owns the work.
+    pub session_id: u64,
+    /// Nonzero request identifier within that session.
+    pub request_id: NonZeroU64,
+}
+
+impl BodyWorkOwner {
+    /// Return the durable authority shared by every item in this request.
+    pub const fn authority(self) -> BodyWorkAuthority {
+        self.authority
+    }
+
+    /// Return the header authority embedded in this body owner.
+    pub const fn header_authority(self) -> HeaderWorkAuthority {
+        self.authority.header
+    }
+
+    /// Return the exact transport session.
+    pub const fn session_id(self) -> u64 {
+        self.session_id
+    }
+
+    /// Return the exact request identity.
+    pub const fn request_id(self) -> NonZeroU64 {
+        self.request_id
+    }
+}
+
+impl std::ops::Deref for BodyWorkOwner {
+    type Target = BodyWorkAuthority;
+
+    fn deref(&self) -> &Self::Target {
+        &self.authority
+    }
+}
+
+impl std::ops::Deref for BodyWorkAuthority {
+    type Target = HeaderWorkAuthority;
+
+    fn deref(&self) -> &Self::Target {
+        &self.header
+    }
+}
+
+/// Domain-discriminated owner used only where header sync can carry either a
+/// normal header target or a verified-generation-bound auxiliary repair.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum HeaderSyncWorkOwner {
+    /// Ordinary header target work.
+    Header(HeaderWorkOwner),
+    /// Body-authorized selected-header auxiliary repair.
+    BodyRepair(BodyWorkOwner),
+}
+
+impl HeaderSyncWorkOwner {
+    /// Return the shared header authority.
+    pub const fn header_authority(self) -> HeaderWorkAuthority {
+        match self {
+            Self::Header(owner) => owner.authority,
+            Self::BodyRepair(owner) => owner.authority.header,
+        }
+    }
+
+    /// Return verified authority only for a body repair.
+    pub const fn body_authority(self) -> Option<BodyWorkAuthority> {
+        match self {
+            Self::Header(_) => None,
+            Self::BodyRepair(owner) => Some(owner.authority),
+        }
+    }
+
+    /// Return the header owner when this is ordinary target work.
+    pub const fn header_owner(self) -> Option<HeaderWorkOwner> {
+        match self {
+            Self::Header(owner) => Some(owner),
+            Self::BodyRepair(_) => None,
+        }
+    }
+
+    /// Return the body owner when this is an auxiliary repair.
+    pub const fn body_owner(self) -> Option<BodyWorkOwner> {
+        match self {
+            Self::Header(_) => None,
+            Self::BodyRepair(owner) => Some(owner),
+        }
+    }
+
+    /// Return the exact transport session.
+    pub const fn session_id(self) -> u64 {
+        match self {
+            Self::Header(owner) => owner.session_id,
+            Self::BodyRepair(owner) => owner.session_id,
+        }
+    }
+
+    /// Return the exact request identity.
+    pub const fn request_id(self) -> NonZeroU64 {
+        match self {
+            Self::Header(owner) => owner.request_id,
+            Self::BodyRepair(owner) => owner.request_id,
+        }
+    }
+
+    /// Rebind ordinary header work to state-proven current authority.
+    ///
+    /// Body-affecting repair authority is deliberately non-rebasable.
+    pub(crate) const fn rebase_header(self, authority: HeaderWorkAuthority) -> Option<Self> {
+        match self {
+            Self::Header(owner) => Some(Self::Header(HeaderWorkOwner {
+                authority,
+                session_id: owner.session_id,
+                request_id: owner.request_id,
+            })),
+            Self::BodyRepair(_) => None,
+        }
+    }
+}
+
+impl From<HeaderWorkOwner> for HeaderSyncWorkOwner {
+    fn from(owner: HeaderWorkOwner) -> Self {
+        Self::Header(owner)
+    }
+}
+
+impl From<BodyWorkOwner> for HeaderSyncWorkOwner {
+    fn from(owner: BodyWorkOwner) -> Self {
+        Self::BodyRepair(owner)
+    }
+}

--- a/crates/zakura-header-chain/src/lib.rs
+++ b/crates/zakura-header-chain/src/lib.rs
@@ -1,0 +1,47 @@
+//! Fork-aware header-chain domain types and transition engine.
+//!
+//! This crate is intentionally synchronous and policy-focused. It owns no
+//! network transport, async runtime, consensus service, or database backend.
+
+mod config;
+mod error;
+mod frontier;
+mod graph;
+mod ids;
+mod locator;
+mod node;
+mod ownership;
+mod retention;
+mod transition;
+mod validation;
+
+pub use config::{
+    CheckpointSet, EngineConfig, EngineConfigError, EngineLimits, EngineMode,
+    SettledUpgradeManifest, SettledUpgradePin, TrustedAnchor, MAX_CANDIDATE_TIPS_V1,
+    MAX_NON_FINALIZED_NODES_V1, MAX_STAGED_TARGETS_V1,
+};
+pub use error::{Attribution, ErrorCategory, ErrorSubject, HeaderChainError, RuleId};
+pub use frontier::{
+    ChainScore, Frontier, FrontierSet, SuffixWork, WorkCoordinate, WorkCoordinateError,
+};
+pub use graph::{GraphError, InsertResult, MemHeaderStore};
+pub use ids::{
+    BodyWorkAuthority, BodyWorkOwner, BranchId, CounterExhausted, EvidenceId, FinalityEpoch,
+    HeaderGeneration, HeaderId, HeaderSyncWorkOwner, HeaderWorkAuthority, HeaderWorkOwner,
+    OperatorInvalidationId, SourceId, StateVersion, VerifiedGeneration,
+};
+pub use locator::{HeaderLocator, VctRepairContext, MAX_HEADER_LOCATOR_HASHES};
+pub use node::{
+    BodyRuleId, BodyUnavailableSummary, BodyValidationState, DurableNodeError, EligibilityReason,
+    EligibilityState, HeaderNode, HeaderValidationState,
+};
+pub use ownership::{
+    CompletionDecision, CompletionGate, CompletionOwner, PendingOwners, StaleReason,
+};
+pub use transition::*;
+pub use validation::{
+    infer_height, validate_commitment_structure, validate_compact_target,
+    validate_encoding_version_hash, validate_future_time, validate_hash_filter, validate_link,
+    CompactTargetError, HashFilterError, HeaderEncodingError, HeaderHeightError, HeaderLinkError,
+    PowPolicy, PowPolicyError,
+};

--- a/crates/zakura-header-chain/src/locator.rs
+++ b/crates/zakura-header-chain/src/locator.rs
@@ -1,0 +1,95 @@
+//! Exact selected-path locators for fork discovery.
+
+use zakura_chain::block;
+
+use crate::{EngineSnapshot, Frontier, StoreError};
+
+/// Maximum hashes in one v8 header locator.
+pub const MAX_HEADER_LOCATOR_HASHES: usize = 13;
+
+const SELECTED_PATH_OFFSETS: [u32; 12] = [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1_000];
+
+/// One ordered, deduplicated locator with locally authenticated heights.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HeaderLocator(Vec<Frontier>);
+
+/// Exact selected-header request context for one auxiliary VCT repair.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VctRepairContext {
+    /// Already-selected header whose auxiliary metadata must be redelivered.
+    pub target: Frontier,
+    /// Single-entry locator naming the target's direct selected predecessor.
+    pub locator: HeaderLocator,
+}
+
+impl HeaderLocator {
+    /// Build the exact fresh-pursuit locator from one committed selected projection.
+    pub fn for_selected_path(
+        snapshot: &EngineSnapshot,
+        mut selected_hash: impl FnMut(block::Height) -> Result<Option<block::Hash>, StoreError>,
+    ) -> Result<Self, StoreError> {
+        let finalized = snapshot.frontiers.finalized;
+        let tip = snapshot.frontiers.header_best;
+        let distance =
+            tip.height
+                .0
+                .checked_sub(finalized.height.0)
+                .ok_or(StoreError::Incoherent(
+                    "selected tip is below the finalized frontier",
+                ))?;
+        let mut entries: Vec<Frontier> = Vec::with_capacity(MAX_HEADER_LOCATOR_HASHES);
+        for offset in SELECTED_PATH_OFFSETS {
+            if offset > distance {
+                continue;
+            }
+            let height = block::Height(tip.height.0 - offset);
+            let hash = selected_hash(height)?.ok_or(StoreError::Incoherent(
+                "selected locator height is absent from the selected projection",
+            ))?;
+            let frontier = Frontier::new(height, hash);
+            if let Some(existing) = entries.iter().find(|entry| entry.hash == hash) {
+                if *existing != frontier {
+                    return Err(StoreError::Incoherent(
+                        "selected locator repeats one hash at different heights",
+                    ));
+                }
+            } else {
+                entries.push(frontier);
+            }
+        }
+        if selected_hash(finalized.height)? != Some(finalized.hash) {
+            return Err(StoreError::Incoherent(
+                "finalized frontier is absent from the selected projection",
+            ));
+        }
+        if !entries.iter().any(|entry| entry.hash == finalized.hash) {
+            entries.push(finalized);
+        }
+        if entries.len() > MAX_HEADER_LOCATOR_HASHES {
+            return Err(StoreError::Incoherent(
+                "selected locator exceeds its protocol entry cap",
+            ));
+        }
+        if entries.first().copied() != Some(tip) {
+            return Err(StoreError::Incoherent(
+                "selected locator does not begin at the committed tip",
+            ));
+        }
+        Ok(Self(entries))
+    }
+
+    /// Build the same-target continuation locator from the last returned suffix tip.
+    pub fn for_continuation(returned_suffix_tip: Frontier) -> Self {
+        Self(vec![returned_suffix_tip])
+    }
+
+    /// Ordered height/hash entries used to authenticate a returned common ancestor.
+    pub fn entries(&self) -> &[Frontier] {
+        &self.0
+    }
+
+    /// Ordered hashes encoded into a v8 request.
+    pub fn hashes(&self) -> Vec<block::Hash> {
+        self.0.iter().map(|frontier| frontier.hash).collect()
+    }
+}

--- a/crates/zakura-header-chain/src/node.rs
+++ b/crates/zakura-header-chain/src/node.rs
@@ -1,0 +1,308 @@
+//! Admitted header records and eligibility state.
+
+use std::{cmp::Ordering, collections::BTreeSet, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use zakura_chain::{block, work::difficulty::Work};
+
+use crate::{EvidenceId, Frontier, OperatorInvalidationId, SourceId, WorkCoordinate};
+
+/// Stable full-state consensus rule identity attached to body evidence.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct BodyRuleId(Arc<str>);
+
+impl BodyRuleId {
+    /// Construct a stable body-rule identity.
+    pub fn new(id: impl Into<Arc<str>>) -> Self {
+        Self(id.into())
+    }
+
+    /// Return the stable identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Observable validation state of an admitted header.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderValidationState {
+    /// Every header rule, including the injected-clock rule, passed.
+    Valid,
+    /// Deterministic rules passed, but local time does not admit this header yet.
+    DeferredUntil(DateTime<Utc>),
+}
+
+/// One durable reason that a header cannot participate in selection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EligibilityReason {
+    /// Header conflicts with a compiled settled-upgrade pin.
+    SettledUpgradeConflict {
+        /// Conflicting height.
+        height: block::Height,
+        /// Required hash.
+        expected: block::Hash,
+    },
+    /// Header conflicts with an authenticated local checkpoint.
+    CheckpointConflict {
+        /// Conflicting height.
+        height: block::Height,
+        /// Required hash.
+        expected: block::Hash,
+    },
+    /// Header conflicts at or below the immutable finality anchor.
+    FinalityConflict {
+        /// Current exact finality anchor.
+        finalized: Frontier,
+    },
+    /// A commitment-matching body deterministically failed consensus.
+    ConsensusBodyInvalid {
+        /// Stable verifier evidence.
+        evidence: EvidenceId,
+        /// Exact failed body rule.
+        rule: BodyRuleId,
+    },
+    /// One independently reversible operator invalidation.
+    OperatorInvalid {
+        /// Exact invalidation to remove on reconsideration.
+        id: OperatorInvalidationId,
+    },
+}
+
+impl Ord for EligibilityReason {
+    fn cmp(&self, other: &Self) -> Ordering {
+        use EligibilityReason::*;
+
+        let rank = |reason: &Self| match reason {
+            SettledUpgradeConflict { .. } => 0,
+            CheckpointConflict { .. } => 1,
+            FinalityConflict { .. } => 2,
+            ConsensusBodyInvalid { .. } => 3,
+            OperatorInvalid { .. } => 4,
+        };
+        rank(self)
+            .cmp(&rank(other))
+            .then_with(|| match (self, other) {
+                (
+                    SettledUpgradeConflict {
+                        height: left_height,
+                        expected: left_hash,
+                    },
+                    SettledUpgradeConflict {
+                        height: right_height,
+                        expected: right_hash,
+                    },
+                )
+                | (
+                    CheckpointConflict {
+                        height: left_height,
+                        expected: left_hash,
+                    },
+                    CheckpointConflict {
+                        height: right_height,
+                        expected: right_hash,
+                    },
+                ) => left_height
+                    .cmp(right_height)
+                    .then_with(|| left_hash.0.cmp(&right_hash.0)),
+                (FinalityConflict { finalized: left }, FinalityConflict { finalized: right }) => {
+                    left.height
+                        .cmp(&right.height)
+                        .then_with(|| left.hash.0.cmp(&right.hash.0))
+                }
+                (
+                    ConsensusBodyInvalid {
+                        evidence: left_evidence,
+                        rule: left_rule,
+                    },
+                    ConsensusBodyInvalid {
+                        evidence: right_evidence,
+                        rule: right_rule,
+                    },
+                ) => left_evidence
+                    .cmp(right_evidence)
+                    .then_with(|| left_rule.cmp(right_rule)),
+                (OperatorInvalid { id: left }, OperatorInvalid { id: right }) => left.cmp(right),
+                _ => Ordering::Equal,
+            })
+    }
+}
+
+impl PartialOrd for EligibilityReason {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl EligibilityReason {
+    /// Return true when resource retention may discard this permanently invalid subtree first.
+    pub fn is_permanent(&self) -> bool {
+        !matches!(self, Self::OperatorInvalid { .. })
+    }
+}
+
+/// Direct and ancestry-derived selection eligibility.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EligibilityState {
+    /// Independent durable reasons attached directly to this header.
+    pub direct_reasons: BTreeSet<EligibilityReason>,
+    /// Nearest ineligible ancestor, if any.
+    pub inherited_from: Option<block::Hash>,
+}
+
+impl EligibilityState {
+    /// Return true when neither this header nor any ancestor is ineligible.
+    pub fn is_eligible(&self, validation: HeaderValidationState) -> bool {
+        validation == HeaderValidationState::Valid
+            && self.direct_reasons.is_empty()
+            && self.inherited_from.is_none()
+    }
+
+    /// Return true when this header has at least one permanent direct reason.
+    pub fn has_permanent_reason(&self) -> bool {
+        self.direct_reasons
+            .iter()
+            .any(|reason| reason.is_permanent())
+    }
+}
+
+/// Full-state knowledge about a header's corresponding block body.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum BodyValidationState {
+    /// No body conclusion is known.
+    #[default]
+    Unknown,
+    /// Applicable header/body commitments matched.
+    CommitmentMatched,
+    /// Full state accepted this body.
+    Verified {
+        /// Stable verification evidence.
+        evidence: EvidenceId,
+    },
+    /// A commitment-matching body deterministically failed consensus.
+    ConsensusInvalid {
+        /// Stable verification evidence.
+        evidence: EvidenceId,
+        /// Exact failed body rule.
+        rule: BodyRuleId,
+    },
+    /// Body acquisition is temporarily unavailable and does not affect selection.
+    Unavailable(BodyUnavailableSummary),
+}
+
+/// Durable bounded summary of one body-unavailability retry episode.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct BodyUnavailableSummary {
+    /// Authoritative start of the current retry episode.
+    pub started_at: DateTime<Utc>,
+    /// Failed delivery attempts in the current episode.
+    pub attempts: u32,
+    /// Currently known eligible suppliers.
+    pub suppliers: u32,
+    /// Stable digest of the complete eligible-supplier identity set.
+    pub supplier_set_digest: [u8; 32],
+    /// Whether the persistent unavailability alarm has fired.
+    pub alarmed: bool,
+    /// Earliest time another repeated-supplier attempt or alarm probe is allowed.
+    pub next_probe_at: DateTime<Utc>,
+}
+
+impl BodyUnavailableSummary {
+    /// Return a stable digest of one complete sorted eligible-supplier set.
+    pub fn supplier_set_digest(suppliers: &BTreeSet<SourceId>) -> [u8; 32] {
+        let mut state = Sha256::new();
+        state.update(b"zakura-body-supplier-set-v1");
+        for supplier in suppliers {
+            state.update(supplier.digest());
+        }
+        state.finalize().into()
+    }
+}
+
+/// One retained header DAG node.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HeaderNode {
+    /// Canonical decoded header.
+    pub header: Arc<block::Header>,
+    /// Locally computed canonical header hash.
+    pub hash: block::Hash,
+    /// Exact parent hash.
+    pub parent_hash: block::Hash,
+    /// Locally inferred height.
+    pub height: block::Height,
+    /// Exact per-block work.
+    pub block_work: Work,
+    pub(crate) work_coordinate: WorkCoordinate,
+    /// Observable header-validation state.
+    pub validation: HeaderValidationState,
+    /// Direct and inherited eligibility state.
+    pub eligibility: EligibilityState,
+    /// Full-state body knowledge.
+    pub body: BodyValidationState,
+    /// Hash-keyed auxiliary delivery evidence IDs.
+    pub aux_delivery_ids: Vec<EvidenceId>,
+}
+
+impl HeaderNode {
+    /// Return true when this node currently participates in fork choice.
+    pub fn is_eligible(&self) -> bool {
+        self.eligibility.is_eligible(self.validation)
+    }
+
+    /// Return this node's checked cumulative work coordinate.
+    pub const fn work_coordinate(&self) -> WorkCoordinate {
+        self.work_coordinate
+    }
+
+    /// Reconstruct one node from audited durable fields.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_durable_parts(
+        header: Arc<block::Header>,
+        hash: block::Hash,
+        parent_hash: block::Hash,
+        height: block::Height,
+        block_work: Work,
+        work_coordinate: WorkCoordinate,
+        validation: HeaderValidationState,
+        eligibility: EligibilityState,
+        body: BodyValidationState,
+        aux_delivery_ids: Vec<EvidenceId>,
+    ) -> Result<Self, DurableNodeError> {
+        if header.hash() != hash {
+            return Err(DurableNodeError::Hash);
+        }
+        if header.previous_block_hash != parent_hash {
+            return Err(DurableNodeError::Parent);
+        }
+        if header.difficulty_threshold.to_work() != Some(block_work) {
+            return Err(DurableNodeError::Work);
+        }
+        Ok(Self {
+            header,
+            hash,
+            parent_hash,
+            height,
+            block_work,
+            work_coordinate,
+            validation,
+            eligibility,
+            body,
+            aux_delivery_ids,
+        })
+    }
+}
+
+/// A durable node row contradicted its canonical header fields.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum DurableNodeError {
+    /// The stored hash did not match the canonical header.
+    #[error("durable header hash mismatch")]
+    Hash,
+    /// The stored parent did not match the canonical header link.
+    #[error("durable header parent mismatch")]
+    Parent,
+    /// The stored per-block work did not match the compact target.
+    #[error("durable header work mismatch")]
+    Work,
+}

--- a/crates/zakura-header-chain/src/ownership.rs
+++ b/crates/zakura-header-chain/src/ownership.rs
@@ -1,0 +1,233 @@
+//! Pure ownership registry and the sole asynchronous completion gate.
+
+use std::{collections::HashMap, num::NonZeroU64};
+
+use crate::{
+    BodyWorkAuthority, BodyWorkOwner, EngineSnapshot, HeaderSyncWorkOwner, HeaderWorkAuthority,
+    HeaderWorkOwner, SourceId,
+};
+
+/// Domain-specific owner facts required by the shared completion registry.
+pub trait CompletionOwner: Copy + Eq {
+    /// Return the header authority common to header and body work.
+    fn header_authority(self) -> HeaderWorkAuthority;
+    /// Return verified authority only for body-affecting work.
+    fn body_authority(self) -> Option<BodyWorkAuthority>;
+    /// Return the exact transport session.
+    fn session_id(self) -> u64;
+    /// Return the exact request identity.
+    fn request_id(self) -> NonZeroU64;
+}
+
+impl CompletionOwner for HeaderWorkOwner {
+    fn header_authority(self) -> HeaderWorkAuthority {
+        self.authority
+    }
+
+    fn body_authority(self) -> Option<BodyWorkAuthority> {
+        None
+    }
+
+    fn session_id(self) -> u64 {
+        self.session_id
+    }
+
+    fn request_id(self) -> NonZeroU64 {
+        self.request_id
+    }
+}
+
+impl CompletionOwner for BodyWorkOwner {
+    fn header_authority(self) -> HeaderWorkAuthority {
+        self.authority.header
+    }
+
+    fn body_authority(self) -> Option<BodyWorkAuthority> {
+        Some(self.authority)
+    }
+
+    fn session_id(self) -> u64 {
+        self.session_id
+    }
+
+    fn request_id(self) -> NonZeroU64 {
+        self.request_id
+    }
+}
+
+impl CompletionOwner for HeaderSyncWorkOwner {
+    fn header_authority(self) -> HeaderWorkAuthority {
+        self.header_authority()
+    }
+
+    fn body_authority(self) -> Option<BodyWorkAuthority> {
+        self.body_authority()
+    }
+
+    fn session_id(self) -> u64 {
+        self.session_id()
+    }
+
+    fn request_id(self) -> NonZeroU64 {
+        self.request_id()
+    }
+}
+
+/// Exact reason an asynchronous completion has no remaining authority.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum StaleReason {
+    /// Selected-header work generation changed.
+    HeaderGeneration,
+    /// Verified-body generation changed for work that depends on it.
+    VerifiedGeneration,
+    /// Finality changed the immutable branch anchor.
+    BranchAnchor,
+    /// No pending entry exists for this source/request pair.
+    MissingOwner,
+    /// The pending entry belongs to another branch, session, generation, or target.
+    OwnerMismatch,
+}
+
+/// Result of the centralized ownership check.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CompletionDecision {
+    /// The completion still has exact current authority.
+    Current,
+    /// The completion is terminally stale and must have no effects.
+    Stale(StaleReason),
+}
+
+/// Exact pending asynchronous owners, keyed by supplier and request identity.
+#[derive(Clone, Debug)]
+pub struct PendingOwners<O = HeaderSyncWorkOwner>(HashMap<(SourceId, NonZeroU64), O>);
+
+impl<O> Default for PendingOwners<O> {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl<O> PendingOwners<O>
+where
+    O: CompletionOwner,
+{
+    /// Register one newly published request, returning any contradictory prior owner.
+    pub fn insert(&mut self, source: SourceId, owner: O) -> Option<O> {
+        self.0.insert((source, owner.request_id()), owner)
+    }
+
+    /// Retire one exact source/request owner.
+    pub fn remove(&mut self, source: SourceId, request_id: NonZeroU64) -> Option<O> {
+        self.0.remove(&(source, request_id))
+    }
+
+    /// Retire every request owned by one source, returning exact retired owners.
+    pub fn remove_source(&mut self, source: SourceId) -> Vec<O> {
+        let keys: Vec<_> = self
+            .0
+            .keys()
+            .filter(|(candidate, _)| *candidate == source)
+            .copied()
+            .collect();
+        keys.into_iter()
+            .filter_map(|key| self.0.remove(&key))
+            .collect()
+    }
+
+    fn get(&self, source: SourceId, request_id: NonZeroU64) -> Option<O> {
+        self.0.get(&(source, request_id)).copied()
+    }
+
+    /// Number of exact pending owners.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether no asynchronous owner remains pending.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl PendingOwners<HeaderSyncWorkOwner> {
+    /// Retire header-sync owners invalidated by a committed transition before scheduling.
+    pub fn apply_retirement(
+        &mut self,
+        retired: &crate::RetiredWork,
+        current: &EngineSnapshot,
+    ) -> Vec<HeaderSyncWorkOwner> {
+        let keys: Vec<_> = self
+            .0
+            .iter()
+            .filter(|(_, owner)| {
+                let header = owner.header_authority();
+                (retired.header_generation_changed
+                    && header.header_generation != current.header_generation)
+                    || (retired.verified_generation_changed
+                        && owner.body_authority().is_some_and(|authority| {
+                            authority.verified_generation != current.verified_generation
+                        }))
+                    || retired.owners.contains(owner)
+                    || header.branch.anchor_hash != current.frontiers.finalized.hash
+            })
+            .map(|(key, _)| *key)
+            .collect();
+        keys.into_iter()
+            .filter_map(|key| self.0.remove(&key))
+            .collect()
+    }
+}
+
+/// Sole pure decision point used before any completion effect.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct CompletionGate;
+
+impl CompletionGate {
+    /// Compare one structurally registered attempt with its completion.
+    pub fn check_registered<O: CompletionOwner>(
+        current: &EngineSnapshot,
+        registered: Option<(SourceId, O)>,
+        source: SourceId,
+        owner: &O,
+    ) -> CompletionDecision {
+        let header = owner.header_authority();
+        if header.header_generation != current.header_generation {
+            return CompletionDecision::Stale(StaleReason::HeaderGeneration);
+        }
+        if owner
+            .body_authority()
+            .is_some_and(|authority| authority.verified_generation != current.verified_generation)
+        {
+            return CompletionDecision::Stale(StaleReason::VerifiedGeneration);
+        }
+        if header.branch.anchor_hash != current.frontiers.finalized.hash {
+            return CompletionDecision::Stale(StaleReason::BranchAnchor);
+        }
+        match registered {
+            None => CompletionDecision::Stale(StaleReason::MissingOwner),
+            Some((registered_source, registered_owner))
+                if registered_source != source || registered_owner != *owner =>
+            {
+                CompletionDecision::Stale(StaleReason::OwnerMismatch)
+            }
+            Some(_) => CompletionDecision::Current,
+        }
+    }
+
+    /// Compare every durable generation, branch anchor, source, session, request, and target fact.
+    pub fn check<O: CompletionOwner>(
+        current: &EngineSnapshot,
+        pending: &PendingOwners<O>,
+        source: SourceId,
+        owner: &O,
+    ) -> CompletionDecision {
+        Self::check_registered(
+            current,
+            pending
+                .get(source, owner.request_id())
+                .map(|pending_owner| (source, pending_owner)),
+            source,
+            owner,
+        )
+    }
+}

--- a/crates/zakura-header-chain/src/retention.rs
+++ b/crates/zakura-header-chain/src/retention.rs
@@ -1,0 +1,236 @@
+//! Deterministic pure retention and resource-eviction planning.
+
+use std::collections::HashSet;
+
+use zakura_chain::block;
+
+use crate::{
+    graph::{HeaderGraphEdit, HeaderGraphView},
+    EngineLimits, Frontier, GraphError,
+};
+
+/// Deterministic result of enforcing DAG resource bounds.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RetentionPlan {
+    /// True when protected paths prevented enforcement of the node bound.
+    pub admission_refused: bool,
+    /// True when integrated verification/finality must advance before admission can resume.
+    pub resource_stalled: bool,
+}
+
+/// Enforce deterministic retention while protecting selected, verified, and context paths.
+pub(crate) fn enforce_retention<G: HeaderGraphEdit>(
+    store: &mut G,
+    header_best: Frontier,
+    verified_best: Frontier,
+    validation_context_references: impl IntoIterator<Item = block::Hash>,
+    limits: EngineLimits,
+) -> Result<RetentionPlan, GraphError> {
+    let mut protected = HashSet::new();
+    protect_path(store, header_best.hash, &mut protected)?;
+    protect_path(store, verified_best.hash, &mut protected)?;
+    for reference in validation_context_references {
+        if !protected.contains(&reference) && store.view_node(reference).is_some() {
+            protect_path(store, reference, &mut protected)?;
+        }
+    }
+
+    let mut plan = RetentionPlan::default();
+    let under_pressure = store.view_eligible_tips().len() > limits.max_candidate_tips.get()
+        || store.view_node_count().saturating_sub(1) > limits.max_non_finalized_nodes.get();
+    if under_pressure {
+        evict_permanently_ineligible(store, &protected)?;
+    }
+
+    while store.view_eligible_tips().len() > limits.max_candidate_tips.get() {
+        let Some(tip) = lowest_unprotected_eligible_tip(store, &protected)? else {
+            plan.admission_refused = true;
+            plan.resource_stalled = true;
+            return Ok(plan);
+        };
+        let previous_node_count = store.view_node_count();
+        evict_tip_branch(store, tip.hash, &protected)?;
+        if store.view_node_count() == previous_node_count {
+            plan.admission_refused = true;
+            plan.resource_stalled = true;
+            return Ok(plan);
+        }
+    }
+
+    while store.view_node_count().saturating_sub(1) > limits.max_non_finalized_nodes.get() {
+        let tip = match lowest_unprotected_eligible_tip(store, &protected)? {
+            Some(tip) => Some(tip.hash),
+            None => lowest_unprotected_leaf(store, &protected)?,
+        };
+        let Some(tip) = tip else {
+            plan.admission_refused = true;
+            plan.resource_stalled = true;
+            return Ok(plan);
+        };
+        let previous_node_count = store.view_node_count();
+        evict_tip_branch(store, tip, &protected)?;
+        if store.view_node_count() == previous_node_count {
+            plan.admission_refused = true;
+            plan.resource_stalled = true;
+            return Ok(plan);
+        }
+    }
+
+    Ok(plan)
+}
+
+fn protect_path<G: HeaderGraphView>(
+    store: &G,
+    tip: block::Hash,
+    protected: &mut HashSet<block::Hash>,
+) -> Result<usize, GraphError> {
+    let mut hash = tip;
+    let mut visited = 0usize;
+    loop {
+        visited = visited.saturating_add(1);
+        if protected.contains(&hash) {
+            return Ok(visited);
+        }
+        let node = store.view_node(hash).ok_or(GraphError::UnknownNode(hash))?;
+        protected.insert(hash);
+        if hash == store.view_finalized().hash {
+            return Ok(visited);
+        }
+        hash = node.parent_hash;
+    }
+}
+
+fn evict_permanently_ineligible<G: HeaderGraphEdit>(
+    store: &mut G,
+    protected: &HashSet<block::Hash>,
+) -> Result<(), GraphError> {
+    let mut roots: Vec<_> = store
+        .view_retained_hashes()
+        .into_iter()
+        .filter(|hash| {
+            !protected.contains(hash)
+                && store
+                    .view_node(*hash)
+                    .is_some_and(|node| node.eligibility.has_permanent_reason())
+        })
+        .collect();
+    roots.sort_unstable_by_key(|hash| {
+        let node = store
+            .view_node(*hash)
+            .expect("permanent roots were read from retained nodes");
+        (node.height, hash.0)
+    });
+    for root in roots {
+        if store.view_node(root).is_none() || subtree_contains_protected(store, root, protected) {
+            continue;
+        }
+        let mut descendants = subtree_postorder(store, root);
+        for hash in descendants.drain(..) {
+            store.edit_remove_leaf(hash)?;
+        }
+    }
+    Ok(())
+}
+
+fn subtree_contains_protected<G: HeaderGraphView>(
+    store: &G,
+    root: block::Hash,
+    protected: &HashSet<block::Hash>,
+) -> bool {
+    let mut pending = vec![root];
+    while let Some(hash) = pending.pop() {
+        if protected.contains(&hash) {
+            return true;
+        }
+        pending.extend(store.view_children(hash));
+    }
+    false
+}
+
+fn subtree_postorder<G: HeaderGraphView>(store: &G, root: block::Hash) -> Vec<block::Hash> {
+    let mut pending = vec![(root, false)];
+    let mut result = Vec::new();
+    while let Some((hash, visited)) = pending.pop() {
+        if visited {
+            result.push(hash);
+        } else {
+            pending.push((hash, true));
+            pending.extend(
+                store
+                    .view_children(hash)
+                    .into_iter()
+                    .rev()
+                    .map(|child| (child, false)),
+            );
+        }
+    }
+    result
+}
+
+fn lowest_unprotected_eligible_tip<G: HeaderGraphView>(
+    store: &G,
+    protected: &HashSet<block::Hash>,
+) -> Result<Option<Frontier>, GraphError> {
+    let mut candidates: Vec<_> = store
+        .view_eligible_tips()
+        .into_iter()
+        .filter(|tip| {
+            !protected.contains(&tip.hash)
+                && !subtree_contains_protected(store, tip.hash, protected)
+        })
+        .map(|tip| Ok((store.view_score(tip.hash)?, tip)))
+        .collect::<Result<_, GraphError>>()?;
+    candidates.sort_unstable_by_key(|(score, _)| *score);
+    Ok(candidates.first().map(|(_, tip)| *tip))
+}
+
+fn lowest_unprotected_leaf<G: HeaderGraphView>(
+    store: &G,
+    protected: &HashSet<block::Hash>,
+) -> Result<Option<block::Hash>, GraphError> {
+    let mut candidates: Vec<_> = store
+        .view_retained_hashes()
+        .into_iter()
+        .filter(|hash| !protected.contains(hash) && store.view_children(*hash).is_empty())
+        .map(|hash| Ok((store.view_score(hash)?, hash)))
+        .collect::<Result<_, GraphError>>()?;
+    candidates.sort_unstable_by_key(|(score, _)| *score);
+    Ok(candidates.first().map(|(_, hash)| *hash))
+}
+
+fn evict_tip_branch<G: HeaderGraphEdit>(
+    store: &mut G,
+    root: block::Hash,
+    protected: &HashSet<block::Hash>,
+) -> Result<(), GraphError> {
+    if protected.contains(&root)
+        || root == store.view_finalized().hash
+        || subtree_contains_protected(store, root, protected)
+    {
+        return Ok(());
+    }
+    let mut hash = store
+        .view_node(root)
+        .ok_or(GraphError::UnknownNode(root))?
+        .parent_hash;
+    for descendant in subtree_postorder(store, root) {
+        store.edit_remove_leaf(descendant)?;
+    }
+
+    loop {
+        if protected.contains(&hash) || hash == store.view_finalized().hash {
+            return Ok(());
+        }
+        let node = store.view_node(hash).ok_or(GraphError::UnknownNode(hash))?;
+        if !store.view_children(hash).is_empty() {
+            return Ok(());
+        }
+        let parent = node.parent_hash;
+        store.edit_remove_leaf(hash)?;
+        if store.view_children(parent).is_empty() {
+            hash = parent;
+        } else {
+            return Ok(());
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/transition/mod.rs
+++ b/crates/zakura-header-chain/src/transition/mod.rs
@@ -1,0 +1,7 @@
+//! Typed transition evidence, durable snapshots, and read-oriented store contracts.
+
+mod store;
+mod types;
+
+pub use store::StoreError;
+pub use types::*;

--- a/crates/zakura-header-chain/src/transition/store.rs
+++ b/crates/zakura-header-chain/src/transition/store.rs
@@ -1,0 +1,14 @@
+//! Storage failures reported while assembling durable engine inputs.
+
+use thiserror::Error;
+
+/// Failure to read one coherent store view.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum StoreError {
+    /// Store rows or indexes are internally incoherent.
+    #[error("incoherent header-chain store: {0}")]
+    Incoherent(&'static str),
+    /// A required row is unavailable because of a local storage failure.
+    #[error("header-chain storage unavailable: {0}")]
+    Unavailable(&'static str),
+}

--- a/crates/zakura-header-chain/src/transition/types.rs
+++ b/crates/zakura-header-chain/src/transition/types.rs
@@ -1,0 +1,1022 @@
+//! Complete typed input and output surface for serialized header-chain transitions.
+
+use std::{num::NonZeroU32, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use zakura_chain::{
+    block::{self, merkle::AuthDataRoot},
+    ironwood, orchard,
+    parameters::NetworkKind,
+    sapling,
+    work::difficulty::Work,
+};
+
+use crate::{
+    BodyRuleId, BodyUnavailableSummary, BodyWorkOwner, BranchId, ChainScore, EligibilityState,
+    EngineMode, EvidenceId, FinalityEpoch, Frontier, FrontierSet, HeaderGeneration, HeaderNode,
+    HeaderSyncWorkOwner, HeaderValidationState, OperatorInvalidationId, SourceId, StateVersion,
+    VerifiedGeneration,
+};
+
+/// Opaque version of the durable header-chain disk schema.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct HeaderChainDiskVersion(pub u32);
+
+/// Persistent externally visible engine alarms.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AlarmSet {
+    /// Protected paths prevented resource-bound enforcement.
+    pub resource_stalled: bool,
+    /// The selected branch has exhausted its current body suppliers/retry episode.
+    pub header_best_body_unavailable: Option<BodyUnavailableSummary>,
+    /// An imported headers-only trust pin was refuted by deterministic body validation.
+    pub migrated_pin_refuted: Option<Frontier>,
+}
+
+/// Atomic read snapshot published only after durable commit.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EngineSnapshot {
+    /// Finality authority mode.
+    pub mode: EngineMode,
+    /// Complete durable state version.
+    pub state_version: StateVersion,
+    /// Selected-header work generation.
+    pub header_generation: HeaderGeneration,
+    /// Full-state verified-path generation.
+    pub verified_generation: VerifiedGeneration,
+    /// Exact finalized, selected-header, and verified frontiers.
+    pub frontiers: FrontierSet,
+    /// Exact score of `frontiers.header_best` after the work anchor.
+    pub header_best_score: ChainScore,
+    /// Lowest retained height available for serving/context.
+    pub oldest_retained_height: block::Height,
+    /// Durable operator-visible alarms.
+    pub alarms: AlarmSet,
+}
+
+/// Singleton durable metadata row that is the logical root of one committed state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EngineMetadata {
+    /// Durable schema version.
+    pub disk_format: HeaderChainDiskVersion,
+    /// Persisted finality mode.
+    pub mode: EngineMode,
+    /// Persisted authenticated network identity.
+    pub network_id: NetworkKind,
+    /// Digest of the release-authenticated settled manifest.
+    pub anchor_manifest_digest: [u8; 32],
+    /// Immutable work-coordinate origin.
+    pub work_origin: Frontier,
+    /// Complete durable state version.
+    pub state_version: StateVersion,
+    /// Selected-header work generation.
+    pub header_generation: HeaderGeneration,
+    /// Full-state verified-path generation.
+    pub verified_generation: VerifiedGeneration,
+    /// Finality advancement epoch.
+    pub finality_epoch: FinalityEpoch,
+    /// Exact durable frontiers.
+    pub frontiers: FrontierSet,
+    /// Exact selected-header score.
+    pub header_best_score: ChainScore,
+    /// Lowest retained height.
+    pub oldest_retained_height: block::Height,
+    /// Durable alarms.
+    pub alarms: AlarmSet,
+    /// Idempotency identity of the most recent committed transition.
+    pub last_transition_id: EvidenceId,
+}
+
+impl EngineMetadata {
+    /// Project the authoritative metadata row into its externally visible snapshot.
+    pub fn snapshot(&self) -> EngineSnapshot {
+        EngineSnapshot {
+            mode: self.mode,
+            state_version: self.state_version,
+            header_generation: self.header_generation,
+            verified_generation: self.verified_generation,
+            frontiers: self.frontiers,
+            header_best_score: self.header_best_score,
+            oldest_retained_height: self.oldest_retained_height,
+            alarms: self.alarms.clone(),
+        }
+    }
+}
+
+/// One immutable predecessor fact sealed into a validation lease.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct HeaderContextFact {
+    /// Exact predecessor frontier.
+    pub frontier: Frontier,
+    /// Compact target and time are authenticated by `frontier.hash`.
+    pub difficulty_threshold: zakura_chain::work::difficulty::CompactDifficulty,
+    /// Canonical predecessor time.
+    pub time: DateTime<Utc>,
+}
+
+/// Exact branch-local context used to prepare a header batch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidationLease {
+    /// Exact known parent.
+    pub(crate) parent: Frontier,
+    /// Up to 28 facts in reverse height order, beginning with `parent`.
+    pub(crate) predecessors: Vec<HeaderContextFact>,
+    /// Digest of current trust anchors.
+    pub(crate) trust_anchor_digest: [u8; 32],
+    /// Digest binding the complete lease contents.
+    pub(crate) context_digest: [u8; 32],
+}
+
+impl ValidationLease {
+    /// Construct a lease digest bound to its exact ordered durable context.
+    pub fn new(
+        parent: Frontier,
+        predecessors: Vec<HeaderContextFact>,
+        trust_anchor_digest: [u8; 32],
+    ) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(b"zakura-header-chain-validation-lease-v1");
+        hasher.update(parent.height.0.to_le_bytes());
+        hasher.update(parent.hash.0);
+        hasher.update(trust_anchor_digest);
+        for fact in &predecessors {
+            hasher.update(fact.frontier.height.0.to_le_bytes());
+            hasher.update(fact.frontier.hash.0);
+            hasher.update(fact.difficulty_threshold.to_le_bytes());
+            hasher.update(fact.time.timestamp().to_le_bytes());
+            hasher.update(fact.time.timestamp_subsec_nanos().to_le_bytes());
+        }
+        Self {
+            parent,
+            predecessors,
+            trust_anchor_digest,
+            context_digest: hasher.finalize().into(),
+        }
+    }
+
+    /// Return the exact known parent.
+    pub const fn parent(&self) -> Frontier {
+        self.parent
+    }
+
+    /// Return the reverse-height predecessor context beginning with the parent.
+    pub fn predecessors(&self) -> &[HeaderContextFact] {
+        &self.predecessors
+    }
+
+    /// Return the digest of the trust anchors used to issue this lease.
+    pub const fn trust_anchor_digest(&self) -> [u8; 32] {
+        self.trust_anchor_digest
+    }
+
+    /// Return the digest binding all lease contents.
+    pub const fn context_digest(&self) -> [u8; 32] {
+        self.context_digest
+    }
+}
+
+/// One fully prepared observable-header result.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreparedHeader {
+    /// Canonical header.
+    pub header: Arc<block::Header>,
+    /// Locally computed hash.
+    pub hash: block::Hash,
+    /// Locally inferred height.
+    pub height: block::Height,
+    /// Exact per-block work.
+    pub block_work: Work,
+    /// Valid or locally future-deferred state.
+    pub validation: HeaderValidationState,
+}
+
+/// Sealed evidence that preparation completed every graph-independent rule.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ContextFreePreparationReceipt {
+    parent: Frontier,
+    trust_anchor_digest: [u8; 32],
+}
+
+impl ContextFreePreparationReceipt {
+    /// Return the caller-supplied parent used for height-dependent local rules.
+    pub const fn parent(&self) -> Frontier {
+        self.parent
+    }
+
+    /// Return the authenticated immutable rule-set identity.
+    pub const fn trust_anchor_digest(&self) -> [u8; 32] {
+        self.trust_anchor_digest
+    }
+}
+
+/// Sealed nonempty batch carrying explicit graph-independent validation evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreparedHeaderBatch {
+    headers: Vec<PreparedHeader>,
+    receipt: ContextFreePreparationReceipt,
+    evidence: EvidenceId,
+}
+
+impl PreparedHeaderBatch {
+    #[allow(dead_code)] // Called by the public preparation pipeline introduced in PR-11.
+    pub(crate) fn new(
+        headers: Vec<PreparedHeader>,
+        parent: Frontier,
+        trust_anchor_digest: [u8; 32],
+        evidence: EvidenceId,
+    ) -> Result<Self, TransitionTypeError> {
+        if headers.is_empty() {
+            return Err(TransitionTypeError::EmptyHeaderBatch);
+        }
+        Ok(Self {
+            headers,
+            receipt: ContextFreePreparationReceipt {
+                parent,
+                trust_anchor_digest,
+            },
+            evidence,
+        })
+    }
+
+    /// Return the prepared headers in exact parent-first order.
+    pub fn headers(&self) -> &[PreparedHeader] {
+        &self.headers
+    }
+
+    /// Return the sealed graph-independent preparation receipt.
+    pub const fn receipt(&self) -> ContextFreePreparationReceipt {
+        self.receipt
+    }
+
+    /// Return the batch's stable validation-evidence identity.
+    pub const fn evidence(&self) -> EvidenceId {
+        self.evidence
+    }
+
+    /// Rebase this sealed batch after an exact prepared header that became finalized.
+    ///
+    /// The remaining headers retain their validated results and absolute heights; the suffix is
+    /// resealed to the now-durable parent. Returns the removed header count.
+    pub(crate) fn rebase_after(&mut self, parent: Frontier) -> Result<usize, TransitionTypeError> {
+        if self.receipt.parent == parent {
+            return Ok(0);
+        }
+        let Some(index) = self
+            .headers
+            .iter()
+            .position(|header| Frontier::new(header.height, header.hash) == parent)
+        else {
+            return Err(TransitionTypeError::InvalidPreparedRebase);
+        };
+        let removed = index.saturating_add(1);
+        self.headers.drain(..removed);
+        self.receipt.parent = parent;
+        let mut hasher = Sha256::new();
+        hasher.update(b"zakura-header-chain-context-free-batch-v1");
+        hasher.update(parent.height.0.to_le_bytes());
+        hasher.update(parent.hash.0);
+        hasher.update(self.receipt.trust_anchor_digest);
+        for header in &self.headers {
+            hasher.update(header.height.0.to_le_bytes());
+            hasher.update(header.hash.0);
+        }
+        self.evidence = EvidenceId::from_digest(hasher.finalize().into());
+        Ok(removed)
+    }
+
+    pub(crate) fn clear_already_applied(&mut self) {
+        self.headers.clear();
+    }
+}
+
+/// Bounded advisory body-size metadata; it cannot allocate or grant admission credit.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BodySizeHint {
+    /// Wire value zero: no size is known.
+    Unknown,
+    /// Canonical block size in `1..=MAX_BLOCK_BYTES`.
+    Known(NonZeroU32),
+}
+
+impl BodySizeHint {
+    /// Validate an advisory wire value.
+    pub fn new(value: u32) -> Result<Self, TransitionTypeError> {
+        if value == 0 {
+            return Ok(Self::Unknown);
+        }
+        if u64::from(value) > block::MAX_BLOCK_BYTES {
+            return Err(TransitionTypeError::InvalidBodySize(value));
+        }
+        Ok(Self::Known(
+            NonZeroU32::new(value).expect("the zero body-size sentinel returned above"),
+        ))
+    }
+}
+
+/// Authentication state of one hash-keyed auxiliary delivery.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AuxAuthentication {
+    /// Peer metadata has no selection or validity authority.
+    Unauthenticated,
+    /// Integrated verification authenticated this exact delivery.
+    Authenticated {
+        /// Stable authentication evidence.
+        evidence: EvidenceId,
+        /// One-header-later authentication boundary.
+        boundary_hash: block::Hash,
+    },
+    /// This delivery was rejected without invalidating its header.
+    Rejected {
+        /// Stable rejection evidence.
+        evidence: EvidenceId,
+    },
+}
+
+/// Hash-keyed auxiliary delivery with complete provenance.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct AuxDelivery {
+    /// Stable delivery identity.
+    pub delivery_id: EvidenceId,
+    /// Exact retained header.
+    pub header_hash: block::Hash,
+    /// Supplying peer/session identity.
+    pub source: SourceId,
+    /// Complete work ownership at receipt.
+    pub owner: HeaderSyncWorkOwner,
+    /// Advisory bounded body size.
+    pub body_size: BodySizeHint,
+    /// Complete schema-1 record retained for later one-header-later authentication.
+    pub tree_aux: Option<TreeAuxRecordV1>,
+    /// Current authentication state.
+    pub authentication: AuxAuthentication,
+}
+
+/// Immutable schema-1 commitment inputs for one inferred block height.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TreeAuxRecordV1 {
+    /// Exact inferred height of this record.
+    pub height: block::Height,
+    /// End-of-block Sapling note-commitment root.
+    pub sapling_root: sapling::tree::Root,
+    /// End-of-block Orchard root, empty below NU5.
+    pub orchard_root: orchard::tree::Root,
+    /// End-of-block Ironwood root, empty before configured NU7.
+    pub ironwood_root: ironwood::tree::Root,
+    /// Per-block Sapling shielded transaction count.
+    pub sapling_tx_count: u64,
+    /// Per-block Orchard shielded transaction count, zero below NU5.
+    pub orchard_tx_count: u64,
+    /// Per-block Ironwood shielded transaction count, zero before configured NU7.
+    pub ironwood_tx_count: u64,
+    /// ZIP-244 authorizing-data root, all zero below NU5.
+    pub auth_data_root: AuthDataRoot,
+}
+
+/// Prepared auxiliary input admitted alongside a header batch.
+pub type PreparedAuxDelivery = AuxDelivery;
+
+/// Completion contract attached to one atomic header insertion.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TargetCompletion {
+    /// Peer-advertised target was completed from this exact common ancestor.
+    TargetComplete {
+        /// Exact locator intersection.
+        common_ancestor: Frontier,
+    },
+    /// A bounded prefix of a larger peer-advertised target was completed.
+    ///
+    /// Prefix admission bounds requester memory while preserving exact validation and
+    /// ownership for the last header actually supplied in this batch.
+    TargetPrefix {
+        /// Exact locator intersection.
+        common_ancestor: Frontier,
+    },
+    /// One already-selected interior header was redelivered solely to replace auxiliary metadata.
+    SelectedAuxiliaryRepair {
+        /// Exact selected predecessor used as the single-entry locator.
+        common_ancestor: Frontier,
+        /// Exact already-selected header whose metadata was redelivered.
+        selected_target: Frontier,
+    },
+}
+
+impl TargetCompletion {
+    pub(crate) fn rebase_common_ancestor(
+        &mut self,
+        common_ancestor: Frontier,
+    ) -> Result<(), TransitionTypeError> {
+        match self {
+            Self::TargetComplete {
+                common_ancestor: current,
+            }
+            | Self::TargetPrefix {
+                common_ancestor: current,
+            } => {
+                *current = common_ancestor;
+                Ok(())
+            }
+            Self::SelectedAuxiliaryRepair { .. } => Err(TransitionTypeError::InvalidPreparedRebase),
+        }
+    }
+}
+
+/// Atomically insert one complete prepared header range.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InsertHeaders {
+    /// Current asynchronous work owner.
+    pub owner: HeaderSyncWorkOwner,
+    /// Header supplier.
+    pub source: SourceId,
+    /// Exact retained parent.
+    pub parent_hash: block::Hash,
+    /// Exact pursued target.
+    pub target_tip_hash: block::Hash,
+    /// Target completion proof kind.
+    pub completion: TargetCompletion,
+    /// Sealed header validation evidence.
+    pub batch: PreparedHeaderBatch,
+    /// Exact parallel hash-keyed auxiliary deliveries.
+    pub aux: Vec<PreparedAuxDelivery>,
+}
+
+/// One exact header reference accepted by full state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedHeaderRef {
+    /// Exact height.
+    pub height: block::Height,
+    /// Exact locally computed hash.
+    pub hash: block::Hash,
+    /// Canonical header.
+    pub header: Arc<block::Header>,
+}
+
+/// Explicit full-state selected-path change kind; height never infers it.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum VerifiedChangeCause {
+    /// Direct or forward growth.
+    Grow,
+    /// Same-height, lower-height, or forward-height branch reset.
+    Reset,
+}
+
+/// Authenticated full-state selected-path transition.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedChainChanged {
+    /// Internal full-state transition identity and authority proof.
+    pub full_state_transition_id: EvidenceId,
+    /// Exact previously selected verified tip.
+    pub old_tip: Frontier,
+    /// Continuous new verified suffix, possibly empty back to finalized.
+    pub new_path: Vec<VerifiedHeaderRef>,
+    /// Explicit branch-aware grow/reset cause.
+    pub cause: VerifiedChangeCause,
+}
+
+/// Full-state acceptance of a block on a path that did not become the verified winner.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedBlockAccepted {
+    /// Internal full-state transition identity and authority proof.
+    pub full_state_transition_id: EvidenceId,
+    /// Exact finalized-rooted path through the accepted block.
+    pub path: Vec<VerifiedHeaderRef>,
+}
+
+/// Exact body/header commitment mismatch kind.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BodyCommitmentKind {
+    /// Delivered block header hash differs from the requested hash.
+    HeaderHash,
+    /// Transaction Merkle root mismatch.
+    TransactionMerkleRoot,
+    /// ZIP-244 authorization-data commitment mismatch.
+    AuthDataRoot,
+    /// Another height-applicable body-derived header commitment.
+    Other(&'static str),
+}
+
+/// Supplier-attributed mismatched body payload; it cannot affect eligibility.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct BodyPayloadMismatch {
+    /// Stable delivery evidence.
+    pub evidence: EvidenceId,
+    /// Requested header hash.
+    pub requested: block::Hash,
+    /// Delivered header hash.
+    pub delivered: block::Hash,
+    /// Exact mismatched commitment.
+    pub kind: BodyCommitmentKind,
+    /// Body supplier, never a header-only supplier.
+    pub source: SourceId,
+}
+
+/// Commitment-matching deterministic body consensus failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConsensusBodyInvalid {
+    /// Exact affected header.
+    pub hash: block::Hash,
+    /// Stable verifier evidence proving commitment matching and failure.
+    pub evidence: EvidenceId,
+    /// Exact full-state rule.
+    pub rule: BodyRuleId,
+    /// Proving body supplier, never inherited header suppliers.
+    pub source: SourceId,
+}
+
+/// Retryable body failure category with no eligibility effect.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TransientBodyFailureKind {
+    /// Required state context is not available yet.
+    MissingContext,
+    /// Work was canceled or superseded.
+    Canceled,
+    /// Local storage failed transiently.
+    Storage,
+    /// Verifier service was unavailable.
+    VerifierUnavailable,
+    /// External wait timed out.
+    Timeout,
+    /// Local resources are temporarily exhausted.
+    ResourceExhausted,
+}
+
+/// Retryable body failure evidence.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TransientBodyFailure {
+    /// Exact affected header.
+    pub hash: block::Hash,
+    /// Stable retry evidence.
+    pub evidence: EvidenceId,
+    /// Exact retry category.
+    pub kind: TransientBodyFailureKind,
+    /// Bounded persistent state of the owning retry episode.
+    pub availability: BodyUnavailableSummary,
+}
+
+/// Authenticated discovery of a changed eligible body-supplier set.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct BodySupplierDiscovered {
+    /// Exact selected header whose persistent retry episode gains a supplier.
+    pub hash: block::Hash,
+    /// Stable identity of the authenticated supplier-set observation.
+    pub evidence: EvidenceId,
+    /// Existing alarm episode with updated supplier evidence and a due probe.
+    pub availability: BodyUnavailableSummary,
+}
+
+/// Authenticated operator request to restart one persistent body retry episode.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct OperatorBodyRetry {
+    /// Exact selected header whose retry episode restarts.
+    pub hash: block::Hash,
+    /// Stable identity of the authenticated operator request.
+    pub evidence: EvidenceId,
+    /// Fresh zero-attempt episode summary.
+    pub availability: BodyUnavailableSummary,
+}
+
+/// Full-state acceptance of one exact body/header pair.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedBodyEvidence {
+    /// Exact accepted header.
+    pub hash: block::Hash,
+    /// Stable verification evidence.
+    pub evidence: EvidenceId,
+}
+
+/// Exhaustive body-result categories with intentionally distinct effects.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BodyVerificationOutcome {
+    /// Full-state accepted the exact body/header pair.
+    Verified(VerifiedBodyEvidence),
+    /// The supplier delivered a payload that did not match the requested header.
+    PayloadMismatch(BodyPayloadMismatch),
+    /// Commitment-matching body data deterministically failed consensus.
+    ConsensusInvalid(ConsensusBodyInvalid),
+    /// Verification could not reach a durable consensus conclusion.
+    Retryable(TransientBodyFailure),
+}
+
+/// Evidence-free verifier classification used before supplier and stable evidence are attached.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BodyVerificationClass {
+    /// The exact body was already accepted by full state.
+    Duplicate,
+    /// Delivered body data disagrees with a commitment in its admitted header.
+    PayloadMismatch(BodyCommitmentKind),
+    /// All applicable commitments matched before one deterministic consensus rule failed.
+    ConsensusInvalid(BodyRuleId),
+    /// Verification could not reach a durable consensus conclusion.
+    Retryable(TransientBodyFailureKind),
+}
+
+impl From<BodyVerificationOutcome> for BodyEvidence {
+    fn from(outcome: BodyVerificationOutcome) -> Self {
+        match outcome {
+            BodyVerificationOutcome::Verified(evidence) => Self::Verified(evidence),
+            BodyVerificationOutcome::PayloadMismatch(evidence) => Self::PayloadMismatch(evidence),
+            BodyVerificationOutcome::ConsensusInvalid(evidence) => Self::ConsensusInvalid(evidence),
+            BodyVerificationOutcome::Retryable(evidence) => Self::Transient(evidence),
+        }
+    }
+}
+
+/// Durable transition evidence derived from one body-verification outcome.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BodyEvidence {
+    /// Bad delivery only.
+    PayloadMismatch(BodyPayloadMismatch),
+    /// Intrinsic deterministic body invalidity.
+    ConsensusInvalid(ConsensusBodyInvalid),
+    /// Retryable local/delivery failure.
+    Transient(TransientBodyFailure),
+    /// Full-state verified body.
+    Verified(VerifiedBodyEvidence),
+}
+
+/// Add one reversible operator reason.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct OperatorInvalidate {
+    /// Exact retained target.
+    pub target: block::Hash,
+    /// Independently removable invalidation identity.
+    pub id: OperatorInvalidationId,
+    /// Stable authenticated operator-reason digest.
+    pub operator_reason_digest: [u8; 32],
+    /// Stable idempotency evidence for this authenticated operator action.
+    pub evidence: EvidenceId,
+}
+
+/// Remove exactly one reversible operator reason.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct OperatorReconsider {
+    /// Exact retained target.
+    pub target: block::Hash,
+    /// Exact invalidation identity to remove.
+    pub id: OperatorInvalidationId,
+    /// Stable idempotency evidence for this authenticated operator action.
+    pub evidence: EvidenceId,
+}
+
+/// Authenticated integrated-mode finality evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FullStateFinalized {
+    /// Internal full-state transition identity.
+    pub full_state_transition_id: EvidenceId,
+    /// Exact nonretreating finalized frontier.
+    pub new_finalized: Frontier,
+    /// Exact verified ancestry proof ending at `new_finalized`.
+    pub verified_path_proof: Vec<block::Hash>,
+}
+
+/// Deterministic full-state evidence that refutes an imported headers-only trust pin.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MigratedPinRefutation {
+    /// Stable internal full-state transition identity.
+    pub full_state_transition_id: EvidenceId,
+    /// Exact preserved headers-only pin whose ancestry was refuted.
+    pub pin: Frontier,
+    /// Exact body-invalid header on the imported path at or below `pin`.
+    pub invalid_header: Frontier,
+    /// Exact deterministic full-state rule.
+    pub rule: BodyRuleId,
+}
+
+/// Auxiliary metadata authentication update.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuxEvidence {
+    /// Current work owner.
+    pub owner: BodyWorkOwner,
+    /// One or two exact deliveries and their immutable provenance.
+    pub deliveries: Vec<PreparedAuxDelivery>,
+    /// New authentication state applied atomically to every named delivery.
+    pub authentication: AuxAuthentication,
+}
+
+/// Dependency-neutral VCT metadata repair status published by the state writer.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct VctRootRepairStatus {
+    /// Current repair need.
+    pub state: VctRootRepairState,
+    /// Monotonic replacement-attempt generation.
+    pub generation: u64,
+}
+
+impl Default for VctRootRepairStatus {
+    fn default() -> Self {
+        Self {
+            state: VctRootRepairState::Idle,
+            generation: 0,
+        }
+    }
+}
+
+/// Exact VCT metadata repair need, independent of state/network service types.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum VctRootRepairState {
+    /// No VCT metadata repair is currently required.
+    Idle,
+    /// The finalized writer needs a replacement delivery for one exact height.
+    Unavailable {
+        /// Height whose selected-header metadata is unavailable or rejected.
+        height: block::Height,
+    },
+}
+
+/// Every chain-changing input accepted by the sole transition planner.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TransitionEvent {
+    /// Prepared header admission.
+    InsertHeaders(Box<InsertHeaders>),
+    /// Full-state selected path changed.
+    VerifiedChainChanged(VerifiedChainChanged),
+    /// Full state accepted a block without changing its selected path.
+    VerifiedBlockAccepted(VerifiedBlockAccepted),
+    /// Body delivery/verification evidence.
+    BodyEvidence(BodyEvidence),
+    /// A newly eligible supplier restarted body acquisition.
+    BodySupplierDiscovered(BodySupplierDiscovered),
+    /// An authenticated operator restarted body acquisition.
+    OperatorBodyRetry(OperatorBodyRetry),
+    /// Reversible operator invalidation.
+    OperatorInvalidate(OperatorInvalidate),
+    /// Reason-scoped operator reconsideration.
+    OperatorReconsider(OperatorReconsider),
+    /// Integrated full-state finality advancement.
+    FullStateFinalized(FullStateFinalized),
+    /// Integrated full state refuted an imported headers-only pin.
+    MigratedPinRefutation(MigratedPinRefutation),
+    /// Hash-scoped auxiliary evidence.
+    AuxEvidence(Box<AuxEvidence>),
+    /// Reevaluate all locally due future-time deferrals.
+    ReevaluateDeferred,
+}
+
+/// Authority/mode gate checked before any transition effect.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum EventAdmission {
+    /// Valid in integrated and headers-only modes.
+    AnyMode,
+    /// Requires authenticated integrated full-state authority.
+    IntegratedFullState,
+}
+
+impl TransitionEvent {
+    /// Return the authority gate fixed for this event category.
+    pub fn admission(&self) -> EventAdmission {
+        match self {
+            Self::VerifiedChainChanged(_)
+            | Self::VerifiedBlockAccepted(_)
+            | Self::BodyEvidence(_)
+            | Self::BodySupplierDiscovered(_)
+            | Self::FullStateFinalized(_)
+            | Self::MigratedPinRefutation(_)
+            | Self::AuxEvidence(_) => EventAdmission::IntegratedFullState,
+            Self::InsertHeaders(_)
+            | Self::OperatorBodyRetry(_)
+            | Self::OperatorInvalidate(_)
+            | Self::OperatorReconsider(_)
+            | Self::ReevaluateDeferred => EventAdmission::AnyMode,
+        }
+    }
+
+    /// Return this event's stable idempotency identity when it carries durable evidence.
+    pub fn idempotency_key(&self) -> Option<EvidenceId> {
+        match self {
+            Self::InsertHeaders(event) => match event.completion {
+                TargetCompletion::SelectedAuxiliaryRepair { .. } => {
+                    event.aux.first().map(|delivery| delivery.delivery_id)
+                }
+                TargetCompletion::TargetComplete { .. } | TargetCompletion::TargetPrefix { .. } => {
+                    Some(event.batch.evidence())
+                }
+            },
+            Self::VerifiedChainChanged(event) => Some(event.full_state_transition_id),
+            Self::VerifiedBlockAccepted(event) => Some(event.full_state_transition_id),
+            Self::BodyEvidence(BodyEvidence::PayloadMismatch(event)) => Some(event.evidence),
+            Self::BodyEvidence(BodyEvidence::ConsensusInvalid(event)) => Some(event.evidence),
+            Self::BodyEvidence(BodyEvidence::Transient(event)) => Some(event.evidence),
+            Self::BodyEvidence(BodyEvidence::Verified(event)) => Some(event.evidence),
+            Self::BodySupplierDiscovered(event) => Some(event.evidence),
+            Self::OperatorBodyRetry(event) => Some(event.evidence),
+            Self::OperatorInvalidate(event) => Some(event.evidence),
+            Self::OperatorReconsider(event) => Some(event.evidence),
+            Self::FullStateFinalized(event) => Some(event.full_state_transition_id),
+            Self::MigratedPinRefutation(event) => Some(event.full_state_transition_id),
+            Self::AuxEvidence(event) => match event.authentication {
+                AuxAuthentication::Unauthenticated => None,
+                AuxAuthentication::Authenticated { evidence, .. }
+                | AuxAuthentication::Rejected { evidence } => Some(evidence),
+            },
+            Self::ReevaluateDeferred => None,
+        }
+    }
+
+    /// Return explicit branch ownership for asynchronous network-originated events.
+    pub fn header_sync_owner(&self) -> Option<HeaderSyncWorkOwner> {
+        match self {
+            Self::InsertHeaders(event) => Some(event.owner),
+            _ => None,
+        }
+    }
+
+    /// Return body authority for asynchronous body-originated evidence.
+    pub fn body_owner(&self) -> Option<BodyWorkOwner> {
+        match self {
+            Self::AuxEvidence(event) => Some(event.owner),
+            _ => None,
+        }
+    }
+}
+
+/// Version-qualified request to the sole serialized transition planner.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransitionRequest {
+    /// Exact durable version observed by the caller.
+    pub expected_version: StateVersion,
+    /// Typed evidence; callers never submit desired consequences.
+    pub event: TransitionEvent,
+}
+
+/// Selected or verified height projection replacement.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProjectionDelta {
+    /// Exclusive upper height for retired prefix rows.
+    pub remove_before: Option<block::Height>,
+    /// First height whose old suffix is removed.
+    pub remove_from: Option<block::Height>,
+    /// Exact replacement suffix in ascending height order.
+    pub put: Vec<Frontier>,
+}
+
+/// One eligibility cache/reason-set change.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EligibilityDelta {
+    /// Exact affected header.
+    pub hash: block::Hash,
+    /// Previous state.
+    pub before: EligibilityState,
+    /// Projected state.
+    pub after: EligibilityState,
+}
+
+/// Reconstructible hash/parent/height index changes.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct IndexChanges {
+    /// Newly indexed frontiers.
+    pub inserted: Vec<Frontier>,
+    /// Hashes removed from every reconstructible index.
+    pub deleted: Vec<block::Hash>,
+}
+
+/// One auxiliary-delivery mutation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AuxDelta {
+    /// Insert or idempotently retain a delivery.
+    Put(Box<AuxDelivery>),
+    /// Delete one bounded delivery record.
+    Delete {
+        /// Header whose auxiliary record is deleted.
+        header_hash: block::Hash,
+        /// Exact delivery identity deleted from that header.
+        delivery_id: EvidenceId,
+    },
+}
+
+/// Provenance of one irreversible finality advancement.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FinalitySource {
+    /// Durable fully verified full-state decision.
+    FullState {
+        /// Internal full-state finalization evidence.
+        evidence: EvidenceId,
+    },
+    /// Disclosed 1,000-deep headers-only local trust rule.
+    HeadersOnlyDepth {
+        /// Selected tip whose depth proved the new pin.
+        selected_tip: Frontier,
+    },
+    /// Preserved local trust pin imported during an explicit mode migration.
+    MigratedHeadersOnly,
+}
+
+/// Append-only finality audit record.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct FinalityRecord {
+    /// Previous immutable anchor.
+    pub previous: Frontier,
+    /// New immutable anchor.
+    pub current: Frontier,
+    /// Exact authority/proof kind.
+    pub source: FinalitySource,
+    /// Resulting finality epoch.
+    pub epoch: FinalityEpoch,
+}
+
+/// Complete pure write plan applied atomically by the state adapter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChangeSet {
+    /// New or replaced nodes.
+    pub put_nodes: Vec<HeaderNode>,
+    /// Evicted or finalized-away nodes.
+    pub delete_nodes: Vec<block::Hash>,
+    /// Reconstructible indexes changed with the nodes.
+    pub index_changes: IndexChanges,
+    /// Selected-header height projection change.
+    pub selected_projection: ProjectionDelta,
+    /// Full-state verified height projection change.
+    pub verified_projection: ProjectionDelta,
+    /// Direct or inherited eligibility changes.
+    pub eligibility_changes: Vec<EligibilityDelta>,
+    /// Hash-keyed auxiliary changes.
+    pub aux_changes: Vec<AuxDelta>,
+    /// Optional append-only finality record.
+    pub finality_append: Option<FinalityRecord>,
+    /// New singleton metadata written last in the atomic batch.
+    pub metadata: EngineMetadata,
+}
+
+/// High-level cause preserved in a committed receipt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TransitionCause {
+    /// One of the externally typed evidence categories.
+    Event,
+    /// Ordinary header work was admitted after a durable monotone-finality rebase.
+    HeaderWorkRebased,
+    /// The complete prepared range was already consumed by monotone finality.
+    HeaderWorkAlreadyApplied,
+    /// Admission was refused without applying the event because protected state filled a limit.
+    ResourceStalled,
+    /// Headers-only depth finality occurred in the same insertion/reselection.
+    HeadersOnlyFinality,
+    /// Startup recovery reconstructed state.
+    Recovery,
+}
+
+/// Work that must be retired before new forward scheduling.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RetiredWork {
+    /// Header generation changed; all old forward owners are stale.
+    pub header_generation_changed: bool,
+    /// Verified generation changed; all old body-forward owners are stale.
+    pub verified_generation_changed: bool,
+    /// Exact owners retired for narrower causes.
+    pub owners: Vec<HeaderSyncWorkOwner>,
+}
+
+/// Successful idempotent replay with no durable effects.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct NoChangeReceipt {
+    /// Unchanged durable version.
+    pub state_version: StateVersion,
+    /// Previously committed event identity, if this event carries one.
+    pub event: Option<EvidenceId>,
+}
+
+/// Stale version/branch/owner result with guaranteed zero effects.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct StaleReceipt {
+    /// Current durable version the caller must reload.
+    pub current_version: StateVersion,
+    /// Exact stale branch when the event is branch-sensitive.
+    pub branch: Option<BranchId>,
+}
+
+/// A resource refusal whose alarm state has already been durably committed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct CommittedStallReceipt {
+    /// Durable version after recording or retaining the resource-stall alarm.
+    pub state_version: StateVersion,
+    /// True when this refusal changed and published the alarm state.
+    pub alarm_changed: bool,
+    /// Exact attempted branch when the refused event was branch-sensitive.
+    pub attempted_branch: Option<BranchId>,
+}
+
+/// Serialized transition outcome.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ApplyResult {
+    /// State adapter durably committed.
+    Committed,
+    /// Idempotent evidence made no change.
+    NoChange(NoChangeReceipt),
+    /// Ownership/version was stale before effects.
+    Stale(StaleReceipt),
+    /// Admission was refused after durably recording or retaining its resource alarm.
+    ResourceStalled(CommittedStallReceipt),
+}
+
+/// Invalid construction at the transition type boundary.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum TransitionTypeError {
+    /// Header insertion batches must be nonempty.
+    #[error("prepared header batch must be nonempty")]
+    EmptyHeaderBatch,
+    /// A new finalized parent was not an exact member of the prepared path.
+    #[error("prepared header batch cannot rebase to the requested parent")]
+    InvalidPreparedRebase,
+    /// Advisory body size exceeded the canonical block limit.
+    #[error("invalid advisory body size {0}")]
+    InvalidBodySize(u32),
+}

--- a/crates/zakura-header-chain/src/validation/mod.rs
+++ b/crates/zakura-header-chain/src/validation/mod.rs
@@ -1,0 +1,268 @@
+//! Shared synchronous observable-header validation primitives.
+
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+use zakura_chain::{
+    block::{self, Commitment, CommitmentError},
+    parameters::{Network, NetworkKind},
+    work::{
+        difficulty::{ExpandedDifficulty, ParameterDifficulty as _},
+        equihash,
+    },
+};
+
+/// Invalid canonical encoding or signed-version semantics for an in-memory header.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[error("invalid block-header version {version}: {reason}")]
+pub struct HeaderEncodingError {
+    /// Rejected unsigned storage representation.
+    pub version: u32,
+    /// Stable reason shared with canonical serialization.
+    pub reason: &'static str,
+}
+
+/// Validate the signed version rule, then compute the canonical full-header hash.
+pub fn validate_encoding_version_hash(
+    header: &block::Header,
+) -> Result<block::Hash, HeaderEncodingError> {
+    block::validate_header_version(header.version).map_err(|reason| HeaderEncodingError {
+        version: header.version,
+        reason,
+    })?;
+    Ok(header.hash())
+}
+
+/// Parent-link failure at one exact zero-based header offset.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[error("header at offset {offset} names parent {actual:?}, expected {expected:?}")]
+pub struct HeaderLinkError {
+    /// Zero-based offset of the failing header.
+    pub offset: usize,
+    /// Expected parent hash.
+    pub expected: block::Hash,
+    /// Actual parent hash.
+    pub actual: block::Hash,
+}
+
+/// Validate the first parent link and every internal link in a header run.
+pub fn validate_link(
+    parent_hash: block::Hash,
+    headers: &[block::Header],
+) -> Result<(), HeaderLinkError> {
+    let mut expected = parent_hash;
+    for (offset, header) in headers.iter().enumerate() {
+        if header.previous_block_hash != expected {
+            return Err(HeaderLinkError {
+                offset,
+                expected,
+                actual: header.previous_block_hash,
+            });
+        }
+        expected = header.hash();
+    }
+    Ok(())
+}
+
+/// Checked inferred-height or advisory peer-height failure.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum HeaderHeightError {
+    /// The known parent is already at the maximum supported height.
+    #[error("child height after parent {0:?} exceeds the supported range")]
+    Overflow(block::Height),
+    /// An advisory peer height disagreed with the locally inferred height.
+    #[error("peer header height {peer:?} does not match inferred height {inferred:?}")]
+    PeerMismatch {
+        /// Height inferred from the known parent.
+        inferred: block::Height,
+        /// Untrusted peer-provided height.
+        peer: block::Height,
+    },
+}
+
+/// Infer a child height from its known parent and optionally compare an advisory peer height.
+pub fn infer_height(
+    parent_height: block::Height,
+    peer_height: Option<block::Height>,
+) -> Result<block::Height, HeaderHeightError> {
+    let inferred = parent_height
+        .0
+        .checked_add(1)
+        .map(block::Height)
+        .filter(|height| *height <= block::Height::MAX)
+        .ok_or(HeaderHeightError::Overflow(parent_height))?;
+    if let Some(peer) = peer_height {
+        if peer != inferred {
+            return Err(HeaderHeightError::PeerMismatch { inferred, peer });
+        }
+    }
+    Ok(inferred)
+}
+
+/// Parse and validate the height- and network-specific commitment field structure.
+pub fn validate_commitment_structure(
+    header: &block::Header,
+    network: &Network,
+    height: block::Height,
+) -> Result<Commitment, CommitmentError> {
+    header.commitment(network, height)
+}
+
+pub(crate) fn validate_trusted_anchor_observables(
+    header: &block::Header,
+    network: &Network,
+    height: block::Height,
+) -> Result<block::Hash, &'static str> {
+    let hash =
+        validate_encoding_version_hash(header).map_err(|_| "canonical header version and hash")?;
+    validate_commitment_structure(header, network, height)
+        .map_err(|_| "height-dependent commitment structure")?;
+    let target =
+        validate_compact_target(header, network).map_err(|_| "compact target and network limit")?;
+    let pow_policy =
+        PowPolicy::for_network(network).map_err(|_| "authenticated proof-of-work policy")?;
+    if !pow_policy.is_authenticated_custom_waiver() {
+        validate_hash_filter(hash, target).map_err(|_| "header hash filter")?;
+    }
+    pow_policy
+        .validate_solution(header)
+        .map_err(|_| "Equihash solution shape or proof")?;
+    Ok(hash)
+}
+
+/// Context-free compact-target domain or proof-of-work-limit failure.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum CompactTargetError {
+    /// Compact encoding represents a negative, zero, overflowed, or otherwise invalid target.
+    #[error("invalid compact difficulty target")]
+    Invalid,
+    /// Expanded target is easier than this network's proof-of-work limit.
+    #[error("difficulty target {target:?} exceeds network limit {limit:?}")]
+    EasierThanLimit {
+        /// Expanded candidate target.
+        target: ExpandedDifficulty,
+        /// Easiest target accepted on this network.
+        limit: ExpandedDifficulty,
+    },
+}
+
+/// Expand and validate a header's compact target against the network proof-of-work limit.
+pub fn validate_compact_target(
+    header: &block::Header,
+    network: &Network,
+) -> Result<ExpandedDifficulty, CompactTargetError> {
+    let target = header
+        .difficulty_threshold
+        .to_expanded()
+        .ok_or(CompactTargetError::Invalid)?;
+    let limit = network.target_difficulty_limit();
+    if target > limit {
+        return Err(CompactTargetError::EasierThanLimit { target, limit });
+    }
+    Ok(target)
+}
+
+/// Header hash failed its already-expanded target threshold.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[error("header hash {hash:?} exceeds difficulty target {target:?}")]
+pub struct HashFilterError {
+    /// Raw internal header hash.
+    pub hash: block::Hash,
+    /// Expanded target threshold.
+    pub target: ExpandedDifficulty,
+}
+
+/// Validate the little-endian header-hash difficulty filter.
+pub fn validate_hash_filter(
+    hash: block::Hash,
+    target: ExpandedDifficulty,
+) -> Result<(), HashFilterError> {
+    if hash > target {
+        return Err(HashFilterError { hash, target });
+    }
+    Ok(())
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum PowPolicyKind {
+    Validate,
+    AuthenticatedCustomWaiver,
+}
+
+/// Network-bound proof-of-work policy; callers cannot construct a production waiver.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PowPolicy {
+    network: Network,
+    kind: PowPolicyKind,
+}
+
+/// Invalid attempt to derive a proof-of-work waiver.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum PowPolicyError {
+    /// Mainnet and the default public Testnet can never receive a waiver.
+    #[error("proof-of-work cannot be disabled for production network {0:?}")]
+    ProductionNetwork(NetworkKind),
+    /// The authenticated custom configuration does not disable proof of work.
+    #[error("custom network configuration does not authenticate a proof-of-work waiver")]
+    PowNotDisabled,
+}
+
+impl PowPolicy {
+    /// Construct a policy that always verifies proof of work for the bound network.
+    pub fn validating(network: &Network) -> Self {
+        Self {
+            network: network.clone(),
+            kind: PowPolicyKind::Validate,
+        }
+    }
+
+    /// Derive the only policy permitted by an authenticated network configuration.
+    pub fn for_network(network: &Network) -> Result<Self, PowPolicyError> {
+        if network.disable_pow() {
+            Self::authenticated_custom_waiver(network)
+        } else {
+            Ok(Self::validating(network))
+        }
+    }
+
+    /// Attempt to construct a waiver from an authenticated custom-network configuration.
+    pub fn authenticated_custom_waiver(network: &Network) -> Result<Self, PowPolicyError> {
+        if matches!(network.kind(), NetworkKind::Mainnet)
+            || (matches!(network.kind(), NetworkKind::Testnet) && network.is_default_testnet())
+        {
+            return Err(PowPolicyError::ProductionNetwork(network.kind()));
+        }
+        if !network.disable_pow() {
+            return Err(PowPolicyError::PowNotDisabled);
+        }
+        Ok(Self {
+            network: network.clone(),
+            kind: PowPolicyKind::AuthenticatedCustomWaiver,
+        })
+    }
+
+    /// Validate solution shape, network parameters, and proof unless this exact custom network
+    /// has an authenticated disabled-PoW configuration.
+    pub fn validate_solution(&self, header: &block::Header) -> Result<(), equihash::Error> {
+        match self.kind {
+            PowPolicyKind::Validate => header.solution.check(header, &self.network),
+            PowPolicyKind::AuthenticatedCustomWaiver => {
+                header.solution.validate_shape(&self.network)
+            }
+        }
+    }
+
+    /// Return true when this exact authenticated custom configuration waives Equihash.
+    pub fn is_authenticated_custom_waiver(&self) -> bool {
+        self.kind == PowPolicyKind::AuthenticatedCustomWaiver
+    }
+}
+
+/// Apply the shared local two-hour future-time rule at an explicit injected clock value.
+pub fn validate_future_time(
+    header: &block::Header,
+    now: DateTime<Utc>,
+    height: block::Height,
+    hash: block::Hash,
+) -> Result<(), block::BlockTimeError> {
+    header.time_is_valid_at(now, &height, &hash)
+}

--- a/docs/changelog/unreleased/559.md
+++ b/docs/changelog/unreleased/559.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR is one review layer of the header-sync stack; the stack's single
+operator-visible entry is owned by #532.


### PR DESCRIPTION
> Stack layer **1/15** (bottom to top) in stack **#573**. Review this PR first; **#560** is next.
> GitHub shows only this layer's diff.

## Motivation

The legacy sync model assumes one linear header path, so it cannot retain competing valid forks or separate selected-header and body-verified frontiers.

## Solution

Add the synchronous fork-aware graph model, exact work accounting, explicit frontiers, ownership, bounded retention, and the pure model types needed by later transitions. This is the final audited representation; superseded representations are not exposed in an earlier layer.

## Testing

- \`cargo check -j 2 -p zakura-header-chain --lib\`
- Transition and property coverage lands in #561.

## Changelog

\`docs/changelog/unreleased/559.md\` explicitly excludes this review slice. The stack's operator-visible entry is owned by #532.

### Specifications & References

- Normative specification and conformance mapping: #572.
- Allocation and exact-equivalence audit are recorded in the Valar header-sync stack ledger.

### Follow-up Work

Review #560 next for the transition authority built on this model.
