### PR TITLE
fix(release): normalize crates when promoting stable releases

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -379,6 +379,14 @@ if [ "$no_crates" = 0 ]; then
 
     base_crate_dir="$(dirname "$base_manifest_rel")"
     if git diff --quiet "$base_tag" -- "$base_crate_dir" "$crate_dir"; then
+      # Stable promotion must de-rc the entire publishable workspace, not only
+      # crates changed since the final release candidate.
+      if [ -z "$suffix" ] && [ "$current_version" != "$(strip_pre "$current_version")" ]; then
+        target="$(strip_pre "$current_version")"
+        add_crate_row "$crate" "$base_version" "$current_version" "$target" \
+          "kept" "unchanged since ${base_tag}; prerelease suffix removed for stable release"
+        add_to_plan "$crate" "$target" "$current_version" "$manifest_rel"
+      fi
       continue
     fi
 
@@ -780,6 +788,36 @@ if [ "${#plan_names[@]}" -gt 0 ]; then
 fi
 assert_version zakura "$version"
 echo "All applied versions match the plan."
+
+# cargo-release's dependent-version = "fix" deliberately keeps compatible
+# requirements. A prerelease requirement is compatible with the corresponding
+# stable version, so stable promotion must normalize internal path requirements
+# explicitly after every package has reached its final workspace version.
+if [ -z "$suffix" ]; then
+  echo
+  echo "==> Normalizing internal prerelease requirements"
+  while IFS=$'\t' read -r manifest_path dependency_key dependency_version; do
+    [ -n "$manifest_path" ] || continue
+    DEPENDENCY="$dependency_key" NEW="$dependency_version" perl -0777 -pi -e '
+      s{
+        (\Q$ENV{DEPENDENCY}\E\s*=\s*\{[^}]*?\bversion\s*=\s*")
+        [^"]*-[^"]*
+        (")
+      }{$1$ENV{NEW}$2}gx
+    ' "$manifest_path"
+  done < <(
+    jq -r '
+      ([.packages[] | {key: .name, value: .version}] | from_entries) as $versions
+      | .packages[]
+      | .manifest_path as $manifest
+      | .dependencies[]
+      | select(.path != null and (.req | test("-")))
+      | [$manifest, (.rename // .name), $versions[.name]]
+      | @tsv
+    ' <<<"$applied" | sort -u
+  )
+  echo "Internal prerelease requirements now use final workspace versions."
+fi
 
 # Requirement rewrites (the workspace's dependent-version = "fix") must stay
 # inside the bump plan: a published crate whose manifest is rewritten but

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -377,6 +377,14 @@ if [ "$no_crates" = 0 ]; then
       continue
     fi
 
+    # Assumes [package] has a literal version before any other version key;
+    # manifests using version.workspace = true would need different parsing.
+    base_version="${base_version_by_crate[$crate]:-}"
+    if [ -z "$base_version" ]; then
+      echo "ERROR: could not read ${crate}'s package version at ${base_tag}." >&2
+      exit 1
+    fi
+
     base_crate_dir="$(dirname "$base_manifest_rel")"
     if git diff --quiet "$base_tag" -- "$base_crate_dir" "$crate_dir"; then
       # Stable promotion must de-rc the entire publishable workspace, not only
@@ -388,14 +396,6 @@ if [ "$no_crates" = 0 ]; then
         add_to_plan "$crate" "$target" "$current_version" "$manifest_rel"
       fi
       continue
-    fi
-
-    # Assumes [package] has a literal version before any other version key;
-    # manifests using version.workspace = true would need different parsing.
-    base_version="${base_version_by_crate[$crate]:-}"
-    if [ -z "$base_version" ]; then
-      echo "ERROR: could not read ${crate}'s package version at ${base_tag}." >&2
-      exit 1
     fi
 
     if [ "$retarget_unpublished" = 1 ] \

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -799,11 +799,11 @@ if [ -z "$suffix" ]; then
   while IFS=$'\t' read -r manifest_path dependency_key dependency_version; do
     [ -n "$manifest_path" ] || continue
     DEPENDENCY="$dependency_key" NEW="$dependency_version" perl -0777 -pi -e '
-      s{
+      s~
         (\Q$ENV{DEPENDENCY}\E\s*=\s*\{[^}]*?\bversion\s*=\s*")
         [^"]*-[^"]*
         (")
-      }{$1$ENV{NEW}$2}gx
+      ~$1$ENV{NEW}$2~gx
     ' "$manifest_path"
   done < <(
     jq -r '


### PR DESCRIPTION
## Motivation

Stable release preparation compared the workspace only against the final RC tag. Publishable crates unchanged since that tag were skipped and retained their prerelease versions. `cargo-release` also kept compatible internal prerelease requirements, causing the final release-requirements gate to fail.

## Solution

- Include unchanged publishable prerelease crates in the stable-release bump plan.
- After all package versions settle, normalize internal path dependency requirements to their final workspace versions.
- Keep the existing release-requirements check as the fail-closed verification gate.

## Testing

- `bash -n scripts/prepare-release.sh`
- `shellcheck scripts/prepare-release.sh`
- `git diff --check`
- Linux replay of `v1.1.0-rc2` to `v1.1.0` confirmed all unchanged prerelease crates enter the bump plan and reach stable package versions.
- Replayed the requirement normalization against that resulting workspace; `make pre-release-requirements RELEASE_TAG=v1.1.0` passes with no prerelease markers.

## Changelog

No Rust source or Cargo manifest changed; no changelog fragment is required.

### Specifications & References

- Failed preparation run: https://github.com/zakura-core/zakura/actions/runs/31043930582/job/92434726521

### Follow-up Work

None currently identified.