### PR TITLE
test(header-chain): cover fork and transition invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8483,9 +8483,12 @@ name = "zakura-header-chain"
 version = "1.0.0-rc0"
 dependencies = [
  "chrono",
+ "proptest",
  "sha2 0.10.9",
  "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
  "zakura-chain",
+ "zakura-test",
 ]
 
 [[package]]

--- a/crates/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/crates/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -350,6 +350,27 @@ fn configured_nu6_3_activation_preserves_upgrade_order() {
     assert_eq!(out_of_order, ParametersBuilderError::OutOfOrderUpgrades);
 }
 
+#[test]
+fn configured_max_block_time_policy_is_local() {
+    let public_testnet = Network::new_default_testnet();
+    assert!(!public_testnet.is_max_block_time_enforced(Height(653_605)));
+    assert!(public_testnet.is_max_block_time_enforced(Height(653_606)));
+
+    let custom = testnet::Parameters::build()
+        .to_network()
+        .expect("the default custom-network builder is valid");
+    assert!(!custom.is_max_block_time_enforced(Height(1)));
+    assert!(custom.is_max_block_time_enforced(Height(2)));
+
+    let configured_height = Height(42);
+    let configured = testnet::Parameters::build()
+        .with_max_block_time_start_height(configured_height)
+        .to_network()
+        .expect("the configured max-time policy is valid");
+    assert!(!configured.is_max_block_time_enforced(Height(41)));
+    assert!(configured.is_max_block_time_enforced(configured_height));
+}
+
 /// Regtest must not activate NU6.3 unless it is explicitly configured, and
 /// must preserve a configured NU6.3 height in its activation map.
 #[test]

--- a/crates/zakura-chain/src/work/difficulty/arbitrary.rs
+++ b/crates/zakura-chain/src/work/difficulty/arbitrary.rs
@@ -46,10 +46,11 @@ impl Arbitrary for Work {
     type Parameters = ();
 
     fn arbitrary_with(_args: ()) -> Self::Strategy {
-        // In the Zcash protocol, a Work is converted from an ExpandedDifficulty.
-        // But some randomised difficulties are impractically large, and will
-        // never appear in any real-world block. So we just use a random Work value.
-        (1..u128::MAX).prop_map(Work).boxed()
+        // Keep the established practical-work distribution used by state test
+        // generators. Full-width boundaries have deterministic vectors.
+        (1..u128::MAX)
+            .prop_map(|work| Work(U256::from(work)))
+            .boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;

--- a/crates/zakura-chain/src/work/difficulty/tests/prop.rs
+++ b/crates/zakura-chain/src/work/difficulty/tests/prop.rs
@@ -39,12 +39,11 @@ proptest! {
             let expanded_trip = compact_trip.to_expanded().expect("roundtrip expanded is valid");
             prop_assert_eq!(expanded_trunc, expanded_trip);
 
-            // Some impossibly hard compact values are not valid work values in Zebra
-            if let Some(work) = work {
-                // roundtrip
-                let work_trip = compact_trip.to_work().expect("roundtrip work is valid if work is valid");
-                prop_assert_eq!(work, work_trip);
-            }
+            let work = work.expect("every positive 256-bit target has representable work");
+            let work_trip = compact_trip
+                .to_work()
+                .expect("roundtrip positive target has representable work");
+            prop_assert_eq!(work, work_trip);
         }
     }
 
@@ -53,8 +52,8 @@ proptest! {
     /// Make sure the conversions don't panic, and that they compare correctly.
     #[test]
     fn prop_work_conversion(work in any::<Work>()) {
-        let work_zero = Work(0);
-        let work_max = Work(u128::MAX);
+        let work_zero = Work(U256::zero());
+        let work_max = Work(U256::MAX);
 
         prop_assert!(work > work_zero);
         // similarly, the maximum compact value has less precision than work
@@ -161,9 +160,8 @@ proptest! {
             prop_assert!(compact1 == compact2);
         }
 
-        // Skip impossibly hard work values
-        prop_assume!(work1.is_some());
-        prop_assume!(work2.is_some());
+        prop_assert!(work1.is_some());
+        prop_assert!(work2.is_some());
 
         match expanded1_seed.cmp(&expanded2_seed) {
             Ordering::Greater => {

--- a/crates/zakura-chain/src/work/difficulty/tests/vectors.rs
+++ b/crates/zakura-chain/src/work/difficulty/tests/vectors.rs
@@ -57,18 +57,18 @@ fn debug_format() {
         "ExpandedDifficulty(\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\")"
     );
 
-    assert_eq!(format!("{:?}", Work(0)), "Work(0x0, 0, -inf)");
-    assert_eq!(format!("{:?}", Work(1)), "Work(0x1, 1, 0.00000)");
+    assert_eq!(format!("{:?}", Work(U256::zero())), "Work(0x0, 0, -inf)");
+    assert_eq!(format!("{:?}", Work(U256::one())), "Work(0x1, 1, 0.00000)");
     assert_eq!(
-        format!("{:?}", Work(u8::MAX as u128)),
+        format!("{:?}", Work(U256::from(u8::MAX))),
         "Work(0xff, 255, 7.99435)"
     );
     assert_eq!(
-        format!("{:?}", Work(u64::MAX as u128)),
+        format!("{:?}", Work(U256::from(u64::MAX))),
         "Work(0xffffffffffffffff, 18446744073709551615, 64.00000)"
     );
     assert_eq!(
-        format!("{:?}", Work(u128::MAX)),
+        format!("{:?}", Work(U256::from(u128::MAX))),
         "Work(0xffffffffffffffffffffffffffffffff, 340282366920938463463374607431768211455, 128.00000)"
     );
 }
@@ -112,7 +112,7 @@ fn compact_extremes() {
 
     // Values equal to one
     let expanded_one = Some(ExpandedDifficulty(U256::one()));
-    let work_one = None;
+    let work_one = Some(Work(U256::one() << 255));
 
     let canonical_one = CompactDifficulty((1 << PRECISION) + (1 << 16));
     assert_eq!(canonical_one.to_expanded(), expanded_one);
@@ -132,7 +132,8 @@ fn compact_extremes() {
 
     // Maximum mantissa
     let expanded_mant = Some(ExpandedDifficulty(UNSIGNED_MANTISSA_MASK.into()));
-    let work_mant = None;
+    let expanded_mant_value = U256::from(UNSIGNED_MANTISSA_MASK);
+    let work_mant = Some(Work((!expanded_mant_value / (expanded_mant_value + 1)) + 1));
 
     let mant = CompactDifficulty(OFFSET as u32 * (1 << PRECISION) + UNSIGNED_MANTISSA_MASK);
     assert_eq!(mant.to_expanded(), expanded_mant);
@@ -143,9 +144,7 @@ fn compact_extremes() {
     let exponent: U256 = (31 * 8).into();
     let u256_exp = U256::from(2).pow(exponent);
     let expanded_exp = Some(ExpandedDifficulty(u256_exp));
-    let work_exp = Some(Work(
-        ((U256::MAX - u256_exp) / (u256_exp + 1) + 1).as_u128(),
-    ));
+    let work_exp = Some(Work((!u256_exp / (u256_exp + 1)) + 1));
 
     let canonical_exp =
         CompactDifficulty(((31 + OFFSET - 2) as u32) * (1 << PRECISION) + (1 << 16));
@@ -167,7 +166,7 @@ fn compact_extremes() {
     let exponent: U256 = (29 * 8).into();
     let u256_me = U256::from(UNSIGNED_MANTISSA_MASK) * U256::from(2).pow(exponent);
     let expanded_me = Some(ExpandedDifficulty(u256_me));
-    let work_me = Some(Work((!u256_me / (u256_me + 1) + 1).as_u128()));
+    let work_me = Some(Work((!u256_me / (u256_me + 1)) + 1));
 
     let me = CompactDifficulty((31 + 1) * (1 << PRECISION) + UNSIGNED_MANTISSA_MASK);
     assert_eq!(me.to_expanded(), expanded_me);
@@ -193,7 +192,7 @@ fn compact_extremes() {
     let difficulty_btc_main = CompactDifficulty(0x1d00ffff);
     let u256_btc_main = U256::from(0xffff) << 208;
     let expanded_btc_main = Some(ExpandedDifficulty(u256_btc_main));
-    let work_btc_main = Some(Work(0x100010001));
+    let work_btc_main = Some(Work(U256::from(0x100010001_u64)));
     assert_eq!(difficulty_btc_main.to_expanded(), expanded_btc_main);
     assert_eq!(
         difficulty_btc_main.to_expanded().unwrap().to_compact(),
@@ -206,7 +205,7 @@ fn compact_extremes() {
     let difficulty_btc_reg = CompactDifficulty(0x207fffff);
     let u256_btc_reg = U256::from(0x7fffff) << 232;
     let expanded_btc_reg = Some(ExpandedDifficulty(u256_btc_reg));
-    let work_btc_reg = Some(Work(0x2));
+    let work_btc_reg = Some(Work(U256::from(0x2_u8)));
     assert_eq!(difficulty_btc_reg.to_expanded(), expanded_btc_reg);
     assert_eq!(
         difficulty_btc_reg.to_expanded().unwrap().to_compact(),
@@ -215,18 +214,69 @@ fn compact_extremes() {
     assert_eq!(difficulty_btc_reg.to_work(), work_btc_reg);
 }
 
+/// HV-07: exact per-block work remains representable above `u128::MAX`.
+///
+/// The smallest target produces the largest representable work, so these
+/// boundary cases are sufficient to catch accidental narrowing to `u128`.
+#[test]
+fn per_block_work_preserves_values_above_u128() {
+    let target_one = CompactDifficulty((1 << PRECISION) + (1 << 16));
+    let work = target_one
+        .to_work()
+        .expect("a positive target has representable 256-bit work");
+
+    assert_eq!(work.as_u256(), U256::one() << 255);
+    assert!(work.as_u256() > U256::from(u128::MAX));
+    assert_eq!(
+        Work::try_from(ExpandedDifficulty(U256::MAX)),
+        Ok(Work(U256::one()))
+    );
+    assert_eq!(Work::try_from(ExpandedDifficulty(U256::zero())), Err(()));
+}
+
+/// HV-07: cumulative work reaches `U256::MAX` exactly and rejects overflow.
+///
+/// Testing the final successful addition and the immediately following
+/// overflow covers the full-width checked-add boundary.
+#[test]
+fn cumulative_work_checks_u256_boundary() {
+    let one = Work(U256::one());
+    let below_max = PartialCumulativeWork(U256::MAX - 1);
+    let max = below_max
+        .checked_add(one)
+        .expect("adding one below the limit reaches the exact limit");
+
+    assert_eq!(max.as_u256(), U256::MAX);
+    assert_eq!(max.checked_add(one), None);
+    assert!(std::panic::catch_unwind(|| max + one).is_err());
+}
+
 /// Bitcoin test vectors for CompactDifficulty, and their corresponding
 /// ExpandedDifficulty and Work values.
 /// See <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
-static COMPACT_DIFFICULTY_CASES: &[(u32, Option<u128>, Option<u128>)] = &[
-    // These Work values will never happen in practice, because the corresponding
-    // difficulties are extremely high. So it is ok for us to reject them.
+static COMPACT_DIFFICULTY_CASES: &[(u32, Option<u128>, Option<&str>)] = &[
     (0x01003456, None /* 0x00 */, None),
-    (0x01123456, Some(0x12), None),
-    (0x02008000, Some(0x80), None),
-    (0x05009234, Some(0x92340000), None),
+    (
+        0x01123456,
+        Some(0x12),
+        Some("0d79435e50d79435e50d79435e50d79435e50d79435e50d79435e50d79435e50"),
+    ),
+    (
+        0x02008000,
+        Some(0x80),
+        Some("01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f0"),
+    ),
+    (
+        0x05009234,
+        Some(0x92340000),
+        Some("00000001c040c95a099201bcaf85db4e7f2e21e18707c8d55a887643b95afb2f"),
+    ),
     (0x04923456, None /* -0x12345600 */, None),
-    (0x04123456, Some(0x12345600), None),
+    (
+        0x04123456,
+        Some(0x12345600),
+        Some("0000000e10005c64415f04ef3e387b97db388404db9fdfaab2b1918f6783471d"),
+    ),
 ];
 
 /// Test Bitcoin test vectors for CompactDifficulty.
@@ -240,7 +290,9 @@ fn compact_bitcoin_test_vectors() {
         /// SPANDOC: Convert compact to expanded and work {?compact, ?expected_expanded, ?expected_work}
         {
             let expected_expanded = expected_expanded.map(U256::from).map(ExpandedDifficulty);
-            let expected_work = expected_work.map(Work);
+            let expected_work = expected_work.map(|work| {
+                Work(U256::from_str_radix(work, 16).expect("golden work value is valid hex"))
+            });
 
             let compact = CompactDifficulty(compact);
             let actual_expanded = compact.to_expanded();
@@ -280,8 +332,8 @@ fn block_difficulty_for_network(network: Network) -> Result<(), Report> {
     let diff_one = ExpandedDifficulty(U256::one());
     let diff_max = ExpandedDifficulty(U256::MAX);
 
-    let work_zero = PartialCumulativeWork(0);
-    let work_max = PartialCumulativeWork(u128::MAX);
+    let work_zero = PartialCumulativeWork(U256::zero());
+    let work_max = PartialCumulativeWork(U256::MAX);
 
     let mut cumulative_work = PartialCumulativeWork::default();
     let mut previous_cumulative_work = PartialCumulativeWork::default();

--- a/crates/zakura-chain/src/work/tests/vectors.rs
+++ b/crates/zakura-chain/src/work/tests/vectors.rs
@@ -17,6 +17,15 @@ const EQUIHASH_SOLUTION_BLOCK_OFFSET: usize = equihash::Solution::INPUT_LENGTH +
 const BLOCK_HEADER_LENGTH: usize = EQUIHASH_SOLUTION_BLOCK_OFFSET + 3 + equihash::SOLUTION_SIZE;
 
 #[test]
+fn compact_difficulty_consensus_bytes_round_trip() {
+    let bytes = [0x01, 0x02, 0x03, 0x04];
+    assert_eq!(
+        difficulty::CompactDifficulty::from_le_bytes(bytes).to_le_bytes(),
+        bytes
+    );
+}
+
+#[test]
 fn equihash_solution_test_vectors() {
     let _init_guard = zakura_test::init();
 

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -20,5 +20,10 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 zakura-chain = { path = "../zakura-chain", version = "4.0.0" }
 
+[dev-dependencies]
+proptest = { workspace = true }
+toml = { workspace = true }
+zakura-test = { path = "../zakura-test/", version = "2.1.0-rc1" }
+
 [lints]
 workspace = true

--- a/crates/zakura-header-chain/src/config.rs
+++ b/crates/zakura-header-chain/src/config.rs
@@ -315,3 +315,225 @@ const _: () = assert!(MAX_BLOCK_REORG_HEIGHT == 1_000);
 const _: () = assert!(MAX_CANDIDATE_TIPS_V1 == 10);
 const _: () = assert!(MAX_NON_FINALIZED_NODES_V1 == 65_536);
 const _: () = assert!(MAX_STAGED_TARGETS_V1 == 16);
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use zakura_chain::{
+        block::{genesis::regtest_genesis_block, Block},
+        parameters::testnet::RegtestParameters,
+        serialization::ZcashDeserialize,
+    };
+
+    #[test]
+    fn engine_limits_v1_match_the_frozen_specification() {
+        let limits = EngineLimits::v1();
+        assert_eq!(limits.local_finality_depth.get(), 1_000);
+        assert_eq!(limits.max_candidate_tips.get(), 10);
+        assert_eq!(limits.max_non_finalized_nodes.get(), 65_536);
+    }
+
+    #[test]
+    fn release_manifest_pins_exact_v1_3_production_tuples() {
+        let manifest = SettledUpgradeManifest::for_release().expect("compiled pins are valid");
+        let pins: Vec<_> = manifest.iter().collect();
+        assert_eq!(pins.len(), 2);
+
+        let mainnet = manifest
+            .pin_for_network(&Network::Mainnet)
+            .expect("mainnet has a mandatory pin");
+        assert_eq!(mainnet.upgrade, NetworkUpgrade::Nu6_2);
+        assert_eq!(mainnet.activation.height, block::Height(3_364_600));
+        assert_eq!(mainnet.activation.hash.0[0], 0x65);
+        assert_eq!(mainnet.activation.hash.0[31], 0x00);
+        assert_eq!(
+            mainnet.activation.hash.to_string(),
+            "0000000000806344c408a4cfdf472f4132c632edbdc24cf2f3f672061da8b865"
+        );
+
+        let testnet = manifest
+            .pin_for_network(&Network::new_default_testnet())
+            .expect("default testnet has a mandatory pin");
+        assert_eq!(testnet.upgrade, NetworkUpgrade::Nu6_2);
+        assert_eq!(testnet.activation.height, block::Height(4_052_000));
+        assert_eq!(testnet.activation.hash.0[0], 0x12);
+        assert_eq!(testnet.activation.hash.0[31], 0x00);
+        assert_eq!(
+            testnet.activation.hash.to_string(),
+            "0010cb912b0188da5bc055ee67e3f77d30cd27611369d865974a5bf0b1ec2912"
+        );
+
+        let regtest = Network::new_regtest(RegtestParameters::default());
+        assert_eq!(manifest.pin_for_network(&regtest), None);
+        assert_eq!(
+            manifest.digest(),
+            SettledUpgradeManifest::for_release()
+                .expect("compiled pins are deterministic")
+                .digest()
+        );
+    }
+
+    #[test]
+    fn production_config_always_installs_the_release_manifest() {
+        for (network, bytes) in [
+            (
+                Network::Mainnet,
+                zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.as_slice(),
+            ),
+            (
+                Network::new_default_testnet(),
+                zakura_test::vectors::BLOCK_TESTNET_GENESIS_BYTES.as_slice(),
+            ),
+        ] {
+            let block = Arc::<Block>::zcash_deserialize(bytes)
+                .expect("the production genesis vector is canonical");
+            let config = EngineConfig::new(
+                EngineMode::Integrated,
+                network.clone(),
+                TrustedAnchor {
+                    frontier: Frontier::new(block::Height(0), block.hash()),
+                    header: block.header.clone(),
+                },
+                CheckpointSet::default(),
+            )
+            .expect("the production genesis anchor passes every direct check");
+            assert!(config.settled_manifest.pin_for_network(&network).is_some());
+        }
+    }
+
+    #[test]
+    fn trusted_anchor_still_runs_every_directly_observable_check() {
+        let sapling =
+            Arc::<Block>::zcash_deserialize(zakura_test::vectors::MAINNET_BLOCKS[&419_200])
+                .expect("the Mainnet Sapling activation vector is canonical");
+        let make_config = |network: Network, height: block::Height, header: Arc<block::Header>| {
+            let frontier_hash =
+                crate::validate_encoding_version_hash(&header).unwrap_or(block::Hash([0; 32]));
+            EngineConfig::new(
+                EngineMode::Integrated,
+                network,
+                TrustedAnchor {
+                    frontier: Frontier::new(height, frontier_hash),
+                    header,
+                },
+                CheckpointSet::default(),
+            )
+        };
+        make_config(
+            Network::Mainnet,
+            block::Height(419_200),
+            sapling.header.clone(),
+        )
+        .expect("the real production activation anchor passes every direct check");
+
+        let mut bad_version = *sapling.header;
+        bad_version.version = 3;
+        assert_eq!(
+            make_config(
+                Network::Mainnet,
+                block::Height(419_200),
+                Arc::new(bad_version)
+            ),
+            Err(EngineConfigError::InvalidTrustedAnchor(
+                "canonical header version and hash"
+            ))
+        );
+
+        let mut bad_commitment = *sapling.header;
+        bad_commitment.commitment_bytes.0 = [0xff; 32];
+        assert_eq!(
+            make_config(
+                Network::Mainnet,
+                block::Height(419_200),
+                Arc::new(bad_commitment)
+            ),
+            Err(EngineConfigError::InvalidTrustedAnchor(
+                "height-dependent commitment structure"
+            ))
+        );
+
+        let mut bad_target = *sapling.header;
+        bad_target.difficulty_threshold =
+            zakura_chain::work::difficulty::CompactDifficulty::from_le_bytes([0; 4]);
+        assert_eq!(
+            make_config(
+                Network::Mainnet,
+                block::Height(419_200),
+                Arc::new(bad_target)
+            ),
+            Err(EngineConfigError::InvalidTrustedAnchor(
+                "compact target and network limit"
+            ))
+        );
+
+        let target = crate::validate_compact_target(&sapling.header, &Network::Mainnet)
+            .expect("the vector target is valid");
+        let mut bad_hash = *sapling.header;
+        bad_hash.nonce.0[0] = bad_hash.nonce.0[0].wrapping_add(1);
+        assert!(
+            crate::validate_hash_filter(bad_hash.hash(), target).is_err(),
+            "the deterministic nonce mutation no longer satisfies production work"
+        );
+        assert_eq!(
+            make_config(Network::Mainnet, block::Height(419_200), Arc::new(bad_hash)),
+            Err(EngineConfigError::InvalidTrustedAnchor(
+                "header hash filter"
+            ))
+        );
+
+        let regtest = Network::new_regtest(RegtestParameters::default());
+        let mut wrong_solution_shape = *regtest_genesis_block().header;
+        wrong_solution_shape.solution = zakura_chain::work::equihash::Solution::for_proposal();
+        assert_eq!(
+            make_config(regtest, block::Height(0), Arc::new(wrong_solution_shape)),
+            Err(EngineConfigError::InvalidTrustedAnchor(
+                "Equihash solution shape or proof"
+            ))
+        );
+    }
+
+    #[test]
+    fn engine_config_binds_and_validates_every_trust_anchor() {
+        let block = regtest_genesis_block();
+        let network = Network::new_regtest(RegtestParameters::default());
+        let anchor = TrustedAnchor {
+            frontier: Frontier::new(block::Height(0), block.hash()),
+            header: block.header.clone(),
+        };
+        let plain = EngineConfig::new(
+            EngineMode::HeadersOnly,
+            network.clone(),
+            anchor.clone(),
+            CheckpointSet::default(),
+        )
+        .expect("the fixture anchor is canonical");
+        let checkpointed = EngineConfig::new(
+            EngineMode::HeadersOnly,
+            network.clone(),
+            anchor.clone(),
+            CheckpointSet::new([Frontier::new(block::Height(10), block::Hash([9; 32]))])
+                .expect("the fixture checkpoint set has unique heights"),
+        )
+        .expect("the fixture checkpoint is hash-qualified");
+        assert_ne!(
+            plain.trust_anchor_digest(),
+            checkpointed.trust_anchor_digest()
+        );
+
+        let mismatched = TrustedAnchor {
+            frontier: Frontier::new(block::Height(0), block::Hash([1; 32])),
+            ..anchor
+        };
+        assert!(matches!(
+            EngineConfig::new(
+                EngineMode::HeadersOnly,
+                network,
+                mismatched,
+                CheckpointSet::default()
+            ),
+            Err(EngineConfigError::AnchorHashMismatch { .. })
+        ));
+    }
+}

--- a/crates/zakura-header-chain/src/error.rs
+++ b/crates/zakura-header-chain/src/error.rs
@@ -290,3 +290,123 @@ impl StdError for HeaderChainError {
             .map(|source| -> &(dyn StdError + 'static) { source })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zakura_chain::block;
+
+    #[test]
+    fn only_malformed_protocol_and_invalid_header_default_to_header_peer_fault() {
+        let source = SourceId::from_digest([1; 32]);
+        let subject = ErrorSubject::Header(HeaderId::new(block::Hash([2; 32])));
+        let malformed =
+            HeaderChainError::malformed_protocol(subject, RuleId::new("LC-WIRE-01"), source, None);
+        let invalid = HeaderChainError::invalid_header(
+            subject,
+            RuleId::new("LC-VAL-01"),
+            EvidenceId::from_digest([3; 32]),
+            source,
+            None,
+        );
+        let unknown = HeaderChainError::unknown_anchor(subject, None);
+        assert!(malformed.is_automatic_header_peer_fault());
+        assert!(invalid.is_automatic_header_peer_fault());
+        assert!(!unknown.is_automatic_header_peer_fault());
+        assert_eq!(unknown.attribution, Attribution::None);
+    }
+
+    #[test]
+    fn supplier_evidence_attribution_matrix_distinguishes_header_body_and_advertiser() {
+        let header_source = SourceId::from_digest([1; 32]);
+        let body_source = SourceId::from_digest([2; 32]);
+        let advertiser = SourceId::from_digest([3; 32]);
+        let hash = block::Hash([4; 32]);
+        let subject = ErrorSubject::Header(HeaderId::new(hash));
+        let header = HeaderChainError::invalid_header(
+            subject,
+            RuleId::new("LC-VAL-01"),
+            EvidenceId::from_digest([5; 32]),
+            header_source,
+            None,
+        );
+        let mismatch = HeaderChainError::body_payload_mismatch(BodyPayloadMismatch {
+            evidence: EvidenceId::from_digest([6; 32]),
+            requested: hash,
+            delivered: block::Hash([7; 32]),
+            kind: crate::BodyCommitmentKind::HeaderHash,
+            source: body_source,
+        });
+        let invalid_evidence = ConsensusBodyInvalid {
+            hash,
+            evidence: EvidenceId::from_digest([8; 32]),
+            rule: crate::BodyRuleId::new("test.consensus_invalid"),
+            source: body_source,
+        };
+        let invalid = HeaderChainError::consensus_body_invalid(&invalid_evidence);
+        let advertised = HeaderChainError::new(
+            ErrorCategory::ValidLosingFork,
+            subject,
+            None,
+            None,
+            Attribution::None,
+            None,
+        );
+
+        assert_eq!(header.attribution, Attribution::HeaderPeer(header_source));
+        assert!(header.is_automatic_header_peer_fault());
+        for body_error in [&mismatch, &invalid] {
+            assert_eq!(body_error.attribution, Attribution::BodyPeer(body_source));
+            assert!(body_error.is_automatic_body_peer_fault());
+            assert_ne!(
+                body_error.attribution,
+                Attribution::HeaderPeer(header_source)
+            );
+            assert_ne!(body_error.attribution, Attribution::HeaderPeer(advertiser));
+        }
+        assert_eq!(advertised.attribution, Attribution::None);
+        assert!(!advertised.is_automatic_header_peer_fault());
+        assert!(!advertised.is_automatic_body_peer_fault());
+    }
+
+    #[test]
+    fn taxonomy_has_stable_exhaustive_metric_and_attribution_labels() {
+        let categories = [
+            (ErrorCategory::MalformedProtocol, "malformed_protocol"),
+            (ErrorCategory::InvalidHeader, "invalid_header"),
+            (ErrorCategory::ValidLosingFork, "valid_losing_fork"),
+            (ErrorCategory::DeferredHeader, "deferred_header"),
+            (ErrorCategory::BodyPayloadMismatch, "body_payload_mismatch"),
+            (
+                ErrorCategory::ConsensusBodyInvalid,
+                "consensus_body_invalid",
+            ),
+            (ErrorCategory::OperatorIneligible, "operator_ineligible"),
+            (
+                ErrorCategory::StaleTargetOrGeneration,
+                "stale_target_or_generation",
+            ),
+            (
+                ErrorCategory::LocalAnchorOrIncoherence,
+                "local_anchor_or_incoherence",
+            ),
+            (
+                ErrorCategory::LocalResourceOrStorage,
+                "local_resource_or_storage",
+            ),
+        ];
+        for (category, expected) in categories {
+            assert_eq!(category.metrics_label(), expected);
+        }
+
+        let source = SourceId::from_digest([9; 32]);
+        for (attribution, expected) in [
+            (Attribution::None, "none"),
+            (Attribution::HeaderPeer(source), "header_peer"),
+            (Attribution::BodyPeer(source), "body_peer"),
+            (Attribution::AuxPeer(source), "aux_peer"),
+        ] {
+            assert_eq!(attribution.metrics_label(), expected);
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/frontier.rs
+++ b/crates/zakura-header-chain/src/frontier.rs
@@ -168,3 +168,50 @@ pub enum WorkCoordinateError {
     #[error("work-coordinate suffix subtraction underflow")]
     Underflow,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_score_breaks_equal_work_ties_using_raw_hash_bytes() {
+        let work = SuffixWork::from(U256::from(7));
+        let lower = ChainScore::new(
+            work,
+            block::Hash([
+                0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ]),
+        );
+        let higher = ChainScore::new(
+            work,
+            block::Hash([
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ]),
+        );
+        assert!(
+            higher > lower,
+            "raw byte order, not display order, breaks ties"
+        );
+    }
+
+    #[test]
+    fn work_coordinates_rebase_only_with_a_shared_origin() {
+        let origin = block::Hash([1; 32]);
+        let anchor = WorkCoordinate::new(origin, U256::from(10));
+        let tip = WorkCoordinate::new(origin, U256::from(17));
+        assert_eq!(
+            tip.suffix_after(anchor),
+            Ok(SuffixWork::from(U256::from(7)))
+        );
+        assert_eq!(
+            anchor.suffix_after(tip),
+            Err(WorkCoordinateError::Underflow)
+        );
+        assert!(matches!(
+            tip.suffix_after(WorkCoordinate::new(block::Hash([2; 32]), U256::from(1))),
+            Err(WorkCoordinateError::OriginMismatch { .. })
+        ));
+    }
+}

--- a/crates/zakura-header-chain/src/graph.rs
+++ b/crates/zakura-header-chain/src/graph.rs
@@ -1035,3 +1035,674 @@ impl HeaderGraphEdit for GraphOverlay<'_> {
         self.remove_leaf(hash)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::collections::BTreeSet;
+    use zakura_chain::block::genesis::regtest_genesis_block;
+
+    fn anchor_store() -> MemHeaderStore {
+        let block = regtest_genesis_block();
+        let hash = block.hash();
+        let work = block
+            .header
+            .difficulty_threshold
+            .to_work()
+            .expect("the regtest genesis target has valid work");
+        MemHeaderStore::new(
+            Frontier::new(block::Height(0), hash),
+            block.header.clone(),
+            work,
+            work.as_u256(),
+        )
+        .expect("the trusted fixture header matches its hash")
+    }
+
+    fn child(parent: block::Hash, seed: u8) -> Arc<block::Header> {
+        let mut header = *regtest_genesis_block().header;
+        header.previous_block_hash = parent;
+        header.nonce = [seed; 32].into();
+        Arc::new(header)
+    }
+
+    fn insert_child(store: &mut MemHeaderStore, parent: block::Hash, seed: u8) -> Frontier {
+        let header = child(parent, seed);
+        let work = header
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture target has valid work");
+        match store
+            .insert(
+                header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the fixture parent is retained")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        }
+    }
+
+    fn rebuild_finalized_reference(
+        store: &mut MemHeaderStore,
+        finalized: Frontier,
+    ) -> Result<Vec<block::Hash>, GraphError> {
+        let node = store
+            .node(finalized.hash)
+            .ok_or(GraphError::UnknownNode(finalized.hash))?;
+        if node.height != finalized.height {
+            return Err(GraphError::UnknownNode(finalized.hash));
+        }
+        if !node.is_eligible() {
+            return Err(GraphError::IneligibleFinalized(finalized.hash));
+        }
+        let mut retained = HashSet::new();
+        let mut pending = vec![finalized.hash];
+        while let Some(hash) = pending.pop() {
+            if retained.insert(hash) {
+                pending.extend(store.children(hash));
+            }
+        }
+        let mut deleted: Vec<_> = store
+            .nodes
+            .keys()
+            .copied()
+            .filter(|hash| !retained.contains(hash))
+            .collect();
+        deleted.sort_unstable_by_key(|hash| hash.0);
+        let nodes: Vec<_> = store
+            .nodes
+            .values()
+            .filter(|node| retained.contains(&node.hash))
+            .cloned()
+            .collect();
+        *store = MemHeaderStore::from_nodes(finalized, nodes)?;
+        store.recompute_all_eligibility()?;
+        Ok(deleted)
+    }
+
+    #[test]
+    fn conflicting_duplicate_reports_the_duplicate_hash() {
+        let mut store = anchor_store();
+        let anchor = store.finalized();
+        let original = child(anchor.hash, 1);
+        let original_hash = original.hash();
+        let frontier = insert_child(&mut store, anchor.hash, 1);
+        assert_eq!(frontier.hash, original_hash);
+
+        store
+            .nodes
+            .get_mut(&original_hash)
+            .expect("the inserted fixture node is retained")
+            .header = child(anchor.hash, 2);
+        let work = original
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture target has valid work");
+
+        assert_eq!(
+            store.insert(
+                original,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            ),
+            Err(GraphError::ConflictingDuplicate(original_hash))
+        );
+    }
+
+    #[test]
+    fn removing_a_non_leaf_reports_that_its_children_are_retained() {
+        let mut store = anchor_store();
+        let anchor = store.finalized();
+        let parent = insert_child(&mut store, anchor.hash, 1);
+        let _child = insert_child(&mut store, parent.hash, 2);
+
+        assert_eq!(
+            store.remove_leaf(parent.hash),
+            Err(GraphError::NodeHasChildren(parent.hash))
+        );
+        assert!(store.node(parent.hash).is_some());
+    }
+
+    #[test]
+    fn advancing_finality_retains_exactly_the_new_finalized_subtree() {
+        let mut store = anchor_store();
+        let anchor = store.finalized();
+        let selected_parent = insert_child(&mut store, anchor.hash, 1);
+        let selected_child = insert_child(&mut store, selected_parent.hash, 2);
+        let selected_tip = insert_child(&mut store, selected_child.hash, 3);
+        let rejected_sibling = insert_child(&mut store, selected_parent.hash, 4);
+        let rejected_descendant = insert_child(&mut store, rejected_sibling.hash, 5);
+
+        let mut rebuilt = store.clone();
+        let rebuilt_deleted = rebuild_finalized_reference(&mut rebuilt, selected_child)
+            .expect("the rebuild oracle accepts the same finalized node");
+
+        let deleted = store
+            .advance_finalized(selected_child)
+            .expect("the retained selected node can become finalized");
+
+        assert_eq!(store.finalized(), selected_child);
+        assert_eq!(deleted, rebuilt_deleted);
+        assert_eq!(store.nodes, rebuilt.nodes);
+        assert_eq!(store.children, rebuilt.children);
+        assert_eq!(store.heights, rebuilt.heights);
+        assert_eq!(store.eligible_tips, rebuilt.eligible_tips);
+        assert!(store.node(selected_child.hash).is_some());
+        assert!(store.node(selected_tip.hash).is_some());
+        assert!(store.node(anchor.hash).is_none());
+        assert!(store.node(selected_parent.hash).is_none());
+        assert!(store.node(rejected_sibling.hash).is_none());
+        assert!(store.node(rejected_descendant.hash).is_none());
+        assert_eq!(
+            deleted.into_iter().collect::<HashSet<_>>(),
+            HashSet::from([
+                anchor.hash,
+                selected_parent.hash,
+                rejected_sibling.hash,
+                rejected_descendant.hash,
+            ])
+        );
+    }
+
+    #[test]
+    fn advancing_finality_rejects_an_ineligible_root_without_mutation() {
+        let mut store = anchor_store();
+        let anchor = store.finalized();
+        let candidate = insert_child(&mut store, anchor.hash, 1);
+        store
+            .add_reason(
+                candidate.hash,
+                EligibilityReason::CheckpointConflict {
+                    height: candidate.height,
+                    expected: block::Hash([0xee; 32]),
+                },
+            )
+            .expect("the fixture marks the candidate ineligible");
+        let before = store.clone();
+
+        assert_eq!(
+            store.advance_finalized(candidate),
+            Err(GraphError::IneligibleFinalized(candidate.hash))
+        );
+        assert_eq!(store.nodes, before.nodes);
+        assert_eq!(store.children, before.children);
+        assert_eq!(store.heights, before.heights);
+        assert_eq!(store.eligible_tips, before.eligible_tips);
+        assert_eq!(store.finalized, before.finalized);
+    }
+
+    fn uncached_eligible_tips(store: &MemHeaderStore) -> Vec<Frontier> {
+        let mut tips: Vec<_> = store
+            .nodes
+            .values()
+            .filter(|node| {
+                node.is_eligible()
+                    && !store.children.get(&node.hash).is_some_and(|children| {
+                        children.iter().any(|child| {
+                            store.nodes.get(child).is_some_and(HeaderNode::is_eligible)
+                        })
+                    })
+            })
+            .map(|node| Frontier::new(node.height, node.hash))
+            .collect();
+        tips.sort_unstable_by_key(|tip| tip.hash.0);
+        tips
+    }
+
+    #[derive(Clone)]
+    struct ReferenceNode {
+        hash: block::Hash,
+        parent: Option<block::Hash>,
+        cumulative_work: U256,
+        validation: HeaderValidationState,
+        direct_reasons: BTreeSet<EligibilityReason>,
+    }
+
+    struct ReferenceDag {
+        anchor: block::Hash,
+        anchor_work: U256,
+        nodes: HashMap<block::Hash, ReferenceNode>,
+        insertion_order: Vec<block::Hash>,
+    }
+
+    impl ReferenceDag {
+        fn new(anchor: &HeaderNode) -> Self {
+            let node = ReferenceNode {
+                hash: anchor.hash,
+                parent: None,
+                cumulative_work: U256::zero(),
+                validation: HeaderValidationState::Valid,
+                direct_reasons: BTreeSet::new(),
+            };
+            Self {
+                anchor: anchor.hash,
+                anchor_work: U256::zero(),
+                nodes: HashMap::from([(anchor.hash, node)]),
+                insertion_order: vec![anchor.hash],
+            }
+        }
+
+        fn insert(&mut self, hash: block::Hash, parent: block::Hash, work: Work) {
+            let cumulative_work = self.nodes[&parent]
+                .cumulative_work
+                .checked_add(work.as_u256())
+                .expect("generated reference work does not overflow");
+            self.nodes.insert(
+                hash,
+                ReferenceNode {
+                    hash,
+                    parent: Some(parent),
+                    cumulative_work,
+                    validation: HeaderValidationState::Valid,
+                    direct_reasons: BTreeSet::new(),
+                },
+            );
+            self.insertion_order.push(hash);
+        }
+
+        fn is_eligible(&self, mut hash: block::Hash) -> bool {
+            loop {
+                let node = &self.nodes[&hash];
+                if node.validation != HeaderValidationState::Valid
+                    || !node.direct_reasons.is_empty()
+                {
+                    return false;
+                }
+                let Some(parent) = node.parent else {
+                    return hash == self.anchor;
+                };
+                hash = parent;
+            }
+        }
+
+        fn selected(&self) -> block::Hash {
+            self.nodes
+                .values()
+                .filter(|node| self.is_eligible(node.hash))
+                .max_by(|left, right| {
+                    let left_work = left
+                        .cumulative_work
+                        .checked_sub(self.anchor_work)
+                        .expect("reference descendants have anchor work");
+                    let right_work = right
+                        .cumulative_work
+                        .checked_sub(self.anchor_work)
+                        .expect("reference descendants have anchor work");
+                    left_work
+                        .cmp(&right_work)
+                        .then_with(|| left.hash.0.cmp(&right.hash.0))
+                })
+                .expect("the reference anchor is always eligible")
+                .hash
+        }
+    }
+
+    fn operation_header(parent: block::Hash, operation: usize) -> Arc<block::Header> {
+        let mut header = *regtest_genesis_block().header;
+        header.previous_block_hash = parent;
+        let operation = u64::try_from(operation).expect("test operation index fits in u64");
+        let mut nonce = [0; 32];
+        nonce[..8].copy_from_slice(&operation.to_le_bytes());
+        header.nonce = nonce.into();
+        Arc::new(header)
+    }
+
+    #[test]
+    fn fork_indexes_selection_and_inherited_reason_sets_are_exact() {
+        let mut store = anchor_store();
+        let anchor = store.finalized();
+        let left = insert_child(&mut store, anchor.hash, 1);
+        let right = insert_child(&mut store, anchor.hash, 2);
+        assert_eq!(store.hashes_at_height(block::Height(1)).len(), 2);
+
+        let left_tip = insert_child(&mut store, left.hash, 3);
+        assert_eq!(
+            store.select_header_best().expect("graph is coherent").0,
+            left_tip
+        );
+
+        let first = EligibilityReason::OperatorInvalid {
+            id: crate::OperatorInvalidationId::new([1; 16]),
+        };
+        let second = EligibilityReason::OperatorInvalid {
+            id: crate::OperatorInvalidationId::new([2; 16]),
+        };
+        store
+            .add_reason(left.hash, first)
+            .expect("left is retained");
+        store
+            .add_reason(left.hash, second)
+            .expect("left is retained");
+        assert_eq!(
+            store
+                .node(left.hash)
+                .expect("retained")
+                .eligibility
+                .direct_reasons
+                .len(),
+            2
+        );
+        assert_eq!(
+            store
+                .node(left_tip.hash)
+                .expect("retained")
+                .eligibility
+                .inherited_from,
+            Some(left.hash)
+        );
+        assert_eq!(
+            store.select_header_best().expect("graph is coherent").0,
+            right
+        );
+
+        store
+            .remove_operator_invalidation(left.hash, crate::OperatorInvalidationId::new([1; 16]))
+            .expect("left is retained");
+        assert!(!store.node(left.hash).expect("retained").is_eligible());
+        store
+            .remove_operator_invalidation(left.hash, crate::OperatorInvalidationId::new([2; 16]))
+            .expect("left is retained");
+        assert!(store.node(left_tip.hash).expect("retained").is_eligible());
+        assert_eq!(
+            store.select_header_best().expect("graph is coherent").0,
+            left_tip
+        );
+    }
+
+    #[test]
+    fn operator_reconsider_preserves_every_unnamed_reason() {
+        let mut store = anchor_store();
+        let anchor = store.finalized();
+        let target = insert_child(&mut store, anchor.hash, 1);
+        let descendant = insert_child(&mut store, target.hash, 2);
+        let first_id = crate::OperatorInvalidationId::new([1; 16]);
+        let second_id = crate::OperatorInvalidationId::new([2; 16]);
+        let permanent_reasons = [
+            EligibilityReason::SettledUpgradeConflict {
+                height: target.height,
+                expected: block::Hash([3; 32]),
+            },
+            EligibilityReason::CheckpointConflict {
+                height: target.height,
+                expected: block::Hash([4; 32]),
+            },
+            EligibilityReason::FinalityConflict { finalized: anchor },
+        ];
+        for reason in permanent_reasons.clone() {
+            store
+                .add_reason(target.hash, reason)
+                .expect("the operator target is retained");
+        }
+        for id in [first_id, second_id] {
+            store
+                .add_reason(target.hash, EligibilityReason::OperatorInvalid { id })
+                .expect("the operator target is retained");
+        }
+        let body_evidence = EvidenceId::from_digest([5; 32]);
+        let body_rule = BodyRuleId::new("test.operator-reconsider");
+        store
+            .set_consensus_body_invalid(target.hash, body_evidence, body_rule.clone())
+            .expect("intrinsic body invalidity is recorded independently");
+
+        store
+            .remove_operator_invalidation(target.hash, first_id)
+            .expect("the operator target is retained");
+
+        let target_node = store.node(target.hash).expect("the target is retained");
+        assert!(!target_node
+            .eligibility
+            .direct_reasons
+            .contains(&EligibilityReason::OperatorInvalid { id: first_id }));
+        assert!(target_node
+            .eligibility
+            .direct_reasons
+            .contains(&EligibilityReason::OperatorInvalid { id: second_id }));
+        for reason in permanent_reasons {
+            assert!(target_node.eligibility.direct_reasons.contains(&reason));
+        }
+        assert!(target_node.eligibility.direct_reasons.contains(
+            &EligibilityReason::ConsensusBodyInvalid {
+                evidence: body_evidence,
+                rule: body_rule,
+            }
+        ));
+        assert_eq!(
+            store
+                .node(descendant.hash)
+                .expect("the descendant is retained")
+                .eligibility
+                .inherited_from,
+            Some(target.hash)
+        );
+    }
+
+    #[test]
+    // DG-05: testing one below, at, and one above the retention boundary in
+    // both insertion orders covers the fixed-anchor replacement edge.
+    fn fixed_anchor_replacements_cover_finalization_boundary_in_both_orders() {
+        fn insert_branch(
+            store: &mut MemHeaderStore,
+            anchor: Frontier,
+            count: u32,
+            seed_offset: u32,
+        ) -> Frontier {
+            let mut tip = anchor;
+            for offset in 0..count {
+                let seed =
+                    u8::try_from((offset + seed_offset) % 251).expect("reduced nonce fits in u8");
+                tip = insert_child(store, tip.hash, seed);
+            }
+            tip
+        }
+
+        for incumbent_depth in [999, 1_000, 1_001] {
+            for competitor_first in [false, true] {
+                let mut store = anchor_store();
+                let anchor = store.finalized();
+                let (incumbent, competitor) = if competitor_first {
+                    let competitor = insert_branch(&mut store, anchor, incumbent_depth + 1, 127);
+                    let incumbent = insert_branch(&mut store, anchor, incumbent_depth, 0);
+                    (incumbent, competitor)
+                } else {
+                    let incumbent = insert_branch(&mut store, anchor, incumbent_depth, 0);
+                    assert_eq!(
+                        store.select_header_best().expect("graph is coherent").0,
+                        incumbent
+                    );
+                    let competitor = insert_branch(&mut store, anchor, incumbent_depth + 1, 127);
+                    (incumbent, competitor)
+                };
+                assert_ne!(incumbent.hash, competitor.hash);
+                assert_eq!(
+                    store.select_header_best().expect("graph is coherent").0,
+                    competitor,
+                    "selection is anchored at finalized and independent of depth or arrival order"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn body_availability_does_not_override_header_work_or_mark_other_bodies() {
+        let mut store = anchor_store();
+        let anchor = store.finalized();
+        let verified = child(anchor.hash, 41);
+        let work = verified.difficulty_threshold.to_work().expect("valid work");
+        let verified_hash = verified.hash();
+        store
+            .insert(
+                verified,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Verified {
+                    evidence: crate::EvidenceId::from_digest([4; 32]),
+                },
+            )
+            .expect("verified fixture is inserted");
+        let unknown_parent = insert_child(&mut store, anchor.hash, 51);
+        let unknown_tip = insert_child(&mut store, unknown_parent.hash, 52);
+        store
+            .set_body_state(
+                unknown_tip.hash,
+                BodyValidationState::Unavailable(crate::BodyUnavailableSummary {
+                    attempts: 10,
+                    suppliers: 0,
+                    alarmed: true,
+                    ..Default::default()
+                }),
+            )
+            .expect("the unavailable tip is retained");
+
+        assert_eq!(
+            store.select_header_best().expect("graph is coherent").0,
+            unknown_tip
+        );
+        assert_eq!(
+            store.node(verified_hash).expect("retained").body,
+            BodyValidationState::Verified {
+                evidence: crate::EvidenceId::from_digest([4; 32])
+            }
+        );
+        assert_eq!(
+            store.node(unknown_tip.hash).expect("retained").body,
+            BodyValidationState::Unavailable(crate::BodyUnavailableSummary {
+                attempts: 10,
+                suppliers: 0,
+                alarmed: true,
+                ..Default::default()
+            })
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn insertion_permutations_match_an_independent_greatest_work_model(
+            branch_lengths in prop::collection::vec(1_u8..8, 1..8),
+            reverse in any::<bool>(),
+        ) {
+            let mut store = anchor_store();
+            let anchor = store.finalized();
+            let mut branches = Vec::new();
+            for (branch, length) in branch_lengths.iter().copied().enumerate() {
+                let mut parent = anchor.hash;
+                let mut headers = Vec::new();
+                for offset in 0..length {
+                    let branch = u8::try_from(branch).expect("generated branch count fits in u8");
+                    let seed = branch.wrapping_mul(17).wrapping_add(offset).wrapping_add(1);
+                    let header = child(parent, seed);
+                    parent = header.hash();
+                    headers.push(header);
+                }
+                branches.push(headers);
+            }
+            if reverse {
+                branches.reverse();
+            }
+            for headers in &branches {
+                for header in headers {
+                    let work = header.difficulty_threshold.to_work().expect("fixture target is valid");
+                    store.insert(
+                        header.clone(),
+                        work,
+                        HeaderValidationState::Valid,
+                        [],
+                        BodyValidationState::Unknown,
+                    ).expect("each branch is inserted parent first");
+                }
+            }
+
+            let expected = branches
+                .iter()
+                .map(|branch| {
+                    let tip = branch.last().expect("generated branches are nonempty");
+                    (branch.len(), tip.hash().0, tip.hash())
+                })
+                .max_by_key(|(length, hash_bytes, _)| (*length, *hash_bytes))
+                .expect("at least one branch was generated")
+                .2;
+            prop_assert_eq!(store.select_header_best().expect("graph is coherent").0.hash, expected);
+        }
+
+
+        #[test]
+        fn arbitrary_graph_operations_match_an_independent_uncached_model(
+            operations in prop::collection::vec((0_u8..5, any::<usize>()), 1..100),
+        ) {
+            let mut store = anchor_store();
+            let anchor = store.node(store.finalized().hash).expect("anchor is retained").clone();
+            let mut model = ReferenceDag::new(&anchor);
+
+            for (operation_index, (kind, target)) in operations.into_iter().enumerate() {
+                let target_index = target % model.insertion_order.len();
+                let target_hash = model.insertion_order[target_index];
+                let mut id_bytes = [0; 16];
+                let target_id = u64::try_from(target_index).expect("test node index fits in u64");
+                id_bytes[..8].copy_from_slice(&target_id.to_le_bytes());
+                let reason = EligibilityReason::OperatorInvalid {
+                    id: crate::OperatorInvalidationId::new(id_bytes),
+                };
+
+                match kind {
+                    0 => {
+                        let header = operation_header(target_hash, operation_index + 1);
+                        let hash = header.hash();
+                        let work = header.difficulty_threshold.to_work().expect("fixture target is valid");
+                        store.insert(
+                            header,
+                            work,
+                            HeaderValidationState::Valid,
+                            [],
+                            BodyValidationState::Unknown,
+                        ).expect("generated parent is retained");
+                        model.insert(hash, target_hash, work);
+                    }
+                    1 => {
+                        if target_hash != model.anchor {
+                            store
+                                .add_reason(target_hash, reason.clone())
+                                .expect("target is retained");
+                            model.nodes.get_mut(&target_hash).expect("target exists").direct_reasons.insert(reason);
+                        }
+                    }
+                    2 => {
+                        if target_hash != model.anchor {
+                            let EligibilityReason::OperatorInvalid { id } = reason else {
+                                unreachable!("the generated reason is operator-scoped")
+                            };
+                            store.remove_operator_invalidation(target_hash, id).expect("target is retained");
+                            model.nodes.get_mut(&target_hash).expect("target exists").direct_reasons.remove(&reason);
+                        }
+                    }
+                    3 => {
+                        if target_hash != model.anchor {
+                            let until = regtest_genesis_block().header.time + chrono::Duration::days(1);
+                            store.set_validation(target_hash, HeaderValidationState::DeferredUntil(until)).expect("target is retained");
+                            model.nodes.get_mut(&target_hash).expect("target exists").validation = HeaderValidationState::DeferredUntil(until);
+                        }
+                    }
+                    4 => {
+                        if target_hash != model.anchor {
+                            store.set_validation(target_hash, HeaderValidationState::Valid).expect("target is retained");
+                            model.nodes.get_mut(&target_hash).expect("target exists").validation = HeaderValidationState::Valid;
+                        }
+                    }
+                    _ => unreachable!("the generated operation kind is bounded"),
+                }
+
+                prop_assert_eq!(
+                    store.select_header_best().expect("graph is coherent").0.hash,
+                    model.selected(),
+                );
+                prop_assert_eq!(store.eligible_tips(), uncached_eligible_tips(&store));
+            }
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/ids.rs
+++ b/crates/zakura-header-chain/src/ids.rs
@@ -391,3 +391,53 @@ impl From<BodyWorkOwner> for HeaderSyncWorkOwner {
         Self::BodyRepair(owner)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_counters_fail_closed_at_exhaustion() {
+        assert_eq!(
+            StateVersion::new(8).checked_next(),
+            Ok(StateVersion::new(9))
+        );
+        assert_eq!(
+            HeaderGeneration::new(u64::MAX).checked_next(),
+            Err(CounterExhausted {
+                counter: "header generation"
+            })
+        );
+        assert_eq!(
+            VerifiedGeneration::new(u64::MAX).checked_next(),
+            Err(CounterExhausted {
+                counter: "verified generation"
+            })
+        );
+        assert_eq!(
+            FinalityEpoch::new(u64::MAX).checked_next(),
+            Err(CounterExhausted {
+                counter: "finality epoch"
+            })
+        );
+    }
+
+    #[test]
+    fn domain_authority_binds_transport_identity_without_irrelevant_coordinates() {
+        let authority = BodyWorkAuthority {
+            header: HeaderWorkAuthority {
+                header_generation: HeaderGeneration::new(2),
+                branch: BranchId::new(block::Hash([4; 32]), block::Hash([5; 32])),
+            },
+            verified_generation: VerifiedGeneration::new(3),
+        };
+        let request_id = NonZeroU64::new(7).expect("seven is nonzero");
+        let owner = authority.bind(6, request_id);
+        assert_eq!(owner.authority, authority);
+        assert_eq!(owner.header_generation, authority.header_generation);
+        assert_eq!(owner.verified_generation, authority.verified_generation);
+        assert_eq!(owner.branch, authority.branch);
+        assert_eq!(owner.session_id, 6);
+        assert_eq!(owner.request_id, request_id);
+    }
+}

--- a/crates/zakura-header-chain/src/lib.rs
+++ b/crates/zakura-header-chain/src/lib.rs
@@ -48,3 +48,141 @@ pub use validation::{
     HeaderRule, HeaderRules, PowPolicy, PowPolicyError, BLOCK_MAX_TIME_SINCE_MEDIAN,
     POW_ADJUSTMENT_BLOCK_SPAN, POW_MEDIAN_BLOCK_SPAN, POW_PREDECESSOR_CONTEXT_SPAN,
 };
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn architecture_dependencies_stay_sync_only_and_layered() {
+        let manifest: toml::Value = toml::from_str(include_str!("../Cargo.toml"))
+            .expect("the checked-in crate manifest is valid TOML");
+        let dependencies = manifest
+            .get("dependencies")
+            .and_then(toml::Value::as_table)
+            .expect("the crate manifest has a dependencies table");
+        for forbidden in [
+            "tokio",
+            "tower",
+            "zakura-state",
+            "zakura-network",
+            "zakura-consensus",
+        ] {
+            assert!(
+                !dependencies.contains_key(forbidden),
+                "header-chain architecture forbids a production dependency on {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn architecture_excludes_wallet_flyclient_and_block_sync_surfaces() {
+        fn production_sources(path: &std::path::Path, sources: &mut Vec<(String, String)>) {
+            for entry in std::fs::read_dir(path).expect("the crate source directory is readable") {
+                let entry = entry.expect("the source directory entry is readable");
+                let path = entry.path();
+                if path.is_dir() {
+                    production_sources(&path, sources);
+                } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+                    let source =
+                        std::fs::read_to_string(&path).expect("the Rust source is readable");
+                    sources.push((
+                        path.display().to_string(),
+                        source
+                            .split("#[cfg(test)]")
+                            .next()
+                            .expect("production code precedes its tests")
+                            .to_ascii_lowercase(),
+                    ));
+                }
+            }
+        }
+
+        let manifest: toml::Value = toml::from_str(include_str!("../Cargo.toml"))
+            .expect("the checked-in crate manifest is valid TOML");
+        let dependencies = manifest
+            .get("dependencies")
+            .and_then(toml::Value::as_table)
+            .expect("the crate manifest has a dependencies table");
+        for forbidden in [
+            "zcash_client_backend",
+            "zcash_client_sqlite",
+            "zcash_keys",
+            "zcash_note_encryption",
+        ] {
+            assert!(
+                !dependencies.contains_key(forbidden),
+                "header-chain architecture forbids wallet dependency {forbidden}"
+            );
+        }
+
+        let public_surface = include_str!("lib.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("the production public surface precedes its tests")
+            .to_ascii_lowercase();
+        for forbidden in [
+            "wallet",
+            "flyclient",
+            "trial_decryption",
+            "note_witness",
+            "compact_block",
+        ] {
+            assert!(
+                !public_surface.contains(forbidden),
+                "header-chain public API contains excluded surface `{forbidden}`"
+            );
+        }
+
+        let config = include_str!("config.rs");
+        let engine_config = config
+            .split_once("pub struct EngineConfig {")
+            .and_then(|(_, rest)| rest.split_once("\n}\n\nimpl EngineConfig"))
+            .map(|(fields, _)| fields.to_ascii_lowercase())
+            .expect("EngineConfig has one inspectable field block");
+        for forbidden in [
+            "block_sync",
+            "token_bucket",
+            "connection_eviction",
+            "readiness",
+            "wallet",
+            "flyclient",
+        ] {
+            assert!(
+                !engine_config.contains(forbidden),
+                "header-chain selection config contains excluded input `{forbidden}`"
+            );
+        }
+
+        let mut sources = Vec::new();
+        production_sources(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src")
+                .as_path(),
+            &mut sources,
+        );
+        for forbidden in [
+            "zip 307",
+            "flyclient",
+            "compact_block",
+            "trial_decryption",
+            "note_witness",
+            "wallet_state",
+            "token_bucket",
+            "connection_eviction",
+            "readiness_accounting",
+        ] {
+            assert!(
+                sources
+                    .iter()
+                    .all(|(_, source)| !source.contains(forbidden)),
+                "header-chain production source contains excluded concern `{forbidden}` in [{}]",
+                sources
+                    .iter()
+                    .filter_map(|(path, source)| source
+                        .contains(forbidden)
+                        .then_some(path.as_str()))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/locator.rs
+++ b/crates/zakura-header-chain/src/locator.rs
@@ -93,3 +93,121 @@ impl HeaderLocator {
         self.0.iter().map(|frontier| frontier.hash).collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        AlarmSet, ChainScore, EngineMode, FrontierSet, HeaderGeneration, StateVersion, SuffixWork,
+        VerifiedGeneration,
+    };
+    use zakura_chain::work::difficulty::U256;
+
+    use super::*;
+
+    fn hash_at(height: block::Height) -> block::Hash {
+        block::Hash(
+            height
+                .0
+                .to_le_bytes()
+                .repeat(8)
+                .try_into()
+                .expect("eight u32 encodings are 32 bytes"),
+        )
+    }
+
+    fn snapshot(tip_height: u32, finalized_height: u32) -> EngineSnapshot {
+        let finalized = Frontier::new(
+            block::Height(finalized_height),
+            hash_at(block::Height(finalized_height)),
+        );
+        let tip = Frontier::new(
+            block::Height(tip_height),
+            hash_at(block::Height(tip_height)),
+        );
+        EngineSnapshot {
+            mode: EngineMode::Integrated,
+            state_version: StateVersion::new(1),
+            header_generation: HeaderGeneration::new(1),
+            verified_generation: VerifiedGeneration::new(1),
+            frontiers: FrontierSet {
+                finalized,
+                header_best: tip,
+                verified_best: finalized,
+            },
+            header_best_score: ChainScore::new(SuffixWork::new(U256::from(tip_height)), tip.hash),
+            oldest_retained_height: finalized.height,
+            alarms: AlarmSet::default(),
+        }
+    }
+
+    #[test]
+    fn selected_path_locators_match_every_offset_and_cap_boundary() {
+        for tip_height in 0..=2_000 {
+            let snapshot = snapshot(tip_height, 0);
+            let locator =
+                HeaderLocator::for_selected_path(&snapshot, |height| Ok(Some(hash_at(height))))
+                    .expect("the fixture selected projection is complete");
+            let expected_heights: Vec<_> = SELECTED_PATH_OFFSETS
+                .into_iter()
+                .filter(|offset| *offset <= tip_height)
+                .map(|offset| block::Height(tip_height - offset))
+                .chain(std::iter::once(block::Height(0)))
+                .fold(Vec::new(), |mut heights, height| {
+                    if !heights.contains(&height) {
+                        heights.push(height);
+                    }
+                    heights
+                });
+            assert_eq!(
+                locator
+                    .entries()
+                    .iter()
+                    .map(|frontier| frontier.height)
+                    .collect::<Vec<_>>(),
+                expected_heights,
+                "tip {tip_height}"
+            );
+            assert!(locator.entries().len() <= MAX_HEADER_LOCATOR_HASHES);
+            assert_eq!(
+                locator.entries().first(),
+                Some(&snapshot.frontiers.header_best)
+            );
+            assert_eq!(
+                locator.entries().last(),
+                Some(&snapshot.frontiers.finalized)
+            );
+        }
+    }
+
+    #[test]
+    fn selected_path_locator_appends_a_non_genesis_finalized_frontier() {
+        let snapshot = snapshot(2_000, 750);
+        let locator =
+            HeaderLocator::for_selected_path(&snapshot, |height| Ok(Some(hash_at(height))))
+                .expect("the fixture selected projection is complete");
+
+        assert_eq!(
+            locator.entries().last(),
+            Some(&snapshot.frontiers.finalized)
+        );
+        assert_eq!(locator.entries().len(), MAX_HEADER_LOCATOR_HASHES);
+        assert_eq!(locator.entries()[11].height, block::Height(1_000));
+    }
+
+    #[test]
+    fn selected_path_locator_fails_closed_on_a_projection_gap() {
+        let snapshot = snapshot(10, 0);
+        assert_eq!(
+            HeaderLocator::for_selected_path(&snapshot, |height| {
+                if height == block::Height(8) {
+                    Ok(None)
+                } else {
+                    Ok(Some(hash_at(height)))
+                }
+            }),
+            Err(StoreError::Incoherent(
+                "selected locator height is absent from the selected projection"
+            ))
+        );
+    }
+}

--- a/crates/zakura-header-chain/src/ownership.rs
+++ b/crates/zakura-header-chain/src/ownership.rs
@@ -231,3 +231,210 @@ impl CompletionGate {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use zakura_chain::{block, work::difficulty::U256};
+
+    use super::*;
+    use crate::{
+        AlarmSet, BranchId, ChainScore, EngineMode, Frontier, FrontierSet, HeaderGeneration,
+        StateVersion, SuffixWork, VerifiedGeneration,
+    };
+
+    fn snapshot() -> EngineSnapshot {
+        let anchor = Frontier::new(block::Height(10), block::Hash([1; 32]));
+        EngineSnapshot {
+            mode: EngineMode::Integrated,
+            state_version: StateVersion::new(7),
+            header_generation: HeaderGeneration::new(8),
+            verified_generation: VerifiedGeneration::new(9),
+            frontiers: FrontierSet {
+                finalized: anchor,
+                header_best: anchor,
+                verified_best: anchor,
+            },
+            header_best_score: ChainScore::new(SuffixWork::new(U256::zero()), anchor.hash),
+            oldest_retained_height: anchor.height,
+            alarms: AlarmSet::default(),
+        }
+    }
+
+    fn owner(snapshot: &EngineSnapshot) -> BodyWorkOwner {
+        BodyWorkOwner {
+            authority: BodyWorkAuthority {
+                header: HeaderWorkAuthority {
+                    header_generation: snapshot.header_generation,
+                    branch: BranchId::new(snapshot.frontiers.finalized.hash, block::Hash([2; 32])),
+                },
+                verified_generation: snapshot.verified_generation,
+            },
+            session_id: 11,
+            request_id: NonZeroU64::new(12).expect("twelve is nonzero"),
+        }
+    }
+
+    #[derive(Debug, Default, Eq, PartialEq)]
+    struct NoEffectsProbe {
+        frontier_writes: usize,
+        coverage_writes: usize,
+        retry_writes: usize,
+        repair_writes: usize,
+        scheduler_writes: usize,
+        publication_writes: usize,
+        body_task_writes: usize,
+        peer_score_writes: usize,
+    }
+
+    fn probe_completion(
+        current: &EngineSnapshot,
+        pending: &PendingOwners<BodyWorkOwner>,
+        source: SourceId,
+        owner: &BodyWorkOwner,
+    ) -> (CompletionDecision, NoEffectsProbe) {
+        let decision = CompletionGate::check(current, pending, source, owner);
+        let mut probe = NoEffectsProbe::default();
+        if decision == CompletionDecision::Current {
+            probe.frontier_writes += 1;
+            probe.coverage_writes += 1;
+            probe.retry_writes += 1;
+            probe.repair_writes += 1;
+            probe.scheduler_writes += 1;
+            probe.publication_writes += 1;
+            probe.body_task_writes += 1;
+            probe.peer_score_writes += 1;
+        }
+        (decision, probe)
+    }
+
+    #[test]
+    fn version_only_changes_remain_current_but_authority_mismatches_are_stale() {
+        let current = snapshot();
+        let source = SourceId::from_digest([3; 32]);
+        let expected = owner(&current);
+        let mut pending = PendingOwners::default();
+        assert_eq!(pending.insert(source, expected), None);
+        assert_eq!(
+            CompletionGate::check(&current, &pending, source, &expected),
+            CompletionDecision::Current
+        );
+
+        let mut changed = current.clone();
+        changed.state_version = StateVersion::new(10);
+        assert_eq!(
+            CompletionGate::check(&changed, &pending, source, &expected),
+            CompletionDecision::Current
+        );
+        changed = current.clone();
+        changed.header_generation = HeaderGeneration::new(10);
+        assert_eq!(
+            CompletionGate::check(&changed, &pending, source, &expected),
+            CompletionDecision::Stale(StaleReason::HeaderGeneration)
+        );
+        changed = current.clone();
+        changed.verified_generation = VerifiedGeneration::new(10);
+        assert_eq!(
+            CompletionGate::check(&changed, &pending, source, &expected),
+            CompletionDecision::Stale(StaleReason::VerifiedGeneration)
+        );
+        changed = current.clone();
+        changed.frontiers.finalized.hash = block::Hash([4; 32]);
+        assert_eq!(
+            CompletionGate::check(&changed, &pending, source, &expected),
+            CompletionDecision::Stale(StaleReason::BranchAnchor)
+        );
+
+        let mut contradictory = expected;
+        contradictory.session_id = 99;
+        pending.insert(source, contradictory);
+        assert_eq!(
+            CompletionGate::check(&current, &pending, source, &expected),
+            CompletionDecision::Stale(StaleReason::OwnerMismatch)
+        );
+        pending.remove(source, expected.request_id);
+        assert_eq!(
+            CompletionGate::check(&current, &pending, source, &expected),
+            CompletionDecision::Stale(StaleReason::MissingOwner)
+        );
+    }
+
+    #[test]
+    fn centralized_retirement_removes_generation_and_exact_owner_work() {
+        let mut current = snapshot();
+        let source = SourceId::from_digest([3; 32]);
+        let old = owner(&current);
+        let mut exact = old;
+        exact.request_id = NonZeroU64::new(13).expect("thirteen is nonzero");
+        let mut pending: PendingOwners<HeaderSyncWorkOwner> = PendingOwners::default();
+        pending.insert(source, old.into());
+        pending.insert(source, exact.into());
+        current.state_version = StateVersion::new(8);
+        current.header_generation = HeaderGeneration::new(9);
+        let retired = crate::RetiredWork {
+            header_generation_changed: true,
+            verified_generation_changed: false,
+            owners: vec![exact.into()],
+        };
+        let removed = pending.apply_retirement(&retired, &current);
+        assert_eq!(removed.len(), 2);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn all_owner_mismatches_have_zero_effects() {
+        let current = snapshot();
+        let source = SourceId::from_digest([3; 32]);
+        let expected = owner(&current);
+        let mut pending = PendingOwners::default();
+        pending.insert(source, expected);
+        let (decision, live_probe) = probe_completion(&current, &pending, source, &expected);
+        assert_eq!(decision, CompletionDecision::Current);
+        assert_ne!(live_probe, NoEffectsProbe::default());
+
+        let mut version_only = current.clone();
+        version_only.state_version = StateVersion::new(10);
+        let (decision, probe) = probe_completion(&version_only, &pending, source, &expected);
+        assert_eq!(decision, CompletionDecision::Current);
+        assert_ne!(probe, NoEffectsProbe::default());
+
+        let mut cases = Vec::new();
+        let mut changed_snapshot = current.clone();
+        changed_snapshot.header_generation = HeaderGeneration::new(10);
+        cases.push((changed_snapshot, source, expected, pending.clone()));
+        let mut changed_snapshot = current.clone();
+        changed_snapshot.verified_generation = VerifiedGeneration::new(10);
+        cases.push((changed_snapshot, source, expected, pending.clone()));
+        let mut changed_snapshot = current.clone();
+        changed_snapshot.frontiers.finalized.hash = block::Hash([4; 32]);
+        cases.push((changed_snapshot, source, expected, pending.clone()));
+
+        let mut changed_owner = expected;
+        changed_owner.authority.header.branch.anchor_hash = block::Hash([4; 32]);
+        cases.push((current.clone(), source, changed_owner, pending.clone()));
+        let mut changed_owner = expected;
+        changed_owner.authority.header.branch.target_tip_hash = block::Hash([4; 32]);
+        cases.push((current.clone(), source, changed_owner, pending.clone()));
+        let mut changed_owner = expected;
+        changed_owner.session_id = 99;
+        cases.push((current.clone(), source, changed_owner, pending.clone()));
+        let mut changed_owner = expected;
+        changed_owner.request_id = NonZeroU64::new(99).expect("ninety-nine is nonzero");
+        cases.push((current.clone(), source, changed_owner, pending.clone()));
+        cases.push((
+            current.clone(),
+            SourceId::from_digest([4; 32]),
+            expected,
+            pending.clone(),
+        ));
+        cases.push((current.clone(), source, expected, PendingOwners::default()));
+
+        for (case_current, case_source, case_owner, case_pending) in cases {
+            let (decision, probe) =
+                probe_completion(&case_current, &case_pending, case_source, &case_owner);
+            assert!(matches!(decision, CompletionDecision::Stale(_)));
+            assert_eq!(probe, NoEffectsProbe::default());
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/retention.rs
+++ b/crates/zakura-header-chain/src/retention.rs
@@ -234,3 +234,250 @@ fn evict_tip_branch<G: HeaderGraphEdit>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{num::NonZeroUsize, sync::Arc};
+
+    use super::*;
+    use crate::{
+        BodyValidationState, EligibilityReason, HeaderValidationState, InsertResult, MemHeaderStore,
+    };
+    use zakura_chain::block::genesis::regtest_genesis_block;
+
+    fn store() -> MemHeaderStore {
+        let block = regtest_genesis_block();
+        let hash = block.hash();
+        let work = block
+            .header
+            .difficulty_threshold
+            .to_work()
+            .expect("valid work");
+        MemHeaderStore::new(
+            Frontier::new(block::Height(0), hash),
+            block.header.clone(),
+            work,
+            work.as_u256(),
+        )
+        .expect("fixture anchor matches")
+    }
+
+    fn insert(
+        store: &mut MemHeaderStore,
+        parent: block::Hash,
+        seed: u8,
+        reasons: impl IntoIterator<Item = EligibilityReason>,
+    ) -> Frontier {
+        let mut header = *regtest_genesis_block().header;
+        header.previous_block_hash = parent;
+        header.nonce = [seed; 32].into();
+        let header = Arc::new(header);
+        let work = header.difficulty_threshold.to_work().expect("valid work");
+        match store
+            .insert(
+                header,
+                work,
+                HeaderValidationState::Valid,
+                reasons,
+                BodyValidationState::Unknown,
+            )
+            .expect("fixture parent is retained")
+        {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        }
+    }
+
+    fn limits(tips: usize, nodes: usize) -> EngineLimits {
+        EngineLimits {
+            max_candidate_tips: NonZeroUsize::new(tips).expect("test limit is nonzero"),
+            max_non_finalized_nodes: NonZeroUsize::new(nodes).expect("test limit is nonzero"),
+            ..EngineLimits::v1()
+        }
+    }
+
+    #[test]
+    fn candidate_tip_eviction_is_lowest_work_then_smallest_raw_hash() {
+        let mut store = store();
+        let anchor = store.finalized();
+        let tips: Vec<_> = (1..=12)
+            .map(|seed| insert(&mut store, anchor.hash, seed, []))
+            .collect();
+        let header_best = store.select_header_best().expect("graph is coherent").0;
+        let mut expected: Vec<_> = tips
+            .iter()
+            .copied()
+            .filter(|tip| *tip != header_best)
+            .collect();
+        expected.sort_unstable_by_key(|tip| store.score(tip.hash).expect("retained").tip_hash.0);
+
+        let plan = enforce_retention(&mut store, header_best, anchor, [], limits(10, 100))
+            .expect("retention succeeds");
+        assert!(store.node(expected[0].hash).is_none());
+        assert!(store.node(expected[1].hash).is_none());
+        assert_eq!(store.eligible_tips().len(), 10);
+        assert!(store.node(header_best.hash).is_some());
+        assert!(!plan.admission_refused);
+
+        let reacquired_seed = (1..=12)
+            .find(|seed| {
+                let mut header = *regtest_genesis_block().header;
+                header.previous_block_hash = anchor.hash;
+                header.nonce = [*seed; 32].into();
+                header.hash() == expected[0].hash
+            })
+            .expect("the evicted fixture tip has a seed");
+        let reacquired = insert(&mut store, anchor.hash, reacquired_seed, []);
+        assert_eq!(reacquired.hash, expected[0].hash);
+        assert!(store
+            .node(reacquired.hash)
+            .expect("reacquired")
+            .is_eligible());
+    }
+
+    #[test]
+    fn eligible_tip_with_deferred_descendant_is_evicted_without_stalling() {
+        let mut store = store();
+        let anchor = store.finalized();
+        let tips: Vec<_> = (1..=12)
+            .map(|seed| insert(&mut store, anchor.hash, seed, []))
+            .collect();
+        let header_best = store.select_header_best().expect("graph is coherent").0;
+        let victim = tips
+            .iter()
+            .copied()
+            .filter(|tip| *tip != header_best)
+            .min_by_key(|tip| store.score(tip.hash).expect("retained"))
+            .expect("one unprotected tip exists");
+        let deferred = insert(&mut store, victim.hash, 13, []);
+        store
+            .set_validation(
+                deferred.hash,
+                HeaderValidationState::DeferredUntil(
+                    regtest_genesis_block().header.time + chrono::Duration::hours(3),
+                ),
+            )
+            .expect("the deferred descendant is retained");
+
+        assert!(store
+            .eligible_tips()
+            .iter()
+            .any(|tip| tip.hash == victim.hash));
+        assert!(!store
+            .node(deferred.hash)
+            .expect("the deferred child is retained")
+            .is_eligible());
+
+        let plan = enforce_retention(&mut store, header_best, anchor, [], limits(10, 100))
+            .expect("retention evicts the ineligible descendant subtree");
+
+        assert!(store.node(deferred.hash).is_none());
+        assert!(store.node(victim.hash).is_none());
+        assert_eq!(store.eligible_tips().len(), 10);
+        assert!(!plan.admission_refused);
+    }
+
+    #[test]
+    fn permanent_subtrees_are_evicted_first_only_under_pressure() {
+        let mut store = store();
+        let anchor = store.finalized();
+        let permanent = insert(
+            &mut store,
+            anchor.hash,
+            1,
+            [EligibilityReason::CheckpointConflict {
+                height: block::Height(1),
+                expected: block::Hash([9; 32]),
+            }],
+        );
+        let selected = insert(&mut store, anchor.hash, 2, []);
+        let spare = insert(&mut store, anchor.hash, 3, []);
+
+        enforce_retention(&mut store, selected, anchor, [], limits(10, 2))
+            .expect("permanent subtree frees capacity");
+        assert!(store.node(permanent.hash).is_none());
+        assert!(store.node(selected.hash).is_some());
+        assert!(store.node(spare.hash).is_some());
+    }
+
+    #[test]
+    fn protected_paths_and_context_references_fail_closed_under_node_pressure() {
+        let mut store = store();
+        let anchor = store.finalized();
+        let first = insert(&mut store, anchor.hash, 1, []);
+        let selected = insert(&mut store, first.hash, 2, []);
+
+        let plan = enforce_retention(&mut store, selected, anchor, [first.hash], limits(10, 1))
+            .expect("retention returns a typed refusal");
+        assert!(plan.admission_refused);
+        assert!(plan.resource_stalled);
+        assert!(store.node(selected.hash).is_some());
+    }
+
+    #[test]
+    fn overlapping_protected_paths_stop_at_their_first_protected_ancestor() {
+        let mut store = store();
+        let anchor = store.finalized();
+        let first = insert(&mut store, anchor.hash, 1, []);
+        let selected = insert(&mut store, first.hash, 2, []);
+        let branch = insert(&mut store, first.hash, 3, []);
+        let mut protected = HashSet::new();
+
+        assert_eq!(
+            protect_path(&store, selected.hash, &mut protected)
+                .expect("the selected path is coherent"),
+            3
+        );
+        assert_eq!(
+            protect_path(&store, branch.hash, &mut protected)
+                .expect("the branch joins the selected path"),
+            2
+        );
+        assert_eq!(
+            protect_path(&store, first.hash, &mut protected)
+                .expect("the context reference is already protected"),
+            1
+        );
+        assert!(protected.contains(&anchor.hash));
+        assert!(protected.contains(&first.hash));
+        assert!(protected.contains(&selected.hash));
+        assert!(protected.contains(&branch.hash));
+    }
+
+    #[test]
+    fn reference_pruned_before_retention_is_no_longer_protectable() {
+        let mut store = store();
+        let anchor = store.finalized();
+
+        let plan = enforce_retention(
+            &mut store,
+            anchor,
+            anchor,
+            [block::Hash([0x91; 32])],
+            limits(10, 100),
+        )
+        .expect("a reference already pruned by finality is ignored");
+
+        assert_eq!(plan, RetentionPlan::default());
+    }
+
+    #[test]
+    fn exact_v1_node_boundary_refuses_to_evict_the_selected_path() {
+        let mut store = store();
+        let anchor = store.finalized();
+        let mut selected = anchor;
+        for offset in 0..=crate::MAX_NON_FINALIZED_NODES_V1 {
+            let seed = u8::try_from(offset % 251).expect("the reduced test nonce fits in u8");
+            selected = insert(&mut store, selected.hash, seed, []);
+        }
+        assert_eq!(
+            store.node_count() - 1,
+            crate::MAX_NON_FINALIZED_NODES_V1 + 1
+        );
+
+        let plan = enforce_retention(&mut store, selected, anchor, [], EngineLimits::v1())
+            .expect("the exact boundary produces a typed refusal");
+        assert!(plan.admission_refused);
+        assert!(plan.resource_stalled);
+        assert!(store.node(selected.hash).is_some());
+    }
+}

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -1542,3 +1542,6 @@ fn projection_delta(old: &[Frontier], new: &[Frontier]) -> ProjectionDelta {
         put: new[common..].to_vec(),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -1,0 +1,428 @@
+use super::*;
+
+fn body_owner(snapshot: &EngineSnapshot, session_id: u64, request_id: u64) -> crate::BodyWorkOwner {
+    crate::BodyWorkAuthority::for_snapshot(snapshot).bind(
+        session_id,
+        NonZeroU64::new(request_id).expect("fixture request IDs are nonzero"),
+    )
+}
+
+#[test]
+fn selected_auxiliary_repair_adds_only_one_exact_provenance_record() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.metadata.frontiers.finalized;
+    let insert = insertion(&store, 2, EvidenceId::from_digest([0x66; 32]));
+    let TransitionEvent::InsertHeaders(initial) = &insert.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    let repaired = initial.batch.headers()[0].clone();
+    let selected_target = Frontier::new(repaired.height, repaired.hash);
+    let inserted = apply_transition(&store, insert, &context(&config, &clock, None))
+        .expect("the selected fixture branch inserts");
+    store.commit(&inserted);
+
+    store.lease.parent = anchor;
+    store.lease.context_digest = [0x67; 32];
+    let owner = body_owner(&store.snapshot(), 8, 9);
+    let source = SourceId::from_digest([0x68; 32]);
+    let delivery = crate::AuxDelivery {
+        delivery_id: EvidenceId::from_digest([0x69; 32]),
+        header_hash: repaired.hash,
+        source,
+        owner: owner.into(),
+        body_size: crate::BodySizeHint::Unknown,
+        tree_aux: Some(crate::TreeAuxRecordV1 {
+            height: repaired.height,
+            sapling_root: zakura_chain::sapling::tree::Root::default(),
+            orchard_root: zakura_chain::orchard::tree::Root::default(),
+            ironwood_root: zakura_chain::ironwood::tree::Root::default(),
+            sapling_tx_count: 1,
+            orchard_tx_count: 2,
+            ironwood_tx_count: 3,
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0x6a; 32]),
+        }),
+        authentication: crate::AuxAuthentication::Unauthenticated,
+    };
+    let repair = TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::InsertHeaders(Box::new(crate::InsertHeaders {
+            owner: owner.into(),
+            source,
+            parent_hash: anchor.hash,
+            target_tip_hash: repaired.hash,
+            completion: TargetCompletion::SelectedAuxiliaryRepair {
+                common_ancestor: anchor,
+                selected_target,
+            },
+            batch: PreparedHeaderBatch::new(
+                vec![repaired],
+                anchor,
+                store.lease.trust_anchor_digest,
+                EvidenceId::from_digest([0x6b; 32]),
+            )
+            .expect("the exact repair batch is nonempty"),
+            aux: vec![delivery],
+        })),
+    };
+
+    assert_eq!(
+        repair.event.idempotency_key(),
+        Some(delivery.delivery_id),
+        "repair replay identity is the new provenance record, not the old header batch"
+    );
+    let mut wrongly_header_authorized = repair.clone();
+    let TransitionEvent::InsertHeaders(wrong) = &mut wrongly_header_authorized.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    let body_owner = wrong
+        .owner
+        .body_owner()
+        .expect("the fixture repair has body authority");
+    let header_owner = crate::HeaderWorkOwner {
+        authority: body_owner.authority.header,
+        session_id: body_owner.session_id,
+        request_id: body_owner.request_id,
+    };
+    wrong.owner = header_owner.into();
+    wrong.aux[0].owner = header_owner.into();
+    assert!(matches!(
+        apply_transition(
+            &store,
+            wrongly_header_authorized,
+            &context(&config, &clock, None)
+        ),
+        Err(TransitionFailure::InvalidEvidence(
+            "selected auxiliary repair does not have body authority"
+        ))
+    ));
+    let repaired = apply_transition(&store, repair, &context(&config, &clock, None))
+        .expect("one exact selected auxiliary repair is admitted");
+    assert_eq!(repaired.change_set.put_nodes.len(), 1);
+    assert_eq!(repaired.change_set.put_nodes[0].hash, selected_target.hash);
+    assert_eq!(
+        repaired.change_set.put_nodes[0].aux_delivery_ids,
+        vec![delivery.delivery_id]
+    );
+    assert!(repaired.change_set.delete_nodes.is_empty());
+    assert!(repaired.change_set.selected_projection.put.is_empty());
+    assert!(repaired.change_set.verified_projection.put.is_empty());
+    assert_eq!(
+        repaired.change_set.metadata.header_generation,
+        store.metadata.header_generation
+    );
+    assert_eq!(
+        repaired.change_set.metadata.verified_generation,
+        store.metadata.verified_generation
+    );
+    assert_eq!(
+        repaired.change_set.aux_changes,
+        vec![crate::AuxDelta::Put(Box::new(delivery))]
+    );
+}
+
+#[test]
+fn auxiliary_delivery_is_batch_hash_scoped_and_selection_neutral() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let without_aux = insertion(&store, 2, EvidenceId::from_digest([0x70; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &without_aux.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    let prepared = insert.batch.headers()[0].clone();
+    let delivery = crate::AuxDelivery {
+        delivery_id: EvidenceId::from_digest([0x71; 32]),
+        header_hash: prepared.hash,
+        source: insert.source,
+        owner: insert.owner,
+        body_size: crate::BodySizeHint::Unknown,
+        tree_aux: Some(crate::TreeAuxRecordV1 {
+            height: prepared.height,
+            sapling_root: zakura_chain::sapling::tree::Root::default(),
+            orchard_root: zakura_chain::orchard::tree::Root::default(),
+            ironwood_root: zakura_chain::ironwood::tree::Root::default(),
+            sapling_tx_count: 1,
+            orchard_tx_count: 2,
+            ironwood_tx_count: 3,
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0x72; 32]),
+        }),
+        authentication: crate::AuxAuthentication::Unauthenticated,
+    };
+    let without_plan =
+        apply_transition(&store, without_aux.clone(), &context(&config, &clock, None))
+            .expect("the control target inserts without advisory metadata");
+    let mut with_aux = without_aux.clone();
+    let TransitionEvent::InsertHeaders(insert) = &mut with_aux.event else {
+        unreachable!("the cloned fixture remains a header insertion")
+    };
+    insert.aux.push(delivery);
+    let with_plan = apply_transition(&store, with_aux, &context(&config, &clock, None))
+        .expect("one exact hash-scoped auxiliary delivery is admitted");
+
+    assert_eq!(
+        with_plan.change_set.metadata,
+        without_plan.change_set.metadata
+    );
+    assert_eq!(
+        with_plan.change_set.selected_projection,
+        without_plan.change_set.selected_projection
+    );
+    assert_eq!(
+        with_plan.change_set.verified_projection,
+        without_plan.change_set.verified_projection
+    );
+    assert_eq!(
+        with_plan.change_set.eligibility_changes,
+        without_plan.change_set.eligibility_changes
+    );
+    assert_eq!(
+        with_plan.change_set.aux_changes,
+        vec![crate::AuxDelta::Put(Box::new(delivery))]
+    );
+
+    let mut unretained_aux = vec![crate::AuxDelta::Put(Box::new(delivery))];
+    unretained_aux.retain(|change| match change {
+        crate::AuxDelta::Put(delivery) => store.graph.node(delivery.header_hash).is_some(),
+        crate::AuxDelta::Delete { .. } => true,
+    });
+    assert!(
+        unretained_aux.is_empty(),
+        "auxiliary metadata for a node removed in the same plan is not persisted"
+    );
+
+    let mut unrelated = delivery;
+    unrelated.header_hash = store.metadata.frontiers.finalized.hash;
+    unrelated.tree_aux = None;
+    let mut wrong_height = delivery;
+    wrong_height
+        .tree_aux
+        .as_mut()
+        .expect("the fixture has tree auxiliary data")
+        .height = prepared
+        .height
+        .next()
+        .expect("the bounded fixture height advances");
+    let mut wrong_owner = delivery;
+    wrong_owner.owner = match wrong_owner.owner {
+        crate::HeaderSyncWorkOwner::Header(owner) => crate::HeaderWorkOwner {
+            session_id: owner.session_id.saturating_add(1),
+            ..owner
+        }
+        .into(),
+        crate::HeaderSyncWorkOwner::BodyRepair(owner) => crate::BodyWorkOwner {
+            session_id: owner.session_id.saturating_add(1),
+            ..owner
+        }
+        .into(),
+    };
+    let mut wrong_source = delivery;
+    wrong_source.source = SourceId::from_digest([0x73; 32]);
+    let mut preauthenticated = delivery;
+    preauthenticated.authentication = crate::AuxAuthentication::Authenticated {
+        evidence: EvidenceId::from_digest([0x74; 32]),
+        boundary_hash: block::Hash([0x75; 32]),
+    };
+    for (label, deliveries) in [
+        ("header outside the admitted batch", vec![unrelated]),
+        ("tree-aux height mismatch", vec![wrong_height]),
+        ("duplicate delivery identity", vec![delivery, delivery]),
+        ("different work owner", vec![wrong_owner]),
+        ("different source", vec![wrong_source]),
+        ("premature authentication", vec![preauthenticated]),
+    ] {
+        let mut request = without_aux.clone();
+        let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+            unreachable!("the cloned fixture remains a header insertion")
+        };
+        insert.aux = deliveries;
+        assert!(
+            matches!(
+                apply_transition(&store, request, &context(&config, &clock, None)),
+                Err(TransitionFailure::InvalidEvidence(
+                    "auxiliary delivery does not match the admitted target"
+                ))
+            ),
+            "{label}"
+        );
+        assert_eq!(
+            store.snapshot(),
+            without_plan.before,
+            "{label} changed the source snapshot"
+        );
+    }
+}
+
+#[test]
+fn auxiliary_authentication_requires_exact_provenance_and_owned_next_header() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let mut insert = insertion(&store, 2, EvidenceId::from_digest([0xb0; 32]));
+    let TransitionEvent::InsertHeaders(insert_event) = &mut insert.event else {
+        unreachable!("the insertion fixture contains header evidence")
+    };
+    let header_hash = insert_event.batch.headers()[0].hash;
+    let boundary_hash = insert_event.batch.headers()[1].hash;
+    let delivery = crate::AuxDelivery {
+        delivery_id: EvidenceId::from_digest([0xb1; 32]),
+        header_hash,
+        source: SourceId::from_digest([0xb2; 32]),
+        owner: insert_event.owner,
+        body_size: crate::BodySizeHint::Unknown,
+        tree_aux: Some(crate::TreeAuxRecordV1 {
+            height: block::Height(1),
+            sapling_root: zakura_chain::sapling::tree::Root::default(),
+            orchard_root: zakura_chain::orchard::tree::Root::default(),
+            ironwood_root: zakura_chain::ironwood::tree::Root::default(),
+            sapling_tx_count: 3,
+            orchard_tx_count: 4,
+            ironwood_tx_count: 5,
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0xb3; 32]),
+        }),
+        authentication: crate::AuxAuthentication::Unauthenticated,
+    };
+    insert_event.source = delivery.source;
+    let second_delivery = crate::AuxDelivery {
+        delivery_id: EvidenceId::from_digest([0xc1; 32]),
+        ..delivery
+    };
+    let third_delivery = crate::AuxDelivery {
+        delivery_id: EvidenceId::from_digest([0xc3; 32]),
+        ..delivery
+    };
+    insert_event
+        .aux
+        .extend([delivery, second_delivery, third_delivery]);
+    let inserted = apply_transition(&store, insert, &context(&config, &clock, None))
+        .expect("the target and unauthenticated delivery insert atomically");
+    store.commit(&inserted);
+
+    let repair_owner = body_owner(&store.snapshot(), 2, 2);
+    let authentication = crate::AuxAuthentication::Authenticated {
+        evidence: EvidenceId::from_digest([0xb4; 32]),
+        boundary_hash,
+    };
+    let request = |delivery, authentication| TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::AuxEvidence(Box::new(crate::AuxEvidence {
+            owner: repair_owner,
+            deliveries: vec![delivery],
+            authentication,
+        })),
+    };
+
+    let mut changed_provenance = delivery;
+    changed_provenance.source = SourceId::from_digest([0xb5; 32]);
+    assert!(matches!(
+        apply_transition(
+            &store,
+            request(changed_provenance, authentication),
+            &context(&config, &clock, Some(&Authority)),
+        ),
+        Err(TransitionFailure::InvalidEvidence(
+            "auxiliary evidence changes delivery provenance"
+        ))
+    ));
+    let wrong_boundary = crate::AuxAuthentication::Authenticated {
+        evidence: EvidenceId::from_digest([0xb6; 32]),
+        boundary_hash: header_hash,
+    };
+    assert!(matches!(
+        apply_transition(
+            &store,
+            request(delivery, wrong_boundary),
+            &context(&config, &clock, Some(&Authority)),
+        ),
+        Err(TransitionFailure::InvalidEvidence(
+            "auxiliary authentication is not the owned one-header-later boundary"
+        ))
+    ));
+
+    let before = store.snapshot();
+    let authenticated = apply_transition(
+        &store,
+        request(delivery, authentication),
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("exact integrated evidence authenticates metadata only");
+    assert!(authenticated.change_set.put_nodes.is_empty());
+    assert!(authenticated.change_set.eligibility_changes.is_empty());
+    assert_eq!(
+        authenticated.change_set.metadata.frontiers,
+        before.frontiers
+    );
+    assert_eq!(
+        authenticated.change_set.metadata.header_generation,
+        before.header_generation
+    );
+    assert_eq!(
+        authenticated.change_set.metadata.verified_generation,
+        before.verified_generation
+    );
+    assert_eq!(
+        authenticated.change_set.aux_changes,
+        vec![crate::AuxDelta::Put(Box::new(crate::AuxDelivery {
+            authentication,
+            ..delivery
+        }))]
+    );
+    store.commit(&authenticated);
+
+    let rejection = crate::AuxAuthentication::Rejected {
+        evidence: EvidenceId::from_digest([0xc5; 32]),
+    };
+    let rejection_owner = body_owner(&store.snapshot(), 2, 2);
+    let rejected = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::AuxEvidence(Box::new(crate::AuxEvidence {
+                owner: rejection_owner,
+                deliveries: vec![second_delivery, third_delivery],
+                authentication: rejection,
+            })),
+        },
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("two exact metadata deliveries reject in one atomic transition");
+    assert_eq!(
+        rejected.change_set.aux_changes,
+        vec![
+            crate::AuxDelta::Put(Box::new(crate::AuxDelivery {
+                authentication: rejection,
+                ..second_delivery
+            })),
+            crate::AuxDelta::Put(Box::new(crate::AuxDelivery {
+                authentication: rejection,
+                ..third_delivery
+            })),
+        ],
+    );
+    assert_eq!(
+        rejected.change_set.metadata.state_version,
+        store
+            .metadata
+            .state_version
+            .checked_next()
+            .expect("the fixture state version can advance"),
+        "the two-delivery rejection advances one atomic state version"
+    );
+    store.commit(&rejected);
+
+    let replay = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::AuxEvidence(Box::new(crate::AuxEvidence {
+                owner: body_owner(&store.snapshot(), 2, 2),
+                deliveries: vec![crate::AuxDelivery {
+                    authentication,
+                    ..delivery
+                }],
+                authentication,
+            })),
+        },
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("authentication replay is idempotent");
+    assert!(replay.is_no_change());
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/body_evidence.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/body_evidence.rs
@@ -1,0 +1,210 @@
+use super::*;
+
+#[test]
+fn transient_body_evidence_cannot_regress_a_verified_body() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    store
+        .graph
+        .set_body_state(
+            store.metadata.frontiers.verified_best.hash,
+            BodyValidationState::Verified {
+                evidence: EvidenceId::from_digest([0xbf; 32]),
+            },
+        )
+        .expect("the fixture body becomes verified");
+    let request = TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::BodyEvidence(BodyEvidence::Transient(
+            crate::TransientBodyFailure {
+                hash: store.metadata.frontiers.verified_best.hash,
+                evidence: EvidenceId::from_digest([0xc0; 32]),
+                kind: crate::TransientBodyFailureKind::Timeout,
+                availability: crate::BodyUnavailableSummary {
+                    attempts: 1,
+                    suppliers: 1,
+                    alarmed: false,
+                    ..Default::default()
+                },
+            },
+        )),
+    };
+
+    let result = apply_transition(&store, request, &context(&config, &clock, Some(&Authority)));
+    assert!(
+        matches!(
+            result,
+            Err(TransitionFailure::InvalidEvidence(
+                "body retry evidence cannot regress an already verified body"
+            ))
+        ),
+        "unexpected transition result: {result:?}"
+    );
+}
+
+#[test]
+fn new_body_supplier_preserves_only_the_selected_persistent_alarm() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let now = Utc::now();
+    let clock = ManualClock(now);
+    let selected = store.metadata.frontiers.header_best;
+    let old = crate::BodyUnavailableSummary {
+        started_at: now - chrono::Duration::minutes(12),
+        attempts: 10,
+        suppliers: 2,
+        supplier_set_digest: [0x11; 32],
+        alarmed: true,
+        next_probe_at: now + chrono::Duration::minutes(8),
+    };
+    store
+        .graph
+        .set_body_state(selected.hash, BodyValidationState::Unavailable(old))
+        .expect("the selected fixture body exists");
+    store.metadata.alarms.header_best_body_unavailable = Some(old);
+    let updated = crate::BodyUnavailableSummary {
+        started_at: old.started_at,
+        attempts: old.attempts,
+        suppliers: 2,
+        supplier_set_digest: [0x22; 32],
+        alarmed: true,
+        next_probe_at: now,
+    };
+    let evidence = EvidenceId::from_digest([0xc1; 32]);
+    let request = TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::BodySupplierDiscovered(crate::BodySupplierDiscovered {
+            hash: selected.hash,
+            evidence,
+            availability: updated,
+        }),
+    };
+
+    let plan = apply_transition(
+        &store,
+        request.clone(),
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("a changed supplier set makes the persistent episode probeable");
+    assert_eq!(plan.change_set.metadata.frontiers, store.metadata.frontiers);
+    assert_eq!(
+        plan.projected
+            .node(selected.hash)
+            .expect("the selected node remains retained")
+            .body,
+        BodyValidationState::Unavailable(updated)
+    );
+    assert_eq!(
+        plan.projected
+            .node(selected.hash)
+            .expect("the selected node remains retained")
+            .eligibility,
+        store
+            .graph
+            .node(selected.hash)
+            .expect("the selected fixture node exists")
+            .eligibility
+    );
+    assert_eq!(
+        plan.change_set.metadata.alarms.header_best_body_unavailable,
+        Some(updated)
+    );
+    store.commit(&plan);
+    let replay = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            ..request
+        },
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("the exact supplier-discovery evidence replays idempotently");
+    assert!(replay.is_no_change());
+}
+
+#[test]
+fn body_supplier_discovery_rejects_reset_or_nonexpanding_evidence() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let now = Utc::now();
+    let clock = ManualClock(now);
+    let selected = store.metadata.frontiers.header_best;
+    let old = crate::BodyUnavailableSummary {
+        started_at: now - chrono::Duration::minutes(12),
+        attempts: 10,
+        suppliers: 2,
+        supplier_set_digest: [0x11; 32],
+        alarmed: true,
+        next_probe_at: now + chrono::Duration::minutes(8),
+    };
+    store
+        .graph
+        .set_body_state(selected.hash, BodyValidationState::Unavailable(old))
+        .expect("the selected fixture body exists");
+    store.metadata.alarms.header_best_body_unavailable = Some(old);
+    let apply = |availability| {
+        apply_transition(
+            &store,
+            TransitionRequest {
+                expected_version: store.metadata.state_version,
+                event: TransitionEvent::BodySupplierDiscovered(crate::BodySupplierDiscovered {
+                    hash: selected.hash,
+                    evidence: EvidenceId::from_digest([0xc2; 32]),
+                    availability,
+                }),
+            },
+            &context(&config, &clock, Some(&Authority)),
+        )
+    };
+
+    assert!(matches!(
+        apply(crate::BodyUnavailableSummary {
+            started_at: old.started_at,
+            attempts: old.attempts,
+            suppliers: 2,
+            supplier_set_digest: old.supplier_set_digest,
+            alarmed: true,
+            next_probe_at: now,
+        }),
+        Err(TransitionFailure::InvalidEvidence(
+            "body supplier discovery does not add an eligible supplier"
+        ))
+    ));
+    assert!(matches!(
+        apply(crate::BodyUnavailableSummary {
+            started_at: now,
+            attempts: old.attempts,
+            suppliers: 3,
+            supplier_set_digest: [0x22; 32],
+            alarmed: true,
+            next_probe_at: now,
+        }),
+        Err(TransitionFailure::InvalidEvidence(
+            "body supplier discovery must preserve the persistent retry episode"
+        ))
+    ));
+    assert!(matches!(
+        apply(crate::BodyUnavailableSummary {
+            started_at: old.started_at,
+            attempts: old.attempts,
+            suppliers: 3,
+            supplier_set_digest: [0x22; 32],
+            alarmed: true,
+            next_probe_at: now + chrono::Duration::minutes(1),
+        }),
+        Err(TransitionFailure::InvalidEvidence(
+            "body supplier discovery must preserve the persistent retry episode"
+        ))
+    ));
+    assert!(matches!(
+        apply(crate::BodyUnavailableSummary {
+            started_at: old.started_at,
+            attempts: old.attempts,
+            suppliers: 1,
+            supplier_set_digest: [0x22; 32],
+            alarmed: true,
+            next_probe_at: now,
+        }),
+        Err(TransitionFailure::InvalidEvidence(
+            "body supplier discovery does not add an eligible supplier"
+        ))
+    ));
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
@@ -1,0 +1,721 @@
+use super::*;
+
+#[test]
+fn finalization_projection_delta_removes_only_the_retired_prefix() {
+    let old: Vec<_> = (0..=3)
+        .map(|height| {
+            let byte = u8::try_from(height).expect("the fixture height is at most three");
+            Frontier::new(block::Height(height), block::Hash([byte; 32]))
+        })
+        .collect();
+    let new = old[1..].to_vec();
+
+    assert_eq!(
+        projection_delta(&old, &new),
+        ProjectionDelta {
+            remove_before: Some(block::Height(1)),
+            remove_from: None,
+            put: Vec::new(),
+        }
+    );
+}
+
+fn validation_lease_for(store: &TestStore, parent: Frontier) -> ValidationLease {
+    let mut facts = Vec::new();
+    let mut current = parent;
+    loop {
+        let node = store
+            .graph
+            .node(current.hash)
+            .expect("the validation fixture path is retained");
+        facts.push(HeaderContextFact {
+            frontier: current,
+            difficulty_threshold: node.header.difficulty_threshold,
+            time: node.header.time,
+        });
+        if current.height == store.graph.finalized().height {
+            break;
+        }
+        let parent_node = store
+            .graph
+            .node(node.parent_hash)
+            .expect("the validation fixture parent is retained");
+        current = Frontier::new(parent_node.height, parent_node.hash);
+    }
+    ValidationLease::new(parent, facts, store.lease.trust_anchor_digest())
+}
+
+fn apply_with_header_rebase_facts(
+    store: &TestStore,
+    request: TransitionRequest,
+    config: &EngineConfig,
+    clock: &ManualClock,
+    validation: ValidationLease,
+) -> Result<TransitionPlan, TransitionFailure> {
+    test_engine(store)
+        .apply(
+            request,
+            &context(config, clock, None),
+            DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![validation],
+                finality_path: store.finality.clone(),
+            },
+        )
+        .map(crate::EngineTransition::into_plan)
+}
+
+#[test]
+fn header_insert_rebases_and_trims_across_each_monotone_finality_position() {
+    for finalized_count in 1..=3_u32 {
+        let (mut store, config) = TestStore::new(EngineMode::Integrated);
+        let clock = ManualClock(Utc::now());
+        let authority = Authority;
+        let original_anchor = store.graph.finalized();
+        let prepared = batch(
+            original_anchor,
+            3,
+            store.lease.trust_anchor_digest(),
+            EvidenceId::from_digest([0x81; 32]),
+        );
+        let target = prepared
+            .headers()
+            .last()
+            .expect("the prepared path is nonempty")
+            .hash;
+        let held = TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::InsertHeaders(Box::new(crate::InsertHeaders {
+                owner: crate::HeaderWorkAuthority::for_target(&store.snapshot(), target)
+                    .bind(9, NonZeroU64::new(7).expect("seven is nonzero"))
+                    .into(),
+                source: SourceId::from_digest([0x82; 32]),
+                parent_hash: original_anchor.hash,
+                target_tip_hash: target,
+                completion: TargetCompletion::TargetComplete {
+                    common_ancestor: original_anchor,
+                },
+                batch: prepared.clone(),
+                aux: Vec::new(),
+            })),
+        };
+
+        let mut inserted = Vec::new();
+        for header in prepared
+            .headers()
+            .iter()
+            .take(usize::try_from(finalized_count).expect("the bounded count fits usize"))
+        {
+            let frontier = match store
+                .graph
+                .insert(
+                    header.header.clone(),
+                    header.block_work,
+                    header.validation,
+                    [],
+                    BodyValidationState::Verified {
+                        evidence: EvidenceId::from_digest([0x83; 32]),
+                    },
+                )
+                .expect("the canonical fixture prefix inserts")
+            {
+                crate::InsertResult::Inserted(frontier)
+                | crate::InsertResult::AlreadyPresent(frontier) => frontier,
+            };
+            inserted.push(frontier);
+        }
+        let verified_tip = *inserted.last().expect("at least one prefix header inserts");
+        synchronize_fixture(&mut store, verified_tip);
+        let rebased_validation = validation_lease_for(&store, verified_tip);
+
+        let mut previous = original_anchor;
+        for (index, next) in inserted.iter().copied().enumerate() {
+            let evidence_byte =
+                0x84_u8.saturating_add(u8::try_from(index).expect("the three-step index fits u8"));
+            let plan = apply_transition(
+                &store,
+                TransitionRequest {
+                    expected_version: store.metadata.state_version,
+                    event: TransitionEvent::FullStateFinalized(crate::FullStateFinalized {
+                        full_state_transition_id: EvidenceId::from_digest([evidence_byte; 32]),
+                        new_finalized: next,
+                        verified_path_proof: vec![previous.hash, next.hash],
+                    }),
+                },
+                &context(&config, &clock, Some(&authority)),
+            )
+            .expect("each monotone finality step commits");
+            store.commit(&plan);
+            previous = next;
+        }
+
+        if finalized_count == 2 {
+            let mut missing_proof = store.clone();
+            missing_proof.finality.clear();
+            assert!(matches!(
+                apply_with_header_rebase_facts(
+                    &missing_proof,
+                    held.clone(),
+                    &config,
+                    &clock,
+                    rebased_validation.clone(),
+                ),
+                Err(TransitionFailure::Stale { .. })
+            ));
+        }
+        if finalized_count == 1 {
+            let mut exhausted = store.clone();
+            exhausted
+                .finality
+                .last_mut()
+                .expect("one finality step produces history")
+                .epoch = FinalityEpoch::new(u64::MAX);
+            assert!(matches!(
+                apply_with_header_rebase_facts(
+                    &exhausted,
+                    held.clone(),
+                    &config,
+                    &clock,
+                    rebased_validation.clone(),
+                ),
+                Err(TransitionFailure::Counter(_))
+            ));
+        }
+
+        let plan =
+            apply_with_header_rebase_facts(&store, held, &config, &clock, rebased_validation)
+                .expect("state-proven monotone finality preserves the prepared suffix");
+        let remaining = 3usize.saturating_sub(
+            usize::try_from(finalized_count).expect("the bounded count fits usize"),
+        );
+        assert_eq!(plan.change_set.put_nodes.len(), remaining);
+        assert_eq!(plan.is_no_change(), remaining == 0);
+        assert_eq!(
+            plan.cause(),
+            if remaining == 0 {
+                TransitionCause::HeaderWorkAlreadyApplied
+            } else {
+                TransitionCause::HeaderWorkRebased
+            }
+        );
+        assert_eq!(plan.change_set.metadata.frontiers.finalized, verified_tip);
+    }
+}
+
+#[test]
+fn header_insert_rebase_rejects_a_competing_finalized_branch() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let original_anchor = store.graph.finalized();
+    let held = insertion(&store, 2, EvidenceId::from_digest([0x91; 32]));
+    let difficulty = store
+        .graph
+        .node(original_anchor.hash)
+        .expect("the anchor is retained")
+        .header
+        .difficulty_threshold;
+    let competing = insert_verified_branch(&mut store.graph, original_anchor, 1, difficulty, 0x92);
+    synchronize_fixture(&mut store, competing);
+    let validation = validation_lease_for(&store, competing);
+    let finality = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::FullStateFinalized(crate::FullStateFinalized {
+                full_state_transition_id: EvidenceId::from_digest([0x93; 32]),
+                new_finalized: competing,
+                verified_path_proof: vec![original_anchor.hash, competing.hash],
+            }),
+        },
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("the competing branch becomes finalized");
+    store.commit(&finality);
+
+    assert!(matches!(
+        apply_with_header_rebase_facts(&store, held, &config, &clock, validation),
+        Err(TransitionFailure::Stale { .. })
+    ));
+}
+
+#[test]
+fn header_insert_rebase_preserves_a_retained_parent_after_new_finality() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let original_anchor = store.graph.finalized();
+    let difficulty = store
+        .graph
+        .node(original_anchor.hash)
+        .expect("the anchor is retained")
+        .header
+        .difficulty_threshold;
+    let parent = insert_verified_branch(&mut store.graph, original_anchor, 2, difficulty, 0xa1);
+    let selected = path(&store.graph, parent).expect("the verified parent path is retained");
+    let new_finalized = selected[1];
+    synchronize_fixture(&mut store, parent);
+    let validation = validation_lease_for(&store, parent);
+    let prepared = batch(
+        parent,
+        1,
+        store.lease.trust_anchor_digest(),
+        EvidenceId::from_digest([0xa2; 32]),
+    );
+    let target = prepared
+        .headers()
+        .last()
+        .expect("the child batch is nonempty")
+        .hash;
+    let held = TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::InsertHeaders(Box::new(crate::InsertHeaders {
+            owner: crate::HeaderWorkAuthority::for_target(&store.snapshot(), target)
+                .bind(4, NonZeroU64::new(5).expect("five is nonzero"))
+                .into(),
+            source: SourceId::from_digest([0xa3; 32]),
+            parent_hash: parent.hash,
+            target_tip_hash: target,
+            completion: TargetCompletion::TargetComplete {
+                common_ancestor: parent,
+            },
+            batch: prepared,
+            aux: Vec::new(),
+        })),
+    };
+    let finality = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::FullStateFinalized(crate::FullStateFinalized {
+                full_state_transition_id: EvidenceId::from_digest([0xa4; 32]),
+                new_finalized,
+                verified_path_proof: vec![original_anchor.hash, new_finalized.hash],
+            }),
+        },
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("the parent remains above new finality");
+    store.commit(&finality);
+
+    let plan = apply_with_header_rebase_facts(&store, held, &config, &clock, validation)
+        .expect("the retained parent preserves all prepared child work");
+    assert_eq!(plan.cause(), TransitionCause::HeaderWorkRebased);
+    assert_eq!(plan.change_set.put_nodes.len(), 1);
+    assert_eq!(plan.change_set.put_nodes[0].parent_hash, parent.hash);
+}
+
+#[test]
+// AUD-13: both operation orders must produce the same durable graph and
+// projections, which covers every observable result of the transition.
+fn finalization_and_replacement_match_serial_histories() {
+    use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
+
+    let (mut base, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let anchor = base.graph.finalized();
+    let easy = base
+        .graph
+        .node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let easy_target: U256 = easy
+        .to_expanded()
+        .expect("the fixture target expands")
+        .into();
+    let hard = ExpandedDifficulty::from(easy_target >> 3).into();
+    let incumbent = insert_verified_branch(&mut base.graph, anchor, 2, easy, 0x61);
+    let incumbent_path = path(&base.graph, incumbent).expect("the incumbent path is retained");
+    let shared_finalized = incumbent_path[1];
+    let replacement = insert_verified_branch(&mut base.graph, shared_finalized, 1, hard, 0x62);
+    base.graph
+        .set_body_state(replacement.hash, BodyValidationState::Unknown)
+        .expect("the replacement deliberately has no verified body");
+    synchronize_fixture(&mut base, incumbent);
+    assert_eq!(base.metadata.frontiers.header_best, replacement);
+
+    let invalidation_id = crate::OperatorInvalidationId::new([0x63; 16]);
+    let invalidate = apply_transition(
+        &base,
+        operator_invalidate(&base, replacement.hash, invalidation_id, 0x64),
+        &context(&config, &clock, None),
+    )
+    .expect("the fixture starts with the incumbent selected");
+    base.commit(&invalidate);
+    assert_eq!(base.metadata.frontiers.header_best, incumbent);
+
+    let reconsider =
+        |store: &TestStore| operator_reconsider(store, replacement.hash, invalidation_id, 0x65);
+    let finalize = |store: &TestStore| TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::FullStateFinalized(crate::FullStateFinalized {
+            full_state_transition_id: EvidenceId::from_digest([0x66; 32]),
+            new_finalized: shared_finalized,
+            verified_path_proof: vec![anchor.hash, shared_finalized.hash],
+        }),
+    };
+
+    let initially_planned_reconsider = reconsider(&base);
+    let initially_planned_finalize = finalize(&base);
+    let held_replacement_plan = apply_transition(
+        &base,
+        initially_planned_reconsider.clone(),
+        &context(&config, &clock, None),
+    )
+    .expect("replacement can pause after planning");
+    let held_finality_plan = apply_transition(
+        &base,
+        initially_planned_finalize.clone(),
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("finalization can pause after planning");
+    assert_eq!(held_replacement_plan.before(), &base.snapshot());
+    assert_eq!(held_finality_plan.before(), &base.snapshot());
+
+    let mut replacement_then_finality = base.clone();
+    let replacement_plan = apply_transition(
+        &replacement_then_finality,
+        reconsider(&replacement_then_finality),
+        &context(&config, &clock, None),
+    )
+    .expect("replacement can win the first serialized position");
+    replacement_then_finality.commit(&replacement_plan);
+    assert_eq!(
+        replacement_then_finality.metadata.frontiers.header_best,
+        replacement
+    );
+    assert!(matches!(
+        apply_transition(
+            &replacement_then_finality,
+            initially_planned_finalize,
+            &context(&config, &clock, Some(&authority))
+        ),
+        Err(TransitionFailure::Stale { .. })
+    ));
+    let finality_plan = apply_transition(
+        &replacement_then_finality,
+        finalize(&replacement_then_finality),
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("finalization replans from the committed replacement snapshot");
+    replacement_then_finality.commit(&finality_plan);
+
+    let mut finality_then_replacement = base.clone();
+    let finality_plan = apply_transition(
+        &finality_then_replacement,
+        finalize(&finality_then_replacement),
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("finalization can win the first serialized position");
+    finality_then_replacement.commit(&finality_plan);
+    assert_eq!(
+        finality_then_replacement.metadata.frontiers.finalized,
+        shared_finalized
+    );
+    assert!(matches!(
+        apply_transition(
+            &finality_then_replacement,
+            initially_planned_reconsider,
+            &context(&config, &clock, None)
+        ),
+        Err(TransitionFailure::Stale { .. })
+    ));
+    let replacement_plan = apply_transition(
+        &finality_then_replacement,
+        reconsider(&finality_then_replacement),
+        &context(&config, &clock, None),
+    )
+    .expect("replacement replans from the committed finality snapshot");
+    finality_then_replacement.commit(&replacement_plan);
+
+    let logical_state = |store: &TestStore| {
+        let mut nodes: Vec<_> = store.graph.nodes().cloned().collect();
+        nodes.sort_by_key(|node| node.hash.0);
+        (
+            store.snapshot(),
+            store.selected.clone(),
+            store.verified.clone(),
+            store.finality.clone(),
+            nodes,
+        )
+    };
+    assert_eq!(
+        logical_state(&replacement_then_finality),
+        logical_state(&finality_then_replacement),
+        "both barrier orders converge to one complete serial history"
+    );
+    assert_eq!(
+        replacement_then_finality.metadata.last_transition_id,
+        EvidenceId::from_digest([0x66; 32]),
+        "replacement-then-finality retains the actual last serialized event"
+    );
+    assert_eq!(
+        finality_then_replacement.metadata.last_transition_id,
+        EvidenceId::from_digest([0x65; 32]),
+        "finality-then-replacement retains the actual last serialized event"
+    );
+    assert_eq!(
+        replacement_then_finality.metadata.frontiers.finalized,
+        shared_finalized
+    );
+    assert_eq!(
+        replacement_then_finality.metadata.frontiers.header_best,
+        replacement
+    );
+    assert_eq!(
+        replacement_then_finality.metadata.frontiers.verified_best,
+        incumbent
+    );
+    assert_eq!(
+        replacement_then_finality.metadata.state_version,
+        StateVersion::new(base.metadata.state_version.get().saturating_add(2))
+    );
+    assert_next_child_commits(
+        &replacement_then_finality,
+        &config,
+        &clock,
+        replacement,
+        0x67,
+    );
+    assert_next_child_commits(
+        &finality_then_replacement,
+        &config,
+        &clock,
+        replacement,
+        0x67,
+    );
+}
+
+#[test]
+fn finality_atomic_prune_rebase_projection_generation() {
+    use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
+
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let old_finalized = store.graph.finalized();
+    let easy = store
+        .graph
+        .node(old_finalized.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let easy_target: U256 = easy
+        .to_expanded()
+        .expect("the fixture target expands")
+        .into();
+    let hard = ExpandedDifficulty::from(easy_target >> 3).into();
+
+    let verified_tip = insert_verified_branch(&mut store.graph, old_finalized, 3, easy, 0x71);
+    let verified_path =
+        path(&store.graph, verified_tip).expect("the verified fixture path is retained");
+    let new_finalized = verified_path[1];
+    let selected_tip = insert_verified_branch(&mut store.graph, old_finalized, 2, hard, 0x72);
+    synchronize_fixture(&mut store, verified_tip);
+    assert_eq!(store.metadata.frontiers.header_best, selected_tip);
+    assert!(
+        !store.selected.contains(&new_finalized),
+        "the selected history deliberately conflicts with the full-state anchor"
+    );
+    let old_selected = store.selected.clone();
+    let old_verified = store.verified.clone();
+    let before = store.snapshot();
+    let retained_tip_coordinate = store
+        .graph
+        .node(verified_tip.hash)
+        .expect("the retained tip exists")
+        .work_coordinate();
+    let new_anchor_coordinate = store
+        .graph
+        .node(new_finalized.hash)
+        .expect("the new anchor exists")
+        .work_coordinate();
+
+    let plan = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: before.state_version,
+            event: TransitionEvent::FullStateFinalized(crate::FullStateFinalized {
+                full_state_transition_id: EvidenceId::from_digest([0x73; 32]),
+                new_finalized,
+                verified_path_proof: vec![old_finalized.hash, new_finalized.hash],
+            }),
+        },
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("authenticated full-state finality transitions both histories atomically");
+
+    let changes = plan.change_set();
+    assert_eq!(changes.metadata.frontiers.finalized, new_finalized);
+    assert_eq!(changes.metadata.frontiers.header_best, verified_tip);
+    assert_eq!(changes.metadata.frontiers.verified_best, verified_tip);
+    assert_eq!(
+        changes.metadata.header_best_score.suffix_work,
+        retained_tip_coordinate
+            .suffix_after(new_anchor_coordinate)
+            .expect("the retained tip descends from the new anchor"),
+        "selection work is rebased to the new finalized anchor"
+    );
+    assert_eq!(
+        changes.delete_nodes.len(),
+        old_selected.len(),
+        "the old anchor and every node on the conflicting selected history are pruned"
+    );
+    assert!(old_selected
+        .iter()
+        .all(|frontier| changes.delete_nodes.contains(&frontier.hash)));
+    assert!(old_verified
+        .iter()
+        .skip(1)
+        .all(|frontier| !changes.delete_nodes.contains(&frontier.hash)));
+    assert_eq!(
+        changes.selected_projection,
+        ProjectionDelta {
+            remove_before: Some(verified_path[1].height),
+            remove_from: Some(verified_path[1].height),
+            put: verified_path[1..].to_vec(),
+        }
+    );
+    assert_eq!(
+        changes.verified_projection,
+        ProjectionDelta {
+            remove_before: Some(verified_path[1].height),
+            remove_from: None,
+            put: Vec::new(),
+        }
+    );
+    assert_eq!(
+        changes.metadata.state_version,
+        before
+            .state_version
+            .checked_next()
+            .expect("the fixture version can advance")
+    );
+    assert_eq!(
+        changes.metadata.header_generation,
+        before
+            .header_generation
+            .checked_next()
+            .expect("the fixture generation can advance")
+    );
+    assert_eq!(
+        changes.metadata.verified_generation,
+        before
+            .verified_generation
+            .checked_next()
+            .expect("the fixture generation can advance")
+    );
+    assert_eq!(
+        changes.finality_append,
+        Some(FinalityRecord {
+            previous: old_finalized,
+            current: new_finalized,
+            source: FinalitySource::FullState {
+                evidence: EvidenceId::from_digest([0x73; 32]),
+            },
+            epoch: FinalityEpoch::new(1),
+        })
+    );
+    verify_plan(&test_engine(&store), &plan)
+        .expect("the complete atomic finality plan is coherent");
+}
+
+#[test]
+fn headers_only_finalizes_exactly_tip_minus_one_thousand_before_publication() {
+    let (store, config) = TestStore::new(EngineMode::HeadersOnly);
+    let clock = ManualClock(Utc::now());
+    let request = insertion(&store, 1_001, EvidenceId::from_digest([1; 32]));
+    let plan = apply_transition(&store, request, &context(&config, &clock, None))
+        .expect("the complete target is admitted atomically");
+
+    assert_eq!(
+        plan.change_set.metadata.frontiers.finalized.height,
+        block::Height(1)
+    );
+    assert_eq!(
+        plan.change_set.metadata.frontiers.header_best.height,
+        block::Height(1_001)
+    );
+    assert_eq!(
+        plan.change_set.metadata.frontiers.verified_best.height,
+        block::Height(1)
+    );
+    assert_eq!(
+        plan.change_set.metadata.finality_epoch,
+        FinalityEpoch::new(1)
+    );
+    assert!(matches!(
+        plan.change_set.finality_append.expect("depth finality is recorded").source,
+        FinalitySource::HeadersOnlyDepth { selected_tip } if selected_tip.height == block::Height(1_001)
+    ));
+    assert_eq!(plan.cause(), TransitionCause::HeadersOnlyFinality);
+}
+
+#[test]
+fn integrated_finality_requires_authority_and_exact_verified_path() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let insert = insertion(&store, 3, EvidenceId::from_digest([2; 32]));
+    let insert_plan = apply_transition(&store, insert, &context(&config, &clock, None))
+        .expect("network insertion itself needs no full-state authority");
+    store.commit(&insert_plan);
+    let new_path: Vec<_> = path(&store.graph, store.metadata.frontiers.header_best)
+        .expect("the selected fixture path is continuous")
+        .into_iter()
+        .skip(1)
+        .map(|frontier| crate::VerifiedHeaderRef {
+            height: frontier.height,
+            hash: frontier.hash,
+            header: store
+                .graph
+                .node(frontier.hash)
+                .expect("path nodes exist")
+                .header
+                .clone(),
+        })
+        .collect();
+    let verified_id = EvidenceId::from_digest([4; 32]);
+    let verified = TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::VerifiedChainChanged(crate::VerifiedChainChanged {
+            full_state_transition_id: verified_id,
+            old_tip: store.metadata.frontiers.verified_best,
+            new_path,
+            cause: crate::VerifiedChangeCause::Grow,
+        }),
+    };
+    assert!(matches!(
+        apply_transition(&store, verified.clone(), &context(&config, &clock, None)),
+        Err(TransitionFailure::Authority)
+    ));
+    let verified_plan = apply_transition(
+        &store,
+        verified,
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("the state writer authenticates its verified-path transition");
+    store.commit(&verified_plan);
+    let new_finalized = store.verified[1];
+    let finality_id = EvidenceId::from_digest([5; 32]);
+    let finalize = TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::FullStateFinalized(crate::FullStateFinalized {
+            full_state_transition_id: finality_id,
+            new_finalized,
+            verified_path_proof: vec![store.verified[0].hash, new_finalized.hash],
+        }),
+    };
+    let plan = apply_transition(
+        &store,
+        finalize,
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("exact verified full-state evidence advances finality");
+    assert_eq!(plan.change_set.metadata.frontiers.finalized, new_finalized);
+    assert!(matches!(
+        plan.change_set.finality_append.expect("full-state finality is recorded").source,
+        FinalitySource::FullState { evidence } if evidence == finality_id
+    ));
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/guards.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/guards.rs
@@ -1,0 +1,260 @@
+use super::*;
+
+#[test]
+fn typed_header_authority_ignores_global_version_but_rejects_stale_generation() {
+    let (store, config) = TestStore::new(EngineMode::HeadersOnly);
+    let clock = ManualClock(Utc::now());
+    let mut request = insertion(&store, 1, EvidenceId::from_digest([6; 32]));
+    request.expected_version = StateVersion::new(9);
+    apply_transition(&store, request, &context(&config, &clock, None))
+        .expect("global state versions do not authorize header work");
+
+    let mut request = insertion(&store, 1, EvidenceId::from_digest([7; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    let owner = insert
+        .owner
+        .header_owner()
+        .expect("the fixture is ordinary header work");
+    insert.owner = crate::HeaderWorkOwner {
+        authority: crate::HeaderWorkAuthority {
+            header_generation: HeaderGeneration::new(9),
+            ..owner.authority
+        },
+        ..owner
+    }
+    .into();
+    assert!(matches!(
+        apply_transition(&store, request, &context(&config, &clock, None)),
+        Err(TransitionFailure::Stale { current }) if current == StateVersion::new(0)
+    ));
+}
+
+#[test]
+fn peer_target_completion_must_match_the_validation_lease_ancestor() {
+    let (store, config) = TestStore::new(EngineMode::HeadersOnly);
+    let clock = ManualClock(Utc::now());
+    let mut request = insertion(&store, 1, EvidenceId::from_digest([0x64; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    insert.completion = TargetCompletion::TargetComplete {
+        common_ancestor: Frontier::new(store.lease.parent.height, block::Hash([0x65; 32])),
+    };
+
+    assert!(matches!(
+        apply_transition(&store, request, &context(&config, &clock, None)),
+        Err(TransitionFailure::InvalidEvidence(
+            "target completion ancestor does not match the retained parent"
+        ))
+    ));
+}
+
+#[test]
+fn bounded_target_prefix_has_the_same_exact_owner_and_validation_guards() {
+    let (store, config) = TestStore::new(EngineMode::HeadersOnly);
+    let clock = ManualClock(Utc::now());
+    let mut request = insertion(&store, 2, EvidenceId::from_digest([0x66; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    insert.completion = TargetCompletion::TargetPrefix {
+        common_ancestor: store.lease.parent,
+    };
+    let expected_target = insert.target_tip_hash;
+
+    let plan = apply_transition(&store, request, &context(&config, &clock, None))
+        .expect("a validated bounded prefix is admitted under its exact target owner");
+
+    assert_eq!(
+        plan.change_set.metadata.frontiers.header_best.hash,
+        expected_target
+    );
+}
+
+#[test]
+fn header_acceptance_cannot_construct_body_or_state_validity() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let before = store.snapshot();
+    let plan = apply_transition(
+        &store,
+        insertion(&store, 2, EvidenceId::from_digest([0xaf; 32])),
+        &context(&config, &clock, None),
+    )
+    .expect("the prepared header-only target is accepted");
+
+    assert!(
+        plan.change_set
+            .put_nodes
+            .iter()
+            .all(|node| node.body == BodyValidationState::Unknown),
+        "header acceptance creates no body-valid fact"
+    );
+    assert_eq!(
+        plan.change_set.metadata.frontiers.verified_best, before.frontiers.verified_best,
+        "header acceptance cannot advance full-state validity"
+    );
+    assert_eq!(
+        plan.change_set.metadata.verified_generation, before.verified_generation,
+        "header acceptance cannot publish a state-valid generation"
+    );
+    assert!(
+        plan.change_set.verified_projection.put.is_empty()
+            && plan.change_set.verified_projection.remove_from.is_none(),
+        "header acceptance cannot mutate the verified projection"
+    );
+}
+
+#[test]
+fn every_named_invariant_category_rejects_its_projected_corruption() {
+    use std::num::NonZeroUsize;
+
+    use crate::{
+        AuxAuthentication, AuxDelivery, BodySizeHint, ChainScore, InvariantViolation, SuffixWork,
+        WorkCoordinate,
+    };
+    use zakura_chain::work::difficulty::U256;
+
+    let (store, config) = TestStore::new(EngineMode::HeadersOnly);
+    let clock = ManualClock(Utc::now());
+    let request = insertion(&store, 2, EvidenceId::from_digest([8; 32]));
+    let owner = request
+        .event
+        .header_sync_owner()
+        .expect("insertion carries an owner");
+    let plan = apply_transition(&store, request, &context(&config, &clock, None))
+        .expect("the baseline plan satisfies every invariant");
+    let tip = plan.change_set.metadata.frontiers.header_best;
+    let first = plan
+        .projected
+        .ancestor(tip.hash, block::Height(1))
+        .expect("the baseline ancestry is coherent")
+        .expect("height one is retained");
+
+    let mut corrupt = plan.clone();
+    corrupt
+        .projected
+        .node_mut(tip.hash)
+        .expect("tip exists")
+        .hash = block::Hash([0; 32]);
+    assert!(matches!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::NodeHash(_))
+    ));
+
+    let mut corrupt = plan.clone();
+    corrupt
+        .projected
+        .node_mut(tip.hash)
+        .expect("tip exists")
+        .parent_hash = block::Hash([0; 32]);
+    assert!(matches!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Parent(_))
+    ));
+
+    let mut corrupt = plan.clone();
+    corrupt.change_set.index_changes.inserted.clear();
+    assert!(matches!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Index(_))
+    ));
+
+    let mut corrupt = plan.clone();
+    corrupt
+        .projected
+        .node_mut(tip.hash)
+        .expect("tip exists")
+        .work_coordinate = WorkCoordinate::new(block::Hash([0; 32]), U256::zero());
+    assert!(matches!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Work(_))
+    ));
+
+    let mut corrupt = plan.clone();
+    corrupt
+        .projected
+        .node_mut(tip.hash)
+        .expect("tip exists")
+        .eligibility
+        .inherited_from = Some(block::Hash([0; 32]));
+    assert!(matches!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Eligibility(_))
+    ));
+
+    let mut corrupt = plan.clone();
+    corrupt.change_set.selected_projection.put.clear();
+    assert!(matches!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::SelectedProjection(_))
+    ));
+
+    let mut corrupt = plan.clone();
+    corrupt.change_set.metadata.header_best_score = ChainScore::new(SuffixWork::zero(), tip.hash);
+    assert_eq!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Selection)
+    );
+
+    let mut corrupt = plan.clone();
+    corrupt.change_set.verified_projection.put = vec![first, tip];
+    corrupt.change_set.metadata.frontiers.verified_best = tip;
+    assert!(matches!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::VerifiedProjection(_))
+    ));
+
+    let mut corrupt = plan.clone();
+    corrupt
+        .trust_pins
+        .push(Frontier::new(first.height, block::Hash([9; 32])));
+    assert_eq!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::TrustPin(first.height))
+    );
+
+    let mut corrupt = plan.clone();
+    corrupt.change_set.delete_nodes.push(tip.hash);
+    corrupt.change_set.index_changes.deleted.push(tip.hash);
+    corrupt.graph_delta.delete_nodes.push(tip.hash);
+    assert_eq!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Protected(tip.hash))
+    );
+
+    let mut corrupt = plan.clone();
+    corrupt.limits.max_non_finalized_nodes = NonZeroUsize::new(1).expect("one is nonzero");
+    assert_eq!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Limits)
+    );
+
+    let mut corrupt = plan.clone();
+    corrupt.change_set.metadata.header_generation = plan.before.header_generation;
+    assert_eq!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Generation)
+    );
+
+    let mut corrupt = plan;
+    let missing = block::Hash([0xab; 32]);
+    corrupt
+        .change_set
+        .aux_changes
+        .push(crate::AuxDelta::Put(Box::new(AuxDelivery {
+            delivery_id: EvidenceId::from_digest([0xac; 32]),
+            header_hash: missing,
+            source: SourceId::from_digest([0xad; 32]),
+            owner,
+            body_size: BodySizeHint::Unknown,
+            tree_aux: None,
+            authentication: AuxAuthentication::Unauthenticated,
+        })));
+    assert_eq!(
+        verify_plan(&test_engine(&store), &corrupt),
+        Err(InvariantViolation::Auxiliary(missing))
+    );
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/insertion.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/insertion.rs
@@ -1,0 +1,378 @@
+use super::*;
+
+#[test]
+fn ordinary_header_insertion_rejects_body_repair_authority() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let mut request = insertion(&store, 1, EvidenceId::from_digest([0x2f; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+        panic!("the fixture request inserts headers");
+    };
+    let header_owner = insert
+        .owner
+        .header_owner()
+        .expect("the fixture is ordinary header work");
+    insert.owner = crate::BodyWorkOwner {
+        authority: crate::BodyWorkAuthority {
+            header: header_owner.authority,
+            verified_generation: store.metadata.verified_generation,
+        },
+        session_id: header_owner.session_id,
+        request_id: header_owner.request_id,
+    }
+    .into();
+
+    assert!(matches!(
+        apply_transition(&store, request, &context(&config, &clock, None)),
+        Err(TransitionFailure::InvalidEvidence(
+            "ordinary header insertion does not have pure header authority"
+        ))
+    ));
+}
+
+#[test]
+fn resource_bound_refusal_commits_only_the_alarm_and_recovers() {
+    let (mut store, mut config) = TestStore::new(EngineMode::Integrated);
+    config.limits.max_non_finalized_nodes = std::num::NonZeroUsize::new(1).expect("one is nonzero");
+    let clock = ManualClock(Utc::now());
+
+    let refused = apply_transition(
+        &store,
+        insertion(&store, 2, EvidenceId::from_digest([0x30; 32])),
+        &context(&config, &clock, None),
+    )
+    .expect("resource refusal produces an alarm-only plan");
+    assert_eq!(refused.cause(), TransitionCause::ResourceStalled);
+    assert!(refused.change_set.metadata.alarms.resource_stalled);
+    assert_eq!(refused.graph_delta, crate::graph::GraphDelta::default());
+    assert_eq!(
+        refused.change_set.metadata.state_version,
+        StateVersion::new(1)
+    );
+    assert!(refused.change_set.put_nodes.is_empty());
+    assert!(refused.change_set.delete_nodes.is_empty());
+    assert_eq!(refused.projected.node_count(), 1);
+    assert_eq!(
+        refused.change_set.metadata.frontiers,
+        store.metadata.frontiers
+    );
+    store.commit(&refused);
+
+    let recovered = apply_transition(
+        &store,
+        insertion(&store, 1, EvidenceId::from_digest([0x31; 32])),
+        &context(&config, &clock, None),
+    )
+    .expect("an insertion within the bound clears the resource alarm");
+    assert_eq!(recovered.cause(), TransitionCause::Event);
+    assert!(!recovered.change_set.metadata.alarms.resource_stalled);
+    assert_eq!(
+        recovered.change_set.metadata.state_version,
+        StateVersion::new(2)
+    );
+    assert_eq!(recovered.projected.node_count(), 2);
+}
+
+#[test]
+fn engine_rejects_context_free_batch_with_invalid_retained_time() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(regtest_genesis_block().header.time + chrono::Duration::hours(1));
+    let mut request = insertion(&store, 1, EvidenceId::from_digest([0x31; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+        panic!("the fixture request inserts headers");
+    };
+    let original = &insert.batch.headers()[0];
+    let mut header = *original.header;
+    header.time = store
+        .graph
+        .node(insert.parent_hash)
+        .expect("the exact parent is retained")
+        .header
+        .time;
+    let header = Arc::new(header);
+    let hash = header.hash();
+    let prepared = PreparedHeader {
+        header: header.clone(),
+        hash,
+        height: original.height,
+        block_work: header
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture target has valid work"),
+        validation: HeaderValidationState::Valid,
+    };
+    insert.target_tip_hash = hash;
+    let owner = insert
+        .owner
+        .header_owner()
+        .expect("the fixture is ordinary header work");
+    insert.owner = crate::HeaderWorkOwner {
+        authority: crate::HeaderWorkAuthority {
+            branch: BranchId::new(insert.parent_hash, hash),
+            ..owner.authority
+        },
+        ..owner
+    }
+    .into();
+    insert.batch = PreparedHeaderBatch::new(
+        vec![prepared],
+        store.lease.parent,
+        store.lease.trust_anchor_digest,
+        EvidenceId::from_digest([0x31; 32]),
+    )
+    .expect("the context-free fixture is nonempty");
+
+    assert!(matches!(
+        apply_transition(&store, request, &context(&config, &clock, None)),
+        Err(TransitionFailure::InvalidEvidence(
+            "prepared header failed retained contextual validation"
+        ))
+    ));
+}
+
+#[test]
+fn insertion_enforces_every_immutable_configured_checkpoint() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let request = insertion(&store, 1, EvidenceId::from_digest([0x44; 32]));
+    let child = match &request.event {
+        TransitionEvent::InsertHeaders(event) => Frontier::new(
+            store
+                .lease
+                .parent
+                .height
+                .next()
+                .expect("the fixture anchor has a next height"),
+            event.target_tip_hash,
+        ),
+        _ => unreachable!("the insertion fixture constructs one header event"),
+    };
+
+    let mut matching_store = store.clone();
+    let mut matching_config = config.clone();
+    matching_config.local_checkpoints =
+        CheckpointSet::new([child]).expect("the matching checkpoint fixture is unique");
+    matching_store.metadata.anchor_manifest_digest = matching_config.trust_anchor_digest();
+    matching_store.lease = ValidationLease::new(
+        matching_store.lease.parent,
+        matching_store.lease.predecessors.clone(),
+        matching_config.trust_anchor_digest(),
+    );
+    let matching_request = insertion(&matching_store, 1, EvidenceId::from_digest([0x44; 32]));
+    let matching = apply_transition(
+        &matching_store,
+        matching_request,
+        &context(&matching_config, &clock, None),
+    )
+    .expect("an insertion matching the immutable configured checkpoint commits");
+    assert_eq!(matching.change_set.metadata.frontiers.header_best, child);
+    assert!(matching
+        .projected
+        .node(child.hash)
+        .expect("the matching checkpoint child is retained")
+        .eligibility
+        .direct_reasons
+        .is_empty());
+
+    let expected = Frontier::new(child.height, block::Hash([0x45; 32]));
+    let mut conflicting_store = store;
+    let mut conflicting_config = config;
+    conflicting_config.local_checkpoints =
+        CheckpointSet::new([expected]).expect("the conflicting checkpoint fixture is unique");
+    conflicting_store.metadata.anchor_manifest_digest = conflicting_config.trust_anchor_digest();
+    conflicting_store.lease = ValidationLease::new(
+        conflicting_store.lease.parent,
+        conflicting_store.lease.predecessors.clone(),
+        conflicting_config.trust_anchor_digest(),
+    );
+    let conflicting_request = insertion(&conflicting_store, 1, EvidenceId::from_digest([0x44; 32]));
+    let conflicting = apply_transition(
+        &conflicting_store,
+        conflicting_request,
+        &context(&conflicting_config, &clock, None),
+    )
+    .expect("a conflicting header is retained only as checkpoint evidence");
+    assert_eq!(
+        conflicting.change_set.metadata.frontiers.header_best,
+        conflicting_store.metadata.frontiers.header_best
+    );
+    assert!(conflicting
+        .projected
+        .node(child.hash)
+        .expect("the conflicting checkpoint child is retained")
+        .eligibility
+        .direct_reasons
+        .contains(&EligibilityReason::CheckpointConflict {
+            height: child.height,
+            expected: expected.hash,
+        }));
+
+    let conflicting_child = conflicting
+        .projected
+        .node(child.hash)
+        .expect("the conflicting checkpoint child is retained");
+    let mut descendant_header = *conflicting_child.header;
+    descendant_header.previous_block_hash = conflicting_child.hash;
+    descendant_header.nonce.0[0] ^= 1;
+    let descendant_header = Arc::new(descendant_header);
+    let descendant_work = descendant_header
+        .difficulty_threshold
+        .to_work()
+        .expect("the fixture target has exact work");
+    let mut descendant_graph = conflicting.projected.clone();
+    let descendant = descendant_graph
+        .insert(
+            descendant_header,
+            descendant_work,
+            HeaderValidationState::Valid,
+            [],
+            BodyValidationState::Unknown,
+        )
+        .expect("the checkpoint-conflicting descendant links");
+    let descendant = match descendant {
+        crate::InsertResult::Inserted(frontier) => descendant_graph
+            .node(frontier.hash)
+            .expect("the inserted descendant is retained"),
+        crate::InsertResult::AlreadyPresent(_) => {
+            unreachable!("the descendant nonce is unique in this fixture")
+        }
+    };
+    assert_eq!(descendant.eligibility.inherited_from, Some(child.hash));
+    assert!(!descendant.is_eligible());
+    let mut committed_conflict = conflicting_store.clone();
+    committed_conflict.commit(&conflicting);
+    let reconsider = apply_transition(
+        &committed_conflict,
+        operator_reconsider(
+            &committed_conflict,
+            child.hash,
+            crate::OperatorInvalidationId::new([0x46; 16]),
+            0x47,
+        ),
+        &context(&conflicting_config, &clock, None),
+    )
+    .expect("operator reconsider can remove only a matching operator reason");
+    assert!(reconsider
+        .projected
+        .node(child.hash)
+        .expect("the checkpoint conflict remains retained")
+        .eligibility
+        .direct_reasons
+        .contains(&EligibilityReason::CheckpointConflict {
+            height: child.height,
+            expected: expected.hash,
+        }));
+    assert_eq!(
+        reconsider.change_set.metadata.frontiers.header_best,
+        committed_conflict.metadata.frontiers.header_best
+    );
+}
+
+#[test]
+fn production_settled_pins_create_exact_permanent_conflict_reasons() {
+    let clock = ManualClock(Utc::now());
+    for (network, bytes) in [
+        (
+            Network::Mainnet,
+            zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.as_slice(),
+        ),
+        (
+            Network::new_default_testnet(),
+            zakura_test::vectors::BLOCK_TESTNET_GENESIS_BYTES.as_slice(),
+        ),
+    ] {
+        let genesis = Arc::<Block>::zcash_deserialize(bytes)
+            .expect("the production genesis vector is canonical");
+        let frontier = Frontier::new(block::Height(0), genesis.hash());
+        let config = EngineConfig::new(
+            EngineMode::Integrated,
+            network.clone(),
+            TrustedAnchor {
+                frontier,
+                header: genesis.header.clone(),
+            },
+            CheckpointSet::default(),
+        )
+        .expect("the production configuration installs its settled pin");
+        let pin = config
+            .settled_manifest
+            .pin_for_network(&network)
+            .expect("the release manifest has a production pin");
+        assert!(anchor_reasons(
+            &context(&config, &clock, None),
+            pin.activation.height,
+            pin.activation.hash,
+        )
+        .is_empty());
+        let conflicting_hash = block::Hash([0x55; 32]);
+        assert_eq!(
+            anchor_reasons(
+                &context(&config, &clock, None),
+                pin.activation.height,
+                conflicting_hash,
+            ),
+            vec![EligibilityReason::SettledUpgradeConflict {
+                height: pin.activation.height,
+                expected: pin.activation.hash,
+            }]
+        );
+    }
+}
+
+#[test]
+fn migrated_pin_refutation_requires_full_state_authority_and_exact_pin() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let pin = store.graph.finalized();
+    store.finality.push(FinalityRecord {
+        previous: pin,
+        current: pin,
+        source: FinalitySource::MigratedHeadersOnly,
+        epoch: FinalityEpoch::new(0),
+    });
+    let evidence = EvidenceId::from_digest([0x61; 32]);
+    let request = |pin| TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::MigratedPinRefutation(crate::MigratedPinRefutation {
+            full_state_transition_id: evidence,
+            pin,
+            invalid_header: Frontier::new(block::Height(0), block::Hash([0x62; 32])),
+            rule: crate::BodyRuleId::new("body.imported-history"),
+        }),
+    };
+
+    assert!(matches!(
+        apply_transition(&store, request(pin), &context(&config, &clock, None)),
+        Err(TransitionFailure::Authority)
+    ));
+    assert!(matches!(
+        apply_transition(
+            &store,
+            request(Frontier::new(pin.height, block::Hash([0x63; 32]))),
+            &context(&config, &clock, Some(&authority)),
+        ),
+        Err(TransitionFailure::InvalidEvidence(_))
+    ));
+
+    let plan = apply_transition(
+        &store,
+        request(pin),
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("full state can persist a refuted imported pin incident");
+    assert_eq!(
+        plan.change_set.metadata.alarms.migrated_pin_refuted,
+        Some(pin)
+    );
+    assert_eq!(
+        plan.change_set.metadata.state_version,
+        store
+            .metadata
+            .state_version
+            .checked_next()
+            .expect("the fixture version has capacity")
+    );
+    assert!(plan.change_set.put_nodes.is_empty());
+    assert!(plan.change_set.delete_nodes.is_empty());
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
@@ -1,0 +1,438 @@
+mod auxiliary;
+mod body_evidence;
+mod finality;
+mod guards;
+mod insertion;
+mod operator;
+mod selection;
+
+use std::{num::NonZeroU64, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use zakura_chain::{
+    block::{genesis::regtest_genesis_block, Block},
+    parameters::{testnet::RegtestParameters, Network},
+    serialization::ZcashDeserialize,
+};
+
+use super::*;
+use crate::{
+    verify_plan, AlarmSet, BranchId, CheckpointSet, EngineConfig, FinalityEpoch,
+    HeaderChainDiskVersion, HeaderContextFact, HeaderGeneration, PreparedHeader,
+    PreparedHeaderBatch, SourceId, TargetCompletion, TrustedAnchor, ValidationLease,
+    VerifiedGeneration,
+};
+
+#[derive(Clone)]
+struct TestStore {
+    graph: MemHeaderStore,
+    metadata: EngineMetadata,
+    selected: Vec<Frontier>,
+    verified: Vec<Frontier>,
+    lease: ValidationLease,
+    finality: Vec<FinalityRecord>,
+    aux: Vec<crate::AuxDelivery>,
+}
+
+impl TestStore {
+    fn new(mode: EngineMode) -> (Self, EngineConfig) {
+        let block = regtest_genesis_block();
+        let frontier = Frontier::new(block::Height(0), block.hash());
+        let work = block
+            .header
+            .difficulty_threshold
+            .to_work()
+            .expect("the regtest genesis target has valid work");
+        let graph = MemHeaderStore::new(frontier, block.header.clone(), work, work.as_u256())
+            .expect("the fixture anchor header matches its hash");
+        let config = EngineConfig::new(
+            mode,
+            Network::new_regtest(RegtestParameters::default()),
+            TrustedAnchor {
+                frontier,
+                header: block.header.clone(),
+            },
+            CheckpointSet::default(),
+        )
+        .expect("the fixture configuration is coherent");
+        let score = graph.score(frontier.hash).expect("the anchor is retained");
+        let metadata = EngineMetadata {
+            disk_format: HeaderChainDiskVersion(1),
+            mode,
+            network_id: config.network.kind(),
+            anchor_manifest_digest: config.trust_anchor_digest(),
+            work_origin: frontier,
+            state_version: StateVersion::new(0),
+            header_generation: HeaderGeneration::new(0),
+            verified_generation: VerifiedGeneration::new(0),
+            finality_epoch: FinalityEpoch::new(0),
+            frontiers: FrontierSet {
+                finalized: frontier,
+                header_best: frontier,
+                verified_best: frontier,
+            },
+            header_best_score: score,
+            oldest_retained_height: frontier.height,
+            alarms: AlarmSet::default(),
+            last_transition_id: EvidenceId::from_digest([0xff; 32]),
+        };
+        let lease = ValidationLease {
+            parent: frontier,
+            predecessors: vec![HeaderContextFact {
+                frontier,
+                difficulty_threshold: block.header.difficulty_threshold,
+                time: block.header.time,
+            }],
+            trust_anchor_digest: config.trust_anchor_digest(),
+            context_digest: [7; 32],
+        };
+        (
+            Self {
+                graph,
+                metadata,
+                selected: vec![frontier],
+                verified: vec![frontier],
+                lease,
+                finality: Vec::new(),
+                aux: Vec::new(),
+            },
+            config,
+        )
+    }
+
+    fn snapshot(&self) -> EngineSnapshot {
+        EngineSnapshot {
+            mode: self.metadata.mode,
+            state_version: self.metadata.state_version,
+            header_generation: self.metadata.header_generation,
+            verified_generation: self.metadata.verified_generation,
+            frontiers: self.metadata.frontiers,
+            header_best_score: self.metadata.header_best_score,
+            oldest_retained_height: self.metadata.oldest_retained_height,
+            alarms: self.metadata.alarms.clone(),
+        }
+    }
+
+    fn commit(&mut self, plan: &TransitionPlan) {
+        self.graph = plan.projected.clone();
+        self.metadata = plan.change_set.metadata.clone();
+        apply_projection(&mut self.selected, &plan.change_set.selected_projection);
+        apply_projection(&mut self.verified, &plan.change_set.verified_projection);
+        if let Some(record) = plan.change_set.finality_append {
+            self.finality.push(record);
+        }
+        for change in &plan.change_set.aux_changes {
+            match change {
+                crate::AuxDelta::Put(delivery) => {
+                    self.aux
+                        .retain(|existing| existing.delivery_id != delivery.delivery_id);
+                    self.aux.push(**delivery);
+                }
+                crate::AuxDelta::Delete { delivery_id, .. } => {
+                    self.aux
+                        .retain(|existing| existing.delivery_id != *delivery_id);
+                }
+            }
+        }
+        self.lease.parent = self.metadata.frontiers.header_best;
+        self.lease.context_digest[0] = self.lease.context_digest[0].wrapping_add(1);
+    }
+}
+
+struct ManualClock(DateTime<Utc>);
+impl super::super::Clock for ManualClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+struct Authority;
+impl super::super::FullStateEvidenceAuthority for Authority {
+    fn authorizes(&self, _evidence: EvidenceId) -> bool {
+        true
+    }
+}
+
+fn context<'a>(
+    config: &'a EngineConfig,
+    clock: &'a ManualClock,
+    authority: Option<&'a Authority>,
+) -> TransitionContext<'a> {
+    let full_state_authority = authority.map(|item| {
+        // This trait-object coercion preserves the borrowed fixture's lifetime and identity.
+        item as &dyn super::super::FullStateEvidenceAuthority
+    });
+    TransitionContext {
+        config,
+        clock,
+        full_state_authority,
+        retention_references: &[],
+    }
+}
+
+fn test_engine(store: &TestStore) -> crate::HeaderChainEngine {
+    crate::HeaderChainEngine::from_audited_state(
+        store.graph.clone(),
+        store.metadata.clone(),
+        store.selected.clone(),
+        store.verified.clone(),
+        store.aux.clone(),
+    )
+    .expect("the planner fixture is coherent before transition")
+}
+
+fn apply_transition(
+    store: &TestStore,
+    request: TransitionRequest,
+    context: &TransitionContext<'_>,
+) -> Result<TransitionPlan, TransitionFailure> {
+    let engine = crate::HeaderChainEngine::from_audited_state(
+        store.graph.clone(),
+        store.metadata.clone(),
+        store.selected.clone(),
+        store.verified.clone(),
+        store.aux.clone(),
+    )
+    .map_err(|_| TransitionFailure::InvalidEvidence("planner fixture engine is incoherent"))?;
+    let durable = match &request.event {
+        TransitionEvent::InsertHeaders(_) => DurableTransitionFacts::HeaderInsertion {
+            validation_contexts: vec![store.lease.clone()],
+            finality_path: Vec::new(),
+        },
+        TransitionEvent::MigratedPinRefutation(event) => {
+            DurableTransitionFacts::MigratedFinalityPin(
+                store
+                    .finality
+                    .iter()
+                    .any(|record| {
+                        record.current == event.pin
+                            && matches!(record.source, FinalitySource::MigratedHeadersOnly)
+                    })
+                    .then_some(event.pin),
+            )
+        }
+        _ => DurableTransitionFacts::None,
+    };
+    engine
+        .apply(request, context, durable)
+        .map(crate::EngineTransition::into_plan)
+}
+
+fn batch(
+    parent: Frontier,
+    count: u32,
+    trust_anchor_digest: [u8; 32],
+    evidence: EvidenceId,
+) -> PreparedHeaderBatch {
+    let mut headers = Vec::new();
+    let mut parent_hash = parent.hash;
+    for offset in 1..=count {
+        let mut header = *regtest_genesis_block().header;
+        header.previous_block_hash = parent_hash;
+        let seconds = i64::from(parent.height.0)
+            .checked_add(i64::from(offset))
+            .expect("the fixture height fits in timestamp arithmetic");
+        header.time = regtest_genesis_block()
+            .header
+            .time
+            .checked_add_signed(chrono::Duration::seconds(seconds))
+            .expect("the fixture timestamp remains representable");
+        let mut nonce = [0; 32];
+        nonce[..4].copy_from_slice(&offset.to_le_bytes());
+        header.nonce = nonce.into();
+        let header = Arc::new(header);
+        let hash = header.hash();
+        headers.push(PreparedHeader {
+            header: header.clone(),
+            hash,
+            height: block::Height(parent.height.0 + offset),
+            block_work: header
+                .difficulty_threshold
+                .to_work()
+                .expect("the fixture target has valid work"),
+            validation: HeaderValidationState::Valid,
+        });
+        parent_hash = hash;
+    }
+    PreparedHeaderBatch::new(headers, parent, trust_anchor_digest, evidence)
+        .expect("the fixture batch is nonempty")
+}
+
+fn insertion(store: &TestStore, count: u32, evidence: EvidenceId) -> TransitionRequest {
+    let batch = batch(
+        store.lease.parent,
+        count,
+        store.lease.trust_anchor_digest,
+        evidence,
+    );
+    let target = batch.headers().last().expect("the batch is nonempty").hash;
+    TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::InsertHeaders(Box::new(crate::InsertHeaders {
+            owner: crate::HeaderWorkOwner {
+                authority: crate::HeaderWorkAuthority {
+                    header_generation: store.metadata.header_generation,
+                    branch: BranchId::new(store.metadata.frontiers.finalized.hash, target),
+                },
+                session_id: 1,
+                request_id: NonZeroU64::new(1).expect("one is nonzero"),
+            }
+            .into(),
+            source: SourceId::from_digest([3; 32]),
+            parent_hash: store.lease.parent.hash,
+            target_tip_hash: target,
+            completion: TargetCompletion::TargetComplete {
+                common_ancestor: store.lease.parent,
+            },
+            batch,
+            aux: Vec::new(),
+        })),
+    }
+}
+
+fn assert_next_child_commits(
+    store: &TestStore,
+    config: &EngineConfig,
+    clock: &ManualClock,
+    expected_parent: Frontier,
+    evidence: u8,
+) {
+    assert_eq!(store.metadata.frontiers.header_best, expected_parent);
+    let mut committed = store.clone();
+    let request = insertion(&committed, 1, EvidenceId::from_digest([evidence; 32]));
+    let child = match &request.event {
+        TransitionEvent::InsertHeaders(event) => {
+            assert_eq!(event.parent_hash, expected_parent.hash);
+            assert_eq!(
+                event.completion,
+                TargetCompletion::TargetComplete {
+                    common_ancestor: expected_parent,
+                }
+            );
+            event.target_tip_hash
+        }
+        _ => unreachable!("the next-child helper constructs one insertion"),
+    };
+    let plan = apply_transition(&committed, request, &context(config, clock, None))
+        .expect("the exact selected parent accepts its next child");
+    assert_eq!(
+        plan.change_set.metadata.frontiers.header_best,
+        Frontier::new(
+            expected_parent
+                .height
+                .next()
+                .expect("the bounded test parent has a next height"),
+            child,
+        )
+    );
+    committed.commit(&plan);
+    assert_eq!(
+        committed
+            .graph
+            .node(child)
+            .expect("the committed next child is retained")
+            .parent_hash,
+        expected_parent.hash
+    );
+}
+
+fn insert_verified_branch(
+    graph: &mut MemHeaderStore,
+    parent: Frontier,
+    count: u32,
+    difficulty: zakura_chain::work::difficulty::CompactDifficulty,
+    nonce_seed: u8,
+) -> Frontier {
+    let mut parent = parent;
+    for offset in 0..count {
+        let mut header = *regtest_genesis_block().header;
+        header.previous_block_hash = parent.hash;
+        header.difficulty_threshold = difficulty;
+        header.nonce.0[0] = nonce_seed;
+        header.nonce.0[1..5].copy_from_slice(&offset.to_be_bytes());
+        let header = Arc::new(header);
+        let work = header
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture target has valid work");
+        parent = match graph
+            .insert(
+                header,
+                work,
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Verified {
+                    evidence: EvidenceId::from_digest([nonce_seed; 32]),
+                },
+            )
+            .expect("the verified fixture branch links to its parent")
+        {
+            crate::InsertResult::Inserted(frontier)
+            | crate::InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+    }
+    parent
+}
+
+fn synchronize_fixture(store: &mut TestStore, verified_tip: Frontier) {
+    store
+        .graph
+        .recompute_all_eligibility()
+        .expect("the fixture eligibility cache recomputes");
+    let header_best = store
+        .graph
+        .select_header_best()
+        .expect("the fixture has an eligible tip")
+        .0;
+    store.selected = path(&store.graph, header_best).expect("the selected path is retained");
+    store.verified = path(&store.graph, verified_tip).expect("the verified path is retained");
+    store.metadata.frontiers.header_best = header_best;
+    store.metadata.frontiers.verified_best = verified_tip;
+    store.metadata.header_best_score = store
+        .graph
+        .score(header_best.hash)
+        .expect("the selected score is exact");
+}
+
+fn operator_invalidate(
+    store: &TestStore,
+    target: block::Hash,
+    id: crate::OperatorInvalidationId,
+    evidence: u8,
+) -> TransitionRequest {
+    TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::OperatorInvalidate(crate::OperatorInvalidate {
+            target,
+            id,
+            operator_reason_digest: [evidence.wrapping_add(1); 32],
+            evidence: EvidenceId::from_digest([evidence; 32]),
+        }),
+    }
+}
+
+fn operator_reconsider(
+    store: &TestStore,
+    target: block::Hash,
+    id: crate::OperatorInvalidationId,
+    evidence: u8,
+) -> TransitionRequest {
+    TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::OperatorReconsider(crate::OperatorReconsider {
+            target,
+            id,
+            evidence: EvidenceId::from_digest([evidence; 32]),
+        }),
+    }
+}
+
+fn apply_projection(projection: &mut Vec<Frontier>, delta: &ProjectionDelta) {
+    if let Some(height) = delta.remove_before {
+        projection.retain(|frontier| frontier.height >= height);
+    }
+    if let Some(height) = delta.remove_from {
+        projection.retain(|frontier| frontier.height < height);
+    }
+    projection.extend(delta.put.iter().copied());
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
@@ -1,0 +1,380 @@
+use super::*;
+
+#[test]
+// AUD-10/AUD-12: invalidation must reselect eligible work without erasing
+// independent exclusion reasons; this fixture exercises both in one graph.
+fn operator_invalidation_promotes_alternate_and_preserves_nested_reasons() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.graph.finalized();
+    let difficulty = store
+        .graph
+        .node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let left = insert_verified_branch(&mut store.graph, anchor, 1, difficulty, 0x11);
+    let right = insert_verified_branch(&mut store.graph, anchor, 1, difficulty, 0x22);
+    let (winner, loser) = if store.graph.score(left.hash).expect("left score exists")
+        > store.graph.score(right.hash).expect("right score exists")
+    {
+        (left, right)
+    } else {
+        (right, left)
+    };
+    synchronize_fixture(&mut store, winner);
+    let first_id = crate::OperatorInvalidationId::new([1; 16]);
+    let second_id = crate::OperatorInvalidationId::new([2; 16]);
+
+    let first = apply_transition(
+        &store,
+        operator_invalidate(&store, winner.hash, first_id, 0x31),
+        &context(&config, &clock, None),
+    )
+    .expect("invalidating the winning verified fork reselects atomically");
+    assert_eq!(first.change_set.metadata.frontiers.header_best, loser);
+    assert_eq!(first.change_set.metadata.frontiers.verified_best, loser);
+    assert_eq!(
+        first.change_set.metadata.header_generation,
+        HeaderGeneration::new(1)
+    );
+    assert_eq!(
+        first.change_set.metadata.verified_generation,
+        VerifiedGeneration::new(1)
+    );
+    store.commit(&first);
+
+    assert_next_child_commits(&store, &config, &clock, loser, 0x36);
+
+    let second = apply_transition(
+        &store,
+        operator_invalidate(&store, winner.hash, second_id, 0x32),
+        &context(&config, &clock, None),
+    )
+    .expect("a nested operator reason is independently durable");
+    store.commit(&second);
+    let reconsider_first = apply_transition(
+        &store,
+        operator_reconsider(&store, winner.hash, first_id, 0x33),
+        &context(&config, &clock, None),
+    )
+    .expect("reconsider removes only the named reason");
+    assert_eq!(
+        reconsider_first.change_set.metadata.frontiers.verified_best,
+        loser
+    );
+    let winner_node = reconsider_first
+        .projected_graph()
+        .node(winner.hash)
+        .expect("the losing node remains retained");
+    assert!(!winner_node
+        .eligibility
+        .direct_reasons
+        .contains(&EligibilityReason::OperatorInvalid { id: first_id }));
+    assert!(winner_node
+        .eligibility
+        .direct_reasons
+        .contains(&EligibilityReason::OperatorInvalid { id: second_id }));
+    store.commit(&reconsider_first);
+
+    let reconsider_second = apply_transition(
+        &store,
+        operator_reconsider(&store, winner.hash, second_id, 0x34),
+        &context(&config, &clock, None),
+    )
+    .expect("removing the final operator reason restores both frontiers");
+    assert_eq!(
+        reconsider_second.change_set.metadata.frontiers.header_best,
+        winner
+    );
+    assert_eq!(
+        reconsider_second
+            .change_set
+            .metadata
+            .frontiers
+            .verified_best,
+        winner
+    );
+    store.commit(&reconsider_second);
+    let absent = apply_transition(
+        &store,
+        operator_reconsider(&store, winner.hash, second_id, 0x35),
+        &context(&config, &clock, None),
+    )
+    .expect("an absent operator ID is a valid no-change");
+    assert!(absent.is_no_change());
+}
+
+#[test]
+// AUD-12: reconsidering the exact reason is sufficient only when the
+// restored branch is again eligible, after which cumulative work wins.
+fn operator_reconsider_restores_shorter_higher_work_verified_branch() {
+    use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
+
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.graph.finalized();
+    let easy = store
+        .graph
+        .node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let easy_target: U256 = easy
+        .to_expanded()
+        .expect("the fixture target expands")
+        .into();
+    let hard = ExpandedDifficulty::from(easy_target >> 3).into();
+    let longer = insert_verified_branch(&mut store.graph, anchor, 2, easy, 0x41);
+    let shorter = insert_verified_branch(&mut store.graph, anchor, 1, hard, 0x42);
+    assert!(
+        store.graph.score(shorter.hash).expect("short score exists")
+            > store.graph.score(longer.hash).expect("long score exists")
+    );
+    synchronize_fixture(&mut store, shorter);
+    let id = crate::OperatorInvalidationId::new([3; 16]);
+
+    let invalidate = apply_transition(
+        &store,
+        operator_invalidate(&store, shorter.hash, id, 0x43),
+        &context(&config, &clock, None),
+    )
+    .expect("invalidating the shorter winner promotes the longer branch");
+    assert_eq!(invalidate.change_set.metadata.frontiers.header_best, longer);
+    assert_eq!(
+        invalidate.change_set.metadata.frontiers.verified_best,
+        longer
+    );
+    store.commit(&invalidate);
+
+    let reconsider = apply_transition(
+        &store,
+        operator_reconsider(&store, shorter.hash, id, 0x44),
+        &context(&config, &clock, None),
+    )
+    .expect("reconsider restores the shorter higher-work branch");
+    assert_eq!(
+        reconsider.change_set.metadata.frontiers.header_best,
+        shorter
+    );
+    assert_eq!(
+        reconsider.change_set.metadata.frontiers.verified_best,
+        shorter
+    );
+    let mut reconsidered = store.clone();
+    reconsidered.commit(&reconsider);
+    assert_next_child_commits(&reconsidered, &config, &clock, shorter, 0x45);
+}
+
+#[test]
+// AUD-11: verified-body eligibility and header fork choice are independent,
+// so invalidating the verified path must not discard a valid header winner.
+fn invalidating_verified_path_preserves_independent_header_best() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.graph.finalized();
+    let difficulty = store
+        .graph
+        .node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let verified_tip = insert_verified_branch(&mut store.graph, anchor, 2, difficulty, 0x51);
+    let header_tip = insert_verified_branch(&mut store.graph, anchor, 3, difficulty, 0x53);
+    for frontier in path(&store.graph, header_tip)
+        .expect("the independent header path is retained")
+        .into_iter()
+        .skip(1)
+    {
+        store
+            .graph
+            .set_body_state(frontier.hash, BodyValidationState::Unknown)
+            .expect("the independent candidate deliberately has no verified body");
+    }
+    synchronize_fixture(&mut store, verified_tip);
+    assert_eq!(store.metadata.frontiers.header_best, header_tip);
+    assert_eq!(store.metadata.frontiers.verified_best, verified_tip);
+
+    let plan = apply_transition(
+        &store,
+        operator_invalidate(
+            &store,
+            store.verified[1].hash,
+            crate::OperatorInvalidationId::new([4; 16]),
+            0x52,
+        ),
+        &context(&config, &clock, None),
+    )
+    .expect("invalidating the only full-state branch falls back atomically");
+    assert_eq!(
+        plan.change_set.metadata.frontiers.header_best, header_tip,
+        "the independently eligible header branch remains selected"
+    );
+    assert_eq!(plan.change_set.metadata.frontiers.verified_best, anchor);
+    assert_eq!(
+        plan.change_set.verified_projection,
+        ProjectionDelta {
+            remove_before: None,
+            remove_from: Some(block::Height(1)),
+            put: Vec::new(),
+        }
+    );
+    let mut invalidated = store.clone();
+    invalidated.commit(&plan);
+    assert_next_child_commits(&invalidated, &config, &clock, header_tip, 0x54);
+}
+
+#[test]
+fn operator_body_retry_restarts_the_selected_alarm_with_the_same_suppliers() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let now = Utc::now();
+    let clock = ManualClock(now);
+    let selected = store.metadata.frontiers.header_best;
+    let old = crate::BodyUnavailableSummary {
+        started_at: now - chrono::Duration::minutes(12),
+        attempts: 10,
+        suppliers: 2,
+        supplier_set_digest: [0x31; 32],
+        alarmed: true,
+        next_probe_at: now + chrono::Duration::minutes(8),
+    };
+    store
+        .graph
+        .set_body_state(selected.hash, BodyValidationState::Unavailable(old))
+        .expect("the selected fixture body exists");
+    store.metadata.alarms.header_best_body_unavailable = Some(old);
+    let fresh = crate::BodyUnavailableSummary {
+        started_at: now,
+        attempts: 0,
+        suppliers: old.suppliers,
+        supplier_set_digest: old.supplier_set_digest,
+        alarmed: false,
+        next_probe_at: now,
+    };
+    let request = TransitionRequest {
+        expected_version: store.metadata.state_version,
+        event: TransitionEvent::OperatorBodyRetry(crate::OperatorBodyRetry {
+            hash: selected.hash,
+            evidence: EvidenceId::from_digest([0xc3; 32]),
+            availability: fresh,
+        }),
+    };
+
+    let plan = apply_transition(&store, request.clone(), &context(&config, &clock, None))
+        .expect("an authenticated operator can restart the same supplier set");
+    assert_eq!(plan.change_set.metadata.frontiers, store.metadata.frontiers);
+    assert_eq!(
+        plan.change_set.metadata.header_generation,
+        store.metadata.header_generation
+    );
+    assert_eq!(
+        plan.change_set.metadata.verified_generation,
+        store.metadata.verified_generation
+    );
+    assert_eq!(
+        plan.projected
+            .node(selected.hash)
+            .expect("the selected node remains retained")
+            .body,
+        BodyValidationState::Unavailable(fresh)
+    );
+    assert_eq!(
+        plan.change_set.metadata.alarms.header_best_body_unavailable,
+        None
+    );
+    store.commit(&plan);
+    let replay = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            ..request
+        },
+        &context(&config, &clock, None),
+    )
+    .expect("the exact operator evidence replays idempotently");
+    assert!(replay.is_no_change());
+    assert_eq!(replay.graph_delta, crate::graph::GraphDelta::default());
+}
+
+#[test]
+fn operator_body_retry_rejects_stale_or_malformed_requests() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let now = Utc::now();
+    let clock = ManualClock(now);
+    let selected = store.metadata.frontiers.header_best;
+    let old = crate::BodyUnavailableSummary {
+        attempts: 10,
+        suppliers: 2,
+        supplier_set_digest: [0x41; 32],
+        alarmed: true,
+        ..Default::default()
+    };
+    store
+        .graph
+        .set_body_state(selected.hash, BodyValidationState::Unavailable(old))
+        .expect("the selected fixture body exists");
+    store.metadata.alarms.header_best_body_unavailable = Some(old);
+    let fresh = crate::BodyUnavailableSummary {
+        started_at: now,
+        attempts: 0,
+        suppliers: 2,
+        supplier_set_digest: old.supplier_set_digest,
+        alarmed: false,
+        next_probe_at: now,
+    };
+    let apply = |hash, availability| {
+        apply_transition(
+            &store,
+            TransitionRequest {
+                expected_version: store.metadata.state_version,
+                event: TransitionEvent::OperatorBodyRetry(crate::OperatorBodyRetry {
+                    hash,
+                    evidence: EvidenceId::from_digest([0xc4; 32]),
+                    availability,
+                }),
+            },
+            &context(&config, &clock, None),
+        )
+    };
+
+    assert!(matches!(
+        apply(block::Hash([0x42; 32]), fresh),
+        Err(TransitionFailure::InvalidEvidence(
+            "operator body retry has an invalid fresh episode"
+        ))
+    ));
+    assert!(matches!(
+        apply(
+            selected.hash,
+            crate::BodyUnavailableSummary {
+                attempts: 1,
+                ..fresh
+            }
+        ),
+        Err(TransitionFailure::InvalidEvidence(
+            "operator body retry has an invalid fresh episode"
+        ))
+    ));
+    store
+        .graph
+        .set_body_state(selected.hash, BodyValidationState::Unknown)
+        .expect("the selected fixture body exists");
+    let non_alarmed = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::OperatorBodyRetry(crate::OperatorBodyRetry {
+                hash: selected.hash,
+                evidence: EvidenceId::from_digest([0xc4; 32]),
+                availability: fresh,
+            }),
+        },
+        &context(&config, &clock, None),
+    );
+    assert!(matches!(
+        non_alarmed,
+        Err(TransitionFailure::InvalidEvidence(
+            "operator body retry requires the selected persistent alarm"
+        ))
+    ));
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+#[test]
+fn full_commit_ensures_exact_node_body_and_independent_selection() {
+    use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
+
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let anchor = store.graph.finalized();
+    let easy = store
+        .graph
+        .node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let easy_target: U256 = easy
+        .to_expanded()
+        .expect("the fixture target expands")
+        .into();
+    let hard = ExpandedDifficulty::from(easy_target >> 3).into();
+    let header_best = insert_verified_branch(&mut store.graph, anchor, 1, hard, 0x58);
+    store
+        .graph
+        .set_body_state(header_best.hash, BodyValidationState::Unknown)
+        .expect("the harder competitor remains header-only");
+    synchronize_fixture(&mut store, anchor);
+    assert_eq!(store.metadata.frontiers.header_best, header_best);
+    assert_eq!(store.metadata.frontiers.verified_best, anchor);
+
+    let mut accepted_header = *regtest_genesis_block().header;
+    accepted_header.previous_block_hash = anchor.hash;
+    accepted_header.difficulty_threshold = easy;
+    accepted_header.nonce.0[0] = 0x59;
+    let accepted_header = Arc::new(accepted_header);
+    let accepted = Frontier::new(
+        anchor
+            .height
+            .next()
+            .expect("the fixture anchor has a next height"),
+        accepted_header.hash(),
+    );
+    assert!(
+        store.graph.node(accepted.hash).is_none(),
+        "the full-state header is deliberately absent from the DAG"
+    );
+    let evidence = EvidenceId::from_digest([0x5a; 32]);
+    let before = store.snapshot();
+    let plan = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: before.state_version,
+            event: TransitionEvent::VerifiedChainChanged(crate::VerifiedChainChanged {
+                full_state_transition_id: evidence,
+                old_tip: anchor,
+                new_path: vec![crate::VerifiedHeaderRef {
+                    height: accepted.height,
+                    hash: accepted.hash,
+                    header: accepted_header,
+                }],
+                cause: crate::VerifiedChangeCause::Grow,
+            }),
+        },
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("the exact full-state growth produces one coherent header transition");
+
+    let accepted_node = plan
+        .projected
+        .node(accepted.hash)
+        .expect("the full-state header is inserted into the projected DAG");
+    assert_eq!(accepted_node.parent_hash, anchor.hash);
+    assert_eq!(
+        accepted_node.body,
+        BodyValidationState::Verified { evidence }
+    );
+    assert_eq!(plan.change_set.metadata.frontiers.verified_best, accepted);
+    assert_eq!(
+        plan.change_set.metadata.frontiers.header_best, header_best,
+        "full-state selection does not override the independently harder header path"
+    );
+    assert_eq!(
+        plan.change_set.metadata.verified_generation,
+        before
+            .verified_generation
+            .checked_next()
+            .expect("the fixture generation can advance")
+    );
+    assert_eq!(
+        plan.change_set.metadata.header_generation,
+        before
+            .header_generation
+            .checked_next()
+            .expect("the fixture generation can advance")
+    );
+    verify_plan(&test_engine(&store), &plan).expect("the full-state integration plan is coherent");
+}
+
+#[test]
+fn accepted_side_path_does_not_replace_the_verified_winner() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let request = insertion(&store, 2, EvidenceId::from_digest([0x56; 32]));
+    let TransitionEvent::InsertHeaders(insert) = request.event else {
+        unreachable!("the fixture constructs a header insertion")
+    };
+    let path: Vec<_> = insert
+        .batch
+        .headers()
+        .iter()
+        .map(|header| crate::VerifiedHeaderRef {
+            height: header.height,
+            hash: header.hash,
+            header: header.header.clone(),
+        })
+        .collect();
+    let accepted = path.last().expect("the side path is nonempty").hash;
+    let evidence = EvidenceId::from_digest([0x57; 32]);
+
+    let plan = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::VerifiedBlockAccepted(crate::VerifiedBlockAccepted {
+                full_state_transition_id: evidence,
+                path,
+            }),
+        },
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("authenticated full state admits the absent side path");
+
+    assert_eq!(
+        plan.change_set.metadata.frontiers.verified_best,
+        store.metadata.frontiers.verified_best
+    );
+    assert_eq!(
+        plan.change_set.verified_projection,
+        ProjectionDelta::default()
+    );
+    assert!(matches!(
+        plan.projected.node(accepted).map(|node| &node.body),
+        Some(BodyValidationState::Verified {
+            evidence: actual
+        }) if *actual == evidence
+    ));
+}
+
+#[test]
+fn apply_transition_is_the_only_public_dag_mutation_entry_point() {
+    let graph_source = include_str!("../../../graph.rs");
+    for old_entry in [
+        "pub fn insert(",
+        "pub fn add_reason(",
+        "pub fn remove_operator_invalidation(",
+        "pub fn set_consensus_body_invalid(",
+        "pub fn set_body_state(",
+        "pub fn set_validation(",
+    ] {
+        assert!(
+            !graph_source.contains(old_entry),
+            "raw mutation entry point escaped: {old_entry}"
+        );
+    }
+    assert!(
+        !include_str!("../../../../src/lib.rs").contains("pub use retention::enforce_retention")
+    );
+}
+
+#[test]
+fn stateful_engine_returns_its_complete_projected_state() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let engine = test_engine(&store);
+    let clock = ManualClock(Utc::now());
+    let request = insertion(&store, 3, EvidenceId::from_digest([0x92; 32]));
+    let before = engine.snapshot();
+    let transition = engine
+        .apply(
+            request,
+            &context(&config, &clock, None),
+            crate::DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![store.lease.clone()],
+                finality_path: Vec::new(),
+            },
+        )
+        .expect("the stateful engine plans the insertion");
+
+    assert_eq!(transition.before(), &before);
+    let expected = transition.change_set().metadata.snapshot();
+    let projected = transition.into_projected_engine();
+    assert_eq!(projected.snapshot(), expected);
+    assert_eq!(
+        projected.selected_projection().last().copied(),
+        Some(expected.frontiers.header_best)
+    );
+}

--- a/crates/zakura-header-chain/src/transition/recovery.rs
+++ b/crates/zakura-header-chain/src/transition/recovery.rs
@@ -656,3 +656,403 @@ fn source_failure(violation: AuditViolation) -> RecoveryFailure {
         violations: vec![violation],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::num::{NonZeroU64, NonZeroUsize};
+
+    use zakura_chain::{
+        block::genesis::regtest_genesis_block,
+        parameters::{testnet::RegtestParameters, Network},
+    };
+
+    use super::*;
+    use crate::{
+        AlarmSet, AuxAuthentication, BodyRuleId, BodySizeHint, BodyUnavailableSummary, BranchId,
+        ChainScore, CheckpointSet, EligibilityState, EngineMode, EvidenceId, FinalityEpoch,
+        FrontierSet, HeaderChainDiskVersion, HeaderGeneration, HeaderValidationState,
+        HeaderWorkAuthority, HeaderWorkOwner, SourceId, StateVersion, SuffixWork, TrustedAnchor,
+        VerifiedGeneration, WorkCoordinate,
+    };
+
+    #[derive(Clone)]
+    struct AuditStore {
+        metadata: EngineMetadata,
+        snapshot: EngineSnapshot,
+        nodes: Vec<HeaderNode>,
+        children: Vec<(block::Hash, block::Hash)>,
+        selected: Vec<Frontier>,
+        verified: Vec<Frontier>,
+        deferred: Vec<(DateTime<Utc>, block::Hash)>,
+        reasons: Vec<(block::Hash, EligibilityReason)>,
+        aux: Vec<AuxDelivery>,
+        contexts: Vec<ValidationContextRecord>,
+        finality: Vec<FinalityRecord>,
+    }
+
+    impl StoreAuditRead for AuditStore {
+        fn snapshot(&self) -> Result<EngineSnapshot, StoreError> {
+            Ok(self.snapshot.clone())
+        }
+
+        fn metadata(&self) -> Result<EngineMetadata, StoreError> {
+            Ok(self.metadata.clone())
+        }
+
+        fn all_nodes(&self) -> Result<Vec<HeaderNode>, StoreError> {
+            Ok(self.nodes.clone())
+        }
+
+        fn child_edges(&self) -> Result<Vec<(block::Hash, block::Hash)>, StoreError> {
+            Ok(self.children.clone())
+        }
+
+        fn selected_projection(&self) -> Result<Vec<Frontier>, StoreError> {
+            Ok(self.selected.clone())
+        }
+
+        fn verified_projection(&self) -> Result<Vec<Frontier>, StoreError> {
+            Ok(self.verified.clone())
+        }
+
+        fn deferred_entries(&self) -> Result<Vec<(DateTime<Utc>, block::Hash)>, StoreError> {
+            Ok(self.deferred.clone())
+        }
+
+        fn eligibility_roots(&self) -> Result<Vec<(block::Hash, EligibilityReason)>, StoreError> {
+            Ok(self.reasons.clone())
+        }
+
+        fn all_aux_deliveries(&self) -> Result<Vec<AuxDelivery>, StoreError> {
+            Ok(self.aux.clone())
+        }
+
+        fn validation_context_records(&self) -> Result<Vec<ValidationContextRecord>, StoreError> {
+            Ok(self.contexts.clone())
+        }
+
+        fn visit_finality_history(
+            &self,
+            visitor: &mut dyn FnMut(FinalityRecord) -> Result<(), StoreError>,
+        ) -> Result<(), StoreError> {
+            for record in &self.finality {
+                visitor(*record)?;
+            }
+            Ok(())
+        }
+    }
+
+    fn fixture() -> (AuditStore, EngineConfig) {
+        let network = Network::new_regtest(RegtestParameters::default());
+        let block = regtest_genesis_block();
+        let anchor = Frontier::new(block::Height(0), block.hash());
+        let config = EngineConfig::new(
+            EngineMode::Integrated,
+            network,
+            TrustedAnchor {
+                frontier: anchor,
+                header: block.header.clone(),
+            },
+            CheckpointSet::default(),
+        )
+        .expect("the audit fixture configuration is coherent");
+        let anchor_work = block
+            .header
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture target has work");
+        let anchor_node = HeaderNode::from_durable_parts(
+            block.header.clone(),
+            anchor.hash,
+            block.header.previous_block_hash,
+            anchor.height,
+            anchor_work,
+            WorkCoordinate::new(anchor.hash, anchor_work.as_u256()),
+            HeaderValidationState::Valid,
+            EligibilityState::default(),
+            BodyValidationState::Unknown,
+            Vec::new(),
+        )
+        .expect("the canonical anchor fields agree");
+        let mut child_header = *block.header;
+        child_header.previous_block_hash = anchor.hash;
+        child_header.nonce = [1; 32].into();
+        let child_header = Arc::new(child_header);
+        let child_hash = child_header.hash();
+        let child_work = child_header
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture child target has work");
+        let child = Frontier::new(block::Height(1), child_hash);
+        let child_node = HeaderNode::from_durable_parts(
+            child_header,
+            child_hash,
+            anchor.hash,
+            child.height,
+            child_work,
+            anchor_node
+                .work_coordinate()
+                .checked_add(child_work)
+                .expect("the fixture work fits"),
+            HeaderValidationState::Valid,
+            EligibilityState::default(),
+            BodyValidationState::Unknown,
+            Vec::new(),
+        )
+        .expect("the canonical child fields agree");
+        let score = ChainScore::new(SuffixWork::new(child_work.as_u256()), child.hash);
+        let metadata = EngineMetadata {
+            disk_format: HeaderChainDiskVersion(1),
+            mode: EngineMode::Integrated,
+            network_id: config.network.kind(),
+            anchor_manifest_digest: config.trust_anchor_digest(),
+            work_origin: anchor,
+            state_version: StateVersion::new(1),
+            header_generation: HeaderGeneration::new(1),
+            verified_generation: VerifiedGeneration::new(1),
+            finality_epoch: FinalityEpoch::new(0),
+            frontiers: FrontierSet {
+                finalized: anchor,
+                header_best: child,
+                verified_best: anchor,
+            },
+            header_best_score: score,
+            oldest_retained_height: anchor.height,
+            alarms: AlarmSet::default(),
+            last_transition_id: EvidenceId::from_digest([0; 32]),
+        };
+        (
+            AuditStore {
+                snapshot: metadata.snapshot(),
+                metadata,
+                nodes: vec![anchor_node, child_node],
+                children: vec![(anchor.hash, child.hash)],
+                selected: vec![anchor, child],
+                verified: vec![anchor],
+                deferred: Vec::new(),
+                reasons: Vec::new(),
+                aux: Vec::new(),
+                contexts: Vec::new(),
+                finality: Vec::new(),
+            },
+            config,
+        )
+    }
+
+    fn violations(store: &AuditStore, config: &EngineConfig) -> Vec<AuditViolation> {
+        match audit_store(store, config) {
+            Err(RecoveryFailure::Source { violations }) => violations,
+            other => panic!("expected source audit failure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coherent_source_and_indexes_need_no_recovery_write() {
+        let (store, config) = fixture();
+        let plan = audit_store(&store, &config).expect("the coherent fixture audits cleanly");
+        assert!(plan.is_clean());
+        assert_eq!(plan.metadata, store.metadata);
+    }
+
+    #[test]
+    fn body_unavailability_alarm_is_reconstructed_from_the_selected_node() {
+        let (mut store, config) = fixture();
+        let summary = BodyUnavailableSummary {
+            attempts: 10,
+            suppliers: 2,
+            alarmed: true,
+            ..Default::default()
+        };
+        store.nodes[1].body = crate::BodyValidationState::Unavailable(summary);
+
+        let plan = audit_store(&store, &config).expect("the derived alarm is reconstructible");
+        assert_eq!(
+            plan.repairs,
+            BTreeSet::from([RecoveryRepair::BodyAvailabilityAlarm])
+        );
+        assert_eq!(
+            plan.metadata.alarms.header_best_body_unavailable,
+            Some(summary)
+        );
+        assert_eq!(plan.metadata.state_version, StateVersion::new(2));
+        assert_eq!(plan.metadata.header_generation, HeaderGeneration::new(1));
+    }
+
+    #[test]
+    fn recompute_not_cached_projection() {
+        let (mut store, config) = fixture();
+        let anchor = store.metadata.frontiers.finalized;
+        let child_hash = store.metadata.frontiers.header_best.hash;
+        store.children.clear();
+        store.selected = vec![anchor];
+        store.verified.clear();
+        store.deferred.push((Utc::now(), child_hash));
+        store.nodes[1].eligibility.inherited_from = Some(anchor.hash);
+
+        let plan = audit_store(&store, &config).expect("cache corruption is reconstructible");
+        assert_eq!(
+            plan.repairs,
+            BTreeSet::from([
+                RecoveryRepair::ChildIndex,
+                RecoveryRepair::DeferredIndex,
+                RecoveryRepair::SelectedProjection,
+                RecoveryRepair::VerifiedProjection,
+                RecoveryRepair::InheritedEligibility,
+            ])
+        );
+        assert_eq!(plan.metadata.state_version, StateVersion::new(2));
+        assert_eq!(plan.metadata.header_generation, HeaderGeneration::new(2));
+        assert_eq!(
+            plan.metadata.verified_generation,
+            VerifiedGeneration::new(2)
+        );
+    }
+
+    #[test]
+    fn audits_each_normative_invariant() {
+        let (base, config) = fixture();
+        let child_hash = base.metadata.frontiers.header_best.hash;
+
+        let mut store = base.clone();
+        store.metadata.anchor_manifest_digest[0] ^= 1;
+        store.snapshot = store.metadata.snapshot();
+        assert!(violations(&store, &config).contains(&AuditViolation::Configuration));
+
+        let mut store = base.clone();
+        store.nodes[1].hash = block::Hash([8; 32]);
+        assert!(
+            violations(&store, &config).contains(&AuditViolation::NodeHash(block::Hash([8; 32])))
+        );
+
+        let mut store = base.clone();
+        let missing = block::Hash([9; 32]);
+        store.nodes[1].parent_hash = missing;
+        store.nodes[1].header = Arc::new(block::Header {
+            previous_block_hash: missing,
+            ..*store.nodes[1].header
+        });
+        store.nodes[1].hash = store.nodes[1].header.hash();
+        assert!(violations(&store, &config)
+            .iter()
+            .any(|violation| matches!(violation, AuditViolation::Parent(_))));
+
+        let mut store = base.clone();
+        store.nodes[1] = HeaderNode::from_durable_parts(
+            store.nodes[1].header.clone(),
+            child_hash,
+            store.nodes[1].parent_hash,
+            store.nodes[1].height,
+            store.nodes[1].block_work,
+            WorkCoordinate::new(store.metadata.work_origin.hash, Default::default()),
+            store.nodes[1].validation,
+            store.nodes[1].eligibility.clone(),
+            store.nodes[1].body.clone(),
+            Vec::new(),
+        )
+        .expect("the isolated node fields remain canonical");
+        assert!(violations(&store, &config).contains(&AuditViolation::Work(child_hash)));
+
+        let mut store = base.clone();
+        store.nodes[1].body = BodyValidationState::ConsensusInvalid {
+            evidence: EvidenceId::from_digest([2; 32]),
+            rule: BodyRuleId::new("body.rule"),
+        };
+        assert!(violations(&store, &config).contains(&AuditViolation::BodyEligibility(child_hash)));
+
+        let mut store = base.clone();
+        let corrupted_until = store.nodes[1].header.time + Duration::hours(100);
+        store.nodes[1].validation = crate::HeaderValidationState::DeferredUntil(corrupted_until);
+        store.deferred = vec![(corrupted_until, child_hash)];
+        assert!(violations(&store, &config).contains(&AuditViolation::HeaderValidation(child_hash)));
+
+        let mut store = base.clone();
+        store.reasons.push((
+            child_hash,
+            EligibilityReason::OperatorInvalid {
+                id: crate::OperatorInvalidationId::new([3; 16]),
+            },
+        ));
+        assert!(violations(&store, &config).contains(&AuditViolation::EligibilityRoot(child_hash)));
+
+        let mut checkpointed = config.clone();
+        checkpointed.local_checkpoints =
+            CheckpointSet::new([Frontier::new(block::Height(1), block::Hash([0xaa; 32]))])
+                .expect("the checkpoint fixture is unique");
+        let mut store = base.clone();
+        store.metadata.anchor_manifest_digest = checkpointed.trust_anchor_digest();
+        store.snapshot = store.metadata.snapshot();
+        assert!(violations(&store, &checkpointed)
+            .contains(&AuditViolation::TrustPin(block::Height(1), child_hash)));
+
+        let mut store = base.clone();
+        store.nodes[1]
+            .aux_delivery_ids
+            .push(EvidenceId::from_digest([4; 32]));
+        assert!(violations(&store, &config).contains(&AuditViolation::Auxiliary(child_hash)));
+
+        let mut store = base.clone();
+        store.contexts.push(ValidationContextRecord {
+            header: regtest_genesis_block().header.clone(),
+            height: block::Height(7),
+        });
+        assert!(violations(&store, &config)
+            .iter()
+            .any(|violation| matches!(violation, AuditViolation::ValidationContext(_))));
+
+        let mut store = base.clone();
+        store.metadata.frontiers.finalized = Frontier::new(block::Height(1), child_hash);
+        store.snapshot = store.metadata.snapshot();
+        assert!(violations(&store, &config)
+            .iter()
+            .any(|violation| matches!(violation, AuditViolation::ValidationContext(_))));
+
+        let mut store = base.clone();
+        store.metadata.finality_epoch = FinalityEpoch::new(1);
+        store.snapshot = store.metadata.snapshot();
+        assert!(violations(&store, &config).contains(&AuditViolation::Finality));
+
+        let mut headers_only = config.clone();
+        headers_only.mode = EngineMode::HeadersOnly;
+        let mut store = base.clone();
+        store.metadata.mode = EngineMode::HeadersOnly;
+        store.snapshot = store.metadata.snapshot();
+        store.finality.push(FinalityRecord {
+            previous: store.metadata.frontiers.finalized,
+            current: store.metadata.frontiers.finalized,
+            source: FinalitySource::HeadersOnlyDepth {
+                selected_tip: store.metadata.frontiers.header_best,
+            },
+            epoch: FinalityEpoch::new(0),
+        });
+        assert!(violations(&store, &headers_only).contains(&AuditViolation::Finality));
+
+        let mut limited = config.clone();
+        limited.limits.max_non_finalized_nodes = NonZeroUsize::new(1).expect("one is nonzero");
+        let mut oversized = base.clone();
+        oversized.nodes.push(oversized.nodes[1].clone());
+        assert!(violations(&oversized, &limited).contains(&AuditViolation::Limits));
+
+        let mut store = base.clone();
+        let evidence = EvidenceId::from_digest([5; 32]);
+        store.aux.push(AuxDelivery {
+            delivery_id: evidence,
+            header_hash: block::Hash([6; 32]),
+            source: SourceId::from_digest([7; 32]),
+            owner: HeaderWorkOwner {
+                authority: HeaderWorkAuthority {
+                    header_generation: HeaderGeneration::new(1),
+                    branch: BranchId::new(base.metadata.work_origin.hash, child_hash),
+                },
+                session_id: 1,
+                request_id: NonZeroU64::new(1).expect("one is nonzero"),
+            }
+            .into(),
+            body_size: BodySizeHint::Unknown,
+            tree_aux: None,
+            authentication: AuxAuthentication::Unauthenticated,
+        });
+        assert!(violations(&store, &config)
+            .iter()
+            .any(|violation| matches!(violation, AuditViolation::Auxiliary(_))));
+    }
+}

--- a/crates/zakura-header-chain/src/transition/types.rs
+++ b/crates/zakura-header-chain/src/transition/types.rs
@@ -1020,3 +1020,151 @@ pub enum TransitionTypeError {
     #[error("invalid advisory body size {0}")]
     InvalidBodySize(u32),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_size_hints_enforce_zero_sentinel_and_canonical_limit() {
+        assert_eq!(BodySizeHint::new(0), Ok(BodySizeHint::Unknown));
+        assert!(matches!(BodySizeHint::new(1), Ok(BodySizeHint::Known(_))));
+        let maximum =
+            u32::try_from(block::MAX_BLOCK_BYTES).expect("the canonical block limit fits in u32");
+        assert!(matches!(
+            BodySizeHint::new(maximum),
+            Ok(BodySizeHint::Known(_))
+        ));
+        assert_eq!(
+            BodySizeHint::new(maximum + 1),
+            Err(TransitionTypeError::InvalidBodySize(maximum + 1))
+        );
+    }
+
+    #[test]
+    fn event_authority_and_evidence_policies_are_typed() {
+        let evidence = EvidenceId::from_digest([7; 32]);
+        let reconsider = TransitionEvent::OperatorReconsider(OperatorReconsider {
+            target: block::Hash([1; 32]),
+            id: OperatorInvalidationId::new([2; 16]),
+            evidence,
+        });
+        assert_eq!(reconsider.admission(), EventAdmission::AnyMode);
+        assert_eq!(reconsider.idempotency_key(), Some(evidence));
+        assert_eq!(reconsider.header_sync_owner(), None);
+        assert_eq!(reconsider.body_owner(), None);
+
+        let refutation = TransitionEvent::MigratedPinRefutation(MigratedPinRefutation {
+            full_state_transition_id: evidence,
+            pin: Frontier::new(block::Height(2), block::Hash([4; 32])),
+            invalid_header: Frontier::new(block::Height(1), block::Hash([5; 32])),
+            rule: BodyRuleId::new("body.rule"),
+        });
+        assert_eq!(refutation.admission(), EventAdmission::IntegratedFullState);
+        assert_eq!(refutation.idempotency_key(), Some(evidence));
+        assert_eq!(refutation.header_sync_owner(), None);
+        assert_eq!(refutation.body_owner(), None);
+
+        assert_eq!(
+            TransitionEvent::ReevaluateDeferred.admission(),
+            EventAdmission::AnyMode
+        );
+        assert_eq!(TransitionEvent::ReevaluateDeferred.idempotency_key(), None);
+    }
+
+    #[test]
+    fn body_verification_outcomes_preserve_distinct_transition_effects() {
+        let evidence = EvidenceId::from_digest([9; 32]);
+        let hash = block::Hash([8; 32]);
+        assert!(matches!(
+            BodyEvidence::from(BodyVerificationOutcome::Verified(VerifiedBodyEvidence {
+                hash,
+                evidence,
+            })),
+            BodyEvidence::Verified(VerifiedBodyEvidence { hash: actual, .. }) if actual == hash
+        ));
+        assert!(matches!(
+            BodyEvidence::from(BodyVerificationOutcome::PayloadMismatch(
+                BodyPayloadMismatch {
+                    evidence,
+                    requested: hash,
+                    delivered: block::Hash([7; 32]),
+                    kind: BodyCommitmentKind::HeaderHash,
+                    source: SourceId::from_digest([6; 32]),
+                }
+            )),
+            BodyEvidence::PayloadMismatch(BodyPayloadMismatch { requested, .. }) if requested == hash
+        ));
+        assert!(matches!(
+            BodyEvidence::from(BodyVerificationOutcome::ConsensusInvalid(
+                ConsensusBodyInvalid {
+                    hash,
+                    evidence,
+                    rule: BodyRuleId::new("body.rule"),
+                    source: SourceId::from_digest([5; 32]),
+                }
+            )),
+            BodyEvidence::ConsensusInvalid(ConsensusBodyInvalid { hash: actual, .. }) if actual == hash
+        ));
+        assert!(matches!(
+            BodyEvidence::from(BodyVerificationOutcome::Retryable(TransientBodyFailure {
+                hash,
+                evidence,
+                kind: TransientBodyFailureKind::MissingContext,
+                availability: BodyUnavailableSummary {
+                    attempts: 1,
+                    suppliers: 1,
+                    alarmed: false,
+                    ..Default::default()
+                },
+            })),
+            BodyEvidence::Transient(TransientBodyFailure { hash: actual, .. }) if actual == hash
+        ));
+    }
+
+    #[test]
+    fn all_named_inputs_use_their_single_serialized_transition_path() {
+        let source = include_str!("types.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("the production type surface precedes its tests");
+        for variant in [
+            "InsertHeaders(Box<InsertHeaders>)",
+            "VerifiedChainChanged(VerifiedChainChanged)",
+            "VerifiedBlockAccepted(VerifiedBlockAccepted)",
+            "BodyEvidence(BodyEvidence)",
+            "BodySupplierDiscovered(BodySupplierDiscovered)",
+            "OperatorBodyRetry(OperatorBodyRetry)",
+            "OperatorInvalidate(OperatorInvalidate)",
+            "OperatorReconsider(OperatorReconsider)",
+            "FullStateFinalized(FullStateFinalized)",
+            "MigratedPinRefutation(MigratedPinRefutation)",
+            "AuxEvidence(Box<AuxEvidence>)",
+            "ReevaluateDeferred",
+        ] {
+            assert!(source.contains(variant), "missing event variant {variant}");
+        }
+        for forbidden in [
+            "pub new_header_best",
+            "pub new_generation",
+            "pub prune",
+            "pub publish",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "event inputs must contain evidence, not requested consequence {forbidden}"
+            );
+        }
+        for obsolete_facade in [
+            "AdvanceLocalCheckpoint",
+            "InternalFullState",
+            "RecoveryEvidence",
+            "TransitionEvent::Recover",
+        ] {
+            assert!(
+                !source.contains(obsolete_facade),
+                "the event surface must not duplicate a real transition path with {obsolete_facade}"
+            );
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/validation/contextual.rs
+++ b/crates/zakura-header-chain/src/validation/contextual.rs
@@ -461,3 +461,436 @@ pub fn validate_contextual_difficulty_and_time(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{hint::black_box, time::Instant};
+
+    use super::*;
+    use zakura_chain::parameters::testnet::{Parameters, RegtestParameters};
+
+    fn compact_half_limit(network: &Network) -> CompactDifficulty {
+        (network.target_difficulty_limit() / U256::from(2_u8)).to_compact()
+    }
+
+    fn context(
+        network: &Network,
+        candidate_time: DateTime<Utc>,
+        spacing: Duration,
+        len: usize,
+    ) -> Vec<(CompactDifficulty, DateTime<Utc>)> {
+        let difficulty = compact_half_limit(network);
+        (1..=len)
+            .map(|offset| {
+                let offset = i32::try_from(offset).expect("test context length fits in i32");
+                (difficulty, candidate_time - spacing * offset)
+            })
+            .collect()
+    }
+
+    fn validate_with_expected_target(
+        network: &Network,
+        candidate_height: block::Height,
+        candidate_time: DateTime<Utc>,
+        context: &[(CompactDifficulty, DateTime<Utc>)],
+    ) -> Result<(), ContextualValidationError> {
+        let previous_height = (candidate_height - 1).expect("test candidate is not genesis");
+        let expected = AdjustedDifficulty::new_from_header_time(
+            candidate_time,
+            previous_height,
+            network,
+            context.iter().copied(),
+        )
+        .expected_difficulty_threshold();
+        validate_contextual_difficulty_and_time(
+            expected,
+            AdjustedDifficulty::new_from_header_time(
+                candidate_time,
+                previous_height,
+                network,
+                context.iter().copied(),
+            ),
+        )
+    }
+
+    #[test]
+    fn difficulty_windows_upgrades_testnet_minimum_and_partitions_match() {
+        let candidate_time =
+            DateTime::from_timestamp(2_000_000_000, 0).expect("test timestamp is in range");
+
+        for network in Network::iter() {
+            for len in [1, 11, 16, 17, 27, 28] {
+                let candidate_height = block::Height(700_000);
+                let spacing = NetworkUpgrade::target_spacing_for_height(&network, candidate_height);
+                let context = context(&network, candidate_time, spacing, len);
+                let previous_height = (candidate_height - 1).expect("height is positive");
+                let expected = AdjustedDifficulty::new_from_header_time(
+                    candidate_time,
+                    previous_height,
+                    &network,
+                    context.iter().copied(),
+                )
+                .expected_difficulty_threshold();
+
+                for split in 0..=context.len() {
+                    let partitioned = context[..split].iter().chain(&context[split..]).copied();
+                    assert_eq!(
+                        AdjustedDifficulty::new_from_header_time(
+                            candidate_time,
+                            previous_height,
+                            &network,
+                            partitioned,
+                        )
+                        .expected_difficulty_threshold(),
+                        expected,
+                        "response partitions must not affect difficulty for {network:?}, len {len}, split {split}"
+                    );
+                }
+            }
+
+            for (height, _) in network.activation_list() {
+                if height == block::Height(0) {
+                    continue;
+                }
+                let spacing = NetworkUpgrade::target_spacing_for_height(&network, height);
+                let context_len = usize::try_from(height.0.min(28))
+                    .expect("bounded test context length fits in usize");
+                let context = context(&network, candidate_time, spacing, context_len);
+                validate_with_expected_target(&network, height, candidate_time, &context)
+                    .expect("the shared result validates at every configured upgrade boundary");
+            }
+        }
+
+        let testnet = Network::new_default_testnet();
+        let activation_height = block::Height(299_188);
+        let spacing = NetworkUpgrade::target_spacing_for_height(&testnet, activation_height);
+        let previous_time = candidate_time - spacing * 6;
+        let mut exact_gap = context(&testnet, candidate_time, spacing, 28);
+        exact_gap[0].1 = previous_time;
+        let previous_height = (activation_height - 1).expect("height is positive");
+        let exact_gap_target = AdjustedDifficulty::new_from_header_time(
+            candidate_time,
+            previous_height,
+            &testnet,
+            exact_gap,
+        )
+        .expected_difficulty_threshold();
+        assert_ne!(
+            exact_gap_target,
+            testnet.target_difficulty_limit().to_compact()
+        );
+
+        let minimum_time = candidate_time + Duration::seconds(1);
+        let minimum_context = context(&testnet, minimum_time, spacing, 28)
+            .into_iter()
+            .enumerate()
+            .map(|(index, (difficulty, time))| {
+                if index == 0 {
+                    (difficulty, previous_time)
+                } else {
+                    (difficulty, time)
+                }
+            });
+        assert_eq!(
+            AdjustedDifficulty::new_from_header_time(
+                minimum_time,
+                previous_height,
+                &testnet,
+                minimum_context,
+            )
+            .expected_difficulty_threshold(),
+            testnet.target_difficulty_limit().to_compact(),
+            "ZIP 205/208 minimum difficulty begins strictly above six target spacings"
+        );
+    }
+
+    #[test]
+    fn difficulty_damping_bounds_are_exact() {
+        let network = Network::Mainnet;
+        let candidate_height = block::Height(700_000);
+        let previous_height = (candidate_height - 1).expect("height is positive");
+        let candidate_time =
+            DateTime::from_timestamp(2_000_000_000, 0).expect("test timestamp is in range");
+        let averaging_timespan =
+            NetworkUpgrade::averaging_window_timespan_for_height(&network, candidate_height);
+        let mean_target = compact_half_limit(&network)
+            .to_expanded()
+            .expect("the test target is valid");
+
+        let fast_context = context(
+            &network,
+            candidate_time,
+            Duration::seconds(1),
+            POW_ADJUSTMENT_BLOCK_SPAN,
+        );
+        let fast = AdjustedDifficulty::new_from_header_time(
+            candidate_time,
+            previous_height,
+            &network,
+            fast_context,
+        )
+        .expected_difficulty_threshold();
+        let minimum_timespan = averaging_timespan * (100 - POW_MAX_ADJUST_UP_PERCENT) / 100;
+        assert_eq!(
+            fast,
+            ((mean_target / averaging_timespan.num_seconds()) * minimum_timespan.num_seconds())
+                .to_compact(),
+            "fast blocks are clipped at the 16% upward-adjustment bound"
+        );
+
+        let slow_context = context(
+            &network,
+            candidate_time,
+            Duration::seconds(10_000),
+            POW_ADJUSTMENT_BLOCK_SPAN,
+        );
+        let slow = AdjustedDifficulty::new_from_header_time(
+            candidate_time,
+            previous_height,
+            &network,
+            slow_context,
+        )
+        .expected_difficulty_threshold();
+        let maximum_timespan = averaging_timespan * (100 + POW_MAX_ADJUST_DOWN_PERCENT) / 100;
+        assert_eq!(
+            slow,
+            ((mean_target / averaging_timespan.num_seconds()) * maximum_timespan.num_seconds())
+                .to_compact(),
+            "slow blocks are clipped at the 32% downward-adjustment bound"
+        );
+    }
+
+    #[test]
+    fn median_and_production_max_time_boundaries_are_exact() {
+        let base = DateTime::from_timestamp(1_600_000_000, 0).expect("test timestamp is in range");
+        let difficulty = Network::Mainnet.target_difficulty_limit().to_compact();
+
+        for len in 1..=POW_ADJUSTMENT_BLOCK_SPAN {
+            let times: Vec<_> = (0..len)
+                .map(|offset| base + Duration::seconds(i64::try_from(offset).expect("fits")))
+                .rev()
+                .collect();
+            let adjustment = AdjustedDifficulty::new_from_header_time(
+                base + Duration::hours(1),
+                block::Height(100),
+                &Network::Mainnet,
+                times.iter().copied().map(|time| (difficulty, time)),
+            );
+            let mut expected: Vec<_> = times.into_iter().take(POW_MEDIAN_BLOCK_SPAN).collect();
+            expected.sort_unstable();
+            assert_eq!(adjustment.median_time_past(), expected[expected.len() / 2]);
+        }
+
+        for (network, height, max_is_active) in [
+            (Network::Mainnet, block::Height(1), false),
+            (Network::Mainnet, block::Height(2), true),
+            (
+                Network::new_default_testnet(),
+                block::Height(653_605),
+                false,
+            ),
+            (Network::new_default_testnet(), block::Height(653_606), true),
+        ] {
+            let context = [(network.target_difficulty_limit().to_compact(), base)];
+            assert!(matches!(
+                validate_with_expected_target(&network, height, base, &context),
+                Err(ContextualValidationError::TimeTooEarly { .. })
+            ));
+
+            let equality = base + Duration::minutes(90);
+            validate_with_expected_target(&network, height, equality, &context)
+                .expect("the 90-minute equality boundary is inclusive");
+
+            let one_second_above = equality + Duration::seconds(1);
+            let result =
+                validate_with_expected_target(&network, height, one_second_above, &context);
+            assert_eq!(
+                matches!(result, Err(ContextualValidationError::TimeTooLate { .. })),
+                max_is_active,
+                "unexpected max-time activation for {network:?} at {height:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_pow_never_waives_median_time() {
+        let network = Network::new_regtest(RegtestParameters::default());
+        assert!(network.disable_pow());
+        let time = DateTime::from_timestamp(1_700_000_000, 0).expect("test timestamp is in range");
+        let context = [(network.target_difficulty_limit().to_compact(), time)];
+        let adjustment =
+            AdjustedDifficulty::new_from_header_time(time, block::Height(0), &network, context);
+        assert!(matches!(
+            validate_contextual_difficulty_and_time(
+                network.target_difficulty_limit().to_compact(),
+                adjustment,
+            ),
+            Err(ContextualValidationError::TimeTooEarly { .. })
+        ));
+    }
+
+    #[test]
+    fn custom_mtp_and_max_time_use_local_parameters_with_pow_on_or_off() {
+        let base = DateTime::from_timestamp(1_700_000_000, 0).expect("test timestamp is in range");
+        let activation = block::Height(10);
+
+        for disable_pow in [false, true] {
+            let network = Parameters::build()
+                .with_network_name(if disable_pow {
+                    "CustomTimePowOff"
+                } else {
+                    "CustomTimePowOn"
+                })
+                .expect("the custom network name is valid")
+                .with_disable_pow(disable_pow)
+                .with_max_block_time_start_height(activation)
+                .to_network()
+                .expect("the custom-network parameters are valid");
+            let context = [(network.target_difficulty_limit().to_compact(), base)];
+
+            assert!(matches!(
+                validate_with_expected_target(&network, block::Height(9), base, &context),
+                Err(ContextualValidationError::TimeTooEarly { .. })
+            ));
+            assert!(
+                validate_with_expected_target(
+                    &network,
+                    block::Height(9),
+                    base + Duration::minutes(90) + Duration::seconds(1),
+                    &context,
+                )
+                .is_ok(),
+                "the local maximum-time rule is not active before its configured height"
+            );
+            assert!(matches!(
+                validate_with_expected_target(
+                    &network,
+                    activation,
+                    base + Duration::minutes(90) + Duration::seconds(1),
+                    &context,
+                ),
+                Err(ContextualValidationError::TimeTooLate { .. })
+            ));
+        }
+
+        let regtest = Network::new_regtest(RegtestParameters::default());
+        assert!(
+            !regtest.is_max_block_time_enforced(block::Height(1))
+                && regtest.is_max_block_time_enforced(block::Height(2)),
+            "Regtest must use its local policy rather than public Testnet height 653,606"
+        );
+    }
+
+    #[allow(clippy::unwrap_in_result)]
+    fn validate_contextual_sequence(
+        network: &Network,
+        mut parent_height: block::Height,
+        predecessors: &[(CompactDifficulty, DateTime<Utc>)],
+        candidates: &[(CompactDifficulty, DateTime<Utc>)],
+    ) -> Result<(), ContextualValidationError> {
+        let mut context = predecessors.to_vec();
+        for (difficulty, time) in candidates {
+            validate_contextual_difficulty_and_time(
+                *difficulty,
+                AdjustedDifficulty::new_from_header_time(
+                    *time,
+                    parent_height,
+                    network,
+                    context.iter().copied(),
+                ),
+            )?;
+            parent_height = parent_height
+                .next()
+                .expect("the benchmark range is far below the height limit");
+            context.insert(0, (*difficulty, *time));
+            context.truncate(POW_ADJUSTMENT_BLOCK_SPAN);
+        }
+        Ok(())
+    }
+
+    /// Run with:
+    /// `cargo test -p zakura-header-chain --release -- --ignored --nocapture contextual_writer_hold_microbench`
+    #[test]
+    #[ignore = "manual release-mode benchmark for the R5 writer-boundary gate"]
+    #[allow(clippy::print_stdout)]
+    fn contextual_writer_hold_microbench() {
+        const TYPICAL_HEADERS: usize = 32;
+        const MAX_HEADERS: usize = 4_096;
+        const TYPICAL_ITERATIONS: u32 = 2_000;
+        const MAX_ITERATIONS: u32 = 20;
+        const MAX_ACCEPTABLE_WRITER_HOLD: std::time::Duration =
+            std::time::Duration::from_millis(25);
+
+        let network = Network::new_regtest(RegtestParameters::default());
+        let parent_height = block::Height(700_000);
+        let base =
+            DateTime::from_timestamp(2_000_000_000, 0).expect("benchmark timestamp is in range");
+        let spacing = Duration::seconds(75);
+        let difficulty = network.target_difficulty_limit().to_compact();
+        let predecessors = context(&network, base, spacing, POW_ADJUSTMENT_BLOCK_SPAN);
+        let candidates = |count: usize| {
+            (1..=count)
+                .map(|offset| {
+                    let offset =
+                        i32::try_from(offset).expect("the maximum batch length fits in an i32");
+                    (difficulty, base + spacing * offset)
+                })
+                .collect::<Vec<_>>()
+        };
+        let typical = candidates(TYPICAL_HEADERS);
+        let maximum = candidates(MAX_HEADERS);
+
+        println!(
+            "R5 contextual writer-hold gate: max 4,096-header average < {:?}",
+            MAX_ACCEPTABLE_WRITER_HOLD
+        );
+        for mode in ["integrated", "headers-only"] {
+            for (case, batch, iterations) in [
+                ("typical-pass", typical.as_slice(), TYPICAL_ITERATIONS),
+                ("maximum-pass", maximum.as_slice(), MAX_ITERATIONS),
+            ] {
+                let started = Instant::now();
+                for _ in 0..iterations {
+                    validate_contextual_sequence(
+                        &network,
+                        parent_height,
+                        &predecessors,
+                        black_box(batch),
+                    )
+                    .expect("the benchmark sequence is contextually valid");
+                }
+                let average = started.elapsed() / iterations;
+                println!(
+                    "mode={mode} case={case} headers={} average={average:?} per_header={:?}",
+                    batch.len(),
+                    average / u32::try_from(batch.len()).expect("benchmark length fits in u32"),
+                );
+                if case == "maximum-pass" {
+                    assert!(
+                        average < MAX_ACCEPTABLE_WRITER_HOLD,
+                        "{mode} maximum batch held the prototype writer gate for {average:?}"
+                    );
+                }
+            }
+
+            for (case, invalid_offset) in [("invalid-first", 0), ("invalid-last", MAX_HEADERS - 1)]
+            {
+                let mut invalid = maximum.clone();
+                invalid[invalid_offset].1 = predecessors[5].1;
+                let started = Instant::now();
+                let result = validate_contextual_sequence(
+                    &network,
+                    parent_height,
+                    &predecessors,
+                    black_box(&invalid),
+                );
+                let elapsed = started.elapsed();
+                assert!(result.is_err(), "{case} must exercise contextual rejection");
+                println!(
+                    "mode={mode} case={case} headers_examined={} elapsed={elapsed:?}",
+                    invalid_offset + 1,
+                );
+            }
+        }
+    }
+}

--- a/crates/zakura-header-chain/src/validation/mod.rs
+++ b/crates/zakura-header-chain/src/validation/mod.rs
@@ -279,3 +279,186 @@ pub fn validate_future_time(
 ) -> Result<(), block::BlockTimeError> {
     header.time_is_valid_at(now, &height, &hash)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zakura_chain::{
+        block::{genesis::regtest_genesis_block, Commitment},
+        parameters::testnet::{ConfiguredActivationHeights, Parameters, RegtestParameters},
+        work::difficulty::U256,
+    };
+
+    #[test]
+    fn canonical_version_hash_link_and_height_boundaries() {
+        let header = *regtest_genesis_block().header;
+        let expected_hash = header.hash();
+        assert_eq!(
+            validate_encoding_version_hash(&header),
+            Ok(expected_hash),
+            "the shared validator hashes the complete canonical header"
+        );
+
+        let mut historical_non_four = header;
+        historical_non_four.version = 5;
+        assert!(validate_encoding_version_hash(&historical_non_four).is_ok());
+        let mut too_old = header;
+        too_old.version = 3;
+        assert!(matches!(
+            validate_encoding_version_hash(&too_old),
+            Err(HeaderEncodingError { version: 3, .. })
+        ));
+        let mut high_bit = header;
+        high_bit.version = 1 << 31;
+        assert!(validate_encoding_version_hash(&high_bit).is_err());
+
+        let mut child = header;
+        child.previous_block_hash = expected_hash;
+        assert_eq!(
+            validate_link(header.previous_block_hash, &[header, child]),
+            Ok(())
+        );
+        child.previous_block_hash = block::Hash([9; 32]);
+        assert!(matches!(
+            validate_link(header.previous_block_hash, &[header, child]),
+            Err(HeaderLinkError { offset: 1, .. })
+        ));
+        assert_eq!(
+            infer_height(block::Height(7), Some(block::Height(8))),
+            Ok(block::Height(8))
+        );
+        assert!(matches!(
+            infer_height(block::Height(7), Some(block::Height(9))),
+            Err(HeaderHeightError::PeerMismatch { .. })
+        ));
+        assert_eq!(
+            infer_height(block::Height::MAX, None),
+            Err(HeaderHeightError::Overflow(block::Height::MAX))
+        );
+    }
+
+    #[test]
+    fn pow_policy_waiver_is_derived_only_from_custom_network_identity() {
+        assert_eq!(
+            PowPolicy::authenticated_custom_waiver(&Network::Mainnet),
+            Err(PowPolicyError::ProductionNetwork(NetworkKind::Mainnet))
+        );
+        assert!(!PowPolicy::for_network(&Network::Mainnet)
+            .expect("mainnet always validates proof of work")
+            .is_authenticated_custom_waiver());
+        let testnet = Network::new_default_testnet();
+        assert_eq!(
+            PowPolicy::authenticated_custom_waiver(&testnet),
+            Err(PowPolicyError::ProductionNetwork(NetworkKind::Testnet))
+        );
+        assert!(!PowPolicy::for_network(&testnet)
+            .expect("default testnet always validates proof of work")
+            .is_authenticated_custom_waiver());
+        let regtest = Network::new_regtest(RegtestParameters::default());
+        let regtest_policy =
+            PowPolicy::for_network(&regtest).expect("regtest is an authenticated custom network");
+        assert!(regtest_policy.is_authenticated_custom_waiver());
+        assert!(validate_compact_target(&regtest_genesis_block().header, &regtest).is_ok());
+        let mut wrong_shape = *regtest_genesis_block().header;
+        wrong_shape.solution = equihash::Solution::for_proposal();
+        assert!(matches!(
+            regtest_policy.validate_solution(&wrong_shape),
+            Err(equihash::Error::InvalidSolutionSize { .. })
+        ));
+
+        let pow_disabled_custom = Parameters::build()
+            .with_network_name("PowDisabledCustom")
+            .expect("the custom network name is valid")
+            .with_disable_pow(true)
+            .to_network()
+            .expect("the test custom-network parameters are valid");
+        let custom_policy = PowPolicy::for_network(&pow_disabled_custom)
+            .expect("configured custom networks may authenticate a PoW waiver");
+        assert!(custom_policy.is_authenticated_custom_waiver());
+        let proposal_header = block::Header {
+            solution: equihash::Solution::for_proposal(),
+            ..*regtest_genesis_block().header
+        };
+        assert!(custom_policy.validate_solution(&proposal_header).is_ok());
+    }
+
+    #[test]
+    fn custom_overlapping_activations_select_the_configured_commitment_variant() {
+        let activation_height = block::Height(10);
+        let heartwood_canopy = Parameters::build()
+            .with_network_name("OverlappingCommitments")
+            .expect("the custom network name is valid")
+            .with_activation_heights(ConfiguredActivationHeights {
+                heartwood: Some(activation_height.0),
+                canopy: Some(activation_height.0),
+                ..Default::default()
+            })
+            .expect("same-height upgrades are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("the custom-network parameters are valid");
+        let mut header = *regtest_genesis_block().header;
+        header.commitment_bytes = [0; 32].into();
+        assert_eq!(
+            validate_commitment_structure(&header, &heartwood_canopy, activation_height),
+            Ok(Commitment::ChainHistoryActivationReserved),
+            "an overwritten Heartwood activation still requires its reserved value"
+        );
+        header.commitment_bytes = [1; 32].into();
+        assert!(matches!(
+            validate_commitment_structure(&header, &heartwood_canopy, activation_height),
+            Err(CommitmentError::InvalidChainHistoryActivationReserved { .. })
+        ));
+
+        let through_nu5 = Parameters::build()
+            .with_network_name("OverlappingNu5Commitment")
+            .expect("the custom network name is valid")
+            .with_activation_heights(ConfiguredActivationHeights {
+                heartwood: Some(activation_height.0),
+                canopy: Some(activation_height.0),
+                nu5: Some(activation_height.0),
+                ..Default::default()
+            })
+            .expect("same-height upgrades are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("the custom-network parameters are valid");
+        assert!(matches!(
+            validate_commitment_structure(&header, &through_nu5, activation_height),
+            Ok(Commitment::ChainHistoryBlockTxAuthCommitment(_))
+        ));
+    }
+
+    #[test]
+    fn hash_filter_accepts_equality_and_rejects_one_above() {
+        let target = ExpandedDifficulty::from(U256::from(42));
+        let mut equal_bytes = [0; 32];
+        equal_bytes[0] = 42;
+        assert_eq!(
+            validate_hash_filter(block::Hash(equal_bytes), target),
+            Ok(())
+        );
+
+        let mut above_bytes = equal_bytes;
+        above_bytes[0] = 43;
+        assert_eq!(
+            validate_hash_filter(block::Hash(above_bytes), target),
+            Err(HashFilterError {
+                hash: block::Hash(above_bytes),
+                target,
+            })
+        );
+    }
+
+    #[test]
+    fn future_time_accepts_two_hour_equality_and_rejects_one_second_above() {
+        let mut header = *regtest_genesis_block().header;
+        let now = header.time;
+        let height = block::Height(1);
+        let hash = header.hash();
+        header.time = now + chrono::Duration::hours(2);
+        assert!(validate_future_time(&header, now, height, hash).is_ok());
+        header.time += chrono::Duration::seconds(1);
+        assert!(validate_future_time(&header, now, height, hash).is_err());
+    }
+}

--- a/crates/zakura-header-chain/src/validation/prepare.rs
+++ b/crates/zakura-header-chain/src/validation/prepare.rs
@@ -327,3 +327,252 @@ fn prepare_headers_inner(
     )
     .map_err(|error| invalid(0, HeaderRule::ValidationLease, error))
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+    use zakura_chain::{
+        block::genesis::regtest_genesis_block,
+        parameters::{testnet::RegtestParameters, Network},
+    };
+
+    use super::*;
+    use crate::{CheckpointSet, EngineMode, Frontier, TrustedAnchor};
+
+    #[derive(Copy, Clone)]
+    struct FixedClock(DateTime<Utc>);
+
+    impl Clock for FixedClock {
+        fn now(&self) -> DateTime<Utc> {
+            self.0
+        }
+    }
+
+    fn fixture() -> (HeaderRules, ValidationLease, Arc<block::Header>) {
+        let anchor_header = regtest_genesis_block().header.clone();
+        let anchor = Frontier::new(block::Height(0), anchor_header.hash());
+        let network = Network::new_regtest(RegtestParameters::default());
+        let config = EngineConfig::new(
+            EngineMode::Integrated,
+            network,
+            TrustedAnchor {
+                frontier: anchor,
+                header: anchor_header.clone(),
+            },
+            CheckpointSet::default(),
+        )
+        .expect("the regtest anchor and release manifest are coherent");
+        let rules = HeaderRules::from_engine_config(&config)
+            .expect("authenticated regtest parameters define their PoW policy");
+        let lease = ValidationLease::new(
+            anchor,
+            vec![HeaderContextFact {
+                frontier: anchor,
+                difficulty_threshold: anchor_header.difficulty_threshold,
+                time: anchor_header.time,
+            }],
+            config.trust_anchor_digest(),
+        );
+        (rules, lease, anchor_header)
+    }
+
+    fn child(parent: Frontier, template: &block::Header, seconds: i64) -> Arc<block::Header> {
+        Arc::new(block::Header {
+            previous_block_hash: parent.hash,
+            time: template.time + Duration::seconds(seconds),
+            nonce: [u8::try_from(seconds).unwrap_or(u8::MAX); 32].into(),
+            ..*template
+        })
+    }
+
+    #[test]
+    fn complete_batch_is_sealed_to_lease_and_uses_internal_context() {
+        let (rules, lease, anchor) = fixture();
+        let first = child(lease.parent, &anchor, 1);
+        let first_frontier = Frontier::new(block::Height(1), first.hash());
+        let second = child(first_frontier, &first, 2);
+        let headers = [first, second];
+
+        let batch = prepare_headers(
+            HeaderBatchInput::new(&headers),
+            &lease,
+            &rules,
+            &FixedClock(anchor.time + Duration::hours(1)),
+        )
+        .expect("the continuous custom-network batch is valid");
+
+        assert_eq!(batch.receipt().parent(), lease.parent());
+        assert_eq!(
+            batch.receipt().trust_anchor_digest(),
+            lease.trust_anchor_digest()
+        );
+        assert_eq!(batch.headers().len(), 2);
+        assert_eq!(batch.headers()[0].height, block::Height(1));
+        assert_eq!(batch.headers()[1].height, block::Height(2));
+        assert_eq!(
+            batch.headers()[1].header.previous_block_hash,
+            headers[0].hash()
+        );
+    }
+
+    #[test]
+    fn future_time_is_deferred_but_deterministic_failures_are_rejected() {
+        let (rules, lease, anchor) = fixture();
+        let future = child(lease.parent, &anchor, 3 * 60 * 60);
+        let now = anchor.time;
+        let batch = prepare_headers(
+            HeaderBatchInput::new(std::slice::from_ref(&future)),
+            &lease,
+            &rules,
+            &FixedClock(now),
+        )
+        .expect("local future time is admitted only as deferred");
+        assert_eq!(
+            batch.headers()[0].validation,
+            HeaderValidationState::DeferredUntil(future.time - Duration::hours(2))
+        );
+
+        let mut disconnected = *future;
+        disconnected.previous_block_hash = block::Hash([0x55; 32]);
+        let disconnected = Arc::new(disconnected);
+        assert!(matches!(
+            prepare_headers(
+                HeaderBatchInput::new(std::slice::from_ref(&disconnected)),
+                &lease,
+                &rules,
+                &FixedClock(now),
+            ),
+            Err(HeaderFailure::Invalid {
+                rule: HeaderRule::ParentLink,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn context_free_receipt_excludes_parent_and_branch_context_claims() {
+        let (rules, lease, anchor) = fixture();
+        let mut disconnected = *child(lease.parent, &anchor, 0);
+        disconnected.previous_block_hash = block::Hash([0x55; 32]);
+        let disconnected = Arc::new(disconnected);
+
+        let batch = prepare_context_free_headers(
+            HeaderBatchInput::new(std::slice::from_ref(&disconnected)),
+            lease.parent(),
+            &rules,
+            &FixedClock(anchor.time),
+        )
+        .expect("graph-independent preparation does not claim parent linkage or MTP");
+
+        assert_eq!(batch.receipt().parent(), lease.parent());
+        assert_eq!(
+            batch.receipt().trust_anchor_digest(),
+            rules.trust_anchor_digest()
+        );
+        assert_eq!(batch.headers()[0].hash, disconnected.hash());
+        assert_eq!(batch.headers()[0].height, block::Height(1));
+    }
+
+    #[test]
+    fn invalid_version_is_rejected_before_link_hashing() {
+        let (rules, lease, anchor) = fixture();
+        let mut invalid = *child(lease.parent, &anchor, 1);
+        invalid.version = 3;
+        let invalid = Arc::new(invalid);
+
+        assert!(matches!(
+            prepare_headers(
+                HeaderBatchInput::new(std::slice::from_ref(&invalid)),
+                &lease,
+                &rules,
+                &FixedClock(anchor.time),
+            ),
+            Err(HeaderFailure::Invalid {
+                rule: HeaderRule::EncodingVersionHash,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn empty_and_mutated_leases_fail_before_header_validation() {
+        let (rules, lease, anchor) = fixture();
+        assert!(matches!(
+            prepare_headers(
+                HeaderBatchInput::new(&[]),
+                &lease,
+                &rules,
+                &FixedClock(anchor.time),
+            ),
+            Err(HeaderFailure::Empty)
+        ));
+
+        let mut mutated = lease.clone();
+        mutated.parent.height = block::Height(1);
+        let header = child(lease.parent, &anchor, 1);
+        assert!(matches!(
+            prepare_headers(
+                HeaderBatchInput::new(std::slice::from_ref(&header)),
+                &mutated,
+                &rules,
+                &FixedClock(anchor.time),
+            ),
+            Err(HeaderFailure::InvalidLease)
+        ));
+
+        let high_parent = Frontier::new(block::Height(100), lease.parent.hash);
+        let short_lease = ValidationLease::new(
+            high_parent,
+            vec![HeaderContextFact {
+                frontier: high_parent,
+                difficulty_threshold: anchor.difficulty_threshold,
+                time: anchor.time,
+            }],
+            lease.trust_anchor_digest,
+        );
+        let header = child(high_parent, &anchor, 1);
+        assert!(matches!(
+            prepare_headers(
+                HeaderBatchInput::new(std::slice::from_ref(&header)),
+                &short_lease,
+                &rules,
+                &FixedClock(anchor.time),
+            ),
+            Err(HeaderFailure::InvalidLease)
+        ));
+    }
+
+    #[test]
+    fn validation_stages_expose_their_exact_normative_rule_ids() {
+        let cases: &[(HeaderRule, &[RuleId])] = &[
+            (HeaderRule::EncodingVersionHash, &[RuleId::new("LC-VAL-02")]),
+            (HeaderRule::ParentLink, &[RuleId::new("LC-VAL-03")]),
+            (HeaderRule::InferredHeight, &[RuleId::new("LC-HEIGHT-01")]),
+            (
+                HeaderRule::CommitmentStructure,
+                &[RuleId::new("LC-COMMIT-01"), RuleId::new("LC-COMMIT-02")],
+            ),
+            (HeaderRule::CompactTarget, &[RuleId::new("LC-VAL-05")]),
+            (HeaderRule::HashToTarget, &[RuleId::new("LC-VAL-05")]),
+            (HeaderRule::Equihash, &[RuleId::new("LC-VAL-04")]),
+            (
+                HeaderRule::ContextualDifficultyAndTime,
+                &[
+                    RuleId::new("LC-VAL-06"),
+                    RuleId::new("LC-VAL-07"),
+                    RuleId::new("LC-TIME-01"),
+                ],
+            ),
+            (HeaderRule::LocalFutureTime, &[RuleId::new("LC-VAL-08")]),
+            (
+                HeaderRule::ValidationLease,
+                &[RuleId::new("LC-ANCHOR-03"), RuleId::new("LC-VAL-11")],
+            ),
+            (HeaderRule::Work, &[RuleId::new("LC-VAL-10")]),
+        ];
+
+        for (stage, expected) in cases {
+            assert_eq!(stage.rule_ids(), *expected, "{stage:?}");
+        }
+    }
+}

--- a/docs/changelog/unreleased/561.md
+++ b/docs/changelog/unreleased/561.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR is one review layer of the header-sync stack; the stack's single
+operator-visible entry is owned by #532.


### PR DESCRIPTION
> Stack layer **3/15** (bottom to top) in stack **#573**. Review after **#560**; **#562** is next.
> GitHub shows only this layer's diff.

## Motivation

Fork choice and recovery defects emerge from combinations of insertion order, eligibility, finality, and crash boundaries that example-only coverage misses.

## Solution

Add focused unit and property suites for graph and transition classes, reference-projection comparisons, planner behavior, and chain primitives.

## Testing

- Complete layer-local \`zakura-header-chain\` library suite: **99 passed, 1 ignored**.

These tests exercise the transition authority introduced by #560 rather than duplicating production code.

## Changelog

\`docs/changelog/unreleased/561.md\` explicitly excludes this test-only layer. The stack's operator-visible entry is owned by #532.

### Specifications & References

- Production under test: #559 and #560.
- Conformance mapping: #572.

### Follow-up Work

None in this layer.
