### PR TITLE
ci(release): reuse published semver baselines

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -189,8 +189,10 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ steps.params.outputs.base_tag }}
-          restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
+          key: semver-baselines-full-${{ steps.toolchain.outputs.cachekey }}-${{ steps.params.outputs.base_tag }}
+          restore-keys: |
+            semver-baselines-full-${{ steps.toolchain.outputs.cachekey }}-
+            semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       # Deliberately unpinned (like semver-checks.yml): cargo-semver-checks
       # must track new stable rustdoc formats.

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -181,6 +181,17 @@ jobs:
           # replacing caches warmed by regular CI.
           cache-save-if: false
 
+      # Read the registry-baseline rustdoc JSON warmed by semver-checks.yml.
+      # Release preparation never saves or replaces this cache. Entries are
+      # keyed internally by crate version, so the rustc-only fallback can
+      # safely supply older published baselines still needed by a base tag.
+      - name: Restore semver baseline rustdoc cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: target/semver-checks/cache
+          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ steps.params.outputs.base_tag }}
+          restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
+
       # Deliberately unpinned (like semver-checks.yml): cargo-semver-checks
       # must track new stable rustdoc formats.
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -82,9 +82,10 @@ jobs:
                 --head "$GITHUB_SHA"
             )"
           else
-            # Trusted main runs populate reusable rustdoc JSON for the latest
-            # stable crates.io baselines. Check every publishable crate so one
-            # cache entry can warm any package selected by a later PR.
+            # Trusted main runs populate reusable rustdoc JSON for both the
+            # stable PR baseline and the exact latest-tag baseline used by
+            # release preparation. Check every publishable crate so one cache
+            # entry can warm any package selected later.
             packages="$(
               python3 .github/workflows/scripts/affected_semver_packages.py --all
             )"
@@ -159,8 +160,10 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
-          restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
+          key: semver-baselines-full-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
+          restore-keys: |
+            semver-baselines-full-${{ steps.toolchain.outputs.cachekey }}-
+            semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       # Deliberately unpinned (like cargo-hack): cargo-semver-checks must
       # track new stable rustdoc formats; pin only if a regression forces it.
@@ -242,6 +245,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
@@ -255,8 +259,10 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
-          restore-keys: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
+          key: semver-baselines-full-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
+          restore-keys: |
+            semver-baselines-full-${{ steps.toolchain.outputs.cachekey }}-
+            semver-baselines-${{ steps.toolchain.outputs.cachekey }}-
 
       - uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd #v2.84.1
         with:
@@ -264,23 +270,71 @@ jobs:
 
       - uses: ./.github/actions/setup-zakura-build
 
-      - name: Check all crates against stable crates.io baselines
+      - name: Check all crates and warm published release baselines
+        id: warm
         env:
+          BASELINE_TAG: ${{ needs.select-packages.outputs.baseline_tag }}
           PACKAGES: ${{ needs.select-packages.outputs.packages }}
         run: |
+          source scripts/lib/crates-index.sh
+          source scripts/lib/release-packages.sh
+
+          declare -A release_versions=()
+          while IFS=$'\t' read -r package version _manifest; do
+            release_versions["$package"]="$version"
+          done < <(list_release_packages_at "$BASELINE_TAG")
+
+          cache_complete=true
           while IFS= read -r package; do
             [[ -n "$package" ]] || continue
-            cargo semver-checks --package "$package" --default-features
+
+            release_version="${release_versions[$package]:-}"
+            if [[ -z "$release_version" ]]; then
+              echo "${package} is absent from ${BASELINE_TAG}; checking the stable baseline only."
+              cargo semver-checks --package "$package" --default-features
+              cache_complete=false
+              continue
+            fi
+
+            index_rc=0
+            crates_index_has_version "$package" "$release_version" \
+              || index_rc=$?
+            case "$index_rc" in
+              0) ;;
+              1)
+                echo "${package}@${release_version} is not published; checking the stable baseline only."
+                cargo semver-checks --package "$package" --default-features
+                cache_complete=false
+                continue
+                ;;
+              *)
+                echo "Could not query the crates.io index for ${package}." >&2
+                exit 1
+                ;;
+            esac
+
+            # cargo-semver-checks deliberately chooses a stable release by
+            # default. Preserve that baseline for ordinary PR checks when the
+            # latest tag is a release candidate, then also cache the exact RC
+            # baseline needed by release preparation.
+            if [[ "$release_version" == *-* ]]; then
+              cargo semver-checks --package "$package" --default-features
+            fi
+            cargo semver-checks --package "$package" --default-features \
+              --baseline-version "$release_version"
           done <<< "$PACKAGES"
+
+          echo "cache_complete=$cache_complete" >> "$GITHUB_OUTPUT"
 
       - name: Save baseline rustdoc cache
         if: >-
           github.ref == 'refs/heads/main'
           && steps.baseline-cache.outputs.cache-hit != 'true'
+          && steps.warm.outputs.cache_complete == 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: target/semver-checks/cache
-          key: semver-baselines-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
+          key: semver-baselines-full-${{ steps.toolchain.outputs.cachekey }}-${{ needs.select-packages.outputs.baseline_tag }}
 
       - name: Explain the failure
         if: failure()

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -453,14 +453,29 @@ if [ "$no_crates" = 0 ]; then
     fi
 
     # Changed but unbumped: let cargo-semver-checks pick the level against the
-    # base tag (a git baseline, unlike semver-checks.yml's crates.io baseline,
-    # because a base-tag crate version may never have been published).
-    echo "Running cargo-semver-checks for ${crate} against ${base_tag}..."
+    # exact base version. Published baselines can reuse the rustdoc JSON warmed
+    # by semver-checks.yml; unpublished base versions fall back to the git tag.
+    baseline_args=(--baseline-rev "$base_tag")
+    baseline_description="$base_tag (git)"
+    index_rc=0
+    crates_index_has_version "$crate" "$base_version" || index_rc=$?
+    case "$index_rc" in
+      0)
+        baseline_args=(--baseline-version "$base_version")
+        baseline_description="${crate}@${base_version} (crates.io)"
+        ;;
+      1) ;;
+      *)
+        echo "ERROR: could not query the crates.io index for ${crate}." >&2
+        exit 1
+        ;;
+    esac
+    echo "Running cargo-semver-checks for ${crate} against ${baseline_description}..."
     semver_output=""
     semver_status=0
     semver_output="$(
       cargo semver-checks --package "$crate" --default-features \
-        --baseline-rev "$base_tag" 2>&1
+        "${baseline_args[@]}" 2>&1
     )" || semver_status=$?
 
     if [ "$semver_status" -eq 0 ]; then


### PR DESCRIPTION
## Motivation

Release preparation compares changed, unbumped crates with the exact base tag
using `cargo semver-checks --baseline-rev`. `cargo-semver-checks` treats Git
revisions as local projects and deliberately does not cache their rustdoc JSON,
so every release-preparation run rebuilds every baseline even when that exact
crate version was published.

Regular semver CI already owns a registry-baseline cache, but its default
baseline selection deliberately prefers stable versions. An RC run therefore
saved a cache named for `v1.1.0-rc2` that actually contained older stable
baselines such as `zakura@1.0.5`, not the exact RC JSON needed by the next
release preparation.

## Solution

- Have trusted main semver runs warm both baseline sets:
  - the latest stable registry version used by ordinary PR semver checks; and
  - the exact published version recorded in the latest release tag.
- Put enriched caches in the new
  `semver-baselines-full-<rustc>-<base-tag>` namespace, while retaining the old
  cache namespace as a restore-only fallback. This is necessary because GitHub
  cache entries are immutable.
- Save an enriched main cache only when every tagged package version is
  published, so a partially published release cannot permanently create an
  incomplete exact-tag cache.
- Restore that cache read-only in release preparation; the workflow never
  saves or replaces semver baseline caches.
- For each changed, unbumped crate, use `--baseline-version` when the exact
  base-tag version exists on crates.io, allowing the full cached rustdoc JSON
  and metadata to be reused.
- Preserve `--baseline-rev` as the fallback for unpublished base versions and
  fail closed on crates.io index transport errors.

## Testing

- `python3 .github/workflows/scripts/test_affected_semver_packages.py`
- `bash -n scripts/prepare-release.sh scripts/lib/crates-index.sh scripts/lib/release-packages.sh`
- `bash scripts/tests/test_release_packages.sh` with local tag signing disabled
  for the temporary fixture repository
- Parsed both changed workflow files with Ruby's YAML parser
- Extracted the new main warming step and checked it with `bash -n`
- `git diff --check`
- Verified through the read-only sparse index that all 13 publishable packages
  at `v1.1.0` have their exact tagged versions on crates.io
- Inspected the `v1.1.0-rc2` main warmer log: its old cache contained stable
  baselines (`zakura@1.0.5`, `zakura-state@5.0.1`, etc.), confirming the RC gap
- Read-only branch dispatch [31220952857](https://github.com/zakura-core/zakura/actions/runs/31220952857)
  passed all 13 exact `v1.1.0` checks in the main warmer. It restored the
  20,071,522-byte legacy archive, parsed every exact baseline as cached, and
  skipped the main-only cache-save step.
- Ran the release planner against the verified Zakura `v1.1.0` release commit;
  it selected `zakura-state@6.0.0 (crates.io)`, exercising the published
  baseline path. The remaining local rustdoc build could not complete because
  RocksDB's bindgen build script could not load this Mac's `libclang.dylib`.

## Changelog

No changelog fragment is required because this changes internal release
automation without modifying Rust sources or Cargo manifests.

### Specifications & References

- `cargo-semver-checks` 0.49 copies the complete registry rustdoc JSON plus
  Cargo metadata into `target/semver-checks/cache`; it disables that cache for
  local-project requests, including Git revision baselines.

### Follow-up Work

Measure the next release-preparation run. If current-crate rustdoc generation
remains the dominant cost, parallelize the independent per-crate checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect internal CI and release automation only; no Rust library or runtime behavior changes, with fail-closed index handling preserved.
> 
> **Overview**
> Release preparation and CI now share **registry-backed** `cargo-semver-checks` rustdoc baselines so release runs can skip rebuilding baselines that already exist on crates.io.
> 
> **`semver-checks.yml`** moves baseline caches to `semver-baselines-full-<rustc>-<tag>` (old keys stay as restore-only fallbacks). On trusted **main**, the warmer runs semver checks for every publishable crate against both the default stable baseline and the **exact version** recorded at the latest release tag; for RC tags it also warms the stable baseline first. The enriched cache is saved only when every tagged package version is published (`cache_complete`), so a partial publish cannot freeze an incomplete cache.
> 
> **`prepare-release-pr.yml`** restores that cache read-only (it never writes semver baseline caches).
> 
> **`scripts/prepare-release.sh`** picks `--baseline-version` when the base-tag crate version is on crates.io (reusing warmed rustdoc JSON); otherwise it keeps `--baseline-rev` for unpublished bases and fails on index errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55efbf93b116711385872ece63ad0e4446afa49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->