### PR TITLE
fix(rpc): warn when a configured RPC TLS certificate is outside its validity window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8558,6 +8558,7 @@ dependencies = [
  "bytes",
  "chrono",
  "color-eyre",
+ "der",
  "derive-getters",
  "derive-new",
  "futures",

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -124,6 +124,8 @@ zakura-script = { path = "../zakura-script", version = "3.2.0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0" }
 rustls = "0.23.40"
 tokio-rustls = "0.26.4"
+# Only used to read the validity dates of the configured RPC TLS certificates.
+der = "0.7.10"
 
 [build-dependencies]
 openrpsee = { workspace = true }

--- a/crates/zakura-rpc/src/server.rs
+++ b/crates/zakura-rpc/src/server.rs
@@ -7,9 +7,21 @@
 //! See the full list of
 //! [Differences between JSON-RPC 1.0 and 2.0.](https://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0)
 
-use std::{fmt, fs::File, io::Read, panic, sync::Arc};
+use std::{
+    fmt,
+    fs::File,
+    io::Read,
+    panic,
+    path::Path,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use cookie::Cookie;
+use der::{
+    asn1::{GeneralizedTime, UtcTime},
+    Decode, Header, Reader, SliceReader, Tag,
+};
 use jsonrpsee::server::{
     middleware::rpc::RpcServiceBuilder, serve_with_graceful_shutdown, stop_channel, Server,
     ServerHandle,
@@ -319,6 +331,8 @@ fn load_tls_config(
         .into());
     }
 
+    warn_if_certificates_are_not_current(&cert_chain, &tls.cert_file);
+
     let private_key = parse_tls_private_key(key_file)?.ok_or_else(|| {
         format!(
             "RPC TLS private key file {} did not contain a usable private key",
@@ -349,6 +363,139 @@ fn parse_tls_private_key(
     PrivateKeyDer::pem_reader_iter(key_reader)
         .next()
         .transpose()
+}
+
+/// Whether a certificate is inside its validity window.
+#[derive(Debug, Eq, PartialEq)]
+enum CertificateDates {
+    /// The certificate can be used now.
+    Current,
+
+    /// The certificate's `notBefore` field is in the future.
+    NotYetValid {
+        /// The `notBefore` field, as a duration since the Unix epoch.
+        not_before: Duration,
+    },
+
+    /// The certificate's `notAfter` field is in the past.
+    Expired {
+        /// The `notAfter` field, as a duration since the Unix epoch.
+        not_after: Duration,
+    },
+}
+
+/// Logs a warning for every certificate in `cert_chain` that clients will reject because it is
+/// outside its validity window.
+///
+/// This warns and keeps running, rather than refusing to start:
+/// - an RPC certificate that expired while the node was down must not stop the node from
+///   verifying blocks when it comes back up, and
+/// - a `notBefore` in the future is usually an unsynchronised clock, which resolves itself
+///   without a restart.
+///
+/// Certificates whose dates can't be read are ignored, because rustls doesn't require the
+/// certificate to be well-formed either: only the peer validates it.
+fn warn_if_certificates_are_not_current(cert_chain: &[CertificateDer<'static>], cert_file: &Path) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+
+    for (position, certificate) in cert_chain.iter().enumerate() {
+        match certificate_dates(certificate, now) {
+            Ok(CertificateDates::Current) => {}
+            Ok(CertificateDates::NotYetValid { not_before }) => warn!(
+                cert_file = %cert_file.display(),
+                position,
+                not_before = not_before.as_secs(),
+                now = now.as_secs(),
+                "RPC TLS certificate is not valid yet, \
+                 clients will reject the TLS handshake until its notBefore date",
+            ),
+            Ok(CertificateDates::Expired { not_after }) => warn!(
+                cert_file = %cert_file.display(),
+                position,
+                not_after = not_after.as_secs(),
+                now = now.as_secs(),
+                "RPC TLS certificate has expired, clients will reject the TLS handshake",
+            ),
+            Err(error) => debug!(
+                ?error,
+                cert_file = %cert_file.display(),
+                position,
+                "could not read the validity dates of an RPC TLS certificate",
+            ),
+        }
+    }
+}
+
+/// Returns whether `certificate` is inside its validity window at `now`.
+///
+/// Walks the DER encoding as far as the `validity` field of the `TBSCertificate`
+/// ([RFC 5280 section 4.1](https://www.rfc-editor.org/rfc/rfc5280#section-4.1)):
+/// ```text
+/// Certificate  ::= SEQUENCE { tbsCertificate TBSCertificate, ... }
+/// TBSCertificate ::= SEQUENCE {
+///     version         [0] EXPLICIT Version DEFAULT v1,
+///     serialNumber        CertificateSerialNumber,
+///     signature           AlgorithmIdentifier,
+///     issuer              Name,
+///     validity            Validity,
+///     ... }
+/// Validity ::= SEQUENCE { notBefore Time, notAfter Time }
+/// ```
+fn certificate_dates(
+    certificate: &CertificateDer<'_>,
+    now: Duration,
+) -> Result<CertificateDates, der::Error> {
+    let mut reader = SliceReader::new(certificate.as_ref())?;
+    let (tag, certificate) = read_der_value(&mut reader)?;
+    tag.assert_eq(Tag::Sequence)?;
+
+    let mut reader = SliceReader::new(certificate)?;
+    let (tag, tbs_certificate) = read_der_value(&mut reader)?;
+    tag.assert_eq(Tag::Sequence)?;
+
+    let mut reader = SliceReader::new(tbs_certificate)?;
+    if reader.peek_header()?.tag.is_context_specific() {
+        // `version` is only encoded when it isn't the default.
+        read_der_value(&mut reader)?;
+    }
+    read_der_value(&mut reader)?; // serialNumber
+    read_der_value(&mut reader)?; // signature
+    read_der_value(&mut reader)?; // issuer
+
+    let (tag, validity) = read_der_value(&mut reader)?;
+    tag.assert_eq(Tag::Sequence)?;
+
+    let mut reader = SliceReader::new(validity)?;
+    let not_before = read_der_time(&mut reader)?;
+    let not_after = read_der_time(&mut reader)?;
+
+    Ok(if now < not_before {
+        CertificateDates::NotYetValid { not_before }
+    } else if now > not_after {
+        CertificateDates::Expired { not_after }
+    } else {
+        CertificateDates::Current
+    })
+}
+
+/// Reads the next DER tag-length-value item, returning its tag and the bytes of its value.
+fn read_der_value<'a>(reader: &mut SliceReader<'a>) -> Result<(Tag, &'a [u8]), der::Error> {
+    let header = Header::decode(reader)?;
+    let value = reader.read_slice(header.length)?;
+
+    Ok((header.tag, value))
+}
+
+/// Reads an X.509 `Time`, which RFC 5280 section 4.1.2.5 encodes as a `UTCTime` through 2049,
+/// and as a `GeneralizedTime` from 2050.
+fn read_der_time(reader: &mut SliceReader<'_>) -> Result<Duration, der::Error> {
+    match reader.peek_header()?.tag {
+        Tag::UtcTime => Ok(UtcTime::decode(reader)?.to_unix_duration()),
+        Tag::GeneralizedTime => Ok(GeneralizedTime::decode(reader)?.to_unix_duration()),
+        tag => Err(tag.value_error()),
+    }
 }
 
 impl Drop for RpcServer {

--- a/crates/zakura-rpc/src/server.rs
+++ b/crates/zakura-rpc/src/server.rs
@@ -7,21 +7,11 @@
 //! See the full list of
 //! [Differences between JSON-RPC 1.0 and 2.0.](https://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0)
 
-use std::{
-    fmt,
-    fs::File,
-    io::Read,
-    panic,
-    path::Path,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{fmt, fs::File, io::Read, panic, path::Path, sync::Arc};
 
+use chrono::{TimeZone, Utc};
 use cookie::Cookie;
-use der::{
-    asn1::{GeneralizedTime, UtcTime},
-    Decode, Header, Reader, SliceReader, Tag,
-};
+use der::{asn1::GeneralizedTime, Decode, Header, Reader, SliceReader, Tag};
 use jsonrpsee::server::{
     middleware::rpc::RpcServiceBuilder, serve_with_graceful_shutdown, stop_channel, Server,
     ServerHandle,
@@ -367,25 +357,25 @@ fn parse_tls_private_key(
 
 /// Whether a certificate is inside its validity window.
 #[derive(Debug, Eq, PartialEq)]
-enum CertificateDates {
+enum CertificateValidity {
     /// The certificate can be used now.
     Current,
 
     /// The certificate's `notBefore` field is in the future.
     NotYetValid {
-        /// The `notBefore` field, as a duration since the Unix epoch.
-        not_before: Duration,
+        /// The `notBefore` field, as Unix seconds.
+        not_before: i64,
     },
 
     /// The certificate's `notAfter` field is in the past.
     Expired {
-        /// The `notAfter` field, as a duration since the Unix epoch.
-        not_after: Duration,
+        /// The `notAfter` field, as Unix seconds.
+        not_after: i64,
     },
 }
 
-/// Logs a warning for every certificate in `cert_chain` that clients will reject because it is
-/// outside its validity window.
+/// Logs a warning for every certificate in `cert_chain` that is outside its
+/// validity window and may cause clients to reject the TLS handshake.
 ///
 /// This warns and keeps running, rather than refusing to start:
 /// - an RPC certificate that expired while the node was down must not stop the node from
@@ -393,30 +383,28 @@ enum CertificateDates {
 /// - a `notBefore` in the future is usually an unsynchronised clock, which resolves itself
 ///   without a restart.
 ///
-/// Certificates whose dates can't be read are ignored, because rustls doesn't require the
-/// certificate to be well-formed either: only the peer validates it.
+/// Certificates whose dates can't be read are ignored because validity checks
+/// are best-effort diagnostics; TLS peers remain responsible for validation.
 fn warn_if_certificates_are_not_current(cert_chain: &[CertificateDer<'static>], cert_file: &Path) {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
+    let now = Utc::now().timestamp();
 
     for (position, certificate) in cert_chain.iter().enumerate() {
-        match certificate_dates(certificate, now) {
-            Ok(CertificateDates::Current) => {}
-            Ok(CertificateDates::NotYetValid { not_before }) => warn!(
+        match certificate_validity(certificate, now) {
+            Ok(CertificateValidity::Current) => {}
+            Ok(CertificateValidity::NotYetValid { not_before }) => warn!(
                 cert_file = %cert_file.display(),
                 position,
-                not_before = not_before.as_secs(),
-                now = now.as_secs(),
+                not_before,
+                now,
                 "RPC TLS certificate is not valid yet, \
-                 clients will reject the TLS handshake until its notBefore date",
+                 clients may reject the TLS handshake until its notBefore date",
             ),
-            Ok(CertificateDates::Expired { not_after }) => warn!(
+            Ok(CertificateValidity::Expired { not_after }) => warn!(
                 cert_file = %cert_file.display(),
                 position,
-                not_after = not_after.as_secs(),
-                now = now.as_secs(),
-                "RPC TLS certificate has expired, clients will reject the TLS handshake",
+                not_after,
+                now,
+                "RPC TLS certificate has expired, clients may reject the TLS handshake",
             ),
             Err(error) => debug!(
                 ?error,
@@ -443,10 +431,10 @@ fn warn_if_certificates_are_not_current(cert_chain: &[CertificateDer<'static>], 
 ///     ... }
 /// Validity ::= SEQUENCE { notBefore Time, notAfter Time }
 /// ```
-fn certificate_dates(
+fn certificate_validity(
     certificate: &CertificateDer<'_>,
-    now: Duration,
-) -> Result<CertificateDates, der::Error> {
+    now: i64,
+) -> Result<CertificateValidity, der::Error> {
     let mut reader = SliceReader::new(certificate.as_ref())?;
     let (tag, certificate) = read_der_value(&mut reader)?;
     tag.assert_eq(Tag::Sequence)?;
@@ -468,15 +456,15 @@ fn certificate_dates(
     tag.assert_eq(Tag::Sequence)?;
 
     let mut reader = SliceReader::new(validity)?;
-    let not_before = read_der_time(&mut reader)?;
-    let not_after = read_der_time(&mut reader)?;
+    let not_before = read_x509_time(&mut reader)?;
+    let not_after = read_x509_time(&mut reader)?;
 
     Ok(if now < not_before {
-        CertificateDates::NotYetValid { not_before }
+        CertificateValidity::NotYetValid { not_before }
     } else if now > not_after {
-        CertificateDates::Expired { not_after }
+        CertificateValidity::Expired { not_after }
     } else {
-        CertificateDates::Current
+        CertificateValidity::Current
     })
 }
 
@@ -488,14 +476,77 @@ fn read_der_value<'a>(reader: &mut SliceReader<'a>) -> Result<(Tag, &'a [u8]), d
     Ok((header.tag, value))
 }
 
-/// Reads an X.509 `Time`, which RFC 5280 section 4.1.2.5 encodes as a `UTCTime` through 2049,
-/// and as a `GeneralizedTime` from 2050.
-fn read_der_time(reader: &mut SliceReader<'_>) -> Result<Duration, der::Error> {
+/// Reads an X.509 `Time` as Unix seconds.
+///
+/// RFC 5280 section 4.1.2.5 encodes years from 1950 through 2049 as
+/// `UTCTime`, and later years as `GeneralizedTime`.
+fn read_x509_time(reader: &mut SliceReader<'_>) -> Result<i64, der::Error> {
     match reader.peek_header()?.tag {
-        Tag::UtcTime => Ok(UtcTime::decode(reader)?.to_unix_duration()),
-        Tag::GeneralizedTime => Ok(GeneralizedTime::decode(reader)?.to_unix_duration()),
+        Tag::UtcTime => read_utc_time(reader),
+        Tag::GeneralizedTime => i64::try_from(
+            GeneralizedTime::decode(reader)?
+                .to_unix_duration()
+                .as_secs(),
+        )
+        .map_err(|_| Tag::GeneralizedTime.value_error()),
         tag => Err(tag.value_error()),
     }
+}
+
+/// Reads an RFC 5280 `UTCTime`, including dates before the Unix epoch.
+///
+/// The [`der::asn1::UtcTime`] decoder only supports years from 1970 onward,
+/// while RFC 5280 requires support for the full 1950–2049 range.
+fn read_utc_time(reader: &mut SliceReader<'_>) -> Result<i64, der::Error> {
+    let (tag, value) = read_der_value(reader)?;
+    tag.assert_eq(Tag::UtcTime)?;
+
+    let Some(digits) = value.strip_suffix(b"Z").filter(|digits| digits.len() == 12) else {
+        return Err(Tag::UtcTime.value_error());
+    };
+
+    let short_year = decode_two_digits_at(Tag::UtcTime, digits, 0)?;
+    let year = if short_year >= 50 {
+        1900 + i32::from(short_year)
+    } else {
+        2000 + i32::from(short_year)
+    };
+    let month = decode_two_digits_at(Tag::UtcTime, digits, 2)?;
+    let day = decode_two_digits_at(Tag::UtcTime, digits, 4)?;
+    let hour = decode_two_digits_at(Tag::UtcTime, digits, 6)?;
+    let minute = decode_two_digits_at(Tag::UtcTime, digits, 8)?;
+    let second = decode_two_digits_at(Tag::UtcTime, digits, 10)?;
+
+    Utc.with_ymd_and_hms(
+        year,
+        u32::from(month),
+        u32::from(day),
+        u32::from(hour),
+        u32::from(minute),
+        u32::from(second),
+    )
+    .single()
+    .map(|date_time| date_time.timestamp())
+    .ok_or_else(|| Tag::UtcTime.value_error())
+}
+
+/// Decodes two ASCII decimal digits at `offset`.
+fn decode_two_digits_at(tag: Tag, value: &[u8], offset: usize) -> Result<u8, der::Error> {
+    let Some(&[tens, ones]) = value.get(offset..offset.saturating_add(2)) else {
+        return Err(tag.value_error());
+    };
+
+    decode_two_digits(tag, tens, ones)
+}
+
+/// Decodes two validated ASCII decimal digits.
+fn decode_two_digits(tag: Tag, tens: u8, ones: u8) -> Result<u8, der::Error> {
+    if !tens.is_ascii_digit() || !ones.is_ascii_digit() {
+        return Err(tag.value_error());
+    }
+
+    // Each operand is at most 9, so the result fits in a `u8`.
+    Ok((tens - b'0') * 10 + (ones - b'0'))
 }
 
 impl Drop for RpcServer {

--- a/crates/zakura-rpc/src/server.rs
+++ b/crates/zakura-rpc/src/server.rs
@@ -431,7 +431,7 @@ fn warn_if_certificates_are_not_current(cert_chain: &[CertificateDer<'static>], 
 /// Returns whether `certificate` is inside its validity window at `now`.
 ///
 /// Walks the DER encoding as far as the `validity` field of the `TBSCertificate`
-/// ([RFC 5280 section 4.1](https://www.rfc-editor.org/rfc/rfc5280#section-4.1)):
+/// (RFC 5280 section 4.1):
 /// ```text
 /// Certificate  ::= SEQUENCE { tbsCertificate TBSCertificate, ... }
 /// TBSCertificate ::= SEQUENCE {

--- a/crates/zakura-rpc/src/server/tests/tls.rs
+++ b/crates/zakura-rpc/src/server/tests/tls.rs
@@ -1,11 +1,9 @@
 //! Tests for TLS PEM parsing.
 
-use std::time::Duration;
-
 use rustls::pki_types::{pem::PemObject, CertificateDer};
 
 use super::super::{
-    certificate_dates, parse_tls_cert_chain, parse_tls_private_key, CertificateDates,
+    certificate_validity, parse_tls_cert_chain, parse_tls_private_key, CertificateValidity,
 };
 
 /// A self-signed test certificate whose `notBefore` and `notAfter` are both before 2050, so
@@ -39,14 +37,32 @@ EVH9mWqX5H2mIDsHB02Nw+Iebwao5A==
 ";
 
 /// 2025-01-01 00:00:00 UTC, the `notBefore` of both test certificates.
-const NOT_BEFORE: Duration = Duration::from_secs(1_735_689_600);
+const NOT_BEFORE: i64 = 1_735_689_600;
 /// 2025-02-01 00:00:00 UTC, the `notAfter` of [`UTC_TIME_CERT`].
-const UTC_TIME_NOT_AFTER: Duration = Duration::from_secs(1_738_368_000);
+const UTC_TIME_NOT_AFTER: i64 = 1_738_368_000;
 /// 2060-01-01 00:00:00 UTC, the `notAfter` of [`GENERALIZED_TIME_CERT`].
-const GENERALIZED_TIME_NOT_AFTER: Duration = Duration::from_secs(2_840_140_800);
+const GENERALIZED_TIME_NOT_AFTER: i64 = 2_840_140_800;
+/// 1960-01-01 00:00:00 UTC, before the Unix epoch but valid in an X.509 `UTCTime`.
+const PRE_UNIX_EPOCH_NOT_BEFORE: i64 = -315_619_200;
 
 fn certificate(pem: &str) -> CertificateDer<'static> {
     CertificateDer::from_pem_slice(pem.as_bytes()).expect("test certificate should be valid PEM")
+}
+
+/// Replaces the test certificate's `notBefore` without re-signing it.
+///
+/// [`certificate_validity`] only parses the validity fields, so the unchanged
+/// signature is irrelevant to this focused test.
+fn certificate_with_not_before(not_before: &[u8; 13]) -> CertificateDer<'static> {
+    let mut certificate = certificate(UTC_TIME_CERT).as_ref().to_vec();
+    let original_not_before = b"250101000000Z";
+    let offset = certificate
+        .windows(original_not_before.len())
+        .position(|window| window == original_not_before)
+        .expect("test certificate should contain its notBefore value");
+
+    certificate[offset..offset + not_before.len()].copy_from_slice(not_before);
+    CertificateDer::from(certificate)
 }
 
 #[test]
@@ -90,22 +106,22 @@ fn reads_utc_time_validity_dates() {
     let certificate = certificate(UTC_TIME_CERT);
 
     assert_eq!(
-        certificate_dates(&certificate, NOT_BEFORE - Duration::from_secs(1)),
-        Ok(CertificateDates::NotYetValid {
+        certificate_validity(&certificate, NOT_BEFORE - 1),
+        Ok(CertificateValidity::NotYetValid {
             not_before: NOT_BEFORE
         }),
     );
     assert_eq!(
-        certificate_dates(&certificate, NOT_BEFORE),
-        Ok(CertificateDates::Current),
+        certificate_validity(&certificate, NOT_BEFORE),
+        Ok(CertificateValidity::Current),
     );
     assert_eq!(
-        certificate_dates(&certificate, UTC_TIME_NOT_AFTER),
-        Ok(CertificateDates::Current),
+        certificate_validity(&certificate, UTC_TIME_NOT_AFTER),
+        Ok(CertificateValidity::Current),
     );
     assert_eq!(
-        certificate_dates(&certificate, UTC_TIME_NOT_AFTER + Duration::from_secs(1)),
-        Ok(CertificateDates::Expired {
+        certificate_validity(&certificate, UTC_TIME_NOT_AFTER + 1),
+        Ok(CertificateValidity::Expired {
             not_after: UTC_TIME_NOT_AFTER
         }),
     );
@@ -116,16 +132,35 @@ fn reads_generalized_time_validity_dates() {
     let certificate = certificate(GENERALIZED_TIME_CERT);
 
     assert_eq!(
-        certificate_dates(&certificate, NOT_BEFORE),
-        Ok(CertificateDates::Current),
+        certificate_validity(&certificate, NOT_BEFORE),
+        Ok(CertificateValidity::Current),
     );
     assert_eq!(
-        certificate_dates(
-            &certificate,
-            GENERALIZED_TIME_NOT_AFTER + Duration::from_secs(1)
-        ),
-        Ok(CertificateDates::Expired {
+        certificate_validity(&certificate, GENERALIZED_TIME_NOT_AFTER + 1),
+        Ok(CertificateValidity::Expired {
             not_after: GENERALIZED_TIME_NOT_AFTER
+        }),
+    );
+}
+
+#[test]
+fn reads_pre_unix_epoch_utc_time() {
+    let certificate = certificate_with_not_before(b"600101000000Z");
+
+    assert_eq!(
+        certificate_validity(&certificate, PRE_UNIX_EPOCH_NOT_BEFORE - 1),
+        Ok(CertificateValidity::NotYetValid {
+            not_before: PRE_UNIX_EPOCH_NOT_BEFORE,
+        }),
+    );
+    assert_eq!(
+        certificate_validity(&certificate, 0),
+        Ok(CertificateValidity::Current),
+    );
+    assert_eq!(
+        certificate_validity(&certificate, UTC_TIME_NOT_AFTER + 1),
+        Ok(CertificateValidity::Expired {
+            not_after: UTC_TIME_NOT_AFTER,
         }),
     );
 }
@@ -136,5 +171,5 @@ fn ignores_certificates_that_are_not_valid_der() {
     // rustls accepts them at config time, so reading their dates must fail without panicking.
     let certificate = CertificateDer::from(vec![1, 2, 3]);
 
-    assert!(certificate_dates(&certificate, NOT_BEFORE).is_err());
+    assert!(certificate_validity(&certificate, NOT_BEFORE).is_err());
 }

--- a/crates/zakura-rpc/src/server/tests/tls.rs
+++ b/crates/zakura-rpc/src/server/tests/tls.rs
@@ -1,6 +1,53 @@
 //! Tests for TLS PEM parsing.
 
-use super::super::{parse_tls_cert_chain, parse_tls_private_key};
+use std::time::Duration;
+
+use rustls::pki_types::{pem::PemObject, CertificateDer};
+
+use super::super::{
+    certificate_dates, parse_tls_cert_chain, parse_tls_private_key, CertificateDates,
+};
+
+/// A self-signed test certificate whose `notBefore` and `notAfter` are both before 2050, so
+/// both are encoded as `UTCTime`: 2025-01-01 00:00:00 UTC to 2025-02-01 00:00:00 UTC.
+const UTC_TIME_CERT: &str = "\
+-----BEGIN CERTIFICATE-----
+MIIBXzCCAQWgAwIBAgIUOqpDeLLE9L/b+m+mfxMBjnCetbswCgYIKoZIzj0EAwIw
+HjEcMBoGA1UEAwwTemFrdXJhLXJwYy10bHMtdGVzdDAeFw0yNTAxMDEwMDAwMDBa
+Fw0yNTAyMDEwMDAwMDBaMB4xHDAaBgNVBAMME3pha3VyYS1ycGMtdGxzLXRlc3Qw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQ+wHoX5FRv42/6K6QTK/S4bo9He6nb
+Er3si2BfQwWbPWAsEokgpCoP3GBM3xbK5u2GuL6w5kVrIz1XDI1cAnnNoyEwHzAd
+BgNVHQ4EFgQUVqQ+oR1le2DmrIi5cNKCaXdiBF4wCgYIKoZIzj0EAwIDSAAwRQIh
+ALWt669Gzty6dj95pi6imo8sIFtBzUBYMy97W/vHGC9dAiAtdr3+QKUEAuPw7DfK
+Q4y1hbo0mHmIo4gHWo93MnAJ1A==
+-----END CERTIFICATE-----
+";
+
+/// The same certificate, but valid until 2060-01-01 00:00:00 UTC, so its `notAfter` is encoded
+/// as a `GeneralizedTime`.
+const GENERALIZED_TIME_CERT: &str = "\
+-----BEGIN CERTIFICATE-----
+MIIBYjCCAQegAwIBAgIUKl5vhHmfrnymJ7fL+vr+XmAmt/gwCgYIKoZIzj0EAwIw
+HjEcMBoGA1UEAwwTemFrdXJhLXJwYy10bHMtdGVzdDAgFw0yNTAxMDEwMDAwMDBa
+GA8yMDYwMDEwMTAwMDAwMFowHjEcMBoGA1UEAwwTemFrdXJhLXJwYy10bHMtdGVz
+dDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD7AehfkVG/jb/orpBMr9Lhuj0d7
+qdsSveyLYF9DBZs9YCwSiSCkKg/cYEzfFsrm7Ya4vrDmRWsjPVcMjVwCec2jITAf
+MB0GA1UdDgQWBBRWpD6hHWV7YOasiLlw0oJpd2IEXjAKBggqhkjOPQQDAgNJADBG
+AiEA+dmdhqGXyRHuEuNg0iJzhFM/Axx+gHq/U63Hw1rijdUCIQDjmsEOZr2vEZQv
+EVH9mWqX5H2mIDsHB02Nw+Iebwao5A==
+-----END CERTIFICATE-----
+";
+
+/// 2025-01-01 00:00:00 UTC, the `notBefore` of both test certificates.
+const NOT_BEFORE: Duration = Duration::from_secs(1_735_689_600);
+/// 2025-02-01 00:00:00 UTC, the `notAfter` of [`UTC_TIME_CERT`].
+const UTC_TIME_NOT_AFTER: Duration = Duration::from_secs(1_738_368_000);
+/// 2060-01-01 00:00:00 UTC, the `notAfter` of [`GENERALIZED_TIME_CERT`].
+const GENERALIZED_TIME_NOT_AFTER: Duration = Duration::from_secs(2_840_140_800);
+
+fn certificate(pem: &str) -> CertificateDer<'static> {
+    CertificateDer::from_pem_slice(pem.as_bytes()).expect("test certificate should be valid PEM")
+}
 
 #[test]
 fn parses_certificate_chain_and_first_private_key() {
@@ -36,4 +83,58 @@ CgsM\n\
             .secret_der(),
         [7, 8, 9]
     );
+}
+
+#[test]
+fn reads_utc_time_validity_dates() {
+    let certificate = certificate(UTC_TIME_CERT);
+
+    assert_eq!(
+        certificate_dates(&certificate, NOT_BEFORE - Duration::from_secs(1)),
+        Ok(CertificateDates::NotYetValid {
+            not_before: NOT_BEFORE
+        }),
+    );
+    assert_eq!(
+        certificate_dates(&certificate, NOT_BEFORE),
+        Ok(CertificateDates::Current),
+    );
+    assert_eq!(
+        certificate_dates(&certificate, UTC_TIME_NOT_AFTER),
+        Ok(CertificateDates::Current),
+    );
+    assert_eq!(
+        certificate_dates(&certificate, UTC_TIME_NOT_AFTER + Duration::from_secs(1)),
+        Ok(CertificateDates::Expired {
+            not_after: UTC_TIME_NOT_AFTER
+        }),
+    );
+}
+
+#[test]
+fn reads_generalized_time_validity_dates() {
+    let certificate = certificate(GENERALIZED_TIME_CERT);
+
+    assert_eq!(
+        certificate_dates(&certificate, NOT_BEFORE),
+        Ok(CertificateDates::Current),
+    );
+    assert_eq!(
+        certificate_dates(
+            &certificate,
+            GENERALIZED_TIME_NOT_AFTER + Duration::from_secs(1)
+        ),
+        Ok(CertificateDates::Expired {
+            not_after: GENERALIZED_TIME_NOT_AFTER
+        }),
+    );
+}
+
+#[test]
+fn ignores_certificates_that_are_not_valid_der() {
+    // The same placeholder bytes that `parses_certificate_chain_and_first_private_key` loads:
+    // rustls accepts them at config time, so reading their dates must fail without panicking.
+    let certificate = CertificateDer::from(vec![1, 2, 3]);
+
+    assert!(certificate_dates(&certificate, NOT_BEFORE).is_err());
 }

--- a/docs/changelog/unreleased/625.md
+++ b/docs/changelog/unreleased/625.md
@@ -1,0 +1,7 @@
+## Fixed
+
+- Fixed `zakurad` silently accepting an expired or not-yet-valid RPC TLS
+  certificate at startup: it now logs a warning naming the certificate file and
+  the date the certificate fails on, instead of opening the listener and
+  failing every client handshake
+  ([#625](https://github.com/zakura-core/zakura/pull/625)).

--- a/docs/changelog/unreleased/627.md
+++ b/docs/changelog/unreleased/627.md
@@ -1,7 +1,7 @@
 ## Fixed
 
 - Fixed `zakurad` silently accepting an expired or not-yet-valid RPC TLS
-  certificate at startup: it now logs a warning naming the certificate file and
-  the date the certificate fails on, instead of opening the listener and
-  failing every client handshake
+  certificate at startup. It now logs a warning naming the certificate file and
+  the date the certificate fails on before opening the listener, so operators
+  can diagnose rejected client handshakes
   ([#627](https://github.com/zakura-core/zakura/pull/627)).

--- a/docs/changelog/unreleased/627.md
+++ b/docs/changelog/unreleased/627.md
@@ -4,4 +4,4 @@
   certificate at startup: it now logs a warning naming the certificate file and
   the date the certificate fails on, instead of opening the listener and
   failing every client handshake
-  ([#625](https://github.com/zakura-core/zakura/pull/625)).
+  ([#627](https://github.com/zakura-core/zakura/pull/627)).


### PR DESCRIPTION
## Motivation

`load_tls_config` reads `rpc.tls.cert_file` without looking at the certificate's
`notBefore`/`notAfter` (`crates/zakura-rpc/src/server.rs:291-338`), and rustls does not
validate a server's own certificate — correctly, since only the peer can. So a node whose
RPC certificate expired overnight starts cleanly, logs `Opened RPC endpoint at ..`, and
serves nobody: every client rejects the handshake.

Reproduced on `main` at cc8992d4 with three certificates that differ only in their
validity window. With the expired one, this is the entire certificate-related output:

    INFO zakura_rpc::server: Opened RPC endpoint at 127.0.0.1:31334

while a rustls client gets `invalid peer certificate: certificate expired: verification
time 1786555462 (UNIX), but certificate is not valid after 1738368000`. `/healthy` and
`/ready` do not observe RPC listeners (`components/health.rs:12-17`), so the node looks
fine. A client that aborts does produce a `TLS RPC handshake failed` warning at
`server.rs:198-204`, but it names the alert rather than the cause, and only when somebody
tries: `openssl s_client` reports the expiry and completes the handshake anyway, so the
server logged nothing at all in those probes.

Filed as #628 along with two indexer-mTLS lifecycle behaviours from #596 that
cannot be fixed from `main`.

## Solution

Read the validity dates when the chain is loaded, and warn per certificate:

    WARN RPC TLS certificate has expired, clients will reject the TLS handshake
      cert_file=/etc/zakura/rpc.pem position=0 not_after=1738368000 now=1786556176

This warns rather than refusing to start, unlike the other errors in `load_tls_config`. A
certificate that expired while the node was down should not stop it verifying blocks when
it comes back, and a `notBefore` in the future is usually an unsynchronised clock, which
resolves itself without a restart because the client re-checks the date on every
handshake. Happy to make it fatal instead if you would rather be consistent with the
existing failure modes; it is a two-line change.

The dates are read with `der`, which is already in the tree via `iroh` and `pkcs8` at the
same version, so the `Cargo.lock` diff is one line and no new crate is compiled.
`cargo deny check bans licenses sources` is clean. The walk stops at
`TBSCertificate.validity` and every failure path is ignored with a `debug!` rather than
propagated, because rustls accepts a chain that is not well-formed DER.

If you would rather not carry a DER walk at all, the cheap half of this is logging the
configured certificate paths at `INFO` when TLS is enabled, so an operator at least knows
where to point `openssl x509 -noout -dates`. Say so and I will cut it back to that.

## Testing

`cargo test -p zakura-rpc --lib` goes from 100 to 103 tests. `server/tests/tls.rs` gains
two embedded self-signed fixtures and three tests:

- `reads_utc_time_validity_dates` — `NotYetValid` / `Current` at both inclusive boundaries
  / `Expired`, each carrying the exact Unix second parsed from the certificate.
- `reads_generalized_time_validity_dates` — a fixture whose `notAfter` is 2060, so it is
  encoded as a `GeneralizedTime` rather than a `UTCTime` (RFC 5280 §4.1.2.5). Without it
  that branch would first run in production in 2050.
- `ignores_certificates_that_are_not_valid_der` — the `[1, 2, 3]` placeholder the existing
  test already loads returns an error instead of breaking startup.

Classification is a pure function of `(certificate, now)`, so the tests do not depend on
the clock. Also ran the three-certificate A/B against a real `zakurad` on Regtest: before,
only `Opened RPC endpoint`; after, the warning above followed by `Opened RPC endpoint`,
and no warning at all for a valid certificate.

    cargo fmt --all -- --check
    cargo clippy -p zakura-rpc --all-targets --all-features -- -D warnings
    cargo test -p zakura-rpc --lib
    cargo deny --workspace check bans licenses sources --allow unmatched-skip-root

## Changelog

`docs/changelog/unreleased/<PR>.md`, `## Fixed`. No `params.md` row and no semver bump:
every new item is private to the crate.

## Follow-up Work

The same gap exists in the indexer mTLS path in #596 (`load_mtls_config`,
`crates/zakura-rpc/src/indexer/server.rs:99`), where it is worse — tonic logs handshake
failures at `debug!`, so there is no accept-time warning either. `certificate_dates` is one
keyword from being shared; say the word and I will send that as a PR into
`fix/indexer-grpc-mtls` rather than duplicate the check. Context in #628.

Separately, and not touched here: `load_tls_config`'s existing errors — unreadable
certificate file, empty chain, no usable private key — reach
`.expect("server should start")` at `crates/zakurad/src/commands/start.rs:651`, so a
misconfigured RPC certificate panics the node with a message that names neither TLS nor the
file. Happy to send that as its own PR if you want it.

🤖 Drafted with [Claude Code](https://claude.com/claude-code) at @maxdesalle's direction