### PR TITLE
feat(zakurad): support embedded nodes and custom p2p services

### DIFF
--- a/crates/zakura-network/src/lib.rs
+++ b/crates/zakura-network/src/lib.rs
@@ -180,7 +180,7 @@ pub use crate::{
         SharedPeerError,
     },
     peer_registry::ConnectedPeer,
-    peer_set::{init, init_with_zakura_header_sync},
+    peer_set::{init, init_with_zakura_custom_services, init_with_zakura_header_sync},
     policies::RetryLimit,
     protocol::{
         external::{Version, VersionMessage, MAX_TX_INV_IN_SENT_MESSAGE},

--- a/crates/zakura-network/src/lib.rs
+++ b/crates/zakura-network/src/lib.rs
@@ -180,7 +180,7 @@ pub use crate::{
         SharedPeerError,
     },
     peer_registry::ConnectedPeer,
-    peer_set::{init, init_with_zakura_custom_services, init_with_zakura_header_sync},
+    peer_set::{init, init_with_zakura, init_with_zakura_header_sync},
     policies::RetryLimit,
     protocol::{
         external::{Version, VersionMessage, MAX_TX_INV_IN_SENT_MESSAGE},

--- a/crates/zakura-network/src/peer/handshake/tests.rs
+++ b/crates/zakura-network/src/peer/handshake/tests.rs
@@ -289,6 +289,7 @@ async fn start_test_zakura_endpoint_with_registry() -> (crate::zakura::ZakuraEnd
         &config,
         |_supervisor, _trace| Arc::new(DropSink) as Arc<dyn ZakuraService>,
         None,
+        Vec::new(),
         peer_registry.clone(),
     )
     .await

--- a/crates/zakura-network/src/peer_set.rs
+++ b/crates/zakura-network/src/peer_set.rs
@@ -14,4 +14,4 @@ pub(crate) use limit::{ActiveConnectionCounter, ConnectionTracker};
 use inventory_registry::InventoryRegistry;
 pub(crate) use set::PeerSet;
 
-pub use initialize::{init, init_with_zakura_header_sync};
+pub use initialize::{init, init_with_zakura_custom_services, init_with_zakura_header_sync};

--- a/crates/zakura-network/src/peer_set.rs
+++ b/crates/zakura-network/src/peer_set.rs
@@ -14,4 +14,4 @@ pub(crate) use limit::{ActiveConnectionCounter, ConnectionTracker};
 use inventory_registry::InventoryRegistry;
 pub(crate) use set::PeerSet;
 
-pub use initialize::{init, init_with_zakura_custom_services, init_with_zakura_header_sync};
+pub use initialize::{init, init_with_zakura, init_with_zakura_header_sync};

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -192,7 +192,7 @@ where
     S::Future: Send + 'static,
     C: ChainTip + Clone + Send + Sync + 'static,
 {
-    init_with_zakura_custom_services(
+    init_with_zakura(
         config,
         inbound_service,
         latest_chain_tip,
@@ -205,8 +205,9 @@ where
     .await
 }
 
-/// Initialize a peer set with application-supplied Zakura protocol services.
-pub async fn init_with_zakura_custom_services<S, C>(
+/// Initialize a peer set with optional Zakura runtime components.
+#[allow(clippy::too_many_arguments)]
+pub async fn init_with_zakura<S, C>(
     config: Config,
     inbound_service: S,
     latest_chain_tip: C,

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -192,6 +192,40 @@ where
     S::Future: Send + 'static,
     C: ChainTip + Clone + Send + Sync + 'static,
 {
+    init_with_zakura_custom_services(
+        config,
+        inbound_service,
+        latest_chain_tip,
+        user_agent,
+        advertised_services,
+        block_gossip_peer_ips,
+        header_sync_driver_startup,
+        Vec::new(),
+    )
+    .await
+}
+
+/// Initialize a peer set with application-supplied Zakura protocol services.
+pub async fn init_with_zakura_custom_services<S, C>(
+    config: Config,
+    inbound_service: S,
+    latest_chain_tip: C,
+    user_agent: String,
+    advertised_services: PeerServices,
+    block_gossip_peer_ips: Vec<IpAddr>,
+    header_sync_driver_startup: Option<crate::zakura::ZakuraHeaderSyncDriverStartup>,
+    custom_services: Vec<crate::zakura::CustomService>,
+) -> (
+    Buffer<BoxService<Request, Response, BoxError>, Request>,
+    Arc<std::sync::Mutex<AddressBook>>,
+    mpsc::Sender<(PeerSocketAddr, u32)>,
+    Option<crate::zakura::ZakuraEndpoint>,
+)
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + Sync + 'static,
+    S::Future: Send + 'static,
+    C: ChainTip + Clone + Send + Sync + 'static,
+{
     let (tcp_listener, listen_addr) = if config.legacy_p2p() {
         let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
         (Some(tcp_listener), listen_addr)
@@ -214,6 +248,7 @@ where
             )) as Arc<dyn crate::zakura::Service>
         },
         header_sync_driver_startup,
+        custom_services,
         peer_registry.clone(),
     )
     .await

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -48,6 +48,7 @@ use crate::{
     peer_registry::PeerRegistry,
     peer_set::{set::MorePeers, ActiveConnectionCounter, CandidateSet, ConnectionTracker, PeerSet},
     protocol::external::{canonical_peer_addr, canonical_socket_addr, types::PeerServices},
+    zakura::{CustomService, ZakuraEndpoint, ZakuraHeaderSyncDriverStartup},
     AddressBook, BannedIps, BoxError, Config, PeerSocketAddr, Request, Response,
 };
 
@@ -180,12 +181,12 @@ pub async fn init_with_zakura_header_sync<S, C>(
     user_agent: String,
     advertised_services: PeerServices,
     block_gossip_peer_ips: Vec<IpAddr>,
-    header_sync_driver_startup: Option<crate::zakura::ZakuraHeaderSyncDriverStartup>,
+    header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
 ) -> (
     Buffer<BoxService<Request, Response, BoxError>, Request>,
     Arc<std::sync::Mutex<AddressBook>>,
     mpsc::Sender<(PeerSocketAddr, u32)>,
-    Option<crate::zakura::ZakuraEndpoint>,
+    Option<ZakuraEndpoint>,
 )
 where
     S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + Sync + 'static,
@@ -203,6 +204,7 @@ where
         Vec::new(),
     )
     .await
+    .expect("Zakura endpoint should start when P2P v2 is enabled")
 }
 
 /// Initialize a peer set with optional Zakura runtime components.
@@ -214,14 +216,17 @@ pub async fn init_with_zakura<S, C>(
     user_agent: String,
     advertised_services: PeerServices,
     block_gossip_peer_ips: Vec<IpAddr>,
-    header_sync_driver_startup: Option<crate::zakura::ZakuraHeaderSyncDriverStartup>,
-    custom_services: Vec<crate::zakura::CustomService>,
-) -> (
-    Buffer<BoxService<Request, Response, BoxError>, Request>,
-    Arc<std::sync::Mutex<AddressBook>>,
-    mpsc::Sender<(PeerSocketAddr, u32)>,
-    Option<crate::zakura::ZakuraEndpoint>,
-)
+    header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
+    custom_services: Vec<CustomService>,
+) -> Result<
+    (
+        Buffer<BoxService<Request, Response, BoxError>, Request>,
+        Arc<std::sync::Mutex<AddressBook>>,
+        mpsc::Sender<(PeerSocketAddr, u32)>,
+        Option<ZakuraEndpoint>,
+    ),
+    BoxError,
+>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + Sync + 'static,
     S::Future: Send + 'static,
@@ -252,8 +257,7 @@ where
         custom_services,
         peer_registry.clone(),
     )
-    .await
-    .expect("Zakura endpoint should start when P2P v2 is enabled");
+    .await?;
 
     let (address_book, bans, address_book_updater, address_metrics, address_book_updater_guard) =
         AddressBookUpdater::spawn_with_peer_registry(
@@ -492,12 +496,12 @@ where
         None => peer_set,
     };
 
-    (
+    Ok((
         peer_set,
         address_book,
         misbehavior_tx,
         returned_zakura_endpoint,
-    )
+    ))
 }
 
 /// Use the provided `outbound_connector` to connect to the configured DNS seeder and

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -29,12 +29,16 @@ use tokio::{
     time::{sleep, Instant},
 };
 use tokio_stream::wrappers::IntervalStream;
+use tokio_util::task::AbortOnDropHandle;
 use tower::{
     buffer::Buffer, discover::Change, layer::Layer, util::BoxService, Service, ServiceExt,
 };
 use tracing_futures::Instrument;
 
-use zakura_chain::{chain_tip::ChainTip, diagnostic::task::WaitForPanics};
+use zakura_chain::{
+    chain_tip::ChainTip,
+    diagnostic::task::{CheckForPanics, WaitForPanics},
+};
 
 use crate::{
     address_book_updater::{AddressBookUpdater, MIN_CHANNEL_SIZE},
@@ -258,6 +262,9 @@ where
         peer_registry.clone(),
     )
     .await?;
+    let zakura_startup_shutdown = zakura_endpoint
+        .as_ref()
+        .map(|endpoint| endpoint.background_shutdown_token().drop_guard());
 
     let (address_book, bans, address_book_updater, address_metrics, address_book_updater_guard) =
         AddressBookUpdater::spawn_with_peer_registry(
@@ -387,7 +394,11 @@ where
     let peer_cache_updater_fut = peer_cache_updater(config.clone(), address_book.clone());
     let peer_cache_updater_guard = tokio::spawn(peer_cache_updater_fut.in_current_span());
 
-    let mut task_handles = vec![address_book_updater_guard, peer_cache_updater_guard];
+    // Abort startup tasks if this initialization future is dropped before handoff.
+    let mut task_handles = vec![
+        AbortOnDropHandle::new(address_book_updater_guard),
+        AbortOnDropHandle::new(peer_cache_updater_guard),
+    ];
 
     if let Some(tcp_listener) = tcp_listener {
         // Connect peerset_tx to the 3 peer sources:
@@ -402,7 +413,9 @@ where
             bans,
             block_gossip_peer_ips,
         );
-        task_handles.push(tokio::spawn(listen_fut.in_current_span()));
+        task_handles.push(AbortOnDropHandle::new(tokio::spawn(
+            listen_fut.in_current_span(),
+        )));
 
         // 2. Initial peers, specified in the config and cached on disk.
         let initial_peers_fut = add_initial_peers(
@@ -411,15 +424,17 @@ where
             peerset_tx.clone(),
             address_book_updater.clone(),
         );
-        let initial_peers_join = tokio::spawn(initial_peers_fut.in_current_span());
+        let initial_peers_join =
+            AbortOnDropHandle::new(tokio::spawn(initial_peers_fut.in_current_span()));
 
         // 3. Outgoing peers we connect to in response to load.
         let mut candidates = CandidateSet::new(address_book.clone(), peer_set.clone());
 
         // Wait for the initial seed peer count
         let mut active_outbound_connections = initial_peers_join
-            .wait_for_panics()
             .await
+            .panic_if_task_has_panicked()
+            .expect("initial peer task is not cancelled")
             .expect("unexpected error connecting to initial peers");
         let active_initial_peer_count = active_outbound_connections.update_count();
 
@@ -457,9 +472,11 @@ where
             address_book_updater,
             Arc::new(AtomicBool::new(false)),
         );
-        task_handles.push(tokio::spawn(crawl_fut.in_current_span()));
+        task_handles.push(AbortOnDropHandle::new(tokio::spawn(
+            crawl_fut.in_current_span(),
+        )));
     } else {
-        task_handles.push(tokio::spawn(
+        task_handles.push(AbortOnDropHandle::new(tokio::spawn(
             async move {
                 let _peerset_tx = peerset_tx;
                 let mut demand_rx = demand_rx;
@@ -471,7 +488,7 @@ where
                 future::pending::<Result<(), BoxError>>().await
             }
             .in_current_span(),
-        ));
+        )));
     }
 
     // Capture the supervisor before the endpoint is moved into the keep-alive
@@ -482,13 +499,20 @@ where
 
     let returned_zakura_endpoint = zakura_endpoint.clone();
     if let Some(zakura_endpoint) = zakura_endpoint {
-        task_handles.push(tokio::spawn(async move {
+        task_handles.push(AbortOnDropHandle::new(tokio::spawn(async move {
             let _zakura_endpoint = zakura_endpoint;
             future::pending::<Result<(), BoxError>>().await
-        }));
+        })));
     }
 
-    handle_tx.send(task_handles).unwrap();
+    handle_tx
+        .send(
+            task_handles
+                .into_iter()
+                .map(AbortOnDropHandle::detach)
+                .collect(),
+        )
+        .unwrap();
 
     // When the Zakura endpoint is active, wrap the legacy peer set so locally
     // originated gossip and inventory fetches also flow over Zakura. The internal
@@ -507,6 +531,10 @@ where
         }
         None => peer_set,
     };
+
+    if let Some(shutdown) = zakura_startup_shutdown {
+        shutdown.disarm();
+    }
 
     Ok((
         peer_set,

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -369,7 +369,19 @@ where
         MinimumPeerVersion::new(latest_chain_tip, &config.network),
         None,
     );
-    let peer_set = Buffer::new(BoxService::new(peer_set), constants::PEERSET_BUFFER_SIZE);
+    let shutdown = zakura_endpoint
+        .as_ref()
+        .map(ZakuraEndpoint::background_shutdown_token)
+        .unwrap_or_default();
+    // Using Buffer::pair returns the background service, letting us inject our cancellation
+    let (peer_set, worker) =
+        Buffer::pair(BoxService::new(peer_set), constants::PEERSET_BUFFER_SIZE);
+    tokio::spawn(async move {
+        tokio::select! {
+            _ = shutdown.cancelled() => {}
+            _ = worker => {}
+        }
+    });
 
     // Start the peer disk cache updater
     let peer_cache_updater_fut = peer_cache_updater(config.clone(), address_book.clone());

--- a/crates/zakura-network/src/zakura/discovery/candidate_dialer.rs
+++ b/crates/zakura-network/src/zakura/discovery/candidate_dialer.rs
@@ -24,6 +24,7 @@ use super::redial::ZAKURA_REDIAL_HEALTHY_CONNECTION;
 use super::trace::DiscoveryDialResultEvent;
 use crate::zakura::{
     canonical_ip, ZakuraEndpoint, ZakuraHandlerError, ZakuraLocalLimits, ZakuraPeerId,
+    ZakuraServiceId,
 };
 
 /// How often the discovery dialer wakes to look for new candidates.
@@ -80,8 +81,14 @@ pub(crate) fn spawn_native_discovery_dialer(
     endpoint: ZakuraEndpoint,
     discovery: ZakuraDiscoveryHandle,
     limits: ZakuraLocalLimits,
+    sought_services: Vec<ZakuraServiceId>,
 ) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(run_native_discovery_dialer(endpoint, discovery, limits))
+    tokio::spawn(run_native_discovery_dialer(
+        endpoint,
+        discovery,
+        limits,
+        sought_services,
+    ))
 }
 
 /// Seed the discovery book with the configured bootstrap peers as trusted static
@@ -109,6 +116,7 @@ pub(crate) async fn run_native_discovery_dialer(
     endpoint: ZakuraEndpoint,
     discovery: ZakuraDiscoveryHandle,
     limits: ZakuraLocalLimits,
+    sought_services: Vec<ZakuraServiceId>,
 ) {
     let shutdown = endpoint.background_shutdown_token();
     let trace = endpoint.trace();
@@ -133,6 +141,7 @@ pub(crate) async fn run_native_discovery_dialer(
             &mut in_flight_by_ip,
             &dial_backoff_by_node_ip,
             &mut workers,
+            &sought_services,
         )
         .await;
 
@@ -182,6 +191,7 @@ pub(crate) async fn run_native_discovery_dialer(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn spawn_discovery_dial_candidates(
     endpoint: &ZakuraEndpoint,
     discovery: &ZakuraDiscoveryHandle,
@@ -190,13 +200,18 @@ async fn spawn_discovery_dial_candidates(
     in_flight_by_ip: &mut HashMap<IpAddr, usize>,
     dial_backoff_by_node_ip: &HashMap<(NodeId, IpAddr), DiscoveryIpBackoff>,
     workers: &mut JoinSet<DiscoveryDialWorkerResult>,
+    sought_services: &[ZakuraServiceId],
 ) {
     if !endpoint.has_native_admission_capacity() {
         return;
     }
 
     let in_flight_node_ids: Vec<_> = in_flight.iter().copied().collect();
-    for candidate in discovery.dial_candidates(&[], &in_flight_node_ids).await {
+    let candidates = discovery
+        .dial_candidates_preferring_any_service(sought_services, &in_flight_node_ids)
+        .await;
+
+    for candidate in candidates {
         if !endpoint.has_native_admission_capacity() {
             return;
         }

--- a/crates/zakura-network/src/zakura/discovery/protocol.rs
+++ b/crates/zakura-network/src/zakura/discovery/protocol.rs
@@ -2061,6 +2061,50 @@ impl ZakuraDiscoveryHandle {
         inner.book.dial_candidates(
             limit,
             &wanted_services,
+            &[],
+            DialCandidateExclusions {
+                connected_node_ids: &connected_node_ids,
+                in_flight_node_ids,
+            },
+            now,
+            (dial_backoff_base, dial_backoff_max),
+            &mut rng,
+        )
+    }
+
+    /// Returns service-matching candidates first, followed by general candidates.
+    pub(crate) async fn dial_candidates_preferring_any_service(
+        &self,
+        preferred_services: &[ZakuraServiceId],
+        in_flight_node_ids: &[NodeId],
+    ) -> Vec<ZakuraDiscoveryDialCandidate> {
+        let connected = self.connected.borrow().clone();
+        let (limit, dial_backoff_base, dial_backoff_max) = {
+            let inner = self.inner.lock().await;
+            (
+                discovery_dial_slot_limit(
+                    connected.len(),
+                    in_flight_node_ids.len(),
+                    inner.config.max_zakura_connections,
+                    inner.config.discovery_connection_headroom,
+                    inner.config.max_concurrent_discovery_dials,
+                ),
+                inner.config.dial_backoff_base,
+                inner.config.dial_backoff_max,
+            )
+        };
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let connected_node_ids = connected_peer_node_ids(&connected);
+        let now = current_unix_secs();
+        let inner = self.inner.lock().await;
+        let mut rng = rand::thread_rng();
+        inner.book.dial_candidates(
+            limit,
+            &[],
+            preferred_services,
             DialCandidateExclusions {
                 connected_node_ids: &connected_node_ids,
                 in_flight_node_ids,
@@ -2134,6 +2178,7 @@ impl ZakuraDiscoveryHandle {
         let mut discovered = inner.book.dial_candidates(
             limit,
             &wanted_services,
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &connected_node_ids,
                 in_flight_node_ids,
@@ -2146,6 +2191,7 @@ impl ZakuraDiscoveryHandle {
         if used_fallback {
             discovered = inner.book.dial_candidates(
                 limit,
+                &[],
                 &[],
                 DialCandidateExclusions {
                     connected_node_ids: &connected_node_ids,
@@ -2252,6 +2298,7 @@ impl ZakuraDiscoveryHandle {
         let mut discovered = inner.book.dial_candidates(
             limit,
             &wanted_services,
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &connected_node_ids,
                 in_flight_node_ids: &excluded_node_ids,
@@ -2264,6 +2311,7 @@ impl ZakuraDiscoveryHandle {
         if used_fallback {
             discovered = inner.book.dial_candidates(
                 limit,
+                &[],
                 &[],
                 DialCandidateExclusions {
                     connected_node_ids: &connected_node_ids,
@@ -2360,6 +2408,7 @@ impl ZakuraDiscoveryHandle {
         let mut discovered = inner.book.dial_candidates(
             limit,
             &wanted_services,
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &connected_node_ids,
                 in_flight_node_ids,
@@ -2372,6 +2421,7 @@ impl ZakuraDiscoveryHandle {
         if used_fallback {
             discovered = inner.book.dial_candidates(
                 limit,
+                &[],
                 &[],
                 DialCandidateExclusions {
                     connected_node_ids: &connected_node_ids,
@@ -2824,7 +2874,7 @@ impl ZakuraDiscoveryBook {
             .map(|(_, entry)| entry)
             .filter(|entry| {
                 !exclude_node_ids.contains(&entry.record.body.node_id)
-                    && has_wanted_services(&entry.record, wanted_services)
+                    && advertises_all_services(&entry.record, wanted_services)
             })
             .take(limit)
             .map(|entry| entry.record.clone())
@@ -2849,10 +2899,12 @@ impl ZakuraDiscoveryBook {
     }
 
     /// Returns bounded dial candidates for later dial-loop code.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn dial_candidates<R: rand::Rng + ?Sized>(
         &self,
         limit: usize,
-        wanted_services: &[ZakuraServiceId],
+        required_services: &[ZakuraServiceId],
+        preferred_services: &[ZakuraServiceId],
         exclusions: DialCandidateExclusions<'_>,
         now: u64,
         dial_backoff: (Duration, Duration),
@@ -2877,12 +2929,12 @@ impl ZakuraDiscoveryBook {
                         dial_backoff.0,
                         dial_backoff.1,
                     )
-                    && has_wanted_services(&entry.record, wanted_services)
+                    && advertises_all_services(&entry.record, required_services)
                     && has_discovery_usable_direct_addrs(entry)
             })
             .map(DialCandidateRef::SignedRecord)
             .chain(self.static_candidates.values().filter_map(|candidate| {
-                if !wanted_services.is_empty()
+                if !required_services.is_empty()
                     || connected_node_ids.contains(&candidate.node_id)
                     || in_flight_node_ids.contains(&candidate.node_id)
                     || self.local_node_id == Some(candidate.node_id)
@@ -2912,11 +2964,22 @@ impl ZakuraDiscoveryBook {
         // per-second candidate-dialer path, yet only `limit` candidates are ever returned. Sorting
         // the whole candidate set (O(n log n)) just to `take(limit)` is replaced with an O(n)
         // partial select of the best `limit` candidates plus an O(limit log limit) sort of the
-        // survivors, keeping the order identical. See finding
+        // survivors, keeping the order identical within each preference group. See finding
         // `claude-discovery-expensive-work-under-global-mutex` (SR-2/SR-4).
-        let mut keyed: Vec<(DialCandidateSortKey, DialCandidateRef<'_>)> = candidates
+        let mut keyed: Vec<((bool, DialCandidateSortKey), DialCandidateRef<'_>)> = candidates
             .into_iter()
-            .map(|candidate| (dial_candidate_sort_key(&candidate, rng), candidate))
+            .map(|candidate| {
+                let is_general = match &candidate {
+                    DialCandidateRef::SignedRecord(entry) => {
+                        !advertises_any_service(&entry.record, preferred_services)
+                    }
+                    DialCandidateRef::StaticConfigured(_) => true,
+                };
+                (
+                    (is_general, dial_candidate_sort_key(&candidate, rng)),
+                    candidate,
+                )
+            })
             .collect();
 
         let take = limit.min(keyed.len());
@@ -3555,10 +3618,16 @@ fn discovery_dial_slot_limit(
     available_connection_slots.min(available_dial_slots)
 }
 
-fn has_wanted_services(record: &ZakuraNodeRecord, wanted_services: &[ZakuraServiceId]) -> bool {
+fn advertises_all_services(record: &ZakuraNodeRecord, wanted_services: &[ZakuraServiceId]) -> bool {
     wanted_services
         .iter()
-        .all(|wanted| record.body.services.iter().any(|service| service == wanted))
+        .all(|wanted| record.body.services.contains(wanted))
+}
+
+fn advertises_any_service(record: &ZakuraNodeRecord, wanted_services: &[ZakuraServiceId]) -> bool {
+    wanted_services
+        .iter()
+        .any(|wanted| record.body.services.contains(wanted))
 }
 
 /// Total sort key for ranked sample entries: hash rank, then node id for hash-collision ties.
@@ -6111,6 +6180,7 @@ mod tests {
             book.dial_candidates(
                 10,
                 &[service(1)],
+                &[],
                 DialCandidateExclusions {
                     connected_node_ids: &[],
                     in_flight_node_ids: &[],
@@ -6150,6 +6220,7 @@ mod tests {
             book.dial_candidates(
                 10,
                 &[service(1)],
+                &[],
                 DialCandidateExclusions {
                     connected_node_ids: &[],
                     in_flight_node_ids: &[],
@@ -6248,6 +6319,7 @@ mod tests {
         assert_eq!(
             book.dial_candidates(
                 10,
+                &[],
                 &[],
                 DialCandidateExclusions {
                     connected_node_ids: &[],
@@ -6524,6 +6596,7 @@ mod tests {
         let candidates = book.dial_candidates(
             10,
             &[service(1)],
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &[],
                 in_flight_node_ids: &[],
@@ -6541,6 +6614,7 @@ mod tests {
         let candidates = book.dial_candidates(
             10,
             &[service(1)],
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &[],
                 in_flight_node_ids: &[],
@@ -6582,6 +6656,7 @@ mod tests {
         let sampled = book.dial_candidates(
             records.len(),
             &[service(1)],
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &[],
                 in_flight_node_ids: &[],
@@ -6597,6 +6672,7 @@ mod tests {
         let other_sampled = book.dial_candidates(
             records.len(),
             &[service(1)],
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &[],
                 in_flight_node_ids: &[],
@@ -6636,6 +6712,7 @@ mod tests {
             .dial_candidates(
                 10,
                 &[service(1)],
+                &[],
                 DialCandidateExclusions {
                     connected_node_ids: &[],
                     in_flight_node_ids: &[],
@@ -6650,6 +6727,7 @@ mod tests {
             book.dial_candidates(
                 10,
                 &[service(1)],
+                &[],
                 DialCandidateExclusions {
                     connected_node_ids: &[],
                     in_flight_node_ids: &[],
@@ -6680,6 +6758,7 @@ mod tests {
             .dial_candidates(
                 10,
                 &[service(1)],
+                &[],
                 DialCandidateExclusions {
                     connected_node_ids: &[],
                     in_flight_node_ids: &[],
@@ -6693,6 +6772,7 @@ mod tests {
             book.dial_candidates(
                 10,
                 &[service(1)],
+                &[],
                 DialCandidateExclusions {
                     connected_node_ids: &[],
                     in_flight_node_ids: &[],
@@ -8265,6 +8345,7 @@ mod tests {
         let selected = book.dial_candidates(
             3,
             &[service(1)],
+            &[],
             DialCandidateExclusions {
                 connected_node_ids: &[],
                 in_flight_node_ids: &[],
@@ -8524,6 +8605,57 @@ mod tests {
             .dial_candidates(&[service(1)], &[candidate_id])
             .await
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn dial_candidates_prefer_any_matching_service() {
+        let (_connected_tx, connected_rx) = watch::channel(Vec::new());
+        let handle = discovery_handle_with_connected(connected_rx);
+        let wanted_a = service(1);
+        let wanted_b = service(2);
+        let matching_a = runtime_record_with(1, wanted_a.clone(), test_addr(1));
+        let matching_b = runtime_record_with(2, wanted_b.clone(), test_addr(2));
+        let neither = runtime_record_with(3, service(3), test_addr(3));
+
+        for record in [&matching_a, &matching_b, &neither] {
+            handle
+                .import_peer_record(record.clone(), Some(record.body.node_id))
+                .await
+                .expect("candidate record imports");
+        }
+
+        assert!(handle
+            .dial_candidates(&[wanted_a, wanted_b], &[])
+            .await
+            .is_empty());
+
+        let prioritized = handle
+            .dial_candidates_preferring_any_service(&[service(1), service(2)], &[])
+            .await;
+        assert_eq!(prioritized.len(), 3);
+        assert_eq!(
+            prioritized[..2]
+                .iter()
+                .map(|candidate| candidate.node_id)
+                .collect::<HashSet<_>>(),
+            HashSet::from([matching_a.body.node_id, matching_b.body.node_id])
+        );
+        assert_eq!(prioritized[2].node_id, neither.body.node_id);
+
+        let general = handle
+            .dial_candidates_preferring_any_service(&[], &[])
+            .await;
+        assert_eq!(
+            general
+                .iter()
+                .map(|candidate| candidate.node_id)
+                .collect::<HashSet<_>>(),
+            HashSet::from([
+                matching_a.body.node_id,
+                matching_b.body.node_id,
+                neither.body.node_id,
+            ])
+        );
     }
 
     #[test]

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -5730,6 +5730,30 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct OrderedStreamService {
+        stream: Stream,
+        sessions: mpsc::UnboundedSender<(FramedRecv, FramedSend)>,
+    }
+
+    impl Service for OrderedStreamService {
+        fn name(&self) -> &'static str {
+            "ordered-stream"
+        }
+
+        fn streams(&self) -> &[Stream] {
+            std::slice::from_ref(&self.stream)
+        }
+
+        fn add_peer(&self, mut peer: Peer) {
+            if let Some(session) = peer.take_stream(self.stream.kind) {
+                let _ = self.sessions.send(session);
+            }
+        }
+
+        fn remove_peer(&self, _peer: &ZakuraPeerId, _conn_id: ZakuraConnId) {}
+    }
+
+    #[derive(Debug)]
     struct GenerationGuardedRecordingService {
         streams: Vec<Stream>,
         active: std::sync::Mutex<HashMap<ZakuraPeerId, (ZakuraConnId, CancellationToken)>>,
@@ -6747,6 +6771,109 @@ mod tests {
         endpoint.cancel_upgrade_native_dial(&peer_id);
         endpoint.shutdown().await;
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn custom_ordered_service_round_trips_over_zakura() -> Result<(), BoxError> {
+        const CUSTOM_STREAM: Stream = Stream {
+            kind: 64,
+            version: 1,
+            frame_cap: 64 * 1024,
+            capability: 1 << 16,
+            mode: StreamMode::Ordered,
+        };
+
+        let _guard = zakura_test::init();
+        let listen_addr = "127.0.0.1:0".parse().expect("valid loopback address");
+        let server_identity = tempfile::tempdir()?;
+        let client_identity = tempfile::tempdir()?;
+        let (server_sessions, mut server_session_rx) = mpsc::unbounded_channel();
+        let (client_sessions, mut client_session_rx) = mpsc::unbounded_channel();
+
+        let mut server_config = Config::for_test(P2pStack::Dual);
+        server_config.identity_dir = server_identity.path().to_owned();
+        server_config.zakura.listen_addr = Some(listen_addr);
+        server_config.zakura.bootstrap_peers.clear();
+        let server = spawn_zakura_endpoint_with_services(
+            &server_config,
+            |_supervisor, _trace| Arc::new(NoopService),
+            None,
+            vec![CustomService {
+                service: Arc::new(OrderedStreamService {
+                    stream: CUSTOM_STREAM,
+                    sessions: server_sessions,
+                }),
+                advertised_services: Vec::new(),
+            }],
+        )
+        .await?
+        .expect("test server uses Zakura");
+        let server_addr = server.node_addr().await;
+        let server_direct = server_addr
+            .direct_addresses()
+            .copied()
+            .find(|addr| addr.ip().is_loopback())
+            .ok_or("test server has no loopback address")?;
+
+        let mut client_config = Config::for_test(P2pStack::Dual);
+        client_config.identity_dir = client_identity.path().to_owned();
+        client_config.zakura.listen_addr = Some(listen_addr);
+        client_config.zakura.bootstrap_peers =
+            vec![format!("{}@{server_direct}", server_addr.node_id)];
+        let client = spawn_zakura_endpoint_with_services(
+            &client_config,
+            |_supervisor, _trace| Arc::new(NoopService),
+            None,
+            vec![CustomService {
+                service: Arc::new(OrderedStreamService {
+                    stream: CUSTOM_STREAM,
+                    sessions: client_sessions,
+                }),
+                advertised_services: Vec::new(),
+            }],
+        )
+        .await?
+        .expect("test client uses Zakura");
+
+        let round_trip = timeout(Duration::from_secs(10), async {
+            let (mut server_recv, server_send) = server_session_rx
+                .recv()
+                .await
+                .ok_or_else(|| -> BoxError { "server custom stream did not open".into() })?;
+            let (mut client_recv, client_send) = client_session_rx
+                .recv()
+                .await
+                .ok_or_else(|| -> BoxError { "client custom stream did not open".into() })?;
+            let outbound = Frame {
+                message_type: 1_001,
+                flags: 3,
+                payload: b"custom client frame".to_vec(),
+            };
+            client_send.send(outbound.clone()).await?;
+            let received = server_recv
+                .recv()
+                .await
+                .ok_or_else(|| -> BoxError { "server custom stream closed".into() })?;
+            assert_eq!(received, outbound);
+
+            let response = Frame {
+                message_type: 2_002,
+                flags: 5,
+                payload: b"custom server frame".to_vec(),
+            };
+            server_send.send(response.clone()).await?;
+            let received = client_recv
+                .recv()
+                .await
+                .ok_or_else(|| -> BoxError { "client custom stream closed".into() })?;
+            assert_eq!(received, response);
+            Ok::<_, BoxError>(())
+        })
+        .await
+        .map_err(|_| -> BoxError { "custom ordered stream round trip timed out".into() })?;
+        client.shutdown().await;
+        server.shutdown().await;
+        round_trip
     }
 
     #[tokio::test]

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -42,7 +42,7 @@ use zakura_chain::{
 };
 
 use self::trace::ZakuraConnTrace;
-use super::discovery::{native_dial_supervised, spawn_native_bootstrap_dialer, RedialPolicy};
+use super::discovery::{self, native_dial_supervised, spawn_native_bootstrap_dialer, RedialPolicy};
 use super::trace::{reject_reason_label, ZakuraTrace};
 #[cfg(any(test, feature = "zakura-testkit"))]
 use crate::zakura::drive_header_sync_actions;
@@ -62,11 +62,11 @@ use crate::{
         ZakuraConnId, ZakuraControlAck, ZakuraControlHello, ZakuraControlRole,
         ZakuraControlValidation, ZakuraHandshakeConfig, ZakuraHandshakePath,
         ZakuraHeaderSyncConfig, ZakuraInitialLimits, ZakuraLimits, ZakuraPeerId,
-        ZakuraPeerSupervisor, ZakuraProtocolError, ZakuraRejectReason, ZakuraUpgradeDialStart,
-        CONTROL_ACK_MAGIC, CONTROL_HELLO_MAGIC, CONTROL_VERSION, FRAME_HEADER_BYTES,
-        MAX_CONTROL_PAYLOAD_BYTES, P2P_V2_ALPN, STREAM_PRELUDE_MAGIC, TRANSCRIPT_HASH_BYTES,
-        ZAKURA_CAP_HEADER_SYNC, ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_PROTOCOL_VERSION_1,
-        ZAKURA_STREAM_BLOCK_SYNC, ZAKURA_STREAM_HEADER_SYNC,
+        ZakuraPeerSupervisor, ZakuraProtocolError, ZakuraRejectReason, ZakuraServiceId,
+        ZakuraUpgradeDialStart, CONTROL_ACK_MAGIC, CONTROL_HELLO_MAGIC, CONTROL_VERSION,
+        FRAME_HEADER_BYTES, MAX_CONTROL_PAYLOAD_BYTES, P2P_V2_ALPN, STREAM_PRELUDE_MAGIC,
+        TRANSCRIPT_HASH_BYTES, ZAKURA_CAP_HEADER_SYNC, ZAKURA_HEADER_SYNC_STREAM_VERSION,
+        ZAKURA_PROTOCOL_VERSION_1, ZAKURA_STREAM_BLOCK_SYNC, ZAKURA_STREAM_HEADER_SYNC,
     },
 };
 
@@ -514,6 +514,24 @@ pub struct ZakuraConnectionLimits {
     pub stream_open_rate_per_second: u32,
     /// Per-stream-kind message rate.
     pub message_rate_per_second: u32,
+}
+
+/// A service supplied by the application embedding Zakura.
+#[derive(Clone, Debug)]
+pub struct CustomService {
+    /// Custom p2p service.
+    pub service: Arc<dyn Service>,
+
+    /// Service ids to include in this node's discovery.
+    ///
+    /// Leave empty to skip discovery.
+    pub advertised_services: Vec<ZakuraServiceId>,
+}
+
+impl From<CustomService> for Arc<dyn Service> {
+    fn from(service: CustomService) -> Self {
+        service.service
+    }
 }
 
 /// Running Zakura endpoint owned by `zakura-network`/`zakurad` startup.
@@ -1857,6 +1875,7 @@ pub(crate) fn service_registry(
     service_demand: Option<
         watch::Receiver<zakura_node_services::sync_lifecycle::SyncServiceDemand>,
     >,
+    custom_services: Vec<CustomService>,
 ) -> Result<Arc<ServiceRegistry>, BoxError> {
     let mut services = vec![legacy_service.clone()];
     let header_sync_service = if let Some(header_sync) = &header_sync {
@@ -1878,13 +1897,16 @@ pub(crate) fn service_registry(
         },
     };
     let block_sync = Arc::new(block_sync.with_service_demand(service_demand)) as Arc<dyn Service>;
-    discovery_service.set_connection_owners(vec![
-        legacy_service,
-        header_sync_service,
-        block_sync.clone(),
-    ]);
+    let custom_services = custom_services
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<_>>();
+    let mut connection_owners = vec![legacy_service, header_sync_service, block_sync.clone()];
+    connection_owners.extend(custom_services.iter().cloned());
+    discovery_service.set_connection_owners(connection_owners);
     services.push(discovery_service as Arc<dyn Service>);
     services.push(block_sync);
+    services.extend(custom_services);
 
     Ok(Arc::new(
         ServiceRegistry::new(services).map_err(|error| -> BoxError { Box::new(error) })?,
@@ -3418,6 +3440,16 @@ async fn enable_header_sync_and_renegotiate(
     disconnected
 }
 
+fn advertised_services_with_custom(custom_services: &[CustomService]) -> Vec<ZakuraServiceId> {
+    let mut advertised_services = discovery::default_advertised_services();
+    advertised_services.extend(
+        custom_services
+            .iter()
+            .flat_map(|custom| custom.advertised_services.iter().cloned()),
+    );
+    advertised_services
+}
+
 /// Start a Zakura endpoint and router when P2P v2 is enabled.
 pub async fn spawn_zakura_endpoint(
     config: &Config,
@@ -3432,19 +3464,44 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
     sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
     header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
 ) -> Result<Option<ZakuraEndpoint>, BoxError> {
-    spawn_zakura_endpoint_inner(config, sink_factory, header_sync_driver_startup, None).await
+    spawn_zakura_endpoint_with_custom_services(
+        config,
+        sink_factory,
+        header_sync_driver_startup,
+        Vec::new(),
+    )
+    .await
+}
+
+/// Start a Zakura endpoint with application-supplied protocol services.
+pub async fn spawn_zakura_endpoint_with_custom_services(
+    config: &Config,
+    sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
+    header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
+    custom_services: Vec<CustomService>,
+) -> Result<Option<ZakuraEndpoint>, BoxError> {
+    spawn_zakura_endpoint_inner(
+        config,
+        sink_factory,
+        header_sync_driver_startup,
+        custom_services,
+        None,
+    )
+    .await
 }
 
 pub(crate) async fn spawn_zakura_endpoint_with_peer_registry(
     config: &Config,
     sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
     header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
+    custom_services: Vec<CustomService>,
     peer_registry: PeerRegistry,
 ) -> Result<Option<ZakuraEndpoint>, BoxError> {
     spawn_zakura_endpoint_inner(
         config,
         sink_factory,
         header_sync_driver_startup,
+        custom_services,
         Some(peer_registry),
     )
     .await
@@ -3454,6 +3511,7 @@ async fn spawn_zakura_endpoint_inner(
     config: &Config,
     sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
     header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
+    custom_services: Vec<CustomService>,
     peer_registry: Option<PeerRegistry>,
 ) -> Result<Option<ZakuraEndpoint>, BoxError> {
     if !config.v2_p2p() {
@@ -3489,10 +3547,10 @@ async fn spawn_zakura_endpoint_inner(
         &config.network,
         config.zakura.dev_network.as_deref(),
     );
-    let discovery = super::discovery::build_discovery_handle(
+    let discovery = discovery::build_discovery_handle(
         discovery_secret_key,
         discovery_direct_addrs(config, local_node_id),
-        super::discovery::default_advertised_services(),
+        advertised_services_with_custom(&custom_services),
         &handshake_config,
         config.zakura.max_connections,
         remote_bootstrap_peer_count(&config.zakura.bootstrap_peers, local_node_id),
@@ -3570,7 +3628,15 @@ async fn spawn_zakura_endpoint_inner(
         legacy_service,
         discovery_service,
         service_demand.clone(),
-    )?;
+        custom_services,
+    );
+    let registry = match registry {
+        Ok(registry) => registry,
+        Err(error) => {
+            header_sync_shutdown.cancel();
+            return Err(error);
+        }
+    };
     let mut tasks = vec![header_sync_task];
     if let Some(task) = block_sync_task {
         tasks.push(task);

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -3464,7 +3464,7 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
     sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
     header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
 ) -> Result<Option<ZakuraEndpoint>, BoxError> {
-    spawn_zakura_endpoint_with_custom_services(
+    spawn_zakura_endpoint_with_services(
         config,
         sink_factory,
         header_sync_driver_startup,
@@ -3473,8 +3473,8 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
     .await
 }
 
-/// Start a Zakura endpoint with application-supplied protocol services.
-pub async fn spawn_zakura_endpoint_with_custom_services(
+/// Start a Zakura endpoint with optional runtime services.
+pub async fn spawn_zakura_endpoint_with_services(
     config: &Config,
     sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
     header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -3693,6 +3693,7 @@ async fn spawn_zakura_endpoint_inner(
         block_sync_actions,
         upgrade_dials: Arc::new(StdMutex::new(HashMap::new())),
     };
+    let startup_shutdown = endpoint.background_shutdown_token().drop_guard();
 
     if let Some(mut service_demand) = service_demand {
         let capability_handler = endpoint.handler.clone();
@@ -3771,6 +3772,7 @@ async fn spawn_zakura_endpoint_inner(
     let discovery_dialer =
         super::discovery::spawn_native_discovery_dialer(endpoint.clone(), discovery, limits);
     endpoint.push_header_sync_task(discovery_dialer).await;
+    startup_shutdown.disarm();
     Ok(Some(endpoint))
 }
 

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -1866,6 +1866,7 @@ pub(crate) struct NativeHandshakeNegotiated {
     pub(crate) accepted_capabilities: u64,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn service_registry(
     _supervisor: &ZakuraSupervisorHandle,
     header_sync: Option<super::HeaderSyncHandle>,

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -522,10 +522,11 @@ pub struct CustomService {
     /// Custom p2p service.
     pub service: Arc<dyn Service>,
 
-    /// Service ids to include in this node's discovery.
-    ///
-    /// Leave empty to skip discovery.
-    pub advertised_services: Vec<ZakuraServiceId>,
+    /// Service ids to advertise to the network.
+    pub provides: Vec<ZakuraServiceId>,
+
+    /// Remote service ids to prefer when selecting outbound discovery peers.
+    pub seeks: Vec<ZakuraServiceId>,
 }
 
 impl From<CustomService> for Arc<dyn Service> {
@@ -3440,14 +3441,24 @@ async fn enable_header_sync_and_renegotiate(
     disconnected
 }
 
-fn advertised_services_with_custom(custom_services: &[CustomService]) -> Vec<ZakuraServiceId> {
-    let mut advertised_services = discovery::default_advertised_services();
-    advertised_services.extend(
+fn provided_services_with_custom(custom_services: &[CustomService]) -> Vec<ZakuraServiceId> {
+    let mut provided_services = discovery::default_advertised_services();
+    provided_services.extend(
         custom_services
             .iter()
-            .flat_map(|custom| custom.advertised_services.iter().cloned()),
+            .flat_map(|custom| custom.provides.iter().cloned()),
     );
-    advertised_services
+    provided_services
+}
+
+fn sought_services_with_custom(custom_services: &[CustomService]) -> Vec<ZakuraServiceId> {
+    let mut sought_services: Vec<_> = custom_services
+        .iter()
+        .flat_map(|custom| custom.seeks.iter().cloned())
+        .collect();
+    sought_services.sort_unstable();
+    sought_services.dedup();
+    sought_services
 }
 
 /// Start a Zakura endpoint and router when P2P v2 is enabled.
@@ -3547,10 +3558,11 @@ async fn spawn_zakura_endpoint_inner(
         &config.network,
         config.zakura.dev_network.as_deref(),
     );
+    let sought_services = sought_services_with_custom(&custom_services);
     let discovery = discovery::build_discovery_handle(
         discovery_secret_key,
         discovery_direct_addrs(config, local_node_id),
-        advertised_services_with_custom(&custom_services),
+        provided_services_with_custom(&custom_services),
         &handshake_config,
         config.zakura.max_connections,
         remote_bootstrap_peer_count(&config.zakura.bootstrap_peers, local_node_id),
@@ -3769,8 +3781,12 @@ async fn spawn_zakura_endpoint_inner(
     ) {
         endpoint.push_header_sync_task(task).await;
     }
-    let discovery_dialer =
-        super::discovery::spawn_native_discovery_dialer(endpoint.clone(), discovery, limits);
+    let discovery_dialer = discovery::spawn_native_discovery_dialer(
+        endpoint.clone(),
+        discovery,
+        limits,
+        sought_services,
+    );
     endpoint.push_header_sync_task(discovery_dialer).await;
     startup_shutdown.disarm();
     Ok(Some(endpoint))
@@ -6676,6 +6692,7 @@ mod tests {
             endpoint.clone(),
             discovery,
             limits,
+            Vec::new(),
         );
 
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -6786,6 +6803,7 @@ mod tests {
         };
 
         let _guard = zakura_test::init();
+        let service_id = ZakuraServiceId::new("zakura.test.ordered.v1")?;
         let listen_addr = "127.0.0.1:0".parse().expect("valid loopback address");
         let server_identity = tempfile::tempdir()?;
         let client_identity = tempfile::tempdir()?;
@@ -6805,7 +6823,8 @@ mod tests {
                     stream: CUSTOM_STREAM,
                     sessions: server_sessions,
                 }),
-                advertised_services: Vec::new(),
+                provides: vec![service_id.clone()],
+                seeks: Vec::new(),
             }],
         )
         .await?
@@ -6831,7 +6850,8 @@ mod tests {
                     stream: CUSTOM_STREAM,
                     sessions: client_sessions,
                 }),
-                advertised_services: Vec::new(),
+                provides: Vec::new(),
+                seeks: vec![service_id],
             }],
         )
         .await?

--- a/crates/zakura-network/src/zakura/testkit/node.rs
+++ b/crates/zakura-network/src/zakura/testkit/node.rs
@@ -109,6 +109,7 @@ impl ZakuraTestNode {
             self.endpoint.clone(),
             self.discovery.clone(),
             self.limits.clone(),
+            Vec::new(),
         ))
     }
 

--- a/crates/zakura-network/src/zakura/testkit/node.rs
+++ b/crates/zakura-network/src/zakura/testkit/node.rs
@@ -563,6 +563,7 @@ impl ZakuraTestNodeBuilder {
             base_service,
             discovery_service,
             None,
+            Vec::new(),
         )?;
         let mut handler = ZakuraProtocolHandler::new_with_registry_and_trace(
             supervisor.clone(),

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -487,7 +487,7 @@ impl StartCmd {
         let advertised_services = Self::advertised_services(&config);
 
         let (peer_set, address_book, misbehavior_sender, zakura_endpoint) =
-            zakura_network::init_with_zakura_custom_services(
+            zakura_network::init_with_zakura(
                 config.network.clone(),
                 inbound,
                 latest_chain_tip.clone(),

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -87,6 +87,7 @@ use futures::FutureExt;
 use tokio::{
     pin, select,
     sync::{oneshot, watch},
+    task::{AbortHandle, JoinHandle},
 };
 use tokio_util::sync::CancellationToken;
 use tower::{builder::ServiceBuilder, util::BoxService, ServiceExt};
@@ -172,6 +173,22 @@ fn check_tcp_slow_start_after_idle() {
 
 fn use_zakura_block_sync(config: &zakura_network::Config) -> bool {
     config.v2_p2p()
+}
+
+#[derive(Default)]
+// Keeps track of `JoinHandle`s, and when `Drop`ped, `aborts` all of them.
+struct NodeTasks(Vec<AbortHandle>);
+
+impl NodeTasks {
+    fn track<T>(&mut self, task: &JoinHandle<T>) {
+        self.0.push(task.abort_handle());
+    }
+}
+
+impl Drop for NodeTasks {
+    fn drop(&mut self) {
+        self.0.iter().for_each(AbortHandle::abort);
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -288,8 +305,10 @@ impl StartCmd {
         config: Arc<ZakuradConfig>,
         custom_services: Vec<zakura_network::zakura::CustomService>,
         shutdown: CancellationToken,
-        cleanup_ready: CancellationToken,
+        shutdown_cleanup_required: CancellationToken,
     ) -> Result<(), Report> {
+        let _shutdown_on_drop = shutdown.clone().drop_guard();
+        let mut node_tasks = NodeTasks::default();
         check_tcp_slow_start_after_idle();
 
         let is_regtest = config.network.network.is_regtest();
@@ -501,6 +520,20 @@ impl StartCmd {
             .await
             .map_err(|error| eyre!(error))?;
 
+        // Not added to node_tasks, because it must outlive start() being dropped to shutdown the
+        // endpoint
+        let zakura_endpoint_shutdown_task = if let Some(endpoint) = zakura_endpoint.clone() {
+            shutdown_cleanup_required.cancel();
+
+            let shutdown = shutdown.clone();
+            Some(tokio::spawn(async move {
+                shutdown.cancelled().await;
+                endpoint.shutdown().await;
+            }))
+        } else {
+            None
+        };
+
         // Start health server if configured (after sync_status is available)
 
         info!("initializing verifiers");
@@ -513,6 +546,7 @@ impl StartCmd {
                 tx_verifier_setup_rx,
             )
             .await;
+        node_tasks.track(&consensus_task_handles.state_checkpoint_verify_handle);
 
         if let Some(endpoint) = zakura_endpoint.clone() {
             let trace = endpoint.trace();
@@ -617,6 +651,7 @@ impl StartCmd {
             LAST_WARN_ERROR_LOG_SENDER.subscribe(),
             Some(submit_block_channel.sender()),
         );
+        node_tasks.track(&rpc_tx_queue_handle);
         let rpc_impl = rpc_impl.with_end_of_support_height(
             sync::end_of_support::end_of_support_height(&config.network.network),
         );
@@ -628,6 +663,7 @@ impl StartCmd {
         } else {
             tokio::spawn(std::future::pending().in_current_span())
         };
+        node_tasks.track(&rpc_task_handle);
 
         let zcashd_compat_shutdown_timeout =
             Self::zcashd_compat_supervisor_shutdown_timeout(&config);
@@ -681,6 +717,7 @@ impl StartCmd {
                 tokio::spawn(std::future::pending().in_current_span())
             }
         };
+        node_tasks.track(&indexer_rpc_task_handle);
 
         // Start concurrent tasks which don't add load to other tasks
         info!("spawning block gossip task");
@@ -693,9 +730,11 @@ impl StartCmd {
             )
             .in_current_span(),
         );
+        node_tasks.track(&block_gossip_task_handle);
 
         info!("spawning mempool queue checker task");
         let mempool_queue_checker_task_handle = mempool::QueueChecker::spawn(mempool.clone());
+        node_tasks.track(&mempool_queue_checker_task_handle);
 
         info!("spawning mempool transaction gossip task");
         let tx_gossip_task_handle = tokio::spawn(
@@ -706,12 +745,14 @@ impl StartCmd {
             )
             .in_current_span(),
         );
+        node_tasks.track(&tx_gossip_task_handle);
 
         info!("spawning delete old databases task");
         let mut old_databases_task_handle = zakura_state::check_and_delete_old_state_databases(
             &config.state,
             &config.network.network,
         );
+        node_tasks.track(&old_databases_task_handle);
 
         info!("spawning progress logging task");
         let (chain_tip_metrics_sender, chain_tip_metrics_receiver) =
@@ -725,6 +766,7 @@ impl StartCmd {
             )
             .in_current_span(),
         );
+        node_tasks.track(&progress_task_handle);
 
         // Start health server if configured
         info!("initializing health endpoints");
@@ -736,6 +778,7 @@ impl StartCmd {
             address_book.clone(),
         )
         .await;
+        node_tasks.track(&health_task_handle);
 
         // Spawn never ending end of support task.
         info!("spawning end of support checking task");
@@ -743,6 +786,7 @@ impl StartCmd {
             sync::end_of_support::start(config.network.network.clone(), latest_chain_tip.clone())
                 .in_current_span(),
         );
+        node_tasks.track(&end_of_support_task_handle);
 
         // Give the inbound service more time to clear its queue,
         // then start concurrent tasks that can add load to the inbound service
@@ -758,6 +802,7 @@ impl StartCmd {
             sync_status.clone(),
             chain_tip_change.clone(),
         );
+        node_tasks.track(&mempool_crawler_task_handle);
 
         info!("spawning syncer task");
         // In regtest, commit the genesis block directly (bypassing the syncer's genesis
@@ -813,6 +858,7 @@ impl StartCmd {
         } else {
             tokio::spawn(syncer.sync().in_current_span())
         };
+        node_tasks.track(&syncer_task_handle);
 
         // And finally, spawn the internal Zcash miner, if it is enabled.
         //
@@ -829,6 +875,7 @@ impl StartCmd {
         // Spawn a dummy miner task which doesn't do anything and never finishes.
         let miner_task_handle: tokio::task::JoinHandle<Result<(), Report>> =
             tokio::spawn(std::future::pending().in_current_span());
+        node_tasks.track(&miner_task_handle);
 
         info!("spawned initial Zakura tasks");
 
@@ -844,7 +891,7 @@ impl StartCmd {
             };
         // The supervisor may own a child after this point, so shutdown must
         // await cleanup. Do not add a yield between the spawn and this marker.
-        cleanup_ready.cancel();
+        shutdown_cleanup_required.cancel();
 
         // TODO: put tasks into an ongoing FuturesUnordered and a startup FuturesUnordered?
 
@@ -997,6 +1044,7 @@ impl StartCmd {
         };
 
         info!("exiting Zakura: asking other tasks to stop");
+        shutdown.cancel();
         zakura_chain::shutdown::set_shutting_down();
 
         // ongoing tasks
@@ -1011,8 +1059,10 @@ impl StartCmd {
         progress_task_handle.abort();
         end_of_support_task_handle.abort();
         miner_task_handle.abort();
-        if let Some(zakura_endpoint) = zakura_endpoint {
-            zakura_endpoint.shutdown().await;
+        if let Some(zakura_endpoint_shutdown_task) = zakura_endpoint_shutdown_task {
+            zakura_endpoint_shutdown_task
+                .await
+                .expect("unexpected panic in the Zakura endpoint shutdown task");
         }
         if zcashd_compat_task_finished {
             debug!("zcashd-compat supervisor task already exited before shutdown");
@@ -1118,8 +1168,13 @@ impl Runnable for StartCmd {
             .take();
 
         rt.expect("runtime should not already be taken")
-            .run_with_graceful_shutdown(|shutdown, cleanup_ready| {
-                self.start(APPLICATION.config(), Vec::new(), shutdown, cleanup_ready)
+            .run_with_graceful_shutdown(|shutdown, shutdown_cleanup_required| {
+                self.start(
+                    APPLICATION.config(),
+                    Vec::new(),
+                    shutdown,
+                    shutdown_cleanup_required,
+                )
             });
 
         info!("stopping zakurad");

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -487,7 +487,7 @@ impl StartCmd {
         let advertised_services = Self::advertised_services(&config);
 
         let (peer_set, address_book, misbehavior_sender, zakura_endpoint) =
-            zakura_network::init_with_zakura_header_sync(
+            zakura_network::init_with_zakura_custom_services(
                 config.network.clone(),
                 inbound,
                 latest_chain_tip.clone(),
@@ -495,6 +495,7 @@ impl StartCmd {
                 advertised_services,
                 zcashd_compat_block_gossip_peer_ips,
                 zakura_header_sync_driver_startup,
+                Vec::new(),
             )
             .await;
 

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -307,8 +307,6 @@ impl StartCmd {
         shutdown: CancellationToken,
         shutdown_cleanup_required: CancellationToken,
     ) -> Result<(), Report> {
-        let _shutdown_on_drop = shutdown.clone().drop_guard();
-        let mut node_tasks = NodeTasks::default();
         check_tcp_slow_start_after_idle();
 
         let is_regtest = config.network.network.is_regtest();
@@ -473,6 +471,10 @@ impl StartCmd {
         } else {
             None
         };
+
+        let mut node_tasks = NodeTasks::default();
+        // Cancel detached tasks before dropping the state services, whose teardown blocks.
+        let _shutdown_on_drop = shutdown.clone().drop_guard();
 
         info!("initializing network");
         // The service that our node uses to respond to requests by peers. The

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -283,14 +283,15 @@ impl StartCmd {
         )
     }
 
-    async fn start(
+    pub(crate) async fn start(
         &self,
+        config: Arc<ZakuradConfig>,
+        custom_services: Vec<zakura_network::zakura::CustomService>,
         shutdown: CancellationToken,
         cleanup_ready: CancellationToken,
     ) -> Result<(), Report> {
         check_tcp_slow_start_after_idle();
 
-        let config = APPLICATION.config();
         let is_regtest = config.network.network.is_regtest();
 
         let config = if is_regtest {
@@ -419,7 +420,7 @@ impl StartCmd {
             };
 
         let state = ServiceBuilder::new()
-            .buffer(Self::state_buffer_bound())
+            .buffer(Self::state_buffer_bound(&config))
             .service(state_service);
 
         let zakura_bootstrap_snapshots = config
@@ -495,9 +496,10 @@ impl StartCmd {
                 advertised_services,
                 zcashd_compat_block_gossip_peer_ips,
                 zakura_header_sync_driver_startup,
-                Vec::new(),
+                custom_services,
             )
-            .await;
+            .await
+            .map_err(|error| eyre!(error))?;
 
         // Start health server if configured (after sync_status is available)
 
@@ -995,6 +997,7 @@ impl StartCmd {
         };
 
         info!("exiting Zakura: asking other tasks to stop");
+        zakura_chain::shutdown::set_shutting_down();
 
         // ongoing tasks
         rpc_task_handle.abort();
@@ -1008,6 +1011,9 @@ impl StartCmd {
         progress_task_handle.abort();
         end_of_support_task_handle.abort();
         miner_task_handle.abort();
+        if let Some(zakura_endpoint) = zakura_endpoint {
+            zakura_endpoint.shutdown().await;
+        }
         if zcashd_compat_task_finished {
             debug!("zcashd-compat supervisor task already exited before shutdown");
         } else if let Some(zcashd_compat_shutdown_timeout) = zcashd_compat_shutdown_timeout {
@@ -1082,9 +1088,7 @@ impl StartCmd {
 
     /// Returns the bound for the state service buffer,
     /// based on the configurations of the services that use the state concurrently.
-    fn state_buffer_bound() -> usize {
-        let config = APPLICATION.config();
-
+    fn state_buffer_bound(config: &ZakuradConfig) -> usize {
         // Ignore the checkpoint verify limit, because it is very large.
         //
         // TODO: do we also need to account for concurrent use across services?
@@ -1115,7 +1119,7 @@ impl Runnable for StartCmd {
 
         rt.expect("runtime should not already be taken")
             .run_with_graceful_shutdown(|shutdown, cleanup_ready| {
-                self.start(shutdown, cleanup_ready)
+                self.start(APPLICATION.config(), Vec::new(), shutdown, cleanup_ready)
             });
 
         info!("stopping zakurad");

--- a/crates/zakurad/src/components/health.rs
+++ b/crates/zakurad/src/components/health.rs
@@ -150,13 +150,6 @@ where
         let _ = num_live_peer_sender.send(metrics);
     }
 
-    // Refresh metrics in the background using a watch channel so request
-    // handlers can read the latest snapshot without taking locks.
-    let metrics_task = tokio::spawn(peer_metrics_refresh_task(
-        address_book.clone(),
-        num_live_peer_sender,
-    ));
-
     let shared = Arc::new(HealthCtx {
         config,
         network,
@@ -165,14 +158,10 @@ where
         num_live_peer_receiver,
     });
 
-    let server_task = tokio::spawn(run_health_server(listener, shared));
-
-    // Keep both async tasks tied to a single JoinHandle so shutdown and
-    // abort semantics mirror other components.
     let task = tokio::spawn(async move {
         tokio::select! {
-            _ = metrics_task => {},
-            _ = server_task => {},
+            _ = peer_metrics_refresh_task(address_book, num_live_peer_sender) => {},
+            _ = run_health_server(listener, shared) => {},
         }
     });
 

--- a/crates/zakurad/src/components/tokio.rs
+++ b/crates/zakurad/src/components/tokio.rs
@@ -83,7 +83,7 @@ impl RuntimeRun for Runtime {
     }
 }
 
-async fn run_until_shutdown(
+pub(crate) async fn run_until_shutdown(
     fut: impl Future<Output = Result<(), Report>>,
     shutdown_signal: impl Future<Output = ()>,
     shutdown_token: CancellationToken,

--- a/crates/zakurad/src/components/tokio.rs
+++ b/crates/zakurad/src/components/tokio.rs
@@ -70,13 +70,14 @@ impl RuntimeRun for Runtime {
         F: Future<Output = Result<(), Report>>,
     {
         let shutdown_token = CancellationToken::new();
-        let cleanup_ready = CancellationToken::new();
-        let fut = run(shutdown_token.clone(), cleanup_ready.clone());
+        // cancelled means shutdown must await the root future's cleanup.
+        let shutdown_cleanup_required = CancellationToken::new();
+        let fut = run(shutdown_token.clone(), shutdown_cleanup_required.clone());
         let result = self.block_on(run_until_shutdown(
             fut,
             shutdown(),
             shutdown_token,
-            cleanup_ready,
+            shutdown_cleanup_required,
         ));
 
         finish_runtime(self, result);
@@ -87,7 +88,7 @@ pub(crate) async fn run_until_shutdown(
     fut: impl Future<Output = Result<(), Report>>,
     shutdown_signal: impl Future<Output = ()>,
     shutdown_token: CancellationToken,
-    cleanup_ready: CancellationToken,
+    shutdown_cleanup_required: CancellationToken,
 ) -> Result<(), Report> {
     tokio::pin!(fut);
     tokio::pin!(shutdown_signal);
@@ -96,7 +97,7 @@ pub(crate) async fn run_until_shutdown(
         biased;
         _ = &mut shutdown_signal => {
             shutdown_token.cancel();
-            if cleanup_ready.is_cancelled() {
+            if shutdown_cleanup_required.is_cancelled() {
                 fut.await
             } else {
                 Ok(())
@@ -137,8 +138,8 @@ mod tests {
     async fn graceful_shutdown_waits_for_root_future_cleanup() {
         let shutdown = CancellationToken::new();
         let future_shutdown = shutdown.clone();
-        let cleanup_ready = CancellationToken::new();
-        cleanup_ready.cancel();
+        let shutdown_cleanup_required = CancellationToken::new();
+        shutdown_cleanup_required.cancel();
         let (cleanup_tx, cleanup_rx) = oneshot::channel();
 
         let fut = async move {
@@ -147,7 +148,7 @@ mod tests {
             Ok(())
         };
 
-        run_until_shutdown(fut, future::ready(()), shutdown, cleanup_ready)
+        run_until_shutdown(fut, future::ready(()), shutdown, shutdown_cleanup_required)
             .await
             .expect("shutdown should succeed");
         cleanup_rx.await.expect("root future ran cleanup");
@@ -156,13 +157,13 @@ mod tests {
     #[tokio::test]
     async fn shutdown_during_startup_does_not_wait_for_root_future() {
         let shutdown = CancellationToken::new();
-        let cleanup_ready = CancellationToken::new();
+        let shutdown_cleanup_required = CancellationToken::new();
 
         run_until_shutdown(
             future::pending(),
             future::ready(()),
             shutdown.clone(),
-            cleanup_ready,
+            shutdown_cleanup_required,
         )
         .await
         .expect("shutdown should succeed");

--- a/crates/zakurad/src/lib.rs
+++ b/crates/zakurad/src/lib.rs
@@ -139,6 +139,7 @@ pub mod application;
 pub mod commands;
 pub mod components;
 pub mod config;
+pub mod node;
 pub mod prelude;
 
 #[cfg(feature = "sentry")]

--- a/crates/zakurad/src/node.rs
+++ b/crates/zakurad/src/node.rs
@@ -49,13 +49,39 @@ pub async fn run_with_services(
 
 #[cfg(test)]
 mod tests {
-    use std::{net::UdpSocket, time::Duration};
+    use std::{
+        net::UdpSocket,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
     use super::*;
     use tokio::time::timeout;
+    use zakura_network::zakura::{Peer, Service, Stream, ZakuraConnId, ZakuraPeerId};
+
+    #[derive(Debug)]
+    struct RegistrationProbe(Arc<AtomicBool>);
+
+    impl Service for RegistrationProbe {
+        fn name(&self) -> &'static str {
+            "registration-probe"
+        }
+
+        fn streams(&self) -> &[Stream] {
+            self.0.store(true, Ordering::Relaxed);
+            &[]
+        }
+
+        fn add_peer(&self, _peer: Peer) {}
+
+        fn remove_peer(&self, _peer: &ZakuraPeerId, _conn_id: ZakuraConnId) {}
+    }
 
     #[tokio::test]
-    async fn dropping_node_future_shuts_down_zakura_endpoint() {
+    async fn embedded_node_registers_custom_service_and_shuts_down_on_drop() {
         let _guard = zakura_test::init();
         let native_socket = UdpSocket::bind("127.0.0.1:0").expect("test UDP port is available");
         let native_addr = native_socket
@@ -73,9 +99,13 @@ mod tests {
         config.network.zakura.listen_addr = Some(native_addr);
         config.network.zakura.bootstrap_peers.clear();
         config.state = zakura_state::Config::ephemeral();
+        let service_registered = Arc::new(AtomicBool::new(false));
         let mut node = Box::pin(run_with_services(
             config,
-            Vec::new(),
+            vec![CustomService {
+                service: Arc::new(RegistrationProbe(service_registered.clone())),
+                advertised_services: Vec::new(),
+            }],
             CancellationToken::new(),
         ));
         timeout(Duration::from_secs(30), async {
@@ -84,13 +114,16 @@ mod tests {
                     result = &mut node => panic!("node exited before starting: {result:?}"),
                     _ = tokio::time::sleep(Duration::from_millis(25)) => {}
                 }
-                if UdpSocket::bind(native_addr).is_err() {
+                if service_registered.load(Ordering::Relaxed)
+                    && UdpSocket::bind(native_addr).is_err()
+                {
                     break;
                 }
             }
         })
         .await
-        .expect("node starts its Zakura endpoint");
+        .expect("node registers its custom service and starts its Zakura endpoint");
+
         drop(node);
 
         let socket = timeout(Duration::from_secs(30), async {

--- a/crates/zakurad/src/node.rs
+++ b/crates/zakurad/src/node.rs
@@ -1,0 +1,96 @@
+//! In-process Zakura node lifecycle.
+
+use abscissa_core::config::Override;
+use color_eyre::Report;
+use tokio_util::sync::CancellationToken;
+
+use crate::{commands::StartCmd, components::tokio::run_until_shutdown, config::ZakuradConfig};
+
+pub use zakura_network::zakura::CustomService;
+
+/// Runs a Zakura node on the current Tokio runtime until shutdown or failure.
+///
+/// tracing, metrics, Rayon setup, and panic hooks are the embedding
+/// application's responsibility.
+pub async fn run(config: ZakuradConfig, shutdown: CancellationToken) -> Result<(), Report> {
+    run_with_services(config, Vec::new(), shutdown).await
+}
+
+/// Runs a Zakura node with custom p2p services
+pub async fn run_with_services(
+    config: ZakuradConfig,
+    custom_services: Vec<CustomService>,
+    shutdown: CancellationToken,
+) -> Result<(), Report> {
+    if shutdown.is_cancelled() {
+        return Ok(());
+    }
+
+    let command = StartCmd::default();
+    let config = command.override_config(config)?;
+    let node_shutdown = CancellationToken::new();
+    let cleanup_ready = CancellationToken::new();
+    let node = command.start(
+        config.into(),
+        custom_services,
+        node_shutdown.clone(),
+        cleanup_ready.clone(),
+    );
+
+    run_until_shutdown(
+        node,
+        shutdown.cancelled_owned(),
+        node_shutdown,
+        cleanup_ready,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::TcpListener, time::Duration};
+
+    use super::*;
+    use tokio::{net::TcpStream, time::timeout};
+
+    #[tokio::test]
+    async fn node_starts_and_stops_on_cancellation() {
+        let _guard = zakura_test::init();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test port is available");
+        let health_addr = listener.local_addr().expect("test listener has an address");
+        drop(listener);
+
+        let mut config = ZakuradConfig::default();
+        config.network.listen_addr = "127.0.0.1:0".parse().expect("valid test address");
+        config.network.p2p_stack = zakura_network::P2pStack::Legacy;
+        config.network.initial_mainnet_peers.clear();
+        config.state = zakura_state::Config::ephemeral();
+        config.health.listen_addr = Some(health_addr);
+        let shutdown = CancellationToken::new();
+        let node = run_with_services(config, Vec::new(), shutdown.clone());
+
+        tokio::pin!(node);
+        timeout(Duration::from_secs(30), async {
+            tokio::select! {
+                result = &mut node => panic!("node exited before starting: {result:?}"),
+                _ = async {
+                    while TcpStream::connect(health_addr).await.is_err() {
+                        tokio::time::sleep(Duration::from_millis(25)).await;
+                    }
+                } => {}
+            }
+        })
+        .await
+        .expect("node starts its health endpoint");
+
+        tokio::select! {
+            result = &mut node => panic!("node exited after starting: {result:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+        shutdown.cancel();
+        timeout(Duration::from_secs(30), &mut node)
+            .await
+            .expect("node shuts down after cancellation")
+            .expect("node shuts down cleanly");
+    }
+}

--- a/crates/zakurad/src/node.rs
+++ b/crates/zakurad/src/node.rs
@@ -80,7 +80,7 @@ mod tests {
         fn remove_peer(&self, _peer: &ZakuraPeerId, _conn_id: ZakuraConnId) {}
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn embedded_node_registers_custom_service_and_shuts_down_on_drop() {
         let _guard = zakura_test::init();
         let native_socket = UdpSocket::bind("127.0.0.1:0").expect("test UDP port is available");

--- a/crates/zakurad/src/node.rs
+++ b/crates/zakurad/src/node.rs
@@ -104,7 +104,8 @@ mod tests {
             config,
             vec![CustomService {
                 service: Arc::new(RegistrationProbe(service_registered.clone())),
-                advertised_services: Vec::new(),
+                provides: Vec::new(),
+                seeks: Vec::new(),
             }],
             CancellationToken::new(),
         ));

--- a/crates/zakurad/src/node.rs
+++ b/crates/zakurad/src/node.rs
@@ -29,68 +29,80 @@ pub async fn run_with_services(
     let command = StartCmd::default();
     let config = command.override_config(config)?;
     let node_shutdown = CancellationToken::new();
-    let cleanup_ready = CancellationToken::new();
+    // One-way latch: cancelled means shutdown must await the root future's cleanup.
+    let shutdown_cleanup_required = CancellationToken::new();
     let node = command.start(
         config.into(),
         custom_services,
         node_shutdown.clone(),
-        cleanup_ready.clone(),
+        shutdown_cleanup_required.clone(),
     );
 
     run_until_shutdown(
         node,
         shutdown.cancelled_owned(),
         node_shutdown,
-        cleanup_ready,
+        shutdown_cleanup_required,
     )
     .await
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{net::TcpListener, time::Duration};
+    use std::{net::UdpSocket, time::Duration};
 
     use super::*;
-    use tokio::{net::TcpStream, time::timeout};
+    use tokio::time::timeout;
 
     #[tokio::test]
-    async fn node_starts_and_stops_on_cancellation() {
+    async fn dropping_node_future_shuts_down_zakura_endpoint() {
         let _guard = zakura_test::init();
-        let listener = TcpListener::bind("127.0.0.1:0").expect("test port is available");
-        let health_addr = listener.local_addr().expect("test listener has an address");
-        drop(listener);
+        let native_socket = UdpSocket::bind("127.0.0.1:0").expect("test UDP port is available");
+        let native_addr = native_socket
+            .local_addr()
+            .expect("test UDP socket has an address");
+        drop(native_socket);
+        let identity_dir = tempfile::tempdir().expect("temporary identity directory is created");
 
         let mut config = ZakuradConfig::default();
         config.network.listen_addr = "127.0.0.1:0".parse().expect("valid test address");
-        config.network.p2p_stack = zakura_network::P2pStack::Legacy;
+        config.network.p2p_stack = zakura_network::P2pStack::Dual;
         config.network.initial_mainnet_peers.clear();
+        config.network.cache_dir = zakura_network::CacheDir::disabled();
+        config.network.identity_dir = identity_dir.path().to_owned();
+        config.network.zakura.listen_addr = Some(native_addr);
+        config.network.zakura.bootstrap_peers.clear();
         config.state = zakura_state::Config::ephemeral();
-        config.health.listen_addr = Some(health_addr);
-        let shutdown = CancellationToken::new();
-        let node = run_with_services(config, Vec::new(), shutdown.clone());
-
-        tokio::pin!(node);
+        let mut node = Box::pin(run_with_services(
+            config,
+            Vec::new(),
+            CancellationToken::new(),
+        ));
         timeout(Duration::from_secs(30), async {
-            tokio::select! {
-                result = &mut node => panic!("node exited before starting: {result:?}"),
-                _ = async {
-                    while TcpStream::connect(health_addr).await.is_err() {
-                        tokio::time::sleep(Duration::from_millis(25)).await;
-                    }
-                } => {}
+            loop {
+                tokio::select! {
+                    result = &mut node => panic!("node exited before starting: {result:?}"),
+                    _ = tokio::time::sleep(Duration::from_millis(25)) => {}
+                }
+                if UdpSocket::bind(native_addr).is_err() {
+                    break;
+                }
             }
         })
         .await
-        .expect("node starts its health endpoint");
+        .expect("node starts its Zakura endpoint");
+        drop(node);
 
-        tokio::select! {
-            result = &mut node => panic!("node exited after starting: {result:?}"),
-            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
-        }
-        shutdown.cancel();
-        timeout(Duration::from_secs(30), &mut node)
-            .await
-            .expect("node shuts down after cancellation")
-            .expect("node shuts down cleanly");
+        let socket = timeout(Duration::from_secs(30), async {
+            loop {
+                if let Ok(socket) = UdpSocket::bind(native_addr) {
+                    break socket;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("dropping the node future releases its Zakura endpoint");
+        drop(socket);
     }
 }

--- a/docs/changelog/unreleased/594.md
+++ b/docs/changelog/unreleased/594.md
@@ -1,4 +1,4 @@
 ## Added
 
-- Applications embedding `zakura-network` can register custom Zakura p2p services during startup and advertise them through native discovery
+- Applications can now embed `zakurad` to register custom Zakura p2p services and advertise them through discovery
   ([#594](https://github.com/zakura-core/zakura/pull/594)).

--- a/docs/changelog/unreleased/594.md
+++ b/docs/changelog/unreleased/594.md
@@ -1,0 +1,4 @@
+## Added
+
+- Applications embedding `zakura-network` can register custom Zakura p2p services during startup and advertise them through native discovery
+  ([#594](https://github.com/zakura-core/zakura/pull/594)).


### PR DESCRIPTION
## Motivation

Related to my #592, but I didn't stack cause I don't know your guys' preference

I wanted to be able to add custom p2p services and the abstractions kinda look like this should be allowed. Originally this PR only passed a vec through `zakura-network` but that didn't do enough to be able to actually use it in a running node. 


## Solution

Expose a helper that essentially runs the abscissa command and lets you pass a config + custom services.

`CustomService` is a new struct that just encapsulates an arced `Service` and a list of discovery IDs. Had to add this since discovery info is a bit disjoint from the service definition.

The embedding callstack is not my favorite flow, but I think it may be the best we can do with abscissa without introducing too much bloat or slop abstractions

## Testing

adds a pretty self explanatory `custom_service_is_registered_and_advertised` and tested manually in a local network that is serving spendability-pir stubs

also added two other slop tests that ensure that:
1.  an embedded node /actually/ starts a node and shuts it down with its cancellation token, 
2. and that a passed custom service can actually be reached between 2 nodes that speak it

## Changelog

```
## Added

- Applications can now embed `zakurad` to register custom Zakura p2p services and advertise them through discovery
  ([#594](https://github.com/zakura-core/zakura/pull/594)).
```

