### PR TITLE
feat(node-services): define typed header-sync contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8563,6 +8563,7 @@ dependencies = [
  "tokio",
  "tower 0.4.13",
  "zakura-chain",
+ "zakura-header-chain",
 ]
 
 [[package]]

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -31,7 +31,8 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "4.0.0-rc0" }
+zakura-chain = { path = "../zakura-chain" , version = "4.0.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/crates/zakura-node-services/src/header_chain.rs
+++ b/crates/zakura-node-services/src/header_chain.rs
@@ -1,0 +1,467 @@
+//! Typed boundary between header-sync policy and header-chain state.
+
+use std::{error::Error, future::Future, pin::Pin, sync::Arc};
+
+use zakura_chain::{block, parameters::Network};
+use zakura_header_chain::{
+    AuxDelivery, BodyWorkOwner, CommittedStallReceipt, Frontier, HeaderChainError, HeaderLocator,
+    HeaderSyncWorkOwner, HeaderWorkAuthority, InsertHeaders, SourceId, TargetCompletion,
+    VctRepairContext,
+};
+
+/// A boxed operation returned by [`HeaderChainPort`].
+pub type HeaderChainFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// A local failure while executing a header-chain port operation.
+#[derive(Clone, Debug)]
+pub enum HeaderChainPortError {
+    /// The adapter's operation deadline elapsed.
+    Timeout,
+    /// The backing service was unavailable or returned an invalid reply.
+    Unavailable {
+        /// Original failure, when the backing service supplied one.
+        source: Option<Arc<dyn Error + Send + Sync + 'static>>,
+    },
+}
+
+/// Result of resolving an exact selected-header auxiliary repair.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VctRepairContextReply {
+    /// The requested owner and height still identify the selected branch.
+    Resolved(VctRepairContext),
+    /// The owner or selected height is no longer current.
+    Stale,
+}
+
+/// Wire-neutral request for an immutable retained header path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcquireHeaderPath {
+    /// Stable requester identity.
+    pub source: SourceId,
+    /// Ordered-stream generation.
+    pub session_id: u64,
+    /// Exact generation and branch to retain.
+    pub scope: HeaderWorkAuthority,
+    /// Exact target branch.
+    pub target_tip_hash: block::Hash,
+    /// Requester-order locator hashes.
+    pub locator_hashes: Vec<block::Hash>,
+}
+
+/// Adapter-private identity for an immutable retained path.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct HeaderPathToken(u64);
+
+impl HeaderPathToken {
+    /// Construct a token in a state adapter.
+    #[doc(hidden)]
+    pub fn from_adapter_id(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Recover the adapter's identity in that same adapter.
+    #[doc(hidden)]
+    pub fn adapter_id(self) -> u64 {
+        self.0
+    }
+}
+
+/// An immutable retained path acquired from the header-chain port.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetainedHeaderPath {
+    token: HeaderPathToken,
+    source: SourceId,
+    session_id: u64,
+    /// First requester-order locator intersection.
+    pub common_ancestor: Frontier,
+    /// Exact retained target.
+    pub target: Frontier,
+    /// Exact generation and branch fixed at acquisition.
+    pub scope: HeaderWorkAuthority,
+}
+
+impl RetainedHeaderPath {
+    /// Construct a retained path in a state adapter.
+    #[doc(hidden)]
+    pub fn from_adapter(
+        token: HeaderPathToken,
+        source: SourceId,
+        session_id: u64,
+        common_ancestor: Frontier,
+        target: Frontier,
+        scope: HeaderWorkAuthority,
+    ) -> Self {
+        Self {
+            token,
+            source,
+            session_id,
+            common_ancestor,
+            target,
+            scope,
+        }
+    }
+
+    /// Return the opaque token to a state adapter.
+    #[doc(hidden)]
+    pub fn adapter_identity(&self) -> (HeaderPathToken, SourceId, u64) {
+        (self.token, self.source, self.session_id)
+    }
+}
+
+/// Result of acquiring an immutable retained path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AcquireHeaderPathReply {
+    /// The requested target path is retained.
+    Acquired(Box<RetainedHeaderPath>),
+    /// The target is no longer retained.
+    TargetNotRetained,
+    /// No requester locator lies on the retained target path.
+    NoLocatorIntersection,
+    /// Required target history has been pruned.
+    HistoryPruned,
+    /// State cannot currently retain another path.
+    Busy,
+}
+
+/// A bounded read from an already acquired retained path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReadHeaderPath {
+    /// Common ancestor or previous page tip.
+    pub after_hash: block::Hash,
+    /// Maximum number of returned headers.
+    pub max_header_count: u32,
+}
+
+/// One raw page from an immutable retained header path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetainedHeaderPathPage {
+    /// Exact page ancestor.
+    pub common_ancestor: Frontier,
+    /// Exact retained target.
+    pub target: Frontier,
+    /// Exact generation and branch fixed at acquisition.
+    pub scope: HeaderWorkAuthority,
+    /// Canonical headers in parent-first order.
+    pub headers: Vec<Arc<block::Header>>,
+    /// Parallel auxiliary deliveries for each retained header.
+    pub aux_deliveries: Vec<Vec<AuxDelivery>>,
+    /// Whether this page reaches the immutable target.
+    pub complete: bool,
+}
+
+/// Result of reading an immutable retained path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReadHeaderPathReply {
+    /// The requested page remains available.
+    Page(Box<RetainedHeaderPathPage>),
+    /// The lease expired or became unavailable.
+    Unavailable,
+}
+
+/// One header and its unauthenticated parallel metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HeaderTargetEntry {
+    /// Canonical Zcash block header.
+    pub header: Arc<block::Header>,
+    /// Serialized-body-size hint; zero means unknown.
+    pub body_size: u32,
+    /// Optional schema-1 commitment record.
+    pub tree_aux: Option<zakura_header_chain::TreeAuxRecordV1>,
+}
+
+/// Complete input to deterministic target preparation.
+#[derive(Clone, Debug)]
+pub struct PrepareHeaderTarget {
+    /// Stable supplier identity.
+    pub source: SourceId,
+    /// Authenticated network parameters.
+    pub network: Network,
+    /// Exact asynchronous owner.
+    pub owner: HeaderSyncWorkOwner,
+    /// Exact initial locator intersection.
+    pub common_ancestor: Frontier,
+    /// Exact advertised target.
+    pub target: Frontier,
+    /// Response entries in parent-first order.
+    pub entries: Vec<HeaderTargetEntry>,
+    /// Proof that the response satisfies its target purpose.
+    pub completion: TargetCompletion,
+}
+
+/// A target sealed by the port's preparation operation.
+#[derive(Clone, Debug)]
+pub struct PreparedHeaderTarget(Box<InsertHeaders>);
+
+impl PreparedHeaderTarget {
+    /// Seal an insertion in a state adapter.
+    #[doc(hidden)]
+    pub fn from_insert(insert: Box<InsertHeaders>) -> Self {
+        Self(insert)
+    }
+
+    /// Consume a sealed target in a state adapter.
+    #[doc(hidden)]
+    pub fn into_insert(self) -> Box<InsertHeaders> {
+        self.0
+    }
+}
+
+/// Result of target preparation.
+pub type PrepareHeaderTargetReply = Result<PreparedHeaderTarget, Arc<HeaderChainError>>;
+
+/// Result of atomically applying a prepared target.
+pub type ApplyHeaderTargetReply = Result<ApplyHeaderTargetOutcome, Arc<HeaderChainError>>;
+
+/// Successful state-side outcome of applying one prepared header target.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ApplyHeaderTargetOutcome {
+    /// State committed the target or recognized its idempotent replay.
+    Applied,
+    /// State committed the resource-stall outcome without admitting the target.
+    ResourceStalled(CommittedStallReceipt),
+}
+
+/// Header-chain operations needed by header-sync policy.
+///
+/// Each request and its typed reply share one future. Implementations own local
+/// deadlines and translation to any backing service protocol.
+pub trait HeaderChainPort: Send + Sync + 'static {
+    /// Read one coherent selected-path continuation locator.
+    fn continuation_locator(
+        &self,
+    ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, HeaderChainPortError>>;
+
+    /// Resolve one exact selected-header auxiliary repair.
+    fn vct_repair_context(
+        &self,
+        owner: BodyWorkOwner,
+        height: block::Height,
+    ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, HeaderChainPortError>>;
+
+    /// Acquire an immutable retained target path.
+    fn acquire_header_path(
+        &self,
+        request: AcquireHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<AcquireHeaderPathReply, HeaderChainPortError>>;
+
+    /// Read one bounded page from an immutable retained target path.
+    fn read_header_path(
+        &self,
+        path: RetainedHeaderPath,
+        request: ReadHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<ReadHeaderPathReply, HeaderChainPortError>>;
+
+    /// Idempotently release an immutable retained target path.
+    fn release_header_path(
+        &self,
+        path: RetainedHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<(), HeaderChainPortError>>;
+
+    /// Validate and seal one complete target outside the serialized writer.
+    fn prepare_header_target(
+        &self,
+        request: PrepareHeaderTarget,
+    ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply>;
+
+    /// Atomically apply one sealed target.
+    fn apply_header_target(
+        &self,
+        target: PreparedHeaderTarget,
+    ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply>;
+}
+
+impl std::fmt::Debug for dyn HeaderChainPort {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("HeaderChainPort")
+    }
+}
+
+/// Explicit unavailable port used when no durable header-chain state is attached.
+#[derive(Debug, Default)]
+pub struct UnavailableHeaderChainPort;
+
+impl HeaderChainPort for UnavailableHeaderChainPort {
+    fn continuation_locator(
+        &self,
+    ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, HeaderChainPortError>> {
+        Box::pin(async { Err(HeaderChainPortError::Unavailable { source: None }) })
+    }
+
+    fn vct_repair_context(
+        &self,
+        _owner: BodyWorkOwner,
+        _height: block::Height,
+    ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, HeaderChainPortError>> {
+        Box::pin(async { Err(HeaderChainPortError::Unavailable { source: None }) })
+    }
+
+    fn acquire_header_path(
+        &self,
+        _request: AcquireHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<AcquireHeaderPathReply, HeaderChainPortError>> {
+        Box::pin(async { Ok(AcquireHeaderPathReply::TargetNotRetained) })
+    }
+
+    fn read_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+        _request: ReadHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<ReadHeaderPathReply, HeaderChainPortError>> {
+        Box::pin(async { Ok(ReadHeaderPathReply::Unavailable) })
+    }
+
+    fn release_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<(), HeaderChainPortError>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn prepare_header_target(
+        &self,
+        request: PrepareHeaderTarget,
+    ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply> {
+        Box::pin(async move {
+            Err(Arc::new(HeaderChainError::local_resource(
+                zakura_header_chain::ErrorSubject::Branch(request.owner.header_authority().branch),
+                None,
+            )))
+        })
+    }
+
+    fn apply_header_target(
+        &self,
+        target: PreparedHeaderTarget,
+    ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply> {
+        let owner = target.0.owner;
+        Box::pin(async move {
+            Err(Arc::new(HeaderChainError::local_resource(
+                zakura_header_chain::ErrorSubject::Branch(owner.header_authority().branch),
+                None,
+            )))
+        })
+    }
+}
+
+/// Inert port used by state-machine tests that drive completions explicitly.
+#[doc(hidden)]
+#[derive(Debug, Default)]
+pub struct InertHeaderChainPort;
+
+impl HeaderChainPort for InertHeaderChainPort {
+    fn continuation_locator(
+        &self,
+    ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, HeaderChainPortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn vct_repair_context(
+        &self,
+        _owner: BodyWorkOwner,
+        _height: block::Height,
+    ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, HeaderChainPortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn acquire_header_path(
+        &self,
+        _request: AcquireHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<AcquireHeaderPathReply, HeaderChainPortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn read_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+        _request: ReadHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<ReadHeaderPathReply, HeaderChainPortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn release_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<(), HeaderChainPortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn prepare_header_target(
+        &self,
+        _request: PrepareHeaderTarget,
+    ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply> {
+        Box::pin(std::future::pending())
+    }
+
+    fn apply_header_target(
+        &self,
+        _target: PreparedHeaderTarget,
+    ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply> {
+        Box::pin(std::future::pending())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct MinimalMock;
+
+    impl HeaderChainPort for MinimalMock {
+        fn continuation_locator(
+            &self,
+        ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, HeaderChainPortError>> {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn vct_repair_context(
+            &self,
+            _owner: BodyWorkOwner,
+            _height: block::Height,
+        ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, HeaderChainPortError>> {
+            Box::pin(async { Ok(VctRepairContextReply::Stale) })
+        }
+
+        fn acquire_header_path(
+            &self,
+            _request: AcquireHeaderPath,
+        ) -> HeaderChainFuture<'_, Result<AcquireHeaderPathReply, HeaderChainPortError>> {
+            Box::pin(async { Ok(AcquireHeaderPathReply::Busy) })
+        }
+
+        fn read_header_path(
+            &self,
+            _path: RetainedHeaderPath,
+            _request: ReadHeaderPath,
+        ) -> HeaderChainFuture<'_, Result<ReadHeaderPathReply, HeaderChainPortError>> {
+            Box::pin(async { Ok(ReadHeaderPathReply::Unavailable) })
+        }
+
+        fn release_header_path(
+            &self,
+            _path: RetainedHeaderPath,
+        ) -> HeaderChainFuture<'_, Result<(), HeaderChainPortError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn prepare_header_target(
+            &self,
+            _request: PrepareHeaderTarget,
+        ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply> {
+            unreachable!("the mock need not construct a state service")
+        }
+
+        fn apply_header_target(
+            &self,
+            _target: PreparedHeaderTarget,
+        ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply> {
+            unreachable!("the mock need not construct a state service")
+        }
+    }
+
+    #[tokio::test]
+    async fn port_is_object_safe_and_mockable_without_state_services() {
+        let port: Arc<dyn HeaderChainPort> = Arc::new(MinimalMock);
+        assert!(port.continuation_locator().await.unwrap().is_none());
+    }
+}

--- a/crates/zakura-node-services/src/lib.rs
+++ b/crates/zakura-node-services/src/lib.rs
@@ -1,8 +1,10 @@
 //! The interfaces of some Zakura node services.
 
 pub use zakura_chain::parameters::checkpoint::constants;
+pub mod header_chain;
 pub mod mempool;
 pub mod service_traits;
+pub mod sync_lifecycle;
 
 #[cfg(any(test, feature = "rpc-client"))]
 pub mod rpc_client;

--- a/crates/zakura-node-services/src/sync_lifecycle.rs
+++ b/crates/zakura-node-services/src/sync_lifecycle.rs
@@ -1,0 +1,621 @@
+//! Process-local sync lifecycle values shared across state, network, and node orchestration.
+
+use std::fmt;
+use std::sync::Arc;
+
+use zakura_header_chain::Frontier;
+
+/// Checked monotonic identity for one lifecycle generation.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct LifecycleEpoch(u64);
+
+impl LifecycleEpoch {
+    /// The first lifecycle generation.
+    pub const INITIAL: Self = Self(0);
+
+    /// Construct an epoch from a durable or test value.
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the numeric epoch for metrics and serialization boundaries.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Advance without wrapping.
+    pub const fn checked_next(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(next) => Some(Self(next)),
+            None => None,
+        }
+    }
+}
+
+/// Authoritative process-local owner of bulk block applies.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ApplyPhase {
+    /// Legacy checkpoint sync owns applies before semantic handoff.
+    LegacyBootstrap {
+        /// Bootstrap ownership generation.
+        epoch: LifecycleEpoch,
+    },
+    /// Native Zakura block sync may begin new applies.
+    Native {
+        /// Native ownership generation.
+        epoch: LifecycleEpoch,
+    },
+    /// Native admission is closed while previously authorized applies drain.
+    FallbackDraining {
+        /// Native generation being drained.
+        epoch: LifecycleEpoch,
+    },
+    /// One fully drained legacy fallback lease owns applies.
+    LegacyFallback {
+        /// Drained generation owned by the fallback lease.
+        epoch: LifecycleEpoch,
+    },
+    /// New bulk applies are permanently fail-closed.
+    Failed {
+        /// Last valid generation before failure.
+        epoch: LifecycleEpoch,
+    },
+}
+
+impl ApplyPhase {
+    /// Return this phase's monotonic generation.
+    pub const fn epoch(self) -> LifecycleEpoch {
+        match self {
+            Self::LegacyBootstrap { epoch }
+            | Self::Native { epoch }
+            | Self::FallbackDraining { epoch }
+            | Self::LegacyFallback { epoch }
+            | Self::Failed { epoch } => epoch,
+        }
+    }
+
+    /// Return a stable metric/log label.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::LegacyBootstrap { .. } => "legacy_bootstrap",
+            Self::Native { .. } => "native",
+            Self::FallbackDraining { .. } => "fallback_draining",
+            Self::LegacyFallback { .. } => "legacy_fallback",
+            Self::Failed { .. } => "failed",
+        }
+    }
+
+    /// Apply one checked lifecycle transition without mutating the caller on failure.
+    pub fn transition(self, transition: ApplyTransition) -> Result<Self, LifecycleTransitionError> {
+        match transition {
+            ApplyTransition::FinishBootstrap => match self {
+                Self::LegacyBootstrap { epoch } => Ok(Self::Native {
+                    epoch: epoch
+                        .checked_next()
+                        .ok_or(LifecycleTransitionError::EpochExhausted)?,
+                }),
+                _ => Err(LifecycleTransitionError::IllegalPhase),
+            },
+            ApplyTransition::BeginFallback { expected_epoch } => {
+                check_epoch(self, expected_epoch)?;
+                match self {
+                    Self::Native { epoch } => Ok(Self::FallbackDraining { epoch }),
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            ApplyTransition::ActivateFallback { expected_epoch } => {
+                check_epoch(self, expected_epoch)?;
+                match self {
+                    Self::FallbackDraining { epoch } => Ok(Self::LegacyFallback { epoch }),
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            ApplyTransition::ResumeNative { expected_epoch } => {
+                check_epoch(self, expected_epoch)?;
+                match self {
+                    Self::FallbackDraining { epoch } | Self::LegacyFallback { epoch } => {
+                        Ok(Self::Native {
+                            epoch: epoch
+                                .checked_next()
+                                .ok_or(LifecycleTransitionError::EpochExhausted)?,
+                        })
+                    }
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            ApplyTransition::Fail => match self {
+                Self::Failed { .. } => Err(LifecycleTransitionError::IllegalPhase),
+                _ => Ok(Self::Failed {
+                    epoch: self.epoch(),
+                }),
+            },
+        }
+    }
+}
+
+fn check_epoch(
+    phase: ApplyPhase,
+    expected: LifecycleEpoch,
+) -> Result<(), LifecycleTransitionError> {
+    let current = phase.epoch();
+    if current != expected {
+        return Err(LifecycleTransitionError::StaleEpoch { expected, current });
+    }
+    Ok(())
+}
+
+/// Requested apply-lifecycle edge.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ApplyTransition {
+    /// Complete checkpoint semantic handoff.
+    FinishBootstrap,
+    /// Stop new native applies and begin draining one native epoch.
+    BeginFallback {
+        /// Exact native generation to drain.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Authorize legacy fallback after the same epoch fully drains.
+    ActivateFallback {
+        /// Exact drained generation to authorize.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Drop/cancel the exact fallback lease and advance native ownership.
+    ResumeNative {
+        /// Exact fallback generation being released.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Fail closed while retaining the last epoch for diagnosis.
+    Fail,
+}
+
+/// Rejected lifecycle transition.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum LifecycleTransitionError {
+    /// The requested edge is not legal from the current phase.
+    IllegalPhase,
+    /// The request was issued for an obsolete lifecycle generation.
+    StaleEpoch {
+        /// Requested generation.
+        expected: LifecycleEpoch,
+        /// Current generation.
+        current: LifecycleEpoch,
+    },
+    /// Advancing the monotonic counter would wrap.
+    EpochExhausted,
+}
+
+impl fmt::Display for LifecycleTransitionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IllegalPhase => formatter.write_str("illegal sync lifecycle transition"),
+            Self::StaleEpoch { expected, current } => write!(
+                formatter,
+                "stale sync lifecycle epoch {} (current {})",
+                expected.get(),
+                current.get()
+            ),
+            Self::EpochExhausted => formatter.write_str("sync lifecycle epoch exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for LifecycleTransitionError {}
+
+/// Coarse startup stage reported while attaching the durable header runtime.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderReconstructionStage {
+    /// Audit authoritative rows and derive any reconstructible repairs.
+    StartupAudit,
+    /// Reconcile the durable header runtime with authenticated full-state frontiers.
+    FullStateReconciliation,
+}
+
+/// Bounded progress facts for one header-runtime attachment attempt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct HeaderReconstructionProgress {
+    /// Current reconstruction stage.
+    pub stage: HeaderReconstructionStage,
+    /// Completed work units within the stage.
+    pub completed: u64,
+    /// Known total work units, or `None` before the audit determines it.
+    pub total: Option<u64>,
+    /// Fixed canonical finalized target for this attachment attempt.
+    pub target: Option<Frontier>,
+    /// Last canonical frontier durably committed with restart progress.
+    pub last_committed: Option<Frontier>,
+}
+
+/// Why the durable header runtime is not attached yet.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderRuntimeDetachedReason {
+    /// Fresh state must first receive checkpoint-verified blocks through semantic sync.
+    AwaitingSemanticHandoff,
+    /// Durable header state exists and the state worker still owes runtime attachment.
+    AttachmentPending,
+}
+
+impl HeaderReconstructionProgress {
+    /// Initial progress before the startup audit has enumerated work.
+    pub const STARTING: Self = Self {
+        stage: HeaderReconstructionStage::StartupAudit,
+        completed: 0,
+        total: None,
+        target: None,
+        last_committed: None,
+    };
+}
+
+/// Authoritative attachment/readiness state of the durable header runtime.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HeaderRuntimeStatus {
+    /// Checkpoint semantic handoff has not started runtime attachment.
+    Detached {
+        /// Last attachment generation.
+        epoch: LifecycleEpoch,
+        /// Explicit startup condition that determines whether callers may bootstrap.
+        reason: HeaderRuntimeDetachedReason,
+    },
+    /// One attachment generation is auditing or reconciling durable state.
+    Reconstructing {
+        /// Exact attachment generation.
+        epoch: LifecycleEpoch,
+        /// Latest bounded progress report.
+        progress: HeaderReconstructionProgress,
+    },
+    /// The coherent reader and committed snapshot publisher are both live.
+    Ready {
+        /// Ready attachment generation.
+        epoch: LifecycleEpoch,
+    },
+    /// Attachment failed closed with its root-cause message.
+    Failed {
+        /// Failed attachment generation.
+        epoch: LifecycleEpoch,
+        /// Stable root-cause text propagated from state startup.
+        error: Arc<str>,
+    },
+}
+
+impl HeaderRuntimeStatus {
+    /// Return this status's monotonic attachment generation.
+    pub const fn epoch(&self) -> LifecycleEpoch {
+        match self {
+            Self::Detached { epoch, .. }
+            | Self::Reconstructing { epoch, .. }
+            | Self::Ready { epoch }
+            | Self::Failed { epoch, .. } => *epoch,
+        }
+    }
+
+    /// Whether the coherent runtime is ready for header service use.
+    pub const fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready { .. })
+    }
+
+    /// Apply one checked runtime transition without changing the caller on failure.
+    pub fn transition(
+        self,
+        transition: HeaderRuntimeTransition,
+    ) -> Result<Self, LifecycleTransitionError> {
+        match transition {
+            HeaderRuntimeTransition::BeginReconstruction => match self {
+                Self::Detached { epoch, .. } => Ok(Self::Reconstructing {
+                    epoch: epoch
+                        .checked_next()
+                        .ok_or(LifecycleTransitionError::EpochExhausted)?,
+                    progress: HeaderReconstructionProgress::STARTING,
+                }),
+                _ => Err(LifecycleTransitionError::IllegalPhase),
+            },
+            HeaderRuntimeTransition::ReportProgress {
+                expected_epoch,
+                progress,
+            } => {
+                check_header_epoch(&self, expected_epoch)?;
+                match self {
+                    Self::Reconstructing { epoch, .. } => {
+                        Ok(Self::Reconstructing { epoch, progress })
+                    }
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            HeaderRuntimeTransition::Ready { expected_epoch } => {
+                check_header_epoch(&self, expected_epoch)?;
+                match self {
+                    Self::Reconstructing { epoch, .. } => Ok(Self::Ready { epoch }),
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            HeaderRuntimeTransition::Fail {
+                expected_epoch,
+                error,
+            } => {
+                check_header_epoch(&self, expected_epoch)?;
+                match self {
+                    Self::Detached { epoch, .. } | Self::Reconstructing { epoch, .. } => {
+                        Ok(Self::Failed { epoch, error })
+                    }
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+        }
+    }
+}
+
+fn check_header_epoch(
+    status: &HeaderRuntimeStatus,
+    expected: LifecycleEpoch,
+) -> Result<(), LifecycleTransitionError> {
+    let current = status.epoch();
+    if current != expected {
+        return Err(LifecycleTransitionError::StaleEpoch { expected, current });
+    }
+    Ok(())
+}
+
+/// Requested header-runtime lifecycle edge.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HeaderRuntimeTransition {
+    /// Start one checked attachment/reconstruction generation.
+    BeginReconstruction,
+    /// Replace progress only for the exact active generation.
+    ReportProgress {
+        /// Active attachment generation.
+        expected_epoch: LifecycleEpoch,
+        /// New bounded progress facts.
+        progress: HeaderReconstructionProgress,
+    },
+    /// Publish coherent readiness for the exact reconstructed generation.
+    Ready {
+        /// Active attachment generation.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Fail the exact detached or reconstructing generation closed.
+    Fail {
+        /// Generation that encountered the failure.
+        expected_epoch: LifecycleEpoch,
+        /// Root-cause text from state attachment.
+        error: Arc<str>,
+    },
+}
+
+/// Coordinator-owned header ordered-service demand.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderServiceDemand {
+    /// Do not advertise or open header-sync sessions before runtime readiness.
+    Disabled {
+        /// Latest observed header-runtime generation.
+        runtime_epoch: LifecycleEpoch,
+    },
+    /// Advertise and schedule header sync exactly once for this readiness generation.
+    Enabled {
+        /// Monotonic capability/readiness generation.
+        capability_epoch: LifecycleEpoch,
+    },
+}
+
+impl HeaderServiceDemand {
+    /// Whether header capability advertisement and ordered sessions are authorized.
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled { .. })
+    }
+
+    /// Return the capability generation when header demand is enabled.
+    pub const fn capability_epoch(self) -> Option<LifecycleEpoch> {
+        match self {
+            Self::Disabled { .. } => None,
+            Self::Enabled { capability_epoch } => Some(capability_epoch),
+        }
+    }
+}
+
+/// Coordinator-owned block ordered-service demand.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BlockServiceDemand {
+    /// Keep body serving live while legacy/bootstrap owns bulk application.
+    ServingOnly {
+        /// Exact apply generation represented by this demand.
+        apply_epoch: LifecycleEpoch,
+    },
+    /// Keep body serving live and admit native body application.
+    ServingAndApplying {
+        /// Exact native apply generation represented by this demand.
+        apply_epoch: LifecycleEpoch,
+    },
+}
+
+impl BlockServiceDemand {
+    /// Whether native body application is authorized in this demand generation.
+    pub const fn is_applying(self) -> bool {
+        matches!(self, Self::ServingAndApplying { .. })
+    }
+
+    /// Return the exact apply generation represented by this demand.
+    pub const fn apply_epoch(self) -> LifecycleEpoch {
+        match self {
+            Self::ServingOnly { apply_epoch } | Self::ServingAndApplying { apply_epoch } => {
+                apply_epoch
+            }
+        }
+    }
+}
+
+/// One coordinator publication consumed by capability and ordered-service scheduling.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SyncServiceDemand {
+    /// Header capability/session demand.
+    pub header: HeaderServiceDemand,
+    /// Block serving/apply demand.
+    pub block: BlockServiceDemand,
+}
+
+impl SyncServiceDemand {
+    /// Derive the complete transport demand from authoritative lifecycle phases.
+    pub fn from_phases(apply: ApplyPhase, header: &HeaderRuntimeStatus) -> Self {
+        let header = match header {
+            HeaderRuntimeStatus::Ready { epoch } => HeaderServiceDemand::Enabled {
+                capability_epoch: *epoch,
+            },
+            _ => HeaderServiceDemand::Disabled {
+                runtime_epoch: header.epoch(),
+            },
+        };
+        let block = match apply {
+            ApplyPhase::Native { epoch } => {
+                BlockServiceDemand::ServingAndApplying { apply_epoch: epoch }
+            }
+            _ => BlockServiceDemand::ServingOnly {
+                apply_epoch: apply.epoch(),
+            },
+        };
+        Self { header, block }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_phase_model_accepts_only_declared_edges() {
+        let zero = LifecycleEpoch::INITIAL;
+        let one = zero
+            .checked_next()
+            .expect("the initial epoch has a successor");
+        let phases = [
+            ApplyPhase::LegacyBootstrap { epoch: zero },
+            ApplyPhase::Native { epoch: one },
+            ApplyPhase::FallbackDraining { epoch: one },
+            ApplyPhase::LegacyFallback { epoch: one },
+            ApplyPhase::Failed { epoch: one },
+        ];
+        let transitions = [
+            ApplyTransition::FinishBootstrap,
+            ApplyTransition::BeginFallback {
+                expected_epoch: one,
+            },
+            ApplyTransition::ActivateFallback {
+                expected_epoch: one,
+            },
+            ApplyTransition::ResumeNative {
+                expected_epoch: one,
+            },
+            ApplyTransition::Fail,
+        ];
+
+        for phase in phases {
+            for transition in transitions {
+                let result = phase.transition(transition);
+                let legal = matches!(
+                    (phase, transition),
+                    (
+                        ApplyPhase::LegacyBootstrap { .. },
+                        ApplyTransition::FinishBootstrap | ApplyTransition::Fail
+                    ) | (
+                        ApplyPhase::Native { .. },
+                        ApplyTransition::BeginFallback { .. } | ApplyTransition::Fail
+                    ) | (
+                        ApplyPhase::FallbackDraining { .. },
+                        ApplyTransition::ActivateFallback { .. }
+                            | ApplyTransition::ResumeNative { .. }
+                            | ApplyTransition::Fail
+                    ) | (
+                        ApplyPhase::LegacyFallback { .. },
+                        ApplyTransition::ResumeNative { .. } | ApplyTransition::Fail
+                    )
+                );
+                assert_eq!(result.is_ok(), legal, "{phase:?} -> {transition:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn stale_and_exhausted_epochs_fail_without_wrapping() {
+        let current = ApplyPhase::Native {
+            epoch: LifecycleEpoch::new(7),
+        };
+        assert_eq!(
+            current.transition(ApplyTransition::BeginFallback {
+                expected_epoch: LifecycleEpoch::new(6),
+            }),
+            Err(LifecycleTransitionError::StaleEpoch {
+                expected: LifecycleEpoch::new(6),
+                current: LifecycleEpoch::new(7),
+            })
+        );
+
+        let exhausted = ApplyPhase::LegacyFallback {
+            epoch: LifecycleEpoch::new(u64::MAX),
+        };
+        assert_eq!(
+            exhausted.transition(ApplyTransition::ResumeNative {
+                expected_epoch: LifecycleEpoch::new(u64::MAX),
+            }),
+            Err(LifecycleTransitionError::EpochExhausted)
+        );
+    }
+
+    #[test]
+    fn header_runtime_requires_one_explicit_reconstruction_epoch() {
+        let detached = HeaderRuntimeStatus::Detached {
+            epoch: LifecycleEpoch::INITIAL,
+            reason: HeaderRuntimeDetachedReason::AttachmentPending,
+        };
+        let reconstructing = detached
+            .clone()
+            .transition(HeaderRuntimeTransition::BeginReconstruction)
+            .expect("detached runtime can begin reconstruction");
+        let epoch = reconstructing.epoch();
+        assert!(matches!(
+            reconstructing,
+            HeaderRuntimeStatus::Reconstructing { .. }
+        ));
+        let ready = reconstructing
+            .clone()
+            .transition(HeaderRuntimeTransition::Ready {
+                expected_epoch: epoch,
+            })
+            .expect("the active reconstruction can become ready");
+        assert_eq!(ready, HeaderRuntimeStatus::Ready { epoch });
+        assert_eq!(
+            detached.transition(HeaderRuntimeTransition::Ready {
+                expected_epoch: LifecycleEpoch::INITIAL,
+            }),
+            Err(LifecycleTransitionError::IllegalPhase)
+        );
+        assert!(matches!(
+            reconstructing.transition(HeaderRuntimeTransition::Ready {
+                expected_epoch: LifecycleEpoch::INITIAL,
+            }),
+            Err(LifecycleTransitionError::StaleEpoch { .. })
+        ));
+    }
+
+    #[test]
+    fn service_demand_keeps_serving_separate_from_native_applying() {
+        let ready = HeaderRuntimeStatus::Ready {
+            epoch: LifecycleEpoch::new(3),
+        };
+        let native = SyncServiceDemand::from_phases(
+            ApplyPhase::Native {
+                epoch: LifecycleEpoch::new(4),
+            },
+            &ready,
+        );
+        assert_eq!(
+            native.header.capability_epoch(),
+            Some(LifecycleEpoch::new(3))
+        );
+        assert!(native.block.is_applying());
+
+        let fallback = SyncServiceDemand::from_phases(
+            ApplyPhase::LegacyFallback {
+                epoch: LifecycleEpoch::new(4),
+            },
+            &ready,
+        );
+        assert_eq!(fallback.header, native.header);
+        assert!(!fallback.block.is_applying());
+        assert_eq!(fallback.block.apply_epoch(), LifecycleEpoch::new(4));
+    }
+}

--- a/docs/changelog/unreleased/562.md
+++ b/docs/changelog/unreleased/562.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR is one review layer of the header-sync stack; the stack's single
+operator-visible entry is owned by #532.


### PR DESCRIPTION
> Stack layer **4/15** (bottom to top) in stack **#573**. Review after **#561**; **#563** is next.
> GitHub shows only this layer's diff.

## Motivation

Readiness, work ownership, and apply mode were inferred across unrelated tasks, allowing cancellation and startup races.

## Solution

Define typed, domain-separated header/body authority and explicit lifecycle, demand, readiness, attachment, and failure contracts. These contracts make illegal ownership transitions unrepresentable for the state, network, and node layers above.

## Testing

- Node-services suite: **7 passed**.
- All-target \`zakura-node-services\` clippy with warnings denied.

## Changelog

\`docs/changelog/unreleased/562.md\` explicitly excludes this stack slice. The stack's operator-visible entry is owned by #532.

### Specifications & References

- Header-chain model and transition authority: #559 and #560.

### Follow-up Work

Layer #563 implements durable state against these contracts.
