### PR TITLE
test(state): cover header-chain durability and recovery

### DIFF
--- a/crates/zakura-state/proptest-regressions/service/finalized_state/header_chain/coherence/prop.txt
+++ b/crates/zakura-state/proptest-regressions/service/finalized_state/header_chain/coherence/prop.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 083dba764caabf595d71004ce93a69ec39173c5d5355ca556922072196f625bd # shrinks to operations = [Verify { source: Branch(0), index: 0 }, InsertHeaders { source: Trunk, offset: 47, len: 11, anchor: Natural }, InsertHeaders { source: Trunk, offset: 47, len: 11, anchor: Natural }]

--- a/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
@@ -16,8 +16,8 @@ use zakura_header_chain::{
     FullStateEvidenceAuthority, FullStateFinalized, HeaderBatchInput, HeaderChainDiskVersion,
     HeaderGeneration, HeaderNode, HeaderRules, HeaderValidationState, InsertHeaders, SourceId,
     StateVersion, StoreAuditRead, SuffixWork, SystemClock, TargetCompletion, TransitionContext,
-    TransitionEvent, TransitionRequest, TrustedAnchor, VerifiedChainChanged, VerifiedChangeCause,
-    VerifiedGeneration, VerifiedHeaderRef, WorkCoordinate,
+    TransitionEvent, TransitionFailure, TransitionRequest, TrustedAnchor, VerifiedChainChanged,
+    VerifiedChangeCause, VerifiedGeneration, VerifiedHeaderRef, WorkCoordinate,
 };
 
 use super::{
@@ -30,9 +30,10 @@ use super::{
             disk_format::{header_chain::HeaderHeightKey, IntoDisk},
             DiskDb, DiskWriteBatch, STATE_COLUMN_FAMILIES_IN_CODE,
         },
-        HeaderChainRuntime, HeaderChainStore, HEADER_AUX_DELIVERY, HEADER_CHILD, HEADER_DEFERRED,
-        HEADER_ELIGIBILITY_ROOT, HEADER_ENGINE_META, HEADER_FINALITY_HISTORY, HEADER_NODE_BY_HASH,
-        HEADER_SELECTED, HEADER_VALIDATION_CONTEXT, HEADER_VERIFIED,
+        HeaderChainRuntime, HeaderChainStore, HeaderChainStoreError, HEADER_AUX_DELIVERY,
+        HEADER_CHILD, HEADER_DEFERRED, HEADER_ELIGIBILITY_ROOT, HEADER_ENGINE_META,
+        HEADER_FINALITY_HISTORY, HEADER_NODE_BY_HASH, HEADER_SELECTED, HEADER_VALIDATION_CONTEXT,
+        HEADER_VERIFIED,
     },
     fabricate::{FabHeader, Universe},
 };
@@ -406,39 +407,52 @@ impl Harness {
             .next_request_id
             .checked_add(1)
             .expect("the bounded coherence sequence cannot exhaust request IDs");
-        let result = self
-            .runtime()
-            .apply(
-                TransitionRequest {
-                    expected_version: snapshot.state_version,
-                    event: TransitionEvent::InsertHeaders(Box::new(InsertHeaders {
-                        owner: zakura_header_chain::HeaderWorkOwner {
-                            authority: zakura_header_chain::HeaderWorkAuthority::for_target(
-                                &snapshot,
-                                target.hash,
-                            ),
-                            session_id: 1,
-                            request_id,
-                        }
-                        .into(),
-                        source: SourceId::from_digest([0x51; 32]),
-                        parent_hash: anchor_hash,
-                        target_tip_hash: target.hash,
-                        completion: TargetCompletion::TargetComplete {
-                            common_ancestor: lease.parent(),
-                        },
-                        batch,
-                        aux: Vec::new(),
-                    })),
-                },
-                &TransitionContext {
-                    config: &self.config,
-                    clock: &SystemClock,
-                    full_state_authority: None,
-                    retention_references: &[],
-                },
-            )
-            .expect("a prepared current coherence range reaches the transition writer");
+        let result = self.runtime().apply(
+            TransitionRequest {
+                expected_version: snapshot.state_version,
+                event: TransitionEvent::InsertHeaders(Box::new(InsertHeaders {
+                    owner: zakura_header_chain::HeaderWorkOwner {
+                        authority: zakura_header_chain::HeaderWorkAuthority::for_target(
+                            &snapshot,
+                            target.hash,
+                        ),
+                        session_id: 1,
+                        request_id,
+                    }
+                    .into(),
+                    source: SourceId::from_digest([0x51; 32]),
+                    parent_hash: anchor_hash,
+                    target_tip_hash: target.hash,
+                    completion: TargetCompletion::TargetComplete {
+                        common_ancestor: lease.parent(),
+                    },
+                    batch,
+                    aux: Vec::new(),
+                })),
+            },
+            &TransitionContext {
+                config: &self.config,
+                clock: &SystemClock,
+                full_state_authority: None,
+                retention_references: &[],
+            },
+        );
+        if matches!(
+            result,
+            Err(HeaderChainStoreError::Transition(
+                TransitionFailure::ConflictingReplay
+            ))
+        ) {
+            assert_eq!(
+                self.logical_dump(),
+                before,
+                "a conflicting replay must not mutate any header family"
+            );
+            self.rejections += 1;
+            return;
+        }
+        let result =
+            result.expect("a prepared current coherence range reaches the transition writer");
         assert!(matches!(
             result,
             ApplyResult::Committed | ApplyResult::NoChange(_)

--- a/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
@@ -227,6 +227,13 @@ impl Harness {
         Frontier::new(header.height, header.hash)
     }
 
+    pub fn branch_frontier(&self, branch: usize, index: usize) -> Frontier {
+        let branches = &self.universe.branches;
+        let headers = &branches[branch % branches.len()].headers;
+        let header = &headers[index.min(headers.len() - 1)];
+        Frontier::new(header.height, header.hash)
+    }
+
     pub fn corrupt_selected_hash(&self, height: block::Height, hash: block::Hash) {
         let mut batch = DiskWriteBatch::new();
         self.runtime()
@@ -311,6 +318,16 @@ impl Harness {
         assert!(
             self.runtime().reader().selected_locator().is_err(),
             "a corrupt selected projection must not produce a locator"
+        );
+    }
+
+    pub fn assert_selected_roots_fail_closed(&self, height: block::Height) {
+        assert!(
+            self.runtime()
+                .reader()
+                .selected_block_roots(height, 1)
+                .is_err(),
+            "a corrupt selected projection must not produce auxiliary roots"
         );
     }
 

--- a/crates/zakura-state/src/service/finalized_state/header_chain/coherence/reads.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/coherence/reads.rs
@@ -26,6 +26,35 @@ fn selected_projection_node_disagreement_never_produces_a_hash_or_locator() {
 }
 
 #[test]
+fn same_height_fork_sibling_never_enters_selected_reads() {
+    let _init_guard = zakura_test::init();
+    let mut harness = Harness::new();
+    harness.run_all(&[
+        Op::InsertHeaders {
+            source: Source::Trunk,
+            offset: 0,
+            len: 60,
+            anchor: Anchor::Natural,
+        },
+        Op::InsertHeaders {
+            source: Source::Branch(0),
+            offset: 0,
+            len: 2,
+            anchor: Anchor::Natural,
+        },
+    ]);
+    let selected = harness.trunk_frontier(52);
+    let sibling = harness.branch_frontier(0, 1);
+    assert_eq!(selected.height, sibling.height);
+    assert_ne!(selected.hash, sibling.hash);
+
+    harness.corrupt_selected_hash(selected.height, sibling.hash);
+    harness.assert_selected_hash_fails_closed(selected.height);
+    harness.assert_selected_locator_fails_closed();
+    harness.assert_selected_roots_fail_closed(selected.height);
+}
+
+#[test]
 fn selected_projection_gap_within_published_bounds_is_incoherent() {
     let _init_guard = zakura_test::init();
     let harness = trunk_harness();

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
@@ -103,6 +103,63 @@ fn coherent_reader_builds_locator_from_the_durable_selected_projection() {
     );
 }
 
+#[test]
+fn selected_body_window_reads_four_thousand_hashes_in_one_coherent_range() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = fixture();
+    let store = HeaderChainStore::new(open(&db_config, &engine_config.network));
+    store
+        .initialize(metadata, anchor.clone())
+        .expect("the empty schema initializes");
+
+    let genesis = VerifiedHeaderRef {
+        height: anchor.height,
+        hash: anchor.hash,
+        header: anchor.header.clone(),
+    };
+    let mut parent = genesis.clone();
+    let mut restored = Vec::new();
+    for height in 1_u32..=4_000 {
+        let mut header = *parent.header;
+        header.previous_block_hash = parent.hash;
+        header.time += chrono::Duration::seconds(1);
+        header.nonce.0[..4].copy_from_slice(&height.to_le_bytes());
+        let header = Arc::new(header);
+        let child = VerifiedHeaderRef {
+            height: block::Height(height),
+            hash: header.hash(),
+            header,
+        };
+        parent = child.clone();
+        restored.push(child);
+    }
+
+    let (runtime, _) = store
+        .startup_reconciled(
+            &engine_config,
+            Frontier::new(genesis.height, genesis.hash),
+            Vec::new(),
+            restored.clone(),
+        )
+        .expect("the genesis-finalized scratch path reconciles");
+    let selected = runtime
+        .reader()
+        .selected_hashes(block::Height(1), 4_000)
+        .expect("the full block-sync window is one coherent projection read");
+
+    assert_eq!(selected.len(), 4_000);
+    assert_eq!(
+        selected.first().copied(),
+        Some(Frontier::new(restored[0].height, restored[0].hash))
+    );
+    assert_eq!(
+        selected.last().copied(),
+        restored
+            .last()
+            .map(|header| Frontier::new(header.height, header.hash))
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn retained_path_serves_a_locator_before_the_header_retention_window() {
     let db_config = Config::ephemeral();
@@ -750,8 +807,11 @@ async fn retained_path_leases_are_exact_bounded_session_scoped_and_expiring() {
         assert!(Arc::ptr_eq(&active_references, &cached_references));
         active_references
     };
-    assert!(active_references.contains(&anchor.hash));
-    assert!(active_references.contains(&child.hash));
+    assert_eq!(
+        active_references.as_ref(),
+        [child.hash],
+        "each lease contributes only its target; retaining that target protects its whole ancestry"
+    );
 
     tokio::time::advance(RETAINED_PATH_LEASE_IDLE + Duration::from_secs(1)).await;
     assert!(runtime

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
@@ -104,6 +104,34 @@ fn coherent_reader_builds_locator_from_the_durable_selected_projection() {
 }
 
 #[test]
+fn body_refill_snapshot_holds_the_complete_transition_barrier() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = fixture();
+    let store = HeaderChainStore::new(open(&db_config, &engine_config.network));
+    store
+        .initialize(metadata, anchor.clone())
+        .expect("the empty schema initializes");
+    let (runtime, _) = store
+        .startup(&engine_config)
+        .expect("the initialized store audits");
+    let reader = runtime.reader();
+    let cloned_reader = reader.clone();
+
+    assert!(Arc::ptr_eq(&reader.config, &cloned_reader.config));
+
+    let (full_state, selected_projection) = reader
+        .with_selected_projection(|| {
+            assert!(reader.store.writer.try_lock().is_err());
+            assert!(reader.transition_engine.try_lock().is_err());
+            Frontier::new(anchor.height, anchor.hash)
+        })
+        .expect("the body refill snapshot is coherent");
+
+    assert_eq!(full_state, Frontier::new(anchor.height, anchor.hash));
+    assert_eq!(selected_projection, vec![full_state]);
+}
+
+#[test]
 fn selected_body_window_reads_four_thousand_hashes_in_one_coherent_range() {
     let db_config = Config::ephemeral();
     let (engine_config, anchor, metadata) = fixture();

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -1,6 +1,46 @@
 use super::*;
 
 #[test]
+fn startup_atomically_rebinds_an_extended_checkpoint_manifest() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = fixture();
+    let previous_state_version = metadata.state_version;
+    let updated_config = EngineConfig::new(
+        engine_config.mode,
+        engine_config.network.clone(),
+        engine_config.bootstrap_anchor().clone(),
+        CheckpointSet::new([Frontier::new(block::Height(10), block::Hash([0x93; 32]))])
+            .expect("the extension checkpoint is unique"),
+    )
+    .expect("the updated engine configuration is coherent");
+    let db = open(&db_config, &engine_config.network);
+    let store = HeaderChainStore::new(db.clone());
+    store
+        .initialize(metadata, anchor)
+        .expect("the old manifest initializes the fixture");
+
+    let (runtime, report) = store
+        .startup(&updated_config)
+        .expect("startup rebinds a fully audited checkpoint extension");
+    assert_eq!(
+        report.repairs,
+        BTreeSet::from([RecoveryRepair::TrustAnchorConfiguration])
+    );
+    assert_eq!(
+        report.current.state_version,
+        previous_state_version
+            .checked_next()
+            .expect("the fixture state version can advance")
+    );
+    drop(runtime);
+
+    let (_, reopened) = HeaderChainStore::new(db)
+        .startup(&updated_config)
+        .expect("the rebound manifest persists atomically");
+    assert!(reopened.repairs.is_empty());
+}
+
+#[test]
 fn startup_reconciles_restored_full_state_before_first_publication() {
     let cache = tempfile::tempdir().expect("the test cache directory is created");
     let db_config = Config {

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -611,6 +611,15 @@ fn chain_identity_uses_retained_hashes_when_checkpoint_bodies_are_skipped() {
     assert_eq!(state.db.hash(tip_height), Some(tip_hash));
     assert_eq!(state.db.height(tip_hash), Some(tip_height));
 
+    let initial_tip = crate::service::finalized_chain_tip(&state.db)
+        .expect("a bodyless pruned finalized tip still initializes chain sync");
+    assert_eq!(
+        (initial_tip.height, initial_tip.hash),
+        (tip_height, tip_hash)
+    );
+    assert!(initial_tip.transactions.is_empty());
+    assert!(initial_tip.transaction_hashes.is_empty());
+
     let no_chain = Option::<Arc<Chain>>::None;
     assert_eq!(
         hash_by_height(no_chain.clone(), &state.db, tip_height),

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -329,7 +329,7 @@ async fn poll_ready_hands_off_at_max_checkpoint_height() -> Result<()> {
     let max_checkpoint_height = blocks[1].coinbase_height().unwrap();
     let mut config = Config::ephemeral();
     config.enable_zakura_header_seed_from_committed_blocks = true;
-    // This state-only fixture commits bodies directly.
+    // The state-only fixture commits bodies directly.
     // The fixture has no network-supplied auxiliary root.
     config.vct_fast_sync = false;
     let (mut state_service, read, _tip, _tip_change) =

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -329,7 +329,8 @@ async fn poll_ready_hands_off_at_max_checkpoint_height() -> Result<()> {
     let max_checkpoint_height = blocks[1].coinbase_height().unwrap();
     let mut config = Config::ephemeral();
     config.enable_zakura_header_seed_from_committed_blocks = true;
-    // This state-only fixture commits bodies directly without a network-supplied auxiliary root.
+    // This state-only fixture commits bodies directly.
+    // The fixture has no network-supplied auxiliary root.
     config.vct_fast_sync = false;
     let (mut state_service, read, _tip, _tip_change) =
         StateService::new(config, &network, max_checkpoint_height, 0).await;

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -32,6 +32,35 @@ use crate::{
 
 const LAST_BLOCK_HEIGHT: u32 = 10;
 
+#[test]
+fn block_sync_body_anchor_rolls_back_to_the_selected_fork_intersection() {
+    let shared = block::Hash([1; 32]);
+    let body_fork = block::Hash([2; 32]);
+    let selected_fork = block::Hash([3; 32]);
+    let anchor = super::highest_common_body_header_frontier(
+        block::Height(2),
+        block::Height(0),
+        |height| match height.0 {
+            1 => Some(shared),
+            2 => Some(body_fork),
+            _ => None,
+        },
+        |height| {
+            Ok(match height.0 {
+                1 => Some(shared),
+                2 => Some(selected_fork),
+                _ => None,
+            })
+        },
+    )
+    .expect("the selected and full-state forks share height one");
+
+    assert_eq!(
+        anchor,
+        zakura_header_chain::Frontier::new(block::Height(1), shared)
+    );
+}
+
 async fn test_populated_state_responds_correctly(
     mut state: Buffer<BoxService<Request, Response, BoxError>, Request>,
 ) -> Result<()> {
@@ -300,12 +329,14 @@ async fn poll_ready_hands_off_at_max_checkpoint_height() -> Result<()> {
     let max_checkpoint_height = blocks[1].coinbase_height().unwrap();
     let mut config = Config::ephemeral();
     config.enable_zakura_header_seed_from_committed_blocks = true;
-    let (mut state_service, _read, _tip, _tip_change) =
+    // This state-only fixture commits bodies directly without a network-supplied auxiliary root.
+    config.vct_fast_sync = false;
+    let (mut state_service, read, _tip, _tip_change) =
         StateService::new(config, &network, max_checkpoint_height, 0).await;
 
     // Commit blocks 0 and 1 to the finalized state and wait for each write to land on disk, so the
     // finalized tip catches up to the maximum checkpoint height and the last block hash we sent.
-    for block in &blocks[0..=1] {
+    for (index, block) in blocks[0..=1].iter().enumerate() {
         let checkpoint = CheckpointVerifiedBlock::from(block.clone());
         let result = state_service
             .queue_and_commit_to_finalized_state(checkpoint)
@@ -314,6 +345,31 @@ async fn poll_ready_hands_off_at_max_checkpoint_height() -> Result<()> {
             matches!(result, Ok(Ok(_))),
             "checkpoint verified block should commit: {result:?}",
         );
+
+        let expected_height = block.coinbase_height().expect("test block has a height");
+        let expected_hash = block.hash();
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let snapshot = read.subscribe_header_chain_snapshots().borrow().clone();
+                if snapshot.as_ref().is_some_and(|snapshot| {
+                    snapshot.frontiers.finalized.height == expected_height
+                        && snapshot.frontiers.finalized.hash == expected_hash
+                        && snapshot.frontiers.verified_best == snapshot.frontiers.finalized
+                }) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("checkpoint commits atomically advance the durable header runtime");
+        if index == 0 {
+            assert!(
+                state_service.block_write_sender.finalized.is_some(),
+                "the header runtime must become ready after genesis while checkpoint writes remain open",
+            );
+            assert!(read.subscribe_header_runtime_status().borrow().is_ready());
+        }
     }
 
     let last_finalized_hash = blocks[1].hash();

--- a/crates/zakura-state/src/service/write/tests/selection_and_evidence.rs
+++ b/crates/zakura-state/src/service/write/tests/selection_and_evidence.rs
@@ -1,6 +1,61 @@
 use super::*;
 
 #[test]
+fn startup_restores_a_missing_full_state_side_path_idempotently() {
+    let _init_guard = zakura_test::init();
+    let network = Network::new_regtest(Default::default());
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), &network)
+        .expect("the fixture finalized state opens");
+    let anchor = regtest_genesis_block();
+    let anchor_height = anchor
+        .coinbase_height()
+        .expect("the anchor has a coinbase height");
+    let writer = header_writer(&finalized_state, &network, anchor_height, &anchor);
+    let lease = writer
+        .runtime
+        .reader()
+        .validation_context(anchor.hash())
+        .expect("the anchor context read succeeds")
+        .expect("the anchor context exists");
+    let rules = HeaderRules::for_validation_lease(&lease)
+        .expect("the regtest validation policy is coherent");
+    let mut side_header = *anchor.header;
+    side_header.previous_block_hash = anchor.hash();
+    side_header.time += chrono::Duration::seconds(1);
+    let side_header = Arc::new(side_header);
+    let prepared = zakura_header_chain::prepare_headers(
+        HeaderBatchInput::new(std::slice::from_ref(&side_header)),
+        &lease,
+        &rules,
+        &SystemClock,
+    )
+    .expect("the full-state side header passes shared validation");
+    let side = prepared
+        .headers()
+        .first()
+        .expect("the prepared side path contains its header");
+    let path = vec![VerifiedHeaderRef {
+        height: side.height,
+        hash: side.hash,
+        header: side_header,
+    }];
+
+    restore_verified_side_paths(&writer.runtime, &writer.config, vec![path.clone()])
+        .expect("startup restores the authenticated full-state side path");
+    let restored = writer.runtime.publisher().snapshot();
+    assert!(writer
+        .runtime
+        .reader()
+        .validation_context(side.hash)
+        .expect("the restored side context reads")
+        .is_some());
+
+    restore_verified_side_paths(&writer.runtime, &writer.config, vec![path])
+        .expect("replaying the same startup repair is idempotent");
+    assert_eq!(writer.runtime.publisher().snapshot(), restored);
+}
+
+#[test]
 fn same_lower_forward_resets_use_identical_branch_path() {
     let header = regtest_genesis_block().header.clone();
     let reference = |height: u32, hash: u8| VerifiedHeaderRef {

--- a/docs/changelog/unreleased/588.md
+++ b/docs/changelog/unreleased/588.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR is one review layer of the header-sync stack; the stack's single
+operator-visible entry is owned by #532.


### PR DESCRIPTION
> Stack layer **4/8**. Parent: #563. Next: #569.

## Motivation

The state replacement needs fault injection and coherence coverage at every transaction, restart, migration, cursor, authority, and writer-health boundary. Legacy tests target APIs removed by #563.

## Solution

- replace the linear coherence harness with a fork-aware oracle;
- cover transaction/crash boundaries, reconstruction, migration, and cursors;
- cover forged evidence, multi-clone writer panic, complete staged-path reconsideration, resource-stall atomicity, VCT proof boundaries, work overflow, and typed startup failures; and
- remove superseded tests without compatibility shims.

This layer is test-only.

## V12 audit corrections

V12 run 6155 exposed a same-height fork sibling passing selected-path validation. The old behavior was reproduced, production authentication was folded into #563, and this layer owns the red-to-green regression proving selected hashes, locators, and auxiliary roots all fail closed. The batched implementation authenticates the requested range in one backward pass.

## Testing

Passed at exact rebased head `53aa22af61e19f037fd86f4f5bd7b8e102107b75`:

- `cargo check -p zakura-state --locked --all-features --all-targets -j 2`
- `cargo clippy -p zakura-state --all-features --all-targets -j 2 -- -D warnings`
- `cargo test -p zakura-state --lib -j 2` — 417 passed, 3 ignored

The cumulative #569 exact head is the first compile-coherent combined state/runtime boundary and passes its locked workspace checks. No Docker, regtest, node, SSH, release, or deployment operation was run.

## Changelog

`docs/changelog/unreleased/588.md` is an explicit no-changelog fragment.

### Specifications & References

Review disk/reconstruction, crash atomicity, service/writer health, evidence/VCT, then coherence/property coverage.

### Landing contract

Review separately, but fold this test layer together with #563 into #569 before landing. The combined #569 exact head must pass required `main` CI; neither #563 nor #588 is merged as a red intermediate commit.