### PR TITLE
test(sync): cover consensus and RPC integration

### DIFF
--- a/crates/tower-batch-control/tests/worker.rs
+++ b/crates/tower-batch-control/tests/worker.rs
@@ -36,7 +36,7 @@ async fn wakes_pending_waiters_on_close() {
     // kill the worker task
     drop(worker);
 
-    let err = assert_ready_err!(response.poll());
+    let err = assert_ready_err!(response.poll(), "worker close should fail the response");
     assert!(
         err.is::<error::Closed>(),
         "response should fail with a Closed, got: {err:?}",
@@ -46,7 +46,7 @@ async fn wakes_pending_waiters_on_close() {
         ready1.is_woken(),
         "dropping worker should wake ready task 1",
     );
-    let err = assert_ready_err!(ready1.poll());
+    let err = assert_ready_err!(ready1.poll(), "worker close should fail ready task 1");
     assert!(
         err.is::<error::ServiceError>(),
         "ready 1 should fail with a ServiceError {{ Closed }}, got: {err:?}",
@@ -56,7 +56,7 @@ async fn wakes_pending_waiters_on_close() {
         ready2.is_woken(),
         "dropping worker should wake ready task 2",
     );
-    let err = assert_ready_err!(ready1.poll());
+    let err = assert_ready_err!(ready2.poll(), "worker close should fail ready task 2");
     assert!(
         err.is::<error::ServiceError>(),
         "ready 2 should fail with a ServiceError {{ Closed }}, got: {err:?}",
@@ -93,7 +93,7 @@ async fn wakes_pending_waiters_on_failure() {
     // worker task terminates
     assert_ready!(worker.poll());
 
-    let err = assert_ready_err!(response.poll());
+    let err = assert_ready_err!(response.poll(), "worker failure should fail the response");
     assert!(
         err.is::<error::ServiceError>(),
         "response should fail with a ServiceError, got: {err:?}"
@@ -103,7 +103,7 @@ async fn wakes_pending_waiters_on_failure() {
         ready1.is_woken(),
         "dropping worker should wake ready task 1"
     );
-    let err = assert_ready_err!(ready1.poll());
+    let err = assert_ready_err!(ready1.poll(), "worker failure should fail ready task 1");
     assert!(
         err.is::<error::ServiceError>(),
         "ready 1 should fail with a ServiceError, got: {err:?}"
@@ -113,7 +113,7 @@ async fn wakes_pending_waiters_on_failure() {
         ready2.is_woken(),
         "dropping worker should wake ready task 2"
     );
-    let err = assert_ready_err!(ready1.poll());
+    let err = assert_ready_err!(ready2.poll(), "worker failure should fail ready task 2");
     assert!(
         err.is::<error::ServiceError>(),
         "ready 2 should fail with a ServiceError, got: {err:?}"

--- a/crates/zakura-consensus/src/router/tests.rs
+++ b/crates/zakura-consensus/src/router/tests.rs
@@ -30,6 +30,127 @@ use super::*;
 /// high system load.
 const VERIFY_TIMEOUT_SECONDS: u64 = 10;
 
+#[test]
+fn routed_body_failures_keep_payload_consensus_and_local_results_distinct() {
+    use zakura_header_chain::{
+        BodyCommitmentKind, BodyRuleId, BodyVerificationClass, TransientBodyFailureKind,
+    };
+
+    let payload = RouterError::Block {
+        source: Box::new(VerifyBlockError::Block {
+            source: crate::error::BlockError::BadMerkleRoot {
+                actual: zakura_chain::block::merkle::Root([0; 32]),
+                expected: zakura_chain::block::merkle::Root([1; 32]),
+            },
+        }),
+    };
+    assert_eq!(
+        payload.body_verification_class(),
+        BodyVerificationClass::PayloadMismatch(BodyCommitmentKind::TransactionMerkleRoot)
+    );
+
+    let consensus = RouterError::Block {
+        source: Box::new(VerifyBlockError::Transaction(TransactionError::NoInputs)),
+    };
+    assert_eq!(
+        consensus.body_verification_class(),
+        BodyVerificationClass::ConsensusInvalid(BodyRuleId::new("transaction.no_inputs"))
+    );
+
+    let local = RouterError::Block {
+        source: Box::new(VerifyBlockError::StateService {
+            source: BoxError::from("state unavailable"),
+            hash: block::Hash([2; 32]),
+        }),
+    };
+    assert_eq!(
+        local.body_verification_class(),
+        BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+    );
+
+    let checkpoint = RouterError::Checkpoint {
+        source: Box::new(VerifyCheckpointError::Dropped),
+    };
+    assert_eq!(
+        checkpoint.body_verification_class(),
+        BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
+    );
+}
+
+#[test]
+// DF-02: each representative full-state failure maps to the precise shared
+// body classification, covering retry, payload, and consensus-invalid paths.
+fn full_state_failure_classes_match_header_engine_contract() {
+    use zakura_header_chain::{
+        BodyCommitmentKind, BodyRuleId, BodyVerificationClass, TransientBodyFailureKind,
+    };
+
+    let cases = [
+        (
+            VerifyCheckpointError::CoinbaseHeight {
+                hash: block::Hash([1; 32]),
+            }
+            .body_verification_class(),
+            BodyVerificationClass::PayloadMismatch(BodyCommitmentKind::Other(
+                "missing_coinbase_height",
+            )),
+        ),
+        (
+            VerifyCheckpointError::BadMerkleRoot {
+                actual: zakura_chain::block::merkle::Root([2; 32]),
+                expected: zakura_chain::block::merkle::Root([3; 32]),
+            }
+            .body_verification_class(),
+            BodyVerificationClass::PayloadMismatch(BodyCommitmentKind::TransactionMerkleRoot),
+        ),
+        (
+            VerifyBlockError::Transaction(TransactionError::NoInputs).body_verification_class(),
+            BodyVerificationClass::ConsensusInvalid(BodyRuleId::new("transaction.no_inputs")),
+        ),
+        (
+            VerifyBlockError::Transaction(TransactionError::Script(
+                zakura_script::Error::ScriptInvalid,
+            ))
+            .body_verification_class(),
+            BodyVerificationClass::ConsensusInvalid(BodyRuleId::new("transaction.script")),
+        ),
+        (
+            VerifyBlockError::Transaction(TransactionError::SaplingVerificationFailed)
+                .body_verification_class(),
+            BodyVerificationClass::ConsensusInvalid(BodyRuleId::new(
+                "transaction.sapling_verification",
+            )),
+        ),
+        (
+            VerifyBlockError::Transaction(TransactionError::Halo2VerificationFailed)
+                .body_verification_class(),
+            BodyVerificationClass::ConsensusInvalid(BodyRuleId::new(
+                "transaction.halo2_verification",
+            )),
+        ),
+        (
+            VerifyBlockError::Transaction(TransactionError::Groth16("invalid proof".to_owned()))
+                .body_verification_class(),
+            BodyVerificationClass::ConsensusInvalid(BodyRuleId::new("transaction.groth16")),
+        ),
+        (
+            VerifyBlockError::Block {
+                source: crate::error::BlockError::MissingHeight(block::Hash([4; 32])),
+            }
+            .body_verification_class(),
+            BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable),
+        ),
+        (
+            VerifyCheckpointError::QueuedLimit.body_verification_class(),
+            BodyVerificationClass::Retryable(TransientBodyFailureKind::ResourceExhausted),
+        ),
+    ];
+
+    for (actual, expected) in cases {
+        assert_eq!(actual, expected);
+    }
+}
+
 /// Generate a block with no transactions (not even a coinbase transaction).
 ///
 /// The generated block should fail validation.

--- a/crates/zakura-rpc/src/methods/tests/prop.rs
+++ b/crates/zakura-rpc/src/methods/tests/prop.rs
@@ -410,6 +410,12 @@ proptest! {
                         .respond(Err(BoxError::from("no chain tip available yet")));
 
                     state
+                        .expect_request(zakura_state::ReadRequest::HeaderChainSnapshot)
+                        .await
+                        .expect("getblockchaininfo should read the authoritative header snapshot")
+                        .respond(zakura_state::ReadResponse::HeaderChainSnapshot(None));
+
+                    state
                         .expect_request(zakura_state::ReadRequest::ChainInfo)
                         .await
                         .expect("getblockchaininfo should call mock state service with correct request")
@@ -462,6 +468,29 @@ proptest! {
         let expected_size_on_disk = 1_000;
         let expected_is_pruned = true;
         let expected_prune_height = Some(Height(1_000));
+        let header_height = block_height.next().unwrap_or(block_height);
+        let header_hash = block::Hash([0xa5; 32]);
+        let header_frontier =
+            zakura_state::HeaderChainFrontier::new(header_height, header_hash);
+        let verified_frontier =
+            zakura_state::HeaderChainFrontier::new(block_height, block_hash);
+        let header_snapshot = zakura_state::HeaderChainSnapshot {
+            mode: zakura_state::HeaderChainMode::Integrated,
+            state_version: zakura_state::HeaderChainStateVersion::new(7),
+            header_generation: zakura_state::HeaderChainGeneration::new(8),
+            verified_generation: zakura_state::HeaderChainVerifiedGeneration::new(9),
+            frontiers: zakura_state::HeaderChainFrontierSet {
+                finalized: verified_frontier,
+                header_best: header_frontier,
+                verified_best: verified_frontier,
+            },
+            header_best_score: zakura_state::HeaderChainScore::new(
+                zakura_state::HeaderChainSuffixWork::zero(),
+                header_hash,
+            ),
+            oldest_retained_height: block_height,
+            alarms: zakura_state::HeaderChainAlarmSet::default(),
+        };
 
         // check no requests were made during this test
         runtime.block_on(async move {
@@ -495,6 +524,14 @@ proptest! {
                         });
 
                     state
+                        .expect_request(zakura_state::ReadRequest::HeaderChainSnapshot)
+                        .await
+                        .expect("getblockchaininfo should read the authoritative header snapshot")
+                        .respond(zakura_state::ReadResponse::HeaderChainSnapshot(Some(
+                            header_snapshot,
+                        )));
+
+                    state
                         .expect_request(zakura_state::ReadRequest::ChainInfo)
                         .await
                         .expect("getblockchaininfo should call mock state service with correct request")
@@ -518,6 +555,14 @@ proptest! {
                     prop_assert_eq!(info.chain, network.bip70_network_name());
                     prop_assert_eq!(info.blocks, block_height);
                     prop_assert_eq!(info.best_block_hash, block_hash);
+                    prop_assert_eq!(info.headers, header_height);
+                    prop_assert_eq!(
+                        info.header_chain
+                            .expect("the committed header snapshot is user-visible")
+                            .header_best
+                            .hash,
+                        header_hash
+                    );
                     prop_assert_eq!(info.size_on_disk, expected_size_on_disk);
                     prop_assert_eq!(info.pruned, expected_is_pruned);
                     prop_assert_eq!(info.prune_height, expected_prune_height);
@@ -609,6 +654,12 @@ proptest! {
                     .await
                     .expect("getblockchaininfo should call mock state service with correct request")
                     .respond(Err(BoxError::from("tip values not available")));
+
+                state
+                    .expect_request(zakura_state::ReadRequest::HeaderChainSnapshot)
+                    .await
+                    .expect("getblockchaininfo should read the authoritative header snapshot")
+                    .respond(zakura_state::ReadResponse::HeaderChainSnapshot(None));
 
                 state
                     .expect_request(zakura_state::ReadRequest::ChainInfo)

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -50,6 +50,145 @@ use super::super::*;
 use config::mining;
 use types::long_poll::LONG_POLL_ID_LENGTH;
 
+#[test]
+fn header_chain_info_exposes_mode_frontiers_and_persistent_alarms() {
+    let now = chrono::DateTime::parse_from_rfc3339("2026-07-23T12:00:00Z")
+        .expect("the fixed time is valid")
+        .with_timezone(&chrono::Utc);
+    let finalized = zakura_state::HeaderChainFrontier::new(Height(10), Hash([0x10; 32]));
+    let verified = zakura_state::HeaderChainFrontier::new(Height(12), Hash([0x12; 32]));
+    let header_best = zakura_state::HeaderChainFrontier::new(Height(15), Hash([0x15; 32]));
+    let migrated_pin = zakura_state::HeaderChainFrontier::new(Height(9), Hash([0x09; 32]));
+    let snapshot = zakura_state::HeaderChainSnapshot {
+        mode: zakura_state::HeaderChainMode::HeadersOnly,
+        state_version: zakura_state::HeaderChainStateVersion::new(21),
+        header_generation: zakura_state::HeaderChainGeneration::new(22),
+        verified_generation: zakura_state::HeaderChainVerifiedGeneration::new(23),
+        frontiers: zakura_state::HeaderChainFrontierSet {
+            finalized,
+            header_best,
+            verified_best: verified,
+        },
+        header_best_score: zakura_state::HeaderChainScore::new(
+            zakura_state::HeaderChainSuffixWork::zero(),
+            header_best.hash,
+        ),
+        oldest_retained_height: finalized.height,
+        alarms: zakura_state::HeaderChainAlarmSet {
+            resource_stalled: true,
+            header_best_body_unavailable: Some(zakura_state::HeaderChainBodyUnavailableSummary {
+                started_at: now - chrono::Duration::seconds(12),
+                attempts: 10,
+                suppliers: 3,
+                supplier_set_digest: [0x44; 32],
+                alarmed: true,
+                next_probe_at: now + chrono::Duration::minutes(10),
+            }),
+            migrated_pin_refuted: Some(migrated_pin),
+        },
+    };
+
+    let info = HeaderChainInfo::from_snapshot(snapshot, now);
+    assert_eq!(info.mode(), "headers-only");
+    assert_eq!(info.state_version(), 21);
+    assert_eq!(
+        info.header_best_semantics(),
+        "best eligible header chain; not a fully valid Zcash chain or body-validity claim"
+    );
+    assert_eq!(info.header_best().height(), Height(15));
+    assert_eq!(info.verified_best().height(), Height(12));
+    assert_eq!(info.finalized().height(), Height(10));
+    let warning = info
+        .finality_warning()
+        .as_ref()
+        .expect("headers-only mode must disclose its irreversible local trust decision");
+    for required_disclosure in [
+        "irreversible local trust decision",
+        "eclipsed or incomplete view",
+        "conflicting greater-work branches are rejected",
+        "durable finality history",
+        "settled-upgrade pins still apply",
+        "deleting the migrated header store and resynchronizing",
+    ] {
+        assert!(
+            warning.contains(required_disclosure),
+            "headers-only warning must disclose {required_disclosure:?}"
+        );
+    }
+    assert!(info.alarms().resource_stalled());
+    let unavailable = info
+        .alarms()
+        .header_best_body_unavailable()
+        .as_ref()
+        .expect("the persistent body alarm is visible");
+    assert_eq!(unavailable.height(), Height(15));
+    assert_eq!(unavailable.hash(), Hash([0x15; 32]));
+    assert_eq!(unavailable.age_seconds(), 12);
+    assert_eq!(unavailable.attempts(), 10);
+    assert_eq!(unavailable.suppliers(), 3);
+    assert_eq!(
+        info.alarms()
+            .migrated_pin_refuted()
+            .as_ref()
+            .expect("the migrated-pin incident is visible")
+            .height(),
+        Height(9)
+    );
+
+    let json = serde_json::to_value(info).expect("header-chain status serializes");
+    assert_eq!(json["mode"], "headers-only");
+    assert_eq!(
+        json["header_best_semantics"],
+        "best eligible header chain; not a fully valid Zcash chain or body-validity claim"
+    );
+    assert_eq!(json["header_best"]["height"], 15);
+    assert_eq!(json["verified_best"]["height"], 12);
+    assert_eq!(json["finalized"]["height"], 10);
+    assert_eq!(
+        json["alarms"]["header_best_body_unavailable"]["suppliers"],
+        3
+    );
+}
+
+#[test]
+fn integrated_header_chain_info_omits_headers_only_warning_and_inactive_alarm() {
+    let now = chrono::Utc::now();
+    let frontier = zakura_state::HeaderChainFrontier::new(Height(0), Hash([0x01; 32]));
+    let snapshot = zakura_state::HeaderChainSnapshot {
+        mode: zakura_state::HeaderChainMode::Integrated,
+        state_version: zakura_state::HeaderChainStateVersion::new(1),
+        header_generation: zakura_state::HeaderChainGeneration::new(1),
+        verified_generation: zakura_state::HeaderChainVerifiedGeneration::new(1),
+        frontiers: zakura_state::HeaderChainFrontierSet {
+            finalized: frontier,
+            header_best: frontier,
+            verified_best: frontier,
+        },
+        header_best_score: zakura_state::HeaderChainScore::new(
+            zakura_state::HeaderChainSuffixWork::zero(),
+            frontier.hash,
+        ),
+        oldest_retained_height: frontier.height,
+        alarms: zakura_state::HeaderChainAlarmSet {
+            header_best_body_unavailable: Some(zakura_state::HeaderChainBodyUnavailableSummary {
+                alarmed: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    };
+
+    let info = HeaderChainInfo::from_snapshot(snapshot, now);
+    assert_eq!(info.mode(), "integrated");
+    assert!(info.finality_warning().is_none());
+    assert!(
+        info.alarms().header_best_body_unavailable().is_none(),
+        "only a fired persistent alarm is user-visible"
+    );
+    let json = serde_json::to_value(info).expect("header-chain status serializes");
+    assert!(json.get("finality_warning").is_none());
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_getinfo() {
     let _init_guard = zakura_test::init();

--- a/docs/changelog/unreleased/568.md
+++ b/docs/changelog/unreleased/568.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR is one review layer of the header-sync stack; the stack's single
+operator-visible entry is owned by #532.


### PR DESCRIPTION
> Stack layer **10/15** (bottom to top) in stack **#573**. Review after **#567**; **#569** is next.
> GitHub shows only this layer's diff.

## Motivation

The consensus router, RPC surface, and batching worker need regression coverage for the new selected-header and service contracts.

## Solution

Add focused cross-crate integration tests without changing production behavior.

## Testing

- Consensus router: **6 passed**.
- RPC methods: **77 passed, 1 ignored**.
- Batch worker: **4 passed**.

## Changelog

\`docs/changelog/unreleased/568.md\` explicitly excludes this test-only layer. The stack's operator-visible entry is owned by #532.

### Specifications & References

- Production adaptation under test: #567.

### Follow-up Work

None in this layer.
