### PR TITLE
test(rpc): make the indexer mTLS client-auth test non-vacuous

### DIFF
--- a/crates/zakura-rpc/src/indexer/tests/certs.rs
+++ b/crates/zakura-rpc/src/indexer/tests/certs.rs
@@ -50,3 +50,25 @@ AwEHoUQDQgAE0IiUsDpz0zII1yw0uYjf4m+LJpLTzDdQcZ/tZsCtN9dUjc9cJxkv
 FTfPb0T+GR98zf+kbOZw7XXakAVIiC4vDQ==
 -----END EC PRIVATE KEY-----
 "#;
+
+/// A client certificate signed by a second CA that the server does not trust,
+/// `CN=Zakura-Test-Untrusted-CA`. Otherwise identical in shape to
+/// [`CLIENT_CERT`]: P-256, ecdsa-with-SHA256, serial 2, same validity window.
+pub(super) const UNTRUSTED_CLIENT_CERT: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBejCCASGgAwIBAgIBAjAKBggqhkjOPQQDAjAjMSEwHwYDVQQDDBhaYWt1cmEt
+VGVzdC1VbnRydXN0ZWQtQ0EwHhcNMjYwODA1MTI1NjIxWhcNMzYwODAyMTI1NjIx
+WjAnMSUwIwYDVQQDDBxaYWt1cmEtVGVzdC1VbnRydXN0ZWQtQ2xpZW50MFkwEwYH
+KoZIzj0CAQYIKoZIzj0DAQcDQgAEZryAGuC1THWnd59RQiTwDSLzqSknT8nvOFgb
+itGEkTugY8wbpPDhtGqHEFlHLyc9pqLToF1dZcuydKKfhOZL+qNCMEAwHQYDVR0O
+BBYEFKXHrQvSGa9GvmdX2vSh1c1gYOrmMB8GA1UdIwQYMBaAFB0upmQpvEkhxChh
+e4j0YJJokeaPMAoGCCqGSM49BAMCA0cAMEQCIEe+Aop1mVwghhxIfuvMpotexJSL
+cn9ij3bghmh081AYAiBeOK3Sj3z4V7yipqDlSRUeH41rns8Mz7mVUD0UWYzgSQ==
+-----END CERTIFICATE-----
+"#;
+
+pub(super) const UNTRUSTED_CLIENT_KEY: &str = r#"-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIOfYiR9PgYMG8//jYaabLGknn1T+djREn5CzGoB0gIq6oAoGCCqGSM49
+AwEHoUQDQgAEZryAGuC1THWnd59RQiTwDSLzqSknT8nvOFgbitGEkTugY8wbpPDh
+tGqHEFlHLyc9pqLToF1dZcuydKKfhOZL+g==
+-----END EC PRIVATE KEY-----
+"#;

--- a/crates/zakura-rpc/src/indexer/tests/vectors.rs
+++ b/crates/zakura-rpc/src/indexer/tests/vectors.rs
@@ -21,7 +21,10 @@ use zakura_test::{
 use crate::indexer::{self, indexer_client::IndexerClient, BlockRequest, Empty};
 use crate::{
     config::rpc::IndexerTlsConfig,
-    indexer::tests::certs::{CA_CERT, CLIENT_CERT, CLIENT_KEY, SERVER_CERT, SERVER_KEY},
+    indexer::tests::certs::{
+        CA_CERT, CLIENT_CERT, CLIENT_KEY, SERVER_CERT, SERVER_KEY, UNTRUSTED_CLIENT_CERT,
+        UNTRUSTED_CLIENT_KEY,
+    },
     sync::{IndexerClientConfig, IndexerClientTlsConfig},
 };
 
@@ -73,15 +76,49 @@ async fn indexer_server_requires_a_trusted_client_certificate() -> Result<()> {
     let unauthenticated_endpoint =
         tonic::transport::Endpoint::new(format!("https://{listen_addr}"))?
             .tls_config(unauthenticated_tls)?;
+    // Every client below sends the same request, which request validation
+    // rejects with `InvalidArgument`. Only a client the server accepted can
+    // reach request validation, so `InvalidArgument` is the signature of an
+    // accepted client and any other status means the connection was refused.
     let mut unauthenticated_client = IndexerClient::connect(unauthenticated_endpoint).await?;
-    assert!(
-        unauthenticated_client
-            .get_block(BlockRequest {
-                hash_or_height: Vec::new(),
-            })
-            .await
-            .is_err(),
-        "the indexer server must reject clients without a certificate"
+    let status = unauthenticated_client
+        .get_block(BlockRequest {
+            hash_or_height: Vec::new(),
+        })
+        .await
+        .expect_err("the indexer server must reject clients without a certificate");
+    assert_ne!(
+        status.code(),
+        tonic::Code::InvalidArgument,
+        "a client without a certificate reached request validation: {status:?}"
+    );
+
+    let untrusted_cert_file = temp_dir.path().join("untrusted-client.pem");
+    let untrusted_key_file = temp_dir.path().join("untrusted-client-key.pem");
+    fs::write(&untrusted_cert_file, UNTRUSTED_CLIENT_CERT)?;
+    fs::write(&untrusted_key_file, UNTRUSTED_CLIENT_KEY)?;
+    let untrusted_endpoint = IndexerClientConfig::mtls(
+        listen_addr,
+        IndexerClientTlsConfig::new(
+            temp_dir.path().join("ca.pem"),
+            untrusted_cert_file,
+            untrusted_key_file,
+            "localhost".to_string(),
+        ),
+    )
+    .endpoint()
+    .map_err(|error| eyre!(error))?;
+    let mut untrusted_client = IndexerClient::connect(untrusted_endpoint).await?;
+    let status = untrusted_client
+        .get_block(BlockRequest {
+            hash_or_height: Vec::new(),
+        })
+        .await
+        .expect_err("the indexer server must reject certificates from an untrusted CA");
+    assert_ne!(
+        status.code(),
+        tonic::Code::InvalidArgument,
+        "a certificate signed by an untrusted CA reached request validation: {status:?}"
     );
 
     let authenticated_endpoint = IndexerClientConfig::mtls(


### PR DESCRIPTION
## Motivation

`indexer_server_requires_a_trusted_client_certificate` passes with client
authentication removed from the server.

The unauthenticated client's only assertion is `.is_err()` on
`BlockRequest { hash_or_height: vec![] }`. Request validation rejects that request with
`InvalidArgument` for *any* client that completes the handshake — which is exactly what
the test's own last assertion says about the authenticated client. So `.is_err()` holds
whether or not client authentication ran.

Confirmed by ablation: deleting `.client_ca_root(..)` from `load_mtls_config` in
`indexer/server.rs`, or adding `.client_auth_optional(true)`, leaves the test green.

## Solution

Assert the negative cases return something *other than* `InvalidArgument`. Reaching
request validation is precisely the signal that the server accepted the connection, so
all three clients now send the same request and the existing
`assert_eq!(status.code(), InvalidArgument)` on the authenticated client is the positive
control. I avoided asserting the specific failure code — today it is `Unknown` /
"transport error", but that is tonic's mapping of a rustls alert and not something a test
should pin.

Also adds a second negative case: a client certificate signed by a CA the server does not
trust. The `UNTRUSTED_CLIENT_*` fixture is generated to match the existing `CLIENT_CERT`
exactly — EC P-256, ecdsa-with-SHA256, serial 2, same validity window, SKI + AKI, SEC1
private key — differing only in issuer (`CN=Zakura-Test-Untrusted-CA`). Only the leaf is
added; an unused `UNTRUSTED_CA_CERT` constant would trip `dead_code` under `-D warnings`.

I kept the new case inside the existing test rather than adding a second
`#[tokio::test]`, to avoid duplicating the server and temp-dir setup in your branch.
Happy to split it if you would rather each property fail under its own name.

No changelog fragment: `scripts/changelog.py` requires a fragment to be named
`<PR-number>.md`, so one added here would ride inside this PR's `main...head` diff after
merge and fail #596's own changelog check.

## Testing

`cargo test -p zakura-rpc --lib` → 104 tests, 103 passed, 0 failed, 1 ignored.
`cargo fmt --all -- --check` and `cargo clippy -p zakura-rpc --all-targets -- -D warnings`
are both clean (run locally).

The test count is unchanged; what changed is what the test proves. Ablating
`crates/zakura-rpc/src/indexer/server.rs` and running
`cargo test -p zakura-rpc --lib indexer_server_requires_a_trusted_client_certificate`:

| server change | before | after |
| --- | --- | --- |
| unmodified | pass | pass |
| `.client_ca_root(..)` removed | pass | **fails** on the no-certificate case |
| `.client_auth_optional(true)` added | pass | **fails** on the no-certificate case |
| `client_ca_file` also trusts a second CA | pass | **fails** on the untrusted-CA case |

The last row is the operator misconfiguration of pointing `client_ca_file` at a broad CA
bundle, and it is what the new untrusted-CA case catches on its own. Ten consecutive runs
of the changed test pass in 0.03–0.06 s.

Branched from `90284ad8f`; happy to rebase once you merge `main` in.

🤖 Drafted with [Claude Code](https://claude.com/claude-code) at @maxdesalle's direction
