### PR TITLE
perf(chain): defer the Sapling rk small-order check

### DIFF
--- a/crates/zakura-chain/src/sapling/arbitrary.rs
+++ b/crates/zakura-chain/src/sapling/arbitrary.rs
@@ -114,9 +114,7 @@ fn spendauth_verification_key_bytes() -> impl Strategy<Value = ValidatingKey> {
     prop::array::uniform32(any::<u8>()).prop_map(|bytes| {
         let rng = ChaChaRng::from_seed(bytes);
         let sk = redjubjub::SigningKey::<redjubjub::SpendAuth>::new(rng);
-        redjubjub::VerificationKey::<redjubjub::SpendAuth>::from(&sk)
-            .try_into()
-            .unwrap()
+        redjubjub::VerificationKey::<redjubjub::SpendAuth>::from(&sk).into()
     })
 }
 

--- a/crates/zakura-chain/src/sapling/keys.rs
+++ b/crates/zakura-chain/src/sapling/keys.rs
@@ -368,7 +368,11 @@ impl ZcashDeserialize for EphemeralPublicKey {
 /// [2]: https://zips.z.cash/protocol/protocol.pdf#concretereddsa
 /// [`ValueCommitment`]: crate::sapling::ValueCommitment
 /// [`Transaction::sapling_point_encodings_are_valid`]: crate::transaction::Transaction::sapling_point_encodings_are_valid
-#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+//
+// Deliberately not `Copy`, unlike its sibling deferred-point types: adding `Copy` to an already
+// published type is a major semver break, and it would buy nothing here — every consumer takes
+// the bytes through `From<&ValidatingKey>`.
+#[derive(Clone, Deserialize, PartialEq, Eq, Serialize)]
 pub struct ValidatingKey(pub(crate) [u8; 32]);
 
 impl ValidatingKey {

--- a/crates/zakura-chain/src/sapling/keys.rs
+++ b/crates/zakura-chain/src/sapling/keys.rs
@@ -345,56 +345,114 @@ impl ZcashDeserialize for EphemeralPublicKey {
 /// represent [SpendAuthSig^{Sapling}.Public][2], which allows any points, including
 /// of small order).
 ///
+/// # Lazy point decompression
+///
+/// Stored as the raw 32-byte compressed encoding, exactly as it appears on the
+/// wire. Decompressing a Jubjub point requires a square root in the base field,
+/// which dominates the cost of parsing a Sapling transaction — so, like
+/// [`ValueCommitment`] and [`EphemeralPublicKey`], the point and its
+/// not-small-order check are deferred off the checkpoint-sync hot path.
+///
+/// # Consensus
+///
+/// Deserialization only checks the byte length; it does not prove the bytes are
+/// a canonical, non-small-order point. The not-small-order check is deferred to
+/// the semantic verifier and mempool, which call
+/// [`ValidatingKey::is_valid_not_small_order`] (via
+/// [`Transaction::sapling_point_encodings_are_valid`]) and also verify the
+/// Sapling bundle through librustzcash, whose `check_spend` rejects a
+/// small-order `rk`. The checkpoint verifier trusts block hashes and skips the
+/// check. Covered by `sapling_small_order_rk_deferred_but_caught_by_librustzcash`.
+///
 /// [1]: https://zips.z.cash/protocol/protocol.pdf#spenddesc
 /// [2]: https://zips.z.cash/protocol/protocol.pdf#concretereddsa
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-pub struct ValidatingKey(redjubjub::VerificationKey<SpendAuth>);
+/// [`ValueCommitment`]: crate::sapling::ValueCommitment
+/// [`Transaction::sapling_point_encodings_are_valid`]: crate::transaction::Transaction::sapling_point_encodings_are_valid
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ValidatingKey(pub(crate) [u8; 32]);
 
-impl From<ValidatingKey> for redjubjub::VerificationKey<SpendAuth> {
-    fn from(rk: ValidatingKey) -> Self {
-        rk.0
-    }
-}
-
-impl TryFrom<redjubjub::VerificationKey<SpendAuth>> for ValidatingKey {
-    type Error = &'static str;
-
-    /// Convert an array into a ValidatingKey.
+impl ValidatingKey {
+    /// Returns true if the stored encoding is a canonical, non-small-order
+    /// Jubjub point, i.e. a valid `rk` per the consensus rules.
     ///
-    /// Returns an error if the key is malformed or [is of small order][1].
+    /// This is the not-small-order check deferred from deserialization, run by
+    /// the semantic verifier (not the checkpoint verifier) on untrusted
+    /// transactions.
     ///
     /// # Consensus
     ///
     /// > Check that a Spend description's cv and rk are not of small order,
     /// > i.e. \[h_J\]cv MUST NOT be 𝒪_J and \[h_J\]rk MUST NOT be 𝒪_J.
     ///
-    /// [1]: https://zips.z.cash/protocol/protocol.pdf#spenddesc
-    fn try_from(key: redjubjub::VerificationKey<SpendAuth>) -> Result<Self, Self::Error> {
-        if bool::from(
-            jubjub::AffinePoint::from_bytes(key.into())
-                .unwrap()
-                .is_small_order(),
-        ) {
-            Err("jubjub::AffinePoint value for Sapling ValidatingKey is of small order")
-        } else {
-            Ok(Self(key))
+    /// <https://zips.z.cash/protocol/protocol.pdf#spenddesc>
+    ///
+    /// To stay in consensus with the rest of the network, this must accept
+    /// exactly the `rk` encodings librustzcash accepts. There, `read_rk` decodes
+    /// the bytes with `redjubjub::VerificationKey::try_from`, which rejects
+    /// off-curve and non-canonical encodings but deliberately allows small-order
+    /// points, and `check_spend` then rejects `rk_affine.is_small_order()`. The
+    /// conjunction is what this reproduces. Equivalence is pinned by
+    /// `sapling_point_checks_match_librustzcash_predicates`.
+    pub fn is_valid_not_small_order(&self) -> bool {
+        match jubjub::AffinePoint::from_bytes(self.0).into_option() {
+            Some(point) => !bool::from(point.is_small_order()),
+            None => false,
         }
+    }
+}
+
+impl fmt::Debug for ValidatingKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ValidatingKey")
+            .field("rk", &hex::encode(self.0))
+            .finish()
+    }
+}
+
+impl TryFrom<ValidatingKey> for redjubjub::VerificationKey<SpendAuth> {
+    type Error = &'static str;
+
+    /// Decompresses the stored encoding into a `redjubjub` validating key.
+    ///
+    /// This is the point decompression that deserialization defers, so it is
+    /// fallible: callers must handle an invalid key rather than assume the
+    /// stored bytes are valid. It does *not* run the not-small-order check —
+    /// `redjubjub` allows small-order keys on purpose, which is why that check
+    /// lives in [`ValidatingKey::is_valid_not_small_order`].
+    fn try_from(rk: ValidatingKey) -> Result<Self, Self::Error> {
+        redjubjub::VerificationKey::<SpendAuth>::try_from(rk.0)
+            .map_err(|_| "Invalid redjubjub::VerificationKey for Sapling ValidatingKey")
+    }
+}
+
+impl From<redjubjub::VerificationKey<SpendAuth>> for ValidatingKey {
+    fn from(key: redjubjub::VerificationKey<SpendAuth>) -> Self {
+        Self(key.into())
     }
 }
 
 impl TryFrom<[u8; 32]> for ValidatingKey {
     type Error = &'static str;
 
+    /// Store a `ValidatingKey` from a byte array, deferring point decompression
+    /// and the not-small-order check (see the type docs).
+    ///
+    /// This constructor is fallible only to match older call sites and trait
+    /// bounds; any 32-byte array is stored successfully.
     fn try_from(value: [u8; 32]) -> Result<Self, Self::Error> {
-        let vk = redjubjub::VerificationKey::<SpendAuth>::try_from(value)
-            .map_err(|_| "Invalid redjubjub::ValidatingKey for Sapling ValidatingKey")?;
-        vk.try_into()
+        Ok(Self(value))
     }
 }
 
 impl From<ValidatingKey> for [u8; 32] {
     fn from(key: ValidatingKey) -> Self {
-        key.0.into()
+        key.0
+    }
+}
+
+impl From<&ValidatingKey> for [u8; 32] {
+    fn from(key: &ValidatingKey) -> Self {
+        key.0
     }
 }
 

--- a/crates/zakura-chain/src/sapling/shielded_data.rs
+++ b/crates/zakura-chain/src/sapling/shielded_data.rs
@@ -262,17 +262,17 @@ where
         self.transfers.outputs()
     }
 
-    /// Returns true if every value commitment and ephemeral public key in this
-    /// bundle is a canonical, non-small-order Jubjub point.
+    /// Returns true if every value commitment, spend validating key, and
+    /// ephemeral public key in this bundle is a canonical, non-small-order
+    /// Jubjub point.
     ///
     /// These points are stored as raw bytes with their not-small-order check
     /// deferred from deserialization, to keep point decompression off the
     /// checkpoint-sync hot path. This runs that check for the semantic verifier;
-    /// the checkpoint verifier trusts block hashes and skips it. Spend `rk` is
-    /// validated separately at deserialization.
+    /// the checkpoint verifier trusts block hashes and skips it.
     pub fn point_encodings_are_valid(&self) -> bool {
         self.spends()
-            .all(|spend| spend.cv.is_valid_not_small_order())
+            .all(|spend| spend.cv.is_valid_not_small_order() && spend.rk.is_valid_not_small_order())
             && self.outputs().all(|output| {
                 output.cv.is_valid_not_small_order()
                     && output.ephemeral_key.is_valid_not_small_order()

--- a/crates/zakura-chain/src/sapling/spend.rs
+++ b/crates/zakura-chain/src/sapling/spend.rs
@@ -65,7 +65,7 @@ pub struct Spend<AnchorV: AnchorVariant> {
 /// Serialized as `SpendDescriptionV5` in [protocol specification §7.3][ps].
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#spendencoding
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SpendPrefixInTransactionV5 {
     /// A value commitment to the value of the input note.
     pub cv: commitment::ValueCommitment,
@@ -75,13 +75,9 @@ pub struct SpendPrefixInTransactionV5 {
     pub rk: ValidatingKey,
 }
 
-// We can't derive Eq because `VerificationKey` does not implement it,
+// We can't derive Eq because `redjubjub::Signature` does not implement it,
 // even if it is valid for it.
 impl<AnchorV: AnchorVariant + PartialEq> Eq for Spend<AnchorV> {}
-
-// We can't derive Eq because `VerificationKey` does not implement it,
-// even if it is valid for it.
-impl Eq for SpendPrefixInTransactionV5 {}
 
 impl<AnchorV> fmt::Display for Spend<AnchorV>
 where
@@ -162,7 +158,7 @@ impl ZcashSerialize for Spend<PerSpendAnchor> {
         writer.write_all(&self.cv.0)?;
         self.per_spend_anchor.zcash_serialize(&mut writer)?;
         writer.write_32_bytes(&self.nullifier.into())?;
-        writer.write_all(&<[u8; 32]>::from(self.rk.clone())[..])?;
+        writer.write_all(&<[u8; 32]>::from(self.rk)[..])?;
         self.zkproof.zcash_serialize(&mut writer)?;
         writer.write_all(&<[u8; 64]>::from(self.spend_auth_sig)[..])?;
         Ok(())
@@ -191,8 +187,8 @@ impl ZcashDeserialize for Spend<PerSpendAnchor> {
         //
         // https://zips.z.cash/protocol/protocol.pdf#spenddesc
         //
-        // Sapling `cv` only stores its bytes here; the point validity check is
-        // deferred to `Transaction::sapling_point_encodings_are_valid`.
+        // Sapling `cv` and `rk` only store their bytes here; the point validity
+        // check is deferred to `Transaction::sapling_point_encodings_are_valid`.
         //
         // > LEOS2IP_{256}(anchorSapling), if present, MUST be less than 𝑞_𝕁.
         //
@@ -213,7 +209,8 @@ impl ZcashDeserialize for Spend<PerSpendAnchor> {
             nullifier: note::Nullifier::from(reader.read_32_bytes()?),
             // Type is `SpendAuthSig^{Sapling}.Public`, i.e. J
             // https://zips.z.cash/protocol/protocol.pdf#concretereddsa
-            // See [`ValidatingKey::try_from`].
+            // Stores the bytes without validating the point; see
+            // [`ValidatingKey`].
             rk: reader
                 .read_32_bytes()?
                 .try_into()
@@ -242,7 +239,7 @@ impl ZcashSerialize for SpendPrefixInTransactionV5 {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         writer.write_all(&self.cv.0)?;
         writer.write_32_bytes(&self.nullifier.into())?;
-        writer.write_all(&<[u8; 32]>::from(self.rk.clone())[..])?;
+        writer.write_all(&<[u8; 32]>::from(self.rk)[..])?;
         Ok(())
     }
 }
@@ -255,8 +252,8 @@ impl ZcashDeserialize for SpendPrefixInTransactionV5 {
         //
         // https://zips.z.cash/protocol/protocol.pdf#spenddesc
         //
-        // Sapling `cv` only stores its bytes here; the point validity check is
-        // deferred to `Transaction::sapling_point_encodings_are_valid`.
+        // Sapling `cv` and `rk` only store their bytes here; the point validity
+        // check is deferred to `Transaction::sapling_point_encodings_are_valid`.
         Ok(SpendPrefixInTransactionV5 {
             // Type is `ValueCommit^{Sapling}.Output`, i.e. J
             // https://zips.z.cash/protocol/protocol.pdf#abstractcommit
@@ -267,7 +264,8 @@ impl ZcashDeserialize for SpendPrefixInTransactionV5 {
             nullifier: note::Nullifier::from(reader.read_32_bytes()?),
             // Type is `SpendAuthSig^{Sapling}.Public`, i.e. J
             // https://zips.z.cash/protocol/protocol.pdf#concretereddsa
-            // See [`ValidatingKey::try_from`].
+            // Stores the bytes without validating the point; see
+            // [`ValidatingKey`].
             rk: reader
                 .read_32_bytes()?
                 .try_into()

--- a/crates/zakura-chain/src/sapling/spend.rs
+++ b/crates/zakura-chain/src/sapling/spend.rs
@@ -158,7 +158,7 @@ impl ZcashSerialize for Spend<PerSpendAnchor> {
         writer.write_all(&self.cv.0)?;
         self.per_spend_anchor.zcash_serialize(&mut writer)?;
         writer.write_32_bytes(&self.nullifier.into())?;
-        writer.write_all(&<[u8; 32]>::from(self.rk)[..])?;
+        writer.write_all(&<[u8; 32]>::from(&self.rk)[..])?;
         self.zkproof.zcash_serialize(&mut writer)?;
         writer.write_all(&<[u8; 64]>::from(self.spend_auth_sig)[..])?;
         Ok(())
@@ -239,7 +239,7 @@ impl ZcashSerialize for SpendPrefixInTransactionV5 {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         writer.write_all(&self.cv.0)?;
         writer.write_32_bytes(&self.nullifier.into())?;
-        writer.write_all(&<[u8; 32]>::from(self.rk)[..])?;
+        writer.write_all(&<[u8; 32]>::from(&self.rk)[..])?;
         Ok(())
     }
 }

--- a/crates/zakura-chain/src/transaction/sighash/v4.rs
+++ b/crates/zakura-chain/src/transaction/sighash/v4.rs
@@ -118,7 +118,7 @@ fn sapling_spends_hash(
         state.update(&spend.cv.to_bytes());
         update_serialized(&mut state, &spend.per_spend_anchor);
         state.update(&<[u8; 32]>::from(spend.nullifier));
-        state.update(&<[u8; 32]>::from(spend.rk.clone()));
+        state.update(&<[u8; 32]>::from(spend.rk));
         update_serialized(&mut state, &spend.zkproof);
     }
     Some(state.finalize())

--- a/crates/zakura-chain/src/transaction/sighash/v4.rs
+++ b/crates/zakura-chain/src/transaction/sighash/v4.rs
@@ -118,7 +118,7 @@ fn sapling_spends_hash(
         state.update(&spend.cv.to_bytes());
         update_serialized(&mut state, &spend.per_spend_anchor);
         state.update(&<[u8; 32]>::from(spend.nullifier));
-        state.update(&<[u8; 32]>::from(spend.rk));
+        state.update(&<[u8; 32]>::from(&spend.rk));
         update_serialized(&mut state, &spend.zkproof);
     }
     Some(state.finalize())

--- a/crates/zakura-chain/src/transaction/tests/vectors.rs
+++ b/crates/zakura-chain/src/transaction/tests/vectors.rs
@@ -2695,6 +2695,11 @@ fn sapling_small_order_rk_deferred_but_caught_by_librustzcash() {
         "to_librustzcash must reject an off-curve rk at read",
     );
 
+    // `check_spend`'s own rejection of the small-order rk is pinned separately, over a real
+    // mainnet bundle, by `librustzcash_check_spend_rejects_a_small_order_rk` — it cannot be
+    // pinned here because this crafted fixture carries an all-zero proof, which
+    // `check_bundle` rejects on its own regardless of `rk`.
+
     // Byte-identity: the lazy representation must not perturb the encoding, since
     // the txid and merkle root hash these bytes.
     let bytes_in = build(off_curve)
@@ -2708,6 +2713,94 @@ fn sapling_small_order_rk_deferred_but_caught_by_librustzcash() {
         bytes_in,
         bytes_out.zcash_serialize_to_vec().expect("re-serializes"),
         "a lazy rk must round-trip byte-for-byte",
+    );
+}
+
+/// librustzcash rejects a small-order `rk` at verify, which is the backstop the deferral leans
+/// on for the semantic and mempool paths.
+///
+/// This drives `sapling_crypto`'s own `BatchValidator` over a **real mainnet Sapling bundle**
+/// rather than re-stating the rule. Re-stating it would be worthless: `check_spend` tests
+/// `jubjub::AffinePoint::from_bytes(..).is_small_order()`, which is character for character what
+/// [`ValidatingKey::is_valid_not_small_order`] runs, so an assertion written that way is
+/// tautologically true and could never detect a divergence. `sapling-crypto` exposes no
+/// byte-level entry point for that half, so the only independent evidence is the library's
+/// observable behaviour on a bundle.
+///
+/// A real bundle is required: `check_bundle` runs every synchronous consensus check before
+/// batching, so a crafted fixture with a placeholder proof is rejected whatever its `rk` is, and
+/// the test would pass for the wrong reason. The accept leg guards exactly that.
+///
+/// Signature and proof validity are *batched*, not checked by `check_bundle`, so replacing `rk`
+/// — which invalidates the spend authorization signature — does not disturb the accept leg.
+///
+/// [`ValidatingKey::is_valid_not_small_order`]: crate::sapling::keys::ValidatingKey::is_valid_not_small_order
+#[test]
+fn librustzcash_check_spend_rejects_a_small_order_rk() {
+    use crate::{
+        parameters::Network,
+        sapling::{self, keys::ValidatingKey},
+        serialization::AtLeastOne,
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let network = Network::Mainnet;
+
+    let (height, transaction) = arbitrary::test_transactions(&network)
+        .find(|(_, tx)| {
+            matches!(tx.as_ref(), Transaction::V4 { .. })
+                && tx.sapling_spends_per_anchor().next().is_some()
+                && tx.inputs().is_empty()
+        })
+        .expect("mainnet test vectors must contain a V4 Sapling transaction with spends");
+
+    let nu = NetworkUpgrade::current(&network, height);
+
+    // Any sighash gives the same synchronous verdict — `check_bundle` only queues the signature
+    // batch items — but use the real one so the accept leg is a faithful bundle.
+    let sighash = transaction
+        .sighasher(nu, Arc::new(Vec::new()))
+        .expect("the transaction has no transparent inputs")
+        .sighash(HashType::ALL, None);
+
+    let check_bundle_accepts = |tx: &Transaction| -> bool {
+        let bundle = tx
+            .to_librustzcash(nu)
+            .expect("librustzcash reads this mainnet transaction")
+            .into_data()
+            .sapling_bundle()
+            .expect("the transaction has a Sapling bundle")
+            .clone();
+
+        sapling_crypto::BatchValidator::new().check_bundle(bundle, sighash.into())
+    };
+
+    assert!(
+        check_bundle_accepts(&transaction),
+        "check_bundle must accept the unmodified mainnet bundle, or the rejection below proves \
+         nothing",
+    );
+
+    let mut small_order_rk = transaction.as_ref().clone();
+    let Transaction::V4 {
+        sapling_shielded_data: Some(shielded_data),
+        ..
+    } = &mut small_order_rk
+    else {
+        panic!("the fixture was selected for being V4 with Sapling data")
+    };
+    let sapling::TransferData::SpendsAndMaybeOutputs { spends, .. } = &mut shielded_data.transfers
+    else {
+        panic!("the fixture was selected for having spends")
+    };
+    let mut spends_vec = spends.as_slice().to_vec();
+    spends_vec[0].rk = ValidatingKey(jubjub::AffinePoint::identity().to_bytes());
+    *spends = AtLeastOne::from_vec(spends_vec).expect("replacing a field keeps at least one spend");
+
+    assert!(
+        !check_bundle_accepts(&small_order_rk),
+        "check_spend must reject a small-order rk",
     );
 }
 
@@ -3305,6 +3398,16 @@ fn sapling_point_checks_match_librustzcash_predicates() {
     // The exact predicate librustzcash applies to an `rk`: decode with
     // `read_rk` (i.e. `redjubjub::VerificationKey::try_from`), then reject a
     // small-order point (as `check_spend` does).
+    //
+    // Only the *decode* half of this is an independent model. `check_spend` rejects with
+    // `jubjub::AffinePoint::from_bytes(..).is_small_order()`, which is character for character
+    // what `ValidatingKey::is_valid_not_small_order` runs, so re-stating it here could not
+    // detect a divergence — `sapling-crypto` exposes no byte-level entry point for that half to
+    // call instead. What this arm genuinely pins is that `reddsa`'s decoder and `jubjub`'s
+    // decoder agree on acceptance, which is not obvious and would break the conjunction if it
+    // stopped holding. The behaviour of `check_spend` itself is pinned separately and
+    // non-tautologically, by driving the real `sapling_crypto::BatchValidator` in
+    // `sapling_small_order_rk_deferred_but_caught_by_librustzcash`.
     let librustzcash_rk_valid = |bytes: [u8; 32]| -> bool {
         redjubjub::VerificationKey::<SpendAuth>::try_from(bytes).is_ok()
             && !bool::from(

--- a/crates/zakura-chain/src/transaction/tests/vectors.rs
+++ b/crates/zakura-chain/src/transaction/tests/vectors.rs
@@ -2560,6 +2560,157 @@ fn sapling_small_order_cv_epk_deferred_but_caught_by_librustzcash() {
     );
 }
 
+/// A small-order Sapling `rk` survives deserialization, and is still rejected by
+/// the deferred check and by librustzcash.
+///
+/// Deserialization stores `rk` as raw bytes, so the not-small-order rule is no
+/// longer enforced there. This pins the two places that now enforce it:
+///
+/// - Zakura's own deferred check,
+///   [`ShieldedData::point_encodings_are_valid`], which the semantic and mempool
+///   paths run via `check::sapling_point_encodings_are_valid`;
+/// - librustzcash, which splits the rule in two — `read_rk` rejects an off-curve
+///   or non-canonical encoding at read (so `to_librustzcash` fails), while
+///   `redjubjub` deliberately admits small-order keys and the Sapling verifier's
+///   `check_spend` rejects them at verify.
+///
+/// The checkpoint verifier reaches neither, which is the tradeoff already
+/// accepted for `cv` and `epk`: its authority is the checkpoint hash chain.
+#[test]
+fn sapling_small_order_rk_deferred_but_caught_by_librustzcash() {
+    use group::Group;
+
+    use crate::{
+        amount::Amount,
+        at_least_one,
+        block::Height,
+        parameters::NetworkUpgrade,
+        primitives::{
+            redjubjub::{self, Binding, Signature, SpendAuth},
+            Groth16Proof,
+        },
+        sapling::{
+            self,
+            keys::ValidatingKey,
+            shielded_data::{ShieldedData, TransferData},
+            Spend, ValueCommitment,
+        },
+        serialization::{ZcashDeserializeInto, ZcashSerialize},
+        transaction::{LockTime, Transaction},
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let valid = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
+    let small_order = jubjub::AffinePoint::from(jubjub::ExtendedPoint::identity()).to_bytes();
+    let off_curve = [0xffu8; 32];
+
+    // librustzcash's `read_rk` is `redjubjub::VerificationKey::try_from`, which
+    // rejects encodings that are not canonical curve points but admits
+    // small-order ones on purpose — reddsa's own comment says Sapling must check
+    // that separately.
+    assert!(
+        redjubjub::VerificationKey::<SpendAuth>::try_from(small_order).is_ok(),
+        "read_rk must accept a small-order rk: the small-order rule is enforced at verify",
+    );
+    assert!(
+        redjubjub::VerificationKey::<SpendAuth>::try_from(off_curve).is_err(),
+        "read_rk must reject an off-curve rk",
+    );
+
+    // ... and `check_spend`, which the Sapling batch verifier runs per spend, is
+    // where the small-order rejection actually happens.
+    assert!(
+        bool::from(
+            jubjub::AffinePoint::from_bytes(small_order)
+                .unwrap()
+                .is_small_order()
+        ),
+        "is_small_order (used by the Sapling verifier check_spend) must flag the small-order rk",
+    );
+
+    // Build a minimal V5 transaction with one Sapling spend carrying `rk_bytes`,
+    // round-tripped through the lazy deserializer.
+    let build = |rk_bytes: [u8; 32]| -> Transaction {
+        let spend = Spend::<sapling::SharedAnchor> {
+            cv: ValueCommitment(valid),
+            per_spend_anchor: sapling::FieldNotPresent,
+            nullifier: sapling::Nullifier::from([0u8; 32]),
+            rk: ValidatingKey(rk_bytes),
+            zkproof: Groth16Proof([0u8; 192]),
+            spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
+        };
+
+        let tx = Transaction::V5 {
+            network_upgrade: NetworkUpgrade::Nu5,
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(0),
+            inputs: vec![],
+            outputs: vec![],
+            sapling_shielded_data: Some(ShieldedData::<sapling::SharedAnchor> {
+                value_balance: Amount::try_from(0).expect("zero is a valid amount"),
+                transfers: TransferData::SpendsAndMaybeOutputs {
+                    shared_anchor: sapling::tree::Root::default(),
+                    spends: at_least_one![spend],
+                    maybe_outputs: vec![],
+                },
+                binding_sig: Signature::<Binding>::from([0u8; 64]),
+            }),
+            orchard_shielded_data: None,
+        };
+
+        tx.zcash_serialize_to_vec()
+            .expect("crafted transaction must serialize")
+            .zcash_deserialize_into()
+            .expect("lazy deserialization accepts any 32-byte rk; validation is deferred")
+    };
+
+    // Deferral: both invalid encodings now parse, where the small-order one used
+    // to fail at deserialization.
+    let small_order_tx = build(small_order);
+    let off_curve_tx = build(off_curve);
+
+    // Zakura's deferred check rejects both, and accepts a valid rk.
+    assert!(
+        build(valid).sapling_point_encodings_are_valid(),
+        "a spend with a valid rk must pass the deferred point check",
+    );
+    assert!(
+        !small_order_tx.sapling_point_encodings_are_valid(),
+        "the deferred point check must reject a small-order rk",
+    );
+    assert!(
+        !off_curve_tx.sapling_point_encodings_are_valid(),
+        "the deferred point check must reject an off-curve rk",
+    );
+
+    // librustzcash agrees: the off-curve rk fails at read, and the small-order rk
+    // is left for `check_spend` at verify.
+    assert!(
+        small_order_tx.to_librustzcash(NetworkUpgrade::Nu5).is_ok(),
+        "to_librustzcash must accept a small-order rk (it is enforced at verify, not read)",
+    );
+    assert!(
+        off_curve_tx.to_librustzcash(NetworkUpgrade::Nu5).is_err(),
+        "to_librustzcash must reject an off-curve rk at read",
+    );
+
+    // Byte-identity: the lazy representation must not perturb the encoding, since
+    // the txid and merkle root hash these bytes.
+    let bytes_in = build(off_curve)
+        .zcash_serialize_to_vec()
+        .expect("serializes");
+    let bytes_out: Transaction = bytes_in
+        .clone()
+        .zcash_deserialize_into()
+        .expect("round-trips");
+    assert_eq!(
+        bytes_in,
+        bytes_out.zcash_serialize_to_vec().expect("re-serializes"),
+        "a lazy rk must round-trip byte-for-byte",
+    );
+}
+
 /// Edge cases for lazy Sapling `cv` / `ephemeral_key` deserialization. Beyond the
 /// small-order case, this checks that:
 /// - an off-curve `cv` is also rejected by `to_librustzcash`, so the safety net
@@ -2567,8 +2718,8 @@ fn sapling_small_order_cv_epk_deferred_but_caught_by_librustzcash() {
 /// - the lazy types round-trip byte-for-byte through serialize/deserialize — the
 ///   txid and merkle root hash these bytes, so any change would break consensus;
 /// - `cv.commitment()` decompresses a valid encoding back to the same point;
-/// - Sapling `rk` was not made lazy, so a small-order `rk` is still rejected at
-///   deserialization.
+/// - Sapling `rk` is lazy too, so a small-order `rk` parses and is caught by the
+///   deferred check instead.
 #[test]
 fn sapling_lazy_cv_epk_edge_cases() {
     use group::Group;
@@ -2683,11 +2834,30 @@ fn sapling_lazy_cv_epk_edge_cases() {
         "commitment() must round-trip a valid value commitment",
     );
 
-    // `rk` was not made lazy: a small-order rk is still rejected at deserialization
-    // via `ValidatingKey::try_from`.
+    // `rk` is lazy as well: every 32-byte encoding is stored, and the
+    // not-small-order check is the deferred one.
     assert!(
-        ValidatingKey::try_from(small_order).is_err(),
-        "Sapling rk must still reject a small-order point at deserialization",
+        ValidatingKey::try_from(small_order).is_ok(),
+        "Sapling rk must store a small-order encoding rather than rejecting it at \
+         deserialization",
+    );
+    assert!(
+        !ValidatingKey::try_from(small_order)
+            .expect("any 32-byte array is stored")
+            .is_valid_not_small_order(),
+        "the deferred rk check must reject a small-order point",
+    );
+    assert!(
+        !ValidatingKey::try_from(off_curve)
+            .expect("any 32-byte array is stored")
+            .is_valid_not_small_order(),
+        "the deferred rk check must reject an off-curve point",
+    );
+    assert!(
+        ValidatingKey::try_from(valid_cv)
+            .expect("any 32-byte array is stored")
+            .is_valid_not_small_order(),
+        "the deferred rk check must accept the Jubjub generator",
     );
 }
 
@@ -2869,7 +3039,7 @@ fn sapling_binding_verification_key_rejects_invalid_lazy_commitments() {
                 cv: ValueCommitment(cv),
                 per_spend_anchor: sapling::tree::Root::default(),
                 nullifier: sapling::Nullifier::from([0u8; 32]),
-                rk: rk.clone(),
+                rk,
                 zkproof: Groth16Proof([0u8; 192]),
                 spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
             }],
@@ -3012,11 +3182,13 @@ fn sapling_point_encodings_check_rejects_bad_points() {
     check_transaction("V6", &make_v6);
 }
 
-/// The deferred Sapling point check also covers V4 spend commitments.
+/// The deferred Sapling point check also covers V4 spend commitments and
+/// validating keys.
 ///
-/// The lazy representation applies to spend `cv` as well as output `cv`/`epk`.
-/// V4 takes a distinct `PerSpendAnchor` branch, so keep a focused regression on
-/// that route rather than relying only on output-only V5/V6 coverage.
+/// The lazy representation applies to spend `cv` and `rk` as well as output
+/// `cv`/`epk`. V4 takes a distinct `PerSpendAnchor` branch, so keep a focused
+/// regression on that route rather than relying only on output-only V5/V6
+/// coverage.
 #[test]
 fn sapling_point_encodings_check_rejects_bad_v4_spend_cv() {
     use group::Group;
@@ -3042,14 +3214,14 @@ fn sapling_point_encodings_check_rejects_bad_v4_spend_cv() {
 
     let valid = jubjub::AffinePoint::from(jubjub::ExtendedPoint::generator()).to_bytes();
     let off_curve = [0xffu8; 32];
-    let rk = ValidatingKey::try_from(valid).expect("the Jubjub generator is a valid Sapling rk");
+    let small_order = jubjub::AffinePoint::from(jubjub::ExtendedPoint::identity()).to_bytes();
 
-    let make_v4 = |cv: [u8; 32]| -> Transaction {
+    let make_v4 = |cv: [u8; 32], rk: [u8; 32]| -> Transaction {
         let spend = Spend::<sapling::PerSpendAnchor> {
             cv: ValueCommitment(cv),
             per_spend_anchor: sapling::tree::Root::default(),
             nullifier: sapling::Nullifier::from([0u8; 32]),
-            rk: rk.clone(),
+            rk: ValidatingKey(rk),
             zkproof: Groth16Proof([0u8; 192]),
             spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
         };
@@ -3073,19 +3245,28 @@ fn sapling_point_encodings_check_rejects_bad_v4_spend_cv() {
     };
 
     assert!(
-        make_v4(valid).sapling_point_encodings_are_valid(),
-        "a V4 spend with a valid cv must pass the deferred point check",
+        make_v4(valid, valid).sapling_point_encodings_are_valid(),
+        "a V4 spend with a valid cv and rk must pass the deferred point check",
     );
     assert!(
-        !make_v4(off_curve).sapling_point_encodings_are_valid(),
+        !make_v4(off_curve, valid).sapling_point_encodings_are_valid(),
         "a V4 spend with an off-curve cv must fail the deferred point check",
+    );
+    assert!(
+        !make_v4(valid, off_curve).sapling_point_encodings_are_valid(),
+        "a V4 spend with an off-curve rk must fail the deferred point check",
+    );
+    assert!(
+        !make_v4(valid, small_order).sapling_point_encodings_are_valid(),
+        "a V4 spend with a small-order rk must fail the deferred point check",
     );
 }
 
-/// The relocated Sapling `cv` / `epk` not-small-order checks accept exactly the
-/// same encodings as the librustzcash functions they mirror.
+/// The relocated Sapling `cv` / `rk` / `epk` not-small-order checks accept exactly
+/// the same encodings as the librustzcash functions they mirror.
 ///
-/// If `ValueCommitment::is_valid_not_small_order` or
+/// If `ValueCommitment::is_valid_not_small_order`,
+/// `ValidatingKey::is_valid_not_small_order` or
 /// `EphemeralPublicKey::is_valid_not_small_order` ever diverged from librustzcash,
 /// Zebra would accept or reject transactions the rest of the network doesn't — a
 /// chain split. This pins each Zebra predicate against the library predicate over
@@ -3093,6 +3274,10 @@ fn sapling_point_encodings_check_rejects_bad_v4_spend_cv() {
 ///
 /// - `cv`: `read_value_commitment` accepts a `cv` iff `from_bytes_not_small_order`
 ///   returns a point.
+/// - `rk`: librustzcash splits the rule across two functions — `read_rk` decodes
+///   with `redjubjub::VerificationKey::try_from`, which admits small-order keys,
+///   and `check_spend` then rejects `rk_affine.is_small_order()`. The Zebra
+///   predicate must equal their conjunction.
 /// - `epk`: sapling-crypto decodes `epk` as an `ExtendedPoint` and `check_output`
 ///   rejects it when `epk.is_small_order()`. Zebra decodes as an `AffinePoint`, so
 ///   this also guards that the two decoders agree.
@@ -3100,7 +3285,13 @@ fn sapling_point_encodings_check_rejects_bad_v4_spend_cv() {
 fn sapling_point_checks_match_librustzcash_predicates() {
     use group::{Group, GroupEncoding};
 
-    use crate::sapling::{keys::EphemeralPublicKey, ValueCommitment};
+    use crate::{
+        primitives::redjubjub::{self, SpendAuth},
+        sapling::{
+            keys::{EphemeralPublicKey, ValidatingKey},
+            ValueCommitment,
+        },
+    };
 
     let _init_guard = zakura_test::init();
 
@@ -3109,6 +3300,18 @@ fn sapling_point_checks_match_librustzcash_predicates() {
         bool::from(
             sapling_crypto::value::ValueCommitment::from_bytes_not_small_order(&bytes).is_some(),
         )
+    };
+
+    // The exact predicate librustzcash applies to an `rk`: decode with
+    // `read_rk` (i.e. `redjubjub::VerificationKey::try_from`), then reject a
+    // small-order point (as `check_spend` does).
+    let librustzcash_rk_valid = |bytes: [u8; 32]| -> bool {
+        redjubjub::VerificationKey::<SpendAuth>::try_from(bytes).is_ok()
+            && !bool::from(
+                jubjub::AffinePoint::from_bytes(bytes)
+                    .expect("read_rk accepted these bytes, so they decode")
+                    .is_small_order(),
+            )
     };
 
     // The exact predicate librustzcash applies to an `epk`: decode as an
@@ -3149,6 +3352,11 @@ fn sapling_point_checks_match_librustzcash_predicates() {
         "cv corpus must contain both accepted and rejected encodings",
     );
     assert!(
+        inputs.iter().any(|&b| librustzcash_rk_valid(b))
+            && inputs.iter().any(|&b| !librustzcash_rk_valid(b)),
+        "rk corpus must contain both accepted and rejected encodings",
+    );
+    assert!(
         inputs.iter().any(|&b| librustzcash_epk_valid(b))
             && inputs.iter().any(|&b| !librustzcash_epk_valid(b)),
         "epk corpus must contain both accepted and rejected encodings",
@@ -3160,6 +3368,12 @@ fn sapling_point_checks_match_librustzcash_predicates() {
             librustzcash_cv_valid(bytes),
             "ValueCommitment::is_valid_not_small_order must match librustzcash \
              read_value_commitment for {bytes:02x?}",
+        );
+        assert_eq!(
+            ValidatingKey(bytes).is_valid_not_small_order(),
+            librustzcash_rk_valid(bytes),
+            "ValidatingKey::is_valid_not_small_order must match librustzcash \
+             read_rk + check_spend for {bytes:02x?}",
         );
         assert_eq!(
             EphemeralPublicKey(bytes).is_valid_not_small_order(),

--- a/crates/zakura-chain/src/transaction/tests/vectors.rs
+++ b/crates/zakura-chain/src/transaction/tests/vectors.rs
@@ -3039,7 +3039,7 @@ fn sapling_binding_verification_key_rejects_invalid_lazy_commitments() {
                 cv: ValueCommitment(cv),
                 per_spend_anchor: sapling::tree::Root::default(),
                 nullifier: sapling::Nullifier::from([0u8; 32]),
-                rk,
+                rk: rk.clone(),
                 zkproof: Groth16Proof([0u8; 192]),
                 spend_auth_sig: Signature::<SpendAuth>::from([0u8; 64]),
             }],

--- a/crates/zakura-chain/src/transaction/zip244.rs
+++ b/crates/zakura-chain/src/transaction/zip244.rs
@@ -545,7 +545,7 @@ fn hash_sapling_spends(
             if let Some(anchor) = &anchor {
                 nh.update(anchor);
             }
-            nh.update(&<[u8; 32]>::from(spend.rk));
+            nh.update(&<[u8; 32]>::from(&spend.rk));
         }
         h.update(ch.finalize().as_bytes());
         h.update(nh.finalize().as_bytes());

--- a/crates/zakura-chain/src/transaction/zip244.rs
+++ b/crates/zakura-chain/src/transaction/zip244.rs
@@ -545,7 +545,7 @@ fn hash_sapling_spends(
             if let Some(anchor) = &anchor {
                 nh.update(anchor);
             }
-            nh.update(&<[u8; 32]>::from(spend.rk.clone()));
+            nh.update(&<[u8; 32]>::from(spend.rk));
         }
         h.update(ch.finalize().as_bytes());
         h.update(nh.finalize().as_bytes());

--- a/crates/zakura-consensus/src/transaction/check.rs
+++ b/crates/zakura-consensus/src/transaction/check.rs
@@ -190,8 +190,8 @@ pub fn orchard_cross_address_disabled(tx: &Transaction) -> Result<(), Transactio
     Ok(())
 }
 
-/// Checks that Sapling value commitments and ephemeral public keys are canonical,
-/// non-small-order Jubjub points.
+/// Checks that Sapling value commitments, spend validating keys, and ephemeral
+/// public keys are canonical, non-small-order Jubjub points.
 ///
 /// # Consensus
 ///
@@ -201,11 +201,10 @@ pub fn orchard_cross_address_disabled(tx: &Transaction) -> Result<(), Transactio
 /// <https://zips.z.cash/protocol/protocol.pdf#outputdesc>
 /// <https://zips.z.cash/protocol/protocol.pdf#spenddesc>
 ///
-/// Deserialization stores Sapling cv and epk as raw bytes and defers their
+/// Deserialization stores Sapling cv, rk and epk as raw bytes and defers their
 /// not-small-order check to keep point decompression off the checkpoint-sync hot
 /// path. The semantic and mempool paths enforce it before any state lookup or
-/// librustzcash conversion so invalid points fail fast. Spend rk is still
-/// validated at deserialization.
+/// librustzcash conversion so invalid points fail fast.
 pub fn sapling_point_encodings_are_valid(tx: &Transaction) -> Result<(), TransactionError> {
     if !tx.sapling_point_encodings_are_valid() {
         return Err(TransactionError::SmallOrder);

--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -3655,6 +3655,144 @@ fn sapling_spends_with_invalid_value_commitments_are_rejected_after_roundtrip() 
     });
 }
 
+/// Transactions whose Sapling spend has an invalid `rk` are rejected by the
+/// verifier with `SmallOrder`.
+///
+/// `rk`'s not-small-order check moved out of deserialization, so the parser now
+/// accepts these bytes and the semantic verifier is what rejects them. This pins
+/// that end to end for both spend encodings — V4 stores the full
+/// `Spend<PerSpendAnchor>` inline, V5 stores `SpendPrefixInTransactionV5`
+/// separately — and covers both invalid classes: an off-curve encoding, which
+/// librustzcash's `read_rk` would also reject, and a small-order point, which it
+/// deliberately would not.
+#[test]
+fn sapling_spends_with_invalid_rk_are_rejected_after_roundtrip() {
+    let _init_guard = zakura_test::init();
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let network = Network::Mainnet;
+
+        let v4 = test_transactions(&network)
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                matches!(transaction.as_ref(), Transaction::V4 { .. })
+                    && transaction.sapling_spends_per_anchor().next().is_some()
+            })
+            .expect("a V4 transaction with Sapling spends");
+
+        let v5 = transactions_from_blocks(network.block_iter())
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.is_coinbase() && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| {
+                matches!(transaction.as_ref(), Transaction::V5 { .. })
+                    && transaction.sapling_spends_per_anchor().next().is_some()
+            })
+            .expect("a V5 transaction with Sapling spends");
+
+        let off_curve = [0xffu8; 32];
+        // The Jubjub identity: a valid encoding that `read_rk` accepts and only
+        // `check_spend` rejects.
+        let small_order = jubjub::AffinePoint::identity().to_bytes();
+
+        for (rk_name, bad_rk) in [("off-curve", off_curve), ("small-order", small_order)] {
+            for (version, height, transaction) in
+                [("V4", v4.0, v4.1.clone()), ("V5", v5.0, v5.1.clone())]
+            {
+                let mut transaction = Arc::unwrap_or_clone(transaction);
+                corrupt_first_sapling_spend_rk(&mut transaction, bad_rk);
+
+                let serialized = transaction
+                    .zcash_serialize_to_vec()
+                    .expect("corrupted transaction must serialize raw Sapling rk bytes");
+                let transaction = Arc::new(
+                    serialized
+                        .zcash_deserialize_into::<Transaction>()
+                        .expect("lazy spend deserialization must preserve invalid rk bytes"),
+                );
+                assert_eq!(
+                    serialized,
+                    transaction
+                        .zcash_serialize_to_vec()
+                        .expect("round-tripped transaction must reserialize"),
+                    "lazy {version} spend rk bytes must round-trip exactly",
+                );
+
+                assert!(
+                    !transaction.sapling_point_encodings_are_valid(),
+                    "the deferred Sapling point check must reject the round-tripped {version} \
+                     {rk_name} rk",
+                );
+
+                let state_service =
+                    service_fn(|_| async { unreachable!("State service should not be called") });
+                let verifier = Verifier::new_for_tests(&network, state_service);
+
+                let result = verifier
+                    .oneshot(Request::Block {
+                        transaction_hash: transaction.hash(),
+                        transaction,
+                        known_utxos: Arc::new(HashMap::new()),
+                        known_outpoint_hashes: Arc::new(HashSet::new()),
+                        height,
+                        time: DateTime::<Utc>::MAX_UTC,
+                    })
+                    .await;
+
+                assert_eq!(
+                    result,
+                    Err(TransactionError::SmallOrder),
+                    "a {version} Sapling spend with a {rk_name} rk must be rejected with \
+                     SmallOrder",
+                );
+            }
+        }
+    });
+}
+
+/// Replaces the first Sapling spend's `rk` with `rk_bytes`, for
+/// `sapling_spends_with_invalid_rk_are_rejected_after_roundtrip`.
+fn corrupt_first_sapling_spend_rk(transaction: &mut Transaction, rk_bytes: [u8; 32]) {
+    let bad_rk = sapling::keys::ValidatingKey::try_from(rk_bytes)
+        .expect("deserialization defers point validation, so it stores the bytes");
+
+    match transaction {
+        Transaction::V4 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_rk(&mut shielded_data.transfers, bad_rk),
+        Transaction::V5 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_rk(&mut shielded_data.transfers, bad_rk),
+        Transaction::V6 {
+            sapling_shielded_data: Some(shielded_data),
+            ..
+        } => set_first_sapling_spend_rk(&mut shielded_data.transfers, bad_rk),
+        _ => panic!("expected a V4, V5, or V6 transaction with Sapling data"),
+    }
+}
+
+fn set_first_sapling_spend_rk<A: sapling::AnchorVariant + Clone>(
+    transfers: &mut sapling::TransferData<A>,
+    rk: sapling::keys::ValidatingKey,
+) {
+    match transfers {
+        sapling::TransferData::SpendsAndMaybeOutputs { spends, .. } => {
+            let mut spends_vec = spends.as_slice().to_vec();
+            spends_vec[0].rk = rk;
+            *spends = AtLeastOne::from_vec(spends_vec)
+                .expect("replacing a field keeps at least one spend");
+        }
+        sapling::TransferData::JustOutputs { .. } => {
+            panic!("expected Sapling shielded data with spends")
+        }
+    }
+}
+
 /// Replaces the first Sapling output's ephemeral key with an off-curve point,
 /// for `sapling_output_with_invalid_ephemeral_key_is_rejected`.
 fn corrupt_first_sapling_output_ephemeral_key(transaction: &mut Transaction) {

--- a/crates/zakura-rpc/src/methods/types/transaction.rs
+++ b/crates/zakura-rpc/src/methods/types/transaction.rs
@@ -1006,7 +1006,7 @@ impl TransactionObject {
                     let mut nullifier = spend.nullifier.as_bytes();
                     nullifier.reverse();
 
-                    let mut rk: [u8; 32] = spend.rk.into();
+                    let mut rk: [u8; 32] = (&spend.rk).into();
                     rk.reverse();
 
                     let spend_auth_sig: [u8; 64] = spend.spend_auth_sig.into();

--- a/crates/zakura-rpc/src/methods/types/transaction.rs
+++ b/crates/zakura-rpc/src/methods/types/transaction.rs
@@ -1006,7 +1006,7 @@ impl TransactionObject {
                     let mut nullifier = spend.nullifier.as_bytes();
                     nullifier.reverse();
 
-                    let mut rk: [u8; 32] = spend.clone().rk.into();
+                    let mut rk: [u8; 32] = spend.rk.into();
                     rk.reverse();
 
                     let spend_auth_sig: [u8; 64] = spend.spend_auth_sig.into();

--- a/docs/changelog/unreleased/599.md
+++ b/docs/changelog/unreleased/599.md
@@ -1,0 +1,10 @@
+## Changed
+
+- Sapling `rk` is now stored as raw bytes at deserialization, with its
+  not-small-order check deferred to the semantic and mempool verifiers, matching
+  the existing treatment of `cv` and `epk`. This removes a redundant Jubjub point
+  decompression that accounted for effectively all of the cost of parsing a
+  Sapling transaction — 107.8 µs per Spend description, off both the
+  deserialization and checkpoint-sync paths. A small-order `rk` is now rejected
+  by the semantic verifier rather than by deserialization
+  ([#599](https://github.com/zakura-core/zakura/pull/599)).


### PR DESCRIPTION
## Motivation

Deserializing a Sapling transaction with 3 spends and 2 outputs takes **322.5 µs** — about thirty times worse per byte than an Orchard transaction. Benchmarked on an otherwise idle 32-vCPU host, effectively all of it is `rk` decoding, and half of that is redundant:

| operation | cost |
|---|---|
| `redjubjub::VerificationKey::<SpendAuth>::try_from([u8; 32])` | 54.0 µs |
| `ValidatingKey::try_from([u8; 32])` (the above, then decompresses again) | 107.8 µs |

3 spends × 107.8 µs = 323 µs, i.e. the entire parse.

For context, the same benchmark over the in-tree mainnet vectors:

| sample | size | deserialize |
|---|---|---|
| V5 coinbase | 201 B | 863 ns |
| Orchard, 2 actions | 9,165 B | 32.5 µs |
| Sapling, 3 spends + 2 outputs | 3,141 B | **322.5 µs** |

**Root cause.** `redjubjub::VerificationKey::try_from` already decompresses the point and keeps it — `reddsa`'s `verification_key.rs:77` stores `point: T::Point` — but the field is `pub(crate)`, so `ValidatingKey::try_from` decompressed the same 32 bytes a second time in order to run the not-small-order check. Point decompression needs a square root in the base field, which is why the second one costs as much as the first.

The check itself is *not* redundant. `reddsa` deliberately stopped rejecting small-order keys and says so at that call site: Sapling has to do it separately. Only the decompression is waste.

## Solution

Finish the job the tree already started for `cv` and `epk`. `crates/zakura-consensus/src/transaction/check.rs` documented the deferral and ended with "Spend rk is still validated at deserialization" — `rk` was the one field left behind, and it is the expensive one.

- `ValidatingKey` now stores the raw 32-byte encoding, exactly like `ValueCommitment` and `EphemeralPublicKey`, with an `is_valid_not_small_order()` that decompresses once.
- `ShieldedData::point_encodings_are_valid` runs that check alongside the ones it already made for the sibling fields, so it is reached in production from `check::sapling_point_encodings_are_valid`.
- `ValidatingKey` becomes `Copy`, dropping the clones at the call sites.

Per Spend description:

| path | before | after |
|---|---|---|
| deserialization | 107.8 µs | ~0 |
| semantic / mempool verification | 54 µs (cv) | 108 µs (cv + rk) |
| checkpoint sync | 107.8 µs | ~0 |

**This moves where a consensus rule is enforced, and reviewers should see it named.** Today a transaction with a small-order `rk` fails to *deserialize*, so it is rejected at the network boundary and under checkpoint sync. Afterwards it deserializes and is rejected by `check::sapling_point_encodings_are_valid` on the semantic and mempool paths — and under checkpoint sync it is not rejected at all. That is the identical tradeoff already accepted for `cv` and `epk`, and it is sound for the same reason: checkpoint sync's authority is the checkpoint hash chain, not per-field validation.

librustzcash is the backstop on the semantic path, and it splits the rule in two: `read_rk` rejects off-curve/non-canonical encodings at read, while `redjubjub` admits small-order keys and the Sapling verifier's `check_spend` (`sapling-crypto-0.7.0/src/verifier.rs`) rejects them at verify.

**Consumer audit.** Every consumer of `Spend::rk` converts straight back to `[u8; 32]`, so nothing anywhere consumes the decompressed group element:

| site | use |
|---|---|
| `sapling/spend.rs` ×3 | moves between the per-anchor and v5-prefix representations |
| `sapling/spend.rs` ×2 | `ZcashSerialize`, via `<[u8; 32]>::from` |
| `transaction/sighash/v4.rs` | v4 sighash digest |
| `transaction/zip244.rs` | ZIP-244 digest |
| `zakura-rpc/.../types/transaction.rs` | RPC output |

Sapling bundle verification runs on the `sapling_crypto` bundle from `to_librustzcash`, not on our `Spend`, so `ValidatingKey`'s decompression was pure overhead once the check moved.

## Testing

- **`sapling_small_order_rk_deferred_but_caught_by_librustzcash`** (new) — pins both halves of the librustzcash backstop: `read_rk` accepts a small-order `rk` and rejects an off-curve one, and `check_spend`'s `is_small_order` is what flags the former. Asserts a small-order `rk` now parses, that the deferred check rejects it, that `to_librustzcash` accepts it and rejects the off-curve one, and that the lazy `rk` round-trips byte-for-byte — the txid and merkle root hash these bytes.
- **`sapling_point_checks_match_librustzcash_predicates`** — gains an `rk` arm. This is the test that makes the new byte-level check trustworthy: it pins `is_valid_not_small_order` against the *conjunction* of `read_rk` and `check_spend` over the existing corpus (valid non-small-order, small-order, off-curve, a byte-pattern sweep, and 64 prime-order points), with the same guard against a vacuous all-accept/all-reject comparison.
- **`sapling_point_encodings_check_rejects_bad_v4_spend_cv`** — now varies `rk` as well as `cv`, covering the distinct V4 `PerSpendAnchor` route for both invalid classes.
- **`sapling_spends_with_invalid_rk_are_rejected_after_roundtrip`** (new) — drives the full transaction verifier over real mainnet V4 and V5 transactions with Sapling spends, for both off-curve and small-order keys, asserting the raw bytes survive the round-trip and the request fails with `TransactionError::SmallOrder`.
- **`sapling_lazy_cv_epk_edge_cases`** — asserted `rk` was *not* lazy; now asserts the deferred check's verdicts instead.

```
cargo fmt --all -- --check
cargo clippy -p zakura-chain -p zakura-consensus -p zakura-rpc --all-targets -- -D warnings
cargo nextest run -p zakura-chain -p zakura-consensus -p zakura-rpc -p zakura-state
cargo doc --no-deps --workspace --all-features --document-private-items
```

All green. Note `transaction::tests::v4_and_v5_with_sapling_spends` fails under plain `cargo test -p zakura-consensus --lib` on `main` as well as on this branch — a pre-existing interaction between parallel tests and the process-global Sapling batch verifier. It passes under nextest, which is what CI runs.

### Specifications & References

- [Spend description](https://zips.z.cash/protocol/protocol.pdf#spenddesc) — "Check that a Spend description's cv and rk are not of small order"
- `sapling-crypto-0.7.0/src/verifier.rs:48-51` — `check_spend`'s small-order `rk` rejection
- `reddsa-0.5.2/src/verification_key.rs:77` — the retained `pub(crate) point`, and the comment at `:107-110` deferring the small-order check to Sapling

### Follow-up Work

Optional, not a blocker: ask `redjubjub` to expose either the decompressed point or an `is_small_order()` on `VerificationKey`. `reddsa`'s own comment says Sapling has to do this check separately, so it is an obvious gap. After this PR Zakura is no longer a caller that would benefit, so it is a courtesy rather than a dependency.



---

### Update — V12 findings handled, and a citation correction

`librustzcash_check_spend_rejects_a_small_order_rk` (d7f2907) addresses **F-188690**: the `rk` arm of the equivalence test partly modelled itself, so half of it was tautological. It now pins `check_spend`'s behaviour by driving `sapling_crypto::BatchValidator::check_bundle` over a real mainnet bundle. See the [full evaluation](#issuecomment-5223173293).

`ValidatingKey` is no longer `Copy` (a8d28a5) — `cargo-semver-checks` correctly flagged `copy_impl_added` as needing a major bump on a published crate. Consumers take the bytes through `From<&ValidatingKey>`, which avoids both the clone and the move.

**Version citations above are corrected.** I originally cited `reddsa-0.5.1` and `sapling-crypto-0.5.0`, read out of the local registry cache rather than `Cargo.lock`. The workspace locks **reddsa 0.5.2, sapling-crypto 0.7.0, jubjub 0.10.0, redjubjub 0.8.0**. Every upstream claim was re-verified against those and all hold.

**Caveat a reviewer should not take from me on trust:** the semver job is green, but the substantive API changes here — `From<ValidatingKey> for redjubjub::VerificationKey<SpendAuth>` becoming a `TryFrom`, and the inverse changing its associated `Error` from `&'static str` to `Infallible` — look breaking and did *not* fire any lint. 222/223 checks passed with only `copy_impl_added`. `cargo-semver-checks` appears not to lint altered trait impls involving foreign types, so please judge those two by eye rather than by the green check.
