### PR TITLE
fix(header-chain): harden engine-model review findings

### DIFF
--- a/crates/zakura-header-chain/src/transition/invariants.rs
+++ b/crates/zakura-header-chain/src/transition/invariants.rs
@@ -59,24 +59,63 @@ pub enum InvariantViolation {
     SourceSnapshot,
 }
 
+/// Selects which projected graph and node set the verifier inspects.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum VerificationMode {
+    /// Materialized projected graph and every retained node (test/fuzz oracle).
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    Exhaustive,
+    /// Delta overlay and changed-boundary nodes (shipped production path).
+    Production,
+}
+
+fn default_verification_mode() -> VerificationMode {
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    {
+        VerificationMode::Exhaustive
+    }
+    #[cfg(not(any(test, feature = "fuzz-impl")))]
+    {
+        VerificationMode::Production
+    }
+}
+
 /// Verify the complete projected state before an adapter may commit `plan`.
 pub(crate) fn verify_plan(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
 ) -> Result<(), InvariantViolation> {
+    verify_plan_with_mode(before, plan, default_verification_mode())
+}
+
+/// Verify `plan` using the exact production overlay and boundary-node path.
+#[cfg(any(test, feature = "fuzz-impl"))]
+pub(crate) fn verify_plan_production(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+) -> Result<(), InvariantViolation> {
+    verify_plan_with_mode(before, plan, VerificationMode::Production)
+}
+
+fn verify_plan_with_mode(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+    mode: VerificationMode,
+) -> Result<(), InvariantViolation> {
     if is_incremental_aux_authentication(before, plan) {
-        return verify_incremental_aux_authentication(before, plan);
+        return verify_incremental_aux_authentication(before, plan, mode);
     }
     if is_incremental_checkpoint_finality(before, plan) {
-        return verify_incremental_checkpoint_finality(before, plan);
+        return verify_incremental_checkpoint_finality(before, plan, mode);
     }
 
-    verify_plan_exhaustive(before, plan)
+    verify_plan_exhaustive(before, plan, mode)
 }
 
 fn verify_plan_exhaustive(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
+    mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     let source = before.snapshot();
     if source != plan.before {
@@ -90,7 +129,38 @@ fn verify_plan_exhaustive(
     let delta_graph = GraphOverlay::from_delta(before.graph(), plan.graph_delta())
         .map_err(|_| InvariantViolation::Index(block::Hash([0; 32])))?;
     let delta_finalized = delta_graph.view_finalized_frontier();
-    let graph = delta_graph;
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    if mode == VerificationMode::Exhaustive {
+        return verify_plan_against_graph(
+            before,
+            plan,
+            &source,
+            source_metadata,
+            plan.projected_graph(),
+            delta_finalized,
+            mode,
+        );
+    }
+    verify_plan_against_graph(
+        before,
+        plan,
+        &source,
+        source_metadata,
+        &delta_graph,
+        delta_finalized,
+        mode,
+    )
+}
+
+fn verify_plan_against_graph<G: HeaderGraphView>(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+    source: &crate::EngineSnapshot,
+    source_metadata: &crate::EngineMetadata,
+    graph: &G,
+    delta_finalized: Frontier,
+    mode: VerificationMode,
+) -> Result<(), InvariantViolation> {
     let metadata = &plan.change_set.metadata;
     let expected_work_origin = if plan.graph_delta().rebases_work_coordinates() {
         source.frontiers.finalized
@@ -143,15 +213,14 @@ fn verify_plan_exhaustive(
     } else if metadata.finality_epoch != source_metadata.finality_epoch {
         return Err(InvariantViolation::Generation);
     }
-    let nodes = changed_boundary_nodes(before, &graph, plan);
-    for node in nodes {
-        verify_node(&graph, node, metadata.work_origin.hash)?;
+    for node in verification_nodes(before, graph, plan, mode) {
+        verify_node(graph, node, metadata.work_origin.hash)?;
     }
     verify_indexes(before, plan)?;
-    let selected = projected_path(before, &source, &plan.change_set.selected_projection, true)?;
-    let verified = projected_path(before, &source, &plan.change_set.verified_projection, false)?;
+    let selected = projected_path(before, source, &plan.change_set.selected_projection, true)?;
+    let verified = projected_path(before, source, &plan.change_set.verified_projection, false)?;
     verify_projection(
-        &graph,
+        graph,
         &selected,
         metadata.frontiers.header_best,
         InvariantViolation::SelectedProjection,
@@ -163,7 +232,7 @@ fn verify_plan_exhaustive(
         return Err(InvariantViolation::Selection);
     }
     verify_verified(
-        &graph,
+        graph,
         metadata.mode,
         &verified,
         metadata.frontiers.verified_best,
@@ -174,14 +243,14 @@ fn verify_plan_exhaustive(
         &verified,
         &plan.change_set.put_nodes,
     )?;
-    verify_protected(&graph, plan)?;
+    verify_protected(graph, plan)?;
     if graph.view_header_node_count().saturating_sub(1) > plan.limits.max_non_finalized_nodes.get()
         || graph.view_eligible_header_tips().len() > plan.limits.max_candidate_tips.get()
     {
         return Err(InvariantViolation::Limits);
     }
     verify_generations(before, plan, &selected, &verified)?;
-    verify_aux(before, &graph, plan)?;
+    verify_aux(before, graph, plan, mode)?;
     Ok(())
 }
 
@@ -224,6 +293,7 @@ pub(super) fn is_incremental_aux_authentication(
 fn verify_incremental_aux_authentication(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
+    mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     if before.snapshot() != plan.before {
         return Err(InvariantViolation::SourceSnapshot);
@@ -252,7 +322,7 @@ fn verify_incremental_aux_authentication(
         before.selected_projection(),
         before.verified_projection(),
     )?;
-    verify_aux(before, before.graph(), plan)?;
+    verify_aux(before, before.graph(), plan, mode)?;
     Ok(())
 }
 
@@ -307,6 +377,7 @@ pub(super) fn is_incremental_checkpoint_finality(
 fn verify_incremental_checkpoint_finality(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
+    mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     let source = before.snapshot();
     if source != plan.before {
@@ -319,7 +390,35 @@ fn verify_incremental_checkpoint_finality(
     let delta_graph = GraphOverlay::from_delta(before.graph(), plan.graph_delta())
         .map_err(|_| InvariantViolation::Index(block::Hash([0; 32])))?;
     let delta_finalized = delta_graph.view_finalized_frontier();
-    let graph = delta_graph;
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    if mode == VerificationMode::Exhaustive {
+        return verify_incremental_checkpoint_against_graph(
+            before,
+            plan,
+            &source,
+            plan.projected_graph(),
+            delta_finalized,
+            mode,
+        );
+    }
+    verify_incremental_checkpoint_against_graph(
+        before,
+        plan,
+        &source,
+        &delta_graph,
+        delta_finalized,
+        mode,
+    )
+}
+
+fn verify_incremental_checkpoint_against_graph<G: HeaderGraphView>(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+    source: &crate::EngineSnapshot,
+    graph: &G,
+    delta_finalized: Frontier,
+    mode: VerificationMode,
+) -> Result<(), InvariantViolation> {
     let metadata = &plan.change_set.metadata;
     let record = plan
         .change_set
@@ -412,7 +511,7 @@ fn verify_incremental_checkpoint_finality(
             return Err(InvariantViolation::TrustPin(finalized.height));
         }
     }
-    verify_protected(&graph, plan)?;
+    verify_protected(graph, plan)?;
     if graph.view_header_node_count().saturating_sub(1) > plan.limits.max_non_finalized_nodes.get()
         || graph.view_eligible_header_tips().len() > plan.limits.max_candidate_tips.get()
     {
@@ -424,7 +523,7 @@ fn verify_incremental_checkpoint_finality(
         &[metadata.frontiers.header_best],
         &[metadata.frontiers.verified_best],
     )?;
-    verify_aux(before, &graph, plan)?;
+    verify_aux(before, graph, plan, mode)?;
     Ok(())
 }
 
@@ -736,6 +835,7 @@ fn verify_aux<G: HeaderGraphView>(
     before: &HeaderChainEngine,
     graph: &G,
     plan: &TransitionPlan,
+    mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     let mut put_ids = HashSet::new();
     for change in &plan.change_set.aux_changes {
@@ -784,15 +884,16 @@ fn verify_aux<G: HeaderGraphView>(
             AuxDelta::Delete { .. } => None,
         })
         .collect();
-    #[cfg(any(test, feature = "fuzz-impl"))]
-    let nodes = graph.view_header_nodes();
-    #[cfg(not(any(test, feature = "fuzz-impl")))]
-    let nodes: Vec<_> = plan
-        .change_set
-        .put_nodes
-        .iter()
-        .filter_map(|changed| graph.view_header_node(changed.hash))
-        .collect();
+    let nodes: Vec<&HeaderNode> = match mode {
+        #[cfg(any(test, feature = "fuzz-impl"))]
+        VerificationMode::Exhaustive => graph.view_header_nodes(),
+        VerificationMode::Production => plan
+            .change_set
+            .put_nodes
+            .iter()
+            .filter_map(|changed| graph.view_header_node(changed.hash))
+            .collect(),
+    };
     for node in nodes {
         let mut deliveries = before.aux_deliveries(node.hash).to_vec();
         deliveries.retain(|delivery| !deleted_ids.contains(&delivery.delivery_id));
@@ -822,6 +923,19 @@ fn verify_aux<G: HeaderGraphView>(
         }
     }
     Ok(())
+}
+
+fn verification_nodes<'a, G: HeaderGraphView>(
+    before: &HeaderChainEngine,
+    graph: &'a G,
+    plan: &TransitionPlan,
+    mode: VerificationMode,
+) -> Vec<&'a HeaderNode> {
+    match mode {
+        #[cfg(any(test, feature = "fuzz-impl"))]
+        VerificationMode::Exhaustive => graph.view_header_nodes(),
+        VerificationMode::Production => changed_boundary_nodes(before, graph, plan),
+    }
 }
 
 fn changed_boundary_nodes<'a, G: HeaderGraphView>(

--- a/crates/zakura-header-chain/src/transition/invariants.rs
+++ b/crates/zakura-header-chain/src/transition/invariants.rs
@@ -131,12 +131,13 @@ fn verify_plan_exhaustive(
     let delta_finalized = delta_graph.view_finalized_frontier();
     #[cfg(any(test, feature = "fuzz-impl"))]
     if mode == VerificationMode::Exhaustive {
+        let projected_graph = materialize_projected_graph(before, plan)?;
         return verify_plan_against_graph(
             before,
             plan,
             &source,
             source_metadata,
-            plan.projected_graph(),
+            &projected_graph,
             delta_finalized,
             mode,
         );
@@ -392,11 +393,12 @@ fn verify_incremental_checkpoint_finality(
     let delta_finalized = delta_graph.view_finalized_frontier();
     #[cfg(any(test, feature = "fuzz-impl"))]
     if mode == VerificationMode::Exhaustive {
+        let projected_graph = materialize_projected_graph(before, plan)?;
         return verify_incremental_checkpoint_against_graph(
             before,
             plan,
             &source,
-            plan.projected_graph(),
+            &projected_graph,
             delta_finalized,
             mode,
         );
@@ -936,6 +938,18 @@ fn verification_nodes<'a, G: HeaderGraphView>(
         VerificationMode::Exhaustive => graph.view_header_nodes(),
         VerificationMode::Production => changed_boundary_nodes(before, graph, plan),
     }
+}
+
+#[cfg(any(test, feature = "fuzz-impl"))]
+fn materialize_projected_graph(
+    before: &HeaderChainEngine,
+    plan: &TransitionPlan,
+) -> Result<crate::graph::MemHeaderStore, InvariantViolation> {
+    let mut graph = before.graph().clone();
+    graph
+        .apply_delta(plan.graph_delta())
+        .map_err(|_| InvariantViolation::Index(block::Hash([0; 32])))?;
+    Ok(graph)
 }
 
 fn changed_boundary_nodes<'a, G: HeaderGraphView>(

--- a/crates/zakura-header-chain/src/transition/mod.rs
+++ b/crates/zakura-header-chain/src/transition/mod.rs
@@ -14,6 +14,8 @@ pub use engine::{
     HeaderChainEngine,
 };
 pub(crate) use invariants::verify_plan;
+#[cfg(any(test, feature = "fuzz-impl"))]
+pub(crate) use invariants::verify_plan_production;
 pub use invariants::InvariantViolation;
 pub use planner::{TransitionFailure, TransitionPlan};
 pub use recovery::{

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -1330,6 +1330,11 @@ fn apply_event<G: HeaderGraphEdit>(
                     "operator invalidation identity is not bound to its target",
                 ));
             }
+            if event.target == graph.view_finalized_frontier().hash {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "operator invalidation cannot target the finalized anchor",
+                ));
+            }
             *operator_reason_changed = graph.edit_add_header_eligibility_reason(
                 event.target,
                 EligibilityReason::operator_invalid(event.target, event.id, event.evidence),

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -1760,7 +1760,7 @@ fn path<G: HeaderGraphView>(graph: &G, tip: Frontier) -> Result<Vec<Frontier>, T
             current
                 .height
                 .previous()
-                .map_err(|_| GraphError::FinalizedNotDescendant {
+                .map_err(|_| GraphError::FinalizedFrontierNotDescendant {
                     current: finalized.hash,
                     candidate: tip.hash,
                 })?,

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -1736,17 +1736,27 @@ fn invariant_pins(context: &TransitionContext<'_>) -> Arc<[Frontier]> {
 }
 
 fn path<G: HeaderGraphView>(graph: &G, tip: Frontier) -> Result<Vec<Frontier>, TransitionFailure> {
+    let finalized = graph.view_finalized_frontier();
     let mut path = Vec::new();
     let mut current = tip;
     loop {
         path.push(current);
-        if current == graph.view_finalized_frontier() {
+        if current == finalized {
             break;
         }
         let node = graph
             .view_header_node(current.hash)
             .ok_or(GraphError::UnknownHeaderNode(current.hash))?;
-        current = Frontier::new(block::Height(current.height.0 - 1), node.parent_hash);
+        current = Frontier::new(
+            current
+                .height
+                .previous()
+                .map_err(|_| GraphError::FinalizedNotDescendant {
+                    current: finalized.hash,
+                    candidate: tip.hash,
+                })?,
+            node.parent_hash,
+        );
     }
     path.reverse();
     Ok(path)

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -344,13 +344,22 @@ pub(super) fn apply_transition_engine(
         crate::AuxDelta::Put(delivery) => graph.view_header_node(delivery.header_hash).is_some(),
         crate::AuxDelta::Delete { .. } => true,
     });
-    for hash in &evicted {
-        for delivery in engine.aux_deliveries(*hash) {
-            aux_changes.push(crate::AuxDelta::Delete {
-                header_hash: *hash,
-                delivery_id: delivery.delivery_id,
-            });
-        }
+    let mut aux_deletes: Vec<_> = evicted
+        .iter()
+        .flat_map(|hash| {
+            engine
+                .aux_deliveries(*hash)
+                .iter()
+                .map(|delivery| (*hash, delivery.delivery_id))
+        })
+        .collect();
+    // HashSet iteration is nondeterministic; match adjacent ChangeSet ordering.
+    aux_deletes.sort_unstable_by_key(|(hash, delivery_id)| (hash.0, *delivery_id));
+    for (header_hash, delivery_id) in aux_deletes {
+        aux_changes.push(crate::AuxDelta::Delete {
+            header_hash,
+            delivery_id,
+        });
     }
     let plan = derive_plan(DerivePlanInputs {
         before,

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -179,10 +179,8 @@ fn auxiliary_deletes_for_evicted_headers_are_sorted_by_hash_and_delivery_id() {
     for delivery in &deliveries {
         store
             .graph
-            .node_mut(delivery.header_hash)
-            .expect("the competing header remains retained")
-            .aux_delivery_ids
-            .push(delivery.delivery_id);
+            .record_aux_delivery(delivery.header_hash, delivery.delivery_id)
+            .expect("the competing header remains retained");
         store.aux.push(*delivery);
     }
 

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -102,6 +102,124 @@ fn same_transition_auxiliary_eviction_has_no_generation_effect() {
     assert!(plan.change_set.aux_changes.is_empty());
 }
 
+#[test]
+fn auxiliary_deletes_for_evicted_headers_are_sorted_by_hash_and_delivery_id() {
+    use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
+
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let old_finalized = store.graph.finalized();
+    let easy = store
+        .graph
+        .node(old_finalized.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let easy_target: U256 = easy
+        .to_expanded()
+        .expect("the fixture target expands")
+        .into();
+    let hard = ExpandedDifficulty::from(easy_target >> 3).into();
+
+    let verified_tip = insert_verified_branch(&mut store.graph, old_finalized, 3, easy, 0xe1);
+    let verified_path =
+        path(&store.graph, verified_tip).expect("the verified fixture path is retained");
+    let new_finalized = verified_path[1];
+    let selected_tip = insert_verified_branch(&mut store.graph, old_finalized, 2, hard, 0xe2);
+    synchronize_fixture(&mut store, verified_tip);
+    assert_eq!(store.metadata.frontiers.header_best, selected_tip);
+
+    let owner = crate::HeaderWorkOwner {
+        authority: crate::HeaderWorkAuthority {
+            header_generation: store.metadata.header_generation,
+            branch: BranchId::new(old_finalized.hash, selected_tip.hash),
+        },
+        session_id: 1,
+        request_id: NonZeroU64::new(1).expect("one is nonzero"),
+    }
+    .into();
+    let source = SourceId::from_digest([0xe3; 32]);
+    let competing = store.selected.iter().copied().skip(1).collect::<Vec<_>>();
+    assert_eq!(
+        competing.len(),
+        2,
+        "the competing branch has two retained headers"
+    );
+    // Attach deliveries out of sorted order so the plan must impose (hash, id) order.
+    let deliveries = [
+        crate::AuxDelivery {
+            delivery_id: EvidenceId::from_digest([0xf2; 32]),
+            header_hash: competing[1].hash,
+            source,
+            owner,
+            body_size: crate::BodySizeHint::Unknown,
+            tree_aux: None,
+            authentication: crate::AuxAuthentication::Unauthenticated,
+        },
+        crate::AuxDelivery {
+            delivery_id: EvidenceId::from_digest([0xf0; 32]),
+            header_hash: competing[0].hash,
+            source,
+            owner,
+            body_size: crate::BodySizeHint::Unknown,
+            tree_aux: None,
+            authentication: crate::AuxAuthentication::Unauthenticated,
+        },
+        crate::AuxDelivery {
+            delivery_id: EvidenceId::from_digest([0xf1; 32]),
+            header_hash: competing[0].hash,
+            source,
+            owner,
+            body_size: crate::BodySizeHint::Unknown,
+            tree_aux: None,
+            authentication: crate::AuxAuthentication::Unauthenticated,
+        },
+    ];
+    for delivery in &deliveries {
+        store
+            .graph
+            .node_mut(delivery.header_hash)
+            .expect("the competing header remains retained")
+            .aux_delivery_ids
+            .push(delivery.delivery_id);
+        store.aux.push(*delivery);
+    }
+
+    let plan = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::FullStateFinalized(crate::FullStateFinalized {
+                full_state_transition_id: EvidenceId::from_digest([0xe4; 32]),
+                new_finalized,
+                verified_path_proof: vec![old_finalized.hash, new_finalized.hash],
+            }),
+        },
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("authenticated full-state finality prunes the competing branch");
+
+    let mut expected: Vec<_> = deliveries
+        .iter()
+        .map(|delivery| AuxDelta::Delete {
+            header_hash: delivery.header_hash,
+            delivery_id: delivery.delivery_id,
+        })
+        .collect();
+    expected.sort_unstable_by_key(|change| match change {
+        AuxDelta::Delete {
+            header_hash,
+            delivery_id,
+        } => (header_hash.0, *delivery_id),
+        AuxDelta::Put(_) => unreachable!("the fixture constructs only deletes"),
+    });
+    assert_eq!(plan.change_set.aux_changes, expected);
+    assert!(competing
+        .iter()
+        .all(|frontier| plan.change_set.delete_nodes.contains(&frontier.hash)));
+}
+
 fn body_owner(snapshot: &EngineSnapshot, session_id: u64, request_id: u64) -> crate::BodyWorkOwner {
     crate::BodyWorkAuthority::for_snapshot(snapshot).bind(
         session_id,

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -109,10 +109,10 @@ fn auxiliary_deletes_for_evicted_headers_are_sorted_by_hash_and_delivery_id() {
     let (mut store, config) = TestStore::new(EngineMode::Integrated);
     let clock = ManualClock(Utc::now());
     let authority = Authority;
-    let old_finalized = store.graph.finalized();
+    let old_finalized = store.graph.finalized_frontier();
     let easy = store
         .graph
-        .node(old_finalized.hash)
+        .header_node(old_finalized.hash)
         .expect("the anchor exists")
         .header
         .difficulty_threshold;
@@ -179,7 +179,7 @@ fn auxiliary_deletes_for_evicted_headers_are_sorted_by_hash_and_delivery_id() {
     for delivery in &deliveries {
         store
             .graph
-            .record_aux_delivery(delivery.header_hash, delivery.delivery_id)
+            .record_auxiliary_evidence_delivery(delivery.header_hash, delivery.delivery_id)
             .expect("the competing header remains retained");
         store.aux.push(*delivery);
     }

--- a/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
@@ -556,7 +556,7 @@ fn path_rejects_zero_height_tip_that_is_not_finalized() {
     assert_eq!(
         path(&store.graph, malformed),
         Err(TransitionFailure::Graph(
-            GraphError::FinalizedNotDescendant {
+            GraphError::FinalizedFrontierNotDescendant {
                 current: anchor.hash,
                 candidate: child.hash,
             }

--- a/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
@@ -295,9 +295,15 @@ fn apply_transition(
         }
         _ => DurableTransitionFacts::None,
     };
-    engine
+    let plan = engine
         .apply(request, context, durable)
-        .map(crate::EngineTransition::into_plan)
+        .map(crate::EngineTransition::into_plan)?;
+    if let Err(error) = crate::verify_plan_production(&engine, &plan) {
+        panic!(
+            "production overlay and boundary-node verification must accept plans that pass the exhaustive verifier: {error:?}"
+        );
+    }
+    Ok(plan)
 }
 
 fn batch(

--- a/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
@@ -544,3 +544,22 @@ fn apply_projection(projection: &mut Vec<Frontier>, delta: &ProjectionDelta) {
     }
     projection.extend(delta.put.iter().copied());
 }
+
+#[test]
+fn path_rejects_zero_height_tip_that_is_not_finalized() {
+    let (mut store, _) = TestStore::new(EngineMode::HeadersOnly);
+    let anchor = store.metadata.frontiers.finalized;
+    let difficulty = regtest_genesis_block().header.difficulty_threshold;
+    let child = insert_verified_branch(&mut store.graph, anchor, 1, difficulty, 0xa1);
+    let malformed = Frontier::new(block::Height::MIN, child.hash);
+
+    assert_eq!(
+        path(&store.graph, malformed),
+        Err(TransitionFailure::Graph(
+            GraphError::FinalizedNotDescendant {
+                current: anchor.hash,
+                candidate: child.hash,
+            }
+        ))
+    );
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
@@ -1,6 +1,31 @@
 use super::*;
 
 #[test]
+fn operator_invalidation_rejects_the_finalized_anchor() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.graph.finalized();
+
+    let err = apply_transition(
+        &store,
+        operator_invalidate(
+            &store,
+            anchor.hash,
+            crate::OperatorInvalidationId::new([0xa1; 16]),
+            0xa2,
+        ),
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect_err("invalidating the finalized anchor must fail before any graph edit");
+    assert_eq!(
+        err,
+        TransitionFailure::InvalidEvidence(
+            "operator invalidation cannot target the finalized anchor"
+        )
+    );
+}
+
+#[test]
 // AUD-10/AUD-12: invalidation must reselect eligible work without erasing
 // independent exclusion reasons. This fixture exercises both rules in one graph.
 fn operator_invalidation_promotes_alternate_and_preserves_nested_reasons() {

--- a/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
@@ -4,7 +4,7 @@ use super::*;
 fn operator_invalidation_rejects_the_finalized_anchor() {
     let (store, config) = TestStore::new(EngineMode::Integrated);
     let clock = ManualClock(Utc::now());
-    let anchor = store.graph.finalized();
+    let anchor = store.graph.finalized_frontier();
 
     let err = apply_transition(
         &store,

--- a/crates/zakura-header-chain/src/transition/types.rs
+++ b/crates/zakura-header-chain/src/transition/types.rs
@@ -313,6 +313,28 @@ impl PreparedHeaderBatch {
         self.evidence
     }
 
+    /// Derive the stable context-free batch evidence identity.
+    ///
+    /// Preparation and finality rebasing must share this exact encoding so a
+    /// rebased suffix keeps the same evidence ID that fresh preparation would
+    /// produce for the same parent, trust anchor, and header path.
+    pub(crate) fn context_free_evidence(
+        parent: Frontier,
+        trust_anchor_digest: [u8; 32],
+        headers: &[PreparedHeader],
+    ) -> EvidenceId {
+        let mut hasher = Sha256::new();
+        hasher.update(b"zakura-header-chain-context-free-batch-v1");
+        hasher.update(parent.height.0.to_le_bytes());
+        hasher.update(parent.hash.0);
+        hasher.update(trust_anchor_digest);
+        for header in headers {
+            hasher.update(header.height.0.to_le_bytes());
+            hasher.update(header.hash.0);
+        }
+        EvidenceId::from_digest(hasher.finalize().into())
+    }
+
     /// Rebase this sealed batch after an exact prepared header that became finalized.
     ///
     /// The remaining headers retain their validated results and absolute heights.
@@ -332,16 +354,8 @@ impl PreparedHeaderBatch {
         let removed = index.saturating_add(1);
         self.headers.drain(..removed);
         self.receipt.parent = parent;
-        let mut hasher = Sha256::new();
-        hasher.update(b"zakura-header-chain-context-free-batch-v1");
-        hasher.update(parent.height.0.to_le_bytes());
-        hasher.update(parent.hash.0);
-        hasher.update(self.receipt.trust_anchor_digest);
-        for header in &self.headers {
-            hasher.update(header.height.0.to_le_bytes());
-            hasher.update(header.hash.0);
-        }
-        self.evidence = EvidenceId::from_digest(hasher.finalize().into());
+        self.evidence =
+            Self::context_free_evidence(parent, self.receipt.trust_anchor_digest, &self.headers);
         Ok(removed)
     }
 

--- a/crates/zakura-header-chain/src/validation/prepare.rs
+++ b/crates/zakura-header-chain/src/validation/prepare.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use chrono::{Duration, Timelike};
 use rayon::prelude::*;
-use sha2::{Digest, Sha256};
 use thiserror::Error;
 use zakura_chain::{block, parameters::Network};
 
@@ -14,7 +13,7 @@ use super::{
     AdjustedDifficulty, PowPolicy, PowPolicyError, POW_ADJUSTMENT_BLOCK_SPAN,
 };
 use crate::{
-    Clock, EngineConfig, EvidenceId, HeaderContextFact, HeaderValidationState, PreparedHeader,
+    Clock, EngineConfig, HeaderContextFact, HeaderValidationState, PreparedHeader,
     PreparedHeaderBatch, RuleId, ValidationLease,
 };
 
@@ -372,21 +371,17 @@ fn prepare_headers_inner(
         prepared.push(prepared_header);
     }
 
-    let mut hasher = Sha256::new();
-    hasher.update(b"zakura-header-chain-context-free-batch-v1");
-    hasher.update(parent_frontier.height.0.to_le_bytes());
-    hasher.update(parent_frontier.hash.0);
-    hasher.update(rules.trust_anchor_digest);
-    for header in &prepared {
-        hasher.update(header.height.0.to_le_bytes());
-        hasher.update(header.hash.0);
-    }
+    let evidence = PreparedHeaderBatch::context_free_evidence(
+        parent_frontier,
+        rules.trust_anchor_digest,
+        &prepared,
+    );
     PreparedHeaderBatch::new(
         prepared,
         parent_frontier,
         rules.network.clone(),
         rules.trust_anchor_digest,
-        EvidenceId::from_digest(hasher.finalize().into()),
+        evidence,
     )
     .map_err(|error| invalid(0, HeaderRule::ValidationLease, error))
 }
@@ -476,6 +471,42 @@ mod tests {
             batch.headers()[1].header.previous_block_hash,
             headers[0].hash()
         );
+    }
+
+    #[test]
+    fn rebased_suffix_evidence_matches_fresh_preparation() {
+        let (rules, lease, anchor) = fixture();
+        let first = child(lease.parent, &anchor, 1);
+        let first_frontier = Frontier::new(block::Height(1), first.hash());
+        let second = child(first_frontier, &first, 2);
+        let third = child(Frontier::new(block::Height(2), second.hash()), &second, 3);
+        let headers = [first.clone(), second.clone(), third.clone()];
+        let clock = FixedClock(anchor.time + Duration::hours(1));
+
+        let mut prepared = prepare_context_free_headers(
+            HeaderBatchInput::new(&headers),
+            lease.parent(),
+            &rules,
+            &clock,
+        )
+        .expect("the continuous context-free batch is valid");
+
+        prepared
+            .rebase_after(first_frontier)
+            .expect("the prepared path contains the finalized parent");
+
+        let fresh_suffix = prepare_context_free_headers(
+            HeaderBatchInput::new(&[second, third]),
+            first_frontier,
+            &rules,
+            &clock,
+        )
+        .expect("fresh preparation of the same suffix succeeds");
+
+        assert_eq!(prepared.receipt().parent(), first_frontier);
+        assert_eq!(prepared.headers().len(), 2);
+        assert_eq!(prepared.headers(), fresh_suffix.headers());
+        assert_eq!(prepared.evidence(), fresh_suffix.evidence());
     }
 
     #[test]

--- a/docs/changelog/unreleased/625.md
+++ b/docs/changelog/unreleased/625.md
@@ -1,4 +1,0 @@
-<!-- changelog: none -->
-
-This PR only hardens header-chain planner/graph test coverage and internal
-engine invariants. It has no operator-visible zakurad effect.

--- a/docs/changelog/unreleased/625.md
+++ b/docs/changelog/unreleased/625.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only hardens header-chain planner/graph test coverage and internal
+engine invariants. It has no operator-visible zakurad effect.


### PR DESCRIPTION
## Motivation

Review of the header-chain engine model (`hc/01-engine-model`) found several planner and evidence bugs that could silently break replay identity, produce nondeterministic eviction deletes, underflow height walks, or allow invalidating the finalized anchor.

## Solution

- Exercise the production invariant verifier from planner tests so plan corruption is caught where transitions are built.
- Reject operator invalidation of the finalized anchor.
- Guard planner path height decrements against underflow.
- Sort eviction auxiliary deletes deterministically.
- Extract one shared `context_free_evidence` helper so preparation and `rebase_after` cannot drift on the batch evidence digest.
- Adapt the aux eviction fixture to `record_aux_delivery` after the base branch removed `node_mut`.

## Testing

- `cargo test -p zakura-header-chain` — 152 passed (includes `rebased_suffix_evidence_matches_fresh_preparation` and aux eviction ordering)

### Specifications & References

- Base: `hc/01-engine-model`
- Touches sealed prepared-batch evidence identity used for transition replay.

### Follow-up Work

- None planned beyond CI/follow-up review comments.