### PR TITLE
fix(release): allow imported release-state dirty tree in prepare

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -201,6 +201,7 @@ jobs:
           ESTIMATED_RELEASE_HEIGHT: ${{ steps.release-state.outputs.estimated_release_height }}
           LATEST_RELEASE_STATE_HEIGHT: ${{ steps.release-state.outputs.bundle_height }}
           RELEASE_STATE_WAIVER: ${{ inputs.release_state_waiver }}
+          RELEASE_STATE_IMPORTED: ${{ steps.release-state-import.outputs.has_changes }}
         run: |
           args=(
             --release-tag "$RELEASE_TAG"
@@ -212,6 +213,8 @@ jobs:
           [ -z "$NO_CRATES_FLAG" ] || args+=("$NO_CRATES_FLAG")
           [ -z "$RELEASE_STATE_WAIVER" ] \
             || args+=(--release-state-waiver "$RELEASE_STATE_WAIVER")
+          [ "$RELEASE_STATE_IMPORTED" = "true" ] \
+            && args+=(--allow-dirty-release-state)
           scripts/prepare-release.sh "${args[@]}"
 
       # cargo package (run by the packaging check) refuses a dirty tree, so

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -31,12 +31,14 @@
 #       [--latest-release-state-height HEIGHT]
 #       [--release-state-waiver REASON]
 #       [--tag-remote URL]
-#       [--no-crates] [--dry-run] [--summary-json PATH]
+#       [--no-crates] [--dry-run] [--allow-dirty-release-state] [--summary-json PATH]
 #
 #   --base-tag      defaults to the most recent v* tag reachable from HEAD
 #   --tag-remote    canonical tag source checked before retargeting
 #   --no-crates     GitHub-only release candidate: bump only the zakura package
 #   --dry-run       print the bump plan and intended edits; modify nothing
+#   --allow-dirty-release-state
+#                   allow a pre-imported release-state update to be present
 #   --summary-json  write a machine-readable summary (used for the PR body)
 set -euo pipefail
 
@@ -53,6 +55,7 @@ release_tag=""
 base_tag=""
 no_crates=0
 dry_run=0
+allow_dirty_release_state=0
 summary_json=""
 estimated_release_height=""
 latest_release_state_height=""
@@ -60,7 +63,7 @@ release_state_waiver=""
 tag_remote="https://github.com/zakura-core/zakura.git"
 
 usage() {
-  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -74,6 +77,7 @@ while [ $# -gt 0 ]; do
     --tag-remote) tag_remote="${2:?--tag-remote needs a value}"; shift 2 ;;
     --no-crates) no_crates=1; shift ;;
     --dry-run) dry_run=1; shift ;;
+    --allow-dirty-release-state) allow_dirty_release_state=1; shift ;;
     --summary-json) summary_json="${2:?--summary-json needs a value}"; shift 2 ;;
     -h|--help) usage ;;
     *) echo "Unknown argument: $1" >&2; usage 1 >&2 ;;
@@ -138,9 +142,36 @@ for height_arg in "$estimated_release_height" "$latest_release_state_height"; do
   fi
 done
 
-if [ "$dry_run" = 0 ] && [ -n "$(git status --porcelain --untracked-files=normal)" ]; then
-  echo "ERROR: the working tree is not clean; commit or stash before preparing a release." >&2
-  exit 1
+if [ "$dry_run" = 0 ]; then
+  dirty_tree="$(git status --porcelain --untracked-files=normal)"
+  if [ -n "$dirty_tree" ]; then
+    if [ "$allow_dirty_release_state" = 1 ]; then
+      allow_only_release_state=1
+      while IFS= read -r dirty_line; do
+        [ -n "$dirty_line" ] || continue
+        dirty_path="${dirty_line:3}"
+        case "$dirty_path" in
+          crates/zakura-chain/src/parameters/checkpoint/main-checkpoints.txt|\
+          crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.bin|\
+          crates/zakura-state/src/service/finalized_state/vct/mainnet-frontier.json|\
+          crates/zakurad/src/components/sync/end_of_support.rs)
+            ;;
+          *)
+            allow_only_release_state=0
+            break
+            ;;
+        esac
+      done <<<"$dirty_tree"
+      if [ "$allow_only_release_state" = 0 ]; then
+        echo "ERROR: the working tree has changes outside the imported release-state files." >&2
+        exit 1
+      fi
+      echo "Allowing imported release-state edits in the working tree."
+    else
+      echo "ERROR: the working tree is not clean; commit or stash before preparing a release." >&2
+      exit 1
+    fi
+  fi
 fi
 
 echo "Preparing ${release_tag} from base ${base_tag}$( [ "$no_crates" = 1 ] && echo ' (zakura package only)' )"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Bugbot found that PR #579 imports a newer Mainnet release-state bundle into tracked checkpoint, frontier, provenance, and EOS files, then calls `scripts/prepare-release.sh` while those edits are still uncommitted. That script refuses a dirty working tree unless `--dry-run` is set, so any import with `has_changes=true` aborts release preparation immediately.

## Solution

- Add `--allow-dirty-release-state` to `scripts/prepare-release.sh`.
- When that flag is set, allow only the four release-state import paths to be dirty; unrelated edits still abort.
- Pass the flag from `prepare-release-pr.yml` only when the import step reports `has_changes=true`.

## Testing

- Simulated the dirty-tree gate:
  - no flag + dirty release-state file → abort
  - flag + release-state-only dirty tree → allow
  - flag + unrelated dirty file → abort
- `python3 .github/scripts/import-release-state.py --self-test`
- `bash -n scripts/prepare-release.sh`
- `actionlint .github/workflows/prepare-release-pr.yml`
- `git diff --check`

## Changelog

Internal release-automation fix only; no Rust source or `Cargo.toml` changes, so no changelog fragment.

### Specifications & References

Fixes Bugbot finding on #579 (dirty tree blocks prepare script).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f60b7cac-0dd9-4038-bff8-d5164948ab95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f60b7cac-0dd9-4038-bff8-d5164948ab95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

