### PR TITLE
feat(consensus): cache Sapling bundle verification

### DIFF
--- a/crates/zakura-consensus/benches/worst_case_tx_verification.rs
+++ b/crates/zakura-consensus/benches/worst_case_tx_verification.rs
@@ -57,6 +57,7 @@ use zakura_chain::{
     transparent,
 };
 use zakura_consensus::{
+    clear_shielded_verification_caches,
     error::TransactionError,
     transaction::{self as tx, Request},
     BoxError,
@@ -284,6 +285,13 @@ fn worst_case_tx_verification(c: &mut Criterion) {
                     let start = Instant::now();
 
                     for _ in 0..iterations {
+                        // Every iteration replays the same workload, and every shielded bundle
+                        // verified once is remembered process-wide. Without this the first
+                        // iteration measures verification and the rest measure cache hits — the
+                        // opposite of the worst case these numbers size the block limits
+                        // against, which is a block of transactions the node has never seen.
+                        clear_shielded_verification_caches();
+
                         let verified = runtime.block_on(async {
                             let verifier =
                                 make_transaction_verifier(requests.len().saturating_add(1));

--- a/crates/zakura-consensus/src/lib.rs
+++ b/crates/zakura-consensus/src/lib.rs
@@ -56,7 +56,10 @@ pub use block::{subsidy::funding_stream_address, Request, VerifyBlockError, MAX_
 pub use checkpoint::{VerifyCheckpointError, MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
 pub use config::Config;
 pub use error::BlockError;
-pub use primitives::{ed25519, groth16, halo2, redjubjub, redpallas, sapling::sapling_prover};
+pub use primitives::{
+    clear_shielded_verification_caches, ed25519, groth16, halo2, redjubjub, redpallas,
+    sapling::sapling_prover,
+};
 pub use router::RouterError;
 
 /// A boxed [`std::error::Error`].

--- a/crates/zakura-consensus/src/lib.rs
+++ b/crates/zakura-consensus/src/lib.rs
@@ -56,10 +56,11 @@ pub use block::{subsidy::funding_stream_address, Request, VerifyBlockError, MAX_
 pub use checkpoint::{VerifyCheckpointError, MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
 pub use config::Config;
 pub use error::BlockError;
-pub use primitives::{
-    clear_shielded_verification_caches, ed25519, groth16, halo2, redjubjub, redpallas,
-    sapling::sapling_prover,
-};
+pub use primitives::{ed25519, groth16, halo2, redjubjub, redpallas, sapling::sapling_prover};
+
+// Benchmarks only: hidden from the documentation, exported so a bench target can reach it.
+#[doc(hidden)]
+pub use primitives::clear_shielded_verification_caches;
 pub use router::RouterError;
 
 /// A boxed [`std::error::Error`].

--- a/crates/zakura-consensus/src/primitives.rs
+++ b/crates/zakura-consensus/src/primitives.rs
@@ -139,7 +139,7 @@ fn flush_block_verifier_batches() {
     }
 
     if let Some(verifier) = Lazy::get(&sapling::VERIFIER) {
-        queue_batch_flush("sapling", sapling::try_flush(verifier));
+        queue_batch_flush("groth16_sapling", sapling::try_flush(verifier));
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {
@@ -170,6 +170,36 @@ fn queue_batch_flush(verifier: &'static str, result: Result<bool, BoxError>) {
                 "could not queue explicit block verifier batch flush"
             );
         }
+    }
+}
+
+/// Forgets every shielded bundle verification this process has cached.
+///
+/// # Benchmarks only
+///
+/// The worst case Zakura is sized against is a block full of transactions the node has never
+/// seen, so a benchmark that replays one workload must start each iteration with cold caches or
+/// it measures cache hits instead of proof and signature verification. Nothing in the node calls
+/// this.
+///
+/// It is always safe to call: forgetting a key costs a re-verification and can never accept a
+/// bundle that was not verified.
+#[doc(hidden)]
+pub fn clear_shielded_verification_caches() {
+    if let Some(verifier) = Lazy::get(&sapling::VERIFIER) {
+        verifier.clear();
+    }
+
+    if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {
+        verifier.clear();
+    }
+
+    if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_2) {
+        verifier.clear();
+    }
+
+    if let Some(verifier) = Lazy::get(&halo2::VERIFIER_NU6_3_ONWARD) {
+        verifier.clear();
     }
 }
 

--- a/crates/zakura-consensus/src/primitives.rs
+++ b/crates/zakura-consensus/src/primitives.rs
@@ -139,7 +139,7 @@ fn flush_block_verifier_batches() {
     }
 
     if let Some(verifier) = Lazy::get(&sapling::VERIFIER) {
-        queue_batch_flush("groth16_sapling", sapling::try_flush(verifier));
+        queue_batch_flush(sapling::VERIFIER_NAME, sapling::try_flush(verifier));
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {

--- a/crates/zakura-consensus/src/primitives.rs
+++ b/crates/zakura-consensus/src/primitives.rs
@@ -10,6 +10,7 @@ use tokio::sync::oneshot::error::RecvError;
 
 use crate::BoxError;
 
+mod cache;
 pub mod ed25519;
 pub mod groth16;
 pub mod halo2;
@@ -138,7 +139,7 @@ fn flush_block_verifier_batches() {
     }
 
     if let Some(verifier) = Lazy::get(&sapling::VERIFIER) {
-        queue_batch_flush("sapling", verifier.primary().clone().try_flush());
+        queue_batch_flush("sapling", sapling::try_flush(verifier));
     }
 
     if let Some(verifier) = Lazy::get(&halo2::VERIFIER_PRE_NU6_2) {

--- a/crates/zakura-consensus/src/primitives/cache.rs
+++ b/crates/zakura-consensus/src/primitives/cache.rs
@@ -154,8 +154,21 @@ impl CacheKey {
 ///
 /// Items without a key are verified normally and never cached, which is how a caller that has no
 /// transaction identity to offer stays correct.
+///
+/// # Correctness
+///
+/// An implementer promises that the returned key determines every input the item's verification
+/// reads: the bundle, and the sighash it is checked against. [`Cached`] answers any later item
+/// with an equal key from the remembered `Ok` without verifying it, so a key that two different
+/// bundles can share accepts a bundle this node never checked. An implementer that cannot offer
+/// a complete key returns `None`, and the item is verified every time.
 pub(super) trait CachedItem {
-    /// Returns this item's cache key, if it has one.
+    /// Returns the key this item's successful verification is remembered under, or `None` if the
+    /// item must always be verified.
+    ///
+    /// The key is a pure function of the item: two calls on one item return the same key, and two
+    /// items with equal keys have identical verification inputs. [`CacheKey`] derives why a
+    /// transaction ID, a sighash and a shielded pool are enough.
     fn cache_key(&self) -> Option<CacheKey>;
 }
 
@@ -181,6 +194,12 @@ struct InsertOutcome {
 /// Eviction is first-in-first-out rather than least-recently-used: the working set is the
 /// mempool, which turns over in arrival order anyway, and FIFO needs no bookkeeping on the read
 /// path. Evicting an entry only costs a re-verification, never correctness.
+///
+/// # Correctness
+///
+/// `keys` and `insertion_order` hold the same keys. `keys` answers [`Self::contains`], and
+/// `insertion_order` chooses which key to drop. Only [`Self::insert`] and [`Self::clear`] change
+/// them, and each changes both, so no caller can leave them holding different keys.
 #[derive(Debug)]
 struct VerifiedBundles {
     /// The keys currently remembered.
@@ -225,6 +244,9 @@ impl VerifiedBundles {
         // rest of the process.
         let mut evicted = 0;
         while self.insertion_order.len() >= self.capacity {
+            // The queue is non-empty whenever its length reaches a capacity of one or more, which
+            // is what every caller passes. Breaking rather than unwrapping keeps a capacity of
+            // zero from looping forever.
             let Some(oldest) = self.insertion_order.pop_front() else {
                 break;
             };
@@ -243,8 +265,8 @@ impl VerifiedBundles {
 
     /// Forgets every key.
     ///
-    /// Benchmarks only, through [`Cached::clear`]. Forgetting a key only costs a
-    /// re-verification, so this is always safe.
+    /// [`Cached::clear`] is the only caller; benchmarks and tests use it to start from a cold
+    /// cache. Forgetting a key only costs a re-verification, so this is always safe.
     fn clear(&mut self) {
         self.keys.clear();
         self.insertion_order.clear();
@@ -252,24 +274,24 @@ impl VerifiedBundles {
 }
 
 impl InsertOutcome {
-    /// Reports this insert under `verifier`.
+    /// Reports this insert under `verifier_name`.
     ///
-    /// Called after the cache lock is released.
-    fn report(self, verifier: &'static str) {
+    /// [`Cached::call`] calls this after it releases the cache lock.
+    fn report(self, verifier_name: &'static str) {
         if !self.inserted {
             return;
         }
 
-        metrics::counter!(CACHE_INSERT, VERIFIER_LABEL => verifier).increment(1);
+        metrics::counter!(CACHE_INSERT, VERIFIER_LABEL => verifier_name).increment(1);
 
         if self.evicted > 0 {
             // Cast is safe: at most `capacity` keys are evicted by one insert.
-            metrics::counter!(CACHE_EVICT, VERIFIER_LABEL => verifier)
+            metrics::counter!(CACHE_EVICT, VERIFIER_LABEL => verifier_name)
                 .increment(self.evicted as u64);
         }
 
         // Cast is safe: the length is bounded by `capacity`, far below f64's exact integer range.
-        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => verifier).set(self.size as f64);
+        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => verifier_name).set(self.size as f64);
     }
 }
 
@@ -287,8 +309,8 @@ pub struct Cached<S> {
     /// The keys of items that have already verified under this cache's verifying key.
     verified: Arc<Mutex<VerifiedBundles>>,
 
-    /// The `verifier` label this cache reports its metrics under.
-    verifier: &'static str,
+    /// The value this cache reports in the `verifier` label of its metrics.
+    verifier_name: &'static str,
 
     /// The keys of the items that reached the inner service, in call order.
     ///
@@ -302,7 +324,7 @@ impl<S: Clone> Clone for Cached<S> {
         Self {
             inner: self.inner.clone(),
             verified: self.verified.clone(),
-            verifier: self.verifier,
+            verifier_name: self.verifier_name,
             #[cfg(test)]
             inner_calls: self.inner_calls.clone(),
         }
@@ -311,12 +333,12 @@ impl<S: Clone> Clone for Cached<S> {
 
 impl<S> Cached<S> {
     /// Wraps `inner` in a cache that retains at most `capacity` verified-bundle keys and reports
-    /// its metrics under the `verifier` label.
-    pub(super) fn new(inner: S, capacity: usize, verifier: &'static str) -> Self {
+    /// its metrics under the `verifier` label `verifier_name`.
+    pub(super) fn new(inner: S, capacity: usize, verifier_name: &'static str) -> Self {
         Self {
             inner,
             verified: Arc::new(Mutex::new(VerifiedBundles::new(capacity))),
-            verifier,
+            verifier_name,
             #[cfg(test)]
             inner_calls: Arc::new(Mutex::new(Vec::new())),
         }
@@ -338,7 +360,7 @@ impl<S> Cached<S> {
             .expect("verified bundle cache mutex should not be poisoned")
             .clear();
 
-        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => self.verifier).set(0.0);
+        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => self.verifier_name).set(0.0);
     }
 
     /// Returns how many times an item equivalent to `item` has reached the inner service.
@@ -373,7 +395,7 @@ impl<S> Cached<S> {
         Cached {
             inner,
             verified: self.verified.clone(),
-            verifier: self.verifier,
+            verifier_name: self.verifier_name,
             inner_calls: self.inner_calls.clone(),
         }
     }
@@ -421,15 +443,15 @@ where
                 .expect("verified bundle cache mutex should not be poisoned")
                 .contains(&key)
             {
-                metrics::counter!(CACHE_HIT, VERIFIER_LABEL => self.verifier).increment(1);
+                metrics::counter!(CACHE_HIT, VERIFIER_LABEL => self.verifier_name).increment(1);
                 return future::ready(Ok(())).boxed();
             }
         }
 
-        metrics::counter!(CACHE_MISS, VERIFIER_LABEL => self.verifier).increment(1);
+        metrics::counter!(CACHE_MISS, VERIFIER_LABEL => self.verifier_name).increment(1);
 
         let verified = self.verified.clone();
-        let verifier = self.verifier;
+        let verifier_name = self.verifier_name;
         let mut inner = self.inner.clone();
 
         #[cfg(test)]
@@ -460,7 +482,7 @@ where
                     .expect("verified bundle cache mutex should not be poisoned")
                     .insert(key);
 
-                outcome.report(verifier);
+                outcome.report(verifier_name);
             }
 
             result

--- a/crates/zakura-consensus/src/primitives/cache.rs
+++ b/crates/zakura-consensus/src/primitives/cache.rs
@@ -41,6 +41,28 @@ use crate::BoxError;
 /// tag use about 2 MB per cache before collection overhead.
 pub(super) const CACHE_CAPACITY: usize = 20_000;
 
+/// The label naming which verifier's cache a metric belongs to.
+///
+/// One cache instance per Orchard circuit era and one for Sapling all report under the same
+/// metric names, so every series carries this label. The values are the names those verifiers
+/// already use in their batch metrics and flush logs, so the two can be joined.
+const VERIFIER_LABEL: &str = "verifier";
+
+/// Counts verifications answered from a cache.
+const CACHE_HIT: &str = "zakura.consensus.cache.hit";
+
+/// Counts verifications that reached a cache's inner service.
+const CACHE_MISS: &str = "zakura.consensus.cache.miss";
+
+/// Counts keys recorded as verified.
+const CACHE_INSERT: &str = "zakura.consensus.cache.insert";
+
+/// Counts keys dropped to stay within a cache's capacity.
+const CACHE_EVICT: &str = "zakura.consensus.cache.evict";
+
+/// Reports how many keys a cache currently remembers.
+const CACHE_SIZE: &str = "zakura.consensus.cache.size";
+
 /// The shielded bundle slot a cache entry was verified for.
 ///
 /// One v6 transaction has an Orchard bundle, an Ironwood bundle and a Sapling bundle, all under
@@ -125,28 +147,6 @@ pub(super) trait CachedItem {
     fn cache_key(&self) -> Option<CacheKey>;
 }
 
-/// The metric names one cache reports under.
-///
-/// Each verifier keeps its own names rather than sharing one name with a `verifier` label,
-/// because the Halo2 names are already released.
-#[derive(Clone, Copy, Debug)]
-pub(super) struct CacheMetrics {
-    /// Counts verifications answered from the cache.
-    pub(super) hit: &'static str,
-
-    /// Counts verifications that reached the inner service.
-    pub(super) miss: &'static str,
-
-    /// Counts keys recorded as verified.
-    pub(super) insert: &'static str,
-
-    /// Counts keys dropped to stay within the capacity.
-    pub(super) evict: &'static str,
-
-    /// Reports how many keys are currently remembered.
-    pub(super) size: &'static str,
-}
-
 #[cfg(test)]
 mod tests;
 
@@ -166,18 +166,18 @@ struct VerifiedProofs {
     /// The maximum number of keys to retain.
     capacity: usize,
 
-    /// The metric names this cache reports under.
-    metrics: CacheMetrics,
+    /// The `verifier` label this cache reports its metrics under.
+    verifier: &'static str,
 }
 
 impl VerifiedProofs {
     /// Creates an empty cache that retains at most `capacity` keys.
-    fn new(capacity: usize, metrics: CacheMetrics) -> Self {
+    fn new(capacity: usize, verifier: &'static str) -> Self {
         Self {
             keys: HashSet::with_capacity(capacity),
             insertion_order: VecDeque::with_capacity(capacity),
             capacity,
-            metrics,
+            verifier,
         }
     }
 
@@ -195,7 +195,7 @@ impl VerifiedProofs {
         }
 
         self.insertion_order.push_back(key);
-        metrics::counter!(self.metrics.insert).increment(1);
+        metrics::counter!(CACHE_INSERT, VERIFIER_LABEL => self.verifier).increment(1);
 
         while self.insertion_order.len() > self.capacity {
             let evicted = self
@@ -203,11 +203,11 @@ impl VerifiedProofs {
                 .pop_front()
                 .expect("queue is longer than the capacity, which is at least one");
             self.keys.remove(&evicted);
-            metrics::counter!(self.metrics.evict).increment(1);
+            metrics::counter!(CACHE_EVICT, VERIFIER_LABEL => self.verifier).increment(1);
         }
 
         // Cast is safe: the length is bounded by `capacity`, far below f64's exact integer range.
-        metrics::gauge!(self.metrics.size).set(self.keys.len() as f64);
+        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => self.verifier).set(self.keys.len() as f64);
     }
 }
 
@@ -225,8 +225,8 @@ pub struct Cached<S> {
     /// The keys of items that have already verified under this cache's verifying key.
     verified: Arc<Mutex<VerifiedProofs>>,
 
-    /// The metric names this cache reports under.
-    metrics: CacheMetrics,
+    /// The `verifier` label this cache reports its metrics under.
+    verifier: &'static str,
 
     /// The keys of the items that reached the inner service, in call order.
     ///
@@ -240,7 +240,7 @@ impl<S: Clone> Clone for Cached<S> {
         Self {
             inner: self.inner.clone(),
             verified: self.verified.clone(),
-            metrics: self.metrics,
+            verifier: self.verifier,
             #[cfg(test)]
             inner_calls: self.inner_calls.clone(),
         }
@@ -249,12 +249,12 @@ impl<S: Clone> Clone for Cached<S> {
 
 impl<S> Cached<S> {
     /// Wraps `inner` in a cache that retains at most `capacity` verified-bundle keys and reports
-    /// under `metrics`.
-    pub(super) fn new(inner: S, capacity: usize, metrics: CacheMetrics) -> Self {
+    /// its metrics under the `verifier` label.
+    pub(super) fn new(inner: S, capacity: usize, verifier: &'static str) -> Self {
         Self {
             inner,
-            verified: Arc::new(Mutex::new(VerifiedProofs::new(capacity, metrics))),
-            metrics,
+            verified: Arc::new(Mutex::new(VerifiedProofs::new(capacity, verifier))),
+            verifier,
             #[cfg(test)]
             inner_calls: Arc::new(Mutex::new(Vec::new())),
         }
@@ -297,7 +297,7 @@ impl<S> Cached<S> {
         Cached {
             inner,
             verified: self.verified.clone(),
-            metrics: self.metrics,
+            verifier: self.verifier,
             inner_calls: self.inner_calls.clone(),
         }
     }
@@ -345,12 +345,12 @@ where
                 .expect("verified proof cache mutex should not be poisoned")
                 .contains(&key)
             {
-                metrics::counter!(self.metrics.hit).increment(1);
+                metrics::counter!(CACHE_HIT, VERIFIER_LABEL => self.verifier).increment(1);
                 return future::ready(Ok(())).boxed();
             }
         }
 
-        metrics::counter!(self.metrics.miss).increment(1);
+        metrics::counter!(CACHE_MISS, VERIFIER_LABEL => self.verifier).increment(1);
 
         let verified = self.verified.clone();
         let mut inner = self.inner.clone();

--- a/crates/zakura-consensus/src/primitives/cache.rs
+++ b/crates/zakura-consensus/src/primitives/cache.rs
@@ -1,7 +1,9 @@
-//! A bounded cache of Halo2 Orchard Action proofs that have already verified.
+//! A bounded cache of shielded bundle verifications that have already succeeded.
 //!
-//! Zakura verifies an Orchard proof when its transaction arrives over mempool gossip, and again
-//! when the transaction arrives in a block. This service skips the second verification.
+//! Zakura verifies a transaction's shielded proofs and signatures when the transaction arrives
+//! over mempool gossip, and again when it arrives in a block. This service skips the second
+//! verification. The Halo2 Orchard and Ironwood verifiers ([`super::halo2`]) and the Sapling
+//! verifier ([`super::sapling`]) share it, and key their entries the same way.
 //!
 //! # Why this is not the mempool bypass
 //!
@@ -9,11 +11,11 @@
 //! removed it as a security fix (PR #10494). Transaction validity depends on height, block time
 //! and spent outputs, and that cache's key named none of them.
 //!
-//! This cache remembers successful bundle verification by witnessed transaction
-//! ID and value pool. A hit still runs the whole transaction verifier against
-//! the block's height, time and spent outputs, and skips only the proof and
-//! signature checks. Each Orchard circuit era has its own cache, which binds an
-//! entry to its verifying key (see [`super::verifier_for`]).
+//! This cache remembers successful bundle verification by transaction ID, sighash and shielded
+//! pool. A hit still runs the whole transaction verifier against the block's height, time and
+//! spent outputs, and skips only the proof and signature checks. Each Orchard circuit era has its
+//! own cache, which binds an entry to its verifying key (see [`super::halo2::verifier_for`]);
+//! Sapling has one verifying key pair for all of history, so one cache covers it.
 //!
 //! Only `Ok` results are cached. A batch error is not per-item evidence, because
 //! [`Fallback`](tower_fallback::Fallback) re-verifies failures singly, and it may not be a verdict
@@ -28,10 +30,125 @@ use std::{
 
 use futures::{future::BoxFuture, FutureExt};
 use tower::{Service, ServiceExt};
+use zakura_chain::transaction::UnminedTxId;
 
 use crate::BoxError;
 
-use super::{CacheKey, Item};
+/// The number of verified-bundle keys retained per cache.
+///
+/// Sized to hold several blocks of history plus a full mempool, so that a transaction gossiped
+/// well before the block that mines it is still remembered. A transaction ID, sighash and pool
+/// tag use about 2 MB per cache before collection overhead.
+pub(super) const CACHE_CAPACITY: usize = 20_000;
+
+/// The shielded bundle slot a cache entry was verified for.
+///
+/// One v6 transaction has an Orchard bundle, an Ironwood bundle and a Sapling bundle, all under
+/// one transaction ID and one sighash, so the key names which one it stands for. The Orchard and
+/// Ironwood caches at NU6.3 onward are the same cache, so this tag is what keeps their entries
+/// apart; Sapling has its own cache and its tag is defence in depth.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) enum ShieldedPool {
+    /// The Sapling value pool.
+    Sapling,
+
+    /// The Orchard value pool.
+    Orchard,
+
+    /// The Ironwood value pool.
+    Ironwood,
+}
+
+impl From<orchard::ValuePool> for ShieldedPool {
+    fn from(pool: orchard::ValuePool) -> Self {
+        match pool {
+            orchard::ValuePool::Orchard => Self::Orchard,
+            orchard::ValuePool::Ironwood => Self::Ironwood,
+        }
+    }
+}
+
+/// A transaction, sighash and shielded pool whose bundle has verified.
+///
+/// # Correctness
+///
+/// A hit replaces a verification, so the key must determine every input that verification reads:
+/// the bundle and the sighash.
+///
+/// The transaction ID determines the bundle, in both of the forms it takes:
+///
+///   * [`UnminedTxId::Witnessed`] carries a [`WtxId`](zakura_chain::transaction::WtxId), whose
+///     txid commits to the transaction's effecting data and whose ZIP 244 authorizing-data digest
+///     commits to its proofs and signatures. The txid alone would not: it excludes authorizing
+///     data, which is what CVE-2026-34377 exploited.
+///   * [`UnminedTxId::Legacy`] is a v1-v4 transaction ID, the hash of the whole serialized
+///     transaction, so it commits to the Sapling proofs and signatures directly. V4 transactions
+///     have no witnessed ID, and this is why they do not need one here.
+///
+/// The sighash is named separately because it is not a function of the transaction alone: the
+/// amounts and `scriptPubKey`s of the spent transparent outputs enter it, and those come from the
+/// verification context.
+///
+/// The verifying key is absent on purpose. Each Orchard circuit era has its own cache, so an
+/// entry is only ever read back under the key it was written against, and Sapling has one key
+/// pair for all of history.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) struct CacheKey {
+    /// The ID of the transaction the bundle was parsed from.
+    tx_id: UnminedTxId,
+
+    /// The signature digest used to verify the bundle's signatures.
+    sighash: [u8; 32],
+
+    /// The bundle slot verified for this transaction.
+    pool: ShieldedPool,
+}
+
+impl CacheKey {
+    /// Returns the key for `pool`'s bundle in the transaction identified by `tx_id`, verified
+    /// against `sighash`.
+    pub(super) fn new(tx_id: UnminedTxId, sighash: [u8; 32], pool: ShieldedPool) -> Self {
+        Self {
+            tx_id,
+            sighash,
+            pool,
+        }
+    }
+}
+
+/// An item whose successful verification can be remembered.
+///
+/// Items without a key are verified normally and never cached, which is how a caller that has no
+/// transaction identity to offer stays correct.
+pub(super) trait CachedItem {
+    /// Returns this item's cache key, if it has one.
+    fn cache_key(&self) -> Option<CacheKey>;
+}
+
+/// The metric names one cache reports under.
+///
+/// Each verifier keeps its own names rather than sharing one name with a `verifier` label,
+/// because the Halo2 names are already released.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct CacheMetrics {
+    /// Counts verifications answered from the cache.
+    pub(super) hit: &'static str,
+
+    /// Counts verifications that reached the inner service.
+    pub(super) miss: &'static str,
+
+    /// Counts keys recorded as verified.
+    pub(super) insert: &'static str,
+
+    /// Counts keys dropped to stay within the capacity.
+    pub(super) evict: &'static str,
+
+    /// Reports how many keys are currently remembered.
+    pub(super) size: &'static str,
+}
+
+#[cfg(test)]
+mod tests;
 
 /// A bounded set of keys for items that have already verified successfully.
 ///
@@ -48,15 +165,19 @@ struct VerifiedProofs {
 
     /// The maximum number of keys to retain.
     capacity: usize,
+
+    /// The metric names this cache reports under.
+    metrics: CacheMetrics,
 }
 
 impl VerifiedProofs {
     /// Creates an empty cache that retains at most `capacity` keys.
-    fn new(capacity: usize) -> Self {
+    fn new(capacity: usize, metrics: CacheMetrics) -> Self {
         Self {
             keys: HashSet::with_capacity(capacity),
             insertion_order: VecDeque::with_capacity(capacity),
             capacity,
+            metrics,
         }
     }
 
@@ -74,7 +195,7 @@ impl VerifiedProofs {
         }
 
         self.insertion_order.push_back(key);
-        metrics::counter!("zakura.consensus.halo2.cache.insert").increment(1);
+        metrics::counter!(self.metrics.insert).increment(1);
 
         while self.insertion_order.len() > self.capacity {
             let evicted = self
@@ -82,27 +203,30 @@ impl VerifiedProofs {
                 .pop_front()
                 .expect("queue is longer than the capacity, which is at least one");
             self.keys.remove(&evicted);
-            metrics::counter!("zakura.consensus.halo2.cache.evict").increment(1);
+            metrics::counter!(self.metrics.evict).increment(1);
         }
 
         // Cast is safe: the length is bounded by `capacity`, far below f64's exact integer range.
-        metrics::gauge!("zakura.consensus.halo2.cache.size").set(self.keys.len() as f64);
+        metrics::gauge!(self.metrics.size).set(self.keys.len() as f64);
     }
 }
 
-/// A service that skips inner verification for items whose proof has already verified.
+/// A service that skips inner verification for items whose bundle has already verified.
 ///
-/// This wraps one Orchard circuit era's batch-and-fallback stack. The cache is shared between
-/// clones, so every handle to a global verifier sees the same set of verified proofs.
+/// This wraps one verifier's batch-and-fallback stack. The cache is shared between clones, so
+/// every handle to a global verifier sees the same set of verified bundles.
 ///
 /// This type is public only because it appears in existing public verifier signatures. The
-/// private `cache` module does not re-export it, and its constructor and accessors are private.
+/// private `cache` module is not re-exported, and its constructor and accessors are private.
 pub struct Cached<S> {
     /// The verification service to consult on a miss.
     inner: S,
 
-    /// The keys of items that have already verified under this era's key.
+    /// The keys of items that have already verified under this cache's verifying key.
     verified: Arc<Mutex<VerifiedProofs>>,
+
+    /// The metric names this cache reports under.
+    metrics: CacheMetrics,
 
     /// The keys of the items that reached the inner service, in call order.
     ///
@@ -116,6 +240,7 @@ impl<S: Clone> Clone for Cached<S> {
         Self {
             inner: self.inner.clone(),
             verified: self.verified.clone(),
+            metrics: self.metrics,
             #[cfg(test)]
             inner_calls: self.inner_calls.clone(),
         }
@@ -123,11 +248,13 @@ impl<S: Clone> Clone for Cached<S> {
 }
 
 impl<S> Cached<S> {
-    /// Wraps `inner` in a cache that retains at most `capacity` verified-proof keys.
-    pub(super) fn new(inner: S, capacity: usize) -> Self {
+    /// Wraps `inner` in a cache that retains at most `capacity` verified-bundle keys and reports
+    /// under `metrics`.
+    pub(super) fn new(inner: S, capacity: usize, metrics: CacheMetrics) -> Self {
         Self {
             inner,
-            verified: Arc::new(Mutex::new(VerifiedProofs::new(capacity))),
+            verified: Arc::new(Mutex::new(VerifiedProofs::new(capacity, metrics))),
+            metrics,
             #[cfg(test)]
             inner_calls: Arc::new(Mutex::new(Vec::new())),
         }
@@ -147,7 +274,7 @@ impl<S> Cached<S> {
     /// Readiness failures are not counted: an item that never reached the inner service was never
     /// verified by it.
     #[cfg(test)]
-    pub(super) fn inner_calls_for(&self, item: &Item) -> usize {
+    pub(super) fn inner_calls_for<I: CachedItem>(&self, item: &I) -> usize {
         let Some(key) = item.cache_key() else {
             return 0;
         };
@@ -170,14 +297,18 @@ impl<S> Cached<S> {
         Cached {
             inner,
             verified: self.verified.clone(),
+            metrics: self.metrics,
             inner_calls: self.inner_calls.clone(),
         }
     }
 }
 
-impl<S> Service<Item> for Cached<S>
+impl<S, I> Service<I> for Cached<S>
 where
-    S: Service<Item, Response = (), Error = BoxError> + Clone + Send + 'static,
+    // `Send + 'static` because a miss moves the item into the boxed future that awaits inner
+    // readiness — see `poll_ready`.
+    I: CachedItem + Send + 'static,
+    S: Service<I, Response = (), Error = BoxError> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response = ();
@@ -203,7 +334,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, item: Item) -> Self::Future {
+    fn call(&mut self, item: I) -> Self::Future {
         // Copied once here, outside `Fallback`, which clones every request eagerly.
         let key = item.cache_key();
 
@@ -214,12 +345,12 @@ where
                 .expect("verified proof cache mutex should not be poisoned")
                 .contains(&key)
             {
-                metrics::counter!("zakura.consensus.halo2.cache.hit").increment(1);
+                metrics::counter!(self.metrics.hit).increment(1);
                 return future::ready(Ok(())).boxed();
             }
         }
 
-        metrics::counter!("zakura.consensus.halo2.cache.miss").increment(1);
+        metrics::counter!(self.metrics.miss).increment(1);
 
         let verified = self.verified.clone();
         let mut inner = self.inner.clone();

--- a/crates/zakura-consensus/src/primitives/cache.rs
+++ b/crates/zakura-consensus/src/primitives/cache.rs
@@ -34,18 +34,27 @@ use zakura_chain::transaction::UnminedTxId;
 
 use crate::BoxError;
 
+#[cfg(test)]
+mod tests;
+
 /// The number of verified-bundle keys retained per cache.
 ///
 /// Sized to hold several blocks of history plus a full mempool, so that a transaction gossiped
-/// well before the block that mines it is still remembered. A transaction ID, sighash and pool
-/// tag use about 2 MB per cache before collection overhead.
+/// well before the block that mines it is still remembered.
+///
+/// Each key is a 98-byte transaction ID, sighash and pool tag, held twice — once in the lookup
+/// set and once in the eviction queue — so a full cache costs about 5 MiB, and about 20 MiB
+/// across the three Orchard circuit eras and Sapling. Only the eras a node actually verifies pay
+/// it, because each cache is built with its verifier on first use.
 pub(super) const CACHE_CAPACITY: usize = 20_000;
 
 /// The label naming which verifier's cache a metric belongs to.
 ///
 /// One cache instance per Orchard circuit era and one for Sapling all report under the same
 /// metric names, so every series carries this label. The values are the names those verifiers
-/// already use in their batch metrics and flush logs, so the two can be joined.
+/// already use in their explicit-flush logs: `halo2_pre_nu6_2`, `halo2_nu6_2`,
+/// `halo2_nu6_3_onward` and `groth16_sapling`. Only Sapling's matches its batch duration metric
+/// as well; the Halo2 batch metric reports all three eras as one `halo2` series.
 const VERIFIER_LABEL: &str = "verifier";
 
 /// Counts verifications answered from a cache.
@@ -107,9 +116,12 @@ impl From<orchard::ValuePool> for ShieldedPool {
 ///     transaction, so it commits to the Sapling proofs and signatures directly. V4 transactions
 ///     have no witnessed ID, and this is why they do not need one here.
 ///
-/// The sighash is named separately because it is not a function of the transaction alone: the
-/// amounts and `scriptPubKey`s of the spent transparent outputs enter it, and those come from the
-/// verification context.
+/// The sighash is named separately because it is not always a function of the transaction alone.
+/// A v5 or v6 sighash also commits to the amounts and `scriptPubKey`s of the spent transparent
+/// outputs, which the verification context supplies. A v4 shielded sighash does not — it is
+/// computed with no input index, so ZIP 143 and ZIP 243 leave the spent output out — but it does
+/// commit to the block's consensus branch id, which a v4 transaction ID does not carry, and which
+/// selects the verification a bundle is checked against.
 ///
 /// The verifying key is absent on purpose. Each Orchard circuit era has its own cache, so an
 /// entry is only ever read back under the key it was written against, and Sapling has one key
@@ -147,16 +159,30 @@ pub(super) trait CachedItem {
     fn cache_key(&self) -> Option<CacheKey>;
 }
 
-#[cfg(test)]
-mod tests;
+/// What one [`VerifiedBundles::insert`] did, so the caller can report it after releasing the
+/// lock.
+///
+/// Metrics are emitted outside the critical section: a labelled `metrics` macro allocates its
+/// label set on every call, and this lock is taken by every shielded verification the node runs.
+#[derive(Clone, Copy, Debug)]
+struct InsertOutcome {
+    /// Whether this key was new, rather than a concurrent duplicate.
+    inserted: bool,
 
-/// A bounded set of keys for items that have already verified successfully.
+    /// How many keys were evicted to make room for it.
+    evicted: usize,
+
+    /// How many keys the cache holds now.
+    size: usize,
+}
+
+/// A bounded set of keys for bundles that have already verified successfully.
 ///
 /// Eviction is first-in-first-out rather than least-recently-used: the working set is the
 /// mempool, which turns over in arrival order anyway, and FIFO needs no bookkeeping on the read
 /// path. Evicting an entry only costs a re-verification, never correctness.
 #[derive(Debug)]
-struct VerifiedProofs {
+struct VerifiedBundles {
     /// The keys currently remembered.
     keys: HashSet<CacheKey>,
 
@@ -165,19 +191,15 @@ struct VerifiedProofs {
 
     /// The maximum number of keys to retain.
     capacity: usize,
-
-    /// The `verifier` label this cache reports its metrics under.
-    verifier: &'static str,
 }
 
-impl VerifiedProofs {
+impl VerifiedBundles {
     /// Creates an empty cache that retains at most `capacity` keys.
-    fn new(capacity: usize, verifier: &'static str) -> Self {
+    fn new(capacity: usize) -> Self {
         Self {
             keys: HashSet::with_capacity(capacity),
             insertion_order: VecDeque::with_capacity(capacity),
             capacity,
-            verifier,
         }
     }
 
@@ -186,28 +208,68 @@ impl VerifiedProofs {
         self.keys.contains(key)
     }
 
-    /// Records that `key` has verified, evicting the oldest keys if that exceeds the capacity.
-    fn insert(&mut self, key: CacheKey) {
+    /// Records that `key` has verified, evicting the oldest keys to stay within the capacity.
+    fn insert(&mut self, key: CacheKey) -> InsertOutcome {
         // Concurrent verifications of the same item both miss and both insert. The second is a
         // no-op, and must not push a duplicate into the eviction queue.
         if !self.keys.insert(key) {
-            return;
+            return InsertOutcome {
+                inserted: false,
+                evicted: 0,
+                size: self.keys.len(),
+            };
+        }
+
+        // Evict before pushing, so the queue never has to grow past the capacity it was built
+        // with. Pushing first would take it to `capacity + 1` and double its allocation for the
+        // rest of the process.
+        let mut evicted = 0;
+        while self.insertion_order.len() >= self.capacity {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.keys.remove(&oldest);
+            evicted += 1;
         }
 
         self.insertion_order.push_back(key);
-        metrics::counter!(CACHE_INSERT, VERIFIER_LABEL => self.verifier).increment(1);
 
-        while self.insertion_order.len() > self.capacity {
-            let evicted = self
-                .insertion_order
-                .pop_front()
-                .expect("queue is longer than the capacity, which is at least one");
-            self.keys.remove(&evicted);
-            metrics::counter!(CACHE_EVICT, VERIFIER_LABEL => self.verifier).increment(1);
+        InsertOutcome {
+            inserted: true,
+            evicted,
+            size: self.keys.len(),
+        }
+    }
+
+    /// Forgets every key.
+    ///
+    /// Benchmarks only, through [`Cached::clear`]. Forgetting a key only costs a
+    /// re-verification, so this is always safe.
+    fn clear(&mut self) {
+        self.keys.clear();
+        self.insertion_order.clear();
+    }
+}
+
+impl InsertOutcome {
+    /// Reports this insert under `verifier`.
+    ///
+    /// Called after the cache lock is released.
+    fn report(self, verifier: &'static str) {
+        if !self.inserted {
+            return;
+        }
+
+        metrics::counter!(CACHE_INSERT, VERIFIER_LABEL => verifier).increment(1);
+
+        if self.evicted > 0 {
+            // Cast is safe: at most `capacity` keys are evicted by one insert.
+            metrics::counter!(CACHE_EVICT, VERIFIER_LABEL => verifier)
+                .increment(self.evicted as u64);
         }
 
         // Cast is safe: the length is bounded by `capacity`, far below f64's exact integer range.
-        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => self.verifier).set(self.keys.len() as f64);
+        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => verifier).set(self.size as f64);
     }
 }
 
@@ -223,7 +285,7 @@ pub struct Cached<S> {
     inner: S,
 
     /// The keys of items that have already verified under this cache's verifying key.
-    verified: Arc<Mutex<VerifiedProofs>>,
+    verified: Arc<Mutex<VerifiedBundles>>,
 
     /// The `verifier` label this cache reports its metrics under.
     verifier: &'static str,
@@ -253,7 +315,7 @@ impl<S> Cached<S> {
     pub(super) fn new(inner: S, capacity: usize, verifier: &'static str) -> Self {
         Self {
             inner,
-            verified: Arc::new(Mutex::new(VerifiedProofs::new(capacity, verifier))),
+            verified: Arc::new(Mutex::new(VerifiedBundles::new(capacity))),
             verifier,
             #[cfg(test)]
             inner_calls: Arc::new(Mutex::new(Vec::new())),
@@ -263,6 +325,20 @@ impl<S> Cached<S> {
     /// Returns the wrapped verification service.
     pub(super) fn inner(&self) -> &S {
         &self.inner
+    }
+
+    /// Forgets every remembered bundle.
+    ///
+    /// This exists for [`clear_shielded_verification_caches`](super::clear_shielded_verification_caches),
+    /// which benchmarks call to measure verification rather than cache hits. Forgetting a key
+    /// only costs a re-verification, so calling it can never accept an unverified bundle.
+    pub(super) fn clear(&self) {
+        self.verified
+            .lock()
+            .expect("verified bundle cache mutex should not be poisoned")
+            .clear();
+
+        metrics::gauge!(CACHE_SIZE, VERIFIER_LABEL => self.verifier).set(0.0);
     }
 
     /// Returns how many times an item equivalent to `item` has reached the inner service.
@@ -342,7 +418,7 @@ where
             if self
                 .verified
                 .lock()
-                .expect("verified proof cache mutex should not be poisoned")
+                .expect("verified bundle cache mutex should not be poisoned")
                 .contains(&key)
             {
                 metrics::counter!(CACHE_HIT, VERIFIER_LABEL => self.verifier).increment(1);
@@ -353,6 +429,7 @@ where
         metrics::counter!(CACHE_MISS, VERIFIER_LABEL => self.verifier).increment(1);
 
         let verified = self.verified.clone();
+        let verifier = self.verifier;
         let mut inner = self.inner.clone();
 
         #[cfg(test)]
@@ -378,10 +455,12 @@ where
 
             // Only successes are recorded: see the module docs.
             if let (Ok(()), Some(key)) = (&result, key) {
-                verified
+                let outcome = verified
                     .lock()
-                    .expect("verified proof cache mutex should not be poisoned")
+                    .expect("verified bundle cache mutex should not be poisoned")
                     .insert(key);
+
+                outcome.report(verifier);
             }
 
             result

--- a/crates/zakura-consensus/src/primitives/cache/tests.rs
+++ b/crates/zakura-consensus/src/primitives/cache/tests.rs
@@ -1,14 +1,15 @@
-//! Tests for the shared verification cache key.
+//! Tests for the shared verification cache key and the bounded store behind it.
 //!
-//! The verifiers pin their own key construction over real bundles. These cover the part of the
-//! key that is the same for all of them: which of its three components separate two entries.
+//! The verifiers pin their own key construction over real bundles. These cover the parts that are
+//! the same for all of them: which of the key's three components separate two entries, and the
+//! store's capacity and eviction.
 
 use zakura_chain::{
     serialization::BytesInDisplayOrder,
     transaction::{AuthDigest, Hash, UnminedTxId, WtxId},
 };
 
-use super::{CacheKey, ShieldedPool};
+use super::{CacheKey, ShieldedPool, VerifiedBundles};
 
 /// Returns a transaction ID with no witness, as a v1-v4 transaction has.
 fn legacy_tx_id(tag: u8) -> UnminedTxId {
@@ -99,4 +100,41 @@ fn orchard_value_pools_map_to_distinct_tags() {
         ShieldedPool::from(orchard::ValuePool::Ironwood),
         ShieldedPool::Ironwood
     );
+}
+
+/// The lookup set and the eviction queue always hold the same keys.
+///
+/// They are two representations of one fact. A path that updated one without the other would
+/// either drop a key that `contains` still answers — remembering a bundle for the rest of the
+/// process — or grow the queue past the capacity it was built with.
+#[test]
+fn the_lookup_set_and_the_eviction_queue_hold_the_same_keys() {
+    let mut verified = VerifiedBundles::new(2);
+    let keys = [
+        CacheKey::new(legacy_tx_id(1), [0; 32], ShieldedPool::Sapling),
+        CacheKey::new(legacy_tx_id(2), [0; 32], ShieldedPool::Sapling),
+        CacheKey::new(legacy_tx_id(3), [0; 32], ShieldedPool::Sapling),
+    ];
+
+    for key in keys {
+        verified.insert(key);
+        assert_eq!(
+            verified.keys.len(),
+            verified.insertion_order.len(),
+            "the lookup set and the eviction queue must hold the same keys"
+        );
+        assert!(verified.keys.len() <= 2, "the capacity bounds the cache");
+    }
+    assert!(
+        !verified.contains(&keys[0]),
+        "the oldest key must be evicted"
+    );
+
+    let repeated = verified.insert(keys[2]);
+    assert!(!repeated.inserted, "a concurrent duplicate is not recorded");
+    assert_eq!(repeated.evicted, 0, "a duplicate must not evict anything");
+    assert_eq!(verified.keys.len(), verified.insertion_order.len());
+
+    verified.clear();
+    assert!(verified.keys.is_empty() && verified.insertion_order.is_empty());
 }

--- a/crates/zakura-consensus/src/primitives/cache/tests.rs
+++ b/crates/zakura-consensus/src/primitives/cache/tests.rs
@@ -1,0 +1,102 @@
+//! Tests for the shared verification cache key.
+//!
+//! The verifiers pin their own key construction over real bundles. These cover the part of the
+//! key that is the same for all of them: which of its three components separate two entries.
+
+use zakura_chain::{
+    serialization::BytesInDisplayOrder,
+    transaction::{AuthDigest, Hash, UnminedTxId, WtxId},
+};
+
+use super::{CacheKey, ShieldedPool};
+
+/// Returns a transaction ID with no witness, as a v1-v4 transaction has.
+fn legacy_tx_id(tag: u8) -> UnminedTxId {
+    UnminedTxId::Legacy(Hash::from_bytes_in_display_order(&[tag; 32]))
+}
+
+/// Returns a witnessed transaction ID, as a v5 or v6 transaction has.
+fn witnessed_tx_id(txid_tag: u8, auth_digest_tag: u8) -> UnminedTxId {
+    UnminedTxId::Witnessed(WtxId {
+        id: Hash::from_bytes_in_display_order(&[txid_tag; 32]),
+        auth_digest: AuthDigest::from_bytes_in_display_order(&[auth_digest_tag; 32]),
+    })
+}
+
+/// The pool separates the bundles a v6 transaction carries under one ID and one sighash.
+///
+/// The Orchard and Ironwood caches are one cache from NU6.3 onward, so this is what keeps their
+/// entries apart there.
+#[test]
+fn keys_for_the_same_transaction_differ_by_pool() {
+    let tx_id = witnessed_tx_id(1, 2);
+    let sighash = [3; 32];
+
+    let keys = [
+        CacheKey::new(tx_id, sighash, ShieldedPool::Sapling),
+        CacheKey::new(tx_id, sighash, ShieldedPool::Orchard),
+        CacheKey::new(tx_id, sighash, ShieldedPool::Ironwood),
+    ];
+
+    let unique: std::collections::HashSet<_> = keys.iter().collect();
+    assert_eq!(
+        unique.len(),
+        keys.len(),
+        "one transaction's three shielded bundles must not share a cache key"
+    );
+}
+
+/// The authorizing-data digest separates two witnessed IDs that share a txid.
+///
+/// Under ZIP 244 a v5 transaction's txid excludes its proofs and signatures, so a key that named
+/// only the txid would answer both of these with one verification. That is CVE-2026-34377.
+#[test]
+fn witnessed_keys_differ_by_authorizing_data() {
+    let sighash = [3; 32];
+
+    assert_ne!(
+        CacheKey::new(witnessed_tx_id(1, 2), sighash, ShieldedPool::Orchard),
+        CacheKey::new(witnessed_tx_id(1, 4), sighash, ShieldedPool::Orchard),
+        "the same txid with different authorizing data must not share a cache key"
+    );
+}
+
+/// The sighash separates two verifications of one transaction's bundle.
+///
+/// The sighash is not a function of the transaction alone: the amounts and scripts of the spent
+/// transparent outputs enter it, and those come from the verification context.
+#[test]
+fn keys_differ_by_sighash() {
+    let tx_id = witnessed_tx_id(1, 2);
+
+    assert_ne!(
+        CacheKey::new(tx_id, [3; 32], ShieldedPool::Sapling),
+        CacheKey::new(tx_id, [4; 32], ShieldedPool::Sapling),
+        "the sighash is an input to verification, so it must be an input to the key"
+    );
+}
+
+/// A legacy ID and a witnessed ID never collide, whatever they contain.
+#[test]
+fn legacy_and_witnessed_keys_differ() {
+    let sighash = [3; 32];
+
+    assert_ne!(
+        CacheKey::new(legacy_tx_id(1), sighash, ShieldedPool::Sapling),
+        CacheKey::new(witnessed_tx_id(1, 1), sighash, ShieldedPool::Sapling),
+        "a v4 transaction ID must not collide with a witnessed one"
+    );
+}
+
+/// Every Orchard value pool has a distinct tag.
+#[test]
+fn orchard_value_pools_map_to_distinct_tags() {
+    assert_eq!(
+        ShieldedPool::from(orchard::ValuePool::Orchard),
+        ShieldedPool::Orchard
+    );
+    assert_eq!(
+        ShieldedPool::from(orchard::ValuePool::Ironwood),
+        ShieldedPool::Ironwood
+    );
+}

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -14,12 +14,11 @@ use once_cell::sync::Lazy;
 use orchard::{
     bundle::{BatchError, BatchValidator},
     circuit::{OrchardCircuitVersion, VerifyingKey},
-    ValuePool,
 };
 use rand::thread_rng;
 use zakura_chain::{
     parameters::NetworkUpgrade,
-    transaction::{SigHash, WtxId},
+    transaction::{SigHash, UnminedTxId, WtxId},
 };
 use zcash_protocol::value::ZatBalance;
 
@@ -32,12 +31,10 @@ use tower_fallback::Fallback;
 
 use super::spawn_fifo;
 
-mod cache;
-
 #[cfg(test)]
 mod tests;
 
-use cache::Cached;
+use super::cache::{CacheKey, CacheMetrics, Cached, CachedItem, ShieldedPool, CACHE_CAPACITY};
 
 /// Adjusted batch size for halo2 batches.
 ///
@@ -49,33 +46,17 @@ use cache::Cached;
 /// [`HALO2_MAX_BATCH_SIZE`] total actions among pending items in the queue.
 const HALO2_MAX_BATCH_SIZE: usize = super::MAX_BATCH_SIZE;
 
-/// The number of verified-proof keys retained per Orchard circuit era.
+/// The metric names each Orchard circuit era's cache reports under.
 ///
-/// Sized to hold several blocks of history plus a full mempool, so that a
-/// transaction gossiped well before the block that mines it is still
-/// remembered. The witnessed transaction ID, sighash, and pool tag use about
-/// 2 MB per era before collection overhead.
-const CACHE_CAPACITY: usize = 20_000;
-
-/// A witnessed transaction, sighash, and value pool whose Halo2 bundle has
-/// verified.
-///
-/// [`WtxId`] contains both the transaction ID, which commits to the bundle's
-/// effecting data, and the authorizing-data digest, which commits to its proof
-/// and signatures. The pool distinguishes the Orchard and Ironwood bundles in
-/// a v6 transaction, because they share one [`WtxId`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct CacheKey {
-    /// The witnessed transaction ID containing the txid and authorizing-data
-    /// digest.
-    wtx_id: WtxId,
-
-    /// The signature digest used to verify the bundle's signatures.
-    sighash: [u8; 32],
-
-    /// The bundle slot verified for this transaction.
-    pool: ValuePool,
-}
+/// The three eras share one set of names, so the counters report the Halo2
+/// cache as a whole.
+const CACHE_METRICS: CacheMetrics = CacheMetrics {
+    hit: "zakura.consensus.halo2.cache.hit",
+    miss: "zakura.consensus.halo2.cache.miss",
+    insert: "zakura.consensus.halo2.cache.insert",
+    evict: "zakura.consensus.halo2.cache.evict",
+    size: "zakura.consensus.halo2.cache.size",
+};
 
 /// The type of verification results.
 type VerifyResult = bool;
@@ -195,16 +176,16 @@ impl Item {
         sighash: SigHash,
         wtx_id: WtxId,
     ) -> Self {
-        let pool = bundle.bundle_version().value_pool();
+        let pool = ShieldedPool::from(bundle.bundle_version().value_pool());
 
         Self {
             bundle: Arc::new(bundle),
             sighash,
-            cache_key: Some(CacheKey {
-                wtx_id,
-                sighash: sighash.0,
+            cache_key: Some(CacheKey::new(
+                UnminedTxId::Witnessed(wtx_id),
+                sighash.0,
                 pool,
-            }),
+            )),
         }
     }
 
@@ -220,7 +201,9 @@ impl Item {
         }
         batch.validate(thread_rng())
     }
+}
 
+impl CachedItem for Item {
     /// Returns this item's cache key, if it was constructed with a witnessed
     /// transaction ID.
     ///
@@ -333,7 +316,7 @@ type VerifierService = Cached<BatchFallbackService>;
 /// verifier here, each era also gets its own cache, which is what binds a remembered result to the
 /// `vk` it was produced under.
 fn batch_verifier(vk: &'static ItemVerifyingKey) -> VerifierService {
-    Cached::new(batch_fallback_verifier(vk), CACHE_CAPACITY)
+    Cached::new(batch_fallback_verifier(vk), CACHE_CAPACITY, CACHE_METRICS)
 }
 
 /// Builds the uncached batching-and-fallback stack for `vk`.

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -302,10 +302,10 @@ type VerifierService = Cached<BatchFallbackService>;
 /// The stack is wrapped in a [`Cached`] so that a proof gossiped into the mempool does not have
 /// to be verified again when the block that mines it arrives. Because each era builds its own
 /// verifier here, each era also gets its own cache, which is what binds a remembered result to the
-/// `vk` it was produced under. `verifier` is the era's `verifier` metrics label, so each era's
-/// cache reports its own hit rate.
-fn batch_verifier(vk: &'static ItemVerifyingKey, verifier: &'static str) -> VerifierService {
-    Cached::new(batch_fallback_verifier(vk), CACHE_CAPACITY, verifier)
+/// `vk` it was produced under. `verifier_name` is the era's `verifier` metrics label, so each
+/// era's cache reports its own hit rate.
+fn batch_verifier(vk: &'static ItemVerifyingKey, verifier_name: &'static str) -> VerifierService {
+    Cached::new(batch_fallback_verifier(vk), CACHE_CAPACITY, verifier_name)
 }
 
 /// Builds the uncached batching-and-fallback stack for `vk`.

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -34,7 +34,7 @@ use super::spawn_fifo;
 #[cfg(test)]
 mod tests;
 
-use super::cache::{CacheKey, CacheMetrics, Cached, CachedItem, ShieldedPool, CACHE_CAPACITY};
+use super::cache::{CacheKey, Cached, CachedItem, ShieldedPool, CACHE_CAPACITY};
 
 /// Adjusted batch size for halo2 batches.
 ///
@@ -45,18 +45,6 @@ use super::cache::{CacheKey, CacheMetrics, Cached, CachedItem, ShieldedPool, CAC
 /// To compensate for larger proofs, we process the batch once there are over
 /// [`HALO2_MAX_BATCH_SIZE`] total actions among pending items in the queue.
 const HALO2_MAX_BATCH_SIZE: usize = super::MAX_BATCH_SIZE;
-
-/// The metric names each Orchard circuit era's cache reports under.
-///
-/// The three eras share one set of names, so the counters report the Halo2
-/// cache as a whole.
-const CACHE_METRICS: CacheMetrics = CacheMetrics {
-    hit: "zakura.consensus.halo2.cache.hit",
-    miss: "zakura.consensus.halo2.cache.miss",
-    insert: "zakura.consensus.halo2.cache.insert",
-    evict: "zakura.consensus.halo2.cache.evict",
-    size: "zakura.consensus.halo2.cache.size",
-};
 
 /// The type of verification results.
 type VerifyResult = bool;
@@ -314,9 +302,10 @@ type VerifierService = Cached<BatchFallbackService>;
 /// The stack is wrapped in a [`Cached`] so that a proof gossiped into the mempool does not have
 /// to be verified again when the block that mines it arrives. Because each era builds its own
 /// verifier here, each era also gets its own cache, which is what binds a remembered result to the
-/// `vk` it was produced under.
-fn batch_verifier(vk: &'static ItemVerifyingKey) -> VerifierService {
-    Cached::new(batch_fallback_verifier(vk), CACHE_CAPACITY, CACHE_METRICS)
+/// `vk` it was produced under. `verifier` is the era's `verifier` metrics label, so each era's
+/// cache reports its own hit rate.
+fn batch_verifier(vk: &'static ItemVerifyingKey, verifier: &'static str) -> VerifierService {
+    Cached::new(batch_fallback_verifier(vk), CACHE_CAPACITY, verifier)
 }
 
 /// Builds the uncached batching-and-fallback stack for `vk`.
@@ -341,7 +330,7 @@ fn batch_fallback_verifier(vk: &'static ItemVerifyingKey) -> BatchFallbackServic
 /// Note that making a `Service` call requires mutable access to the service, so you should call
 /// `.clone()` on the global handle to create a local, mutable handle.
 pub static VERIFIER_PRE_NU6_2: Lazy<VerifierService> =
-    Lazy::new(|| batch_verifier(&VERIFYING_KEY_PRE_NU6_2));
+    Lazy::new(|| batch_verifier(&VERIFYING_KEY_PRE_NU6_2, "halo2_pre_nu6_2"));
 
 /// Global batch verification context for **NU6.2-until-NU6.3** Halo2 Action proofs.
 ///
@@ -352,7 +341,7 @@ pub static VERIFIER_PRE_NU6_2: Lazy<VerifierService> =
 /// Note that making a `Service` call requires mutable access to the service, so you should call
 /// `.clone()` on the global handle to create a local, mutable handle.
 pub static VERIFIER_NU6_2: Lazy<VerifierService> =
-    Lazy::new(|| batch_verifier(&VERIFYING_KEY_NU6_2));
+    Lazy::new(|| batch_verifier(&VERIFYING_KEY_NU6_2, "halo2_nu6_2"));
 
 /// Global batch verification context for **NU6.3-onward** Halo2 Action proofs.
 ///
@@ -365,7 +354,7 @@ pub static VERIFIER_NU6_2: Lazy<VerifierService> =
 /// Note that making a `Service` call requires mutable access to the service, so you should call
 /// `.clone()` on the global handle to create a local, mutable handle.
 pub static VERIFIER_NU6_3_ONWARD: Lazy<VerifierService> =
-    Lazy::new(|| batch_verifier(&VERIFYING_KEY_NU6_3_ONWARD));
+    Lazy::new(|| batch_verifier(&VERIFYING_KEY_NU6_3_ONWARD, "halo2_nu6_3_onward"));
 
 /// Selects the lazily initialized Halo2 verifier for `network_upgrade`.
 ///

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -41,9 +41,21 @@ use zcash_protocol::value::ZatBalance;
 use crate::{error::TransactionError, BoxError};
 
 use super::{
-    lazy_verifier_for, BatchFallbackService, CacheKey, Cached, Item, ItemVerifyingKey,
-    OrchardFallback, Verifier, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD, VERIFIER_PRE_NU6_2,
-    VERIFYING_KEY_NU6_2, VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
+    lazy_verifier_for, BatchFallbackService, CacheKey, CacheMetrics, Cached, CachedItem, Item,
+    ItemVerifyingKey, OrchardFallback, Verifier, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD,
+    VERIFIER_PRE_NU6_2, VERIFYING_KEY_NU6_2, VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
+};
+
+/// The metric names the test caches report under.
+///
+/// Test caches use their own names so their counts never land in the metrics
+/// the production verifiers report.
+const TEST_CACHE_METRICS: CacheMetrics = CacheMetrics {
+    hit: "zakura.consensus.halo2.test_cache.hit",
+    miss: "zakura.consensus.halo2.test_cache.miss",
+    insert: "zakura.consensus.halo2.test_cache.insert",
+    evict: "zakura.consensus.halo2.test_cache.evict",
+    size: "zakura.consensus.halo2.test_cache.size",
 };
 
 const EXPLICIT_FLUSH_TEST_MAX_BATCH_WEIGHT: usize = 10_000;
@@ -517,7 +529,7 @@ impl Service<Item> for CountingVerifier {
 async fn cache_skips_the_inner_service_for_an_already_verified_item() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
 
     for _ in 0..3 {
         verifier
@@ -540,7 +552,7 @@ async fn cache_skips_the_inner_service_for_an_already_verified_item() {
 async fn items_without_a_wtxid_are_not_cached() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
 
     for _ in 0..2 {
         verifier
@@ -564,7 +576,7 @@ async fn cache_does_not_reuse_a_result_across_items() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
 
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
 
     for wtx_id in [test_wtx_id(1), test_wtx_id(2)] {
         verifier
@@ -592,7 +604,7 @@ async fn cache_does_not_reuse_a_result_across_items() {
 async fn cache_does_not_remember_failures() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(false);
-    let mut verifier = Cached::new(inner.clone(), 8);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
 
     for _ in 0..3 {
         verifier
@@ -630,7 +642,7 @@ where
 async fn cache_evicts_in_insertion_order_and_stays_correct_when_full() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 2);
+    let mut verifier = Cached::new(inner.clone(), 2, TEST_CACHE_METRICS);
 
     let wtx_ids = [test_wtx_id(1), test_wtx_id(2), test_wtx_id(3)];
 
@@ -666,7 +678,7 @@ async fn cache_is_shared_between_clones() {
     let item = cacheable_item(&bundle, sighash, test_wtx_id(1));
 
     let inner = CountingVerifier::new(true);
-    let verifier = Cached::new(inner.clone(), 8);
+    let verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
 
     let mut warming_clone = verifier.clone();
     verify_through(&mut warming_clone, item.clone()).await;
@@ -726,7 +738,7 @@ async fn cancelling_a_verification_does_not_populate_the_cache() {
     let item = cacheable_item(&bundle, sighash, test_wtx_id(1));
 
     let hanging = PendingVerifier::new();
-    let mut verifier = Cached::new(hanging.clone(), 8);
+    let mut verifier = Cached::new(hanging.clone(), 8, TEST_CACHE_METRICS);
 
     // Start a verification and drop it before the inner service can answer.
     let in_flight = verifier
@@ -804,7 +816,7 @@ async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
 
     // Warm the cache through a healthy inner service.
     let healthy = CountingVerifier::new(true);
-    let mut verifier = Cached::new(healthy.clone(), 8);
+    let mut verifier = Cached::new(healthy.clone(), 8, TEST_CACHE_METRICS);
     verify_through(&mut verifier, item.clone()).await;
     assert_eq!(healthy.calls(), 1, "the first verification must be a miss");
 
@@ -836,7 +848,7 @@ async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
 async fn cache_miss_propagates_an_inner_readiness_failure() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let dead = UnreadyVerifier::new();
-    let mut verifier = Cached::new(dead.clone(), 8);
+    let mut verifier = Cached::new(dead.clone(), 8, TEST_CACHE_METRICS);
 
     verifier
         .ready()

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -666,6 +666,34 @@ async fn cache_evicts_in_insertion_order_and_stays_correct_when_full() {
 /// `&'static` handle and every request goes through a fresh `.clone()` of it. A cache that lived
 /// in the handle rather than behind the shared `Arc` would be empty for every request, so this
 /// pins the sharing that makes the cache reachable at all.
+/// A remembered result is never visible to another era's cache.
+///
+/// The cache key deliberately does not name the verifying key. What binds an entry to the key it
+/// was produced under is which era's cache holds it — [`batch_verifier`](super::batch_verifier)
+/// builds one per era, and [`verifier_routes_each_network_upgrade_to_the_correct_key`] pins the
+/// routing. This pins the other half: two cache instances share no state, so an item verified
+/// under the pre-NU6.2 insecure key can never be answered from that entry when it is later
+/// routed to a different era's verifier.
+#[tokio::test]
+async fn a_result_cached_under_one_era_is_not_visible_to_another() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+    let item = cacheable_item(&bundle, sighash, test_wtx_id(9));
+
+    let inner = CountingVerifier::new(true);
+    let mut one_era = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
+    let mut another_era = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
+
+    verify_through(&mut one_era, item.clone()).await;
+    assert_eq!(inner.calls(), 1, "the first verification must be a miss");
+
+    verify_through(&mut another_era, item).await;
+    assert_eq!(
+        inner.calls(),
+        2,
+        "another era's cache must not answer from an entry this one never recorded"
+    );
+}
+
 #[tokio::test]
 async fn cache_is_shared_between_clones() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -41,22 +41,16 @@ use zcash_protocol::value::ZatBalance;
 use crate::{error::TransactionError, BoxError};
 
 use super::{
-    lazy_verifier_for, BatchFallbackService, CacheKey, CacheMetrics, Cached, CachedItem, Item,
-    ItemVerifyingKey, OrchardFallback, Verifier, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD,
-    VERIFIER_PRE_NU6_2, VERIFYING_KEY_NU6_2, VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
+    lazy_verifier_for, BatchFallbackService, CacheKey, Cached, CachedItem, Item, ItemVerifyingKey,
+    OrchardFallback, Verifier, VERIFIER_NU6_2, VERIFIER_NU6_3_ONWARD, VERIFIER_PRE_NU6_2,
+    VERIFYING_KEY_NU6_2, VERIFYING_KEY_NU6_3_ONWARD, VERIFYING_KEY_PRE_NU6_2,
 };
 
-/// The metric names the test caches report under.
+/// The `verifier` label the test caches report their metrics under.
 ///
-/// Test caches use their own names so their counts never land in the metrics
+/// Test caches use their own label so their counts never land in the series
 /// the production verifiers report.
-const TEST_CACHE_METRICS: CacheMetrics = CacheMetrics {
-    hit: "zakura.consensus.halo2.test_cache.hit",
-    miss: "zakura.consensus.halo2.test_cache.miss",
-    insert: "zakura.consensus.halo2.test_cache.insert",
-    evict: "zakura.consensus.halo2.test_cache.evict",
-    size: "zakura.consensus.halo2.test_cache.size",
-};
+const TEST_CACHE_VERIFIER_LABEL: &str = "halo2_test";
 
 const EXPLICIT_FLUSH_TEST_MAX_BATCH_WEIGHT: usize = 10_000;
 const EXPLICIT_FLUSH_TEST_LATENCY: Duration = Duration::from_secs(1000);
@@ -529,7 +523,7 @@ impl Service<Item> for CountingVerifier {
 async fn cache_skips_the_inner_service_for_an_already_verified_item() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     for _ in 0..3 {
         verifier
@@ -552,7 +546,7 @@ async fn cache_skips_the_inner_service_for_an_already_verified_item() {
 async fn items_without_a_wtxid_are_not_cached() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     for _ in 0..2 {
         verifier
@@ -576,7 +570,7 @@ async fn cache_does_not_reuse_a_result_across_items() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
 
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     for wtx_id in [test_wtx_id(1), test_wtx_id(2)] {
         verifier
@@ -604,7 +598,7 @@ async fn cache_does_not_reuse_a_result_across_items() {
 async fn cache_does_not_remember_failures() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(false);
-    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     for _ in 0..3 {
         verifier
@@ -642,7 +636,7 @@ where
 async fn cache_evicts_in_insertion_order_and_stays_correct_when_full() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 2, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 2, TEST_CACHE_VERIFIER_LABEL);
 
     let wtx_ids = [test_wtx_id(1), test_wtx_id(2), test_wtx_id(3)];
 
@@ -678,7 +672,7 @@ async fn cache_is_shared_between_clones() {
     let item = cacheable_item(&bundle, sighash, test_wtx_id(1));
 
     let inner = CountingVerifier::new(true);
-    let verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     let mut warming_clone = verifier.clone();
     verify_through(&mut warming_clone, item.clone()).await;
@@ -738,7 +732,7 @@ async fn cancelling_a_verification_does_not_populate_the_cache() {
     let item = cacheable_item(&bundle, sighash, test_wtx_id(1));
 
     let hanging = PendingVerifier::new();
-    let mut verifier = Cached::new(hanging.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(hanging.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     // Start a verification and drop it before the inner service can answer.
     let in_flight = verifier
@@ -816,7 +810,7 @@ async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
 
     // Warm the cache through a healthy inner service.
     let healthy = CountingVerifier::new(true);
-    let mut verifier = Cached::new(healthy.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(healthy.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
     verify_through(&mut verifier, item.clone()).await;
     assert_eq!(healthy.calls(), 1, "the first verification must be a miss");
 
@@ -848,7 +842,7 @@ async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
 async fn cache_miss_propagates_an_inner_readiness_failure() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
     let dead = UnreadyVerifier::new();
-    let mut verifier = Cached::new(dead.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(dead.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     verifier
         .ready()

--- a/crates/zakura-consensus/src/primitives/halo2/tests.rs
+++ b/crates/zakura-consensus/src/primitives/halo2/tests.rs
@@ -660,12 +660,6 @@ async fn cache_evicts_in_insertion_order_and_stays_correct_when_full() {
     assert_eq!(inner.calls(), 4, "an evicted entry must be re-verified");
 }
 
-/// Clones of a cache answer from the same set of verified proofs.
-///
-/// Production never calls a global verifier directly: [`super::verifier_for`] hands out a
-/// `&'static` handle and every request goes through a fresh `.clone()` of it. A cache that lived
-/// in the handle rather than behind the shared `Arc` would be empty for every request, so this
-/// pins the sharing that makes the cache reachable at all.
 /// A remembered result is never visible to another era's cache.
 ///
 /// The cache key deliberately does not name the verifying key. What binds an entry to the key it
@@ -694,6 +688,12 @@ async fn a_result_cached_under_one_era_is_not_visible_to_another() {
     );
 }
 
+/// Clones of a cache answer from the same set of verified proofs.
+///
+/// Production never calls a global verifier directly: [`super::verifier_for`] hands out a
+/// `&'static` handle and every request goes through a fresh `.clone()` of it. A cache that lived
+/// in the handle rather than behind the shared `Arc` would be empty for every request, so this
+/// pins the sharing that makes the cache reachable at all.
 #[tokio::test]
 async fn cache_is_shared_between_clones() {
     let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();

--- a/crates/zakura-consensus/src/primitives/sapling.rs
+++ b/crates/zakura-consensus/src/primitives/sapling.rs
@@ -23,19 +23,15 @@ use zcash_protocol::value::ZatBalance;
 
 use crate::{error::TransactionError, BoxError};
 
-use super::cache::{CacheKey, CacheMetrics, Cached, CachedItem, ShieldedPool, CACHE_CAPACITY};
+use super::cache::{CacheKey, Cached, CachedItem, ShieldedPool, CACHE_CAPACITY};
 
 #[cfg(test)]
 mod tests;
 
-/// The metric names the Sapling cache reports under.
-const CACHE_METRICS: CacheMetrics = CacheMetrics {
-    hit: "zakura.consensus.sapling.cache.hit",
-    miss: "zakura.consensus.sapling.cache.miss",
-    insert: "zakura.consensus.sapling.cache.insert",
-    evict: "zakura.consensus.sapling.cache.evict",
-    size: "zakura.consensus.sapling.cache.size",
-};
+/// The `verifier` label the Sapling cache reports its metrics under.
+///
+/// It matches the label this verifier's batch duration metric already uses.
+const CACHE_VERIFIER_LABEL: &str = "groth16_sapling";
 
 /// Sapling prover containing spend and output params for the Sapling circuit.
 ///
@@ -291,8 +287,13 @@ type VerifierService = Cached<BatchFallbackService>;
 /// gossiped into the mempool does not have to be verified again when the block that mines it
 /// arrives. One cache covers all of Sapling: its spend and output verifying keys have never
 /// changed, so unlike Orchard there are no circuit eras to keep apart.
-pub static VERIFIER: Lazy<VerifierService> =
-    Lazy::new(|| Cached::new(batch_fallback_verifier(), CACHE_CAPACITY, CACHE_METRICS));
+pub static VERIFIER: Lazy<VerifierService> = Lazy::new(|| {
+    Cached::new(
+        batch_fallback_verifier(),
+        CACHE_CAPACITY,
+        CACHE_VERIFIER_LABEL,
+    )
+});
 
 /// Builds the uncached batching-and-fallback stack.
 fn batch_fallback_verifier() -> BatchFallbackService {

--- a/crates/zakura-consensus/src/primitives/sapling.rs
+++ b/crates/zakura-consensus/src/primitives/sapling.rs
@@ -68,11 +68,9 @@ impl Item {
     /// Creates a new [`Item`] from a Sapling bundle, its sighash, and its transaction's ID.
     ///
     /// `tx_id` must identify the transaction containing `bundle`, because the cache treats it as
-    /// determining the bundle — see [`Item::cache_key`]. The transaction verifier passes the
-    /// precomputed ID from its [`Request`](crate::transaction::Request), whose caller must
-    /// preserve this invariant.
-    ///
-    /// [`Item::cache_key`]: Item#method.cache_key
+    /// determining the bundle — see this type's [`CachedItem`] implementation. The transaction
+    /// verifier passes the precomputed ID from its [`Request`](crate::transaction::Request),
+    /// whose caller must preserve this invariant.
     pub fn new(
         bundle: Bundle<Authorized, ZatBalance>,
         sighash: SigHash,
@@ -96,8 +94,12 @@ impl CachedItem for Item {
     /// authorizing data. So unlike Orchard, which only exists in v5 and v6 transactions, Sapling
     /// caches v4 bundles too.
     ///
-    /// The sighash additionally commits to the amounts and scripts of spent transparent outputs,
-    /// which are supplied by the verification context and are not part of the transaction ID.
+    /// The sighash is keyed separately because it is not always a function of the transaction
+    /// alone. A v5 or v6 sighash also commits to the amounts and scripts of the spent transparent
+    /// outputs, which the verification context supplies. A v4 shielded sighash does not — it is
+    /// computed with no input index, so ZIP 143 and ZIP 243 leave the spent output out — but it
+    /// does commit to the consensus branch id of the block, which the transaction ID of a v4
+    /// transaction does not carry.
     ///
     /// The verifying keys are absent on purpose: Sapling has one spend and one output verifying
     /// key for all of history, so unlike Orchard it has no circuit eras to keep apart, and every

--- a/crates/zakura-consensus/src/primitives/sapling.rs
+++ b/crates/zakura-consensus/src/primitives/sapling.rs
@@ -17,11 +17,25 @@ use tower_batch_control::{Batch, BatchControl, RequestWeight};
 use tower_fallback::Fallback;
 
 use sapling_crypto::{bundle::Authorized, BatchValidator, Bundle};
-use zakura_chain::transaction::SigHash;
+use zakura_chain::transaction::{SigHash, UnminedTxId};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::value::ZatBalance;
 
 use crate::{error::TransactionError, BoxError};
+
+use super::cache::{CacheKey, CacheMetrics, Cached, CachedItem, ShieldedPool, CACHE_CAPACITY};
+
+#[cfg(test)]
+mod tests;
+
+/// The metric names the Sapling cache reports under.
+const CACHE_METRICS: CacheMetrics = CacheMetrics {
+    hit: "zakura.consensus.sapling.cache.hit",
+    miss: "zakura.consensus.sapling.cache.miss",
+    insert: "zakura.consensus.sapling.cache.insert",
+    evict: "zakura.consensus.sapling.cache.evict",
+    size: "zakura.consensus.sapling.cache.size",
+};
 
 /// Sapling prover containing spend and output params for the Sapling circuit.
 ///
@@ -40,18 +54,60 @@ pub fn sapling_prover() -> &'static LocalTxProver {
     Lazy::force(&SAPLING)
 }
 
+/// A Sapling verification item, used as the request type of the service.
+///
+/// Every item carries the cache key its successful verification is remembered under, derived
+/// from its transaction's ID and sighash.
 #[derive(Clone)]
 pub struct Item {
     /// The bundle containing the Sapling shielded data to verify.
     bundle: Bundle<Authorized, ZatBalance>,
     /// The sighash of the transaction that contains the Sapling shielded data.
     sighash: SigHash,
+    /// The key this item's successful verification is remembered under.
+    cache_key: CacheKey,
 }
 
 impl Item {
-    /// Creates a new [`Item`] from a Sapling bundle and sighash.
-    pub fn new(bundle: Bundle<Authorized, ZatBalance>, sighash: SigHash) -> Self {
-        Self { bundle, sighash }
+    /// Creates a new [`Item`] from a Sapling bundle, its sighash, and its transaction's ID.
+    ///
+    /// `tx_id` must identify the transaction containing `bundle`, because the cache treats it as
+    /// determining the bundle — see [`Item::cache_key`]. The transaction verifier passes the
+    /// precomputed ID from its [`Request`](crate::transaction::Request), whose caller must
+    /// preserve this invariant.
+    ///
+    /// [`Item::cache_key`]: Item#method.cache_key
+    pub fn new(
+        bundle: Bundle<Authorized, ZatBalance>,
+        sighash: SigHash,
+        tx_id: UnminedTxId,
+    ) -> Self {
+        Self {
+            bundle,
+            sighash,
+            cache_key: CacheKey::new(tx_id, sighash.0, ShieldedPool::Sapling),
+        }
+    }
+}
+
+impl CachedItem for Item {
+    /// Returns the key this item's successful verification is remembered under.
+    ///
+    /// The transaction ID commits to the bundle, in both of the forms it takes. A v5 or v6
+    /// transaction's [`WtxId`](zakura_chain::transaction::WtxId) pairs a txid over the effecting
+    /// data with a ZIP 244 authorizing-data digest over the proofs and signatures; a v4
+    /// transaction's legacy ID is the hash of its whole serialization, which contains the same
+    /// authorizing data. So unlike Orchard, which only exists in v5 and v6 transactions, Sapling
+    /// caches v4 bundles too.
+    ///
+    /// The sighash additionally commits to the amounts and scripts of spent transparent outputs,
+    /// which are supplied by the verification context and are not part of the transaction ID.
+    ///
+    /// The verifying keys are absent on purpose: Sapling has one spend and one output verifying
+    /// key for all of history, so unlike Orchard it has no circuit eras to keep apart, and every
+    /// entry in this cache was written under the same keys it is read back under.
+    fn cache_key(&self) -> Option<CacheKey> {
+        Some(self.cache_key)
     }
 }
 
@@ -220,15 +276,26 @@ pub fn verify_single(
     .boxed()
 }
 
+/// The batching-and-fallback stack for Sapling bundle verification, before caching.
+type BatchFallbackService = Fallback<
+    Batch<Verifier, Item>,
+    ServiceFn<fn(Item) -> BoxFuture<'static, Result<(), Box<dyn std::error::Error + Send + Sync>>>>,
+>;
+
+/// The concrete type of the global Sapling verification service.
+type VerifierService = Cached<BatchFallbackService>;
+
 /// Global batch verification context for Sapling shielded data.
-pub static VERIFIER: Lazy<
-    Fallback<
-        Batch<Verifier, Item>,
-        ServiceFn<
-            fn(Item) -> BoxFuture<'static, Result<(), Box<dyn std::error::Error + Send + Sync>>>,
-        >,
-    >,
-> = Lazy::new(|| {
+///
+/// The stack is wrapped in a [`Cached`] so that a bundle verified when its transaction was
+/// gossiped into the mempool does not have to be verified again when the block that mines it
+/// arrives. One cache covers all of Sapling: its spend and output verifying keys have never
+/// changed, so unlike Orchard there are no circuit eras to keep apart.
+pub static VERIFIER: Lazy<VerifierService> =
+    Lazy::new(|| Cached::new(batch_fallback_verifier(), CACHE_CAPACITY, CACHE_METRICS));
+
+/// Builds the uncached batching-and-fallback stack.
+fn batch_fallback_verifier() -> BatchFallbackService {
     Fallback::new(
         Batch::new(
             Verifier::default(),
@@ -236,16 +303,17 @@ pub static VERIFIER: Lazy<
             None,
             super::MAX_BATCH_LATENCY,
         ),
-        tower::service_fn(verify_single),
+        tower::service_fn(verify_single as fn(Item) -> _),
     )
-});
+}
 
+/// Attempts to flush the batching service wrapped by `verifier`.
+pub(super) fn try_flush(verifier: &VerifierService) -> Result<bool, BoxError> {
+    verifier.inner().primary().clone().try_flush()
+}
+
+/// Returns how many times `item` has reached the inner Sapling verifier.
 #[cfg(test)]
-mod tests {
-    use super::sapling_prover;
-
-    #[test]
-    fn sapling_prover_is_reused() {
-        assert!(std::ptr::eq(sapling_prover(), sapling_prover()));
-    }
+pub(crate) fn inner_calls_for(item: &Item) -> usize {
+    VERIFIER.inner_calls_for(item)
 }

--- a/crates/zakura-consensus/src/primitives/sapling.rs
+++ b/crates/zakura-consensus/src/primitives/sapling.rs
@@ -28,10 +28,11 @@ use super::cache::{CacheKey, Cached, CachedItem, ShieldedPool, CACHE_CAPACITY};
 #[cfg(test)]
 mod tests;
 
-/// The `verifier` label the Sapling cache reports its metrics under.
+/// The name this verifier reports under in every metric and log line.
 ///
-/// It matches the label this verifier's batch duration metric already uses.
-const CACHE_VERIFIER_LABEL: &str = "groth16_sapling";
+/// The cache metrics, the batch duration histogram and the explicit-flush log all carry it, so
+/// one verifier is named the same way everywhere.
+pub(super) const VERIFIER_NAME: &str = "groth16_sapling";
 
 /// Sapling prover containing spend and output params for the Sapling circuit.
 ///
@@ -71,7 +72,7 @@ impl Item {
     /// determining the bundle — see this type's [`CachedItem`] implementation. The transaction
     /// verifier passes the precomputed ID from its [`Request`](crate::transaction::Request),
     /// whose caller must preserve this invariant.
-    pub fn new(
+    pub(crate) fn new(
         bundle: Bundle<Authorized, ZatBalance>,
         sighash: SigHash,
         tx_id: UnminedTxId,
@@ -227,7 +228,7 @@ impl Service<BatchControl<Item>> for Verifier {
                     };
                     metrics::histogram!(
                         "zakura.consensus.batch.duration_seconds",
-                        "verifier" => "groth16_sapling",
+                        "verifier" => VERIFIER_NAME,
                         "result" => result_label
                     )
                     .record(duration);
@@ -289,13 +290,8 @@ type VerifierService = Cached<BatchFallbackService>;
 /// gossiped into the mempool does not have to be verified again when the block that mines it
 /// arrives. One cache covers all of Sapling: its spend and output verifying keys have never
 /// changed, so unlike Orchard there are no circuit eras to keep apart.
-pub static VERIFIER: Lazy<VerifierService> = Lazy::new(|| {
-    Cached::new(
-        batch_fallback_verifier(),
-        CACHE_CAPACITY,
-        CACHE_VERIFIER_LABEL,
-    )
-});
+pub static VERIFIER: Lazy<VerifierService> =
+    Lazy::new(|| Cached::new(batch_fallback_verifier(), CACHE_CAPACITY, VERIFIER_NAME));
 
 /// Builds the uncached batching-and-fallback stack.
 fn batch_fallback_verifier() -> BatchFallbackService {
@@ -310,7 +306,11 @@ fn batch_fallback_verifier() -> BatchFallbackService {
     )
 }
 
-/// Attempts to flush the batching service wrapped by `verifier`.
+/// Attempts to queue an explicit flush of the batch service inside `verifier`.
+///
+/// Returns `Ok(true)` when it queued the flush, and `Ok(false)` when the batch queue has no free
+/// capacity — a full queue is already flushing on size, so the caller skips it rather than
+/// waiting. An `Err` reports that the batch worker has exited.
 pub(super) fn try_flush(verifier: &VerifierService) -> Result<bool, BoxError> {
     verifier.inner().primary().clone().try_flush()
 }

--- a/crates/zakura-consensus/src/primitives/sapling/tests.rs
+++ b/crates/zakura-consensus/src/primitives/sapling/tests.rs
@@ -32,19 +32,13 @@ use zakura_chain::{
 
 use crate::BoxError;
 
-use super::{sapling_prover, CacheKey, CacheMetrics, Cached, CachedItem, Item};
+use super::{sapling_prover, CacheKey, Cached, CachedItem, Item};
 
-/// The metric names the test caches report under.
+/// The `verifier` label the test caches report their metrics under.
 ///
-/// Test caches use their own names so their counts never land in the metrics the production
+/// Test caches use their own label so their counts never land in the series the production
 /// verifier reports.
-const TEST_CACHE_METRICS: CacheMetrics = CacheMetrics {
-    hit: "zakura.consensus.sapling.test_cache.hit",
-    miss: "zakura.consensus.sapling.test_cache.miss",
-    insert: "zakura.consensus.sapling.test_cache.insert",
-    evict: "zakura.consensus.sapling.test_cache.evict",
-    size: "zakura.consensus.sapling.test_cache.size",
-};
+const TEST_CACHE_VERIFIER_LABEL: &str = "groth16_sapling_test";
 
 #[test]
 fn sapling_prover_is_reused() {
@@ -425,7 +419,7 @@ impl Service<Item> for CountingVerifier {
 async fn cache_skips_the_inner_service_for_an_already_verified_bundle() {
     let tx = sapling_transaction();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     for _ in 0..3 {
         verifier
@@ -448,7 +442,7 @@ async fn cache_skips_the_inner_service_for_an_already_verified_bundle() {
 async fn cache_does_not_reuse_a_result_across_bundles() {
     let transactions = sapling_transactions();
     let inner = CountingVerifier::new(true);
-    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     for tx in transactions.iter().take(2) {
         verifier
@@ -476,7 +470,7 @@ async fn cache_does_not_reuse_a_result_across_bundles() {
 async fn cache_does_not_remember_failures() {
     let tx = sapling_transaction();
     let inner = CountingVerifier::new(false);
-    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     for _ in 0..3 {
         verifier
@@ -540,7 +534,7 @@ async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
     let tx = sapling_transaction();
 
     let healthy = CountingVerifier::new(true);
-    let mut verifier = Cached::new(healthy.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(healthy.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
     verifier
         .ready()
         .await
@@ -574,7 +568,7 @@ async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
 async fn cache_miss_propagates_an_inner_readiness_failure() {
     let tx = sapling_transaction();
     let dead = UnreadyVerifier::new();
-    let mut verifier = Cached::new(dead.clone(), 8, TEST_CACHE_METRICS);
+    let mut verifier = Cached::new(dead.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
 
     verifier
         .ready()
@@ -612,7 +606,11 @@ async fn cache_miss_propagates_an_inner_readiness_failure() {
 /// fallback stack behind a fresh cache, so a test can prove what a cold cache does with real
 /// Sapling verification underneath.
 fn uncached_verification_behind_a_fresh_cache() -> Cached<super::BatchFallbackService> {
-    Cached::new(super::batch_fallback_verifier(), 8, TEST_CACHE_METRICS)
+    Cached::new(
+        super::batch_fallback_verifier(),
+        8,
+        TEST_CACHE_VERIFIER_LABEL,
+    )
 }
 
 /// The cache still rejects an invalid bundle after a valid one, with real verification underneath.

--- a/crates/zakura-consensus/src/primitives/sapling/tests.rs
+++ b/crates/zakura-consensus/src/primitives/sapling/tests.rs
@@ -1,0 +1,672 @@
+//! Tests for the Sapling bundle verifier.
+//!
+//! Most of these are cache-key completeness tests. [`Cached`] reuses a previous `Ok` for any item
+//! whose key matches, so a key that misses one of verification's inputs is a consensus bug: it
+//! would accept a bundle that was never checked.
+//!
+//! Sapling keys its entries the same way Halo2 does — transaction ID, sighash and pool — but its
+//! bundles also appear in v4 transactions, which have no witnessed ID. These tests pin both
+//! forms: that a v4 transaction's legacy ID covers its Sapling proofs and signatures, and that a
+//! v5 transaction's authorizing-data digest does, since its txid does not.
+
+use std::{
+    future,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+};
+
+use tower::{Service, ServiceExt};
+use zakura_chain::{
+    amount::Amount,
+    block::{Block, Height},
+    parameters::{Network, NetworkUpgrade},
+    primitives::Groth16Proof,
+    sapling::{PerSpendAnchor, ShieldedData, Spend, TransferData},
+    serialization::{AtLeastOne, ZcashDeserializeInto},
+    transaction::{arbitrary::transaction_to_fake_v5, HashType, Transaction},
+    transparent,
+};
+
+use crate::BoxError;
+
+use super::{sapling_prover, CacheKey, CacheMetrics, Cached, CachedItem, Item};
+
+/// The metric names the test caches report under.
+///
+/// Test caches use their own names so their counts never land in the metrics the production
+/// verifier reports.
+const TEST_CACHE_METRICS: CacheMetrics = CacheMetrics {
+    hit: "zakura.consensus.sapling.test_cache.hit",
+    miss: "zakura.consensus.sapling.test_cache.miss",
+    insert: "zakura.consensus.sapling.test_cache.insert",
+    evict: "zakura.consensus.sapling.test_cache.evict",
+    size: "zakura.consensus.sapling.test_cache.size",
+};
+
+#[test]
+fn sapling_prover_is_reused() {
+    assert!(std::ptr::eq(sapling_prover(), sapling_prover()));
+}
+
+/// Returns the mainnet test transactions that carry a Sapling bundle, with the network upgrade
+/// each one was mined under.
+///
+/// Transactions with transparent inputs are skipped, because their sighash needs the previous
+/// outputs they spend, which are not in the test vectors.
+///
+/// The upgrade matters for the tests that actually verify: a V4 sighash commits to the consensus
+/// branch id, so a real bundle only verifies under the upgrade its block was mined in. The
+/// cache-key tests do not need a valid sighash and pass an upgrade of their own.
+fn mined_sapling_transactions() -> Vec<(NetworkUpgrade, Transaction)> {
+    let mut transactions = Vec::new();
+
+    for (height, bytes) in zakura_test::vectors::MAINNET_BLOCKS.iter() {
+        let block: Block = bytes
+            .zcash_deserialize_into()
+            .expect("hard-coded test vector must deserialize");
+
+        let nu = NetworkUpgrade::current(&Network::Mainnet, Height(*height));
+
+        for tx in &block.transactions {
+            if !tx.inputs().is_empty() {
+                continue;
+            }
+
+            if item(tx, nu).is_some() {
+                transactions.push((nu, tx.as_ref().clone()));
+            }
+        }
+    }
+
+    assert!(
+        !transactions.is_empty(),
+        "mainnet test blocks must contain a transparent-input-free Sapling transaction"
+    );
+
+    transactions
+}
+
+/// Returns the mainnet test transactions that carry a Sapling bundle.
+fn sapling_transactions() -> Vec<Transaction> {
+    mined_sapling_transactions()
+        .into_iter()
+        .map(|(_, tx)| tx)
+        .collect()
+}
+
+/// Returns one real mainnet Sapling transaction.
+fn sapling_transaction() -> Transaction {
+    sapling_transactions()
+        .into_iter()
+        .next()
+        .expect("there is at least one Sapling transaction")
+}
+
+/// Returns one real mainnet V4 Sapling transaction that has spends, with the network upgrade it
+/// was mined under.
+///
+/// It has spends so that every field `check_bundle` batches is present to mutate, and it is V4
+/// because that is the shape the mutation helpers are written against.
+fn mined_v4_sapling_transaction_with_spends() -> (NetworkUpgrade, Transaction) {
+    mined_sapling_transactions()
+        .into_iter()
+        .find(|(_, tx)| {
+            matches!(tx, Transaction::V4 { .. }) && tx.sapling_spends_per_anchor().next().is_some()
+        })
+        .expect("mainnet test blocks must contain a V4 Sapling transaction with spends")
+}
+
+/// Returns one real mainnet V4 Sapling transaction that has spends.
+fn sapling_transaction_with_spends() -> Transaction {
+    mined_v4_sapling_transaction_with_spends().1
+}
+
+/// Returns the verification item for `tx`'s Sapling bundle under `nu`, if it has one.
+fn item(tx: &Transaction, nu: NetworkUpgrade) -> Option<Item> {
+    let all_previous_outputs: Arc<Vec<transparent::Output>> = Arc::new(Vec::new());
+    let sighasher = tx.sighasher(nu, all_previous_outputs).ok()?;
+    let bundle = sighasher.sapling_bundle()?;
+
+    Some(Item::new(
+        bundle,
+        sighasher.sighash(HashType::ALL, None),
+        tx.unmined_id(),
+    ))
+}
+
+/// Returns the cache key of `tx`'s Sapling bundle under `nu`.
+fn cache_key(tx: &Transaction, nu: NetworkUpgrade) -> CacheKey {
+    item(tx, nu)
+        .expect("the transaction was selected for having a Sapling bundle")
+        .cache_key()
+        .expect("every Sapling item carries a cache key")
+}
+
+/// Returns `tx` with `mutate` applied to its V4 Sapling shielded data.
+///
+/// The Sapling test vectors are V4 transactions, so the mutations are written against that shape
+/// once; the V5 tests convert the result with [`as_fake_v5`].
+fn mutated_transaction(
+    tx: &Transaction,
+    mutate: impl FnOnce(&mut ShieldedData<PerSpendAnchor>),
+) -> Transaction {
+    let mut mutated = tx.clone();
+
+    let Transaction::V4 {
+        sapling_shielded_data: Some(shielded_data),
+        ..
+    } = &mut mutated
+    else {
+        panic!("this fixture is a V4 transaction with Sapling shielded data")
+    };
+    mutate(shielded_data);
+
+    mutated
+}
+
+/// Returns `tx` with `mutate` applied to the first spend of its V4 Sapling shielded data.
+fn mutated_spend(tx: &Transaction, mutate: impl FnOnce(&mut Spend<PerSpendAnchor>)) -> Transaction {
+    mutated_transaction(tx, |shielded_data| {
+        let TransferData::SpendsAndMaybeOutputs { spends, .. } = &mut shielded_data.transfers
+        else {
+            panic!("the fixture was selected for having spends")
+        };
+
+        let mut spends_vec = spends.as_slice().to_vec();
+        mutate(&mut spends_vec[0]);
+        *spends =
+            AtLeastOne::from_vec(spends_vec).expect("replacing a field keeps at least one spend");
+    })
+}
+
+/// Returns `tx` as a V5 transaction carrying the same Sapling bundle.
+///
+/// The Sapling test vectors are V4 transactions, so this is how the V5 side of the key — the
+/// ZIP 244 authorizing-data digest — gets exercised over real bundles.
+fn as_fake_v5(tx: &Transaction) -> Transaction {
+    let network = Network::Mainnet;
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 has an activation height on Mainnet");
+
+    let v5 = transaction_to_fake_v5(tx, &network, nu5_height);
+    assert!(
+        matches!(v5, Transaction::V5 { .. }),
+        "the fixture must have been converted to V5"
+    );
+
+    v5
+}
+
+#[test]
+fn cache_key_is_deterministic() {
+    let tx = sapling_transaction();
+
+    assert_eq!(
+        cache_key(&tx, NetworkUpgrade::Nu5),
+        cache_key(&tx, NetworkUpgrade::Nu5),
+        "the same transaction, bundle and sighash must always produce the same key"
+    );
+}
+
+/// Two different Sapling bundles get different keys.
+#[test]
+fn cache_key_distinguishes_different_transactions() {
+    let transactions = sapling_transactions();
+
+    assert!(
+        transactions.len() > 1,
+        "this test needs at least two Sapling transactions in the test vectors"
+    );
+
+    let keys: Vec<_> = transactions
+        .iter()
+        .map(|tx| cache_key(tx, NetworkUpgrade::Nu5))
+        .collect();
+
+    let unique: std::collections::HashSet<_> = keys.iter().collect();
+    assert_eq!(
+        unique.len(),
+        keys.len(),
+        "distinct Sapling transactions must not share a cache key"
+    );
+}
+
+/// The sighash is part of the key.
+///
+/// It is not a function of the transaction alone: the amounts and scripts of the spent
+/// transparent outputs enter it, and those come from the verification context.
+#[test]
+fn cache_key_commits_to_the_sighash() {
+    let tx = sapling_transaction();
+    let original = item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle");
+
+    let mut tweaked_sighash = original.sighash;
+    tweaked_sighash.0[0] ^= 1;
+    let tweaked = Item::new(original.bundle.clone(), tweaked_sighash, tx.unmined_id());
+
+    assert_ne!(
+        original.cache_key(),
+        tweaked.cache_key(),
+        "the sighash is an input to verification, so it must be an input to the key"
+    );
+}
+
+/// Every piece of authorizing data that verification reads changes a V4 transaction's key.
+///
+/// `check_bundle` batches each spend's proof and `spendAuthSig`, each output's proof, and the
+/// binding signature, and `value_balance` enters the binding verification key. A v1-v4
+/// transaction ID is the hash of the whole serialized transaction, so each of those is inside it.
+#[test]
+fn v4_cache_key_changes_with_every_piece_of_authorizing_data() {
+    let tx = sapling_transaction_with_spends();
+    let original = cache_key(&tx, NetworkUpgrade::Nu5);
+
+    let mutations = authorizing_data_mutations(&tx).into_iter().chain([(
+        mutated_value_balance(&tx),
+        "the value balance, which enters the binding verification key",
+    )]);
+
+    for (mutated, what) in mutations {
+        assert_ne!(
+            original,
+            cache_key(&mutated, NetworkUpgrade::Nu5),
+            "{what} is verified, so it must be an input to the key"
+        );
+    }
+}
+
+/// The same authorizing data changes a V5 transaction's key, which its txid does not cover.
+///
+/// This is the shape of CVE-2026-34377: under ZIP 244 a v5 transaction's txid excludes proofs and
+/// signatures, so a key derived from the txid alone would collide across all of these mutations.
+/// The [`WtxId`](zakura_chain::transaction::WtxId) in the key carries the authorizing-data digest
+/// as well, which is what makes it complete.
+#[test]
+fn v5_cache_key_changes_with_authorizing_data_its_txid_ignores() {
+    let v4 = sapling_transaction_with_spends();
+    let v5 = as_fake_v5(&v4);
+    let original = cache_key(&v5, NetworkUpgrade::Nu5);
+
+    for (mutated, what) in authorizing_data_mutations(&v4) {
+        let mutated = as_fake_v5(&mutated);
+
+        assert_eq!(
+            v5.hash(),
+            mutated.hash(),
+            "changing {what} must leave the V5 txid alone, or this test proves nothing"
+        );
+        assert_ne!(
+            original,
+            cache_key(&mutated, NetworkUpgrade::Nu5),
+            "{what} is verified, so it must be an input to the key"
+        );
+    }
+
+    // The value balance is the one input to the same check that a V5 txid does cover.
+    assert_ne!(
+        original,
+        cache_key(
+            &as_fake_v5(&mutated_value_balance(&v4)),
+            NetworkUpgrade::Nu5
+        ),
+        "the value balance enters the binding verification key, so it must be in the key"
+    );
+}
+
+/// Returns `tx` with each piece of the authorizing data `check_bundle` reads mutated in turn.
+///
+/// These are the fields ZIP 244 puts in a v5 transaction's authorizing-data digest rather than
+/// its txid, so mutating one leaves the v5 txid unchanged.
+fn authorizing_data_mutations(tx: &Transaction) -> Vec<(Transaction, &'static str)> {
+    vec![
+        (
+            mutated_spend(tx, |spend| spend.zkproof = Groth16Proof([0xFF; 192])),
+            "a spend proof",
+        ),
+        (
+            mutated_spend(tx, |spend| spend.spend_auth_sig = [0xFF; 64].into()),
+            "a spend authorization signature",
+        ),
+        (
+            mutated_transaction(tx, |shielded_data| {
+                shielded_data.binding_sig = [0xFF; 64].into()
+            }),
+            "the binding signature",
+        ),
+    ]
+}
+
+/// Returns `tx` with its Sapling value balance changed.
+///
+/// `value_balance` is the one input to the binding signature check that is effecting data, so it
+/// is inside every transaction ID rather than only the authorizing-data digest.
+fn mutated_value_balance(tx: &Transaction) -> Transaction {
+    mutated_transaction(tx, |shielded_data| {
+        shielded_data.value_balance = (shielded_data.value_balance
+            + Amount::try_from(1).expect("one is a valid amount"))
+        .expect("the fixture's value balance is not at the maximum");
+    })
+}
+
+/// A V4 transaction and a V5 carrying the same Sapling bundle do not share a key.
+///
+/// The two transaction IDs are computed differently and over different bytes, so this is
+/// automatic. It is pinned because the two bundles verify identically, which is exactly when a
+/// key that named the bundle instead of the transaction could collide.
+#[test]
+fn cache_key_distinguishes_v4_and_v5_carrying_the_same_bundle() {
+    let v4 = sapling_transactions()
+        .into_iter()
+        .find(|tx| matches!(tx, Transaction::V4 { .. }))
+        .expect("mainnet test blocks must contain a V4 Sapling transaction");
+    let v5 = as_fake_v5(&v4);
+
+    let v4_item = item(&v4, NetworkUpgrade::Nu5).expect("the V4 transaction has a bundle");
+    let v5_item = item(&v5, NetworkUpgrade::Nu5).expect("the V5 transaction has a bundle");
+
+    assert_eq!(
+        format!("{:?}", v4_item.bundle),
+        format!("{:?}", v5_item.bundle),
+        "the conversion must carry the Sapling bundle across unchanged, or this test proves \
+         nothing"
+    );
+    assert_ne!(
+        v4_item.cache_key(),
+        v5_item.cache_key(),
+        "the same bundle in two transaction versions must not share a cache key"
+    );
+}
+
+/// A verifier that counts calls and always returns the same verdict.
+#[derive(Clone)]
+struct CountingVerifier {
+    calls: Arc<AtomicUsize>,
+    accepts: bool,
+}
+
+impl CountingVerifier {
+    fn new(accepts: bool) -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+            accepts,
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl Service<Item> for CountingVerifier {
+    type Response = ();
+    type Error = BoxError;
+    type Future = future::Ready<Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _item: Item) -> Self::Future {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+
+        future::ready(if self.accepts {
+            Ok(())
+        } else {
+            Err(BoxError::from("rejected"))
+        })
+    }
+}
+
+#[tokio::test]
+async fn cache_skips_the_inner_service_for_an_already_verified_bundle() {
+    let tx = sapling_transaction();
+    let inner = CountingVerifier::new(true);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+
+    for _ in 0..3 {
+        verifier
+            .ready()
+            .await
+            .expect("the cache must become ready")
+            .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+            .await
+            .expect("a valid item must verify");
+    }
+
+    assert_eq!(
+        inner.calls(),
+        1,
+        "only the first verification of a bundle may reach the inner service"
+    );
+}
+
+#[tokio::test]
+async fn cache_does_not_reuse_a_result_across_bundles() {
+    let transactions = sapling_transactions();
+    let inner = CountingVerifier::new(true);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+
+    for tx in transactions.iter().take(2) {
+        verifier
+            .ready()
+            .await
+            .expect("the cache must become ready")
+            .call(item(tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+            .await
+            .expect("the inner service accepts everything in this test");
+    }
+
+    assert_eq!(
+        inner.calls(),
+        2,
+        "bundles with different keys must each be verified"
+    );
+}
+
+/// A failure is never remembered.
+///
+/// A batch error is not per-item evidence — `Fallback` resolves those by re-verifying singly —
+/// and an error can report that the batch worker shut down rather than that a proof is invalid.
+/// Remembering either as "invalid" would make the node reject valid blocks.
+#[tokio::test]
+async fn cache_does_not_remember_failures() {
+    let tx = sapling_transaction();
+    let inner = CountingVerifier::new(false);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_METRICS);
+
+    for _ in 0..3 {
+        verifier
+            .ready()
+            .await
+            .expect("the cache must become ready")
+            .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+            .await
+            .expect_err("the inner service rejects everything in this test");
+    }
+
+    assert_eq!(
+        inner.calls(),
+        3,
+        "a failed verification must not be remembered"
+    );
+}
+
+/// An inner service whose readiness always fails, standing in for a dead batch worker.
+#[derive(Clone)]
+struct UnreadyVerifier {
+    poll_readies: Arc<AtomicUsize>,
+}
+
+impl UnreadyVerifier {
+    fn new() -> Self {
+        Self {
+            poll_readies: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn poll_readies(&self) -> usize {
+        self.poll_readies.load(Ordering::SeqCst)
+    }
+}
+
+impl Service<Item> for UnreadyVerifier {
+    type Response = ();
+    type Error = BoxError;
+    type Future = future::Ready<Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.poll_readies.fetch_add(1, Ordering::SeqCst);
+        Poll::Ready(Err(BoxError::from("batch worker finished unexpectedly")))
+    }
+
+    fn call(&mut self, _item: Item) -> Self::Future {
+        unreachable!("a service whose poll_ready failed must not be called")
+    }
+}
+
+/// A Sapling cache hit is answered even when the inner service can no longer become ready.
+///
+/// The Sapling verifier shares [`Cached`] with Halo2, so this is the same property
+/// `cache_hit_survives_an_inner_service_that_never_becomes_ready` pins there. It is worth pinning
+/// per pool as well: the shared `poll_ready` must not start delegating again for either of them,
+/// and a `Batch` whose worker has exited would otherwise turn a remembered `Ok` into a
+/// verification failure.
+#[tokio::test]
+async fn cache_hit_survives_an_inner_service_that_never_becomes_ready() {
+    let tx = sapling_transaction();
+
+    let healthy = CountingVerifier::new(true);
+    let mut verifier = Cached::new(healthy.clone(), 8, TEST_CACHE_METRICS);
+    verifier
+        .ready()
+        .await
+        .expect("the cache must become ready")
+        .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+        .await
+        .expect("the first verification must succeed");
+    assert_eq!(healthy.calls(), 1, "the first verification must be a miss");
+
+    let dead = UnreadyVerifier::new();
+    let mut verifier = verifier.with_inner(dead.clone());
+
+    verifier
+        .ready()
+        .await
+        .expect("the cache must be ready even when the inner service is not")
+        .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+        .await
+        .expect("a cache hit must be answered from the cache, not from the dead inner service");
+
+    assert_eq!(
+        dead.poll_readies(),
+        0,
+        "a hit must not poll the inner service for readiness at all"
+    );
+}
+
+/// A Sapling cache miss still propagates an inner readiness failure, and does not record it as a
+/// success.
+#[tokio::test]
+async fn cache_miss_propagates_an_inner_readiness_failure() {
+    let tx = sapling_transaction();
+    let dead = UnreadyVerifier::new();
+    let mut verifier = Cached::new(dead.clone(), 8, TEST_CACHE_METRICS);
+
+    verifier
+        .ready()
+        .await
+        .expect("the cache itself is always ready")
+        .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+        .await
+        .expect_err("a miss must surface the inner service's readiness failure");
+
+    assert!(
+        dead.poll_readies() > 0,
+        "a miss must acquire inner readiness"
+    );
+
+    let counting = CountingVerifier::new(true);
+    let mut verifier = verifier.with_inner(counting.clone());
+    verifier
+        .ready()
+        .await
+        .expect("the cache must become ready")
+        .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+        .await
+        .expect("the retry must succeed");
+    assert_eq!(
+        counting.calls(),
+        1,
+        "the bundle must still be verified, so the readiness failure was not recorded as an Ok"
+    );
+}
+
+/// The real verification stack, behind a cache private to one test.
+///
+/// The production [`VERIFIER`](super::VERIFIER) is a process-wide `Lazy`, so its cache carries
+/// whatever every other test in this binary has already verified. This builds the same batch and
+/// fallback stack behind a fresh cache, so a test can prove what a cold cache does with real
+/// Sapling verification underneath.
+fn uncached_verification_behind_a_fresh_cache() -> Cached<super::BatchFallbackService> {
+    Cached::new(super::batch_fallback_verifier(), 8, TEST_CACHE_METRICS)
+}
+
+/// The cache still rejects an invalid bundle after a valid one, with real verification underneath.
+///
+/// The unit tests above use a stub inner service, so they prove the cache's own behaviour but not
+/// that the key is sound over real bundles. This runs the real batch-and-fallback stack: a valid
+/// mainnet bundle is verified (and therefore cached), then the same transaction with a corrupted
+/// spend proof is submitted. A key that collided between the two would return the remembered `Ok`
+/// and let an unverified proof through.
+///
+/// The corruption keeps the proof well-formed, so it passes `check_bundle`'s synchronous checks
+/// and can only be caught by the batch validation the cache would have skipped.
+#[tokio::test(flavor = "multi_thread")]
+async fn cached_verifier_still_rejects_a_corrupted_proof_after_verifying_a_valid_one() {
+    use crate::error::TransactionError;
+
+    let _init_guard = zakura_test::init();
+
+    let (nu, valid) = mined_v4_sapling_transaction_with_spends();
+
+    let corrupted = mutated_spend(&valid, |spend| {
+        // A Groth16 proof is two 48-byte compressed G1 elements around a 96-byte compressed G2
+        // element. Swapping the G1 elements keeps the proof well-formed but invalid, so it fails
+        // batch validation rather than the synchronous well-formedness checks.
+        let (first, rest) = spend.zkproof.0.split_at_mut(48);
+        first.swap_with_slice(&mut rest[96..144]);
+    });
+
+    let valid_item = item(&valid, nu).expect("the transaction has a bundle");
+    let corrupted_item = item(&corrupted, nu).expect("the transaction has a bundle");
+    assert_ne!(
+        valid_item.cache_key(),
+        corrupted_item.cache_key(),
+        "the corrupted proof must key differently, or the cache would return the remembered Ok"
+    );
+
+    let verifier = uncached_verification_behind_a_fresh_cache();
+
+    verifier
+        .clone()
+        .oneshot(valid_item)
+        .await
+        .expect("a real mainnet Sapling bundle must verify");
+
+    let error =
+        verifier.clone().oneshot(corrupted_item).await.expect_err(
+            "a corrupted Sapling proof must be rejected even after a valid one verified",
+        );
+
+    let error = error
+        .downcast::<TransactionError>()
+        .expect("the verifier reports a typed transaction error");
+    assert!(
+        matches!(*error, TransactionError::SaplingVerificationFailed),
+        "expected SaplingVerificationFailed, got: {error:?}"
+    );
+}

--- a/crates/zakura-consensus/src/primitives/sapling/tests.rs
+++ b/crates/zakura-consensus/src/primitives/sapling/tests.rs
@@ -24,7 +24,7 @@ use zakura_chain::{
     block::{Block, Height},
     parameters::{Network, NetworkUpgrade},
     primitives::Groth16Proof,
-    sapling::{PerSpendAnchor, ShieldedData, Spend, TransferData},
+    sapling::{Nullifier, Output, PerSpendAnchor, ShieldedData, Spend, TransferData},
     serialization::{AtLeastOne, ZcashDeserializeInto},
     transaction::{arbitrary::transaction_to_fake_v5, HashType, Transaction},
     transparent,
@@ -32,7 +32,7 @@ use zakura_chain::{
 
 use crate::BoxError;
 
-use super::{sapling_prover, CacheKey, Cached, CachedItem, Item};
+use super::{sapling_prover, Authorized, Bundle, CacheKey, Cached, CachedItem, Item, ZatBalance};
 
 /// The `verifier` label the test caches report their metrics under.
 ///
@@ -176,6 +176,50 @@ fn mutated_spend(tx: &Transaction, mutate: impl FnOnce(&mut Spend<PerSpendAnchor
     })
 }
 
+/// Returns a fingerprint of everything `check_bundle` reads out of `bundle`.
+///
+/// Used where a test needs "these two transactions carry the same bundle" as a precondition.
+/// Comparing the fields directly rather than a `Debug` rendering keeps the assertion meaningful
+/// if an upstream `Debug` is ever redacted.
+fn bundle_fingerprint(bundle: &Bundle<Authorized, ZatBalance>) -> Vec<Vec<u8>> {
+    let mut parts = vec![
+        i64::from(*bundle.value_balance()).to_le_bytes().to_vec(),
+        <[u8; 64]>::from(bundle.authorization().binding_sig).to_vec(),
+    ];
+
+    for spend in bundle.shielded_spends() {
+        parts.push(spend.anchor().to_bytes().to_vec());
+        parts.push(spend.nullifier().0.to_vec());
+        parts.push(spend.zkproof().to_vec());
+        parts.push(<[u8; 64]>::from(*spend.spend_auth_sig()).to_vec());
+    }
+
+    for output in bundle.shielded_outputs() {
+        parts.push(output.cmu().to_bytes().to_vec());
+        parts.push(output.ephemeral_key().0.to_vec());
+        parts.push(output.zkproof().to_vec());
+    }
+
+    parts
+}
+
+/// Returns `tx` with `mutate` applied to the first output of its V4 Sapling shielded data.
+fn mutated_output(tx: &Transaction, mutate: impl FnOnce(&mut Output)) -> Transaction {
+    mutated_transaction(tx, |shielded_data| {
+        let TransferData::SpendsAndMaybeOutputs { maybe_outputs, .. } =
+            &mut shielded_data.transfers
+        else {
+            panic!("the fixture was selected for having spends")
+        };
+
+        mutate(
+            maybe_outputs
+                .first_mut()
+                .expect("the fixture was selected for having outputs"),
+        );
+    })
+}
+
 /// Returns `tx` as a V5 transaction carrying the same Sapling bundle.
 ///
 /// The Sapling test vectors are V4 transactions, so this is how the V5 side of the key — the
@@ -259,10 +303,16 @@ fn v4_cache_key_changes_with_every_piece_of_authorizing_data() {
     let tx = sapling_transaction_with_spends();
     let original = cache_key(&tx, NetworkUpgrade::Nu5);
 
-    let mutations = authorizing_data_mutations(&tx).into_iter().chain([(
-        mutated_value_balance(&tx),
-        "the value balance, which enters the binding verification key",
-    )]);
+    let mutations = authorizing_data_mutations(&tx).into_iter().chain([
+        (
+            mutated_value_balance(&tx),
+            "the value balance, which enters the binding verification key",
+        ),
+        (
+            mutated_nullifier(&tx),
+            "a spend nullifier, which is a public input to its proof",
+        ),
+    ]);
 
     for (mutated, what) in mutations {
         assert_ne!(
@@ -300,15 +350,23 @@ fn v5_cache_key_changes_with_authorizing_data_its_txid_ignores() {
         );
     }
 
-    // The value balance is the one input to the same check that a V5 txid does cover.
-    assert_ne!(
-        original,
-        cache_key(
-            &as_fake_v5(&mutated_value_balance(&v4)),
-            NetworkUpgrade::Nu5
+    // These are inputs to the same verification that a V5 txid does cover.
+    for (mutated, what) in [
+        (
+            mutated_value_balance(&v4),
+            "the value balance, which enters the binding verification key",
         ),
-        "the value balance enters the binding verification key, so it must be in the key"
-    );
+        (
+            mutated_nullifier(&v4),
+            "a spend nullifier, which is a public input to its proof",
+        ),
+    ] {
+        assert_ne!(
+            original,
+            cache_key(&as_fake_v5(&mutated), NetworkUpgrade::Nu5),
+            "{what} is verified, so it must be an input to the key"
+        );
+    }
 }
 
 /// Returns `tx` with each piece of the authorizing data `check_bundle` reads mutated in turn.
@@ -326,12 +384,25 @@ fn authorizing_data_mutations(tx: &Transaction) -> Vec<(Transaction, &'static st
             "a spend authorization signature",
         ),
         (
+            mutated_output(tx, |output| output.zkproof = Groth16Proof([0xFF; 192])),
+            "an output proof",
+        ),
+        (
             mutated_transaction(tx, |shielded_data| {
                 shielded_data.binding_sig = [0xFF; 64].into()
             }),
             "the binding signature",
         ),
     ]
+}
+
+/// Returns `tx` with the nullifier of its first Sapling spend changed.
+///
+/// The nullifier is effecting data rather than authorizing data — it is inside every transaction
+/// ID including a v5 txid — but it is also a public input to the spend proof, so a key that
+/// missed it would reuse one spend's verification for another's.
+fn mutated_nullifier(tx: &Transaction) -> Transaction {
+    mutated_spend(tx, |spend| spend.nullifier = Nullifier([0xFF; 32].into()))
 }
 
 /// Returns `tx` with its Sapling value balance changed.
@@ -363,8 +434,8 @@ fn cache_key_distinguishes_v4_and_v5_carrying_the_same_bundle() {
     let v5_item = item(&v5, NetworkUpgrade::Nu5).expect("the V5 transaction has a bundle");
 
     assert_eq!(
-        format!("{:?}", v4_item.bundle),
-        format!("{:?}", v5_item.bundle),
+        bundle_fingerprint(&v4_item.bundle),
+        bundle_fingerprint(&v5_item.bundle),
         "the conversion must carry the Sapling bundle across unchanged, or this test proves \
          nothing"
     );
@@ -458,6 +529,44 @@ async fn cache_does_not_reuse_a_result_across_bundles() {
         inner.calls(),
         2,
         "bundles with different keys must each be verified"
+    );
+}
+
+/// Clearing a cache forces re-verification.
+///
+/// This is what [`clear_shielded_verification_caches`](crate::clear_shielded_verification_caches)
+/// gives the benchmarks: a workload replayed against a cleared cache measures verification, not
+/// hits.
+#[tokio::test]
+async fn clearing_the_cache_forces_reverification() {
+    let tx = sapling_transaction();
+    let inner = CountingVerifier::new(true);
+    let mut verifier = Cached::new(inner.clone(), 8, TEST_CACHE_VERIFIER_LABEL);
+
+    for _ in 0..2 {
+        verifier
+            .ready()
+            .await
+            .expect("the cache must become ready")
+            .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+            .await
+            .expect("a valid item must verify");
+    }
+    assert_eq!(inner.calls(), 1, "the second verification must be a hit");
+
+    verifier.clear();
+
+    verifier
+        .ready()
+        .await
+        .expect("the cache must become ready")
+        .call(item(&tx, NetworkUpgrade::Nu5).expect("the transaction has a bundle"))
+        .await
+        .expect("a valid item must verify");
+    assert_eq!(
+        inner.calls(),
+        2,
+        "a cleared cache must send the bundle back to the inner service"
     );
 }
 
@@ -611,6 +720,69 @@ fn uncached_verification_behind_a_fresh_cache() -> Cached<super::BatchFallbackSe
         8,
         TEST_CACHE_VERIFIER_LABEL,
     )
+}
+
+/// A bundle verified under one network upgrade is not reused under another.
+///
+/// The sighash is the only key component that separates these two verifications: one transaction
+/// has one transaction ID whatever height it is verified at, but a V4 sighash commits to the
+/// consensus branch id of the block that mines it (ZIP 143 and ZIP 243 put it in the BLAKE2b
+/// personalization). So this is the end-to-end evidence for keying on the sighash at all: the
+/// same bundle, the same transaction ID, a different branch id, and the remembered `Ok` must not
+/// answer it.
+///
+/// Real verification runs underneath, so the second call is not merely a miss — the mainnet
+/// signatures do not verify against another era's sighash, and the rejection proves the bundle
+/// was actually checked rather than answered from the cache.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_bundle_verified_under_one_upgrade_is_not_reused_under_another() {
+    use crate::error::TransactionError;
+
+    let _init_guard = zakura_test::init();
+
+    let (mined_upgrade, tx) = mined_v4_sapling_transaction_with_spends();
+
+    // Any other upgrade that accepts V4 transactions will do: only its branch id matters here.
+    let other_upgrade = if mined_upgrade == NetworkUpgrade::Nu5 {
+        NetworkUpgrade::Canopy
+    } else {
+        NetworkUpgrade::Nu5
+    };
+
+    let mined_item = item(&tx, mined_upgrade).expect("the transaction has a bundle");
+    let other_item = item(&tx, other_upgrade).expect("the transaction has a bundle");
+    assert_eq!(
+        bundle_fingerprint(&mined_item.bundle),
+        bundle_fingerprint(&other_item.bundle),
+        "the branch id must not change the parsed bundle, or this test proves nothing"
+    );
+    assert_ne!(
+        mined_item.cache_key(),
+        other_item.cache_key(),
+        "the two sighashes must produce different keys"
+    );
+
+    let verifier = uncached_verification_behind_a_fresh_cache();
+
+    verifier
+        .clone()
+        .oneshot(mined_item)
+        .await
+        .expect("a real mainnet Sapling bundle must verify under the upgrade that mined it");
+
+    let error = verifier
+        .clone()
+        .oneshot(other_item)
+        .await
+        .expect_err("the same bundle must not verify against another upgrade's sighash");
+
+    let error = error
+        .downcast::<TransactionError>()
+        .expect("the verifier reports a typed transaction error");
+    assert!(
+        matches!(*error, TransactionError::SaplingVerificationFailed),
+        "expected SaplingVerificationFailed, got: {error:?}"
+    );
 }
 
 /// The cache still rejects an invalid bundle after a valid one, with real verification underneath.

--- a/crates/zakura-consensus/src/transaction.rs
+++ b/crates/zakura-consensus/src/transaction.rs
@@ -277,9 +277,17 @@ impl Request {
     }
 
     /// The unmined transaction ID for the transaction in this request.
+    ///
+    /// The shielded verification cache keys its entries on this ID, so it must always be derived
+    /// from the transaction carried here. A witnessed ID's authorizing-data digest is what commits
+    /// the key to the proofs and signatures; keying on a mined ID instead would let a transaction
+    /// be answered from the cached verification of a differently-signed twin. Both arms below
+    /// recompute the ID, and the `Request::Block::transaction_hash` field the caller supplies is
+    /// deliberately not used.
     pub fn tx_id(&self) -> UnminedTxId {
         match self {
-            // TODO: get the precalculated ID from the block verifier
+            // TODO: get the precalculated ID from the block verifier. It must be a full unmined
+            // ID recomputed from the transaction, for the reason given above.
             Request::Block { transaction, .. } => transaction.unmined_id(),
             Request::Mempool { transaction, .. } => transaction.id(),
         }

--- a/crates/zakura-consensus/src/transaction.rs
+++ b/crates/zakura-consensus/src/transaction.rs
@@ -593,6 +593,7 @@ where
                     script_verifier,
                     cached_ffi_transaction.clone(),
                     joinsplit_data,
+                    tx_id,
                 )?,
                 Transaction::V5 {
                     ..
@@ -917,6 +918,7 @@ where
     /// - the prepared `cached_ffi_transaction` used by the script verifier
     /// - the Sprout `joinsplit_data` shielded data in the transaction
     /// - the `sapling_shielded_data` in the transaction
+    /// - the transaction's precomputed `tx_id`, used by the Sapling cache
     #[allow(clippy::unwrap_in_result)]
     fn verify_v4_transaction(
         request: &Request,
@@ -924,6 +926,7 @@ where
         script_verifier: script::Verifier,
         cached_ffi_transaction: Arc<CachedFfiTransaction>,
         joinsplit_data: &Option<transaction::JoinSplitData<Groth16Proof>>,
+        tx_id: UnminedTxId,
     ) -> Result<AsyncChecks, TransactionError> {
         let tx = request.transaction();
         let nu = request.upgrade(network);
@@ -942,7 +945,7 @@ where
             cached_ffi_transaction,
         )?
         .and(Self::verify_sprout_shielded_data(joinsplit_data, &sighash)?)
-        .and(Self::verify_sapling_bundle(sapling_bundle, &sighash)))
+        .and(Self::verify_sapling_bundle(sapling_bundle, &sighash, tx_id)))
     }
 
     /// Verifies if a V4 `transaction` is supported by `network_upgrade`.
@@ -1033,7 +1036,11 @@ where
             script_verifier,
             cached_ffi_transaction,
         )?
-        .and(Self::verify_sapling_bundle(sapling_bundle, &sighash))
+        .and(Self::verify_sapling_bundle(
+            sapling_bundle,
+            &sighash,
+            UnminedTxId::Witnessed(wtx_id),
+        ))
         .and(Self::verify_orchard_bundle(
             orchard_bundle,
             &sighash,
@@ -1110,7 +1117,11 @@ where
             script_verifier,
             cached_ffi_transaction,
         )?
-        .and(Self::verify_sapling_bundle(sapling_bundle, &sighash))
+        .and(Self::verify_sapling_bundle(
+            sapling_bundle,
+            &sighash,
+            UnminedTxId::Witnessed(wtx_id),
+        ))
         .and(Self::verify_orchard_bundle(
             orchard_bundle,
             &sighash,
@@ -1241,9 +1252,13 @@ where
     }
 
     /// Verifies a transaction's Sapling shielded data.
+    ///
+    /// `tx_id` identifies the transaction containing `bundle`; the cache adds it to the key that
+    /// lets a mempool verification be reused for the block that mines it.
     fn verify_sapling_bundle(
         bundle: Option<sapling_crypto::Bundle<sapling_crypto::bundle::Authorized, ZatBalance>>,
         sighash: &SigHash,
+        tx_id: UnminedTxId,
     ) -> AsyncChecks {
         let mut async_checks = AsyncChecks::new();
 
@@ -1298,7 +1313,7 @@ where
             async_checks.push(
                 primitives::sapling::VERIFIER
                     .clone()
-                    .oneshot(primitives::sapling::Item::new(bundle, *sighash)),
+                    .oneshot(primitives::sapling::Item::new(bundle, *sighash, tx_id)),
             );
         }
 

--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -3132,6 +3132,7 @@ fn v4_with_invalid_sapling_proof_returns_typed_error() {
 
             (valid_bundle_one, valid_bundle_two, valid_sighash)
         };
+        let valid_tx_id = transaction.unmined_id();
 
         modify_first_sapling_spend_proof(
             Arc::get_mut(&mut transaction).expect("transaction only has one active reference"),
@@ -3158,6 +3159,7 @@ fn v4_with_invalid_sapling_proof_returns_typed_error() {
             .expect("test fixture has Sapling shielded data");
         let sighash = sighasher.sighash(HashType::ALL, None);
         drop(sighasher);
+        let tx_id = transaction.unmined_id();
 
         let mut verifier = sapling_crypto::BatchValidator::default();
         assert!(
@@ -3167,7 +3169,7 @@ fn v4_with_invalid_sapling_proof_returns_typed_error() {
 
         let mut batch_verifier = crate::primitives::sapling::Verifier::default();
         let batch_result = batch_verifier.call(BatchControl::Item(
-            crate::primitives::sapling::Item::new(batch_bundle, sighash),
+            crate::primitives::sapling::Item::new(batch_bundle, sighash, tx_id),
         ));
         let flush_result = batch_verifier.call(BatchControl::Flush);
         let (batch_result, flush_result) = futures::join!(batch_result, flush_result);
@@ -3178,18 +3180,18 @@ fn v4_with_invalid_sapling_proof_returns_typed_error() {
         );
 
         let single_result = crate::primitives::sapling::verify_single(
-            crate::primitives::sapling::Item::new(single_bundle, sighash),
+            crate::primitives::sapling::Item::new(single_bundle, sighash, tx_id),
         )
         .await;
         assert_sapling_verification_error(
             single_result.expect_err("corrupted Sapling proof must be rejected"),
         );
 
-        let invalid_item = crate::primitives::sapling::Item::new(fallback_bundle, sighash);
+        let invalid_item = crate::primitives::sapling::Item::new(fallback_bundle, sighash, tx_id);
         let items = vec![
-            crate::primitives::sapling::Item::new(valid_bundle_one, valid_sighash),
+            crate::primitives::sapling::Item::new(valid_bundle_one, valid_sighash, valid_tx_id),
             invalid_item.clone(),
-            crate::primitives::sapling::Item::new(valid_bundle_two, valid_sighash),
+            crate::primitives::sapling::Item::new(valid_bundle_two, valid_sighash, valid_tx_id),
         ];
         let expected_results: Vec<_> = futures::future::join_all(
             items
@@ -3336,7 +3338,7 @@ fn v4_with_malformed_sapling_proof_returns_typed_error() {
         );
 
         let result = crate::primitives::sapling::verify_single(
-            crate::primitives::sapling::Item::new(bundle, sighash),
+            crate::primitives::sapling::Item::new(bundle, sighash, transaction.unmined_id()),
         )
         .await;
         assert_sapling_verification_error(
@@ -6182,6 +6184,245 @@ fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
                 primitives::halo2::inner_calls_for(network_upgrade, &mutated_item),
                 1,
                 "the {mutated_field} mutation must reach the inner Halo2 verifier"
+            );
+        }
+    });
+}
+
+/// Returns the real mainnet Sapling transaction that the Sapling cache test drives through the
+/// verifier, with the network upgrade whose branch id its signatures commit to.
+///
+/// Selected from the mainnet test blocks for what full verification needs:
+///
+///   * a Sapling bundle with spends, which is what the cache holds;
+///   * no transparent inputs, so its sighash does not depend on previous outputs that the test
+///     vectors do not carry;
+///   * no Sprout JoinSplits and no Orchard bundle, which keeps the test on the Sapling verifier;
+///     and
+///   * a fee covering its own inputs and outputs, so the mempool's ZIP-317 policy accepts it.
+///
+/// It is taken from the front of the test vectors on purpose. Every other test that verifies a
+/// real Sapling transaction successfully takes the last matching one, so this transaction reaches
+/// the process-wide Sapling verifier only here and its cache entry is cold when this test starts.
+fn cacheable_mainnet_sapling_transaction() -> (NetworkUpgrade, Transaction) {
+    test_transactions(&Network::Mainnet)
+        .find(|(_, tx)| {
+            tx.sapling_spends_per_anchor().next().is_some()
+                && tx.inputs().is_empty()
+                && tx.joinsplit_count() == 0
+                && tx.orchard_shielded_data().is_none()
+                && tx
+                    .value_balance(&HashMap::new())
+                    .ok()
+                    .and_then(|balance| balance.remaining_transaction_value().ok())
+                    .is_some_and(|fee| fee >= zip317::conventional_fee(tx))
+        })
+        .map(|(height, tx)| {
+            (
+                NetworkUpgrade::current(&Network::Mainnet, height),
+                tx.as_ref().clone(),
+            )
+        })
+        .expect("the mainnet test blocks must contain a fee-paying Sapling-only transaction")
+}
+
+/// Returns the Sapling verification item the transaction verifier builds for `tx` at
+/// `network_upgrade`.
+///
+/// Mirrors `Verifier::verify_v4_transaction`: the bundle and the sighash come from one sighasher
+/// over an empty set of previous outputs, which is correct only because
+/// [`cacheable_mainnet_sapling_transaction`] has no transparent inputs.
+fn sapling_item(tx: &Transaction, network_upgrade: NetworkUpgrade) -> primitives::sapling::Item {
+    let sighasher = tx
+        .sighasher(network_upgrade, Arc::new(Vec::new()))
+        .expect("a mainnet Sapling transaction has a sighasher at its own network upgrade");
+    let bundle = sighasher
+        .sapling_bundle()
+        .expect("the transaction was selected for having a Sapling bundle");
+
+    primitives::sapling::Item::new(
+        bundle,
+        sighasher.sighash(HashType::ALL, None),
+        tx.unmined_id(),
+    )
+}
+
+/// Returns `tx`'s V4 Sapling shielded data for mutation.
+fn sapling_shielded_data_for_mutation(
+    tx: &mut Transaction,
+) -> &mut sapling::ShieldedData<sapling::PerSpendAnchor> {
+    let Transaction::V4 {
+        sapling_shielded_data: Some(shielded_data),
+        ..
+    } = tx
+    else {
+        panic!("the transaction was selected for being a V4 transaction with Sapling data")
+    };
+
+    shielded_data
+}
+
+/// Applies `mutate` to the first Sapling spend of `tx`.
+fn mutate_first_sapling_spend(
+    tx: &mut Transaction,
+    mutate: impl FnOnce(&mut sapling::Spend<sapling::PerSpendAnchor>),
+) {
+    let sapling::TransferData::SpendsAndMaybeOutputs { spends, .. } =
+        &mut sapling_shielded_data_for_mutation(tx).transfers
+    else {
+        panic!("the transaction was selected for having Sapling spends")
+    };
+
+    let mut spends_vec = spends.as_slice().to_vec();
+    mutate(&mut spends_vec[0]);
+    *spends = AtLeastOne::from_vec(spends_vec).expect("replacing a field keeps at least one spend");
+}
+
+/// Mutations that must each force a fresh Sapling verification.
+///
+/// Every one is a single bit flip in authorizing data, so the mutated transaction still passes
+/// the structural checks that run before verification — including the not-small-order check on
+/// `cv` and `epk`, which neither proofs nor signatures are part of.
+///
+/// All three are inside a v1-v4 transaction ID, which is the hash of the whole serialized
+/// transaction. That is why a Sapling bundle in a V4 transaction can be cached at all: it has no
+/// witnessed transaction ID, and its txid is what commits to its authorizing data.
+const SAPLING_CACHE_KEY_MUTATIONS: &[(&str, fn(&mut Transaction))] = &[
+    ("spend proof", |tx| {
+        mutate_first_sapling_spend(tx, |spend| spend.zkproof.0[0] ^= 1);
+    }),
+    ("spend authorization signature", |tx| {
+        mutate_first_sapling_spend(tx, |spend| {
+            let mut bytes = <[u8; 64]>::from(spend.spend_auth_sig);
+            bytes[0] ^= 1;
+            spend.spend_auth_sig = bytes.into();
+        });
+    }),
+    ("binding signature", |tx| {
+        let data = sapling_shielded_data_for_mutation(tx);
+        let mut bytes = <[u8; 64]>::from(data.binding_sig);
+        bytes[0] ^= 1;
+        data.binding_sig = bytes.into();
+    }),
+];
+
+/// The Sapling bundle cache, exercised end to end through the transaction verifier.
+///
+/// This is the Sapling counterpart of
+/// [`the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it`], and it is one test for
+/// the same reason: all three claims need the same transaction and a cold cache for it.
+///
+/// It also covers what Sapling does not share with Orchard. Its fixture is a V4 transaction,
+/// which has no witnessed transaction ID, so its cache key is built from the legacy transaction
+/// ID instead — and these mutations are the evidence that the legacy ID commits to the
+/// authorizing data the witnessed ID's digest would have covered.
+///
+/// The three claims, in order:
+///
+///   1. a mempool verification records the bundle, and the block that mines the same transaction
+///      is answered from that record instead of verifying the bundle again;
+///   2. the record does not carry the transaction past the height-dependent checks: the block one
+///      height past its expiry is still rejected;
+///   3. a transaction with any verification input mutated never inherits the record.
+#[test]
+fn the_sapling_cache_is_reused_only_for_the_transaction_that_earned_it() {
+    let _init_guard = zakura_test::init();
+
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let (mut verifier, state) = cache_test_verifier();
+
+        let (network_upgrade, tx) = cacheable_mainnet_sapling_transaction();
+        let expiry_height = tx
+            .expiry_height()
+            .expect("the fixture is an Overwinter-onward transaction with an expiry height");
+        assert_eq!(
+            NetworkUpgrade::current(&Network::Mainnet, expiry_height),
+            network_upgrade,
+            "the expiry height must be in the same upgrade as the block that mined the fixture, \
+             or its V4 sighash would commit to a different branch id"
+        );
+
+        let item = sapling_item(&tx, network_upgrade);
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&item),
+            0,
+            "this transaction's bundle must not have been verified before this test"
+        );
+
+        // 1. The mempool verification is the only one that reaches the Sapling verifier.
+        respond_to_nullifier_and_anchor_check(&state);
+        verify(
+            &mut verifier,
+            Request::Mempool {
+                transaction: tx.clone().into(),
+                height: expiry_height,
+            },
+        )
+        .await
+        .expect("a real mainnet Sapling transaction must verify at its expiry height");
+
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&item),
+            1,
+            "the mempool verification must reach the inner Sapling verifier"
+        );
+
+        verify(&mut verifier, block_request(&tx, expiry_height))
+            .await
+            .expect("the same transaction must verify in a block");
+
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&item),
+            1,
+            "the block verification must be answered from the cache"
+        );
+
+        // 2. The cached bundle does not carry the transaction past the expiry check.
+        let too_late =
+            (expiry_height + 1).expect("a mainnet expiry height is far below the maximum");
+        let error = verify(&mut verifier, block_request(&tx, too_late))
+            .await
+            .expect_err("a transaction mined past its expiry height must be rejected");
+
+        assert_eq!(
+            error,
+            TransactionError::ExpiredTransaction {
+                expiry_height,
+                block_height: too_late,
+                transaction_hash: tx.hash(),
+            },
+            "the rejection must be the expiry rule, not some other failure"
+        );
+
+        // 3. No mutated transaction inherits the cached result.
+        for (mutated_field, mutate) in SAPLING_CACHE_KEY_MUTATIONS {
+            let mut mutated_tx = tx.clone();
+            mutate(&mut mutated_tx);
+            let mutated_item = sapling_item(&mutated_tx, network_upgrade);
+
+            // A collision here would already be the failure: the mutation would inherit the
+            // valid transaction's result instead of being verified.
+            assert_eq!(
+                primitives::sapling::inner_calls_for(&mutated_item),
+                0,
+                "the {mutated_field} mutation must get a different cache key"
+            );
+
+            let Err(error) = verify(&mut verifier, block_request(&mutated_tx, expiry_height)).await
+            else {
+                panic!("a transaction with a mutated {mutated_field} must be rejected");
+            };
+
+            assert_eq!(
+                error,
+                TransactionError::SaplingVerificationFailed,
+                "the {mutated_field} twin must fail Sapling verification"
+            );
+
+            assert_eq!(
+                primitives::sapling::inner_calls_for(&mutated_item),
+                1,
+                "the {mutated_field} mutation must reach the inner Sapling verifier"
             );
         }
     });

--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -6201,15 +6201,16 @@ fn the_halo2_cache_is_reused_only_for_the_transaction_that_earned_it() {
 ///     and
 ///   * a fee covering its own inputs and outputs, so the mempool's ZIP-317 policy accepts it.
 ///
-/// It is taken from the front of the test vectors on purpose. Every other test that verifies a
-/// real Sapling transaction successfully takes the last matching one, so this transaction reaches
-/// the process-wide Sapling verifier only here and its cache entry is cold when this test starts.
+/// It is taken from the front of the test vectors on purpose. The other tests that verify a real
+/// Sapling transaction successfully take the last matching one, so this transaction reaches the
+/// process-wide Sapling verifier only here and its cache entry is cold when this test starts.
+/// That precondition is asserted rather than assumed, because it depends on which transactions
+/// the vectors happen to contain.
 fn cacheable_mainnet_sapling_transaction() -> (NetworkUpgrade, Transaction) {
-    test_transactions(&Network::Mainnet)
+    let selected = mainnet_sapling_transactions_with_spends()
+        .into_iter()
         .find(|(_, tx)| {
-            tx.sapling_spends_per_anchor().next().is_some()
-                && tx.inputs().is_empty()
-                && tx.joinsplit_count() == 0
+            tx.joinsplit_count() == 0
                 && tx.orchard_shielded_data().is_none()
                 && tx
                     .value_balance(&HashMap::new())
@@ -6217,13 +6218,64 @@ fn cacheable_mainnet_sapling_transaction() -> (NetworkUpgrade, Transaction) {
                     .and_then(|balance| balance.remaining_transaction_value().ok())
                     .is_some_and(|fee| fee >= zip317::conventional_fee(tx))
         })
+        .expect("the mainnet test blocks must contain a fee-paying Sapling-only transaction");
+
+    assert_cache_fixture_is_unshared(&selected.1);
+
+    selected
+}
+
+/// Returns the mainnet V5 Sapling transaction the V5 cache test drives through the verifier.
+///
+/// Same requirements as [`cacheable_mainnet_sapling_transaction`] minus the fee: no V5 Sapling
+/// transaction in the vectors pays the conventional fee, so the V5 test uses block requests only
+/// and never reaches the mempool's ZIP-317 policy.
+fn cacheable_mainnet_v5_sapling_transaction() -> (NetworkUpgrade, Transaction) {
+    let selected = mainnet_sapling_transactions_with_spends()
+        .into_iter()
+        .find(|(_, tx)| {
+            matches!(tx, Transaction::V5 { .. })
+                && tx.joinsplit_count() == 0
+                && tx.orchard_shielded_data().is_none()
+        })
+        .expect("the mainnet test blocks must contain a V5 Sapling-only transaction with spends");
+
+    assert_cache_fixture_is_unshared(&selected.1);
+
+    selected
+}
+
+/// Returns every mainnet test transaction with Sapling spends and no transparent inputs, with the
+/// network upgrade each one was mined under.
+fn mainnet_sapling_transactions_with_spends() -> Vec<(NetworkUpgrade, Transaction)> {
+    test_transactions(&Network::Mainnet)
+        .filter(|(_, tx)| tx.sapling_spends_per_anchor().next().is_some() && tx.inputs().is_empty())
         .map(|(height, tx)| {
             (
                 NetworkUpgrade::current(&Network::Mainnet, height),
                 tx.as_ref().clone(),
             )
         })
-        .expect("the mainnet test blocks must contain a fee-paying Sapling-only transaction")
+        .collect()
+}
+
+/// Asserts that no other test verifies `fixture` successfully, so its cache entry is cold.
+///
+/// The other tests that put a real Sapling transaction through the verifier and expect it to pass
+/// select with `.rev()`, so they all share one fixture: the last transaction with Sapling spends
+/// and no transparent inputs. A cache test whose fixture is that transaction would depend on test
+/// order for its cold-cache precondition.
+fn assert_cache_fixture_is_unshared(fixture: &Transaction) {
+    let shared = mainnet_sapling_transactions_with_spends()
+        .pop()
+        .expect("the mainnet test blocks contain Sapling transactions with spends");
+
+    assert_ne!(
+        fixture.hash(),
+        shared.1.hash(),
+        "the cache fixture must not be the transaction the other Sapling tests verify, or its \
+         cache entry would not be cold when this test starts"
+    );
 }
 
 /// Returns the Sapling verification item the transaction verifier builds for `tx` at
@@ -6297,6 +6349,19 @@ const SAPLING_CACHE_KEY_MUTATIONS: &[(&str, fn(&mut Transaction))] = &[
             bytes[0] ^= 1;
             spend.spend_auth_sig = bytes.into();
         });
+    }),
+    ("output proof", |tx| {
+        let sapling::TransferData::SpendsAndMaybeOutputs { maybe_outputs, .. } =
+            &mut sapling_shielded_data_for_mutation(tx).transfers
+        else {
+            panic!("the transaction was selected for having Sapling spends")
+        };
+
+        maybe_outputs
+            .first_mut()
+            .expect("the fixture has Sapling outputs")
+            .zkproof
+            .0[0] ^= 1;
     }),
     ("binding signature", |tx| {
         let data = sapling_shielded_data_for_mutation(tx);
@@ -6426,4 +6491,117 @@ fn the_sapling_cache_is_reused_only_for_the_transaction_that_earned_it() {
             );
         }
     });
+}
+
+/// The Sapling cache over a V5 transaction, whose key uses a witnessed transaction ID.
+///
+/// [`the_sapling_cache_is_reused_only_for_the_transaction_that_earned_it`] drives a V4
+/// transaction, whose legacy ID hashes the whole serialization. A V5 transaction is the other
+/// half of the key: its txid deliberately excludes proofs and signatures, and only the ZIP 244
+/// authorizing-data digest in its `WtxId` covers them. So this is the end-to-end check that the
+/// digest is really in the key — the shape of CVE-2026-34377, where a txid-keyed cache would
+/// answer a corrupted twin with the valid transaction's result.
+///
+/// Block requests only: no V5 Sapling transaction in the test vectors pays the conventional fee,
+/// so the mempool would reject this one on ZIP-317 policy before ever reaching verification. The
+/// mempool-to-block path is covered by the V4 test; what is specific here is the key.
+#[test]
+fn the_sapling_cache_distinguishes_a_v5_transaction_from_its_corrupted_twin() {
+    let _init_guard = zakura_test::init();
+
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        let (mut verifier, _state) = cache_test_verifier();
+
+        let (network_upgrade, tx) = cacheable_mainnet_v5_sapling_transaction();
+        let height = NetworkUpgrade::Nu5
+            .activation_height(&Network::Mainnet)
+            .expect("NU5 has an activation height on Mainnet");
+        let height = tx
+            .expiry_height()
+            .filter(|expiry| NetworkUpgrade::current(&Network::Mainnet, *expiry) == network_upgrade)
+            .unwrap_or(height);
+
+        let item = sapling_item(&tx, network_upgrade);
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&item),
+            0,
+            "this transaction's bundle must not have been verified before this test"
+        );
+
+        verify(&mut verifier, block_request(&tx, height))
+            .await
+            .expect("a real mainnet V5 Sapling transaction must verify in a block");
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&item),
+            1,
+            "the first verification must reach the inner Sapling verifier"
+        );
+
+        verify(&mut verifier, block_request(&tx, height))
+            .await
+            .expect("the same transaction must verify again");
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&item),
+            1,
+            "the second verification must be answered from the cache"
+        );
+
+        // Corrupt only authorizing data, which leaves the V5 txid untouched.
+        let mut corrupted = tx.clone();
+        let sapling::TransferData::SpendsAndMaybeOutputs { spends, .. } =
+            &mut v5_sapling_shielded_data_for_mutation(&mut corrupted).transfers
+        else {
+            panic!("the transaction was selected for having Sapling spends")
+        };
+        let mut spends_vec = spends.as_slice().to_vec();
+        let mut spend_auth_sig = <[u8; 64]>::from(spends_vec[0].spend_auth_sig);
+        spend_auth_sig[0] ^= 1;
+        spends_vec[0].spend_auth_sig = spend_auth_sig.into();
+        *spends =
+            AtLeastOne::from_vec(spends_vec).expect("replacing a field keeps at least one spend");
+
+        assert_eq!(
+            tx.hash(),
+            corrupted.hash(),
+            "the corruption must leave the V5 txid unchanged, or this test proves nothing"
+        );
+
+        let corrupted_item = sapling_item(&corrupted, network_upgrade);
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&corrupted_item),
+            0,
+            "the corrupted twin must get a different cache key"
+        );
+
+        let error = verify(&mut verifier, block_request(&corrupted, height))
+            .await
+            .expect_err(
+                "a transaction with a corrupted spend authorization signature must be rejected",
+            );
+        assert_eq!(
+            error,
+            TransactionError::SaplingVerificationFailed,
+            "the corrupted twin must fail Sapling verification"
+        );
+        assert_eq!(
+            primitives::sapling::inner_calls_for(&corrupted_item),
+            1,
+            "the corrupted twin must reach the inner Sapling verifier"
+        );
+    });
+}
+
+/// Returns `tx`'s V5 Sapling shielded data for mutation.
+fn v5_sapling_shielded_data_for_mutation(
+    tx: &mut Transaction,
+) -> &mut sapling::ShieldedData<sapling::SharedAnchor> {
+    let Transaction::V5 {
+        sapling_shielded_data: Some(shielded_data),
+        ..
+    } = tx
+    else {
+        panic!("the transaction was selected for being a V5 transaction with Sapling data")
+    };
+
+    shielded_data
 }

--- a/docs/changelog/unreleased/600.md
+++ b/docs/changelog/unreleased/600.md
@@ -1,0 +1,10 @@
+## Changed
+
+- Sapling bundle verification is now cached, so a transaction's Sapling proofs
+  and signatures are not verified a second time when the block that mines it
+  arrives. This extends the Orchard and Ironwood cache added in #597 to the
+  remaining shielded pool, under the same transaction-ID key. New
+  `zakura.consensus.sapling.cache.{hit,miss,insert,evict}` counters and a
+  `zakura.consensus.sapling.cache.size` gauge report its behaviour, alongside
+  the existing `zakura.consensus.halo2.cache.*` metrics
+  ([#600](https://github.com/zakura-core/zakura/pull/600)).

--- a/docs/changelog/unreleased/600.md
+++ b/docs/changelog/unreleased/600.md
@@ -8,8 +8,17 @@
 - The shielded verification cache metrics moved from
   `zakura.consensus.halo2.cache.{hit,miss,insert,evict,size}` to
   `zakura.consensus.cache.{hit,miss,insert,evict,size}`, each carrying a
-  `verifier` label. The label values are `halo2_pre_nu6_2`, `halo2_nu6_2`,
-  `halo2_nu6_3_onward` and `groth16_sapling`, so cache series can be joined with
-  the batch series of the same verifier, and each Orchard circuit era now
-  reports its own hit rate instead of sharing one
+  `verifier` label whose values are `halo2_pre_nu6_2`, `halo2_nu6_2`,
+  `halo2_nu6_3_onward` and `groth16_sapling`. Each Orchard circuit era now
+  reports its own hit rate instead of the three sharing one series. The
+  explicit-flush log for the Sapling batch also reports `groth16_sapling`
+  instead of `sapling`, matching that verifier's other metrics
   ([#600](https://github.com/zakura-core/zakura/pull/600)).
+
+## Added
+
+- `zakura_consensus::clear_shielded_verification_caches` forgets every cached
+  shielded bundle verification. It is hidden from the documentation and exists
+  for benchmarks, which must start each iteration with cold caches to measure
+  verification rather than cache hits. Clearing a cache only costs a
+  re-verification ([#600](https://github.com/zakura-core/zakura/pull/600)).

--- a/docs/changelog/unreleased/600.md
+++ b/docs/changelog/unreleased/600.md
@@ -3,8 +3,13 @@
 - Sapling bundle verification is now cached, so a transaction's Sapling proofs
   and signatures are not verified a second time when the block that mines it
   arrives. This extends the Orchard and Ironwood cache added in #597 to the
-  remaining shielded pool, under the same transaction-ID key. New
-  `zakura.consensus.sapling.cache.{hit,miss,insert,evict}` counters and a
-  `zakura.consensus.sapling.cache.size` gauge report its behaviour, alongside
-  the existing `zakura.consensus.halo2.cache.*` metrics
+  remaining shielded pool, under the same transaction-ID key
+  ([#600](https://github.com/zakura-core/zakura/pull/600)).
+- The shielded verification cache metrics moved from
+  `zakura.consensus.halo2.cache.{hit,miss,insert,evict,size}` to
+  `zakura.consensus.cache.{hit,miss,insert,evict,size}`, each carrying a
+  `verifier` label. The label values are `halo2_pre_nu6_2`, `halo2_nu6_2`,
+  `halo2_nu6_3_onward` and `groth16_sapling`, so cache series can be joined with
+  the batch series of the same verifier, and each Orchard circuit era now
+  reports its own hit rate instead of sharing one
   ([#600](https://github.com/zakura-core/zakura/pull/600)).


### PR DESCRIPTION
## Motivation

#597 cached Orchard and Ironwood bundle verification, and #613 rekeyed that cache
by witnessed transaction ID. Sapling is the one shielded pool left verifying twice:
once when a transaction is gossiped into the mempool, and again when the block that
mines it arrives.

Per review feedback (#600 (comment)), this covers Sapling **under the same
`CacheKey`** as Halo2 rather than a Sapling-specific key construction. The earlier
revision of this PR hashed a digest of the transaction bytes the bundle was parsed
from; all of that machinery is gone, along with its `zakura-chain` changes.

**What it is worth.** Measured over 582 recent mainnet blocks, Sapling is about 12%
of shielded verification work (0.48 Sapling units per block against 3.55
Orchard/Ironwood actions, ~0.97 ms per unit either way), so a hit saves roughly
0.5 ms per block next to the ~3.5 ms #597 already covers. That share is falling as
Ironwood ramps. The case for landing it now is that it costs one shared key
construction instead of a second one: the cache, its key, and its safety argument
are the ones already reviewed in #597 and #613.

## Solution

### One cache, one key

`primitives::halo2::cache` moves up to `primitives::cache` and becomes generic over
a `CachedItem` trait, so the Halo2 and Sapling verifiers share one service, one
eviction policy and one set of safety notes. The key is the one #613 introduced,
with two changes:

- `wtx_id: WtxId` becomes `tx_id: UnminedTxId`, because Sapling bundles also appear
  in v4 transactions, which have no witnessed ID; and
- `pool: orchard::ValuePool` becomes a `ShieldedPool` tag with a `Sapling` variant.

```rust
struct CacheKey {
    tx_id: UnminedTxId,
    sighash: [u8; 32],
    pool: ShieldedPool,
}
```

**Both ID forms commit to the bundle**, which is the whole safety argument:

- `UnminedTxId::Witnessed` carries a `WtxId`, whose txid commits to effecting data
  and whose ZIP 244 authorizing-data digest commits to the proofs and signatures.
  The txid alone would not — that is CVE-2026-34377.
- `UnminedTxId::Legacy` is a v1-v4 transaction ID: the hash of the whole serialized
  transaction, which contains the Sapling proofs, `spendAuthSig`s and `bindingSig`
  directly. This is why v4 Sapling bundles can be cached without a witnessed ID.

The sighash stays in the key because it is not a function of the transaction alone:
the amounts and `scriptPubKey`s of spent transparent outputs enter it and come from
the verification context. The verifying keys stay out: each Orchard circuit era has
its own cache instance, and Sapling has one spend and one output verifying key for
all of history, so one cache covers it with no eras to keep apart.

The transaction verifier passes the ID it has already computed (`Request::tx_id()`),
so the lookup path adds no hashing and no allocation. `sapling::Item::new` now takes
that ID; the type is not part of the crate's public API (`primitives` is private and
only `sapling_prover` is re-exported), so this is not a public-API change.

### Benchmark accuracy

`worst_case_tx_verification` replays one workload of repeated mainnet transactions, so with a
process-wide cache every iteration after the first measured cache hits instead of verification —
`full_sapling_limit` reported **38.4 ms** where verifying those 300 Sapling spends actually takes
**283.1 ms**. Since that benchmark is what sizes the ZIP-1271 action limits and `max_block_bytes`
against worst-case block cost, and the worst case is a block of transactions the node has never
seen, it now clears the caches between iterations through a hidden
`clear_shielded_verification_caches`. This also restores the Orchard half of the measurement,
blind since #597.

### Metrics

One cache implementation now reports one set of series. The
`zakura.consensus.halo2.cache.{hit,miss,insert,evict,size}` metrics released in
v1.2.0 become `zakura.consensus.cache.{...}` with a `verifier` label, whose values
are `halo2_pre_nu6_2`, `halo2_nu6_2`, `halo2_nu6_3_onward` and `groth16_sapling`.
Those are the names the same verifiers already use in their batch metrics and flush
logs, so cache and batch series can be joined, and each Orchard circuit era now
reports its own hit rate instead of the three sharing one series.

## Testing

`crates/zakura-consensus/src/primitives/cache/tests.rs` — the shared key: the pool
tag separates the three bundles of one v6 transaction, the authorizing-data digest
separates two witnessed IDs sharing a txid, the sighash separates two verifications
of one bundle, and a legacy ID never collides with a witnessed one.

`crates/zakura-consensus/src/primitives/sapling/tests.rs` — the Sapling key over
real mainnet bundles:

- `v4_cache_key_changes_with_every_piece_of_authorizing_data` — a spend proof, a
  `spendAuthSig`, the binding signature and `value_balance`. These are exactly what
  `check_bundle` batches, and each one changes the v4 transaction ID.
- `v5_cache_key_changes_with_authorizing_data_its_txid_ignores` — the same
  mutations, carried into a v5 transaction, **asserting the v5 txid is unchanged**
  and the key still differs. That is the CVE-2026-34377 shape.
- deterministic keys, distinct transactions, sighash, and v4-vs-v5 carrying the same
  bundle.
- cache behaviour: skips the inner service on a repeat, never reuses a result across
  bundles, never remembers a failure, answers a hit when the inner service can no
  longer become ready, and propagates an inner readiness failure on a miss.
- `cached_verifier_still_rejects_a_corrupted_proof_after_verifying_a_valid_one` —
  the real batch-and-fallback stack behind a fresh cache. A valid mainnet bundle
  verifies and is cached, then the same transaction with a G1-swapped spend proof —
  well-formed, so it passes `check_bundle`'s synchronous checks and can only be
  caught by the batch validation a bad key would have skipped — must still be
  rejected.

- `a_bundle_verified_under_one_upgrade_is_not_reused_under_another` — real verification
  underneath: the same transaction, the same ID, another branch id, and the remembered `Ok` must
  not answer it. This is the end-to-end evidence for keying on the sighash.
- `clearing_the_cache_forces_reverification`, and in `halo2/tests.rs`
  `a_result_cached_under_one_era_is_not_visible_to_another`, which pins what binds an entry to the
  verifying key it was produced under.

`the_sapling_cache_is_reused_only_for_the_transaction_that_earned_it` and
`the_sapling_cache_distinguishes_a_v5_transaction_from_its_corrupted_twin` in
`transaction/tests.rs` — the production path, mirroring the Halo2 test #613 added. The second
drives a v5 transaction and its authorizing-data twin, whose txids are identical.
A real mainnet Sapling transaction verifies from the mempool, the block that mines
it is answered from the cache, the block one height past its expiry is still
rejected, and each authorizing-data mutation gets a fresh verification and fails.
Its fixture is a v4 transaction, so it is also the end-to-end evidence that the
legacy transaction ID covers what a witnessed ID's digest would have.

```
cargo test -p zakura-consensus --lib          # 203 passed
cargo test -p zakura-consensus --lib -- --test-threads=1
cargo clippy -p zakura-consensus --all-targets -- -D warnings
cargo check --workspace --all-targets
cargo fmt --all -- --check
./scripts/changelog.py check
```

## Review

Four independent adversarial reviews covered the key's completeness against everything
`check_bundle`/`add_bundle` reads, the identity plumbing at every call site, the cache service
under load and failure, and the tests. **None found a way for a cache hit to stand in for an
unverified bundle.** Notable confirmations:

- For v4, the legacy txid hashes `zcash_serialize(tx)` and the bundle is parsed by librustzcash
  from the output of that same function, so key and bundle derive from identical bytes.
- Dropping the earlier revision's explicit branch-id commitment is safe twice over: the branch id
  is inside the v4 sighash personalization, and `read_v4` never passes it to the Sapling parser,
  so it cannot change a parsed v4 bundle.
- A mismatched bundle/ID pair is not constructible: `Request::Block::tx_id()` recomputes from the
  carried transaction and never uses the caller-supplied `transaction_hash`, and `UnminedTx`'s
  `id` is private with no constructor that does not derive it.
- Era routing matches `BranchId::orchard_protocol_revision` and `BundleVersion::circuit_version`
  one for one, and Sapling's verification takes no era parameter at all.
- Mutation testing: dropping `tx_id`, the authorizing-data digest, the sighash or the pool from
  the key each fails the suite.

Their findings are fixed in this PR: the benchmark above; metrics reported after the cache lock is
released rather than allocating a label set inside it; the eviction queue evicting before pushing
so it stops doubling its allocation; corrected claims about the v4 sighash, the metric labels and
the cache's memory footprint; and the extra tests listed above.

A fifth review then re-audited the finished branch end to end and found nothing above LOW. It read
the `sapling_crypto` batch verifier to enumerate every field the verification actually consumes,
and traced each one to the component of the key that commits to it — per-spend `cv`, `anchor`,
`nullifier`, `rk`, `zkproof`, `spend_auth_sig`, per-output `cv`, `cmu`, `ephemeral_key`, `zkproof`,
plus `value_balance`, `binding_sig` and the sighash. It also confirmed what a hit does **not**
skip: duplicate-nullifier checks, ZIP 216 point-encoding canonicity, expiry and lock-time, scripts,
and the state-side anchor and nullifier checks all still run. Its two latent findings are addressed
here — `Request::tx_id` now documents the invariant its `TODO` must preserve, since implementing it
with a mined ID would reintroduce the CVE-2026-34377 shape, and `sapling::Item::new` is
`pub(crate)` like its Halo2 twin.

A `core-rust-readability` pass supplied the rest of the final commit: the `CachedItem` contract,
the `VerifiedBundles` invariant and its direct unit test, `VERIFIER_NAME` replacing a repeated
label literal, and `verifier_name` for the metrics-label parameter.

### Specifications & References

- [ZIP 239: Transaction Identifier Digests and Signature Validation](https://zips.z.cash/zip-0239)
- [ZIP 244: Transaction Identifier Non-Malleability](https://zips.z.cash/zip-0244)
