### PR TITLE
fix(release): resolve base version before stable de-rc rows

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -379,6 +379,14 @@ if [ "$no_crates" = 0 ]; then
 
     base_crate_dir="$(dirname "$base_manifest_rel")"
     if git diff --quiet "$base_tag" -- "$base_crate_dir" "$crate_dir"; then
+      # Stable promotion must de-rc the entire publishable workspace, not only
+      # crates changed since the final release candidate.
+      if [ -z "$suffix" ] && [ "$current_version" != "$(strip_pre "$current_version")" ]; then
+        target="$(strip_pre "$current_version")"
+        add_crate_row "$crate" "$base_version" "$current_version" "$target" \
+          "kept" "unchanged since ${base_tag}; prerelease suffix removed for stable release"
+        add_to_plan "$crate" "$target" "$current_version" "$manifest_rel"
+      fi
       continue
     fi
 
@@ -780,6 +788,36 @@ if [ "${#plan_names[@]}" -gt 0 ]; then
 fi
 assert_version zakura "$version"
 echo "All applied versions match the plan."
+
+# cargo-release's dependent-version = "fix" deliberately keeps compatible
+# requirements. A prerelease requirement is compatible with the corresponding
+# stable version, so stable promotion must normalize internal path requirements
+# explicitly after every package has reached its final workspace version.
+if [ -z "$suffix" ]; then
+  echo
+  echo "==> Normalizing internal prerelease requirements"
+  while IFS=$'\t' read -r manifest_path dependency_key dependency_version; do
+    [ -n "$manifest_path" ] || continue
+    DEPENDENCY="$dependency_key" NEW="$dependency_version" perl -0777 -pi -e '
+      s{
+        (\Q$ENV{DEPENDENCY}\E\s*=\s*\{[^}]*?\bversion\s*=\s*")
+        [^"]*-[^"]*
+        (")
+      }{$1$ENV{NEW}$2}gx
+    ' "$manifest_path"
+  done < <(
+    jq -r '
+      ([.packages[] | {key: .name, value: .version}] | from_entries) as $versions
+      | .packages[]
+      | .manifest_path as $manifest
+      | .dependencies[]
+      | select(.path != null and (.req | test("-")))
+      | [$manifest, (.rename // .name), $versions[.name]]
+      | @tsv
+    ' <<<"$applied" | sort -u
+  )
+  echo "Internal prerelease requirements now use final workspace versions."
+fi
 
 # Requirement rewrites (the workspace's dependent-version = "fix") must stay
 # inside the bump plan: a published crate whose manifest is rewritten but

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -378,6 +378,17 @@ if [ "$no_crates" = 0 ]; then
     fi
 
     base_crate_dir="$(dirname "$base_manifest_rel")"
+
+    # Assumes [package] has a literal version before any other version key;
+    # manifests using version.workspace = true would need different parsing.
+    # Resolve before the unchanged-crate de-rc path so stable promotion does not
+    # reuse a leftover $base_version from an earlier loop iteration.
+    base_version="${base_version_by_crate[$crate]:-}"
+    if [ -z "$base_version" ]; then
+      echo "ERROR: could not read ${crate}'s package version at ${base_tag}." >&2
+      exit 1
+    fi
+
     if git diff --quiet "$base_tag" -- "$base_crate_dir" "$crate_dir"; then
       # Stable promotion must de-rc the entire publishable workspace, not only
       # crates changed since the final release candidate.
@@ -388,14 +399,6 @@ if [ "$no_crates" = 0 ]; then
         add_to_plan "$crate" "$target" "$current_version" "$manifest_rel"
       fi
       continue
-    fi
-
-    # Assumes [package] has a literal version before any other version key;
-    # manifests using version.workspace = true would need different parsing.
-    base_version="${base_version_by_crate[$crate]:-}"
-    if [ -z "$base_version" ]; then
-      echo "ERROR: could not read ${crate}'s package version at ${base_tag}." >&2
-      exit 1
     fi
 
     if [ "$retarget_unpublished" = 1 ] \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

When preparing a stable release, unchanged publishable crates that still carry a prerelease suffix are folded into the bump plan so the whole workspace can be de-rc'd. That path called `add_crate_row` with `$base_version` before reading the crate's entry from `base_version_by_crate`, so the recorded base version was whatever an earlier loop left behind.

## Solution

Resolve `base_version` from `base_version_by_crate` (and fail if missing) before the unchanged-crate de-rc branch, so every plan row uses that crate's base-tag version.

## Testing

- Confirmed the bug on `fix/stable-release-de-rc`: the unchanged de-rc path at the former lines 385–386 used `$base_version` before the map lookup.
- Reproduced with a minimal bash scenario: after processing `crate-a` (`1.0.0-rc0`), unchanged `crate-b` (`2.0.0-rc0`) recorded `base=1.0.0-rc0` under the old order and `base=2.0.0-rc0` after the fix.
- `bash -n scripts/prepare-release.sh` passed.
- No Rust/`Cargo.toml` changes, so no changelog fragment.

## Changelog

N/A — shell script only; no Rust or `Cargo.toml` changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b02242f-99c5-41f1-a51b-09c470f8017d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b02242f-99c5-41f1-a51b-09c470f8017d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

