### PR TITLE
fix(release): clarify hotfix mode and harden capability probe

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -96,13 +96,19 @@ allows `hotfix/v*`).
       completed steps):
 
   ```sh
+  # Main base: squash-merge the public PR, then release from main.
+  ./scripts/release-t0.sh publish --hotfix --tag v<version> \
+      --mode main --pr <N> --head-sha <final-commit>
+
+  # Previous-release base: push and release from the hotfix branch.
   ./scripts/release-t0.sh publish --hotfix --tag v<version> \
       --mode branch --head-sha <final-commit>
   ```
 
-  Manual fallback: push `hotfix/v<version>`, dispatch `Create release`
-  **from the branch** with the exact tag, and verify each step landed before
-  the next.
+  Manual fallback: for a main-base hotfix, squash-merge the public PR and
+  dispatch `Create release` from `main`; for a previous-release-base hotfix,
+  push `hotfix/v<version>` and dispatch from that branch. Use the exact tag
+  and verify each step landed before the next.
 - [ ] Approve the `release` environment deployment when the script announces
       it (right commit? right tag?). The workflow publishes a complete
       pre-release and creates the protected tag; the tag push starts Docker

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -35,10 +35,14 @@ canary soak, announcement) apply on top of this checklist.
       branch cut from the previous release. Do not rebase the branch onto a
       different base after choosing the mode.
 - [ ] Make the required changes, minimal and with tests.
-- [ ] For a public (non-embargoed) hotfix: open this PR from the branch with
+- [ ] For a public (non-embargoed) previous-release-base hotfix
+      (`--mode branch`): open this PR from the branch with
       `&template=hotfix-release-checklist.md` in the compare URL, and add the
-      `do-not-merge` label — the release is dispatched from the branch itself,
-      and the PR is merged (as a merge commit) only after the release.
+      `do-not-merge` label. Release from the branch, then forward-merge this PR
+      after the release.
+- [ ] For a main-base hotfix (`--mode main`): do not add `do-not-merge`.
+      The T-0 orchestrator squash-merges this PR before dispatching the release
+      from `main`.
 - [ ] Add the `A-release` and `C-exclude-from-changelog` labels **when
       opening the PR**: the changelog fragment check only accepts a
       fragment-consuming release branch in release-PR mode, and relabeling

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -30,6 +30,10 @@ canary soak, announcement) apply on top of this checklist.
       those names belong to the regular release process, and disjoint
       namespaces are what prevent an embargo-blind collision with it (see
       the process doc's branch namespace rule).
+- [ ] Choose and review the release mode before opening the public PR: use
+      `--mode main` for a branch cut from `main`, or `--mode branch` for a
+      branch cut from the previous release. Do not rebase the branch onto a
+      different base after choosing the mode.
 - [ ] Make the required changes, minimal and with tests.
 - [ ] For a public (non-embargoed) hotfix: open this PR from the branch with
       `&template=hotfix-release-checklist.md` in the compare URL, and add the
@@ -91,14 +95,14 @@ allows `hotfix/v*`).
       and verifies each step's target state (resumable — re-runs skip
       completed steps):
 
-      ```sh
-      ./scripts/release-t0.sh publish --hotfix --tag v<version> \
-          --mode branch --head-sha <final-commit>
-      ```
+  ```sh
+  ./scripts/release-t0.sh publish --hotfix --tag v<version> \
+      --mode branch --head-sha <final-commit>
+  ```
 
-      Manual fallback: push `hotfix/v<version>`, dispatch `Create release`
-      **from the branch** with the exact tag, and verify each step landed
-      before the next.
+  Manual fallback: push `hotfix/v<version>`, dispatch `Create release`
+  **from the branch** with the exact tag, and verify each step landed before
+  the next.
 - [ ] Approve the `release` environment deployment when the script announces
       it (right commit? right tag?). The workflow publishes a complete
       pre-release and creates the protected tag; the tag push starts Docker

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -8,32 +8,35 @@ assignees: ""
 
 A hotfix release should only be created when a bug or critical issue is
 discovered in an existing release, and waiting for the next scheduled release
-is impractical or unacceptable. It ships the fix on top of the release
-operators are already running, instead of everything unreleased on `main`.
+is impractical or unacceptable. Prefer shipping the fix on top of the release
+operators are already running; use `main` only when its unreleased changes are
+safe to include.
 
 For an **embargoed security fix**, follow
 [`docs/security-hotfix-release.md`](https://github.com/zakura-core/zakura/blob/main/docs/security-hotfix-release.md):
-all preparation below happens in the private staging repo, this PR is opened
-at forward-merge time, and the extra steps there (advisory, dress rehearsal,
-canary soak, announcement) apply on top of this checklist.
+all preparation below happens in the private staging repo. Open this PR at T-0
+for a main-base hotfix, or at forward-merge time for a previous-release-base
+hotfix. The extra steps there (advisory, dress rehearsal, canary soak,
+announcement) apply on top of this checklist.
 
 ## Create the Hotfix Branch
 
-- [ ] Cut `hotfix/v<version>` from the tag of the release being fixed (not
-      from `main`). The branch **must** be named for the exact tag it will
-      release — the `Create release` workflow refuses to tag `v<version>`
-      from any other branch. The `hotfix/v*` ruleset blocks deletion and
-      force-pushes.
-- [ ] Embargoed main-base hotfix: the T-0 public PR branch is **also** named
-      `hotfix/v<version>` (based on `main`, pushed at T-0). Whatever the
-      base, the hotfix process never pushes `release/v*` or `bump-v*` —
+- [ ] Choose and review the release mode before creating the hotfix branch:
+      use `--mode main` when the unreleased changes on `main` are safe to
+      include, or `--mode branch` to release only the fix on top of the
+      previous release. Record the choice and do not rebase the branch onto a
+      different base.
+- [ ] Create `hotfix/v<version>` from `main` for `--mode main`, or from the
+      previous release tag for `--mode branch`. The branch **must** be named
+      for the exact tag it will release — the `Create release` workflow
+      refuses to tag `v<version>` from any other branch. The `hotfix/v*`
+      ruleset blocks deletion and force-pushes.
+- [ ] For an embargoed main-base hotfix, push the `hotfix/v<version>` branch
+      to the public repository at T-0. Whatever the base, the hotfix process
+      never pushes `release/v*` or `bump-v*` —
       those names belong to the regular release process, and disjoint
       namespaces are what prevent an embargo-blind collision with it (see
       the process doc's branch namespace rule).
-- [ ] Choose and review the release mode before opening the public PR: use
-      `--mode main` for a branch cut from `main`, or `--mode branch` for a
-      branch cut from the previous release. Do not rebase the branch onto a
-      different base after choosing the mode.
 - [ ] Make the required changes, minimal and with tests.
 - [ ] For a public (non-embargoed) previous-release-base hotfix
       (`--mode branch`): open this PR from the branch with

--- a/docs/security-hotfix-release.md
+++ b/docs/security-hotfix-release.md
@@ -159,6 +159,12 @@ the right to withhold reproduction details for counterfeiting-class bugs.
 | `hotfix/vX.Y.Z` cut from the last release tag | Default for solo, and whenever `main` has unreleased work operators shouldn't absorb mid-emergency | Minimal auditable diff; **mechanically simplest solo**: direct maintainer push, no PR review rule, no Mergify interaction. The branch must be named for the exact tag it releases — the `Create release` validate job enforces this. Fix must be forward-merged to `main` right after release. |
 | `main` | `main` is essentially the last release plus safe changes | Direct pushes to `main` are blocked for everyone: at T-0, open a public PR **from `hotfix/vX.Y.Z`** and **squash-merge** it — the only method the `main` ruleset allows, and safe in this order because `Create release` tags the squash commit _after_ the merge. Freeze the Mergify `batched` queue first. |
 
+Choose and record the mode when creating the hotfix branch, before opening the
+public PR, and do not rebase the branch onto a different base. Use `main` mode
+for a branch cut from `main`, or branch mode for a minimal branch cut from the
+previous release. Review this choice before T-0 to avoid publishing unreleased
+`main` changes directly from the hotfix branch.
+
 Record the choice and reasoning in the advisory.
 
 **Branch namespace rule.** Whatever the base, the hotfix process creates

--- a/scripts/release-t0.sh
+++ b/scripts/release-t0.sh
@@ -196,7 +196,7 @@ check_globals() {
   gh auth status >/dev/null 2>&1 \
     || die "tools" "gh auth status" "not authenticated" "authenticated" \
         "run: gh auth login"
-  gh pr merge --help 2>/dev/null | grep -q -- '--match-head-commit' \
+  gh pr merge --help 2>/dev/null | grep -- '--match-head-commit' >/dev/null \
     || die "tools" "gh pr merge --help" "no --match-head-commit flag" \
         "gh with --match-head-commit support" "upgrade gh (>= 2.30)"
 


### PR DESCRIPTION
## Summary

- make the GitHub CLI capability probe reliable under `set -o pipefail`
- require operators to choose and record the hotfix release mode before opening the public PR
- show mode-specific T-0 commands and manual fallbacks in the hotfix checklist

## Motivation

The v1.1.1 emergency release exposed two process hazards: `grep -q` could falsely reject a supported `gh` version after SIGPIPE, and a branch rebased onto `main` was initially treated as a release-tag-base hotfix. Both failures occurred before or around T-0 and made the intended release path ambiguous.

This change keeps mode selection explicit and ensures the checklist remains actionable for both main-base and previous-release-base hotfixes.

## Test plan

- [x] `bash -n scripts/release-t0.sh`
- [x] `shellcheck scripts/release-t0.sh`
- [x] capability probe succeeds under `bash -o pipefail`
- [x] Markdown lint passes for both updated process documents
- [x] checklist documents the main-base and previous-release-base publish paths

## Changelog

Internal release tooling and process documentation only; no user-visible Zakura behavior change.

## AI disclosure

AI assistance was used to implement and validate these release-process safeguards. The maintainer remains responsible for review and merge.