### PR TITLE
refactor(header-chain): split transition planner into phases

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -48,19 +48,41 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
+      - name: Install Lychee
+        env:
+          LYCHEE_VERSION: 0.24.2
+          LYCHEE_SHA256: 1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
+        run: |
+          set -euo pipefail
+
+          tmp_dir="$(mktemp -d)"
+          archive="${tmp_dir}/lychee.tar.gz"
+          trap 'rm -rf "${tmp_dir}"' EXIT
+
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            --output "${archive}" \
+            "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' "${LYCHEE_SHA256}" "${archive}" |
+            sha256sum --check --strict -
+          tar -xzf "${archive}" -C "${tmp_dir}"
+
+          lychee_bin="${tmp_dir}/lychee-x86_64-unknown-linux-gnu/lychee"
+          test -f "${lychee_bin}"
+          install -Dm755 "${lychee_bin}" "${RUNNER_TEMP}/lychee/bin/lychee"
+          echo "${RUNNER_TEMP}/lychee/bin" >> "${GITHUB_PATH}"
+
       - name: Link Checker
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 #v2.9.0
-        with:
-          args: >-
-            --verbose
-            --no-progress
-            --cache
-            --max-cache-age 2d
-            --config .github/lychee.toml
-            "**/*.md"
-          fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          lychee \
+            --verbose \
+            --no-progress \
+            --cache \
+            --max-cache-age 2d \
+            --config .github/lychee.toml \
+            "**/*.md"
 
       - name: Save lychee cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/crates/xtask/src/header_conformance.rs
+++ b/crates/xtask/src/header_conformance.rs
@@ -10,7 +10,7 @@ use std::{
 use serde::Deserialize;
 
 const SUPPORTED_SPEC_VERSION: &str = "1.4";
-const EXPECTED_RULE_COUNT: usize = 110;
+const EXPECTED_RULE_COUNT: usize = 114;
 const SPEC_PATH: &str = "docs/specs/fork-aware-header-chain-engine.md";
 const MANIFEST_PATH: &str = "crates/zakura-header-chain/conformance.toml";
 const MAX_DOCUMENT_BYTES: u64 = 2 * 1024 * 1024;

--- a/crates/zakura-header-chain/conformance.toml
+++ b/crates/zakura-header-chain/conformance.toml
@@ -23,7 +23,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-SCOPE-03"
 name = "Header-validity boundary"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["DF-02::header_acceptance_cannot_construct_body_or_state_validity", "DF-02::body_verification_outcomes_preserve_distinct_transition_effects"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -111,7 +111,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-FRONTIER-02"
 name = "Independent frontier selection"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["DG-02::body_availability_does_not_override_header_work_or_mark_other_bodies", "DG-02::invalidating_verified_path_preserves_independent_header_best", "DG-07::finalization_and_replacement_match_serial_histories"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -135,7 +135,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-GEN-01"
 name = "State-version advancement"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["IN-05::structured_replay_is_bounded_and_deterministic", "IN-05::bounded_transition_examples_replay_deterministically", "IN-06::auxiliary_authentication_requires_exact_provenance_and_owned_next_header"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -143,7 +143,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-GEN-02"
 name = "Frontier-generation advancement"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["IN-05::structured_replay_is_bounded_and_deterministic", "IN-05::bounded_transition_examples_replay_deterministically", "DG-07::finalization_and_replacement_match_serial_histories"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -166,7 +166,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-GEN-04"
 name = "Stale-result rejection"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["IN-02::all_owner_mismatches_have_zero_effects"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -193,7 +193,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-TXN-02"
 name = "Uniform transition path"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["IN-02::apply_transition_is_the_only_public_dag_mutation_entry_point"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -449,7 +449,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-FINAL-02"
 name = "Full-state finality"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["DG-07::integrated_finality_requires_authority_and_exact_verified_path"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -457,7 +457,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-FINAL-03"
 name = "Headers-only depth finality"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["DG-07::headers_only_finalizes_exactly_tip_minus_one_thousand_before_publication"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -537,7 +537,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-INT-05"
 name = "Owner-qualified freshness"
 status = "implemented"
-owner = "zakura_header_chain::transition::planner::apply_transition_engine"
+owner = "zakura_header_chain::transition::planner::derive_transition_plan"
 tests = ["DF-02::typed_header_authority_ignores_global_version_but_rejects_stale_generation", "DF-02::typed_body_authority_ignores_global_version_but_rejects_stale_generation", "IN-01::all_owner_mismatches_have_zero_effects"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -561,7 +561,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-INT-08"
 name = "Distinct admission-pressure outcomes"
 status = "implemented"
-owner = "zakura_header_chain::transition::planner::apply_transition_engine"
+owner = "zakura_header_chain::transition::planner::derive_transition_plan"
 tests = ["DG-06::protected_paths_and_context_references_fail_closed_under_node_pressure", "DG-06::exact_v1_node_boundary_refuses_to_evict_the_selected_path", "IN-06::auxiliary_resource_limits_reject_equal_plus_one_without_effects"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -689,7 +689,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-AUX-02"
 name = "Unauthenticated metadata isolation"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
 tests = ["IN-06::auxiliary_delivery_is_batch_hash_scoped_and_selection_neutral", "IN-06::auxiliary_authentication_requires_exact_provenance_and_owned_next_header", "PW-06::oversized_body_hint_is_malformed_metadata_not_an_invalid_header", "IN-06::vct_boundary_failure_attribution_never_weakens_authenticated_evidence"]
 networks = ["mainnet", "testnet", "custom"]
 
@@ -897,7 +897,7 @@ networks = ["mainnet", "testnet", "custom"]
 id = "LC-ACCEPT-02"
 name = "Durable deterministic frontiers"
 status = "implemented"
-owner = "zakura_header_chain::HeaderChainEngine::apply + zakura_state::HeaderChainRuntime::apply_combined"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition + zakura_state::HeaderChainRuntime::apply_combined"
 tests = ["AUD-15::every_changed_frontier_accepts_an_exact_parent_next_child", "DG-03::every_crash_boundary_reopens_to_complete_transition", "DG-01::same_height_forks_are_insertion_order_independent", "PW-03::complete_target_is_independent_of_page_partition", "DG-07::finalization_and_replacement_match_serial_histories", "DG-07::headers_only_finalizes_exactly_tip_minus_one_thousand_before_publication", "DG-07::migrated_headers_only_pin_refutation_is_durable_and_fail_closed"]
 networks = ["mainnet", "testnet", "custom"]
 

--- a/crates/zakura-header-chain/conformance.toml
+++ b/crates/zakura-header-chain/conformance.toml
@@ -534,6 +534,38 @@ tests = ["IN-01::generated_nu5_graph_matches_full_state_before_finalization", "A
 networks = ["mainnet", "testnet", "custom"]
 
 [[rule]]
+id = "LC-INT-05"
+name = "Owner-qualified freshness"
+status = "implemented"
+owner = "zakura_header_chain::transition::planner::apply_transition_engine"
+tests = ["DF-02::typed_header_authority_ignores_global_version_but_rejects_stale_generation", "DF-02::typed_body_authority_ignores_global_version_but_rejects_stale_generation", "IN-01::all_owner_mismatches_have_zero_effects"]
+networks = ["mainnet", "testnet", "custom"]
+
+[[rule]]
+id = "LC-INT-06"
+name = "Adjacent replay scope"
+status = "implemented"
+owner = "zakura_header_chain::EngineMetadata::last_transition"
+tests = ["IN-04::replay_identity_is_domain_payload_and_authority_bound", "IN-04::replay_protection_covers_only_the_adjacent_state_changing_transition"]
+networks = ["mainnet", "testnet", "custom"]
+
+[[rule]]
+id = "LC-INT-07"
+name = "Durable-fact provenance"
+status = "implemented"
+owner = "zakura_state::HeaderChainRuntime"
+tests = ["DG-05::finality_atomic_prune_rebase_projection_generation", "DG-01::complete_batch_is_sealed_to_lease_and_uses_internal_context", "IN-07::stale_anchor_admission_reanchors_from_durable_snapshot_without_retry_or_score"]
+networks = ["mainnet", "testnet", "custom"]
+
+[[rule]]
+id = "LC-INT-08"
+name = "Distinct admission-pressure outcomes"
+status = "implemented"
+owner = "zakura_header_chain::transition::planner::apply_transition_engine"
+tests = ["DG-06::protected_paths_and_context_references_fail_closed_under_node_pressure", "DG-06::exact_v1_node_boundary_refuses_to_evict_the_selected_path", "IN-06::auxiliary_resource_limits_reject_equal_plus_one_without_effects"]
+networks = ["mainnet", "testnet", "custom"]
+
+[[rule]]
 id = "LC-BODY-01"
 name = "Body-payload mismatch"
 status = "implemented"

--- a/crates/zakura-header-chain/src/fuzz.rs
+++ b/crates/zakura-header-chain/src/fuzz.rs
@@ -821,7 +821,7 @@ pub fn replay_fork_transition_bytes(bytes: &[u8]) -> ForkReplaySummary {
             | Err(TransitionFailure::InvalidEvidence(_))
             | Err(TransitionFailure::Mode)
             | Err(TransitionFailure::StalePreparation)
-            | Err(TransitionFailure::ResourceStalled) => {
+            | Err(TransitionFailure::AuxiliaryLimitExceeded) => {
                 assert_eq!(store.snapshot(), before);
                 refused = refused.saturating_add(1);
             }

--- a/crates/zakura-header-chain/src/fuzz.rs
+++ b/crates/zakura-header-chain/src/fuzz.rs
@@ -439,7 +439,7 @@ fn apply_transition(
         _ => DurableTransitionFacts::None,
     };
     engine
-        .apply(request, context, durable)
+        .plan_transition(request, context, durable)
         .map(crate::EngineTransition::into_plan)
 }
 

--- a/crates/zakura-header-chain/src/transition/engine.rs
+++ b/crates/zakura-header-chain/src/transition/engine.rs
@@ -11,7 +11,7 @@ use crate::{
     TransitionRequest, ValidationLease,
 };
 
-use super::planner::apply_transition_engine;
+use super::planner::derive_transition_plan;
 
 /// Incoherent state supplied while hydrating an audited engine.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
@@ -168,19 +168,29 @@ impl HeaderChainEngine {
         })
     }
 
-    /// Derive and verify one complete projected engine state without mutating this engine.
-    pub fn apply(
+    /// Plan one verified transition without mutating this engine.
+    ///
+    /// Returns a durable write set and the exact post-transition snapshot that
+    /// the runtime may commit and then install. This method never writes durable
+    /// state or publishes watches.
+    pub fn plan_transition(
         &self,
         request: TransitionRequest,
         context: &TransitionContext<'_>,
         durable: DurableTransitionFacts,
     ) -> Result<EngineTransition, TransitionFailure> {
-        let plan = apply_transition_engine(self, &durable, request, context)?;
+        let plan = derive_transition_plan(self, &durable, request, context)?;
         Ok(EngineTransition { plan })
     }
 
-    /// Apply a verified graph delta after its durable batch has committed.
-    pub fn apply_committed(
+    /// Install a verified transition after its durable batch has committed.
+    ///
+    /// The caller must have already persisted [`EngineTransition::change_set`].
+    /// Returns [`CommittedTransitionError::StaleSource`] when another transition
+    /// changed this engine after planning. On success, in-memory graph,
+    /// projections, metadata, and auxiliary deliveries match the committed
+    /// write set.
+    pub fn install_committed_transition(
         &mut self,
         transition: EngineTransition,
     ) -> Result<(), CommittedTransitionError> {
@@ -251,7 +261,7 @@ impl HeaderChainEngine {
     }
 }
 
-/// A verified durable write set ready for one post-commit in-memory application.
+/// A verified durable write set ready for one post-commit in-memory installation.
 #[derive(Clone, Debug)]
 pub struct EngineTransition {
     plan: TransitionPlan,
@@ -263,12 +273,20 @@ impl EngineTransition {
         self.plan.before()
     }
 
+    /// Return the coherent state that exists after this transition commits.
+    pub fn after(&self) -> EngineSnapshot {
+        self.plan.change_set().metadata.snapshot()
+    }
+
     /// Return the atomic durable write set.
     pub const fn change_set(&self) -> &ChangeSet {
         self.plan.change_set()
     }
 
-    /// Return true when the request is an idempotent replay.
+    /// Return true when admission produced no durable effects.
+    ///
+    /// This covers exact adjacent replay, already-applied work, immediately
+    /// evicted insertions, and other zero-effect admissions.
     pub fn is_no_change(&self) -> bool {
         self.plan.is_no_change()
     }

--- a/crates/zakura-header-chain/src/transition/invariants.rs
+++ b/crates/zakura-header-chain/src/transition/invariants.rs
@@ -7,9 +7,11 @@ use zakura_chain::block;
 
 use crate::graph::GraphOverlay;
 use crate::graph::HeaderGraphView;
+#[cfg(any(test, feature = "fuzz-impl"))]
+use crate::TransitionPlan;
 use crate::{
     AuxDelta, BodyValidationState, EligibilityReason, EngineMode, FinalitySource, Frontier,
-    HeaderChainEngine, HeaderNode, ProjectionDelta, TransitionCause, TransitionPlan,
+    HeaderChainEngine, HeaderNode, PlanCandidate, ProjectionDelta, TransitionCause,
 };
 
 /// Stable, category-specific projected-state invariant failures.
@@ -80,12 +82,21 @@ fn default_verification_mode() -> VerificationMode {
     }
 }
 
-/// Verify the complete projected state before an adapter may commit `plan`.
+/// Verify a complete projected candidate before it becomes commit-capable.
+pub(crate) fn verify_candidate(
+    before: &HeaderChainEngine,
+    plan: &PlanCandidate,
+) -> Result<(), InvariantViolation> {
+    verify_plan_with_mode(before, plan, default_verification_mode())
+}
+
+/// Re-run verification against an already verified plan in tests and fuzzing.
+#[cfg(any(test, feature = "fuzz-impl"))]
 pub(crate) fn verify_plan(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
 ) -> Result<(), InvariantViolation> {
-    verify_plan_with_mode(before, plan, default_verification_mode())
+    verify_plan_with_mode(before, plan.candidate(), default_verification_mode())
 }
 
 /// Verify `plan` using the exact production overlay and boundary-node path.
@@ -94,12 +105,12 @@ pub(crate) fn verify_plan_production(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
 ) -> Result<(), InvariantViolation> {
-    verify_plan_with_mode(before, plan, VerificationMode::Production)
+    verify_plan_with_mode(before, plan.candidate(), VerificationMode::Production)
 }
 
 fn verify_plan_with_mode(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     if is_incremental_aux_authentication(before, plan) {
@@ -114,7 +125,7 @@ fn verify_plan_with_mode(
 
 fn verify_plan_exhaustive(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     let source = before.snapshot();
@@ -155,7 +166,7 @@ fn verify_plan_exhaustive(
 
 fn verify_plan_against_graph<G: HeaderGraphView>(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     source: &crate::EngineSnapshot,
     source_metadata: &crate::EngineMetadata,
     graph: &G,
@@ -257,7 +268,7 @@ fn verify_plan_against_graph<G: HeaderGraphView>(
 
 pub(super) fn is_incremental_aux_authentication(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
 ) -> bool {
     let metadata = &plan.change_set.metadata;
     let source_metadata = before.metadata();
@@ -293,7 +304,7 @@ pub(super) fn is_incremental_aux_authentication(
 
 fn verify_incremental_aux_authentication(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     if before.snapshot() != plan.before {
@@ -329,7 +340,7 @@ fn verify_incremental_aux_authentication(
 
 pub(super) fn is_incremental_checkpoint_finality(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
 ) -> bool {
     let source = before.snapshot();
     let metadata = &plan.change_set.metadata;
@@ -377,7 +388,7 @@ pub(super) fn is_incremental_checkpoint_finality(
 
 fn verify_incremental_checkpoint_finality(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     let source = before.snapshot();
@@ -415,7 +426,7 @@ fn verify_incremental_checkpoint_finality(
 
 fn verify_incremental_checkpoint_against_graph<G: HeaderGraphView>(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     source: &crate::EngineSnapshot,
     graph: &G,
     delta_finalized: Frontier,
@@ -571,7 +582,7 @@ fn verify_node<G: HeaderGraphView>(
 
 fn verify_indexes(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
 ) -> Result<(), InvariantViolation> {
     if plan.change_set.put_nodes != plan.graph_delta().updated_header_nodes()
         || plan.change_set.delete_nodes != plan.graph_delta().deleted_header_hashes()
@@ -742,7 +753,7 @@ fn verify_pins(
 
 fn verify_protected<G: HeaderGraphView>(
     graph: &G,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
 ) -> Result<(), InvariantViolation> {
     for frontier in [
         plan.change_set.metadata.frontiers.finalized,
@@ -760,7 +771,7 @@ fn verify_protected<G: HeaderGraphView>(
 
 fn verify_generations(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     selected: &[Frontier],
     verified: &[Frontier],
 ) -> Result<(), InvariantViolation> {
@@ -836,7 +847,7 @@ fn verify_generations(
 fn verify_aux<G: HeaderGraphView>(
     before: &HeaderChainEngine,
     graph: &G,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     mode: VerificationMode,
 ) -> Result<(), InvariantViolation> {
     let mut put_ids = HashSet::new();
@@ -930,7 +941,7 @@ fn verify_aux<G: HeaderGraphView>(
 fn verification_nodes<'a, G: HeaderGraphView>(
     before: &HeaderChainEngine,
     graph: &'a G,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
     mode: VerificationMode,
 ) -> Vec<&'a HeaderNode> {
     match mode {
@@ -943,7 +954,7 @@ fn verification_nodes<'a, G: HeaderGraphView>(
 #[cfg(any(test, feature = "fuzz-impl"))]
 fn materialize_projected_graph(
     before: &HeaderChainEngine,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
 ) -> Result<crate::graph::MemHeaderStore, InvariantViolation> {
     let mut graph = before.graph().clone();
     graph
@@ -955,7 +966,7 @@ fn materialize_projected_graph(
 fn changed_boundary_nodes<'a, G: HeaderGraphView>(
     before: &HeaderChainEngine,
     graph: &'a G,
-    plan: &TransitionPlan,
+    plan: &PlanCandidate,
 ) -> Vec<&'a HeaderNode> {
     let mut hashes = HashSet::from([
         plan.change_set.metadata.frontiers.finalized.hash,

--- a/crates/zakura-header-chain/src/transition/invariants.rs
+++ b/crates/zakura-header-chain/src/transition/invariants.rs
@@ -7,7 +7,7 @@ use zakura_chain::block;
 
 use crate::graph::GraphOverlay;
 use crate::graph::HeaderGraphView;
-#[cfg(any(test, feature = "fuzz-impl"))]
+#[cfg(test)]
 use crate::TransitionPlan;
 use crate::{
     AuxDelta, BodyValidationState, EligibilityReason, EngineMode, FinalitySource, Frontier,
@@ -68,6 +68,7 @@ enum VerificationMode {
     #[cfg(any(test, feature = "fuzz-impl"))]
     Exhaustive,
     /// Delta overlay and changed-boundary nodes (shipped production path).
+    #[cfg(any(test, not(feature = "fuzz-impl")))]
     Production,
 }
 
@@ -91,7 +92,7 @@ pub(crate) fn verify_candidate(
 }
 
 /// Re-run verification against an already verified plan in tests and fuzzing.
-#[cfg(any(test, feature = "fuzz-impl"))]
+#[cfg(test)]
 pub(crate) fn verify_plan(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
@@ -100,7 +101,7 @@ pub(crate) fn verify_plan(
 }
 
 /// Verify `plan` using the exact production overlay and boundary-node path.
-#[cfg(any(test, feature = "fuzz-impl"))]
+#[cfg(test)]
 pub(crate) fn verify_plan_production(
     before: &HeaderChainEngine,
     plan: &TransitionPlan,
@@ -900,6 +901,7 @@ fn verify_aux<G: HeaderGraphView>(
     let nodes: Vec<&HeaderNode> = match mode {
         #[cfg(any(test, feature = "fuzz-impl"))]
         VerificationMode::Exhaustive => graph.view_header_nodes(),
+        #[cfg(any(test, not(feature = "fuzz-impl")))]
         VerificationMode::Production => plan
             .change_set
             .put_nodes
@@ -939,15 +941,16 @@ fn verify_aux<G: HeaderGraphView>(
 }
 
 fn verification_nodes<'a, G: HeaderGraphView>(
-    before: &HeaderChainEngine,
+    _before: &HeaderChainEngine,
     graph: &'a G,
-    plan: &PlanCandidate,
+    _plan: &PlanCandidate,
     mode: VerificationMode,
 ) -> Vec<&'a HeaderNode> {
     match mode {
         #[cfg(any(test, feature = "fuzz-impl"))]
         VerificationMode::Exhaustive => graph.view_header_nodes(),
-        VerificationMode::Production => changed_boundary_nodes(before, graph, plan),
+        #[cfg(any(test, not(feature = "fuzz-impl")))]
+        VerificationMode::Production => changed_boundary_nodes(_before, graph, _plan),
     }
 }
 
@@ -963,6 +966,7 @@ fn materialize_projected_graph(
     Ok(graph)
 }
 
+#[cfg(any(test, not(feature = "fuzz-impl")))]
 fn changed_boundary_nodes<'a, G: HeaderGraphView>(
     before: &HeaderChainEngine,
     graph: &'a G,

--- a/crates/zakura-header-chain/src/transition/mod.rs
+++ b/crates/zakura-header-chain/src/transition/mod.rs
@@ -17,7 +17,8 @@ pub(crate) use invariants::verify_plan;
 #[cfg(any(test, feature = "fuzz-impl"))]
 pub(crate) use invariants::verify_plan_production;
 pub use invariants::InvariantViolation;
-pub use planner::{TransitionFailure, TransitionPlan};
+pub use planner::TransitionFailure;
+pub(crate) use planner::TransitionPlan;
 pub use recovery::{
     audit_store, audit_store_at, audit_store_for_trust_anchor_update, AuditViolation,
     RecoveryFailure, RecoveryPlan, RecoveryRepair, StoreAuditRead, ValidationContextRecord,

--- a/crates/zakura-header-chain/src/transition/mod.rs
+++ b/crates/zakura-header-chain/src/transition/mod.rs
@@ -13,12 +13,12 @@ pub use engine::{
     CommittedTransitionError, DurableTransitionFacts, EngineHydrationError, EngineTransition,
     HeaderChainEngine,
 };
-pub(crate) use invariants::verify_plan;
-#[cfg(any(test, feature = "fuzz-impl"))]
-pub(crate) use invariants::verify_plan_production;
+pub(crate) use invariants::verify_candidate;
 pub use invariants::InvariantViolation;
+#[cfg(any(test, feature = "fuzz-impl"))]
+pub(crate) use invariants::{verify_plan, verify_plan_production};
 pub use planner::TransitionFailure;
-pub(crate) use planner::TransitionPlan;
+pub(crate) use planner::{PlanCandidate, TransitionPlan};
 pub use recovery::{
     audit_store, audit_store_at, audit_store_for_trust_anchor_update, AuditViolation,
     RecoveryFailure, RecoveryPlan, RecoveryRepair, StoreAuditRead, ValidationContextRecord,

--- a/crates/zakura-header-chain/src/transition/mod.rs
+++ b/crates/zakura-header-chain/src/transition/mod.rs
@@ -15,7 +15,7 @@ pub use engine::{
 };
 pub(crate) use invariants::verify_candidate;
 pub use invariants::InvariantViolation;
-#[cfg(any(test, feature = "fuzz-impl"))]
+#[cfg(test)]
 pub(crate) use invariants::{verify_plan, verify_plan_production};
 pub use planner::TransitionFailure;
 pub(crate) use planner::{PlanCandidate, TransitionPlan};

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -1,31 +1,40 @@
 //! The sole pure mutation algorithm for durable header-chain state.
 
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+mod admission;
+mod event_effects;
+mod projected_state;
+mod settlement;
+mod write_set;
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
 
 use thiserror::Error;
-use zakura_chain::block;
 
-use crate::graph::{GraphDelta, GraphOverlay, HeaderGraphEdit, HeaderGraphView};
-use crate::retention::RetentionPlan;
+use crate::graph::GraphDelta;
 use crate::{
-    BodyEvidence, BodyValidationState, BodyWorkOwner, ChangeSet, CounterExhausted,
-    DurableTransitionFacts, EligibilityDelta, EligibilityReason, EngineLimits, EngineMetadata,
-    EngineMode, EngineSnapshot, EventAdmission, EvidenceId, FinalityRecord, FinalitySource,
-    Frontier, FrontierSet, GraphError, HeaderChainEngine, HeaderSyncWorkOwner,
-    HeaderValidationState, IndexChanges, MemHeaderStore, ProjectionDelta, StateVersion, StoreError,
-    TargetCompletion, TransitionCause, TransitionContext, TransitionEvent, TransitionRequest,
+    ChangeSet, CounterExhausted, DurableTransitionFacts, EngineLimits, EngineSnapshot, Frontier,
+    GraphError, HeaderChainEngine, StoreError, TransitionCause, TransitionContext,
+    TransitionRequest,
 };
 
-/// A complete write set and the private graph delta that the verifier checked.
-///
-/// Production callers consume [`crate::EngineTransition`]; this plan type stays
-/// crate-private so the planner representation is not part of the public API.
+use admission::{
+    authenticate_and_admit, rebase_header_insertion, validate_body_owner,
+    validate_header_sync_owner, AdmittedRequest, HeaderInsertionRebase,
+};
+use event_effects::{apply_event_evidence, migrated_pin_refuted, ApplyEventContext};
+use projected_state::ProjectedTransitionState;
+use settlement::{
+    apply_migrated_pin_alarm, derive_finality_and_retention, FinalityRetentionOutcome,
+    SettlementInputs,
+};
+use write_set::{derive_plan, invariant_pins, no_change, resource_stalled, DerivePlanInputs};
+
+/// A complete projected write set awaiting independent invariant verification.
 #[derive(Clone, Debug)]
-pub(crate) struct TransitionPlan {
+pub(crate) struct PlanCandidate {
     pub(super) before: EngineSnapshot,
     pub(super) change_set: ChangeSet,
     pub(super) graph_delta: GraphDelta,
@@ -34,30 +43,76 @@ pub(crate) struct TransitionPlan {
     pub(super) limits: EngineLimits,
 }
 
+impl PlanCandidate {
+    /// Return the opaque graph transition paired with this candidate.
+    pub(super) const fn graph_delta(&self) -> &GraphDelta {
+        &self.graph_delta
+    }
+
+    /// Return the candidate's classified transition cause.
+    pub(super) const fn cause(&self) -> TransitionCause {
+        self.cause
+    }
+}
+
+/// A candidate accepted by the independent transition invariant verifier.
+///
+/// Production callers consume [`crate::EngineTransition`]; this verified type
+/// stays crate-private so adapters cannot construct unchecked transitions.
+#[derive(Clone, Debug)]
+pub(crate) struct TransitionPlan {
+    candidate: PlanCandidate,
+}
+
 impl TransitionPlan {
+    fn from_verified(candidate: PlanCandidate) -> Self {
+        Self { candidate }
+    }
+
+    #[cfg(any(test, feature = "fuzz-impl"))]
+    pub(super) const fn candidate(&self) -> &PlanCandidate {
+        &self.candidate
+    }
+
     /// Return the atomic write set for the state adapter.
     pub const fn change_set(&self) -> &ChangeSet {
-        &self.change_set
+        &self.candidate.change_set
     }
 
     /// Return the coherent state observed before planning.
     pub const fn before(&self) -> &EngineSnapshot {
-        &self.before
+        &self.candidate.before
     }
 
     /// Return the classified transition cause.
     pub const fn cause(&self) -> TransitionCause {
-        self.cause
+        self.candidate.cause
     }
 
     /// Return true when the evidence was valid but changed no durable fact.
     pub fn is_no_change(&self) -> bool {
-        self.before.state_version == self.change_set.metadata.state_version
+        self.candidate.before.state_version == self.candidate.change_set.metadata.state_version
     }
 
     /// Return the opaque graph transition that matches the durable write set.
     pub(crate) const fn graph_delta(&self) -> &GraphDelta {
-        &self.graph_delta
+        &self.candidate.graph_delta
+    }
+}
+
+#[cfg(test)]
+impl std::ops::Deref for TransitionPlan {
+    type Target = PlanCandidate;
+
+    fn deref(&self) -> &Self::Target {
+        &self.candidate
+    }
+}
+
+#[cfg(test)]
+impl std::ops::DerefMut for TransitionPlan {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.candidate
     }
 }
 
@@ -68,7 +123,7 @@ pub enum TransitionFailure {
     #[error("stale transition work at state version {current:?}")]
     Stale {
         /// Current durable version.
-        current: StateVersion,
+        current: crate::StateVersion,
     },
     /// The store could not read durable rows coherently.
     #[error(transparent)]
@@ -113,39 +168,109 @@ pub enum TransitionFailure {
 pub(super) fn derive_transition_plan(
     engine: &HeaderChainEngine,
     durable: &DurableTransitionFacts,
-    mut request: TransitionRequest,
+    request: TransitionRequest,
     context: &TransitionContext<'_>,
 ) -> Result<TransitionPlan, TransitionFailure> {
-    let before = engine.snapshot();
-    let mut metadata = engine.metadata().clone();
-    validate_snapshot(&before, &metadata, context)?;
-    if context.retention_references.len() > context.config.limits.max_retention_references.get() {
-        return Err(TransitionFailure::InvalidEvidence(
-            "retained-path references exceed the per-transition limit",
-        ));
+    let candidate = derive_plan_candidate(engine, durable, request, context)?;
+    // Phase 6: verify invariants
+    verify_invariants(engine, &candidate)?;
+    Ok(TransitionPlan::from_verified(candidate))
+}
+
+fn derive_plan_candidate(
+    engine: &HeaderChainEngine,
+    durable: &DurableTransitionFacts,
+    request: TransitionRequest,
+    context: &TransitionContext<'_>,
+) -> Result<PlanCandidate, TransitionFailure> {
+    // Phase 1: authenticate / admit
+    let (before, mut metadata, admitted) = authenticate_and_admit(engine, request, context)?;
+
+    // Phase 2: bind replay and freshness
+    let bound = bind_replay_and_freshness(engine, durable, &before, &metadata, admitted)?;
+    if let Some(cause) = bound.no_change_cause {
+        return no_change(engine, before, metadata, bound.event, context, cause);
     }
-    validate_event_resource_bounds(engine, &request.event, context.config.limits)?;
-    validate_authority(&request.event, context)?;
-    let header_rebase =
-        rebase_header_insertion(&mut request.event, &before, engine.graph(), durable)?;
-    if let Some(owner) = request.event.header_sync_owner() {
-        validate_header_sync_owner(owner, &before)?;
+    let event = bound.event;
+
+    // Phase 3: apply event evidence
+    let old_selected = engine.selected_projection();
+    let old_verified = engine.verified_projection();
+    let mut projected = ProjectedTransitionState::new(engine);
+    let migrated_pin = migrated_pin_refuted(durable, &event)?;
+    apply_migrated_pin_alarm(&mut metadata, migrated_pin);
+    let event_context = ApplyEventContext {
+        engine,
+        durable,
+        transition: context,
+        before: &before,
+        old_selected,
+        migrated_pin_refuted: migrated_pin,
+    };
+    apply_event_evidence(&mut projected, &event, &event_context)?;
+
+    // Phase 4: derive finality and retention
+    let settlement = derive_finality_and_retention(SettlementInputs {
+        engine,
+        projected,
+        metadata,
+        before: &before,
+        event: &event,
+        header_rebase: bound.header_rebase,
+        context,
+        old_selected,
+    })?;
+    let settled = match settlement {
+        FinalityRetentionOutcome::ResourceStalled => {
+            return resource_stalled(engine, before, context);
+        }
+        FinalityRetentionOutcome::Settled(settled) => *settled,
+    };
+
+    // Phase 5: assemble writes
+    assemble_writes(
+        engine,
+        before,
+        old_selected,
+        old_verified,
+        settled,
+        &event,
+        context,
+    )
+}
+
+struct BoundRequest {
+    event: crate::TransitionEvent,
+    header_rebase: HeaderInsertionRebase,
+    no_change_cause: Option<TransitionCause>,
+}
+
+fn bind_replay_and_freshness(
+    engine: &HeaderChainEngine,
+    durable: &DurableTransitionFacts,
+    before: &EngineSnapshot,
+    metadata: &crate::EngineMetadata,
+    request: AdmittedRequest,
+) -> Result<BoundRequest, TransitionFailure> {
+    let AdmittedRequest {
+        mut event,
+        expected_version,
+    } = request;
+    let header_rebase = rebase_header_insertion(&mut event, before, engine.graph(), durable)?;
+    if let Some(owner) = event.header_sync_owner() {
+        validate_header_sync_owner(owner, before)?;
     }
-    if let Some(owner) = request.event.body_owner() {
-        validate_body_owner(owner, &before)?;
+    if let Some(owner) = event.body_owner() {
+        validate_body_owner(owner, before)?;
     }
-    let fingerprint = request.event.fingerprint();
+
+    let fingerprint = event.fingerprint();
     if fingerprint.is_some() && metadata.last_transition == fingerprint {
-        let plan = no_change(
-            engine,
-            before,
-            metadata,
-            request.event,
-            context,
-            TransitionCause::Event,
-        )?;
-        super::verify_plan(engine, &plan)?;
-        return Ok(plan);
+        return Ok(BoundRequest {
+            event,
+            header_rebase,
+            no_change_cause: Some(TransitionCause::Event),
+        });
     }
     if metadata
         .last_transition
@@ -154,1691 +279,57 @@ pub(super) fn derive_transition_plan(
     {
         return Err(TransitionFailure::ConflictingReplay);
     }
-    let has_async_authority =
-        request.event.header_sync_owner().is_some() || request.event.body_owner().is_some();
-    if !has_async_authority && request.expected_version != before.state_version {
+    let has_async_authority = event.header_sync_owner().is_some() || event.body_owner().is_some();
+    if !has_async_authority && expected_version != before.state_version {
         return Err(TransitionFailure::Stale {
             current: before.state_version,
         });
     }
-    if header_rebase == HeaderInsertionRebase::AlreadyApplied {
-        let plan = no_change(
-            engine,
-            before,
-            metadata,
-            request.event,
-            context,
-            TransitionCause::HeaderWorkAlreadyApplied,
-        )?;
-        super::verify_plan(engine, &plan)?;
-        return Ok(plan);
-    }
-    let mut graph = GraphOverlay::new(engine.graph());
-    let old_selected = engine.selected_projection();
-    let old_verified = engine.verified_projection();
-    let mut verified = Cow::Borrowed(old_verified);
-    let mut aux_changes = Vec::new();
-    let mut finality = None;
-    let mut operator_reason_changed = false;
-    let migrated_pin_refuted = migrated_pin_refuted(durable, &request.event)?;
-    let event_context = ApplyEventContext {
-        engine,
-        durable,
-        transition: context,
-        before: &before,
-        old_selected,
-        migrated_pin_refuted,
-    };
+    Ok(BoundRequest {
+        event,
+        header_rebase,
+        no_change_cause: (header_rebase == HeaderInsertionRebase::AlreadyApplied)
+            .then_some(TransitionCause::HeaderWorkAlreadyApplied),
+    })
+}
 
-    apply_event(
-        &mut graph,
-        &mut verified,
-        &mut aux_changes,
-        &mut operator_reason_changed,
-        &request.event,
-        &event_context,
-    )?;
-    let work_coordinates_rebased = graph.work_coordinates_rebased();
-    if work_coordinates_rebased {
-        metadata.work_origin = graph.view_finalized_frontier();
-    }
-    if let Some(pin) = migrated_pin_refuted {
-        metadata.alarms.migrated_pin_refuted = Some(pin);
-    }
-    if operator_reason_changed {
-        verified = Cow::Owned(select_fully_verified_path(&graph)?);
-    }
-    let (mut header_best, _) = graph.view_select_best_header_chain()?;
-
-    let full_state_finalized = match &request.event {
-        TransitionEvent::FullStateFinalized(event) => {
-            Some((event.new_finalized, event.full_state_transition_id))
-        }
-        TransitionEvent::VerifiedChainChanged(event)
-            if event.cause == crate::VerifiedChangeCause::CheckpointFinalizedGrow =>
-        {
-            event.new_path.last().map(|header| {
-                (
-                    Frontier::new(header.height, header.hash),
-                    event.full_state_transition_id,
-                )
-            })
-        }
-        _ => None,
-    };
-    if let Some((new_finalized, evidence)) = full_state_finalized {
-        if new_finalized.height < before.frontiers.finalized.height {
-            return Err(TransitionFailure::InvalidEvidence("finality retreated"));
-        }
-        if !verified.contains(&new_finalized) {
-            return Err(TransitionFailure::InvalidEvidence(
-                "integrated finality is not on the verified projection",
-            ));
-        }
-        finality = Some((new_finalized, FinalitySource::FullState { evidence }));
-    } else if context.config.mode == EngineMode::HeadersOnly {
-        let depth = context.config.limits.local_finality_depth.get();
-        if header_best
-            .height
-            .0
-            .saturating_sub(graph.view_finalized_frontier().height.0)
-            > depth
-        {
-            let height = block::Height(header_best.height.0 - depth);
-            let new_finalized = graph
-                .view_header_ancestor(header_best.hash, height)?
-                .ok_or(TransitionFailure::InvalidEvidence(
-                    "selected ancestry is incomplete",
-                ))?;
-            finality = Some((
-                new_finalized,
-                FinalitySource::HeadersOnlyDepth {
-                    selected_tip: header_best,
-                },
-            ));
-        }
-    }
-
-    let mut cause = if work_coordinates_rebased || header_rebase == HeaderInsertionRebase::Rebased {
-        TransitionCause::HeaderWorkRebased
-    } else if matches!(
-        request.event,
-        TransitionEvent::VerifiedChainChanged(ref event)
-            if event.cause == crate::VerifiedChangeCause::CheckpointFinalizedGrow
-    ) {
-        TransitionCause::CheckpointFinality
-    } else if matches!(request.event, TransitionEvent::AuxEvidence(_)) {
-        TransitionCause::AuxAuthentication
-    } else {
-        TransitionCause::Event
-    };
-    let mut finality_append = None;
-    if let Some((new_finalized, source)) = finality {
-        if new_finalized != graph.view_finalized_frontier() {
-            let previous = graph.view_finalized_frontier();
-            let epoch = metadata.finality_epoch.checked_next()?;
-            graph.edit_advance_finalized_frontier(new_finalized)?;
-            let verified = verified.to_mut();
-            verified.retain(|frontier| frontier.height >= new_finalized.height);
-            if verified.first().copied() != Some(new_finalized) {
-                verified.insert(0, new_finalized);
-            }
-            finality_append = Some(FinalityRecord {
-                previous,
-                current: new_finalized,
-                source,
-                epoch,
-            });
-            header_best = graph.view_select_best_header_chain()?.0;
-            if matches!(source, FinalitySource::HeadersOnlyDepth { .. }) {
-                cause = TransitionCause::HeadersOnlyFinality;
-            }
-        }
-    }
-
-    if context.config.mode == EngineMode::HeadersOnly {
-        verified = Cow::Owned(vec![graph.view_finalized_frontier()]);
-    }
-    let verified_best = verified
-        .last()
-        .copied()
-        .unwrap_or(graph.view_finalized_frontier());
-    let retention = crate::retention::enforce_retention(
-        &mut graph,
-        header_best,
-        verified_best,
-        context.retention_references.iter().copied(),
-        context.config.limits,
-    )?;
-    if retention.admission_refused {
-        let plan = resource_stalled(engine, before, context)?;
-        super::verify_plan(engine, &plan)?;
-        return Ok(plan);
-    }
-    header_best = graph.view_select_best_header_chain()?.0;
-    let selected = if cause == TransitionCause::CheckpointFinality
-        && header_best == before.frontiers.header_best
-        && finality_append.is_some_and(|record| {
-            old_selected
-                .binary_search_by_key(&record.current.height, |frontier| frontier.height)
-                .ok()
-                .is_some_and(|index| old_selected[index] == record.current)
-        }) {
-        let Some(record) = finality_append else {
-            return Err(TransitionFailure::InvalidEvidence(
-                "checkpoint finality has no finality record",
-            ));
-        };
-        let index = old_selected
-            .binary_search_by_key(&record.current.height, |frontier| frontier.height)
-            .map_err(|_| {
-                TransitionFailure::InvalidEvidence(
-                    "checkpoint finality left the selected projection",
-                )
-            })?;
-        Cow::Borrowed(&old_selected[index..])
-    } else {
-        Cow::Owned(path(&graph, header_best)?)
-    };
-    let verified = trim_projection(&graph, verified)?;
-    let graph_delta = graph.delta();
-    let evicted: HashSet<_> = graph_delta
-        .deleted_header_hashes()
-        .iter()
-        .copied()
-        .collect();
-    aux_changes.retain(|change| match change {
-        crate::AuxDelta::Put(delivery) => graph.view_header_node(delivery.header_hash).is_some(),
-        crate::AuxDelta::Delete { .. } => true,
-    });
-    let mut aux_deletes: Vec<_> = evicted
-        .iter()
-        .flat_map(|hash| {
-            engine
-                .aux_deliveries(*hash)
-                .iter()
-                .map(|delivery| (*hash, delivery.delivery_id))
-        })
-        .collect();
-    // HashSet iteration is nondeterministic; match adjacent ChangeSet ordering.
-    aux_deletes.sort_unstable_by_key(|(hash, delivery_id)| (hash.0, *delivery_id));
-    for (header_hash, delivery_id) in aux_deletes {
-        aux_changes.push(crate::AuxDelta::Delete {
-            header_hash,
-            delivery_id,
-        });
-    }
-    let plan = derive_plan(DerivePlanInputs {
+fn assemble_writes<'a>(
+    engine: &'a HeaderChainEngine,
+    before: EngineSnapshot,
+    old_selected: &'a [Frontier],
+    old_verified: &'a [Frontier],
+    settled: settlement::SettledTransition<'a>,
+    event: &crate::TransitionEvent,
+    context: &TransitionContext<'_>,
+) -> Result<PlanCandidate, TransitionFailure> {
+    let settlement::SettledTransition {
+        projected,
+        selected,
+        finality_append,
+        retention,
+        cause,
+        metadata,
+    } = settled;
+    derive_plan(DerivePlanInputs {
         before,
         metadata,
         base_graph: engine.graph(),
-        graph,
-        graph_delta,
+        projected,
         old_selected,
         old_verified,
         selected,
-        verified,
-        aux_changes,
         finality_append,
         retention,
-        fingerprint: request.event.fingerprint(),
+        fingerprint: event.fingerprint(),
         cause,
         trust_pins: invariant_pins(context),
         limits: context.config.limits,
-    })?;
-    super::verify_plan(engine, &plan)?;
-    Ok(plan)
+    })
 }
 
-fn validate_event_resource_bounds(
+fn verify_invariants(
     engine: &HeaderChainEngine,
-    event: &TransitionEvent,
-    limits: EngineLimits,
+    candidate: &PlanCandidate,
 ) -> Result<(), TransitionFailure> {
-    let TransitionEvent::InsertHeaders(insert) = event else {
-        return Ok(());
-    };
-    if insert.batch.headers().len() > limits.max_headers_per_transition.get() {
-        return Err(TransitionFailure::InvalidEvidence(
-            "prepared header batch exceeds the per-transition limit",
-        ));
-    }
-    if insert.aux.len() > limits.max_aux_deliveries_total.get() {
-        return Err(TransitionFailure::AuxiliaryLimitExceeded);
-    }
-    let mut additions = HashMap::<block::Hash, HashSet<EvidenceId>>::new();
-    for delivery in &insert.aux {
-        additions
-            .entry(delivery.header_hash)
-            .or_default()
-            .insert(delivery.delivery_id);
-    }
-    let mut new_total = engine.aux_delivery_count();
-    for (hash, delivery_ids) in additions {
-        let existing = engine.aux_deliveries(hash);
-        let new_count = delivery_ids
-            .iter()
-            .filter(|id| !existing.iter().any(|row| row.delivery_id == **id))
-            .count();
-        if existing.len().saturating_add(new_count) > limits.max_aux_deliveries_per_header.get() {
-            return Err(TransitionFailure::AuxiliaryLimitExceeded);
-        }
-        new_total = new_total.saturating_add(new_count);
-    }
-    if new_total > limits.max_aux_deliveries_total.get() {
-        return Err(TransitionFailure::AuxiliaryLimitExceeded);
-    }
-    Ok(())
+    Ok(super::verify_candidate(engine, candidate)?)
 }
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum HeaderInsertionRebase {
-    Current,
-    Rebased,
-    AlreadyApplied,
-}
-
-fn rebase_header_insertion(
-    event: &mut TransitionEvent,
-    current: &EngineSnapshot,
-    graph: &MemHeaderStore,
-    durable: &DurableTransitionFacts,
-) -> Result<HeaderInsertionRebase, TransitionFailure> {
-    let TransitionEvent::InsertHeaders(insert) = event else {
-        return Ok(HeaderInsertionRebase::Current);
-    };
-    if matches!(
-        insert.completion,
-        TargetCompletion::SelectedAuxiliaryRepair { .. }
-    ) {
-        return Ok(HeaderInsertionRebase::Current);
-    }
-    let Some(original_owner) = insert.owner.header_owner() else {
-        return Ok(HeaderInsertionRebase::Current);
-    };
-    let original = original_owner.authority;
-    if original.branch.target_tip_hash != insert.target_tip_hash {
-        return Err(TransitionFailure::Stale {
-            current: current.state_version,
-        });
-    }
-    if original.header_generation == current.header_generation
-        && original.branch.anchor_hash == current.frontiers.finalized.hash
-    {
-        return Ok(HeaderInsertionRebase::Current);
-    }
-    if original.branch.anchor_hash == current.frontiers.finalized.hash {
-        return Err(TransitionFailure::Stale {
-            current: current.state_version,
-        });
-    }
-    if original.header_generation.get() >= current.header_generation.get() {
-        return Err(TransitionFailure::Stale {
-            current: current.state_version,
-        });
-    }
-    let DurableTransitionFacts::HeaderInsertion { finality_path, .. } = durable else {
-        return Err(TransitionFailure::Stale {
-            current: current.state_version,
-        });
-    };
-    if finality_path.is_empty() {
-        return Err(TransitionFailure::Stale {
-            current: current.state_version,
-        });
-    }
-    validate_finality_rebase_path(
-        original.branch.anchor_hash,
-        current.frontiers.finalized,
-        finality_path,
-    )?;
-
-    let finalized = current.frontiers.finalized;
-    let parent_is_current_descendant = match graph.header_node(insert.parent_hash) {
-        Some(parent) if parent.height >= finalized.height => {
-            graph.header_ancestor(insert.parent_hash, finalized.height)? == Some(finalized)
-        }
-        Some(_) | None => false,
-    };
-    let mut removed = 0usize;
-    if !parent_is_current_descendant {
-        if insert
-            .batch
-            .headers()
-            .iter()
-            .any(|header| Frontier::new(header.height, header.hash) == finalized)
-        {
-            removed = insert
-                .batch
-                .rebase_after(finalized)
-                .map_err(|_| TransitionFailure::StalePreparation)?;
-            insert.parent_hash = finalized.hash;
-            insert
-                .completion
-                .rebase_common_ancestor(finalized)
-                .map_err(|_| TransitionFailure::StalePreparation)?;
-        } else {
-            let prepared_tip = insert
-                .batch
-                .headers()
-                .last()
-                .map(|header| Frontier::new(header.height, header.hash))
-                .ok_or(TransitionFailure::StalePreparation)?;
-            let prepared_tip_was_finalized = finality_path
-                .iter()
-                .any(|record| record.previous == prepared_tip || record.current == prepared_tip);
-            if prepared_tip_was_finalized && prepared_tip.height <= finalized.height {
-                insert.batch.clear_already_applied();
-                removed = insert.aux.len();
-            } else {
-                return Err(TransitionFailure::Stale {
-                    current: current.state_version,
-                });
-            }
-        }
-    }
-
-    let authority = crate::HeaderWorkAuthority {
-        header_generation: current.header_generation,
-        branch: crate::BranchId::new(finalized.hash, original.branch.target_tip_hash),
-    };
-    insert.owner = insert
-        .owner
-        .rebase_header(authority)
-        .ok_or(TransitionFailure::Authority)?;
-    for delivery in &mut insert.aux {
-        delivery.owner = delivery
-            .owner
-            .rebase_header(authority)
-            .ok_or(TransitionFailure::Authority)?;
-    }
-    if removed != 0 {
-        let retained: HashSet<_> = insert
-            .batch
-            .headers()
-            .iter()
-            .map(|header| header.hash)
-            .collect();
-        insert
-            .aux
-            .retain(|delivery| retained.contains(&delivery.header_hash));
-    }
-    if insert.batch.headers().is_empty() {
-        return Ok(HeaderInsertionRebase::AlreadyApplied);
-    }
-    Ok(HeaderInsertionRebase::Rebased)
-}
-
-fn validate_finality_rebase_path(
-    original_anchor: block::Hash,
-    current_finalized: Frontier,
-    path: &[FinalityRecord],
-) -> Result<(), TransitionFailure> {
-    if original_anchor == current_finalized.hash {
-        return path
-            .is_empty()
-            .then_some(())
-            .ok_or(TransitionFailure::StalePreparation);
-    }
-    let mut expected_frontier = None;
-    let mut expected_epoch = None;
-    for record in path {
-        let predecessor_matches = expected_frontier.map_or_else(
-            || record.previous.hash == original_anchor,
-            |expected| record.previous == expected,
-        );
-        if !predecessor_matches
-            || expected_epoch.is_some_and(|epoch| record.epoch != epoch)
-            || record.current.height < record.previous.height
-        {
-            return Err(TransitionFailure::StalePreparation);
-        }
-        expected_frontier = Some(record.current);
-        expected_epoch = Some(record.epoch.checked_next()?);
-    }
-    if expected_frontier != Some(current_finalized) {
-        return Err(TransitionFailure::StalePreparation);
-    }
-    Ok(())
-}
-
-fn migrated_pin_refuted(
-    durable: &DurableTransitionFacts,
-    event: &TransitionEvent,
-) -> Result<Option<Frontier>, TransitionFailure> {
-    let TransitionEvent::MigratedPinRefutation(event) = event else {
-        return Ok(None);
-    };
-    match durable {
-        DurableTransitionFacts::MigratedFinalityPin(preserved) => {
-            Ok((*preserved == Some(event.pin)).then_some(event.pin))
-        }
-        _ => Err(StoreError::Unavailable("migrated finality fact was not supplied").into()),
-    }
-}
-
-fn select_fully_verified_path<G: HeaderGraphView>(
-    graph: &G,
-) -> Result<Vec<Frontier>, TransitionFailure> {
-    let finalized = graph.view_finalized_frontier();
-    let mut connected = HashSet::from([finalized.hash]);
-    let mut nodes = graph.view_header_nodes();
-    nodes.sort_unstable_by_key(|node| (node.height, node.hash.0));
-    for node in nodes {
-        if node.hash != finalized.hash
-            && node.is_eligible()
-            && matches!(
-                node.body_validation_state,
-                BodyValidationState::Verified { .. }
-            )
-            && connected.contains(&node.parent_hash)
-        {
-            connected.insert(node.hash);
-        }
-    }
-    let tip = connected
-        .into_iter()
-        .map(|hash| {
-            let node = graph
-                .view_header_node(hash)
-                .expect("verified candidates are retained graph nodes");
-            graph
-                .view_header_chain_score(hash)
-                .map(|score| (score, Frontier::new(node.height, hash)))
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .max_by_key(|(score, _)| *score)
-        .map(|(_, frontier)| frontier)
-        .ok_or(GraphError::UnknownHeaderNode(finalized.hash))?;
-    path(graph, tip)
-}
-
-fn validate_snapshot(
-    snapshot: &EngineSnapshot,
-    metadata: &EngineMetadata,
-    context: &TransitionContext<'_>,
-) -> Result<(), TransitionFailure> {
-    if snapshot.mode != context.config.mode
-        || metadata.mode != context.config.mode
-        || metadata.network_id != context.config.network.kind()
-        || metadata.anchor_manifest_digest != context.config.trust_anchor_digest()
-        || snapshot.state_version != metadata.state_version
-        || snapshot.frontiers != metadata.frontiers
-    {
-        return Err(TransitionFailure::ConfigurationMismatch);
-    }
-    Ok(())
-}
-
-fn validate_header_sync_owner(
-    owner: HeaderSyncWorkOwner,
-    before: &EngineSnapshot,
-) -> Result<(), TransitionFailure> {
-    let header = owner.header_authority();
-    if header.header_generation != before.header_generation
-        || owner
-            .body_authority()
-            .is_some_and(|authority| authority.verified_generation != before.verified_generation)
-        || header.branch.anchor_hash != before.frontiers.finalized.hash
-    {
-        return Err(TransitionFailure::Stale {
-            current: before.state_version,
-        });
-    }
-    Ok(())
-}
-
-fn validate_body_owner(
-    owner: BodyWorkOwner,
-    before: &EngineSnapshot,
-) -> Result<(), TransitionFailure> {
-    if owner.header_generation != before.header_generation
-        || owner.verified_generation != before.verified_generation
-        || owner.branch.anchor_hash != before.frontiers.finalized.hash
-    {
-        return Err(TransitionFailure::Stale {
-            current: before.state_version,
-        });
-    }
-    Ok(())
-}
-
-fn validate_authority(
-    event: &TransitionEvent,
-    context: &TransitionContext<'_>,
-) -> Result<(), TransitionFailure> {
-    match event.admission() {
-        EventAdmission::AnyMode => Ok(()),
-        EventAdmission::IntegratedFullState if context.config.mode != EngineMode::Integrated => {
-            Err(TransitionFailure::Mode)
-        }
-        EventAdmission::IntegratedFullState => {
-            if context
-                .full_state_authority
-                .is_some_and(|authority| authority.authorizes_full_state(event))
-            {
-                Ok(())
-            } else {
-                Err(TransitionFailure::Authority)
-            }
-        }
-        EventAdmission::RegisteredScheduler => {
-            let TransitionEvent::OperatorBodyRetry(retry) = event else {
-                return Err(TransitionFailure::Authority);
-            };
-            if context
-                .full_state_authority
-                .is_some_and(|authority| authority.authorizes_scheduler_retry(retry))
-            {
-                Ok(())
-            } else {
-                Err(TransitionFailure::Authority)
-            }
-        }
-        EventAdmission::RegisteredHeaderCompletion => {
-            let TransitionEvent::InsertHeaders(insert) = event else {
-                return Err(TransitionFailure::Authority);
-            };
-            if context
-                .full_state_authority
-                .is_some_and(|authority| authority.authorizes_header_completion(insert))
-            {
-                Ok(())
-            } else {
-                Err(TransitionFailure::Authority)
-            }
-        }
-    }
-}
-
-struct ApplyEventContext<'a> {
-    engine: &'a HeaderChainEngine,
-    durable: &'a DurableTransitionFacts,
-    transition: &'a TransitionContext<'a>,
-    before: &'a EngineSnapshot,
-    old_selected: &'a [Frontier],
-    migrated_pin_refuted: Option<Frontier>,
-}
-
-fn retained_header_context<G: HeaderGraphView>(
-    graph: &G,
-    parent: Frontier,
-    durable: &DurableTransitionFacts,
-    transition: &TransitionContext<'_>,
-) -> Result<
-    Vec<(
-        zakura_chain::work::difficulty::CompactDifficulty,
-        chrono::DateTime<chrono::Utc>,
-    )>,
-    TransitionFailure,
-> {
-    let required = usize::try_from(parent.height.0)
-        .map_err(|_| StoreError::Unavailable("retained parent height does not fit in memory"))?
-        .checked_add(1)
-        .ok_or(StoreError::Unavailable(
-            "retained parent context length overflowed",
-        ))?
-        .min(crate::POW_ADJUSTMENT_BLOCK_SPAN);
-    let mut context = Vec::with_capacity(required);
-    let mut hash = parent.hash;
-    while context.len() < required {
-        let Some(node) = graph.view_header_node(hash) else {
-            let DurableTransitionFacts::HeaderInsertion {
-                validation_contexts,
-                ..
-            } = durable
-            else {
-                return Err(
-                    StoreError::Unavailable("retained predecessor context is incomplete").into(),
-                );
-            };
-            let authorized_lease = validation_contexts.iter().find_map(|lease| {
-                if !lease.is_coherent(
-                    &transition.config.network,
-                    transition.config.trust_anchor_digest(),
-                ) || !transition
-                    .full_state_authority
-                    .is_some_and(|authority| authority.authorizes_validation_lease(lease))
-                {
-                    return None;
-                }
-                let overlap = context
-                    .iter()
-                    .position(|(_, _, frontier)| *frontier == lease.parent())
-                    .or_else(|| {
-                        context
-                            .is_empty()
-                            .then_some(0)
-                            .filter(|_| lease.parent() == parent)
-                    })?;
-                let graph_overlap = &context[overlap..];
-                let lease_overlap = lease.predecessors().get(..graph_overlap.len())?;
-                graph_overlap
-                    .iter()
-                    .zip(lease_overlap)
-                    .all(|((_, _, frontier), fact)| *frontier == fact.frontier)
-                    .then_some((lease, overlap))
-            });
-            let Some((lease, overlap)) = authorized_lease else {
-                return Err(
-                    StoreError::Unavailable("durable predecessor context is incoherent").into(),
-                );
-            };
-            context.truncate(overlap);
-            context.extend(
-                lease
-                    .predecessors()
-                    .iter()
-                    .take(required.saturating_sub(context.len()))
-                    .map(|fact| {
-                        (
-                            fact.header.difficulty_threshold,
-                            fact.header.time,
-                            fact.frontier,
-                        )
-                    }),
-            );
-            if context.len() != required {
-                return Err(
-                    StoreError::Unavailable("durable predecessor context is incomplete").into(),
-                );
-            }
-            return Ok(context
-                .into_iter()
-                .map(|(difficulty, time, _)| (difficulty, time))
-                .collect());
-        };
-        context.push((
-            node.header.difficulty_threshold,
-            node.header.time,
-            Frontier::new(node.height, node.hash),
-        ));
-        hash = node.parent_hash;
-    }
-    Ok(context
-        .into_iter()
-        .map(|(difficulty, time, _)| (difficulty, time))
-        .collect())
-}
-
-fn validate_full_state_header<G: HeaderGraphView>(
-    graph: &G,
-    parent: Frontier,
-    header: &crate::VerifiedHeaderRef,
-    durable: &DurableTransitionFacts,
-    context: &TransitionContext<'_>,
-) -> Result<zakura_chain::work::difficulty::Work, TransitionFailure> {
-    let rules = crate::HeaderRules::from_engine_config(context.config).map_err(|_| {
-        TransitionFailure::InvalidEvidence("full-state header policy is incoherent")
-    })?;
-    let headers = [header.header.clone()];
-    let prepared = crate::prepare_context_free_headers(
-        crate::HeaderBatchInput::new(&headers),
-        parent,
-        &rules,
-        context.clock,
-    )
-    .map_err(|_| {
-        TransitionFailure::InvalidEvidence("full-state header failed observable validation")
-    })?;
-    let prepared = prepared
-        .headers()
-        .first()
-        .ok_or(TransitionFailure::InvalidEvidence(
-            "full-state header validation produced no result",
-        ))?;
-    if prepared.hash != header.hash
-        || prepared.height != header.height
-        || prepared.validation != HeaderValidationState::Valid
-    {
-        return Err(TransitionFailure::InvalidEvidence(
-            "full-state header identity or local-time state is invalid",
-        ));
-    }
-    let contextual = retained_header_context(graph, parent, durable, context)?;
-    let adjustment = crate::AdjustedDifficulty::new_from_header_time(
-        header.header.time,
-        parent.height,
-        &context.config.network,
-        contextual,
-    )
-    .map_err(|_| {
-        TransitionFailure::InvalidEvidence(
-            "full-state header has incomplete retained difficulty context",
-        )
-    })?;
-    crate::validate_contextual_difficulty_and_time(header.header.difficulty_threshold, adjustment)
-        .map_err(|_| {
-            TransitionFailure::InvalidEvidence(
-                "full-state header failed contextual difficulty or time validation",
-            )
-        })?;
-    Ok(prepared.block_work)
-}
-
-fn apply_event<G: HeaderGraphEdit>(
-    graph: &mut G,
-    verified: &mut Cow<'_, [Frontier]>,
-    aux_changes: &mut Vec<crate::AuxDelta>,
-    operator_reason_changed: &mut bool,
-    event: &TransitionEvent,
-    event_context: &ApplyEventContext<'_>,
-) -> Result<(), TransitionFailure> {
-    let engine = event_context.engine;
-    let durable = event_context.durable;
-    let context = event_context.transition;
-    match event {
-        TransitionEvent::InsertHeaders(event) => {
-            let receipt = event.batch.receipt();
-            if receipt.parent().hash != event.parent_hash
-                || receipt.trust_anchor_digest() != context.config.trust_anchor_digest()
-            {
-                return Err(TransitionFailure::StalePreparation);
-            }
-            let parent_node =
-                graph
-                    .view_header_node(event.parent_hash)
-                    .ok_or(GraphError::UnknownParent {
-                        header: event.target_tip_hash,
-                        parent: event.parent_hash,
-                    })?;
-            let parent_frontier = Frontier::new(parent_node.height, parent_node.hash);
-            if receipt.parent() != parent_frontier
-                || receipt.network() != &context.config.network
-                || receipt.trust_anchor_digest() != context.config.trust_anchor_digest()
-            {
-                return Err(TransitionFailure::StalePreparation);
-            }
-            let common_ancestor = match event.completion {
-                TargetCompletion::TargetComplete { common_ancestor }
-                | TargetCompletion::TargetPrefix { common_ancestor }
-                | TargetCompletion::SelectedAuxiliaryRepair {
-                    common_ancestor, ..
-                } => common_ancestor,
-            };
-            if common_ancestor != parent_frontier {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "target completion ancestor does not match the retained parent",
-                ));
-            }
-            let mut contextual = retained_header_context(graph, parent_frontier, durable, context)?;
-            let mut parent = parent_frontier;
-            for prepared in event.batch.headers() {
-                if prepared.header.previous_block_hash != parent.hash
-                    || prepared.hash != prepared.header.hash()
-                    || prepared.height
-                        != parent
-                            .height
-                            .next()
-                            .map_err(|_| GraphError::HeightOverflow {
-                                parent: parent.hash,
-                            })?
-                    || prepared.block_work
-                        != prepared.header.difficulty_threshold.to_work().ok_or(
-                            TransitionFailure::InvalidEvidence("invalid prepared target"),
-                        )?
-                {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "prepared header batch is inconsistent",
-                    ));
-                }
-                let adjustment = crate::AdjustedDifficulty::new_from_header_time(
-                    prepared.header.time,
-                    parent.height,
-                    &context.config.network,
-                    contextual.iter().copied(),
-                )
-                .map_err(|_| {
-                    TransitionFailure::InvalidEvidence(
-                        "prepared header has incomplete retained difficulty context",
-                    )
-                })?;
-                crate::validate_contextual_difficulty_and_time(
-                    prepared.header.difficulty_threshold,
-                    adjustment,
-                )
-                .map_err(|_| {
-                    TransitionFailure::InvalidEvidence(
-                        "prepared header failed retained contextual validation",
-                    )
-                })?;
-                let validation = match prepared.validation {
-                    HeaderValidationState::DeferredUntil(until) if until <= context.clock.now() => {
-                        HeaderValidationState::Valid
-                    }
-                    state => state,
-                };
-                let reasons = anchor_reasons(context, prepared.height, prepared.hash);
-                parent = match graph.edit_insert_header(
-                    prepared.header.clone(),
-                    validation,
-                    reasons,
-                    BodyValidationState::Unknown,
-                )? {
-                    crate::InsertResult::Inserted(frontier)
-                    | crate::InsertResult::AlreadyPresent(frontier) => frontier,
-                };
-                contextual.insert(
-                    0,
-                    (prepared.header.difficulty_threshold, prepared.header.time),
-                );
-                contextual.truncate(crate::POW_ADJUSTMENT_BLOCK_SPAN);
-            }
-            if parent.hash != event.target_tip_hash {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "target completion does not end at the pursued hash",
-                ));
-            }
-            match event.completion {
-                TargetCompletion::SelectedAuxiliaryRepair {
-                    selected_target, ..
-                } => {
-                    if event.owner.body_owner().is_none() {
-                        return Err(TransitionFailure::InvalidEvidence(
-                            "selected auxiliary repair does not have body authority",
-                        ));
-                    }
-                    if event.batch.headers().len() != 1
-                        || event.aux.len() != 1
-                        || event.aux[0].tree_aux.is_none()
-                        || selected_target != parent
-                        || event.owner.header_authority().branch.target_tip_hash
-                            != event_context.before.frontiers.header_best.hash
-                        || event_context
-                            .old_selected
-                            .iter()
-                            .find(|frontier| frontier.height == selected_target.height)
-                            .map(|frontier| frontier.hash)
-                            != Some(selected_target.hash)
-                        || graph.view_header_ancestor(
-                            event.owner.header_authority().branch.target_tip_hash,
-                            selected_target.height,
-                        )? != Some(selected_target)
-                    {
-                        return Err(TransitionFailure::InvalidEvidence(
-                            "auxiliary repair is not one exact selected header",
-                        ));
-                    }
-                }
-                TargetCompletion::TargetComplete { .. } | TargetCompletion::TargetPrefix { .. } => {
-                    if event.owner.header_owner().is_none() {
-                        return Err(TransitionFailure::InvalidEvidence(
-                            "ordinary header insertion does not have pure header authority",
-                        ));
-                    }
-                    if event.owner.header_authority().branch.target_tip_hash
-                        != event.target_tip_hash
-                    {
-                        return Err(TransitionFailure::InvalidEvidence(
-                            "target completion does not end at the pursued hash",
-                        ));
-                    }
-                }
-            }
-            let batch_headers: HashMap<_, _> = event
-                .batch
-                .headers()
-                .iter()
-                .map(|header| (header.hash, header.height))
-                .collect();
-            let mut delivery_ids = HashSet::new();
-            for delivery in &event.aux {
-                let expected_height = batch_headers.get(&delivery.header_hash).copied();
-                if !delivery_ids.insert(delivery.delivery_id)
-                    || delivery.owner != event.owner
-                    || delivery.source != event.source
-                    || delivery.authentication != crate::AuxAuthentication::Unauthenticated
-                    || expected_height.is_none()
-                    || delivery
-                        .tree_aux
-                        .is_some_and(|aux| Some(aux.height) != expected_height)
-                {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "auxiliary delivery does not match the admitted target",
-                    ));
-                }
-                let indexed_count = graph
-                    .view_header_node(delivery.header_hash)
-                    .expect("the auxiliary header was checked above")
-                    .aux_delivery_ids
-                    .iter()
-                    .filter(|delivery_id| **delivery_id == delivery.delivery_id)
-                    .count();
-                let stored = engine.aux_delivery(delivery.delivery_id).copied();
-                match (stored, indexed_count) {
-                    (Some(stored), 1) if stored == *delivery => continue,
-                    (None, 0) => {}
-                    _ => {
-                        return Err(TransitionFailure::InvalidEvidence(
-                            "auxiliary delivery replay changes provenance or indexing",
-                        ));
-                    }
-                }
-                graph.edit_record_auxiliary_evidence_delivery(
-                    delivery.header_hash,
-                    delivery.delivery_id,
-                )?;
-                aux_changes.push(crate::AuxDelta::Put(Box::new(*delivery)));
-            }
-        }
-        TransitionEvent::VerifiedChainChanged(event) => {
-            if verified.last().copied() != Some(event.old_tip) {
-                return Err(TransitionFailure::StalePreparation);
-            }
-            let mut parent = match event.cause {
-                crate::VerifiedChangeCause::Grow
-                | crate::VerifiedChangeCause::CheckpointFinalizedGrow => event.old_tip,
-                crate::VerifiedChangeCause::Reset => graph.view_finalized_frontier(),
-            };
-            if matches!(event.cause, crate::VerifiedChangeCause::Reset) {
-                let verified = verified.to_mut();
-                verified.clear();
-                verified.push(parent);
-            }
-            for header in &event.new_path {
-                if header.header.hash() != header.hash
-                    || header.header.previous_block_hash != parent.hash
-                    || header.height
-                        != parent
-                            .height
-                            .next()
-                            .map_err(|_| GraphError::HeightOverflow {
-                                parent: parent.hash,
-                            })?
-                {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "verified path is not continuous",
-                    ));
-                }
-                if graph.view_header_node(header.hash).is_none() {
-                    validate_full_state_header(graph, parent, header, durable, context)?;
-                    graph.edit_insert_header(
-                        header.header.clone(),
-                        HeaderValidationState::Valid,
-                        anchor_reasons(context, header.height, header.hash),
-                        BodyValidationState::Verified {
-                            evidence: event.full_state_transition_id,
-                        },
-                    )?;
-                } else {
-                    graph.edit_set_body_validation_state(
-                        header.hash,
-                        BodyValidationState::Verified {
-                            evidence: event.full_state_transition_id,
-                        },
-                    )?;
-                }
-                parent = Frontier::new(header.height, header.hash);
-                verified.to_mut().push(parent);
-            }
-        }
-        TransitionEvent::VerifiedBlockAccepted(event) => {
-            if event.path.is_empty() {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "accepted full-state side path is empty",
-                ));
-            }
-            let mut parent = graph.view_finalized_frontier();
-            let last_index = event.path.len().saturating_sub(1);
-            for (index, header) in event.path.iter().enumerate() {
-                if header.header.hash() != header.hash
-                    || header.header.previous_block_hash != parent.hash
-                    || header.height
-                        != parent
-                            .height
-                            .next()
-                            .map_err(|_| GraphError::HeightOverflow {
-                                parent: parent.hash,
-                            })?
-                {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "accepted full-state side path is not continuous",
-                    ));
-                }
-                if graph.view_header_node(header.hash).is_none() {
-                    validate_full_state_header(graph, parent, header, durable, context)?;
-                    graph.edit_insert_header(
-                        header.header.clone(),
-                        HeaderValidationState::Valid,
-                        anchor_reasons(context, header.height, header.hash),
-                        BodyValidationState::Verified {
-                            evidence: event.full_state_transition_id,
-                        },
-                    )?;
-                } else if index == last_index {
-                    graph.edit_set_body_validation_state(
-                        header.hash,
-                        BodyValidationState::Verified {
-                            evidence: event.full_state_transition_id,
-                        },
-                    )?;
-                }
-                parent = Frontier::new(header.height, header.hash);
-            }
-        }
-        TransitionEvent::BodyEvidence(BodyEvidence::PayloadMismatch(_)) => {}
-        TransitionEvent::BodyEvidence(BodyEvidence::Transient(event)) => {
-            if event.availability.attempts == 0
-                || event.availability.suppliers == 0
-                || event.availability.started_at > event.availability.next_probe_at
-            {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "body retry evidence has an invalid episode summary",
-                ));
-            }
-            if matches!(
-                graph
-                    .view_header_node(event.hash)
-                    .map(|node| &node.body_validation_state),
-                Some(BodyValidationState::Verified { .. })
-            ) {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "body retry evidence cannot regress an already verified body",
-                ));
-            }
-            graph.edit_set_body_validation_state(
-                event.hash,
-                BodyValidationState::Unavailable(event.availability),
-            )?;
-        }
-        TransitionEvent::BodySupplierDiscovered(event) => {
-            let old = match graph
-                .view_header_node(event.hash)
-                .map(|node| &node.body_validation_state)
-            {
-                Some(BodyValidationState::Unavailable(summary))
-                    if event.hash == graph.view_select_best_header_chain()?.0.hash
-                        && summary.alarmed =>
-                {
-                    *summary
-                }
-                _ => {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "body supplier discovery requires the selected persistent alarm",
-                    ));
-                }
-            };
-            if event.availability.started_at != old.started_at
-                || event.availability.attempts != old.attempts
-                || event.availability.suppliers == 0
-                || !event.availability.alarmed
-                || event.availability.next_probe_at < event.availability.started_at
-                || event.availability.next_probe_at > context.clock.now()
-            {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "body supplier discovery must preserve the persistent retry episode",
-                ));
-            }
-            let has_new_supplier = event.availability.suppliers > old.suppliers
-                || (event.availability.suppliers == old.suppliers
-                    && event.availability.supplier_set_digest != old.supplier_set_digest);
-            if !has_new_supplier {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "body supplier discovery does not add an eligible supplier",
-                ));
-            }
-            graph.edit_set_body_validation_state(
-                event.hash,
-                BodyValidationState::Unavailable(event.availability),
-            )?;
-        }
-        TransitionEvent::OperatorBodyRetry(event) => {
-            if event.hash != graph.view_select_best_header_chain()?.0.hash
-                || event.availability.attempts != 0
-                || event.availability.suppliers == 0
-                || event.availability.alarmed
-                || event.availability.started_at != event.availability.next_probe_at
-            {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "operator body retry has an invalid fresh episode",
-                ));
-            }
-            if !matches!(
-                graph.view_header_node(event.hash).map(|node| &node.body_validation_state),
-                Some(BodyValidationState::Unavailable(summary)) if summary.alarmed
-            ) {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "operator body retry requires the selected persistent alarm",
-                ));
-            }
-            graph.edit_set_body_validation_state(
-                event.hash,
-                BodyValidationState::Unavailable(event.availability),
-            )?;
-        }
-        TransitionEvent::BodyEvidence(BodyEvidence::ConsensusInvalid(event)) => {
-            if matches!(
-                graph
-                    .view_header_node(event.hash)
-                    .map(|node| &node.body_validation_state),
-                Some(BodyValidationState::Verified { .. })
-            ) {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "body invalid evidence cannot contradict an already verified body",
-                ));
-            }
-            graph.edit_set_body_validation_state(
-                event.hash,
-                BodyValidationState::ConsensusInvalid {
-                    evidence: event.evidence,
-                    rule: event.rule.clone(),
-                },
-            )?;
-        }
-        TransitionEvent::BodyEvidence(BodyEvidence::Verified(event)) => {
-            graph.edit_set_body_validation_state(
-                event.hash,
-                BodyValidationState::Verified {
-                    evidence: event.evidence,
-                },
-            )?;
-        }
-        TransitionEvent::OperatorInvalidate(event) => {
-            let mut hasher = sha2::Sha256::new();
-            use sha2::Digest as _;
-            hasher.update(b"zakura-operator-invalidation-v1");
-            hasher.update(event.target.0);
-            hasher.update(event.id.bytes());
-            let expected_digest: [u8; 32] = hasher.finalize().into();
-            if event.operator_reason_digest != expected_digest {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "operator invalidation identity is not bound to its target",
-                ));
-            }
-            if event.target == graph.view_finalized_frontier().hash {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "operator invalidation cannot target the finalized anchor",
-                ));
-            }
-            *operator_reason_changed = graph.edit_add_header_eligibility_reason(
-                event.target,
-                EligibilityReason::operator_invalid(event.target, event.id, event.evidence),
-            )?;
-        }
-        TransitionEvent::OperatorReconsider(event) => {
-            *operator_reason_changed = graph.edit_remove_header_operator_invalidation(
-                event.target,
-                event.id,
-                event.invalidation_evidence,
-            )?;
-        }
-        TransitionEvent::FullStateFinalized(event) => {
-            let expected: Vec<_> = verified
-                .iter()
-                .take_while(|frontier| frontier.height <= event.new_finalized.height)
-                .map(|frontier| frontier.hash)
-                .collect();
-            if event.verified_path_proof != expected {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "finality proof is not the exact verified ancestry",
-                ));
-            }
-        }
-        TransitionEvent::MigratedPinRefutation(event) => {
-            if event.invalid_header.height > event.pin.height
-                || event_context.migrated_pin_refuted != Some(event.pin)
-            {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "full-state refutation does not name an imported pin ancestor",
-                ));
-            }
-        }
-        TransitionEvent::AuxEvidence(event) => {
-            if event.deliveries.is_empty() || event.deliveries.len() > 2 {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "auxiliary evidence must name one or two exact deliveries",
-                ));
-            }
-
-            for (index, event_delivery) in event.deliveries.iter().enumerate() {
-                if event.deliveries[..index].iter().any(|prior| {
-                    prior.header_hash == event_delivery.header_hash
-                        && prior.delivery_id == event_delivery.delivery_id
-                }) {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "auxiliary evidence names the same delivery more than once",
-                    ));
-                }
-                let header = graph.view_header_node(event_delivery.header_hash).ok_or(
-                    TransitionFailure::InvalidEvidence(
-                        "auxiliary evidence references an unknown header",
-                    ),
-                )?;
-                let header_frontier = Frontier::new(header.height, header.hash);
-                if graph.view_header_ancestor(event.owner.branch.target_tip_hash, header.height)?
-                    != Some(header_frontier)
-                {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "auxiliary evidence is outside its owned branch",
-                    ));
-                }
-                let existing = engine
-                    .aux_deliveries(event_delivery.header_hash)
-                    .iter()
-                    .copied()
-                    .find(|delivery| delivery.delivery_id == event_delivery.delivery_id)
-                    .ok_or(TransitionFailure::InvalidEvidence(
-                        "auxiliary evidence references an unknown delivery",
-                    ))?;
-                if existing != *event_delivery
-                    || !header.aux_delivery_ids.contains(&existing.delivery_id)
-                {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "auxiliary evidence changes delivery provenance",
-                    ));
-                }
-                if existing.authentication == event.authentication {
-                    continue;
-                }
-                if existing.authentication != crate::AuxAuthentication::Unauthenticated {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "an authenticated or rejected auxiliary delivery is immutable",
-                    ));
-                }
-                if let crate::AuxAuthentication::Authenticated { boundary_hash, .. } =
-                    event.authentication
-                {
-                    let boundary = graph.view_header_node(boundary_hash).ok_or(
-                        TransitionFailure::InvalidEvidence(
-                            "auxiliary authentication boundary is unknown",
-                        ),
-                    )?;
-                    let expected_height = header.height.next().map_err(|_| {
-                        TransitionFailure::InvalidEvidence(
-                            "auxiliary authentication boundary height overflowed",
-                        )
-                    })?;
-                    let boundary_frontier = Frontier::new(boundary.height, boundary.hash);
-                    if boundary.height != expected_height
-                        || boundary.parent_hash != header.hash
-                        || graph.view_header_ancestor(
-                            event.owner.branch.target_tip_hash,
-                            boundary.height,
-                        )? != Some(boundary_frontier)
-                    {
-                        return Err(TransitionFailure::InvalidEvidence(
-                            "auxiliary authentication is not the owned one-header-later boundary",
-                        ));
-                    }
-                } else if event.authentication == crate::AuxAuthentication::Unauthenticated {
-                    return Err(TransitionFailure::InvalidEvidence(
-                        "auxiliary evidence cannot remove authentication",
-                    ));
-                }
-                let mut delivery = existing;
-                delivery.authentication = event.authentication;
-                aux_changes.push(crate::AuxDelta::Put(Box::new(delivery)));
-            }
-            if event.authentication == crate::AuxAuthentication::Unauthenticated {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "auxiliary evidence cannot remove authentication",
-                ));
-            }
-        }
-        TransitionEvent::ReevaluateDeferred => {
-            let due: Vec<_> = graph
-                .view_header_nodes()
-                .into_iter()
-                .filter_map(|node| match node.validation {
-                    HeaderValidationState::DeferredUntil(until) if until <= context.clock.now() => {
-                        Some(node.hash)
-                    }
-                    _ => None,
-                })
-                .collect();
-            for hash in due {
-                graph.edit_set_header_validation_state(hash, HeaderValidationState::Valid)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-fn anchor_reasons(
-    context: &TransitionContext<'_>,
-    height: block::Height,
-    hash: block::Hash,
-) -> Vec<EligibilityReason> {
-    let mut reasons = Vec::new();
-    if let Some(pin) = context
-        .config
-        .settled_manifest()
-        .pin_for_network(&context.config.network)
-    {
-        if pin.activation.height == height && pin.activation.hash != hash {
-            reasons.push(EligibilityReason::SettledUpgradeConflict {
-                height,
-                expected: pin.activation.hash,
-            });
-        }
-    }
-    if let Some(expected) = context.config.local_checkpoints().hash(height) {
-        if expected != hash {
-            reasons.push(EligibilityReason::CheckpointConflict { height, expected });
-        }
-    }
-    reasons
-}
-
-struct DerivePlanInputs<'a> {
-    before: EngineSnapshot,
-    metadata: EngineMetadata,
-    base_graph: &'a MemHeaderStore,
-    graph: GraphOverlay<'a>,
-    graph_delta: GraphDelta,
-    old_selected: &'a [Frontier],
-    old_verified: &'a [Frontier],
-    selected: Cow<'a, [Frontier]>,
-    verified: Cow<'a, [Frontier]>,
-    aux_changes: Vec<crate::AuxDelta>,
-    finality_append: Option<FinalityRecord>,
-    retention: RetentionPlan,
-    fingerprint: Option<crate::TransitionFingerprint>,
-    cause: TransitionCause,
-    trust_pins: Arc<[Frontier]>,
-    limits: EngineLimits,
-}
-
-fn derive_plan(inputs: DerivePlanInputs<'_>) -> Result<TransitionPlan, TransitionFailure> {
-    let DerivePlanInputs {
-        before,
-        mut metadata,
-        base_graph,
-        graph,
-        graph_delta,
-        old_selected,
-        old_verified,
-        selected,
-        verified,
-        aux_changes,
-        finality_append,
-        retention,
-        fingerprint,
-        cause,
-        trust_pins,
-        limits,
-    } = inputs;
-    let put_nodes = graph_delta.updated_header_nodes().to_vec();
-    let delete_nodes = graph_delta.deleted_header_hashes().to_vec();
-    let put_consensus_invalid_body_tombstones =
-        graph_delta.new_consensus_invalid_body_tombstones().to_vec();
-    let mut eligibility_changes: Vec<_> = put_nodes
-        .iter()
-        .filter_map(|node| {
-            let old = base_graph.header_node(node.hash)?;
-            (old.eligibility != node.eligibility).then(|| EligibilityDelta {
-                hash: node.hash,
-                before: old.eligibility.clone(),
-                after: node.eligibility.clone(),
-            })
-        })
-        .collect();
-    eligibility_changes.sort_unstable_by_key(|delta| delta.hash.0);
-    let selected_changed = selected.as_ref() != old_selected;
-    let verified_changed = verified.as_ref() != old_verified;
-    let header_topology_changed = !delete_nodes.is_empty()
-        || put_nodes
-            .iter()
-            .any(|node| base_graph.header_node(node.hash).is_none());
-    let header_validation_changed = put_nodes.iter().any(|node| {
-        base_graph
-            .header_node(node.hash)
-            .is_some_and(|old| old.validation != node.validation)
-    });
-    let header_eligibility_changed = put_nodes.iter().any(|node| {
-        base_graph
-            .header_node(node.hash)
-            .is_some_and(|old| old.is_eligible() != node.is_eligible())
-    });
-    let header_best = *selected.last().ok_or(TransitionFailure::InvalidEvidence(
-        "selected projection is empty",
-    ))?;
-    metadata.alarms.resource_stalled = retention.resource_stalled;
-    let header_best_node = graph
-        .view_header_node(header_best.hash)
-        .ok_or(GraphError::UnknownHeaderNode(header_best.hash))?;
-    metadata.alarms.header_best_body_unavailable = match &header_best_node.body_validation_state {
-        BodyValidationState::Unavailable(summary) if summary.alarmed => Some(*summary),
-        _ => None,
-    };
-    let alarm_changed = metadata.alarms != before.alarms;
-    let changed = !put_nodes.is_empty()
-        || !delete_nodes.is_empty()
-        || !aux_changes.is_empty()
-        || finality_append.is_some()
-        || selected_changed
-        || verified_changed
-        || alarm_changed;
-    if changed {
-        metadata.state_version = metadata.state_version.checked_next()?;
-        if selected_changed
-            || header_topology_changed
-            || header_validation_changed
-            || header_eligibility_changed
-            || !eligibility_changes.is_empty()
-            || finality_append.is_some()
-        {
-            metadata.header_generation = metadata.header_generation.checked_next()?;
-        }
-        if verified_changed || finality_append.is_some() {
-            metadata.verified_generation = metadata.verified_generation.checked_next()?;
-        }
-        if let Some(record) = finality_append {
-            metadata.finality_epoch = record.epoch;
-        }
-        if let Some(fingerprint) = fingerprint {
-            metadata.last_transition = Some(fingerprint);
-        }
-    }
-    let verified_best = *verified.last().ok_or(TransitionFailure::InvalidEvidence(
-        "verified projection is empty",
-    ))?;
-    metadata.frontiers = FrontierSet {
-        finalized: graph.view_finalized_frontier(),
-        header_best,
-        verified_best,
-    };
-    metadata.header_best_score = graph.view_header_chain_score(header_best.hash)?;
-    metadata.oldest_retained_height = if delete_nodes.is_empty() {
-        put_nodes
-            .iter()
-            .map(|node| node.height)
-            .min()
-            .map_or(before.oldest_retained_height, |height| {
-                height.min(before.oldest_retained_height)
-            })
-    } else {
-        graph
-            .view_header_nodes()
-            .into_iter()
-            .map(|node| node.height)
-            .min()
-            .unwrap_or(graph.view_finalized_frontier().height)
-    };
-    let inserted = put_nodes
-        .iter()
-        .filter(|node| base_graph.header_node(node.hash).is_none())
-        .map(|node| Frontier::new(node.height, node.hash))
-        .collect();
-    let change_set = ChangeSet {
-        put_nodes,
-        delete_nodes: delete_nodes.clone(),
-        put_consensus_invalid_body_tombstones,
-        index_changes: IndexChanges {
-            inserted,
-            deleted: delete_nodes,
-        },
-        selected_projection: projection_delta(old_selected, &selected),
-        verified_projection: projection_delta(old_verified, &verified),
-        eligibility_changes,
-        aux_changes,
-        finality_append,
-        metadata,
-    };
-    Ok(TransitionPlan {
-        before,
-        change_set,
-        graph_delta,
-        cause,
-        trust_pins,
-        limits,
-    })
-}
-
-fn no_change(
-    _engine: &HeaderChainEngine,
-    before: EngineSnapshot,
-    metadata: EngineMetadata,
-    event: TransitionEvent,
-    context: &TransitionContext<'_>,
-    cause: TransitionCause,
-) -> Result<TransitionPlan, TransitionFailure> {
-    validate_authority(&event, context)?;
-    Ok(TransitionPlan {
-        before,
-        change_set: ChangeSet {
-            put_nodes: Vec::new(),
-            delete_nodes: Vec::new(),
-            put_consensus_invalid_body_tombstones: Vec::new(),
-            index_changes: IndexChanges::default(),
-            selected_projection: ProjectionDelta::default(),
-            verified_projection: ProjectionDelta::default(),
-            eligibility_changes: Vec::new(),
-            aux_changes: Vec::new(),
-            finality_append: None,
-            metadata,
-        },
-        graph_delta: GraphDelta::empty(_engine.graph()),
-        cause,
-        trust_pins: invariant_pins(context),
-        limits: context.config.limits,
-    })
-}
-
-fn resource_stalled(
-    engine: &HeaderChainEngine,
-    before: EngineSnapshot,
-    context: &TransitionContext<'_>,
-) -> Result<TransitionPlan, TransitionFailure> {
-    let mut metadata = engine.metadata().clone();
-    if !metadata.alarms.resource_stalled {
-        metadata.alarms.resource_stalled = true;
-        metadata.state_version = metadata.state_version.checked_next()?;
-    }
-    Ok(TransitionPlan {
-        before,
-        change_set: ChangeSet {
-            put_nodes: Vec::new(),
-            delete_nodes: Vec::new(),
-            put_consensus_invalid_body_tombstones: Vec::new(),
-            index_changes: IndexChanges::default(),
-            selected_projection: ProjectionDelta::default(),
-            verified_projection: ProjectionDelta::default(),
-            eligibility_changes: Vec::new(),
-            aux_changes: Vec::new(),
-            finality_append: None,
-            metadata,
-        },
-        graph_delta: GraphDelta::empty(engine.graph()),
-        cause: TransitionCause::ResourceStalled,
-        trust_pins: invariant_pins(context),
-        limits: context.config.limits,
-    })
-}
-
-fn invariant_pins(context: &TransitionContext<'_>) -> Arc<[Frontier]> {
-    context.config.trust_pins()
-}
-
-fn path<G: HeaderGraphView>(graph: &G, tip: Frontier) -> Result<Vec<Frontier>, TransitionFailure> {
-    let finalized = graph.view_finalized_frontier();
-    let mut path = Vec::new();
-    let mut current = tip;
-    loop {
-        path.push(current);
-        if current == finalized {
-            break;
-        }
-        let node = graph
-            .view_header_node(current.hash)
-            .ok_or(GraphError::UnknownHeaderNode(current.hash))?;
-        current = Frontier::new(
-            current
-                .height
-                .previous()
-                .map_err(|_| GraphError::FinalizedFrontierNotDescendant {
-                    current: finalized.hash,
-                    candidate: tip.hash,
-                })?,
-            node.parent_hash,
-        );
-    }
-    path.reverse();
-    Ok(path)
-}
-
-fn trim_projection<'a, G: HeaderGraphView>(
-    graph: &G,
-    projection: Cow<'a, [Frontier]>,
-) -> Result<Cow<'a, [Frontier]>, TransitionFailure> {
-    let requires_trim = projection.first().copied() != Some(graph.view_finalized_frontier())
-        || projection.iter().any(|frontier| {
-            frontier.height < graph.view_finalized_frontier().height
-                || graph.view_header_node(frontier.hash).is_none()
-        });
-    if !requires_trim {
-        return Ok(projection);
-    }
-    let mut result: Vec<_> = projection
-        .iter()
-        .copied()
-        .filter(|frontier| {
-            frontier.height >= graph.view_finalized_frontier().height
-                && graph.view_header_node(frontier.hash).is_some()
-        })
-        .collect();
-    if result.first().copied() != Some(graph.view_finalized_frontier()) {
-        result.insert(0, graph.view_finalized_frontier());
-    }
-    for pair in result.windows(2) {
-        if pair[1].height.0 != pair[0].height.0 + 1
-            || graph
-                .view_header_node(pair[1].hash)
-                .is_none_or(|node| node.parent_hash != pair[0].hash)
-        {
-            return Err(TransitionFailure::InvalidEvidence(
-                "verified projection is not continuous",
-            ));
-        }
-    }
-    Ok(Cow::Owned(result))
-}
-
-fn projection_delta(old: &[Frontier], new: &[Frontier]) -> ProjectionDelta {
-    let remove_before = new.first().and_then(|first| {
-        old.first()
-            .is_some_and(|old_first| old_first.height < first.height)
-            .then_some(first.height)
-    });
-    let old_start = remove_before
-        .map(|height| old.partition_point(|frontier| frontier.height < height))
-        .unwrap_or(0);
-    let comparable_old = &old[old_start..];
-    let common = comparable_old
-        .iter()
-        .zip(new)
-        .take_while(|(left, right)| left == right)
-        .count();
-    ProjectionDelta {
-        remove_before,
-        remove_from: comparable_old
-            .get(common)
-            .or_else(|| new.get(common))
-            .map(|frontier| frontier.height),
-        put: new[common..].to_vec(),
-    }
-}
-
-#[cfg(test)]
-mod tests;

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -69,7 +69,7 @@ impl TransitionPlan {
         Self { candidate }
     }
 
-    #[cfg(any(test, feature = "fuzz-impl"))]
+    #[cfg(test)]
     pub(super) const fn candidate(&self) -> &PlanCandidate {
         &self.candidate
     }

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -94,9 +94,13 @@ pub enum TransitionFailure {
     /// Event fields contradict canonical headers or durable ancestry.
     #[error("invalid transition evidence: {0}")]
     InvalidEvidence(&'static str),
-    /// Retention could not admit this event without evicting protected state.
-    #[error("header admission refused because protected paths fill the resource bound")]
-    ResourceStalled,
+    /// Auxiliary delivery bounds refused this event before any durable mutation.
+    ///
+    /// Unlike [`TransitionCause::ResourceStalled`], this is a zero-effect planner
+    /// failure: it does not raise the durable resource-stall alarm or produce a
+    /// [`crate::CommittedStallReceipt`].
+    #[error("header admission refused because auxiliary delivery limits are exceeded")]
+    AuxiliaryLimitExceeded,
     /// The projected write set violated a commit invariant.
     #[error(transparent)]
     Invariant(#[from] super::InvariantViolation),
@@ -397,7 +401,7 @@ fn validate_event_resource_bounds(
         ));
     }
     if insert.aux.len() > limits.max_aux_deliveries_total.get() {
-        return Err(TransitionFailure::ResourceStalled);
+        return Err(TransitionFailure::AuxiliaryLimitExceeded);
     }
     let mut additions = HashMap::<block::Hash, HashSet<EvidenceId>>::new();
     for delivery in &insert.aux {
@@ -414,12 +418,12 @@ fn validate_event_resource_bounds(
             .filter(|id| !existing.iter().any(|row| row.delivery_id == **id))
             .count();
         if existing.len().saturating_add(new_count) > limits.max_aux_deliveries_per_header.get() {
-            return Err(TransitionFailure::ResourceStalled);
+            return Err(TransitionFailure::AuxiliaryLimitExceeded);
         }
         new_total = new_total.saturating_add(new_count);
     }
     if new_total > limits.max_aux_deliveries_total.get() {
-        return Err(TransitionFailure::ResourceStalled);
+        return Err(TransitionFailure::AuxiliaryLimitExceeded);
     }
     Ok(())
 }

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -21,8 +21,11 @@ use crate::{
 };
 
 /// A complete write set and the private graph delta that the verifier checked.
+///
+/// Production callers consume [`crate::EngineTransition`]; this plan type stays
+/// crate-private so the planner representation is not part of the public API.
 #[derive(Clone, Debug)]
-pub struct TransitionPlan {
+pub(crate) struct TransitionPlan {
     pub(super) before: EngineSnapshot,
     pub(super) change_set: ChangeSet,
     pub(super) graph_delta: GraphDelta,
@@ -107,7 +110,7 @@ pub enum TransitionFailure {
 }
 
 /// Derive one atomic transition without mutating the coherent engine.
-pub(super) fn apply_transition_engine(
+pub(super) fn derive_transition_plan(
     engine: &HeaderChainEngine,
     durable: &DurableTransitionFacts,
     mut request: TransitionRequest,

--- a/crates/zakura-header-chain/src/transition/planner/admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/admission.rs
@@ -1,0 +1,367 @@
+//! Bounded admission, authentication, and header-insertion rebasing.
+
+use std::collections::{HashMap, HashSet};
+
+use zakura_chain::block;
+
+use super::TransitionFailure;
+use crate::{
+    BodyWorkOwner, DurableTransitionFacts, EngineLimits, EngineMetadata, EngineMode,
+    EngineSnapshot, EventAdmission, EvidenceId, FinalityRecord, Frontier, HeaderChainEngine,
+    HeaderSyncWorkOwner, MemHeaderStore, TargetCompletion, TransitionContext, TransitionEvent,
+};
+
+/// Request admitted against its original authority and resource bounds.
+///
+/// Header work can still be canonically rebased before freshness binding, so
+/// this type does not claim that its event bytes remain authenticated.
+#[derive(Debug)]
+pub(super) struct AdmittedRequest {
+    /// Admitted event ready for canonical rebasing and freshness binding.
+    pub(super) event: TransitionEvent,
+    /// Caller-observed durable version.
+    pub(super) expected_version: crate::StateVersion,
+}
+
+/// How a pure header insertion related to newer monotone finality.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum HeaderInsertionRebase {
+    /// The insertion already targeted the current finality anchor.
+    Current,
+    /// The insertion was rewritten onto newer monotone finality.
+    Rebased,
+    /// Newer finality fully consumed the prepared batch.
+    AlreadyApplied,
+}
+
+/// Authenticate the caller and admit the event before any projection work.
+pub(super) fn authenticate_and_admit(
+    engine: &HeaderChainEngine,
+    request: crate::TransitionRequest,
+    context: &TransitionContext<'_>,
+) -> Result<(EngineSnapshot, EngineMetadata, AdmittedRequest), TransitionFailure> {
+    let before = engine.snapshot();
+    let metadata = engine.metadata().clone();
+    validate_snapshot(&before, &metadata, context)?;
+    if context.retention_references.len() > context.config.limits.max_retention_references.get() {
+        return Err(TransitionFailure::InvalidEvidence(
+            "retained-path references exceed the per-transition limit",
+        ));
+    }
+    validate_event_resource_bounds(engine, &request.event, context.config.limits)?;
+    validate_authority(&request.event, context)?;
+    Ok((
+        before,
+        metadata,
+        AdmittedRequest {
+            event: request.event,
+            expected_version: request.expected_version,
+        },
+    ))
+}
+
+/// Validate snapshot and persisted metadata against the active configuration.
+pub(super) fn validate_snapshot(
+    snapshot: &EngineSnapshot,
+    metadata: &EngineMetadata,
+    context: &TransitionContext<'_>,
+) -> Result<(), TransitionFailure> {
+    if snapshot.mode != context.config.mode
+        || metadata.mode != context.config.mode
+        || metadata.network_id != context.config.network.kind()
+        || metadata.anchor_manifest_digest != context.config.trust_anchor_digest()
+        || snapshot.state_version != metadata.state_version
+        || snapshot.frontiers != metadata.frontiers
+    {
+        return Err(TransitionFailure::ConfigurationMismatch);
+    }
+    Ok(())
+}
+
+fn validate_event_resource_bounds(
+    engine: &HeaderChainEngine,
+    event: &TransitionEvent,
+    limits: EngineLimits,
+) -> Result<(), TransitionFailure> {
+    let TransitionEvent::InsertHeaders(insert) = event else {
+        return Ok(());
+    };
+    if insert.batch.headers().len() > limits.max_headers_per_transition.get() {
+        return Err(TransitionFailure::InvalidEvidence(
+            "prepared header batch exceeds the per-transition limit",
+        ));
+    }
+    if insert.aux.len() > limits.max_aux_deliveries_total.get() {
+        return Err(TransitionFailure::AuxiliaryLimitExceeded);
+    }
+    let mut additions = HashMap::<block::Hash, HashSet<EvidenceId>>::new();
+    for delivery in &insert.aux {
+        additions
+            .entry(delivery.header_hash)
+            .or_default()
+            .insert(delivery.delivery_id);
+    }
+    let mut new_total = engine.aux_delivery_count();
+    for (hash, delivery_ids) in additions {
+        let existing = engine.aux_deliveries(hash);
+        let new_count = delivery_ids
+            .iter()
+            .filter(|id| !existing.iter().any(|row| row.delivery_id == **id))
+            .count();
+        if existing.len().saturating_add(new_count) > limits.max_aux_deliveries_per_header.get() {
+            return Err(TransitionFailure::AuxiliaryLimitExceeded);
+        }
+        new_total = new_total.saturating_add(new_count);
+    }
+    if new_total > limits.max_aux_deliveries_total.get() {
+        return Err(TransitionFailure::AuxiliaryLimitExceeded);
+    }
+    Ok(())
+}
+
+/// Enforce the event's admission gate against trusted authorities.
+pub(super) fn validate_authority(
+    event: &TransitionEvent,
+    context: &TransitionContext<'_>,
+) -> Result<(), TransitionFailure> {
+    match event.admission() {
+        EventAdmission::AnyMode => Ok(()),
+        EventAdmission::IntegratedFullState if context.config.mode != EngineMode::Integrated => {
+            Err(TransitionFailure::Mode)
+        }
+        EventAdmission::IntegratedFullState => {
+            if context
+                .full_state_authority
+                .is_some_and(|authority| authority.authorizes_full_state(event))
+            {
+                Ok(())
+            } else {
+                Err(TransitionFailure::Authority)
+            }
+        }
+        EventAdmission::RegisteredScheduler => {
+            let TransitionEvent::OperatorBodyRetry(retry) = event else {
+                return Err(TransitionFailure::Authority);
+            };
+            if context
+                .full_state_authority
+                .is_some_and(|authority| authority.authorizes_scheduler_retry(retry))
+            {
+                Ok(())
+            } else {
+                Err(TransitionFailure::Authority)
+            }
+        }
+        EventAdmission::RegisteredHeaderCompletion => {
+            let TransitionEvent::InsertHeaders(insert) = event else {
+                return Err(TransitionFailure::Authority);
+            };
+            if context
+                .full_state_authority
+                .is_some_and(|authority| authority.authorizes_header_completion(insert))
+            {
+                Ok(())
+            } else {
+                Err(TransitionFailure::Authority)
+            }
+        }
+    }
+}
+
+pub(super) fn validate_header_sync_owner(
+    owner: HeaderSyncWorkOwner,
+    before: &EngineSnapshot,
+) -> Result<(), TransitionFailure> {
+    let header = owner.header_authority();
+    if header.header_generation != before.header_generation
+        || owner
+            .body_authority()
+            .is_some_and(|authority| authority.verified_generation != before.verified_generation)
+        || header.branch.anchor_hash != before.frontiers.finalized.hash
+    {
+        return Err(TransitionFailure::Stale {
+            current: before.state_version,
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn validate_body_owner(
+    owner: BodyWorkOwner,
+    before: &EngineSnapshot,
+) -> Result<(), TransitionFailure> {
+    if owner.header_generation != before.header_generation
+        || owner.verified_generation != before.verified_generation
+        || owner.branch.anchor_hash != before.frontiers.finalized.hash
+    {
+        return Err(TransitionFailure::Stale {
+            current: before.state_version,
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn rebase_header_insertion(
+    event: &mut TransitionEvent,
+    current: &EngineSnapshot,
+    graph: &MemHeaderStore,
+    durable: &DurableTransitionFacts,
+) -> Result<HeaderInsertionRebase, TransitionFailure> {
+    let TransitionEvent::InsertHeaders(insert) = event else {
+        return Ok(HeaderInsertionRebase::Current);
+    };
+    if matches!(
+        insert.completion,
+        TargetCompletion::SelectedAuxiliaryRepair { .. }
+    ) {
+        return Ok(HeaderInsertionRebase::Current);
+    }
+    let Some(original_owner) = insert.owner.header_owner() else {
+        return Ok(HeaderInsertionRebase::Current);
+    };
+    let original = original_owner.authority;
+    if original.branch.target_tip_hash != insert.target_tip_hash {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    if original.header_generation == current.header_generation
+        && original.branch.anchor_hash == current.frontiers.finalized.hash
+    {
+        return Ok(HeaderInsertionRebase::Current);
+    }
+    if original.branch.anchor_hash == current.frontiers.finalized.hash {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    if original.header_generation.get() >= current.header_generation.get() {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    let DurableTransitionFacts::HeaderInsertion { finality_path, .. } = durable else {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    };
+    if finality_path.is_empty() {
+        return Err(TransitionFailure::Stale {
+            current: current.state_version,
+        });
+    }
+    validate_finality_rebase_path(
+        original.branch.anchor_hash,
+        current.frontiers.finalized,
+        finality_path,
+    )?;
+
+    let finalized = current.frontiers.finalized;
+    let parent_is_current_descendant = match graph.header_node(insert.parent_hash) {
+        Some(parent) if parent.height >= finalized.height => {
+            graph.header_ancestor(insert.parent_hash, finalized.height)? == Some(finalized)
+        }
+        Some(_) | None => false,
+    };
+    let mut removed = 0usize;
+    if !parent_is_current_descendant {
+        if insert
+            .batch
+            .headers()
+            .iter()
+            .any(|header| Frontier::new(header.height, header.hash) == finalized)
+        {
+            removed = insert
+                .batch
+                .rebase_after(finalized)
+                .map_err(|_| TransitionFailure::StalePreparation)?;
+            insert.parent_hash = finalized.hash;
+            insert
+                .completion
+                .rebase_common_ancestor(finalized)
+                .map_err(|_| TransitionFailure::StalePreparation)?;
+        } else {
+            let prepared_tip = insert
+                .batch
+                .headers()
+                .last()
+                .map(|header| Frontier::new(header.height, header.hash))
+                .ok_or(TransitionFailure::StalePreparation)?;
+            let prepared_tip_was_finalized = finality_path
+                .iter()
+                .any(|record| record.previous == prepared_tip || record.current == prepared_tip);
+            if prepared_tip_was_finalized && prepared_tip.height <= finalized.height {
+                insert.batch.clear_already_applied();
+                removed = insert.aux.len();
+            } else {
+                return Err(TransitionFailure::Stale {
+                    current: current.state_version,
+                });
+            }
+        }
+    }
+
+    let authority = crate::HeaderWorkAuthority {
+        header_generation: current.header_generation,
+        branch: crate::BranchId::new(finalized.hash, original.branch.target_tip_hash),
+    };
+    insert.owner = insert
+        .owner
+        .rebase_header(authority)
+        .ok_or(TransitionFailure::Authority)?;
+    for delivery in &mut insert.aux {
+        delivery.owner = delivery
+            .owner
+            .rebase_header(authority)
+            .ok_or(TransitionFailure::Authority)?;
+    }
+    if removed != 0 {
+        let retained: HashSet<_> = insert
+            .batch
+            .headers()
+            .iter()
+            .map(|header| header.hash)
+            .collect();
+        insert
+            .aux
+            .retain(|delivery| retained.contains(&delivery.header_hash));
+    }
+    if insert.batch.headers().is_empty() {
+        return Ok(HeaderInsertionRebase::AlreadyApplied);
+    }
+    Ok(HeaderInsertionRebase::Rebased)
+}
+
+/// Validate a durable finality-history suffix used to rebase header work.
+pub(super) fn validate_finality_rebase_path(
+    original_anchor: block::Hash,
+    current_finalized: Frontier,
+    path: &[FinalityRecord],
+) -> Result<(), TransitionFailure> {
+    if original_anchor == current_finalized.hash {
+        return path
+            .is_empty()
+            .then_some(())
+            .ok_or(TransitionFailure::StalePreparation);
+    }
+    let mut expected_frontier = None;
+    let mut expected_epoch = None;
+    for record in path {
+        let predecessor_matches = expected_frontier.map_or_else(
+            || record.previous.hash == original_anchor,
+            |expected| record.previous == expected,
+        );
+        if !predecessor_matches
+            || expected_epoch.is_some_and(|epoch| record.epoch != epoch)
+            || record.current.height < record.previous.height
+        {
+            return Err(TransitionFailure::StalePreparation);
+        }
+        expected_frontier = Some(record.current);
+        expected_epoch = Some(record.epoch.checked_next()?);
+    }
+    if expected_frontier != Some(current_finalized) {
+        return Err(TransitionFailure::StalePreparation);
+    }
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/auxiliary_authentication.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/auxiliary_authentication.rs
@@ -1,0 +1,105 @@
+//! Auxiliary delivery authentication and rejection.
+
+use crate::graph::HeaderGraphView;
+use crate::{Frontier, TransitionFailure};
+
+use super::super::projected_state::ProjectedTransitionState;
+use super::ApplyEventContext;
+
+/// Authenticate or reject previously admitted auxiliary deliveries.
+pub(super) fn apply(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::AuxEvidence,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    let engine = event_context.engine;
+    if event.deliveries.is_empty() || event.deliveries.len() > 2 {
+        return Err(TransitionFailure::InvalidEvidence(
+            "auxiliary evidence must name one or two exact deliveries",
+        ));
+    }
+
+    for (index, event_delivery) in event.deliveries.iter().enumerate() {
+        if event.deliveries[..index].iter().any(|prior| {
+            prior.header_hash == event_delivery.header_hash
+                && prior.delivery_id == event_delivery.delivery_id
+        }) {
+            return Err(TransitionFailure::InvalidEvidence(
+                "auxiliary evidence names the same delivery more than once",
+            ));
+        }
+        let header = projected
+            .graph()
+            .view_header_node(event_delivery.header_hash)
+            .ok_or(TransitionFailure::InvalidEvidence(
+                "auxiliary evidence references an unknown header",
+            ))?;
+        let header_frontier = Frontier::new(header.height, header.hash);
+        if projected
+            .graph()
+            .view_header_ancestor(event.owner.branch.target_tip_hash, header.height)?
+            != Some(header_frontier)
+        {
+            return Err(TransitionFailure::InvalidEvidence(
+                "auxiliary evidence is outside its owned branch",
+            ));
+        }
+        let existing = engine
+            .aux_deliveries(event_delivery.header_hash)
+            .iter()
+            .copied()
+            .find(|delivery| delivery.delivery_id == event_delivery.delivery_id)
+            .ok_or(TransitionFailure::InvalidEvidence(
+                "auxiliary evidence references an unknown delivery",
+            ))?;
+        if existing != *event_delivery || !header.aux_delivery_ids.contains(&existing.delivery_id) {
+            return Err(TransitionFailure::InvalidEvidence(
+                "auxiliary evidence changes delivery provenance",
+            ));
+        }
+        if existing.authentication == event.authentication {
+            continue;
+        }
+        if existing.authentication != crate::AuxAuthentication::Unauthenticated {
+            return Err(TransitionFailure::InvalidEvidence(
+                "an authenticated or rejected auxiliary delivery is immutable",
+            ));
+        }
+        if let crate::AuxAuthentication::Authenticated { boundary_hash, .. } = event.authentication
+        {
+            let boundary = projected.graph().view_header_node(boundary_hash).ok_or(
+                TransitionFailure::InvalidEvidence("auxiliary authentication boundary is unknown"),
+            )?;
+            let expected_height = header.height.next().map_err(|_| {
+                TransitionFailure::InvalidEvidence(
+                    "auxiliary authentication boundary height overflowed",
+                )
+            })?;
+            let boundary_frontier = Frontier::new(boundary.height, boundary.hash);
+            if boundary.height != expected_height
+                || boundary.parent_hash != header.hash
+                || projected
+                    .graph()
+                    .view_header_ancestor(event.owner.branch.target_tip_hash, boundary.height)?
+                    != Some(boundary_frontier)
+            {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "auxiliary authentication is not the owned one-header-later boundary",
+                ));
+            }
+        } else if event.authentication == crate::AuxAuthentication::Unauthenticated {
+            return Err(TransitionFailure::InvalidEvidence(
+                "auxiliary evidence cannot remove authentication",
+            ));
+        }
+        let mut delivery = existing;
+        delivery.authentication = event.authentication;
+        projected.update_aux_delivery(delivery);
+    }
+    if event.authentication == crate::AuxAuthentication::Unauthenticated {
+        return Err(TransitionFailure::InvalidEvidence(
+            "auxiliary evidence cannot remove authentication",
+        ));
+    }
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/body_availability.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/body_availability.rs
@@ -1,0 +1,95 @@
+//! Transient body availability and supplier-discovery evidence.
+
+use crate::graph::HeaderGraphView;
+use crate::{BodyValidationState, TransitionFailure};
+
+use super::super::projected_state::ProjectedTransitionState;
+use super::ApplyEventContext;
+
+/// Payload mismatches are informational and must not mutate the header DAG.
+pub(super) fn apply_payload_mismatch(
+    _event: &crate::BodyPayloadMismatch,
+) -> Result<(), TransitionFailure> {
+    Ok(())
+}
+
+/// Record a transient body-unavailable episode without regressing verified bodies.
+pub(super) fn apply_transient(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::TransientBodyFailure,
+) -> Result<(), TransitionFailure> {
+    if event.availability.attempts == 0
+        || event.availability.suppliers == 0
+        || event.availability.started_at > event.availability.next_probe_at
+    {
+        return Err(TransitionFailure::InvalidEvidence(
+            "body retry evidence has an invalid episode summary",
+        ));
+    }
+    if matches!(
+        projected
+            .graph()
+            .view_header_node(event.hash)
+            .map(|node| &node.body_validation_state),
+        Some(BodyValidationState::Verified { .. })
+    ) {
+        return Err(TransitionFailure::InvalidEvidence(
+            "body retry evidence cannot regress an already verified body",
+        ));
+    }
+    projected.set_body_validation_state(
+        event.hash,
+        BodyValidationState::Unavailable(event.availability),
+    )?;
+    Ok(())
+}
+
+/// Expand the selected persistent body's supplier set for an already-due probe.
+pub(super) fn apply_supplier_discovery(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::BodySupplierDiscovered,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    let context = event_context.transition;
+    let old = match projected
+        .graph()
+        .view_header_node(event.hash)
+        .map(|node| &node.body_validation_state)
+    {
+        Some(BodyValidationState::Unavailable(summary))
+            if event.hash == projected.graph().view_select_best_header_chain()?.0.hash
+                && summary.alarmed =>
+        {
+            *summary
+        }
+        _ => {
+            return Err(TransitionFailure::InvalidEvidence(
+                "body supplier discovery requires the selected persistent alarm",
+            ));
+        }
+    };
+    if event.availability.started_at != old.started_at
+        || event.availability.attempts != old.attempts
+        || event.availability.suppliers == 0
+        || !event.availability.alarmed
+        || event.availability.next_probe_at < event.availability.started_at
+        || event.availability.next_probe_at > context.clock.now()
+    {
+        return Err(TransitionFailure::InvalidEvidence(
+            "body supplier discovery must preserve the persistent retry episode",
+        ));
+    }
+    let has_new_supplier = event.availability.suppliers > old.suppliers
+        || (event.availability.suppliers == old.suppliers
+            && event.availability.supplier_set_digest != old.supplier_set_digest);
+    if !has_new_supplier {
+        return Err(TransitionFailure::InvalidEvidence(
+            "body supplier discovery does not add an eligible supplier",
+        ));
+    }
+    projected.set_body_validation_state(
+        event.hash,
+        BodyValidationState::Unavailable(event.availability),
+    )?;
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/deferred_time.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/deferred_time.rs
@@ -1,0 +1,31 @@
+//! Deferred local-time header reevaluation.
+
+use crate::graph::HeaderGraphView;
+use crate::{HeaderValidationState, TransitionFailure};
+
+use super::super::projected_state::ProjectedTransitionState;
+use super::ApplyEventContext;
+
+/// Promote every due deferred header to valid using the authoritative clock.
+pub(super) fn apply(
+    projected: &mut ProjectedTransitionState<'_>,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    let due: Vec<_> = projected
+        .graph()
+        .view_header_nodes()
+        .into_iter()
+        .filter_map(|node| match node.validation {
+            HeaderValidationState::DeferredUntil(until)
+                if until <= event_context.transition.clock.now() =>
+            {
+                Some(node.hash)
+            }
+            _ => None,
+        })
+        .collect();
+    for hash in due {
+        projected.set_header_validation_state(hash, HeaderValidationState::Valid)?;
+    }
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/full_state_evidence.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/full_state_evidence.rs
@@ -1,0 +1,194 @@
+//! Authoritative full-state conclusions and finality evidence.
+
+use crate::graph::HeaderGraphView;
+use crate::{BodyValidationState, Frontier, GraphError, HeaderValidationState, TransitionFailure};
+
+use super::super::projected_state::ProjectedTransitionState;
+use super::header_validation::{anchor_reasons, validate_full_state_header};
+use super::ApplyEventContext;
+
+/// Apply a verified winning-path change.
+pub(super) fn apply_chain_change(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::VerifiedChainChanged,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    let durable = event_context.durable;
+    let context = event_context.transition;
+    if projected.verified().last().copied() != Some(event.old_tip) {
+        return Err(TransitionFailure::StalePreparation);
+    }
+    let mut parent = match event.cause {
+        crate::VerifiedChangeCause::Grow | crate::VerifiedChangeCause::CheckpointFinalizedGrow => {
+            event.old_tip
+        }
+        crate::VerifiedChangeCause::Reset => projected.graph().view_finalized_frontier(),
+    };
+    if matches!(event.cause, crate::VerifiedChangeCause::Reset) {
+        projected.reset_verified(parent);
+    }
+    for header in &event.new_path {
+        if header.header.hash() != header.hash
+            || header.header.previous_block_hash != parent.hash
+            || header.height
+                != parent
+                    .height
+                    .next()
+                    .map_err(|_| GraphError::HeightOverflow {
+                        parent: parent.hash,
+                    })?
+        {
+            return Err(TransitionFailure::InvalidEvidence(
+                "verified path is not continuous",
+            ));
+        }
+        if projected.graph().view_header_node(header.hash).is_none() {
+            validate_full_state_header(projected.graph(), parent, header, durable, context)?;
+            projected.insert_header(
+                header.header.clone(),
+                HeaderValidationState::Valid,
+                anchor_reasons(context, header.height, header.hash),
+                BodyValidationState::Verified {
+                    evidence: event.full_state_transition_id,
+                },
+            )?;
+        } else {
+            projected.set_body_validation_state(
+                header.hash,
+                BodyValidationState::Verified {
+                    evidence: event.full_state_transition_id,
+                },
+            )?;
+        }
+        parent = Frontier::new(header.height, header.hash);
+        projected.push_verified(parent);
+    }
+    Ok(())
+}
+
+/// Accept a finalized-rooted side path without replacing the verified winner.
+pub(super) fn apply_block_acceptance(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::VerifiedBlockAccepted,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    let durable = event_context.durable;
+    let context = event_context.transition;
+    if event.path.is_empty() {
+        return Err(TransitionFailure::InvalidEvidence(
+            "accepted full-state side path is empty",
+        ));
+    }
+    let mut parent = projected.graph().view_finalized_frontier();
+    let last_index = event.path.len().saturating_sub(1);
+    for (index, header) in event.path.iter().enumerate() {
+        if header.header.hash() != header.hash
+            || header.header.previous_block_hash != parent.hash
+            || header.height
+                != parent
+                    .height
+                    .next()
+                    .map_err(|_| GraphError::HeightOverflow {
+                        parent: parent.hash,
+                    })?
+        {
+            return Err(TransitionFailure::InvalidEvidence(
+                "accepted full-state side path is not continuous",
+            ));
+        }
+        if projected.graph().view_header_node(header.hash).is_none() {
+            validate_full_state_header(projected.graph(), parent, header, durable, context)?;
+            projected.insert_header(
+                header.header.clone(),
+                HeaderValidationState::Valid,
+                anchor_reasons(context, header.height, header.hash),
+                BodyValidationState::Verified {
+                    evidence: event.full_state_transition_id,
+                },
+            )?;
+        } else if index == last_index {
+            projected.set_body_validation_state(
+                header.hash,
+                BodyValidationState::Verified {
+                    evidence: event.full_state_transition_id,
+                },
+            )?;
+        }
+        parent = Frontier::new(header.height, header.hash);
+    }
+    Ok(())
+}
+
+/// Install permanent consensus-invalid body evidence.
+pub(super) fn apply_consensus_invalid(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::ConsensusBodyInvalid,
+) -> Result<(), TransitionFailure> {
+    if matches!(
+        projected
+            .graph()
+            .view_header_node(event.hash)
+            .map(|node| &node.body_validation_state),
+        Some(BodyValidationState::Verified { .. })
+    ) {
+        return Err(TransitionFailure::InvalidEvidence(
+            "body invalid evidence cannot contradict an already verified body",
+        ));
+    }
+    projected.set_body_validation_state(
+        event.hash,
+        BodyValidationState::ConsensusInvalid {
+            evidence: event.evidence,
+            rule: event.rule.clone(),
+        },
+    )?;
+    Ok(())
+}
+
+/// Install exact full-state body acceptance.
+pub(super) fn apply_verified_body(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::VerifiedBodyEvidence,
+) -> Result<(), TransitionFailure> {
+    projected.set_body_validation_state(
+        event.hash,
+        BodyValidationState::Verified {
+            evidence: event.evidence,
+        },
+    )?;
+    Ok(())
+}
+
+/// Validate that a full-state finality proof matches the exact verified prefix.
+pub(super) fn apply_finality_proof(
+    projected: &ProjectedTransitionState<'_>,
+    event: &crate::FullStateFinalized,
+) -> Result<(), TransitionFailure> {
+    let expected: Vec<_> = projected
+        .verified()
+        .iter()
+        .take_while(|frontier| frontier.height <= event.new_finalized.height)
+        .map(|frontier| frontier.hash)
+        .collect();
+    if event.verified_path_proof != expected {
+        return Err(TransitionFailure::InvalidEvidence(
+            "finality proof is not the exact verified ancestry",
+        ));
+    }
+    Ok(())
+}
+
+/// Validate migrated-pin refutation evidence against durable authentication.
+pub(super) fn apply_migrated_pin_refutation(
+    event: &crate::MigratedPinRefutation,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    if event.invalid_header.height > event.pin.height
+        || event_context.migrated_pin_refuted != Some(event.pin)
+    {
+        return Err(TransitionFailure::InvalidEvidence(
+            "full-state refutation does not name an imported pin ancestor",
+        ));
+    }
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
@@ -1,0 +1,212 @@
+//! Prepared header insertion and atomic auxiliary delivery admission.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::graph::HeaderGraphView;
+use crate::{
+    BodyValidationState, Frontier, GraphError, HeaderValidationState, TargetCompletion,
+    TransitionFailure,
+};
+
+use super::super::projected_state::ProjectedTransitionState;
+use super::header_validation::{anchor_reasons, retained_header_context};
+use super::ApplyEventContext;
+
+/// Admit a prepared header batch and any accompanying unauthenticated auxiliary deliveries.
+pub(super) fn apply(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::InsertHeaders,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    let engine = event_context.engine;
+    let durable = event_context.durable;
+    let context = event_context.transition;
+    let receipt = event.batch.receipt();
+    if receipt.parent().hash != event.parent_hash
+        || receipt.trust_anchor_digest() != context.config.trust_anchor_digest()
+    {
+        return Err(TransitionFailure::StalePreparation);
+    }
+    let parent_node = projected
+        .graph()
+        .view_header_node(event.parent_hash)
+        .ok_or(GraphError::UnknownParent {
+            header: event.target_tip_hash,
+            parent: event.parent_hash,
+        })?;
+    let parent_frontier = Frontier::new(parent_node.height, parent_node.hash);
+    if receipt.parent() != parent_frontier
+        || receipt.network() != &context.config.network
+        || receipt.trust_anchor_digest() != context.config.trust_anchor_digest()
+    {
+        return Err(TransitionFailure::StalePreparation);
+    }
+    let common_ancestor = match event.completion {
+        TargetCompletion::TargetComplete { common_ancestor }
+        | TargetCompletion::TargetPrefix { common_ancestor }
+        | TargetCompletion::SelectedAuxiliaryRepair {
+            common_ancestor, ..
+        } => common_ancestor,
+    };
+    if common_ancestor != parent_frontier {
+        return Err(TransitionFailure::InvalidEvidence(
+            "target completion ancestor does not match the retained parent",
+        ));
+    }
+    let mut contextual =
+        retained_header_context(projected.graph(), parent_frontier, durable, context)?;
+    let mut parent = parent_frontier;
+    for prepared in event.batch.headers() {
+        if prepared.header.previous_block_hash != parent.hash
+            || prepared.hash != prepared.header.hash()
+            || prepared.height
+                != parent
+                    .height
+                    .next()
+                    .map_err(|_| GraphError::HeightOverflow {
+                        parent: parent.hash,
+                    })?
+            || prepared.block_work
+                != prepared.header.difficulty_threshold.to_work().ok_or(
+                    TransitionFailure::InvalidEvidence("invalid prepared target"),
+                )?
+        {
+            return Err(TransitionFailure::InvalidEvidence(
+                "prepared header batch is inconsistent",
+            ));
+        }
+        let adjustment = crate::AdjustedDifficulty::new_from_header_time(
+            prepared.header.time,
+            parent.height,
+            &context.config.network,
+            contextual.iter().copied(),
+        )
+        .map_err(|_| {
+            TransitionFailure::InvalidEvidence(
+                "prepared header has incomplete retained difficulty context",
+            )
+        })?;
+        crate::validate_contextual_difficulty_and_time(
+            prepared.header.difficulty_threshold,
+            adjustment,
+        )
+        .map_err(|_| {
+            TransitionFailure::InvalidEvidence(
+                "prepared header failed retained contextual validation",
+            )
+        })?;
+        let validation = match prepared.validation {
+            HeaderValidationState::DeferredUntil(until) if until <= context.clock.now() => {
+                HeaderValidationState::Valid
+            }
+            state => state,
+        };
+        let reasons = anchor_reasons(context, prepared.height, prepared.hash);
+        parent = match projected.insert_header(
+            prepared.header.clone(),
+            validation,
+            reasons,
+            BodyValidationState::Unknown,
+        )? {
+            crate::InsertResult::Inserted(frontier)
+            | crate::InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+        contextual.insert(
+            0,
+            (prepared.header.difficulty_threshold, prepared.header.time),
+        );
+        contextual.truncate(crate::POW_ADJUSTMENT_BLOCK_SPAN);
+    }
+    if parent.hash != event.target_tip_hash {
+        return Err(TransitionFailure::InvalidEvidence(
+            "target completion does not end at the pursued hash",
+        ));
+    }
+    match event.completion {
+        TargetCompletion::SelectedAuxiliaryRepair {
+            selected_target, ..
+        } => {
+            if event.owner.body_owner().is_none() {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "selected auxiliary repair does not have body authority",
+                ));
+            }
+            if event.batch.headers().len() != 1
+                || event.aux.len() != 1
+                || event.aux[0].tree_aux.is_none()
+                || selected_target != parent
+                || event.owner.header_authority().branch.target_tip_hash
+                    != event_context.before.frontiers.header_best.hash
+                || event_context
+                    .old_selected
+                    .iter()
+                    .find(|frontier| frontier.height == selected_target.height)
+                    .map(|frontier| frontier.hash)
+                    != Some(selected_target.hash)
+                || projected.graph().view_header_ancestor(
+                    event.owner.header_authority().branch.target_tip_hash,
+                    selected_target.height,
+                )? != Some(selected_target)
+            {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "auxiliary repair is not one exact selected header",
+                ));
+            }
+        }
+        TargetCompletion::TargetComplete { .. } | TargetCompletion::TargetPrefix { .. } => {
+            if event.owner.header_owner().is_none() {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "ordinary header insertion does not have pure header authority",
+                ));
+            }
+            if event.owner.header_authority().branch.target_tip_hash != event.target_tip_hash {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "target completion does not end at the pursued hash",
+                ));
+            }
+        }
+    }
+    let batch_headers: HashMap<_, _> = event
+        .batch
+        .headers()
+        .iter()
+        .map(|header| (header.hash, header.height))
+        .collect();
+    let mut delivery_ids = HashSet::new();
+    for delivery in &event.aux {
+        let expected_height = batch_headers.get(&delivery.header_hash).copied();
+        if !delivery_ids.insert(delivery.delivery_id)
+            || delivery.owner != event.owner
+            || delivery.source != event.source
+            || delivery.authentication != crate::AuxAuthentication::Unauthenticated
+            || expected_height.is_none()
+            || delivery
+                .tree_aux
+                .is_some_and(|aux| Some(aux.height) != expected_height)
+        {
+            return Err(TransitionFailure::InvalidEvidence(
+                "auxiliary delivery does not match the admitted target",
+            ));
+        }
+        let indexed_count = projected
+            .graph()
+            .view_header_node(delivery.header_hash)
+            .expect("the auxiliary header was checked above")
+            .aux_delivery_ids
+            .iter()
+            .filter(|delivery_id| **delivery_id == delivery.delivery_id)
+            .count();
+        let stored = engine.aux_delivery(delivery.delivery_id).copied();
+        match (stored, indexed_count) {
+            (Some(stored), 1) if stored == *delivery => continue,
+            (None, 0) => {}
+            _ => {
+                return Err(TransitionFailure::InvalidEvidence(
+                    "auxiliary delivery replay changes provenance or indexing",
+                ));
+            }
+        }
+        projected.record_aux_delivery(*delivery)?;
+    }
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
@@ -1,0 +1,192 @@
+//! Shared retained-context and full-state header validation for event handlers.
+
+use crate::graph::HeaderGraphView;
+use crate::{
+    DurableTransitionFacts, EligibilityReason, Frontier, HeaderValidationState, StoreError,
+    TransitionContext, TransitionFailure,
+};
+
+/// Reconstruct difficulty/time context for a retained parent, splicing durable leases when needed.
+pub(in crate::transition::planner) fn retained_header_context<G: HeaderGraphView>(
+    graph: &G,
+    parent: Frontier,
+    durable: &DurableTransitionFacts,
+    transition: &TransitionContext<'_>,
+) -> Result<
+    Vec<(
+        zakura_chain::work::difficulty::CompactDifficulty,
+        chrono::DateTime<chrono::Utc>,
+    )>,
+    TransitionFailure,
+> {
+    let required = usize::try_from(parent.height.0)
+        .map_err(|_| StoreError::Unavailable("retained parent height does not fit in memory"))?
+        .checked_add(1)
+        .ok_or(StoreError::Unavailable(
+            "retained parent context length overflowed",
+        ))?
+        .min(crate::POW_ADJUSTMENT_BLOCK_SPAN);
+    let mut context = Vec::with_capacity(required);
+    let mut hash = parent.hash;
+    while context.len() < required {
+        let Some(node) = graph.view_header_node(hash) else {
+            let DurableTransitionFacts::HeaderInsertion {
+                validation_contexts,
+                ..
+            } = durable
+            else {
+                return Err(
+                    StoreError::Unavailable("retained predecessor context is incomplete").into(),
+                );
+            };
+            let authorized_lease = validation_contexts.iter().find_map(|lease| {
+                if !lease.is_coherent(
+                    &transition.config.network,
+                    transition.config.trust_anchor_digest(),
+                ) || !transition
+                    .full_state_authority
+                    .is_some_and(|authority| authority.authorizes_validation_lease(lease))
+                {
+                    return None;
+                }
+                let overlap = context
+                    .iter()
+                    .position(|(_, _, frontier)| *frontier == lease.parent())
+                    .or_else(|| {
+                        context
+                            .is_empty()
+                            .then_some(0)
+                            .filter(|_| lease.parent() == parent)
+                    })?;
+                let graph_overlap = &context[overlap..];
+                let lease_overlap = lease.predecessors().get(..graph_overlap.len())?;
+                graph_overlap
+                    .iter()
+                    .zip(lease_overlap)
+                    .all(|((_, _, frontier), fact)| *frontier == fact.frontier)
+                    .then_some((lease, overlap))
+            });
+            let Some((lease, overlap)) = authorized_lease else {
+                return Err(
+                    StoreError::Unavailable("durable predecessor context is incoherent").into(),
+                );
+            };
+            context.truncate(overlap);
+            context.extend(
+                lease
+                    .predecessors()
+                    .iter()
+                    .take(required.saturating_sub(context.len()))
+                    .map(|fact| {
+                        (
+                            fact.header.difficulty_threshold,
+                            fact.header.time,
+                            fact.frontier,
+                        )
+                    }),
+            );
+            if context.len() != required {
+                return Err(
+                    StoreError::Unavailable("durable predecessor context is incomplete").into(),
+                );
+            }
+            return Ok(context
+                .into_iter()
+                .map(|(difficulty, time, _)| (difficulty, time))
+                .collect());
+        };
+        context.push((
+            node.header.difficulty_threshold,
+            node.header.time,
+            Frontier::new(node.height, node.hash),
+        ));
+        hash = node.parent_hash;
+    }
+    Ok(context
+        .into_iter()
+        .map(|(difficulty, time, _)| (difficulty, time))
+        .collect())
+}
+
+/// Validate a full-state header against observable and retained contextual rules.
+pub(super) fn validate_full_state_header<G: HeaderGraphView>(
+    graph: &G,
+    parent: Frontier,
+    header: &crate::VerifiedHeaderRef,
+    durable: &DurableTransitionFacts,
+    context: &TransitionContext<'_>,
+) -> Result<zakura_chain::work::difficulty::Work, TransitionFailure> {
+    let rules = crate::HeaderRules::from_engine_config(context.config).map_err(|_| {
+        TransitionFailure::InvalidEvidence("full-state header policy is incoherent")
+    })?;
+    let headers = [header.header.clone()];
+    let prepared = crate::prepare_context_free_headers(
+        crate::HeaderBatchInput::new(&headers),
+        parent,
+        &rules,
+        context.clock,
+    )
+    .map_err(|_| {
+        TransitionFailure::InvalidEvidence("full-state header failed observable validation")
+    })?;
+    let prepared = prepared
+        .headers()
+        .first()
+        .ok_or(TransitionFailure::InvalidEvidence(
+            "full-state header validation produced no result",
+        ))?;
+    if prepared.hash != header.hash
+        || prepared.height != header.height
+        || prepared.validation != HeaderValidationState::Valid
+    {
+        return Err(TransitionFailure::InvalidEvidence(
+            "full-state header identity or local-time state is invalid",
+        ));
+    }
+    let contextual = retained_header_context(graph, parent, durable, context)?;
+    let adjustment = crate::AdjustedDifficulty::new_from_header_time(
+        header.header.time,
+        parent.height,
+        &context.config.network,
+        contextual,
+    )
+    .map_err(|_| {
+        TransitionFailure::InvalidEvidence(
+            "full-state header has incomplete retained difficulty context",
+        )
+    })?;
+    crate::validate_contextual_difficulty_and_time(header.header.difficulty_threshold, adjustment)
+        .map_err(|_| {
+            TransitionFailure::InvalidEvidence(
+                "full-state header failed contextual difficulty or time validation",
+            )
+        })?;
+    Ok(prepared.block_work)
+}
+
+/// Configured settled-pin and checkpoint conflict reasons for an admitted header.
+pub(in crate::transition::planner) fn anchor_reasons(
+    context: &TransitionContext<'_>,
+    height: zakura_chain::block::Height,
+    hash: zakura_chain::block::Hash,
+) -> Vec<EligibilityReason> {
+    let mut reasons = Vec::new();
+    if let Some(pin) = context
+        .config
+        .settled_manifest()
+        .pin_for_network(&context.config.network)
+    {
+        if pin.activation.height == height && pin.activation.hash != hash {
+            reasons.push(EligibilityReason::SettledUpgradeConflict {
+                height,
+                expected: pin.activation.hash,
+            });
+        }
+    }
+    if let Some(expected) = context.config.local_checkpoints().hash(height) {
+        if expected != hash {
+            reasons.push(EligibilityReason::CheckpointConflict { height, expected });
+        }
+    }
+    reasons
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/mod.rs
@@ -1,0 +1,95 @@
+//! Read-only context and exhaustive dispatch for event evidence application.
+
+mod auxiliary_authentication;
+mod body_availability;
+mod deferred_time;
+mod full_state_evidence;
+mod header_admission;
+pub(super) mod header_validation;
+mod operator_policy;
+
+use crate::{
+    BodyEvidence, DurableTransitionFacts, EngineSnapshot, Frontier, HeaderChainEngine,
+    TransitionContext, TransitionEvent, TransitionFailure,
+};
+
+use super::projected_state::ProjectedTransitionState;
+
+/// Read-only inputs shared by every domain event handler.
+pub(in crate::transition::planner) struct ApplyEventContext<'a> {
+    pub(super) engine: &'a HeaderChainEngine,
+    pub(super) durable: &'a DurableTransitionFacts,
+    pub(super) transition: &'a TransitionContext<'a>,
+    pub(super) before: &'a EngineSnapshot,
+    pub(super) old_selected: &'a [Frontier],
+    pub(super) migrated_pin_refuted: Option<Frontier>,
+}
+
+/// Apply typed event evidence into the projected transition state.
+pub(super) fn apply_event_evidence(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &TransitionEvent,
+    event_context: &ApplyEventContext<'_>,
+) -> Result<(), TransitionFailure> {
+    match event {
+        TransitionEvent::InsertHeaders(event) => {
+            header_admission::apply(projected, event, event_context)
+        }
+        TransitionEvent::VerifiedChainChanged(event) => {
+            full_state_evidence::apply_chain_change(projected, event, event_context)
+        }
+        TransitionEvent::VerifiedBlockAccepted(event) => {
+            full_state_evidence::apply_block_acceptance(projected, event, event_context)
+        }
+        TransitionEvent::BodyEvidence(BodyEvidence::PayloadMismatch(event)) => {
+            body_availability::apply_payload_mismatch(event)
+        }
+        TransitionEvent::BodyEvidence(BodyEvidence::Transient(event)) => {
+            body_availability::apply_transient(projected, event)
+        }
+        TransitionEvent::BodyEvidence(BodyEvidence::ConsensusInvalid(event)) => {
+            full_state_evidence::apply_consensus_invalid(projected, event)
+        }
+        TransitionEvent::BodyEvidence(BodyEvidence::Verified(event)) => {
+            full_state_evidence::apply_verified_body(projected, event)
+        }
+        TransitionEvent::BodySupplierDiscovered(event) => {
+            body_availability::apply_supplier_discovery(projected, event, event_context)
+        }
+        TransitionEvent::OperatorBodyRetry(event) => {
+            operator_policy::apply_body_retry(projected, event)
+        }
+        TransitionEvent::OperatorInvalidate(event) => {
+            operator_policy::apply_invalidate(projected, event)
+        }
+        TransitionEvent::OperatorReconsider(event) => {
+            operator_policy::apply_reconsider(projected, event)
+        }
+        TransitionEvent::FullStateFinalized(event) => {
+            full_state_evidence::apply_finality_proof(projected, event)
+        }
+        TransitionEvent::MigratedPinRefutation(event) => {
+            full_state_evidence::apply_migrated_pin_refutation(event, event_context)
+        }
+        TransitionEvent::AuxEvidence(event) => {
+            auxiliary_authentication::apply(projected, event, event_context)
+        }
+        TransitionEvent::ReevaluateDeferred => deferred_time::apply(projected, event_context),
+    }
+}
+
+/// Resolve whether durable facts authenticate a migrated-pin refutation.
+pub(super) fn migrated_pin_refuted(
+    durable: &DurableTransitionFacts,
+    event: &TransitionEvent,
+) -> Result<Option<Frontier>, TransitionFailure> {
+    let TransitionEvent::MigratedPinRefutation(event) = event else {
+        return Ok(None);
+    };
+    match durable {
+        DurableTransitionFacts::MigratedFinalityPin(preserved) => {
+            Ok((*preserved == Some(event.pin)).then_some(event.pin))
+        }
+        _ => Err(crate::StoreError::Unavailable("migrated finality fact was not supplied").into()),
+    }
+}

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/operator_policy.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/operator_policy.rs
@@ -1,0 +1,73 @@
+//! Operator-driven eligibility and body-retry policy.
+
+use crate::graph::HeaderGraphView;
+use crate::{BodyValidationState, EligibilityReason, TransitionFailure};
+
+use super::super::projected_state::ProjectedTransitionState;
+
+/// Restart the selected persistent body alarm with a fresh episode.
+pub(super) fn apply_body_retry(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::OperatorBodyRetry,
+) -> Result<(), TransitionFailure> {
+    if event.hash != projected.graph().view_select_best_header_chain()?.0.hash
+        || event.availability.attempts != 0
+        || event.availability.suppliers == 0
+        || event.availability.alarmed
+        || event.availability.started_at != event.availability.next_probe_at
+    {
+        return Err(TransitionFailure::InvalidEvidence(
+            "operator body retry has an invalid fresh episode",
+        ));
+    }
+    if !matches!(
+        projected.graph().view_header_node(event.hash).map(|node| &node.body_validation_state),
+        Some(BodyValidationState::Unavailable(summary)) if summary.alarmed
+    ) {
+        return Err(TransitionFailure::InvalidEvidence(
+            "operator body retry requires the selected persistent alarm",
+        ));
+    }
+    projected.set_body_validation_state(
+        event.hash,
+        BodyValidationState::Unavailable(event.availability),
+    )?;
+    Ok(())
+}
+
+/// Add one reversible operator invalidation reason and dirty verified selection.
+pub(super) fn apply_invalidate(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::OperatorInvalidate,
+) -> Result<(), TransitionFailure> {
+    let mut hasher = sha2::Sha256::new();
+    use sha2::Digest as _;
+    hasher.update(b"zakura-operator-invalidation-v1");
+    hasher.update(event.target.0);
+    hasher.update(event.id.bytes());
+    let expected_digest: [u8; 32] = hasher.finalize().into();
+    if event.operator_reason_digest != expected_digest {
+        return Err(TransitionFailure::InvalidEvidence(
+            "operator invalidation identity is not bound to its target",
+        ));
+    }
+    if event.target == projected.graph().view_finalized_frontier().hash {
+        return Err(TransitionFailure::InvalidEvidence(
+            "operator invalidation cannot target the finalized anchor",
+        ));
+    }
+    projected.add_operator_invalidation(
+        event.target,
+        EligibilityReason::operator_invalid(event.target, event.id, event.evidence),
+    )?;
+    Ok(())
+}
+
+/// Remove one reversible operator invalidation and dirty verified selection when needed.
+pub(super) fn apply_reconsider(
+    projected: &mut ProjectedTransitionState<'_>,
+    event: &crate::OperatorReconsider,
+) -> Result<(), TransitionFailure> {
+    projected.remove_operator_invalidation(event.target, event.id, event.invalidation_evidence)?;
+    Ok(())
+}

--- a/crates/zakura-header-chain/src/transition/planner/projected_state.rs
+++ b/crates/zakura-header-chain/src/transition/planner/projected_state.rs
@@ -1,0 +1,363 @@
+//! Cohesive mutable projection of graph, verified path, and auxiliary deltas.
+
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
+
+use zakura_chain::block;
+
+use crate::graph::{GraphDelta, GraphOverlay, HeaderGraphEdit, HeaderGraphView};
+use crate::retention::RetentionPlan;
+use crate::{
+    AuxDelta, BodyValidationState, EligibilityReason, EngineLimits, EvidenceId, Frontier,
+    GraphError, HeaderChainEngine, HeaderValidationState, InsertResult, OperatorInvalidationId,
+    TransitionFailure,
+};
+
+/// Mutable projected state accumulated while applying one transition event.
+pub(super) struct ProjectedTransitionState<'a> {
+    graph: GraphOverlay<'a>,
+    verified: Cow<'a, [Frontier]>,
+    aux_changes: Vec<AuxDelta>,
+    verified_selection_dirty: bool,
+}
+
+impl<'a> ProjectedTransitionState<'a> {
+    /// Borrow the engine's graph and verified projection as the starting point.
+    pub(super) fn new(engine: &'a HeaderChainEngine) -> Self {
+        Self {
+            graph: GraphOverlay::new(engine.graph()),
+            verified: Cow::Borrowed(engine.verified_projection()),
+            aux_changes: Vec::new(),
+            verified_selection_dirty: false,
+        }
+    }
+
+    /// Borrow the projected graph.
+    pub(super) fn graph(&self) -> &GraphOverlay<'a> {
+        &self.graph
+    }
+
+    /// Borrow the projected verified path.
+    pub(super) fn verified(&self) -> &[Frontier] {
+        &self.verified
+    }
+
+    /// Replace the verified path with one finalized-rooted frontier.
+    pub(super) fn reset_verified(&mut self, frontier: Frontier) {
+        self.verified = Cow::Owned(vec![frontier]);
+    }
+
+    /// Extend the verified path by one validated frontier.
+    pub(super) fn push_verified(&mut self, frontier: Frontier) {
+        self.verified.to_mut().push(frontier);
+    }
+
+    /// Insert one admitted header into the projected graph.
+    pub(super) fn insert_header(
+        &mut self,
+        header: Arc<block::Header>,
+        validation: HeaderValidationState,
+        direct_reasons: Vec<EligibilityReason>,
+        body_validation_state: BodyValidationState,
+    ) -> Result<InsertResult, TransitionFailure> {
+        Ok(self.graph.edit_insert_header(
+            header,
+            validation,
+            direct_reasons,
+            body_validation_state,
+        )?)
+    }
+
+    /// Replace one retained header's body-validation state.
+    pub(super) fn set_body_validation_state(
+        &mut self,
+        hash: block::Hash,
+        body_validation_state: BodyValidationState,
+    ) -> Result<(), TransitionFailure> {
+        self.graph
+            .edit_set_body_validation_state(hash, body_validation_state)?;
+        Ok(())
+    }
+
+    /// Replace one retained header's time-dependent validation state.
+    pub(super) fn set_header_validation_state(
+        &mut self,
+        hash: block::Hash,
+        validation: HeaderValidationState,
+    ) -> Result<(), TransitionFailure> {
+        self.graph
+            .edit_set_header_validation_state(hash, validation)?;
+        Ok(())
+    }
+
+    /// Record one auxiliary delivery and stage its durable row together.
+    pub(super) fn record_aux_delivery(
+        &mut self,
+        delivery: crate::AuxDelivery,
+    ) -> Result<(), TransitionFailure> {
+        self.graph
+            .edit_record_auxiliary_evidence_delivery(delivery.header_hash, delivery.delivery_id)?;
+        self.aux_changes.push(AuxDelta::Put(Box::new(delivery)));
+        Ok(())
+    }
+
+    /// Stage an updated auxiliary delivery row.
+    pub(super) fn update_aux_delivery(&mut self, delivery: crate::AuxDelivery) {
+        self.aux_changes.push(AuxDelta::Put(Box::new(delivery)));
+    }
+
+    /// Add an operator invalidation and dirty verified selection when it changes state.
+    pub(super) fn add_operator_invalidation(
+        &mut self,
+        target: block::Hash,
+        reason: EligibilityReason,
+    ) -> Result<(), TransitionFailure> {
+        if self
+            .graph
+            .edit_add_header_eligibility_reason(target, reason)?
+        {
+            self.verified_selection_dirty = true;
+        }
+        Ok(())
+    }
+
+    /// Remove an operator invalidation and dirty verified selection when it changes state.
+    pub(super) fn remove_operator_invalidation(
+        &mut self,
+        target: block::Hash,
+        id: OperatorInvalidationId,
+        evidence: Option<EvidenceId>,
+    ) -> Result<(), TransitionFailure> {
+        if self
+            .graph
+            .edit_remove_header_operator_invalidation(target, id, evidence)?
+        {
+            self.verified_selection_dirty = true;
+        }
+        Ok(())
+    }
+
+    /// Reselect the strongest fully verified eligible path when operator policy dirtied it.
+    pub(super) fn refresh_verified_after_operator_change(
+        &mut self,
+    ) -> Result<(), TransitionFailure> {
+        if self.verified_selection_dirty {
+            self.verified = Cow::Owned(select_fully_verified_path(&self.graph)?);
+            self.verified_selection_dirty = false;
+        }
+        Ok(())
+    }
+
+    /// Advance finality and trim the verified projection to the new anchor.
+    pub(super) fn advance_finality(
+        &mut self,
+        new_finalized: Frontier,
+    ) -> Result<(), TransitionFailure> {
+        self.graph.edit_advance_finalized_frontier(new_finalized)?;
+        let verified = self.verified.to_mut();
+        verified.retain(|frontier| frontier.height >= new_finalized.height);
+        if verified.first().copied() != Some(new_finalized) {
+            verified.insert(0, new_finalized);
+        }
+        Ok(())
+    }
+
+    /// Collapse verified state to finality in headers-only mode.
+    pub(super) fn force_headers_only_verified(&mut self) {
+        self.verified = Cow::Owned(vec![self.graph.view_finalized_frontier()]);
+    }
+
+    /// Enforce retention against the projected graph.
+    pub(super) fn enforce_retention(
+        &mut self,
+        header_best: Frontier,
+        retention_references: impl IntoIterator<Item = zakura_chain::block::Hash>,
+        limits: EngineLimits,
+    ) -> Result<RetentionPlan, TransitionFailure> {
+        let verified_best = self
+            .verified
+            .last()
+            .copied()
+            .unwrap_or_else(|| self.graph.view_finalized_frontier());
+        Ok(crate::retention::enforce_retention(
+            &mut self.graph,
+            header_best,
+            verified_best,
+            retention_references,
+            limits,
+        )?)
+    }
+
+    /// Trim the verified projection against the retained graph and reconcile auxiliary rows.
+    pub(super) fn finish_after_retention(
+        mut self,
+        engine: &HeaderChainEngine,
+    ) -> Result<SettledProjectedState<'a>, TransitionFailure> {
+        self.verified = trim_projection(&self.graph, self.verified)?;
+        let graph_delta = self.graph.delta();
+        let evicted: HashSet<_> = graph_delta
+            .deleted_header_hashes()
+            .iter()
+            .copied()
+            .collect();
+        self.aux_changes.retain(|change| match change {
+            AuxDelta::Put(delivery) => self.graph.view_header_node(delivery.header_hash).is_some(),
+            AuxDelta::Delete { .. } => true,
+        });
+        let mut aux_deletes: Vec<_> = evicted
+            .iter()
+            .flat_map(|hash| {
+                engine
+                    .aux_deliveries(*hash)
+                    .iter()
+                    .map(|delivery| (*hash, delivery.delivery_id))
+            })
+            .collect();
+        // HashSet iteration is nondeterministic; match adjacent ChangeSet ordering.
+        aux_deletes.sort_unstable_by_key(|(hash, delivery_id)| (hash.0, *delivery_id));
+        for (header_hash, delivery_id) in aux_deletes {
+            self.aux_changes.push(AuxDelta::Delete {
+                header_hash,
+                delivery_id,
+            });
+        }
+        Ok(SettledProjectedState {
+            graph: self.graph,
+            verified: self.verified,
+            aux_changes: self.aux_changes,
+        })
+    }
+
+    /// Return true when event application rebased work coordinates.
+    pub(super) fn work_coordinates_rebased(&self) -> bool {
+        self.graph.work_coordinates_rebased()
+    }
+}
+
+/// Fully settled projected state ready for write-set assembly.
+pub(super) struct SettledProjectedState<'a> {
+    graph: GraphOverlay<'a>,
+    verified: Cow<'a, [Frontier]>,
+    aux_changes: Vec<AuxDelta>,
+}
+
+impl<'a> SettledProjectedState<'a> {
+    /// Atomically expose the graph and its matching final delta to write derivation.
+    pub(super) fn into_write_parts(
+        self,
+    ) -> (
+        GraphOverlay<'a>,
+        GraphDelta,
+        Cow<'a, [Frontier]>,
+        Vec<AuxDelta>,
+    ) {
+        let graph_delta = self.graph.delta();
+        (self.graph, graph_delta, self.verified, self.aux_changes)
+    }
+}
+
+/// Reconstruct the finalized-rooted path ending at `tip`.
+pub(super) fn path<G: HeaderGraphView>(
+    graph: &G,
+    tip: Frontier,
+) -> Result<Vec<Frontier>, TransitionFailure> {
+    let finalized = graph.view_finalized_frontier();
+    let mut path = Vec::new();
+    let mut current = tip;
+    loop {
+        path.push(current);
+        if current == finalized {
+            break;
+        }
+        let node = graph
+            .view_header_node(current.hash)
+            .ok_or(GraphError::UnknownHeaderNode(current.hash))?;
+        current = Frontier::new(
+            current
+                .height
+                .previous()
+                .map_err(|_| GraphError::FinalizedFrontierNotDescendant {
+                    current: finalized.hash,
+                    candidate: tip.hash,
+                })?,
+            node.parent_hash,
+        );
+    }
+    path.reverse();
+    Ok(path)
+}
+
+/// Select the strongest fully verified eligible path.
+pub(super) fn select_fully_verified_path<G: HeaderGraphView>(
+    graph: &G,
+) -> Result<Vec<Frontier>, TransitionFailure> {
+    let finalized = graph.view_finalized_frontier();
+    let mut connected = HashSet::from([finalized.hash]);
+    let mut nodes = graph.view_header_nodes();
+    nodes.sort_unstable_by_key(|node| (node.height, node.hash.0));
+    for node in nodes {
+        if node.hash != finalized.hash
+            && node.is_eligible()
+            && matches!(
+                node.body_validation_state,
+                BodyValidationState::Verified { .. }
+            )
+            && connected.contains(&node.parent_hash)
+        {
+            connected.insert(node.hash);
+        }
+    }
+    let tip = connected
+        .into_iter()
+        .map(|hash| {
+            let node = graph
+                .view_header_node(hash)
+                .expect("verified candidates are retained graph nodes");
+            graph
+                .view_header_chain_score(hash)
+                .map(|score| (score, Frontier::new(node.height, hash)))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .max_by_key(|(score, _)| *score)
+        .map(|(_, frontier)| frontier)
+        .ok_or(GraphError::UnknownHeaderNode(finalized.hash))?;
+    path(graph, tip)
+}
+
+/// Trim a projection so it starts at finality and only names retained nodes.
+pub(super) fn trim_projection<'a, G: HeaderGraphView>(
+    graph: &G,
+    projection: Cow<'a, [Frontier]>,
+) -> Result<Cow<'a, [Frontier]>, TransitionFailure> {
+    let requires_trim = projection.first().copied() != Some(graph.view_finalized_frontier())
+        || projection.iter().any(|frontier| {
+            frontier.height < graph.view_finalized_frontier().height
+                || graph.view_header_node(frontier.hash).is_none()
+        });
+    if !requires_trim {
+        return Ok(projection);
+    }
+    let mut result: Vec<_> = projection
+        .iter()
+        .copied()
+        .filter(|frontier| {
+            frontier.height >= graph.view_finalized_frontier().height
+                && graph.view_header_node(frontier.hash).is_some()
+        })
+        .collect();
+    if result.first().copied() != Some(graph.view_finalized_frontier()) {
+        result.insert(0, graph.view_finalized_frontier());
+    }
+    for pair in result.windows(2) {
+        if pair[1].height.0 != pair[0].height.0 + 1
+            || graph
+                .view_header_node(pair[1].hash)
+                .is_none_or(|node| node.parent_hash != pair[0].hash)
+        {
+            return Err(TransitionFailure::InvalidEvidence(
+                "verified projection is not continuous",
+            ));
+        }
+    }
+    Ok(Cow::Owned(result))
+}

--- a/crates/zakura-header-chain/src/transition/planner/projected_state.rs
+++ b/crates/zakura-header-chain/src/transition/planner/projected_state.rs
@@ -222,6 +222,7 @@ impl<'a> ProjectedTransitionState<'a> {
         }
         Ok(SettledProjectedState {
             graph: self.graph,
+            graph_delta,
             verified: self.verified,
             aux_changes: self.aux_changes,
         })
@@ -236,6 +237,7 @@ impl<'a> ProjectedTransitionState<'a> {
 /// Fully settled projected state ready for write-set assembly.
 pub(super) struct SettledProjectedState<'a> {
     graph: GraphOverlay<'a>,
+    graph_delta: GraphDelta,
     verified: Cow<'a, [Frontier]>,
     aux_changes: Vec<AuxDelta>,
 }
@@ -250,8 +252,12 @@ impl<'a> SettledProjectedState<'a> {
         Cow<'a, [Frontier]>,
         Vec<AuxDelta>,
     ) {
-        let graph_delta = self.graph.delta();
-        (self.graph, graph_delta, self.verified, self.aux_changes)
+        (
+            self.graph,
+            self.graph_delta,
+            self.verified,
+            self.aux_changes,
+        )
     }
 }
 

--- a/crates/zakura-header-chain/src/transition/planner/settlement.rs
+++ b/crates/zakura-header-chain/src/transition/planner/settlement.rs
@@ -1,0 +1,214 @@
+//! Finality, retention, and projection settlement after event evidence.
+
+use std::borrow::Cow;
+
+use crate::graph::HeaderGraphView;
+use crate::retention::RetentionPlan;
+use crate::{
+    EngineMetadata, EngineMode, EngineSnapshot, FinalityRecord, FinalitySource, Frontier,
+    HeaderChainEngine, TransitionCause, TransitionContext, TransitionEvent, TransitionFailure,
+};
+
+use super::admission::HeaderInsertionRebase;
+use super::projected_state::{path, ProjectedTransitionState, SettledProjectedState};
+
+/// Inputs required to settle finality and retention after event evidence.
+pub(super) struct SettlementInputs<'engine, 'ctx> {
+    pub(super) engine: &'engine HeaderChainEngine,
+    pub(super) projected: ProjectedTransitionState<'engine>,
+    pub(super) metadata: EngineMetadata,
+    pub(super) before: &'ctx EngineSnapshot,
+    pub(super) event: &'ctx TransitionEvent,
+    pub(super) header_rebase: HeaderInsertionRebase,
+    pub(super) context: &'ctx TransitionContext<'ctx>,
+    pub(super) old_selected: &'engine [Frontier],
+}
+
+/// Settled projections ready for write-set assembly.
+pub(super) struct SettledTransition<'a> {
+    /// Projected graph after finality and retention.
+    pub(super) projected: SettledProjectedState<'a>,
+    /// Selected projection after settlement.
+    pub(super) selected: Cow<'a, [Frontier]>,
+    /// Optional finality record to append.
+    pub(super) finality_append: Option<FinalityRecord>,
+    /// Retention outcome.
+    pub(super) retention: RetentionPlan,
+    /// Classified transition cause.
+    pub(super) cause: TransitionCause,
+    /// Updated metadata carrying work-origin and alarm side effects.
+    pub(super) metadata: EngineMetadata,
+}
+
+/// Outcome of finality and retention settlement.
+pub(super) enum FinalityRetentionOutcome<'a> {
+    /// Settlement completed and write assembly may proceed.
+    Settled(Box<SettledTransition<'a>>),
+    /// Protected paths made limits unenforceable; discard event effects.
+    ResourceStalled,
+}
+
+/// Decide and apply finality, enforce retention, and settle projections.
+pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
+    inputs: SettlementInputs<'engine, 'ctx>,
+) -> Result<FinalityRetentionOutcome<'engine>, TransitionFailure> {
+    let SettlementInputs {
+        engine,
+        mut projected,
+        mut metadata,
+        before,
+        event,
+        header_rebase,
+        context,
+        old_selected,
+    } = inputs;
+    let work_rebased = projected.work_coordinates_rebased();
+    if work_rebased {
+        metadata.work_origin = projected.graph().view_finalized_frontier();
+    }
+    projected.refresh_verified_after_operator_change()?;
+
+    let (mut header_best, _) = projected.graph().view_select_best_header_chain()?;
+    let full_state_finalized = match event {
+        TransitionEvent::FullStateFinalized(event) => {
+            Some((event.new_finalized, event.full_state_transition_id))
+        }
+        TransitionEvent::VerifiedChainChanged(event)
+            if event.cause == crate::VerifiedChangeCause::CheckpointFinalizedGrow =>
+        {
+            event.new_path.last().map(|header| {
+                (
+                    Frontier::new(header.height, header.hash),
+                    event.full_state_transition_id,
+                )
+            })
+        }
+        _ => None,
+    };
+
+    let mut finality = None;
+    if let Some((new_finalized, evidence)) = full_state_finalized {
+        if new_finalized.height < before.frontiers.finalized.height {
+            return Err(TransitionFailure::InvalidEvidence("finality retreated"));
+        }
+        if !projected.verified().contains(&new_finalized) {
+            return Err(TransitionFailure::InvalidEvidence(
+                "integrated finality is not on the verified projection",
+            ));
+        }
+        finality = Some((new_finalized, FinalitySource::FullState { evidence }));
+    } else if context.config.mode == EngineMode::HeadersOnly {
+        let depth = context.config.limits.local_finality_depth.get();
+        if header_best
+            .height
+            .0
+            .saturating_sub(projected.graph().view_finalized_frontier().height.0)
+            > depth
+        {
+            let height = zakura_chain::block::Height(header_best.height.0 - depth);
+            let new_finalized = projected
+                .graph()
+                .view_header_ancestor(header_best.hash, height)?
+                .ok_or(TransitionFailure::InvalidEvidence(
+                    "selected ancestry is incomplete",
+                ))?;
+            finality = Some((
+                new_finalized,
+                FinalitySource::HeadersOnlyDepth {
+                    selected_tip: header_best,
+                },
+            ));
+        }
+    }
+
+    let mut cause = if work_rebased || header_rebase == HeaderInsertionRebase::Rebased {
+        TransitionCause::HeaderWorkRebased
+    } else if matches!(
+        event,
+        TransitionEvent::VerifiedChainChanged(ref event)
+            if event.cause == crate::VerifiedChangeCause::CheckpointFinalizedGrow
+    ) {
+        TransitionCause::CheckpointFinality
+    } else if matches!(event, TransitionEvent::AuxEvidence(_)) {
+        TransitionCause::AuxAuthentication
+    } else {
+        TransitionCause::Event
+    };
+
+    let mut finality_append = None;
+    if let Some((new_finalized, source)) = finality {
+        if new_finalized != projected.graph().view_finalized_frontier() {
+            let previous = projected.graph().view_finalized_frontier();
+            let epoch = metadata.finality_epoch.checked_next()?;
+            projected.advance_finality(new_finalized)?;
+            finality_append = Some(FinalityRecord {
+                previous,
+                current: new_finalized,
+                source,
+                epoch,
+            });
+            header_best = projected.graph().view_select_best_header_chain()?.0;
+            if matches!(source, FinalitySource::HeadersOnlyDepth { .. }) {
+                cause = TransitionCause::HeadersOnlyFinality;
+            }
+        }
+    }
+
+    if context.config.mode == EngineMode::HeadersOnly {
+        projected.force_headers_only_verified();
+    }
+
+    let retention = projected.enforce_retention(
+        header_best,
+        context.retention_references.iter().copied(),
+        context.config.limits,
+    )?;
+    if retention.admission_refused {
+        return Ok(FinalityRetentionOutcome::ResourceStalled);
+    }
+
+    header_best = projected.graph().view_select_best_header_chain()?.0;
+    let selected = if cause == TransitionCause::CheckpointFinality
+        && header_best == before.frontiers.header_best
+        && finality_append.is_some_and(|record| {
+            old_selected
+                .binary_search_by_key(&record.current.height, |frontier| frontier.height)
+                .ok()
+                .is_some_and(|index| old_selected[index] == record.current)
+        }) {
+        let Some(record) = finality_append else {
+            return Err(TransitionFailure::InvalidEvidence(
+                "checkpoint finality has no finality record",
+            ));
+        };
+        let index = old_selected
+            .binary_search_by_key(&record.current.height, |frontier| frontier.height)
+            .map_err(|_| {
+                TransitionFailure::InvalidEvidence(
+                    "checkpoint finality left the selected projection",
+                )
+            })?;
+        Cow::Borrowed(&old_selected[index..])
+    } else {
+        Cow::Owned(path(projected.graph(), header_best)?)
+    };
+
+    let projected = projected.finish_after_retention(engine)?;
+    Ok(FinalityRetentionOutcome::Settled(Box::new(
+        SettledTransition {
+            projected,
+            selected,
+            finality_append,
+            retention,
+            cause,
+            metadata,
+        },
+    )))
+}
+
+/// Apply a migrated-pin refutation alarm before settlement when durable facts authenticate it.
+pub(super) fn apply_migrated_pin_alarm(metadata: &mut EngineMetadata, pin: Option<Frontier>) {
+    if let Some(pin) = pin {
+        metadata.alarms.migrated_pin_refuted = Some(pin);
+    }
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -1,3 +1,4 @@
+use super::super::projected_state::path;
 use super::*;
 use crate::{AuxDelta, InvariantViolation};
 

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -700,7 +700,7 @@ fn auxiliary_resource_limits_reject_equal_plus_one_without_effects() {
     insert.aux.push(duplicate);
     assert!(matches!(
         apply_transition(&store, oversized.clone(), &context(&config, &clock, None)),
-        Err(TransitionFailure::ResourceStalled)
+        Err(TransitionFailure::AuxiliaryLimitExceeded)
     ));
 
     config.limits.max_aux_deliveries_per_header =
@@ -709,8 +709,9 @@ fn auxiliary_resource_limits_reject_equal_plus_one_without_effects() {
         std::num::NonZeroUsize::new(1).expect("one is nonzero");
     assert!(matches!(
         apply_transition(&store, oversized, &context(&config, &clock, None)),
-        Err(TransitionFailure::ResourceStalled)
+        Err(TransitionFailure::AuxiliaryLimitExceeded)
     ));
     assert_eq!(store.metadata.state_version, StateVersion::new(0));
+    assert!(!store.metadata.alarms.resource_stalled);
     assert!(store.aux.is_empty());
 }

--- a/crates/zakura-header-chain/src/transition/planner/tests/coherence.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/coherence.rs
@@ -1,0 +1,78 @@
+//! Snapshot and configuration coherence characterization.
+
+use super::super::admission::validate_snapshot;
+use super::*;
+use zakura_chain::parameters::NetworkKind;
+
+#[test]
+fn validate_snapshot_rejects_configuration_and_metadata_mismatches() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let ctx = context(&config, &clock, None);
+    let snapshot = store.snapshot();
+    let metadata = store.metadata.clone();
+
+    let cases = [
+        ("snapshot mode", {
+            let mut snapshot = snapshot.clone();
+            snapshot.mode = EngineMode::HeadersOnly;
+            (snapshot, metadata.clone())
+        }),
+        ("metadata mode", {
+            let mut metadata = metadata.clone();
+            metadata.mode = EngineMode::HeadersOnly;
+            (snapshot.clone(), metadata)
+        }),
+        ("network identity", {
+            let mut metadata = metadata.clone();
+            metadata.network_id = NetworkKind::Mainnet;
+            (snapshot.clone(), metadata)
+        }),
+        ("trust-anchor digest", {
+            let mut metadata = metadata.clone();
+            metadata.anchor_manifest_digest = [0xab; 32];
+            (snapshot.clone(), metadata)
+        }),
+        ("state version", {
+            let mut snapshot = snapshot.clone();
+            snapshot.state_version = StateVersion::new(9);
+            (snapshot, metadata.clone())
+        }),
+        ("frontiers", {
+            let mut snapshot = snapshot.clone();
+            snapshot.frontiers.header_best = Frontier::new(block::Height(1), block::Hash([1; 32]));
+            (snapshot, metadata.clone())
+        }),
+    ];
+
+    for (label, (snapshot, metadata)) in cases {
+        assert_eq!(
+            validate_snapshot(&snapshot, &metadata, &ctx),
+            Err(TransitionFailure::ConfigurationMismatch),
+            "{label} must fail closed"
+        );
+    }
+
+    validate_snapshot(&snapshot, &metadata, &ctx)
+        .expect("the coherent fixture snapshot must be accepted");
+}
+
+#[test]
+fn validate_snapshot_does_not_require_startup_audit_fields() {
+    let (store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let ctx = context(&config, &clock, None);
+    let mut snapshot = store.snapshot();
+    let metadata = store.metadata.clone();
+
+    // These fields are compared by startup audit, not by the planner helper.
+    snapshot.header_generation = HeaderGeneration::new(77);
+    snapshot.verified_generation = VerifiedGeneration::new(88);
+    snapshot.header_best_score.tip_hash = block::Hash([0x42; 32]);
+    snapshot.oldest_retained_height = block::Height(99);
+    snapshot.alarms.resource_stalled = true;
+
+    validate_snapshot(&snapshot, &metadata, &ctx).expect(
+        "planner snapshot checks intentionally leave generation, score, retention height, and alarms to startup audit",
+    );
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
@@ -1,3 +1,6 @@
+use super::super::{
+    admission::validate_finality_rebase_path, projected_state::path, write_set::projection_delta,
+};
 use super::*;
 use crate::InvariantViolation;
 
@@ -822,5 +825,264 @@ fn checkpoint_verified_growth_advances_verified_and_finalized_atomically() {
     assert_eq!(
         verify_plan(&test_engine(&store), &pin_conflict),
         Err(InvariantViolation::TrustPin(checkpoint.height))
+    );
+}
+
+#[test]
+fn validate_finality_rebase_path_table() {
+    let a0 = Frontier::new(block::Height(0), block::Hash([0x10; 32]));
+    let a1 = Frontier::new(block::Height(1), block::Hash([0x11; 32]));
+    let a2 = Frontier::new(block::Height(2), block::Hash([0x12; 32]));
+    let a3 = Frontier::new(block::Height(3), block::Hash([0x13; 32]));
+    let competing = Frontier::new(block::Height(1), block::Hash([0x91; 32]));
+    let evidence = EvidenceId::from_digest([0x44; 32]);
+    let source = FinalitySource::FullState { evidence };
+
+    struct Case {
+        label: &'static str,
+        original_anchor: block::Hash,
+        current_finalized: Frontier,
+        path: Vec<FinalityRecord>,
+        expected: Result<(), TransitionFailure>,
+    }
+
+    let cases = [
+        Case {
+            label: "unchanged anchor with empty path",
+            original_anchor: a1.hash,
+            current_finalized: a1,
+            path: Vec::new(),
+            expected: Ok(()),
+        },
+        Case {
+            label: "unchanged anchor with nonempty path",
+            original_anchor: a1.hash,
+            current_finalized: a1,
+            path: vec![FinalityRecord {
+                previous: a0,
+                current: a1,
+                source,
+                epoch: FinalityEpoch::new(1),
+            }],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "one valid advancement",
+            original_anchor: a0.hash,
+            current_finalized: a1,
+            path: vec![FinalityRecord {
+                previous: a0,
+                current: a1,
+                source,
+                epoch: FinalityEpoch::new(1),
+            }],
+            expected: Ok(()),
+        },
+        Case {
+            label: "multiple contiguous advancements",
+            original_anchor: a0.hash,
+            current_finalized: a3,
+            path: vec![
+                FinalityRecord {
+                    previous: a0,
+                    current: a1,
+                    source,
+                    epoch: FinalityEpoch::new(1),
+                },
+                FinalityRecord {
+                    previous: a1,
+                    current: a2,
+                    source,
+                    epoch: FinalityEpoch::new(2),
+                },
+                FinalityRecord {
+                    previous: a2,
+                    current: a3,
+                    source,
+                    epoch: FinalityEpoch::new(3),
+                },
+            ],
+            expected: Ok(()),
+        },
+        Case {
+            label: "first record may begin at any epoch",
+            original_anchor: a0.hash,
+            current_finalized: a1,
+            path: vec![FinalityRecord {
+                previous: a0,
+                current: a1,
+                source,
+                epoch: FinalityEpoch::new(9),
+            }],
+            expected: Ok(()),
+        },
+        Case {
+            label: "changed anchor with empty path",
+            original_anchor: a0.hash,
+            current_finalized: a1,
+            path: Vec::new(),
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "first predecessor hash mismatch",
+            original_anchor: a0.hash,
+            current_finalized: a1,
+            path: vec![FinalityRecord {
+                previous: competing,
+                current: a1,
+                source,
+                epoch: FinalityEpoch::new(1),
+            }],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "gap between current and next previous",
+            original_anchor: a0.hash,
+            current_finalized: a3,
+            path: vec![
+                FinalityRecord {
+                    previous: a0,
+                    current: a1,
+                    source,
+                    epoch: FinalityEpoch::new(1),
+                },
+                FinalityRecord {
+                    previous: a2,
+                    current: a3,
+                    source,
+                    epoch: FinalityEpoch::new(2),
+                },
+            ],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "duplicate epoch",
+            original_anchor: a0.hash,
+            current_finalized: a2,
+            path: vec![
+                FinalityRecord {
+                    previous: a0,
+                    current: a1,
+                    source,
+                    epoch: FinalityEpoch::new(1),
+                },
+                FinalityRecord {
+                    previous: a1,
+                    current: a2,
+                    source,
+                    epoch: FinalityEpoch::new(1),
+                },
+            ],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "skipped epoch",
+            original_anchor: a0.hash,
+            current_finalized: a2,
+            path: vec![
+                FinalityRecord {
+                    previous: a0,
+                    current: a1,
+                    source,
+                    epoch: FinalityEpoch::new(1),
+                },
+                FinalityRecord {
+                    previous: a1,
+                    current: a2,
+                    source,
+                    epoch: FinalityEpoch::new(3),
+                },
+            ],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "reversed epoch",
+            original_anchor: a0.hash,
+            current_finalized: a2,
+            path: vec![
+                FinalityRecord {
+                    previous: a0,
+                    current: a1,
+                    source,
+                    epoch: FinalityEpoch::new(2),
+                },
+                FinalityRecord {
+                    previous: a1,
+                    current: a2,
+                    source,
+                    epoch: FinalityEpoch::new(1),
+                },
+            ],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "height retreat",
+            original_anchor: a0.hash,
+            current_finalized: Frontier::new(block::Height(4), block::Hash([0x14; 32])),
+            path: vec![FinalityRecord {
+                previous: Frontier::new(block::Height(5), a0.hash),
+                current: Frontier::new(block::Height(4), block::Hash([0x14; 32])),
+                source,
+                epoch: FinalityEpoch::new(1),
+            }],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+        Case {
+            label: "wrong terminal frontier",
+            original_anchor: a0.hash,
+            current_finalized: a2,
+            path: vec![FinalityRecord {
+                previous: a0,
+                current: a1,
+                source,
+                epoch: FinalityEpoch::new(1),
+            }],
+            expected: Err(TransitionFailure::StalePreparation),
+        },
+    ];
+
+    for case in cases {
+        assert_eq!(
+            validate_finality_rebase_path(case.original_anchor, case.current_finalized, &case.path),
+            case.expected,
+            "{}",
+            case.label
+        );
+    }
+
+    assert_eq!(
+        validate_finality_rebase_path(
+            a0.hash,
+            a1,
+            &[FinalityRecord {
+                previous: a0,
+                current: a1,
+                source,
+                epoch: FinalityEpoch::new(u64::MAX),
+            }],
+        ),
+        Err(TransitionFailure::Counter(
+            FinalityEpoch::new(u64::MAX)
+                .checked_next()
+                .expect_err("u64::MAX has no next finality epoch"),
+        )),
+        "epoch exhaustion at u64::MAX"
+    );
+
+    // First predecessor compares only its hash because BranchId retains only the anchor hash.
+    // Equal heights are allowed; only a height retreat is rejected.
+    assert_eq!(
+        validate_finality_rebase_path(
+            a0.hash,
+            a1,
+            &[FinalityRecord {
+                previous: Frontier::new(block::Height(1), a0.hash),
+                current: a1,
+                source,
+                epoch: FinalityEpoch::new(1),
+            }],
+        ),
+        Ok(()),
+        "first-record predecessor height is intentionally ignored when it does not retreat"
     );
 }

--- a/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
@@ -58,7 +58,7 @@ fn apply_with_header_rebase_facts(
     validation: ValidationLease,
 ) -> Result<TransitionPlan, TransitionFailure> {
     test_engine(store)
-        .apply(
+        .plan_transition(
             request,
             &context(config, clock, None),
             DurableTransitionFacts::HeaderInsertion {

--- a/crates/zakura-header-chain/src/transition/planner/tests/guards.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/guards.rs
@@ -87,6 +87,83 @@ fn typed_header_authority_ignores_global_version_but_rejects_stale_generation() 
 }
 
 #[test]
+fn typed_body_authority_ignores_global_version_but_rejects_stale_generation() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let mut insert = insertion(&store, 2, EvidenceId::from_digest([0xa0; 32]));
+    let TransitionEvent::InsertHeaders(insert_event) = &mut insert.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    let header_hash = insert_event.batch.headers()[0].hash;
+    let boundary_hash = insert_event.batch.headers()[1].hash;
+    let delivery = crate::AuxDelivery {
+        delivery_id: EvidenceId::from_digest([0xa1; 32]),
+        header_hash,
+        source: SourceId::from_digest([0xa2; 32]),
+        owner: insert_event.owner,
+        body_size: crate::BodySizeHint::Unknown,
+        tree_aux: Some(crate::TreeAuxRecordV1 {
+            height: block::Height(1),
+            sapling_root: zakura_chain::sapling::tree::Root::default(),
+            orchard_root: zakura_chain::orchard::tree::Root::default(),
+            ironwood_root: zakura_chain::ironwood::tree::Root::default(),
+            sapling_tx_count: 1,
+            orchard_tx_count: 1,
+            ironwood_tx_count: 1,
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0xa3; 32]),
+        }),
+        authentication: crate::AuxAuthentication::Unauthenticated,
+    };
+    insert_event.source = delivery.source;
+    insert_event.aux.push(delivery);
+    let inserted = apply_transition(&store, insert, &context(&config, &clock, None))
+        .expect("the header and unauthenticated delivery insert");
+    store.commit(&inserted);
+
+    let owner = crate::BodyWorkAuthority::for_snapshot(&store.snapshot()).bind(
+        1,
+        NonZeroU64::new(1).expect("fixture request IDs are nonzero"),
+    );
+    let authentication = crate::AuxAuthentication::Authenticated {
+        evidence: EvidenceId::from_digest([0xa4; 32]),
+        boundary_hash,
+    };
+    let mut request = TransitionRequest {
+        expected_version: StateVersion::new(9),
+        event: TransitionEvent::AuxEvidence(Box::new(crate::AuxEvidence {
+            owner,
+            deliveries: vec![delivery],
+            authentication,
+        })),
+    };
+    apply_transition(
+        &store,
+        request.clone(),
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("global state versions do not authorize auxiliary evidence");
+
+    let TransitionEvent::AuxEvidence(event) = &mut request.event else {
+        panic!("the fixture constructs auxiliary evidence");
+    };
+    event.owner = crate::BodyWorkOwner {
+        authority: crate::BodyWorkAuthority {
+            verified_generation: VerifiedGeneration::new(9),
+            ..event.owner.authority
+        },
+        ..event.owner
+    };
+    assert!(matches!(
+        apply_transition(
+            &store,
+            request,
+            &context(&config, &clock, Some(&Authority)),
+        ),
+        Err(TransitionFailure::Stale { current }) if current == store.metadata.state_version
+    ));
+}
+
+#[test]
 fn peer_target_completion_must_match_the_validation_lease_ancestor() {
     let (store, config) = TestStore::new(EngineMode::HeadersOnly);
     let clock = ManualClock(Utc::now());

--- a/crates/zakura-header-chain/src/transition/planner/tests/insertion.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/insertion.rs
@@ -1,3 +1,4 @@
+use super::super::event_effects::header_validation::anchor_reasons;
 use super::*;
 
 #[test]

--- a/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
@@ -1,26 +1,31 @@
 mod auxiliary;
 mod body_evidence;
+mod coherence;
 mod finality;
 mod guards;
 mod insertion;
 mod operator;
+mod predecessor_context;
 mod selection;
 
-use std::{collections::HashMap, num::NonZeroU64, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, num::NonZeroU64, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use zakura_chain::{
-    block::{genesis::regtest_genesis_block, Block},
+    block::{self, genesis::regtest_genesis_block, Block},
     parameters::{testnet::RegtestParameters, Network},
     serialization::ZcashDeserialize,
 };
 
-use super::*;
+use super::{projected_state::path, TransitionFailure, TransitionPlan};
 use crate::{
-    verify_plan, AlarmSet, BranchId, CheckpointSet, EngineConfig, FinalityEpoch,
-    HeaderChainDiskVersion, HeaderContextFact, HeaderGeneration, PreparedHeader,
-    PreparedHeaderBatch, SourceId, TargetCompletion, TrustedAnchor, ValidationLease,
-    VerifiedGeneration,
+    verify_plan, AlarmSet, BodyEvidence, BodyValidationState, BranchId, CheckpointSet,
+    DurableTransitionFacts, EligibilityReason, EngineConfig, EngineMetadata, EngineMode,
+    EngineSnapshot, EvidenceId, FinalityEpoch, FinalityRecord, FinalitySource, Frontier,
+    FrontierSet, GraphError, HeaderChainDiskVersion, HeaderContextFact, HeaderGeneration,
+    HeaderValidationState, MemHeaderStore, PreparedHeader, PreparedHeaderBatch, ProjectionDelta,
+    SourceId, StateVersion, TargetCompletion, TransitionCause, TransitionContext, TransitionEvent,
+    TransitionRequest, TrustedAnchor, ValidationLease, VerifiedGeneration,
 };
 
 #[derive(Clone)]

--- a/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
@@ -296,7 +296,7 @@ fn apply_transition(
         _ => DurableTransitionFacts::None,
     };
     let plan = engine
-        .apply(request, context, durable)
+        .plan_transition(request, context, durable)
         .map(crate::EngineTransition::into_plan)?;
     if let Err(error) = crate::verify_plan_production(&engine, &plan) {
         panic!(

--- a/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
@@ -274,6 +274,74 @@ fn replay_identity_is_domain_payload_and_authority_bound() {
 }
 
 #[test]
+fn replay_protection_covers_only_the_adjacent_state_changing_transition() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.graph.finalized_frontier();
+    let difficulty = store
+        .graph
+        .header_node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let tip = insert_verified_branch(&mut store.graph, anchor, 1, difficulty, 0x80);
+    synchronize_fixture(&mut store, tip);
+    let target = tip.hash;
+    let id = crate::OperatorInvalidationId::new([0x81; 16]);
+    let invalidate = operator_invalidate(&store, target, id, 0x82);
+    let committed = apply_transition(
+        &store,
+        invalidate.clone(),
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("the original authenticated action commits");
+    store.commit(&committed);
+
+    let adjacent = apply_transition(
+        &store,
+        invalidate.clone(),
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("an exact adjacent replay is short-circuited");
+    assert!(adjacent.is_no_change());
+
+    let reconsider = operator_reconsider(&store, target, id, 0x83);
+    let intervening = apply_transition(
+        &store,
+        reconsider,
+        &context(&config, &clock, Some(&Authority)),
+    )
+    .expect("an intervening state-changing transition commits");
+    store.commit(&intervening);
+    assert_eq!(
+        store
+            .metadata
+            .last_transition
+            .expect("the intervening transition is replay protected")
+            .evidence(),
+        EvidenceId::from_digest([0x83; 32]),
+    );
+
+    let mut older = invalidate;
+    older.expected_version = store.metadata.state_version;
+    let replayed = apply_transition(&store, older, &context(&config, &clock, Some(&Authority)))
+        .expect("an older event replans after an intervening transition");
+    assert!(
+        !replayed.is_no_change(),
+        "one-slot replay protection does not short-circuit older events"
+    );
+    store.commit(&replayed);
+    assert_eq!(
+        store
+            .metadata
+            .last_transition
+            .expect("the replanned older event becomes the adjacent slot")
+            .evidence(),
+        EvidenceId::from_digest([0x82; 32]),
+    );
+}
+
+#[test]
 fn full_state_authority_is_bound_to_the_complete_event_payload() {
     struct ExactAuthority(crate::TransitionFingerprint);
 

--- a/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
@@ -1,3 +1,4 @@
+use super::super::projected_state::path;
 use super::*;
 
 #[test]

--- a/crates/zakura-header-chain/src/transition/planner/tests/predecessor_context.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/predecessor_context.rs
@@ -1,0 +1,262 @@
+//! Retained and durable predecessor-context reconstruction characterization.
+
+use super::super::event_effects::header_validation::retained_header_context;
+use super::*;
+use crate::{DurableTransitionFacts, FullStateEvidenceAuthority, StoreError};
+
+struct NoLeaseAuthority;
+impl FullStateEvidenceAuthority for NoLeaseAuthority {
+    fn authorizes_full_state(&self, _event: &TransitionEvent) -> bool {
+        true
+    }
+
+    fn authorizes_validation_lease(&self, _lease: &crate::ValidationLease) -> bool {
+        false
+    }
+}
+
+fn build_chain(count: u32) -> (TestStore, EngineConfig, Vec<Frontier>) {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let tip = insert_verified_branch(
+        &mut store.graph,
+        store.metadata.frontiers.finalized,
+        count,
+        regtest_genesis_block().header.difficulty_threshold,
+        0x31,
+    );
+    synchronize_fixture(&mut store, tip);
+    let mut frontiers = path(&store.graph, tip).expect("the fixture path is retained");
+    assert_eq!(frontiers[0].height, block::Height(0));
+    assert_eq!(frontiers.last().copied(), Some(tip));
+    // Ensure indexing by height works even if path order changes.
+    frontiers.sort_by_key(|frontier| frontier.height);
+    (store, config, frontiers)
+}
+
+fn header_path(
+    store: &TestStore,
+    parent: Frontier,
+) -> Vec<(Frontier, Arc<zakura_chain::block::Header>)> {
+    let mut facts = Vec::new();
+    let mut current = parent;
+    loop {
+        let node = store
+            .graph
+            .header_node(current.hash)
+            .expect("requested path is retained in the fixture");
+        facts.push((current, node.header.clone()));
+        if current.height == block::Height(0) {
+            break;
+        }
+        current = Frontier::new(
+            current
+                .height
+                .previous()
+                .expect("non-zero fixture heights have parents"),
+            node.parent_hash,
+        );
+    }
+    facts
+}
+
+fn lease_for_path(
+    store: &TestStore,
+    parent: Frontier,
+    path: &[(Frontier, Arc<zakura_chain::block::Header>)],
+) -> ValidationLease {
+    ValidationLease::new(
+        parent,
+        path.iter()
+            .map(|(frontier, header)| HeaderContextFact {
+                frontier: *frontier,
+                header: header.clone(),
+            })
+            .collect(),
+        store.lease.network().clone(),
+        store.lease.trust_anchor_digest(),
+    )
+}
+
+#[test]
+fn retained_header_context_uses_exact_span_and_newest_to_oldest_order() {
+    let (store, config, frontiers) = build_chain(35);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let ctx = context(&config, &clock, Some(&authority));
+
+    for &height in &[0_u32, 27, 28, 35] {
+        let parent = frontiers[height as usize];
+        let expected_len = usize::try_from(height)
+            .expect("fixture height fits")
+            .saturating_add(1)
+            .min(crate::POW_ADJUSTMENT_BLOCK_SPAN);
+        let reconstructed =
+            retained_header_context(&store.graph, parent, &DurableTransitionFacts::None, &ctx)
+                .expect("fully retained context succeeds without durable facts");
+        assert_eq!(reconstructed.len(), expected_len, "height {height}");
+
+        let expected: Vec<_> = header_path(&store, parent)
+            .iter()
+            .take(expected_len)
+            .map(|(_, header)| (header.difficulty_threshold, header.time))
+            .collect();
+        assert_eq!(
+            reconstructed, expected,
+            "height {height} newest-to-oldest order"
+        );
+    }
+}
+
+#[test]
+fn retained_header_context_splices_authorized_leases_and_rejects_bad_facts() {
+    let (mut store, config, frontiers) = build_chain(35);
+    let clock = ManualClock(Utc::now());
+    let authority = Authority;
+    let ctx = context(&config, &clock, Some(&authority));
+
+    let parent = frontiers[30];
+    let full_path = header_path(&store, parent);
+    let lease_path: Vec<_> = full_path
+        .iter()
+        .take(crate::POW_ADJUSTMENT_BLOCK_SPAN)
+        .cloned()
+        .collect();
+    let matching_lease = lease_for_path(&store, parent, &lease_path);
+    let short_lease = lease_for_path(&store, parent, &lease_path[..3]);
+    let wrong_digest = ValidationLease::new(
+        parent,
+        lease_path
+            .iter()
+            .map(|(frontier, header)| HeaderContextFact {
+                frontier: *frontier,
+                header: header.clone(),
+            })
+            .collect(),
+        store.lease.network().clone(),
+        [0x55; 32],
+    );
+    let genesis_path = header_path(&store, frontiers[0]);
+    let genesis_lease = lease_for_path(&store, frontiers[0], &genesis_path);
+    let expected: Vec<_> = lease_path
+        .iter()
+        .map(|(_, header)| (header.difficulty_threshold, header.time))
+        .collect();
+
+    // Advance finality and drop the pruned prefix from the retained graph.
+    let new_finalized = frontiers[20];
+    store
+        .graph
+        .advance_finalized_frontier(new_finalized)
+        .expect("fixture finality advances along the retained path");
+    store.metadata.frontiers.finalized = new_finalized;
+    synchronize_fixture(&mut store, frontiers[35]);
+
+    let cases = [
+        (
+            "authorized coherent lease",
+            DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![matching_lease.clone()],
+                finality_path: Vec::new(),
+            },
+            Ok(expected.clone()),
+        ),
+        (
+            "unrelated lease then matching lease",
+            DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![genesis_lease, matching_lease.clone()],
+                finality_path: Vec::new(),
+            },
+            Ok(expected.clone()),
+        ),
+        (
+            "missing durable facts",
+            DurableTransitionFacts::None,
+            Err(TransitionFailure::Store(StoreError::Unavailable(
+                "retained predecessor context is incomplete",
+            ))),
+        ),
+        (
+            "no matching lease",
+            DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![lease_for_path(
+                    &store,
+                    frontiers[20],
+                    &[(
+                        frontiers[20],
+                        store
+                            .graph
+                            .header_node(frontiers[20].hash)
+                            .expect("new finalized remains")
+                            .header
+                            .clone(),
+                    )],
+                )],
+                finality_path: Vec::new(),
+            },
+            Err(TransitionFailure::Store(StoreError::Unavailable(
+                "durable predecessor context is incoherent",
+            ))),
+        ),
+        (
+            "wrong trust digest",
+            DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![wrong_digest],
+                finality_path: Vec::new(),
+            },
+            Err(TransitionFailure::Store(StoreError::Unavailable(
+                "durable predecessor context is incoherent",
+            ))),
+        ),
+        (
+            "insufficient lease span",
+            DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![short_lease],
+                finality_path: Vec::new(),
+            },
+            Err(TransitionFailure::Store(StoreError::Unavailable(
+                "durable predecessor context is incoherent",
+            ))),
+        ),
+        (
+            "empty header-insertion leases",
+            DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: Vec::new(),
+                finality_path: Vec::new(),
+            },
+            Err(TransitionFailure::Store(StoreError::Unavailable(
+                "durable predecessor context is incoherent",
+            ))),
+        ),
+    ];
+
+    for (label, durable, expected_result) in cases {
+        assert_eq!(
+            retained_header_context(&store.graph, parent, &durable, &ctx),
+            expected_result,
+            "{label}"
+        );
+    }
+
+    let no_lease = NoLeaseAuthority;
+    let unauthorized_ctx = TransitionContext {
+        config: &config,
+        clock: &clock,
+        full_state_authority: Some(&no_lease),
+        retention_references: &[],
+    };
+    assert_eq!(
+        retained_header_context(
+            &store.graph,
+            parent,
+            &DurableTransitionFacts::HeaderInsertion {
+                validation_contexts: vec![matching_lease],
+                finality_path: Vec::new(),
+            },
+            &unauthorized_ctx,
+        ),
+        Err(TransitionFailure::Store(StoreError::Unavailable(
+            "durable predecessor context is incoherent",
+        ))),
+        "coherent lease without lease authority is incoherent"
+    );
+}

--- a/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
@@ -21,17 +21,17 @@ fn committed_transition_reports_a_stale_source_without_panicking() {
     };
     let mut engine = test_engine(&store);
     let first = engine
-        .apply(request.clone(), &context(&config, &clock, None), durable())
+        .plan_transition(request.clone(), &context(&config, &clock, None), durable())
         .expect("the first transition plans from the source snapshot");
     let stale = engine
-        .apply(request, &context(&config, &clock, None), durable())
+        .plan_transition(request, &context(&config, &clock, None), durable())
         .expect("the second transition plans from the same source snapshot");
 
     engine
-        .apply_committed(first)
+        .install_committed_transition(first)
         .expect("the first transition still has its exact source");
     assert_eq!(
-        engine.apply_committed(stale),
+        engine.install_committed_transition(stale),
         Err(crate::CommittedTransitionError::StaleSource)
     );
 }
@@ -216,7 +216,7 @@ fn committed_transition_applies_to_a_cloned_source_engine() {
     let request = insertion(&store, 3, EvidenceId::from_digest([0x92; 32]));
     let before = engine.snapshot();
     let transition = engine
-        .apply(
+        .plan_transition(
             request,
             &context(&config, &clock, None),
             crate::DurableTransitionFacts::HeaderInsertion {
@@ -227,10 +227,20 @@ fn committed_transition_applies_to_a_cloned_source_engine() {
         .expect("the stateful engine plans the insertion");
 
     assert_eq!(transition.before(), &before);
-    let expected = transition.change_set().metadata.snapshot();
+    assert_ne!(
+        transition.after().state_version,
+        before.state_version,
+        "a state-changing insertion advances the durable version"
+    );
+    assert_eq!(
+        engine.snapshot(),
+        before,
+        "planning must leave the source engine unchanged"
+    );
+    let expected = transition.after();
     let mut projected = engine.clone();
     projected
-        .apply_committed(transition)
+        .install_committed_transition(transition)
         .expect("the transition still has its exact source");
     assert_eq!(projected.snapshot(), expected);
     assert_eq!(

--- a/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
@@ -1,3 +1,4 @@
+use super::super::projected_state::trim_projection;
 use super::*;
 
 #[test]

--- a/crates/zakura-header-chain/src/transition/planner/write_set.rs
+++ b/crates/zakura-header-chain/src/transition/planner/write_set.rs
@@ -1,0 +1,272 @@
+//! Generation policy and durable write-set derivation.
+
+use std::{borrow::Cow, sync::Arc};
+
+use crate::graph::{GraphDelta, HeaderGraphView};
+use crate::retention::RetentionPlan;
+use crate::{
+    BodyValidationState, ChangeSet, EligibilityDelta, EngineLimits, EngineMetadata, EngineSnapshot,
+    Frontier, FrontierSet, GraphError, HeaderChainEngine, IndexChanges, MemHeaderStore,
+    ProjectionDelta, TransitionCause, TransitionContext, TransitionEvent, TransitionFingerprint,
+};
+
+use super::admission::validate_authority;
+use super::projected_state::SettledProjectedState;
+use super::{PlanCandidate, TransitionFailure};
+
+/// Inputs required to derive the atomic write set from settled projections.
+pub(super) struct DerivePlanInputs<'a> {
+    pub(super) before: EngineSnapshot,
+    pub(super) metadata: EngineMetadata,
+    pub(super) base_graph: &'a MemHeaderStore,
+    pub(super) projected: SettledProjectedState<'a>,
+    pub(super) old_selected: &'a [Frontier],
+    pub(super) old_verified: &'a [Frontier],
+    pub(super) selected: Cow<'a, [Frontier]>,
+    pub(super) finality_append: Option<crate::FinalityRecord>,
+    pub(super) retention: RetentionPlan,
+    pub(super) fingerprint: Option<TransitionFingerprint>,
+    pub(super) cause: TransitionCause,
+    pub(super) trust_pins: Arc<[Frontier]>,
+    pub(super) limits: EngineLimits,
+}
+
+/// Derive the atomic change set and private graph delta.
+pub(super) fn derive_plan(
+    inputs: DerivePlanInputs<'_>,
+) -> Result<PlanCandidate, TransitionFailure> {
+    let DerivePlanInputs {
+        before,
+        mut metadata,
+        base_graph,
+        projected,
+        old_selected,
+        old_verified,
+        selected,
+        finality_append,
+        retention,
+        fingerprint,
+        cause,
+        trust_pins,
+        limits,
+    } = inputs;
+    let (graph, graph_delta, verified, aux_changes) = projected.into_write_parts();
+    let put_nodes = graph_delta.updated_header_nodes().to_vec();
+    let delete_nodes = graph_delta.deleted_header_hashes().to_vec();
+    let put_consensus_invalid_body_tombstones =
+        graph_delta.new_consensus_invalid_body_tombstones().to_vec();
+    let mut eligibility_changes: Vec<_> = put_nodes
+        .iter()
+        .filter_map(|node| {
+            let old = base_graph.header_node(node.hash)?;
+            (old.eligibility != node.eligibility).then(|| EligibilityDelta {
+                hash: node.hash,
+                before: old.eligibility.clone(),
+                after: node.eligibility.clone(),
+            })
+        })
+        .collect();
+    eligibility_changes.sort_unstable_by_key(|delta| delta.hash.0);
+    let selected_changed = selected.as_ref() != old_selected;
+    let verified_changed = verified.as_ref() != old_verified;
+    let header_topology_changed = !delete_nodes.is_empty()
+        || put_nodes
+            .iter()
+            .any(|node| base_graph.header_node(node.hash).is_none());
+    let header_validation_changed = put_nodes.iter().any(|node| {
+        base_graph
+            .header_node(node.hash)
+            .is_some_and(|old| old.validation != node.validation)
+    });
+    let header_eligibility_changed = put_nodes.iter().any(|node| {
+        base_graph
+            .header_node(node.hash)
+            .is_some_and(|old| old.is_eligible() != node.is_eligible())
+    });
+    let header_best = *selected.last().ok_or(TransitionFailure::InvalidEvidence(
+        "selected projection is empty",
+    ))?;
+    metadata.alarms.resource_stalled = retention.resource_stalled;
+    let header_best_node = graph
+        .view_header_node(header_best.hash)
+        .ok_or(GraphError::UnknownHeaderNode(header_best.hash))?;
+    metadata.alarms.header_best_body_unavailable = match &header_best_node.body_validation_state {
+        BodyValidationState::Unavailable(summary) if summary.alarmed => Some(*summary),
+        _ => None,
+    };
+    let alarm_changed = metadata.alarms != before.alarms;
+    let changed = !put_nodes.is_empty()
+        || !delete_nodes.is_empty()
+        || !aux_changes.is_empty()
+        || finality_append.is_some()
+        || selected_changed
+        || verified_changed
+        || alarm_changed;
+    if changed {
+        metadata.state_version = metadata.state_version.checked_next()?;
+        if selected_changed
+            || header_topology_changed
+            || header_validation_changed
+            || header_eligibility_changed
+            || !eligibility_changes.is_empty()
+            || finality_append.is_some()
+        {
+            metadata.header_generation = metadata.header_generation.checked_next()?;
+        }
+        if verified_changed || finality_append.is_some() {
+            metadata.verified_generation = metadata.verified_generation.checked_next()?;
+        }
+        if let Some(record) = finality_append {
+            metadata.finality_epoch = record.epoch;
+        }
+        if let Some(fingerprint) = fingerprint {
+            metadata.last_transition = Some(fingerprint);
+        }
+    }
+    let verified_best = *verified.last().ok_or(TransitionFailure::InvalidEvidence(
+        "verified projection is empty",
+    ))?;
+    metadata.frontiers = FrontierSet {
+        finalized: graph.view_finalized_frontier(),
+        header_best,
+        verified_best,
+    };
+    metadata.header_best_score = graph.view_header_chain_score(header_best.hash)?;
+    metadata.oldest_retained_height = if delete_nodes.is_empty() {
+        put_nodes
+            .iter()
+            .map(|node| node.height)
+            .min()
+            .map_or(before.oldest_retained_height, |height| {
+                height.min(before.oldest_retained_height)
+            })
+    } else {
+        graph
+            .view_header_nodes()
+            .into_iter()
+            .map(|node| node.height)
+            .min()
+            .unwrap_or(graph.view_finalized_frontier().height)
+    };
+    let inserted = put_nodes
+        .iter()
+        .filter(|node| base_graph.header_node(node.hash).is_none())
+        .map(|node| Frontier::new(node.height, node.hash))
+        .collect();
+    let change_set = ChangeSet {
+        put_nodes,
+        delete_nodes: delete_nodes.clone(),
+        put_consensus_invalid_body_tombstones,
+        index_changes: IndexChanges {
+            inserted,
+            deleted: delete_nodes,
+        },
+        selected_projection: projection_delta(old_selected, &selected),
+        verified_projection: projection_delta(old_verified, &verified),
+        eligibility_changes,
+        aux_changes,
+        finality_append,
+        metadata,
+    };
+    Ok(PlanCandidate {
+        before,
+        change_set,
+        graph_delta,
+        cause,
+        trust_pins,
+        limits,
+    })
+}
+
+/// Construct a zero-effect plan after re-checking authority.
+pub(super) fn no_change(
+    engine: &HeaderChainEngine,
+    before: EngineSnapshot,
+    metadata: EngineMetadata,
+    event: TransitionEvent,
+    context: &TransitionContext<'_>,
+    cause: TransitionCause,
+) -> Result<PlanCandidate, TransitionFailure> {
+    validate_authority(&event, context)?;
+    Ok(PlanCandidate {
+        before,
+        change_set: ChangeSet {
+            put_nodes: Vec::new(),
+            delete_nodes: Vec::new(),
+            put_consensus_invalid_body_tombstones: Vec::new(),
+            index_changes: IndexChanges::default(),
+            selected_projection: ProjectionDelta::default(),
+            verified_projection: ProjectionDelta::default(),
+            eligibility_changes: Vec::new(),
+            aux_changes: Vec::new(),
+            finality_append: None,
+            metadata,
+        },
+        graph_delta: GraphDelta::empty(engine.graph()),
+        cause,
+        trust_pins: invariant_pins(context),
+        limits: context.config.limits,
+    })
+}
+
+/// Construct an alarm-only resource-stall plan that discards staged event effects.
+pub(super) fn resource_stalled(
+    engine: &HeaderChainEngine,
+    before: EngineSnapshot,
+    context: &TransitionContext<'_>,
+) -> Result<PlanCandidate, TransitionFailure> {
+    let mut metadata = engine.metadata().clone();
+    if !metadata.alarms.resource_stalled {
+        metadata.alarms.resource_stalled = true;
+        metadata.state_version = metadata.state_version.checked_next()?;
+    }
+    Ok(PlanCandidate {
+        before,
+        change_set: ChangeSet {
+            put_nodes: Vec::new(),
+            delete_nodes: Vec::new(),
+            put_consensus_invalid_body_tombstones: Vec::new(),
+            index_changes: IndexChanges::default(),
+            selected_projection: ProjectionDelta::default(),
+            verified_projection: ProjectionDelta::default(),
+            eligibility_changes: Vec::new(),
+            aux_changes: Vec::new(),
+            finality_append: None,
+            metadata,
+        },
+        graph_delta: GraphDelta::empty(engine.graph()),
+        cause: TransitionCause::ResourceStalled,
+        trust_pins: invariant_pins(context),
+        limits: context.config.limits,
+    })
+}
+
+pub(super) fn invariant_pins(context: &TransitionContext<'_>) -> Arc<[Frontier]> {
+    context.config.trust_pins()
+}
+
+/// Compute a projection delta between consecutive retained frontiers.
+pub(super) fn projection_delta(old: &[Frontier], new: &[Frontier]) -> ProjectionDelta {
+    let remove_before = new.first().and_then(|first| {
+        old.first()
+            .is_some_and(|old_first| old_first.height < first.height)
+            .then_some(first.height)
+    });
+    let old_start = remove_before
+        .map(|height| old.partition_point(|frontier| frontier.height < height))
+        .unwrap_or(0);
+    let comparable_old = &old[old_start..];
+    let common = comparable_old
+        .iter()
+        .zip(new)
+        .take_while(|(left, right)| left == right)
+        .count();
+    ProjectionDelta {
+        remove_before,
+        remove_from: comparable_old
+            .get(common)
+            .or_else(|| new.get(common))
+            .map(|frontier| frontier.height),
+        put: new[common..].to_vec(),
+    }
+}

--- a/crates/zakura-header-chain/src/transition/types.rs
+++ b/crates/zakura-header-chain/src/transition/types.rs
@@ -1510,13 +1510,18 @@ pub struct RetiredWork {
     pub owners: Vec<HeaderSyncWorkOwner>,
 }
 
-/// Successful idempotent replay with no durable effects.
+/// Successful admission that produced no durable effects.
+///
+/// This covers exact adjacent replay of the most recent state-changing
+/// transition, already-applied rebased header work, immediately evicted
+/// insertions, and other zero-effect admissions. It is not a general
+/// historical replay ledger.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct NoChangeReceipt {
     /// Unchanged durable version.
     pub state_version: StateVersion,
-    /// Previously committed event identity, if this event carries one.
-    pub event: Option<EvidenceId>,
+    /// Submitted event identity when the event carries an idempotency key.
+    pub idempotency_key: Option<EvidenceId>,
 }
 
 /// Stale version/branch/owner result with guaranteed zero effects.
@@ -1544,7 +1549,7 @@ pub struct CommittedStallReceipt {
 pub enum ApplyResult {
     /// State adapter durably committed.
     Committed,
-    /// Idempotent evidence made no change.
+    /// Admission produced no durable effects.
     NoChange(NoChangeReceipt),
     /// Ownership/version was stale before effects.
     Stale(StaleReceipt),

--- a/crates/zakura-header-chain/tests/production_transition.rs
+++ b/crates/zakura-header-chain/tests/production_transition.rs
@@ -172,7 +172,7 @@ fn production_incremental_verifier_accepts_exact_auxiliary_evidence() {
         })),
     };
     let transition = engine
-        .apply(
+        .plan_transition(
             insertion,
             &context,
             DurableTransitionFacts::HeaderInsertion {
@@ -182,7 +182,7 @@ fn production_incremental_verifier_accepts_exact_auxiliary_evidence() {
         )
         .expect("the fixture insertion verifies");
     engine
-        .apply_committed(transition)
+        .install_committed_transition(transition)
         .expect("the fixture insertion commits");
 
     let authentication = AuxAuthentication::Authenticated {
@@ -203,19 +203,19 @@ fn production_incremental_verifier_accepts_exact_auxiliary_evidence() {
     let mut altered = delivery;
     altered.source = SourceId::from_digest([7; 32]);
     assert!(matches!(
-        engine.apply(request(altered), &context, DurableTransitionFacts::None),
+        engine.plan_transition(request(altered), &context, DurableTransitionFacts::None),
         Err(TransitionFailure::InvalidEvidence(
             "auxiliary evidence changes delivery provenance"
         ))
     ));
 
     let transition = engine
-        .apply(request(delivery), &context, DurableTransitionFacts::None)
+        .plan_transition(request(delivery), &context, DurableTransitionFacts::None)
         .expect("the production incremental verifier accepts exact evidence");
     assert_eq!(transition.cause(), TransitionCause::AuxAuthentication);
     let mut projected = engine.clone();
     projected
-        .apply_committed(transition)
+        .install_committed_transition(transition)
         .expect("the verified transition applies to a cloned source engine");
     assert_eq!(
         projected.aux_deliveries(header_hash)[0].authentication,

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -2237,7 +2237,7 @@ impl HeaderChainRuntime {
             fault(FaultPoint::AfterMemorySwap)?;
             return Ok(ApplyResult::NoChange(NoChangeReceipt {
                 state_version: transition.before().state_version,
-                event,
+                idempotency_key: event,
             }));
         }
 
@@ -2522,7 +2522,9 @@ impl HeaderChainStore {
         let max_nodes = config.limits.max_non_finalized_nodes.get();
         if finalized_path.len().saturating_add(restored_path.len()) > max_nodes {
             if restored_path.len() > max_nodes {
-                return Err(TransitionFailure::ResourceStalled.into());
+                return Err(HeaderChainStoreError::Incoherent(
+                    "restored verified path exceeds the non-finalized node limit",
+                ));
             }
             for chunk in finalized_path.chunks(max_nodes) {
                 let chunk = chunk.to_vec();

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -1877,8 +1877,11 @@ impl HeaderChainRuntime {
             retention_references: lease_references.as_ref(),
         };
 
-        let first =
-            transition_engine.apply(first_request, &first_context, DurableTransitionFacts::None)?;
+        let first = transition_engine.plan_transition(
+            first_request,
+            &first_context,
+            DurableTransitionFacts::None,
+        )?;
         if first.cause() == TransitionCause::ResourceStalled {
             return Err(HeaderChainStoreError::Incoherent(
                 "checkpoint auxiliary authentication exhausted header resources",
@@ -1891,7 +1894,7 @@ impl HeaderChainRuntime {
         // The publisher continues to expose the durable snapshot.
         // The writer can stage the first transition without exposing it.
         // The runtime reloads the unchanged durable engine after an error before the atomic write.
-        if let Err(error) = transition_engine.apply_committed(first) {
+        if let Err(error) = transition_engine.install_committed_transition(first) {
             let error = restore_transition_engine_after_staging_error(
                 &self.store,
                 &mut transition_engine,
@@ -1901,7 +1904,7 @@ impl HeaderChainRuntime {
         }
 
         checkpoint_request.expected_version = transition_engine.snapshot().state_version;
-        let checkpoint = match transition_engine.apply(
+        let checkpoint = match transition_engine.plan_transition(
             checkpoint_request,
             &checkpoint_context,
             DurableTransitionFacts::HeaderInsertion {
@@ -1930,7 +1933,7 @@ impl HeaderChainRuntime {
             return Err(error);
         }
 
-        let current = checkpoint.change_set().metadata.snapshot();
+        let current = checkpoint.after();
         let batch = match self
             .store
             .batch_for_combined(checkpoint.change_set(), batch)
@@ -1953,7 +1956,7 @@ impl HeaderChainRuntime {
             );
             return Err(error);
         }
-        if let Err(error) = transition_engine.apply_committed(checkpoint) {
+        if let Err(error) = transition_engine.install_committed_transition(checkpoint) {
             let error = restore_transition_engine_after_staging_error(
                 &self.store,
                 &mut transition_engine,
@@ -2128,16 +2131,17 @@ impl HeaderChainRuntime {
             full_state_authority: Some(&state_authority),
             retention_references: base_context.retention_references,
         };
-        let transition = match transition_engine.apply(request, &transition_context, durable) {
-            Ok(plan) => plan,
-            Err(TransitionFailure::Stale { current }) => {
-                return Ok(ApplyResult::Stale(StaleReceipt {
-                    current_version: current,
-                    branch,
-                }));
-            }
-            Err(error) => return Err(error.into()),
-        };
+        let transition =
+            match transition_engine.plan_transition(request, &transition_context, durable) {
+                Ok(plan) => plan,
+                Err(TransitionFailure::Stale { current }) => {
+                    return Ok(ApplyResult::Stale(StaleReceipt {
+                        current_version: current,
+                        branch,
+                    }));
+                }
+                Err(error) => return Err(error.into()),
+            };
         let transition_cause = transition.cause();
         let resource_stalled = transition_cause == TransitionCause::ResourceStalled;
         let stall_receipt = resource_stalled.then(|| CommittedStallReceipt {
@@ -2174,12 +2178,12 @@ impl HeaderChainRuntime {
             if transition.is_no_change() {
                 return Ok(ApplyResult::ResourceStalled(receipt));
             }
-            let current = transition.change_set().metadata.snapshot();
+            let current = transition.after();
             let batch = self.store.batch_for(transition.change_set())?;
             #[cfg(test)]
             fault(FaultPoint::BeforeCommit)?;
             self.store.db.write(batch)?;
-            transition_engine.apply_committed(transition)?;
+            transition_engine.install_committed_transition(transition)?;
             #[cfg(test)]
             fault(FaultPoint::AfterCommit)?;
             self.publisher.publish(current);
@@ -2241,7 +2245,7 @@ impl HeaderChainRuntime {
             }));
         }
 
-        let current = transition.change_set().metadata.snapshot();
+        let current = transition.after();
         let migrated_pin_refuted = transition.change_set().metadata.alarms.migrated_pin_refuted;
         let batch = self
             .store
@@ -2249,7 +2253,7 @@ impl HeaderChainRuntime {
         #[cfg(test)]
         fault(FaultPoint::BeforeCommit)?;
         self.store.db.write(batch)?;
-        transition_engine.apply_committed(transition)?;
+        transition_engine.install_committed_transition(transition)?;
         #[cfg(test)]
         fault(FaultPoint::AfterCommit)?;
         if let Some(pin) = migrated_pin_refuted {
@@ -2845,7 +2849,7 @@ impl HeaderChainStore {
             retention_references: &[],
         };
         let engine = load_transition_engine(self)?;
-        let transition = engine.apply(
+        let transition = engine.plan_transition(
             TransitionRequest {
                 expected_version: snapshot.state_version,
                 event,
@@ -2923,7 +2927,7 @@ impl HeaderChainStore {
             retention_references: &[],
         };
         let engine = load_transition_engine(self)?;
-        let transition = engine.apply(
+        let transition = engine.plan_transition(
             TransitionRequest {
                 expected_version: snapshot.state_version,
                 event,

--- a/docs/changelog/unreleased/625.md
+++ b/docs/changelog/unreleased/625.md
@@ -1,4 +1,0 @@
-<!-- changelog: none -->
-
-This PR only hardens header-chain planner/graph test coverage and internal
-engine invariants. It has no operator-visible zakurad effect.

--- a/docs/changelog/unreleased/625.md
+++ b/docs/changelog/unreleased/625.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only hardens header-chain planner/graph test coverage and internal
+engine invariants. It has no operator-visible zakurad effect.

--- a/docs/changelog/unreleased/630.md
+++ b/docs/changelog/unreleased/630.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR refactors internal header-chain transition planning without changing operator-visible behavior.

--- a/docs/specs/fork-aware-header-chain-engine.md
+++ b/docs/specs/fork-aware-header-chain-engine.md
@@ -296,7 +296,18 @@ Eligibility reasons are a set, not a single overwritable flag. Permanent reasons
 
 ### 4.1 One transition interface
 
-All calls below submit evidence to one serialized durable transition. The transition reads an expected `state_version`; commit uses compare-and-swap semantics and retries from the new durable state on conflict. It computes both frontiers independently, commits all changes, and then emits one ordered observation containing the committed version and generations.
+All calls below submit evidence to one serialized durable transition. The planner computes both frontiers independently. The runtime commits all changes and then emits one ordered observation containing the committed version and generations.
+
+Freshness uses two complementary models:
+
+- Ordinary caller-serialized events carry an expected `state_version` and use compare-and-swap semantics. On conflict the caller MUST reload and retry from the new durable state.
+- Owner-qualified asynchronous completions—header-range insertion and auxiliary evidence that carry a header-sync or body work owner—MUST derive freshness from that owner's generation, branch anchor, and identity. Their supplied `state_version` MUST NOT authorize the work.
+
+Durable facts supplied with a transition MUST come from the same serialized durable snapshot the planner reads. Validation leases MUST be coherent and explicitly authorized. A finality rebase path MUST be proven by walking durable finality history for that snapshot; the planner MAY check only structural linkage and that the path ends at the current finalized frontier.
+
+Replay short-circuit and conflicting-payload detection compare only against the identity of the most recent state-changing transition. An exact adjacent replay MUST be recognized before ordinary version rejection. Older exact replays are not required to short-circuit; graph-level event idempotence MUST still keep them safe.
+
+Protected-path retention pressure that cannot admit work without evicting `header_best` or `verified_best` MUST raise the durable resource-stalled alarm and return a committed stall receipt. Exceeding auxiliary-delivery bounds MUST refuse the event with zero durable effects and MUST NOT raise that alarm.
 
 **LC-INT-01 [ZW] — Unified transition events.** The following events MUST use that transition interface: header-range insertion, full-block grow, full-block reset at any height, deterministic body-invalid feedback, operator invalidate, operator reconsider, finalization, configured-checkpoint advancement, VCT metadata repair, and restart reconstruction.
 
@@ -305,6 +316,14 @@ All calls below submit evidence to one serialized durable transition. The transi
 **LC-INT-03 [ZW] — Full-block integration.** A full-block commit MUST ensure its exact header node exists in the DAG with correct parent linkage, update body-validation state, update `verified_best` from full state, apply any body-derived eligibility evidence, and then independently reevaluate `header_best`.
 
 **LC-INT-04 [ZW] — Atomic invalidate and reconsider.** Invalidate or reconsider MUST complete its durable eligibility and both-frontier transition before returning externally complete or publishing watches. If full state has no non-finalized chain, `verified_best` MUST become `finalized`; the header DAG remains independently selected subject to its eligibility set.
+
+**LC-INT-05 [LS] — Owner-qualified freshness.** Header-range insertion and auxiliary-evidence events that carry a typed work owner MUST admit or reject based on that owner's generation, branch identity, and ownership checks. They MUST NOT treat a mismatched `state_version` alone as authorization failure when the owner remains current.
+
+**LC-INT-06 [LS] — Adjacent replay scope.** Durable metadata MUST retain at most the fingerprint of the most recent state-changing transition for replay short-circuit and conflicting-payload detection. Exact adjacent replay MUST return no durable effects. An intervening state-changing transition MUST clear that adjacent protection for earlier events.
+
+**LC-INT-07 [LS] — Durable-fact provenance.** Validation leases supplied with a transition MUST be authorized against the current serialized snapshot. Finality rebase paths and migrated-pin facts MUST be read from durable history for that same snapshot; planner structural checks alone MUST NOT be treated as proof of provenance.
+
+**LC-INT-08 [LS] — Distinct admission-pressure outcomes.** Retention pressure that would require evicting a protected path MUST commit or retain the resource-stalled alarm and return a committed stall receipt without applying the refused event. Auxiliary-delivery limit overflow MUST fail closed with zero durable effects and MUST NOT set that alarm.
 
 ### 4.2 Body evidence
 
@@ -664,7 +683,7 @@ Every normative rule is mapped here. A range such as `LC-SCOPE-01..03` includes 
 | LC-SELECT-01..04 | DG-01, HV-07, DF-01, AUD-01..03 |
 | LC-REORG-01, LC-FINAL-01..04 | DG-05, DG-07, AUD-13 |
 | LC-RETAIN-01..04 | DG-06, PW-05 |
-| LC-INT-01..04 | IN-01, IN-04, IN-06, AUD-04, AUD-10..15 |
+| LC-INT-01..08 | IN-01, IN-04, IN-06, AUD-04, AUD-10..15 |
 | LC-BODY-01..04 | IN-02, DF-02 |
 | LC-OP-01..02 | IN-04, AUD-10..12 |
 | LC-AVAIL-01..03 | IN-03 |


### PR DESCRIPTION
## Motivation

The transition planner combined admission, replay binding, domain evidence, finality, retention, write derivation, and invariant verification in one large function and event match. That made ordering-sensitive behavior and coupled projected state difficult to review safely.

## Solution

- express transition planning as six named phases with one verified-plan boundary
- encapsulate projected graph, verified-path, and auxiliary mutations in typed state
- dispatch event evidence to discoverable domain handlers
- add table-driven coverage for configuration coherence, finality rebase histories, and predecessor-context reconstruction
- make Lychee installation retry transient release-download failures and verify the pinned archive checksum

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p zakura-header-chain --all-targets -- -D warnings`
- [x] `cargo clippy -p zakura-header-chain --features fuzz-impl -- -D warnings`
- [x] `cargo test -p zakura-header-chain`
- [x] `./scripts/changelog.py check`
- [x] Docs Check workflow: link-check, spell-check, and markdown-lint

## Changelog

Internal-only refactor: `docs/changelog/unreleased/630.md` uses the explicit no-changelog marker.

### Specifications & References

- `docs/specs/fork-aware-header-chain-engine.md`