### PR TITLE
fix(indexer): test and version feature-gated state API

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -61,9 +61,9 @@ env:
   COLORBT_SHOW_HIDDEN: 1
 
 jobs:
-  # Decide whether this change can affect generated or historical zakurad
-  # configuration. Scheduled runs have no source change to check, while manual
-  # runs explicitly request the complete workflow.
+  # Decide which specialized test suites a change can affect. Scheduled runs
+  # have no source change to check, while manual runs explicitly request the
+  # complete workflow.
   changes:
     name: detect config-relevant changes
     runs-on: ubuntu-latest
@@ -73,6 +73,7 @@ jobs:
       pull-requests: read
     outputs:
       config: ${{ steps.filter.outputs.config }}
+      indexer: ${{ steps.filter.outputs.indexer }}
       rust: ${{ steps.filter.outputs.rust }}
     steps:
       - id: filter
@@ -96,6 +97,7 @@ jobs:
               if ! [[ "$TOTAL_CHANGED_FILES" =~ ^[0-9]+$ ]] || \
                  (( TOTAL_CHANGED_FILES >= 3000 )); then
                 echo "config=true" >> "$GITHUB_OUTPUT"
+                echo "indexer=true" >> "$GITHUB_OUTPUT"
                 echo "rust=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
@@ -126,11 +128,13 @@ jobs:
               ;;
             workflow_dispatch)
               echo "config=true" >> "$GITHUB_OUTPUT"
+              echo "indexer=true" >> "$GITHUB_OUTPUT"
               echo "rust=true" >> "$GITHUB_OUTPUT"
               exit 0
               ;;
             schedule)
               echo "config=false" >> "$GITHUB_OUTPUT"
+              echo "indexer=false" >> "$GITHUB_OUTPUT"
               echo "rust=false" >> "$GITHUB_OUTPUT"
               exit 0
               ;;
@@ -161,6 +165,26 @@ jobs:
             esac
           done <<< "$changed"
 
+          indexer=false
+          while IFS= read -r path; do
+            case "$path" in
+              Cargo.toml | Cargo.lock | rust-toolchain.toml | */Cargo.toml | \
+              crates/zakura-chain/* | crates/zakura-node-services/* | \
+              crates/zakura-state/* | crates/zakura-test/* | \
+              crates/zakura-rpc/Cargo.toml | crates/zakura-rpc/build.rs | \
+              crates/zakura-rpc/proto/indexer.proto | \
+              crates/zakura-rpc/proto/__generated__/indexer_descriptor.bin | \
+              crates/zakura-rpc/proto/__generated__/zebra.indexer.rpc.rs | \
+              crates/zakura-rpc/src/indexer.rs | crates/zakura-rpc/src/indexer/* | \
+              .cargo/config.toml | .config/nextest.toml | \
+              .github/actions/setup-zakura-build/* | \
+              .github/workflows/tests-unit.yml)
+                indexer=true
+                break
+                ;;
+            esac
+          done <<< "$changed"
+
           # Broad test-relevant filter (the paths that formerly gated the whole
           # workflow on pull_request). Every config-relevant change also needs
           # the build archive consumed by zakura-config, so `config` implies
@@ -173,6 +197,7 @@ jobs:
           fi
 
           echo "config=$config" >> "$GITHUB_OUTPUT"
+          echo "indexer=$indexer" >> "$GITHUB_OUTPUT"
           echo "rust=$rust" >> "$GITHUB_OUTPUT"
 
   # Compile the whole workspace and every test binary ONCE, then hand the result
@@ -286,6 +311,38 @@ jobs:
           fi
         env:
           FULL_COVERAGE: ${{ github.event_name != 'pull_request' }}
+
+  indexer-tests:
+    name: indexer feature tests
+    needs: changes
+    # Run on indexer-relevant PRs and every non-PR unit-test workflow event.
+    if: needs.changes.outputs.indexer == 'true' || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+          cache-shared-key: zakura-drb-debug
+          cache-on-failure: true
+          cache-save-if: false
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 #v2.85.7
+        with:
+          tool: cargo-nextest
+      - uses: ./.github/actions/setup-zakura-build
+      - name: Run indexer-enabled state and RPC tests
+        run: >-
+          cargo nextest run --locked --lib
+          -p zakura-rpc -p zakura-state
+          --features zakura-rpc/indexer
+          --no-fail-fast
 
   zakura-config:
     name: zakura config compatibility
@@ -413,6 +470,7 @@ jobs:
       - changes
       - build-tests
       - unit-tests
+      - indexer-tests
       - zakura-config
       - network-dependent
       - pruned-storage
@@ -426,10 +484,11 @@ jobs:
           # These jobs are skipped outside their event or changed-path scope:
           # build-tests / unit-tests / network-dependent skip on pull requests
           # that touch no test-relevant paths (unit-tests and zakura-config
-          # cascade-skip with build-tests), pruned-storage is push-main only,
+          # cascade-skip with build-tests), indexer-tests skips on PRs without
+          # indexer-relevant changes, pruned-storage is push-main only, and
           # check-no-git-dependencies is A-release-label only. Failed,
           # non-skipped jobs still fail this aggregate status.
-          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, network-dependent
+          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, indexer-tests, network-dependent
 
   report-nightly-result:
     name: report nightly release test result

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -873,7 +873,20 @@ impl DbFormatChange {
              running: {running_version}"
         );
 
-        db.update_format_version_on_disk(format_upgrade_version)
+        // Preserve the indexer marker while a non-indexer build applies numeric
+        // upgrades. The cleanup below uses it to remove indexer-only data.
+        #[cfg(feature = "indexer")]
+        let version_to_write = format_upgrade_version;
+        #[cfg(not(feature = "indexer"))]
+        let version_to_write = {
+            let mut version = format_upgrade_version.clone();
+            if version.build.is_empty() && disk_version.build.contains("indexer") {
+                version.build = disk_version.build.clone();
+            }
+            version
+        };
+
+        db.update_format_version_on_disk(&version_to_write)
             .expect("unable to write database format version file to disk");
 
         info!(
@@ -881,7 +894,7 @@ impl DbFormatChange {
             %disk_version,
             // wait_for_state_version_upgrade() needs this to be the last field,
             // so the regex matches correctly
-            %format_upgrade_version,
+            format_upgrade_version = %version_to_write,
             "marked database format as upgraded"
         );
     }

--- a/crates/zakura-state/src/service/finalized_state/tests/transparent.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/transparent.rs
@@ -159,6 +159,11 @@ fn intra_block_self_spend_chain_in_finalized_state() {
         (existing_output_location, existing_utxo),
         (t0_output_location, t0_output_utxo),
     ]);
+    #[cfg(feature = "indexer")]
+    let out_loc_by_outpoint = HashMap::from([
+        (existing_outpoint, existing_output_location),
+        (t0_output_outpoint, t0_output_location),
+    ]);
 
     // Pre-populate `address_balances` with A's pre-block on-chain balance, the way
     // `block.rs` does via `read_addr_locs`.
@@ -182,7 +187,7 @@ fn intra_block_self_spend_chain_in_finalized_state() {
         &spent_utxos_by_outpoint,
         &spent_utxos_by_out_loc,
         #[cfg(feature = "indexer")]
-        &HashMap::new(),
+        &out_loc_by_outpoint,
         address_balances,
     );
 

--- a/crates/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -425,7 +425,8 @@ impl ZakuraDb {
 
                 // We block here because the checks are quick and database validity is
                 // consensus-critical.
-                if disk_version.cmp_precedence(self.db.format_version_in_code()) != Ordering::Less {
+                if disk_version.cmp_precedence(&self.db.format_version_in_code()) != Ordering::Less
+                {
                     DbFormatChange::check_new_blocks(self)
                         .run_format_change_or_check(
                             self,

--- a/crates/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -9,7 +9,7 @@
 //! [`crate::constants::state_database_format_version_in_code()`] must be incremented
 //! each time the database format (column, serialization, etc) changes.
 
-use std::{path::Path, sync::Arc};
+use std::{cmp::Ordering, path::Path, sync::Arc};
 
 use crossbeam_channel::bounded;
 use semver::Version;
@@ -425,7 +425,7 @@ impl ZakuraDb {
 
                 // We block here because the checks are quick and database validity is
                 // consensus-critical.
-                if disk_version >= self.db.format_version_in_code() {
+                if disk_version.cmp_precedence(self.db.format_version_in_code()) != Ordering::Less {
                     DbFormatChange::check_new_blocks(self)
                         .run_format_change_or_check(
                             self,

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -396,7 +396,7 @@ impl ZakuraDb {
     /// are missing because they have been pruned.
     #[cfg(feature = "indexer")]
     #[allow(clippy::unwrap_in_result)]
-    pub fn raw_block_bytes(&self, hash_or_height: HashOrHeight) -> Option<Vec<u8>> {
+    pub(crate) fn raw_block_bytes(&self, hash_or_height: HashOrHeight) -> Option<Vec<u8>> {
         let (raw_header, raw_txs) = self.raw_block(hash_or_height)?;
 
         let tx_count = CompactSizeMessage::try_from(raw_txs.len())

--- a/crates/zakurad/tests/common/cached_state.rs
+++ b/crates/zakurad/tests/common/cached_state.rs
@@ -91,8 +91,13 @@ pub fn wait_for_state_version_upgrade<T>(
     );
 
     if state_version_message.contains("launching upgrade task") {
+        // Upgrade log fields contain the numeric format version, without the
+        // feature build metadata used by indexer binaries.
+        let mut logged_version = required_version.clone();
+        logged_version.build = semver::BuildMetadata::EMPTY;
         let upgrade_pattern = format!(
-            "marked database format as upgraded.*format_upgrade_version.*=.*{required_version}"
+            "marked database format as upgraded.*format_upgrade_version.*=.*{}",
+            regex::escape(&logged_version.to_string())
         );
         let extra_required_log_regexes = extra_required_log_regexes.into_iter();
         let required_logs: Vec<String> = iter::once(upgrade_pattern)

--- a/docs/changelog/unreleased/623.md
+++ b/docs/changelog/unreleased/623.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR adds CI coverage, test fixes, and versioning hygiene for an unreleased
+indexer RPC change, with no operator-visible behavior change.


### PR DESCRIPTION
## Motivation

PR #612 added indexer-gated variants to the public exhaustive `ReadRequest` and
`ReadResponse` enums, but the default-feature SemVer job cannot see that source
break and `zakura-state` remained on 6.x. The same feature-gated implementation
and its substantive tests were not exercised by CI; enabling the feature also
exposed two tests whose setup assumed the default feature state.

## Solution

- Bump `zakura-state` to 7.0.0 and update workspace reverse-dependency
  requirements.
- Narrow the raw block database helper to crate visibility.
- Repair the database-version assertion and transparent self-spend fixture so
  both feature states are valid.
- Add a path-gated indexer feature test job for `zakura-state` and `zakura-rpc`.
  It also runs on non-PR unit-test workflow events, including the merge queue and
  main pushes.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-rpc --lib --features indexer` (99 passed, 1 ignored)
- `cargo test -p zakura-state --lib --features indexer` (459 passed, 3 ignored)
- `./scripts/changelog.py check`
- Parsed `.github/workflows/tests-unit.yml` with Ruby YAML
- `git diff --check`
- Hosted `indexer feature tests` job passed

## Changelog

Added `docs/changelog/unreleased/623.md` as an internal-only fragment because
the indexer RPC remains unreleased and this follow-up has no operator-visible
behavior change.

### Specifications & References

- Follow-up to #612.

### Follow-up Work

None currently.
