### PR TITLE
refactor(sync): adapt consensus and RPC to header-chain work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8427,7 +8427,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "6.0.0-rc2"
+version = "6.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8465,6 +8465,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "zakura-chain",
+ "zakura-header-chain",
  "zakura-node-services",
  "zakura-script",
  "zakura-state",

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "6.0.0-rc2"
+version = "6.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -71,7 +71,8 @@ tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower
 zakura-script = { path = "../zakura-script", version = "3.1.0-rc1" }
 zakura-state = { path = "../zakura-state", version = "6.0.0-rc0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.1.0-rc1" }
-zakura-chain = { path = "../zakura-chain", version = "4.0.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "4.0.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 
 zcash_protocol.workspace = true
 
@@ -97,7 +98,7 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 zakura-state = { path = "../zakura-state", version = "6.0.0-rc0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "4.0.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0-rc1" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-consensus/src/block.rs
+++ b/crates/zakura-consensus/src/block.rs
@@ -73,6 +73,9 @@ pub enum VerifyBlockError {
     },
 
     #[error(transparent)]
+    PowPolicy(#[from] zakura_header_chain::PowPolicyError),
+
+    #[error(transparent)]
     Time(zakura_chain::block::BlockTimeError),
 
     /// Error when attempting to commit a block after semantic verification.
@@ -96,6 +99,54 @@ pub enum VerifyBlockError {
 }
 
 impl VerifyBlockError {
+    /// Classify semantic verification without treating local failures as invalid bodies.
+    pub fn body_verification_class(&self) -> zakura_header_chain::BodyVerificationClass {
+        use zakura_header_chain::{
+            BodyCommitmentKind, BodyRuleId, BodyVerificationClass, TransientBodyFailureKind,
+        };
+
+        let consensus = |rule| BodyVerificationClass::ConsensusInvalid(BodyRuleId::new(rule));
+        match self {
+            Self::Depth { .. } => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::MissingContext)
+            }
+            Self::Block { source } => match source {
+                BlockError::BadMerkleRoot { .. } => BodyVerificationClass::PayloadMismatch(
+                    BodyCommitmentKind::TransactionMerkleRoot,
+                ),
+                BlockError::AlreadyInChain(..) => BodyVerificationClass::Duplicate,
+                BlockError::Transaction(error) => error.body_verification_class(),
+                BlockError::NoTransactions => consensus("block.no_transactions"),
+                BlockError::DuplicateTransaction => consensus("block.duplicate_transaction"),
+                BlockError::WrongTransactionConsensusBranchId => {
+                    consensus("block.wrong_transaction_consensus_branch_id")
+                }
+                BlockError::TooManyTransparentSignatureOperations { .. } => {
+                    consensus("block.too_many_transparent_signature_operations")
+                }
+                BlockError::SummingMinerFees { .. } => consensus("block.summing_miner_fees"),
+                BlockError::InvalidHeaderEncoding(_)
+                | BlockError::MissingHeight(_)
+                | BlockError::MaxHeight(_, _, _)
+                | BlockError::InvalidDifficulty(_, _)
+                | BlockError::TargetDifficultyLimit(_, _, _, _, _)
+                | BlockError::DifficultyFilter(_, _, _, _)
+                | BlockError::Other(_) => {
+                    BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+                }
+            },
+            Self::Equihash { .. } | Self::PowPolicy(_) | Self::Time(_) => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::Commit(error) => error.body_verification_class(),
+            Self::ValidateProposal(_) | Self::StateService { .. } => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::Transaction(error) => error.body_verification_class(),
+            Self::Subsidy(_) => consensus("block.subsidy"),
+        }
+    }
+
     /// Returns `true` if this is definitely a duplicate request.
     /// Some duplicate requests might not be detected, and therefore return `false`.
     pub fn is_duplicate_request(&self) -> bool {
@@ -214,7 +265,8 @@ where
         let span = tracing::debug_span!("block", height = ?block.coinbase_height());
 
         async move {
-            let hash = block.hash();
+            let hash = zakura_header_chain::validate_encoding_version_hash(&block.header)
+                .map_err(BlockError::from)?;
             // Check that this block is actually a new block.
             tracing::trace!("checking that block is not already in state");
             match state_service
@@ -246,7 +298,8 @@ where
             // > The block data MUST be validated and checked against the server's usual
             // > acceptance rules (excluding the check for a valid proof-of-work).
             // <https://en.bitcoin.it/wiki/BIP_0023#Block_Proposal>
-            if request.is_proposal() || network.disable_pow() {
+            let pow_policy = zakura_header_chain::PowPolicy::for_network(&network)?;
+            if request.is_proposal() || pow_policy.is_authenticated_custom_waiver() {
                 check::difficulty_threshold_is_valid(&block.header, &network, &height, &hash)?;
             } else {
                 // Do the difficulty checks first, to raise the threshold for

--- a/crates/zakura-consensus/src/block/check.rs
+++ b/crates/zakura-consensus/src/block/check.rs
@@ -19,11 +19,9 @@ use zakura_chain::{
     },
     transaction::{self, Transaction},
     transparent::{Address, Output},
-    work::{
-        difficulty::{ExpandedDifficulty, ParameterDifficulty as _},
-        equihash,
-    },
+    work::{difficulty::ExpandedDifficulty, equihash},
 };
+use zakura_header_chain::{CompactTargetError, PowPolicy};
 
 use crate::{error::*, funding_stream_address};
 
@@ -79,27 +77,13 @@ pub fn difficulty_threshold_is_valid(
     height: &Height,
     hash: &Hash,
 ) -> Result<ExpandedDifficulty, BlockError> {
-    let difficulty_threshold = header
-        .difficulty_threshold
-        .to_expanded()
-        .ok_or(BlockError::InvalidDifficulty(*height, *hash))?;
-
-    // Note: the comparison in this function is a u256 integer comparison, like
-    // zcashd and bitcoin. Greater values represent *less* work.
-
-    // The PowLimit check is part of `Threshold()` in the spec, but it doesn't
-    // actually depend on any previous blocks.
-    if difficulty_threshold > network.target_difficulty_limit() {
-        Err(BlockError::TargetDifficultyLimit(
-            *height,
-            *hash,
-            difficulty_threshold,
-            network.clone(),
-            network.target_difficulty_limit(),
-        ))?;
+    match zakura_header_chain::validate_compact_target(header, network) {
+        Ok(target) => Ok(target),
+        Err(CompactTargetError::Invalid) => Err(BlockError::InvalidDifficulty(*height, *hash)),
+        Err(CompactTargetError::EasierThanLimit { target, limit }) => Err(
+            BlockError::TargetDifficultyLimit(*height, *hash, target, network.clone(), limit),
+        ),
     }
-
-    Ok(difficulty_threshold)
 }
 
 /// Returns `Ok(())` if `hash` passes:
@@ -127,13 +111,13 @@ pub fn difficulty_is_valid(
     // https://zips.z.cash/protocol/protocol.pdf#blockheader
     //
     // The difficulty filter is also context-free.
-    if hash > &difficulty_threshold {
-        Err(BlockError::DifficultyFilter(
+    if zakura_header_chain::validate_hash_filter(*hash, difficulty_threshold).is_err() {
+        return Err(BlockError::DifficultyFilter(
             *height,
             *hash,
             difficulty_threshold,
             network.clone(),
-        ))?;
+        ));
     }
 
     Ok(())
@@ -153,7 +137,7 @@ pub fn equihash_solution_is_valid(
     // The Equihash `(n, k)` parameters are bound to `network`, so a peer cannot
     // downgrade the proof of work to the trivial Regtest `(48, 5)` parameters
     // by sending a short 36-byte solution on Mainnet or Testnet.
-    header.solution.check(header, network)
+    PowPolicy::validating(network).validate_solution(header)
 }
 
 /// Returns `Ok()` with the deferred pool balance change of the coinbase transaction if the block
@@ -393,7 +377,7 @@ pub fn time_is_valid_at(
     height: &Height,
     hash: &Hash,
 ) -> Result<(), zakura_chain::block::BlockTimeError> {
-    header.time_is_valid_at(now, height, hash)
+    zakura_header_chain::validate_future_time(header, now, *height, *hash)
 }
 
 /// Check Merkle root validity.

--- a/crates/zakura-consensus/src/checkpoint.rs
+++ b/crates/zakura-consensus/src/checkpoint.rs
@@ -595,13 +595,16 @@ where
         &self,
         block: Arc<Block>,
     ) -> Result<CheckpointVerifiedBlock, VerifyCheckpointError> {
-        let hash = block.hash();
+        let hash = zakura_header_chain::validate_encoding_version_hash(&block.header)
+            .map_err(BlockError::from)?;
         let height = block
             .coinbase_height()
             .ok_or(VerifyCheckpointError::CoinbaseHeight { hash })?;
         self.check_height(height)?;
 
-        if self.network.disable_pow() {
+        let pow_policy = zakura_header_chain::PowPolicy::for_network(&self.network)
+            .map_err(VerifyBlockError::from)?;
+        if pow_policy.is_authenticated_custom_waiver() {
             crate::block::check::difficulty_threshold_is_valid(
                 &block.header,
                 &self.network,
@@ -1035,6 +1038,53 @@ impl From<equihash::Error> for VerifyCheckpointError {
 }
 
 impl VerifyCheckpointError {
+    /// Classify checkpoint verification without attributing scheduler or state failures to peers.
+    pub fn body_verification_class(&self) -> zakura_header_chain::BodyVerificationClass {
+        use zakura_header_chain::{
+            BodyCommitmentKind, BodyRuleId, BodyVerificationClass, TransientBodyFailureKind,
+        };
+
+        let consensus = |rule| BodyVerificationClass::ConsensusInvalid(BodyRuleId::new(rule));
+        match self {
+            Self::AlreadyVerified { .. } | Self::NewerRequest { .. } => {
+                BodyVerificationClass::Duplicate
+            }
+            Self::CoinbaseHeight { .. } => BodyVerificationClass::PayloadMismatch(
+                BodyCommitmentKind::Other("missing_coinbase_height"),
+            ),
+            Self::BadMerkleRoot { .. } => {
+                BodyVerificationClass::PayloadMismatch(BodyCommitmentKind::TransactionMerkleRoot)
+            }
+            Self::DuplicateTransaction => consensus("checkpoint.duplicate_transaction"),
+            Self::VerifyBlock(error) => error.body_verification_class(),
+            Self::SubsidyError(_) => consensus("checkpoint.subsidy"),
+            Self::AmountError(_) => consensus("checkpoint.amount"),
+            Self::CommitCheckpointVerified(source) => source
+                .downcast_ref::<zs::CommitCheckpointVerifiedError>()
+                .map(|error| error.inner().body_verification_class())
+                .or_else(|| {
+                    source
+                        .downcast_ref::<zs::CommitBlockError>()
+                        .map(zs::CommitBlockError::body_verification_class)
+                })
+                .unwrap_or(BodyVerificationClass::Retryable(
+                    TransientBodyFailureKind::Storage,
+                )),
+            Self::Finished
+            | Self::TooHigh { .. }
+            | Self::UnexpectedSideChain { .. }
+            | Self::ShuttingDown => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::Canceled)
+            }
+            Self::Dropped | Self::Tip(_) | Self::CheckpointList(_) => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::QueuedLimit => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::ResourceExhausted)
+            }
+        }
+    }
+
     /// Returns `true` if this is definitely a duplicate request.
     /// Some duplicate requests might not be detected, and therefore return `false`.
     pub fn is_duplicate_request(&self) -> bool {

--- a/crates/zakura-consensus/src/error.rs
+++ b/crates/zakura-consensus/src/error.rs
@@ -381,6 +381,126 @@ impl From<BoxError> for TransactionError {
 }
 
 impl TransactionError {
+    /// Classify a transaction-verification failure for the body-evidence boundary.
+    pub fn body_verification_class(&self) -> zakura_header_chain::BodyVerificationClass {
+        use zakura_header_chain::{BodyRuleId, BodyVerificationClass, TransientBodyFailureKind};
+
+        let consensus = |rule| BodyVerificationClass::ConsensusInvalid(BodyRuleId::new(rule));
+        match self {
+            Self::CoinbasePosition => consensus("transaction.coinbase_position"),
+            Self::CoinbaseAfterFirst => consensus("transaction.coinbase_after_first"),
+            Self::CoinbaseHasJoinSplit => consensus("transaction.coinbase_has_joinsplit"),
+            Self::CoinbaseHasSpend => consensus("transaction.coinbase_has_spend"),
+            Self::CoinbaseHasOutputPreHeartwood => {
+                consensus("transaction.coinbase_has_output_pre_heartwood")
+            }
+            Self::CoinbaseHasEnableSpendsOrchard => {
+                consensus("transaction.coinbase_enables_orchard_spends")
+            }
+            Self::CoinbaseHasEnableSpendsIronwood => {
+                consensus("transaction.coinbase_enables_ironwood_spends")
+            }
+            Self::CoinbaseHasOrchardShieldedData => {
+                consensus("transaction.coinbase_has_orchard_shielded_data")
+            }
+            Self::CoinbaseOutputsNotDecryptable => {
+                consensus("transaction.coinbase_outputs_not_decryptable")
+            }
+            Self::CoinbaseInMempool => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::NonCoinbaseHasCoinbaseInput => {
+                consensus("transaction.non_coinbase_has_coinbase_input")
+            }
+            Self::NotCoinbase => consensus("transaction.not_coinbase"),
+            Self::LockedUntilAfterBlockHeight(_) => {
+                consensus("transaction.locked_until_after_block_height")
+            }
+            Self::LockedUntilAfterBlockTime(_) => {
+                consensus("transaction.locked_until_after_block_time")
+            }
+            Self::CoinbaseExpiryBlockHeight { .. } => {
+                consensus("transaction.coinbase_expiry_block_height")
+            }
+            Self::CoinbaseConstruction(_) => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::MaximumExpiryHeight { .. } => consensus("transaction.maximum_expiry_height"),
+            Self::ExpiredTransaction { .. } => consensus("transaction.expired"),
+            Self::Subsidy(_) => consensus("transaction.subsidy"),
+            Self::WrongVersion => consensus("transaction.wrong_version"),
+            Self::UnsupportedByNetworkUpgrade(_, _) => {
+                consensus("transaction.unsupported_by_network_upgrade")
+            }
+            Self::NoInputs => consensus("transaction.no_inputs"),
+            Self::NoOutputs => consensus("transaction.no_outputs"),
+            Self::BadBalance => consensus("transaction.bad_balance"),
+            Self::Script(_) => consensus("transaction.script"),
+            Self::SaplingVerificationFailed => consensus("transaction.sapling_verification"),
+            Self::Halo2VerificationFailed => consensus("transaction.halo2_verification"),
+            Self::SmallOrder => consensus("transaction.small_order"),
+            Self::Groth16(_) => consensus("transaction.groth16"),
+            Self::MalformedGroth16(_) => consensus("transaction.malformed_groth16"),
+            Self::Ed25519(_) => consensus("transaction.ed25519"),
+            Self::RedJubjub(_) => consensus("transaction.redjubjub"),
+            Self::RedPallas(_) => consensus("transaction.redpallas"),
+            Self::InternalDowncastError(_) => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::BothVPubsNonZero => consensus("transaction.both_vpubs_nonzero"),
+            Self::DisabledAddToSproutPool => consensus("transaction.disabled_sprout_pool_add"),
+            Self::DisabledAddToOrchardPool => consensus("transaction.disabled_orchard_pool_add"),
+            Self::IncorrectFee => consensus("transaction.incorrect_fee"),
+            Self::DuplicateTransparentSpend(_) => {
+                consensus("transaction.duplicate_transparent_spend")
+            }
+            Self::DuplicateSproutNullifier(_) => {
+                consensus("transaction.duplicate_sprout_nullifier")
+            }
+            Self::DuplicateSaplingNullifier(_) => {
+                consensus("transaction.duplicate_sapling_nullifier")
+            }
+            Self::DuplicateOrchardNullifier(_) => {
+                consensus("transaction.duplicate_orchard_nullifier")
+            }
+            Self::DuplicateIronwoodNullifier(_) => {
+                consensus("transaction.duplicate_ironwood_nullifier")
+            }
+            Self::NotEnoughFlags => consensus("transaction.orchard_flags"),
+            Self::NotEnoughIronwoodFlags => consensus("transaction.ironwood_flags"),
+            Self::OrchardHasEnableCrossAddress => {
+                consensus("transaction.orchard_enable_cross_address")
+            }
+            Self::TransparentInputNotFound => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::MissingContext)
+            }
+            Self::ValidateContextError(error) => error.body_verification_class(),
+            Self::ValidateMempoolLockTimeError(_)
+            | Self::Zip317(_)
+            | Self::NonStandardScriptSigSize { .. }
+            | Self::NonStandardScriptSigNotPushOnly { .. }
+            | Self::NonStandardInputs
+            | Self::WrongConsensusBranchIdNu6_3GracePeriod => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::WrongConsensusBranchId => consensus("transaction.wrong_consensus_branch_id"),
+            Self::MissingConsensusBranchId => consensus("transaction.missing_consensus_branch_id"),
+            Self::Io(_) | Self::TryFromSlice(_) | Self::Other(_) => {
+                BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+            }
+            Self::Amount(_) => consensus("transaction.amount"),
+            Self::Balance(_) => consensus("transaction.balance"),
+            Self::OrchardProofSize => consensus("transaction.orchard_proof_size"),
+            Self::IronwoodProofSize => consensus("transaction.ironwood_proof_size"),
+            Self::ImmatureTransparentCoinbaseSpend { .. } => {
+                consensus("transaction.immature_transparent_coinbase_spend")
+            }
+            Self::UnshieldedTransparentCoinbaseSpend { .. } => {
+                consensus("transaction.unshielded_transparent_coinbase_spend")
+            }
+        }
+    }
+
     /// Returns a suggested misbehaviour score increment for a certain error when
     /// verifying a mempool transaction.
     pub fn mempool_misbehavior_score(&self) -> u32 {
@@ -524,6 +644,9 @@ mod tests {
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum BlockError {
+    #[error(transparent)]
+    InvalidHeaderEncoding(#[from] zakura_header_chain::HeaderEncodingError),
+
     #[error("block contains invalid transactions")]
     Transaction(#[from] TransactionError),
 
@@ -622,7 +745,8 @@ impl BlockError {
         use BlockError::*;
 
         match self {
-            MissingHeight(_)
+            InvalidHeaderEncoding(_)
+            | MissingHeight(_)
             | MaxHeight(_, _, _)
             | InvalidDifficulty(_, _)
             | TargetDifficultyLimit(_, _, _, _, _)

--- a/crates/zakura-consensus/src/router.rs
+++ b/crates/zakura-consensus/src/router.rs
@@ -134,6 +134,14 @@ impl From<VerifyBlockError> for RouterError {
 }
 
 impl RouterError {
+    /// Classify the concrete verifier failure selected by the routing boundary.
+    pub fn body_verification_class(&self) -> zakura_header_chain::BodyVerificationClass {
+        match self {
+            Self::Checkpoint { source } => source.body_verification_class(),
+            Self::Block { source } => source.body_verification_class(),
+        }
+    }
+
     /// Returns `true` if this is definitely a duplicate request.
     /// Some duplicate requests might not be detected, and therefore return `false`.
     pub fn is_duplicate_request(&self) -> bool {

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -109,10 +109,10 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0-rc0", features = [
+zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "6.0.0-rc0" }
+zakura-consensus = { path = "../zakura-consensus", version = "6.0.0" }
 zakura-network = { path = "../zakura-network", version = "6.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.1.0-rc1", features = [
     "rpc-client",
@@ -139,10 +139,10 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0-rc0", features = [
+zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "6.0.0-rc0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "6.0.0", features = [
     "proptest-impl",
 ] }
 zakura-network = { path = "../zakura-network", version = "6.0.0", features = [

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -1087,13 +1087,20 @@ where
         let debug_force_finished_sync = self.debug_force_finished_sync;
         let network = &self.network;
 
-        let (usage_info_rsp, pruning_info_rsp, tip_pool_values_rsp, chain_tip_difficulty) = {
+        let (
+            usage_info_rsp,
+            pruning_info_rsp,
+            tip_pool_values_rsp,
+            header_chain_snapshot_rsp,
+            chain_tip_difficulty,
+        ) = {
             use zakura_state::ReadRequest::*;
             let state_call = |request| self.read_state.clone().oneshot(request);
             tokio::join!(
                 state_call(UsageInfo),
                 state_call(PruningInfo),
                 state_call(TipPoolValues),
+                state_call(HeaderChainSnapshot),
                 chain_tip_difficulty(network.clone(), self.read_state.clone(), true)
             )
         };
@@ -1144,6 +1151,16 @@ where
         };
 
         let now = Utc::now();
+        let header_chain_snapshot = match header_chain_snapshot_rsp.map_misc_error()? {
+            ReadResponse::HeaderChainSnapshot(snapshot) => snapshot,
+            _ => unreachable!("unmatched response to a HeaderChainSnapshot request"),
+        };
+        let header_chain = header_chain_snapshot
+            .clone()
+            .map(|snapshot| HeaderChainInfo::from_snapshot(snapshot, now));
+        let header_height = header_chain_snapshot
+            .as_ref()
+            .map_or(tip_height, |snapshot| snapshot.frontiers.header_best.height);
         let (estimated_height, verification_progress) = self
             .latest_chain_tip
             .best_tip_height_and_block_time()
@@ -1224,7 +1241,7 @@ where
             value_pools: GetBlockchainInfoBalance::value_pools(value_balance, None),
             upgrades,
             consensus,
-            headers: tip_height,
+            headers: header_height,
             difficulty,
             verification_progress,
             // TODO: store work in the finalized state for each height (#7109)
@@ -1234,6 +1251,7 @@ where
             size_on_disk,
             // TODO: Investigate whether this needs to be implemented (it's sprout-only in zcashd)
             commitments: 0,
+            header_chain,
         };
 
         Ok(response)
@@ -2892,14 +2910,17 @@ where
 
         let solution_rate = match response {
             // zcashd returns a 0 rate when the calculation is invalid
-            ReadResponse::SolutionRate(solution_rate) => solution_rate.unwrap_or(0),
+            ReadResponse::SolutionRate(solution_rate) => solution_rate.unwrap_or_default(),
 
             _ => unreachable!("unmatched response to a solution rate request"),
         };
 
-        Ok(solution_rate
-            .try_into()
-            .expect("per-second solution rate always fits in u64"))
+        assert!(
+            solution_rate <= U256::from(u64::MAX),
+            "per-second solution rate fits in the legacy u64 RPC response"
+        );
+
+        Ok(solution_rate.as_u64())
     }
 
     async fn get_network_info(&self) -> Result<GetNetworkInfoResponse> {
@@ -3552,7 +3573,7 @@ const END_OF_SERVICE_ESTIMATE_SAFETY_MARGIN: i64 = 24 * 60 * 60;
 
 /// Response to a `getdeprecationinfo` RPC request.
 ///
-/// See the notes for [`Rpc::get_deprecation_info`].
+/// See the notes for [`RpcServer::get_deprecation_info`].
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
 pub struct GetDeprecationInfoResponse {
     /// End-of-service information, only present on Mainnet.
@@ -3708,6 +3729,135 @@ pub struct GetBlockchainInfoResponse {
     /// Branch IDs of the current and upcoming consensus rules
     #[getter(copy)]
     consensus: TipConsensusBranch,
+
+    /// Zakura's authoritative header-chain state after semantic handoff.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    header_chain: Option<HeaderChainInfo>,
+}
+
+/// One hash-qualified frontier in the authoritative header-chain state.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Getters)]
+pub struct HeaderChainFrontierInfo {
+    /// Exact frontier height.
+    #[getter(copy)]
+    height: Height,
+    /// Exact frontier hash.
+    #[serde(with = "hex")]
+    #[getter(copy)]
+    hash: block::Hash,
+}
+
+/// Persistent selected-tip body-unavailability alarm details.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Getters)]
+pub struct HeaderChainBodyUnavailableInfo {
+    /// Exact selected header whose body is unavailable.
+    #[getter(copy)]
+    height: Height,
+    /// Exact selected header hash.
+    #[serde(with = "hex")]
+    #[getter(copy)]
+    hash: block::Hash,
+    /// Current retry episode age in seconds.
+    #[getter(copy)]
+    age_seconds: u64,
+    /// Failed deliveries in the current episode.
+    #[getter(copy)]
+    attempts: u32,
+    /// Currently known eligible body suppliers.
+    #[getter(copy)]
+    suppliers: u32,
+}
+
+/// Persistent alarms from the authoritative header-chain state.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Getters)]
+pub struct HeaderChainAlarmInfo {
+    /// Protected paths prevented resource-bound enforcement.
+    #[getter(copy)]
+    resource_stalled: bool,
+    /// The selected header exhausted its current body-supplier retry episode.
+    header_best_body_unavailable: Option<HeaderChainBodyUnavailableInfo>,
+    /// An imported headers-only trust pin was refuted by deterministic body validation.
+    migrated_pin_refuted: Option<HeaderChainFrontierInfo>,
+}
+
+/// User-facing view of the sole committed header-chain publisher.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Getters)]
+pub struct HeaderChainInfo {
+    /// `integrated` or `headers-only`.
+    mode: String,
+    /// Monotonic durable state version.
+    #[getter(copy)]
+    state_version: u64,
+    /// Meaning and validity boundary of `header_best`.
+    header_best_semantics: String,
+    /// Best locally header-valid frontier; this is not a body-validity claim.
+    header_best: HeaderChainFrontierInfo,
+    /// Best fully body-verified frontier on the selected path.
+    verified_best: HeaderChainFrontierInfo,
+    /// Irreversible local finality frontier.
+    finalized: HeaderChainFrontierInfo,
+    /// Headers-only mode's irreversible local trust warning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    finality_warning: Option<String>,
+    /// Persistent engine alarms.
+    alarms: HeaderChainAlarmInfo,
+}
+
+impl From<zakura_state::HeaderChainFrontier> for HeaderChainFrontierInfo {
+    fn from(frontier: zakura_state::HeaderChainFrontier) -> Self {
+        Self {
+            height: frontier.height,
+            hash: frontier.hash,
+        }
+    }
+}
+
+impl HeaderChainInfo {
+    fn from_snapshot(
+        snapshot: zakura_state::HeaderChainSnapshot,
+        now: chrono::DateTime<Utc>,
+    ) -> Self {
+        let mode = match snapshot.mode {
+            zakura_state::HeaderChainMode::Integrated => "integrated",
+            zakura_state::HeaderChainMode::HeadersOnly => "headers-only",
+        };
+        let finality_warning = matches!(snapshot.mode, zakura_state::HeaderChainMode::HeadersOnly)
+            .then(|| {
+                "headers-only finality is an irreversible local trust decision made 1,000 headers behind header_best; an eclipsed or incomplete view can pin the wrong header-valid branch, and later conflicting greater-work branches are rejected; correctness is relative to the durable finality history, settled-upgrade pins still apply, and a pin refuted after migration to integrated mode requires deleting the migrated header store and resynchronizing".to_string()
+            });
+        let header_best_body_unavailable = snapshot
+            .alarms
+            .header_best_body_unavailable
+            .filter(|summary| summary.alarmed)
+            .map(|summary| HeaderChainBodyUnavailableInfo {
+                height: snapshot.frontiers.header_best.height,
+                hash: snapshot.frontiers.header_best.hash,
+                age_seconds: u64::try_from(
+                    now.signed_duration_since(summary.started_at)
+                        .num_seconds()
+                        .max(0),
+                )
+                .unwrap_or(u64::MAX),
+                attempts: summary.attempts,
+                suppliers: summary.suppliers,
+            });
+        Self {
+            mode: mode.to_string(),
+            state_version: snapshot.state_version.get(),
+            header_best_semantics:
+                "best eligible header chain; not a fully valid Zcash chain or body-validity claim"
+                    .to_string(),
+            header_best: snapshot.frontiers.header_best.into(),
+            verified_best: snapshot.frontiers.verified_best.into(),
+            finalized: snapshot.frontiers.finalized.into(),
+            finality_warning,
+            alarms: HeaderChainAlarmInfo {
+                resource_stalled: snapshot.alarms.resource_stalled,
+                header_best_body_unavailable,
+                migrated_pin_refuted: snapshot.alarms.migrated_pin_refuted.map(Into::into),
+            },
+        }
+    }
 }
 
 impl Default for GetBlockchainInfoResponse {
@@ -3732,6 +3882,7 @@ impl Default for GetBlockchainInfoResponse {
             prune_height: None,
             size_on_disk: 0,
             commitments: 0,
+            header_chain: None,
         }
     }
 }
@@ -3776,6 +3927,7 @@ impl GetBlockchainInfoResponse {
             prune_height,
             size_on_disk,
             commitments,
+            header_chain: None,
         }
     }
 }

--- a/docs/changelog/unreleased/567.md
+++ b/docs/changelog/unreleased/567.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR is one review layer of the header-sync stack; the stack's single
+operator-visible entry is owned by #532.


### PR DESCRIPTION
> Stack layer **9/15** (bottom to top) in stack **#573**. Review after **#566**; **#568** is next.
> GitHub shows only this layer's diff.

## Motivation

Consensus and RPC consumers previously assumed linear header progress and old network work types, so they could not consume the final selected-header and lifecycle contracts safely.

## Solution

Adapt consensus and RPC production paths to the final header-chain work, routing, error, and readiness contracts. Network production is intentionally owned by #565 so no temporary implementation appears here.

## Testing

- Proportional \`cargo check\` across the affected production crates.
- Proportional clippy with warnings denied.
- Cross-service regression tests land in #568.

## Changelog

\`docs/changelog/unreleased/567.md\` explicitly excludes this review slice. The stack's operator-visible entry is owned by #532.

### Specifications & References

- Final network contracts: #565.
- Typed service contracts: #562.

### Follow-up Work

Review #568 for consensus/RPC integration coverage.
