### PR TITLE
refactor(header-chain): type transition boundary contracts

### DIFF
--- a/crates/zakura-header-chain/src/fuzz.rs
+++ b/crates/zakura-header-chain/src/fuzz.rs
@@ -19,17 +19,18 @@ use zakura_chain::{
 use crate::{
     AlarmSet, AuxDelivery, AuxDelta, BodyCommitmentKind, BodyEvidence, BodyPayloadMismatch,
     BodyRuleId, BodyUnavailableSummary, BodyValidationState, BranchId, ChainScore, CheckpointSet,
-    Clock, ConsensusBodyInvalid, DurableTransitionFacts, EngineConfig, EngineMetadata, EngineMode,
-    EngineSnapshot, EvidenceId, FinalityEpoch, FinalityRecord, FinalitySource, Frontier,
-    FrontierSet, FullStateEvidenceAuthority, FullStateFinalized, GraphError, HeaderBatchInput,
+    Clock, ConsensusBodyInvalid, EngineConfig, EngineMetadata, EngineMode, EngineSnapshot,
+    EvidenceId, FinalityEpoch, FinalityRecord, FinalitySource, Frontier, FrontierSet,
+    FullStateEvidenceAuthority, FullStateFinalized, GraphError, HeaderBatchInput,
     HeaderChainDiskVersion, HeaderChainEngine, HeaderContextFact, HeaderFailure, HeaderGeneration,
-    HeaderRule, HeaderRules, HeaderValidationState, HeaderWorkAuthority, HeaderWorkOwner,
-    InsertHeaders, MemHeaderStore, OperatorInvalidate, OperatorInvalidationId, OperatorReconsider,
-    PreparedHeader, PreparedHeaderBatch, ProjectionDelta, SourceId, StateVersion, SuffixWork,
-    TargetCompletion, TransientBodyFailure, TransientBodyFailureKind, TransitionContext,
-    TransitionFailure, TransitionPlan, TransitionRequest, TrustedAnchor, ValidationLease,
-    VerifiedBodyEvidence, VerifiedChainChanged, VerifiedChangeCause, VerifiedGeneration,
-    VerifiedHeaderRef, MAX_CANDIDATE_TIPS_V1,
+    HeaderInsertionFacts, HeaderRule, HeaderRules, HeaderValidationFacts, HeaderValidationState,
+    HeaderWorkAuthority, HeaderWorkOwner, InsertHeaders, MemHeaderStore, OperatorInvalidate,
+    OperatorInvalidationId, OperatorReconsider, PreparedHeader, PreparedHeaderBatch,
+    ProjectionDelta, SourceId, StateVersion, SuffixWork, TargetCompletion, TransientBodyFailure,
+    TransientBodyFailureKind, TransitionContext, TransitionFailure, TransitionInput,
+    TransitionPlan, TransitionRequest, TrustedAnchor, ValidationLease, VerifiedBodyEvidence,
+    VerifiedChainChanged, VerifiedChangeCause, VerifiedGeneration, VerifiedHeaderRef,
+    MAX_CANDIDATE_TIPS_V1,
 };
 
 /// Deterministic summary of one bounded structured-operation replay.
@@ -400,6 +401,93 @@ impl FuzzStore {
     }
 }
 
+fn fuzz_transition_input(store: &FuzzStore, request: TransitionRequest) -> TransitionInput {
+    let expected_version = request.expected_version;
+    match request.event {
+        crate::TransitionEvent::InsertHeaders(event) => {
+            let parent = store
+                .graph
+                .header_node(event.parent_hash)
+                .expect("an insertion fixture names a retained parent");
+            TransitionInput::InsertHeaders {
+                event,
+                facts: HeaderInsertionFacts {
+                    validation: HeaderValidationFacts {
+                        validation_leases: vec![
+                            store.lease(Frontier::new(parent.height, parent.hash))
+                        ],
+                    },
+                    finality_rebase_history: Vec::new(),
+                },
+            }
+        }
+        crate::TransitionEvent::VerifiedChainChanged(event) => {
+            TransitionInput::VerifiedChainChanged {
+                expected_version,
+                event,
+                facts: HeaderValidationFacts {
+                    validation_leases: Vec::new(),
+                },
+            }
+        }
+        crate::TransitionEvent::VerifiedBlockAccepted(event) => {
+            TransitionInput::VerifiedBlockAccepted {
+                expected_version,
+                event,
+                facts: HeaderValidationFacts {
+                    validation_leases: Vec::new(),
+                },
+            }
+        }
+        crate::TransitionEvent::BodyEvidence(event) => TransitionInput::BodyEvidence {
+            expected_version,
+            event,
+        },
+        crate::TransitionEvent::BodySupplierDiscovered(event) => {
+            TransitionInput::BodySupplierDiscovered {
+                expected_version,
+                event,
+            }
+        }
+        crate::TransitionEvent::OperatorBodyRetry(event) => TransitionInput::OperatorBodyRetry {
+            expected_version,
+            event,
+        },
+        crate::TransitionEvent::OperatorInvalidate(event) => TransitionInput::OperatorInvalidate {
+            expected_version,
+            event,
+        },
+        crate::TransitionEvent::OperatorReconsider(event) => TransitionInput::OperatorReconsider {
+            expected_version,
+            event,
+        },
+        crate::TransitionEvent::FullStateFinalized(event) => TransitionInput::FullStateFinalized {
+            expected_version,
+            event,
+        },
+        crate::TransitionEvent::MigratedPinRefutation(event) => {
+            let preserved_pin = store
+                .finality
+                .iter()
+                .any(|record| {
+                    record.current == event.pin
+                        && matches!(record.source, FinalitySource::MigratedHeadersOnly)
+                })
+                .then_some(event.pin);
+            TransitionInput::MigratedPinRefutation {
+                expected_version,
+                event,
+                preserved_pin,
+            }
+        }
+        crate::TransitionEvent::AuxEvidence(event) => TransitionInput::AuxEvidence { event },
+        crate::TransitionEvent::ReevaluateDeferred => {
+            TransitionInput::ReevaluateDeferred { expected_version }
+        }
+    }
+}
+
+#[allow(clippy::unwrap_in_result)]
 fn apply_transition(
     store: &FuzzStore,
     request: TransitionRequest,
@@ -412,34 +500,9 @@ fn apply_transition(
         store.verified.clone(),
         store.aux.clone(),
     )
-    .map_err(|_| TransitionFailure::InvalidEvidence("fuzz fixture engine is incoherent"))?;
-    let durable = match &request.event {
-        crate::TransitionEvent::InsertHeaders(event) => {
-            let parent = store
-                .graph
-                .header_node(event.parent_hash)
-                .expect("an insertion fixture names a retained parent");
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![store.lease(Frontier::new(parent.height, parent.hash))],
-                finality_path: Vec::new(),
-            }
-        }
-        crate::TransitionEvent::MigratedPinRefutation(event) => {
-            DurableTransitionFacts::MigratedFinalityPin(
-                store
-                    .finality
-                    .iter()
-                    .any(|record| {
-                        record.current == event.pin
-                            && matches!(record.source, FinalitySource::MigratedHeadersOnly)
-                    })
-                    .then_some(event.pin),
-            )
-        }
-        _ => DurableTransitionFacts::None,
-    };
+    .expect("the fuzz fixture engine is coherent");
     engine
-        .plan_transition(request, context, durable)
+        .plan_transition(fuzz_transition_input(store, request), context)
         .map(crate::EngineTransition::into_plan)
 }
 

--- a/crates/zakura-header-chain/src/transition/engine.rs
+++ b/crates/zakura-header-chain/src/transition/engine.rs
@@ -6,9 +6,12 @@ use thiserror::Error;
 use zakura_chain::block;
 
 use crate::{
-    AuxDelivery, AuxDelta, ChangeSet, EngineMetadata, EngineSnapshot, Frontier, GraphError,
-    MemHeaderStore, ProjectionDelta, TransitionContext, TransitionFailure, TransitionPlan,
-    TransitionRequest, ValidationLease,
+    AuxDelivery, AuxDelta, AuxEvidence, BodyEvidence, BodySupplierDiscovered, ChangeSet,
+    EngineMetadata, EngineSnapshot, FinalityRecord, Frontier, FullStateFinalized, GraphError,
+    InsertHeaders, MemHeaderStore, MigratedPinRefutation, OperatorBodyRetry, OperatorInvalidate,
+    OperatorReconsider, ProjectionDelta, StateVersion, TransitionContext, TransitionDomain,
+    TransitionEvent, TransitionFailure, TransitionPlan, ValidationLease, VerifiedBlockAccepted,
+    VerifiedChainChanged,
 };
 
 use super::planner::derive_transition_plan;
@@ -35,21 +38,225 @@ pub enum CommittedTransitionError {
     Graph(#[from] GraphError),
 }
 
-/// The narrow durable authority needed by one transition.
+/// Durable predecessor leases used for contextual header validation.
 #[derive(Clone, Debug, Default)]
-pub enum DurableTransitionFacts {
-    /// This event needs no fact outside the coherent engine state.
-    #[default]
-    None,
-    /// Durable context and finality provenance for one header insertion.
-    HeaderInsertion {
-        /// Exact predecessor leases available for the original and rebased parents.
-        validation_contexts: Vec<ValidationLease>,
-        /// Contiguous finality records from the work's stable anchor to current finality.
-        finality_path: Vec<crate::FinalityRecord>,
+pub struct HeaderValidationFacts {
+    /// Exact predecessor leases available for missing retained parents.
+    pub validation_leases: Vec<ValidationLease>,
+}
+
+/// Durable facts consumed by prepared header insertion, including finality rebase history.
+#[derive(Clone, Debug, Default)]
+pub struct HeaderInsertionFacts {
+    /// Predecessor leases for the original and rebased parents.
+    pub validation: HeaderValidationFacts,
+    /// Contiguous finality records from the work's stable anchor to current finality.
+    pub finality_rebase_history: Vec<FinalityRecord>,
+}
+
+/// Engine-boundary package that binds one [`TransitionEvent`] to the durable
+/// facts that event may consume.
+///
+/// The state write adapter builds this from a [`crate::TransitionRequest`]: it
+/// authenticates the event, loads only the store rows that variant needs, and
+/// hands the result to [`HeaderChainEngine::plan_transition`]. The planner never
+/// reads the durable store itself.
+///
+/// Exhaustiveness is the contract. Each variant carries exactly its allowed
+/// facts (for example validation leases and finality rebase history for header
+/// insertion, or a preserved migration pin for pin refutation). Unrelated store
+/// facts are unrepresentable.
+///
+/// Freshness is also variant-specific: most inputs are version-qualified via
+/// `expected_version`, while [`Self::InsertHeaders`] and [`Self::AuxEvidence`]
+/// omit it and rely on work ownership instead.
+#[derive(Clone, Debug)]
+pub enum TransitionInput {
+    /// Prepared header admission with contextual leases and optional rebase history.
+    InsertHeaders {
+        /// Authenticated prepared insertion.
+        event: Box<InsertHeaders>,
+        /// Durable validation and rebase facts for this insertion.
+        facts: HeaderInsertionFacts,
     },
-    /// The exact preserved migration pin, if durable finality history contains the requested pin.
-    MigratedFinalityPin(Option<Frontier>),
+    /// Full-state selected-path replacement with contextual header leases.
+    VerifiedChainChanged {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated verified-path change.
+        event: VerifiedChainChanged,
+        /// Durable predecessor leases for missing path headers.
+        facts: HeaderValidationFacts,
+    },
+    /// Full-state side-path acceptance with contextual header leases.
+    VerifiedBlockAccepted {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated side-path acceptance.
+        event: VerifiedBlockAccepted,
+        /// Durable predecessor leases for missing path headers.
+        facts: HeaderValidationFacts,
+    },
+    /// Body delivery or verification evidence.
+    BodyEvidence {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated body evidence.
+        event: BodyEvidence,
+    },
+    /// Newly eligible body-supplier discovery.
+    BodySupplierDiscovered {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated supplier discovery.
+        event: BodySupplierDiscovered,
+    },
+    /// Authenticated operator body retry.
+    OperatorBodyRetry {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated retry.
+        event: OperatorBodyRetry,
+    },
+    /// Reversible operator invalidation.
+    OperatorInvalidate {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated invalidation.
+        event: OperatorInvalidate,
+    },
+    /// Reason-scoped operator reconsideration.
+    OperatorReconsider {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated reconsideration.
+        event: OperatorReconsider,
+    },
+    /// Integrated full-state finality advancement.
+    FullStateFinalized {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated finality evidence.
+        event: FullStateFinalized,
+    },
+    /// Migrated headers-only pin refutation with the preserved durable pin fact.
+    MigratedPinRefutation {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+        /// Authenticated refutation.
+        event: MigratedPinRefutation,
+        /// The exact preserved migration pin when durable history contains it.
+        preserved_pin: Option<Frontier>,
+    },
+    /// Hash-scoped auxiliary evidence; freshness is owner-qualified.
+    AuxEvidence {
+        /// Authenticated auxiliary update.
+        event: Box<AuxEvidence>,
+    },
+    /// Reevaluate all locally due future-time deferrals.
+    ReevaluateDeferred {
+        /// Exact durable version observed by the caller.
+        expected_version: StateVersion,
+    },
+}
+
+impl TransitionInput {
+    /// Return the submitted event domain.
+    pub fn domain(&self) -> TransitionDomain {
+        self.event().domain()
+    }
+
+    /// Return the typed event carried by this input.
+    pub fn event(&self) -> TransitionEvent {
+        match self {
+            Self::InsertHeaders { event, .. } => TransitionEvent::InsertHeaders(event.clone()),
+            Self::VerifiedChainChanged { event, .. } => {
+                TransitionEvent::VerifiedChainChanged(event.clone())
+            }
+            Self::VerifiedBlockAccepted { event, .. } => {
+                TransitionEvent::VerifiedBlockAccepted(event.clone())
+            }
+            Self::BodyEvidence { event, .. } => TransitionEvent::BodyEvidence(event.clone()),
+            Self::BodySupplierDiscovered { event, .. } => {
+                TransitionEvent::BodySupplierDiscovered(*event)
+            }
+            Self::OperatorBodyRetry { event, .. } => TransitionEvent::OperatorBodyRetry(*event),
+            Self::OperatorInvalidate { event, .. } => TransitionEvent::OperatorInvalidate(*event),
+            Self::OperatorReconsider { event, .. } => TransitionEvent::OperatorReconsider(*event),
+            Self::FullStateFinalized { event, .. } => {
+                TransitionEvent::FullStateFinalized(event.clone())
+            }
+            Self::MigratedPinRefutation { event, .. } => {
+                TransitionEvent::MigratedPinRefutation(event.clone())
+            }
+            Self::AuxEvidence { event } => TransitionEvent::AuxEvidence(event.clone()),
+            Self::ReevaluateDeferred { .. } => TransitionEvent::ReevaluateDeferred,
+        }
+    }
+
+    /// Return the caller-observed durable version when the input is version-qualified.
+    ///
+    /// Owner-qualified insertion and auxiliary inputs return `None` because their
+    /// freshness is enforced by work ownership rather than state version.
+    pub const fn expected_version(&self) -> Option<StateVersion> {
+        match self {
+            Self::InsertHeaders { .. } | Self::AuxEvidence { .. } => None,
+            Self::VerifiedChainChanged {
+                expected_version, ..
+            }
+            | Self::VerifiedBlockAccepted {
+                expected_version, ..
+            }
+            | Self::BodyEvidence {
+                expected_version, ..
+            }
+            | Self::BodySupplierDiscovered {
+                expected_version, ..
+            }
+            | Self::OperatorBodyRetry {
+                expected_version, ..
+            }
+            | Self::OperatorInvalidate {
+                expected_version, ..
+            }
+            | Self::OperatorReconsider {
+                expected_version, ..
+            }
+            | Self::FullStateFinalized {
+                expected_version, ..
+            }
+            | Self::MigratedPinRefutation {
+                expected_version, ..
+            }
+            | Self::ReevaluateDeferred { expected_version } => Some(*expected_version),
+        }
+    }
+
+    /// Return header-validation leases when this input carries them.
+    pub fn header_validation_facts(&self) -> Option<&HeaderValidationFacts> {
+        match self {
+            Self::InsertHeaders { facts, .. } => Some(&facts.validation),
+            Self::VerifiedChainChanged { facts, .. }
+            | Self::VerifiedBlockAccepted { facts, .. } => Some(facts),
+            _ => None,
+        }
+    }
+
+    /// Return finality rebase history when this input is a header insertion.
+    pub fn finality_rebase_history(&self) -> Option<&[FinalityRecord]> {
+        match self {
+            Self::InsertHeaders { facts, .. } => Some(&facts.finality_rebase_history),
+            _ => None,
+        }
+    }
+
+    /// Return the preserved migrated pin fact when this input is a pin refutation.
+    pub const fn preserved_migrated_pin(&self) -> Option<Option<Frontier>> {
+        match self {
+            Self::MigratedPinRefutation { preserved_pin, .. } => Some(*preserved_pin),
+            _ => None,
+        }
+    }
 }
 
 /// Owns coherent in-memory header-chain state and decides its valid transitions.
@@ -175,11 +382,10 @@ impl HeaderChainEngine {
     /// state or publishes watches.
     pub fn plan_transition(
         &self,
-        request: TransitionRequest,
+        input: TransitionInput,
         context: &TransitionContext<'_>,
-        durable: DurableTransitionFacts,
     ) -> Result<EngineTransition, TransitionFailure> {
-        let plan = derive_transition_plan(self, &durable, request, context)?;
+        let plan = derive_transition_plan(self, input, context)?;
         Ok(EngineTransition { plan })
     }
 
@@ -291,9 +497,14 @@ impl EngineTransition {
         self.plan.is_no_change()
     }
 
-    /// Return the classified transition cause.
-    pub const fn cause(&self) -> crate::TransitionCause {
-        self.plan.cause()
+    /// Return the submitted transition domain.
+    pub const fn domain(&self) -> crate::TransitionDomain {
+        self.plan.domain()
+    }
+
+    /// Return the orthogonal effects produced by this transition.
+    pub const fn effect(&self) -> crate::TransitionEffect {
+        self.plan.effect()
     }
 
     #[cfg(any(test, feature = "fuzz-impl"))]

--- a/crates/zakura-header-chain/src/transition/invariants.rs
+++ b/crates/zakura-header-chain/src/transition/invariants.rs
@@ -11,7 +11,7 @@ use crate::graph::HeaderGraphView;
 use crate::TransitionPlan;
 use crate::{
     AuxDelta, BodyValidationState, EligibilityReason, EngineMode, FinalitySource, Frontier,
-    HeaderChainEngine, HeaderNode, PlanCandidate, ProjectionDelta, TransitionCause,
+    HeaderChainEngine, HeaderNode, PlanCandidate, ProjectionDelta,
 };
 
 /// Stable, category-specific projected-state invariant failures.
@@ -274,7 +274,7 @@ pub(super) fn is_incremental_aux_authentication(
     let metadata = &plan.change_set.metadata;
     let source_metadata = before.metadata();
 
-    plan.cause() == TransitionCause::AuxAuthentication
+    plan.effect().is_aux_authentication()
         && !plan.change_set.aux_changes.is_empty()
         && plan.change_set.aux_changes.len() <= 2
         && plan
@@ -350,7 +350,7 @@ pub(super) fn is_incremental_checkpoint_finality(
     };
     let finalized = record.current;
 
-    plan.cause() == TransitionCause::CheckpointFinality
+    plan.effect().is_checkpoint_finality()
         && source.mode == EngineMode::Integrated
         && matches!(record.source, FinalitySource::FullState { .. })
         && record.previous == source.frontiers.finalized

--- a/crates/zakura-header-chain/src/transition/mod.rs
+++ b/crates/zakura-header-chain/src/transition/mod.rs
@@ -10,14 +10,19 @@ mod types;
 
 pub use authority::{Clock, FullStateEvidenceAuthority, SystemClock, TransitionContext};
 pub use engine::{
-    CommittedTransitionError, DurableTransitionFacts, EngineHydrationError, EngineTransition,
-    HeaderChainEngine,
+    CommittedTransitionError, EngineHydrationError, EngineTransition, HeaderChainEngine,
+    HeaderInsertionFacts, HeaderValidationFacts, TransitionInput,
 };
 pub(crate) use invariants::verify_candidate;
 pub use invariants::InvariantViolation;
 #[cfg(test)]
 pub(crate) use invariants::{verify_plan, verify_plan_production};
-pub use planner::TransitionFailure;
+pub use planner::{
+    AuxiliaryViolation, BodyViolation, FinalityViolation, HeaderPathKind, HeaderPathProblem,
+    HeaderValidationCheck, HeaderValidationSource, HeaderViolation, InvalidTransitionEvidence,
+    LimitViolation, OperatorViolation, PlannerCoherenceViolation, ProjectionKind,
+    TransitionFailure,
+};
 pub(crate) use planner::{PlanCandidate, TransitionPlan};
 pub use recovery::{
     audit_store, audit_store_at, audit_store_for_trust_anchor_update, AuditViolation,

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -2,6 +2,7 @@
 
 mod admission;
 mod event_effects;
+mod evidence;
 mod projected_state;
 mod settlement;
 mod write_set;
@@ -15,9 +16,15 @@ use thiserror::Error;
 
 use crate::graph::GraphDelta;
 use crate::{
-    ChangeSet, CounterExhausted, DurableTransitionFacts, EngineLimits, EngineSnapshot, Frontier,
-    GraphError, HeaderChainEngine, StoreError, TransitionCause, TransitionContext,
-    TransitionRequest,
+    ChangeSet, CounterExhausted, EngineLimits, EngineSnapshot, Frontier, GraphError,
+    HeaderChainEngine, StoreError, TransitionContext, TransitionDomain, TransitionEffect,
+    TransitionInput,
+};
+
+pub use evidence::{
+    AuxiliaryViolation, BodyViolation, FinalityViolation, HeaderPathKind, HeaderPathProblem,
+    HeaderValidationCheck, HeaderValidationSource, HeaderViolation, InvalidTransitionEvidence,
+    LimitViolation, OperatorViolation, PlannerCoherenceViolation, ProjectionKind,
 };
 
 use admission::{
@@ -38,7 +45,8 @@ pub(crate) struct PlanCandidate {
     pub(super) before: EngineSnapshot,
     pub(super) change_set: ChangeSet,
     pub(super) graph_delta: GraphDelta,
-    pub(super) cause: TransitionCause,
+    pub(super) domain: TransitionDomain,
+    pub(super) effect: TransitionEffect,
     pub(super) trust_pins: Arc<[Frontier]>,
     pub(super) limits: EngineLimits,
 }
@@ -49,9 +57,9 @@ impl PlanCandidate {
         &self.graph_delta
     }
 
-    /// Return the candidate's classified transition cause.
-    pub(super) const fn cause(&self) -> TransitionCause {
-        self.cause
+    /// Return the orthogonal transition effects.
+    pub(super) const fn effect(&self) -> TransitionEffect {
+        self.effect
     }
 }
 
@@ -84,9 +92,14 @@ impl TransitionPlan {
         &self.candidate.before
     }
 
-    /// Return the classified transition cause.
-    pub const fn cause(&self) -> TransitionCause {
-        self.candidate.cause
+    /// Return the submitted transition domain.
+    pub const fn domain(&self) -> TransitionDomain {
+        self.candidate.domain
+    }
+
+    /// Return the orthogonal transition effects.
+    pub const fn effect(&self) -> TransitionEffect {
+        self.candidate.effect
     }
 
     /// Return true when the evidence was valid but changed no durable fact.
@@ -150,12 +163,12 @@ pub enum TransitionFailure {
     #[error("transition replay key conflicts with the previously committed payload")]
     ConflictingReplay,
     /// Event fields contradict canonical headers or durable ancestry.
-    #[error("invalid transition evidence: {0}")]
-    InvalidEvidence(&'static str),
+    #[error(transparent)]
+    InvalidEvidence(#[from] InvalidTransitionEvidence),
     /// Auxiliary delivery bounds refused this event before any durable mutation.
     ///
-    /// Unlike [`TransitionCause::ResourceStalled`], this is a zero-effect planner
-    /// failure: it does not raise the durable resource-stall alarm or produce a
+    /// Unlike a [`TransitionEffect`] with `resource_stalled`, this is a zero-effect
+    /// planner failure: it does not raise the durable resource-stall alarm or produce a
     /// [`crate::CommittedStallReceipt`].
     #[error("header admission refused because auxiliary delivery limits are exceeded")]
     AuxiliaryLimitExceeded,
@@ -167,11 +180,10 @@ pub enum TransitionFailure {
 /// Derive one atomic transition without mutating the coherent engine.
 pub(super) fn derive_transition_plan(
     engine: &HeaderChainEngine,
-    durable: &DurableTransitionFacts,
-    request: TransitionRequest,
+    input: TransitionInput,
     context: &TransitionContext<'_>,
 ) -> Result<TransitionPlan, TransitionFailure> {
-    let candidate = derive_plan_candidate(engine, durable, request, context)?;
+    let candidate = derive_plan_candidate(engine, input, context)?;
     // Phase 6: verify invariants
     verify_invariants(engine, &candidate)?;
     Ok(TransitionPlan::from_verified(candidate))
@@ -179,29 +191,37 @@ pub(super) fn derive_transition_plan(
 
 fn derive_plan_candidate(
     engine: &HeaderChainEngine,
-    durable: &DurableTransitionFacts,
-    request: TransitionRequest,
+    input: TransitionInput,
     context: &TransitionContext<'_>,
 ) -> Result<PlanCandidate, TransitionFailure> {
     // Phase 1: authenticate / admit
-    let (before, mut metadata, admitted) = authenticate_and_admit(engine, request, context)?;
+    let (before, mut metadata, admitted) = authenticate_and_admit(engine, &input, context)?;
 
     // Phase 2: bind replay and freshness
-    let bound = bind_replay_and_freshness(engine, durable, &before, &metadata, admitted)?;
-    if let Some(cause) = bound.no_change_cause {
-        return no_change(engine, before, metadata, bound.event, context, cause);
+    let bound = bind_replay_and_freshness(engine, &input, &before, &metadata, admitted)?;
+    if let Some(effect) = bound.no_change_effect {
+        return no_change(
+            engine,
+            before,
+            metadata,
+            bound.event,
+            context,
+            bound.domain,
+            effect,
+        );
     }
     let event = bound.event;
+    let domain = bound.domain;
 
     // Phase 3: apply event evidence
     let old_selected = engine.selected_projection();
     let old_verified = engine.verified_projection();
     let mut projected = ProjectedTransitionState::new(engine);
-    let migrated_pin = migrated_pin_refuted(durable, &event)?;
+    let migrated_pin = migrated_pin_refuted(&input, &event)?;
     apply_migrated_pin_alarm(&mut metadata, migrated_pin);
     let event_context = ApplyEventContext {
         engine,
-        durable,
+        input: &input,
         transition: context,
         before: &before,
         old_selected,
@@ -222,7 +242,7 @@ fn derive_plan_candidate(
     })?;
     let settled = match settlement {
         FinalityRetentionOutcome::ResourceStalled => {
-            return resource_stalled(engine, before, context);
+            return resource_stalled(engine, before, domain, context);
         }
         FinalityRetentionOutcome::Settled(settled) => *settled,
     };
@@ -241,13 +261,14 @@ fn derive_plan_candidate(
 
 struct BoundRequest {
     event: crate::TransitionEvent,
+    domain: TransitionDomain,
     header_rebase: HeaderInsertionRebase,
-    no_change_cause: Option<TransitionCause>,
+    no_change_effect: Option<TransitionEffect>,
 }
 
 fn bind_replay_and_freshness(
     engine: &HeaderChainEngine,
-    durable: &DurableTransitionFacts,
+    input: &TransitionInput,
     before: &EngineSnapshot,
     metadata: &crate::EngineMetadata,
     request: AdmittedRequest,
@@ -256,7 +277,8 @@ fn bind_replay_and_freshness(
         mut event,
         expected_version,
     } = request;
-    let header_rebase = rebase_header_insertion(&mut event, before, engine.graph(), durable)?;
+    let domain = event.domain();
+    let header_rebase = rebase_header_insertion(&mut event, before, engine.graph(), input)?;
     if let Some(owner) = event.header_sync_owner() {
         validate_header_sync_owner(owner, before)?;
     }
@@ -268,8 +290,9 @@ fn bind_replay_and_freshness(
     if fingerprint.is_some() && metadata.last_transition == fingerprint {
         return Ok(BoundRequest {
             event,
+            domain,
             header_rebase,
-            no_change_cause: Some(TransitionCause::Event),
+            no_change_effect: Some(TransitionEffect::event()),
         });
     }
     if metadata
@@ -280,16 +303,24 @@ fn bind_replay_and_freshness(
         return Err(TransitionFailure::ConflictingReplay);
     }
     let has_async_authority = event.header_sync_owner().is_some() || event.body_owner().is_some();
-    if !has_async_authority && expected_version != before.state_version {
-        return Err(TransitionFailure::Stale {
-            current: before.state_version,
-        });
+    if !has_async_authority {
+        let Some(expected_version) = expected_version else {
+            return Err(TransitionFailure::Stale {
+                current: before.state_version,
+            });
+        };
+        if expected_version != before.state_version {
+            return Err(TransitionFailure::Stale {
+                current: before.state_version,
+            });
+        }
     }
     Ok(BoundRequest {
         event,
+        domain,
         header_rebase,
-        no_change_cause: (header_rebase == HeaderInsertionRebase::AlreadyApplied)
-            .then_some(TransitionCause::HeaderWorkAlreadyApplied),
+        no_change_effect: (header_rebase == HeaderInsertionRebase::AlreadyApplied)
+            .then_some(TransitionEffect::header_work_already_applied()),
     })
 }
 
@@ -307,7 +338,7 @@ fn assemble_writes<'a>(
         selected,
         finality_append,
         retention,
-        cause,
+        effect,
         metadata,
     } = settled;
     derive_plan(DerivePlanInputs {
@@ -321,7 +352,8 @@ fn assemble_writes<'a>(
         finality_append,
         retention,
         fingerprint: event.fingerprint(),
-        cause,
+        domain: event.domain(),
+        effect,
         trust_pins: invariant_pins(context),
         limits: context.config.limits,
     })

--- a/crates/zakura-header-chain/src/transition/planner/admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/admission.rs
@@ -4,11 +4,11 @@ use std::collections::{HashMap, HashSet};
 
 use zakura_chain::block;
 
-use super::TransitionFailure;
+use super::{InvalidTransitionEvidence, LimitViolation, TransitionFailure};
 use crate::{
-    BodyWorkOwner, DurableTransitionFacts, EngineLimits, EngineMetadata, EngineMode,
-    EngineSnapshot, EventAdmission, EvidenceId, FinalityRecord, Frontier, HeaderChainEngine,
-    HeaderSyncWorkOwner, MemHeaderStore, TargetCompletion, TransitionContext, TransitionEvent,
+    BodyWorkOwner, EngineLimits, EngineMetadata, EngineMode, EngineSnapshot, EventAdmission,
+    EvidenceId, FinalityRecord, Frontier, HeaderChainEngine, HeaderSyncWorkOwner, MemHeaderStore,
+    TargetCompletion, TransitionContext, TransitionEvent, TransitionInput,
 };
 
 /// Request admitted against its original authority and resource bounds.
@@ -19,8 +19,8 @@ use crate::{
 pub(super) struct AdmittedRequest {
     /// Admitted event ready for canonical rebasing and freshness binding.
     pub(super) event: TransitionEvent,
-    /// Caller-observed durable version.
-    pub(super) expected_version: crate::StateVersion,
+    /// Caller-observed durable version when the input is version-qualified.
+    pub(super) expected_version: Option<crate::StateVersion>,
 }
 
 /// How a pure header insertion related to newer monotone finality.
@@ -37,25 +37,26 @@ pub(super) enum HeaderInsertionRebase {
 /// Authenticate the caller and admit the event before any projection work.
 pub(super) fn authenticate_and_admit(
     engine: &HeaderChainEngine,
-    request: crate::TransitionRequest,
+    input: &TransitionInput,
     context: &TransitionContext<'_>,
 ) -> Result<(EngineSnapshot, EngineMetadata, AdmittedRequest), TransitionFailure> {
     let before = engine.snapshot();
     let metadata = engine.metadata().clone();
     validate_snapshot(&before, &metadata, context)?;
     if context.retention_references.len() > context.config.limits.max_retention_references.get() {
-        return Err(TransitionFailure::InvalidEvidence(
-            "retained-path references exceed the per-transition limit",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Limit(LimitViolation::RetentionReferencesExceeded).into(),
+        );
     }
-    validate_event_resource_bounds(engine, &request.event, context.config.limits)?;
-    validate_authority(&request.event, context)?;
+    let event = input.event();
+    validate_event_resource_bounds(engine, &event, context.config.limits)?;
+    validate_authority(&event, context)?;
     Ok((
         before,
         metadata,
         AdmittedRequest {
-            event: request.event,
-            expected_version: request.expected_version,
+            event,
+            expected_version: input.expected_version(),
         },
     ))
 }
@@ -87,9 +88,9 @@ fn validate_event_resource_bounds(
         return Ok(());
     };
     if insert.batch.headers().len() > limits.max_headers_per_transition.get() {
-        return Err(TransitionFailure::InvalidEvidence(
-            "prepared header batch exceeds the per-transition limit",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Limit(LimitViolation::PreparedHeadersExceeded).into(),
+        );
     }
     if insert.aux.len() > limits.max_aux_deliveries_total.get() {
         return Err(TransitionFailure::AuxiliaryLimitExceeded);
@@ -205,7 +206,7 @@ pub(super) fn rebase_header_insertion(
     event: &mut TransitionEvent,
     current: &EngineSnapshot,
     graph: &MemHeaderStore,
-    durable: &DurableTransitionFacts,
+    input: &TransitionInput,
 ) -> Result<HeaderInsertionRebase, TransitionFailure> {
     let TransitionEvent::InsertHeaders(insert) = event else {
         return Ok(HeaderInsertionRebase::Current);
@@ -240,12 +241,12 @@ pub(super) fn rebase_header_insertion(
             current: current.state_version,
         });
     }
-    let DurableTransitionFacts::HeaderInsertion { finality_path, .. } = durable else {
+    let Some(finality_rebase_history) = input.finality_rebase_history() else {
         return Err(TransitionFailure::Stale {
             current: current.state_version,
         });
     };
-    if finality_path.is_empty() {
+    if finality_rebase_history.is_empty() {
         return Err(TransitionFailure::Stale {
             current: current.state_version,
         });
@@ -253,7 +254,7 @@ pub(super) fn rebase_header_insertion(
     validate_finality_rebase_path(
         original.branch.anchor_hash,
         current.frontiers.finalized,
-        finality_path,
+        finality_rebase_history,
     )?;
 
     let finalized = current.frontiers.finalized;
@@ -287,7 +288,7 @@ pub(super) fn rebase_header_insertion(
                 .last()
                 .map(|header| Frontier::new(header.height, header.hash))
                 .ok_or(TransitionFailure::StalePreparation)?;
-            let prepared_tip_was_finalized = finality_path
+            let prepared_tip_was_finalized = finality_rebase_history
                 .iter()
                 .any(|record| record.previous == prepared_tip || record.current == prepared_tip);
             if prepared_tip_was_finalized && prepared_tip.height <= finalized.height {

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/auxiliary_authentication.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/auxiliary_authentication.rs
@@ -1,7 +1,8 @@
 //! Auxiliary delivery authentication and rejection.
 
+use super::super::{AuxiliaryViolation, InvalidTransitionEvidence, TransitionFailure};
 use crate::graph::HeaderGraphView;
-use crate::{Frontier, TransitionFailure};
+use crate::Frontier;
 
 use super::super::projected_state::ProjectedTransitionState;
 use super::ApplyEventContext;
@@ -14,9 +15,7 @@ pub(super) fn apply(
 ) -> Result<(), TransitionFailure> {
     let engine = event_context.engine;
     if event.deliveries.is_empty() || event.deliveries.len() > 2 {
-        return Err(TransitionFailure::InvalidEvidence(
-            "auxiliary evidence must name one or two exact deliveries",
-        ));
+        return Err(InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::DeliveryCount).into());
     }
 
     for (index, event_delivery) in event.deliveries.iter().enumerate() {
@@ -24,15 +23,16 @@ pub(super) fn apply(
             prior.header_hash == event_delivery.header_hash
                 && prior.delivery_id == event_delivery.delivery_id
         }) {
-            return Err(TransitionFailure::InvalidEvidence(
-                "auxiliary evidence names the same delivery more than once",
-            ));
+            return Err(InvalidTransitionEvidence::Auxiliary(
+                AuxiliaryViolation::DuplicateDelivery,
+            )
+            .into());
         }
         let header = projected
             .graph()
             .view_header_node(event_delivery.header_hash)
             .ok_or(TransitionFailure::InvalidEvidence(
-                "auxiliary evidence references an unknown header",
+                InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::UnknownHeader),
             ))?;
         let header_frontier = Frontier::new(header.height, header.hash);
         if projected
@@ -40,9 +40,10 @@ pub(super) fn apply(
             .view_header_ancestor(event.owner.branch.target_tip_hash, header.height)?
             != Some(header_frontier)
         {
-            return Err(TransitionFailure::InvalidEvidence(
-                "auxiliary evidence is outside its owned branch",
-            ));
+            return Err(InvalidTransitionEvidence::Auxiliary(
+                AuxiliaryViolation::OutsideOwnedBranch,
+            )
+            .into());
         }
         let existing = engine
             .aux_deliveries(event_delivery.header_hash)
@@ -50,30 +51,32 @@ pub(super) fn apply(
             .copied()
             .find(|delivery| delivery.delivery_id == event_delivery.delivery_id)
             .ok_or(TransitionFailure::InvalidEvidence(
-                "auxiliary evidence references an unknown delivery",
+                InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::UnknownDelivery),
             ))?;
         if existing != *event_delivery || !header.aux_delivery_ids.contains(&existing.delivery_id) {
-            return Err(TransitionFailure::InvalidEvidence(
-                "auxiliary evidence changes delivery provenance",
-            ));
+            return Err(InvalidTransitionEvidence::Auxiliary(
+                AuxiliaryViolation::ProvenanceMismatch,
+            )
+            .into());
         }
         if existing.authentication == event.authentication {
             continue;
         }
         if existing.authentication != crate::AuxAuthentication::Unauthenticated {
-            return Err(TransitionFailure::InvalidEvidence(
-                "an authenticated or rejected auxiliary delivery is immutable",
-            ));
+            return Err(InvalidTransitionEvidence::Auxiliary(
+                AuxiliaryViolation::ImmutableAuthentication,
+            )
+            .into());
         }
         if let crate::AuxAuthentication::Authenticated { boundary_hash, .. } = event.authentication
         {
             let boundary = projected.graph().view_header_node(boundary_hash).ok_or(
-                TransitionFailure::InvalidEvidence("auxiliary authentication boundary is unknown"),
+                TransitionFailure::InvalidEvidence(InvalidTransitionEvidence::Auxiliary(
+                    AuxiliaryViolation::UnknownBoundary,
+                )),
             )?;
             let expected_height = header.height.next().map_err(|_| {
-                TransitionFailure::InvalidEvidence(
-                    "auxiliary authentication boundary height overflowed",
-                )
+                InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::BoundaryHeightOverflow)
             })?;
             let boundary_frontier = Frontier::new(boundary.height, boundary.hash);
             if boundary.height != expected_height
@@ -83,23 +86,26 @@ pub(super) fn apply(
                     .view_header_ancestor(event.owner.branch.target_tip_hash, boundary.height)?
                     != Some(boundary_frontier)
             {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "auxiliary authentication is not the owned one-header-later boundary",
-                ));
+                return Err(InvalidTransitionEvidence::Auxiliary(
+                    AuxiliaryViolation::InvalidBoundary,
+                )
+                .into());
             }
         } else if event.authentication == crate::AuxAuthentication::Unauthenticated {
-            return Err(TransitionFailure::InvalidEvidence(
-                "auxiliary evidence cannot remove authentication",
-            ));
+            return Err(InvalidTransitionEvidence::Auxiliary(
+                AuxiliaryViolation::AuthenticationRemoval,
+            )
+            .into());
         }
         let mut delivery = existing;
         delivery.authentication = event.authentication;
         projected.update_aux_delivery(delivery);
     }
     if event.authentication == crate::AuxAuthentication::Unauthenticated {
-        return Err(TransitionFailure::InvalidEvidence(
-            "auxiliary evidence cannot remove authentication",
-        ));
+        return Err(InvalidTransitionEvidence::Auxiliary(
+            AuxiliaryViolation::AuthenticationRemoval,
+        )
+        .into());
     }
     Ok(())
 }

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/body_availability.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/body_availability.rs
@@ -1,7 +1,8 @@
 //! Transient body availability and supplier-discovery evidence.
 
+use super::super::{BodyViolation, InvalidTransitionEvidence, TransitionFailure};
 use crate::graph::HeaderGraphView;
-use crate::{BodyValidationState, TransitionFailure};
+use crate::BodyValidationState;
 
 use super::super::projected_state::ProjectedTransitionState;
 use super::ApplyEventContext;
@@ -22,9 +23,7 @@ pub(super) fn apply_transient(
         || event.availability.suppliers == 0
         || event.availability.started_at > event.availability.next_probe_at
     {
-        return Err(TransitionFailure::InvalidEvidence(
-            "body retry evidence has an invalid episode summary",
-        ));
+        return Err(InvalidTransitionEvidence::Body(BodyViolation::InvalidTransientEpisode).into());
     }
     if matches!(
         projected
@@ -33,9 +32,9 @@ pub(super) fn apply_transient(
             .map(|node| &node.body_validation_state),
         Some(BodyValidationState::Verified { .. })
     ) {
-        return Err(TransitionFailure::InvalidEvidence(
-            "body retry evidence cannot regress an already verified body",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Body(BodyViolation::RetryConflictsWithVerified).into(),
+        );
     }
     projected.set_body_validation_state(
         event.hash,
@@ -63,9 +62,10 @@ pub(super) fn apply_supplier_discovery(
             *summary
         }
         _ => {
-            return Err(TransitionFailure::InvalidEvidence(
-                "body supplier discovery requires the selected persistent alarm",
-            ));
+            return Err(InvalidTransitionEvidence::Body(
+                BodyViolation::SupplierRequiresPersistentAlarm,
+            )
+            .into());
         }
     };
     if event.availability.started_at != old.started_at
@@ -75,17 +75,13 @@ pub(super) fn apply_supplier_discovery(
         || event.availability.next_probe_at < event.availability.started_at
         || event.availability.next_probe_at > context.clock.now()
     {
-        return Err(TransitionFailure::InvalidEvidence(
-            "body supplier discovery must preserve the persistent retry episode",
-        ));
+        return Err(InvalidTransitionEvidence::Body(BodyViolation::SupplierEpisodeChanged).into());
     }
     let has_new_supplier = event.availability.suppliers > old.suppliers
         || (event.availability.suppliers == old.suppliers
             && event.availability.supplier_set_digest != old.supplier_set_digest);
     if !has_new_supplier {
-        return Err(TransitionFailure::InvalidEvidence(
-            "body supplier discovery does not add an eligible supplier",
-        ));
+        return Err(InvalidTransitionEvidence::Body(BodyViolation::NoNewSupplier).into());
     }
     projected.set_body_validation_state(
         event.hash,

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/full_state_evidence.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/full_state_evidence.rs
@@ -1,9 +1,13 @@
 //! Authoritative full-state conclusions and finality evidence.
 
 use crate::graph::HeaderGraphView;
-use crate::{BodyValidationState, Frontier, GraphError, HeaderValidationState, TransitionFailure};
+use crate::{BodyValidationState, Frontier, GraphError, HeaderValidationState};
 
 use super::super::projected_state::ProjectedTransitionState;
+use super::super::{
+    BodyViolation, FinalityViolation, HeaderPathKind, HeaderPathProblem, InvalidTransitionEvidence,
+    TransitionFailure,
+};
 use super::header_validation::{anchor_reasons, validate_full_state_header};
 use super::ApplyEventContext;
 
@@ -13,7 +17,7 @@ pub(super) fn apply_chain_change(
     event: &crate::VerifiedChainChanged,
     event_context: &ApplyEventContext<'_>,
 ) -> Result<(), TransitionFailure> {
-    let durable = event_context.durable;
+    let facts = event_context.input.header_validation_facts();
     let context = event_context.transition;
     if projected.verified().last().copied() != Some(event.old_tip) {
         return Err(TransitionFailure::StalePreparation);
@@ -38,12 +42,16 @@ pub(super) fn apply_chain_change(
                         parent: parent.hash,
                     })?
         {
-            return Err(TransitionFailure::InvalidEvidence(
-                "verified path is not continuous",
-            ));
+            return Err(
+                InvalidTransitionEvidence::Header(crate::HeaderViolation::Path {
+                    kind: HeaderPathKind::Verified,
+                    problem: HeaderPathProblem::Discontinuous,
+                })
+                .into(),
+            );
         }
         if projected.graph().view_header_node(header.hash).is_none() {
-            validate_full_state_header(projected.graph(), parent, header, durable, context)?;
+            validate_full_state_header(projected.graph(), parent, header, facts, context)?;
             projected.insert_header(
                 header.header.clone(),
                 HeaderValidationState::Valid,
@@ -72,12 +80,16 @@ pub(super) fn apply_block_acceptance(
     event: &crate::VerifiedBlockAccepted,
     event_context: &ApplyEventContext<'_>,
 ) -> Result<(), TransitionFailure> {
-    let durable = event_context.durable;
+    let facts = event_context.input.header_validation_facts();
     let context = event_context.transition;
     if event.path.is_empty() {
-        return Err(TransitionFailure::InvalidEvidence(
-            "accepted full-state side path is empty",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Header(crate::HeaderViolation::Path {
+                kind: HeaderPathKind::AcceptedSide,
+                problem: HeaderPathProblem::Empty,
+            })
+            .into(),
+        );
     }
     let mut parent = projected.graph().view_finalized_frontier();
     let last_index = event.path.len().saturating_sub(1);
@@ -92,12 +104,16 @@ pub(super) fn apply_block_acceptance(
                         parent: parent.hash,
                     })?
         {
-            return Err(TransitionFailure::InvalidEvidence(
-                "accepted full-state side path is not continuous",
-            ));
+            return Err(
+                InvalidTransitionEvidence::Header(crate::HeaderViolation::Path {
+                    kind: HeaderPathKind::AcceptedSide,
+                    problem: HeaderPathProblem::Discontinuous,
+                })
+                .into(),
+            );
         }
         if projected.graph().view_header_node(header.hash).is_none() {
-            validate_full_state_header(projected.graph(), parent, header, durable, context)?;
+            validate_full_state_header(projected.graph(), parent, header, facts, context)?;
             projected.insert_header(
                 header.header.clone(),
                 HeaderValidationState::Valid,
@@ -131,9 +147,10 @@ pub(super) fn apply_consensus_invalid(
             .map(|node| &node.body_validation_state),
         Some(BodyValidationState::Verified { .. })
     ) {
-        return Err(TransitionFailure::InvalidEvidence(
-            "body invalid evidence cannot contradict an already verified body",
-        ));
+        return Err(InvalidTransitionEvidence::Body(
+            BodyViolation::InvalidityConflictsWithVerified,
+        )
+        .into());
     }
     projected.set_body_validation_state(
         event.hash,
@@ -171,9 +188,7 @@ pub(super) fn apply_finality_proof(
         .map(|frontier| frontier.hash)
         .collect();
     if event.verified_path_proof != expected {
-        return Err(TransitionFailure::InvalidEvidence(
-            "finality proof is not the exact verified ancestry",
-        ));
+        return Err(InvalidTransitionEvidence::Finality(FinalityViolation::ProofMismatch).into());
     }
     Ok(())
 }
@@ -186,9 +201,10 @@ pub(super) fn apply_migrated_pin_refutation(
     if event.invalid_header.height > event.pin.height
         || event_context.migrated_pin_refuted != Some(event.pin)
     {
-        return Err(TransitionFailure::InvalidEvidence(
-            "full-state refutation does not name an imported pin ancestor",
-        ));
+        return Err(InvalidTransitionEvidence::Finality(
+            FinalityViolation::ImportedPinRefutationMismatch,
+        )
+        .into());
     }
     Ok(())
 }

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
@@ -1,12 +1,13 @@
 //! Prepared header insertion and atomic auxiliary delivery admission.
 
+use super::super::{
+    AuxiliaryViolation, HeaderPathKind, HeaderPathProblem, HeaderValidationCheck, HeaderViolation,
+    InvalidTransitionEvidence, TransitionFailure,
+};
 use std::collections::{HashMap, HashSet};
 
 use crate::graph::HeaderGraphView;
-use crate::{
-    BodyValidationState, Frontier, GraphError, HeaderValidationState, TargetCompletion,
-    TransitionFailure,
-};
+use crate::{BodyValidationState, Frontier, GraphError, HeaderValidationState, TargetCompletion};
 
 use super::super::projected_state::ProjectedTransitionState;
 use super::header_validation::{anchor_reasons, retained_header_context};
@@ -19,7 +20,7 @@ pub(super) fn apply(
     event_context: &ApplyEventContext<'_>,
 ) -> Result<(), TransitionFailure> {
     let engine = event_context.engine;
-    let durable = event_context.durable;
+    let facts = event_context.input.header_validation_facts();
     let context = event_context.transition;
     let receipt = event.batch.receipt();
     if receipt.parent().hash != event.parent_hash
@@ -49,12 +50,16 @@ pub(super) fn apply(
         } => common_ancestor,
     };
     if common_ancestor != parent_frontier {
-        return Err(TransitionFailure::InvalidEvidence(
-            "target completion ancestor does not match the retained parent",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Header(crate::HeaderViolation::Path {
+                kind: HeaderPathKind::Completion,
+                problem: HeaderPathProblem::AncestorMismatch,
+            })
+            .into(),
+        );
     }
     let mut contextual =
-        retained_header_context(projected.graph(), parent_frontier, durable, context)?;
+        retained_header_context(projected.graph(), parent_frontier, facts, context)?;
     let mut parent = parent_frontier;
     for prepared in event.batch.headers() {
         if prepared.header.previous_block_hash != parent.hash
@@ -68,12 +73,17 @@ pub(super) fn apply(
                     })?
             || prepared.block_work
                 != prepared.header.difficulty_threshold.to_work().ok_or(
-                    TransitionFailure::InvalidEvidence("invalid prepared target"),
+                    TransitionFailure::InvalidEvidence(InvalidTransitionEvidence::header_path(
+                        HeaderPathKind::Completion,
+                        HeaderPathProblem::InvalidPreparedTarget,
+                    )),
                 )?
         {
-            return Err(TransitionFailure::InvalidEvidence(
-                "prepared header batch is inconsistent",
-            ));
+            return Err(InvalidTransitionEvidence::header_path(
+                HeaderPathKind::Completion,
+                HeaderPathProblem::BatchInconsistent,
+            )
+            .into());
         }
         let adjustment = crate::AdjustedDifficulty::new_from_header_time(
             prepared.header.time,
@@ -82,18 +92,20 @@ pub(super) fn apply(
             contextual.iter().copied(),
         )
         .map_err(|_| {
-            TransitionFailure::InvalidEvidence(
-                "prepared header has incomplete retained difficulty context",
-            )
+            InvalidTransitionEvidence::Header(crate::HeaderViolation::Validation {
+                source: crate::HeaderValidationSource::Prepared,
+                check: HeaderValidationCheck::IncompleteDifficultyContext,
+            })
         })?;
         crate::validate_contextual_difficulty_and_time(
             prepared.header.difficulty_threshold,
             adjustment,
         )
         .map_err(|_| {
-            TransitionFailure::InvalidEvidence(
-                "prepared header failed retained contextual validation",
-            )
+            InvalidTransitionEvidence::Header(crate::HeaderViolation::Validation {
+                source: crate::HeaderValidationSource::Prepared,
+                check: HeaderValidationCheck::ContextualValidation,
+            })
         })?;
         let validation = match prepared.validation {
             HeaderValidationState::DeferredUntil(until) if until <= context.clock.now() => {
@@ -118,18 +130,23 @@ pub(super) fn apply(
         contextual.truncate(crate::POW_ADJUSTMENT_BLOCK_SPAN);
     }
     if parent.hash != event.target_tip_hash {
-        return Err(TransitionFailure::InvalidEvidence(
-            "target completion does not end at the pursued hash",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Header(crate::HeaderViolation::Path {
+                kind: HeaderPathKind::Completion,
+                problem: HeaderPathProblem::TipMismatch,
+            })
+            .into(),
+        );
     }
     match event.completion {
         TargetCompletion::SelectedAuxiliaryRepair {
             selected_target, ..
         } => {
             if event.owner.body_owner().is_none() {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "selected auxiliary repair does not have body authority",
-                ));
+                return Err(InvalidTransitionEvidence::Header(
+                    HeaderViolation::RepairOwnerRoleMismatch,
+                )
+                .into());
             }
             if event.batch.headers().len() != 1
                 || event.aux.len() != 1
@@ -148,21 +165,27 @@ pub(super) fn apply(
                     selected_target.height,
                 )? != Some(selected_target)
             {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "auxiliary repair is not one exact selected header",
-                ));
+                return Err(InvalidTransitionEvidence::Header(
+                    HeaderViolation::AuxiliaryRepairShape,
+                )
+                .into());
             }
         }
         TargetCompletion::TargetComplete { .. } | TargetCompletion::TargetPrefix { .. } => {
             if event.owner.header_owner().is_none() {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "ordinary header insertion does not have pure header authority",
-                ));
+                return Err(InvalidTransitionEvidence::Header(
+                    HeaderViolation::OrdinaryOwnerRoleMismatch,
+                )
+                .into());
             }
             if event.owner.header_authority().branch.target_tip_hash != event.target_tip_hash {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "target completion does not end at the pursued hash",
-                ));
+                return Err(
+                    InvalidTransitionEvidence::Header(crate::HeaderViolation::Path {
+                        kind: HeaderPathKind::Completion,
+                        problem: HeaderPathProblem::TipMismatch,
+                    })
+                    .into(),
+                );
             }
         }
     }
@@ -184,9 +207,10 @@ pub(super) fn apply(
                 .tree_aux
                 .is_some_and(|aux| Some(aux.height) != expected_height)
         {
-            return Err(TransitionFailure::InvalidEvidence(
-                "auxiliary delivery does not match the admitted target",
-            ));
+            return Err(InvalidTransitionEvidence::Auxiliary(
+                AuxiliaryViolation::AdmittedTargetMismatch,
+            )
+            .into());
         }
         let indexed_count = projected
             .graph()
@@ -201,9 +225,10 @@ pub(super) fn apply(
             (Some(stored), 1) if stored == *delivery => continue,
             (None, 0) => {}
             _ => {
-                return Err(TransitionFailure::InvalidEvidence(
-                    "auxiliary delivery replay changes provenance or indexing",
-                ));
+                return Err(InvalidTransitionEvidence::Auxiliary(
+                    AuxiliaryViolation::ReplayConflict,
+                )
+                .into());
             }
         }
         projected.record_aux_delivery(*delivery)?;

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
@@ -1,16 +1,17 @@
 //! Shared retained-context and full-state header validation for event handlers.
 
+use super::super::{HeaderValidationCheck, InvalidTransitionEvidence, TransitionFailure};
 use crate::graph::HeaderGraphView;
 use crate::{
-    DurableTransitionFacts, EligibilityReason, Frontier, HeaderValidationState, StoreError,
-    TransitionContext, TransitionFailure,
+    EligibilityReason, Frontier, HeaderValidationFacts, HeaderValidationState, StoreError,
+    TransitionContext,
 };
 
 /// Reconstruct difficulty/time context for a retained parent, splicing durable leases when needed.
 pub(in crate::transition::planner) fn retained_header_context<G: HeaderGraphView>(
     graph: &G,
     parent: Frontier,
-    durable: &DurableTransitionFacts,
+    facts: Option<&crate::HeaderValidationFacts>,
     transition: &TransitionContext<'_>,
 ) -> Result<
     Vec<(
@@ -30,16 +31,12 @@ pub(in crate::transition::planner) fn retained_header_context<G: HeaderGraphView
     let mut hash = parent.hash;
     while context.len() < required {
         let Some(node) = graph.view_header_node(hash) else {
-            let DurableTransitionFacts::HeaderInsertion {
-                validation_contexts,
-                ..
-            } = durable
-            else {
+            let Some(facts) = facts else {
                 return Err(
                     StoreError::Unavailable("retained predecessor context is incomplete").into(),
                 );
             };
-            let authorized_lease = validation_contexts.iter().find_map(|lease| {
+            let authorized_lease = facts.validation_leases.iter().find_map(|lease| {
                 if !lease.is_coherent(
                     &transition.config.network,
                     transition.config.trust_anchor_digest(),
@@ -113,11 +110,11 @@ pub(super) fn validate_full_state_header<G: HeaderGraphView>(
     graph: &G,
     parent: Frontier,
     header: &crate::VerifiedHeaderRef,
-    durable: &DurableTransitionFacts,
+    facts: Option<&HeaderValidationFacts>,
     context: &TransitionContext<'_>,
 ) -> Result<zakura_chain::work::difficulty::Work, TransitionFailure> {
     let rules = crate::HeaderRules::from_engine_config(context.config).map_err(|_| {
-        TransitionFailure::InvalidEvidence("full-state header policy is incoherent")
+        InvalidTransitionEvidence::full_state_header(HeaderValidationCheck::PolicyIncoherent)
     })?;
     let headers = [header.header.clone()];
     let prepared = crate::prepare_context_free_headers(
@@ -127,23 +124,24 @@ pub(super) fn validate_full_state_header<G: HeaderGraphView>(
         context.clock,
     )
     .map_err(|_| {
-        TransitionFailure::InvalidEvidence("full-state header failed observable validation")
+        InvalidTransitionEvidence::full_state_header(HeaderValidationCheck::ObservableValidation)
     })?;
     let prepared = prepared
         .headers()
         .first()
         .ok_or(TransitionFailure::InvalidEvidence(
-            "full-state header validation produced no result",
+            InvalidTransitionEvidence::full_state_header(HeaderValidationCheck::NoResult),
         ))?;
     if prepared.hash != header.hash
         || prepared.height != header.height
         || prepared.validation != HeaderValidationState::Valid
     {
-        return Err(TransitionFailure::InvalidEvidence(
-            "full-state header identity or local-time state is invalid",
-        ));
+        return Err(InvalidTransitionEvidence::full_state_header(
+            HeaderValidationCheck::IdentityOrLocalTime,
+        )
+        .into());
     }
-    let contextual = retained_header_context(graph, parent, durable, context)?;
+    let contextual = retained_header_context(graph, parent, facts, context)?;
     let adjustment = crate::AdjustedDifficulty::new_from_header_time(
         header.header.time,
         parent.height,
@@ -151,14 +149,14 @@ pub(super) fn validate_full_state_header<G: HeaderGraphView>(
         contextual,
     )
     .map_err(|_| {
-        TransitionFailure::InvalidEvidence(
-            "full-state header has incomplete retained difficulty context",
+        InvalidTransitionEvidence::full_state_header(
+            HeaderValidationCheck::IncompleteDifficultyContext,
         )
     })?;
     crate::validate_contextual_difficulty_and_time(header.header.difficulty_threshold, adjustment)
         .map_err(|_| {
-            TransitionFailure::InvalidEvidence(
-                "full-state header failed contextual difficulty or time validation",
+            InvalidTransitionEvidence::full_state_header(
+                HeaderValidationCheck::ContextualValidation,
             )
         })?;
     Ok(prepared.block_work)

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/mod.rs
@@ -9,8 +9,8 @@ pub(super) mod header_validation;
 mod operator_policy;
 
 use crate::{
-    BodyEvidence, DurableTransitionFacts, EngineSnapshot, Frontier, HeaderChainEngine,
-    TransitionContext, TransitionEvent, TransitionFailure,
+    BodyEvidence, EngineSnapshot, Frontier, HeaderChainEngine, TransitionContext, TransitionEvent,
+    TransitionFailure, TransitionInput,
 };
 
 use super::projected_state::ProjectedTransitionState;
@@ -18,7 +18,7 @@ use super::projected_state::ProjectedTransitionState;
 /// Read-only inputs shared by every domain event handler.
 pub(in crate::transition::planner) struct ApplyEventContext<'a> {
     pub(super) engine: &'a HeaderChainEngine,
-    pub(super) durable: &'a DurableTransitionFacts,
+    pub(super) input: &'a TransitionInput,
     pub(super) transition: &'a TransitionContext<'a>,
     pub(super) before: &'a EngineSnapshot,
     pub(super) old_selected: &'a [Frontier],
@@ -80,16 +80,16 @@ pub(super) fn apply_event_evidence(
 
 /// Resolve whether durable facts authenticate a migrated-pin refutation.
 pub(super) fn migrated_pin_refuted(
-    durable: &DurableTransitionFacts,
+    input: &TransitionInput,
     event: &TransitionEvent,
 ) -> Result<Option<Frontier>, TransitionFailure> {
     let TransitionEvent::MigratedPinRefutation(event) = event else {
         return Ok(None);
     };
-    match durable {
-        DurableTransitionFacts::MigratedFinalityPin(preserved) => {
-            Ok((*preserved == Some(event.pin)).then_some(event.pin))
-        }
-        _ => Err(crate::StoreError::Unavailable("migrated finality fact was not supplied").into()),
-    }
+    let Some(preserved) = input.preserved_migrated_pin() else {
+        return Err(
+            crate::StoreError::Unavailable("migrated finality fact was not supplied").into(),
+        );
+    };
+    Ok((preserved == Some(event.pin)).then_some(event.pin))
 }

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/operator_policy.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/operator_policy.rs
@@ -1,7 +1,10 @@
 //! Operator-driven eligibility and body-retry policy.
 
+use super::super::{
+    BodyViolation, InvalidTransitionEvidence, OperatorViolation, TransitionFailure,
+};
 use crate::graph::HeaderGraphView;
-use crate::{BodyValidationState, EligibilityReason, TransitionFailure};
+use crate::{BodyValidationState, EligibilityReason};
 
 use super::super::projected_state::ProjectedTransitionState;
 
@@ -16,17 +19,18 @@ pub(super) fn apply_body_retry(
         || event.availability.alarmed
         || event.availability.started_at != event.availability.next_probe_at
     {
-        return Err(TransitionFailure::InvalidEvidence(
-            "operator body retry has an invalid fresh episode",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Body(BodyViolation::InvalidOperatorRetryEpisode).into(),
+        );
     }
     if !matches!(
         projected.graph().view_header_node(event.hash).map(|node| &node.body_validation_state),
         Some(BodyValidationState::Unavailable(summary)) if summary.alarmed
     ) {
-        return Err(TransitionFailure::InvalidEvidence(
-            "operator body retry requires the selected persistent alarm",
-        ));
+        return Err(InvalidTransitionEvidence::Body(
+            BodyViolation::OperatorRetryRequiresPersistentAlarm,
+        )
+        .into());
     }
     projected.set_body_validation_state(
         event.hash,
@@ -47,14 +51,12 @@ pub(super) fn apply_invalidate(
     hasher.update(event.id.bytes());
     let expected_digest: [u8; 32] = hasher.finalize().into();
     if event.operator_reason_digest != expected_digest {
-        return Err(TransitionFailure::InvalidEvidence(
-            "operator invalidation identity is not bound to its target",
-        ));
+        return Err(InvalidTransitionEvidence::Operator(OperatorViolation::BindingMismatch).into());
     }
     if event.target == projected.graph().view_finalized_frontier().hash {
-        return Err(TransitionFailure::InvalidEvidence(
-            "operator invalidation cannot target the finalized anchor",
-        ));
+        return Err(
+            InvalidTransitionEvidence::Operator(OperatorViolation::FinalizedAnchorTarget).into(),
+        );
     }
     projected.add_operator_invalidation(
         event.target,

--- a/crates/zakura-header-chain/src/transition/planner/evidence.rs
+++ b/crates/zakura-header-chain/src/transition/planner/evidence.rs
@@ -1,0 +1,296 @@
+//! Domain-specific invalid-evidence failures for the transition planner.
+
+use thiserror::Error;
+
+/// Structured invalid-evidence failure replacing stringly typed planner messages.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum InvalidTransitionEvidence {
+    /// Request or resource bounds were exceeded.
+    #[error(transparent)]
+    Limit(#[from] LimitViolation),
+    /// Finality evidence or ancestry was invalid.
+    #[error(transparent)]
+    Finality(#[from] FinalityViolation),
+    /// Header path or contextual validation evidence was invalid.
+    #[error(transparent)]
+    Header(#[from] HeaderViolation),
+    /// Body availability evidence was invalid.
+    #[error(transparent)]
+    Body(#[from] BodyViolation),
+    /// Auxiliary provenance or authentication evidence was invalid.
+    #[error(transparent)]
+    Auxiliary(#[from] AuxiliaryViolation),
+    /// Operator invalidation or retry evidence was invalid.
+    #[error(transparent)]
+    Operator(#[from] OperatorViolation),
+    /// Planner projection/coherence failed after event application.
+    #[error(transparent)]
+    Planner(#[from] PlannerCoherenceViolation),
+}
+
+/// Request or preflight limit violations.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum LimitViolation {
+    /// Retention references exceed the per-transition bound.
+    #[error("retained-path references exceed the per-transition limit")]
+    RetentionReferencesExceeded,
+    /// Prepared header batch exceeds the per-transition bound.
+    #[error("prepared header batch exceeds the per-transition limit")]
+    PreparedHeadersExceeded,
+}
+
+/// Finality evidence and ancestry violations.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum FinalityViolation {
+    /// Proposed finality retreated below the current pin.
+    #[error("finality retreated")]
+    Retreated,
+    /// Integrated finality is not on the verified projection.
+    #[error("integrated finality is not on the verified projection")]
+    OutsideVerifiedProjection,
+    /// Finality proof is not the exact verified ancestry.
+    #[error("finality proof is not the exact verified ancestry")]
+    ProofMismatch,
+    /// Full-state refutation does not name an imported pin ancestor.
+    #[error("full-state refutation does not name an imported pin ancestor")]
+    ImportedPinRefutationMismatch,
+}
+
+/// Which header-validation path produced a failure.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum HeaderValidationSource {
+    /// Full-state verified path insertion/validation.
+    #[error("full-state")]
+    FullState,
+    /// Prepared network header insertion.
+    #[error("prepared")]
+    Prepared,
+}
+
+/// Specific header validation check that failed.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum HeaderValidationCheck {
+    /// Header policy construction failed.
+    #[error("header policy is incoherent")]
+    PolicyIncoherent,
+    /// Observable/context-free validation failed.
+    #[error("header failed observable validation")]
+    ObservableValidation,
+    /// Validator returned no prepared header.
+    #[error("header validation produced no result")]
+    NoResult,
+    /// Identity or local-time state disagreed.
+    #[error("header identity or local-time state is invalid")]
+    IdentityOrLocalTime,
+    /// Retained difficulty context was incomplete.
+    #[error("header has incomplete retained difficulty context")]
+    IncompleteDifficultyContext,
+    /// Contextual difficulty or time validation failed.
+    #[error("header failed contextual difficulty or time validation")]
+    ContextualValidation,
+}
+
+/// Which path kind failed continuity/emptiness checks.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum HeaderPathKind {
+    /// Prepared target-completion path.
+    #[error("target completion")]
+    Completion,
+    /// Full-state verified path.
+    #[error("verified path")]
+    Verified,
+    /// Accepted full-state side path.
+    #[error("accepted side path")]
+    AcceptedSide,
+}
+
+/// Path-shape problem on a header path.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum HeaderPathProblem {
+    /// Path contained no headers.
+    #[error("is empty")]
+    Empty,
+    /// Parent links or heights were discontinuous.
+    #[error("is not continuous")]
+    Discontinuous,
+    /// Completion ancestor disagreed with the retained parent.
+    #[error("ancestor does not match the retained parent")]
+    AncestorMismatch,
+    /// Completion tip disagreed with the pursued hash.
+    #[error("does not end at the pursued hash")]
+    TipMismatch,
+    /// Prepared batch fields were internally inconsistent.
+    #[error("batch is inconsistent")]
+    BatchInconsistent,
+    /// Prepared compact target was invalid.
+    #[error("has an invalid prepared target")]
+    InvalidPreparedTarget,
+}
+
+/// Header path and contextual validation violations.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum HeaderViolation {
+    /// A concrete header validation check failed.
+    #[error("{source} {check}")]
+    Validation {
+        /// Whether the failure came from prepared or full-state validation.
+        source: HeaderValidationSource,
+        /// Exact failed check.
+        check: HeaderValidationCheck,
+    },
+    /// A header path shape invariant failed.
+    #[error("{kind} {problem}")]
+    Path {
+        /// Which path failed.
+        kind: HeaderPathKind,
+        /// Exact shape problem.
+        problem: HeaderPathProblem,
+    },
+    /// Authenticated owner role does not match the completion kind.
+    #[error("ordinary header insertion does not have pure header authority")]
+    OrdinaryOwnerRoleMismatch,
+    /// Selected auxiliary repair lacks body authority.
+    #[error("selected auxiliary repair does not have body authority")]
+    RepairOwnerRoleMismatch,
+    /// Auxiliary repair is not one exact selected header.
+    #[error("auxiliary repair is not one exact selected header")]
+    AuxiliaryRepairShape,
+}
+
+/// Body availability and episode violations.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum BodyViolation {
+    /// Transient retry episode summary is malformed.
+    #[error("body retry evidence has an invalid episode summary")]
+    InvalidTransientEpisode,
+    /// Retry would regress an already verified body.
+    #[error("body retry evidence cannot regress an already verified body")]
+    RetryConflictsWithVerified,
+    /// Invalidity contradicts an already verified body.
+    #[error("body invalid evidence cannot contradict an already verified body")]
+    InvalidityConflictsWithVerified,
+    /// Supplier discovery requires the selected persistent alarm.
+    #[error("body supplier discovery requires the selected persistent alarm")]
+    SupplierRequiresPersistentAlarm,
+    /// Supplier discovery must preserve the persistent retry episode.
+    #[error("body supplier discovery must preserve the persistent retry episode")]
+    SupplierEpisodeChanged,
+    /// Supplier discovery does not add an eligible supplier.
+    #[error("body supplier discovery does not add an eligible supplier")]
+    NoNewSupplier,
+    /// Operator body retry has an invalid fresh episode.
+    #[error("operator body retry has an invalid fresh episode")]
+    InvalidOperatorRetryEpisode,
+    /// Operator body retry requires the selected persistent alarm.
+    #[error("operator body retry requires the selected persistent alarm")]
+    OperatorRetryRequiresPersistentAlarm,
+}
+
+/// Auxiliary provenance and authentication violations.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum AuxiliaryViolation {
+    /// Delivery count must be one or two.
+    #[error("auxiliary evidence must name one or two exact deliveries")]
+    DeliveryCount,
+    /// The same delivery was named more than once.
+    #[error("auxiliary evidence names the same delivery more than once")]
+    DuplicateDelivery,
+    /// Delivery references an unknown header.
+    #[error("auxiliary evidence references an unknown header")]
+    UnknownHeader,
+    /// Delivery is outside its owned branch.
+    #[error("auxiliary evidence is outside its owned branch")]
+    OutsideOwnedBranch,
+    /// Delivery references an unknown stored delivery.
+    #[error("auxiliary evidence references an unknown delivery")]
+    UnknownDelivery,
+    /// Delivery changes stored provenance.
+    #[error("auxiliary evidence changes delivery provenance")]
+    ProvenanceMismatch,
+    /// Authenticated or rejected delivery is immutable.
+    #[error("an authenticated or rejected auxiliary delivery is immutable")]
+    ImmutableAuthentication,
+    /// Authentication boundary header is unknown.
+    #[error("auxiliary authentication boundary is unknown")]
+    UnknownBoundary,
+    /// Authentication boundary height overflowed.
+    #[error("auxiliary authentication boundary height overflowed")]
+    BoundaryHeightOverflow,
+    /// Authentication is not the owned one-header-later boundary.
+    #[error("auxiliary authentication is not the owned one-header-later boundary")]
+    InvalidBoundary,
+    /// Evidence attempted to remove authentication.
+    #[error("auxiliary evidence cannot remove authentication")]
+    AuthenticationRemoval,
+    /// Insertion-time delivery does not match the admitted target.
+    #[error("auxiliary delivery does not match the admitted target")]
+    AdmittedTargetMismatch,
+    /// Insertion-time delivery replay changes provenance or indexing.
+    #[error("auxiliary delivery replay changes provenance or indexing")]
+    ReplayConflict,
+}
+
+/// Operator invalidation violations.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum OperatorViolation {
+    /// Invalidation identity is not bound to its target.
+    #[error("operator invalidation identity is not bound to its target")]
+    BindingMismatch,
+    /// Invalidation targeted the finalized anchor.
+    #[error("operator invalidation cannot target the finalized anchor")]
+    FinalizedAnchorTarget,
+}
+
+/// Which projection failed a coherence check.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum ProjectionKind {
+    /// Selected header projection.
+    #[error("selected")]
+    Selected,
+    /// Verified body projection.
+    #[error("verified")]
+    Verified,
+}
+
+/// Planner coherence failures that are not caller evidence failures.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub enum PlannerCoherenceViolation {
+    /// Selected ancestry required for headers-only finality was incomplete.
+    #[error("selected ancestry is incomplete")]
+    IncompleteSelectedAncestry,
+    /// Checkpoint finality advanced without a finality record.
+    #[error("checkpoint finality has no finality record")]
+    MissingCheckpointRecord,
+    /// Checkpoint finality left the selected projection.
+    #[error("checkpoint finality left the selected projection")]
+    CheckpointOutsideSelection,
+    /// A projection became empty.
+    #[error("{0} projection is empty")]
+    EmptyProjection(ProjectionKind),
+    /// A projection became discontinuous.
+    #[error("{0} projection is not continuous")]
+    DiscontinuousProjection(ProjectionKind),
+}
+
+impl InvalidTransitionEvidence {
+    /// Construct a full-state header validation failure.
+    pub const fn full_state_header(check: HeaderValidationCheck) -> Self {
+        Self::Header(HeaderViolation::Validation {
+            source: HeaderValidationSource::FullState,
+            check,
+        })
+    }
+
+    /// Construct a prepared header validation failure.
+    pub const fn prepared_header(check: HeaderValidationCheck) -> Self {
+        Self::Header(HeaderViolation::Validation {
+            source: HeaderValidationSource::Prepared,
+            check,
+        })
+    }
+
+    /// Construct a header path failure.
+    pub const fn header_path(kind: HeaderPathKind, problem: HeaderPathProblem) -> Self {
+        Self::Header(HeaderViolation::Path { kind, problem })
+    }
+}

--- a/crates/zakura-header-chain/src/transition/planner/projected_state.rs
+++ b/crates/zakura-header-chain/src/transition/planner/projected_state.rs
@@ -1,5 +1,8 @@
 //! Cohesive mutable projection of graph, verified path, and auxiliary deltas.
 
+use super::{
+    InvalidTransitionEvidence, PlannerCoherenceViolation, ProjectionKind, TransitionFailure,
+};
 use std::{borrow::Cow, collections::HashSet, sync::Arc};
 
 use zakura_chain::block;
@@ -9,7 +12,6 @@ use crate::retention::RetentionPlan;
 use crate::{
     AuxDelta, BodyValidationState, EligibilityReason, EngineLimits, EvidenceId, Frontier,
     GraphError, HeaderChainEngine, HeaderValidationState, InsertResult, OperatorInvalidationId,
-    TransitionFailure,
 };
 
 /// Mutable projected state accumulated while applying one transition event.
@@ -360,9 +362,10 @@ pub(super) fn trim_projection<'a, G: HeaderGraphView>(
                 .view_header_node(pair[1].hash)
                 .is_none_or(|node| node.parent_hash != pair[0].hash)
         {
-            return Err(TransitionFailure::InvalidEvidence(
-                "verified projection is not continuous",
-            ));
+            return Err(InvalidTransitionEvidence::Planner(
+                PlannerCoherenceViolation::DiscontinuousProjection(ProjectionKind::Verified),
+            )
+            .into());
         }
     }
     Ok(Cow::Owned(result))

--- a/crates/zakura-header-chain/src/transition/planner/settlement.rs
+++ b/crates/zakura-header-chain/src/transition/planner/settlement.rs
@@ -2,11 +2,15 @@
 
 use std::borrow::Cow;
 
+use super::{
+    FinalityViolation, InvalidTransitionEvidence, PlannerCoherenceViolation, TransitionFailure,
+};
 use crate::graph::HeaderGraphView;
 use crate::retention::RetentionPlan;
 use crate::{
-    EngineMetadata, EngineMode, EngineSnapshot, FinalityRecord, FinalitySource, Frontier,
-    HeaderChainEngine, TransitionCause, TransitionContext, TransitionEvent, TransitionFailure,
+    AuxiliaryEffect, EngineMetadata, EngineMode, EngineSnapshot, FinalityEffect, FinalityRecord,
+    FinalitySource, Frontier, HeaderChainEngine, HeaderWorkEffect, TransitionContext,
+    TransitionEffect, TransitionEvent,
 };
 
 use super::admission::HeaderInsertionRebase;
@@ -34,8 +38,8 @@ pub(super) struct SettledTransition<'a> {
     pub(super) finality_append: Option<FinalityRecord>,
     /// Retention outcome.
     pub(super) retention: RetentionPlan,
-    /// Classified transition cause.
-    pub(super) cause: TransitionCause,
+    /// Orthogonal transition effects.
+    pub(super) effect: TransitionEffect,
     /// Updated metadata carrying work-origin and alarm side effects.
     pub(super) metadata: EngineMetadata,
 }
@@ -89,12 +93,13 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
     let mut finality = None;
     if let Some((new_finalized, evidence)) = full_state_finalized {
         if new_finalized.height < before.frontiers.finalized.height {
-            return Err(TransitionFailure::InvalidEvidence("finality retreated"));
+            return Err(InvalidTransitionEvidence::Finality(FinalityViolation::Retreated).into());
         }
         if !projected.verified().contains(&new_finalized) {
-            return Err(TransitionFailure::InvalidEvidence(
-                "integrated finality is not on the verified projection",
-            ));
+            return Err(InvalidTransitionEvidence::Finality(
+                FinalityViolation::OutsideVerifiedProjection,
+            )
+            .into());
         }
         finality = Some((new_finalized, FinalitySource::FullState { evidence }));
     } else if context.config.mode == EngineMode::HeadersOnly {
@@ -110,7 +115,9 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
                 .graph()
                 .view_header_ancestor(header_best.hash, height)?
                 .ok_or(TransitionFailure::InvalidEvidence(
-                    "selected ancestry is incomplete",
+                    InvalidTransitionEvidence::Planner(
+                        PlannerCoherenceViolation::IncompleteSelectedAncestry,
+                    ),
                 ))?;
             finality = Some((
                 new_finalized,
@@ -121,19 +128,21 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
         }
     }
 
-    let mut cause = if work_rebased || header_rebase == HeaderInsertionRebase::Rebased {
-        TransitionCause::HeaderWorkRebased
-    } else if matches!(
+    let mut effect = TransitionEffect::none();
+    if work_rebased || header_rebase == HeaderInsertionRebase::Rebased {
+        effect.header_work = Some(HeaderWorkEffect::Rebased);
+    }
+    if matches!(
         event,
         TransitionEvent::VerifiedChainChanged(ref event)
             if event.cause == crate::VerifiedChangeCause::CheckpointFinalizedGrow
     ) {
-        TransitionCause::CheckpointFinality
+        effect.finality = Some(FinalityEffect::Checkpoint);
     } else if matches!(event, TransitionEvent::AuxEvidence(_)) {
-        TransitionCause::AuxAuthentication
-    } else {
-        TransitionCause::Event
-    };
+        effect.auxiliary = Some(AuxiliaryEffect::Authentication);
+    } else if matches!(event, TransitionEvent::FullStateFinalized(_)) {
+        // Finality effect is set when a record is actually appended below.
+    }
 
     let mut finality_append = None;
     if let Some((new_finalized, source)) = finality {
@@ -148,8 +157,16 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
                 epoch,
             });
             header_best = projected.graph().view_select_best_header_chain()?.0;
-            if matches!(source, FinalitySource::HeadersOnlyDepth { .. }) {
-                cause = TransitionCause::HeadersOnlyFinality;
+            match source {
+                FinalitySource::HeadersOnlyDepth { .. } => {
+                    effect.finality = Some(FinalityEffect::HeadersOnlyDepth);
+                }
+                FinalitySource::FullState { .. } => {
+                    if effect.finality.is_none() {
+                        effect.finality = Some(FinalityEffect::FullState);
+                    }
+                }
+                FinalitySource::MigratedHeadersOnly => {}
             }
         }
     }
@@ -168,7 +185,7 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
     }
 
     header_best = projected.graph().view_select_best_header_chain()?.0;
-    let selected = if cause == TransitionCause::CheckpointFinality
+    let selected = if effect.is_checkpoint_finality()
         && header_best == before.frontiers.header_best
         && finality_append.is_some_and(|record| {
             old_selected
@@ -177,15 +194,16 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
                 .is_some_and(|index| old_selected[index] == record.current)
         }) {
         let Some(record) = finality_append else {
-            return Err(TransitionFailure::InvalidEvidence(
-                "checkpoint finality has no finality record",
-            ));
+            return Err(InvalidTransitionEvidence::Planner(
+                PlannerCoherenceViolation::MissingCheckpointRecord,
+            )
+            .into());
         };
         let index = old_selected
             .binary_search_by_key(&record.current.height, |frontier| frontier.height)
             .map_err(|_| {
-                TransitionFailure::InvalidEvidence(
-                    "checkpoint finality left the selected projection",
+                InvalidTransitionEvidence::Planner(
+                    PlannerCoherenceViolation::CheckpointOutsideSelection,
                 )
             })?;
         Cow::Borrowed(&old_selected[index..])
@@ -200,7 +218,7 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
             selected,
             finality_append,
             retention,
-            cause,
+            effect,
             metadata,
         },
     )))

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -49,7 +49,7 @@ fn auxiliary_delivery_ids_are_globally_unique_across_headers() {
     assert!(matches!(
         apply_transition(&store, second, &context(&config, &clock, None)),
         Err(TransitionFailure::InvalidEvidence(
-            "auxiliary delivery replay changes provenance or indexing"
+            InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::ReplayConflict)
         ))
     ));
 }
@@ -313,7 +313,7 @@ fn selected_auxiliary_repair_adds_only_one_exact_provenance_record() {
             &context(&config, &clock, None)
         ),
         Err(TransitionFailure::InvalidEvidence(
-            "selected auxiliary repair does not have body authority"
+            InvalidTransitionEvidence::Header(HeaderViolation::RepairOwnerRoleMismatch)
         ))
     ));
     let repaired = apply_transition(&store, repair, &context(&config, &clock, None))
@@ -460,7 +460,9 @@ fn auxiliary_delivery_is_batch_hash_scoped_and_selection_neutral() {
             matches!(
                 apply_transition(&store, request, &context(&config, &clock, None)),
                 Err(TransitionFailure::InvalidEvidence(
-                    "auxiliary delivery does not match the admitted target"
+                    InvalidTransitionEvidence::Auxiliary(
+                        AuxiliaryViolation::AdmittedTargetMismatch
+                    )
                 ))
             ),
             "{label}"
@@ -540,7 +542,7 @@ fn auxiliary_authentication_requires_exact_provenance_and_owned_next_header() {
             &context(&config, &clock, Some(&Authority)),
         ),
         Err(TransitionFailure::InvalidEvidence(
-            "auxiliary evidence changes delivery provenance"
+            InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::ProvenanceMismatch)
         ))
     ));
     let wrong_boundary = crate::AuxAuthentication::Authenticated {
@@ -554,7 +556,7 @@ fn auxiliary_authentication_requires_exact_provenance_and_owned_next_header() {
             &context(&config, &clock, Some(&Authority)),
         ),
         Err(TransitionFailure::InvalidEvidence(
-            "auxiliary authentication is not the owned one-header-later boundary"
+            InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::InvalidBoundary)
         ))
     ));
 
@@ -579,7 +581,8 @@ fn auxiliary_authentication_requires_exact_provenance_and_owned_next_header() {
         authenticated.change_set.metadata.verified_generation,
         before.verified_generation
     );
-    assert_eq!(authenticated.cause(), TransitionCause::AuxAuthentication);
+    assert!(authenticated.effect().is_aux_authentication());
+    assert_eq!(authenticated.domain(), TransitionDomain::AuxEvidence);
     assert!(
         super::super::super::invariants::is_incremental_aux_authentication(
             &test_engine(&store),
@@ -622,7 +625,8 @@ fn auxiliary_authentication_requires_exact_provenance_and_owned_next_header() {
         &context(&config, &clock, Some(&Authority)),
     )
     .expect("two exact metadata deliveries reject in one atomic transition");
-    assert_eq!(rejected.cause(), TransitionCause::AuxAuthentication);
+    assert!(rejected.effect().is_aux_authentication());
+    assert_eq!(rejected.domain(), TransitionDomain::AuxEvidence);
     assert_eq!(
         rejected.change_set.aux_changes,
         vec![

--- a/crates/zakura-header-chain/src/transition/planner/tests/body_evidence.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/body_evidence.rs
@@ -108,7 +108,7 @@ fn transient_body_evidence_cannot_regress_a_verified_body() {
         matches!(
             result,
             Err(TransitionFailure::InvalidEvidence(
-                "body retry evidence cannot regress an already verified body"
+                InvalidTransitionEvidence::Body(BodyViolation::RetryConflictsWithVerified)
             ))
         ),
         "unexpected transition result: {result:?}"
@@ -239,7 +239,7 @@ fn body_supplier_discovery_rejects_reset_or_nonexpanding_evidence() {
             next_probe_at: now,
         }),
         Err(TransitionFailure::InvalidEvidence(
-            "body supplier discovery does not add an eligible supplier"
+            InvalidTransitionEvidence::Body(BodyViolation::NoNewSupplier)
         ))
     ));
     assert!(matches!(
@@ -252,7 +252,7 @@ fn body_supplier_discovery_rejects_reset_or_nonexpanding_evidence() {
             next_probe_at: now,
         }),
         Err(TransitionFailure::InvalidEvidence(
-            "body supplier discovery must preserve the persistent retry episode"
+            InvalidTransitionEvidence::Body(BodyViolation::SupplierEpisodeChanged)
         ))
     ));
     assert!(matches!(
@@ -265,7 +265,7 @@ fn body_supplier_discovery_rejects_reset_or_nonexpanding_evidence() {
             next_probe_at: now + chrono::Duration::minutes(1),
         }),
         Err(TransitionFailure::InvalidEvidence(
-            "body supplier discovery must preserve the persistent retry episode"
+            InvalidTransitionEvidence::Body(BodyViolation::SupplierEpisodeChanged)
         ))
     ));
     assert!(matches!(
@@ -278,7 +278,7 @@ fn body_supplier_discovery_rejects_reset_or_nonexpanding_evidence() {
             next_probe_at: now,
         }),
         Err(TransitionFailure::InvalidEvidence(
-            "body supplier discovery does not add an eligible supplier"
+            InvalidTransitionEvidence::Body(BodyViolation::NoNewSupplier)
         ))
     ));
 }

--- a/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
@@ -60,14 +60,21 @@ fn apply_with_header_rebase_facts(
     clock: &ManualClock,
     validation: ValidationLease,
 ) -> Result<TransitionPlan, TransitionFailure> {
+    let TransitionEvent::InsertHeaders(event) = request.event else {
+        panic!("rebase fixtures insert headers");
+    };
     test_engine(store)
         .plan_transition(
-            request,
-            &context(config, clock, None),
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![validation],
-                finality_path: store.finality.clone(),
+            TransitionInput::InsertHeaders {
+                event,
+                facts: HeaderInsertionFacts {
+                    validation: HeaderValidationFacts {
+                        validation_leases: vec![validation],
+                    },
+                    finality_rebase_history: store.finality.clone(),
+                },
             },
+            &context(config, clock, None),
         )
         .map(crate::EngineTransition::into_plan)
 }
@@ -197,11 +204,11 @@ fn header_insert_rebases_and_trims_across_each_monotone_finality_position() {
         assert_eq!(plan.change_set.put_nodes.len(), remaining);
         assert_eq!(plan.is_no_change(), remaining == 0);
         assert_eq!(
-            plan.cause(),
+            plan.effect().header_work,
             if remaining == 0 {
-                TransitionCause::HeaderWorkAlreadyApplied
+                Some(HeaderWorkEffect::AlreadyApplied)
             } else {
-                TransitionCause::HeaderWorkRebased
+                Some(HeaderWorkEffect::Rebased)
             }
         );
         assert_eq!(plan.change_set.metadata.frontiers.finalized, verified_tip);
@@ -306,7 +313,7 @@ fn header_insert_rebase_preserves_a_retained_parent_after_new_finality() {
 
     let plan = apply_with_header_rebase_facts(&store, held, &config, &clock, validation)
         .expect("the retained parent preserves all prepared child work");
-    assert_eq!(plan.cause(), TransitionCause::HeaderWorkRebased);
+    assert!(plan.effect().is_header_work_rebased());
     assert_eq!(plan.change_set.put_nodes.len(), 1);
     assert_eq!(plan.change_set.put_nodes[0].parent_hash, parent.hash);
 }
@@ -664,7 +671,8 @@ fn headers_only_finalizes_exactly_tip_minus_one_thousand_before_publication() {
         plan.change_set.finality_append.expect("depth finality is recorded").source,
         FinalitySource::HeadersOnlyDepth { selected_tip } if selected_tip.height == block::Height(1_001)
     ));
-    assert_eq!(plan.cause(), TransitionCause::HeadersOnlyFinality);
+    assert!(plan.effect().is_headers_only_finality());
+    assert_eq!(plan.domain(), TransitionDomain::InsertHeaders);
 }
 
 #[test]
@@ -772,7 +780,8 @@ fn checkpoint_verified_growth_advances_verified_and_finalized_atomically() {
         .expect("checkpoint authority advances verification and finality together");
     assert_eq!(plan.change_set.metadata.frontiers.verified_best, checkpoint);
     assert_eq!(plan.change_set.metadata.frontiers.finalized, checkpoint);
-    assert_eq!(plan.cause(), TransitionCause::CheckpointFinality);
+    assert!(plan.effect().is_checkpoint_finality());
+    assert_eq!(plan.domain(), TransitionDomain::VerifiedChainChanged);
     assert!(
         super::super::super::invariants::is_incremental_checkpoint_finality(
             &test_engine(&store),

--- a/crates/zakura-header-chain/src/transition/planner/tests/guards.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/guards.rs
@@ -50,7 +50,7 @@ fn retention_references_are_bounded_before_ancestry_walks() {
     assert!(matches!(
         result,
         Err(TransitionFailure::InvalidEvidence(
-            "retained-path references exceed the per-transition limit"
+            InvalidTransitionEvidence::Limit(LimitViolation::RetentionReferencesExceeded)
         ))
     ));
 }
@@ -178,7 +178,10 @@ fn peer_target_completion_must_match_the_validation_lease_ancestor() {
     assert!(matches!(
         apply_transition(&store, request, &context(&config, &clock, None)),
         Err(TransitionFailure::InvalidEvidence(
-            "target completion ancestor does not match the retained parent"
+            InvalidTransitionEvidence::Header(crate::HeaderViolation::Path {
+                kind: HeaderPathKind::Completion,
+                problem: HeaderPathProblem::AncestorMismatch
+            })
         ))
     ));
 }

--- a/crates/zakura-header-chain/src/transition/planner/tests/insertion.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/insertion.rs
@@ -26,7 +26,7 @@ fn ordinary_header_insertion_rejects_body_repair_authority() {
     assert!(matches!(
         apply_transition(&store, request, &context(&config, &clock, None)),
         Err(TransitionFailure::InvalidEvidence(
-            "ordinary header insertion does not have pure header authority"
+            InvalidTransitionEvidence::Header(HeaderViolation::OrdinaryOwnerRoleMismatch)
         ))
     ));
 }
@@ -43,7 +43,8 @@ fn resource_bound_refusal_commits_only_the_alarm_and_recovers() {
         &context(&config, &clock, None),
     )
     .expect("resource refusal produces an alarm-only plan");
-    assert_eq!(refused.cause(), TransitionCause::ResourceStalled);
+    assert!(refused.effect().is_resource_stalled());
+    assert_eq!(refused.domain(), TransitionDomain::InsertHeaders);
     assert!(refused.change_set.metadata.alarms.resource_stalled);
     assert!(refused.graph_delta.is_empty());
     assert_eq!(
@@ -68,7 +69,8 @@ fn resource_bound_refusal_commits_only_the_alarm_and_recovers() {
         &context(&config, &clock, None),
     )
     .expect("an insertion within the bound clears the resource alarm");
-    assert_eq!(recovered.cause(), TransitionCause::Event);
+    assert_eq!(recovered.effect(), TransitionEffect::none());
+    assert_eq!(recovered.domain(), TransitionDomain::InsertHeaders);
     assert!(!recovered.change_set.metadata.alarms.resource_stalled);
     assert_eq!(
         recovered.change_set.metadata.state_version,
@@ -133,7 +135,10 @@ fn engine_rejects_context_free_batch_with_invalid_retained_time() {
     assert!(matches!(
         apply_transition(&store, request, &context(&config, &clock, None)),
         Err(TransitionFailure::InvalidEvidence(
-            "prepared header failed retained contextual validation"
+            InvalidTransitionEvidence::Header(crate::HeaderViolation::Validation {
+                source: crate::HeaderValidationSource::Prepared,
+                check: HeaderValidationCheck::ContextualValidation
+            })
         ))
     ));
 }

--- a/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/mod.rs
@@ -19,12 +19,15 @@ use zakura_chain::{
 
 use super::{projected_state::path, TransitionFailure, TransitionPlan};
 use crate::{
-    verify_plan, AlarmSet, BodyEvidence, BodyValidationState, BranchId, CheckpointSet,
-    DurableTransitionFacts, EligibilityReason, EngineConfig, EngineMetadata, EngineMode,
+    verify_plan, AlarmSet, AuxiliaryViolation, BodyEvidence, BodyValidationState, BodyViolation,
+    BranchId, CheckpointSet, EligibilityReason, EngineConfig, EngineMetadata, EngineMode,
     EngineSnapshot, EvidenceId, FinalityEpoch, FinalityRecord, FinalitySource, Frontier,
     FrontierSet, GraphError, HeaderChainDiskVersion, HeaderContextFact, HeaderGeneration,
-    HeaderValidationState, MemHeaderStore, PreparedHeader, PreparedHeaderBatch, ProjectionDelta,
-    SourceId, StateVersion, TargetCompletion, TransitionCause, TransitionContext, TransitionEvent,
+    HeaderInsertionFacts, HeaderPathKind, HeaderPathProblem, HeaderValidationCheck,
+    HeaderValidationFacts, HeaderValidationState, HeaderViolation, HeaderWorkEffect,
+    InvalidTransitionEvidence, LimitViolation, MemHeaderStore, OperatorViolation, PreparedHeader,
+    PreparedHeaderBatch, ProjectionDelta, SourceId, StateVersion, TargetCompletion,
+    TransitionContext, TransitionDomain, TransitionEffect, TransitionEvent, TransitionInput,
     TransitionRequest, TrustedAnchor, ValidationLease, VerifiedGeneration,
 };
 
@@ -268,6 +271,79 @@ fn test_engine(store: &TestStore) -> crate::HeaderChainEngine {
     .expect("the planner fixture is coherent before transition")
 }
 
+fn fixture_transition_input(store: &TestStore, request: TransitionRequest) -> TransitionInput {
+    let expected_version = request.expected_version;
+    match request.event {
+        TransitionEvent::InsertHeaders(event) => TransitionInput::InsertHeaders {
+            event,
+            facts: HeaderInsertionFacts {
+                validation: HeaderValidationFacts {
+                    validation_leases: vec![store.lease.clone()],
+                },
+                finality_rebase_history: Vec::new(),
+            },
+        },
+        TransitionEvent::VerifiedChainChanged(event) => TransitionInput::VerifiedChainChanged {
+            expected_version,
+            event,
+            facts: HeaderValidationFacts {
+                validation_leases: vec![store.lease.clone()],
+            },
+        },
+        TransitionEvent::VerifiedBlockAccepted(event) => TransitionInput::VerifiedBlockAccepted {
+            expected_version,
+            event,
+            facts: HeaderValidationFacts {
+                validation_leases: vec![store.lease.clone()],
+            },
+        },
+        TransitionEvent::BodyEvidence(event) => TransitionInput::BodyEvidence {
+            expected_version,
+            event,
+        },
+        TransitionEvent::BodySupplierDiscovered(event) => TransitionInput::BodySupplierDiscovered {
+            expected_version,
+            event,
+        },
+        TransitionEvent::OperatorBodyRetry(event) => TransitionInput::OperatorBodyRetry {
+            expected_version,
+            event,
+        },
+        TransitionEvent::OperatorInvalidate(event) => TransitionInput::OperatorInvalidate {
+            expected_version,
+            event,
+        },
+        TransitionEvent::OperatorReconsider(event) => TransitionInput::OperatorReconsider {
+            expected_version,
+            event,
+        },
+        TransitionEvent::FullStateFinalized(event) => TransitionInput::FullStateFinalized {
+            expected_version,
+            event,
+        },
+        TransitionEvent::MigratedPinRefutation(event) => {
+            let preserved_pin = store
+                .finality
+                .iter()
+                .any(|record| {
+                    record.current == event.pin
+                        && matches!(record.source, FinalitySource::MigratedHeadersOnly)
+                })
+                .then_some(event.pin);
+            TransitionInput::MigratedPinRefutation {
+                expected_version,
+                event,
+                preserved_pin,
+            }
+        }
+        TransitionEvent::AuxEvidence(event) => TransitionInput::AuxEvidence { event },
+        TransitionEvent::ReevaluateDeferred => {
+            TransitionInput::ReevaluateDeferred { expected_version }
+        }
+    }
+}
+
+#[allow(clippy::unwrap_in_result)]
 fn apply_transition(
     store: &TestStore,
     request: TransitionRequest,
@@ -280,28 +356,10 @@ fn apply_transition(
         store.verified.clone(),
         store.aux.clone(),
     )
-    .map_err(|_| TransitionFailure::InvalidEvidence("planner fixture engine is incoherent"))?;
-    let durable = match &request.event {
-        TransitionEvent::InsertHeaders(_) => DurableTransitionFacts::HeaderInsertion {
-            validation_contexts: vec![store.lease.clone()],
-            finality_path: Vec::new(),
-        },
-        TransitionEvent::MigratedPinRefutation(event) => {
-            DurableTransitionFacts::MigratedFinalityPin(
-                store
-                    .finality
-                    .iter()
-                    .any(|record| {
-                        record.current == event.pin
-                            && matches!(record.source, FinalitySource::MigratedHeadersOnly)
-                    })
-                    .then_some(event.pin),
-            )
-        }
-        _ => DurableTransitionFacts::None,
-    };
+    .expect("the planner fixture is coherent before transition");
+    let input = fixture_transition_input(store, request);
     let plan = engine
-        .plan_transition(request, context, durable)
+        .plan_transition(input, context)
         .map(crate::EngineTransition::into_plan)?;
     if let Err(error) = crate::verify_plan_production(&engine, &plan) {
         panic!(

--- a/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/operator.rs
@@ -20,9 +20,9 @@ fn operator_invalidation_rejects_the_finalized_anchor() {
     .expect_err("invalidating the finalized anchor must fail before any graph edit");
     assert_eq!(
         err,
-        TransitionFailure::InvalidEvidence(
-            "operator invalidation cannot target the finalized anchor"
-        )
+        TransitionFailure::InvalidEvidence(InvalidTransitionEvidence::Operator(
+            OperatorViolation::FinalizedAnchorTarget
+        ))
     );
 }
 
@@ -635,7 +635,7 @@ fn operator_body_retry_rejects_stale_or_malformed_requests() {
     assert!(matches!(
         apply(block::Hash([0x42; 32]), fresh),
         Err(TransitionFailure::InvalidEvidence(
-            "operator body retry has an invalid fresh episode"
+            InvalidTransitionEvidence::Body(BodyViolation::InvalidOperatorRetryEpisode)
         ))
     ));
     assert!(matches!(
@@ -647,7 +647,7 @@ fn operator_body_retry_rejects_stale_or_malformed_requests() {
             }
         ),
         Err(TransitionFailure::InvalidEvidence(
-            "operator body retry has an invalid fresh episode"
+            InvalidTransitionEvidence::Body(BodyViolation::InvalidOperatorRetryEpisode)
         ))
     ));
     store
@@ -669,7 +669,7 @@ fn operator_body_retry_rejects_stale_or_malformed_requests() {
     assert!(matches!(
         non_alarmed,
         Err(TransitionFailure::InvalidEvidence(
-            "operator body retry requires the selected persistent alarm"
+            InvalidTransitionEvidence::Body(BodyViolation::OperatorRetryRequiresPersistentAlarm)
         ))
     ));
 }

--- a/crates/zakura-header-chain/src/transition/planner/tests/predecessor_context.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/predecessor_context.rs
@@ -2,7 +2,7 @@
 
 use super::super::event_effects::header_validation::retained_header_context;
 use super::*;
-use crate::{DurableTransitionFacts, FullStateEvidenceAuthority, StoreError};
+use crate::{FullStateEvidenceAuthority, HeaderValidationFacts, StoreError};
 
 struct NoLeaseAuthority;
 impl FullStateEvidenceAuthority for NoLeaseAuthority {
@@ -90,9 +90,8 @@ fn retained_header_context_uses_exact_span_and_newest_to_oldest_order() {
             .expect("fixture height fits")
             .saturating_add(1)
             .min(crate::POW_ADJUSTMENT_BLOCK_SPAN);
-        let reconstructed =
-            retained_header_context(&store.graph, parent, &DurableTransitionFacts::None, &ctx)
-                .expect("fully retained context succeeds without durable facts");
+        let reconstructed = retained_header_context(&store.graph, parent, None, &ctx)
+            .expect("fully retained context succeeds without durable facts");
         assert_eq!(reconstructed.len(), expected_len, "height {height}");
 
         let expected: Vec<_> = header_path(&store, parent)
@@ -154,31 +153,29 @@ fn retained_header_context_splices_authorized_leases_and_rejects_bad_facts() {
     let cases = [
         (
             "authorized coherent lease",
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![matching_lease.clone()],
-                finality_path: Vec::new(),
-            },
+            Some(HeaderValidationFacts {
+                validation_leases: vec![matching_lease.clone()],
+            }),
             Ok(expected.clone()),
         ),
         (
             "unrelated lease then matching lease",
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![genesis_lease, matching_lease.clone()],
-                finality_path: Vec::new(),
-            },
+            Some(HeaderValidationFacts {
+                validation_leases: vec![genesis_lease, matching_lease.clone()],
+            }),
             Ok(expected.clone()),
         ),
         (
             "missing durable facts",
-            DurableTransitionFacts::None,
+            None,
             Err(TransitionFailure::Store(StoreError::Unavailable(
                 "retained predecessor context is incomplete",
             ))),
         ),
         (
             "no matching lease",
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![lease_for_path(
+            Some(HeaderValidationFacts {
+                validation_leases: vec![lease_for_path(
                     &store,
                     frontiers[20],
                     &[(
@@ -191,47 +188,43 @@ fn retained_header_context_splices_authorized_leases_and_rejects_bad_facts() {
                             .clone(),
                     )],
                 )],
-                finality_path: Vec::new(),
-            },
+            }),
             Err(TransitionFailure::Store(StoreError::Unavailable(
                 "durable predecessor context is incoherent",
             ))),
         ),
         (
             "wrong trust digest",
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![wrong_digest],
-                finality_path: Vec::new(),
-            },
+            Some(HeaderValidationFacts {
+                validation_leases: vec![wrong_digest],
+            }),
             Err(TransitionFailure::Store(StoreError::Unavailable(
                 "durable predecessor context is incoherent",
             ))),
         ),
         (
             "insufficient lease span",
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![short_lease],
-                finality_path: Vec::new(),
-            },
+            Some(HeaderValidationFacts {
+                validation_leases: vec![short_lease],
+            }),
             Err(TransitionFailure::Store(StoreError::Unavailable(
                 "durable predecessor context is incoherent",
             ))),
         ),
         (
             "empty header-insertion leases",
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: Vec::new(),
-                finality_path: Vec::new(),
-            },
+            Some(HeaderValidationFacts {
+                validation_leases: Vec::new(),
+            }),
             Err(TransitionFailure::Store(StoreError::Unavailable(
                 "durable predecessor context is incoherent",
             ))),
         ),
     ];
 
-    for (label, durable, expected_result) in cases {
+    for (label, facts, expected_result) in cases {
         assert_eq!(
-            retained_header_context(&store.graph, parent, &durable, &ctx),
+            retained_header_context(&store.graph, parent, facts.as_ref(), &ctx),
             expected_result,
             "{label}"
         );
@@ -248,10 +241,9 @@ fn retained_header_context_splices_authorized_leases_and_rejects_bad_facts() {
         retained_header_context(
             &store.graph,
             parent,
-            &DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![matching_lease],
-                finality_path: Vec::new(),
-            },
+            Some(&HeaderValidationFacts {
+                validation_leases: vec![matching_lease],
+            }),
             &unauthorized_ctx,
         ),
         Err(TransitionFailure::Store(StoreError::Unavailable(

--- a/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/selection.rs
@@ -16,16 +16,13 @@ fn committed_transition_reports_a_stale_source_without_panicking() {
     let (store, config) = TestStore::new(EngineMode::HeadersOnly);
     let clock = ManualClock(Utc::now());
     let request = insertion(&store, 1, EvidenceId::from_digest([0xe0; 32]));
-    let durable = || DurableTransitionFacts::HeaderInsertion {
-        validation_contexts: vec![store.lease.clone()],
-        finality_path: Vec::new(),
-    };
+    let input = || fixture_transition_input(&store, request.clone());
     let mut engine = test_engine(&store);
     let first = engine
-        .plan_transition(request.clone(), &context(&config, &clock, None), durable())
+        .plan_transition(input(), &context(&config, &clock, None))
         .expect("the first transition plans from the source snapshot");
     let stale = engine
-        .plan_transition(request, &context(&config, &clock, None), durable())
+        .plan_transition(input(), &context(&config, &clock, None))
         .expect("the second transition plans from the same source snapshot");
 
     engine
@@ -218,12 +215,8 @@ fn committed_transition_applies_to_a_cloned_source_engine() {
     let before = engine.snapshot();
     let transition = engine
         .plan_transition(
-            request,
+            fixture_transition_input(&store, request),
             &context(&config, &clock, None),
-            crate::DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![store.lease.clone()],
-                finality_path: Vec::new(),
-            },
         )
         .expect("the stateful engine plans the insertion");
 

--- a/crates/zakura-header-chain/src/transition/planner/write_set.rs
+++ b/crates/zakura-header-chain/src/transition/planner/write_set.rs
@@ -7,12 +7,16 @@ use crate::retention::RetentionPlan;
 use crate::{
     BodyValidationState, ChangeSet, EligibilityDelta, EngineLimits, EngineMetadata, EngineSnapshot,
     Frontier, FrontierSet, GraphError, HeaderChainEngine, IndexChanges, MemHeaderStore,
-    ProjectionDelta, TransitionCause, TransitionContext, TransitionEvent, TransitionFingerprint,
+    ProjectionDelta, TransitionContext, TransitionDomain, TransitionEffect, TransitionEvent,
+    TransitionFingerprint,
 };
 
 use super::admission::validate_authority;
 use super::projected_state::SettledProjectedState;
-use super::{PlanCandidate, TransitionFailure};
+use super::{
+    InvalidTransitionEvidence, PlanCandidate, PlannerCoherenceViolation, ProjectionKind,
+    TransitionFailure,
+};
 
 /// Inputs required to derive the atomic write set from settled projections.
 pub(super) struct DerivePlanInputs<'a> {
@@ -26,7 +30,8 @@ pub(super) struct DerivePlanInputs<'a> {
     pub(super) finality_append: Option<crate::FinalityRecord>,
     pub(super) retention: RetentionPlan,
     pub(super) fingerprint: Option<TransitionFingerprint>,
-    pub(super) cause: TransitionCause,
+    pub(super) domain: TransitionDomain,
+    pub(super) effect: TransitionEffect,
     pub(super) trust_pins: Arc<[Frontier]>,
     pub(super) limits: EngineLimits,
 }
@@ -46,7 +51,8 @@ pub(super) fn derive_plan(
         finality_append,
         retention,
         fingerprint,
-        cause,
+        domain,
+        effect,
         trust_pins,
         limits,
     } = inputs;
@@ -84,7 +90,9 @@ pub(super) fn derive_plan(
             .is_some_and(|old| old.is_eligible() != node.is_eligible())
     });
     let header_best = *selected.last().ok_or(TransitionFailure::InvalidEvidence(
-        "selected projection is empty",
+        InvalidTransitionEvidence::Planner(PlannerCoherenceViolation::EmptyProjection(
+            ProjectionKind::Selected,
+        )),
     ))?;
     metadata.alarms.resource_stalled = retention.resource_stalled;
     let header_best_node = graph
@@ -124,7 +132,9 @@ pub(super) fn derive_plan(
         }
     }
     let verified_best = *verified.last().ok_or(TransitionFailure::InvalidEvidence(
-        "verified projection is empty",
+        InvalidTransitionEvidence::Planner(PlannerCoherenceViolation::EmptyProjection(
+            ProjectionKind::Verified,
+        )),
     ))?;
     metadata.frontiers = FrontierSet {
         finalized: graph.view_finalized_frontier(),
@@ -172,7 +182,8 @@ pub(super) fn derive_plan(
         before,
         change_set,
         graph_delta,
-        cause,
+        domain,
+        effect,
         trust_pins,
         limits,
     })
@@ -185,7 +196,8 @@ pub(super) fn no_change(
     metadata: EngineMetadata,
     event: TransitionEvent,
     context: &TransitionContext<'_>,
-    cause: TransitionCause,
+    domain: TransitionDomain,
+    effect: TransitionEffect,
 ) -> Result<PlanCandidate, TransitionFailure> {
     validate_authority(&event, context)?;
     Ok(PlanCandidate {
@@ -203,7 +215,8 @@ pub(super) fn no_change(
             metadata,
         },
         graph_delta: GraphDelta::empty(engine.graph()),
-        cause,
+        domain,
+        effect,
         trust_pins: invariant_pins(context),
         limits: context.config.limits,
     })
@@ -213,6 +226,7 @@ pub(super) fn no_change(
 pub(super) fn resource_stalled(
     engine: &HeaderChainEngine,
     before: EngineSnapshot,
+    domain: TransitionDomain,
     context: &TransitionContext<'_>,
 ) -> Result<PlanCandidate, TransitionFailure> {
     let mut metadata = engine.metadata().clone();
@@ -235,7 +249,8 @@ pub(super) fn resource_stalled(
             metadata,
         },
         graph_delta: GraphDelta::empty(engine.graph()),
-        cause: TransitionCause::ResourceStalled,
+        domain,
+        effect: TransitionEffect::resource_stalled(),
         trust_pins: invariant_pins(context),
         limits: context.config.limits,
     })

--- a/crates/zakura-header-chain/src/transition/types.rs
+++ b/crates/zakura-header-chain/src/transition/types.rs
@@ -804,7 +804,20 @@ pub enum VctRootRepairState {
     },
 }
 
-/// Every chain-changing input accepted by the sole transition planner.
+/// Authenticated evidence that one state-service transition may apply.
+///
+/// The state write path builds a [`TransitionRequest`] around this value. Peers
+/// and consensus never submit it directly: they produce higher-level work that
+/// the adapter authenticates and classifies into one of these variants.
+///
+/// An event records only what happened (header admission, body evidence,
+/// operator action, and so on). It does not carry durable store facts; the
+/// adapter binds those separately into [`crate::TransitionInput`] before the
+/// engine plans. Callers also never submit desired consequences—the planner
+/// derives effects from the event and coherent state.
+///
+/// Domains that are replay-protected hash this payload into
+/// [`TransitionFingerprint`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TransitionEvent {
     /// Prepared header admission.
@@ -833,7 +846,12 @@ pub enum TransitionEvent {
     ReevaluateDeferred,
 }
 
-/// Stable domain of one replay-protected transition event.
+/// Stable domain of one submitted transition input.
+///
+/// Replay-protected domains keep their version-one disk discriminants.
+/// [`Self::ReevaluateDeferred`] is submitted without a durable fingerprint and
+/// therefore uses an appended code that is never persisted in
+/// [`TransitionFingerprint`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TransitionDomain {
     /// Prepared header admission.
@@ -864,6 +882,8 @@ pub enum TransitionDomain {
     MigratedPinRefutation,
     /// Auxiliary authentication evidence.
     AuxEvidence,
+    /// Local reevaluation of due future-time deferrals.
+    ReevaluateDeferred,
 }
 
 impl TransitionDomain {
@@ -884,6 +904,8 @@ impl TransitionDomain {
             Self::FullStateFinalized => 11,
             Self::MigratedPinRefutation => 12,
             Self::AuxEvidence => 13,
+            // Appended after the replay-protected set; never persisted in fingerprints.
+            Self::ReevaluateDeferred => 14,
         }
     }
 
@@ -904,6 +926,7 @@ impl TransitionDomain {
             11 => Self::FullStateFinalized,
             12 => Self::MigratedPinRefutation,
             13 => Self::AuxEvidence,
+            14 => Self::ReevaluateDeferred,
             _ => return None,
         })
     }
@@ -1068,6 +1091,33 @@ impl TransitionEvent {
         match self {
             Self::AuxEvidence(event) => Some(event.owner),
             _ => None,
+        }
+    }
+
+    /// Return the submitted event's domain, including non-replayed inputs.
+    pub fn domain(&self) -> TransitionDomain {
+        match self {
+            Self::InsertHeaders(_) => TransitionDomain::InsertHeaders,
+            Self::VerifiedChainChanged(_) => TransitionDomain::VerifiedChainChanged,
+            Self::VerifiedBlockAccepted(_) => TransitionDomain::VerifiedBlockAccepted,
+            Self::BodyEvidence(BodyEvidence::PayloadMismatch(_)) => {
+                TransitionDomain::BodyPayloadMismatch
+            }
+            Self::BodyEvidence(BodyEvidence::ConsensusInvalid(_)) => {
+                TransitionDomain::ConsensusBodyInvalid
+            }
+            Self::BodyEvidence(BodyEvidence::Transient(_)) => {
+                TransitionDomain::TransientBodyFailure
+            }
+            Self::BodyEvidence(BodyEvidence::Verified(_)) => TransitionDomain::VerifiedBody,
+            Self::BodySupplierDiscovered(_) => TransitionDomain::BodySupplierDiscovered,
+            Self::OperatorBodyRetry(_) => TransitionDomain::OperatorBodyRetry,
+            Self::OperatorInvalidate(_) => TransitionDomain::OperatorInvalidate,
+            Self::OperatorReconsider(_) => TransitionDomain::OperatorReconsider,
+            Self::FullStateFinalized(_) => TransitionDomain::FullStateFinalized,
+            Self::MigratedPinRefutation(_) => TransitionDomain::MigratedPinRefutation,
+            Self::AuxEvidence(_) => TransitionDomain::AuxEvidence,
+            Self::ReevaluateDeferred => TransitionDomain::ReevaluateDeferred,
         }
     }
 }
@@ -1363,12 +1413,17 @@ fn hash_aux_authentication(hasher: &mut Sha256, authentication: AuxAuthenticatio
     }
 }
 
-/// Version-qualified request to the sole serialized transition planner.
+/// Version-qualified request assembled by the state write path.
+///
+/// [`Self::event`] is the authenticated evidence; [`Self::expected_version`] is
+/// the caller's observed durable version. The adapter then binds event-specific
+/// store facts into [`crate::TransitionInput`] for the engine.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransitionRequest {
     /// Exact durable version observed by the caller.
     pub expected_version: StateVersion,
-    /// Typed evidence.
+    /// Authenticated evidence of what happened.
+    ///
     /// Callers never submit desired consequences.
     pub event: TransitionEvent,
 }
@@ -1475,26 +1530,117 @@ pub struct ChangeSet {
     pub metadata: EngineMetadata,
 }
 
-/// High-level cause preserved in a committed receipt.
+/// How ordinary header work related to newer monotone finality.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum TransitionCause {
-    /// One of the externally typed evidence categories.
-    Event,
-    /// Checkpoint body growth advanced integrated finality on the retained selected path.
-    CheckpointFinality,
-    /// Full state authenticated or rejected auxiliary metadata without changing the DAG.
-    AuxAuthentication,
+pub enum HeaderWorkEffect {
     /// The planner admitted ordinary header work after a durable monotone-finality rebase.
-    HeaderWorkRebased,
+    Rebased,
     /// Monotone finality already consumed the complete prepared range.
-    HeaderWorkAlreadyApplied,
-    /// The planner refused admission because protected state filled a limit.
-    /// The planner did not apply the event.
-    ResourceStalled,
+    AlreadyApplied,
+}
+
+/// Finality effects produced while settling one transition.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FinalityEffect {
+    /// Checkpoint body growth advanced integrated finality on the retained selected path.
+    Checkpoint,
     /// Headers-only depth finality occurred in the same insertion/reselection.
-    HeadersOnlyFinality,
-    /// Startup recovery reconstructed state.
-    Recovery,
+    HeadersOnlyDepth,
+    /// Integrated full-state finality advanced from an explicit finality event.
+    FullState,
+}
+
+/// Auxiliary-delivery effects produced while settling one transition.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AuxiliaryEffect {
+    /// Full state authenticated or rejected auxiliary metadata without changing the DAG.
+    Authentication,
+}
+
+/// Orthogonal effects produced by one planned transition.
+///
+/// The submitted [`TransitionDomain`] identifies the input. This record describes
+/// the resulting admission transformations and side effects, which may coexist.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct TransitionEffect {
+    /// Ordinary header-work rebase or already-applied classification.
+    pub header_work: Option<HeaderWorkEffect>,
+    /// Optional finality advancement produced while settling.
+    pub finality: Option<FinalityEffect>,
+    /// Optional auxiliary authentication/rejection effect.
+    pub auxiliary: Option<AuxiliaryEffect>,
+    /// True when retention limits refused the event and only an alarm may change.
+    pub resource_stalled: bool,
+}
+
+impl TransitionEffect {
+    /// Construct an empty effect record for an ordinary event admission.
+    pub const fn none() -> Self {
+        Self {
+            header_work: None,
+            finality: None,
+            auxiliary: None,
+            resource_stalled: false,
+        }
+    }
+
+    /// Construct an exact adjacent-replay or zero-effect ordinary admission.
+    pub const fn event() -> Self {
+        Self::none()
+    }
+
+    /// Construct an already-applied header-work effect.
+    pub const fn header_work_already_applied() -> Self {
+        Self {
+            header_work: Some(HeaderWorkEffect::AlreadyApplied),
+            finality: None,
+            auxiliary: None,
+            resource_stalled: false,
+        }
+    }
+
+    /// Construct a committed resource-stall refusal.
+    pub const fn resource_stalled() -> Self {
+        Self {
+            header_work: None,
+            finality: None,
+            auxiliary: None,
+            resource_stalled: true,
+        }
+    }
+
+    /// True when retention refused admission.
+    pub const fn is_resource_stalled(self) -> bool {
+        self.resource_stalled
+    }
+
+    /// True when checkpoint finality advanced on the retained selected path.
+    pub const fn is_checkpoint_finality(self) -> bool {
+        matches!(self.finality, Some(FinalityEffect::Checkpoint))
+    }
+
+    /// True when the plan only authenticated or rejected auxiliary deliveries.
+    pub const fn is_aux_authentication(self) -> bool {
+        matches!(self.auxiliary, Some(AuxiliaryEffect::Authentication))
+            && self.header_work.is_none()
+            && self.finality.is_none()
+            && !self.resource_stalled
+    }
+
+    /// True when ordinary header work was rebased onto newer finality.
+    pub const fn is_header_work_rebased(self) -> bool {
+        matches!(self.header_work, Some(HeaderWorkEffect::Rebased))
+    }
+
+    /// True when monotone finality already consumed the prepared range.
+    pub const fn is_header_work_already_applied(self) -> bool {
+        matches!(self.header_work, Some(HeaderWorkEffect::AlreadyApplied))
+    }
+
+    /// True when headers-only depth finality appended in this transition.
+    pub const fn is_headers_only_finality(self) -> bool {
+        matches!(self.finality, Some(FinalityEffect::HeadersOnlyDepth))
+    }
 }
 
 /// Work that the coordinator must retire before scheduling new forward work.

--- a/crates/zakura-header-chain/tests/production_transition.rs
+++ b/crates/zakura-header-chain/tests/production_transition.rs
@@ -8,14 +8,14 @@ use zakura_chain::{
     parameters::{testnet::RegtestParameters, Network},
 };
 use zakura_header_chain::{
-    prepare_headers, AlarmSet, AuxAuthentication, AuxDelivery, AuxEvidence, BodySizeHint,
-    BodyWorkAuthority, BranchId, CheckpointSet, Clock, DurableTransitionFacts, EngineConfig,
-    EngineMetadata, EngineMode, EvidenceId, FinalityEpoch, Frontier, FrontierSet,
-    FullStateEvidenceAuthority, HeaderBatchInput, HeaderChainDiskVersion, HeaderChainEngine,
-    HeaderContextFact, HeaderGeneration, HeaderRules, HeaderWorkAuthority, MemHeaderStore,
-    SourceId, StateVersion, TargetCompletion, TransitionCause, TransitionContext, TransitionEvent,
-    TransitionFailure, TransitionRequest, TreeAuxRecordV1, TrustedAnchor, ValidationLease,
-    VerifiedGeneration,
+    prepare_headers, AlarmSet, AuxAuthentication, AuxDelivery, AuxEvidence, AuxiliaryViolation,
+    BodySizeHint, BodyWorkAuthority, BranchId, CheckpointSet, Clock, EngineConfig, EngineMetadata,
+    EngineMode, EvidenceId, FinalityEpoch, Frontier, FrontierSet, FullStateEvidenceAuthority,
+    HeaderBatchInput, HeaderChainDiskVersion, HeaderChainEngine, HeaderContextFact,
+    HeaderGeneration, HeaderInsertionFacts, HeaderRules, HeaderValidationFacts,
+    HeaderWorkAuthority, InvalidTransitionEvidence, MemHeaderStore, SourceId, StateVersion,
+    TargetCompletion, TransitionContext, TransitionEvent, TransitionFailure, TransitionInput,
+    TransitionRequest, TreeAuxRecordV1, TrustedAnchor, ValidationLease, VerifiedGeneration,
 };
 
 struct FixedClock(DateTime<Utc>);
@@ -171,14 +171,21 @@ fn production_incremental_verifier_accepts_exact_auxiliary_evidence() {
             aux: vec![delivery],
         })),
     };
+    let TransitionEvent::InsertHeaders(event) = insertion.event else {
+        panic!("fixture constructs InsertHeaders");
+    };
     let transition = engine
         .plan_transition(
-            insertion,
-            &context,
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![lease],
-                finality_path: Vec::new(),
+            TransitionInput::InsertHeaders {
+                event,
+                facts: HeaderInsertionFacts {
+                    validation: HeaderValidationFacts {
+                        validation_leases: vec![lease],
+                    },
+                    finality_rebase_history: Vec::new(),
+                },
             },
+            &context,
         )
         .expect("the fixture insertion verifies");
     engine
@@ -203,16 +210,33 @@ fn production_incremental_verifier_accepts_exact_auxiliary_evidence() {
     let mut altered = delivery;
     altered.source = SourceId::from_digest([7; 32]);
     assert!(matches!(
-        engine.plan_transition(request(altered), &context, DurableTransitionFacts::None),
+        engine.plan_transition(
+            TransitionInput::AuxEvidence {
+                event: {
+                    let TransitionEvent::AuxEvidence(event) = request(altered).event else {
+                        panic!("fixture constructs AuxEvidence");
+                    };
+                    event
+                },
+            },
+            &context,
+        ),
         Err(TransitionFailure::InvalidEvidence(
-            "auxiliary evidence changes delivery provenance"
+            InvalidTransitionEvidence::Auxiliary(AuxiliaryViolation::ProvenanceMismatch)
         ))
     ));
 
+    let TransitionEvent::AuxEvidence(event) = request(delivery).event else {
+        panic!("fixture constructs AuxEvidence");
+    };
     let transition = engine
-        .plan_transition(request(delivery), &context, DurableTransitionFacts::None)
+        .plan_transition(TransitionInput::AuxEvidence { event }, &context)
         .expect("the production incremental verifier accepts exact evidence");
-    assert_eq!(transition.cause(), TransitionCause::AuxAuthentication);
+    assert!(transition.effect().is_aux_authentication());
+    assert_eq!(
+        transition.domain(),
+        zakura_header_chain::TransitionDomain::AuxEvidence
+    );
     let mut projected = engine.clone();
     projected
         .install_committed_transition(transition)

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -16,12 +16,12 @@ use zakura_chain::{block, parallel::commitment_aux::BlockCommitmentRoots, parame
 use zakura_header_chain::{
     audit_store, audit_store_for_trust_anchor_update, ApplyResult, AuxDelivery, AuxDelta,
     BodyWorkAuthority, BodyWorkOwner, ChangeSet, CommittedStallReceipt, CounterExhausted,
-    DurableTransitionFacts, EligibilityReason, EngineConfig, EngineMetadata, EngineMode,
-    EngineSnapshot, EvidenceId, FinalityRecord, FinalitySource, Frontier,
-    FullStateEvidenceAuthority, FullStateFinalized, HeaderChainEngine, HeaderLocator, HeaderNode,
-    HeaderSyncWorkOwner, HeaderWorkAuthority, MemHeaderStore, NoChangeReceipt, RecoveryFailure,
+    EligibilityReason, EngineConfig, EngineMetadata, EngineMode, EngineSnapshot, EvidenceId,
+    FinalityRecord, FinalitySource, Frontier, FullStateEvidenceAuthority, FullStateFinalized,
+    HeaderChainEngine, HeaderInsertionFacts, HeaderLocator, HeaderNode, HeaderSyncWorkOwner,
+    HeaderValidationFacts, HeaderWorkAuthority, MemHeaderStore, NoChangeReceipt, RecoveryFailure,
     RecoveryPlan, RecoveryRepair, SourceId, StaleReceipt, StateVersion, StoreAuditRead, StoreError,
-    SystemClock, TransitionCause, TransitionContext, TransitionEvent, TransitionFailure,
+    SystemClock, TransitionContext, TransitionEvent, TransitionFailure, TransitionInput,
     TransitionRequest, ValidationContextRecord, ValidationLease, VerifiedChainChanged,
     VerifiedChangeCause, VerifiedHeaderRef,
 };
@@ -1805,7 +1805,7 @@ impl HeaderChainRuntime {
         &self,
         first_request: TransitionRequest,
         first_context: &TransitionContext<'_>,
-        mut checkpoint_request: TransitionRequest,
+        checkpoint_request: TransitionRequest,
         checkpoint_context: &TransitionContext<'_>,
         full_state_batch: DiskWriteBatch,
         memory_swap: M,
@@ -1877,12 +1877,16 @@ impl HeaderChainRuntime {
             retention_references: lease_references.as_ref(),
         };
 
+        let TransitionEvent::AuxEvidence(first_event) = first_request.event else {
+            return Err(HeaderChainStoreError::Incoherent(
+                "combined auxiliary transition has the wrong event kind",
+            ));
+        };
         let first = transition_engine.plan_transition(
-            first_request,
+            TransitionInput::AuxEvidence { event: first_event },
             &first_context,
-            DurableTransitionFacts::None,
         )?;
-        if first.cause() == TransitionCause::ResourceStalled {
+        if first.effect().is_resource_stalled() {
             return Err(HeaderChainStoreError::Incoherent(
                 "checkpoint auxiliary authentication exhausted header resources",
             ));
@@ -1903,14 +1907,22 @@ impl HeaderChainRuntime {
             return Err(error);
         }
 
-        checkpoint_request.expected_version = transition_engine.snapshot().state_version;
+        let expected_version = transition_engine.snapshot().state_version;
+        let TransitionEvent::VerifiedChainChanged(checkpoint_event) = checkpoint_request.event
+        else {
+            return Err(HeaderChainStoreError::Incoherent(
+                "combined checkpoint transition has the wrong event kind",
+            ));
+        };
         let checkpoint = match transition_engine.plan_transition(
-            checkpoint_request,
-            &checkpoint_context,
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: validation_leases.to_vec(),
-                finality_path: Vec::new(),
+            TransitionInput::VerifiedChainChanged {
+                expected_version,
+                event: checkpoint_event,
+                facts: HeaderValidationFacts {
+                    validation_leases: validation_leases.to_vec(),
+                },
             },
+            &checkpoint_context,
         ) {
             Ok(checkpoint) => checkpoint,
             Err(error) => {
@@ -1922,7 +1934,7 @@ impl HeaderChainRuntime {
                 return Err(error);
             }
         };
-        if checkpoint.cause() == TransitionCause::ResourceStalled {
+        if checkpoint.effect().is_resource_stalled() {
             let error = restore_transition_engine_after_staging_error(
                 &self.store,
                 &mut transition_engine,
@@ -1992,6 +2004,118 @@ impl HeaderChainRuntime {
         )
     }
 
+    /// Bind a state-service request to the exact durable facts its event may consume.
+    fn build_transition_input(
+        &self,
+        request: TransitionRequest,
+        before: &EngineSnapshot,
+        network: &Network,
+    ) -> Result<TransitionInput, HeaderChainStoreError> {
+        let expected_version = request.expected_version;
+        Ok(match request.event {
+            TransitionEvent::InsertHeaders(event) => {
+                let anchor_changed = event.owner.header_authority().branch.anchor_hash
+                    != before.frontiers.finalized.hash;
+                let mut validation_leases = Vec::new();
+                if self.store.header_node(event.parent_hash)?.is_some() {
+                    validation_leases
+                        .push(self.store.validation_context(event.parent_hash, network)?);
+                }
+                if anchor_changed && event.parent_hash != before.frontiers.finalized.hash {
+                    validation_leases.push(
+                        self.store
+                            .validation_context(before.frontiers.finalized.hash, network)?,
+                    );
+                }
+                validation_leases.dedup_by_key(|lease| lease.parent());
+                let finality_rebase_history = self.store.finality_rebase_history(
+                    event.owner.header_authority().branch.anchor_hash,
+                    before.frontiers.finalized,
+                    before
+                        .header_generation
+                        .get()
+                        .saturating_sub(event.owner.header_authority().header_generation.get()),
+                )?;
+                TransitionInput::InsertHeaders {
+                    event,
+                    facts: HeaderInsertionFacts {
+                        validation: HeaderValidationFacts { validation_leases },
+                        finality_rebase_history,
+                    },
+                }
+            }
+            TransitionEvent::VerifiedChainChanged(event) => {
+                let parent = match event.cause {
+                    VerifiedChangeCause::Grow | VerifiedChangeCause::CheckpointFinalizedGrow => {
+                        event.old_tip
+                    }
+                    VerifiedChangeCause::Reset => before.frontiers.finalized,
+                };
+                TransitionInput::VerifiedChainChanged {
+                    expected_version,
+                    event,
+                    facts: HeaderValidationFacts {
+                        validation_leases: vec![self
+                            .store
+                            .validation_context(parent.hash, network)?],
+                    },
+                }
+            }
+            TransitionEvent::VerifiedBlockAccepted(event) => {
+                TransitionInput::VerifiedBlockAccepted {
+                    expected_version,
+                    event,
+                    facts: HeaderValidationFacts {
+                        validation_leases: vec![self
+                            .store
+                            .validation_context(before.frontiers.finalized.hash, network)?],
+                    },
+                }
+            }
+            TransitionEvent::BodyEvidence(event) => TransitionInput::BodyEvidence {
+                expected_version,
+                event,
+            },
+            TransitionEvent::BodySupplierDiscovered(event) => {
+                TransitionInput::BodySupplierDiscovered {
+                    expected_version,
+                    event,
+                }
+            }
+            TransitionEvent::OperatorBodyRetry(event) => TransitionInput::OperatorBodyRetry {
+                expected_version,
+                event,
+            },
+            TransitionEvent::OperatorInvalidate(event) => TransitionInput::OperatorInvalidate {
+                expected_version,
+                event,
+            },
+            TransitionEvent::OperatorReconsider(event) => TransitionInput::OperatorReconsider {
+                expected_version,
+                event,
+            },
+            TransitionEvent::FullStateFinalized(event) => TransitionInput::FullStateFinalized {
+                expected_version,
+                event,
+            },
+            TransitionEvent::MigratedPinRefutation(event) => {
+                let preserved_pin = self
+                    .store
+                    .is_migrated_finality_pin(event.pin)?
+                    .then_some(event.pin);
+                TransitionInput::MigratedPinRefutation {
+                    expected_version,
+                    event,
+                    preserved_pin,
+                }
+            }
+            TransitionEvent::AuxEvidence(event) => TransitionInput::AuxEvidence { event },
+            TransitionEvent::ReevaluateDeferred => {
+                TransitionInput::ReevaluateDeferred { expected_version }
+            }
+        })
+    }
+
     fn apply_combined_inner<M>(
         &self,
         request: TransitionRequest,
@@ -2052,75 +2176,11 @@ impl HeaderChainRuntime {
             .map(HeaderSyncWorkOwner::header_authority)
             .map(|authority| authority.branch)
             .or_else(|| request.event.body_owner().map(|owner| owner.branch));
-        let durable = match &request.event {
-            TransitionEvent::InsertHeaders(event) => {
-                let anchor_changed = event.owner.header_authority().branch.anchor_hash
-                    != before.frontiers.finalized.hash;
-                let mut validation_contexts = Vec::new();
-                if self.store.header_node(event.parent_hash)?.is_some() {
-                    validation_contexts.push(
-                        self.store
-                            .validation_context(event.parent_hash, &base_context.config.network)?,
-                    );
-                }
-                if anchor_changed && event.parent_hash != before.frontiers.finalized.hash {
-                    validation_contexts.push(self.store.validation_context(
-                        before.frontiers.finalized.hash,
-                        &base_context.config.network,
-                    )?);
-                }
-                validation_contexts.dedup_by_key(|lease| lease.parent());
-                DurableTransitionFacts::HeaderInsertion {
-                    validation_contexts,
-                    finality_path: self.store.finality_rebase_path(
-                        event.owner.header_authority().branch.anchor_hash,
-                        before.frontiers.finalized,
-                        before
-                            .header_generation
-                            .get()
-                            .saturating_sub(event.owner.header_authority().header_generation.get()),
-                    )?,
-                }
-            }
-            TransitionEvent::VerifiedChainChanged(event) => {
-                let parent = match event.cause {
-                    VerifiedChangeCause::Grow | VerifiedChangeCause::CheckpointFinalizedGrow => {
-                        event.old_tip
-                    }
-                    VerifiedChangeCause::Reset => before.frontiers.finalized,
-                };
-                DurableTransitionFacts::HeaderInsertion {
-                    validation_contexts: vec![self
-                        .store
-                        .validation_context(parent.hash, &base_context.config.network)?],
-                    finality_path: Vec::new(),
-                }
-            }
-            TransitionEvent::VerifiedBlockAccepted(_) => DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![self.store.validation_context(
-                    before.frontiers.finalized.hash,
-                    &base_context.config.network,
-                )?],
-                finality_path: Vec::new(),
-            },
-            TransitionEvent::MigratedPinRefutation(event) => {
-                DurableTransitionFacts::MigratedFinalityPin(
-                    self.store
-                        .is_migrated_finality_pin(event.pin)?
-                        .then_some(event.pin),
-                )
-            }
-            _ => DurableTransitionFacts::None,
-        };
-        let validation_leases = match &durable {
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts,
-                ..
-            } => validation_contexts.clone(),
-            DurableTransitionFacts::None | DurableTransitionFacts::MigratedFinalityPin(_) => {
-                Vec::new()
-            }
-        };
+        let input = self.build_transition_input(request, &before, &base_context.config.network)?;
+        let validation_leases = input
+            .header_validation_facts()
+            .map(|facts| facts.validation_leases.clone())
+            .unwrap_or_default();
         let state_authority = StateIssuedAuthority {
             inner: base_context.full_state_authority,
             validation_leases: &validation_leases,
@@ -2131,47 +2191,35 @@ impl HeaderChainRuntime {
             full_state_authority: Some(&state_authority),
             retention_references: base_context.retention_references,
         };
-        let transition =
-            match transition_engine.plan_transition(request, &transition_context, durable) {
-                Ok(plan) => plan,
-                Err(TransitionFailure::Stale { current }) => {
-                    return Ok(ApplyResult::Stale(StaleReceipt {
-                        current_version: current,
-                        branch,
-                    }));
-                }
-                Err(error) => return Err(error.into()),
-            };
-        let transition_cause = transition.cause();
-        let resource_stalled = transition_cause == TransitionCause::ResourceStalled;
+        let transition = match transition_engine.plan_transition(input, &transition_context) {
+            Ok(plan) => plan,
+            Err(TransitionFailure::Stale { current }) => {
+                return Ok(ApplyResult::Stale(StaleReceipt {
+                    current_version: current,
+                    branch,
+                }));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let transition_effect = transition.effect();
+        let resource_stalled = transition_effect.is_resource_stalled();
         let stall_receipt = resource_stalled.then(|| CommittedStallReceipt {
             state_version: transition.change_set().metadata.state_version,
             alarm_changed: transition.before().alarms.resource_stalled
                 != transition.change_set().metadata.alarms.resource_stalled,
             attempted_branch: branch,
         });
-        match transition_cause {
-            TransitionCause::HeaderWorkRebased => {
-                metrics::counter!("state.header.work.rebase.total", "outcome" => "rebased")
-                    .increment(1);
-                metrics::counter!(
-                    "state.header.work.rebase.headers.total",
-                    "outcome" => "rebased"
-                )
-                .increment(
-                    u64::try_from(transition.change_set().put_nodes.len()).unwrap_or(u64::MAX),
-                );
-            }
-            TransitionCause::HeaderWorkAlreadyApplied => {
-                metrics::counter!("state.header.work.rebase.total", "outcome" => "already_applied")
-                    .increment(1);
-            }
-            TransitionCause::Event
-            | TransitionCause::CheckpointFinality
-            | TransitionCause::AuxAuthentication
-            | TransitionCause::ResourceStalled
-            | TransitionCause::HeadersOnlyFinality
-            | TransitionCause::Recovery => {}
+        if transition_effect.is_header_work_rebased() {
+            metrics::counter!("state.header.work.rebase.total", "outcome" => "rebased")
+                .increment(1);
+            metrics::counter!(
+                "state.header.work.rebase.headers.total",
+                "outcome" => "rebased"
+            )
+            .increment(u64::try_from(transition.change_set().put_nodes.len()).unwrap_or(u64::MAX));
+        } else if transition_effect.is_header_work_already_applied() {
+            metrics::counter!("state.header.work.rebase.total", "outcome" => "already_applied")
+                .increment(1);
         }
         if resource_stalled {
             let receipt = stall_receipt.expect("resource-stalled transitions construct a receipt");
@@ -2849,16 +2897,18 @@ impl HeaderChainStore {
             retention_references: &[],
         };
         let engine = load_transition_engine(self)?;
+        let TransitionEvent::VerifiedChainChanged(event) = event else {
+            unreachable!("startup reconciliation constructs VerifiedChainChanged");
+        };
         let transition = engine.plan_transition(
-            TransitionRequest {
+            TransitionInput::VerifiedChainChanged {
                 expected_version: snapshot.state_version,
                 event,
+                facts: HeaderValidationFacts {
+                    validation_leases: vec![validation_context],
+                },
             },
             &context,
-            DurableTransitionFacts::HeaderInsertion {
-                validation_contexts: vec![validation_context],
-                finality_path: Vec::new(),
-            },
         )?;
         if !transition.is_no_change() {
             self.db.write(self.batch_for(transition.change_set())?)?;
@@ -2927,13 +2977,15 @@ impl HeaderChainStore {
             retention_references: &[],
         };
         let engine = load_transition_engine(self)?;
+        let TransitionEvent::FullStateFinalized(event) = event else {
+            unreachable!("startup finalization constructs FullStateFinalized");
+        };
         let transition = engine.plan_transition(
-            TransitionRequest {
+            TransitionInput::FullStateFinalized {
                 expected_version: snapshot.state_version,
                 event,
             },
             &context,
-            DurableTransitionFacts::None,
         )?;
         if !transition.is_no_change() {
             let mut batch = DiskWriteBatch::new();
@@ -3734,7 +3786,7 @@ impl HeaderChainStore {
         Ok(records)
     }
 
-    fn finality_rebase_path(
+    fn finality_rebase_history(
         &self,
         original_anchor: block::Hash,
         current_finalized: Frontier,

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
@@ -73,18 +73,18 @@ fn finality_rebase_reads_only_the_generation_bounded_recent_suffix() {
 
     assert_eq!(
         store
-            .finality_rebase_path(third.hash, fourth, 1)
+            .finality_rebase_history(third.hash, fourth, 1)
             .expect("one recent epoch is sufficient"),
         vec![record_four]
     );
     assert_eq!(
         store
-            .finality_rebase_path(second.hash, fourth, 2)
+            .finality_rebase_history(second.hash, fourth, 2)
             .expect("two recent epochs are sufficient"),
         vec![record_three, record_four]
     );
     assert!(store
-        .finality_rebase_path(anchor_frontier.hash, fourth, 2)
+        .finality_rebase_history(anchor_frontier.hash, fourth, 2)
         .expect("an insufficient generation bound is a stale path")
         .is_empty());
 }

--- a/crates/zakura-state/src/service/write/tests/mod.rs
+++ b/crates/zakura-state/src/service/write/tests/mod.rs
@@ -53,14 +53,14 @@ use crate::{
 };
 use zakura_header_chain::{
     AdjustedDifficulty, AlarmSet, ApplyResult, AuxAuthentication, BodyRuleId,
-    BodyUnavailableSummary, BodyValidationState, ChainScore, CheckpointSet, ConsensusBodyInvalid,
-    EngineConfig, EngineMetadata, EngineMode, EngineSnapshot, EvidenceId, FinalityEpoch, Frontier,
-    FrontierSet, HeaderBatchInput, HeaderChainDiskVersion, HeaderGeneration, HeaderNode,
-    HeaderRules, HeaderValidationState, InsertHeaders, SourceId, StateVersion, SuffixWork,
-    SystemClock, TargetCompletion, TransientBodyFailure, TransientBodyFailureKind,
-    TransitionContext, TransitionEvent, TransitionFailure, TransitionRequest, TrustedAnchor,
-    VerifiedChangeCause, VerifiedGeneration, VerifiedHeaderRef, WorkCoordinate,
-    POW_ADJUSTMENT_BLOCK_SPAN,
+    BodyUnavailableSummary, BodyValidationState, BodyViolation, ChainScore, CheckpointSet,
+    ConsensusBodyInvalid, EngineConfig, EngineMetadata, EngineMode, EngineSnapshot, EvidenceId,
+    FinalityEpoch, Frontier, FrontierSet, HeaderBatchInput, HeaderChainDiskVersion,
+    HeaderGeneration, HeaderNode, HeaderRules, HeaderValidationState, InsertHeaders,
+    InvalidTransitionEvidence, SourceId, StateVersion, SuffixWork, SystemClock, TargetCompletion,
+    TransientBodyFailure, TransientBodyFailureKind, TransitionContext, TransitionEvent,
+    TransitionFailure, TransitionRequest, TrustedAnchor, VerifiedChangeCause, VerifiedGeneration,
+    VerifiedHeaderRef, WorkCoordinate, POW_ADJUSTMENT_BLOCK_SPAN,
 };
 
 fn header_owner(

--- a/crates/zakura-state/src/service/write/tests/selection_and_evidence.rs
+++ b/crates/zakura-state/src/service/write/tests/selection_and_evidence.rs
@@ -128,9 +128,9 @@ fn production_body_unavailability_writer_authenticates_exact_evidence() {
     assert!(matches!(
         result,
         Err(HeaderChainStoreError::Transition(
-            TransitionFailure::InvalidEvidence(
-                "body retry evidence cannot regress an already verified body"
-            )
+            TransitionFailure::InvalidEvidence(InvalidTransitionEvidence::Body(
+                BodyViolation::RetryConflictsWithVerified
+            ))
         ))
     ));
 }


### PR DESCRIPTION
## Motivation

The header-chain transition boundary mixed three different concerns into shared shapes:

- authenticated evidence of what happened
- the write path's observed durable version
- durable store facts the planner is allowed to consume

That made illegal combinations representable: events could be paired with unrelated facts via a shared fact bag, evidence failures were stringly, and `TransitionCause` conflated submitted domain with derived effects.

## Solution

Introduce explicit typed contracts at each ownership boundary:

### `TransitionEvent` — authenticated evidence

Records only **what happened** (header admission, body evidence, operator action, and so on). Built by the state write path after authenticating higher-level work; peers never submit it directly. Fingerprinted for replay. Does **not** carry durable store facts or desired consequences.

### `TransitionRequest` — pre-fact write command

`{ expected_version, event }`. The uniform command the write path builds **before** loading store rows. Still version-qualified for API uniformity even when the eventual engine input is owner-qualified.

### `TransitionInput` — engine-boundary package

The adapter binds each event to **exactly** the durable facts that variant may consume, then calls `plan_transition`. The planner does not read the durable store itself. Exhaustiveness is the contract:

- header insertion → validation leases + finality rebase history
- verified path changes → validation leases
- migrated pin refutation → preserved pin
- most events → `expected_version`
- `InsertHeaders` / `AuxEvidence` → omit version; freshness is owner-qualified

### `TransitionDomain` + `TransitionEffect` — identity vs outcomes

Replace `TransitionCause` with:

- **`TransitionDomain`**: submitted input identity (stable disk discriminants unchanged)
- **`TransitionEffect`**: composable planner-derived outcomes (`HeaderWorkEffect`, `FinalityEffect`, `AuxiliaryEffect`, resource stall)

Callers submit evidence; they never submit desired consequences.

### `InvalidTransitionEvidence` — structured failures

Replace `InvalidEvidence(&'static str)` with nested typed violations (`Limit`, `Finality`, `Header`, `Body`, `Auxiliary`, `Operator`, `Planner`).

State adapters, tests, and fuzz support are migrated to the new API.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p zakura-header-chain -p zakura-state --all-targets -- -D warnings`
- [ ] `cargo test -p zakura-header-chain --lib --tests` (interrupted; will rerun)
- [ ] `cargo test -p zakura-state --lib -- selection_and_evidence header_chain::tests::`

### Specifications & References

Builds on the phased planner from #630.

### Follow-up Work

None required for the typed boundary itself; remaining engine-model review items stay on the `hc/01-engine-model` series.