### PR TITLE
ci(release): import fresh state during release preparation

### DIFF
--- a/.github/scripts/import-release-state.py
+++ b/.github/scripts/import-release-state.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Import a verified Mainnet release-state bundle into a Zakura checkout."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+CHECKPOINTS = Path("crates/zakura-chain/src/parameters/checkpoint/main-checkpoints.txt")
+FRONTIER = Path("crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.bin")
+PROVENANCE = Path("crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json")
+EOS_FILE = Path("crates/zakurad/src/components/sync/end_of_support.rs")
+EOS_PATTERN = re.compile(r"(ESTIMATED_RELEASE_HEIGHT: u32 = )([0-9_]+)")
+RESOLUTION_KEYS = {
+    "height",
+    "block_hash",
+    "generated_at",
+    "meta_url",
+    "meta_sha256",
+}
+
+
+class BundleImportError(RuntimeError):
+    """The verified bundle cannot safely extend the committed release state."""
+
+
+def _load_resolution(path: Path) -> dict[str, Any]:
+    try:
+        resolution = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise BundleImportError(f"cannot read release-state resolution: {error}") from error
+    if not isinstance(resolution, dict) or set(resolution) != RESOLUTION_KEYS:
+        raise BundleImportError("release-state resolution has unexpected keys")
+    height = resolution["height"]
+    if isinstance(height, bool) or not isinstance(height, int) or not 0 < height < 2**32:
+        raise BundleImportError("release-state resolution height is invalid")
+    for key in RESOLUTION_KEYS - {"height"}:
+        if not isinstance(resolution[key], str) or not resolution[key]:
+            raise BundleImportError(f"release-state resolution {key} is invalid")
+    return resolution
+
+
+def _checkpoint_height(checkpoints: bytes, label: str) -> int:
+    try:
+        height, _hash = checkpoints.decode().splitlines()[-1].split(" ")
+        return int(height)
+    except (UnicodeDecodeError, ValueError, IndexError) as error:
+        raise BundleImportError(f"{label} has an invalid terminal checkpoint") from error
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def import_bundle(
+    repo_root: Path,
+    bundle: Path,
+    resolution_path: Path,
+) -> dict[str, Any]:
+    """Import a newer bundle while requiring an append-only checkpoint history."""
+
+    resolution = _load_resolution(resolution_path)
+    checkpoint_path = repo_root / CHECKPOINTS
+    frontier_path = repo_root / FRONTIER
+    provenance_path = repo_root / PROVENANCE
+    eos_path = repo_root / EOS_FILE
+
+    try:
+        committed_checkpoints = checkpoint_path.read_bytes()
+        bundle_checkpoints = (bundle / CHECKPOINTS.name).read_bytes()
+        bundle_frontier = (bundle / FRONTIER.name).read_bytes()
+    except OSError as error:
+        raise BundleImportError(f"cannot read release-state input: {error}") from error
+
+    committed_height = _checkpoint_height(committed_checkpoints, str(CHECKPOINTS))
+    bundle_height = resolution["height"]
+    result = {
+        **resolution,
+        "committed_height": committed_height,
+        "has_changes": bundle_height > committed_height,
+    }
+    print(f"bundle height {bundle_height}, committed height {committed_height}")
+    if not result["has_changes"]:
+        print("The committed checkpoint list is already at or above the bundle; nothing to do.")
+        return result
+
+    if not bundle_checkpoints.startswith(committed_checkpoints):
+        raise BundleImportError(
+            "bundle checkpoint list does not extend the committed list byte-for-byte; "
+            "publisher and repository are on different selection grids"
+        )
+    if _checkpoint_height(bundle_checkpoints, "bundle checkpoint list") != bundle_height:
+        raise BundleImportError("bundle checkpoint height does not match the resolution")
+
+    checkpoint_path.write_bytes(bundle_checkpoints)
+    frontier_path.write_bytes(bundle_frontier)
+    _write_json(
+        provenance_path,
+        {
+            "schema_version": 1,
+            "network": "Mainnet",
+            "source": "release-state-bundle",
+            "generated_at": resolution["generated_at"],
+            "finalized_height": bundle_height,
+            "finalized_hash": resolution["block_hash"],
+            "checkpoints_sha256": hashlib.sha256(bundle_checkpoints).hexdigest(),
+            "frontier_sha256": hashlib.sha256(bundle_frontier).hexdigest(),
+            "frontier_size": len(bundle_frontier),
+            "meta_sha256": resolution["meta_sha256"],
+        },
+    )
+
+    try:
+        eos_text = eos_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise BundleImportError(f"cannot read {EOS_FILE}: {error}") from error
+    match = EOS_PATTERN.search(eos_text)
+    if match is None:
+        raise BundleImportError(f"cannot find ESTIMATED_RELEASE_HEIGHT in {EOS_FILE}")
+    current_eos = int(match.group(2).replace("_", ""))
+    eos_floor = bundle_height + 3456
+    if current_eos < eos_floor:
+        formatted = f"{eos_floor:_}"
+        eos_path.write_text(
+            EOS_PATTERN.sub(rf"\g<1>{formatted}", eos_text, count=1),
+            encoding="utf-8",
+        )
+        print(f"floored ESTIMATED_RELEASE_HEIGHT at {formatted}")
+    else:
+        print(f"ESTIMATED_RELEASE_HEIGHT {current_eos} already at or above the floor")
+
+    return result
+
+
+def _self_test() -> int:
+    class SelfTest(unittest.TestCase):
+        def setUp(self) -> None:
+            self.scratch = tempfile.TemporaryDirectory()
+            self.root = Path(self.scratch.name)
+            for relative in (CHECKPOINTS, FRONTIER, PROVENANCE, EOS_FILE):
+                (self.root / relative).parent.mkdir(parents=True, exist_ok=True)
+            (self.root / CHECKPOINTS).write_text("1 aa\n", encoding="utf-8")
+            (self.root / FRONTIER).write_bytes(b"old")
+            (self.root / EOS_FILE).write_text(
+                "const ESTIMATED_RELEASE_HEIGHT: u32 = 1_000;\n",
+                encoding="utf-8",
+            )
+            self.bundle = self.root / "bundle"
+            self.bundle.mkdir()
+            (self.bundle / CHECKPOINTS.name).write_text("1 aa\n2 bb\n", encoding="utf-8")
+            (self.bundle / FRONTIER.name).write_bytes(b"new")
+            self.resolution = self.root / "resolution.json"
+            self.resolution.write_text(
+                json.dumps(
+                    {
+                        "height": 2,
+                        "block_hash": "bb",
+                        "generated_at": "2026-08-05T00:00:00Z",
+                        "meta_url": "https://example.test/meta.json",
+                        "meta_sha256": "cc",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        def tearDown(self) -> None:
+            self.scratch.cleanup()
+
+        def test_import_and_no_op(self) -> None:
+            result = import_bundle(self.root, self.bundle, self.resolution)
+            self.assertTrue(result["has_changes"])
+            self.assertEqual((self.root / CHECKPOINTS).read_text(), "1 aa\n2 bb\n")
+            self.assertEqual(
+                json.loads((self.root / PROVENANCE).read_text())["finalized_height"],
+                2,
+            )
+            self.assertIn("3_458", (self.root / EOS_FILE).read_text())
+            self.assertFalse(import_bundle(self.root, self.bundle, self.resolution)["has_changes"])
+
+        def test_rewritten_history_is_rejected(self) -> None:
+            (self.bundle / CHECKPOINTS.name).write_text("1 cc\n2 bb\n", encoding="utf-8")
+            with self.assertRaisesRegex(BundleImportError, "byte-for-byte"):
+                import_bundle(self.root, self.bundle, self.resolution)
+
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(SelfTest)
+    return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--bundle", type=Path)
+    parser.add_argument("--resolution", type=Path)
+    parser.add_argument("--result-out", type=Path)
+    args = parser.parse_args()
+    if args.self_test:
+        return _self_test()
+    if not (args.bundle and args.resolution and args.result_out):
+        parser.error("--bundle, --resolution, and --result-out are required")
+    try:
+        result = import_bundle(args.repo_root, args.bundle, args.resolution)
+        _write_json(args.result_out, result)
+    except BundleImportError as error:
+        print(f"release-state import failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/import-release-state.py
+++ b/.github/scripts/import-release-state.py
@@ -58,7 +58,7 @@ def _checkpoint_height(checkpoints: bytes, label: str) -> int:
 def _write_json(path: Path, value: dict[str, Any]) -> None:
     temporary = path.with_name(f".{path.name}.tmp")
     temporary.write_text(
-        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        json.dumps(value, indent=2) + "\n",
         encoding="utf-8",
     )
     temporary.replace(path)
@@ -68,6 +68,8 @@ def import_bundle(
     repo_root: Path,
     bundle: Path,
     resolution_path: Path,
+    *,
+    floor_eos: bool = True,
 ) -> dict[str, Any]:
     """Import a newer bundle while requiring an append-only checkpoint history."""
 
@@ -75,7 +77,6 @@ def import_bundle(
     checkpoint_path = repo_root / CHECKPOINTS
     frontier_path = repo_root / FRONTIER
     provenance_path = repo_root / PROVENANCE
-    eos_path = repo_root / EOS_FILE
 
     try:
         committed_checkpoints = checkpoint_path.read_bytes()
@@ -122,24 +123,26 @@ def import_bundle(
         },
     )
 
-    try:
-        eos_text = eos_path.read_text(encoding="utf-8")
-    except OSError as error:
-        raise BundleImportError(f"cannot read {EOS_FILE}: {error}") from error
-    match = EOS_PATTERN.search(eos_text)
-    if match is None:
-        raise BundleImportError(f"cannot find ESTIMATED_RELEASE_HEIGHT in {EOS_FILE}")
-    current_eos = int(match.group(2).replace("_", ""))
-    eos_floor = bundle_height + 3456
-    if current_eos < eos_floor:
-        formatted = f"{eos_floor:_}"
-        eos_path.write_text(
-            EOS_PATTERN.sub(rf"\g<1>{formatted}", eos_text, count=1),
-            encoding="utf-8",
-        )
-        print(f"floored ESTIMATED_RELEASE_HEIGHT at {formatted}")
-    else:
-        print(f"ESTIMATED_RELEASE_HEIGHT {current_eos} already at or above the floor")
+    if floor_eos:
+        eos_path = repo_root / EOS_FILE
+        try:
+            eos_text = eos_path.read_text(encoding="utf-8")
+        except OSError as error:
+            raise BundleImportError(f"cannot read {EOS_FILE}: {error}") from error
+        match = EOS_PATTERN.search(eos_text)
+        if match is None:
+            raise BundleImportError(f"cannot find ESTIMATED_RELEASE_HEIGHT in {EOS_FILE}")
+        current_eos = int(match.group(2).replace("_", ""))
+        eos_floor = bundle_height + 3456
+        if current_eos < eos_floor:
+            formatted = f"{eos_floor:_}"
+            eos_path.write_text(
+                EOS_PATTERN.sub(rf"\g<1>{formatted}", eos_text, count=1),
+                encoding="utf-8",
+            )
+            print(f"floored ESTIMATED_RELEASE_HEIGHT at {formatted}")
+        else:
+            print(f"ESTIMATED_RELEASE_HEIGHT {current_eos} already at or above the floor")
 
     return result
 
@@ -194,6 +197,28 @@ def _self_test() -> int:
             with self.assertRaisesRegex(BundleImportError, "byte-for-byte"):
                 import_bundle(self.root, self.bundle, self.resolution)
 
+        def test_resolution_height_mismatch_is_rejected(self) -> None:
+            resolution = json.loads(self.resolution.read_text(encoding="utf-8"))
+            resolution["height"] = 3
+            self.resolution.write_text(json.dumps(resolution), encoding="utf-8")
+            (self.bundle / CHECKPOINTS.name).write_text(
+                "1 aa\n2 bb\n4 dd\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(BundleImportError, "does not match"):
+                import_bundle(self.root, self.bundle, self.resolution)
+
+        def test_import_can_leave_eos_for_release_preparation(self) -> None:
+            before = (self.root / EOS_FILE).read_text(encoding="utf-8")
+            result = import_bundle(
+                self.root,
+                self.bundle,
+                self.resolution,
+                floor_eos=False,
+            )
+            self.assertTrue(result["has_changes"])
+            self.assertEqual((self.root / EOS_FILE).read_text(encoding="utf-8"), before)
+
     suite = unittest.defaultTestLoader.loadTestsFromTestCase(SelfTest)
     return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
 
@@ -205,13 +230,23 @@ def main() -> int:
     parser.add_argument("--bundle", type=Path)
     parser.add_argument("--resolution", type=Path)
     parser.add_argument("--result-out", type=Path)
+    parser.add_argument(
+        "--no-eos-floor",
+        action="store_true",
+        help="leave ESTIMATED_RELEASE_HEIGHT unchanged",
+    )
     args = parser.parse_args()
     if args.self_test:
         return _self_test()
     if not (args.bundle and args.resolution and args.result_out):
         parser.error("--bundle, --resolution, and --result-out are required")
     try:
-        result = import_bundle(args.repo_root, args.bundle, args.resolution)
+        result = import_bundle(
+            args.repo_root,
+            args.bundle,
+            args.resolution,
+            floor_eos=not args.no_eos_floor,
+        )
         _write_json(args.result_out, result)
     except BundleImportError as error:
         print(f"release-state import failed: {error}", file=sys.stderr)

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -2,11 +2,11 @@
 #
 # Runs scripts/prepare-release.sh on a fresh checkout of main (crate bumps via
 # cargo-semver-checks, Zakura release-level validation, lockfile, config
-# fixture, README tag, projected end-of-support height, release-state freshness,
-# and changelog assembly), verifies the result with
-# `make pre-release`, and opens or updates a draft PR through the release
-# GitHub App. Nothing merges, tags, or publishes from this workflow: the PR is
-# always a draft, judgment items (bump-level review, authoritative
+# fixture, README tag, projected end-of-support height, an automatic import of
+# the latest verified release state, and changelog assembly), verifies the
+# result with `make pre-release`, and opens or updates a draft PR through the
+# release GitHub App. Nothing merges, tags, or publishes from this workflow:
+# the PR is always a draft, judgment items (bump-level review, authoritative
 # end-of-support height, changelog curation) are listed in the PR body, and
 # create-release.yml re-validates everything after merge.
 #
@@ -124,6 +124,7 @@ jobs:
             exit 1
           fi
           python3 .github/scripts/fetch-release-state.py --self-test
+          python3 .github/scripts/import-release-state.py --self-test
           python3 scripts/release-readiness.py self-test
           python3 .github/scripts/fetch-release-state.py \
             --latest-url "$LATEST_URL" \
@@ -142,6 +143,33 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           jq . <<<"$report" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Import the latest Mainnet release state
+        if: inputs.release_state_waiver == ''
+        id: release-state-import
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/import-release-state.py \
+            --bundle "$RUNNER_TEMP/release-state-bundle" \
+            --resolution "$RUNNER_TEMP/release-state-resolution.json" \
+            --result-out "$RUNNER_TEMP/release-state-import.json"
+          jq -r '
+            "has_changes=\(.has_changes)",
+            "committed_height=\(.committed_height)",
+            "height=\(.height)",
+            "block_hash=\(.block_hash)",
+            "generated_at=\(.generated_at)",
+            "meta_url=\(.meta_url)",
+            "meta_sha256=\(.meta_sha256)"
+          ' "$RUNNER_TEMP/release-state-import.json" >> "$GITHUB_OUTPUT"
+
+      - name: Validate the imported release state
+        if: steps.release-state-import.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          .github/scripts/validate-checkpoints.sh \
+            crates/zakura-chain/src/parameters/checkpoint/main-checkpoints.txt
+          ZAKURA_ALLOW_BOOTSTRAP_RELEASE_STATE=0 scripts/check-release-state.sh
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         id: toolchain
         with:
@@ -159,6 +187,10 @@ jobs:
           tool: cargo-release,cargo-semver-checks
 
       - uses: ./.github/actions/setup-zakura-build
+
+      - name: Re-prove the imported checkpoint/frontier pairing in cargo
+        if: steps.release-state-import.outputs.has_changes == 'true'
+        run: cargo test -p zakura-state --lib -- frontier sprout_change
 
       - name: Prepare the release
         id: prep
@@ -233,6 +265,12 @@ jobs:
           VERIFY_PRERELEASE: ${{ steps.verify-prerelease.outcome }}
           VERIFY_CONFIG: ${{ steps.verify-config.outcome }}
           VERIFY_FMT: ${{ steps.verify-fmt.outcome }}
+          RELEASE_STATE_IMPORTED: ${{ steps.release-state-import.outputs.has_changes }}
+          PREVIOUS_RELEASE_STATE_HEIGHT: ${{ steps.release-state-import.outputs.committed_height }}
+          RELEASE_STATE_HASH: ${{ steps.release-state-import.outputs.block_hash }}
+          RELEASE_STATE_GENERATED_AT: ${{ steps.release-state-import.outputs.generated_at }}
+          RELEASE_STATE_META_URL: ${{ steps.release-state-import.outputs.meta_url }}
+          RELEASE_STATE_META_SHA256: ${{ steps.release-state-import.outputs.meta_sha256 }}
         run: |
           python3 - "$RUNNER_TEMP/prep-summary.json" > "$RUNNER_TEMP/pr-body.md" <<'PY'
           import json, os, sys
@@ -310,6 +348,18 @@ jobs:
               f"{release_state['committed_height']}, latest verified "
               f"{release_state['latest_verified_height']}."
           )
+          if os.environ["RELEASE_STATE_IMPORTED"] == "true":
+              lines.append(
+                  f"- Mainnet release state imported automatically: "
+                  f"{os.environ['PREVIOUS_RELEASE_STATE_HEIGHT']} → "
+                  f"{release_state['committed_height']}."
+              )
+              lines.append(
+                  f"- Imported bundle: `{os.environ['RELEASE_STATE_HASH']}`, "
+                  f"generated `{os.environ['RELEASE_STATE_GENERATED_AT']}`, "
+                  f"[metadata]({os.environ['RELEASE_STATE_META_URL']}) "
+                  f"(`{os.environ['RELEASE_STATE_META_SHA256']}`)."
+              )
           if release_state["waiver"]:
               lines.append(
                   f"- ⚠️ Rapid-RC release-state waiver: "
@@ -351,6 +401,13 @@ jobs:
               "- [ ] <!-- release-judgment:changelog --> Curate the assembled "
               "changelog (dedupe, trim trivial entries, check categories).",
           ]
+          if os.environ["RELEASE_STATE_IMPORTED"] == "true":
+              lines.append(
+                  "- [ ] <!-- release-judgment:release-state --> Review the "
+                  "consensus-critical checkpoint/frontier update; spot-check "
+                  "new heights and the terminal hash against an independent "
+                  "node or explorer."
+              )
           manual_crates = [
               crate["name"] for crate in summary["crates"]
               if crate["level"] == "manual"

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -201,6 +201,7 @@ jobs:
           ESTIMATED_RELEASE_HEIGHT: ${{ steps.release-state.outputs.estimated_release_height }}
           LATEST_RELEASE_STATE_HEIGHT: ${{ steps.release-state.outputs.bundle_height }}
           RELEASE_STATE_WAIVER: ${{ inputs.release_state_waiver }}
+          RELEASE_STATE_IMPORTED: ${{ steps.release-state-import.outputs.has_changes }}
         run: |
           args=(
             --release-tag "$RELEASE_TAG"
@@ -212,6 +213,8 @@ jobs:
           [ -z "$NO_CRATES_FLAG" ] || args+=("$NO_CRATES_FLAG")
           [ -z "$RELEASE_STATE_WAIVER" ] \
             || args+=(--release-state-waiver "$RELEASE_STATE_WAIVER")
+          [ "$RELEASE_STATE_IMPORTED" = "true" ] \
+            && args+=(--allow-dirty-release-state)
           scripts/prepare-release.sh "${args[@]}"
 
       # cargo package (run by the packaging check) refuses a dirty tree, so

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -151,7 +151,8 @@ jobs:
           python3 .github/scripts/import-release-state.py \
             --bundle "$RUNNER_TEMP/release-state-bundle" \
             --resolution "$RUNNER_TEMP/release-state-resolution.json" \
-            --result-out "$RUNNER_TEMP/release-state-import.json"
+            --result-out "$RUNNER_TEMP/release-state-import.json" \
+            --no-eos-floor
           jq -r '
             "has_changes=\(.has_changes)",
             "committed_height=\(.committed_height)",

--- a/.github/workflows/update-release-state.yml
+++ b/.github/workflows/update-release-state.yml
@@ -38,8 +38,10 @@ jobs:
           persist-credentials: false
           ref: main
 
-      - name: Self-test the bundle fetcher
-        run: python3 .github/scripts/fetch-release-state.py --self-test
+      - name: Self-test the release-state tooling
+        run: |
+          python3 .github/scripts/fetch-release-state.py --self-test
+          python3 .github/scripts/import-release-state.py --self-test
 
       - name: Fetch one immutable bundle
         env:
@@ -61,77 +63,20 @@ jobs:
         env:
           BUNDLE: ${{ runner.temp }}/release-state-bundle
           RESOLUTION: ${{ runner.temp }}/release-state-resolution.json
-          CHECKPOINTS: crates/zakura-chain/src/parameters/checkpoint/main-checkpoints.txt
-          FRONTIER: crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.bin
-          PROVENANCE: crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json
-          EOS_FILE: crates/zakurad/src/components/sync/end_of_support.rs
         run: |
           set -euo pipefail
-
-          BUNDLE_HEIGHT=$(jq -er '.height' "$RESOLUTION")
-          COMMITTED_HEIGHT=$(tail -1 "$CHECKPOINTS" | cut -d' ' -f1)
-          echo "bundle height ${BUNDLE_HEIGHT}, committed height ${COMMITTED_HEIGHT}"
-
-          if [ "$BUNDLE_HEIGHT" -le "$COMMITTED_HEIGHT" ]; then
-            echo "The committed checkpoint list is already at or above the bundle; nothing to do."
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # The committed list must be a byte-identical prefix of the bundle's
-          # full list (the selection-grid contract): any rewrite of committed
-          # history fails closed here and in review.
-          COMMITTED_SIZE=$(stat -c%s "$CHECKPOINTS")
-          if ! head -c "$COMMITTED_SIZE" "$BUNDLE/main-checkpoints.txt" | cmp -s - "$CHECKPOINTS"; then
-            echo "Bundle checkpoint list does not extend the committed list byte-for-byte." >&2
-            echo "Publisher and repository are on different selection grids; investigate before retrying." >&2
-            exit 1
-          fi
-
-          cp "$BUNDLE/main-checkpoints.txt" "$CHECKPOINTS"
-          cp "$BUNDLE/mainnet-frontier.bin" "$FRONTIER"
-
-          python3 - "$RESOLUTION" "$BUNDLE" "$CHECKPOINTS" "$FRONTIER" "$PROVENANCE" <<'PY'
-          import hashlib, json, sys
-          resolution_path, bundle, checkpoints, frontier, provenance_path = sys.argv[1:6]
-          resolution = json.load(open(resolution_path, encoding="utf-8"))
-          frontier_bytes = open(frontier, "rb").read()
-          provenance = {
-              "schema_version": 1,
-              "network": "Mainnet",
-              "source": "release-state-bundle",
-              "generated_at": resolution["generated_at"],
-              "finalized_height": resolution["height"],
-              "finalized_hash": resolution["block_hash"],
-              "checkpoints_sha256": hashlib.sha256(open(checkpoints, "rb").read()).hexdigest(),
-              "frontier_sha256": hashlib.sha256(frontier_bytes).hexdigest(),
-              "frontier_size": len(frontier_bytes),
-              "meta_sha256": resolution["meta_sha256"],
-          }
-          with open(provenance_path, "w", encoding="utf-8") as out:
-              json.dump(provenance, out, indent=2)
-              out.write("\n")
-          PY
-
-          # Floor the end-of-support estimate at the bundle height plus ~3 days
-          # of blocks. The release checklist's manual estimate stays
-          # authoritative; this only keeps a skipped checklist step from
-          # shipping a long-stale estimate inside an 18-day support window.
-          EOS_HEIGHT=$((BUNDLE_HEIGHT + 3456))
-          FORMATTED=$(echo "$EOS_HEIGHT" | awk '{n=$0; r=""; for(i=length(n);i>0;i--) { r=substr(n,i,1) r; if((length(n)-i)%3==2 && i>1) r="_" r }; print r}')
-          CURRENT_EOS=$(grep -oE 'ESTIMATED_RELEASE_HEIGHT: u32 = [0-9_]+' "$EOS_FILE" | grep -oE '[0-9_]+$' | tr -d '_')
-          if [ "$CURRENT_EOS" -lt "$EOS_HEIGHT" ]; then
-            sed -i "s/ESTIMATED_RELEASE_HEIGHT: u32 = [0-9_]*/ESTIMATED_RELEASE_HEIGHT: u32 = ${FORMATTED}/" "$EOS_FILE"
-            echo "floored ESTIMATED_RELEASE_HEIGHT at ${FORMATTED}"
-          else
-            echo "ESTIMATED_RELEASE_HEIGHT ${CURRENT_EOS} already at or above the floor"
-          fi
-
-          {
-            echo "has_changes=true"
-            echo "height=${BUNDLE_HEIGHT}"
-            jq -r '"block_hash=\(.block_hash)", "generated_at=\(.generated_at)", "meta_url=\(.meta_url)", "meta_sha256=\(.meta_sha256)"' "$RESOLUTION"
-          } >> "$GITHUB_OUTPUT"
+          python3 .github/scripts/import-release-state.py \
+            --bundle "$BUNDLE" \
+            --resolution "$RESOLUTION" \
+            --result-out "$RUNNER_TEMP/release-state-import.json"
+          jq -r '
+            "has_changes=\(.has_changes)",
+            "height=\(.height)",
+            "block_hash=\(.block_hash)",
+            "generated_at=\(.generated_at)",
+            "meta_url=\(.meta_url)",
+            "meta_sha256=\(.meta_sha256)"
+          ' "$RUNNER_TEMP/release-state-import.json" >> "$GITHUB_OUTPUT"
 
       - name: Validate the imported release state
         if: steps.import.outputs.has_changes == 'true'

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -843,15 +843,21 @@ The publisher (`deploy/release-state/`) uploads each export to R2 as an immutabl
 file's size and SHA-256 — then atomically replaces the mutable `release-state/latest.json`
 pointer (height, hash, `meta_url`, `meta_sha256`), keeping the newest few bundles.
 
-The `update-release-state.yml` workflow (manual dispatch plus a weekly cron) resolves the
-pointer once over a pinned HTTPS host with no redirects, bounded reads, digest verification
-at every hop, and a maximum bundle age. It exits green without changes when the bundle does
-not advance the committed list. Otherwise it verifies the committed `main-checkpoints.txt` is
-a byte-identical prefix of the bundle's list, replaces the checkpoint file and frontier,
+The `update-release-state.yml` workflow (manual dispatch plus a weekly cron) and
+`prepare-release-pr.yml` both resolve the pointer once over a pinned HTTPS host with no
+redirects, bounded reads, digest verification at every hop, and a maximum bundle age. They
+exit green without release-state changes when the bundle does not advance the committed
+list. Otherwise their shared importer verifies the committed `main-checkpoints.txt` is a
+byte-identical prefix of the bundle's list, replaces the checkpoint file and frontier, and
 writes `vct/mainnet-frontier.json` provenance (source `release-state-bundle`, heights,
-digests, bundle binding), floors `ESTIMATED_RELEASE_HEIGHT`, validates everything —
-including `cargo test -p zakura-state --lib -- frontier` — restricts the diff to exactly
-those four files, and opens a signed **draft PR** for human review. Checkpoints are
+digests, bundle binding).
+
+The standalone update workflow also floors `ESTIMATED_RELEASE_HEIGHT`, validates everything
+— including `cargo test -p zakura-state --lib -- frontier` — restricts the diff to exactly
+those four files, and opens a signed **draft PR** for human review. During release
+preparation, the importer leaves that constant unchanged so `prepare-release.sh` remains the
+sole owner of its projected value and summary. The release workflow re-proves the imported
+checkpoint/frontier pairing and includes the import in its draft release PR. Checkpoints are
 consensus-critical: the reviewed, committed files are the trust root, and the pipeline's
 digests only prove faithful transport from our own publisher.
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -31,12 +31,14 @@
 #       [--latest-release-state-height HEIGHT]
 #       [--release-state-waiver REASON]
 #       [--tag-remote URL]
-#       [--no-crates] [--dry-run] [--summary-json PATH]
+#       [--no-crates] [--dry-run] [--allow-dirty-release-state] [--summary-json PATH]
 #
 #   --base-tag      defaults to the most recent v* tag reachable from HEAD
 #   --tag-remote    canonical tag source checked before retargeting
 #   --no-crates     GitHub-only release candidate: bump only the zakura package
 #   --dry-run       print the bump plan and intended edits; modify nothing
+#   --allow-dirty-release-state
+#                   allow a pre-imported release-state update to be present
 #   --summary-json  write a machine-readable summary (used for the PR body)
 set -euo pipefail
 
@@ -53,6 +55,7 @@ release_tag=""
 base_tag=""
 no_crates=0
 dry_run=0
+allow_dirty_release_state=0
 summary_json=""
 estimated_release_height=""
 latest_release_state_height=""
@@ -60,7 +63,7 @@ release_state_waiver=""
 tag_remote="https://github.com/zakura-core/zakura.git"
 
 usage() {
-  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -74,6 +77,7 @@ while [ $# -gt 0 ]; do
     --tag-remote) tag_remote="${2:?--tag-remote needs a value}"; shift 2 ;;
     --no-crates) no_crates=1; shift ;;
     --dry-run) dry_run=1; shift ;;
+    --allow-dirty-release-state) allow_dirty_release_state=1; shift ;;
     --summary-json) summary_json="${2:?--summary-json needs a value}"; shift 2 ;;
     -h|--help) usage ;;
     *) echo "Unknown argument: $1" >&2; usage 1 >&2 ;;
@@ -138,9 +142,36 @@ for height_arg in "$estimated_release_height" "$latest_release_state_height"; do
   fi
 done
 
-if [ "$dry_run" = 0 ] && [ -n "$(git status --porcelain --untracked-files=normal)" ]; then
-  echo "ERROR: the working tree is not clean; commit or stash before preparing a release." >&2
-  exit 1
+if [ "$dry_run" = 0 ]; then
+  dirty_tree="$(git status --porcelain --untracked-files=normal)"
+  if [ -n "$dirty_tree" ]; then
+    if [ "$allow_dirty_release_state" = 1 ]; then
+      allow_only_release_state=1
+      while IFS= read -r dirty_line; do
+        [ -n "$dirty_line" ] || continue
+        dirty_path="${dirty_line:3}"
+        case "$dirty_path" in
+          crates/zakura-chain/src/parameters/checkpoint/main-checkpoints.txt|\
+          crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.bin|\
+          crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json|\
+          crates/zakurad/src/components/sync/end_of_support.rs)
+            ;;
+          *)
+            allow_only_release_state=0
+            break
+            ;;
+        esac
+      done <<<"$dirty_tree"
+      if [ "$allow_only_release_state" = 0 ]; then
+        echo "ERROR: the working tree has changes outside the imported release-state files." >&2
+        exit 1
+      fi
+      echo "Allowing imported release-state edits in the working tree."
+    else
+      echo "ERROR: the working tree is not clean; commit or stash before preparing a release." >&2
+      exit 1
+    fi
+  fi
 fi
 
 echo "Preparing ${release_tag} from base ${base_tag}$( [ "$no_crates" = 1 ] && echo ' (zakura package only)' )"


### PR DESCRIPTION
## Motivation

Release preparation compares the committed Mainnet release state with a pointer that advances daily. Even after merging a release-state update, the next publisher bundle can make preparation fail again before the release PR is opened.

## Solution

- Extract the existing append-only release-state import into a shared, self-tested Python helper.
- Import and validate a newer verified bundle directly into the draft release PR before running release preparation.
- Re-run the checkpoint/frontier Rust proofs when an import occurs and include bundle provenance plus an explicit review item in the PR body.
- Keep the standalone update workflow on the same importer so both paths enforce identical behavior.
- Preserve the urgent-RC waiver path by skipping automatic import when a waiver is supplied.

## Testing

- `python3 .github/scripts/import-release-state.py --self-test`
- `python3 .github/scripts/fetch-release-state.py --self-test`
- `python3 scripts/release-readiness.py self-test`
- `actionlint .github/workflows/prepare-release-pr.yml .github/workflows/update-release-state.yml`
- `git diff --check`
- IDE diagnostics: no errors

The importer tests exercise successful append-only import, a current-state no-op, end-of-support flooring, provenance generation, and rejection of rewritten checkpoint history.

## Changelog

Internal release automation only; no changelog fragment required because no Rust source or `Cargo.toml` changed.

### Specifications & References

The imported checkpoints and frontier remain subject to the existing consensus-state validation and manual review requirements.