### PR TITLE
feat(chain): public NoteCommitmentTree::from_frontier for Sapling and Orchard

### DIFF
--- a/crates/zakura-chain/src/orchard/tree.rs
+++ b/crates/zakura-chain/src/orchard/tree.rs
@@ -391,6 +391,28 @@ pub struct NoteCommitmentTree {
 }
 
 impl NoteCommitmentTree {
+    /// Builds a tree whose state is exactly the given frontier.
+    ///
+    /// A frontier is the rightmost path of an append-only Merkle tree, and is
+    /// all the state this tree keeps: this constructor cannot produce a tree
+    /// that the append path could not have produced, because a malformed
+    /// frontier cannot exist
+    /// ([`Frontier::from_parts`](incrementalmerkletree::frontier::Frontier::from_parts)
+    /// validates before a value can be constructed) and capacity is enforced
+    /// by the `MERKLE_DEPTH` const generic. Verifying that the frontier
+    /// belongs to the chain remains the caller's responsibility, as it is for
+    /// every other way of obtaining one.
+    ///
+    /// The root cache starts empty and is recomputed on first use.
+    pub fn from_frontier(
+        frontier: incrementalmerkletree::frontier::Frontier<Node, MERKLE_DEPTH>,
+    ) -> Self {
+        Self {
+            inner: frontier,
+            cached_root: Default::default(),
+        }
+    }
+
     /// Adds a note commitment x-coordinate to the tree.
     ///
     /// The leaves of the tree are actually a base field element, the
@@ -788,6 +810,41 @@ mod tests {
 
         Option::<pallas::Base>::from(pallas::Base::from_repr(bytes))
             .expect("small little-endian integers are canonical field elements")
+    }
+
+    /// A tree rebuilt from its own frontier answers exactly like the
+    /// original, and keeps appending identically.
+    #[test]
+    fn from_frontier_round_trips_root_position_and_appends() {
+        let mut original = NoteCommitmentTree::default();
+        for value in 0..37 {
+            original
+                .append(note_commitment(value))
+                .expect("small test tree is not full");
+        }
+
+        let live = original.frontier().expect("37 appends leave a leaf");
+        let frontier = incrementalmerkletree::frontier::Frontier::from_parts(
+            live.position(),
+            *live.leaf(),
+            live.ommers().to_vec(),
+        )
+        .expect("the parts of a live frontier are valid");
+
+        let mut rebuilt = NoteCommitmentTree::from_frontier(frontier);
+
+        assert_eq!(rebuilt.root(), original.root());
+        assert_eq!(rebuilt.count(), original.count());
+        assert_eq!(rebuilt.position(), original.position());
+
+        original
+            .append(note_commitment(37))
+            .expect("small test tree is not full");
+        rebuilt
+            .append(note_commitment(37))
+            .expect("small test tree is not full");
+
+        assert_eq!(rebuilt.root(), original.root());
     }
 
     /// Verbatim copy of the pre-cache `merkle_crh_orchard`: it rebuilds the

--- a/crates/zakura-chain/src/sapling/tree.rs
+++ b/crates/zakura-chain/src/sapling/tree.rs
@@ -193,6 +193,25 @@ pub struct NoteCommitmentTree {
 }
 
 impl NoteCommitmentTree {
+    /// Builds a tree whose state is exactly the given frontier.
+    ///
+    /// A frontier is the rightmost path of an append-only Merkle tree, and is
+    /// all the state this tree keeps: this constructor cannot produce a tree
+    /// that the append path could not have produced, because a malformed
+    /// frontier cannot exist ([`Frontier::from_parts`] validates before a
+    /// value can be constructed) and capacity is enforced by the
+    /// `MERKLE_DEPTH` const generic. Verifying that the frontier belongs to
+    /// the chain remains the caller's responsibility, as it is for every
+    /// other way of obtaining one.
+    ///
+    /// The root cache starts empty and is recomputed on first use.
+    pub fn from_frontier(frontier: Frontier<sapling_crypto::Node, MERKLE_DEPTH>) -> Self {
+        Self {
+            inner: frontier,
+            cached_root: Default::default(),
+        }
+    }
+
     /// Adds a note commitment u-coordinate to the tree.
     ///
     /// The leaves of the tree are actually a base field element, the
@@ -604,6 +623,36 @@ mod tests {
         }
 
         tree
+    }
+
+    /// A tree rebuilt from its own frontier answers exactly like the
+    /// original, and keeps appending identically.
+    #[test]
+    fn from_frontier_round_trips_root_position_and_appends() {
+        let mut original = build_tree(37);
+
+        let live = original.frontier().expect("37 appends leave a leaf");
+        let frontier = Frontier::from_parts(
+            live.position(),
+            *live.leaf(),
+            live.ommers().to_vec(),
+        )
+        .expect("the parts of a live frontier are valid");
+
+        let mut rebuilt = NoteCommitmentTree::from_frontier(frontier);
+
+        assert_eq!(rebuilt.root(), original.root());
+        assert_eq!(rebuilt.count(), original.count());
+        assert_eq!(rebuilt.position(), original.position());
+
+        original
+            .append(note_commitment(37))
+            .expect("small test tree is not full");
+        rebuilt
+            .append(note_commitment(37))
+            .expect("small test tree is not full");
+
+        assert_eq!(rebuilt.root(), original.root());
     }
 
     fn pre_subtree_boundary_tree() -> NoteCommitmentTree {

--- a/crates/zakura-chain/src/sapling/tree.rs
+++ b/crates/zakura-chain/src/sapling/tree.rs
@@ -632,12 +632,8 @@ mod tests {
         let mut original = build_tree(37);
 
         let live = original.frontier().expect("37 appends leave a leaf");
-        let frontier = Frontier::from_parts(
-            live.position(),
-            *live.leaf(),
-            live.ommers().to_vec(),
-        )
-        .expect("the parts of a live frontier are valid");
+        let frontier = Frontier::from_parts(live.position(), *live.leaf(), live.ommers().to_vec())
+            .expect("the parts of a live frontier are valid");
 
         let mut rebuilt = NoteCommitmentTree::from_frontier(frontier);
 

--- a/docs/changelog/unreleased/602.md
+++ b/docs/changelog/unreleased/602.md
@@ -1,0 +1,8 @@
+## Added
+
+- Added the public `NoteCommitmentTree::from_frontier` constructor to the Sapling
+  and Orchard note commitment trees (Ironwood inherits it via the `ironwood::tree`
+  re-export), building a tree from an already-validated frontier without
+  re-appending its leaves. `parallel::batch_frontier` already returns bare
+  frontiers publicly; this adds the way back in
+  ([#602](https://github.com/zakura-core/zakura/pull/602)).


### PR DESCRIPTION
## Motivation

Closes #601. `parallel::batch_frontier::append_batch_with_subtree` is public and
returns a bare `Frontier`, but there is no public way to wrap a `Frontier` back
into a `NoteCommitmentTree` — the supported constructors are `Default` (empty)
and `From<Vec<ExtractedNoteCommitment>>`, which re-appends every leaf. A
downstream consumer that derives frontiers in parallel batches must therefore
re-hash every batch's leaves a second time purely to obtain the authoritative
tree type (~11 CPU-minutes of duplicated hashing per mainnet genesis walk in
zindex's case, per the issue).

## Solution

Adds `NoteCommitmentTree::from_frontier` to the Sapling and Orchard trees — the
same two-field construction the in-crate tests already use (`Self { inner,
cached_root: Default::default() }`). Ironwood inherits via the `ironwood::tree`
re-export. Infallible by construction: a malformed frontier cannot exist
(`Frontier::from_parts` validates before a value can be constructed), capacity
is enforced by the `MERKLE_DEPTH` const generic, and the root cache starts
empty. Verifying that a frontier belongs to the chain remains the caller's
responsibility, as with every other way of obtaining one — matching the
verify-then-install pattern the finalized state already uses for VCT final
frontiers.

## Testing

`cargo test -p zakura-chain --release tree`: 47 passed, 0 failed, including the
two new round-trip tests (`from_frontier_round_trips_root_position_and_appends`
per pool): build a tree through the ordinary append path, rebuild it from its
own frontier alone, assert root/count/position equality, then append one more
commitment to both and assert the roots still agree.

## Changelog

`docs/changelog/unreleased/<PR>.md` added after opening this draft.

---
🤖 Drafted with [Claude Code](https://claude.com/claude-code) at @maxdesalle's direction, per the discussion on #601.
