### PR TITLE
fix(sync): stop scoring peers that serve far-ahead blocks

### DIFF
--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -2139,9 +2139,9 @@ where
             // requested, but the height came from whichever peer supplied the
             // hash in a `FindBlocks` response. Those are usually different
             // peers, and `Response::BlockHashes` carries no address, so the
-            // responsible peer is unknown here. The block is still dropped by
-            // `handle_response`; scoring the server would ban a peer for
-            // honestly answering our own request.
+            // responsible peer is unknown here. The download task has already
+            // discarded the block without verifying it; scoring the server as
+            // well would ban a peer for honestly answering our own request.
             Err(_) => {}
         };
 

--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -2127,13 +2127,6 @@ where
                     .try_send((advertiser_addr, error.misbehavior_score()));
             }
 
-            Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
-                advertiser_addr: Some(advertiser_addr),
-                ..
-            }) => {
-                let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
-            }
-
             Err(BlockDownloadVerifyError::InvalidHeight {
                 advertiser_addr: Some(advertiser_addr),
                 ..
@@ -2141,6 +2134,14 @@ where
                 let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
             }
 
+            // `AboveLookaheadHeightLimit` is deliberately unscored. Its
+            // `advertiser_addr` is the peer that served a block this node
+            // requested, but the height came from whichever peer supplied the
+            // hash in a `FindBlocks` response. Those are usually different
+            // peers, and `Response::BlockHashes` carries no address, so the
+            // responsible peer is unknown here. The block is still dropped by
+            // `handle_response`; scoring the server would ban a peer for
+            // honestly answering our own request.
             Err(_) => {}
         };
 

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -1441,6 +1441,55 @@ fn invalid_ancestor_does_not_score_descendant_advertiser() {
     );
 }
 
+/// A block above the lookahead limit is dropped without scoring the peer that
+/// served it, because that peer answered a hash this node asked for. Errors the
+/// serving peer is genuinely responsible for are still scored.
+#[test]
+fn far_ahead_block_does_not_score_serving_peer() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        _peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+    let (misbehavior_tx, mut misbehavior_rx) = tokio::sync::mpsc::channel(2);
+    chain_sync.misbehavior_sender = misbehavior_tx;
+
+    let serving_peer: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+
+    let far_ahead = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
+        height: Height(60_000),
+        hash: block::Hash([0xC1; 32]),
+        advertiser_addr: Some(serving_peer),
+    };
+
+    assert!(chain_sync.handle_block_response(Err(far_ahead)).is_err());
+    assert!(
+        matches!(
+            misbehavior_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ),
+        "the peer that served a far-ahead block we requested must not be scored"
+    );
+
+    // The same peer is still scored for a block whose own contents are bad.
+    let invalid_height = BlockDownloadVerifyError::InvalidHeight {
+        hash: block::Hash([0xC2; 32]),
+        advertiser_addr: Some(serving_peer),
+    };
+
+    assert!(chain_sync
+        .handle_block_response(Err(invalid_height))
+        .is_err());
+    assert_eq!(
+        misbehavior_rx.try_recv(),
+        Ok((serving_peer, 100)),
+        "a block with no valid height is still the serving peer's fault"
+    );
+}
+
 /// A scratch state can have finalized genesis tip metadata before
 /// `KnownBlock(genesis)` can find a block body. In that state, committing the
 /// downloaded genesis block returns duplicate/finalized; the genesis bootstrap
@@ -1591,8 +1640,9 @@ async fn above_lookahead_does_not_restart_sync() {
     );
 }
 
-/// Verifies fix for GHSA-gvjc-3w7c-92jx: `AboveLookaheadHeightLimit` now
-/// carries `advertiser_addr` so the offending peer can be scored.
+/// Verifies fix for GHSA-gvjc-3w7c-92jx: `AboveLookaheadHeightLimit` carries
+/// `advertiser_addr` so the serving peer is named in the drop logs. It is not
+/// scored — see [`far_ahead_block_does_not_score_serving_peer`].
 #[tokio::test]
 async fn above_lookahead_has_peer_attribution() {
     let addr: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
@@ -1605,7 +1655,7 @@ async fn above_lookahead_has_peer_attribution() {
     assert_eq!(
         err.advertiser_addr(),
         Some(addr),
-        "AboveLookaheadHeightLimit should carry advertiser_addr for peer scoring \
+        "AboveLookaheadHeightLimit should carry advertiser_addr for drop logs \
          (GHSA-gvjc-3w7c-92jx fix)"
     );
 }

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -1465,7 +1465,10 @@ fn far_ahead_block_does_not_score_serving_peer() {
         advertiser_addr: Some(serving_peer),
     };
 
-    assert!(chain_sync.handle_block_response(Err(far_ahead)).is_err());
+    assert!(
+        chain_sync.handle_block_response(Err(far_ahead)).is_ok(),
+        "a far-ahead block is dropped without restarting sync"
+    );
     assert!(
         matches!(
             misbehavior_rx.try_recv(),
@@ -1482,7 +1485,7 @@ fn far_ahead_block_does_not_score_serving_peer() {
 
     assert!(chain_sync
         .handle_block_response(Err(invalid_height))
-        .is_err());
+        .is_ok());
     assert_eq!(
         misbehavior_rx.try_recv(),
         Ok((serving_peer, 100)),

--- a/docs/changelog/unreleased/574.md
+++ b/docs/changelog/unreleased/574.md
@@ -1,0 +1,10 @@
+## Fixed
+
+- `zakurad` no longer bans a peer for serving a block whose height is above the
+  sync lookahead limit. The ban used the address of the peer that answered the
+  block request, but a far-ahead height comes from whichever peer supplied that
+  hash in an earlier `FindBlocks` response — usually a different peer — so an
+  honest peer could be banned for correctly answering a request this node made.
+  Such blocks are still dropped without restarting sync, and peers that serve
+  blocks with no valid height or that fail consensus verification are still
+  scored ([#574](https://github.com/zakura-core/zakura/pull/574)).


### PR DESCRIPTION
## Motivation

`handle_block_response` scored 100 misbehavior points — an immediate ban at the
address book's threshold — whenever a downloaded block came back above the
lookahead height limit:

```rust
Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
    advertiser_addr: Some(advertiser_addr),
    ..
}) => {
    let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
}
```

`advertiser_addr` there is filled in by the block download task from the peer
that answered our `BlocksByHash` request. But a far-ahead height does not
originate with that peer: the hash was queued into `download_set` by
`obtain_tips` / `extend_tips` from some peer's `FindBlocks` response, and
`request_blocks` carries only hashes forward. The two peers are usually
different, so the ban lands on a peer whose only action was to honestly serve a
block this node asked for.

This is OtterSec finding OS-ZCA-ADV-15, *Far-Ahead Hash Rejection is
Misattributed* (Low).

## Solution

Stop scoring `AboveLookaheadHeightLimit`, and document why at the match arm.

The peer actually responsible cannot be identified at this point:
`zn::Response::BlockHashes(Vec<Hash>)` carries no peer address, so there is
nothing to attribute the far-ahead height to. Attributing it correctly means
plumbing the responding peer through the `FindBlocks` response type, which is a
larger network-layer change than this fix.

Everything protective about the current path is unchanged:

- the far-ahead block is still dropped by `handle_response`;
- sync still does not restart on this error (GHSA-gvjc-3w7c-92jx);
- `advertiser_addr` is still carried on the error, so the drop log still names
  the serving peer;
- `InvalidHeight` and consensus-invalid blocks — where the serving peer *is* at
  fault, because the fault is in the bytes it sent — keep their 100-point
  scores.

The same hunk was previously written as part of #457, which was closed because
of the near-tip singleton gate it was bundled with. This PR takes only the
attribution fix, with none of the gating.

## Testing

- `cargo fmt --all -- --check`
- `CXXFLAGS='-include cstdint' cargo test -p zakura --lib components::sync::tests`
  - 55 passed; 0 failed
- `CXXFLAGS='-include cstdint' cargo clippy -p zakura --all-targets --locked -- -D warnings`
- `./scripts/changelog.py check`
- `npx markdownlint-cli docs/changelog/unreleased/574.md --config .github/.markdownlint.yaml`

New regression test `far_ahead_block_does_not_score_serving_peer` drives
`handle_block_response` with an `AboveLookaheadHeightLimit` error carrying a
serving-peer address and asserts the misbehavior channel stays empty, then
drives the *same* peer through an `InvalidHeight` error and asserts it is still
scored 100 — pinning the boundary rather than just the removal. Both calls
return `Ok(())`, which is the existing no-restart behavior for these errors;
the block itself is discarded earlier, in the download task, before it ever
reaches the verifier.

`above_lookahead_has_peer_attribution` still asserts the error carries
`advertiser_addr`; its doc comment now says the address is for the drop logs
rather than for scoring.

## Changelog

`docs/changelog/unreleased/<PR>.md` under `Fixed`.

### Specifications & References

- OtterSec, *Zcash — Security Assessment* (July 18, 2026), finding
  `OS-ZCA-ADV-15`.
- Prior attempt: #457 (closed).
- Related, still open: #460, which removes one *source* of bad attribution
  (block gossip mistaken for a `FindBlocks` response) but does not change this
  scoring arm.

### Follow-up Work

Attributing far-ahead hashes to the peer that supplied them requires carrying
the responding peer address on `FindBlocks` responses. Not attempted here.
