### PR TITLE
docs(header-chain): map the production code in the fork-aware change

### DIFF
--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -1,0 +1,572 @@
+# Production Code in the Fork-Aware Header-Chain Change
+
+Parent: `docs/specs/fork-aware-header-chain-engine.md` (rules cited as `LC-*`).
+Source: PR #586, branch `hc/01-engine-model`, merge base `ba9261a73`, measured at
+`664607d4f`.
+
+## The problem all of this answers
+
+Four independent sources want the tip to move. Peers deliver headers, full state
+verifies bodies, an operator invalidates a branch, and finality advances. If each source
+computes the move, the node runs as many fork-choice implementations as it has sources,
+and they disagree. Timing breaks it even when they agree: a source that computed its
+answer against an old view lands late and overwrites a newer one. That is the production
+incident this design replaced.
+
+The answer is one rule. A source states what it observed, and one planner turns that
+evidence into every consequence. The five layers below are that rule under five
+different constraints: keep the planner pure, keep the network crate unable to reach the
+database, make the durable order survive a crash, keep async work from outliving its
+authority, and keep two block-apply paths from running at once.
+
+## The abstractions to know first
+
+The file list below assumes this vocabulary.
+
+### The graph, the overlay, and the delta
+
+`MemHeaderStore` in `graph.rs` is the graph. It holds every retained header as a
+`HeaderNode` keyed by consensus hash, rooted at the finalized `Frontier`. A `Frontier`
+is a height and a hash together, and it is the only way this design names a position on
+a chain. A node carries the header, its parent hash, a height from a checked parent
+increment, the block work derived from the validated compact target, a
+`WorkCoordinate`, a header validation state, an eligibility state, a body validation
+state, and its auxiliary delivery ids. Beside the node map the graph keeps three
+indexes it can rebuild from the nodes alone: children by parent, hashes by height, and
+the set of eligible tips.
+
+Selection reads that graph. `select_best_header_chain` takes the maximum score over the
+eligible tips, so permuting arrivals cannot change the answer (LC-SELECT-04). A node is
+eligible when its header is valid, it carries no exclusion reason, and no ancestor is
+ineligible, which makes ineligibility a set of durable reasons rather than a flag. A
+flag is last-writer-wins, and last-writer-wins is arrival order in disguise.
+
+The engine holds the graph and two projections beside it. The selected projection lists
+the frontier of every prefix of the best header chain from finality to the tip, and the
+verified projection lists the same for the chain full state has verified. A projection
+is a list, so a reader answers a height query without walking the DAG.
+
+`GraphOverlay` in `graph/overlay.rs` is a mutable view over a borrowed graph. Reads see
+the base plus whatever the overlay staged, writes land in the overlay's own maps, and
+the base never changes. `GraphDelta` is what the overlay extracts: a new finalized
+frontier when finality moved, the nodes to put, and the nodes to delete. A node the
+overlay inserted and then deleted appears in neither list, and a node it wrote back
+unchanged appears in neither, so the delta holds the difference and nothing else.
+
+Both types implement `HeaderGraphView` and `HeaderGraphEdit`, so selection, eligibility
+propagation, and the invariant checks run one implementation against committed state
+and against a staged one. The planner therefore derives a complete transition without
+copying the graph and without touching the live one.
+
+`TransitionPlan` is what it derives: the change set the store will write, the private
+`GraphDelta` the engine will install, and `before()`, the snapshot it was derived from.
+
+### Work owners, generations, and branches
+
+The reactor issues requests asynchronously, so an answer can arrive after the question
+stopped meaning anything. A `BranchId` names the work an answer belongs to by the
+anchor it was rooted at and the tip it pursued. It carries no height, because a reset at
+the same height passes every height comparison. Three counters move underneath it.
+`state_version` increments on every committed transition that changed a durable fact.
+`header_generation` increments when selection, header topology, header validation,
+eligibility, or finality moved. `verified_generation` increments when the verified
+projection moved or finality advanced.
+
+`Gate` in `ownership.rs` judges a response against the current snapshot and returns a
+`CompletionDecision`: `Current`, or `Stale` carrying a typed `StaleReason` of
+`HeaderGeneration`, `VerifiedGeneration`, `BranchAnchor`, `MissingOwner`, or
+`OwnerMismatch`. It reads the generations and the branch anchor, and it ignores
+`state_version`, because that counter also moves for transitions on branches the request
+never went near, so binding header work to it would cancel in-flight requests faster
+than they complete for no correctness gain. The planner repeats the same check as
+`TransitionFailure::Stale`, and the scheduler keys its work by `(generation, branch)`.
+
+### Keeping three copies in agreement
+
+The same state exists three times: staged in an overlay, committed in the engine's
+graph, and durable in the store. Six rules keep them from diverging.
+
+The overlay never writes to its base, and `GraphDelta`'s fields are private to the
+crate, so no caller assembles a partial one.
+
+The delta rechecks itself against whichever graph it lands on. `derive_index_changes`
+recomputes each put node's hash, parent link, and work from the compact target, refuses
+a delete of a node the base does not hold, refuses a hash that is both put and deleted,
+and refuses a finalized frontier that is missing or ineligible. `apply_delta` runs that
+check before it mutates, and `validate_delta` runs it without mutating.
+
+`verify_plan` checks the plan against a graph rebuilt from the delta with
+`GraphOverlay::from_delta`, not against the overlay the planner mutated, so the verifier
+approves the transition the engine will install rather than the one it staged.
+
+`install_committed_transition` compares the live snapshot with the plan's `before()` and
+refuses with `StaleSource` when they differ. `plan_transition` takes `&self`, so two
+planners can run against one engine; only one of them can install.
+
+Disk leads memory leads observers, and that order is forced. The next restart reads
+disk, so a crash in this order leaves disk ahead of memory, which the startup audit
+repairs by rehydrating, and a crash in any other order leaves an observer holding a
+frontier that is not on disk, which nothing repairs. One transition makes one atomic
+`db.write`, so a crash leaves the whole batch or none of it. A failure between the write
+and the install fails closed: the runtime returns the store error, publishes nothing,
+and the next open rehydrates the engine from disk.
+
+The durable indexes are caches. The authoritative rows are the per-node rows in
+`header_node_by_hash` and the singleton in `header_engine_meta`. Children, heights,
+eligibility roots, deferrals, and both projections are rebuilt by the startup audit from
+the node rows, which is why a crash that leaves disk ahead of memory is repairable and
+the reverse order is not.
+
+### When the store is written
+
+Once per committed transition, inside the writer lock, and nowhere else in the steady
+state. There is no accumulation and no background flush: the runtime builds one
+`DiskWriteBatch` from the change set and calls `db.write` once (LC-TXN-01). What else
+lands in that one write depends on which call the state writer made.
+
+| Call | What lands in the one write |
+| --- | --- |
+| `apply` | the header-chain rows alone |
+| `apply_combined` | those rows appended to the block batch the state writer already filled |
+| `apply_aux_then_checkpoint_combined` | auxiliary authentication and the checkpoint advance that depends on it, planned into the same batch |
+| a no-change plan | the caller's batch alone, with nothing installed and nothing published |
+| a `ResourceStalled` plan | an alarm-only batch, discarding the caller's rows, so the state writer stops with its own rows unwritten |
+
+Two more writes happen outside that path. When the startup audit finds repairs, the
+runtime commits one repair batch before the engine exists. On first run against a store
+that predates the DAG, `migration.rs` builds the initial nodes and the migrated finality
+pin in its own write.
+
+One transition starts without any component observing anything. The write loop keeps a
+timer for `earliest_deferred()` and submits `ReevaluateDeferred` when it elapses, which
+is how a header held for a local future time becomes eligible. It flushes like every
+other transition.
+
+### What a header is checked against, and when
+
+Validation runs four times before disk, each pass against more context than the last,
+and no pass trusts the one before it.
+
+Off the writer lock, `prepare_header_target` in the driver reads a validation lease for
+the common ancestor through the read service, derives `HeaderRules` from that lease, and
+runs `prepare_context_free_headers` on a blocking thread. Those are the rules that read
+no ancestor: canonical version and hash, checked height inference, commitment structure
+for that height, compact-target domain and network limit, hash at or below target, and
+Equihash. A header whose time runs more than two hours ahead of the local clock comes
+back `DeferredUntil` rather than rejected (LC-VAL-08). The result is a
+`PreparedHeaderBatch` sealed with a receipt naming the parent frontier, the network, and
+the trust-anchor digest.
+
+Under the writer lock and before planning, the runtime reads the predecessor facts
+itself rather than accepting any the caller supplies. It seals the parent's validation
+context, the anchor's when finality moved, and the finality rebase path, then wraps the
+caller's authority in `StateIssuedAuthority` over exactly the leases it just issued, so
+a lease from anywhere else is refused.
+
+In the planner, against the graph, the receipt's parent, network, and trust-anchor
+digest must still match the live config, or the transition fails with
+`StalePreparation` (LC-VAL-11). The planner then re-derives, per header, the parent
+link, the hash, the height increment, and the work from the compact target, and runs
+`validate_contextual_difficulty_and_time` against ancestry it reads from the graph and
+the lease. A peer's framing height is never evidence.
+
+After planning and before disk, `verify_plan` re-derives the projected result: hashes
+and linkage, index round-trips, work coordinates, inherited eligibility, both
+projections' contiguity, that `header_best` really is the maximum eligible score, trust
+pins, protected nodes, frozen limits, generation increments, and auxiliary provenance.
+A disagreement between the planner and the verifier is `InvariantViolation`, and that
+batch never reaches disk.
+
+Startup adds a pass that answers to no caller: `audit_store` re-derives what the DAG
+determines before the engine exists.
+
+## How this list was cut
+
+The change touches 303 files, adding 88,706 lines and removing 46,587. Most of that is
+not the design. Tests and harnesses account for 26,382 added lines, fuzzing for 10,388,
+docs and manifests for 1,180, CI, docker, and policy for 1,150, and a lockfile and two
+data files for 34. What remains is 152 Rust files of production code, 49,572 lines added
+and 23,994 removed.
+
+Twelve of those files are deletions, listed at the end. Sixty-five of the surviving 140
+carry the design. The other 75 are integration: a call site moved, a type re-exported, a
+service registered. This document lists the 65 by layer, then names the integration
+edits and the code the change deletes.
+
+Exclusions applied, in order: `fuzz/`, every `fuzz.rs`, `/tests/` and `tests.rs`,
+`testkit/`, the `header_chain/coherence/` model harness, `bench.rs`, `arbitrary.rs`,
+`crates/xtask/`, `docs/`, `.github/`, `docker/`, `deploy/`, `qa/`, and lockfiles. Two
+excluded files still matter to a reader: `crates/zakura-header-chain/conformance.toml`
+(926 lines) is the machine-checked rule manifest, and
+`crates/xtask/src/header_conformance.rs` (1,285 lines) is the checker that enforces it.
+
+One caveat on every count below. Rust colocates unit tests, so a file's added-line
+figure includes its `#[cfg(test)]` module. In the new crate, 17,176 added lines are
+12,360 lines of code and 4,816 lines of colocated tests.
+
+## Five layers
+
+```mermaid
+flowchart TD
+  ZD["zakurad<br/>drivers, coordinator, lifecycle"]
+  NW["zakura-network<br/>header-sync reactor, wire, scheduler"]
+  ST["zakura-state<br/>runtime, store, schema"]
+  NS["zakura-node-services<br/>typed port traits"]
+  HC["zakura-header-chain<br/>pure, synchronous, decides which chain is best"]
+  ZD --> NW
+  ZD --> ST
+  NW --> NS
+  ST --> HC
+  NS --> HC
+```
+
+Thirteen commits landed the change. Four introduce the production code, and each of the
+first three is one layer. The fourth covers both the reactor and the drivers, because
+the port implementation and the facility that calls it have to arrive together. Five
+later commits revise that code after review, and the remaining four add tests, fuzzing,
+docs, and release plumbing.
+
+| Commit | Adds |
+| --- | --- |
+| `04ed5f077 feat(header-chain)!: add fork-aware graph model` | the pure crate |
+| `dd5b79dd1 refactor(node-services)!: add typed header-sync contracts` | the port |
+| `4fefdd266 feat(state)!: persist and recover fork-aware header chains` | runtime, store, schema |
+| `ebb60ab2d feat(network)!: add bounded fork-aware header sync` | reactor, wire, drivers |
+
+## Layer 1: `zakura-header-chain`, 34 files, +17,176
+
+A new crate, synchronous and pure. It holds every rule about which chain of headers is
+best and performs no effect: no disk, no socket, no clock of its own, no task. Purity is
+what makes fork choice testable without a node, replayable from an event list, and
+usable by a headers-only client that links no database.
+
+A crate stays pure only if its dependency list does, so the boundary sits where a test
+can fail the build. Two architecture tests in `lib.rs` hold it: one fails if the
+manifest gains `tokio`, `tower`, `zakura-state`, `zakura-network`, or
+`zakura-consensus`, and the other scans the crate's own sources for wallet, FlyClient,
+and block-sync surfaces (LC-SCOPE-06).
+
+### Vocabulary: nine files that refuse things
+
+These files name values, but each one exists to make a mistake unrepresentable rather
+than to hold data. A `WorkCoordinate` carries the origin hash it accumulated from, so
+two coordinates from different origins refuse to compare instead of returning a
+plausible number that would silently decide fork choice. Generation counters use
+`checked_next` and fail closed at `u64::MAX` rather than wrap. Every error carries an
+explicit `Attribution`, so no generic conversion can charge a local disk failure to a
+peer.
+
+| File | Added | Role |
+| --- | --- | --- |
+| `src/lib.rs` | 196 | module list, public re-export surface, the two architecture tests |
+| `src/ids.rs` | 443 | identities and generation counters: `HeaderId`, `EvidenceId`, `SourceId`, `BranchId`, `StateVersion`, `FinalityEpoch`, and the work owners and authorities |
+| `src/frontier.rs` | 220 | `Frontier`, `ChainScore`, `WorkCoordinate`, `SuffixWork`, and exact chain-work ordering |
+| `src/header_node.rs` | 351 | `HeaderNode`, the admitted header record, plus header, body, and eligibility state |
+| `src/error.rs` | 412 | `HeaderChainError`, `ErrorCategory`, `RuleId`, and `Attribution`, the peer-blame boundary |
+| `src/config.rs` | 669 | `EngineConfig`, `EngineMode`, `TrustedAnchor`, `CheckpointSet`, settled-upgrade pins, and the versioned `_V1` limits |
+| `src/locator.rs` | 213 | `HeaderLocator` built from a committed selected path, capped at 13 hashes |
+| `src/ownership.rs` | 441 | `PendingOwners` and `Gate`, which decide whether a late response still owns its branch |
+| `src/retention.rs` | 582 | `enforce_retention`, the deterministic eviction planner |
+
+Two of the nine hold algorithms rather than types. `ownership.rs` holds the completion
+gate described above. `retention.rs` holds the eviction planner, and eviction is the one
+place a resource limit could pass for a verdict about a chain. It refuses that twice.
+Eviction writes no reason and no body state, so re-inserting the identical header
+restores an eligible node. When protected paths alone fill the node bound,
+`RetentionPlan` sets `admission_refused` and `resource_stalled` instead of evicting
+protected state or synthesizing finality for room (LC-RETAIN-01).
+
+### The DAG: two files split by one question
+
+The question is whether the code may mutate committed state. `graph.rs` owns the queries
+and selection over committed state, and holds the two properties that keep arrival order
+out of fork choice: selection is `max` over a set, and height comes from a checked
+parent increment rather than the height a peer framed. `graph/overlay.rs` holds the
+staging types, which is what lets planning be pure. A plan the caller drops leaves
+nothing behind, so the durable caller chooses the order of its effects.
+
+| File | Added | Role |
+| --- | --- | --- |
+| `src/graph.rs` | 2,538 | in-memory DAG, ancestry and height queries, eligibility propagation, selection, tombstones |
+| `src/graph/overlay.rs` | 1,443 | `GraphOverlay`, `GraphDelta`, and the copy-on-write staging of one transition |
+
+### The transition: twenty files in refusal order
+
+The split follows the order in which a transition can still be refused for free. Types
+constrain what an event may say. Admission decides who may say it. The event effects
+derive each event's consequences against a staged projection. Settlement and the write
+set turn that projection into a plan. The verifier re-derives that result before disk
+can see it. Recovery is the one path that skips all of them, so it is separate.
+
+| File | Added | Role |
+| --- | --- | --- |
+| `src/transition/mod.rs` | 27 | the module's re-export surface |
+| `src/transition/types.rs` | 1,724 | every typed input and output: the twelve events, `TransitionRequest`, `EngineSnapshot`, change sets, `AuxDelivery`, `ValidationLease` |
+| `src/transition/planner.rs` | 335 | the phase sequence, `PlanCandidate`, and `TransitionPlan` |
+| `src/transition/planner/admission.rs` | 367 | bounded admission, authentication, and header-insertion rebasing |
+| `src/transition/planner/projected_state.rs` | 369 | `ProjectedTransitionState`: graph, verified path, and auxiliary deltas as one mutable projection |
+| `src/transition/planner/settlement.rs` | 214 | finality, retention, and projection settlement after the event effects run |
+| `src/transition/planner/write_set.rs` | 272 | generation policy and durable write-set derivation |
+| `src/transition/planner/event_effects/mod.rs` | 95 | the read-only event context and the exhaustive dispatch over the twelve events |
+| `src/transition/planner/event_effects/header_admission.rs` | 212 | prepared header insertion and atomic auxiliary delivery admission |
+| `src/transition/planner/event_effects/full_state_evidence.rs` | 194 | authoritative full-state conclusions and finality evidence |
+| `src/transition/planner/event_effects/header_validation.rs` | 192 | shared retained-context and full-state header validation |
+| `src/transition/planner/event_effects/auxiliary_authentication.rs` | 105 | auxiliary delivery authentication and rejection |
+| `src/transition/planner/event_effects/body_availability.rs` | 95 | transient body availability and supplier-discovery evidence |
+| `src/transition/planner/event_effects/operator_policy.rs` | 73 | operator-driven eligibility and body-retry policy |
+| `src/transition/planner/event_effects/deferred_time.rs` | 31 | deferred local-time header reevaluation |
+| `src/transition/invariants.rs` | 995 | `verify_plan` and its 14 numbered violations, checked on the projected result |
+| `src/transition/engine.rs` | 573 | `HeaderChainEngine`: `from_audited_state`, the pure `plan_transition`, the post-write `install_committed_transition`, `snapshot`, and the two projections |
+| `src/transition/recovery.rs` | 1,606 | `audit_store` and `RecoveryPlan`, the startup audit and its deterministic repairs |
+| `src/transition/authority.rs` | 55 | `Clock`, `FullStateEvidenceAuthority`, and `TransitionContext` |
+| `src/transition/store.rs` | 14 | `StoreError`, with `Incoherent` and `Unavailable` |
+
+`types.rs` is where evidence is kept from asserting an answer. An event carries
+identities, hashes, and a stable evidence id, and never a tip, a generation, a prune
+list, or a publication request. The fingerprint over its effect-bearing fields turns an
+exact resubmission into `NoChange` and a reused key with different effects into a hard
+conflict.
+
+The planner is one algorithm in six named phases rather than one function. A request is
+admitted, its event's effects are applied to a `ProjectedTransitionState`, finality and
+retention settle that projection, and the write set derives the durable rows and the
+generation bumps. The result is a `PlanCandidate`, which becomes a `TransitionPlan` only
+after the independent verifier accepts it, so the type system carries the distinction
+between a projected write set and a verified one.
+
+`event_effects/mod.rs` dispatches on the twelve events with no fall-through arm, so a
+new event fails the build rather than defaulting to a no-op. Each of the seven handler
+modules owns one evidence domain, which is what keeps a change to operator policy from
+touching header admission.
+
+`authority.rs` is 55 lines and holds the whole capability model. It states that an event
+cannot supply its own time, so time arrives through `Clock`. It states that only a
+caller inside the state writer may vouch for staged full-state evidence, a scheduler
+retry, a header completion, or a validation lease. One of the four questions is required
+and the other three default to false, so an implementation that forgets an override
+refuses evidence instead of admitting it. `TransitionContext` holds the authority as an
+`Option`, so a caller outside the writer has no way to vouch at all.
+
+`recovery.rs` is the only path that builds engine state without the planner, so it
+decides on its own whether the store still describes one coherent chain. It repairs only
+what a DAG can reconstruct, recomputes selection rather than trusting a stored answer,
+and fails closed on anything else, with publication disabled until it finishes.
+
+### Validation: three files split by the context a rule reads
+
+The split decides which lock the caller needs, and production takes the context-free
+entry point traced above. `prepare_headers` is the other one: it runs parent linkage and
+contextual difficulty and time during preparation rather than leaving them to the
+planner, so it takes a `ValidationLease` that `is_coherent` re-derives. The tests and
+the fuzzer drive it; production does not.
+
+| File | Added | Role |
+| --- | --- | --- |
+| `src/validation/mod.rs` | 466 | per-header rules: link, encoding, compact target, hash filter, future time, commitment structure |
+| `src/validation/prepare.rs` | 691 | the two entry points and the sealed `PreparedHeaderBatch` |
+| `src/validation/contextual.rs` | 963 | `AdjustedDifficulty`, ThresholdBits, the ZIP 205 and 208 testnet rule, and median-time-past |
+
+`contextual.rs` moved here from `zakura-state/src/service/check/difficulty.rs`, so one
+implementation now decides difficulty for a candidate header and for a block.
+
+## Layer 2: `zakura-node-services`, 2 files, +1,387
+
+This layer exists to make a dependency impossible rather than discouraged.
+`zakura-network` needs header-chain state, and `zakura-state` sits above it, so a direct
+call would invert the stack and put the database within the reactor's reach. The port is
+a trait in a crate below both. The reactor calls seven named operations and can reach
+nothing else.
+
+| File | Added | Role |
+| --- | --- | --- |
+| `src/header_chain.rs` | 693 | the `Port` trait, the `AdapterKey` seal, `PortError`, and the `UnavailablePort` and `InertHeaderChainPort` stand-ins |
+| `src/sync_lifecycle.rs` | 694 | `ApplyPhase` and its declared edges, `LifecycleEpoch`, `HeaderRuntimeStatus`, `SyncServiceDemand` |
+
+The seven operations are `continuation_locator`, `vct_repair_context`,
+`acquire_header_path`, `read_header_path`, `release_header_path`,
+`prepare_header_target`, and `apply_header_target`. `AdapterKey` is what makes the last
+two safe as two separate calls: the adapter seals a `PreparedHeaderTarget` on the way
+out and is the only holder that can open it on the way back, so nothing can forge or
+substitute a prepared batch in between.
+
+`sync_lifecycle.rs` is here for the same reason as the port. `ApplyPhase`, its declared
+edges, and `LifecycleEpoch` are shared by state, network, and orchestration, and none of
+those three may own them without one of the others depending upward.
+
+## Layer 3: `zakura-state`, 11 files, +10,759 / -1,541
+
+This layer decides what survives a crash. The engine performs no effect, so its durable
+caller performs all of them, in the order set out above.
+
+One file dominates. `finalized_state/header_chain.rs` holds `HeaderChainRuntime`, the
+sole writer and sole publisher, alongside `HeaderChainStore`, the `Publisher`, the
+reader, the retained-path lease registry, the startup report, and four `FaultPoint`s
+that let the recovery tests interrupt the sequence at each step and check that the next
+startup repairs it.
+
+| File | Added | Removed | Role |
+| --- | --- | --- | --- |
+| `src/service/finalized_state/header_chain.rs` | 4,349 | 0 | the runtime, the store, the publisher, the reader, leases, fault points |
+| `src/service/finalized_state/disk_format/header_chain_values.rs` | 1,825 | 0 | version-one value codecs for the new column families |
+| `src/service/finalized_state/disk_format/header_chain.rs` | 492 | 0 | ordered key encodings for children, heights, eligibility roots, deliveries, deferrals, finality |
+| `src/service/finalized_state/header_chain/migration.rs` | 424 | 0 | first-run construction of the DAG from authenticated full state |
+| `src/service/write.rs` | 1,945 | 727 | the write loop: the only production caller of `apply`, combined batches, the deferred timer |
+| `src/service.rs` | 588 | 265 | runtime construction and the read and write service split |
+| `src/error.rs` | 376 | 274 | state error taxonomy for the new failures |
+| `src/service/finalized_state.rs` | 326 | 117 | opening the store, running the startup audit, wiring the runtime |
+| `src/request.rs` | 293 | 146 | new state requests |
+| `src/header_chain.rs` | 82 | 0 | the public retained-path contract: `RetainedPathLease`, `RetainedPathPage`, outcomes |
+| `src/response.rs` | 59 | 12 | new state responses |
+
+The schema adds fourteen column families, all suffixed `_v1`: `header_node_by_hash`,
+`header_child`, `header_height_hash`, `header_candidate`, `header_selected`,
+`header_verified`, `header_eligibility_root`, `header_aux_delivery`, `header_deferred`,
+`header_finality_history`, `header_validation_context`,
+`header_consensus_invalid_tombstone`, `header_body_evidence_authority`, and
+`header_engine_meta`. The key encodings are ordered on purpose, so a range scan answers
+a query that would otherwise need an index, and every index the schema does keep is a
+cache that the startup audit rebuilds from the node rows.
+
+`migration.rs` is the one-time problem. An existing store recorded one chain by height
+and never had a DAG, so first run reads the height-indexed header rows and builds a
+single selected path with a migrated finality pin. That pin is the reason
+`MigratedPinRefutation` exists as an event: an imported pin cannot be rolled back, so
+refuting one alarms and fails the node closed.
+
+## Layer 4: `zakura-network`, 14 files, +8,970 / -6,088
+
+This layer keeps its clock and gives up its authority. The reactor still decides when to
+ask, whom to ask, and how much to ask for, because those are timing questions and it is
+the only component with a timer. Everything else moved below it: whether a header is
+valid, which chain is best, whether a late response still counts. The reactor issues
+requests against a committed snapshot and reports what it observed through the port.
+
+| File | Added | Removed | Role |
+| --- | --- | --- | --- |
+| `header_sync/reactor.rs` | 3,834 | 3,207 | the single loop: admission, target selection, issuance, response routing, serving, leases, repair, alarms |
+| `header_sync/scheduler/peer_work.rs` | 1,424 | 0 | `PeerWorkQueue`, work priorities and phases, and the shared header-chunk budget |
+| `header_sync/wire.rs` | 1,073 | 256 | the four message discriminants and the bounded codec |
+| `header_sync/scheduler/retry.rs` | 643 | 0 | branch-owned body-availability retry episodes |
+| `header_sync/scheduler/repair.rs` | 503 | 0 | generation- and branch-owned auxiliary VCT repair work |
+| `header_sync/events.rs` | 394 | 551 | `HeaderSyncStartup`, the event enum, the handle |
+| `header_sync/service.rs` | 393 | 574 | the stream declaration and per-peer session spawn |
+| `header_sync/pipe.rs` | 346 | 1,121 | `run_peer`, the per-peer decode loop and its cancelled-response grace window |
+| `header_sync/scheduler/completed_targets.rs` | 147 | 0 | generation- and branch-keyed completed targets |
+| `header_sync/scheduler/status.rs` | 140 | 0 | `StatusPublisher`, coalescing advertisements behind a one-per-second floor |
+| `header_sync/config.rs` | 38 | 130 | `ZakuraHeaderSyncConfig` |
+| `header_sync/mod.rs` | 30 | 55 | module surface |
+| `header_sync/scheduler/mod.rs` | 5 | 0 | scheduler module list |
+| `header_sync/error.rs` | 0 | 194 | reduced to the startup error; the rest became `HeaderChainError` and `PortError` |
+
+Header sync is stream kind 5 at stream version 8, behind capability bit five, with a 2
+MiB message cap. The four discriminants are `Status`, `GetHeaders`, `Headers`, and
+`HeadersOutcome`, and they are closed: new wire data needs an advertised auxiliary
+schema bit or a successor stream version (LC-WIRE-15). The stream version is the
+compatibility barrier, so a peer that cannot speak version 8 never negotiates the stream
+rather than half-speaking it.
+
+The `scheduler/` split is the shape the sole-writer rule forces on a facility that owns
+no state. Work that used to sit in the reactor's own fields now sits in five small
+modules, each keyed by generation and branch, so one retirement pass retires exactly the
+work a reset invalidated and leaves the rest alive. `completed_targets.rs` is 147 lines
+and shows the idea at its smallest: a set whose key is `(generation, branch)`, which
+therefore cannot alias across either.
+
+`peer_work.rs` owns the one number the whole facility shares. A response page carries up
+to 1,000 headers by default and 4,000 at the cap, and the chunk budget divides that same
+4,000 across receiving, preparation, and application on every staged target, so one
+target cannot starve the others and the total in flight cannot exceed one transition's
+worth.
+
+`pipe.rs` handles the awkward case that follows from cancelling work. A retired request
+still gets an honest answer from the peer, so the pipe remembers up to 64 cancelled ids
+for 30 seconds and drops those responses instead of scoring them as protocol violations.
+
+## Layer 5: `zakurad`, 4 files, +3,797 / -2,274
+
+This layer is where the abstractions meet one process, and two of its four files answer
+a problem no lower layer can see: the node has two paths that apply blocks, and only one
+may run at a time.
+
+| File | Added | Removed | Role |
+| --- | --- | --- | --- |
+| `commands/start/zakura/header_sync_driver.rs` | 1,743 | 1,896 | the `Port` implementation over the state service, plus reactor startup assembly |
+| `commands/start/zakura/coordinator.rs` | 939 | 0 | `SyncCoordinator`: apply phases, apply permits, operation records, legacy-fallback leases |
+| `commands/start/zakura/block_sync_driver.rs` | 775 | 325 | turns block-sync actions into verified applies that carry a `BodyWorkOwner` |
+| `components/sync.rs` | 340 | 53 | legacy syncer changes for the lifecycle handshake |
+
+`header_sync_driver.rs` implements the port. It turns each of the seven operations into
+state-service requests and assembles the reactor's startup inputs, and it is the only
+file where header-sync policy and the state service know each other's names.
+
+`coordinator.rs` owns apply-phase transitions for the process. It holds the phase, a
+watch channel per observer, the in-flight count, a record per block-apply operation, and
+a drain notification, so the native and legacy paths hand off rather than overlap. It is
+the only new file in this layer with no deletions against it, because nothing like it
+existed.
+
+## Integration edits, 75 files, +7,483 / -5,471
+
+These files change because the core changed. None of them holds a rule.
+
+| Area | Files | Added | Removed | Why it changed |
+| --- | --- | --- | --- | --- |
+| network: block sync | 15 | 2,901 | 446 | consumes committed header snapshots for scheduling, and carries a body work owner |
+| network: transport, handler, discovery, trace | 13 | 1,777 | 1,764 | registers the header-sync service and its stream, and reworks the trace tables |
+| zakurad: start, trace, inbound | 8 | 1,291 | 1,381 | wiring, driver spawn, and trace plumbing |
+| state: adjacent modules | 21 | 902 | 1,764 | difficulty checks moved out, VCT plumbing, database open path |
+| consensus | 5 | 253 | 34 | body verification failure classes the engine can act on |
+| rpc | 1 | 160 | 7 | header-chain fields on existing methods |
+| chain | 10 | 153 | 74 | shared header and difficulty types |
+| jsonl trace and node-services re-exports | 2 | 46 | 1 | new trace rows and one re-export line |
+
+The state row removes more than it adds because `service/check/difficulty.rs` lost 375
+lines to `zakura-header-chain/src/validation/contextual.rs`, and `zakura_db/block.rs`
+lost 738 lines to the runtime and its audit.
+
+## What the change deletes
+
+Twelve production files, 8,620 lines.
+
+| Deleted file | Lines | Replaced by |
+| --- | --- | --- |
+| `network/header_sync/reactor/trace.rs` | 2,162 | the shared trace tables in `zakura/trace.rs` |
+| `network/header_sync/work_queue.rs` | 1,288 | `scheduler/peer_work.rs` |
+| `network/header_sync/state.rs` | 1,287 | the committed `EngineSnapshot` and the scheduler modules |
+| `network/exchange.rs` | 873 | the header-sync service and its stream |
+| `state/zakura_db/block/startup_audit.rs` | 667 | `transition/recovery.rs` and the runtime's audit |
+| `zakurad/start/zakura/trace/header_driver.rs` | 666 | reactor trace rows |
+| `network/header_sync/range.rs` | 508 | `HeaderLocator` and the selected projection |
+| `network/header_sync/validation.rs` | 383 | `zakura-header-chain/src/validation/` |
+| `network/header_sync/requester.rs` | 314 | the reactor's issuance path |
+| `zakurad/start/zakura/trace/chain_tip_mirror.rs` | 210 | the publisher's watch channel |
+| `network/header_sync/header_root_auth.rs` | 143 | `scheduler/repair.rs` and the auxiliary path |
+| `network/exchange/trace.rs` | 119 | the shared trace tables |
+
+Each deletion is one place where policy used to sit in the network crate and now sits
+below it. Header validity, fork choice, and work ownership left the reactor, which kept
+transport, scheduling, and timing.
+
+## Pieces that read well on their own
+
+Each of these is self-contained, and each one settles a question the rest of the design
+then assumes.
+
+| File | Lines | The question it settles |
+| --- | --- | --- |
+| `transition/authority.rs` | 55 | the entire capability model on one screen |
+| `frontier.rs` | 220 | why chain work is not a number you compare: only differences are comparable, and a mismatched origin is an error rather than a smaller number |
+| `retention.rs` | 582 | why an eviction planner should refuse new data rather than delete protected data |
+| `locator.rs` | 213 | why a locator fails on a gap instead of returning a shorter one, which would be a wrong answer that looks like a valid one |
+| `graph/overlay.rs` | 1,443 | what pure planning costs in practice once the graph is large |
+| `transition/planner/event_effects/mod.rs` | 95 | the twelve events dispatched with no fall-through arm, so a new event fails the build |
+| `transition/invariants.rs` | 995 | fourteen numbered violations, each with a comment naming what it caught |
+| `transition/recovery.rs` | 1,606 | the only code that decides for itself whether a store still describes one coherent chain |
+| `validation/contextual.rs` | 963 | the difficulty adjustment, the ZIP 205 and 208 testnet rule, and median-time-past, in one place |
+| `header_chain/migration.rs` | 424 | how to build a fork-aware DAG for a database that only ever stored one chain, and what that costs later |
+| `header_sync/wire.rs` | 1,073 | the case for a stream version as a hard compatibility barrier |
+| `scheduler/completed_targets.rs` | 147 | branch keying with nothing else in the file to distract from it |
+| `scheduler/retry.rs` | 643 | backoff whose jitter is deterministic: seeded from branch, header, and attempt and bounded to ten percent either way, so a test reproduces a retry schedule exactly |
+| `scheduler/status.rs` | 140 | coalescing under a one-second floor and a two-second ceiling on delay, the smallest complete example of the reactor owning timing |
+| `header_sync/pipe.rs` | 346 | why cancelling work must not turn a peer's honest answer into misbehaviour |
+| `coordinator.rs` | 939 | what "only one path may apply blocks" looks like once it is code |

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -22,7 +22,7 @@ these calls as `OperatorInvalidate` and `OperatorReconsider` events.
 
 ## Header-chain state
 
-[`MemHeaderStore`](../../../crates/zakura-header-chain/src/graph.rs) holds every retained
+[`MemHeaderStore`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/graph.rs) holds every retained
 header in a directed acyclic graph (DAG). Each `HeaderNode` is keyed by its consensus
 hash and names its parent. The finalized `Frontier` is the graph root. A `Frontier`
 contains both height and hash, so it identifies one position on one branch.
@@ -63,7 +63,7 @@ The planner then checks parent linkage, height, work, difficulty, and time again
 staged graph. It admits a header only after every required check passes. This implements
 [validation before admission (`LC-VAL-11`)](../../specs/fork-aware-header-chain-engine.md#lc-val-11).
 After planning,
-[`verify_plan`](../../../crates/zakura-header-chain/src/transition/invariants.rs)
+[`verify_plan`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/transition/invariants.rs)
 independently checks the resulting graph, projections, generation changes, and protected
 nodes before the runtime writes anything.
 
@@ -72,7 +72,7 @@ nodes before the runtime writes anything.
 `MemHeaderStore` contains the committed graph.
 [`GraphOverlay`](../../../crates/zakura-header-chain/src/graph/overlay.rs) reads that graph
 and records staged changes without mutating it.
-[`HeaderChainEngine`](../../../crates/zakura-header-chain/src/transition/engine.rs)
+[`HeaderChainEngine`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/transition/engine.rs)
 extracts those changes as a `GraphDelta`. The runtime applies the delta to
 `MemHeaderStore` only after the durable write succeeds.
 
@@ -131,7 +131,7 @@ the runtime commits the DAG changes, metadata, projections, and related indexes 
 RocksDB batch before it publishes the new snapshot.
 
 Startup uses
-[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery/mod.rs) while
+[`audit_store`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/transition/recovery.rs) while
 publication is disabled. The audit checks the stored source rows and rebuilds derived
 indexes and projections. It refuses inconsistencies that it cannot reconstruct.
 
@@ -217,7 +217,7 @@ the anchor and tip that a request belongs to. It deliberately omits height becau
 fork switch can replace a branch without changing its height.
 
 When a result returns, `Gate` in
-[`ownership.rs`](../../../crates/zakura-header-chain/src/ownership.rs) compares its branch
+[`ownership.rs`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/ownership.rs) compares its branch
 and generation with the current snapshot. It accepts current work and rejects stale
 work. It ignores `state_version` because unrelated transitions increment that counter
 and would cancel valid requests. The scheduler uses the same branch and generation to
@@ -248,7 +248,7 @@ and verifies the result. This boundary implements
 [block-sync concerns excluded (`LC-SCOPE-06`)](../../specs/fork-aware-header-chain-engine.md#lc-scope-06):
 unrelated block-sync policy cannot affect header fork choice.
 
-[`retention.rs`](../../../crates/zakura-header-chain/src/retention.rs) protects the
+[`retention.rs`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/retention.rs) protects the
 selected and verified paths. When protected state fills the node limit, the engine
 refuses admission instead of deleting either path. This implements
 [fork and node limits (`LC-RETAIN-01`)](../../specs/fork-aware-header-chain-engine.md#lc-retain-01).

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -22,7 +22,7 @@ these calls as `OperatorInvalidate` and `OperatorReconsider` events.
 
 ## Header-chain state
 
-[`MemHeaderStore`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/graph.rs) holds every retained
+[`MemHeaderStore`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/graph/mod.rs) holds every retained
 header in a directed acyclic graph (DAG). Each `HeaderNode` is keyed by its consensus
 hash and names its parent. The finalized `Frontier` is the graph root. A `Frontier`
 contains both height and hash, so it identifies one position on one branch.
@@ -31,6 +31,9 @@ The engine keeps two paths through the DAG. The selected path ends at the best e
 header tip. The verified path ends at the tip whose blocks full state has accepted.
 Each path is stored as an ordered list of frontiers, so readers can answer height queries
 without walking the graph.
+
+Integrated mode advances the verified path only when full state accepts blocks. In
+headers-only mode, the verified path contains only the finalized frontier.
 
 A node is eligible when its header is valid, it has no direct exclusion reason, and its
 ancestors are eligible. The graph stores exclusion reasons instead of one boolean flag.
@@ -41,12 +44,21 @@ Selection takes the maximum score over all eligible tips. This implements
 [deterministic selection (`LC-SELECT-04`)](../../specs/fork-aware-header-chain-engine.md#lc-select-04):
 the same eligible DAG selects the same tip regardless of header arrival order.
 
+Integrated mode advances finality only from authenticated full-state evidence.
+Headers-only mode advances finality with a 1,000-block local depth rule. This local rule
+does not verify block bodies. When finality advances, the engine removes old ancestors
+and competing sibling subtrees. It rebases retained work onto the new root.
+
 ## Header admission and validation
 
 The header-sync driver prepares a downloaded batch before it takes the state writer
 lock. It obtains a validation lease for the common ancestor and checks properties that
 need no candidate ancestry, including encoding, proof of work, and commitment format.
 CPU-heavy checks run on a blocking thread.
+
+The full-block and checkpoint verifiers call the same context-free checks. This prevents
+an in-memory or locally constructed block from bypassing header-version and timestamp
+checks. Only an authenticated custom network can disable proof-of-work verification.
 
 A header whose time is more than two hours ahead of the local clock waits until that
 time becomes valid. It does not become permanently invalid. This implements
@@ -62,8 +74,13 @@ parent context.
 The planner then checks parent linkage, height, work, difficulty, and time against the
 staged graph. It admits a header only after every required check passes. This implements
 [validation before admission (`LC-VAL-11`)](../../specs/fork-aware-header-chain-engine.md#lc-val-11).
+The engine calculates cumulative work with full 256-bit values and rejects cumulative
+overflow. Its difficulty calculation requires the complete predecessor window. It caps
+target scaling before multiplication can overflow. It reads Testnet's maximum-time
+activation height from network parameters.
+
 After planning,
-[`verify_plan`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/transition/invariants.rs)
+[`verify_plan`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/invariants/mod.rs)
 independently checks the resulting graph, projections, generation changes, and protected
 nodes before the runtime writes anything.
 
@@ -72,7 +89,7 @@ nodes before the runtime writes anything.
 `MemHeaderStore` contains the committed graph.
 [`GraphOverlay`](../../../crates/zakura-header-chain/src/graph/overlay.rs) reads that graph
 and records staged changes without mutating it.
-[`HeaderChainEngine`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/transition/engine.rs)
+[`HeaderChainEngine`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/engine/mod.rs)
 extracts those changes as a `GraphDelta`. The runtime applies the delta to
 `MemHeaderStore` only after the durable write succeeds.
 
@@ -131,9 +148,14 @@ the runtime commits the DAG changes, metadata, projections, and related indexes 
 RocksDB batch before it publishes the new snapshot.
 
 Startup uses
-[`audit_store`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/transition/recovery.rs) while
-publication is disabled. The audit checks the stored source rows and rebuilds derived
-indexes and projections. It refuses inconsistencies that it cannot reconstruct.
+[`audit_store`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/recovery/mod.rs) while
+publication is disabled. The audit rejects contradictions in authoritative rows. It
+repairs only indexes, projections, alarms, and other values that it can derive from those
+rows.
+
+During a live transition, the graph reuses header hashes that admission already verified.
+Recovery recomputes canonical hashes from durable rows. This avoids repeated hashing
+without weakening the startup audit.
 
 ### Write paths
 
@@ -150,8 +172,12 @@ authentication, a dependent checkpoint advance, and the block-state change in on
 batch.
 
 A no-change plan still commits the caller's block-state batch when one exists, but it
-does not install or publish a header-chain change. A `ResourceStalled` result discards
-the caller's block-state rows. It writes a changed header-chain alarm when needed.
+does not install or publish a header-chain change. A `ResourceStalled` result means that
+retention cannot make room without deleting protected state. It discards the caller's
+block-state rows and writes a changed header-chain alarm when needed.
+
+An auxiliary-evidence limit rejects the event before any change and does not raise the
+resource alarm. A limit failure from the independent invariant check returns no plan.
 
 ## Fork switching
 
@@ -192,6 +218,11 @@ the verified path must move to the other branch. `SyncCoordinator` holds the pro
 apply permit during that handoff, so the native and legacy block-apply paths cannot run
 at the same time.
 
+When full state rejects a body as consensus-invalid, the block-sync driver waits for
+state to commit that evidence. It refreshes a stale state version and retries a bounded
+number of times. If state cannot persist the evidence, the driver shuts down instead of
+continuing while the branch remains eligible.
+
 ## VCT evidence and authentication
 
 Peers can provide commitment-tree roots before the node downloads the corresponding
@@ -205,6 +236,11 @@ only when that next header directly follows the target on the same owned branch 
 delivery provenance has not changed. The exact transition checks live in
 [`auxiliary_authentication.rs`](../../../crates/zakura-header-chain/src/transition/planner/event_effects/auxiliary_authentication.rs).
 
+The DAG can retain an unauthenticated delivery while the check is pending. State exposes
+a peer-supplied root through the authoritative commitment-root index only after that root
+passes authentication. A root derived from an accepted block body can also enter that
+index. This replaces the former height-keyed authentication frontier.
+
 Unauthenticated evidence does not affect header validity or fork choice. The
 [repair scheduler](../../../crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs)
 fetches missing evidence separately for each branch and generation. The full tree design
@@ -212,16 +248,33 @@ lives in [Verified commitment trees](../verified-commitment-trees.md).
 
 ## Stale work rejection
 
+Serialized events require an exact `state_version`. The planner rejects an event as stale
+when that version does not match.
+
 Header requests can finish after the selected branch has changed. `BranchId` identifies
 the anchor and tip that a request belongs to. It deliberately omits height because a
 fork switch can replace a branch without changing its height.
 
 When a result returns, `Gate` in
-[`ownership.rs`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/ownership.rs) compares its branch
+[`completion.rs`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/work/completion.rs) compares its branch
 and generation with the current snapshot. It accepts current work and rejects stale
 work. It ignores `state_version` because unrelated transitions increment that counter
 and would cancel valid requests. The scheduler uses the same branch and generation to
 retire stale work.
+
+The engine advances `header_generation` when a change makes header work stale. It
+advances `verified_generation` when a verified-path or finality change makes body-forward
+work stale. Prepared headers have a separate stale result when their durable validation
+context changes. The caller must prepare and validate those headers again.
+
+Finality can advance while a header request is active. The planner can remove an
+already-finalized prefix and bind the remaining headers to the new root. It rejects the
+result when durable finality history cannot prove that rebase.
+
+For replay-protected events, the engine saves the fingerprint of the latest state change.
+An exact repeat produces a verified no-change plan even if its serialized version is old.
+Normal authority and ownership checks still apply. Reusing the same evidence key with
+different content fails as a conflicting replay.
 
 ## Component boundaries
 
@@ -248,10 +301,12 @@ and verifies the result. This boundary implements
 [block-sync concerns excluded (`LC-SCOPE-06`)](../../specs/fork-aware-header-chain-engine.md#lc-scope-06):
 unrelated block-sync policy cannot affect header fork choice.
 
-[`retention.rs`](https://github.com/zakura-core/zakura/blob/37aaf0ddcc5d45ad21aebadc6ccadd6c4a58ef79/crates/zakura-header-chain/src/retention.rs) protects the
-selected and verified paths. When protected state fills the node limit, the engine
-refuses admission instead of deleting either path. This implements
-[fork and node limits (`LC-RETAIN-01`)](../../specs/fork-aware-header-chain-engine.md#lc-retain-01).
+[`retention.rs`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/planner/retention.rs) protects the
+selected path, the verified path, the path to every retained body that full state has
+verified, and nodes that active work still references. When protected state fills the
+node limit, the engine refuses admission. The
+[fork and node limits rule (`LC-RETAIN-01`)](../../specs/fork-aware-header-chain-engine.md#lc-retain-01)
+requires the engine to preserve protected state.
 
 [`conformance.toml`](../../../crates/zakura-header-chain/conformance.toml) lists the
 machine-checked rules. The
@@ -275,7 +330,12 @@ The [header-chain schema](../../../crates/zakura-state/src/service/finalized_sta
 uses a `_v1` suffix for each header-chain column family. A future incompatible encoding
 can use a new family instead of reinterpreting existing data. The
 [`migration`](../../../crates/zakura-state/src/service/finalized_state/header_chain/migration.rs)
-builds an initial DAG when an existing database stores only one chain.
+builds an initial DAG from authenticated full-state facts when the database contains no
+predecessor header-overlay rows. It downloads headers above the verified block tip again.
+Startup rejects a database that contains predecessor header-overlay rows before it
+publishes the new DAG. That cutover requires a fresh state database and resynchronization.
+The [migration guide](../../header-chain-v1.4-migration.md) also covers removed
+configuration and the status interface.
 
 ### `zakura-network`: protocol timing and branch-owned work
 

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -7,14 +7,13 @@ remains authoritative.
 
 ## Single-planner fork choice
 
-Four events can change the selected header chain. Peers add headers. Full state reports
-verified blocks and consensus-invalid bodies. A node administrator can exclude or
-restore a block through `invalidateblock` and `reconsiderblock`. Finalization moves the
-point below which the node will not reorganize.
+Several inputs can change the selected header chain. New headers extend the DAG.
+Validation results and explicit block exclusions change which headers are eligible.
+Finalization changes the root from which the engine selects a chain.
 
-Separate code paths must not update fork choice independently. They could choose
-different tips, or a late result could overwrite a newer result. Each path now reports
-what it observed to one planner. The planner alone selects the best eligible tip.
+The engine sends every input through one planner. Independent fork-choice updates could
+select different tips. A late result could also overwrite a newer result. Each path
+reports what it observed to the planner. The planner selects the best eligible tip.
 
 `invalidateblock` makes the named block and its descendants ineligible for selection.
 It does not delete them. `reconsiderblock` removes that exclusion, so the branch can
@@ -23,7 +22,7 @@ these calls as `OperatorInvalidate` and `OperatorReconsider` events.
 
 ## Header-chain state
 
-[`MemHeaderStore`](../../../crates/zakura-header-chain/src/graph/mod.rs) holds every retained
+[`MemHeaderStore`](../../../crates/zakura-header-chain/src/graph.rs) holds every retained
 header in a directed acyclic graph (DAG). Each `HeaderNode` is keyed by its consensus
 hash and names its parent. The finalized `Frontier` is the graph root. A `Frontier`
 contains both height and hash, so it identifies one position on one branch.
@@ -63,16 +62,19 @@ parent context.
 The planner then checks parent linkage, height, work, difficulty, and time against the
 staged graph. It admits a header only after every required check passes. This implements
 [validation before admission (`LC-VAL-11`)](../../specs/fork-aware-header-chain-engine.md#lc-val-11).
-After planning, `verify_plan` independently checks the resulting graph, projections,
-generation changes, and protected nodes before the runtime writes anything.
+After planning,
+[`verify_plan`](../../../crates/zakura-header-chain/src/transition/invariants.rs)
+independently checks the resulting graph, projections, generation changes, and protected
+nodes before the runtime writes anything.
 
 ## Transition commit order
 
 `MemHeaderStore` contains the committed graph.
 [`GraphOverlay`](../../../crates/zakura-header-chain/src/graph/overlay.rs) reads that graph
-and records staged changes without mutating it. Planning extracts those changes as a
-`GraphDelta`. The runtime applies the delta to `MemHeaderStore` only after the durable
-write succeeds.
+and records staged changes without mutating it.
+[`HeaderChainEngine`](../../../crates/zakura-header-chain/src/transition/engine.rs)
+extracts those changes as a `GraphDelta`. The runtime applies the delta to
+`MemHeaderStore` only after the durable write succeeds.
 
 ```mermaid
 sequenceDiagram
@@ -82,7 +84,6 @@ sequenceDiagram
   participant O as GraphOverlay
   participant M as MemHeaderStore
   participant D as Durable store
-  participant P as Observers
 
   W->>R: apply(request)
   R->>E: plan_transition(request)
@@ -93,16 +94,31 @@ sequenceDiagram
   E-->>R: TransitionPlan
   R->>D: write change set atomically
 
-  alt write succeeds
-    D-->>R: success
-    R->>E: install_committed_transition(plan)
-    E->>M: apply GraphDelta
-    R->>P: publish snapshot
-    R-->>W: success
-  else write fails
+  alt write fails
     D-->>R: error
-    R-->>W: error; memory and observers stay unchanged
+    R-->>W: error, memory and observers remain unchanged
+  else write succeeds
+    D-->>R: success
   end
+```
+
+After the durable write succeeds, the runtime installs the same plan in memory. It then
+publishes the resulting snapshot:
+
+```mermaid
+sequenceDiagram
+  participant W as State writer
+  participant R as HeaderChainRuntime
+  participant E as HeaderChainEngine
+  participant M as MemHeaderStore
+  participant P as Observers
+
+  R->>E: install_committed_transition(plan)
+  E->>M: apply GraphDelta
+  M-->>E: updated
+  E-->>R: installed
+  R-)P: publish snapshot
+  R-->>W: success
 ```
 
 The runtime updates disk first, memory second, and observers last. After a crash,
@@ -115,7 +131,7 @@ the runtime commits the DAG changes, metadata, projections, and related indexes 
 RocksDB batch before it publishes the new snapshot.
 
 Startup uses
-[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery/mod.rs) while
+[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery.rs) while
 publication is disabled. The audit checks the stored source rows and rebuilds derived
 indexes and projections. It refuses inconsistencies that it cannot reconstruct.
 
@@ -152,9 +168,12 @@ sequenceDiagram
 
   P-->>N: headers on an alternate branch
   N->>D: prepare_header_target
-  D->>S: read validation context
-  S-->>D: prepared target
-  N->>D: apply_header_target
+  D->>S: request validation lease
+  S-->>D: validation lease
+  D->>D: validate and seal target
+  D-->>N: PreparedHeaderTarget
+  N->>N: confirm request and authority are current
+  N->>D: apply_header_target(PreparedHeaderTarget)
   D->>S: apply prepared headers
   S->>E: plan InsertHeaders
   E->>E: validate and score eligible tips
@@ -198,7 +217,7 @@ the anchor and tip that a request belongs to. It deliberately omits height becau
 fork switch can replace a branch without changing its height.
 
 When a result returns, `Gate` in
-[`completion.rs`](../../../crates/zakura-header-chain/src/work/completion.rs) compares its branch
+[`ownership.rs`](../../../crates/zakura-header-chain/src/ownership.rs) compares its branch
 and generation with the current snapshot. It accepts current work and rejects stale
 work. It ignores `state_version` because unrelated transitions increment that counter
 and would cancel valid requests. The scheduler uses the same branch and generation to
@@ -229,7 +248,7 @@ and verifies the result. This boundary implements
 [block-sync concerns excluded (`LC-SCOPE-06`)](../../specs/fork-aware-header-chain-engine.md#lc-scope-06):
 unrelated block-sync policy cannot affect header fork choice.
 
-[`retention.rs`](../../../crates/zakura-header-chain/src/transition/planner/retention.rs) protects the
+[`retention.rs`](../../../crates/zakura-header-chain/src/retention.rs) protects the
 selected and verified paths. When protected state fills the node limit, the engine
 refuses admission instead of deleting either path. This implements
 [fork and node limits (`LC-RETAIN-01`)](../../specs/fork-aware-header-chain-engine.md#lc-retain-01).
@@ -252,7 +271,8 @@ it between preparation and application.
 is the sole header-chain writer and publisher. The runtime builds one durable batch,
 installs the committed transition, and publishes the new snapshot in that order.
 
-The header-chain column families use a `_v1` suffix, so a future incompatible encoding
+The [header-chain schema](../../../crates/zakura-state/src/service/finalized_state.rs)
+uses a `_v1` suffix for each header-chain column family. A future incompatible encoding
 can use a new family instead of reinterpreting existing data. The
 [`migration`](../../../crates/zakura-state/src/service/finalized_state/header_chain/migration.rs)
 builds an initial DAG when an existing database stores only one chain.

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -22,7 +22,7 @@ these calls as `OperatorInvalidate` and `OperatorReconsider` events.
 
 ## Header-chain state
 
-[`MemHeaderStore`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/graph/mod.rs) holds every retained
+[`MemHeaderStore`](../../../crates/zakura-header-chain/src/graph/mod.rs) holds every retained
 header in a directed acyclic graph (DAG). Each `HeaderNode` is keyed by its consensus
 hash and names its parent. The finalized `Frontier` is the graph root. A `Frontier`
 contains both height and hash, so it identifies one position on one branch.
@@ -80,7 +80,7 @@ target scaling before multiplication can overflow. It reads Testnet's maximum-ti
 activation height from network parameters.
 
 After planning,
-[`verify_plan`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/invariants/mod.rs)
+[`verify_candidate`](../../../crates/zakura-header-chain/src/transition/invariants/mod.rs)
 independently checks the resulting graph, projections, generation changes, and protected
 nodes before the runtime writes anything.
 
@@ -89,7 +89,7 @@ nodes before the runtime writes anything.
 `MemHeaderStore` contains the committed graph.
 [`GraphOverlay`](../../../crates/zakura-header-chain/src/graph/overlay.rs) reads that graph
 and records staged changes without mutating it.
-[`HeaderChainEngine`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/engine/mod.rs)
+[`HeaderChainEngine`](../../../crates/zakura-header-chain/src/transition/engine/mod.rs)
 extracts those changes as a `GraphDelta`. The runtime applies the delta to
 `MemHeaderStore` only after the durable write succeeds.
 
@@ -108,7 +108,7 @@ sequenceDiagram
   O->>M: read committed nodes
   M-->>O: committed state
   O-->>E: GraphDelta
-  E-->>R: TransitionPlan
+  E-->>R: EngineTransition
   R->>D: write change set atomically
 
   alt write fails
@@ -148,7 +148,7 @@ the runtime commits the DAG changes, metadata, projections, and related indexes 
 RocksDB batch before it publishes the new snapshot.
 
 Startup uses
-[`audit_store`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/recovery/mod.rs) while
+[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery/mod.rs) while
 publication is disabled. The audit rejects contradictions in authoritative rows. It
 repairs only indexes, projections, alarms, and other values that it can derive from those
 rows.
@@ -256,7 +256,7 @@ the anchor and tip that a request belongs to. It deliberately omits height becau
 fork switch can replace a branch without changing its height.
 
 When a result returns, `Gate` in
-[`completion.rs`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/work/completion.rs) compares its branch
+[`completion.rs`](../../../crates/zakura-header-chain/src/work/completion.rs) compares its branch
 and generation with the current snapshot. It accepts current work and rejects stale
 work. It ignores `state_version` because unrelated transitions increment that counter
 and would cancel valid requests. The scheduler uses the same branch and generation to
@@ -301,7 +301,7 @@ and verifies the result. This boundary implements
 [block-sync concerns excluded (`LC-SCOPE-06`)](../../specs/fork-aware-header-chain-engine.md#lc-scope-06):
 unrelated block-sync policy cannot affect header fork choice.
 
-[`retention.rs`](https://github.com/zakura-core/zakura/blob/722f615550cb29637f3f5ed95f71e4522decd1cd/crates/zakura-header-chain/src/transition/planner/retention.rs) protects the
+[`retention.rs`](../../../crates/zakura-header-chain/src/transition/planner/retention.rs) protects the
 selected path, the verified path, the path to every retained body that full state has
 verified, and nodes that active work still references. When protected state fills the
 node limit, the engine refuses admission. The

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -1,11 +1,11 @@
-# How the fork-aware header chain works
+# Fork-aware header-chain implementation
 
 This guide explains how PR #586 implements the
 [fork-aware header-chain specification](../../specs/fork-aware-header-chain-engine.md).
 Each linked property names the behavior that the code implements. The specification
 remains authoritative.
 
-## Why one planner selects the chain
+## Single-planner fork choice
 
 Four events can change the selected header chain. Peers add headers. Full state reports
 verified blocks and consensus-invalid bodies. A node administrator can exclude or
@@ -21,9 +21,9 @@ It does not delete them. `reconsiderblock` removes that exclusion, so the branch
 become eligible again unless another reason still excludes it. The code represents
 these calls as `OperatorInvalidate` and `OperatorReconsider` events.
 
-## What state the engine keeps
+## Header-chain state
 
-[`MemHeaderStore`](../../../crates/zakura-header-chain/src/graph.rs) holds every retained
+[`MemHeaderStore`](../../../crates/zakura-header-chain/src/graph/mod.rs) holds every retained
 header in a directed acyclic graph (DAG). Each `HeaderNode` is keyed by its consensus
 hash and names its parent. The finalized `Frontier` is the graph root. A `Frontier`
 contains both height and hash, so it identifies one position on one branch.
@@ -42,7 +42,7 @@ Selection takes the maximum score over all eligible tips. This implements
 [deterministic selection (`LC-SELECT-04`)](../../specs/fork-aware-header-chain-engine.md#lc-select-04):
 the same eligible DAG selects the same tip regardless of header arrival order.
 
-## How a header reaches the graph
+## Header admission and validation
 
 The header-sync driver prepares a downloaded batch before it takes the state writer
 lock. It obtains a validation lease for the common ancestor and checks properties that
@@ -66,7 +66,7 @@ staged graph. It admits a header only after every required check passes. This im
 After planning, `verify_plan` independently checks the resulting graph, projections,
 generation changes, and protected nodes before the runtime writes anything.
 
-## How a transition commits
+## Transition commit order
 
 `MemHeaderStore` contains the committed graph.
 [`GraphOverlay`](../../../crates/zakura-header-chain/src/graph/overlay.rs) reads that graph
@@ -115,11 +115,11 @@ the runtime commits the DAG changes, metadata, projections, and related indexes 
 RocksDB batch before it publishes the new snapshot.
 
 Startup uses
-[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery.rs) while
+[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery/mod.rs) while
 publication is disabled. The audit checks the stored source rows and rebuilds derived
 indexes and projections. It refuses inconsistencies that it cannot reconstruct.
 
-### The three write paths
+### Write paths
 
 `apply` commits a header-chain change without a block-state change. Header downloads,
 deferred-header reevaluation, and body evidence use this path.
@@ -137,7 +137,7 @@ A no-change plan still commits the caller's block-state batch when one exists, b
 does not install or publish a header-chain change. A `ResourceStalled` result discards
 the caller's block-state rows. It writes a changed header-chain alarm when needed.
 
-## How a fork switch runs
+## Fork switching
 
 A fork switch changes the selected path. It does not roll back the header DAG.
 
@@ -173,7 +173,7 @@ the verified path must move to the other branch. `SyncCoordinator` holds the pro
 apply permit during that handoff, so the native and legacy block-apply paths cannot run
 at the same time.
 
-## How VCT evidence is tracked
+## VCT evidence and authentication
 
 Peers can provide commitment-tree roots before the node downloads the corresponding
 block body. The engine stores each delivery against a header hash instead of a height.
@@ -191,14 +191,14 @@ Unauthenticated evidence does not affect header validity or fork choice. The
 fetches missing evidence separately for each branch and generation. The full tree design
 lives in [Verified commitment trees](../verified-commitment-trees.md).
 
-## How the node rejects late work
+## Stale work rejection
 
 Header requests can finish after the selected branch has changed. `BranchId` identifies
 the anchor and tip that a request belongs to. It deliberately omits height because a
 fork switch can replace a branch without changing its height.
 
 When a result returns, `Gate` in
-[`ownership.rs`](../../../crates/zakura-header-chain/src/ownership.rs) compares its branch
+[`completion.rs`](../../../crates/zakura-header-chain/src/work/completion.rs) compares its branch
 and generation with the current snapshot. It accepts current work and rejects stale
 work. It ignores `state_version` because unrelated transitions increment that counter
 and would cancel valid requests. The scheduler uses the same branch and generation to
@@ -229,7 +229,7 @@ and verifies the result. This boundary implements
 [block-sync concerns excluded (`LC-SCOPE-06`)](../../specs/fork-aware-header-chain-engine.md#lc-scope-06):
 unrelated block-sync policy cannot affect header fork choice.
 
-[`retention.rs`](../../../crates/zakura-header-chain/src/retention.rs) protects the
+[`retention.rs`](../../../crates/zakura-header-chain/src/transition/planner/retention.rs) protects the
 selected and verified paths. When protected state fills the node limit, the engine
 refuses admission instead of deleting either path. This implements
 [fork and node limits (`LC-RETAIN-01`)](../../specs/fork-aware-header-chain-engine.md#lc-retain-01).

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -1,218 +1,218 @@
-# Production Code in the Fork-Aware Header-Chain Change
+# How the fork-aware header chain works
 
-Parent: `docs/specs/fork-aware-header-chain-engine.md` (rules cited as `LC-*`).
-Source: PR #586, branch `hc/01-engine-model`, merge base `ba9261a73`, measured at
-`664607d4f`.
+This guide explains how PR #586 implements the
+[fork-aware header-chain specification](../../specs/fork-aware-header-chain-engine.md).
+Each linked property names the behavior that the code implements. The specification
+remains authoritative.
 
-## The problem all of this answers
+## Why one planner selects the chain
 
-Four independent sources want the tip to move. Peers deliver headers, full state
-verifies bodies, an operator invalidates a branch, and finality advances. If each source
-computes the move, the node runs as many fork-choice implementations as it has sources,
-and they disagree. Timing breaks it even when they agree: a source that computed its
-answer against an old view lands late and overwrites a newer one. That is the production
-incident this design replaced.
+Four events can change the selected header chain. Peers add headers. Full state reports
+verified blocks and consensus-invalid bodies. A node administrator can exclude or
+restore a block through `invalidateblock` and `reconsiderblock`. Finalization moves the
+point below which the node will not reorganize.
 
-The answer is one rule. A source states what it observed, and one planner turns that
-evidence into every consequence. The five layers below are that rule under five
-different constraints: keep the planner pure, keep the network crate unable to reach the
-database, make the durable order survive a crash, keep async work from outliving its
-authority, and keep two block-apply paths from running at once.
+Separate code paths must not update fork choice independently. They could choose
+different tips, or a late result could overwrite a newer result. Each path now reports
+what it observed to one planner. The planner alone selects the best eligible tip.
 
-## The abstractions to know first
+`invalidateblock` makes the named block and its descendants ineligible for selection.
+It does not delete them. `reconsiderblock` removes that exclusion, so the branch can
+become eligible again unless another reason still excludes it. The code represents
+these calls as `OperatorInvalidate` and `OperatorReconsider` events.
 
-The file list below assumes this vocabulary.
+## What state the engine keeps
 
-### The graph, the overlay, and the delta
+[`MemHeaderStore`](../../../crates/zakura-header-chain/src/graph.rs) holds every retained
+header in a directed acyclic graph (DAG). Each `HeaderNode` is keyed by its consensus
+hash and names its parent. The finalized `Frontier` is the graph root. A `Frontier`
+contains both height and hash, so it identifies one position on one branch.
 
-`MemHeaderStore` in `graph.rs` is the graph. It holds every retained header as a
-`HeaderNode` keyed by consensus hash, rooted at the finalized `Frontier`. A `Frontier`
-is a height and a hash together, and it is the only way this design names a position on
-a chain. A node carries the header, its parent hash, a height from a checked parent
-increment, the block work derived from the validated compact target, a
-`WorkCoordinate`, a header validation state, an eligibility state, a body validation
-state, and its auxiliary delivery ids. Beside the node map the graph keeps three
-indexes it can rebuild from the nodes alone: children by parent, hashes by height, and
-the set of eligible tips.
+The engine keeps two paths through the DAG. The selected path ends at the best eligible
+header tip. The verified path ends at the tip whose blocks full state has accepted.
+Each path is stored as an ordered list of frontiers, so readers can answer height queries
+without walking the graph.
 
-Selection reads that graph. `select_best_header_chain` takes the maximum score over the
-eligible tips, so permuting arrivals cannot change the answer (LC-SELECT-04). A node is
-eligible when its header is valid, it carries no exclusion reason, and no ancestor is
-ineligible, which makes ineligibility a set of durable reasons rather than a flag. A
-flag is last-writer-wins, and last-writer-wins is arrival order in disguise.
+A node is eligible when its header is valid, it has no direct exclusion reason, and its
+ancestors are eligible. The graph stores exclusion reasons instead of one boolean flag.
+This lets independent causes coexist and lets `reconsiderblock` remove one manual
+exclusion without removing a consensus-invalid body result.
 
-The engine holds the graph and two projections beside it. The selected projection lists
-the frontier of every prefix of the best header chain from finality to the tip, and the
-verified projection lists the same for the chain full state has verified. A projection
-is a list, so a reader answers a height query without walking the DAG.
+Selection takes the maximum score over all eligible tips. This implements
+[deterministic selection (`LC-SELECT-04`)](../../specs/fork-aware-header-chain-engine.md#lc-select-04):
+the same eligible DAG selects the same tip regardless of header arrival order.
 
-`GraphOverlay` in `graph/overlay.rs` is a mutable view over a borrowed graph. Reads see
-the base plus whatever the overlay staged, writes land in the overlay's own maps, and
-the base never changes. `GraphDelta` is what the overlay extracts: a new finalized
-frontier when finality moved, the nodes to put, and the nodes to delete. A node the
-overlay inserted and then deleted appears in neither list, and a node it wrote back
-unchanged appears in neither, so the delta holds the difference and nothing else.
+## How a header reaches the graph
 
-Both types implement `HeaderGraphView` and `HeaderGraphEdit`, so selection, eligibility
-propagation, and the invariant checks run one implementation against committed state
-and against a staged one. The planner therefore derives a complete transition without
-copying the graph and without touching the live one.
+The header-sync driver prepares a downloaded batch before it takes the state writer
+lock. It obtains a validation lease for the common ancestor and checks properties that
+need no candidate ancestry, including encoding, proof of work, and commitment format.
+CPU-heavy checks run on a blocking thread.
 
-`TransitionPlan` is what it derives: the change set the store will write, the private
-`GraphDelta` the engine will install, and `before()`, the snapshot it was derived from.
+A header whose time is more than two hours ahead of the local clock waits until that
+time becomes valid. It does not become permanently invalid. This implements
+[future-header deferral (`LC-VAL-08`)](../../specs/fork-aware-header-chain-engine.md#lc-val-08).
+The state write loop schedules reevaluation, so the peer does not need to send the
+header again.
 
-### Work owners, generations, and branches
+Under the writer lock, `HeaderChainRuntime` reads the parent and finality context from
+the durable store. The runtime does not trust ancestry supplied by the caller. It also
+checks that the prepared batch still belongs to the current network, trust anchor, and
+parent context.
 
-The reactor issues requests asynchronously, so an answer can arrive after the question
-stopped meaning anything. A `BranchId` names the work an answer belongs to by the
-anchor it was rooted at and the tip it pursued. It carries no height, because a reset at
-the same height passes every height comparison. Three counters move underneath it.
-`state_version` increments on every committed transition that changed a durable fact.
-`header_generation` increments when selection, header topology, header validation,
-eligibility, or finality moved. `verified_generation` increments when the verified
-projection moved or finality advanced.
+The planner then checks parent linkage, height, work, difficulty, and time against the
+staged graph. It admits a header only after every required check passes. This implements
+[validation before admission (`LC-VAL-11`)](../../specs/fork-aware-header-chain-engine.md#lc-val-11).
+After planning, `verify_plan` independently checks the resulting graph, projections,
+generation changes, and protected nodes before the runtime writes anything.
 
-`Gate` in `ownership.rs` judges a response against the current snapshot and returns a
-`CompletionDecision`: `Current`, or `Stale` carrying a typed `StaleReason` of
-`HeaderGeneration`, `VerifiedGeneration`, `BranchAnchor`, `MissingOwner`, or
-`OwnerMismatch`. It reads the generations and the branch anchor, and it ignores
-`state_version`, because that counter also moves for transitions on branches the request
-never went near, so binding header work to it would cancel in-flight requests faster
-than they complete for no correctness gain. The planner repeats the same check as
-`TransitionFailure::Stale`, and the scheduler keys its work by `(generation, branch)`.
+## How a transition commits
 
-### Keeping three copies in agreement
+`MemHeaderStore` contains the committed graph.
+[`GraphOverlay`](../../../crates/zakura-header-chain/src/graph/overlay.rs) reads that graph
+and records staged changes without mutating it. Planning extracts those changes as a
+`GraphDelta`. The runtime applies the delta to `MemHeaderStore` only after the durable
+write succeeds.
 
-The same state exists three times: staged in an overlay, committed in the engine's
-graph, and durable in the store. Six rules keep them from diverging.
+```mermaid
+sequenceDiagram
+  participant W as State writer
+  participant R as HeaderChainRuntime
+  participant E as HeaderChainEngine
+  participant O as GraphOverlay
+  participant M as MemHeaderStore
+  participant D as Durable store
+  participant P as Observers
 
-The overlay never writes to its base, and `GraphDelta`'s fields are private to the
-crate, so no caller assembles a partial one.
+  W->>R: apply(request)
+  R->>E: plan_transition(request)
+  E->>O: stage changes
+  O->>M: read committed nodes
+  M-->>O: committed state
+  O-->>E: GraphDelta
+  E-->>R: TransitionPlan
+  R->>D: write change set atomically
 
-The delta rechecks itself against whichever graph it lands on. `derive_index_changes`
-recomputes each put node's hash, parent link, and work from the compact target, refuses
-a delete of a node the base does not hold, refuses a hash that is both put and deleted,
-and refuses a finalized frontier that is missing or ineligible. `apply_delta` runs that
-check before it mutates, and `validate_delta` runs it without mutating.
+  alt write succeeds
+    D-->>R: success
+    R->>E: install_committed_transition(plan)
+    E->>M: apply GraphDelta
+    R->>P: publish snapshot
+    R-->>W: success
+  else write fails
+    D-->>R: error
+    R-->>W: error; memory and observers stay unchanged
+  end
+```
 
-`verify_plan` checks the plan against a graph rebuilt from the delta with
-`GraphOverlay::from_delta`, not against the overlay the planner mutated, so the verifier
-approves the transition the engine will install rather than the one it staged.
+The runtime updates disk first, memory second, and observers last. After a crash,
+startup can rebuild memory from disk. Publishing before the write would expose state
+that the next restart cannot recover.
 
-`install_committed_transition` compares the live snapshot with the plan's `before()` and
-refuses with `StaleSource` when they differ. `plan_transition` takes `&self`, so two
-planners can run against one engine; only one of them can install.
+A frontier-changing transition follows
+[atomic frontier mutation (`LC-TXN-01`)](../../specs/fork-aware-header-chain-engine.md#lc-txn-01):
+the runtime commits the DAG changes, metadata, projections, and related indexes in one
+RocksDB batch before it publishes the new snapshot.
 
-Disk leads memory leads observers, and that order is forced. The next restart reads
-disk, so a crash in this order leaves disk ahead of memory, which the startup audit
-repairs by rehydrating, and a crash in any other order leaves an observer holding a
-frontier that is not on disk, which nothing repairs. One transition makes one atomic
-`db.write`, so a crash leaves the whole batch or none of it. A failure between the write
-and the install fails closed: the runtime returns the store error, publishes nothing,
-and the next open rehydrates the engine from disk.
+Startup uses
+[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery.rs) while
+publication is disabled. The audit checks the stored source rows and rebuilds derived
+indexes and projections. It refuses inconsistencies that it cannot reconstruct.
 
-The durable indexes are caches. The authoritative rows are the per-node rows in
-`header_node_by_hash` and the singleton in `header_engine_meta`. Children, heights,
-eligibility roots, deferrals, and both projections are rebuilt by the startup audit from
-the node rows, which is why a crash that leaves disk ahead of memory is repairable and
-the reverse order is not.
+### The three write paths
 
-### When the store is written
+`apply` commits a header-chain change without a block-state change. Header downloads,
+deferred-header reevaluation, and body evidence use this path.
 
-Once per committed transition, inside the writer lock, and nowhere else in the steady
-state. There is no accumulation and no background flush: the runtime builds one
-`DiskWriteBatch` from the change set and calls `db.write` once (LC-TXN-01). What else
-lands in that one write depends on which call the state writer made.
+`apply_combined` commits a block-state change and its related header-chain change in one
+RocksDB batch. This prevents block state and header metadata from disagreeing.
+`apply_combined_expected` adds the expected-state guard used by normal block
+verification.
 
-| Call | What lands in the one write |
-| --- | --- |
-| `apply` | the header-chain rows alone |
-| `apply_combined` | those rows appended to the block batch the state writer already filled |
-| `apply_aux_then_checkpoint_combined` | auxiliary authentication and the checkpoint advance that depends on it, planned into the same batch |
-| a no-change plan | the caller's batch alone, with nothing installed and nothing published |
-| a `ResourceStalled` plan | an alarm-only batch, discarding the caller's rows, so the state writer stops with its own rows unwritten |
+`apply_aux_then_checkpoint_combined` commits verified commitment tree (VCT)
+authentication, a dependent checkpoint advance, and the block-state change in one
+batch.
 
-Two more writes happen outside that path. When the startup audit finds repairs, the
-runtime commits one repair batch before the engine exists. On first run against a store
-that predates the DAG, `migration.rs` builds the initial nodes and the migrated finality
-pin in its own write.
+A no-change plan still commits the caller's block-state batch when one exists, but it
+does not install or publish a header-chain change. A `ResourceStalled` result discards
+the caller's block-state rows. It writes a changed header-chain alarm when needed.
 
-One transition starts without any component observing anything. The write loop keeps a
-timer for `earliest_deferred()` and submits `ReevaluateDeferred` when it elapses, which
-is how a header held for a local future time becomes eligible. It flushes like every
-other transition.
+## How a fork switch runs
 
-### What a header is checked against, and when
+A fork switch changes the selected path. It does not roll back the header DAG.
 
-Validation runs four times before disk, each pass against more context than the last,
-and no pass trusts the one before it.
+```mermaid
+sequenceDiagram
+  participant P as Peer
+  participant N as Header-sync reactor
+  participant D as Header-sync driver
+  participant S as State service
+  participant E as HeaderChainEngine
+  participant O as Subscribers
 
-Off the writer lock, `prepare_header_target` in the driver reads a validation lease for
-the common ancestor through the read service, derives `HeaderRules` from that lease, and
-runs `prepare_context_free_headers` on a blocking thread. Those are the rules that read
-no ancestor: canonical version and hash, checked height inference, commitment structure
-for that height, compact-target domain and network limit, hash at or below target, and
-Equihash. A header whose time runs more than two hours ahead of the local clock comes
-back `DeferredUntil` rather than rejected (LC-VAL-08). The result is a
-`PreparedHeaderBatch` sealed with a receipt naming the parent frontier, the network, and
-the trust-anchor digest.
+  P-->>N: headers on an alternate branch
+  N->>D: prepare_header_target
+  D->>S: read validation context
+  S-->>D: prepared target
+  N->>D: apply_header_target
+  D->>S: apply prepared headers
+  S->>E: plan InsertHeaders
+  E->>E: validate and score eligible tips
+  E-->>S: plan with selected path
+  S->>S: write, install, and publish
+  S-->>O: new selected path and generation
+```
 
-Under the writer lock and before planning, the runtime reads the predecessor facts
-itself rather than accepting any the caller supplies. It seals the parent's validation
-context, the anchor's when finality moved, and the finality rebase path, then wraps the
-caller's authority in `StateIssuedAuthority` over exactly the leases it just issued, so
-a lease from anywhere else is refused.
+If the new branch has the best eligible score, the plan replaces the selected path and
+records a new header generation. The old branch remains in the DAG with its own tip.
+Header-sync and block-sync subscribers read the new path from the published snapshot.
+Their completion gates reject late work from the old generation.
 
-In the planner, against the graph, the receipt's parent, network, and trust-anchor
-digest must still match the live config, or the transition fails with
-`StalePreparation` (LC-VAL-11). The planner then re-derives, per header, the parent
-link, the hash, the height increment, and the work from the compact target, and runs
-`validate_contextual_difficulty_and_time` against ancestry it reads from the graph and
-the lease. A peer's framing height is never evidence.
+Full state then verifies blocks on the new path. It reports a verified-chain reset when
+the verified path must move to the other branch. `SyncCoordinator` holds the process-wide
+apply permit during that handoff, so the native and legacy block-apply paths cannot run
+at the same time.
 
-After planning and before disk, `verify_plan` re-derives the projected result: hashes
-and linkage, index round-trips, work coordinates, inherited eligibility, both
-projections' contiguity, that `header_best` really is the maximum eligible score, trust
-pins, protected nodes, frozen limits, generation increments, and auxiliary provenance.
-A disagreement between the planner and the verifier is `InvariantViolation`, and that
-batch never reaches disk.
+## How VCT evidence is tracked
 
-Startup adds a pass that answers to no caller: `audit_store` re-derives what the DAG
-determines before the engine exists.
+Peers can provide commitment-tree roots before the node downloads the corresponding
+block body. The engine stores each delivery against a header hash instead of a height.
+Deliveries from competing branches therefore remain separate.
 
-## How this list was cut
+A delivery starts unauthenticated. The
+[state VCT code](../../../crates/zakura-state/src/service/finalized_state/vct.rs) checks it
+against the commitment in the next header. The planner accepts the resulting evidence
+only when that next header directly follows the target on the same owned branch and the
+delivery provenance has not changed. The exact transition checks live in
+[`auxiliary_authentication.rs`](../../../crates/zakura-header-chain/src/transition/planner/event_effects/auxiliary_authentication.rs).
 
-The change touches 303 files, adding 88,706 lines and removing 46,587. Most of that is
-not the design. Tests and harnesses account for 26,382 added lines, fuzzing for 10,388,
-docs and manifests for 1,180, CI, docker, and policy for 1,150, and a lockfile and two
-data files for 34. What remains is 152 Rust files of production code, 49,572 lines added
-and 23,994 removed.
+Unauthenticated evidence does not affect header validity or fork choice. The
+[repair scheduler](../../../crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs)
+fetches missing evidence separately for each branch and generation. The full tree design
+lives in [Verified commitment trees](../verified-commitment-trees.md).
 
-Twelve of those files are deletions, listed at the end. Sixty-five of the surviving 140
-carry the design. The other 75 are integration: a call site moved, a type re-exported, a
-service registered. This document lists the 65 by layer, then names the integration
-edits and the code the change deletes.
+## How the node rejects late work
 
-Exclusions applied, in order: `fuzz/`, every `fuzz.rs`, `/tests/` and `tests.rs`,
-`testkit/`, the `header_chain/coherence/` model harness, `bench.rs`, `arbitrary.rs`,
-`crates/xtask/`, `docs/`, `.github/`, `docker/`, `deploy/`, `qa/`, and lockfiles. Two
-excluded files still matter to a reader: `crates/zakura-header-chain/conformance.toml`
-(926 lines) is the machine-checked rule manifest, and
-`crates/xtask/src/header_conformance.rs` (1,285 lines) is the checker that enforces it.
+Header requests can finish after the selected branch has changed. `BranchId` identifies
+the anchor and tip that a request belongs to. It deliberately omits height because a
+fork switch can replace a branch without changing its height.
 
-One caveat on every count below. Rust colocates unit tests, so a file's added-line
-figure includes its `#[cfg(test)]` module. In the new crate, 17,176 added lines are
-12,360 lines of code and 4,816 lines of colocated tests.
+When a result returns, `Gate` in
+[`ownership.rs`](../../../crates/zakura-header-chain/src/ownership.rs) compares its branch
+and generation with the current snapshot. It accepts current work and rejects stale
+work. It ignores `state_version` because unrelated transitions increment that counter
+and would cancel valid requests. The scheduler uses the same branch and generation to
+retire stale work.
 
-## Five layers
+## Component boundaries
 
 ```mermaid
 flowchart TD
-  ZD["zakurad<br/>drivers, coordinator, lifecycle"]
-  NW["zakura-network<br/>header-sync reactor, wire, scheduler"]
-  ST["zakura-state<br/>runtime, store, schema"]
-  NS["zakura-node-services<br/>typed port traits"]
-  HC["zakura-header-chain<br/>pure, synchronous, decides which chain is best"]
+  ZD["zakurad<br/>drivers and process coordination"]
+  NW["zakura-network<br/>protocol, timing, and scheduling"]
+  ST["zakura-state<br/>durability and publication"]
+  NS["zakura-node-services<br/>network-state port"]
+  HC["zakura-header-chain<br/>validation, planning, and selection"]
   ZD --> NW
   ZD --> ST
   NW --> NS
@@ -220,353 +220,58 @@ flowchart TD
   NS --> HC
 ```
 
-Thirteen commits landed the change. Four introduce the production code, and each of the
-first three is one layer. The fourth covers both the reactor and the drivers, because
-the port implementation and the facility that calls it have to arrive together. Five
-later commits revise that code after review, and the remaining four add tests, fuzzing,
-docs, and release plumbing.
+### `zakura-header-chain`: validation and selection
 
-| Commit | Adds |
-| --- | --- |
-| `04ed5f077 feat(header-chain)!: add fork-aware graph model` | the pure crate |
-| `dd5b79dd1 refactor(node-services)!: add typed header-sync contracts` | the port |
-| `4fefdd266 feat(state)!: persist and recover fork-aware header chains` | runtime, store, schema |
-| `ebb60ab2d feat(network)!: add bounded fork-aware header sync` | reactor, wire, drivers |
+This crate is synchronous and performs no disk or network I/O. Its
+[`transition` package](../../../crates/zakura-header-chain/src/transition/) admits an
+event, applies it to staged state, settles finality and retention, derives the write set,
+and verifies the result. This boundary implements
+[block-sync concerns excluded (`LC-SCOPE-06`)](../../specs/fork-aware-header-chain-engine.md#lc-scope-06):
+unrelated block-sync policy cannot affect header fork choice.
 
-## Layer 1: `zakura-header-chain`, 34 files, +17,176
+[`retention.rs`](../../../crates/zakura-header-chain/src/retention.rs) protects the
+selected and verified paths. When protected state fills the node limit, the engine
+refuses admission instead of deleting either path. This implements
+[fork and node limits (`LC-RETAIN-01`)](../../specs/fork-aware-header-chain-engine.md#lc-retain-01).
 
-A new crate, synchronous and pure. It holds every rule about which chain of headers is
-best and performs no effect: no disk, no socket, no clock of its own, no task. Purity is
-what makes fork choice testable without a node, replayable from an event list, and
-usable by a headers-only client that links no database.
+[`conformance.toml`](../../../crates/zakura-header-chain/conformance.toml) lists the
+machine-checked rules. The
+[`header_conformance` checker](../../../crates/xtask/src/header_conformance.rs) enforces
+that manifest.
 
-A crate stays pure only if its dependency list does, so the boundary sits where a test
-can fail the build. Two architecture tests in `lib.rs` hold it: one fails if the
-manifest gains `tokio`, `tower`, `zakura-state`, `zakura-network`, or
-`zakura-consensus`, and the other scans the crate's own sources for wallet, FlyClient,
-and block-sync surfaces (LC-SCOPE-06).
+### `zakura-node-services`: the network-state port
 
-### Vocabulary: nine files that refuse things
+[`header_chain.rs`](../../../crates/zakura-node-services/src/header_chain.rs) defines the
+port between the network reactor and state. The port prevents `zakura-network` from
+reaching the database. `AdapterKey` seals prepared header work so no caller can replace
+it between preparation and application.
 
-These files name values, but each one exists to make a mistake unrepresentable rather
-than to hold data. A `WorkCoordinate` carries the origin hash it accumulated from, so
-two coordinates from different origins refuse to compare instead of returning a
-plausible number that would silently decide fork choice. Generation counters use
-`checked_next` and fail closed at `u64::MAX` rather than wrap. Every error carries an
-explicit `Attribution`, so no generic conversion can charge a local disk failure to a
-peer.
+### `zakura-state`: durability and recovery
 
-| File | Added | Role |
-| --- | --- | --- |
-| `src/lib.rs` | 196 | module list, public re-export surface, the two architecture tests |
-| `src/ids.rs` | 443 | identities and generation counters: `HeaderId`, `EvidenceId`, `SourceId`, `BranchId`, `StateVersion`, `FinalityEpoch`, and the work owners and authorities |
-| `src/frontier.rs` | 220 | `Frontier`, `ChainScore`, `WorkCoordinate`, `SuffixWork`, and exact chain-work ordering |
-| `src/header_node.rs` | 351 | `HeaderNode`, the admitted header record, plus header, body, and eligibility state |
-| `src/error.rs` | 412 | `HeaderChainError`, `ErrorCategory`, `RuleId`, and `Attribution`, the peer-blame boundary |
-| `src/config.rs` | 669 | `EngineConfig`, `EngineMode`, `TrustedAnchor`, `CheckpointSet`, settled-upgrade pins, and the versioned `_V1` limits |
-| `src/locator.rs` | 213 | `HeaderLocator` built from a committed selected path, capped at 13 hashes |
-| `src/ownership.rs` | 441 | `PendingOwners` and `Gate`, which decide whether a late response still owns its branch |
-| `src/retention.rs` | 582 | `enforce_retention`, the deterministic eviction planner |
+[`HeaderChainRuntime`](../../../crates/zakura-state/src/service/finalized_state/header_chain.rs)
+is the sole header-chain writer and publisher. The runtime builds one durable batch,
+installs the committed transition, and publishes the new snapshot in that order.
 
-Two of the nine hold algorithms rather than types. `ownership.rs` holds the completion
-gate described above. `retention.rs` holds the eviction planner, and eviction is the one
-place a resource limit could pass for a verdict about a chain. It refuses that twice.
-Eviction writes no reason and no body state, so re-inserting the identical header
-restores an eligible node. When protected paths alone fill the node bound,
-`RetentionPlan` sets `admission_refused` and `resource_stalled` instead of evicting
-protected state or synthesizing finality for room (LC-RETAIN-01).
+The header-chain column families use a `_v1` suffix, so a future incompatible encoding
+can use a new family instead of reinterpreting existing data. The
+[`migration`](../../../crates/zakura-state/src/service/finalized_state/header_chain/migration.rs)
+builds an initial DAG when an existing database stores only one chain.
 
-### The DAG: two files split by one question
+### `zakura-network`: protocol timing and branch-owned work
 
-The question is whether the code may mutate committed state. `graph.rs` owns the queries
-and selection over committed state, and holds the two properties that keep arrival order
-out of fork choice: selection is `max` over a set, and height comes from a checked
-parent increment rather than the height a peer framed. `graph/overlay.rs` holds the
-staging types, which is what lets planning be pure. A plan the caller drops leaves
-nothing behind, so the durable caller chooses the order of its effects.
+The network component decides when to request data, which peer to ask, and how much work
+to keep in flight. It cannot validate headers or select a chain. The
+[`scheduler`](../../../crates/zakura-network/src/zakura/header_sync/scheduler/) keys work
+by branch and generation, so a fork switch retires only stale work.
 
-| File | Added | Role |
-| --- | --- | --- |
-| `src/graph.rs` | 2,538 | in-memory DAG, ancestry and height queries, eligibility propagation, selection, tombstones |
-| `src/graph/overlay.rs` | 1,443 | `GraphOverlay`, `GraphDelta`, and the copy-on-write staging of one transition |
+The header-sync stream uses its version as a compatibility boundary. This implements
+[immutable schema evolution (`LC-WIRE-15`)](../../specs/fork-aware-header-chain-engine.md#lc-wire-15):
+changing a message schema requires a new schema identifier or stream version. The
+[`pipe`](../../../crates/zakura-network/src/zakura/header_sync/pipe.rs) briefly remembers
+cancelled request IDs, so a late valid response does not count as peer misbehavior.
 
-### The transition: twenty files in refusal order
+### `zakurad`: process coordination
 
-The split follows the order in which a transition can still be refused for free. Types
-constrain what an event may say. Admission decides who may say it. The event effects
-derive each event's consequences against a staged projection. Settlement and the write
-set turn that projection into a plan. The verifier re-derives that result before disk
-can see it. Recovery is the one path that skips all of them, so it is separate.
-
-| File | Added | Role |
-| --- | --- | --- |
-| `src/transition/mod.rs` | 27 | the module's re-export surface |
-| `src/transition/types.rs` | 1,724 | every typed input and output: the twelve events, `TransitionRequest`, `EngineSnapshot`, change sets, `AuxDelivery`, `ValidationLease` |
-| `src/transition/planner.rs` | 335 | the phase sequence, `PlanCandidate`, and `TransitionPlan` |
-| `src/transition/planner/admission.rs` | 367 | bounded admission, authentication, and header-insertion rebasing |
-| `src/transition/planner/projected_state.rs` | 369 | `ProjectedTransitionState`: graph, verified path, and auxiliary deltas as one mutable projection |
-| `src/transition/planner/settlement.rs` | 214 | finality, retention, and projection settlement after the event effects run |
-| `src/transition/planner/write_set.rs` | 272 | generation policy and durable write-set derivation |
-| `src/transition/planner/event_effects/mod.rs` | 95 | the read-only event context and the exhaustive dispatch over the twelve events |
-| `src/transition/planner/event_effects/header_admission.rs` | 212 | prepared header insertion and atomic auxiliary delivery admission |
-| `src/transition/planner/event_effects/full_state_evidence.rs` | 194 | authoritative full-state conclusions and finality evidence |
-| `src/transition/planner/event_effects/header_validation.rs` | 192 | shared retained-context and full-state header validation |
-| `src/transition/planner/event_effects/auxiliary_authentication.rs` | 105 | auxiliary delivery authentication and rejection |
-| `src/transition/planner/event_effects/body_availability.rs` | 95 | transient body availability and supplier-discovery evidence |
-| `src/transition/planner/event_effects/operator_policy.rs` | 73 | operator-driven eligibility and body-retry policy |
-| `src/transition/planner/event_effects/deferred_time.rs` | 31 | deferred local-time header reevaluation |
-| `src/transition/invariants.rs` | 995 | `verify_plan` and its 14 numbered violations, checked on the projected result |
-| `src/transition/engine.rs` | 573 | `HeaderChainEngine`: `from_audited_state`, the pure `plan_transition`, the post-write `install_committed_transition`, `snapshot`, and the two projections |
-| `src/transition/recovery.rs` | 1,606 | `audit_store` and `RecoveryPlan`, the startup audit and its deterministic repairs |
-| `src/transition/authority.rs` | 55 | `Clock`, `FullStateEvidenceAuthority`, and `TransitionContext` |
-| `src/transition/store.rs` | 14 | `StoreError`, with `Incoherent` and `Unavailable` |
-
-`types.rs` is where evidence is kept from asserting an answer. An event carries
-identities, hashes, and a stable evidence id, and never a tip, a generation, a prune
-list, or a publication request. The fingerprint over its effect-bearing fields turns an
-exact resubmission into `NoChange` and a reused key with different effects into a hard
-conflict.
-
-The planner is one algorithm in six named phases rather than one function. A request is
-admitted, its event's effects are applied to a `ProjectedTransitionState`, finality and
-retention settle that projection, and the write set derives the durable rows and the
-generation bumps. The result is a `PlanCandidate`, which becomes a `TransitionPlan` only
-after the independent verifier accepts it, so the type system carries the distinction
-between a projected write set and a verified one.
-
-`event_effects/mod.rs` dispatches on the twelve events with no fall-through arm, so a
-new event fails the build rather than defaulting to a no-op. Each of the seven handler
-modules owns one evidence domain, which is what keeps a change to operator policy from
-touching header admission.
-
-`authority.rs` is 55 lines and holds the whole capability model. It states that an event
-cannot supply its own time, so time arrives through `Clock`. It states that only a
-caller inside the state writer may vouch for staged full-state evidence, a scheduler
-retry, a header completion, or a validation lease. One of the four questions is required
-and the other three default to false, so an implementation that forgets an override
-refuses evidence instead of admitting it. `TransitionContext` holds the authority as an
-`Option`, so a caller outside the writer has no way to vouch at all.
-
-`recovery.rs` is the only path that builds engine state without the planner, so it
-decides on its own whether the store still describes one coherent chain. It repairs only
-what a DAG can reconstruct, recomputes selection rather than trusting a stored answer,
-and fails closed on anything else, with publication disabled until it finishes.
-
-### Validation: three files split by the context a rule reads
-
-The split decides which lock the caller needs, and production takes the context-free
-entry point traced above. `prepare_headers` is the other one: it runs parent linkage and
-contextual difficulty and time during preparation rather than leaving them to the
-planner, so it takes a `ValidationLease` that `is_coherent` re-derives. The tests and
-the fuzzer drive it; production does not.
-
-| File | Added | Role |
-| --- | --- | --- |
-| `src/validation/mod.rs` | 466 | per-header rules: link, encoding, compact target, hash filter, future time, commitment structure |
-| `src/validation/prepare.rs` | 691 | the two entry points and the sealed `PreparedHeaderBatch` |
-| `src/validation/contextual.rs` | 963 | `AdjustedDifficulty`, ThresholdBits, the ZIP 205 and 208 testnet rule, and median-time-past |
-
-`contextual.rs` moved here from `zakura-state/src/service/check/difficulty.rs`, so one
-implementation now decides difficulty for a candidate header and for a block.
-
-## Layer 2: `zakura-node-services`, 2 files, +1,387
-
-This layer exists to make a dependency impossible rather than discouraged.
-`zakura-network` needs header-chain state, and `zakura-state` sits above it, so a direct
-call would invert the stack and put the database within the reactor's reach. The port is
-a trait in a crate below both. The reactor calls seven named operations and can reach
-nothing else.
-
-| File | Added | Role |
-| --- | --- | --- |
-| `src/header_chain.rs` | 693 | the `Port` trait, the `AdapterKey` seal, `PortError`, and the `UnavailablePort` and `InertHeaderChainPort` stand-ins |
-| `src/sync_lifecycle.rs` | 694 | `ApplyPhase` and its declared edges, `LifecycleEpoch`, `HeaderRuntimeStatus`, `SyncServiceDemand` |
-
-The seven operations are `continuation_locator`, `vct_repair_context`,
-`acquire_header_path`, `read_header_path`, `release_header_path`,
-`prepare_header_target`, and `apply_header_target`. `AdapterKey` is what makes the last
-two safe as two separate calls: the adapter seals a `PreparedHeaderTarget` on the way
-out and is the only holder that can open it on the way back, so nothing can forge or
-substitute a prepared batch in between.
-
-`sync_lifecycle.rs` is here for the same reason as the port. `ApplyPhase`, its declared
-edges, and `LifecycleEpoch` are shared by state, network, and orchestration, and none of
-those three may own them without one of the others depending upward.
-
-## Layer 3: `zakura-state`, 11 files, +10,759 / -1,541
-
-This layer decides what survives a crash. The engine performs no effect, so its durable
-caller performs all of them, in the order set out above.
-
-One file dominates. `finalized_state/header_chain.rs` holds `HeaderChainRuntime`, the
-sole writer and sole publisher, alongside `HeaderChainStore`, the `Publisher`, the
-reader, the retained-path lease registry, the startup report, and four `FaultPoint`s
-that let the recovery tests interrupt the sequence at each step and check that the next
-startup repairs it.
-
-| File | Added | Removed | Role |
-| --- | --- | --- | --- |
-| `src/service/finalized_state/header_chain.rs` | 4,349 | 0 | the runtime, the store, the publisher, the reader, leases, fault points |
-| `src/service/finalized_state/disk_format/header_chain_values.rs` | 1,825 | 0 | version-one value codecs for the new column families |
-| `src/service/finalized_state/disk_format/header_chain.rs` | 492 | 0 | ordered key encodings for children, heights, eligibility roots, deliveries, deferrals, finality |
-| `src/service/finalized_state/header_chain/migration.rs` | 424 | 0 | first-run construction of the DAG from authenticated full state |
-| `src/service/write.rs` | 1,945 | 727 | the write loop: the only production caller of `apply`, combined batches, the deferred timer |
-| `src/service.rs` | 588 | 265 | runtime construction and the read and write service split |
-| `src/error.rs` | 376 | 274 | state error taxonomy for the new failures |
-| `src/service/finalized_state.rs` | 326 | 117 | opening the store, running the startup audit, wiring the runtime |
-| `src/request.rs` | 293 | 146 | new state requests |
-| `src/header_chain.rs` | 82 | 0 | the public retained-path contract: `RetainedPathLease`, `RetainedPathPage`, outcomes |
-| `src/response.rs` | 59 | 12 | new state responses |
-
-The schema adds fourteen column families, all suffixed `_v1`: `header_node_by_hash`,
-`header_child`, `header_height_hash`, `header_candidate`, `header_selected`,
-`header_verified`, `header_eligibility_root`, `header_aux_delivery`, `header_deferred`,
-`header_finality_history`, `header_validation_context`,
-`header_consensus_invalid_tombstone`, `header_body_evidence_authority`, and
-`header_engine_meta`. The key encodings are ordered on purpose, so a range scan answers
-a query that would otherwise need an index, and every index the schema does keep is a
-cache that the startup audit rebuilds from the node rows.
-
-`migration.rs` is the one-time problem. An existing store recorded one chain by height
-and never had a DAG, so first run reads the height-indexed header rows and builds a
-single selected path with a migrated finality pin. That pin is the reason
-`MigratedPinRefutation` exists as an event: an imported pin cannot be rolled back, so
-refuting one alarms and fails the node closed.
-
-## Layer 4: `zakura-network`, 14 files, +8,970 / -6,088
-
-This layer keeps its clock and gives up its authority. The reactor still decides when to
-ask, whom to ask, and how much to ask for, because those are timing questions and it is
-the only component with a timer. Everything else moved below it: whether a header is
-valid, which chain is best, whether a late response still counts. The reactor issues
-requests against a committed snapshot and reports what it observed through the port.
-
-| File | Added | Removed | Role |
-| --- | --- | --- | --- |
-| `header_sync/reactor.rs` | 3,834 | 3,207 | the single loop: admission, target selection, issuance, response routing, serving, leases, repair, alarms |
-| `header_sync/scheduler/peer_work.rs` | 1,424 | 0 | `PeerWorkQueue`, work priorities and phases, and the shared header-chunk budget |
-| `header_sync/wire.rs` | 1,073 | 256 | the four message discriminants and the bounded codec |
-| `header_sync/scheduler/retry.rs` | 643 | 0 | branch-owned body-availability retry episodes |
-| `header_sync/scheduler/repair.rs` | 503 | 0 | generation- and branch-owned auxiliary VCT repair work |
-| `header_sync/events.rs` | 394 | 551 | `HeaderSyncStartup`, the event enum, the handle |
-| `header_sync/service.rs` | 393 | 574 | the stream declaration and per-peer session spawn |
-| `header_sync/pipe.rs` | 346 | 1,121 | `run_peer`, the per-peer decode loop and its cancelled-response grace window |
-| `header_sync/scheduler/completed_targets.rs` | 147 | 0 | generation- and branch-keyed completed targets |
-| `header_sync/scheduler/status.rs` | 140 | 0 | `StatusPublisher`, coalescing advertisements behind a one-per-second floor |
-| `header_sync/config.rs` | 38 | 130 | `ZakuraHeaderSyncConfig` |
-| `header_sync/mod.rs` | 30 | 55 | module surface |
-| `header_sync/scheduler/mod.rs` | 5 | 0 | scheduler module list |
-| `header_sync/error.rs` | 0 | 194 | reduced to the startup error; the rest became `HeaderChainError` and `PortError` |
-
-Header sync is stream kind 5 at stream version 8, behind capability bit five, with a 2
-MiB message cap. The four discriminants are `Status`, `GetHeaders`, `Headers`, and
-`HeadersOutcome`, and they are closed: new wire data needs an advertised auxiliary
-schema bit or a successor stream version (LC-WIRE-15). The stream version is the
-compatibility barrier, so a peer that cannot speak version 8 never negotiates the stream
-rather than half-speaking it.
-
-The `scheduler/` split is the shape the sole-writer rule forces on a facility that owns
-no state. Work that used to sit in the reactor's own fields now sits in five small
-modules, each keyed by generation and branch, so one retirement pass retires exactly the
-work a reset invalidated and leaves the rest alive. `completed_targets.rs` is 147 lines
-and shows the idea at its smallest: a set whose key is `(generation, branch)`, which
-therefore cannot alias across either.
-
-`peer_work.rs` owns the one number the whole facility shares. A response page carries up
-to 1,000 headers by default and 4,000 at the cap, and the chunk budget divides that same
-4,000 across receiving, preparation, and application on every staged target, so one
-target cannot starve the others and the total in flight cannot exceed one transition's
-worth.
-
-`pipe.rs` handles the awkward case that follows from cancelling work. A retired request
-still gets an honest answer from the peer, so the pipe remembers up to 64 cancelled ids
-for 30 seconds and drops those responses instead of scoring them as protocol violations.
-
-## Layer 5: `zakurad`, 4 files, +3,797 / -2,274
-
-This layer is where the abstractions meet one process, and two of its four files answer
-a problem no lower layer can see: the node has two paths that apply blocks, and only one
-may run at a time.
-
-| File | Added | Removed | Role |
-| --- | --- | --- | --- |
-| `commands/start/zakura/header_sync_driver.rs` | 1,743 | 1,896 | the `Port` implementation over the state service, plus reactor startup assembly |
-| `commands/start/zakura/coordinator.rs` | 939 | 0 | `SyncCoordinator`: apply phases, apply permits, operation records, legacy-fallback leases |
-| `commands/start/zakura/block_sync_driver.rs` | 775 | 325 | turns block-sync actions into verified applies that carry a `BodyWorkOwner` |
-| `components/sync.rs` | 340 | 53 | legacy syncer changes for the lifecycle handshake |
-
-`header_sync_driver.rs` implements the port. It turns each of the seven operations into
-state-service requests and assembles the reactor's startup inputs, and it is the only
-file where header-sync policy and the state service know each other's names.
-
-`coordinator.rs` owns apply-phase transitions for the process. It holds the phase, a
-watch channel per observer, the in-flight count, a record per block-apply operation, and
-a drain notification, so the native and legacy paths hand off rather than overlap. It is
-the only new file in this layer with no deletions against it, because nothing like it
-existed.
-
-## Integration edits, 75 files, +7,483 / -5,471
-
-These files change because the core changed. None of them holds a rule.
-
-| Area | Files | Added | Removed | Why it changed |
-| --- | --- | --- | --- | --- |
-| network: block sync | 15 | 2,901 | 446 | consumes committed header snapshots for scheduling, and carries a body work owner |
-| network: transport, handler, discovery, trace | 13 | 1,777 | 1,764 | registers the header-sync service and its stream, and reworks the trace tables |
-| zakurad: start, trace, inbound | 8 | 1,291 | 1,381 | wiring, driver spawn, and trace plumbing |
-| state: adjacent modules | 21 | 902 | 1,764 | difficulty checks moved out, VCT plumbing, database open path |
-| consensus | 5 | 253 | 34 | body verification failure classes the engine can act on |
-| rpc | 1 | 160 | 7 | header-chain fields on existing methods |
-| chain | 10 | 153 | 74 | shared header and difficulty types |
-| jsonl trace and node-services re-exports | 2 | 46 | 1 | new trace rows and one re-export line |
-
-The state row removes more than it adds because `service/check/difficulty.rs` lost 375
-lines to `zakura-header-chain/src/validation/contextual.rs`, and `zakura_db/block.rs`
-lost 738 lines to the runtime and its audit.
-
-## What the change deletes
-
-Twelve production files, 8,620 lines.
-
-| Deleted file | Lines | Replaced by |
-| --- | --- | --- |
-| `network/header_sync/reactor/trace.rs` | 2,162 | the shared trace tables in `zakura/trace.rs` |
-| `network/header_sync/work_queue.rs` | 1,288 | `scheduler/peer_work.rs` |
-| `network/header_sync/state.rs` | 1,287 | the committed `EngineSnapshot` and the scheduler modules |
-| `network/exchange.rs` | 873 | the header-sync service and its stream |
-| `state/zakura_db/block/startup_audit.rs` | 667 | `transition/recovery.rs` and the runtime's audit |
-| `zakurad/start/zakura/trace/header_driver.rs` | 666 | reactor trace rows |
-| `network/header_sync/range.rs` | 508 | `HeaderLocator` and the selected projection |
-| `network/header_sync/validation.rs` | 383 | `zakura-header-chain/src/validation/` |
-| `network/header_sync/requester.rs` | 314 | the reactor's issuance path |
-| `zakurad/start/zakura/trace/chain_tip_mirror.rs` | 210 | the publisher's watch channel |
-| `network/header_sync/header_root_auth.rs` | 143 | `scheduler/repair.rs` and the auxiliary path |
-| `network/exchange/trace.rs` | 119 | the shared trace tables |
-
-Each deletion is one place where policy used to sit in the network crate and now sits
-below it. Header validity, fork choice, and work ownership left the reactor, which kept
-transport, scheduling, and timing.
-
-## Pieces that read well on their own
-
-Each of these is self-contained, and each one settles a question the rest of the design
-then assumes.
-
-| File | Lines | The question it settles |
-| --- | --- | --- |
-| `transition/authority.rs` | 55 | the entire capability model on one screen |
-| `frontier.rs` | 220 | why chain work is not a number you compare: only differences are comparable, and a mismatched origin is an error rather than a smaller number |
-| `retention.rs` | 582 | why an eviction planner should refuse new data rather than delete protected data |
-| `locator.rs` | 213 | why a locator fails on a gap instead of returning a shorter one, which would be a wrong answer that looks like a valid one |
-| `graph/overlay.rs` | 1,443 | what pure planning costs in practice once the graph is large |
-| `transition/planner/event_effects/mod.rs` | 95 | the twelve events dispatched with no fall-through arm, so a new event fails the build |
-| `transition/invariants.rs` | 995 | fourteen numbered violations, each with a comment naming what it caught |
-| `transition/recovery.rs` | 1,606 | the only code that decides for itself whether a store still describes one coherent chain |
-| `validation/contextual.rs` | 963 | the difficulty adjustment, the ZIP 205 and 208 testnet rule, and median-time-past, in one place |
-| `header_chain/migration.rs` | 424 | how to build a fork-aware DAG for a database that only ever stored one chain, and what that costs later |
-| `header_sync/wire.rs` | 1,073 | the case for a stream version as a hard compatibility barrier |
-| `scheduler/completed_targets.rs` | 147 | branch keying with nothing else in the file to distract from it |
-| `scheduler/retry.rs` | 643 | backoff whose jitter is deterministic: seeded from branch, header, and attempt and bounded to ten percent either way, so a test reproduces a retry schedule exactly |
-| `scheduler/status.rs` | 140 | coalescing under a one-second floor and a two-second ceiling on delay, the smallest complete example of the reactor owning timing |
-| `header_sync/pipe.rs` | 346 | why cancelling work must not turn a peer's honest answer into misbehaviour |
-| `coordinator.rs` | 939 | what "only one path may apply blocks" looks like once it is code |
+`zakurad` implements the state-service adapter and uses
+[`SyncCoordinator`](../../../crates/zakurad/src/commands/start/zakura/coordinator.rs) to
+prevent the native and legacy block-apply paths from running at the same time.

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -131,7 +131,7 @@ the runtime commits the DAG changes, metadata, projections, and related indexes 
 RocksDB batch before it publishes the new snapshot.
 
 Startup uses
-[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery.rs) while
+[`audit_store`](../../../crates/zakura-header-chain/src/transition/recovery/mod.rs) while
 publication is disabled. The audit checks the stored source rows and rebuilds derived
 indexes and projections. It refuses inconsistencies that it cannot reconstruct.
 

--- a/docs/design/headerchain/production_code_header-chain.md
+++ b/docs/design/headerchain/production_code_header-chain.md
@@ -5,6 +5,27 @@ This guide explains how PR #586 implements the
 Each linked property names the behavior that the code implements. The specification
 remains authoritative.
 
+## Engine modes
+
+[`EngineMode`](../../../crates/zakura-header-chain/src/config.rs) has two values. A
+deployment picks one, and the durable store records it. Startup fails closed when the
+configured mode disagrees with the stored mode.
+
+**Integrated** is the mode `zakurad` runs. Full state downloads and validates block
+bodies. Only that evidence advances the verified path and finality.
+
+**Headers-only** is the mode a deployment runs when it validates headers but never
+downloads bodies. It has no body evidence, so it has no verified path to advance and no
+proof to finalize with. It instead finalizes the selected header 1,000 blocks behind the
+tip. That depth rule is a local trust decision, not a consensus rule: an eclipsed node
+can pin the wrong branch, and it then rejects the real one. See
+[headers-only finality disclosure (`LC-SCOPE-08`)](../../specs/fork-aware-header-chain-engine.md#lc-scope-08).
+
+The mode changes two things: what advances the verified path, and what advances
+finality. The rest of this document applies to both. Migrating a headers-only store to
+integrated mode imports its pins as header trust anchors only, and the
+[migration guide](../../header-chain-v1.4-migration.md) covers that path.
+
 ## Single-planner fork choice
 
 Several inputs can change the selected header chain. New headers extend the DAG.
@@ -32,29 +53,66 @@ header tip. The verified path ends at the tip whose blocks full state has accept
 Each path is stored as an ordered list of frontiers, so readers can answer height queries
 without walking the graph.
 
-Integrated mode advances the verified path only when full state accepts blocks. In
-headers-only mode, the verified path contains only the finalized frontier.
+The two paths can end on different branches:
+
+```text
+finalized ── A ── B ── C          verified path (bodies already applied)
+              ╲
+               D ── E ── F        selected path (more work, headers only)
+```
+
+Header sync follows the selected path. Full state verifies bodies along that path, and
+the verified path advances behind it. In headers-only mode the verified path holds only
+the finalized frontier, because full state never verifies a body.
 
 A node is eligible when its header is valid, it has no direct exclusion reason, and its
-ancestors are eligible. The graph stores exclusion reasons instead of one boolean flag.
-This lets independent causes coexist and lets `reconsiderblock` remove one manual
-exclusion without removing a consensus-invalid body result.
+ancestors are eligible. The graph stores a set of
+[`EligibilityReason`](../../../crates/zakura-header-chain/src/graph/header_node.rs) values
+per node instead of one boolean flag:
+
+- `SettledUpgradeConflict`: the header contradicts a compiled settled-upgrade pin.
+- `CheckpointConflict`: the header contradicts an authenticated local checkpoint.
+- `FinalityConflict`: the header contradicts the current finality anchor.
+- `ConsensusBodyInvalid`: a full-state verifier proved that the body failed a consensus
+  rule.
+- `OperatorInvalid`: an `invalidateblock` call excluded the header.
+
+Only `OperatorInvalid` is reversible. A set lets independent causes coexist, so
+`reconsiderblock` removes one manual exclusion without removing a consensus-invalid body
+result that also excludes the same header.
 
 Selection takes the maximum score over all eligible tips. This implements
 [deterministic selection (`LC-SELECT-04`)](../../specs/fork-aware-header-chain-engine.md#lc-select-04):
 the same eligible DAG selects the same tip regardless of header arrival order.
 
-Integrated mode advances finality only from authenticated full-state evidence.
-Headers-only mode advances finality with a 1,000-block local depth rule. This local rule
-does not verify block bodies. When finality advances, the engine removes old ancestors
-and competing sibling subtrees. It rebases retained work onto the new root.
+When finality advances, the engine removes old ancestors and competing sibling subtrees.
+It rebases retained work onto the new root.
 
 ## Header admission and validation
 
 The header-sync driver prepares a downloaded batch before it takes the state writer
-lock. It obtains a validation lease for the common ancestor and checks properties that
-need no candidate ancestry, including encoding, proof of work, and commitment format.
-CPU-heavy checks run on a blocking thread.
+lock. It first asks state for a validation lease.
+
+A validation lease is the durable header context, sealed. `zakura-header-chain` performs
+no I/O, so it cannot read that context itself. State reads it once and hands it over as a
+[`ValidationLease`](../../../crates/zakura-header-chain/src/transition/types/preparation.rs):
+the exact parent frontier, up to 28 headers in reverse height order beginning with the
+parent, the network parameters, and a digest of the trust anchors, with one context
+digest binding all of it. Twenty-eight is the span that the difficulty and median-time
+rules need.
+
+The lease reserves nothing and blocks nobody. It is a consistency token, not a lock. The
+driver uses it to run contextual checks off the writer lock. The planner accepts it as a
+substitute for predecessor context that retention has already pruned from the graph, but
+only when the lease is internally consistent, meaning each fact hash-links to the next
+and the context digest recomputes, and when the state writer vouches for it through
+`authorizes_validation_lease`. A caller therefore cannot supply its own ancestry. A lease
+whose context has moved fails preparation as `InvalidLease`, and the caller prepares the
+batch again. The separate retained-path lease that the driver holds over a download range
+is a different mechanism with the same word in its name.
+
+The driver then checks properties that need no candidate ancestry, including encoding,
+proof of work, and commitment format. CPU-heavy checks run on a blocking thread.
 
 The full-block and checkpoint verifiers call the same context-free checks. This prevents
 an in-memory or locally constructed block from bypassing header-version and timestamp
@@ -76,8 +134,7 @@ staged graph. It admits a header only after every required check passes. This im
 [validation before admission (`LC-VAL-11`)](../../specs/fork-aware-header-chain-engine.md#lc-val-11).
 The engine calculates cumulative work with full 256-bit values and rejects cumulative
 overflow. Its difficulty calculation requires the complete predecessor window. It caps
-target scaling before multiplication can overflow. It reads Testnet's maximum-time
-activation height from network parameters.
+target scaling before multiplication can overflow.
 
 After planning,
 [`verify_candidate`](../../../crates/zakura-header-chain/src/transition/invariants/mod.rs)
@@ -92,6 +149,20 @@ and records staged changes without mutating it.
 [`HeaderChainEngine`](../../../crates/zakura-header-chain/src/transition/engine/mod.rs)
 extracts those changes as a `GraphDelta`. The runtime applies the delta to
 `MemHeaderStore` only after the durable write succeeds.
+
+The overlay exists because the engine cannot know whether the durable write will succeed.
+A single mutable in-memory graph would have to change before that write. Undoing a
+partial change after a RocksDB failure needs a second, inverse mutation path, and that
+path would run exactly when something has already gone wrong. Staging removes the
+problem. `MemHeaderStore` stays untouched until the write returns success, so a failed
+write leaves memory identical to what disk still holds. Recovery keeps what it has
+instead of rolling anything back.
+
+Staging also gives the engine a complete result to check before it commits anything.
+`verify_candidate` runs against the staged graph, so an invalid plan reaches neither disk
+nor memory. The extracted `GraphDelta` records the graph revision it was staged against,
+and `MemHeaderStore` rejects a delta whose base revision no longer matches. That check
+makes the gap between planning and installation safe.
 
 ```mermaid
 sequenceDiagram
@@ -262,10 +333,28 @@ work. It ignores `state_version` because unrelated transitions increment that co
 and would cancel valid requests. The scheduler uses the same branch and generation to
 retire stale work.
 
-The engine advances `header_generation` when a change makes header work stale. It
-advances `verified_generation` when a verified-path or finality change makes body-forward
-work stale. Prepared headers have a separate stale result when their durable validation
-context changes. The caller must prepare and validate those headers again.
+The engine keeps four monotonic counters in
+[`counters.rs`](../../../crates/zakura-header-chain/src/identity/counters.rs). Each one
+answers a different question about whether work is still current, and each fails closed
+at `u64::MAX` instead of wrapping.
+
+- `state_version` versions the complete durable header-chain state.
+- `header_generation` advances when a change makes selected-header work stale.
+- `verified_generation` advances when a verified-path or finality change makes
+  body-forward work stale.
+- `finality_epoch` counts irreversible finality advances.
+  `headers_only_migration_epoch` records the last epoch that a headers-only to integrated
+  migration imported, so the startup audit can separate imported trust pins from
+  full-state finality.
+
+Two more values answer the same question about position instead of time. `GraphRevision`
+identifies one committed in-memory graph, so a staged delta cannot apply to a graph that
+has moved underneath it. `WorkCoordinate` is cumulative work measured from an immutable
+origin, and finality rebases every retained coordinate onto the new root rather than
+advancing a counter.
+
+Prepared headers have a separate stale result when their durable validation context
+changes. The caller must prepare and validate those headers again.
 
 Finality can advance while a header request is active. The planner can remove an
 already-finalized prefix and bind the remaining headers to the new root. It rejects the

--- a/docs/specs/fork-aware-header-chain-engine.md
+++ b/docs/specs/fork-aware-header-chain-engine.md
@@ -127,6 +127,7 @@ Version 1 includes linear download and verification of all headers, a bounded fo
 
 **LC-SCOPE-05 [LS] — FlyClient proofs excluded.** Version 1 MUST NOT claim or implement ZIP 221 FlyClient logarithmic sampling or succinct chain proofs. It validates every retained header on a candidate suffix. ZIP 221 history-tree data is covered only as auxiliary metadata used by the integrated node.
 
+<a id="lc-scope-06"></a>
 **LC-SCOPE-06 [LS] — Block-sync concerns excluded.** Block-sync token-bucket connection eviction and readiness/accounting defects unrelated to header-chain selection are outside this engine and MUST NOT be coupled to its fork-choice state.
 
 **LC-SCOPE-09 [LS] — Single protocol, no compatibility surface.** This engine MUST expose exactly one header-exchange protocol on the Zakura v2 P2P stack: one message set, one codec, one status message, and one supported stream version. It MUST NOT implement version negotiation between header-sync codecs, a frozen predecessor codec, a legacy Zcash `getheaders` request/serve path, or any other fallback header-exchange path. It MUST NOT read, write, serve, or otherwise modify the legacy Zcash P2P stack, which remains outside this specification. Identifiers, modules, metrics, configuration fields, and test names MUST NOT carry protocol-version suffixes, because there is only one of each thing to name.
@@ -185,6 +186,7 @@ The durable metadata contains monotonically increasing unsigned counters. Counte
 
 ### 2.4 Transactions and restart
 
+<a id="lc-txn-01"></a>
 **LC-TXN-01 [LS] — Atomic frontier mutation.** A frontier-affecting mutation MUST atomically update DAG rows, reverse indexes, height/child indexes, selected projections, eligibility, auxiliary provenance, generations, and frontier metadata before any observer is notified.
 
 **LC-TXN-02 [LS] — Uniform transition path.** Invalidation, reconsideration, body feedback, finalization, checkpoint advancement, direct growth, fork replacement, VCT repair, and full-state grow/reset MUST use the same durable transition API. A direct-extension fast path is allowed only if it produces the same transaction and selection result.
@@ -227,6 +229,7 @@ Non-normative implementation advice: run LC-VAL-05 before LC-VAL-04 so the inexp
 
 **LC-TIME-01 [ZW] — Custom-network time rules.** Regtest and configured custom networks MUST apply the same MTP algorithm and the exact height-dependent maximum-time policy returned by their authenticated local network parameters and full state. They MUST NOT inherit Mainnet/Testnet activation heights by name or bypass MTP merely because proof of work is disabled.
 
+<a id="lc-val-08"></a>
 **LC-VAL-08 [LS] — Future-header deferral.** A header more than two hours ahead of the validating node’s local clock MUST enter `DeferredUntil(nTime - 2 hours)`, not permanent invalidity. Deferred nodes and descendants MUST be excluded from selection until reevaluation succeeds, and reevaluation MUST occur without retransmission. This local-clock rule is nondeterministic and is not Zcash consensus.
 
 **LC-VAL-09 [LS] — Checkpoint ancestry.** At every configured local sync-checkpoint height present in a candidate path, the computed hash MUST exactly equal the configured checkpoint hash. The candidate’s ancestry MUST be consistent with genesis, every applicable settled-upgrade pin and local checkpoint, and `finalized`. This is trusted local selection policy, not a context-free Zcash header rule.
@@ -235,6 +238,7 @@ Non-normative implementation advice: run LC-VAL-05 before LC-VAL-04 so the inexp
 
 **LC-WORKCALC-01 [LS] — Checked cumulative work.** Candidate suffix cumulative work MUST use a 256-bit unsigned representation and MUST be the checked sum of exact per-block work from the current work anchor. No per-block or cumulative value may be narrowed to `u128`. Overflow beyond `2^256 - 1` is a fail-closed local representation error under the Zcash ecosystem assumption that total chain work remains below `2^256`; it MUST NOT wrap, produce a selectable candidate, or produce advertised work.
 
+<a id="lc-val-11"></a>
 **LC-VAL-11 [LS] — Validation before admission.** Only after every applicable preceding pipeline rule, including LC-COMMIT-01/02 and LC-POW-01, passes MAY the engine apply resource admission, atomically insert nodes and indexes, recompute eligibility, and evaluate fork choice. `DeferredUntil` is the sole non-passing result admitted by LC-VAL-08; all other deterministic checks MUST still pass before that node is stored as deferred. Response partitioning MUST NOT create intermediate selection semantics different from insertion of the complete validated sequence.
 
 ### 3.2 Trusted anchors and checkpoint context
@@ -270,6 +274,7 @@ Eligibility reasons are a set, not a single overwritable flag. Permanent reasons
 
 **LC-SELECT-03 [ZF] — Raw-hash tie-breaker.** If cumulative work is equal, the engine MUST compare the tips’ raw internal `block::Hash.0` byte arrays lexicographically and select the greater array, exactly as `zakura-state::service::non_finalized_state::Chain::cmp`. Display-order hex, first-seen time, arrival order, peer identity, response range, and response partitioning MUST NOT break the tie.
 
+<a id="lc-select-04"></a>
 **LC-SELECT-04 [LS] — Deterministic selection.** For a fixed finalized anchor, selection MUST be a pure deterministic function of the admitted DAG, eligibility set, and the comparator in LC-SELECT-02/03. Replaying any permutation of equivalent insertions and completions before the same durable finalization event MUST yield the same `header_best`. A headers-only finality event deliberately makes its chosen ancestor a new trust pin under LC-FINAL-03; discovery after that event cannot revise history at or below the pin.
 
 ### 3.4 Reorg boundary, finality, and retention
@@ -284,6 +289,7 @@ Eligibility reasons are a set, not a single overwritable flag. Permanent reasons
 
 **LC-FINAL-04 [LS] — Mode and finality provenance.** The durable store MUST record whether it is integrated or headers-only and the finality source for every advancement. Startup MUST fail closed on a mode mismatch or a finality record without the required full-state evidence or headers-only 1,000-deep ancestor proof. Switching modes requires an explicit migration that preserves existing pins; it MUST NOT roll finality back. A headers-only finality record is local trust, never body-verification evidence: a migration to integrated mode MUST import headers-only pins as header trust anchors only, MUST NOT count them as full-state finalization, and integrated mode MUST still body-verify the imported history from its own last full-state-verified anchor. If deterministic body validation refutes an imported headers-only pin, the node MUST fail closed with an explicit incident naming that pin; the only supported recovery is deleting the migrated header store and its finality records and resynchronizing, which discards a local trust artifact rather than rolling back integrated finality, because integrated finality was never granted to the imported pin.
 
+<a id="lc-retain-01"></a>
 **LC-RETAIN-01 [LS] — Fork and node limits.** The engine MUST retain no more than `MAX_NON_FINALIZED_CHAIN_FORKS` eligible candidate tips—the same shared constant that caps full-state non-finalized chains, currently 10—and 65,536 non-finalized DAG nodes. The tip cap MUST be consumed from the same shared `zakura-chain`-level definition as full state, so the header engine can never retain an eligible fork that integrated full state cannot represent. It MUST protect every node on `header_best` and `verified_best` from resource eviction. If integrated-mode verification/finalization stalls and admitting another node would exceed the node cap after all permitted eviction, the engine MUST refuse or stage that admission, retain the current frontiers, and raise an explicit resource-stalled alarm; it MUST NOT evict either protected path or synthesize finality to make room.
 
 **LC-RETAIN-02 [LS] — Deterministic eviction order.** On pressure, the engine MUST remove permanently ineligible subtrees first. It MUST then evict unprotected candidate tips in ascending order of cumulative work, breaking equal-work eviction ties by the smallest raw tip hash. Shared ancestors MUST be removed only when no retained path or validation-context window references them.
@@ -494,6 +500,7 @@ Each schema-1 height must equal its parallel header’s inferred height. Root de
 
 **LC-WIRE-14 [ZW] — Auxiliary-schema validation.** Tree-aux negotiation and schema-1 records MUST use the exact mask, selector, length, field order, encoding, height correspondence, and activation-dependent defaults above. An unknown, unadvertised, mismatched, malformed, or wrong-length schema is `MalformedProtocol`: the response MUST be rejected before any of its headers or records are admitted, but no independently obtained header becomes invalid. A structurally valid record that later fails cryptographic authentication invalidates only that metadata delivery under LC-AUX-02.
 
+<a id="lc-wire-15"></a>
 **LC-WIRE-15 [ZW] — Immutable schema evolution.** Auxiliary schema meanings are immutable. NU6.3, NU7, or any later upgrade MUST be handled by the existing schema’s explicitly defined activation semantics or by assigning a new advertised schema bit; an implementation MUST NOT reinterpret schema 1 based on a candidate-upgrade name. Adding, removing, resizing, or reordering fields requires a new schema, and exhausting the 32-bit mask or changing message framing requires a successor stream version.
 
 **LC-WIRE-16 [ZW] — Fixed discriminants and no block relay.** The four discriminants above are the complete message set. There is no `NewBlock` message and no other block-relay message in header sync; a payload claiming one MUST be rejected as an unknown discriminant. A header-sync session MUST use the ordinary Zcash block-announcement/download path or the separately negotiated Zakura block-sync facility for full blocks. No decoder may infer a message type, protocol variant, or version from payload shape.


### PR DESCRIPTION
## Motivation

The fork-aware header chain landed in #586, a change that spans five crates. The
design lives in a minority of those files, and nothing in the tree tells a reader
which files carry a rule and which only update a call site.

## Solution

Adds `docs/design/headerchain/production_code_header-chain.md`, which explains how
the production code implements the design.

- Opens with the single-planner rule the split exists to enforce, then the state
  the engine keeps.
- Follows a header through admission and validation, then states the commit order
  that keeps the staged, committed, and durable copies in agreement, and the write
  paths that reach it.
- Covers fork switching, VCT evidence and authentication, and the branch and
  generation checks that reject stale work.
- Closes with the boundary each crate enforces, one section per crate, linking the
  entry point rather than listing files.

Each `LC-*` citation links to the rule it names, so a reader can check the claim
without searching the specification. The specification gains seven anchors so those
links resolve.

## Verification

Every link target and every backticked identifier resolves against `main` at
`05caf7f6a`. The document states no file counts, line counts, or constants, so
nothing in it goes stale as the tree moves: the specification defines the rules and
the code defines the values.

`markdownlint` and `codespell` pass locally under the repo configs.

## Review notes

Rebased onto `main` now that #586 has merged. This PR previously targeted
`hc/01-engine-model`, and two things in the document depended on that base.

Six source links pinned file contents to the tip of `hc/01-engine-model`, a commit
that is not on main and is not reachable from it. They now name paths in the tree,
which is what the other fourteen source links already did.

`verify_plan` survives on main only as a `#[cfg(test)]` helper that re-runs
verification for tests and fuzzing, so the guide named a test function for the
production invariant gate. It now names `verify_candidate`, the gate a candidate
passes before an `EngineTransition` can exist, and the commit-order diagram returns
`EngineTransition` rather than the old `TransitionPlan`.

Documentation only, no Rust or `Cargo.toml` change, so no changelog fragment per
`docs/changelog/guidelines.md`.
