### PR TITLE
fix(network): attribute and score Zakura-supplied sync blocks

### DIFF
--- a/crates/zakura-network/src/peer/connection.rs
+++ b/crates/zakura-network/src/peer/connection.rs
@@ -35,7 +35,7 @@ use crate::{
     peer_set::ConnectionTracker,
     protocol::{
         external::{types::Nonce, InventoryHash, Message},
-        internal::{InventoryResponse, Request, Response},
+        internal::{InventoryResponse, PeerSource, Request, Response},
     },
     BoxError, PeerSocketAddr, MAX_TX_INV_IN_SENT_MESSAGE,
 };
@@ -342,9 +342,10 @@ impl Handler {
 
                 if pending_hashes.is_empty() {
                     // If we got everything we wanted, let the internal client know.
+                    let source = transient_addr.map(PeerSource::LegacySocket);
                     let available = blocks
                         .into_iter()
-                        .map(|block| InventoryResponse::Available((block, transient_addr)));
+                        .map(|block| InventoryResponse::Available((block, source.clone())));
                     Handler::Finished(Ok(Response::Blocks(available.collect())))
                 } else {
                     // Keep on waiting for all the blocks we wanted, until we get them or time out.
@@ -388,9 +389,10 @@ impl Handler {
                     Handler::Finished(Err(PeerError::NotFoundResponse(missing_block_hashes)))
                 } else {
                     // If we got some of what we wanted, let the internal client know.
+                    let source = transient_addr.map(PeerSource::LegacySocket);
                     let available = blocks
                         .into_iter()
-                        .map(|block| InventoryResponse::Available((block, transient_addr)));
+                        .map(|block| InventoryResponse::Available((block, source.clone())));
                     let missing = pending_hashes.into_iter().map(InventoryResponse::Missing);
 
                     Handler::Finished(Ok(Response::Blocks(available.chain(missing).collect())))

--- a/crates/zakura-network/src/protocol/internal/response.rs
+++ b/crates/zakura-network/src/protocol/internal/response.rs
@@ -7,7 +7,11 @@ use zakura_chain::{
     transaction::{UnminedTx, UnminedTxId},
 };
 
-use crate::{meta_addr::MetaAddr, protocol::internal::InventoryResponse, PeerSocketAddr};
+use crate::{
+    meta_addr::MetaAddr,
+    protocol::internal::{InventoryResponse, PeerSource},
+    PeerSocketAddr,
+};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -72,7 +76,11 @@ pub enum Response {
     /// `zcashd` sometimes sends no response, and sometimes sends `notfound`.
     //
     // TODO: make this into a HashMap<block::Hash, InventoryResponse<Arc<Block>, ()>> - a unique list (#2244)
-    Blocks(Vec<InventoryResponse<(Arc<Block>, Option<PeerSocketAddr>), block::Hash>>),
+    /// Available entries carry the transport peer that supplied the block, when known.
+    /// Legacy TCP responses use [`PeerSource::LegacySocket`]; Zakura compatibility
+    /// responses use [`PeerSource::Zakura`]. Locally served inventory remains
+    /// unattributed (`None`).
+    Blocks(Vec<InventoryResponse<(Arc<Block>, Option<PeerSource>), block::Hash>>),
 
     /// A list of found unmined transactions, and missing unmined transaction IDs.
     ///

--- a/crates/zakura-network/src/zakura.rs
+++ b/crates/zakura-network/src/zakura.rs
@@ -23,6 +23,7 @@ mod handshake;
 mod header_sync;
 mod ip;
 mod legacy_gossip;
+mod misbehavior;
 #[cfg(any(test, feature = "zakura-testkit"))]
 pub mod testkit;
 mod trace;
@@ -36,6 +37,7 @@ pub use handshake::*;
 pub use header_sync::*;
 pub(crate) use ip::canonical_ip;
 pub use legacy_gossip::*;
+pub use misbehavior::ZakuraMisbehaviorHandle;
 pub use trace::{
     commit_state_trace, peer_label as zakura_trace_peer_label,
     reject_reason_label as zakura_trace_reject_reason_label, ZakuraTrace, ZakuraTraceEvent,

--- a/crates/zakura-network/src/zakura/block_sync/events.rs
+++ b/crates/zakura-network/src/zakura/block_sync/events.rs
@@ -171,6 +171,30 @@ pub enum BlockSyncMisbehavior {
     StatusSpam,
 }
 
+impl BlockSyncMisbehavior {
+    /// Numeric misbehavior score for this violation.
+    ///
+    /// Uses the shared [`crate::constants::MAX_PEER_MISBEHAVIOR_SCORE`] threshold
+    /// for clear protocol/body faults. Availability misses are unscored because
+    /// a peer can honestly lack a requested range.
+    pub fn misbehavior_score(self) -> u32 {
+        use crate::constants::MAX_PEER_MISBEHAVIOR_SCORE;
+
+        match self {
+            Self::MalformedMessage
+            | Self::UnsolicitedBlock
+            | Self::GetBlocksTooLong
+            | Self::GetBlocksSpam
+            | Self::InvalidBlock
+            | Self::SizeMismatch
+            | Self::InvalidStatus
+            | Self::UnsolicitedDone
+            | Self::StatusSpam => MAX_PEER_MISBEHAVIOR_SCORE,
+            Self::RangeUnavailable => 0,
+        }
+    }
+}
+
 /// The shared routine→reactor channel (per-peer routines inverted data flow).
 ///
 /// Each per-peer pipe-routine ([`PeerRoutine`](super::peer_routine)) decodes its

--- a/crates/zakura-network/src/zakura/legacy_gossip.rs
+++ b/crates/zakura-network/src/zakura/legacy_gossip.rs
@@ -2161,6 +2161,17 @@ impl ZakuraRequestClient {
                 return Err(error.into());
             }
         };
+        // Attribute available blocks to the Zakura peer that supplied them.
+        // The wire codec has no peer field; only the outbound requester knows
+        // which authenticated peer answered this request.
+        if let Response::Blocks(blocks) = &mut response {
+            let source = PeerSource::Zakura(handle.peer_id().clone());
+            for entry in blocks.iter_mut() {
+                if let InventoryResponse::Available((_, peer)) = entry {
+                    *peer = Some(source.clone());
+                }
+            }
+        }
         if request_kind == LegacyRequestKind::Ping {
             // The responder can only acknowledge a Ping; the requester stamps the RTT.
             response = Response::Pong(started_at.elapsed());
@@ -3798,7 +3809,7 @@ mod tests {
         let response = adapter
             .request_from_source(
                 Request::BlocksByHash(HashSet::from([block.hash()])),
-                Some(PeerSource::Zakura(a_peer_id)),
+                Some(PeerSource::Zakura(a_peer_id.clone())),
             )
             .await?;
 
@@ -3807,8 +3818,47 @@ mod tests {
         };
         assert!(matches!(
             blocks.as_slice(),
-            [InventoryResponse::Available((received, None))] if received.hash() == block.hash()
+            [InventoryResponse::Available((received, Some(PeerSource::Zakura(peer_id))))]
+                if received.hash() == block.hash() && *peer_id == a_peer_id
         ));
+
+        node_a.shutdown().await;
+        node_b.shutdown().await;
+        Ok(())
+    }
+
+    /// Dual-stack compatibility requests must attribute available blocks to the
+    /// authenticated Zakura peer that answered, so legacy ChainSync can retain
+    /// the supplier across verification failures.
+    #[tokio::test]
+    async fn request_adapter_attributes_available_block_to_zakura_peer() -> Result<(), BoxError> {
+        let _guard = zakura_test::init();
+        let block = Arc::new(Block::zcash_deserialize(
+            BLOCK_TESTNET_141042_BYTES.as_slice(),
+        )?);
+        let node_a = block_inventory_node(168, block.clone()).await?;
+        let node_b = ZakuraTestNode::builder(169).spawn().await?;
+        node_b.connect_native(&node_a, TEST_NET_TIMEOUT).await?;
+        let a_peer_id = node_peer_id(&node_a).await?;
+
+        let adapter = LegacyRequestAdapter::new(node_b.supervisor());
+        let response = adapter
+            .request_from_source(
+                Request::BlocksByHash(HashSet::from([block.hash()])),
+                Some(PeerSource::Zakura(a_peer_id.clone())),
+            )
+            .await?;
+
+        let Response::Blocks(blocks) = response else {
+            panic!("unexpected response: {response:?}");
+        };
+        assert_eq!(
+            blocks,
+            vec![InventoryResponse::Available((
+                block.clone(),
+                Some(PeerSource::Zakura(a_peer_id))
+            ))]
+        );
 
         node_a.shutdown().await;
         node_b.shutdown().await;
@@ -3901,7 +3951,7 @@ mod tests {
             .request_from_source(
                 Request::BlocksByHashFrom {
                     hashes: remote_hashes.into_iter().collect(),
-                    source: PeerSource::Zakura(a_peer_id),
+                    source: PeerSource::Zakura(a_peer_id.clone()),
                 },
                 None,
             )
@@ -3910,10 +3960,14 @@ mod tests {
             panic!("unexpected block response: {block_response:?}");
         };
         for response in blocks {
-            let received = response
+            let (received, advertiser) = response
                 .available()
-                .expect("mock sync peer serves the advertised block")
-                .0;
+                .expect("mock sync peer serves the advertised block");
+            assert_eq!(
+                advertiser,
+                Some(PeerSource::Zakura(a_peer_id.clone())),
+                "Zakura-supplied blocks must retain the delivering peer"
+            );
             local_chain.push(received.hash());
         }
         assert_eq!(local_chain.last(), Some(&block.hash()));

--- a/crates/zakura-network/src/zakura/misbehavior.rs
+++ b/crates/zakura-network/src/zakura/misbehavior.rs
@@ -1,0 +1,149 @@
+//! Peer-id keyed misbehavior scoring for authenticated Zakura peers.
+//!
+//! Legacy TCP peers are scored through the address-book IP ban path. Zakura peers
+//! are identified by [`ZakuraPeerId`], so this module accumulates scores by peer
+//! id and disconnects the peer once the shared misbehavior threshold is reached.
+
+use std::{collections::HashMap, time::Duration};
+
+use tokio::sync::mpsc;
+use tokio_stream::{wrappers::IntervalStream, StreamExt};
+use tracing::{debug, info};
+
+use crate::constants::MAX_PEER_MISBEHAVIOR_SCORE;
+
+use super::{ZakuraPeerId, ZakuraSupervisorHandle};
+
+/// Batching interval for Zakura peer-id misbehavior reports.
+///
+/// Matches the legacy address-book batcher so ban-threshold disconnects stay
+/// prompt without turning every invalid block into a supervisor lock.
+const ZAKURA_MISBEHAVIOR_BATCH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Cloneable handle for reporting authenticated Zakura peer misbehavior.
+#[derive(Clone, Debug)]
+pub struct ZakuraMisbehaviorHandle {
+    tx: mpsc::Sender<(ZakuraPeerId, u32)>,
+}
+
+impl ZakuraMisbehaviorHandle {
+    /// Spawn a background task that batches peer-id scores and disconnects
+    /// peers that reach [`MAX_PEER_MISBEHAVIOR_SCORE`].
+    pub fn spawn(supervisor: ZakuraSupervisorHandle) -> Self {
+        // Bound the channel similarly to the legacy misbehavior path: enough
+        // room for a burst of concurrent sync validations without unbounded growth.
+        let (tx, rx) = mpsc::channel(256);
+        tokio::spawn(batch_zakura_misbehavior(rx, supervisor));
+        Self { tx }
+    }
+
+    /// Create a handle that drops reports (for tests that do not enforce).
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn noop() -> Self {
+        let (tx, _rx) = mpsc::channel(1);
+        Self { tx }
+    }
+
+    /// Create a handle backed by an existing sender (for unit tests).
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn from_sender(tx: mpsc::Sender<(ZakuraPeerId, u32)>) -> Self {
+        Self { tx }
+    }
+
+    /// Best-effort report of a score increment for `peer`.
+    ///
+    /// Zero-score reports are ignored. Full channels drop the report rather than
+    /// blocking sync/validation paths.
+    pub fn try_report(&self, peer: ZakuraPeerId, score_increment: u32) {
+        if score_increment == 0 {
+            return;
+        }
+        if self.tx.try_send((peer, score_increment)).is_err() {
+            metrics::counter!("sync.zakura.peer.misbehavior.report_dropped").increment(1);
+        }
+    }
+}
+
+async fn batch_zakura_misbehavior(
+    mut misbehavior_rx: mpsc::Receiver<(ZakuraPeerId, u32)>,
+    supervisor: ZakuraSupervisorHandle,
+) {
+    // Increments received since the last flush.
+    let mut pending: HashMap<ZakuraPeerId, u32> = HashMap::new();
+    // Lifetime scores for peers that have not yet reached the disconnect threshold.
+    let mut totals: HashMap<ZakuraPeerId, u32> = HashMap::new();
+    let mut flush_timer = IntervalStream::new(tokio::time::interval_at(
+        tokio::time::Instant::now() + ZAKURA_MISBEHAVIOR_BATCH_INTERVAL,
+        ZAKURA_MISBEHAVIOR_BATCH_INTERVAL,
+    ));
+
+    loop {
+        tokio::select! {
+            msg = misbehavior_rx.recv() => match msg {
+                Some((peer_id, score_increment)) => {
+                    let entry = pending.entry(peer_id).or_default();
+                    *entry = entry.saturating_add(score_increment);
+                }
+                None => break,
+            },
+
+            _ = flush_timer.next() => {
+                for (peer_id, score_increment) in pending.drain() {
+                    metrics::counter!("sync.zakura.peer.misbehavior.score")
+                        .increment(u64::from(score_increment));
+                    let total = totals.entry(peer_id.clone()).or_default();
+                    *total = total.saturating_add(score_increment);
+                    if *total < MAX_PEER_MISBEHAVIOR_SCORE {
+                        continue;
+                    }
+
+                    totals.remove(&peer_id);
+                    metrics::counter!("sync.zakura.peer.misbehavior.disconnect").increment(1);
+                    let disconnected = supervisor.disconnect_peer(&peer_id).await;
+                    if disconnected {
+                        info!(?peer_id, "disconnected Zakura peer after misbehavior threshold");
+                    } else {
+                        debug!(
+                            ?peer_id,
+                            "Zakura misbehavior threshold reached but peer was already gone"
+                        );
+                    }
+                }
+            },
+        }
+    }
+
+    tracing::warn!("exiting Zakura misbehavior update batch task");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zakura::ZakuraSupervisorHandle;
+
+    #[tokio::test]
+    async fn zero_score_reports_are_ignored() {
+        let handle = ZakuraMisbehaviorHandle::spawn(ZakuraSupervisorHandle::new(1));
+        let peer = ZakuraPeerId::new(vec![1; 32]).expect("test peer id is valid");
+        handle.try_report(peer, 0);
+        // Channel stays empty for zero scores; nothing to assert beyond no panic.
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn threshold_disconnects_peer() {
+        let supervisor = ZakuraSupervisorHandle::new(1);
+        let peer = ZakuraPeerId::new(vec![2; 32]).expect("test peer id is valid");
+        // Register a fake active peer with a disconnect token so disconnect_peer
+        // can observe cancellation. Supervisor registration in tests is heavy;
+        // instead verify the handle accepts reports and the batcher runs.
+        let handle = ZakuraMisbehaviorHandle::spawn(supervisor.clone());
+        handle.try_report(peer.clone(), MAX_PEER_MISBEHAVIOR_SCORE);
+
+        tokio::time::advance(ZAKURA_MISBEHAVIOR_BATCH_INTERVAL * 2).await;
+        tokio::task::yield_now().await;
+
+        // Peer was never registered, so disconnect returns false — the batcher
+        // still processed the threshold path without panicking.
+        assert!(!supervisor.disconnect_peer(&peer).await);
+    }
+}

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -486,6 +486,9 @@ impl StartCmd {
         // Hands off the Zakura bulk-apply pipeline so legacy fallback can drain
         // in-flight applies before driving commits through the same pipeline.
         let zakura_block_sync_handoff = zakura::BlockSyncHandoff::new();
+        let zakura_misbehavior = zakura_endpoint.as_ref().map(|endpoint| {
+            zakura_network::zakura::ZakuraMisbehaviorHandle::spawn(endpoint.supervisor())
+        });
 
         if let Some(endpoint) = zakura_endpoint.clone() {
             let trace = endpoint.trace();
@@ -538,7 +541,7 @@ impl StartCmd {
                     let block_driver_task = tokio::spawn(
                         drive_block_sync_actions(
                             block_actions,
-                            endpoint.supervisor(),
+                            zakura_misbehavior.clone(),
                             Some(endpoint.clone()),
                             block_sync.clone(),
                             latest_chain_tip.clone(),
@@ -583,6 +586,7 @@ impl StartCmd {
             state.clone(),
             latest_chain_tip.clone(),
             misbehavior_sender.clone(),
+            zakura_misbehavior,
         );
 
         info!("initializing mempool");
@@ -2733,7 +2737,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -2876,7 +2880,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3026,7 +3030,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3140,7 +3144,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3242,7 +3246,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3345,7 +3349,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3426,7 +3430,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3521,7 +3525,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3630,7 +3634,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3706,7 +3710,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -3829,7 +3833,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let mut driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -4257,7 +4261,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -4351,7 +4355,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -4472,7 +4476,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync.clone(),
             latest_chain_tip,
@@ -4596,7 +4600,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync.clone(),
             zakura_chain::chain_tip::NoChainTip,
@@ -4733,7 +4737,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             zakura_chain::chain_tip::NoChainTip,
@@ -4861,7 +4865,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             _latest_tip,
@@ -5018,7 +5022,7 @@ mod zakura_header_sync_driver_tests {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let driver = tokio::spawn(drive_block_sync_actions(
             action_rx,
-            zakura_network::zakura::ZakuraSupervisorHandle::new(1),
+            None,
             None,
             block_sync,
             latest_tip,

--- a/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
+++ b/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
@@ -18,7 +18,8 @@ use tracing::{debug, warn};
 use zakura_chain::{block, chain_tip::ChainTip};
 use zakura_network::zakura::{
     BlockApplyResult, BlockApplyToken, BlockSizeEstimate, BlockSyncAction, BlockSyncBlockMeta,
-    BlockSyncEvent, BlockSyncHandle, Frontier, FrontierChange, ZakuraEndpoint, ZakuraTrace,
+    BlockSyncEvent, BlockSyncHandle, Frontier, FrontierChange, ZakuraEndpoint,
+    ZakuraMisbehaviorHandle, ZakuraTrace,
 };
 
 use crate::components::sync;
@@ -95,9 +96,7 @@ impl CheckpointFrontierRefresh {
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn drive_block_sync_actions<ReadState, BlockVerifier>(
     mut actions: mpsc::Receiver<BlockSyncAction>,
-    // Retained so the disconnect capability stays wired into the driver, even
-    // though peer scoring no longer drives disconnects (misbehavior is record-only).
-    _supervisor: zakura_network::zakura::ZakuraSupervisorHandle,
+    zakura_misbehavior: Option<ZakuraMisbehaviorHandle>,
     endpoint: Option<ZakuraEndpoint>,
     block_sync: BlockSyncHandle,
     latest_chain_tip: impl ChainTip + Clone + Send + Sync + 'static,
@@ -282,8 +281,18 @@ pub(crate) async fn drive_block_sync_actions<ReadState, BlockVerifier>(
         trace.trace_block_action_received(&action);
         match action {
             BlockSyncAction::Misbehavior { peer, reason } => {
-                // Record-only: peer scoring no longer drives disconnects.
-                debug!(?peer, ?reason, "recorded Zakura block-sync peer violation");
+                let score = reason.misbehavior_score();
+                if score != 0 {
+                    if let Some(handle) = &zakura_misbehavior {
+                        handle.try_report(peer.clone(), score);
+                    }
+                }
+                debug!(
+                    ?peer,
+                    ?reason,
+                    ?score,
+                    "recorded Zakura block-sync peer violation"
+                );
             }
             BlockSyncAction::QueryNeededBlocks {
                 from,

--- a/crates/zakurad/src/components/inbound.rs
+++ b/crates/zakurad/src/components/inbound.rs
@@ -547,7 +547,7 @@ impl Service<zn::Request> for Inbound {
                 let state = state.clone();
 
                 async move {
-                    let mut blocks: Vec<InventoryResponse<(Arc<Block>, Option<PeerSocketAddr>), block::Hash>> = Vec::new();
+                    let mut blocks: Vec<InventoryResponse<(Arc<Block>, Option<zn::PeerSource>), block::Hash>> = Vec::new();
                     let mut total_size = 0;
 
                     // Ignore any block hashes past the response limit.

--- a/crates/zakurad/src/components/inbound/downloads.rs
+++ b/crates/zakurad/src/components/inbound/downloads.rs
@@ -436,7 +436,7 @@ where
                 None => zn::Request::BlocksByHash(request_hashes),
             };
 
-            let (block, advertiser_addr) = if let zn::Response::Blocks(blocks) =
+            let (block, advertiser) = if let zn::Response::Blocks(blocks) =
                 network.oneshot(request).await.map_err(|e| (e, None))?
             {
                 // A peer must answer a single-hash block request with exactly one
@@ -466,6 +466,11 @@ where
                 available
             } else {
                 unreachable!("wrong response to block request");
+            };
+            // The inbound misbehavior channel only accepts legacy sockets.
+            let advertiser_addr = match advertiser {
+                Some(zn::PeerSource::LegacySocket(addr)) => Some(addr),
+                Some(zn::PeerSource::Zakura(_)) | None => None,
             };
 
             // Bind the delivered block to the hash we requested. A peer that

--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -33,7 +33,7 @@ use zakura_chain::{
     block::{self, Height, HeightDiff},
     chain_tip::ChainTip,
 };
-use zakura_network::{self as zn, PeerSocketAddr};
+use zakura_network::{self as zn, zakura::ZakuraMisbehaviorHandle, PeerSocketAddr, PeerSource};
 use zakura_state as zs;
 
 use crate::{
@@ -74,10 +74,11 @@ const FANOUT: usize = 3;
 const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
 
 fn block_error_peer_label(error: &BlockDownloadVerifyError, expose_peer_addresses: bool) -> String {
-    error
-        .advertiser_addr()
-        .map(|addr| peer_addr_label(addr, expose_peer_addresses))
-        .unwrap_or_else(|| "unattributed".to_string())
+    match error.advertiser() {
+        Some(PeerSource::LegacySocket(addr)) => peer_addr_label(*addr, expose_peer_addresses),
+        Some(PeerSource::Zakura(peer_id)) => format!("zakura:{peer_id:?}"),
+        None => "unattributed".to_string(),
+    }
 }
 
 /// Controls how many times the syncer requeues a required block hash after a peer responds
@@ -808,6 +809,9 @@ where
     /// Sender for reporting peer addresses that advertised unexpectedly invalid transactions.
     misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
 
+    /// Optional Zakura peer-id misbehavior sink for blocks supplied over P2P v2.
+    zakura_misbehavior: Option<ZakuraMisbehaviorHandle>,
+
     /// Structured diagnostics for the legacy sync pipeline.
     trace: LegacySyncTrace,
 }
@@ -856,6 +860,7 @@ where
         state: ZS,
         latest_chain_tip: ZSTip,
         misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
+        zakura_misbehavior: Option<ZakuraMisbehaviorHandle>,
     ) -> (Self, SyncStatus) {
         let mut download_concurrency_limit = config.sync.download_concurrency_limit;
         let mut checkpoint_verify_concurrency_limit =
@@ -956,6 +961,7 @@ where
             registry_miss_retry: HashMap::new(),
             past_lookahead_limit_receiver,
             misbehavior_sender,
+            zakura_misbehavior,
             trace,
         };
 
@@ -2119,32 +2125,42 @@ where
 
             Err(BlockDownloadVerifyError::Invalid {
                 ref error,
-                advertiser_addr: Some(advertiser_addr),
+                ref advertiser,
                 ..
             }) if error.misbehavior_score() != 0 => {
-                let _ = self
-                    .misbehavior_sender
-                    .try_send((advertiser_addr, error.misbehavior_score()));
+                self.report_block_misbehavior(advertiser.as_ref(), error.misbehavior_score());
             }
 
-            Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
-                advertiser_addr: Some(advertiser_addr),
-                ..
-            }) => {
-                let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
+            Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit { ref advertiser, .. }) => {
+                self.report_block_misbehavior(advertiser.as_ref(), 100);
             }
 
-            Err(BlockDownloadVerifyError::InvalidHeight {
-                advertiser_addr: Some(advertiser_addr),
-                ..
-            }) => {
-                let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
+            Err(BlockDownloadVerifyError::InvalidHeight { ref advertiser, .. }) => {
+                self.report_block_misbehavior(advertiser.as_ref(), 100);
             }
 
             Err(_) => {}
         };
 
         Self::handle_response(response, self.expose_peer_addresses)
+    }
+
+    /// Report a block-supplier misbehavior score to the matching transport sink.
+    fn report_block_misbehavior(&mut self, advertiser: Option<&PeerSource>, score: u32) {
+        if score == 0 {
+            return;
+        }
+        match advertiser {
+            Some(PeerSource::LegacySocket(addr)) => {
+                let _ = self.misbehavior_sender.try_send((*addr, score));
+            }
+            Some(PeerSource::Zakura(peer_id)) => {
+                if let Some(handle) = &self.zakura_misbehavior {
+                    handle.try_report(peer_id.clone(), score);
+                }
+            }
+            None => {}
+        }
     }
 
     /// Handles a downloaded block response, requeueing required missing block hashes.

--- a/crates/zakurad/src/components/sync/downloads.rs
+++ b/crates/zakurad/src/components/sync/downloads.rs
@@ -28,7 +28,7 @@ use zakura_chain::{
     block::{self, Height, HeightDiff},
     chain_tip::ChainTip,
 };
-use zakura_network::{self as zn, PeerSocketAddr};
+use zakura_network::{self as zn, PeerSocketAddr, PeerSource};
 use zakura_state as zs;
 
 use crate::components::sync::{
@@ -112,7 +112,7 @@ pub enum BlockDownloadVerifyError {
     AboveLookaheadHeightLimit {
         height: block::Height,
         hash: block::Hash,
-        advertiser_addr: Option<PeerSocketAddr>,
+        advertiser: Option<PeerSource>,
     },
 
     #[error("downloaded block was too far behind the chain tip: {height:?} {hash:?}")]
@@ -124,7 +124,7 @@ pub enum BlockDownloadVerifyError {
     #[error("downloaded block had an invalid height: {hash:?}")]
     InvalidHeight {
         hash: block::Hash,
-        advertiser_addr: Option<PeerSocketAddr>,
+        advertiser: Option<PeerSource>,
     },
 
     #[error("block failed consensus validation: {error:?} {height:?} {hash:?}")]
@@ -133,7 +133,7 @@ pub enum BlockDownloadVerifyError {
         error: zakura_consensus::router::RouterError,
         height: block::Height,
         hash: block::Hash,
-        advertiser_addr: Option<PeerSocketAddr>,
+        advertiser: Option<PeerSource>,
     },
 
     #[error("block validation request failed: {error:?} {height:?} {hash:?}")]
@@ -192,19 +192,24 @@ pub(super) enum NotFoundKind {
 }
 
 impl BlockDownloadVerifyError {
-    /// Returns the connected legacy peer that supplied the invalid block, if known.
-    pub(super) fn advertiser_addr(&self) -> Option<PeerSocketAddr> {
+    /// Returns the transport peer that supplied the invalid block, if known.
+    pub(super) fn advertiser(&self) -> Option<&PeerSource> {
         match self {
-            Self::AboveLookaheadHeightLimit {
-                advertiser_addr, ..
-            }
-            | Self::InvalidHeight {
-                advertiser_addr, ..
-            }
-            | Self::Invalid {
-                advertiser_addr, ..
-            } => *advertiser_addr,
+            Self::AboveLookaheadHeightLimit { advertiser, .. }
+            | Self::InvalidHeight { advertiser, .. }
+            | Self::Invalid { advertiser, .. } => advertiser.as_ref(),
             _ => None,
+        }
+    }
+
+    /// Returns the connected legacy peer socket that supplied the invalid block, if known.
+    ///
+    /// Zakura-authenticated suppliers are excluded here: they are scored through
+    /// the Zakura peer-id misbehavior handle instead of the legacy IP ban channel.
+    pub(super) fn advertiser_addr(&self) -> Option<PeerSocketAddr> {
+        match self.advertiser()? {
+            PeerSource::LegacySocket(addr) => Some(*addr),
+            PeerSource::Zakura(_) => None,
         }
     }
 
@@ -561,7 +566,7 @@ where
                     None,
                 );
 
-                let (block, advertiser_addr) = if let zn::Response::Blocks(blocks) = rsp {
+                let (block, advertiser) = if let zn::Response::Blocks(blocks) = rsp {
                     // A cooperating peer returns exactly one available block for a
                     // single-hash request. A response with a different count, or a
                     // `Missing` status, means the peer is misbehaving or raced us
@@ -660,13 +665,13 @@ where
                     );
                     metrics::counter!("sync.no.height.dropped.block.count").increment(1);
 
-                    return Err(BlockDownloadVerifyError::InvalidHeight { hash, advertiser_addr });
+                    return Err(BlockDownloadVerifyError::InvalidHeight { hash, advertiser });
                 };
                 trace.block_downloaded(
                     hash,
                     block_height,
                     download_start.elapsed(),
-                    advertiser_addr,
+                    advertiser.as_ref(),
                 );
                 Self::transition_task(
                     &task_states,
@@ -677,7 +682,11 @@ where
                 );
 
                 if block_height > lookahead_drop_height {
-                    Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit { height: block_height, hash, advertiser_addr })?;
+                    return Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
+                        height: block_height,
+                        hash,
+                        advertiser,
+                    });
                 } else if block_height > lookahead_pause_height {
                     // This log can be very verbose, usually hundreds of blocks are dropped.
                     // So we only log at info level for the first above-height block.
@@ -795,7 +804,7 @@ where
                     .map(|hash| (block_height, hash))
                     .map_err(|err| {
                         match err.downcast::<zakura_consensus::router::RouterError>() {
-                            Ok(error) => BlockDownloadVerifyError::Invalid { error: *error, height: block_height, hash, advertiser_addr },
+                            Ok(error) => BlockDownloadVerifyError::Invalid { error: *error, height: block_height, hash, advertiser },
                             Err(error) => BlockDownloadVerifyError::ValidationRequestError { error, height: block_height, hash },
                         }
                     })

--- a/crates/zakurad/src/components/sync/legacy_trace.rs
+++ b/crates/zakurad/src/components/sync/legacy_trace.rs
@@ -9,7 +9,7 @@ use std::{
 use serde::Serialize;
 use zakura_chain::block::{self, Height};
 use zakura_jsonl_trace::{JsonlEventEmitter, JsonlTraceTable, JsonlTracer};
-use zakura_network::PeerSocketAddr;
+use zakura_network::{PeerSocketAddr, PeerSource};
 
 const TABLE: JsonlTraceTable = JsonlTraceTable::new("legacy_sync", "legacy_sync.jsonl");
 
@@ -51,6 +51,14 @@ impl LegacySyncTrace {
         Self {
             emitter: JsonlEventEmitter::new(tracer, zakura_jsonl_trace::node_id()),
             expose_peer_addresses,
+        }
+    }
+
+    /// Returns a transport peer label using this trace's configured privacy policy.
+    pub(super) fn peer_source_label(&self, source: &PeerSource) -> String {
+        match source {
+            PeerSource::LegacySocket(addr) => self.peer_label(*addr),
+            PeerSource::Zakura(peer_id) => format!("zakura:{peer_id:?}"),
         }
     }
 
@@ -154,13 +162,13 @@ impl LegacySyncTrace {
         hash: block::Hash,
         height: Height,
         download_elapsed: Duration,
-        peer: Option<PeerSocketAddr>,
+        peer: Option<&PeerSource>,
     ) {
         self.emitter.emit_event(|| LegacyEvent::BlockDownloaded {
             hash: hash.to_string(),
             height: height.0,
             download_elapsed_ms: elapsed_millis(download_elapsed),
-            peer: peer.map(|peer| self.peer_label(peer)),
+            peer: peer.map(|peer| self.peer_source_label(peer)),
         });
     }
 }

--- a/crates/zakurad/src/components/sync/tests/timing.rs
+++ b/crates/zakurad/src/components/sync/tests/timing.rs
@@ -159,6 +159,7 @@ fn request_genesis_is_rate_limited() {
         state_service,
         latest_chain_tip,
         misbehavior_tx,
+        None,
     );
 
     // Run `request_genesis()` long enough to observe multiple retries.

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -24,7 +24,7 @@ use zakura_chain::{
 use zakura_consensus::{
     Config as ConsensusConfig, RouterError, VerifyBlockError, VerifyCheckpointError,
 };
-use zakura_network::{InventoryResponse, PeerSocketAddr};
+use zakura_network::{InventoryResponse, PeerSocketAddr, PeerSource};
 use zakura_state::Config as StateConfig;
 use zakura_test::mock_service::{MockService, PanicAssertion};
 
@@ -1355,7 +1355,7 @@ async fn should_restart_sync_returns_false() {
         error: router_error,
         height: block::Height(42),
         hash: block::Hash::from([0xAA; 32]),
-        advertiser_addr: None,
+        advertiser: None,
     };
 
     let restart = ChainSync::<
@@ -1404,7 +1404,7 @@ fn invalid_ancestor_does_not_score_descendant_advertiser() {
         error: parent_error,
         height: Height(42),
         hash: parent_hash,
-        advertiser_addr: Some(parent_advertiser),
+        advertiser: Some(PeerSource::LegacySocket(parent_advertiser)),
     };
 
     assert!(chain_sync
@@ -1426,7 +1426,7 @@ fn invalid_ancestor_does_not_score_descendant_advertiser() {
         error: child_error,
         height: Height(43),
         hash: child_hash,
-        advertiser_addr: Some(child_advertiser),
+        advertiser: Some(PeerSource::LegacySocket(child_advertiser)),
     };
 
     assert!(chain_sync
@@ -1518,6 +1518,7 @@ async fn request_genesis_accepts_duplicate_finalized_genesis() -> Result<(), cra
         state_service,
         mock_chain_tip,
         misbehavior_tx,
+        None,
     );
 
     tokio::time::timeout(Duration::from_secs(2), chain_sync.request_genesis())
@@ -1555,7 +1556,7 @@ fn duplicate_finalized_checkpoint_block_does_not_restart_sync() -> Result<(), cr
         error: router_error,
         height: Height(1),
         hash: block1_hash,
-        advertiser_addr: None,
+        advertiser: None,
     };
 
     let restart = TestChainSync::should_restart_sync(&err, false);
@@ -1575,7 +1576,7 @@ async fn above_lookahead_does_not_restart_sync() {
     let err = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
         height: block::Height(60_000),
         hash: block::Hash::from([0xBB; 32]),
-        advertiser_addr: None,
+        advertiser: None,
     };
 
     let restart = ChainSync::<
@@ -1592,14 +1593,14 @@ async fn above_lookahead_does_not_restart_sync() {
 }
 
 /// Verifies fix for GHSA-gvjc-3w7c-92jx: `AboveLookaheadHeightLimit` now
-/// carries `advertiser_addr` so the offending peer can be scored.
+/// carries advertiser attribution so the offending peer can be scored.
 #[tokio::test]
 async fn above_lookahead_has_peer_attribution() {
     let addr: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
     let err = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
         height: block::Height(60_000),
         hash: block::Hash::from([0xCC; 32]),
-        advertiser_addr: Some(addr),
+        advertiser: Some(PeerSource::LegacySocket(addr)),
     };
 
     assert_eq!(
@@ -1622,7 +1623,7 @@ async fn both_height_limits_do_not_restart_sync() {
     let above = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
         height: block::Height(60_000),
         hash: block::Hash::from([0xEE; 32]),
-        advertiser_addr: None,
+        advertiser: None,
     };
 
     let restart_below = ChainSync::<
@@ -1650,13 +1651,13 @@ async fn both_height_limits_do_not_restart_sync() {
 }
 
 /// Verifies fix for GHSA-rj6c-83wx-jxf2: `InvalidHeight` does not trigger
-/// sync restart and carries `advertiser_addr` for peer scoring.
+/// sync restart and carries advertiser attribution for peer scoring.
 #[tokio::test]
 async fn invalid_height_does_not_restart_sync() {
     let addr: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
     let err = BlockDownloadVerifyError::InvalidHeight {
         hash: block::Hash::from([0xFF; 32]),
-        advertiser_addr: Some(addr),
+        advertiser: Some(PeerSource::LegacySocket(addr)),
     };
 
     let restart = ChainSync::<
@@ -1675,6 +1676,64 @@ async fn invalid_height_does_not_restart_sync() {
         err.advertiser_addr(),
         Some(addr),
         "InvalidHeight should carry advertiser_addr for peer scoring"
+    );
+}
+
+/// Zakura-supplied invalid blocks retain authenticated attribution and are
+/// scored through the Zakura peer-id sink, not the legacy IP ban channel.
+#[test]
+fn zakura_advertiser_is_scored_without_legacy_ip_report() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        _peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+    let (misbehavior_tx, mut misbehavior_rx) = tokio::sync::mpsc::channel(2);
+    chain_sync.misbehavior_sender = misbehavior_tx;
+    let (zakura_tx, mut zakura_rx) = tokio::sync::mpsc::channel(2);
+    chain_sync.zakura_misbehavior =
+        Some(zn::zakura::ZakuraMisbehaviorHandle::from_sender(zakura_tx));
+
+    let peer_id =
+        zn::zakura::ZakuraPeerId::new(vec![7; 32]).expect("test peer id is within bounds");
+    let advertiser = PeerSource::Zakura(peer_id.clone());
+    let hash = block::Hash([0xC3; 32]);
+
+    let invalid = zs::CommitBlockError::ValidateContextError(Box::new(
+        zs::ValidateContextError::InvalidBlockCommitment(
+            zakura_chain::block::CommitmentError::InvalidChainHistoryActivationReserved {
+                actual: [2; 32],
+            },
+        ),
+    ));
+    let invalid = RouterError::Block {
+        source: Box::new(VerifyBlockError::Commit(invalid)),
+    };
+    let response = BlockDownloadVerifyError::Invalid {
+        error: invalid,
+        height: Height(42),
+        hash,
+        advertiser: Some(advertiser.clone()),
+    };
+
+    assert_eq!(response.advertiser(), Some(&advertiser));
+    assert_eq!(
+        response.advertiser_addr(),
+        None,
+        "Zakura peers are not convertible to legacy socket scores"
+    );
+    assert!(chain_sync.handle_block_response(Err(response)).is_err());
+    assert!(
+        misbehavior_rx.try_recv().is_err(),
+        "Zakura attribution must not emit legacy IP misbehavior reports"
+    );
+    assert_eq!(
+        zakura_rx.try_recv(),
+        Ok((peer_id, 100)),
+        "Zakura-supplied invalid blocks must be scored against the peer id"
     );
 }
 
@@ -2643,6 +2702,7 @@ fn setup_chain_sync_with_options(
         state_service.clone(),
         mock_chain_tip,
         misbehavior_tx,
+        None,
     );
 
     (

--- a/docs/changelog/unreleased/590.md
+++ b/docs/changelog/unreleased/590.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Preserve Zakura peer attribution for blocks fetched through the dual-stack
+  compatibility path, and disconnect authenticated Zakura peers that supply
+  invalid sync blocks once they reach the shared misbehavior threshold
+  ([#590](https://github.com/zakura-core/zakura/pull/590)).


### PR DESCRIPTION
## Motivation

In dual sync mode, when legacy ChainSync verifies a block that arrived over the Zakura compatibility stream, the delivering peer was dropped at decode time (`Available((block, None))`). Penalizable failures therefore became unattributed, and Zakura peers could not be scored the way legacy TCP sockets already are.

## Solution

- Carry `Option<PeerSource>` on available `Response::Blocks` entries.
- Stamp `PeerSource::Zakura(peer_id)` in the outbound compatibility requester for the peer that actually returned the body.
- Propagate that source through legacy download/verify errors and diagnostics.
- Score legacy sockets via the existing IP ban channel; score Zakura peers via a new peer-id accumulator that disconnects at the shared misbehavior threshold.
- Wire the same sink into the native block-sync driver for `BlockSyncMisbehavior`.

## Testing

- Compatibility-path tests assert the delivering Zakura peer survives in `Response::Blocks`.
- Sync vector tests assert Zakura-supplied invalid blocks score the peer id and do not emit legacy IP reports; legacy socket scoring remains unchanged.
- Local checks: `cargo fmt --check`, `./scripts/changelog.py check`, targeted `zakura-network` attribution/scoring tests, and targeted `zakura` sync scoring tests. Broader CI coverage is in progress on the draft PR.

## Changelog

- Added [`docs/changelog/unreleased/590.md`](docs/changelog/unreleased/590.md).

### Follow-up Work

- Inbound gossip verification still maps Zakura advertisers to `None` before the legacy IP misbehavior path; extend that path to the shared Zakura sink if desired.
- Header-sync misbehavior remains record-only and is not yet wired into `ZakuraMisbehaviorHandle`.