### PR TITLE
docs(rules): prefer facade packages over overloaded modules

### DIFF
--- a/.agents/rules/core-rust-readability.mdc
+++ b/.agents/rules/core-rust-readability.mdc
@@ -31,9 +31,9 @@ Write for a human reviewer who should understand the architecture and each API w
 
 ## Module Packages
 
-Do not grow overloaded multi-responsibility files. When a module mixes a high-level API with lower-level helpers or phases, keep a thin façade and move cohesive clusters into private children.
+Do not grow overloaded multi-responsibility files. When a module mixes a high-level API with lower-level helpers or phases, keep a thin facade and move cohesive clusters into private children.
 
-- Façade shows entry points and phase order; children hide mechanism (`pub(super)` / package-private).
+- Facade shows entry points and phase order; children hide mechanism (`pub(super)` / package-private).
 - Split by responsibility or phase (admit → apply → settle; load → audit → derive → classify), not by arbitrary line count.
 - Keep one-way dependencies: leaves and DTOs below planners/recovery/engine; do not park shared durable types under a single consumer.
 - Prefer behavior-grouped tests with shared fixtures over source-layout guards that break when files move.

--- a/.agents/rules/core-rust-readability.mdc
+++ b/.agents/rules/core-rust-readability.mdc
@@ -29,6 +29,18 @@ Write for a human reviewer who should understand the architecture and each API w
 - Prefer one cohesive typed transition API over several overlapping special-case methods.
 - Use distinct, accurate errors for distinct states so debugging does not require reading the implementation.
 
+## Module Packages
+
+Do not grow overloaded multi-responsibility files. When a module mixes a high-level API with lower-level helpers or phases, keep a thin façade and move cohesive clusters into private children.
+
+- Façade shows entry points and phase order; children hide mechanism (`pub(super)` / package-private).
+- Split by responsibility or phase (admit → apply → settle; load → audit → derive → classify), not by arbitrary line count.
+- Keep one-way dependencies: leaves and DTOs below planners/recovery/engine; do not park shared durable types under a single consumer.
+- Prefer behavior-grouped tests with shared fixtures over source-layout guards that break when files move.
+- Pure module moves should preserve the external API; visibility tightening is a separate change.
+
+Reference: `crates/zakura-header-chain/src/transition/{planner,types,recovery}`.
+
 ## Production and Test Boundaries
 
 - Keep test-only fields, return values, and `#[cfg(test)]` branches out of core production data paths when black-box tests or test helpers can observe the same behavior.


### PR DESCRIPTION
## Motivation

Core modules were growing into overloaded files where high-level APIs and lower-level helpers lived together. The header-chain transition refactor (`planner`, then `types` / `recovery`) showed a clearer pattern: keep a thin facade and hide phase details in private children.

e.g. https://github.com/zakura-core/zakura/pull/634

## Solution

Add a concise **Module Packages** section to `.agents/rules/core-rust-readability.mdc` (symlinked from `.cursor/rules/`) capturing that guidance:

- facade for entry points and phase order
- private children for mechanism
- one-way dependencies
- behavior-grouped tests
- stable external API during pure module moves

## Testing

Docs-only agent-rule change; no code or changelog fragment required.

## Changelog

Not applicable (no Rust or `Cargo.toml` changes).