### PR TITLE
feat(consensus): memoize Halo2 proof verification results

### DIFF
--- a/crates/zakura-consensus/src/primitives.rs
+++ b/crates/zakura-consensus/src/primitives.rs
@@ -142,15 +142,24 @@ fn flush_block_verifier_batches() {
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {
-        queue_batch_flush("halo2_pre_nu6_2", verifier.primary().clone().try_flush());
+        queue_batch_flush(
+            "halo2_pre_nu6_2",
+            verifier.inner().primary().clone().try_flush(),
+        );
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_2) {
-        queue_batch_flush("halo2_nu6_2", verifier.primary().clone().try_flush());
+        queue_batch_flush(
+            "halo2_nu6_2",
+            verifier.inner().primary().clone().try_flush(),
+        );
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_3_ONWARD) {
-        queue_batch_flush("halo2_nu6_3_onward", verifier.primary().clone().try_flush());
+        queue_batch_flush(
+            "halo2_nu6_3_onward",
+            verifier.inner().primary().clone().try_flush(),
+        );
     }
 }
 

--- a/crates/zakura-consensus/src/primitives.rs
+++ b/crates/zakura-consensus/src/primitives.rs
@@ -142,24 +142,15 @@ fn flush_block_verifier_batches() {
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {
-        queue_batch_flush(
-            "halo2_pre_nu6_2",
-            verifier.inner().primary().clone().try_flush(),
-        );
+        queue_batch_flush("halo2_pre_nu6_2", halo2::try_flush(verifier));
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_2) {
-        queue_batch_flush(
-            "halo2_nu6_2",
-            verifier.inner().primary().clone().try_flush(),
-        );
+        queue_batch_flush("halo2_nu6_2", halo2::try_flush(verifier));
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_3_ONWARD) {
-        queue_batch_flush(
-            "halo2_nu6_3_onward",
-            verifier.inner().primary().clone().try_flush(),
-        );
+        queue_batch_flush("halo2_nu6_3_onward", halo2::try_flush(verifier));
     }
 }
 

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -12,11 +12,13 @@ use std::{
 use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use orchard::{
-    bundle::{BatchError, BatchValidator},
+    bundle::{BatchError, BatchValidator, BundleVersion},
     circuit::{OrchardCircuitVersion, VerifyingKey},
+    ProtocolVersion, ValuePool,
 };
 use rand::thread_rng;
 use zakura_chain::{parameters::NetworkUpgrade, transaction::SigHash};
+use zcash_primitives::transaction::components::orchard::write_v5_bundle;
 use zcash_protocol::value::ZatBalance;
 
 use crate::{error::TransactionError, BoxError};
@@ -28,8 +30,14 @@ use tower_fallback::Fallback;
 
 use super::spawn_fifo;
 
+mod memo;
+
 #[cfg(test)]
 mod tests;
+
+pub use memo::Memoized;
+
+use memo::{CacheKey, MEMO_CAPACITY};
 
 /// Adjusted batch size for halo2 batches.
 ///
@@ -50,6 +58,12 @@ type Sender = watch::Sender<Option<VerifyResult>>;
 /// The type of a prepared verifying key.
 /// This is the key used to verify individual items.
 pub type ItemVerifyingKey = VerifyingKey;
+
+/// The BLAKE2b personalization for [`Item`] memo cache keys.
+///
+/// Domain-separates these keys from every other BLAKE2b-256 hash in the protocol, so that a
+/// memo key can never be confused with a txid, an auth digest, or a sighash.
+const HALO2_MEMO_PERSONALIZATION: &[u8; 15] = b"ZakuraHalo2Memo";
 
 // The Orchard Action circuit, and therefore its verifying key, changes across protocol eras.
 // A proof produced under one circuit version does not verify under the other keys. So we keep
@@ -150,6 +164,76 @@ impl Item {
         }
         batch.validate(thread_rng())
     }
+
+    /// Returns a key that determines every input to this item's proof verification.
+    ///
+    /// [`Memoized`] reuses a previous `Ok` result whenever this key matches, so the key must
+    /// commit to everything [`BatchValidator::add_bundle`] reads. It hashes the bundle's own
+    /// consensus encoding, which is injective and covers all of it: the per-action value
+    /// commitments, nullifiers, validating keys, note commitments and spend authorization
+    /// signatures, the bundle flags, value balance, anchor, proof, and binding signature.
+    ///
+    /// The verifying key is *not* in the key. It does not need to be: each Orchard circuit era
+    /// has its own verifier and therefore its own memo, so an entry can only ever be read back
+    /// under the key it was written against. See [`verifier_for`].
+    ///
+    /// Deriving this by hand from things that "obviously" determine the bundle is how this goes
+    /// wrong. The txid does not commit to authorizing data at all under ZIP 244 — that was
+    /// CVE-2026-34377 — and even `(auth digest, sighash)` is incomplete, because the Orchard and
+    /// Ironwood bundles of one v6 transaction share both. Hashing the encoding avoids having to
+    /// get that reasoning right.
+    fn cache_key(&self) -> CacheKey {
+        // Destructured exhaustively on purpose: adding a field to `Item` is a compile error here
+        // until someone decides whether it belongs in the key.
+        let Item { bundle, sighash } = self;
+
+        let mut hasher = blake2b_simd::Params::new()
+            .hash_length(32)
+            .personal(HALO2_MEMO_PERSONALIZATION)
+            .to_state();
+
+        hasher.update(&[bundle_version_discriminant(bundle.bundle_version())]);
+        hasher.update(&sighash.0);
+
+        // `write_v5_bundle` is the total encoder: it is `write_v6_bundle` without the precondition
+        // that rejects pre-NU6.3 bundle versions, and the two produce identical bytes otherwise.
+        // The v5/v6 distinction it therefore does not encode is supplied by the discriminant above.
+        let mut encoded = Vec::new();
+        write_v5_bundle(Some(bundle.as_ref()), &mut encoded)
+            .expect("encoding a bundle into a Vec cannot fail: the encoder only reports IO errors");
+        hasher.update(&encoded);
+
+        hasher
+            .finalize()
+            .as_bytes()
+            .try_into()
+            .expect("hash_length(32) produces exactly 32 bytes")
+    }
+}
+
+/// Returns a stable one-byte discriminant for `version`.
+///
+/// A bundle's consensus encoding contains its flag byte but not its [`BundleVersion`], and two
+/// bundles in different value pools can share a flag byte, so [`Item::cache_key`] commits to the
+/// value pool and protocol version separately. Today the pool affects verification only through
+/// the flags, but the bundle version already selects other version-dependent behaviour in the
+/// `orchard` crate, and one byte removes the need to re-check that on every dependency bump.
+///
+/// Both matches are exhaustive: a new value pool or protocol version is a compile error here
+/// until it is given a discriminant on purpose.
+fn bundle_version_discriminant(version: BundleVersion) -> u8 {
+    let pool = match version.value_pool() {
+        ValuePool::Orchard => 0x00,
+        ValuePool::Ironwood => 0x10,
+    };
+
+    let protocol = match version.protocol_version() {
+        ProtocolVersion::InsecureV1 => 0x00,
+        ProtocolVersion::V2 => 0x01,
+        ProtocolVersion::V3 => 0x02,
+    };
+
+    pool | protocol
 }
 
 trait QueueBatchVerify {
@@ -217,12 +301,15 @@ impl Service<Item> for OrchardFallback {
     }
 }
 
+/// The batching-and-fallback stack for one Orchard circuit era, before memoization.
+type BatchFallbackService = Fallback<Batch<Verifier, Item>, OrchardFallback>;
+
 /// The concrete type of a global Halo2 verification service.
 ///
 /// Each Orchard circuit era gets its own instance — see [`VERIFIER_PRE_NU6_2`], [`VERIFIER_NU6_2`],
-/// or [`VERIFIER_NU6_3_ONWARD`] — so that batches, fallbacks, and verifying keys are fully
+/// or [`VERIFIER_NU6_3_ONWARD`] — so that batches, fallbacks, verifying keys, and memos are fully
 /// separated per era.
-type VerifierService = Fallback<Batch<Verifier, Item>, OrchardFallback>;
+type VerifierService = Memoized<BatchFallbackService>;
 
 /// Builds a global Halo2 verifier that validates every item against `vk`.
 ///
@@ -231,7 +318,17 @@ type VerifierService = Fallback<Batch<Verifier, Item>, OrchardFallback>;
 /// passed here, so an item built by this verifier is always checked against exactly one era's key.
 /// Callers select the correct era's key by which `VERIFYING_KEY_*` they pass; there is no runtime
 /// key resolution.
+///
+/// The stack is wrapped in a [`Memoized`] so that a proof gossiped into the mempool does not have
+/// to be verified again when the block that mines it arrives. Because each era builds its own
+/// verifier here, each era also gets its own memo, which is what binds a remembered result to the
+/// `vk` it was produced under.
 fn batch_verifier(vk: &'static ItemVerifyingKey) -> VerifierService {
+    Memoized::new(batch_fallback_verifier(vk), MEMO_CAPACITY)
+}
+
+/// Builds the un-memoized batching-and-fallback stack for `vk`.
+fn batch_fallback_verifier(vk: &'static ItemVerifyingKey) -> BatchFallbackService {
     Fallback::new(
         Batch::new(
             Verifier::new(vk),

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -35,9 +35,7 @@ mod cache;
 #[cfg(test)]
 mod tests;
 
-pub use cache::Cached;
-
-use cache::{CacheKey, CACHE_CAPACITY};
+use cache::Cached;
 
 /// Adjusted batch size for halo2 batches.
 ///
@@ -48,6 +46,18 @@ use cache::{CacheKey, CACHE_CAPACITY};
 /// To compensate for larger proofs, we process the batch once there are over
 /// [`HALO2_MAX_BATCH_SIZE`] total actions among pending items in the queue.
 const HALO2_MAX_BATCH_SIZE: usize = super::MAX_BATCH_SIZE;
+
+/// The number of verified-proof keys retained per Orchard circuit era.
+///
+/// Sized to hold several blocks of history plus a full mempool, so that a transaction gossiped
+/// well before the block that mines it is still remembered. At 32-byte keys this is on the order
+/// of a megabyte per era.
+const CACHE_CAPACITY: usize = 20_000;
+
+/// A key that determines every input to one [`Item`]'s proof verification.
+///
+/// See [`Item::cache_key`] for the construction and for why completeness matters.
+type CacheKey = [u8; 32];
 
 /// The type of verification results.
 type VerifyResult = bool;
@@ -428,6 +438,17 @@ fn lazy_verifier_for(network_upgrade: NetworkUpgrade) -> &'static Lazy<VerifierS
 /// is a compile error here until it is bound to a key on purpose.
 pub fn verifier_for(network_upgrade: NetworkUpgrade) -> &'static VerifierService {
     lazy_verifier_for(network_upgrade)
+}
+
+/// Returns how many times `item` has reached its era's inner Halo2 verifier.
+#[cfg(test)]
+pub(crate) fn inner_calls_for(network_upgrade: NetworkUpgrade, item: &Item) -> usize {
+    verifier_for(network_upgrade).inner_calls_for(item)
+}
+
+/// Attempts to flush the batching service wrapped by `verifier`.
+pub(super) fn try_flush(verifier: &VerifierService) -> Result<bool, BoxError> {
+    verifier.inner().primary().clone().try_flush()
 }
 
 /// Halo2 proof verifier implementation

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -195,9 +195,11 @@ impl Item {
         hasher.update(&[bundle_version_discriminant(bundle.bundle_version())]);
         hasher.update(&sighash.0);
 
-        // `write_v5_bundle` is the total encoder: it is `write_v6_bundle` without the precondition
-        // that rejects pre-NU6.3 bundle versions, and the two produce identical bytes otherwise.
-        // The v5/v6 distinction it therefore does not encode is supplied by the discriminant above.
+        // A total encoder is required, because `cache_key` cannot fail. `write_v5_bundle` and
+        // `write_v6_bundle` both delegate to one private `write_bundle` and differ only in v6's
+        // precondition on the bundle version, so v5 encodes every version — including the
+        // Ironwood ones outside its documented v5 contract — and the choice between the two
+        // cannot change the bytes. The version itself is the discriminant above.
         let mut encoded = Vec::new();
         write_v5_bundle(Some(bundle.as_ref()), &mut encoded)
             .expect("encoding a bundle into a Vec cannot fail: the encoder only reports IO errors");

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -168,16 +168,14 @@ impl Item {
     /// Returns a key that determines every input to this item's proof verification.
     ///
     /// [`Cached`] reuses a previous `Ok` result whenever this key matches, so the key must commit
-    /// to everything [`BatchValidator::add_bundle`] reads. Hashing the bundle's own consensus
-    /// encoding does that, being injective over the whole bundle.
+    /// to everything [`BatchValidator::add_bundle`] reads. The bundle's consensus encoding is
+    /// injective, so hashing it commits to the whole bundle. The verifying key is absent on
+    /// purpose: each Orchard circuit era has its own cache, so an entry is only read back under
+    /// the key it was written against (see [`verifier_for`]).
     ///
-    /// The verifying key is deliberately absent: each Orchard circuit era has its own verifier and
-    /// so its own cache, so an entry is only ever read back under the key it was written against
-    /// (see [`verifier_for`]).
-    ///
-    /// Deriving the key by hand instead is how this goes wrong. The txid does not commit to
-    /// authorizing data under ZIP 244 (CVE-2026-34377), and even `(auth digest, sighash)` is
-    /// incomplete, because the Orchard and Ironwood bundles of one v6 transaction share both.
+    /// Do not derive this key by hand. The txid does not commit to authorizing data under ZIP 244
+    /// (CVE-2026-34377), and `(auth digest, sighash)` is also incomplete: the Orchard and Ironwood
+    /// bundles of one v6 transaction share both.
     fn cache_key(&self) -> CacheKey {
         // Destructured exhaustively on purpose: adding a field to `Item` is a compile error here
         // until someone decides whether it belongs in the key.

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -167,21 +167,17 @@ impl Item {
 
     /// Returns a key that determines every input to this item's proof verification.
     ///
-    /// [`Cached`] reuses a previous `Ok` result whenever this key matches, so the key must
-    /// commit to everything [`BatchValidator::add_bundle`] reads. It hashes the bundle's own
-    /// consensus encoding, which is injective and covers all of it: the per-action value
-    /// commitments, nullifiers, validating keys, note commitments and spend authorization
-    /// signatures, the bundle flags, value balance, anchor, proof, and binding signature.
+    /// [`Cached`] reuses a previous `Ok` result whenever this key matches, so the key must commit
+    /// to everything [`BatchValidator::add_bundle`] reads. Hashing the bundle's own consensus
+    /// encoding does that, being injective over the whole bundle.
     ///
-    /// The verifying key is *not* in the key. It does not need to be: each Orchard circuit era
-    /// has its own verifier and therefore its own cache, so an entry can only ever be read back
-    /// under the key it was written against. See [`verifier_for`].
+    /// The verifying key is deliberately absent: each Orchard circuit era has its own verifier and
+    /// so its own cache, so an entry is only ever read back under the key it was written against
+    /// (see [`verifier_for`]).
     ///
-    /// Deriving this by hand from things that "obviously" determine the bundle is how this goes
-    /// wrong. The txid does not commit to authorizing data at all under ZIP 244 — that was
-    /// CVE-2026-34377 — and even `(auth digest, sighash)` is incomplete, because the Orchard and
-    /// Ironwood bundles of one v6 transaction share both. Hashing the encoding avoids having to
-    /// get that reasoning right.
+    /// Deriving the key by hand instead is how this goes wrong. The txid does not commit to
+    /// authorizing data under ZIP 244 (CVE-2026-34377), and even `(auth digest, sighash)` is
+    /// incomplete, because the Orchard and Ironwood bundles of one v6 transaction share both.
     fn cache_key(&self) -> CacheKey {
         // Destructured exhaustively on purpose: adding a field to `Item` is a compile error here
         // until someone decides whether it belongs in the key.
@@ -196,10 +192,9 @@ impl Item {
         hasher.update(&sighash.0);
 
         // A total encoder is required, because `cache_key` cannot fail. `write_v5_bundle` and
-        // `write_v6_bundle` both delegate to one private `write_bundle` and differ only in v6's
-        // precondition on the bundle version, so v5 encodes every version — including the
-        // Ironwood ones outside its documented v5 contract — and the choice between the two
-        // cannot change the bytes. The version itself is the discriminant above.
+        // `write_v6_bundle` both delegate to one private `write_bundle`, differing only in v6's
+        // precondition on the bundle version, so v5 encodes every version — including Ironwood's,
+        // outside its documented v5 contract — and the choice cannot change the bytes.
         let mut encoded = Vec::new();
         write_v5_bundle(Some(bundle.as_ref()), &mut encoded)
             .expect("encoding a bundle into a Vec cannot fail: the encoder only reports IO errors");

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -30,14 +30,14 @@ use tower_fallback::Fallback;
 
 use super::spawn_fifo;
 
-mod memo;
+mod cache;
 
 #[cfg(test)]
 mod tests;
 
-pub use memo::Memoized;
+pub use cache::Cached;
 
-use memo::{CacheKey, MEMO_CAPACITY};
+use cache::{CacheKey, CACHE_CAPACITY};
 
 /// Adjusted batch size for halo2 batches.
 ///
@@ -59,11 +59,11 @@ type Sender = watch::Sender<Option<VerifyResult>>;
 /// This is the key used to verify individual items.
 pub type ItemVerifyingKey = VerifyingKey;
 
-/// The BLAKE2b personalization for [`Item`] memo cache keys.
+/// The BLAKE2b personalization for [`Item`] cache keys.
 ///
 /// Domain-separates these keys from every other BLAKE2b-256 hash in the protocol, so that a
-/// memo key can never be confused with a txid, an auth digest, or a sighash.
-const HALO2_MEMO_PERSONALIZATION: &[u8; 15] = b"ZakuraHalo2Memo";
+/// cache key can never be confused with a txid, an auth digest, or a sighash.
+const HALO2_CACHE_PERSONALIZATION: &[u8; 16] = b"ZakuraHalo2Cache";
 
 // The Orchard Action circuit, and therefore its verifying key, changes across protocol eras.
 // A proof produced under one circuit version does not verify under the other keys. So we keep
@@ -167,14 +167,14 @@ impl Item {
 
     /// Returns a key that determines every input to this item's proof verification.
     ///
-    /// [`Memoized`] reuses a previous `Ok` result whenever this key matches, so the key must
+    /// [`Cached`] reuses a previous `Ok` result whenever this key matches, so the key must
     /// commit to everything [`BatchValidator::add_bundle`] reads. It hashes the bundle's own
     /// consensus encoding, which is injective and covers all of it: the per-action value
     /// commitments, nullifiers, validating keys, note commitments and spend authorization
     /// signatures, the bundle flags, value balance, anchor, proof, and binding signature.
     ///
     /// The verifying key is *not* in the key. It does not need to be: each Orchard circuit era
-    /// has its own verifier and therefore its own memo, so an entry can only ever be read back
+    /// has its own verifier and therefore its own cache, so an entry can only ever be read back
     /// under the key it was written against. See [`verifier_for`].
     ///
     /// Deriving this by hand from things that "obviously" determine the bundle is how this goes
@@ -189,7 +189,7 @@ impl Item {
 
         let mut hasher = blake2b_simd::Params::new()
             .hash_length(32)
-            .personal(HALO2_MEMO_PERSONALIZATION)
+            .personal(HALO2_CACHE_PERSONALIZATION)
             .to_state();
 
         hasher.update(&[bundle_version_discriminant(bundle.bundle_version())]);
@@ -301,15 +301,15 @@ impl Service<Item> for OrchardFallback {
     }
 }
 
-/// The batching-and-fallback stack for one Orchard circuit era, before memoization.
+/// The batching-and-fallback stack for one Orchard circuit era, before caching.
 type BatchFallbackService = Fallback<Batch<Verifier, Item>, OrchardFallback>;
 
 /// The concrete type of a global Halo2 verification service.
 ///
 /// Each Orchard circuit era gets its own instance — see [`VERIFIER_PRE_NU6_2`], [`VERIFIER_NU6_2`],
-/// or [`VERIFIER_NU6_3_ONWARD`] — so that batches, fallbacks, verifying keys, and memos are fully
+/// or [`VERIFIER_NU6_3_ONWARD`] — so that batches, fallbacks, verifying keys, and caches are fully
 /// separated per era.
-type VerifierService = Memoized<BatchFallbackService>;
+type VerifierService = Cached<BatchFallbackService>;
 
 /// Builds a global Halo2 verifier that validates every item against `vk`.
 ///
@@ -319,15 +319,15 @@ type VerifierService = Memoized<BatchFallbackService>;
 /// Callers select the correct era's key by which `VERIFYING_KEY_*` they pass; there is no runtime
 /// key resolution.
 ///
-/// The stack is wrapped in a [`Memoized`] so that a proof gossiped into the mempool does not have
+/// The stack is wrapped in a [`Cached`] so that a proof gossiped into the mempool does not have
 /// to be verified again when the block that mines it arrives. Because each era builds its own
-/// verifier here, each era also gets its own memo, which is what binds a remembered result to the
+/// verifier here, each era also gets its own cache, which is what binds a remembered result to the
 /// `vk` it was produced under.
 fn batch_verifier(vk: &'static ItemVerifyingKey) -> VerifierService {
-    Memoized::new(batch_fallback_verifier(vk), MEMO_CAPACITY)
+    Cached::new(batch_fallback_verifier(vk), CACHE_CAPACITY)
 }
 
-/// Builds the un-memoized batching-and-fallback stack for `vk`.
+/// Builds the uncached batching-and-fallback stack for `vk`.
 fn batch_fallback_verifier(vk: &'static ItemVerifyingKey) -> BatchFallbackService {
     Fallback::new(
         Batch::new(

--- a/crates/zakura-consensus/src/primitives/halo2/cache.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/cache.rs
@@ -1,31 +1,22 @@
 //! A bounded cache of Halo2 Orchard Action proofs that have already verified.
 //!
-//! An Orchard proof is verified once when its transaction arrives over mempool gossip, and again
+//! Zakura verifies an Orchard proof when its transaction arrives over mempool gossip, and again
 //! when the transaction arrives in a block. This service skips the second verification.
 //!
 //! # Why this is not the mempool bypass
 //!
-//! Zebra used to skip *whole-transaction* verification for block transactions already in the
-//! mempool, and removed it as a security fix (PR #10494). Whole-transaction validity depends on
-//! height, block time and spent outputs, none of which were in the key — and a transaction valid
-//! at one height need not be valid at the next. Zakura keeps the regression tests for both
-//! failures: `block_with_garbage_orchard_proofs_is_rejected` and
-//! `mempool_cached_result_bypasses_expiry_check_for_block_at_next_height`.
+//! Zebra once skipped whole-transaction verification for transactions already in the mempool, and
+//! removed it as a security fix (PR #10494). Transaction validity depends on height, block time
+//! and spent outputs, and that cache's key named none of them.
 //!
-//! This cache holds `verify(bundle, sighash, vk)`, which is a pure function. On a hit the
-//! transaction verifier still runs end to end against the block's height, time and spent outputs;
-//! only the proof check is skipped. So the safety argument is just that the key names every input:
+//! This cache holds `verify(bundle, sighash, vk)`, a pure function of its key. A hit still runs
+//! the whole transaction verifier against the block's height, time and spent outputs, and skips
+//! only the proof check. [`Item::cache_key`] commits to `bundle` and `sighash`; each Orchard
+//! circuit era has its own cache, which commits to `vk` (see [`super::verifier_for`]).
 //!
-//!   * `bundle` and `sighash` come from [`Item::cache_key`], which destructures [`Item`]
-//!     exhaustively, so adding a field is a compile error until someone decides whether it belongs
-//!     in the key;
-//!   * `vk` is structural — each Orchard circuit era gets its own cache, for the same reason eras
-//!     cannot share a batch (see [`super::verifier_for`]).
-//!
-//! Only `Ok` results are cached. An error is not per-item evidence, because
-//! [`Fallback`](tower_fallback::Fallback) re-verifies a failed batch one item at a time, and it
-//! need not be a verdict at all — a shut-down batch worker looks the same. Caching that as
-//! "invalid" would reject a valid block.
+//! Only `Ok` results are cached. A batch error is not per-item evidence, because
+//! [`Fallback`](tower_fallback::Fallback) re-verifies failures singly, and it may not be a verdict
+//! at all — a shut-down batch worker reports the same way. Caching it would reject a valid block.
 
 use std::{
     collections::{HashSet, VecDeque},
@@ -170,27 +161,19 @@ where
 
     /// Always ready.
     ///
-    /// This deliberately does **not** delegate to the inner service, because at this point the
-    /// item is not yet known and so neither is whether the inner service will be used at all.
-    /// Delegating would reserve inner capacity for every request, including the hits that never
-    /// spend it:
+    /// This does not delegate to the inner service, because the item is not known yet, so neither
+    /// is whether the inner service will be used at all. Delegating would reserve inner capacity
+    /// for every request, including the hits that never spend it:
     ///
-    ///   * [`Batch::poll_ready`](tower_batch_control::Batch) holds a semaphore permit in the
-    ///     service until `Batch::call` consumes it. A hit returns without calling the inner
-    ///     service, so that permit is only released when the handle is dropped — until then it
-    ///     is capacity denied to a genuine miss.
+    ///   * [`Batch::poll_ready`](tower_batch_control::Batch) holds a semaphore permit until
+    ///     `Batch::call` consumes it. A hit never calls, so it holds that permit until the handle
+    ///     drops, denying capacity to a genuine miss.
+    ///   * `Batch::poll_ready` also errors once its worker exits. Callers poll before they call,
+    ///     so that error would surface for an item this cache already holds, reporting a verified
+    ///     proof as a verification failure.
     ///
-    ///   * More importantly, `Batch::poll_ready` returns an error when its worker has exited or
-    ///     its channel has closed. Callers poll readiness *before* `call`, so that error would
-    ///     be returned for an item whose result this cache already holds — reporting a verified
-    ///     proof as a verification failure, which is exactly the "an error need not be a verdict"
-    ///     case the module docs are about. Returning ready here means a hit is answered from the
-    ///     cache whatever state the batch worker is in.
-    ///
-    /// Readiness is instead awaited inside [`Self::call`], on the miss path, where it belongs.
-    /// The semaphore still bounds concurrent batch requests: a miss acquires its permit before
-    /// calling, exactly as before. What changes is only *when* the wait happens, which for the
-    /// `oneshot` call sites this service has is the same instant either way.
+    /// [`Self::call`] awaits readiness on the miss path instead. The semaphore still bounds
+    /// concurrent batch requests; only the timing of the wait changes.
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }

--- a/crates/zakura-consensus/src/primitives/halo2/cache.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/cache.rs
@@ -1,40 +1,31 @@
 //! A bounded cache of Halo2 Orchard Action proofs that have already verified.
 //!
-//! A transaction's Orchard proof is verified once when the transaction arrives over mempool
-//! gossip, and again when it arrives inside a block. This service skips the second verification
-//! when it can prove the two are the same computation.
+//! An Orchard proof is verified once when its transaction arrives over mempool gossip, and again
+//! when the transaction arrives in a block. This service skips the second verification.
 //!
 //! # Why this is not the mempool bypass
 //!
-//! Zebra used to skip *whole-transaction* verification for block transactions already accepted
-//! into the mempool. That was removed upstream as a security fix (PR #10494), after two rounds of
-//! patching, because the cached proposition was `valid(tx, height, block time, spent outputs)` —
-//! not a function of the key it was stored under. A transaction valid at one height is not
-//! necessarily valid at another: expiry, lock time, the consensus branch id, the Orchard soft-fork
-//! gates and the proof-size rule all move with height, and the network upgrade even selects which
-//! Orchard circuit verifying key applies. Zakura keeps the regression tests for both failures
-//! (`block_with_garbage_orchard_proofs_is_rejected` and
-//! `mempool_cached_result_bypasses_expiry_check_for_block_at_next_height`).
+//! Zebra used to skip *whole-transaction* verification for block transactions already in the
+//! mempool, and removed it as a security fix (PR #10494). Whole-transaction validity depends on
+//! height, block time and spent outputs, none of which were in the key — and a transaction valid
+//! at one height need not be valid at the next. Zakura keeps the regression tests for both
+//! failures: `block_with_garbage_orchard_proofs_is_rejected` and
+//! `mempool_cached_result_bypasses_expiry_check_for_block_at_next_height`.
 //!
-//! What is cached here is `verify(bundle, sighash, vk) -> bool`, which *is* a pure function.
-//! On a hit, `transaction::Verifier::call` still runs end to end at the block's height, with the
-//! block's time and the block's spent outputs; the only thing that does not re-run is a
-//! deterministic computation whose every input is pinned by the key.
+//! This cache holds `verify(bundle, sighash, vk)`, which is a pure function. On a hit the
+//! transaction verifier still runs end to end against the block's height, time and spent outputs;
+//! only the proof check is skipped. So the safety argument is just that the key names every input:
 //!
-//! That makes key completeness the whole of the safety argument:
+//!   * `bundle` and `sighash` come from [`Item::cache_key`], which destructures [`Item`]
+//!     exhaustively, so adding a field is a compile error until someone decides whether it belongs
+//!     in the key;
+//!   * `vk` is structural — each Orchard circuit era gets its own cache, for the same reason eras
+//!     cannot share a batch (see [`super::verifier_for`]).
 //!
-//!   * `bundle` and `sighash` are committed to by [`Item::cache_key`], which destructures [`Item`]
-//!     exhaustively so that adding a field is a compile error until someone decides whether it
-//!     belongs in the key;
-//!   * `vk` is committed to structurally, by giving each Orchard circuit era its own cache. Eras
-//!     cannot mix in a cache for the same reason they cannot mix in a batch — see
-//!     [`super::verifier_for`].
-//!
-//! Only `Ok` results are recorded. A batch error is not per-item evidence, because
-//! [`Fallback`](tower_fallback::Fallback) resolves batch failures by re-verifying each item
-//! singly; and an error out of the service need not be a verdict at all — it can report that the
-//! batch worker shut down. Recording that as "this proof is invalid" would make the node reject a
-//! valid block, which is a chain split in the other direction.
+//! Only `Ok` results are cached. An error is not per-item evidence, because
+//! [`Fallback`](tower_fallback::Fallback) re-verifies a failed batch one item at a time, and it
+//! need not be a verdict at all — a shut-down batch worker looks the same. Caching that as
+//! "invalid" would reject a valid block.
 
 use std::{
     collections::{HashSet, VecDeque},
@@ -185,7 +176,7 @@ where
     /// spend it:
     ///
     ///   * [`Batch::poll_ready`](tower_batch_control::Batch) holds a semaphore permit in the
-    ///     service until [`Batch::call`] consumes it. A hit returns without calling the inner
+    ///     service until `Batch::call` consumes it. A hit returns without calling the inner
     ///     service, so that permit is only released when the handle is dropped — until then it
     ///     is capacity denied to a genuine miss.
     ///

--- a/crates/zakura-consensus/src/primitives/halo2/cache.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/cache.rs
@@ -30,19 +30,7 @@ use tower::{Service, ServiceExt};
 
 use crate::BoxError;
 
-use super::Item;
-
-/// The number of verified-proof keys retained per Orchard circuit era.
-///
-/// Sized to hold several blocks of history plus a full mempool, so that a transaction gossiped
-/// well before the block that mines it is still remembered. At 32-byte keys this is on the order
-/// of a megabyte per era.
-pub const CACHE_CAPACITY: usize = 20_000;
-
-/// A key that determines every input to one [`Item`]'s proof verification.
-///
-/// See [`Item::cache_key`] for the construction and for why completeness matters.
-pub type CacheKey = [u8; 32];
+use super::{CacheKey, Item};
 
 /// A bounded set of keys for items that have already verified successfully.
 ///
@@ -105,6 +93,9 @@ impl VerifiedProofs {
 ///
 /// This wraps one Orchard circuit era's batch-and-fallback stack. The cache is shared between
 /// clones, so every handle to a global verifier sees the same set of verified proofs.
+///
+/// This type is public only because it appears in existing public verifier signatures. The
+/// private `cache` module does not re-export it, and its constructor and accessors are private.
 pub struct Cached<S> {
     /// The verification service to consult on a miss.
     inner: S,
@@ -142,7 +133,7 @@ impl<S> Cached<S> {
     }
 
     /// Returns the wrapped verification service.
-    pub fn inner(&self) -> &S {
+    pub(super) fn inner(&self) -> &S {
         &self.inner
     }
 
@@ -155,7 +146,7 @@ impl<S> Cached<S> {
     /// Readiness failures are not counted: an item that never reached the inner service was never
     /// verified by it.
     #[cfg(test)]
-    pub(crate) fn inner_calls_for(&self, item: &Item) -> usize {
+    pub(super) fn inner_calls_for(&self, item: &Item) -> usize {
         let key = item.cache_key();
 
         self.inner_calls

--- a/crates/zakura-consensus/src/primitives/halo2/cache.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/cache.rs
@@ -111,6 +111,12 @@ pub struct Cached<S> {
 
     /// The keys of items that have already verified under this era's key.
     verified: Arc<Mutex<VerifiedProofs>>,
+
+    /// The keys of the items that reached the inner service, in call order.
+    ///
+    /// Test-only. See [`Self::inner_calls_for`].
+    #[cfg(test)]
+    inner_calls: Arc<Mutex<Vec<CacheKey>>>,
 }
 
 impl<S: Clone> Clone for Cached<S> {
@@ -118,6 +124,8 @@ impl<S: Clone> Clone for Cached<S> {
         Self {
             inner: self.inner.clone(),
             verified: self.verified.clone(),
+            #[cfg(test)]
+            inner_calls: self.inner_calls.clone(),
         }
     }
 }
@@ -128,12 +136,34 @@ impl<S> Cached<S> {
         Self {
             inner,
             verified: Arc::new(Mutex::new(VerifiedProofs::new(capacity))),
+            #[cfg(test)]
+            inner_calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     /// Returns the wrapped verification service.
     pub fn inner(&self) -> &S {
         &self.inner
+    }
+
+    /// Returns how many times an item equivalent to `item` has reached the inner service.
+    ///
+    /// Test-only. It counts one item rather than all calls because the global verifiers are shared
+    /// by every test in the process, so a plain call counter would also see verifications a test
+    /// did not make. Counting one transaction's own item isolates a test from the rest.
+    ///
+    /// Readiness failures are not counted: an item that never reached the inner service was never
+    /// verified by it.
+    #[cfg(test)]
+    pub(crate) fn inner_calls_for(&self, item: &Item) -> usize {
+        let key = item.cache_key();
+
+        self.inner_calls
+            .lock()
+            .expect("inner call record mutex should not be poisoned")
+            .iter()
+            .filter(|called| **called == key)
+            .count()
     }
 
     /// Returns a cache sharing this one's remembered keys, but consulting `inner` on a miss.
@@ -146,6 +176,7 @@ impl<S> Cached<S> {
         Cached {
             inner,
             verified: self.verified.clone(),
+            inner_calls: self.inner_calls.clone(),
         }
     }
 }
@@ -197,11 +228,22 @@ where
         let verified = self.verified.clone();
         let mut inner = self.inner.clone();
 
+        #[cfg(test)]
+        let inner_calls = self.inner_calls.clone();
+
         async move {
             // Readiness is acquired here rather than in `poll_ready` so that only misses reserve
             // inner capacity. See `poll_ready`.
             let result = match inner.ready().await {
-                Ok(inner) => inner.call(item).await,
+                Ok(inner) => {
+                    #[cfg(test)]
+                    inner_calls
+                        .lock()
+                        .expect("inner call record mutex should not be poisoned")
+                        .push(key);
+
+                    inner.call(item).await
+                }
                 Err(error) => Err(error),
             };
 

--- a/crates/zakura-consensus/src/primitives/halo2/cache.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/cache.rs
@@ -1,4 +1,4 @@
-//! A bounded memo of Halo2 Orchard Action proofs that have already verified.
+//! A bounded cache of Halo2 Orchard Action proofs that have already verified.
 //!
 //! A transaction's Orchard proof is verified once when the transaction arrives over mempool
 //! gossip, and again when it arrives inside a block. This service skips the second verification
@@ -16,7 +16,7 @@
 //! (`block_with_garbage_orchard_proofs_is_rejected` and
 //! `mempool_cached_result_bypasses_expiry_check_for_block_at_next_height`).
 //!
-//! What is memoized here is `verify(bundle, sighash, vk) -> bool`, which *is* a pure function.
+//! What is cached here is `verify(bundle, sighash, vk) -> bool`, which *is* a pure function.
 //! On a hit, `transaction::Verifier::call` still runs end to end at the block's height, with the
 //! block's time and the block's spent outputs; the only thing that does not re-run is a
 //! deterministic computation whose every input is pinned by the key.
@@ -26,8 +26,8 @@
 //!   * `bundle` and `sighash` are committed to by [`Item::cache_key`], which destructures [`Item`]
 //!     exhaustively so that adding a field is a compile error until someone decides whether it
 //!     belongs in the key;
-//!   * `vk` is committed to structurally, by giving each Orchard circuit era its own memo. Eras
-//!     cannot mix in a memo for the same reason they cannot mix in a batch — see
+//!   * `vk` is committed to structurally, by giving each Orchard circuit era its own cache. Eras
+//!     cannot mix in a cache for the same reason they cannot mix in a batch — see
 //!     [`super::verifier_for`].
 //!
 //! Only `Ok` results are recorded. A batch error is not per-item evidence, because
@@ -55,7 +55,7 @@ use super::Item;
 /// Sized to hold several blocks of history plus a full mempool, so that a transaction gossiped
 /// well before the block that mines it is still remembered. At 32-byte keys this is on the order
 /// of a megabyte per era.
-pub const MEMO_CAPACITY: usize = 20_000;
+pub const CACHE_CAPACITY: usize = 20_000;
 
 /// A key that determines every input to one [`Item`]'s proof verification.
 ///
@@ -80,7 +80,7 @@ struct VerifiedProofs {
 }
 
 impl VerifiedProofs {
-    /// Creates an empty memo that retains at most `capacity` keys.
+    /// Creates an empty cache that retains at most `capacity` keys.
     fn new(capacity: usize) -> Self {
         Self {
             keys: HashSet::with_capacity(capacity),
@@ -103,7 +103,7 @@ impl VerifiedProofs {
         }
 
         self.insertion_order.push_back(key);
-        metrics::counter!("zakura.consensus.halo2.memo.insert").increment(1);
+        metrics::counter!("zakura.consensus.halo2.cache.insert").increment(1);
 
         while self.insertion_order.len() > self.capacity {
             let evicted = self
@@ -111,19 +111,19 @@ impl VerifiedProofs {
                 .pop_front()
                 .expect("queue is longer than the capacity, which is at least one");
             self.keys.remove(&evicted);
-            metrics::counter!("zakura.consensus.halo2.memo.evict").increment(1);
+            metrics::counter!("zakura.consensus.halo2.cache.evict").increment(1);
         }
 
         // Cast is safe: the length is bounded by `capacity`, far below f64's exact integer range.
-        metrics::gauge!("zakura.consensus.halo2.memo.size").set(self.keys.len() as f64);
+        metrics::gauge!("zakura.consensus.halo2.cache.size").set(self.keys.len() as f64);
     }
 }
 
 /// A service that skips inner verification for items whose proof has already verified.
 ///
-/// This wraps one Orchard circuit era's batch-and-fallback stack. The memo is shared between
+/// This wraps one Orchard circuit era's batch-and-fallback stack. The cache is shared between
 /// clones, so every handle to a global verifier sees the same set of verified proofs.
-pub struct Memoized<S> {
+pub struct Cached<S> {
     /// The verification service to consult on a miss.
     inner: S,
 
@@ -131,7 +131,7 @@ pub struct Memoized<S> {
     verified: Arc<Mutex<VerifiedProofs>>,
 }
 
-impl<S: Clone> Clone for Memoized<S> {
+impl<S: Clone> Clone for Cached<S> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -140,8 +140,8 @@ impl<S: Clone> Clone for Memoized<S> {
     }
 }
 
-impl<S> Memoized<S> {
-    /// Wraps `inner` in a memo that retains at most `capacity` verified-proof keys.
+impl<S> Cached<S> {
+    /// Wraps `inner` in a cache that retains at most `capacity` verified-proof keys.
     pub(super) fn new(inner: S, capacity: usize) -> Self {
         Self {
             inner,
@@ -154,21 +154,21 @@ impl<S> Memoized<S> {
         &self.inner
     }
 
-    /// Returns a memo sharing this one's remembered keys, but consulting `inner` on a miss.
+    /// Returns a cache sharing this one's remembered keys, but consulting `inner` on a miss.
     ///
-    /// Test-only. It exists so a test can warm the memo through a healthy service and then swap
+    /// Test-only. It exists so a test can warm the cache through a healthy service and then swap
     /// in a broken one, which is how the hit path is exercised in isolation from the inner
     /// service.
     #[cfg(test)]
-    pub(super) fn with_inner<T>(&self, inner: T) -> Memoized<T> {
-        Memoized {
+    pub(super) fn with_inner<T>(&self, inner: T) -> Cached<T> {
+        Cached {
             inner,
             verified: self.verified.clone(),
         }
     }
 }
 
-impl<S> Service<Item> for Memoized<S>
+impl<S> Service<Item> for Cached<S>
 where
     S: Service<Item, Response = (), Error = BoxError> + Clone + Send + 'static,
     S::Future: Send + 'static,
@@ -191,10 +191,10 @@ where
     ///
     ///   * More importantly, `Batch::poll_ready` returns an error when its worker has exited or
     ///     its channel has closed. Callers poll readiness *before* `call`, so that error would
-    ///     be returned for an item whose result this memo already holds — reporting a verified
+    ///     be returned for an item whose result this cache already holds — reporting a verified
     ///     proof as a verification failure, which is exactly the "an error need not be a verdict"
     ///     case the module docs are about. Returning ready here means a hit is answered from the
-    ///     memo whatever state the batch worker is in.
+    ///     cache whatever state the batch worker is in.
     ///
     /// Readiness is instead awaited inside [`Self::call`], on the miss path, where it belongs.
     /// The semaphore still bounds concurrent batch requests: a miss acquires its permit before
@@ -211,14 +211,14 @@ where
         if self
             .verified
             .lock()
-            .expect("verified proof memo mutex should not be poisoned")
+            .expect("verified proof cache mutex should not be poisoned")
             .contains(&key)
         {
-            metrics::counter!("zakura.consensus.halo2.memo.hit").increment(1);
+            metrics::counter!("zakura.consensus.halo2.cache.hit").increment(1);
             return future::ready(Ok(())).boxed();
         }
 
-        metrics::counter!("zakura.consensus.halo2.memo.miss").increment(1);
+        metrics::counter!("zakura.consensus.halo2.cache.miss").increment(1);
 
         let verified = self.verified.clone();
         let mut inner = self.inner.clone();
@@ -235,7 +235,7 @@ where
             if result.is_ok() {
                 verified
                     .lock()
-                    .expect("verified proof memo mutex should not be poisoned")
+                    .expect("verified proof cache mutex should not be poisoned")
                     .insert(key);
             }
 

--- a/crates/zakura-consensus/src/primitives/halo2/memo.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/memo.rs
@@ -1,0 +1,205 @@
+//! A bounded memo of Halo2 Orchard Action proofs that have already verified.
+//!
+//! A transaction's Orchard proof is verified once when the transaction arrives over mempool
+//! gossip, and again when it arrives inside a block. This service skips the second verification
+//! when it can prove the two are the same computation.
+//!
+//! # Why this is not the mempool bypass
+//!
+//! Zebra used to skip *whole-transaction* verification for block transactions already accepted
+//! into the mempool. That was removed upstream as a security fix (PR #10494), after two rounds of
+//! patching, because the cached proposition was `valid(tx, height, block time, spent outputs)` —
+//! not a function of the key it was stored under. A transaction valid at one height is not
+//! necessarily valid at another: expiry, lock time, the consensus branch id, the Orchard soft-fork
+//! gates and the proof-size rule all move with height, and the network upgrade even selects which
+//! Orchard circuit verifying key applies. Zakura keeps the regression tests for both failures
+//! (`block_with_garbage_orchard_proofs_is_rejected` and
+//! `mempool_cached_result_bypasses_expiry_check_for_block_at_next_height`).
+//!
+//! What is memoized here is `verify(bundle, sighash, vk) -> bool`, which *is* a pure function.
+//! On a hit, `transaction::Verifier::call` still runs end to end at the block's height, with the
+//! block's time and the block's spent outputs; the only thing that does not re-run is a
+//! deterministic computation whose every input is pinned by the key.
+//!
+//! That makes key completeness the whole of the safety argument:
+//!
+//!   * `bundle` and `sighash` are committed to by [`Item::cache_key`], which destructures [`Item`]
+//!     exhaustively so that adding a field is a compile error until someone decides whether it
+//!     belongs in the key;
+//!   * `vk` is committed to structurally, by giving each Orchard circuit era its own memo. Eras
+//!     cannot mix in a memo for the same reason they cannot mix in a batch — see
+//!     [`super::verifier_for`].
+//!
+//! Only `Ok` results are recorded. A batch error is not per-item evidence, because
+//! [`Fallback`](tower_fallback::Fallback) resolves batch failures by re-verifying each item
+//! singly; and an error out of the service need not be a verdict at all — it can report that the
+//! batch worker shut down. Recording that as "this proof is invalid" would make the node reject a
+//! valid block, which is a chain split in the other direction.
+
+use std::{
+    collections::{HashSet, VecDeque},
+    future,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+
+use futures::{future::BoxFuture, FutureExt};
+use tower::Service;
+
+use crate::BoxError;
+
+use super::Item;
+
+/// The number of verified-proof keys retained per Orchard circuit era.
+///
+/// Sized to hold several blocks of history plus a full mempool, so that a transaction gossiped
+/// well before the block that mines it is still remembered. At 32-byte keys this is on the order
+/// of a megabyte per era.
+pub const MEMO_CAPACITY: usize = 20_000;
+
+/// A key that determines every input to one [`Item`]'s proof verification.
+///
+/// See [`Item::cache_key`] for the construction and for why completeness matters.
+pub type CacheKey = [u8; 32];
+
+/// A bounded set of keys for items that have already verified successfully.
+///
+/// Eviction is first-in-first-out rather than least-recently-used: the working set is the
+/// mempool, which turns over in arrival order anyway, and FIFO needs no bookkeeping on the read
+/// path. Evicting an entry only costs a re-verification, never correctness.
+#[derive(Debug)]
+struct VerifiedProofs {
+    /// The keys currently remembered.
+    keys: HashSet<CacheKey>,
+
+    /// The same keys in insertion order, so the oldest can be evicted.
+    insertion_order: VecDeque<CacheKey>,
+
+    /// The maximum number of keys to retain.
+    capacity: usize,
+}
+
+impl VerifiedProofs {
+    /// Creates an empty memo that retains at most `capacity` keys.
+    fn new(capacity: usize) -> Self {
+        Self {
+            keys: HashSet::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Returns `true` if `key` has already verified.
+    fn contains(&self, key: &CacheKey) -> bool {
+        self.keys.contains(key)
+    }
+
+    /// Records that `key` has verified, evicting the oldest keys if that exceeds the capacity.
+    fn insert(&mut self, key: CacheKey) {
+        // Concurrent verifications of the same item both miss and both insert. The second is a
+        // no-op, and must not push a duplicate into the eviction queue.
+        if !self.keys.insert(key) {
+            return;
+        }
+
+        self.insertion_order.push_back(key);
+        metrics::counter!("zakura.consensus.halo2.memo.insert").increment(1);
+
+        while self.insertion_order.len() > self.capacity {
+            let evicted = self
+                .insertion_order
+                .pop_front()
+                .expect("queue is longer than the capacity, which is at least one");
+            self.keys.remove(&evicted);
+            metrics::counter!("zakura.consensus.halo2.memo.evict").increment(1);
+        }
+
+        // Cast is safe: the length is bounded by `capacity`, far below f64's exact integer range.
+        metrics::gauge!("zakura.consensus.halo2.memo.size").set(self.keys.len() as f64);
+    }
+}
+
+/// A service that skips inner verification for items whose proof has already verified.
+///
+/// This wraps one Orchard circuit era's batch-and-fallback stack. The memo is shared between
+/// clones, so every handle to a global verifier sees the same set of verified proofs.
+pub struct Memoized<S> {
+    /// The verification service to consult on a miss.
+    inner: S,
+
+    /// The keys of items that have already verified under this era's key.
+    verified: Arc<Mutex<VerifiedProofs>>,
+}
+
+impl<S: Clone> Clone for Memoized<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            verified: self.verified.clone(),
+        }
+    }
+}
+
+impl<S> Memoized<S> {
+    /// Wraps `inner` in a memo that retains at most `capacity` verified-proof keys.
+    pub(super) fn new(inner: S, capacity: usize) -> Self {
+        Self {
+            inner,
+            verified: Arc::new(Mutex::new(VerifiedProofs::new(capacity))),
+        }
+    }
+
+    /// Returns the wrapped verification service.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+}
+
+impl<S> Service<Item> for Memoized<S>
+where
+    S: Service<Item, Response = (), Error = BoxError>,
+    S::Future: Send + 'static,
+{
+    type Response = ();
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, item: Item) -> Self::Future {
+        // Derived once here, outside `Fallback`, which clones every request eagerly.
+        let key = item.cache_key();
+
+        if self
+            .verified
+            .lock()
+            .expect("verified proof memo mutex should not be poisoned")
+            .contains(&key)
+        {
+            metrics::counter!("zakura.consensus.halo2.memo.hit").increment(1);
+            return future::ready(Ok(())).boxed();
+        }
+
+        metrics::counter!("zakura.consensus.halo2.memo.miss").increment(1);
+
+        let verified = self.verified.clone();
+        let response = self.inner.call(item);
+
+        async move {
+            let result = response.await;
+
+            // Only successes are recorded: see the module docs.
+            if result.is_ok() {
+                verified
+                    .lock()
+                    .expect("verified proof memo mutex should not be poisoned")
+                    .insert(key);
+            }
+
+            result
+        }
+        .boxed()
+    }
+}

--- a/crates/zakura-consensus/src/primitives/halo2/memo.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/memo.rs
@@ -44,7 +44,7 @@ use std::{
 };
 
 use futures::{future::BoxFuture, FutureExt};
-use tower::Service;
+use tower::{Service, ServiceExt};
 
 use crate::BoxError;
 
@@ -153,19 +153,55 @@ impl<S> Memoized<S> {
     pub fn inner(&self) -> &S {
         &self.inner
     }
+
+    /// Returns a memo sharing this one's remembered keys, but consulting `inner` on a miss.
+    ///
+    /// Test-only. It exists so a test can warm the memo through a healthy service and then swap
+    /// in a broken one, which is how the hit path is exercised in isolation from the inner
+    /// service.
+    #[cfg(test)]
+    pub(super) fn with_inner<T>(&self, inner: T) -> Memoized<T> {
+        Memoized {
+            inner,
+            verified: self.verified.clone(),
+        }
+    }
 }
 
 impl<S> Service<Item> for Memoized<S>
 where
-    S: Service<Item, Response = (), Error = BoxError>,
+    S: Service<Item, Response = (), Error = BoxError> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response = ();
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<(), BoxError>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
+    /// Always ready.
+    ///
+    /// This deliberately does **not** delegate to the inner service, because at this point the
+    /// item is not yet known and so neither is whether the inner service will be used at all.
+    /// Delegating would reserve inner capacity for every request, including the hits that never
+    /// spend it:
+    ///
+    ///   * [`Batch::poll_ready`](tower_batch_control::Batch) holds a semaphore permit in the
+    ///     service until [`Batch::call`] consumes it. A hit returns without calling the inner
+    ///     service, so that permit is only released when the handle is dropped — until then it
+    ///     is capacity denied to a genuine miss.
+    ///
+    ///   * More importantly, `Batch::poll_ready` returns an error when its worker has exited or
+    ///     its channel has closed. Callers poll readiness *before* `call`, so that error would
+    ///     be returned for an item whose result this memo already holds — reporting a verified
+    ///     proof as a verification failure, which is exactly the "an error need not be a verdict"
+    ///     case the module docs are about. Returning ready here means a hit is answered from the
+    ///     memo whatever state the batch worker is in.
+    ///
+    /// Readiness is instead awaited inside [`Self::call`], on the miss path, where it belongs.
+    /// The semaphore still bounds concurrent batch requests: a miss acquires its permit before
+    /// calling, exactly as before. What changes is only *when* the wait happens, which for the
+    /// `oneshot` call sites this service has is the same instant either way.
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, item: Item) -> Self::Future {
@@ -185,10 +221,15 @@ where
         metrics::counter!("zakura.consensus.halo2.memo.miss").increment(1);
 
         let verified = self.verified.clone();
-        let response = self.inner.call(item);
+        let mut inner = self.inner.clone();
 
         async move {
-            let result = response.await;
+            // Readiness is acquired here rather than in `poll_ready` so that only misses reserve
+            // inner capacity. See `poll_ready`.
+            let result = match inner.ready().await {
+                Ok(inner) => inner.call(item).await,
+                Err(error) => Err(error),
+            };
 
             // Only successes are recorded: see the module docs.
             if result.is_ok() {

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use futures::future::join_all;
-use orchard::bundle::{Authorized, Bundle, BundleVersion};
+use orchard::bundle::{Authorized, Bundle, BundleVersion, Flags};
 use tower::{Service, ServiceExt};
 use tower_batch_control::Batch;
 use tower_fallback::Fallback;
@@ -421,6 +421,63 @@ fn cache_key_distinguishes_different_bundles_with_the_same_sighash() {
     );
 }
 
+/// Returns `bundle`'s parts rebuilt under `flags` and `version`.
+fn rebuilt_as(
+    bundle: &Bundle<Authorized, ZatBalance>,
+    flags: Flags,
+    version: BundleVersion,
+) -> Bundle<Authorized, ZatBalance> {
+    Bundle::try_from_parts(
+        bundle.actions().clone(),
+        flags,
+        *bundle.value_balance(),
+        *bundle.anchor(),
+        bundle.authorization().clone(),
+        version,
+    )
+    .expect("a real mainnet Orchard bundle's parts are representable under the given version")
+}
+
+/// The Orchard and Ironwood pools of one v6 transaction never share a cache key.
+///
+/// A v6 transaction verifies both of its bundles against the same sighash under the same network
+/// upgrade, and — because both pools use the NU6.3 circuit — through the same verifier and so the
+/// same memo. A key that did not separate the pools would answer one pool's verification with the
+/// other's result.
+///
+/// The two bundles here are built from identical parts, and with cross-address transfers disabled
+/// their flag bytes are identical too, so their consensus encodings are byte-for-byte the same.
+/// Only the pool discriminant tells them apart. This is the collision that `(auth digest, sighash)`
+/// would have had.
+#[test]
+fn cache_key_distinguishes_the_orchard_and_ironwood_pools() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+
+    // Cross-address transfers are disallowed in the NU6.3 Orchard pool and optional in Ironwood,
+    // so this is the one flag set both pools can encode — and they encode it identically.
+    let orchard = rebuilt_as(
+        &bundle,
+        Flags::CROSS_ADDRESS_DISABLED,
+        BundleVersion::orchard_v3(),
+    );
+    let ironwood = rebuilt_as(
+        &bundle,
+        Flags::CROSS_ADDRESS_DISABLED,
+        BundleVersion::ironwood_v3(),
+    );
+
+    assert_eq!(
+        orchard.flag_byte(),
+        ironwood.flag_byte(),
+        "this test is only meaningful if the two pools encode these flags identically"
+    );
+    assert_ne!(
+        cache_key(&orchard, sighash),
+        cache_key(&ironwood, sighash),
+        "the Orchard and Ironwood bundles of one transaction must not share a cache key"
+    );
+}
+
 /// The bundle version is committed to even when nothing else about the bundle changes.
 ///
 /// The consensus encoding of a bundle contains its flag byte but not its [`BundleVersion`], and
@@ -430,15 +487,7 @@ fn cache_key_distinguishes_different_bundles_with_the_same_sighash() {
 fn cache_key_changes_with_the_bundle_version() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
 
-    let rebuilt = Bundle::try_from_parts(
-        bundle.actions().clone(),
-        *bundle.flags(),
-        *bundle.value_balance(),
-        *bundle.anchor(),
-        bundle.authorization().clone(),
-        BundleVersion::orchard_v2(),
-    )
-    .expect("a real mainnet Orchard bundle is representable under the NU6.2 bundle version");
+    let rebuilt = rebuilt_as(&bundle, *bundle.flags(), BundleVersion::orchard_v2());
 
     assert_eq!(
         bundle.flag_byte(),

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -13,40 +13,52 @@
 //!     matching circuit era's key (pre-NU6.2 insecure, NU6.2-until-NU6.3 fixed, or
 //!     NU6.3-onward).
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    future,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use futures::future::join_all;
-use orchard::bundle::{Authorized, Bundle};
+use orchard::bundle::{Authorized, Bundle, BundleVersion};
 use tower::{Service, ServiceExt};
 use tower_batch_control::Batch;
 use tower_fallback::Fallback;
 use zakura_chain::{
     block::Block,
     parameters::NetworkUpgrade,
+    primitives::Halo2Proof,
     serialization::ZcashDeserializeInto,
-    transaction::{HashType, SigHash},
+    transaction::{HashType, SigHash, Transaction},
     transparent,
 };
 use zcash_protocol::value::ZatBalance;
 
+use crate::{error::TransactionError, BoxError};
+
 use super::{
-    lazy_verifier_for, Item, ItemVerifyingKey, OrchardFallback, Verifier, VerifierService,
-    VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD, VERIFIER_PRE_NU6_2, VERIFYING_KEY_NU6_2,
-    VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
+    bundle_version_discriminant, lazy_verifier_for, BatchFallbackService, CacheKey, Item,
+    ItemVerifyingKey, Memoized, OrchardFallback, Verifier, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD,
+    VERIFIER_PRE_NU6_2, VERIFYING_KEY_NU6_2, VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
 };
 
 const EXPLICIT_FLUSH_TEST_MAX_BATCH_WEIGHT: usize = 10_000;
 const EXPLICIT_FLUSH_TEST_LATENCY: Duration = Duration::from_secs(1000);
 const EXPLICIT_FLUSH_TEST_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Returns one real pre-NU6.2 Orchard bundle and its sighash, extracted from the mainnet test
-/// blocks.
+/// Returns the real pre-NU6.2 Orchard transactions in the mainnet test blocks.
 ///
 /// These mainnet blocks are NU5-era Orchard history, mined long before NU6.2, so their proofs
 /// were produced by the historical (insecure) circuit and only verify under
 /// [`VERIFYING_KEY_PRE_NU6_2`]. Transactions with transparent inputs are skipped because their
 /// sighash needs the previous outputs they spend, which are not in the test vectors.
-fn pre_nu6_2_bundle_and_sighash() -> (Bundle<Authorized, ZatBalance>, SigHash) {
+fn pre_nu6_2_transactions() -> Vec<Transaction> {
+    let mut transactions = Vec::new();
+
     for bytes in zakura_test::vectors::MAINNET_BLOCKS.values() {
         let block: Block = bytes
             .zcash_deserialize_into()
@@ -57,23 +69,42 @@ fn pre_nu6_2_bundle_and_sighash() -> (Bundle<Authorized, ZatBalance>, SigHash) {
                 continue;
             }
 
-            let all_previous_outputs: Arc<Vec<transparent::Output>> = Arc::new(Vec::new());
-            let Ok(sighasher) = tx.sighasher(NetworkUpgrade::Nu5, all_previous_outputs) else {
-                continue;
-            };
-            let Some(bundle) = sighasher.orchard_bundle() else {
-                continue;
-            };
-
-            let sighash = sighasher.sighash(HashType::ALL, None);
-            return (bundle, sighash);
+            if bundle_and_sighash(tx).is_some() {
+                transactions.push(tx.as_ref().clone());
+            }
         }
     }
 
-    panic!("mainnet test blocks must contain a transparent-input-free Orchard transaction");
+    assert!(
+        !transactions.is_empty(),
+        "mainnet test blocks must contain a transparent-input-free Orchard transaction"
+    );
+
+    transactions
 }
 
-fn explicit_flush_verifier(vk: &'static ItemVerifyingKey) -> VerifierService {
+/// Returns `tx`'s Orchard bundle and the sighash it is verified against, if it has one.
+fn bundle_and_sighash(tx: &Transaction) -> Option<(Bundle<Authorized, ZatBalance>, SigHash)> {
+    let all_previous_outputs: Arc<Vec<transparent::Output>> = Arc::new(Vec::new());
+    let sighasher = tx
+        .sighasher(NetworkUpgrade::Nu5, all_previous_outputs)
+        .ok()?;
+    let bundle = sighasher.orchard_bundle()?;
+
+    Some((bundle, sighasher.sighash(HashType::ALL, None)))
+}
+
+/// Returns one real pre-NU6.2 Orchard bundle and its sighash.
+fn pre_nu6_2_bundle_and_sighash() -> (Bundle<Authorized, ZatBalance>, SigHash) {
+    let tx = pre_nu6_2_transactions()
+        .into_iter()
+        .next()
+        .expect("there is at least one pre-NU6.2 Orchard transaction");
+
+    bundle_and_sighash(&tx).expect("the transaction was selected for having a bundle")
+}
+
+fn explicit_flush_verifier(vk: &'static ItemVerifyingKey) -> BatchFallbackService {
     Fallback::new(
         Batch::new(
             Verifier::new(vk),
@@ -238,4 +269,376 @@ async fn explicit_flush_rejects_single_proof_under_each_wrong_era_key() {
         .await
         .expect("explicitly flushed Orchard verification must complete");
     }
+}
+
+// Cache key completeness.
+//
+// [`Memoized`] reuses a previous `Ok` for any item whose key matches, so a key that misses one of
+// verification's inputs is a consensus bug: it would accept a proof that was never checked. These
+// tests pin every input down.
+
+/// Returns the cache key of `bundle` under `sighash`.
+fn cache_key(bundle: &Bundle<Authorized, ZatBalance>, sighash: SigHash) -> CacheKey {
+    Item::new(bundle.clone(), sighash).cache_key()
+}
+
+/// Returns `tx` with `mutate` applied to its Orchard shielded data, along with the resulting
+/// bundle and sighash.
+///
+/// The mutations below all change *authorizing* data only, which under ZIP 244 leaves the txid
+/// untouched. That is the shape of CVE-2026-34377: a key derived from the txid would collide here.
+fn mutated_bundle_and_sighash(
+    tx: &Transaction,
+    mutate: impl FnOnce(&mut zakura_chain::orchard::ShieldedData),
+) -> (Bundle<Authorized, ZatBalance>, SigHash) {
+    let mut mutated = tx.clone();
+    mutate(
+        mutated
+            .orchard_shielded_data_mut()
+            .expect("the transaction was selected for having Orchard shielded data"),
+    );
+
+    assert_eq!(
+        tx.hash(),
+        mutated.hash(),
+        "mutating authorizing data must leave the txid unchanged, or this test proves nothing"
+    );
+
+    bundle_and_sighash(&mutated).expect("a mutated Orchard transaction still has a bundle")
+}
+
+#[test]
+fn cache_key_is_deterministic() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+
+    assert_eq!(
+        cache_key(&bundle, sighash),
+        cache_key(&bundle, sighash),
+        "the same bundle and sighash must always produce the same key"
+    );
+}
+
+#[test]
+fn cache_key_changes_with_the_sighash() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+
+    let mut other_sighash = sighash;
+    other_sighash.0[0] ^= 1;
+
+    assert_ne!(
+        cache_key(&bundle, sighash),
+        cache_key(&bundle, other_sighash),
+        "the sighash is an input to verification, so it must be an input to the key"
+    );
+}
+
+/// Every piece of authorizing data that verification reads changes the key.
+///
+/// This is the direct unit-level analogue of `block_with_garbage_orchard_proofs_is_rejected`:
+/// those are exactly the fields that CVE-2026-34377 substituted while keeping the txid fixed.
+#[test]
+fn cache_key_changes_with_every_piece_of_authorizing_data() {
+    let tx = pre_nu6_2_transactions()
+        .into_iter()
+        .next()
+        .expect("there is at least one pre-NU6.2 Orchard transaction");
+    let (bundle, sighash) = bundle_and_sighash(&tx).expect("the transaction has a bundle");
+    let original = cache_key(&bundle, sighash);
+
+    let (garbage_proof, garbage_proof_sighash) = mutated_bundle_and_sighash(&tx, |data| {
+        data.proof = Halo2Proof(vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    });
+    assert_ne!(
+        original,
+        cache_key(&garbage_proof, garbage_proof_sighash),
+        "the proof is what is being verified, so it must be an input to the key"
+    );
+
+    let (garbage_binding_sig, garbage_binding_sig_sighash) =
+        mutated_bundle_and_sighash(&tx, |data| {
+            data.binding_sig = [0xFF; 64].into();
+        });
+    assert_ne!(
+        original,
+        cache_key(&garbage_binding_sig, garbage_binding_sig_sighash),
+        "the binding signature is batch-verified alongside the proof, so it must be in the key"
+    );
+
+    let (garbage_spend_auth_sigs, garbage_spend_auth_sigs_sighash) =
+        mutated_bundle_and_sighash(&tx, |data| {
+            for action in data.actions.iter_mut() {
+                action.spend_auth_sig = [0xFF; 64].into();
+            }
+        });
+    assert_ne!(
+        original,
+        cache_key(&garbage_spend_auth_sigs, garbage_spend_auth_sigs_sighash),
+        "spend authorization signatures are batch-verified too, so they must be in the key"
+    );
+}
+
+/// Two different bundles that share a sighash get different keys.
+///
+/// This is the regression test for the collision that a `(auth digest, sighash)` key would have:
+/// a v6 transaction verifies its Orchard bundle and its Ironwood bundle against the same sighash
+/// under the same network upgrade, so those two would have shared a key and the first result
+/// would have been returned for the second bundle. Hashing the bundle's own encoding means only
+/// byte-identical bundles can share a key, and byte-identical bundles verify identically.
+#[test]
+fn cache_key_distinguishes_different_bundles_with_the_same_sighash() {
+    let transactions = pre_nu6_2_transactions();
+    let mut keys = Vec::new();
+    let mut bundles = Vec::new();
+
+    // One arbitrary sighash, shared by every bundle, so that only the bundle can distinguish them.
+    let (_, shared_sighash) =
+        bundle_and_sighash(&transactions[0]).expect("the transaction has a bundle");
+
+    for tx in &transactions {
+        let (bundle, _) = bundle_and_sighash(tx).expect("the transaction has a bundle");
+
+        if bundles
+            .iter()
+            .any(|seen| format!("{seen:?}") == format!("{bundle:?}"))
+        {
+            continue;
+        }
+
+        keys.push(cache_key(&bundle, shared_sighash));
+        bundles.push(bundle);
+    }
+
+    assert!(
+        bundles.len() > 1,
+        "this test needs at least two distinct Orchard bundles in the test vectors"
+    );
+
+    let unique: std::collections::HashSet<_> = keys.iter().collect();
+    assert_eq!(
+        unique.len(),
+        keys.len(),
+        "distinct bundles sharing a sighash must not share a cache key"
+    );
+}
+
+/// The bundle version is committed to even when nothing else about the bundle changes.
+///
+/// The consensus encoding of a bundle contains its flag byte but not its [`BundleVersion`], and
+/// the same flags encode to the same byte in more than one version — so without the explicit
+/// discriminant these two bundles would hash identically.
+#[test]
+fn cache_key_changes_with_the_bundle_version() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+
+    let rebuilt = Bundle::try_from_parts(
+        bundle.actions().clone(),
+        *bundle.flags(),
+        *bundle.value_balance(),
+        *bundle.anchor(),
+        bundle.authorization().clone(),
+        BundleVersion::orchard_v2(),
+    )
+    .expect("a real mainnet Orchard bundle is representable under the NU6.2 bundle version");
+
+    assert_eq!(
+        bundle.flag_byte(),
+        rebuilt.flag_byte(),
+        "this test is only meaningful if the encoded flags are identical"
+    );
+    assert_ne!(
+        cache_key(&bundle, sighash),
+        cache_key(&rebuilt, sighash),
+        "the bundle version must be committed to separately from the encoding"
+    );
+}
+
+/// Every bundle version gets its own discriminant.
+#[test]
+fn bundle_version_discriminants_are_distinct() {
+    let versions = [
+        BundleVersion::orchard_insecure_v1(),
+        BundleVersion::orchard_v2(),
+        BundleVersion::orchard_v3(),
+        BundleVersion::ironwood_v3(),
+    ];
+
+    let discriminants: Vec<_> = versions
+        .into_iter()
+        .map(bundle_version_discriminant)
+        .collect();
+    let unique: std::collections::HashSet<_> = discriminants.iter().collect();
+
+    assert_eq!(
+        unique.len(),
+        versions.len(),
+        "each bundle version must have its own discriminant: {discriminants:?}"
+    );
+}
+
+// Memoization behaviour.
+
+/// An inner verification service that counts calls and returns a fixed result.
+#[derive(Clone)]
+struct CountingVerifier {
+    calls: Arc<AtomicUsize>,
+    succeeds: bool,
+}
+
+impl CountingVerifier {
+    fn new(succeeds: bool) -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+            succeeds,
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl Service<Item> for CountingVerifier {
+    type Response = ();
+    type Error = BoxError;
+    type Future = future::Ready<Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _item: Item) -> Self::Future {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+
+        future::ready(if self.succeeds {
+            Ok(())
+        } else {
+            Err(TransactionError::Halo2VerificationFailed.into())
+        })
+    }
+}
+
+#[tokio::test]
+async fn memo_skips_the_inner_service_for_an_already_verified_item() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let inner = CountingVerifier::new(true);
+    let mut verifier = Memoized::new(inner.clone(), 8);
+
+    for _ in 0..3 {
+        verifier
+            .ready()
+            .await
+            .expect("the memo must become ready")
+            .call(Item::new(bundle.clone(), sighash))
+            .await
+            .expect("a valid item must verify");
+    }
+
+    assert_eq!(
+        inner.calls(),
+        1,
+        "only the first verification of an item may reach the inner service"
+    );
+}
+
+#[tokio::test]
+async fn memo_does_not_reuse_a_result_across_items() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let mut other_sighash = sighash;
+    other_sighash.0[0] ^= 1;
+
+    let inner = CountingVerifier::new(true);
+    let mut verifier = Memoized::new(inner.clone(), 8);
+
+    for sighash in [sighash, other_sighash] {
+        verifier
+            .ready()
+            .await
+            .expect("the memo must become ready")
+            .call(Item::new(bundle.clone(), sighash))
+            .await
+            .expect("the inner service accepts everything in this test");
+    }
+
+    assert_eq!(
+        inner.calls(),
+        2,
+        "items with different keys must each be verified"
+    );
+}
+
+/// A failure is never remembered.
+///
+/// A batch error is not per-item evidence — `Fallback` resolves those by re-verifying singly —
+/// and an error can report that the batch worker shut down rather than that a proof is invalid.
+/// Remembering either as "invalid" would make the node reject valid blocks.
+#[tokio::test]
+async fn memo_does_not_remember_failures() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let inner = CountingVerifier::new(false);
+    let mut verifier = Memoized::new(inner.clone(), 8);
+
+    for _ in 0..3 {
+        verifier
+            .ready()
+            .await
+            .expect("the memo must become ready")
+            .call(Item::new(bundle.clone(), sighash))
+            .await
+            .expect_err("the inner service rejects everything in this test");
+    }
+
+    assert_eq!(
+        inner.calls(),
+        3,
+        "a failed verification must be retried, not remembered"
+    );
+}
+
+/// Verifies `item` through `verifier`, asserting that it succeeds.
+async fn verify_through<S>(verifier: &mut Memoized<S>, item: Item)
+where
+    S: Service<Item, Response = (), Error = BoxError>,
+    S::Future: Send + 'static,
+{
+    verifier
+        .ready()
+        .await
+        .expect("the memo must become ready")
+        .call(item)
+        .await
+        .expect("the inner service accepts everything in this test");
+}
+
+#[tokio::test]
+async fn memo_evicts_in_insertion_order_and_stays_correct_when_full() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let inner = CountingVerifier::new(true);
+    let mut verifier = Memoized::new(inner.clone(), 2);
+
+    let sighashes: Vec<_> = (0..3)
+        .map(|i| {
+            let mut sighash = sighash;
+            sighash.0[0] ^= i + 1;
+            sighash
+        })
+        .collect();
+
+    for sighash in &sighashes {
+        verify_through(&mut verifier, Item::new(bundle.clone(), *sighash)).await;
+    }
+    assert_eq!(
+        inner.calls(),
+        3,
+        "three distinct items, three verifications"
+    );
+
+    // The two most recent are still remembered.
+    for sighash in &sighashes[1..] {
+        verify_through(&mut verifier, Item::new(bundle.clone(), *sighash)).await;
+    }
+    assert_eq!(inner.calls(), 3, "entries within the capacity must be kept");
+
+    // The oldest was evicted, so it is verified again rather than silently mis-answered.
+    verify_through(&mut verifier, Item::new(bundle.clone(), sighashes[0])).await;
+    assert_eq!(inner.calls(), 4, "an evicted entry must be re-verified");
 }

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -646,7 +646,7 @@ async fn memo_does_not_remember_failures() {
 /// Verifies `item` through `verifier`, asserting that it succeeds.
 async fn verify_through<S>(verifier: &mut Memoized<S>, item: Item)
 where
-    S: Service<Item, Response = (), Error = BoxError>,
+    S: Service<Item, Response = (), Error = BoxError> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
     verifier
@@ -690,4 +690,112 @@ async fn memo_evicts_in_insertion_order_and_stays_correct_when_full() {
     // The oldest was evicted, so it is verified again rather than silently mis-answered.
     verify_through(&mut verifier, Item::new(bundle.clone(), sighashes[0])).await;
     assert_eq!(inner.calls(), 4, "an evicted entry must be re-verified");
+}
+
+/// An inner service whose readiness always fails, standing in for a dead batch worker.
+///
+/// `Batch::poll_ready` reports an error when its worker has exited, panicked, or closed its
+/// channel. `call` panics here because it must never be reached: a service that is not ready
+/// must not be called, and the tests below are about what happens *before* that point.
+#[derive(Clone)]
+struct UnreadyVerifier {
+    poll_readies: Arc<AtomicUsize>,
+}
+
+impl UnreadyVerifier {
+    fn new() -> Self {
+        Self {
+            poll_readies: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn poll_readies(&self) -> usize {
+        self.poll_readies.load(Ordering::SeqCst)
+    }
+}
+
+impl Service<Item> for UnreadyVerifier {
+    type Response = ();
+    type Error = BoxError;
+    type Future = future::Ready<Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.poll_readies.fetch_add(1, Ordering::SeqCst);
+        Poll::Ready(Err(BoxError::from("batch worker finished unexpectedly")))
+    }
+
+    fn call(&mut self, _item: Item) -> Self::Future {
+        unreachable!("a service whose poll_ready failed must not be called")
+    }
+}
+
+/// A memo hit is answered even when the inner service can no longer become ready.
+///
+/// `Memoized::poll_ready` must not delegate to the inner service. Callers poll readiness before
+/// `call`, so delegating would surface a dead batch worker's error for an item whose result the
+/// memo already holds — reporting a verified proof as a verification failure, and rejecting a
+/// valid block. That is the "an error need not be a verdict" case the module docs are about.
+#[tokio::test]
+async fn memo_hit_survives_an_inner_service_that_never_becomes_ready() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let item = Item::new(bundle, sighash);
+
+    // Warm the memo through a healthy inner service.
+    let healthy = CountingVerifier::new(true);
+    let mut verifier = Memoized::new(healthy.clone(), 8);
+    verify_through(&mut verifier, item.clone()).await;
+    assert_eq!(healthy.calls(), 1, "the first verification must be a miss");
+
+    // Swap in an inner service that can never become ready, keeping the same memo.
+    let dead = UnreadyVerifier::new();
+    let mut verifier = verifier.with_inner(dead.clone());
+
+    verifier
+        .ready()
+        .await
+        .expect("the memo must be ready even when the inner service is not")
+        .call(item)
+        .await
+        .expect("a memo hit must be answered from the memo, not from the dead inner service");
+
+    assert_eq!(
+        dead.poll_readies(),
+        0,
+        "a hit must not poll the inner service for readiness at all"
+    );
+}
+
+/// A miss still propagates an inner readiness failure.
+///
+/// Moving readiness off `poll_ready` must not make the memo swallow it: an item that is not in
+/// the memo has to reach the inner service, and if that service cannot become ready the request
+/// must fail rather than be reported as verified.
+#[tokio::test]
+async fn memo_miss_propagates_an_inner_readiness_failure() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let dead = UnreadyVerifier::new();
+    let mut verifier = Memoized::new(dead.clone(), 8);
+
+    verifier
+        .ready()
+        .await
+        .expect("the memo itself is always ready")
+        .call(Item::new(bundle.clone(), sighash))
+        .await
+        .expect_err("a miss must surface the inner service's readiness failure");
+
+    assert!(
+        dead.poll_readies() > 0,
+        "a miss must acquire inner readiness"
+    );
+
+    // And the failure must not be remembered as a success.
+    let mut verifier = verifier.with_inner(CountingVerifier::new(true));
+    let counting = verifier.inner().clone();
+    verify_through(&mut verifier, Item::new(bundle, sighash)).await;
+    assert_eq!(
+        counting.calls(),
+        1,
+        "the item must still be verified, so the readiness failure was not recorded as an Ok"
+    );
 }

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -692,6 +692,106 @@ async fn cache_evicts_in_insertion_order_and_stays_correct_when_full() {
     assert_eq!(inner.calls(), 4, "an evicted entry must be re-verified");
 }
 
+/// Clones of a cache answer from the same set of verified proofs.
+///
+/// Production never calls a global verifier directly: [`super::verifier_for`] hands out a
+/// `&'static` handle and every request goes through a fresh `.clone()` of it. A cache that lived
+/// in the handle rather than behind the shared `Arc` would be empty for every request, so this
+/// pins the sharing that makes the cache reachable at all.
+#[tokio::test]
+async fn cache_is_shared_between_clones() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let item = Item::new(bundle, sighash);
+
+    let inner = CountingVerifier::new(true);
+    let verifier = Cached::new(inner.clone(), 8);
+
+    let mut warming_clone = verifier.clone();
+    verify_through(&mut warming_clone, item.clone()).await;
+    assert_eq!(inner.calls(), 1, "the first verification must be a miss");
+
+    let mut reading_clone = verifier.clone();
+    verify_through(&mut reading_clone, item).await;
+    assert_eq!(
+        inner.calls(),
+        1,
+        "a clone must answer from the result another clone recorded"
+    );
+}
+
+/// An inner service that never returns a result, standing in for a verification in flight.
+#[derive(Clone)]
+struct PendingVerifier {
+    calls: Arc<AtomicUsize>,
+}
+
+impl PendingVerifier {
+    fn new() -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl Service<Item> for PendingVerifier {
+    type Response = ();
+    type Error = BoxError;
+    type Future = future::Pending<Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _item: Item) -> Self::Future {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        future::pending()
+    }
+}
+
+/// A verification that is cancelled before it returns is not remembered.
+///
+/// The cache records a key from inside the response future, so dropping that future has to leave
+/// the cache untouched. Recording on the way in would remember a proof that was never checked:
+/// callers drop these futures routinely, because a block or mempool verification abandons its
+/// remaining checks as soon as one of them fails.
+#[tokio::test]
+async fn cancelling_a_verification_does_not_populate_the_cache() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let item = Item::new(bundle, sighash);
+
+    let hanging = PendingVerifier::new();
+    let mut verifier = Cached::new(hanging.clone(), 8);
+
+    // Start a verification and drop it before the inner service can answer.
+    let in_flight = verifier
+        .ready()
+        .await
+        .expect("the cache must become ready")
+        .call(item.clone());
+    tokio::time::timeout(Duration::from_millis(50), in_flight)
+        .await
+        .expect_err("the inner service never returns, so the verification cannot complete");
+    assert_eq!(
+        hanging.calls(),
+        1,
+        "the cancelled verification must have reached the inner service"
+    );
+
+    // Retrying must verify again rather than read an entry the cancelled call never earned.
+    let mut verifier = verifier.with_inner(CountingVerifier::new(true));
+    let counting = verifier.inner().clone();
+    verify_through(&mut verifier, item).await;
+    assert_eq!(
+        counting.calls(),
+        1,
+        "a cancelled verification must not be remembered as a success"
+    );
+}
+
 /// An inner service whose readiness always fails, standing in for a dead batch worker.
 ///
 /// `Batch::poll_ready` reports an error when its worker has exited, panicked, or closed its

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -41,8 +41,8 @@ use zcash_protocol::value::ZatBalance;
 use crate::{error::TransactionError, BoxError};
 
 use super::{
-    bundle_version_discriminant, lazy_verifier_for, BatchFallbackService, CacheKey, Item,
-    ItemVerifyingKey, Memoized, OrchardFallback, Verifier, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD,
+    bundle_version_discriminant, lazy_verifier_for, BatchFallbackService, CacheKey, Cached, Item,
+    ItemVerifyingKey, OrchardFallback, Verifier, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD,
     VERIFIER_PRE_NU6_2, VERIFYING_KEY_NU6_2, VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
 };
 
@@ -273,7 +273,7 @@ async fn explicit_flush_rejects_single_proof_under_each_wrong_era_key() {
 
 // Cache key completeness.
 //
-// [`Memoized`] reuses a previous `Ok` for any item whose key matches, so a key that misses one of
+// [`Cached`] reuses a previous `Ok` for any item whose key matches, so a key that misses one of
 // verification's inputs is a consensus bug: it would accept a proof that was never checked. These
 // tests pin every input down.
 
@@ -442,7 +442,7 @@ fn rebuilt_as(
 ///
 /// A v6 transaction verifies both of its bundles against the same sighash under the same network
 /// upgrade, and — because both pools use the NU6.3 circuit — through the same verifier and so the
-/// same memo. A key that did not separate the pools would answer one pool's verification with the
+/// same cache. A key that did not separate the pools would answer one pool's verification with the
 /// other's result.
 ///
 /// The two bundles here are built from identical parts, and with cross-address transfers disabled
@@ -524,7 +524,7 @@ fn bundle_version_discriminants_are_distinct() {
     );
 }
 
-// Memoization behaviour.
+// Caching behaviour.
 
 /// An inner verification service that counts calls and returns a fixed result.
 #[derive(Clone)]
@@ -567,16 +567,16 @@ impl Service<Item> for CountingVerifier {
 }
 
 #[tokio::test]
-async fn memo_skips_the_inner_service_for_an_already_verified_item() {
+async fn cache_skips_the_inner_service_for_an_already_verified_item() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Memoized::new(inner.clone(), 8);
+    let mut verifier = Cached::new(inner.clone(), 8);
 
     for _ in 0..3 {
         verifier
             .ready()
             .await
-            .expect("the memo must become ready")
+            .expect("the cache must become ready")
             .call(Item::new(bundle.clone(), sighash))
             .await
             .expect("a valid item must verify");
@@ -590,19 +590,19 @@ async fn memo_skips_the_inner_service_for_an_already_verified_item() {
 }
 
 #[tokio::test]
-async fn memo_does_not_reuse_a_result_across_items() {
+async fn cache_does_not_reuse_a_result_across_items() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let mut other_sighash = sighash;
     other_sighash.0[0] ^= 1;
 
     let inner = CountingVerifier::new(true);
-    let mut verifier = Memoized::new(inner.clone(), 8);
+    let mut verifier = Cached::new(inner.clone(), 8);
 
     for sighash in [sighash, other_sighash] {
         verifier
             .ready()
             .await
-            .expect("the memo must become ready")
+            .expect("the cache must become ready")
             .call(Item::new(bundle.clone(), sighash))
             .await
             .expect("the inner service accepts everything in this test");
@@ -621,16 +621,16 @@ async fn memo_does_not_reuse_a_result_across_items() {
 /// and an error can report that the batch worker shut down rather than that a proof is invalid.
 /// Remembering either as "invalid" would make the node reject valid blocks.
 #[tokio::test]
-async fn memo_does_not_remember_failures() {
+async fn cache_does_not_remember_failures() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(false);
-    let mut verifier = Memoized::new(inner.clone(), 8);
+    let mut verifier = Cached::new(inner.clone(), 8);
 
     for _ in 0..3 {
         verifier
             .ready()
             .await
-            .expect("the memo must become ready")
+            .expect("the cache must become ready")
             .call(Item::new(bundle.clone(), sighash))
             .await
             .expect_err("the inner service rejects everything in this test");
@@ -644,7 +644,7 @@ async fn memo_does_not_remember_failures() {
 }
 
 /// Verifies `item` through `verifier`, asserting that it succeeds.
-async fn verify_through<S>(verifier: &mut Memoized<S>, item: Item)
+async fn verify_through<S>(verifier: &mut Cached<S>, item: Item)
 where
     S: Service<Item, Response = (), Error = BoxError> + Clone + Send + 'static,
     S::Future: Send + 'static,
@@ -652,17 +652,17 @@ where
     verifier
         .ready()
         .await
-        .expect("the memo must become ready")
+        .expect("the cache must become ready")
         .call(item)
         .await
         .expect("the inner service accepts everything in this test");
 }
 
 #[tokio::test]
-async fn memo_evicts_in_insertion_order_and_stays_correct_when_full() {
+async fn cache_evicts_in_insertion_order_and_stays_correct_when_full() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Memoized::new(inner.clone(), 2);
+    let mut verifier = Cached::new(inner.clone(), 2);
 
     let sighashes: Vec<_> = (0..3)
         .map(|i| {
@@ -729,34 +729,34 @@ impl Service<Item> for UnreadyVerifier {
     }
 }
 
-/// A memo hit is answered even when the inner service can no longer become ready.
+/// A cache hit is answered even when the inner service can no longer become ready.
 ///
-/// `Memoized::poll_ready` must not delegate to the inner service. Callers poll readiness before
+/// `Cached::poll_ready` must not delegate to the inner service. Callers poll readiness before
 /// `call`, so delegating would surface a dead batch worker's error for an item whose result the
-/// memo already holds — reporting a verified proof as a verification failure, and rejecting a
+/// cache already holds — reporting a verified proof as a verification failure, and rejecting a
 /// valid block. That is the "an error need not be a verdict" case the module docs are about.
 #[tokio::test]
-async fn memo_hit_survives_an_inner_service_that_never_becomes_ready() {
+async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let item = Item::new(bundle, sighash);
 
-    // Warm the memo through a healthy inner service.
+    // Warm the cache through a healthy inner service.
     let healthy = CountingVerifier::new(true);
-    let mut verifier = Memoized::new(healthy.clone(), 8);
+    let mut verifier = Cached::new(healthy.clone(), 8);
     verify_through(&mut verifier, item.clone()).await;
     assert_eq!(healthy.calls(), 1, "the first verification must be a miss");
 
-    // Swap in an inner service that can never become ready, keeping the same memo.
+    // Swap in an inner service that can never become ready, keeping the same cache.
     let dead = UnreadyVerifier::new();
     let mut verifier = verifier.with_inner(dead.clone());
 
     verifier
         .ready()
         .await
-        .expect("the memo must be ready even when the inner service is not")
+        .expect("the cache must be ready even when the inner service is not")
         .call(item)
         .await
-        .expect("a memo hit must be answered from the memo, not from the dead inner service");
+        .expect("a cache hit must be answered from the cache, not from the dead inner service");
 
     assert_eq!(
         dead.poll_readies(),
@@ -767,19 +767,19 @@ async fn memo_hit_survives_an_inner_service_that_never_becomes_ready() {
 
 /// A miss still propagates an inner readiness failure.
 ///
-/// Moving readiness off `poll_ready` must not make the memo swallow it: an item that is not in
-/// the memo has to reach the inner service, and if that service cannot become ready the request
+/// Moving readiness off `poll_ready` must not make the cache swallow it: an item that is not in
+/// the cache has to reach the inner service, and if that service cannot become ready the request
 /// must fail rather than be reported as verified.
 #[tokio::test]
-async fn memo_miss_propagates_an_inner_readiness_failure() {
+async fn cache_miss_propagates_an_inner_readiness_failure() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let dead = UnreadyVerifier::new();
-    let mut verifier = Memoized::new(dead.clone(), 8);
+    let mut verifier = Cached::new(dead.clone(), 8);
 
     verifier
         .ready()
         .await
-        .expect("the memo itself is always ready")
+        .expect("the cache itself is always ready")
         .call(Item::new(bundle.clone(), sighash))
         .await
         .expect_err("a miss must surface the inner service's readiness failure");

--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -5384,9 +5384,15 @@ async fn mempool_transaction_with_sufficient_fee_is_rejected_by_script() {
     );
 }
 
-/// Test for CVE-2026-34377 https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-3vmh-33xr-9cqh
+/// Regression test for the whole-transaction mempool bypass removed in Zebra PR #10494.
 ///
-/// Ensure a block with a transaction with garbage Orchard proofs is rejected, even if the mempool has a valid version of the same transaction.
+/// The mock mempool can return a valid transaction with the same txid as the block transaction,
+/// whose authorizing data is corrupted. Current Zakura does not query that verdict during block
+/// verification; if the old bypass is reintroduced, the mock response makes the block skip its
+/// normal checks and this test fails.
+///
+/// This does not populate or exercise the Halo2 proof cache. See
+/// [`the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it`] for that coverage.
 #[tokio::test(flavor = "multi_thread")]
 async fn block_with_garbage_orchard_proofs_is_rejected() {
     use zakura_chain::{primitives::Halo2Proof, transaction::VerifiedUnminedTx};
@@ -5442,7 +5448,8 @@ async fn block_with_garbage_orchard_proofs_is_rejected() {
     }
     assert_eq!(tx.hash(), garbage_tx.hash());
 
-    // simulate valid version in mempool
+    // Arm the mock mempool with a valid same-txid version. The current block verifier does not
+    // query it, but the removed whole-transaction bypass would.
     let spent_output = known_utxos
         .get(&input_outpoint)
         .unwrap()
@@ -5486,31 +5493,14 @@ async fn block_with_garbage_orchard_proofs_is_rejected() {
     assert!(resp.is_err(), "garbage proof must be rejected");
 }
 
-/// Regression test for the mempool-cache expiry bypass vulnerability.
+/// A block transaction mined past its expiry height is rejected.
 ///
-/// A non-coinbase transaction with `nExpiryHeight = H+1` that was cached in the
-/// mempool as valid at height `H+1` can be presented inside a block at height
-/// `H+2`.  The block transaction verifier must re-run the expiry check even
-/// when it hits the mempool cache fast path in `find_verified_unmined_tx`;
-/// skipping that check lets Zebra accept a block that honest nodes reject,
-/// causing a consensus split.
-///
-/// # Attack window
-///
-/// The attack is possible because:
-/// * The mempool is active while Zebra is "close to tip" (not only at exact tip).
-/// * The download/verification pipeline accepts blocks up to
-///   `tip + full_verify_concurrency_limit` ahead of the current tip.
-/// * `find_verified_unmined_tx` returns the cached result before the normal
-///   expiry validation.
-///
-/// Concretely: while Zebra's best tip is still `H`, the mempool can already
-/// hold a `VerifiedUnminedTx` for a transaction with `nExpiryHeight = H+1`.
-/// If the verifier is simultaneously asked to semantically verify a candidate
-/// block at `H+2` that contains the same transaction, the cache hit fires and
-/// the block passes semantic verification with an expired transaction inside.
+/// This is baseline coverage for the height-dependent check. It does not populate either a
+/// transaction-verdict cache or the Halo2 proof cache: the transaction is transparent-only and is
+/// submitted only as a block request. The Halo2 cache expiry regression is covered by
+/// [`the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it`].
 #[tokio::test(flavor = "multi_thread")]
-async fn mempool_cached_result_bypasses_expiry_check_for_block_at_next_height() {
+async fn block_transaction_past_expiry_height_is_rejected() {
     let _init_guard = zakura_test::init();
 
     let network = Network::Mainnet;
@@ -5563,12 +5553,7 @@ async fn mempool_cached_result_bypasses_expiry_check_for_block_at_next_height() 
         .ok()
         .expect("send should succeed");
 
-    // Submit the same transaction as a Block request at expired_block_height
-    // (H+2).  The known_outpoint_hashes set satisfies the dependency check
-    // inside find_verified_unmined_tx so the cache hit fires immediately.
-    //
-    // The verifier must return Err(TransactionError::ExpiredTransaction)
-    // because H+2 > nExpiryHeight.
+    // Submit the transaction at H+2, where it is expired because H+2 > nExpiryHeight.
     let result = timeout(
         test_timeout(),
         verifier.clone().oneshot(Request::Block {
@@ -5585,17 +5570,15 @@ async fn mempool_cached_result_bypasses_expiry_check_for_block_at_next_height() 
 
     // Buffer boxes the service error, so downcast to check the specific variant.
     let err = result.expect_err(
-        "expected block verification to fail for a transaction with \
-         expired nExpiryHeight mined via the mempool cache path",
+        "expected block verification to fail for a transaction with expired nExpiryHeight",
     );
     let tx_err = err
         .downcast::<TransactionError>()
         .expect("error should downcast to TransactionError");
     assert!(
         matches!(*tx_err, TransactionError::ExpiredTransaction { .. }),
-        "expected ExpiredTransaction error for block at height {expired_block_height:?} \
-         with nExpiryHeight {mempool_height:?} via mempool cache; \
-         got: {tx_err:?}"
+        "expected ExpiredTransaction error for block at height {expired_block_height:?} with \
+         nExpiryHeight {mempool_height:?}; got: {tx_err:?}"
     );
 }
 
@@ -6045,7 +6028,7 @@ fn block_request(tx: &Transaction, height: block::Height) -> Request {
 /// That is the shape of CVE-2026-34377, and a cache keyed on the txid would answer all three with
 /// the valid transaction's result. The fourth is the one field of the four that lives outside the
 /// Orchard bundle: it changes the txid too, and reaches the cache key through the sighash.
-const AUTHORIZATION_MUTATIONS: &[(&str, fn(&mut Transaction))] = &[
+const CACHE_KEY_MUTATIONS: &[(&str, fn(&mut Transaction))] = &[
     ("Halo2 proof", |tx| {
         orchard_shielded_data_for_mutation(tx).proof.0[0] ^= 1;
     }),
@@ -6100,7 +6083,7 @@ fn orchard_shielded_data_for_mutation(tx: &mut Transaction) -> &mut orchard::Shi
 ///      height past its expiry is still rejected. That is the mempool bypass Zebra removed as a
 ///      security fix in PR #10494, and the reason this cache holds a proof rather than a verdict
 ///      on a transaction;
-///   3. a twin with mutated authorizing data never inherits the record.
+///   3. a transaction with any verification input mutated never inherits the record.
 #[test]
 fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
     let _init_guard = zakura_test::init();
@@ -6114,10 +6097,8 @@ fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
             .expect("a V5 transaction has an expiry height");
         let network_upgrade = NetworkUpgrade::current(&Network::Mainnet, expiry_height);
         let item = orchard_item(&tx, network_upgrade);
-        let cache = primitives::halo2::verifier_for(network_upgrade);
-
         assert_eq!(
-            cache.inner_calls_for(&item),
+            primitives::halo2::inner_calls_for(network_upgrade, &item),
             0,
             "this transaction's bundle must not have been verified before this test"
         );
@@ -6135,7 +6116,7 @@ fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
         .expect("a real mainnet Orchard transaction must verify at its expiry height");
 
         assert_eq!(
-            cache.inner_calls_for(&item),
+            primitives::halo2::inner_calls_for(network_upgrade, &item),
             1,
             "the mempool verification must reach the inner Halo2 verifier"
         );
@@ -6145,7 +6126,7 @@ fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
             .expect("the same transaction must verify in a block");
 
         assert_eq!(
-            cache.inner_calls_for(&item),
+            primitives::halo2::inner_calls_for(network_upgrade, &item),
             1,
             "the block verification must be answered from the cache"
         );
@@ -6167,21 +6148,21 @@ fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
             "the rejection must be the expiry rule, not some other failure"
         );
 
-        // 3. No twin inherits the cached result.
-        for (mutated_field, mutate) in AUTHORIZATION_MUTATIONS {
-            let mut twin = tx.clone();
-            mutate(&mut twin);
-            let twin_item = orchard_item(&twin, network_upgrade);
+        // 3. No mutated transaction inherits the cached result.
+        for (mutated_field, mutate) in CACHE_KEY_MUTATIONS {
+            let mut mutated_tx = tx.clone();
+            mutate(&mut mutated_tx);
+            let mutated_item = orchard_item(&mutated_tx, network_upgrade);
 
-            // A collision here would already be the failure: the twin would inherit the valid
-            // transaction's result instead of being verified.
+            // A collision here would already be the failure: the mutation would inherit the
+            // valid transaction's result instead of being verified.
             assert_eq!(
-                cache.inner_calls_for(&twin_item),
+                primitives::halo2::inner_calls_for(network_upgrade, &mutated_item),
                 0,
-                "the {mutated_field} twin must get its own cache key, not the valid transaction's"
+                "the {mutated_field} mutation must get a different cache key"
             );
 
-            let Err(error) = verify(&mut verifier, block_request(&twin, expiry_height)).await
+            let Err(error) = verify(&mut verifier, block_request(&mutated_tx, expiry_height)).await
             else {
                 panic!("a transaction with a mutated {mutated_field} must be rejected");
             };
@@ -6193,9 +6174,9 @@ fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
             );
 
             assert_eq!(
-                cache.inner_calls_for(&twin_item),
+                primitives::halo2::inner_calls_for(network_upgrade, &mutated_item),
                 1,
-                "the {mutated_field} twin must reach the inner Halo2 verifier"
+                "the {mutated_field} mutation must reach the inner Halo2 verifier"
             );
         }
     });

--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -48,7 +48,7 @@ use zakura_node_services::mempool;
 use zakura_state::ValidateContextError;
 use zakura_test::mock_service::MockService;
 
-use crate::{error::TransactionError, transaction::POLL_MEMPOOL_DELAY};
+use crate::{error::TransactionError, primitives, transaction::POLL_MEMPOOL_DELAY, BoxError};
 
 use super::{check, Request, Verifier};
 
@@ -5889,4 +5889,314 @@ fn script_sig_args_expected_values() {
     let ms_kind = check::standard_script_kind(&ms_kind)
         .expect("1-of-1 multisig should be a standard script kind");
     assert_eq!(check::script_sig_args_expected(&ms_kind), Some(2));
+}
+
+// The Halo2 proof cache, exercised through the production transaction verifier.
+//
+// The unit tests in `primitives::halo2::tests` drive a hand-built `Cached` over a synthetic inner
+// service. What follows drives the real `Request::Mempool` and `Request::Block` flows over the
+// real global verifier, which is what production uses.
+
+/// The mock state service the cache test verifies against.
+type CacheTestState = MockService<
+    zakura_state::Request,
+    zakura_state::Response,
+    zakura_test::mock_service::PropTestAssertion,
+    BoxError,
+>;
+
+/// The mock mempool service the cache test verifies against.
+type CacheTestMempool = MockService<
+    mempool::Request,
+    mempool::Response,
+    zakura_test::mock_service::PropTestAssertion,
+    BoxError,
+>;
+
+/// The transaction verifier the cache test drives.
+///
+/// Unbuffered, so failures arrive as a typed [`TransactionError`] rather than a boxed one.
+/// Requests are issued in sequence, so one `&mut` handle is enough.
+type CacheTestVerifier = Verifier<CacheTestState, CacheTestMempool>;
+
+/// Returns the real mainnet Orchard transaction that the cache test drives through the verifier.
+///
+/// Selected from the mainnet test blocks for what full verification needs:
+///
+///   * an Orchard bundle, which is what the cache holds;
+///   * no transparent inputs, so its sighash does not depend on previous outputs that the test
+///     vectors do not carry;
+///   * a fee covering its own actions, so the mempool's ZIP-317 policy accepts it; and
+///   * no Sapling bundle, which keeps the test on the Halo2 verifier rather than also loading the
+///     Sapling parameters and batching Groth16 proofs that prove nothing here.
+///
+/// Its proof is NU5-era, so it verifies only under the pre-NU6.2 circuit key, and every height
+/// used with it must be a pre-NU6.2 mainnet height.
+fn cacheable_mainnet_orchard_transaction() -> Transaction {
+    zakura_test::vectors::MAINNET_BLOCKS
+        .values()
+        .flat_map(|bytes| {
+            let block: Block = bytes
+                .zcash_deserialize_into()
+                .expect("hard-coded test vector must deserialize");
+            block.transactions.clone()
+        })
+        .find(|tx| {
+            tx.orchard_shielded_data().is_some()
+                && tx.inputs().is_empty()
+                && !tx.has_sapling_shielded_data()
+                && tx
+                    .value_balance(&HashMap::new())
+                    .ok()
+                    .and_then(|balance| balance.remaining_transaction_value().ok())
+                    .is_some_and(|fee| fee >= zip317::conventional_fee(tx))
+        })
+        .map(|tx| tx.as_ref().clone())
+        .expect("the mainnet test blocks must contain a fee-paying Orchard-only transaction")
+}
+
+/// Returns the Orchard verification item the transaction verifier builds for `tx` at
+/// `network_upgrade`.
+///
+/// Mirrors `Verifier::verify_v5_transaction`: the bundle and the sighash come from one sighasher
+/// over an empty set of previous outputs, which is correct only because
+/// [`cacheable_mainnet_orchard_transaction`] has no transparent inputs.
+fn orchard_item(tx: &Transaction, network_upgrade: NetworkUpgrade) -> primitives::halo2::Item {
+    let sighasher = tx
+        .sighasher(network_upgrade, Arc::new(Vec::new()))
+        .expect("a mainnet Orchard transaction has a sighasher at its own network upgrade");
+    let bundle = sighasher
+        .orchard_bundle()
+        .expect("the transaction was selected for having an Orchard bundle");
+
+    primitives::halo2::Item::new(bundle, sighasher.sighash(HashType::ALL, None))
+}
+
+/// Builds a transaction verifier over mock state and mempool services, and returns the state.
+fn cache_test_verifier() -> (CacheTestVerifier, CacheTestState) {
+    let state: CacheTestState = MockService::build().for_prop_tests();
+    let mempool: CacheTestMempool = MockService::build().for_prop_tests();
+    let (mempool_setup_tx, mempool_setup_rx) = tokio::sync::oneshot::channel();
+
+    let verifier = Verifier::new(&Network::Mainnet, state.clone(), mempool_setup_rx);
+
+    mempool_setup_tx
+        .send(mempool)
+        .ok()
+        .expect("the mempool setup channel must accept the mock");
+
+    (verifier, state)
+}
+
+/// Answers the one state query that verifying a shielded-only transaction from the mempool makes.
+///
+/// Block requests make none: this transaction has no transparent inputs to look up, and the
+/// nullifier and anchor check is a mempool-only query.
+fn respond_to_nullifier_and_anchor_check(state: &CacheTestState) {
+    let mut state = state.clone();
+
+    tokio::spawn(async move {
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zakura_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("a mempool verification must check nullifiers and anchors")
+            .respond(zakura_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+}
+
+/// Verifies `request`, leaving `verifier` usable for the next one.
+async fn verify(
+    verifier: &mut CacheTestVerifier,
+    request: Request,
+) -> Result<super::Response, TransactionError> {
+    verifier
+        .ready()
+        .await
+        .expect("the transaction verifier is always ready")
+        .call(request)
+        .await
+}
+
+/// Returns a block request that mines `tx` at `height`.
+fn block_request(tx: &Transaction, height: block::Height) -> Request {
+    Request::Block {
+        transaction_hash: tx.hash(),
+        transaction: Arc::new(tx.clone()),
+        known_outpoint_hashes: Arc::new(HashSet::new()),
+        known_utxos: Arc::new(HashMap::new()),
+        height,
+        time: Utc::now(),
+    }
+}
+
+/// Mutations that must each force a fresh verification.
+///
+/// Every one is a canonical-length bit flip, so the mutated transaction still passes the
+/// structural checks that run before verification. That matters most for the proof:
+/// `shielded_proof_size_is_canonical` rejects a wrong-length proof long before the cache is
+/// consulted, so a garbage-length proof would not exercise the cache at all.
+///
+/// The first three change only authorizing data, which under ZIP 244 leaves the txid unchanged.
+/// That is the shape of CVE-2026-34377, and a cache keyed on the txid would answer all three with
+/// the valid transaction's result. The fourth is the one field of the four that lives outside the
+/// Orchard bundle: it changes the txid too, and reaches the cache key through the sighash.
+const AUTHORIZATION_MUTATIONS: &[(&str, fn(&mut Transaction))] = &[
+    ("Halo2 proof", |tx| {
+        orchard_shielded_data_for_mutation(tx).proof.0[0] ^= 1;
+    }),
+    ("binding signature", |tx| {
+        let data = orchard_shielded_data_for_mutation(tx);
+        let mut bytes = <[u8; 64]>::from(data.binding_sig);
+        bytes[0] ^= 1;
+        data.binding_sig = bytes.into();
+    }),
+    ("spend authorization signature", |tx| {
+        for action in orchard_shielded_data_for_mutation(tx).actions.iter_mut() {
+            let mut bytes = <[u8; 64]>::from(action.spend_auth_sig);
+            bytes[0] ^= 1;
+            action.spend_auth_sig = bytes.into();
+        }
+    }),
+    ("expiry height", |tx| {
+        // Raised rather than lowered, so the transaction still passes the expiry check and
+        // reaches verification. Under ZIP 244 the expiry height is in the sighash, and the
+        // Orchard signatures are verified against that sighash.
+        let raised = (tx
+            .expiry_height()
+            .expect("a V5 transaction has an expiry height")
+            + 1)
+        .expect("a mainnet expiry height is far below the maximum");
+
+        *tx.expiry_height_mut() = raised;
+    }),
+];
+
+/// Returns `tx`'s Orchard shielded data for mutation.
+fn orchard_shielded_data_for_mutation(tx: &mut Transaction) -> &mut orchard::ShieldedData {
+    tx.orchard_shielded_data_mut()
+        .expect("the transaction was selected for having Orchard shielded data")
+}
+
+/// The Halo2 proof cache, exercised end to end through the transaction verifier.
+///
+/// This is one test rather than three because all three claims need the same transaction and a
+/// cold cache for it. The Halo2 verifiers are process-wide `Lazy` statics, so only one test can
+/// ever see that transaction's cache entry cold.
+///
+/// It runs on [`zakura_test::MULTI_THREADED_RUNTIME`] because it reaches a global verifier.
+/// `tower-batch-control` spawns that verifier's batch worker on whichever runtime first touches
+/// it, so a per-test runtime would leave the worker cancelled for every test that ran afterwards.
+///
+/// The three claims, in order:
+///
+///   1. a mempool verification records the proof, and the block that mines the same transaction is
+///      answered from that record instead of verifying the proof again;
+///   2. the record does not carry the transaction past the height-dependent checks: the block one
+///      height past its expiry is still rejected. That is the mempool bypass Zebra removed as a
+///      security fix in PR #10494, and the reason this cache holds a proof rather than a verdict
+///      on a transaction;
+///   3. a twin with mutated authorizing data never inherits the record.
+#[test]
+fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
+    let _init_guard = zakura_test::init();
+
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let (mut verifier, state) = cache_test_verifier();
+
+        let tx = cacheable_mainnet_orchard_transaction();
+        let expiry_height = tx
+            .expiry_height()
+            .expect("a V5 transaction has an expiry height");
+        let network_upgrade = NetworkUpgrade::current(&Network::Mainnet, expiry_height);
+        let item = orchard_item(&tx, network_upgrade);
+        let cache = primitives::halo2::verifier_for(network_upgrade);
+
+        assert_eq!(
+            cache.inner_calls_for(&item),
+            0,
+            "this transaction's bundle must not have been verified before this test"
+        );
+
+        // 1. The mempool verification is the only one that reaches the Halo2 verifier.
+        respond_to_nullifier_and_anchor_check(&state);
+        verify(
+            &mut verifier,
+            Request::Mempool {
+                transaction: tx.clone().into(),
+                height: expiry_height,
+            },
+        )
+        .await
+        .expect("a real mainnet Orchard transaction must verify at its expiry height");
+
+        assert_eq!(
+            cache.inner_calls_for(&item),
+            1,
+            "the mempool verification must reach the inner Halo2 verifier"
+        );
+
+        verify(&mut verifier, block_request(&tx, expiry_height))
+            .await
+            .expect("the same transaction must verify in a block");
+
+        assert_eq!(
+            cache.inner_calls_for(&item),
+            1,
+            "the block verification must be answered from the cache"
+        );
+
+        // 2. The cached proof does not carry the transaction past the expiry check.
+        let too_late =
+            (expiry_height + 1).expect("a mainnet expiry height is far below the maximum");
+        let error = verify(&mut verifier, block_request(&tx, too_late))
+            .await
+            .expect_err("a transaction mined past its expiry height must be rejected");
+
+        assert_eq!(
+            error,
+            TransactionError::ExpiredTransaction {
+                expiry_height,
+                block_height: too_late,
+                transaction_hash: tx.hash(),
+            },
+            "the rejection must be the expiry rule, not some other failure"
+        );
+
+        // 3. No twin inherits the cached result.
+        for (mutated_field, mutate) in AUTHORIZATION_MUTATIONS {
+            let mut twin = tx.clone();
+            mutate(&mut twin);
+            let twin_item = orchard_item(&twin, network_upgrade);
+
+            // A collision here would already be the failure: the twin would inherit the valid
+            // transaction's result instead of being verified.
+            assert_eq!(
+                cache.inner_calls_for(&twin_item),
+                0,
+                "the {mutated_field} twin must get its own cache key, not the valid transaction's"
+            );
+
+            let Err(error) = verify(&mut verifier, block_request(&twin, expiry_height)).await
+            else {
+                panic!("a transaction with a mutated {mutated_field} must be rejected");
+            };
+
+            assert_eq!(
+                error,
+                TransactionError::Halo2VerificationFailed,
+                "the {mutated_field} twin must fail Orchard verification"
+            );
+
+            assert_eq!(
+                cache.inner_calls_for(&twin_item),
+                1,
+                "the {mutated_field} twin must reach the inner Halo2 verifier"
+            );
+        }
+    });
 }

--- a/docs/changelog/unreleased/597.md
+++ b/docs/changelog/unreleased/597.md
@@ -1,0 +1,10 @@
+## Changed
+
+- Orchard Halo2 proofs verified from the mempool are no longer verified a second
+  time when the block that mines them arrives. The result is memoized per Orchard
+  circuit era under a key that hashes the bundle's consensus encoding, its bundle
+  version and the sighash, so a reused result is bit-identical to the computation
+  it replaces; every other consensus check still runs at the block's own height.
+  New `zakura.consensus.halo2.memo.{hit,miss,insert,evict}` counters and a
+  `zakura.consensus.halo2.memo.size` gauge report the memo's behaviour
+  ([#597](https://github.com/zakura-core/zakura/pull/597)).

--- a/docs/changelog/unreleased/597.md
+++ b/docs/changelog/unreleased/597.md
@@ -1,10 +1,10 @@
 ## Changed
 
 - Orchard Halo2 proofs verified from the mempool are no longer verified a second
-  time when the block that mines them arrives. The result is memoized per Orchard
+  time when the block that mines them arrives. The result is cached per Orchard
   circuit era under a key that hashes the bundle's consensus encoding, its bundle
   version and the sighash, so a reused result is bit-identical to the computation
   it replaces; every other consensus check still runs at the block's own height.
-  New `zakura.consensus.halo2.memo.{hit,miss,insert,evict}` counters and a
-  `zakura.consensus.halo2.memo.size` gauge report the memo's behaviour
+  New `zakura.consensus.halo2.cache.{hit,miss,insert,evict}` counters and a
+  `zakura.consensus.halo2.cache.size` gauge report the cache's behaviour
   ([#597](https://github.com/zakura-core/zakura/pull/597)).


### PR DESCRIPTION
## Motivation

Every Orchard proof is verified twice: once when the transaction arrives over mempool gossip, and again when it arrives inside the block that mines it. Measured on one box with matched block sizes, a block's halo2 batch weights sum to exactly the block's Orchard action count *plus* the mempool's — the signature of doing the same work twice.

Zebra used to avoid this with a mempool bypass: if a block's transaction had already been verified in the mempool, `tx::Verifier::call()` returned `Ok` immediately. Upstream removed it in [#10494](https://github.com/ZcashFoundation/zebra/pull/10494) and did not replace it, so modern Zebra pays the same cost. Zakura forked from v5.0.0 and never had it.

It was removed for a structural reason, not a fixable bug. It cached a *verdict* — `valid(tx, height, block time, spent outputs)` — under a key that did not determine that proposition:

| | |
|---|---|
| added, #8951 `1974fea88` | `find_verified_unmined_tx` becomes the first statement of `call()` |
| patched, #10425 `2429f97f7` | **CVE-2026-34377** / GHSA-3vmh-33xr-9cqh — the lookup was by txid, which under ZIP 244 commits to no authorizing data, so proof and signatures could be swapped freely. Fixed narrowly by comparing the full `UnminedTxId`; the bypass was kept |
| deleted, #10494 `1f605eca5` | removed entirely, 84 lines, "consensus: remove mempool bypass" |

Everything between the early return and the response was skipped, including `consensus_branch_id`, `is_orchard_temporarily_disabled`, the NU6.2 proof-size rule, `non_coinbase_expiry_height`, `disabled_add_to_sprout_pool`, and `lock_time_has_passed` — all of which move with height, and the last of which also moves with the miner-chosen block time. The deepest one is `nu = request.upgrade(network)`, which selects both the sighash and, via `verifier_for(nu)`, *which Orchard circuit verifying key the bundle is checked against*. Across a network upgrade boundary the bypass was not skipping policy; it was answering a different cryptographic question and returning the stale answer.

Zakura carries both regression tests: `block_with_garbage_orchard_proofs_is_rejected` and `mempool_cached_result_bypasses_expiry_check_for_block_at_next_height`.

## Solution

Memoize the proof verification itself rather than the verdict. `Item::verify_single(self, vk) -> bool` is a pure function, so a hit is bit-identical to the computation it replaces.

|  | #8951 | this PR |
|---|---|---|
| cached proposition | `valid(tx, height, block time, utxos)` | `verify(bundle, sighash, vk) -> bool` |
| pure function of the key? | **no** | **yes, if the key is complete** |
| short-circuits | `tx::Verifier::call()` | one `oneshot` inside `verify_orchard_bundle` |
| consensus checks skipped on a hit | all of them | **none** |

On a hit, `transaction::Verifier::call` still runs end to end at the block's height, with the block's time and the block's spent outputs. Expiry, lock time, the branch id, the soft-fork gates, UTXO resolution, fees and sigops all still run.

**Key completeness is therefore the entire safety argument, and it is where review effort is best spent** — `Item::cache_key` in `primitives/halo2.rs` and the module docs in `primitives/halo2/memo.rs`.

- **`bundle` and `sighash`** are committed to by hashing the bundle's own consensus encoding (`write_v5_bundle`), which is injective and covers everything `BatchValidator::add_bundle` reads: per-action value commitments, nullifiers, validating keys, note commitments and spend authorization signatures, plus the flags, value balance, anchor, proof and binding signature. An explicit `BundleVersion` discriminant is hashed alongside it, because the encoding contains the flag byte but not the version.
- **`vk`** is committed to structurally. There are already three global verifiers, one per Orchard circuit era; each now has its own memo, so an entry can only ever be read back under the key it was written against. Eras cannot mix in a memo for the same reason they cannot mix in a batch.

Two forcing functions guard the key against drift. `cache_key` destructures `Item` exhaustively, so adding a field is a compile error until someone decides whether it belongs in the key; and `bundle_version_discriminant` matches exhaustively on `ValuePool` and `ProtocolVersion`, so a new pool or protocol version is a compile error too.

Deriving the key by hand from things that "obviously" determine the bundle is how this goes wrong, and it is easy to get wrong twice. The txid does not commit to authorizing data at all (CVE-2026-34377). `(auth digest, sighash)` looks complete and is not: a v6 transaction verifies its Orchard bundle and its Ironwood bundle against the same sighash under the same network upgrade, so those two share both components. Hashing the encoding means only byte-identical bundles can share a key, and byte-identical bundles verify identically.

**Only `Ok` is recorded.** A batch error is not per-item evidence, because `Fallback` resolves batch failures by re-verifying each item singly; and an error out of the service need not be a verdict at all — it can report that the batch worker shut down. Recording either as "this proof is invalid" would make the node reject a valid block, which is a chain split in the other direction.

The memo is a small tower middleware wrapping each era's existing stack, built inside `batch_verifier`, so no call site changes and `verifier_for` returns the same shape it did before. Storage is a FIFO-bounded `HashSet` of 32-byte keys, 20,000 entries per era, no new dependency; the mutex is held only across a set operation and never across an await. Metrics: `zakura.consensus.halo2.memo.{hit,miss,insert,evict}` and a size gauge.

There is deliberately **no config knob**. A runtime lever that changes verification behaviour produces irreproducible bug reports for no operator benefit. If a kill switch is ever wanted for incident response, a startup-only, documented-as-debug env var would be the right shape — a `Config` field would make it supported surface.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p zakura-consensus`.

The upstream regression tests are the headline gate, and both pass unchanged:

- **`block_with_garbage_orchard_proofs_is_rejected`** is the direct test of key completeness. The mempool populates a key from the valid bundle; the block carries the auth-substituted twin with an identical txid; the twin encodes differently, so it misses, is fully verified, and is rejected. If the key is ever weakened to something txid-derived, this test fails.
- **`mempool_cached_result_bypasses_expiry_check_for_block_at_next_height`** — the memo does not touch expiry, so this must pass untouched.
- `dont_skip_verification_of_block_transactions_in_mempool` also passes.

New unit tests in `primitives/halo2/tests.rs`:

- the key is deterministic, and changes with the sighash;
- the key changes with the proof, the binding signature, and the spend authorization signatures — asserting in each case that the txid did *not* change, so the test is exercising the CVE's shape;
- the key changes with the bundle version even when the encoded flag byte is identical, which is what the explicit discriminant is for;
- distinct bundles sharing one sighash get distinct keys (the Orchard/Ironwood collision above);
- every `BundleVersion` gets its own discriminant;
- the memo skips the inner service on a hit, does not reuse a result across different keys, never remembers a failure, and re-verifies an evicted entry rather than mis-answering it.

`transaction::tests::v4_and_v5_with_sapling_spends` fails under a parallel full-crate run on this branch. It also fails identically on `origin/main` with these changes stashed, and passes in isolation on both — pre-existing and unrelated.

Not yet measured: the field speedup. The 93.5% figure that motivated this is *crypto* occupancy, which also contains script verification and redpallas batches that this change does not address; the halo2 term has not been sized separately. See follow-up.

## Specifications & References

- Zebra [#8951](https://github.com/ZcashFoundation/zebra/pull/8951), [#10425](https://github.com/ZcashFoundation/zebra/pull/10425) (CVE-2026-34377 / GHSA-3vmh-33xr-9cqh), [#10494](https://github.com/ZcashFoundation/zebra/pull/10494)
- ZIP 244 (txid does not commit to authorizing data), ZIP 229 (Orchard cross-address restriction, which is why the era split exists)
- GHSA-jfw5-j458-pfv6 (the NU6.2 circuit fix behind the per-era verifying keys)

## Follow-up Work

- Split the block transaction phase into halo2 / sapling / redpallas / script to size the actual ceiling for this change, then measure warm-vs-cold and the field hit rate. Note that `worst_case_tx_verification` cannot show this: it passes a closed mempool setup channel, so the population path never runs.
- Worth taking to the Zebra maintainers. #10494 removed the optimization with no replacement, so every Zebra node on the network pays this cost too; if the pure-function framing survives their review, we are not carrying a consensus-critical divergence alone.
- `TransactionWithDepsByMinedId` is still served in Zakura but consumed only by a test — inherited API surface from a bypass we never had. This PR does not need it, so it can be removed separately.
- Sapling groth16 and redpallas admit the same treatment; neither is measured yet, and groth16 is unbatched here, so they should follow rather than ride along.
