### PR TITLE
test(consensus): run the Orchard soft-fork boundary test on the shared runtime

### DIFF
--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -4159,68 +4159,99 @@ async fn orchard_disabling_soft_fork_accepts_non_orchard_transactions() {
 /// Mirrors the zcashd boundary test: the soft fork must accept an Orchard
 /// transaction one block below its activation height but reject the same
 /// transaction at the activation height.
-#[tokio::test]
-async fn orchard_disabling_soft_fork_accepts_orchard_actions_below_activation_height() {
+///
+/// Runs on the shared runtime because it verifies a real Orchard bundle, so it can be the test
+/// that first forces the global Halo2 verifier and spawns its batch worker. A per-test runtime
+/// takes that worker down when the test ends, and every later test reaching the same global then
+/// sees the cancelled worker as a verification error rather than a verdict.
+#[test]
+fn orchard_disabling_soft_fork_accepts_orchard_actions_below_activation_height() {
     let _init_guard = zakura_test::init();
-
-    // Use an unmodified Orchard-only V5 transaction from the test vectors so its
-    // proofs remain valid for the acceptance path.
-    let default_testnet = Network::new_default_testnet();
-    let tx = v5_transactions(default_testnet.block_iter())
-        .rev()
-        .find(|transaction| {
-            transaction.inputs().is_empty()
-                && transaction.outputs().is_empty()
-                && transaction.sapling_spends_per_anchor().next().is_none()
-                && transaction.sapling_outputs().next().is_none()
-                && transaction.joinsplit_count() == 0
-        })
-        .expect("V5 tx with only Orchard actions");
-
-    assert!(
-        tx.orchard_shielded_data().is_some(),
-        "test transaction must contain Orchard actions",
-    );
-
-    let height = tx.expiry_height().expect("V5 tx has an expiry height");
-
-    // The soft fork activates one block above the transaction's height, so it is
-    // inactive for this transaction and verification proceeds normally.
-    let accepting_network = Parameters::build()
-        .with_temporary_orchard_disabling_soft_fork_height(
-            (height + 1).expect("height is too large"),
-        )
-        .to_network()
-        .expect("failed to build configured network");
-
-    assert!(
-        !accepting_network.temporary_orchard_disabling_soft_fork_active(height),
-        "soft fork must be inactive below its activation height",
-    );
-
-    // The only state request for an Orchard-only transaction verified as part of
-    // a block is the nullifier and anchor check.
-    let mut state: MockService<zakura_state::Request, zakura_state::Response, _, _> =
-        MockService::build().for_prop_tests();
-    let accept_verifier = Verifier::new_for_tests(&accepting_network, state.clone());
-
-    tokio::spawn(async move {
-        state
-            .expect_request_that(|req| {
-                matches!(
-                    req,
-                    zakura_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
-                )
+    zakura_test::MULTI_THREADED_RUNTIME.block_on(async {
+        // Use an unmodified Orchard-only V5 transaction from the test vectors so its
+        // proofs remain valid for the acceptance path.
+        let default_testnet = Network::new_default_testnet();
+        let tx = v5_transactions(default_testnet.block_iter())
+            .rev()
+            .find(|transaction| {
+                transaction.inputs().is_empty()
+                    && transaction.outputs().is_empty()
+                    && transaction.sapling_spends_per_anchor().next().is_none()
+                    && transaction.sapling_outputs().next().is_none()
+                    && transaction.joinsplit_count() == 0
             })
-            .await
-            .expect("verifier should call mock state service with correct request")
-            .respond(zakura_state::Response::ValidBestChainTipNullifiersAndAnchors);
-    });
+            .expect("V5 tx with only Orchard actions");
 
-    let accept_response = accept_verifier
+        assert!(
+            tx.orchard_shielded_data().is_some(),
+            "test transaction must contain Orchard actions",
+        );
+
+        let height = tx.expiry_height().expect("V5 tx has an expiry height");
+
+        // The soft fork activates one block above the transaction's height, so it is
+        // inactive for this transaction and verification proceeds normally.
+        let accepting_network = Parameters::build()
+            .with_temporary_orchard_disabling_soft_fork_height(
+                (height + 1).expect("height is too large"),
+            )
+            .to_network()
+            .expect("failed to build configured network");
+
+        assert!(
+            !accepting_network.temporary_orchard_disabling_soft_fork_active(height),
+            "soft fork must be inactive below its activation height",
+        );
+
+        // The only state request for an Orchard-only transaction verified as part of
+        // a block is the nullifier and anchor check.
+        let mut state: MockService<zakura_state::Request, zakura_state::Response, _, _> =
+            MockService::build().for_prop_tests();
+        let accept_verifier = Verifier::new_for_tests(&accepting_network, state.clone());
+
+        tokio::spawn(async move {
+            state
+                .expect_request_that(|req| {
+                    matches!(
+                        req,
+                        zakura_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                    )
+                })
+                .await
+                .expect("verifier should call mock state service with correct request")
+                .respond(zakura_state::Response::ValidBestChainTipNullifiersAndAnchors);
+        });
+
+        let accept_response = accept_verifier
+            .oneshot(Request::Block {
+                transaction_hash: tx.hash(),
+                transaction: Arc::new(tx.clone()),
+                known_utxos: Arc::new(HashMap::new()),
+                known_outpoint_hashes: Arc::new(HashSet::new()),
+                height,
+                time: DateTime::<Utc>::MAX_UTC,
+            })
+            .await;
+
+        assert!(
+            accept_response.is_ok(),
+            "Orchard transaction must be accepted below the soft fork height, got: {accept_response:?}",
+        );
+
+        // At the activation height the same transaction is rejected. The soft-fork
+        // check runs before any state query, so the state service is never called.
+        let rejecting_network = Parameters::build()
+            .with_temporary_orchard_disabling_soft_fork_height(height)
+            .to_network()
+            .expect("failed to build configured network");
+
+        let reject_response = Verifier::new_for_tests(
+            &rejecting_network,
+            service_fn(|_| async { unreachable!("state service should not be called") }),
+        )
         .oneshot(Request::Block {
             transaction_hash: tx.hash(),
-            transaction: Arc::new(tx.clone()),
+            transaction: Arc::new(tx),
             known_utxos: Arc::new(HashMap::new()),
             known_outpoint_hashes: Arc::new(HashSet::new()),
             height,
@@ -4228,39 +4259,14 @@ async fn orchard_disabling_soft_fork_accepts_orchard_actions_below_activation_he
         })
         .await;
 
-    assert!(
-        accept_response.is_ok(),
-        "Orchard transaction must be accepted below the soft fork height, got: {accept_response:?}",
-    );
-
-    // At the activation height the same transaction is rejected. The soft-fork
-    // check runs before any state query, so the state service is never called.
-    let rejecting_network = Parameters::build()
-        .with_temporary_orchard_disabling_soft_fork_height(height)
-        .to_network()
-        .expect("failed to build configured network");
-
-    let reject_response = Verifier::new_for_tests(
-        &rejecting_network,
-        service_fn(|_| async { unreachable!("state service should not be called") }),
-    )
-    .oneshot(Request::Block {
-        transaction_hash: tx.hash(),
-        transaction: Arc::new(tx),
-        known_utxos: Arc::new(HashMap::new()),
-        known_outpoint_hashes: Arc::new(HashSet::new()),
-        height,
-        time: DateTime::<Utc>::MAX_UTC,
-    })
-    .await;
-
-    assert_eq!(
-        reject_response,
-        Err(TransactionError::Other(
-            "transaction has Orchard actions (temporarily disabled)".into()
-        )),
-        "Orchard transaction must be rejected at the soft fork height",
-    );
+        assert_eq!(
+            reject_response,
+            Err(TransactionError::Other(
+                "transaction has Orchard actions (temporarily disabled)".into()
+            )),
+            "Orchard transaction must be rejected at the soft fork height",
+        );
+    });
 }
 
 /// Checks that public-network branch-ID admission switches exactly at NU6.3 activation.

--- a/docs/changelog/unreleased/605.md
+++ b/docs/changelog/unreleased/605.md
@@ -1,0 +1,5 @@
+<!-- changelog: none -->
+
+Test-only: moves an existing consensus test onto the shared Tokio runtime so
+`cargo test -p zakura-consensus --lib` stops failing. No user-visible change to
+`zakurad`.


### PR DESCRIPTION
## Motivation

`cargo test -p zakura-consensus --lib` fails on `main`:

```
transaction::tests::v4_and_v5_with_sapling_spends
  unexpected error response: InternalDowncastError(
    "downcast to known transaction error type failed, original error: JoinError::Cancelled(Id(2653))")

test result: FAILED. 163 passed; 1 failed
```

The batch verifiers are global `Lazy` statics, so whichever test *first* forces
one spawns its `Batch` worker onto that test's tokio runtime.
`orchard_disabling_soft_fork_accepts_orchard_actions_below_activation_height` is
a `#[tokio::test]` that verifies a real Orchard bundle, so it can be the test
that forces the Halo2 verifiers. Its per-test runtime is dropped when it
returns, which cancels the worker.

`Batch::poll_ready` polls the worker's `JoinHandle` and returns
`JoinError::Cancelled` to the caller (`crates/tower-batch-control/src/service.rs:294`).
So every later test that reaches the same global gets a cancellation instead of
a verdict, surfacing as an `InternalDowncastError` in whichever test happens to
run next.

This is the hazard `zakura_test::SINGLE_THREADED_RUNTIME`'s own documentation
describes, and the shared runtimes exist for it:

> This background task is stopped when the runtime is shut down, so having a
> runtime per test means that only the first test actually manages to
> successfully use the background task.

CI runs under nextest's process-per-test model, where each test gets a fresh
process and this cannot happen — which is why it is invisible there and only
bites `cargo test`.

## Solution

Move the test to `zakura_test::MULTI_THREADED_RUNTIME`, which the shielded
transaction tests around it already use. Its assertions are unchanged.

## Testing

The offending test was identified rather than guessed: each global `Lazy` was
temporarily instrumented to log the forcing thread (cargo names test threads
after the test), and `Batch::poll_ready` to log the type of the cancelled batch.
That named this test and `halo2::Verifier` directly. The instrumentation was
reverted before the change in this PR.

- Before: `163 passed; 1 failed`, reproducing on every run.
- After: `164 passed; 0 failed`, three consecutive runs.
- `cargo fmt --all -- --check` and
  `cargo clippy -p zakura-consensus --all-targets --all-features -D warnings` clean.

## Changelog

Test-only; no user-visible change.

### Follow-up Work

The same hazard applies to any future `#[tokio::test]` that reaches a global
verifier. Nothing in the type system prevents it — the only guard today is the
convention of using the shared runtimes, which this PR restores.
