### PR TITLE
feat(header-chain): plan and validate atomic graph transitions

### DIFF
--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["cryptography::cryptocurrencies"]
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+fuzz-impl = []
+
 [dependencies]
 chrono = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/zakura-header-chain/src/lib.rs
+++ b/crates/zakura-header-chain/src/lib.rs
@@ -40,8 +40,11 @@ pub use ownership::{
 };
 pub use transition::*;
 pub use validation::{
-    infer_height, validate_commitment_structure, validate_compact_target,
+    infer_height, prepare_context_free_headers, prepare_headers, validate_commitment_structure,
+    validate_compact_target, validate_contextual_difficulty_and_time,
     validate_encoding_version_hash, validate_future_time, validate_hash_filter, validate_link,
-    CompactTargetError, HashFilterError, HeaderEncodingError, HeaderHeightError, HeaderLinkError,
-    PowPolicy, PowPolicyError,
+    AdjustedDifficulty, CompactTargetError, ContextualValidationError, HashFilterError,
+    HeaderBatchInput, HeaderEncodingError, HeaderFailure, HeaderHeightError, HeaderLinkError,
+    HeaderRule, HeaderRules, PowPolicy, PowPolicyError, BLOCK_MAX_TIME_SINCE_MEDIAN,
+    POW_ADJUSTMENT_BLOCK_SPAN, POW_MEDIAN_BLOCK_SPAN, POW_PREDECESSOR_CONTEXT_SPAN,
 };

--- a/crates/zakura-header-chain/src/transition/authority.rs
+++ b/crates/zakura-header-chain/src/transition/authority.rs
@@ -1,0 +1,39 @@
+//! Capabilities and authoritative clock inputs for pure transition planning.
+
+use chrono::{DateTime, Utc};
+
+use crate::{EngineConfig, EvidenceId};
+
+/// Consensus-local time source; transition events cannot supply their own time.
+pub trait Clock: Send + Sync {
+    /// Return the current consensus-local time.
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// Production wall-clock implementation.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// State-writer capability that authenticates staged full-state transition IDs.
+pub trait FullStateEvidenceAuthority: Send + Sync {
+    /// Return true only when `evidence` identifies the writer's staged mutation.
+    fn authorizes(&self, evidence: EvidenceId) -> bool;
+}
+
+/// Trusted dependencies used while deriving a transition plan.
+pub struct TransitionContext<'a> {
+    /// Immutable mode, anchors, and resource limits.
+    pub config: &'a EngineConfig,
+    /// Authoritative local time.
+    pub clock: &'a dyn Clock,
+    /// Integrated full-state authority, available only inside the state writer.
+    pub full_state_authority: Option<&'a dyn FullStateEvidenceAuthority>,
+    /// Active retained-path targets that resource eviction must protect.
+    pub retention_references: &'a [zakura_chain::block::Hash],
+}

--- a/crates/zakura-header-chain/src/transition/engine.rs
+++ b/crates/zakura-header-chain/src/transition/engine.rs
@@ -1,0 +1,288 @@
+//! Stateful ownership boundary for coherent header-chain planning.
+
+use std::collections::{HashMap, HashSet};
+
+use thiserror::Error;
+use zakura_chain::block;
+
+use crate::{
+    AuxDelivery, AuxDelta, ChangeSet, EngineMetadata, EngineSnapshot, Frontier, GraphError,
+    MemHeaderStore, ProjectionDelta, TransitionContext, TransitionFailure, TransitionPlan,
+    TransitionRequest, ValidationLease,
+};
+
+use super::planner::apply_transition_engine;
+
+/// Incoherent state supplied while hydrating an audited engine.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum EngineHydrationError {
+    /// The supplied graph, projections, metadata, or auxiliary rows disagree.
+    #[error("incoherent audited header-chain engine state: {0}")]
+    Incoherent(&'static str),
+    /// The supplied graph is internally incoherent.
+    #[error(transparent)]
+    Graph(#[from] GraphError),
+}
+
+/// The narrow durable authority needed by one transition.
+#[derive(Clone, Debug, Default)]
+pub enum DurableTransitionFacts {
+    /// This event needs no fact outside the coherent engine state.
+    #[default]
+    None,
+    /// Durable context and finality provenance for one header insertion.
+    HeaderInsertion {
+        /// Exact predecessor leases available for the original and rebased parents.
+        validation_contexts: Vec<ValidationLease>,
+        /// Contiguous finality records from the work's stable anchor to current finality.
+        finality_path: Vec<crate::FinalityRecord>,
+    },
+    /// The exact preserved migration pin, when the requested pin is in durable finality history.
+    MigratedFinalityPin(Option<Frontier>),
+}
+
+/// One coherent in-memory owner for transition planning state.
+#[derive(Clone, Debug)]
+pub struct HeaderChainEngine {
+    graph: MemHeaderStore,
+    metadata: EngineMetadata,
+    selected: Vec<Frontier>,
+    verified: Vec<Frontier>,
+    aux: HashMap<block::Hash, Vec<AuxDelivery>>,
+}
+
+impl HeaderChainEngine {
+    /// Hydrate state that has already passed the exhaustive durable recovery audit.
+    pub fn from_audited_state(
+        graph: MemHeaderStore,
+        metadata: EngineMetadata,
+        selected: Vec<Frontier>,
+        verified: Vec<Frontier>,
+        deliveries: impl IntoIterator<Item = AuxDelivery>,
+    ) -> Result<Self, EngineHydrationError> {
+        if graph.finalized() != metadata.frontiers.finalized {
+            return Err(EngineHydrationError::Incoherent(
+                "graph finality disagrees with metadata",
+            ));
+        }
+        verify_projection(&graph, &selected, metadata.frontiers.header_best)?;
+        verify_projection(&graph, &verified, metadata.frontiers.verified_best)?;
+        let (_, score) = graph.select_header_best()?;
+        if score != metadata.header_best_score {
+            return Err(EngineHydrationError::Incoherent(
+                "selected score disagrees with graph",
+            ));
+        }
+
+        let mut aux: HashMap<_, Vec<_>> = HashMap::new();
+        let mut delivery_ids = HashSet::new();
+        for delivery in deliveries {
+            let node = graph
+                .node(delivery.header_hash)
+                .ok_or(EngineHydrationError::Incoherent(
+                    "auxiliary delivery has no retained header",
+                ))?;
+            if !delivery_ids.insert(delivery.delivery_id)
+                || !node.aux_delivery_ids.contains(&delivery.delivery_id)
+            {
+                return Err(EngineHydrationError::Incoherent(
+                    "auxiliary delivery index disagrees with graph",
+                ));
+            }
+            aux.entry(delivery.header_hash).or_default().push(delivery);
+        }
+        for node in graph.nodes() {
+            if node.aux_delivery_ids.iter().any(|delivery_id| {
+                !aux.get(&node.hash)
+                    .is_some_and(|rows| rows.iter().any(|row| row.delivery_id == *delivery_id))
+            }) {
+                return Err(EngineHydrationError::Incoherent(
+                    "graph auxiliary index has no delivery",
+                ));
+            }
+        }
+        for rows in aux.values_mut() {
+            rows.sort_unstable_by_key(|delivery| delivery.delivery_id);
+        }
+
+        Ok(Self {
+            graph,
+            metadata,
+            selected,
+            verified,
+            aux,
+        })
+    }
+
+    /// Derive and verify one complete projected engine state without mutating this engine.
+    pub fn apply(
+        &self,
+        request: TransitionRequest,
+        context: &TransitionContext<'_>,
+        durable: DurableTransitionFacts,
+    ) -> Result<EngineTransition, TransitionFailure> {
+        let plan = apply_transition_engine(self, &durable, request, context)?;
+        #[cfg(any(test, feature = "fuzz-impl"))]
+        let projected = {
+            let mut projected = self.clone();
+            projected.apply_verified_plan(&plan)?;
+            projected
+        };
+        Ok(EngineTransition {
+            plan,
+            #[cfg(any(test, feature = "fuzz-impl"))]
+            projected,
+        })
+    }
+
+    /// Apply a verified graph delta after its durable batch has committed.
+    pub fn apply_committed(&mut self, transition: EngineTransition) {
+        assert_eq!(
+            self.snapshot(),
+            *transition.before(),
+            "a committed header transition must apply to its verified source snapshot"
+        );
+        self.apply_verified_plan(&transition.plan)
+            .expect("a verified header graph delta applies to its unchanged source graph");
+    }
+
+    fn apply_verified_plan(&mut self, plan: &TransitionPlan) -> Result<(), GraphError> {
+        self.graph.apply_delta(plan.graph_delta())?;
+        self.metadata = plan.change_set().metadata.clone();
+        apply_projection_delta(&mut self.selected, &plan.change_set().selected_projection);
+        apply_projection_delta(&mut self.verified, &plan.change_set().verified_projection);
+        apply_aux_delta(&mut self.aux, &plan.change_set().aux_changes);
+        Ok(())
+    }
+
+    /// Return the atomic externally meaningful snapshot.
+    pub fn snapshot(&self) -> EngineSnapshot {
+        self.metadata.snapshot()
+    }
+
+    /// Return complete engine metadata.
+    pub const fn metadata(&self) -> &EngineMetadata {
+        &self.metadata
+    }
+
+    /// Return the engine-owned retained graph.
+    pub const fn graph(&self) -> &MemHeaderStore {
+        &self.graph
+    }
+
+    /// Return the complete selected projection.
+    pub fn selected_projection(&self) -> &[Frontier] {
+        &self.selected
+    }
+
+    /// Return the complete verified projection.
+    pub fn verified_projection(&self) -> &[Frontier] {
+        &self.verified
+    }
+
+    /// Return bounded auxiliary deliveries for one retained header.
+    pub fn aux_deliveries(&self, hash: block::Hash) -> &[AuxDelivery] {
+        self.aux.get(&hash).map(Vec::as_slice).unwrap_or_default()
+    }
+}
+
+/// A verified durable write set ready for one post-commit in-memory application.
+#[derive(Clone, Debug)]
+pub struct EngineTransition {
+    plan: TransitionPlan,
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    projected: HeaderChainEngine,
+}
+
+impl EngineTransition {
+    /// Return the coherent state observed before planning.
+    pub const fn before(&self) -> &EngineSnapshot {
+        self.plan.before()
+    }
+
+    /// Return the atomic durable write set.
+    pub const fn change_set(&self) -> &ChangeSet {
+        self.plan.change_set()
+    }
+
+    /// Return true when the request is an idempotent replay.
+    pub fn is_no_change(&self) -> bool {
+        self.plan.is_no_change()
+    }
+
+    /// Return the classified transition cause.
+    pub const fn cause(&self) -> crate::TransitionCause {
+        self.plan.cause()
+    }
+
+    /// Consume the verified transition and return its complete projected engine state.
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    pub fn into_projected_engine(self) -> HeaderChainEngine {
+        self.projected
+    }
+
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    pub(crate) fn into_plan(self) -> TransitionPlan {
+        self.plan
+    }
+}
+
+fn verify_projection(
+    graph: &MemHeaderStore,
+    projection: &[Frontier],
+    tip: Frontier,
+) -> Result<(), EngineHydrationError> {
+    if projection.first().copied() != Some(graph.finalized())
+        || projection.last().copied() != Some(tip)
+    {
+        return Err(EngineHydrationError::Incoherent(
+            "projection endpoints disagree with metadata",
+        ));
+    }
+    for pair in projection.windows(2) {
+        if pair[1].height.0 != pair[0].height.0 + 1
+            || graph
+                .node(pair[1].hash)
+                .is_none_or(|node| node.parent_hash != pair[0].hash)
+        {
+            return Err(EngineHydrationError::Incoherent(
+                "projection is not a contiguous graph path",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn apply_projection_delta(projection: &mut Vec<Frontier>, delta: &ProjectionDelta) {
+    if let Some(height) = delta.remove_before {
+        projection.retain(|frontier| frontier.height >= height);
+    }
+    if let Some(height) = delta.remove_from {
+        projection.retain(|frontier| frontier.height < height);
+    }
+    projection.extend(delta.put.iter().copied());
+}
+
+fn apply_aux_delta(aux: &mut HashMap<block::Hash, Vec<AuxDelivery>>, changes: &[AuxDelta]) {
+    for change in changes {
+        match change {
+            AuxDelta::Put(delivery) => {
+                let rows = aux.entry(delivery.header_hash).or_default();
+                rows.retain(|row| row.delivery_id != delivery.delivery_id);
+                rows.push(**delivery);
+                rows.sort_unstable_by_key(|row| row.delivery_id);
+            }
+            AuxDelta::Delete {
+                header_hash,
+                delivery_id,
+            } => {
+                if let Some(rows) = aux.get_mut(header_hash) {
+                    rows.retain(|row| row.delivery_id != *delivery_id);
+                    if rows.is_empty() {
+                        aux.remove(header_hash);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/transition/invariants.rs
+++ b/crates/zakura-header-chain/src/transition/invariants.rs
@@ -1,0 +1,566 @@
+//! Bounded commit-time verification of every projected transition invariant.
+
+use std::collections::{HashMap, HashSet};
+
+use thiserror::Error;
+use zakura_chain::block;
+
+#[cfg(not(any(test, feature = "fuzz-impl")))]
+use crate::graph::GraphOverlay;
+use crate::graph::HeaderGraphView;
+use crate::{
+    AuxDelta, BodyValidationState, EligibilityReason, EngineMode, FinalitySource, Frontier,
+    HeaderChainEngine, HeaderNode, ProjectionDelta, TransitionPlan,
+};
+
+/// Stable, category-specific projected-state invariant failures.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum InvariantViolation {
+    /// 1. A row key, canonical header, and locally computed hash disagree.
+    #[error("node hash invariant failed at {0:?}")]
+    NodeHash(block::Hash),
+    /// 2. A non-anchor node lacks one exact height-minus-one parent.
+    #[error("parent invariant failed at {0:?}")]
+    Parent(block::Hash),
+    /// 3. Hash, parent/child, height, or planned indexes do not round-trip.
+    #[error("index invariant failed at {0:?}")]
+    Index(block::Hash),
+    /// 4. A work coordinate has the wrong origin or parent-plus-block value.
+    #[error("work invariant failed at {0:?}")]
+    Work(block::Hash),
+    /// 5. Cached inherited eligibility differs from exact ancestry.
+    #[error("eligibility invariant failed at {0:?}")]
+    Eligibility(block::Hash),
+    /// 6. The selected projection is not a gapless finalized-to-tip path.
+    #[error("selected projection invariant failed at {0:?}")]
+    SelectedProjection(block::Hash),
+    /// 7. `header_best` is not the maximum eligible score.
+    #[error("selection invariant failed")]
+    Selection,
+    /// 8. The verified projection contradicts its mode or body evidence.
+    #[error("verified projection invariant failed at {0:?}")]
+    VerifiedProjection(block::Hash),
+    /// 9. A retained path conflicts with an authenticated trust pin.
+    #[error("trust-pin invariant failed at height {0:?}")]
+    TrustPin(block::Height),
+    /// 10. Finalized, selected, or verified protected state was evicted.
+    #[error("protected-path invariant failed at {0:?}")]
+    Protected(block::Hash),
+    /// 11. The projected DAG exceeds a frozen resource limit.
+    #[error("resource-limit invariant failed")]
+    Limits,
+    /// 12. State or frontier generation increments disagree with actual changes.
+    #[error("generation invariant failed")]
+    Generation,
+    /// 13. Auxiliary evidence lacks a retained foreign key or provenance link.
+    #[error("auxiliary invariant failed at {0:?}")]
+    Auxiliary(block::Hash),
+    /// The coherent source view changed or failed while checking the plan.
+    #[error("source snapshot changed during invariant verification")]
+    SourceSnapshot,
+}
+
+/// Verify the complete projected state before an adapter may commit `plan`.
+pub(crate) fn verify_plan(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+) -> Result<(), InvariantViolation> {
+    let source = before.snapshot();
+    if source != plan.before {
+        return Err(InvariantViolation::SourceSnapshot);
+    }
+    let source_metadata = before.metadata();
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    let graph = plan.projected_graph().clone();
+    #[cfg(not(any(test, feature = "fuzz-impl")))]
+    let graph = GraphOverlay::from_delta(before.graph(), plan.graph_delta());
+    let metadata = &plan.change_set.metadata;
+    if source_metadata.state_version != source.state_version
+        || metadata.mode != source.mode
+        || metadata.work_origin != source_metadata.work_origin
+    {
+        return Err(InvariantViolation::SourceSnapshot);
+    }
+    if metadata.frontiers.finalized != graph.view_finalized()
+        || metadata.frontiers.finalized.height < source.frontiers.finalized.height
+        || match plan.change_set.finality_append {
+            Some(record) => {
+                record.previous != source.frontiers.finalized
+                    || record.current != metadata.frontiers.finalized
+                    || record.epoch != metadata.finality_epoch
+            }
+            None => metadata.frontiers.finalized != source.frontiers.finalized,
+        }
+    {
+        return Err(InvariantViolation::Protected(
+            metadata.frontiers.finalized.hash,
+        ));
+    }
+    if let Some(record) = plan.change_set.finality_append {
+        let valid_source = match record.source {
+            FinalitySource::FullState { .. } => metadata.mode == EngineMode::Integrated,
+            FinalitySource::HeadersOnlyDepth { selected_tip } => {
+                metadata.mode == EngineMode::HeadersOnly
+                    && selected_tip
+                        .height
+                        .0
+                        .saturating_sub(record.current.height.0)
+                        == plan.limits.local_finality_depth.get()
+                    && graph
+                        .view_ancestor(selected_tip.hash, record.current.height)
+                        .ok()
+                        .flatten()
+                        == Some(record.current)
+            }
+            FinalitySource::MigratedHeadersOnly => true,
+        };
+        if !valid_source {
+            return Err(InvariantViolation::Protected(record.current.hash));
+        }
+    } else if metadata.finality_epoch != source_metadata.finality_epoch {
+        return Err(InvariantViolation::Generation);
+    }
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    let nodes = graph.view_nodes();
+    #[cfg(not(any(test, feature = "fuzz-impl")))]
+    let nodes = changed_boundary_nodes(&graph, plan);
+    for node in nodes {
+        verify_node(&graph, node, metadata.work_origin.hash)?;
+    }
+    verify_indexes(before, plan)?;
+    let selected = projected_path(before, &source, &plan.change_set.selected_projection, true)?;
+    let verified = projected_path(before, &source, &plan.change_set.verified_projection, false)?;
+    verify_projection(
+        &graph,
+        &selected,
+        metadata.frontiers.header_best,
+        InvariantViolation::SelectedProjection,
+    )?;
+    let best = graph
+        .view_select_header_best()
+        .map_err(|_| InvariantViolation::Selection)?;
+    if best.0 != metadata.frontiers.header_best || best.1 != metadata.header_best_score {
+        return Err(InvariantViolation::Selection);
+    }
+    verify_verified(
+        &graph,
+        metadata.mode,
+        &verified,
+        metadata.frontiers.verified_best,
+    )?;
+    verify_pins(&graph, &plan.trust_pins, &selected, &verified)?;
+    verify_protected(&graph, plan)?;
+    if graph.view_node_count().saturating_sub(1) > plan.limits.max_non_finalized_nodes.get()
+        || graph.view_eligible_tips().len() > plan.limits.max_candidate_tips.get()
+    {
+        return Err(InvariantViolation::Limits);
+    }
+    verify_generations(before, plan, &selected, &verified)?;
+    verify_aux(before, &graph, plan)?;
+    Ok(())
+}
+
+fn verify_node<G: HeaderGraphView>(
+    graph: &G,
+    node: &HeaderNode,
+    work_origin: block::Hash,
+) -> Result<(), InvariantViolation> {
+    if node.header.hash() != node.hash {
+        return Err(InvariantViolation::NodeHash(node.hash));
+    }
+    if !graph
+        .view_hashes_at_height(node.height)
+        .contains(&node.hash)
+    {
+        return Err(InvariantViolation::Index(node.hash));
+    }
+    if node.work_coordinate().origin_hash() != work_origin {
+        return Err(InvariantViolation::Work(node.hash));
+    }
+    if node.hash == graph.view_finalized().hash {
+        if node.eligibility.inherited_from.is_some() {
+            return Err(InvariantViolation::Eligibility(node.hash));
+        }
+        return Ok(());
+    }
+    let parent = graph
+        .view_node(node.parent_hash)
+        .ok_or(InvariantViolation::Parent(node.hash))?;
+    if parent.height.next().ok() != Some(node.height)
+        || !graph.view_children(parent.hash).contains(&node.hash)
+    {
+        return Err(InvariantViolation::Parent(node.hash));
+    }
+    if parent.work_coordinate().checked_add(node.block_work).ok() != Some(node.work_coordinate()) {
+        return Err(InvariantViolation::Work(node.hash));
+    }
+    if node.eligibility.inherited_from != (!parent.is_eligible()).then_some(parent.hash) {
+        return Err(InvariantViolation::Eligibility(node.hash));
+    }
+    Ok(())
+}
+
+fn verify_indexes(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+) -> Result<(), InvariantViolation> {
+    if plan.change_set.put_nodes != plan.graph_delta().put_nodes
+        || plan.change_set.delete_nodes != plan.graph_delta().delete_nodes
+    {
+        return Err(InvariantViolation::Index(block::Hash([0; 32])));
+    }
+    let mut inserted = HashSet::new();
+    for node in &plan.change_set.put_nodes {
+        if before.graph().node(node.hash).is_none() {
+            inserted.insert(Frontier::new(node.height, node.hash));
+        }
+    }
+    let indexed: HashSet<_> = plan
+        .change_set
+        .index_changes
+        .inserted
+        .iter()
+        .copied()
+        .collect();
+    if inserted != indexed {
+        return Err(InvariantViolation::Index(
+            inserted
+                .symmetric_difference(&indexed)
+                .next()
+                .map_or(block::Hash([0; 32]), |frontier| frontier.hash),
+        ));
+    }
+    let deleted: HashSet<_> = plan.change_set.delete_nodes.iter().copied().collect();
+    let deindexed: HashSet<_> = plan
+        .change_set
+        .index_changes
+        .deleted
+        .iter()
+        .copied()
+        .collect();
+    if deleted != deindexed {
+        return Err(InvariantViolation::Index(
+            deleted
+                .symmetric_difference(&deindexed)
+                .next()
+                .copied()
+                .unwrap_or(block::Hash([0; 32])),
+        ));
+    }
+    Ok(())
+}
+
+fn projected_path(
+    before: &HeaderChainEngine,
+    source: &crate::EngineSnapshot,
+    delta: &ProjectionDelta,
+    selected: bool,
+) -> Result<Vec<Frontier>, InvariantViolation> {
+    let tip = if selected {
+        source.frontiers.header_best
+    } else {
+        source.frontiers.verified_best
+    };
+    let mut path = if selected {
+        before.selected_projection().to_vec()
+    } else {
+        before.verified_projection().to_vec()
+    };
+    if path.last().copied() != Some(tip)
+        || path.first().copied() != Some(source.frontiers.finalized)
+    {
+        return Err(InvariantViolation::SourceSnapshot);
+    }
+    if let Some(remove_before) = delta.remove_before {
+        path.retain(|frontier| frontier.height >= remove_before);
+    }
+    if let Some(remove_from) = delta.remove_from {
+        path.retain(|frontier| frontier.height < remove_from);
+    }
+    path.extend(delta.put.iter().copied());
+    Ok(path)
+}
+
+fn verify_projection<G: HeaderGraphView>(
+    graph: &G,
+    projection: &[Frontier],
+    tip: Frontier,
+    failure: fn(block::Hash) -> InvariantViolation,
+) -> Result<(), InvariantViolation> {
+    if projection.first().copied() != Some(graph.view_finalized())
+        || projection.last().copied() != Some(tip)
+    {
+        return Err(failure(tip.hash));
+    }
+    for pair in projection.windows(2) {
+        if pair[1].height.0 != pair[0].height.0 + 1
+            || graph
+                .view_node(pair[1].hash)
+                .is_none_or(|node| node.parent_hash != pair[0].hash)
+        {
+            return Err(failure(pair[1].hash));
+        }
+    }
+    Ok(())
+}
+
+fn verify_verified<G: HeaderGraphView>(
+    graph: &G,
+    mode: EngineMode,
+    projection: &[Frontier],
+    tip: Frontier,
+) -> Result<(), InvariantViolation> {
+    verify_projection(
+        graph,
+        projection,
+        tip,
+        InvariantViolation::VerifiedProjection,
+    )?;
+    if mode == EngineMode::HeadersOnly && projection != [graph.view_finalized()] {
+        return Err(InvariantViolation::VerifiedProjection(tip.hash));
+    }
+    if mode == EngineMode::Integrated {
+        for frontier in projection.iter().skip(1) {
+            if !matches!(
+                graph.view_node(frontier.hash).map(|node| node.body.clone()),
+                Some(BodyValidationState::Verified { .. })
+            ) {
+                return Err(InvariantViolation::VerifiedProjection(frontier.hash));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_pins<G: HeaderGraphView>(
+    graph: &G,
+    pins: &[Frontier],
+    selected: &[Frontier],
+    verified: &[Frontier],
+) -> Result<(), InvariantViolation> {
+    for pin in pins {
+        for projection in [selected, verified] {
+            if let Some(frontier) = projection
+                .iter()
+                .find(|frontier| frontier.height == pin.height)
+            {
+                if frontier.hash != pin.hash {
+                    return Err(InvariantViolation::TrustPin(pin.height));
+                }
+            }
+        }
+        for hash in graph.view_hashes_at_height(pin.height) {
+            if hash == pin.hash {
+                continue;
+            }
+            let node = graph
+                .view_node(hash)
+                .ok_or(InvariantViolation::TrustPin(pin.height))?;
+            let has_reason = node.eligibility.direct_reasons.iter().any(|reason| {
+                matches!(reason,
+                    EligibilityReason::SettledUpgradeConflict { height, expected }
+                    | EligibilityReason::CheckpointConflict { height, expected }
+                    if *height == pin.height && *expected == pin.hash)
+            });
+            if !has_reason {
+                return Err(InvariantViolation::TrustPin(pin.height));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_protected<G: HeaderGraphView>(
+    graph: &G,
+    plan: &TransitionPlan,
+) -> Result<(), InvariantViolation> {
+    for frontier in [
+        plan.change_set.metadata.frontiers.finalized,
+        plan.change_set.metadata.frontiers.header_best,
+        plan.change_set.metadata.frontiers.verified_best,
+    ] {
+        if graph.view_node(frontier.hash).is_none()
+            || plan.change_set.delete_nodes.contains(&frontier.hash)
+        {
+            return Err(InvariantViolation::Protected(frontier.hash));
+        }
+    }
+    Ok(())
+}
+
+fn verify_generations(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+    selected: &[Frontier],
+    verified: &[Frontier],
+) -> Result<(), InvariantViolation> {
+    let old_selected = plan.before.frontiers.header_best;
+    let old_verified = plan.before.frontiers.verified_best;
+    let selected_changed = selected.last().copied() != Some(old_selected)
+        || !plan.change_set.selected_projection.put.is_empty()
+        || plan.change_set.selected_projection.remove_before.is_some()
+        || plan.change_set.selected_projection.remove_from.is_some();
+    let verified_changed = verified.last().copied() != Some(old_verified)
+        || !plan.change_set.verified_projection.put.is_empty()
+        || plan.change_set.verified_projection.remove_before.is_some()
+        || plan.change_set.verified_projection.remove_from.is_some();
+    let alarm_changed = plan.before.alarms != plan.change_set.metadata.alarms;
+    let effects = !plan.change_set.put_nodes.is_empty()
+        || !plan.change_set.delete_nodes.is_empty()
+        || !plan.change_set.aux_changes.is_empty()
+        || plan.change_set.finality_append.is_some()
+        || selected_changed
+        || verified_changed
+        || alarm_changed;
+    let expected_state = if effects {
+        plan.before.state_version.checked_next().ok()
+    } else {
+        Some(plan.before.state_version)
+    };
+    let header_validation_changed =
+        plan.change_set
+            .put_nodes
+            .iter()
+            .try_fold(false, |changed, node| {
+                Ok::<_, InvariantViolation>(
+                    changed
+                        || before
+                            .graph()
+                            .node(node.hash)
+                            .is_some_and(|old| old.validation != node.validation),
+                )
+            })?;
+    let header_effect = selected_changed
+        || !plan.change_set.index_changes.inserted.is_empty()
+        || !plan.change_set.delete_nodes.is_empty()
+        || header_validation_changed
+        || !plan.change_set.eligibility_changes.is_empty()
+        || plan.change_set.finality_append.is_some();
+    let expected_header = if header_effect {
+        plan.before.header_generation.checked_next().ok()
+    } else {
+        Some(plan.before.header_generation)
+    };
+    let verified_effect = verified_changed || plan.change_set.finality_append.is_some();
+    let expected_verified = if verified_effect {
+        plan.before.verified_generation.checked_next().ok()
+    } else {
+        Some(plan.before.verified_generation)
+    };
+    if Some(plan.change_set.metadata.state_version) != expected_state
+        || Some(plan.change_set.metadata.header_generation) != expected_header
+        || Some(plan.change_set.metadata.verified_generation) != expected_verified
+    {
+        return Err(InvariantViolation::Generation);
+    }
+    Ok(())
+}
+
+fn verify_aux<G: HeaderGraphView>(
+    before: &HeaderChainEngine,
+    graph: &G,
+    plan: &TransitionPlan,
+) -> Result<(), InvariantViolation> {
+    let deletes: Vec<_> = plan
+        .change_set
+        .aux_changes
+        .iter()
+        .filter_map(|change| match change {
+            AuxDelta::Delete {
+                header_hash,
+                delivery_id,
+            } => Some((*header_hash, *delivery_id)),
+            AuxDelta::Put(_) => None,
+        })
+        .collect();
+    for (header_hash, delivery_id) in &deletes {
+        let exists = before
+            .aux_deliveries(*header_hash)
+            .iter()
+            .any(|delivery| delivery.delivery_id == *delivery_id);
+        if !exists {
+            return Err(InvariantViolation::Auxiliary(*header_hash));
+        }
+    }
+    let deleted_ids: HashSet<_> = deletes
+        .into_iter()
+        .map(|(_, delivery_id)| delivery_id)
+        .collect();
+    let puts: HashMap<_, _> = plan
+        .change_set
+        .aux_changes
+        .iter()
+        .filter_map(|change| match change {
+            AuxDelta::Put(delivery) => Some((delivery.delivery_id, delivery.as_ref())),
+            AuxDelta::Delete { .. } => None,
+        })
+        .collect();
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    let nodes = graph.view_nodes();
+    #[cfg(not(any(test, feature = "fuzz-impl")))]
+    let nodes: Vec<_> = plan
+        .change_set
+        .put_nodes
+        .iter()
+        .filter_map(|changed| graph.view_node(changed.hash))
+        .collect();
+    for node in nodes {
+        let mut deliveries = before.aux_deliveries(node.hash).to_vec();
+        deliveries.retain(|delivery| !deleted_ids.contains(&delivery.delivery_id));
+        deliveries.extend(
+            puts.values()
+                .filter(|delivery| delivery.header_hash == node.hash)
+                .map(|delivery| **delivery),
+        );
+        for delivery in deliveries {
+            if delivery.header_hash != node.hash
+                || !node.aux_delivery_ids.contains(&delivery.delivery_id)
+            {
+                return Err(InvariantViolation::Auxiliary(node.hash));
+            }
+        }
+    }
+    for delivery in puts.values() {
+        if graph.view_node(delivery.header_hash).is_none() {
+            return Err(InvariantViolation::Auxiliary(delivery.header_hash));
+        }
+    }
+    for hash in &plan.change_set.delete_nodes {
+        for delivery in before.aux_deliveries(*hash) {
+            if !deleted_ids.contains(&delivery.delivery_id) {
+                return Err(InvariantViolation::Auxiliary(*hash));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(any(test, feature = "fuzz-impl")))]
+fn changed_boundary_nodes<'a, G: HeaderGraphView>(
+    graph: &'a G,
+    plan: &TransitionPlan,
+) -> Vec<&'a HeaderNode> {
+    let mut hashes = HashSet::from([
+        plan.change_set.metadata.frontiers.finalized.hash,
+        plan.change_set.metadata.frontiers.header_best.hash,
+        plan.change_set.metadata.frontiers.verified_best.hash,
+    ]);
+    for node in &plan.graph_delta().put_nodes {
+        hashes.insert(node.hash);
+        hashes.insert(node.parent_hash);
+        hashes.extend(graph.view_children(node.hash));
+    }
+    for (parent, child) in plan
+        .graph_delta()
+        .add_children
+        .iter()
+        .chain(&plan.graph_delta().remove_children)
+    {
+        hashes.insert(*parent);
+        hashes.insert(*child);
+    }
+    hashes
+        .into_iter()
+        .filter_map(|hash| graph.view_node(hash))
+        .collect()
+}

--- a/crates/zakura-header-chain/src/transition/mod.rs
+++ b/crates/zakura-header-chain/src/transition/mod.rs
@@ -1,7 +1,23 @@
 //! Typed transition evidence, durable snapshots, and read-oriented store contracts.
 
+mod authority;
+mod engine;
+mod invariants;
+mod planner;
+mod recovery;
 mod store;
 mod types;
 
+pub use authority::{Clock, FullStateEvidenceAuthority, SystemClock, TransitionContext};
+pub use engine::{
+    DurableTransitionFacts, EngineHydrationError, EngineTransition, HeaderChainEngine,
+};
+pub(crate) use invariants::verify_plan;
+pub use invariants::InvariantViolation;
+pub use planner::{TransitionFailure, TransitionPlan};
+pub use recovery::{
+    audit_store, AuditViolation, RecoveryFailure, RecoveryPlan, RecoveryRepair, StoreAuditRead,
+    ValidationContextRecord,
+};
 pub use store::StoreError;
 pub use types::*;

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -1,0 +1,1544 @@
+//! The sole pure mutation algorithm for durable header-chain state.
+
+use std::collections::{HashMap, HashSet};
+
+use thiserror::Error;
+use zakura_chain::block;
+
+use crate::graph::{GraphDelta, GraphOverlay, HeaderGraphEdit, HeaderGraphView};
+use crate::retention::RetentionPlan;
+use crate::{
+    BodyEvidence, BodyValidationState, BodyWorkOwner, ChangeSet, CounterExhausted,
+    DurableTransitionFacts, EligibilityDelta, EligibilityReason, EngineLimits, EngineMetadata,
+    EngineMode, EngineSnapshot, EventAdmission, EvidenceId, FinalityRecord, FinalitySource,
+    Frontier, FrontierSet, GraphError, HeaderChainEngine, HeaderSyncWorkOwner,
+    HeaderValidationState, IndexChanges, MemHeaderStore, ProjectionDelta, StateVersion, StoreError,
+    TargetCompletion, TransitionCause, TransitionContext, TransitionEvent, TransitionRequest,
+};
+
+/// A complete write set plus the private graph delta it was verified against.
+#[derive(Clone, Debug)]
+pub struct TransitionPlan {
+    pub(super) before: EngineSnapshot,
+    pub(super) change_set: ChangeSet,
+    pub(super) graph_delta: GraphDelta,
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    pub(super) projected: MemHeaderStore,
+    pub(super) cause: TransitionCause,
+    pub(super) trust_pins: Vec<Frontier>,
+    pub(super) limits: EngineLimits,
+}
+
+impl TransitionPlan {
+    /// Return the atomic write set for the state adapter.
+    pub const fn change_set(&self) -> &ChangeSet {
+        &self.change_set
+    }
+
+    /// Return the coherent state observed before planning.
+    pub const fn before(&self) -> &EngineSnapshot {
+        &self.before
+    }
+
+    /// Return the classified transition cause.
+    pub const fn cause(&self) -> TransitionCause {
+        self.cause
+    }
+
+    /// Return true when the evidence was valid but changed no durable fact.
+    pub fn is_no_change(&self) -> bool {
+        self.before.state_version == self.change_set.metadata.state_version
+    }
+
+    pub(crate) const fn graph_delta(&self) -> &GraphDelta {
+        &self.graph_delta
+    }
+
+    /// Return the test/reference materialization of the verified graph delta.
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    pub const fn projected_graph(&self) -> &MemHeaderStore {
+        &self.projected
+    }
+}
+
+/// Typed failure produced before any durable mutation is attempted.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum TransitionFailure {
+    /// The caller's version or asynchronous owner was stale.
+    #[error("stale transition work at state version {current:?}")]
+    Stale {
+        /// Current durable version.
+        current: StateVersion,
+    },
+    /// Durable rows could not be read coherently.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    /// The projected graph would be incoherent.
+    #[error(transparent)]
+    Graph(#[from] GraphError),
+    /// A monotonic durable counter was exhausted.
+    #[error(transparent)]
+    Counter(#[from] CounterExhausted),
+    /// Persisted immutable configuration differs from this engine.
+    #[error("persisted header-chain configuration does not match the active engine")]
+    ConfigurationMismatch,
+    /// This event is unavailable in the configured mode.
+    #[error("transition event is not admitted in the configured engine mode")]
+    Mode,
+    /// Required internal authority did not authenticate the evidence.
+    #[error("transition evidence lacks the required internal authority")]
+    Authority,
+    /// Prepared work no longer matches its durable validation context.
+    #[error("prepared header context is stale")]
+    StalePreparation,
+    /// Event fields contradict canonical headers or durable ancestry.
+    #[error("invalid transition evidence: {0}")]
+    InvalidEvidence(&'static str),
+    /// Retention could not admit this event without evicting protected state.
+    #[error("header admission refused because protected paths fill the resource bound")]
+    ResourceStalled,
+    /// The projected write set violated a commit invariant.
+    #[error(transparent)]
+    Invariant(#[from] super::InvariantViolation),
+}
+
+/// Derive one atomic transition without mutating the coherent engine.
+pub(super) fn apply_transition_engine(
+    engine: &HeaderChainEngine,
+    durable: &DurableTransitionFacts,
+    mut request: TransitionRequest,
+    context: &TransitionContext<'_>,
+) -> Result<TransitionPlan, TransitionFailure> {
+    let before = engine.snapshot();
+    let mut metadata = engine.metadata().clone();
+    validate_snapshot(&before, &metadata, context)?;
+    if metadata.last_transition_id
+        == request
+            .event
+            .idempotency_key()
+            .unwrap_or(metadata.last_transition_id)
+        && request.event.idempotency_key().is_some()
+    {
+        let plan = no_change(
+            engine,
+            before,
+            metadata,
+            request.event,
+            context,
+            TransitionCause::Event,
+        )?;
+        super::verify_plan(engine, &plan)?;
+        return Ok(plan);
+    }
+    let has_async_authority =
+        request.event.header_sync_owner().is_some() || request.event.body_owner().is_some();
+    if !has_async_authority && request.expected_version != before.state_version {
+        return Err(TransitionFailure::Stale {
+            current: before.state_version,
+        });
+    }
+    let header_rebase =
+        rebase_header_insertion(&mut request.event, &before, engine.graph(), durable)?;
+    if header_rebase == HeaderInsertionRebase::AlreadyApplied {
+        let plan = no_change(
+            engine,
+            before,
+            metadata,
+            request.event,
+            context,
+            TransitionCause::HeaderWorkAlreadyApplied,
+        )?;
+        super::verify_plan(engine, &plan)?;
+        return Ok(plan);
+    }
+    if let Some(owner) = request.event.header_sync_owner() {
+        validate_header_sync_owner(owner, &before)?;
+    }
+    if let Some(owner) = request.event.body_owner() {
+        validate_body_owner(owner, &before)?;
+    }
+    validate_authority(&request.event, context)?;
+
+    let mut graph = GraphOverlay::new(engine.graph());
+    let old_selected = engine.selected_projection().to_vec();
+    let old_verified = engine.verified_projection().to_vec();
+    let mut verified = old_verified.clone();
+    let mut aux_changes = Vec::new();
+    let mut finality = None;
+    let mut operator_reason_changed = false;
+    let migrated_pin_refuted = migrated_pin_refuted(durable, &request.event)?;
+    let event_context = ApplyEventContext {
+        engine,
+        durable,
+        transition: context,
+        before: &before,
+        old_selected: &old_selected,
+        migrated_pin_refuted,
+    };
+
+    apply_event(
+        &mut graph,
+        &mut verified,
+        &mut aux_changes,
+        &mut operator_reason_changed,
+        &request.event,
+        &event_context,
+    )?;
+    if let Some(pin) = migrated_pin_refuted {
+        metadata.alarms.migrated_pin_refuted = Some(pin);
+    }
+    if operator_reason_changed {
+        verified = select_fully_verified_path(&graph)?;
+    }
+    let (mut header_best, _) = graph.view_select_header_best()?;
+
+    if let TransitionEvent::FullStateFinalized(event) = &request.event {
+        if event.new_finalized.height < before.frontiers.finalized.height {
+            return Err(TransitionFailure::InvalidEvidence("finality retreated"));
+        }
+        if !verified.contains(&event.new_finalized) {
+            return Err(TransitionFailure::InvalidEvidence(
+                "integrated finality is not on the verified projection",
+            ));
+        }
+        finality = Some((
+            event.new_finalized,
+            FinalitySource::FullState {
+                evidence: event.full_state_transition_id,
+            },
+        ));
+    } else if context.config.mode == EngineMode::HeadersOnly {
+        let depth = context.config.limits.local_finality_depth.get();
+        if header_best
+            .height
+            .0
+            .saturating_sub(graph.view_finalized().height.0)
+            > depth
+        {
+            let height = block::Height(header_best.height.0 - depth);
+            let new_finalized = graph.view_ancestor(header_best.hash, height)?.ok_or(
+                TransitionFailure::InvalidEvidence("selected ancestry is incomplete"),
+            )?;
+            finality = Some((
+                new_finalized,
+                FinalitySource::HeadersOnlyDepth {
+                    selected_tip: header_best,
+                },
+            ));
+        }
+    }
+
+    let mut cause = if header_rebase == HeaderInsertionRebase::Rebased {
+        TransitionCause::HeaderWorkRebased
+    } else {
+        TransitionCause::Event
+    };
+    let mut finality_append = None;
+    if let Some((new_finalized, source)) = finality {
+        if new_finalized != graph.view_finalized() {
+            let previous = graph.view_finalized();
+            let epoch = metadata.finality_epoch.checked_next()?;
+            graph.edit_advance_finalized(new_finalized)?;
+            verified.retain(|frontier| frontier.height >= new_finalized.height);
+            if verified.first().copied() != Some(new_finalized) {
+                verified.insert(0, new_finalized);
+            }
+            finality_append = Some(FinalityRecord {
+                previous,
+                current: new_finalized,
+                source,
+                epoch,
+            });
+            header_best = graph.view_select_header_best()?.0;
+            if matches!(source, FinalitySource::HeadersOnlyDepth { .. }) {
+                cause = TransitionCause::HeadersOnlyFinality;
+            }
+        }
+    }
+
+    if context.config.mode == EngineMode::HeadersOnly {
+        verified = vec![graph.view_finalized()];
+    }
+    let verified_best = verified.last().copied().unwrap_or(graph.view_finalized());
+    let retention = crate::retention::enforce_retention(
+        &mut graph,
+        header_best,
+        verified_best,
+        context.retention_references.iter().copied(),
+        context.config.limits,
+    )?;
+    if retention.admission_refused {
+        let plan = resource_stalled(engine, before, context)?;
+        super::verify_plan(engine, &plan)?;
+        return Ok(plan);
+    }
+    header_best = graph.view_select_header_best()?.0;
+    let selected = path(&graph, header_best)?;
+    let verified = trim_projection(&graph, verified)?;
+    let mut plan = derive_plan(
+        before,
+        metadata,
+        engine.graph(),
+        graph,
+        old_selected,
+        old_verified,
+        selected,
+        verified,
+        aux_changes,
+        finality_append,
+        retention,
+        request.event.idempotency_key(),
+        cause,
+        invariant_pins(context),
+        context.config.limits,
+    )?;
+    let projected = GraphOverlay::from_delta(engine.graph(), plan.graph_delta());
+    plan.change_set.aux_changes.retain(|change| match change {
+        crate::AuxDelta::Put(delivery) => projected.node(delivery.header_hash).is_some(),
+        crate::AuxDelta::Delete { .. } => true,
+    });
+    for hash in &plan.change_set.delete_nodes {
+        for delivery in engine.aux_deliveries(*hash) {
+            plan.change_set.aux_changes.push(crate::AuxDelta::Delete {
+                header_hash: *hash,
+                delivery_id: delivery.delivery_id,
+            });
+        }
+    }
+    super::verify_plan(engine, &plan)?;
+    Ok(plan)
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum HeaderInsertionRebase {
+    Current,
+    Rebased,
+    AlreadyApplied,
+}
+
+fn rebase_header_insertion(
+    event: &mut TransitionEvent,
+    current: &EngineSnapshot,
+    graph: &MemHeaderStore,
+    durable: &DurableTransitionFacts,
+) -> Result<HeaderInsertionRebase, TransitionFailure> {
+    let TransitionEvent::InsertHeaders(insert) = event else {
+        return Ok(HeaderInsertionRebase::Current);
+    };
+    if matches!(
+        insert.completion,
+        TargetCompletion::SelectedAuxiliaryRepair { .. }
+    ) {
+        return Ok(HeaderInsertionRebase::Current);
+    }
+    let Some(original_owner) = insert.owner.header_owner() else {
+        return Ok(HeaderInsertionRebase::Current);
+    };
+    let original = original_owner.authority;
+    if original.branch.target_tip_hash != insert.target_tip_hash {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    if original.header_generation == current.header_generation
+        && original.branch.anchor_hash == current.frontiers.finalized.hash
+    {
+        return Ok(HeaderInsertionRebase::Current);
+    }
+    if original.branch.anchor_hash == current.frontiers.finalized.hash {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    if original.header_generation.get() >= current.header_generation.get() {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    let DurableTransitionFacts::HeaderInsertion { finality_path, .. } = durable else {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    };
+    if finality_path.is_empty() {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    validate_finality_rebase_path(
+        original.branch.anchor_hash,
+        current.frontiers.finalized,
+        finality_path,
+    )?;
+
+    let finalized = current.frontiers.finalized;
+    let parent_is_current_descendant = match graph.node(insert.parent_hash) {
+        Some(parent) if parent.height >= finalized.height => {
+            graph.ancestor(insert.parent_hash, finalized.height)? == Some(finalized)
+        }
+        Some(_) | None => false,
+    };
+    let mut removed = 0usize;
+    if !parent_is_current_descendant {
+        if insert
+            .batch
+            .headers()
+            .iter()
+            .any(|header| Frontier::new(header.height, header.hash) == finalized)
+        {
+            removed = insert
+                .batch
+                .rebase_after(finalized)
+                .map_err(|_| TransitionFailure::StalePreparation)?;
+            insert.parent_hash = finalized.hash;
+            insert
+                .completion
+                .rebase_common_ancestor(finalized)
+                .map_err(|_| TransitionFailure::StalePreparation)?;
+        } else {
+            let prepared_tip = insert
+                .batch
+                .headers()
+                .last()
+                .map(|header| Frontier::new(header.height, header.hash))
+                .ok_or(TransitionFailure::StalePreparation)?;
+            let prepared_tip_was_finalized = finality_path
+                .iter()
+                .any(|record| record.previous == prepared_tip || record.current == prepared_tip);
+            if prepared_tip_was_finalized && prepared_tip.height <= finalized.height {
+                insert.batch.clear_already_applied();
+                removed = insert.aux.len();
+            } else {
+                return Err(TransitionFailure::Stale {
+                    current: current.state_version,
+                });
+            }
+        }
+    }
+
+    let authority = crate::HeaderWorkAuthority {
+        header_generation: current.header_generation,
+        branch: crate::BranchId::new(finalized.hash, original.branch.target_tip_hash),
+    };
+    insert.owner = insert
+        .owner
+        .rebase_header(authority)
+        .ok_or(TransitionFailure::Authority)?;
+    for delivery in &mut insert.aux {
+        delivery.owner = delivery
+            .owner
+            .rebase_header(authority)
+            .ok_or(TransitionFailure::Authority)?;
+    }
+    if removed != 0 {
+        let retained: HashSet<_> = insert
+            .batch
+            .headers()
+            .iter()
+            .map(|header| header.hash)
+            .collect();
+        insert
+            .aux
+            .retain(|delivery| retained.contains(&delivery.header_hash));
+    }
+    if insert.batch.headers().is_empty() {
+        return Ok(HeaderInsertionRebase::AlreadyApplied);
+    }
+    Ok(HeaderInsertionRebase::Rebased)
+}
+
+fn validate_finality_rebase_path(
+    original_anchor: block::Hash,
+    current_finalized: Frontier,
+    path: &[FinalityRecord],
+) -> Result<(), TransitionFailure> {
+    if original_anchor == current_finalized.hash {
+        return path
+            .is_empty()
+            .then_some(())
+            .ok_or(TransitionFailure::StalePreparation);
+    }
+    let mut expected_frontier = None;
+    let mut expected_epoch = None;
+    for record in path {
+        let predecessor_matches = expected_frontier.map_or_else(
+            || record.previous.hash == original_anchor,
+            |expected| record.previous == expected,
+        );
+        if !predecessor_matches
+            || expected_epoch.is_some_and(|epoch| record.epoch != epoch)
+            || record.current.height < record.previous.height
+        {
+            return Err(TransitionFailure::StalePreparation);
+        }
+        expected_frontier = Some(record.current);
+        expected_epoch = Some(record.epoch.checked_next()?);
+    }
+    if expected_frontier != Some(current_finalized) {
+        return Err(TransitionFailure::StalePreparation);
+    }
+    Ok(())
+}
+
+fn migrated_pin_refuted(
+    durable: &DurableTransitionFacts,
+    event: &TransitionEvent,
+) -> Result<Option<Frontier>, TransitionFailure> {
+    let TransitionEvent::MigratedPinRefutation(event) = event else {
+        return Ok(None);
+    };
+    match durable {
+        DurableTransitionFacts::MigratedFinalityPin(preserved) => {
+            Ok((*preserved == Some(event.pin)).then_some(event.pin))
+        }
+        _ => Err(StoreError::Unavailable("migrated finality fact was not supplied").into()),
+    }
+}
+
+fn select_fully_verified_path<G: HeaderGraphView>(
+    graph: &G,
+) -> Result<Vec<Frontier>, TransitionFailure> {
+    let finalized = graph.view_finalized();
+    let mut connected = HashSet::from([finalized.hash]);
+    let mut nodes = graph.view_nodes();
+    nodes.sort_unstable_by_key(|node| (node.height, node.hash.0));
+    for node in nodes {
+        if node.hash != finalized.hash
+            && node.is_eligible()
+            && matches!(node.body, BodyValidationState::Verified { .. })
+            && connected.contains(&node.parent_hash)
+        {
+            connected.insert(node.hash);
+        }
+    }
+    let tip = connected
+        .into_iter()
+        .map(|hash| {
+            let node = graph
+                .view_node(hash)
+                .expect("verified candidates are retained graph nodes");
+            graph
+                .view_score(hash)
+                .map(|score| (score, Frontier::new(node.height, hash)))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .max_by_key(|(score, _)| *score)
+        .map(|(_, frontier)| frontier)
+        .ok_or(GraphError::UnknownNode(finalized.hash))?;
+    path(graph, tip)
+}
+
+fn validate_snapshot(
+    snapshot: &EngineSnapshot,
+    metadata: &EngineMetadata,
+    context: &TransitionContext<'_>,
+) -> Result<(), TransitionFailure> {
+    if snapshot.mode != context.config.mode
+        || metadata.mode != context.config.mode
+        || metadata.network_id != context.config.network.kind()
+        || metadata.anchor_manifest_digest != context.config.trust_anchor_digest()
+        || snapshot.state_version != metadata.state_version
+        || snapshot.frontiers != metadata.frontiers
+    {
+        return Err(TransitionFailure::ConfigurationMismatch);
+    }
+    Ok(())
+}
+
+fn validate_header_sync_owner(
+    owner: HeaderSyncWorkOwner,
+    before: &EngineSnapshot,
+) -> Result<(), TransitionFailure> {
+    let header = owner.header_authority();
+    if header.header_generation != before.header_generation
+        || owner
+            .body_authority()
+            .is_some_and(|authority| authority.verified_generation != before.verified_generation)
+        || header.branch.anchor_hash != before.frontiers.finalized.hash
+    {
+        return Err(TransitionFailure::Stale {
+            current: before.state_version,
+        });
+    }
+    Ok(())
+}
+
+fn validate_body_owner(
+    owner: BodyWorkOwner,
+    before: &EngineSnapshot,
+) -> Result<(), TransitionFailure> {
+    if owner.header_generation != before.header_generation
+        || owner.verified_generation != before.verified_generation
+        || owner.branch.anchor_hash != before.frontiers.finalized.hash
+    {
+        return Err(TransitionFailure::Stale {
+            current: before.state_version,
+        });
+    }
+    Ok(())
+}
+
+fn validate_authority(
+    event: &TransitionEvent,
+    context: &TransitionContext<'_>,
+) -> Result<(), TransitionFailure> {
+    match event.admission() {
+        EventAdmission::AnyMode => Ok(()),
+        EventAdmission::IntegratedFullState if context.config.mode != EngineMode::Integrated => {
+            Err(TransitionFailure::Mode)
+        }
+        EventAdmission::IntegratedFullState => {
+            let evidence = event
+                .idempotency_key()
+                .ok_or(TransitionFailure::Authority)?;
+            if context
+                .full_state_authority
+                .is_some_and(|authority| authority.authorizes(evidence))
+            {
+                Ok(())
+            } else {
+                Err(TransitionFailure::Authority)
+            }
+        }
+    }
+}
+
+struct ApplyEventContext<'a> {
+    engine: &'a HeaderChainEngine,
+    durable: &'a DurableTransitionFacts,
+    transition: &'a TransitionContext<'a>,
+    before: &'a EngineSnapshot,
+    old_selected: &'a [Frontier],
+    migrated_pin_refuted: Option<Frontier>,
+}
+
+fn retained_header_context<G: HeaderGraphView>(
+    graph: &G,
+    parent: Frontier,
+    durable: &DurableTransitionFacts,
+) -> Result<
+    Vec<(
+        zakura_chain::work::difficulty::CompactDifficulty,
+        chrono::DateTime<chrono::Utc>,
+    )>,
+    TransitionFailure,
+> {
+    let required = usize::try_from(parent.height.0)
+        .map_err(|_| StoreError::Unavailable("retained parent height does not fit in memory"))?
+        .checked_add(1)
+        .ok_or(StoreError::Unavailable(
+            "retained parent context length overflowed",
+        ))?
+        .min(crate::POW_ADJUSTMENT_BLOCK_SPAN);
+    let mut context = Vec::with_capacity(required);
+    let mut hash = parent.hash;
+    while context.len() < required {
+        let Some(node) = graph.view_node(hash) else {
+            let DurableTransitionFacts::HeaderInsertion {
+                validation_contexts,
+                ..
+            } = durable
+            else {
+                return Err(
+                    StoreError::Unavailable("retained predecessor context is incomplete").into(),
+                );
+            };
+            let Some(lease) = validation_contexts
+                .iter()
+                .find(|lease| lease.parent() == parent)
+            else {
+                return Err(
+                    StoreError::Unavailable("durable predecessor context is incoherent").into(),
+                );
+            };
+            if lease.parent() != parent || lease.predecessors().len() != required {
+                #[cfg(test)]
+                if !context.is_empty() {
+                    return Ok(context);
+                }
+                return Err(
+                    StoreError::Unavailable("durable predecessor context is incoherent").into(),
+                );
+            }
+            return Ok(lease
+                .predecessors()
+                .iter()
+                .map(|fact| (fact.difficulty_threshold, fact.time))
+                .collect());
+        };
+        context.push((node.header.difficulty_threshold, node.header.time));
+        hash = node.parent_hash;
+    }
+    Ok(context)
+}
+
+fn apply_event<G: HeaderGraphEdit>(
+    graph: &mut G,
+    verified: &mut Vec<Frontier>,
+    aux_changes: &mut Vec<crate::AuxDelta>,
+    operator_reason_changed: &mut bool,
+    event: &TransitionEvent,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    let engine = event_context.engine;
+    let durable = event_context.durable;
+    let context = event_context.transition;
+    match event {
+        TransitionEvent::InsertHeaders(event) => {
+            let receipt = event.batch.receipt();
+            if receipt.parent().hash != event.parent_hash
+                || receipt.trust_anchor_digest() != context.config.trust_anchor_digest()
+            {
+                return Err(TransitionFailure::StalePreparation);
+            }
+            let parent_node =
+                graph
+                    .view_node(event.parent_hash)
+                    .ok_or(GraphError::UnknownParent {
+                        header: event.target_tip_hash,
+                        parent: event.parent_hash,
+                    })?;
+            let parent_frontier = Frontier::new(parent_node.height, parent_node.hash);
+            if receipt.parent() != parent_frontier {
+                return Err(TransitionFailure::StalePreparation);
+            }
+            let common_ancestor = match event.completion {
+                TargetCompletion::TargetComplete { common_ancestor }
+                | TargetCompletion::TargetPrefix { common_ancestor }
+                | TargetCompletion::SelectedAuxiliaryRepair {
+                    common_ancestor, ..
+                } => common_ancestor,
+            };
+            if common_ancestor != parent_frontier {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "target completion ancestor does not match the retained parent",
+                ));
+            }
+            let mut contextual = retained_header_context(graph, parent_frontier, durable)?;
+            let mut parent = parent_frontier;
+            for prepared in event.batch.headers() {
+                if prepared.header.previous_block_hash != parent.hash
+                    || prepared.hash != prepared.header.hash()
+                    || prepared.height
+                        != parent
+                            .height
+                            .next()
+                            .map_err(|_| GraphError::HeightOverflow {
+                                parent: parent.hash,
+                            })?
+                    || prepared.block_work
+                        != prepared.header.difficulty_threshold.to_work().ok_or(
+                            TransitionFailure::InvalidEvidence("invalid prepared target"),
+                        )?
+                {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "prepared header batch is inconsistent",
+                    ));
+                }
+                let adjustment = crate::AdjustedDifficulty::new_from_header_time(
+                    prepared.header.time,
+                    parent.height,
+                    &context.config.network,
+                    contextual.iter().copied(),
+                );
+                crate::validate_contextual_difficulty_and_time(
+                    prepared.header.difficulty_threshold,
+                    adjustment,
+                )
+                .map_err(|_| {
+                    TransitionFailure::InvalidEvidence(
+                        "prepared header failed retained contextual validation",
+                    )
+                })?;
+                let validation = match prepared.validation {
+                    HeaderValidationState::DeferredUntil(until) if until <= context.clock.now() => {
+                        HeaderValidationState::Valid
+                    }
+                    state => state,
+                };
+                let reasons = anchor_reasons(context, prepared.height, prepared.hash);
+                parent = match graph.edit_insert(
+                    prepared.header.clone(),
+                    prepared.block_work,
+                    validation,
+                    reasons,
+                    BodyValidationState::Unknown,
+                )? {
+                    crate::InsertResult::Inserted(frontier)
+                    | crate::InsertResult::AlreadyPresent(frontier) => frontier,
+                };
+                contextual.insert(
+                    0,
+                    (prepared.header.difficulty_threshold, prepared.header.time),
+                );
+                contextual.truncate(crate::POW_ADJUSTMENT_BLOCK_SPAN);
+            }
+            if parent.hash != event.target_tip_hash {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "target completion does not end at the pursued hash",
+                ));
+            }
+            match event.completion {
+                TargetCompletion::SelectedAuxiliaryRepair {
+                    selected_target, ..
+                } => {
+                    if event.owner.body_owner().is_none() {
+                        return Err(TransitionFailure::InvalidEvidence(
+                            "selected auxiliary repair does not have body authority",
+                        ));
+                    }
+                    if event.batch.headers().len() != 1
+                        || event.aux.len() != 1
+                        || event.aux[0].tree_aux.is_none()
+                        || selected_target != parent
+                        || event.owner.header_authority().branch.target_tip_hash
+                            != event_context.before.frontiers.header_best.hash
+                        || event_context
+                            .old_selected
+                            .iter()
+                            .find(|frontier| frontier.height == selected_target.height)
+                            .map(|frontier| frontier.hash)
+                            != Some(selected_target.hash)
+                        || graph.view_ancestor(
+                            event.owner.header_authority().branch.target_tip_hash,
+                            selected_target.height,
+                        )? != Some(selected_target)
+                    {
+                        return Err(TransitionFailure::InvalidEvidence(
+                            "auxiliary repair is not one exact selected header",
+                        ));
+                    }
+                }
+                TargetCompletion::TargetComplete { .. } | TargetCompletion::TargetPrefix { .. } => {
+                    if event.owner.header_owner().is_none() {
+                        return Err(TransitionFailure::InvalidEvidence(
+                            "ordinary header insertion does not have pure header authority",
+                        ));
+                    }
+                    if event.owner.header_authority().branch.target_tip_hash
+                        != event.target_tip_hash
+                    {
+                        return Err(TransitionFailure::InvalidEvidence(
+                            "target completion does not end at the pursued hash",
+                        ));
+                    }
+                }
+            }
+            let batch_headers: HashMap<_, _> = event
+                .batch
+                .headers()
+                .iter()
+                .map(|header| (header.hash, header.height))
+                .collect();
+            let mut delivery_ids = HashSet::new();
+            for delivery in &event.aux {
+                let expected_height = batch_headers.get(&delivery.header_hash).copied();
+                if !delivery_ids.insert(delivery.delivery_id)
+                    || delivery.owner != event.owner
+                    || delivery.source != event.source
+                    || delivery.authentication != crate::AuxAuthentication::Unauthenticated
+                    || expected_height.is_none()
+                    || delivery
+                        .tree_aux
+                        .is_some_and(|aux| Some(aux.height) != expected_height)
+                {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "auxiliary delivery does not match the admitted target",
+                    ));
+                }
+                let indexed_count = graph
+                    .view_node(delivery.header_hash)
+                    .expect("the auxiliary header was checked above")
+                    .aux_delivery_ids
+                    .iter()
+                    .filter(|delivery_id| **delivery_id == delivery.delivery_id)
+                    .count();
+                let stored = engine
+                    .aux_deliveries(delivery.header_hash)
+                    .iter()
+                    .copied()
+                    .find(|stored| stored.delivery_id == delivery.delivery_id);
+                match (stored, indexed_count) {
+                    (Some(stored), 1) if stored == *delivery => continue,
+                    (None, 0) => {}
+                    _ => {
+                        return Err(TransitionFailure::InvalidEvidence(
+                            "auxiliary delivery replay changes provenance or indexing",
+                        ));
+                    }
+                }
+                graph
+                    .edit_node_mut(delivery.header_hash)?
+                    .aux_delivery_ids
+                    .push(delivery.delivery_id);
+                aux_changes.push(crate::AuxDelta::Put(Box::new(*delivery)));
+            }
+        }
+        TransitionEvent::VerifiedChainChanged(event) => {
+            if verified.last().copied() != Some(event.old_tip) {
+                return Err(TransitionFailure::StalePreparation);
+            }
+            let mut parent = match event.cause {
+                crate::VerifiedChangeCause::Grow => event.old_tip,
+                crate::VerifiedChangeCause::Reset => graph.view_finalized(),
+            };
+            if matches!(event.cause, crate::VerifiedChangeCause::Reset) {
+                verified.clear();
+                verified.push(parent);
+            }
+            for header in &event.new_path {
+                if header.header.hash() != header.hash
+                    || header.header.previous_block_hash != parent.hash
+                    || header.height
+                        != parent
+                            .height
+                            .next()
+                            .map_err(|_| GraphError::HeightOverflow {
+                                parent: parent.hash,
+                            })?
+                {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "verified path is not continuous",
+                    ));
+                }
+                if graph.view_node(header.hash).is_none() {
+                    let work = header.header.difficulty_threshold.to_work().ok_or(
+                        TransitionFailure::InvalidEvidence("invalid verified target"),
+                    )?;
+                    graph.edit_insert(
+                        header.header.clone(),
+                        work,
+                        HeaderValidationState::Valid,
+                        anchor_reasons(context, header.height, header.hash),
+                        BodyValidationState::Verified {
+                            evidence: event.full_state_transition_id,
+                        },
+                    )?;
+                } else {
+                    graph.edit_set_body_state(
+                        header.hash,
+                        BodyValidationState::Verified {
+                            evidence: event.full_state_transition_id,
+                        },
+                    )?;
+                }
+                parent = Frontier::new(header.height, header.hash);
+                verified.push(parent);
+            }
+        }
+        TransitionEvent::VerifiedBlockAccepted(event) => {
+            if event.path.is_empty() {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "accepted full-state side path is empty",
+                ));
+            }
+            let mut parent = graph.view_finalized();
+            let last_index = event.path.len().saturating_sub(1);
+            for (index, header) in event.path.iter().enumerate() {
+                if header.header.hash() != header.hash
+                    || header.header.previous_block_hash != parent.hash
+                    || header.height
+                        != parent
+                            .height
+                            .next()
+                            .map_err(|_| GraphError::HeightOverflow {
+                                parent: parent.hash,
+                            })?
+                {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "accepted full-state side path is not continuous",
+                    ));
+                }
+                if graph.view_node(header.hash).is_none() {
+                    let work = header.header.difficulty_threshold.to_work().ok_or(
+                        TransitionFailure::InvalidEvidence("invalid accepted full-state header"),
+                    )?;
+                    graph.edit_insert(
+                        header.header.clone(),
+                        work,
+                        HeaderValidationState::Valid,
+                        anchor_reasons(context, header.height, header.hash),
+                        BodyValidationState::Verified {
+                            evidence: event.full_state_transition_id,
+                        },
+                    )?;
+                } else if index == last_index {
+                    graph.edit_set_body_state(
+                        header.hash,
+                        BodyValidationState::Verified {
+                            evidence: event.full_state_transition_id,
+                        },
+                    )?;
+                }
+                parent = Frontier::new(header.height, header.hash);
+            }
+        }
+        TransitionEvent::BodyEvidence(BodyEvidence::PayloadMismatch(_)) => {}
+        TransitionEvent::BodyEvidence(BodyEvidence::Transient(event)) => {
+            if event.availability.attempts == 0
+                || event.availability.suppliers == 0
+                || event.availability.started_at > event.availability.next_probe_at
+            {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "body retry evidence has an invalid episode summary",
+                ));
+            }
+            if matches!(
+                graph.view_node(event.hash).map(|node| &node.body),
+                Some(BodyValidationState::Verified { .. })
+            ) {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "body retry evidence cannot regress an already verified body",
+                ));
+            }
+            graph.edit_set_body_state(
+                event.hash,
+                BodyValidationState::Unavailable(event.availability),
+            )?;
+        }
+        TransitionEvent::BodySupplierDiscovered(event) => {
+            let old = match graph.view_node(event.hash).map(|node| &node.body) {
+                Some(BodyValidationState::Unavailable(summary))
+                    if event.hash == graph.view_select_header_best()?.0.hash && summary.alarmed =>
+                {
+                    *summary
+                }
+                _ => {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "body supplier discovery requires the selected persistent alarm",
+                    ));
+                }
+            };
+            if event.availability.started_at != old.started_at
+                || event.availability.attempts != old.attempts
+                || event.availability.suppliers == 0
+                || !event.availability.alarmed
+                || event.availability.next_probe_at < event.availability.started_at
+                || event.availability.next_probe_at > context.clock.now()
+            {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "body supplier discovery must preserve the persistent retry episode",
+                ));
+            }
+            let has_new_supplier = event.availability.suppliers > old.suppliers
+                || (event.availability.suppliers == old.suppliers
+                    && event.availability.supplier_set_digest != old.supplier_set_digest);
+            if !has_new_supplier {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "body supplier discovery does not add an eligible supplier",
+                ));
+            }
+            graph.edit_set_body_state(
+                event.hash,
+                BodyValidationState::Unavailable(event.availability),
+            )?;
+        }
+        TransitionEvent::OperatorBodyRetry(event) => {
+            if event.hash != graph.view_select_header_best()?.0.hash
+                || event.availability.attempts != 0
+                || event.availability.suppliers == 0
+                || event.availability.alarmed
+                || event.availability.started_at != event.availability.next_probe_at
+            {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "operator body retry has an invalid fresh episode",
+                ));
+            }
+            if !matches!(
+                graph.view_node(event.hash).map(|node| &node.body),
+                Some(BodyValidationState::Unavailable(summary)) if summary.alarmed
+            ) {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "operator body retry requires the selected persistent alarm",
+                ));
+            }
+            graph.edit_set_body_state(
+                event.hash,
+                BodyValidationState::Unavailable(event.availability),
+            )?;
+        }
+        TransitionEvent::BodyEvidence(BodyEvidence::ConsensusInvalid(event)) => {
+            if matches!(
+                graph.view_node(event.hash).map(|node| &node.body),
+                Some(BodyValidationState::Verified { .. })
+            ) {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "body invalid evidence cannot contradict an already verified body",
+                ));
+            }
+            graph.edit_set_consensus_body_invalid(
+                event.hash,
+                event.evidence,
+                event.rule.clone(),
+            )?;
+        }
+        TransitionEvent::BodyEvidence(BodyEvidence::Verified(event)) => {
+            graph.edit_set_body_state(
+                event.hash,
+                BodyValidationState::Verified {
+                    evidence: event.evidence,
+                },
+            )?;
+        }
+        TransitionEvent::OperatorInvalidate(event) => {
+            *operator_reason_changed = graph.edit_add_reason(
+                event.target,
+                EligibilityReason::OperatorInvalid { id: event.id },
+            )?;
+        }
+        TransitionEvent::OperatorReconsider(event) => {
+            *operator_reason_changed =
+                graph.edit_remove_operator_invalidation(event.target, event.id)?;
+        }
+        TransitionEvent::FullStateFinalized(event) => {
+            let expected: Vec<_> = verified
+                .iter()
+                .take_while(|frontier| frontier.height <= event.new_finalized.height)
+                .map(|frontier| frontier.hash)
+                .collect();
+            if event.verified_path_proof != expected {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "finality proof is not the exact verified ancestry",
+                ));
+            }
+        }
+        TransitionEvent::MigratedPinRefutation(event) => {
+            if event.invalid_header.height > event.pin.height
+                || event_context.migrated_pin_refuted != Some(event.pin)
+            {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "full-state refutation does not name an imported pin ancestor",
+                ));
+            }
+        }
+        TransitionEvent::AuxEvidence(event) => {
+            if event.deliveries.is_empty() || event.deliveries.len() > 2 {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "auxiliary evidence must name one or two exact deliveries",
+                ));
+            }
+
+            for (index, event_delivery) in event.deliveries.iter().enumerate() {
+                if event.deliveries[..index].iter().any(|prior| {
+                    prior.header_hash == event_delivery.header_hash
+                        && prior.delivery_id == event_delivery.delivery_id
+                }) {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "auxiliary evidence names the same delivery more than once",
+                    ));
+                }
+                let header = graph.view_node(event_delivery.header_hash).ok_or(
+                    TransitionFailure::InvalidEvidence(
+                        "auxiliary evidence references an unknown header",
+                    ),
+                )?;
+                let header_frontier = Frontier::new(header.height, header.hash);
+                if graph.view_ancestor(event.owner.branch.target_tip_hash, header.height)?
+                    != Some(header_frontier)
+                {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "auxiliary evidence is outside its owned branch",
+                    ));
+                }
+                let existing = engine
+                    .aux_deliveries(event_delivery.header_hash)
+                    .iter()
+                    .copied()
+                    .find(|delivery| delivery.delivery_id == event_delivery.delivery_id)
+                    .ok_or(TransitionFailure::InvalidEvidence(
+                        "auxiliary evidence references an unknown delivery",
+                    ))?;
+                if existing != *event_delivery
+                    || !header.aux_delivery_ids.contains(&existing.delivery_id)
+                {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "auxiliary evidence changes delivery provenance",
+                    ));
+                }
+                if existing.authentication == event.authentication {
+                    continue;
+                }
+                if existing.authentication != crate::AuxAuthentication::Unauthenticated {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "an authenticated or rejected auxiliary delivery is immutable",
+                    ));
+                }
+                if let crate::AuxAuthentication::Authenticated { boundary_hash, .. } =
+                    event.authentication
+                {
+                    let boundary = graph.view_node(boundary_hash).ok_or(
+                        TransitionFailure::InvalidEvidence(
+                            "auxiliary authentication boundary is unknown",
+                        ),
+                    )?;
+                    let expected_height = header.height.next().map_err(|_| {
+                        TransitionFailure::InvalidEvidence(
+                            "auxiliary authentication boundary height overflowed",
+                        )
+                    })?;
+                    let boundary_frontier = Frontier::new(boundary.height, boundary.hash);
+                    if boundary.height != expected_height
+                        || boundary.parent_hash != header.hash
+                        || graph
+                            .view_ancestor(event.owner.branch.target_tip_hash, boundary.height)?
+                            != Some(boundary_frontier)
+                    {
+                        return Err(TransitionFailure::InvalidEvidence(
+                            "auxiliary authentication is not the owned one-header-later boundary",
+                        ));
+                    }
+                } else if event.authentication == crate::AuxAuthentication::Unauthenticated {
+                    return Err(TransitionFailure::InvalidEvidence(
+                        "auxiliary evidence cannot remove authentication",
+                    ));
+                }
+                let mut delivery = existing;
+                delivery.authentication = event.authentication;
+                aux_changes.push(crate::AuxDelta::Put(Box::new(delivery)));
+            }
+            if event.authentication == crate::AuxAuthentication::Unauthenticated {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "auxiliary evidence cannot remove authentication",
+                ));
+            }
+        }
+        TransitionEvent::ReevaluateDeferred => {
+            let due: Vec<_> = graph
+                .view_nodes()
+                .into_iter()
+                .filter_map(|node| match node.validation {
+                    HeaderValidationState::DeferredUntil(until) if until <= context.clock.now() => {
+                        Some(node.hash)
+                    }
+                    _ => None,
+                })
+                .collect();
+            for hash in due {
+                graph.edit_set_validation(hash, HeaderValidationState::Valid)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn anchor_reasons(
+    context: &TransitionContext<'_>,
+    height: block::Height,
+    hash: block::Hash,
+) -> Vec<EligibilityReason> {
+    let mut reasons = Vec::new();
+    if let Some(pin) = context
+        .config
+        .settled_manifest
+        .pin_for_network(&context.config.network)
+    {
+        if pin.activation.height == height && pin.activation.hash != hash {
+            reasons.push(EligibilityReason::SettledUpgradeConflict {
+                height,
+                expected: pin.activation.hash,
+            });
+        }
+    }
+    if let Some(expected) = context.config.local_checkpoints.hash(height) {
+        if expected != hash {
+            reasons.push(EligibilityReason::CheckpointConflict { height, expected });
+        }
+    }
+    reasons
+}
+
+#[allow(clippy::too_many_arguments)]
+fn derive_plan(
+    before: EngineSnapshot,
+    mut metadata: EngineMetadata,
+    base_graph: &MemHeaderStore,
+    graph: GraphOverlay<'_>,
+    old_selected: Vec<Frontier>,
+    old_verified: Vec<Frontier>,
+    selected: Vec<Frontier>,
+    verified: Vec<Frontier>,
+    aux_changes: Vec<crate::AuxDelta>,
+    finality_append: Option<FinalityRecord>,
+    retention: RetentionPlan,
+    event_id: Option<EvidenceId>,
+    cause: TransitionCause,
+    trust_pins: Vec<Frontier>,
+    limits: EngineLimits,
+) -> Result<TransitionPlan, TransitionFailure> {
+    let graph_delta = graph.delta();
+    let put_nodes = graph_delta.put_nodes.clone();
+    let delete_nodes = graph_delta.delete_nodes.clone();
+    let mut eligibility_changes: Vec<_> = put_nodes
+        .iter()
+        .filter_map(|node| {
+            let old = base_graph.node(node.hash)?;
+            (old.eligibility != node.eligibility).then(|| EligibilityDelta {
+                hash: node.hash,
+                before: old.eligibility.clone(),
+                after: node.eligibility.clone(),
+            })
+        })
+        .collect();
+    eligibility_changes.sort_unstable_by_key(|delta| delta.hash.0);
+    let selected_changed = selected != old_selected;
+    let verified_changed = verified != old_verified;
+    let header_topology_changed = !delete_nodes.is_empty()
+        || put_nodes
+            .iter()
+            .any(|node| base_graph.node(node.hash).is_none());
+    let header_validation_changed = put_nodes.iter().any(|node| {
+        base_graph
+            .node(node.hash)
+            .is_some_and(|old| old.validation != node.validation)
+    });
+    let header_best = *selected.last().ok_or(TransitionFailure::InvalidEvidence(
+        "selected projection is empty",
+    ))?;
+    metadata.alarms.resource_stalled = retention.resource_stalled;
+    let header_best_node = graph
+        .view_node(header_best.hash)
+        .ok_or(GraphError::UnknownNode(header_best.hash))?;
+    metadata.alarms.header_best_body_unavailable = match &header_best_node.body {
+        BodyValidationState::Unavailable(summary) if summary.alarmed => Some(*summary),
+        _ => None,
+    };
+    let alarm_changed = metadata.alarms != before.alarms;
+    let changed = !put_nodes.is_empty()
+        || !delete_nodes.is_empty()
+        || !aux_changes.is_empty()
+        || finality_append.is_some()
+        || selected_changed
+        || verified_changed
+        || alarm_changed;
+    if changed {
+        metadata.state_version = metadata.state_version.checked_next()?;
+        if selected_changed
+            || header_topology_changed
+            || header_validation_changed
+            || !eligibility_changes.is_empty()
+            || finality_append.is_some()
+        {
+            metadata.header_generation = metadata.header_generation.checked_next()?;
+        }
+        if verified_changed || finality_append.is_some() {
+            metadata.verified_generation = metadata.verified_generation.checked_next()?;
+        }
+        if let Some(record) = finality_append {
+            metadata.finality_epoch = record.epoch;
+        }
+        if let Some(event_id) = event_id {
+            metadata.last_transition_id = event_id;
+        }
+    }
+    let verified_best = *verified.last().ok_or(TransitionFailure::InvalidEvidence(
+        "verified projection is empty",
+    ))?;
+    metadata.frontiers = FrontierSet {
+        finalized: graph.view_finalized(),
+        header_best,
+        verified_best,
+    };
+    metadata.header_best_score = graph.view_score(header_best.hash)?;
+    metadata.oldest_retained_height = if delete_nodes.is_empty() {
+        put_nodes
+            .iter()
+            .map(|node| node.height)
+            .min()
+            .map_or(before.oldest_retained_height, |height| {
+                height.min(before.oldest_retained_height)
+            })
+    } else {
+        graph
+            .view_nodes()
+            .into_iter()
+            .map(|node| node.height)
+            .min()
+            .unwrap_or(graph.view_finalized().height)
+    };
+    let inserted = put_nodes
+        .iter()
+        .filter(|node| base_graph.node(node.hash).is_none())
+        .map(|node| Frontier::new(node.height, node.hash))
+        .collect();
+    let change_set = ChangeSet {
+        put_nodes,
+        delete_nodes: delete_nodes.clone(),
+        index_changes: IndexChanges {
+            inserted,
+            deleted: delete_nodes,
+        },
+        selected_projection: projection_delta(&old_selected, &selected),
+        verified_projection: projection_delta(&old_verified, &verified),
+        eligibility_changes,
+        aux_changes,
+        finality_append,
+        metadata,
+    };
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    let projected = materialize_graph(&graph)?;
+    Ok(TransitionPlan {
+        before,
+        change_set,
+        graph_delta,
+        #[cfg(any(test, feature = "fuzz-impl"))]
+        projected,
+        cause,
+        trust_pins,
+        limits,
+    })
+}
+
+fn no_change(
+    _engine: &HeaderChainEngine,
+    before: EngineSnapshot,
+    metadata: EngineMetadata,
+    event: TransitionEvent,
+    context: &TransitionContext<'_>,
+    cause: TransitionCause,
+) -> Result<TransitionPlan, TransitionFailure> {
+    validate_authority(&event, context)?;
+    Ok(TransitionPlan {
+        before,
+        change_set: ChangeSet {
+            put_nodes: Vec::new(),
+            delete_nodes: Vec::new(),
+            index_changes: IndexChanges::default(),
+            selected_projection: ProjectionDelta::default(),
+            verified_projection: ProjectionDelta::default(),
+            eligibility_changes: Vec::new(),
+            aux_changes: Vec::new(),
+            finality_append: None,
+            metadata,
+        },
+        graph_delta: GraphDelta::default(),
+        #[cfg(any(test, feature = "fuzz-impl"))]
+        projected: _engine.graph().clone(),
+        cause,
+        trust_pins: invariant_pins(context),
+        limits: context.config.limits,
+    })
+}
+
+fn resource_stalled(
+    engine: &HeaderChainEngine,
+    before: EngineSnapshot,
+    context: &TransitionContext<'_>,
+) -> Result<TransitionPlan, TransitionFailure> {
+    let mut metadata = engine.metadata().clone();
+    if !metadata.alarms.resource_stalled {
+        metadata.alarms.resource_stalled = true;
+        metadata.state_version = metadata.state_version.checked_next()?;
+    }
+    Ok(TransitionPlan {
+        before,
+        change_set: ChangeSet {
+            put_nodes: Vec::new(),
+            delete_nodes: Vec::new(),
+            index_changes: IndexChanges::default(),
+            selected_projection: ProjectionDelta::default(),
+            verified_projection: ProjectionDelta::default(),
+            eligibility_changes: Vec::new(),
+            aux_changes: Vec::new(),
+            finality_append: None,
+            metadata,
+        },
+        graph_delta: GraphDelta::default(),
+        #[cfg(any(test, feature = "fuzz-impl"))]
+        projected: engine.graph().clone(),
+        cause: TransitionCause::ResourceStalled,
+        trust_pins: invariant_pins(context),
+        limits: context.config.limits,
+    })
+}
+
+fn invariant_pins(context: &TransitionContext<'_>) -> Vec<Frontier> {
+    let mut pins: Vec<_> = context.config.local_checkpoints.iter().collect();
+    if let Some(pin) = context
+        .config
+        .settled_manifest
+        .pin_for_network(&context.config.network)
+    {
+        pins.push(pin.activation);
+    }
+    pins.sort_unstable_by_key(|pin| (pin.height, pin.hash.0));
+    pins
+}
+
+#[cfg(any(test, feature = "fuzz-impl"))]
+fn materialize_graph<G: HeaderGraphView>(graph: &G) -> Result<MemHeaderStore, GraphError> {
+    MemHeaderStore::from_nodes(
+        graph.view_finalized(),
+        graph.view_nodes().into_iter().cloned(),
+    )
+}
+
+fn path<G: HeaderGraphView>(graph: &G, tip: Frontier) -> Result<Vec<Frontier>, TransitionFailure> {
+    let mut path = Vec::new();
+    let mut current = tip;
+    loop {
+        path.push(current);
+        if current == graph.view_finalized() {
+            break;
+        }
+        let node = graph
+            .view_node(current.hash)
+            .ok_or(GraphError::UnknownNode(current.hash))?;
+        current = Frontier::new(block::Height(current.height.0 - 1), node.parent_hash);
+    }
+    path.reverse();
+    Ok(path)
+}
+
+fn trim_projection<G: HeaderGraphView>(
+    graph: &G,
+    projection: Vec<Frontier>,
+) -> Result<Vec<Frontier>, TransitionFailure> {
+    let mut result: Vec<_> = projection
+        .into_iter()
+        .filter(|frontier| {
+            frontier.height >= graph.view_finalized().height
+                && graph.view_node(frontier.hash).is_some()
+        })
+        .collect();
+    if result.first().copied() != Some(graph.view_finalized()) {
+        result.insert(0, graph.view_finalized());
+    }
+    for pair in result.windows(2) {
+        if pair[1].height.0 != pair[0].height.0 + 1
+            || graph
+                .view_node(pair[1].hash)
+                .is_none_or(|node| node.parent_hash != pair[0].hash)
+        {
+            return Err(TransitionFailure::InvalidEvidence(
+                "verified projection is not continuous",
+            ));
+        }
+    }
+    Ok(result)
+}
+
+fn projection_delta(old: &[Frontier], new: &[Frontier]) -> ProjectionDelta {
+    let remove_before = new.first().and_then(|first| {
+        old.first()
+            .is_some_and(|old_first| old_first.height < first.height)
+            .then_some(first.height)
+    });
+    let old_start = remove_before
+        .map(|height| old.partition_point(|frontier| frontier.height < height))
+        .unwrap_or(0);
+    let comparable_old = &old[old_start..];
+    let common = comparable_old
+        .iter()
+        .zip(new)
+        .take_while(|(left, right)| left == right)
+        .count();
+    ProjectionDelta {
+        remove_before,
+        remove_from: comparable_old
+            .get(common)
+            .or_else(|| new.get(common))
+            .map(|frontier| frontier.height),
+        put: new[common..].to_vec(),
+    }
+}

--- a/crates/zakura-header-chain/src/transition/recovery.rs
+++ b/crates/zakura-header-chain/src/transition/recovery.rs
@@ -1,0 +1,658 @@
+//! Exhaustive startup audit and deterministic reconstruction planning.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    sync::Arc,
+};
+
+use chrono::{DateTime, Duration, Utc};
+use thiserror::Error;
+use zakura_chain::block;
+
+use crate::{
+    AuxDelivery, BodyValidationState, CounterExhausted, EligibilityReason, EngineConfig,
+    EngineMetadata, EngineMode, EngineSnapshot, FinalityRecord, FinalitySource, Frontier,
+    HeaderNode, MemHeaderStore, StoreError,
+};
+
+/// One immutable predecessor record stored below the selectable finalized anchor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidationContextRecord {
+    /// Canonical context header, including its backward link.
+    pub header: Arc<block::Header>,
+    /// Authenticated context height.
+    pub height: block::Height,
+}
+
+/// Complete exhaustive row/index view used only while publication is disabled.
+pub trait StoreAuditRead {
+    /// Return the atomic externally meaningful snapshot.
+    fn snapshot(&self) -> Result<EngineSnapshot, StoreError>;
+    /// Return complete singleton metadata from the same version.
+    fn metadata(&self) -> Result<EngineMetadata, StoreError>;
+    /// Every node row, including disconnected rows.
+    fn all_nodes(&self) -> Result<Vec<HeaderNode>, StoreError>;
+    /// Every persisted parent/child edge.
+    fn child_edges(&self) -> Result<Vec<(block::Hash, block::Hash)>, StoreError>;
+    /// Complete selected projection.
+    fn selected_projection(&self) -> Result<Vec<Frontier>, StoreError>;
+    /// Complete verified projection.
+    fn verified_projection(&self) -> Result<Vec<Frontier>, StoreError>;
+    /// Complete deferred-time index.
+    fn deferred_entries(&self) -> Result<Vec<(DateTime<Utc>, block::Hash)>, StoreError>;
+    /// Every authoritative direct-reason root.
+    fn eligibility_roots(&self) -> Result<Vec<(block::Hash, EligibilityReason)>, StoreError>;
+    /// Every auxiliary delivery, including dangling rows.
+    fn all_aux_deliveries(&self) -> Result<Vec<AuxDelivery>, StoreError>;
+    /// Every immutable below-finalized context row.
+    fn validation_context_records(&self) -> Result<Vec<ValidationContextRecord>, StoreError>;
+    /// Visit append-only finality provenance in ascending epoch order.
+    fn visit_finality_history(
+        &self,
+        visitor: &mut dyn FnMut(FinalityRecord) -> Result<(), StoreError>,
+    ) -> Result<(), StoreError>;
+}
+
+/// Stable exhaustive-audit violation categories.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AuditViolation {
+    /// Canonical header and stored hash disagreed.
+    NodeHash(block::Hash),
+    /// A non-anchor node had no exact height-minus-one parent.
+    Parent(block::Hash),
+    /// Exact cumulative work did not equal parent plus block work.
+    Work(block::Hash),
+    /// Body invalidity and direct eligibility evidence disagreed.
+    BodyEligibility(block::Hash),
+    /// Header validation state contradicted deterministic header facts.
+    HeaderValidation(block::Hash),
+    /// A trust pin was absent or lacked its exact conflict reason.
+    TrustPin(block::Height, block::Hash),
+    /// Authoritative reason roots disagreed with node source rows.
+    EligibilityRoot(block::Hash),
+    /// Auxiliary provenance or a node foreign key was invalid.
+    Auxiliary(block::Hash),
+    /// Immutable validation context was malformed or discontinuous.
+    ValidationContext(block::Hash),
+    /// Finality history contradicted finalized metadata.
+    Finality,
+    /// Mode, network, manifest, schema, or snapshot contradicted configuration.
+    Configuration,
+    /// A protected source path was absent or discontinuous.
+    ProtectedPath(block::Hash),
+    /// Authoritative rows exceeded frozen limits without the permitted alarm.
+    Limits,
+}
+
+/// Reconstructible categories replaced by one atomic recovery transaction.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum RecoveryRepair {
+    /// Parent/child adjacency differed from source nodes.
+    ChildIndex,
+    /// Future-time index differed from node states.
+    DeferredIndex,
+    /// Selected projection/frontier differed from recomputation.
+    SelectedProjection,
+    /// Verified projection differed from its authoritative frontier.
+    VerifiedProjection,
+    /// Cached inherited eligibility differed from ancestry.
+    InheritedEligibility,
+    /// Oldest-retained metadata differed from source nodes.
+    RetentionMetadata,
+    /// Selected-tip body-unavailability alarm differed from its durable node.
+    BodyAvailabilityAlarm,
+}
+
+/// Exact source-derived state to install before startup publication.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecoveryPlan {
+    /// Snapshot observed before repair.
+    pub before: EngineSnapshot,
+    /// Corrected metadata with counters advanced exactly once when required.
+    pub metadata: EngineMetadata,
+    /// Nodes with reconstructed inherited eligibility caches.
+    pub nodes: Vec<HeaderNode>,
+    /// Complete expected adjacency index.
+    pub child_edges: Vec<(block::Hash, block::Hash)>,
+    /// Complete selected projection.
+    pub selected_projection: Vec<Frontier>,
+    /// Complete verified projection.
+    pub verified_projection: Vec<Frontier>,
+    /// Complete deferred index.
+    pub deferred_entries: Vec<(DateTime<Utc>, block::Hash)>,
+    /// Exact repairs, empty for a coherent store.
+    pub repairs: BTreeSet<RecoveryRepair>,
+}
+
+impl RecoveryPlan {
+    /// Return true when startup may publish without a repair transaction.
+    pub fn is_clean(&self) -> bool {
+        self.repairs.is_empty()
+    }
+}
+
+/// Startup audit failed before publication became available.
+#[derive(Clone, Debug, Error, PartialEq)]
+pub enum RecoveryFailure {
+    /// Exhaustive rows could not be read.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    /// Authoritative source invariants failed.
+    #[error("authoritative header-chain source rows failed startup audit")]
+    Source {
+        /// Deterministically ordered violations.
+        violations: Vec<AuditViolation>,
+    },
+    /// A repair-required monotonic counter was exhausted.
+    #[error(transparent)]
+    Counter(#[from] CounterExhausted),
+}
+
+/// Audit authoritative rows and derive only reconstructible repairs.
+pub fn audit_store<S: StoreAuditRead>(
+    store: &S,
+    config: &EngineConfig,
+) -> Result<RecoveryPlan, RecoveryFailure> {
+    let before = store.snapshot()?;
+    let mut metadata = store.metadata()?;
+    let mut violations = Vec::new();
+    if before != metadata.snapshot()
+        || metadata.disk_format.0 != 1
+        || metadata.mode != config.mode
+        || metadata.network_id != config.network.kind()
+        || metadata.anchor_manifest_digest != config.trust_anchor_digest()
+        || metadata.work_origin != config.bootstrap_anchor.frontier
+    {
+        violations.push(AuditViolation::Configuration);
+    }
+
+    let mut source_nodes = store.all_nodes()?;
+    source_nodes.sort_unstable_by_key(|node| (node.height, node.hash.0));
+    let mut unique = HashSet::new();
+    for node in &source_nodes {
+        if !unique.insert(node.hash) || node.header.hash() != node.hash {
+            violations.push(AuditViolation::NodeHash(node.hash));
+        }
+    }
+    let by_hash: HashMap<_, _> = source_nodes.iter().map(|node| (node.hash, node)).collect();
+    let finalized = metadata.frontiers.finalized;
+    if by_hash
+        .get(&finalized.hash)
+        .is_none_or(|node| node.height != finalized.height)
+    {
+        violations.push(AuditViolation::ProtectedPath(finalized.hash));
+    }
+    check_nodes(&source_nodes, &by_hash, &metadata, &mut violations);
+    check_finalized_connectivity(&source_nodes, finalized, &mut violations);
+    check_trust_pins(&source_nodes, config, &mut violations);
+    check_authoritative_rows(store, &source_nodes, &metadata, config, &mut violations)?;
+    if source_nodes.len().saturating_sub(1) > config.limits.max_non_finalized_nodes.get()
+        && !metadata.alarms.resource_stalled
+    {
+        violations.push(AuditViolation::Limits);
+    }
+    violations.sort_by_key(violation_key);
+    violations.dedup();
+    if !violations.is_empty() {
+        return Err(RecoveryFailure::Source { violations });
+    }
+
+    let mut graph = MemHeaderStore::from_nodes(finalized, source_nodes.clone()).map_err(|_| {
+        RecoveryFailure::Source {
+            violations: vec![AuditViolation::ProtectedPath(finalized.hash)],
+        }
+    })?;
+    graph
+        .recompute_all_eligibility()
+        .map_err(|_| RecoveryFailure::Source {
+            violations: vec![AuditViolation::ProtectedPath(finalized.hash)],
+        })?;
+    let mut nodes: Vec<_> = graph.nodes().cloned().collect();
+    nodes.sort_unstable_by_key(|node| (node.height, node.hash.0));
+    let node_map: HashMap<_, _> = nodes.iter().map(|node| (node.hash, node.clone())).collect();
+
+    let mut child_edges: Vec<_> = nodes
+        .iter()
+        .filter(|node| node.hash != finalized.hash)
+        .map(|node| (node.parent_hash, node.hash))
+        .collect();
+    child_edges.sort_unstable_by_key(|(parent, child)| (parent.0, child.0));
+    let mut deferred_entries: Vec<_> = nodes
+        .iter()
+        .filter_map(|node| match node.validation {
+            crate::HeaderValidationState::Valid => None,
+            crate::HeaderValidationState::DeferredUntil(until) => Some((until, node.hash)),
+        })
+        .collect();
+    deferred_entries.sort_unstable_by_key(|(until, hash)| (*until, hash.0));
+    if graph.eligible_tips().len() > config.limits.max_candidate_tips.get() {
+        return Err(source_failure(AuditViolation::Limits));
+    }
+    let (selected_tip, selected_score) = graph
+        .select_header_best()
+        .map_err(|_| source_failure(AuditViolation::ProtectedPath(finalized.hash)))?;
+    let selected_projection = path_to(&node_map, finalized, selected_tip)?;
+    let verified_projection = verified_path(&node_map, &metadata)?;
+
+    let mut repairs = BTreeSet::new();
+    compare_by_key(
+        store.child_edges()?,
+        &child_edges,
+        |(parent, child)| (parent.0, child.0),
+        RecoveryRepair::ChildIndex,
+        &mut repairs,
+    );
+    compare_by_key(
+        store.deferred_entries()?,
+        &deferred_entries,
+        |(until, hash)| (until.timestamp(), until.timestamp_subsec_nanos(), hash.0),
+        RecoveryRepair::DeferredIndex,
+        &mut repairs,
+    );
+    if store.selected_projection()? != selected_projection
+        || metadata.frontiers.header_best != selected_tip
+        || metadata.header_best_score != selected_score
+    {
+        repairs.insert(RecoveryRepair::SelectedProjection);
+    }
+    if store.verified_projection()? != verified_projection {
+        repairs.insert(RecoveryRepair::VerifiedProjection);
+    }
+    if source_nodes != nodes {
+        repairs.insert(RecoveryRepair::InheritedEligibility);
+    }
+    let oldest_retained_height = nodes
+        .iter()
+        .map(|node| node.height)
+        .min()
+        .unwrap_or(finalized.height);
+    if metadata.oldest_retained_height != oldest_retained_height {
+        repairs.insert(RecoveryRepair::RetentionMetadata);
+    }
+    let body_unavailable_alarm = match &node_map
+        .get(&selected_tip.hash)
+        .ok_or_else(|| source_failure(AuditViolation::ProtectedPath(selected_tip.hash)))?
+        .body
+    {
+        crate::BodyValidationState::Unavailable(summary) if summary.alarmed => Some(*summary),
+        _ => None,
+    };
+    if metadata.alarms.header_best_body_unavailable != body_unavailable_alarm {
+        repairs.insert(RecoveryRepair::BodyAvailabilityAlarm);
+    }
+
+    if !repairs.is_empty() {
+        metadata.state_version = metadata.state_version.checked_next()?;
+        if repairs.contains(&RecoveryRepair::SelectedProjection)
+            || repairs.contains(&RecoveryRepair::InheritedEligibility)
+        {
+            metadata.header_generation = metadata.header_generation.checked_next()?;
+        }
+        if repairs.contains(&RecoveryRepair::VerifiedProjection) {
+            metadata.verified_generation = metadata.verified_generation.checked_next()?;
+        }
+        metadata.frontiers.header_best = selected_tip;
+        metadata.header_best_score = selected_score;
+        metadata.oldest_retained_height = oldest_retained_height;
+        metadata.alarms.header_best_body_unavailable = body_unavailable_alarm;
+    }
+
+    Ok(RecoveryPlan {
+        before,
+        metadata,
+        nodes,
+        child_edges,
+        selected_projection,
+        verified_projection,
+        deferred_entries,
+        repairs,
+    })
+}
+
+fn check_nodes(
+    nodes: &[HeaderNode],
+    by_hash: &HashMap<block::Hash, &HeaderNode>,
+    metadata: &EngineMetadata,
+    violations: &mut Vec<AuditViolation>,
+) {
+    for node in nodes {
+        if node.work_coordinate().origin_hash() != metadata.work_origin.hash {
+            violations.push(AuditViolation::Work(node.hash));
+        }
+        if node.hash == metadata.frontiers.finalized.hash {
+            if node.eligibility.inherited_from.is_some() {
+                violations.push(AuditViolation::Parent(node.hash));
+            }
+        } else if let Some(parent) = by_hash.get(&node.parent_hash) {
+            if parent.height.next().ok() != Some(node.height)
+                || node.header.previous_block_hash != parent.hash
+            {
+                violations.push(AuditViolation::Parent(node.hash));
+            }
+            if parent.work_coordinate().checked_add(node.block_work).ok()
+                != Some(node.work_coordinate())
+            {
+                violations.push(AuditViolation::Work(node.hash));
+            }
+        } else {
+            violations.push(AuditViolation::Parent(node.hash));
+        }
+        let body_reason = node
+            .eligibility
+            .direct_reasons
+            .iter()
+            .find(|reason| matches!(reason, EligibilityReason::ConsensusBodyInvalid { .. }));
+        let matches = match (&node.body, body_reason) {
+            (
+                BodyValidationState::ConsensusInvalid {
+                    evidence: left_evidence,
+                    rule: left_rule,
+                },
+                Some(EligibilityReason::ConsensusBodyInvalid {
+                    evidence: right_evidence,
+                    rule: right_rule,
+                }),
+            ) => left_evidence == right_evidence && left_rule == right_rule,
+            (BodyValidationState::ConsensusInvalid { .. }, _) => false,
+            (_, None) => true,
+            (_, Some(_)) => false,
+        };
+        if !matches {
+            violations.push(AuditViolation::BodyEligibility(node.hash));
+        }
+        if let crate::HeaderValidationState::DeferredUntil(until) = node.validation {
+            let expected = node.header.time.checked_sub_signed(Duration::hours(2));
+            if expected != Some(until) {
+                violations.push(AuditViolation::HeaderValidation(node.hash));
+            }
+        }
+    }
+}
+
+fn check_finalized_connectivity(
+    nodes: &[HeaderNode],
+    finalized: Frontier,
+    violations: &mut Vec<AuditViolation>,
+) {
+    let mut connected = HashSet::from([finalized.hash]);
+    for node in nodes {
+        if node.hash == finalized.hash {
+            continue;
+        }
+        if connected.contains(&node.parent_hash) {
+            connected.insert(node.hash);
+        } else {
+            violations.push(AuditViolation::ProtectedPath(node.hash));
+        }
+    }
+}
+
+fn check_trust_pins(
+    nodes: &[HeaderNode],
+    config: &EngineConfig,
+    violations: &mut Vec<AuditViolation>,
+) {
+    let settled = config.settled_manifest.pin_for_network(&config.network);
+    for node in nodes {
+        let expected = if settled.is_some_and(|pin| pin.activation.height == node.height) {
+            settled.map(|pin| (pin.activation.hash, true))
+        } else {
+            config
+                .local_checkpoints
+                .hash(node.height)
+                .map(|hash| (hash, false))
+        };
+        let Some((expected, settled_reason)) = expected else {
+            continue;
+        };
+        let reason = node
+            .eligibility
+            .direct_reasons
+            .iter()
+            .any(|reason| match reason {
+                EligibilityReason::SettledUpgradeConflict {
+                    height,
+                    expected: hash,
+                } if settled_reason => *height == node.height && *hash == expected,
+                EligibilityReason::CheckpointConflict {
+                    height,
+                    expected: hash,
+                } if !settled_reason => *height == node.height && *hash == expected,
+                _ => false,
+            });
+        if (node.hash == expected && reason) || (node.hash != expected && !reason) {
+            violations.push(AuditViolation::TrustPin(node.height, node.hash));
+        }
+    }
+}
+
+fn check_authoritative_rows<S: StoreAuditRead>(
+    store: &S,
+    nodes: &[HeaderNode],
+    metadata: &EngineMetadata,
+    config: &EngineConfig,
+    violations: &mut Vec<AuditViolation>,
+) -> Result<(), StoreError> {
+    let mut expected: Vec<_> = nodes
+        .iter()
+        .flat_map(|node| {
+            node.eligibility
+                .direct_reasons
+                .iter()
+                .cloned()
+                .map(move |reason| (node.hash, reason))
+        })
+        .collect();
+    let mut actual = store.eligibility_roots()?;
+    expected.sort_by_key(|(hash, reason)| (hash.0, reason.clone()));
+    actual.sort_by_key(|(hash, reason)| (hash.0, reason.clone()));
+    if expected != actual {
+        let hash = expected
+            .iter()
+            .zip(&actual)
+            .find(|(left, right)| left != right)
+            .map(|(left, _)| left.0)
+            .or_else(|| {
+                expected
+                    .get(actual.len())
+                    .or_else(|| actual.get(expected.len()))
+                    .map(|(hash, _)| *hash)
+            })
+            .unwrap_or(block::Hash([0; 32]));
+        violations.push(AuditViolation::EligibilityRoot(hash));
+    }
+
+    let by_hash: HashMap<_, _> = nodes.iter().map(|node| (node.hash, node)).collect();
+    let deliveries = store.all_aux_deliveries()?;
+    let delivery_ids: HashSet<_> = deliveries.iter().map(|row| row.delivery_id).collect();
+    if delivery_ids.len() != deliveries.len() {
+        violations.push(AuditViolation::Auxiliary(block::Hash([0; 32])));
+    }
+    for delivery in &deliveries {
+        if by_hash
+            .get(&delivery.header_hash)
+            .is_none_or(|node| !node.aux_delivery_ids.contains(&delivery.delivery_id))
+        {
+            violations.push(AuditViolation::Auxiliary(delivery.header_hash));
+        }
+    }
+    for node in nodes {
+        let node_ids: HashSet<_> = node.aux_delivery_ids.iter().copied().collect();
+        if node_ids.len() != node.aux_delivery_ids.len()
+            || node_ids.iter().any(|id| !delivery_ids.contains(id))
+        {
+            violations.push(AuditViolation::Auxiliary(node.hash));
+        }
+    }
+
+    let mut contexts = store.validation_context_records()?;
+    contexts.sort_unstable_by_key(|record| record.height);
+    let predecessor_span = u32::try_from(crate::POW_PREDECESSOR_CONTEXT_SPAN)
+        .map_err(|_| StoreError::Incoherent("validation context bound does not fit in u32"))?;
+    let required_contexts = usize::try_from(
+        metadata.frontiers.finalized.height.0.min(predecessor_span),
+    )
+    .map_err(|_| StoreError::Incoherent("validation context bound does not fit in usize"))?;
+    if contexts.len() != required_contexts {
+        violations.push(AuditViolation::ValidationContext(
+            metadata.frontiers.finalized.hash,
+        ));
+    }
+    for pair in contexts.windows(2) {
+        if pair[0].height.next().ok() != Some(pair[1].height)
+            || pair[1].header.previous_block_hash != pair[0].header.hash()
+        {
+            violations.push(AuditViolation::ValidationContext(pair[1].header.hash()));
+        }
+    }
+    if let (Some(last), Some(finalized_node)) = (
+        contexts.last(),
+        by_hash.get(&metadata.frontiers.finalized.hash),
+    ) {
+        if last.height.next().ok() != Some(finalized_node.height)
+            || finalized_node.header.previous_block_hash != last.header.hash()
+        {
+            violations.push(AuditViolation::ValidationContext(last.header.hash()));
+        }
+    }
+
+    let mut previous = None;
+    let mut last = None;
+    let mut invalid_history = false;
+    store.visit_finality_history(&mut |record| {
+        if previous.is_some_and(|previous: FinalityRecord| {
+            previous.current != record.previous
+                || previous.epoch.get().checked_add(1) != Some(record.epoch.get())
+        }) || !source_matches_mode(&record, metadata.mode, config)
+        {
+            invalid_history = true;
+        }
+        previous = Some(record);
+        last = Some(record);
+        Ok(())
+    })?;
+    if invalid_history
+        || last.is_some_and(|record| {
+            record.current != metadata.frontiers.finalized
+                || record.epoch != metadata.finality_epoch
+        })
+        || last.is_none() && metadata.finality_epoch.get() != 0
+    {
+        violations.push(AuditViolation::Finality);
+    }
+    Ok(())
+}
+
+fn source_matches_mode(record: &FinalityRecord, mode: EngineMode, config: &EngineConfig) -> bool {
+    match (mode, record.source) {
+        (EngineMode::Integrated, FinalitySource::FullState { .. })
+        | (_, FinalitySource::MigratedHeadersOnly) => true,
+        (EngineMode::HeadersOnly, FinalitySource::HeadersOnlyDepth { selected_tip }) => {
+            record.current.height > record.previous.height
+                && selected_tip
+                    .height
+                    .0
+                    .saturating_sub(record.current.height.0)
+                    == config.limits.local_finality_depth.get()
+        }
+        _ => false,
+    }
+}
+
+fn verified_path(
+    nodes: &HashMap<block::Hash, HeaderNode>,
+    metadata: &EngineMetadata,
+) -> Result<Vec<Frontier>, RecoveryFailure> {
+    if metadata.mode == EngineMode::HeadersOnly {
+        if metadata.frontiers.verified_best != metadata.frontiers.finalized {
+            return Err(source_failure(AuditViolation::ProtectedPath(
+                metadata.frontiers.verified_best.hash,
+            )));
+        }
+        return Ok(vec![metadata.frontiers.finalized]);
+    }
+    let path = path_to(
+        nodes,
+        metadata.frontiers.finalized,
+        metadata.frontiers.verified_best,
+    )?;
+    if path.iter().skip(1).any(|frontier| {
+        nodes
+            .get(&frontier.hash)
+            .is_none_or(|node| !matches!(node.body, BodyValidationState::Verified { .. }))
+    }) {
+        return Err(source_failure(AuditViolation::ProtectedPath(
+            metadata.frontiers.verified_best.hash,
+        )));
+    }
+    Ok(path)
+}
+
+fn path_to(
+    nodes: &HashMap<block::Hash, HeaderNode>,
+    finalized: Frontier,
+    tip: Frontier,
+) -> Result<Vec<Frontier>, RecoveryFailure> {
+    let mut current = tip;
+    let mut path = Vec::new();
+    loop {
+        let node = nodes
+            .get(&current.hash)
+            .filter(|node| node.height == current.height)
+            .ok_or_else(|| source_failure(AuditViolation::ProtectedPath(current.hash)))?;
+        path.push(current);
+        if current == finalized {
+            break;
+        }
+        current = Frontier::new(
+            current
+                .height
+                .previous()
+                .map_err(|_| source_failure(AuditViolation::ProtectedPath(current.hash)))?,
+            node.parent_hash,
+        );
+    }
+    path.reverse();
+    Ok(path)
+}
+
+fn compare_by_key<T, K: Ord, F: FnMut(&T) -> K>(
+    mut actual: Vec<T>,
+    expected: &[T],
+    mut key: F,
+    repair: RecoveryRepair,
+    repairs: &mut BTreeSet<RecoveryRepair>,
+) where
+    T: Clone + Eq,
+{
+    let mut expected = expected.to_vec();
+    actual.sort_by_key(&mut key);
+    expected.sort_by_key(key);
+    if actual != expected {
+        repairs.insert(repair);
+    }
+}
+
+fn violation_key(violation: &AuditViolation) -> (u8, u32, [u8; 32]) {
+    match violation {
+        AuditViolation::NodeHash(hash) => (0, 0, hash.0),
+        AuditViolation::Parent(hash) => (1, 0, hash.0),
+        AuditViolation::Work(hash) => (2, 0, hash.0),
+        AuditViolation::BodyEligibility(hash) => (3, 0, hash.0),
+        AuditViolation::HeaderValidation(hash) => (4, 0, hash.0),
+        AuditViolation::TrustPin(height, hash) => (5, height.0, hash.0),
+        AuditViolation::EligibilityRoot(hash) => (6, 0, hash.0),
+        AuditViolation::Auxiliary(hash) => (7, 0, hash.0),
+        AuditViolation::ValidationContext(hash) => (8, 0, hash.0),
+        AuditViolation::Finality => (9, 0, [0; 32]),
+        AuditViolation::Configuration => (10, 0, [0; 32]),
+        AuditViolation::ProtectedPath(hash) => (11, 0, hash.0),
+        AuditViolation::Limits => (12, 0, [0; 32]),
+    }
+}
+
+fn source_failure(violation: AuditViolation) -> RecoveryFailure {
+    RecoveryFailure::Source {
+        violations: vec![violation],
+    }
+}

--- a/crates/zakura-header-chain/src/validation/contextual.rs
+++ b/crates/zakura-header-chain/src/validation/contextual.rs
@@ -1,0 +1,463 @@
+//! Block difficulty adjustment calculations for contextual validation.
+//!
+//! This module supports the following consensus rule calculations:
+//!  * `ThresholdBits` from the Zcash Specification,
+//!  * the Testnet minimum difficulty adjustment from ZIPs 205 and 208, and
+//!  * `median-time-past`.
+
+use std::cmp::{max, min};
+
+use chrono::{DateTime, Duration, Utc};
+use thiserror::Error;
+
+use zakura_chain::{
+    block::{self, Block},
+    parameters::{Network, NetworkUpgrade, POW_AVERAGING_WINDOW},
+    work::difficulty::{CompactDifficulty, ExpandedDifficulty, ParameterDifficulty as _, U256},
+    BoundedVec,
+};
+
+/// The median block span for time median calculations.
+///
+/// `PoWMedianBlockSpan` in the Zcash specification.
+pub const POW_MEDIAN_BLOCK_SPAN: usize = 11;
+
+/// The overall block span used for adjusting Zcash block difficulty.
+///
+/// `PoWAveragingWindow + PoWMedianBlockSpan` in the Zcash specification based on
+/// > ActualTimespan(height : N) := MedianTime(height) − MedianTime(height − PoWAveragingWindow)
+pub const POW_ADJUSTMENT_BLOCK_SPAN: usize = POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN;
+
+/// Durable predecessors needed below a separately retained parent frontier.
+pub const POW_PREDECESSOR_CONTEXT_SPAN: usize = POW_ADJUSTMENT_BLOCK_SPAN - 1;
+
+/// The damping factor for median timespan variance.
+///
+/// `PoWDampingFactor` in the Zcash specification.
+pub const POW_DAMPING_FACTOR: i32 = 4;
+
+/// The maximum upward adjustment percentage for median timespan variance.
+///
+/// `PoWMaxAdjustUp * 100` in the Zcash specification.
+pub const POW_MAX_ADJUST_UP_PERCENT: i32 = 16;
+
+/// The maximum downward adjustment percentage for median timespan variance.
+///
+/// `PoWMaxAdjustDown * 100` in the Zcash specification.
+pub const POW_MAX_ADJUST_DOWN_PERCENT: i32 = 32;
+
+/// The maximum number of seconds between the `median-time-past` of a block,
+/// and the block's `time` field.
+///
+/// Part of the block header consensus rules in the Zcash specification.
+pub const BLOCK_MAX_TIME_SINCE_MEDIAN: u32 = 90 * 60;
+
+/// Contains the context needed to calculate the adjusted difficulty for a block.
+pub struct AdjustedDifficulty {
+    /// The `header.time` field from the candidate block
+    candidate_time: DateTime<Utc>,
+    /// The coinbase height from the candidate block
+    ///
+    /// If we only have the header, this field is calculated from the previous
+    /// block height.
+    candidate_height: block::Height,
+    /// The configured network
+    network: Network,
+    /// The `header.difficulty_threshold`s from the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
+    /// order.
+    relevant_difficulty_thresholds: BoundedVec<CompactDifficulty, 1, POW_ADJUSTMENT_BLOCK_SPAN>,
+    /// The `header.time`s from the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
+    /// order.
+    ///
+    /// Only the first and last `PoWMedianBlockSpan` times are used. Times
+    /// `11..=16` are ignored.
+    relevant_times: BoundedVec<DateTime<Utc>, 1, POW_ADJUSTMENT_BLOCK_SPAN>,
+}
+
+impl AdjustedDifficulty {
+    /// Initialise and return a new `AdjustedDifficulty` using a `candidate_block`,
+    /// `network`, and a `context`.
+    ///
+    /// The `context` contains the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) `difficulty_threshold`s and
+    /// `time`s from the relevant chain for `candidate_block`, in reverse height
+    /// order, starting with the previous block.
+    ///
+    /// Note that the `time`s might not be in reverse chronological order, because
+    /// block times are supplied by miners.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic in the following cases:
+    /// - The `candidate_block` has no coinbase height (should never happen for valid blocks).
+    /// - The `candidate_block` is the genesis block, so `previous_block_height` cannot be computed.
+    /// - `AdjustedDifficulty::new_from_header_time` panics.
+    pub fn new_from_block<C>(
+        candidate_block: &Block,
+        network: &Network,
+        context: C,
+    ) -> AdjustedDifficulty
+    where
+        C: IntoIterator<Item = (CompactDifficulty, DateTime<Utc>)>,
+    {
+        let candidate_block_height = candidate_block
+            .coinbase_height()
+            .expect("semantically valid blocks have a coinbase height");
+        let previous_block_height = (candidate_block_height - 1)
+            .expect("contextual validation is never run on the genesis block");
+
+        AdjustedDifficulty::new_from_header_time(
+            candidate_block.header.time,
+            previous_block_height,
+            network,
+            context,
+        )
+    }
+
+    /// Initialise and return a new [`AdjustedDifficulty`] using a
+    /// `candidate_header_time`, `previous_block_height`, `network`, and a `context`.
+    ///
+    /// Designed for use when validating block headers, where the full block has not
+    /// been downloaded yet.
+    ///
+    /// See [`Self::new_from_block`] for detailed information about the `context`.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic in the following cases:
+    /// - The next block height is invalid.
+    /// - The `context` iterator is empty, because at least one difficulty threshold
+    ///   and block time are required to construct the `Bounded` vectors.
+    /// - The context iterator is empty, because at least one difficulty threshold and block time are required.
+    pub fn new_from_header_time<C>(
+        candidate_header_time: DateTime<Utc>,
+        previous_block_height: block::Height,
+        network: &Network,
+        context: C,
+    ) -> AdjustedDifficulty
+    where
+        C: IntoIterator<Item = (CompactDifficulty, DateTime<Utc>)>,
+    {
+        let candidate_height = (previous_block_height + 1).expect("next block height is valid");
+
+        let (thresholds, times) = context
+            .into_iter()
+            .take(POW_ADJUSTMENT_BLOCK_SPAN)
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        let relevant_difficulty_thresholds: BoundedVec<
+            CompactDifficulty,
+            1,
+            POW_ADJUSTMENT_BLOCK_SPAN,
+        > = thresholds
+            .try_into()
+            .expect("context must provide a bounded number of difficulty thresholds");
+        let relevant_times: BoundedVec<DateTime<Utc>, 1, POW_ADJUSTMENT_BLOCK_SPAN> = times
+            .try_into()
+            .expect("context must provide a bounded number of block times");
+
+        AdjustedDifficulty {
+            candidate_time: candidate_header_time,
+            candidate_height,
+            network: network.clone(),
+            relevant_difficulty_thresholds,
+            relevant_times,
+        }
+    }
+
+    /// Returns the candidate block's height.
+    pub fn candidate_height(&self) -> block::Height {
+        self.candidate_height
+    }
+
+    /// Returns the candidate block's time field.
+    pub fn candidate_time(&self) -> DateTime<Utc> {
+        self.candidate_time
+    }
+
+    /// Returns the configured network.
+    pub fn network(&self) -> Network {
+        self.network.clone()
+    }
+
+    /// Calculate the expected `difficulty_threshold` for a candidate block, based
+    /// on the `candidate_time`, `candidate_height`, `network`, and the
+    /// `difficulty_threshold`s and `time`s from the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks in the relevant chain.
+    ///
+    /// Implements `ThresholdBits` from the Zcash specification, and the Testnet
+    /// minimum difficulty adjustment from ZIPs 205 and 208.
+    pub fn expected_difficulty_threshold(&self) -> CompactDifficulty {
+        if NetworkUpgrade::is_testnet_min_difficulty_block(
+            &self.network,
+            self.candidate_height,
+            self.candidate_time,
+            *self.relevant_times.first(),
+        ) {
+            assert!(
+                self.network.is_a_test_network(),
+                "invalid network: the minimum difficulty rule only applies on test networks"
+            );
+            self.network.target_difficulty_limit().to_compact()
+        } else {
+            self.threshold_bits()
+        }
+    }
+
+    /// Calculate the `difficulty_threshold` for a candidate block, based on the
+    /// `candidate_height`, `network`, and the relevant `difficulty_threshold`s and
+    /// `time`s.
+    ///
+    /// See [`Self::expected_difficulty_threshold`] for details.
+    ///
+    /// Implements `ThresholdBits` from the Zcash specification. (Which excludes the
+    /// Testnet minimum difficulty adjustment.)
+    fn threshold_bits(&self) -> CompactDifficulty {
+        let averaging_window_height = u32::try_from(POW_AVERAGING_WINDOW)
+            .expect("averaging window is much smaller than u32::MAX");
+
+        if self.candidate_height.0 <= averaging_window_height {
+            // # Consensus
+            //
+            // `ThresholdBits(height)` is `PoWLimit` for `height <= PoWAveragingWindow`.
+            // Zebra's full-block contextual validation on Mainnet and Testnet
+            // starts after the mandatory checkpoint, so this early-chain path is
+            // only reachable through header sync and non-checkpointed test networks.
+            return self.network.target_difficulty_limit().to_compact();
+        }
+
+        let averaging_window_timespan = NetworkUpgrade::averaging_window_timespan_for_height(
+            &self.network,
+            self.candidate_height,
+        );
+
+        let threshold = (self.mean_target_difficulty() / averaging_window_timespan.num_seconds())
+            * self.median_timespan_bounded().num_seconds();
+        let threshold = min(self.network.target_difficulty_limit(), threshold);
+
+        threshold.to_compact()
+    }
+
+    /// Calculate the arithmetic mean of the averaging window thresholds: the
+    /// expanded `difficulty_threshold`s from the previous `PoWAveragingWindow` (17)
+    /// blocks in the relevant chain.
+    ///
+    /// Implements `MeanTarget` from the Zcash specification.
+    fn mean_target_difficulty(&self) -> ExpandedDifficulty {
+        // `threshold_bits` returns `PoWLimit` before calling this function for
+        // early-chain heights. At later heights, a valid relevant chain contains
+        // at least 17 blocks.
+
+        let averaging_window_thresholds =
+            if self.relevant_difficulty_thresholds.len() >= POW_AVERAGING_WINDOW {
+                &self.relevant_difficulty_thresholds.as_slice()[0..POW_AVERAGING_WINDOW]
+            } else {
+                return self.network.target_difficulty_limit();
+            };
+
+        // Since the PoWLimits are `2^251 − 1` for Testnet, and `2^243 − 1` for
+        // Mainnet, the sum of 17 `ExpandedDifficulty` will be less than or equal
+        // to: `(2^251 − 1) * 17 = 2^255 + 2^251 - 17`. Therefore, the sum can
+        // not overflow a u256 value.
+        let total: ExpandedDifficulty = averaging_window_thresholds
+            .iter()
+            .map(|compact| {
+                compact
+                    .to_expanded()
+                    .expect("difficulty thresholds in previously verified blocks are valid")
+            })
+            .sum();
+
+        let divisor: U256 = POW_AVERAGING_WINDOW.into();
+        total / divisor
+    }
+
+    /// Calculate the bounded median timespan. The median timespan is the
+    /// difference of medians of the timespan times, which are the `time`s from
+    /// the previous `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks in the
+    /// relevant chain.
+    ///
+    /// Uses the candidate block's `height' and `network` to calculate the
+    /// `AveragingWindowTimespan` for that block.
+    ///
+    /// The median timespan is damped by the `PoWDampingFactor`, and bounded by
+    /// `PoWMaxAdjustDown` and `PoWMaxAdjustUp`.
+    ///
+    /// Implements `ActualTimespanBounded` from the Zcash specification.
+    ///
+    /// Note: This calculation only uses `PoWMedianBlockSpan` (11) times at the
+    /// start and end of the timespan times. timespan times `[11..=16]` are ignored.
+    fn median_timespan_bounded(&self) -> Duration {
+        let averaging_window_timespan = NetworkUpgrade::averaging_window_timespan_for_height(
+            &self.network,
+            self.candidate_height,
+        );
+        // This value is exact, but we need to truncate its nanoseconds component
+        let damped_variance =
+            (self.median_timespan() - averaging_window_timespan) / POW_DAMPING_FACTOR;
+        // num_seconds truncates negative values towards zero, matching the Zcash specification
+        let damped_variance = Duration::seconds(damped_variance.num_seconds());
+
+        // `ActualTimespanDamped` in the Zcash specification
+        let median_timespan_damped = averaging_window_timespan + damped_variance;
+
+        // `MinActualTimespan` and `MaxActualTimespan` in the Zcash spec
+        let min_median_timespan =
+            averaging_window_timespan * (100 - POW_MAX_ADJUST_UP_PERCENT) / 100;
+        let max_median_timespan =
+            averaging_window_timespan * (100 + POW_MAX_ADJUST_DOWN_PERCENT) / 100;
+
+        // `ActualTimespanBounded` in the Zcash specification
+        max(
+            min_median_timespan,
+            min(max_median_timespan, median_timespan_damped),
+        )
+    }
+
+    /// Calculate the median timespan. The median timespan is the difference of
+    /// medians of the timespan times, which are the `time`s from the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks in the relevant chain.
+    ///
+    /// Implements `ActualTimespan` from the Zcash specification.
+    ///
+    /// See [`Self::median_timespan_bounded`] for details.
+    fn median_timespan(&self) -> Duration {
+        let newer_median = self.median_time_past();
+
+        // MedianTime(height : N) := median([ nTime(𝑖) for 𝑖 from max(0, height − PoWMedianBlockSpan) up to max(0, height − 1) ])
+        let older_median = if self.relevant_times.len() > POW_AVERAGING_WINDOW {
+            let older_times: Vec<_> = self
+                .relevant_times
+                .iter()
+                .skip(POW_AVERAGING_WINDOW)
+                .cloned()
+                .take(POW_MEDIAN_BLOCK_SPAN)
+                .collect();
+
+            AdjustedDifficulty::median_time(older_times)
+        } else {
+            *self.relevant_times.last()
+        };
+
+        // `ActualTimespan` in the Zcash specification
+        newer_median - older_median
+    }
+
+    /// Calculate the median of the `time`s from the previous
+    /// `PoWMedianBlockSpan` (11) blocks in the relevant chain.
+    ///
+    /// Implements `median-time-past` and `MedianTime(candidate_height)` from the
+    /// Zcash specification. (These functions are identical, but they are
+    /// specified in slightly different ways.)
+    pub fn median_time_past(&self) -> DateTime<Utc> {
+        let median_times: Vec<DateTime<Utc>> = self
+            .relevant_times
+            .iter()
+            .take(POW_MEDIAN_BLOCK_SPAN)
+            .cloned()
+            .collect();
+
+        AdjustedDifficulty::median_time(median_times)
+    }
+
+    /// Calculate the median of the `median_block_span_times`: the `time`s from a
+    /// Vec of `PoWMedianBlockSpan` (11) or fewer blocks in the relevant chain.
+    ///
+    /// Implements `MedianTime` from the Zcash specification.
+    ///
+    /// # Panics
+    ///
+    /// If provided an empty Vec
+    pub fn median_time(mut median_block_span_times: Vec<DateTime<Utc>>) -> DateTime<Utc> {
+        median_block_span_times.sort_unstable();
+
+        // > median(𝑆) := sorted(𝑆)_{ceiling((length(𝑆)+1)/2)}
+        // <https://zips.z.cash/protocol/protocol.pdf>, section 7.7.3, Difficulty Adjustment (p. 132)
+        let median_idx = median_block_span_times.len() / 2;
+        median_block_span_times[median_idx]
+    }
+}
+
+/// Contextual candidate time or difficulty failure.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum ContextualValidationError {
+    /// Candidate time is not strictly greater than median-time-past.
+    #[error("block time {candidate_time:?} is less than or equal to median-time-past {median_time_past:?}")]
+    TimeTooEarly {
+        /// Candidate header time.
+        candidate_time: DateTime<Utc>,
+        /// Median of the preceding header times.
+        median_time_past: DateTime<Utc>,
+    },
+    /// Candidate time exceeds the active 90-minute median-time-past limit.
+    #[error("block time {candidate_time:?} exceeds maximum {block_time_max:?}")]
+    TimeTooLate {
+        /// Candidate header time.
+        candidate_time: DateTime<Utc>,
+        /// Inclusive maximum candidate time.
+        block_time_max: DateTime<Utc>,
+    },
+    /// Candidate compact target does not match the contextual expected target.
+    #[error(
+        "block difficulty {difficulty_threshold:?} does not match expected {expected_difficulty:?}"
+    )]
+    InvalidDifficultyThreshold {
+        /// Candidate header compact target.
+        difficulty_threshold: CompactDifficulty,
+        /// Compact target calculated from the branch-local context.
+        expected_difficulty: CompactDifficulty,
+    },
+}
+
+/// Validate contextual median-time and compact-target rules using exact branch-local context.
+pub fn validate_contextual_difficulty_and_time(
+    difficulty_threshold: CompactDifficulty,
+    difficulty_adjustment: AdjustedDifficulty,
+) -> Result<(), ContextualValidationError> {
+    let candidate_height = difficulty_adjustment.candidate_height();
+    let candidate_time = difficulty_adjustment.candidate_time();
+    let network = difficulty_adjustment.network();
+    let median_time_past = difficulty_adjustment.median_time_past();
+    let block_time_max = median_time_past + Duration::seconds(BLOCK_MAX_TIME_SINCE_MEDIAN.into());
+
+    let genesis_height = NetworkUpgrade::Genesis
+        .activation_height(&network)
+        .expect("Zakura always has a genesis height available");
+
+    if candidate_time <= median_time_past && candidate_height != genesis_height {
+        return Err(ContextualValidationError::TimeTooEarly {
+            candidate_time,
+            median_time_past,
+        });
+    }
+
+    // Mainnet height 1 and Testnet heights below 653,606 are outside this rule.
+    if candidate_height.0 >= 2
+        && network.is_max_block_time_enforced(candidate_height)
+        && candidate_time > block_time_max
+    {
+        return Err(ContextualValidationError::TimeTooLate {
+            candidate_time,
+            block_time_max,
+        });
+    }
+
+    let expected_difficulty = difficulty_adjustment.expected_difficulty_threshold();
+    if network.disable_pow() {
+        if difficulty_threshold.to_work().is_none() {
+            return Err(ContextualValidationError::InvalidDifficultyThreshold {
+                difficulty_threshold,
+                expected_difficulty,
+            });
+        }
+    } else if difficulty_threshold != expected_difficulty {
+        return Err(ContextualValidationError::InvalidDifficultyThreshold {
+            difficulty_threshold,
+            expected_difficulty,
+        });
+    }
+
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/validation/mod.rs
+++ b/crates/zakura-header-chain/src/validation/mod.rs
@@ -1,5 +1,18 @@
 //! Shared synchronous observable-header validation primitives.
 
+mod contextual;
+mod prepare;
+
+pub use contextual::{
+    validate_contextual_difficulty_and_time, AdjustedDifficulty, ContextualValidationError,
+    BLOCK_MAX_TIME_SINCE_MEDIAN, POW_ADJUSTMENT_BLOCK_SPAN, POW_MEDIAN_BLOCK_SPAN,
+    POW_PREDECESSOR_CONTEXT_SPAN,
+};
+pub use prepare::{
+    prepare_context_free_headers, prepare_headers, HeaderBatchInput, HeaderFailure, HeaderRule,
+    HeaderRules,
+};
+
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 use zakura_chain::{

--- a/crates/zakura-header-chain/src/validation/prepare.rs
+++ b/crates/zakura-header-chain/src/validation/prepare.rs
@@ -1,0 +1,329 @@
+//! Sealed validation of complete observable-header batches.
+
+use std::sync::Arc;
+
+use chrono::Duration;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use zakura_chain::{block, parameters::Network};
+
+use super::{
+    infer_height, validate_commitment_structure, validate_compact_target,
+    validate_contextual_difficulty_and_time, validate_encoding_version_hash, validate_hash_filter,
+    AdjustedDifficulty, PowPolicy, PowPolicyError, POW_ADJUSTMENT_BLOCK_SPAN,
+};
+use crate::{
+    Clock, EngineConfig, EvidenceId, HeaderContextFact, HeaderValidationState, PreparedHeader,
+    PreparedHeaderBatch, RuleId, ValidationLease,
+};
+
+/// Ordered, nonempty canonical headers to validate against one exact parent lease.
+#[derive(Copy, Clone, Debug)]
+pub struct HeaderBatchInput<'a> {
+    /// Headers in exact parent-first wire order.
+    pub headers: &'a [Arc<block::Header>],
+}
+
+impl<'a> HeaderBatchInput<'a> {
+    /// Construct an input over one complete target response assembled by the requester.
+    pub const fn new(headers: &'a [Arc<block::Header>]) -> Self {
+        Self { headers }
+    }
+}
+
+/// Immutable authenticated rules used by the pure preparation pipeline.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HeaderRules {
+    network: Network,
+    pow_policy: PowPolicy,
+    trust_anchor_digest: [u8; 32],
+}
+
+impl HeaderRules {
+    /// Derive rules only from the validated engine configuration.
+    pub fn from_engine_config(config: &EngineConfig) -> Result<Self, PowPolicyError> {
+        Ok(Self {
+            network: config.network.clone(),
+            pow_policy: PowPolicy::for_network(&config.network)?,
+            trust_anchor_digest: config.trust_anchor_digest(),
+        })
+    }
+
+    /// Bind authenticated network parameters to a state-issued validation lease. The state
+    /// transition independently rechecks the lease's anchor digest before any mutation.
+    pub fn for_validation_lease(
+        network: Network,
+        lease: &ValidationLease,
+    ) -> Result<Self, PowPolicyError> {
+        Ok(Self {
+            pow_policy: PowPolicy::for_network(&network)?,
+            network,
+            trust_anchor_digest: lease.trust_anchor_digest,
+        })
+    }
+
+    /// Return the authenticated network parameters bound into these rules.
+    pub fn network(&self) -> &Network {
+        &self.network
+    }
+
+    /// Return the authenticated trust-anchor identity sealed into preparation receipts.
+    pub const fn trust_anchor_digest(&self) -> [u8; 32] {
+        self.trust_anchor_digest
+    }
+}
+
+/// Stable preparation stage used for peer attribution and conformance diagnostics.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderRule {
+    /// Canonical signed version and full-header hash.
+    EncodingVersionHash,
+    /// Exact parent and internal linkage.
+    ParentLink,
+    /// Checked local height inference.
+    InferredHeight,
+    /// Height-dependent commitment interpretation.
+    CommitmentStructure,
+    /// Compact target domain and network limit.
+    CompactTarget,
+    /// Header hash at or below its target.
+    HashToTarget,
+    /// Network-bound Equihash shape and proof.
+    Equihash,
+    /// Branch-local target adjustment and median-time rules.
+    ContextualDifficultyAndTime,
+    /// Local-clock future-header classification.
+    LocalFutureTime,
+    /// Exact durable validation lease and trust-anchor identity.
+    ValidationLease,
+    /// Exact per-block work calculation.
+    Work,
+}
+
+impl HeaderRule {
+    /// Return every normative rule implemented by this validation stage.
+    pub const fn rule_ids(self) -> &'static [RuleId] {
+        const ENCODING_VERSION_HASH: &[RuleId] = &[RuleId::new("LC-VAL-02")];
+        const PARENT_LINK: &[RuleId] = &[RuleId::new("LC-VAL-03")];
+        const INFERRED_HEIGHT: &[RuleId] = &[RuleId::new("LC-HEIGHT-01")];
+        const COMMITMENT_STRUCTURE: &[RuleId] =
+            &[RuleId::new("LC-COMMIT-01"), RuleId::new("LC-COMMIT-02")];
+        const TARGET: &[RuleId] = &[RuleId::new("LC-VAL-05")];
+        const EQUIHASH: &[RuleId] = &[RuleId::new("LC-VAL-04")];
+        const CONTEXTUAL_DIFFICULTY_AND_TIME: &[RuleId] = &[
+            RuleId::new("LC-VAL-06"),
+            RuleId::new("LC-VAL-07"),
+            RuleId::new("LC-TIME-01"),
+        ];
+        const LOCAL_FUTURE_TIME: &[RuleId] = &[RuleId::new("LC-VAL-08")];
+        const VALIDATION_LEASE: &[RuleId] =
+            &[RuleId::new("LC-ANCHOR-03"), RuleId::new("LC-VAL-11")];
+        const WORK: &[RuleId] = &[RuleId::new("LC-VAL-10")];
+
+        match self {
+            Self::EncodingVersionHash => ENCODING_VERSION_HASH,
+            Self::ParentLink => PARENT_LINK,
+            Self::InferredHeight => INFERRED_HEIGHT,
+            Self::CommitmentStructure => COMMITMENT_STRUCTURE,
+            Self::CompactTarget | Self::HashToTarget => TARGET,
+            Self::Equihash => EQUIHASH,
+            Self::ContextualDifficultyAndTime => CONTEXTUAL_DIFFICULTY_AND_TIME,
+            Self::LocalFutureTime => LOCAL_FUTURE_TIME,
+            Self::ValidationLease => VALIDATION_LEASE,
+            Self::Work => WORK,
+        }
+    }
+}
+
+/// Failure to prepare a batch. Only local future time is represented in a successful batch.
+#[derive(Debug, Error)]
+pub enum HeaderFailure {
+    /// The caller supplied no headers for an insertion event.
+    #[error("header batch is empty")]
+    Empty,
+    /// Durable state supplied an incoherent or stale validation lease.
+    #[error("validation lease is incoherent with the authenticated header rules")]
+    InvalidLease,
+    /// One deterministic observable-header rule failed.
+    #[error("header at offset {offset} failed {rule:?}: {reason}")]
+    Invalid {
+        /// Zero-based header offset.
+        offset: usize,
+        /// Exact failed stage.
+        rule: HeaderRule,
+        /// Stable human-readable source description.
+        reason: String,
+    },
+    /// A local time calculation exceeded the representable timestamp range.
+    #[error("local future-time boundary is outside the representable timestamp range")]
+    ClockRange,
+}
+
+fn invalid(offset: usize, rule: HeaderRule, error: impl std::fmt::Display) -> HeaderFailure {
+    HeaderFailure::Invalid {
+        offset,
+        rule,
+        reason: error.to_string(),
+    }
+}
+
+/// Validate a complete batch without reading retained graph state.
+pub fn prepare_context_free_headers(
+    input: HeaderBatchInput<'_>,
+    parent: crate::Frontier,
+    rules: &HeaderRules,
+    clock: &dyn Clock,
+) -> Result<PreparedHeaderBatch, HeaderFailure> {
+    prepare_headers_inner(input, parent, None, rules, clock)
+}
+
+/// Validate a complete batch without mutation and seal its results to `lease`.
+///
+/// This compatibility entry point retains contextual validation until production callers have
+/// moved to [`prepare_context_free_headers`] and the engine performs the graph-dependent rules.
+pub fn prepare_headers(
+    input: HeaderBatchInput<'_>,
+    lease: &ValidationLease,
+    rules: &HeaderRules,
+    clock: &dyn Clock,
+) -> Result<PreparedHeaderBatch, HeaderFailure> {
+    let required_predecessors = usize::try_from(lease.parent.height.0)
+        .map_err(|_| HeaderFailure::InvalidLease)?
+        .checked_add(1)
+        .ok_or(HeaderFailure::InvalidLease)?
+        .min(POW_ADJUSTMENT_BLOCK_SPAN);
+    if lease.trust_anchor_digest != rules.trust_anchor_digest
+        || lease.predecessors.first().map(|fact| fact.frontier) != Some(lease.parent)
+        || lease.predecessors.len() != required_predecessors
+    {
+        return Err(HeaderFailure::InvalidLease);
+    }
+    prepare_headers_inner(input, lease.parent, Some(lease), rules, clock)
+}
+
+fn prepare_headers_inner(
+    input: HeaderBatchInput<'_>,
+    parent_frontier: crate::Frontier,
+    contextual_lease: Option<&ValidationLease>,
+    rules: &HeaderRules,
+    clock: &dyn Clock,
+) -> Result<PreparedHeaderBatch, HeaderFailure> {
+    if input.headers.is_empty() {
+        return Err(HeaderFailure::Empty);
+    }
+
+    let hashes: Vec<_> = input
+        .headers
+        .iter()
+        .enumerate()
+        .map(|(offset, header)| {
+            validate_encoding_version_hash(header)
+                .map_err(|error| invalid(offset, HeaderRule::EncodingVersionHash, error))
+        })
+        .collect::<Result<_, _>>()?;
+    if contextual_lease.is_some() {
+        let mut expected_parent = parent_frontier.hash;
+        for (offset, (header, hash)) in input.headers.iter().zip(&hashes).enumerate() {
+            if header.previous_block_hash != expected_parent {
+                let error = super::HeaderLinkError {
+                    offset,
+                    expected: expected_parent,
+                    actual: header.previous_block_hash,
+                };
+                return Err(invalid(offset, HeaderRule::ParentLink, error));
+            }
+            expected_parent = *hash;
+        }
+    }
+
+    let now = clock.now();
+    let future_limit = now
+        .checked_add_signed(Duration::hours(2))
+        .ok_or(HeaderFailure::ClockRange)?;
+    let mut parent = parent_frontier;
+    let mut context = contextual_lease.map(|lease| lease.predecessors.clone());
+    let mut prepared = Vec::with_capacity(input.headers.len());
+
+    for (offset, header) in input.headers.iter().enumerate() {
+        let hash = hashes[offset];
+        let height = infer_height(parent.height, None)
+            .map_err(|error| invalid(offset, HeaderRule::InferredHeight, error))?;
+        validate_commitment_structure(header, &rules.network, height)
+            .map_err(|error| invalid(offset, HeaderRule::CommitmentStructure, error))?;
+        let target = validate_compact_target(header, &rules.network)
+            .map_err(|error| invalid(offset, HeaderRule::CompactTarget, error))?;
+        if !rules.pow_policy.is_authenticated_custom_waiver() {
+            validate_hash_filter(hash, target)
+                .map_err(|error| invalid(offset, HeaderRule::HashToTarget, error))?;
+        }
+        rules
+            .pow_policy
+            .validate_solution(header)
+            .map_err(|error| invalid(offset, HeaderRule::Equihash, error))?;
+
+        if let Some(context) = context.as_ref() {
+            let adjustment = AdjustedDifficulty::new_from_header_time(
+                header.time,
+                parent.height,
+                &rules.network,
+                context
+                    .iter()
+                    .map(|fact| (fact.difficulty_threshold, fact.time)),
+            );
+            validate_contextual_difficulty_and_time(header.difficulty_threshold, adjustment)
+                .map_err(|error| invalid(offset, HeaderRule::ContextualDifficultyAndTime, error))?;
+        }
+
+        let validation = if header.time > future_limit {
+            HeaderValidationState::DeferredUntil(
+                header
+                    .time
+                    .checked_sub_signed(Duration::hours(2))
+                    .ok_or(HeaderFailure::ClockRange)?,
+            )
+        } else {
+            HeaderValidationState::Valid
+        };
+        let block_work = header
+            .difficulty_threshold
+            .to_work()
+            .ok_or_else(|| invalid(offset, HeaderRule::Work, "invalid compact target"))?;
+
+        prepared.push(PreparedHeader {
+            header: header.clone(),
+            hash,
+            height,
+            block_work,
+            validation,
+        });
+        parent = crate::Frontier::new(height, hash);
+        if let Some(context) = context.as_mut() {
+            context.insert(
+                0,
+                HeaderContextFact {
+                    frontier: parent,
+                    difficulty_threshold: header.difficulty_threshold,
+                    time: header.time,
+                },
+            );
+            context.truncate(POW_ADJUSTMENT_BLOCK_SPAN);
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"zakura-header-chain-context-free-batch-v1");
+    hasher.update(parent_frontier.height.0.to_le_bytes());
+    hasher.update(parent_frontier.hash.0);
+    hasher.update(rules.trust_anchor_digest);
+    for header in &prepared {
+        hasher.update(header.height.0.to_le_bytes());
+        hasher.update(header.hash.0);
+    }
+    PreparedHeaderBatch::new(
+        prepared,
+        parent_frontier,
+        rules.trust_anchor_digest,
+        EvidenceId::from_digest(hasher.finalize().into()),
+    )
+    .map_err(|error| invalid(0, HeaderRule::ValidationLease, error))
+}

--- a/docs/changelog/unreleased/560.md
+++ b/docs/changelog/unreleased/560.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR is one review layer of the header-sync stack; the stack's single
+operator-visible entry is owned by #532.


### PR DESCRIPTION
> Stack layer **2/15** (bottom to top) in stack **#573**. Review after **#559**; **#561** is next.
> GitHub shows only this layer's diff.

## Motivation

Graph mutations, contextual checks, finality, and recovery need one versioned authority. Independently mutating indexes made crash consistency and deterministic fork selection difficult to reason about.

## Solution

Add contextual validation and a pure transition planner that emits checked sparse deltas for one atomic store commit, including finality rebase, incremental indexes, recovery, and the later audit corrections. The implementation is the final audited form rather than an initial version followed by fixups.

## Testing

- \`cargo check -j 2 -p zakura-header-chain --lib\`
- \`cargo clippy -j 2 -p zakura-header-chain --lib -- -D warnings\`
- Exhaustive and property coverage lands in #561.

## Changelog

\`docs/changelog/unreleased/560.md\` explicitly excludes this review slice. The stack's operator-visible entry is owned by #532.

### Specifications & References

- Model dependency: #559.
- Normative transition rules: #572.

### Follow-up Work

Review #561 for the invariant and projection test suite.
