### PR TITLE
docs(chain): clarify frontier trust boundary

### DIFF
--- a/crates/zakura-chain/src/orchard/tree.rs
+++ b/crates/zakura-chain/src/orchard/tree.rs
@@ -269,11 +269,10 @@ impl ToHex for Node {
 
 /// Required to serialize [`NoteCommitmentTree`]s in a format compatible with `zcashd`.
 ///
-/// Zebra stores Orchard note commitment trees as [`Frontier`][1]s while the
+/// Zebra stores Orchard note commitment trees as [`Frontier`]s while the
 /// [`z_gettreestate`][2] RPC requires [`CommitmentTree`][3]s. Implementing
 /// [`HashSer`] for [`Node`]s allows the conversion.
 ///
-/// [1]: incrementalmerkletree::frontier::Frontier
 /// [2]: https://zcash.github.io/rpc/z_gettreestate.html
 /// [3]: incrementalmerkletree::frontier::CommitmentTree
 impl HashSer for Node {
@@ -396,9 +395,11 @@ pub struct NoteCommitmentTree {
 impl NoteCommitmentTree {
     /// Wraps an existing [`Frontier`] as a note commitment tree.
     ///
+    /// # Correctness
+    ///
     /// [`Frontier::from_parts`] validates only that the position and ommer
     /// count are consistent and that the frontier fits within
-    /// [`MERKLE_DEPTH`]. It does not verify that the nodes were derived from
+    /// `MERKLE_DEPTH`. It does not verify that the nodes were derived from
     /// note commitments or that the root belongs to an authenticated chain
     /// and shielded pool state.
     ///

--- a/crates/zakura-chain/src/orchard/tree.rs
+++ b/crates/zakura-chain/src/orchard/tree.rs
@@ -20,7 +20,10 @@ use std::{
 use bitvec::prelude::*;
 use halo2::pasta::{group::ff::PrimeField, pallas};
 use hex::ToHex;
-use incrementalmerkletree::{frontier::NonEmptyFrontier, Hashable};
+use incrementalmerkletree::{
+    frontier::{Frontier, NonEmptyFrontier},
+    Hashable,
+};
 use lazy_static::lazy_static;
 use thiserror::Error;
 use zcash_primitives::merkle_tree::HashSer;
@@ -391,22 +394,20 @@ pub struct NoteCommitmentTree {
 }
 
 impl NoteCommitmentTree {
-    /// Builds a tree whose state is exactly the given frontier.
+    /// Wraps an existing [`Frontier`] as a note commitment tree.
     ///
-    /// A frontier is the rightmost path of an append-only Merkle tree, and is
-    /// all the state this tree keeps: this constructor cannot produce a tree
-    /// that the append path could not have produced, because a malformed
-    /// frontier cannot exist
-    /// ([`Frontier::from_parts`](incrementalmerkletree::frontier::Frontier::from_parts)
-    /// validates before a value can be constructed) and capacity is enforced
-    /// by the `MERKLE_DEPTH` const generic. Verifying that the frontier
-    /// belongs to the chain remains the caller's responsibility, as it is for
-    /// every other way of obtaining one.
+    /// [`Frontier::from_parts`] validates only that the position and ommer
+    /// count are consistent and that the frontier fits within
+    /// [`MERKLE_DEPTH`]. It does not verify that the nodes were derived from
+    /// note commitments or that the root belongs to an authenticated chain
+    /// and shielded pool state.
+    ///
+    /// Callers must derive the frontier from validated commitments or
+    /// authenticate its root against the expected chain and shielded pool
+    /// state before treating the resulting tree as authoritative.
     ///
     /// The root cache starts empty and is recomputed on first use.
-    pub fn from_frontier(
-        frontier: incrementalmerkletree::frontier::Frontier<Node, MERKLE_DEPTH>,
-    ) -> Self {
+    pub fn from_frontier(frontier: Frontier<Node, MERKLE_DEPTH>) -> Self {
         Self {
             inner: frontier,
             cached_root: Default::default(),

--- a/crates/zakura-chain/src/sapling/tree.rs
+++ b/crates/zakura-chain/src/sapling/tree.rs
@@ -193,16 +193,17 @@ pub struct NoteCommitmentTree {
 }
 
 impl NoteCommitmentTree {
-    /// Builds a tree whose state is exactly the given frontier.
+    /// Wraps an existing [`Frontier`] as a note commitment tree.
     ///
-    /// A frontier is the rightmost path of an append-only Merkle tree, and is
-    /// all the state this tree keeps: this constructor cannot produce a tree
-    /// that the append path could not have produced, because a malformed
-    /// frontier cannot exist ([`Frontier::from_parts`] validates before a
-    /// value can be constructed) and capacity is enforced by the
-    /// `MERKLE_DEPTH` const generic. Verifying that the frontier belongs to
-    /// the chain remains the caller's responsibility, as it is for every
-    /// other way of obtaining one.
+    /// [`Frontier::from_parts`] validates only that the position and ommer
+    /// count are consistent and that the frontier fits within
+    /// [`MERKLE_DEPTH`]. It does not verify that the nodes were derived from
+    /// note commitments or that the root belongs to an authenticated chain
+    /// and shielded pool state.
+    ///
+    /// Callers must derive the frontier from validated commitments or
+    /// authenticate its root against the expected chain and shielded pool
+    /// state before treating the resulting tree as authoritative.
     ///
     /// The root cache starts empty and is recomputed on first use.
     pub fn from_frontier(frontier: Frontier<sapling_crypto::Node, MERKLE_DEPTH>) -> Self {

--- a/crates/zakura-chain/src/sapling/tree.rs
+++ b/crates/zakura-chain/src/sapling/tree.rs
@@ -195,9 +195,11 @@ pub struct NoteCommitmentTree {
 impl NoteCommitmentTree {
     /// Wraps an existing [`Frontier`] as a note commitment tree.
     ///
+    /// # Correctness
+    ///
     /// [`Frontier::from_parts`] validates only that the position and ommer
     /// count are consistent and that the frontier fits within
-    /// [`MERKLE_DEPTH`]. It does not verify that the nodes were derived from
+    /// `MERKLE_DEPTH`. It does not verify that the nodes were derived from
     /// note commitments or that the root belongs to an authenticated chain
     /// and shielded pool state.
     ///

--- a/docs/changelog/unreleased/604.md
+++ b/docs/changelog/unreleased/604.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only corrects public API documentation and has no operator-visible
+effect.


### PR DESCRIPTION
## Motivation

PR #602 introduced public constructors for wrapping Sapling and Orchard frontiers. Their rustdoc overstates what `Frontier::from_parts` validates: it checks structural consistency and depth, but not hash provenance or chain membership. For a consensus-critical state type, that trust boundary should be explicit.

## Solution

Clarify on both constructors that callers must either derive the frontier from validated commitments or authenticate its root against the expected chain and shielded pool state. Import `Frontier` consistently in the Orchard module so the documentation uses concise intra-doc links.

This changes documentation only; constructor behavior is unchanged.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `npx --yes markdownlint-cli docs/changelog/unreleased/604.md --config .github/.markdownlint.yaml`
- `RUSTDOCFLAGS="-Dwarnings -Arustdoc::private-intra-doc-links" cargo doc -p zakura-chain --no-deps --document-private-items`

The rustdoc allowance covers existing links from public documentation to private items; the changed documentation builds without warnings.

## Changelog

Added `docs/changelog/unreleased/604.md` with an explicit no-changelog marker because this correction has no operator-visible effect.

### Specifications & References

- Follow-up to #602
- `incrementalmerkletree` 0.8.2 `Frontier::from_parts` validation contract

### Follow-up Work

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and intra-doc link cleanup only; no runtime or consensus logic changes.
> 
> **Overview**
> This PR **only updates rustdoc and changelog metadata**; `NoteCommitmentTree::from_frontier` behavior is unchanged.
> 
> For **Sapling and Orchard** `NoteCommitmentTree::from_frontier`, the docs now state that wrapping a [`Frontier`] does not prove the nodes came from real note commitments or that the root matches authenticated chain/shielded-pool state. [`Frontier::from_parts`] only checks structural consistency (position, ommer count, depth). Callers must build the frontier from validated commitments or verify the root before treating the tree as authoritative.
> 
> In **Orchard** `tree.rs`, `Frontier` is imported for shorter doc links, `HashSer` docs use [`Frontier`] instead of a footnote link, and the `from_frontier` parameter type uses the imported `Frontier` name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3103bc294362a5a714d89c7c85497535bbd98338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->