### PR TITLE
chore(deps): disable routine Cargo updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -17,20 +17,20 @@ For performance and security, we want to update the Zakura checkpoints in every 
 
 - [ ] You can copy the latest checkpoints from CI by following [the zakura-checkpoints README](https://github.com/zakura-core/zakura/blob/main/crates/zakura-utils/README.md#zakura-checkpoints).
 
-## Missed Dependency Updates
+## Curated Dependency Updates
 
-Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.
+Routine Cargo version updates are intentionally disabled. Do not run a blanket
+`cargo update` during release preparation: it can introduce a large cargo-vet
+evidence backlog without a release-specific justification.
 
-This step can be skipped if there is a large pending dependency upgrade. (For example, shared ECC crates.)
-
-Here's how we make sure we got everything:
-
-- [ ] Run `cargo update` on the latest `main` branch, and keep the output
-- [ ] Until we bump the workspace MSRV to 1.88 or higher, `home` must be downgraded manually: `cargo update home@0.5.12 --precise 0.5.11`
-- [ ] If needed, add duplicate dependency exceptions to `deny.toml`.
-- [ ] If needed, remove resolved duplicate dependencies from `deny.toml`
-- [ ] Open a separate PR with the changes
-- [ ] Add the output of `cargo update` to that PR as a comment
+- [ ] Review open Dependabot security alerts and focused dependency updates
+      already planned for this release.
+- [ ] If an update is needed, open a separate focused PR from the latest `main`.
+- [ ] Restrict the update to the required crate or dependency family, and include
+      the update command and output in the PR.
+- [ ] Confirm cargo-vet evidence covers the update and run targeted runtime tests.
+- [ ] Update duplicate dependency exceptions in `deny.toml` only as required by
+      the focused resolution change.
 
 # Prepare and Publish the Release
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -17,20 +17,20 @@ For performance and security, every release should carry a current Mainnet check
 - [ ] `make pre-release` verifies the committed pairing and rejects pre-pipeline `legacy-bootstrap` state; for an emergency release with a broken publisher, export `ZAKURA_ALLOW_BOOTSTRAP_RELEASE_STATE=1` locally, check the `allow_bootstrap_release_state` input when dispatching the Create release workflow, and note it in the release PR.
 - [ ] Testnet checkpoints are still updated manually when needed, per [the zakura-checkpoints README](https://github.com/zakura-core/zakura/blob/main/crates/zakura-utils/README.md#zakura-checkpoints).
 
-# Missed Dependency Updates
+# Curated Dependency Updates
 
-Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.
+Routine Cargo version updates are intentionally disabled. Do not run a blanket
+`cargo update` during release preparation: it can introduce a large cargo-vet
+evidence backlog without a release-specific justification.
 
-This step can be skipped if there is a large pending dependency upgrade. (For example, shared ECC crates.)
-
-Here's how we make sure we got everything:
-
-- [ ] Run `cargo update` on the latest `main` branch, and keep the output
-- [ ] Until we bump the workspace MSRV to 1.88 or higher, `home` must be downgraded manually: `cargo update home@0.5.12 --precise 0.5.11`
-- [ ] If needed, add duplicate dependency exceptions to `deny.toml`.
-- [ ] If needed, remove resolved duplicate dependencies from `deny.toml`
-- [ ] Open a separate PR with the changes
-- [ ] Add the output of `cargo update` to that PR as a comment
+- [ ] Review open Dependabot security alerts and focused dependency updates
+      already planned for this release.
+- [ ] If an update is needed, open a separate focused PR from the latest `main`.
+- [ ] Restrict the update to the required crate or dependency family, and include
+      the update command and output in the PR.
+- [ ] Confirm cargo-vet evidence covers the update and run targeted runtime tests.
+- [ ] Update duplicate dependency exceptions in `deny.toml` only as required by
+      the focused resolution change.
 
 # Summarise Release Changes
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,51 +2,30 @@ version: 2
 updates:
   # Rust section
   - package-ecosystem: cargo
-    directory: '/'
+    directory: "/"
     # Update only the lockfile. We shouldn't update Cargo.toml unless it's for
     # a security issue, or if we need a new feature of the dependency.
     versioning-strategy: lockfile-only
-    # serde, clap, and other dependencies sometimes have multiple updates in a week
+    # Keep this entry so Dependabot can open security updates, but do not open
+    # routine Cargo version updates. Lockfile-only version batches need matching
+    # cargo-vet evidence and otherwise fail the supply-chain gate, so maintainers
+    # curate those updates explicitly.
     schedule:
       interval: monthly
       timezone: America/New_York
-    # Cooldown delays adoption of fresh releases — the window when a
-    # compromised dependency is most likely to slip through. See:
-    # https://astral.sh/blog/open-source-security-at-astral#dependency-security
+    # Defense in depth if routine version updates are re-enabled later.
     cooldown:
       default-days: 7
       semver-major-days: 30
-    # Limit dependabot to 1 PR per reviewer
-    open-pull-requests-limit: 6
+    # Keep the repository's Dependabot security updates setting enabled;
+    # security pull requests use a separate limit and are unaffected by this.
+    open-pull-requests-limit: 0
     labels:
-      - 'C-exclude-from-changelog'
-      - 'A-rust'
-      - 'A-dependencies'
-      - 'P-Low :snowflake:'
-    groups:
-        ecc:
-          patterns:
-            # deliberately include zcash_script (even though it is maintained by ZF)
-            - "zcash_*"
-            - "orchard"
-            - "halo2*"
-            - "incrementalmerkletree"
-            - "bridgetree"
-            - "equihash"
-        prod:
-          dependency-type: "production"
-          exclude-patterns:
-            - "zcash_*"
-            - "orchard"
-            - "halo2*"
-            - "incrementalmerkletree"
-            - "bridgetree"
-            - "equihash"
-        dev:
-          dependency-type: "development"
+      - "C-exclude-from-changelog"
+      - "C-security"
   # Devops section
   - package-ecosystem: github-actions
-    directory: '/'
+    directory: "/"
     schedule:
       # tj-actions/changed-files often updates daily, which is too much for us
       interval: weekly
@@ -59,10 +38,7 @@ updates:
       default-days: 7
     open-pull-requests-limit: 4
     labels:
-      - 'C-exclude-from-changelog'
-      - 'A-devops'
-      - 'A-dependencies'
-      - 'P-Low :snowflake:'
+      - "C-exclude-from-changelog"
     groups:
       devops:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,14 @@ updates:
   # Rust section
   - package-ecosystem: cargo
     directory: "/"
-    # Update only the lockfile. We shouldn't update Cargo.toml unless it's for
-    # a security issue, or if we need a new feature of the dependency.
-    versioning-strategy: lockfile-only
-    # Keep this entry so Dependabot can open security updates, but do not open
-    # routine Cargo version updates. Lockfile-only version batches need matching
-    # cargo-vet evidence and otherwise fail the supply-chain gate, so maintainers
-    # curate those updates explicitly.
+    # Routine version updates are disabled below. For security updates, preserve
+    # compatible requirements but allow Cargo.toml changes when a patched version
+    # falls outside the existing requirement.
+    versioning-strategy: increase-if-necessary
+    # Keep this entry to customize security updates, but do not open routine Cargo
+    # version updates. Routine dependency upgrades need matching cargo-vet evidence
+    # and otherwise fail the supply-chain gate, so maintainers curate them
+    # explicitly.
     schedule:
       interval: monthly
       timezone: America/New_York

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   # Rust section
   - package-ecosystem: cargo
     directory: "/"
-    # Routine version updates are disabled below. For security updates, preserve
-    # compatible requirements but allow Cargo.toml changes when a patched version
+    # Routine version updates are disabled below. Use the automatic strategy for
+    # security updates so Dependabot can change Cargo.toml when a patched version
     # falls outside the existing requirement.
-    versioning-strategy: increase-if-necessary
+    versioning-strategy: auto
     # Keep this entry to customize security updates, but do not open routine Cargo
     # version updates. Routine dependency upgrades need matching cargo-vet evidence
     # and otherwise fail the supply-chain gate, so maintainers curate them

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,11 @@ updates:
       semver-major-days: 30
     # Keep the repository's Dependabot security updates setting enabled;
     # security pull requests use a separate limit and are unaffected by this.
+    # Re-enabling routine updates also requires restoring lockfile-only and
+    # replacing C-security with C-exclude-from-changelog before raising the
+    # pull request limit.
     open-pull-requests-limit: 0
     labels:
-      - "C-exclude-from-changelog"
       - "C-security"
   # Devops section
   - package-ecosystem: github-actions


### PR DESCRIPTION
Reduces noise in dependabot PRs like https://github.com/zakura-core/zakura/pull/622. It stops routine Cargo Dependabot PRs and invalid-label warnings, while keeping security and GitHub Actions updates enabled. It also tells release maintainers to use focused dependency updates instead of blanket cargo update.

- Stops routine Cargo update PRs.
- Stops missing-label warning spam.
- Keeps real security alerts/PRs and GitHub Actions updates enabled.
- Does not dismiss alerts or existing PRs/comments; those need manual cleanup.
