### PR TITLE
docs(skills): convert core-rust-readability into an explicit skill

### DIFF
--- a/.agents/skills/core-rust-readability/SKILL.md
+++ b/.agents/skills/core-rust-readability/SKILL.md
@@ -3,15 +3,19 @@ name: core-rust-readability
 description: >-
   Keep core Rust code semantically named, discoverable, cohesive, and
   understandable as a black box. Prefer facade modules with private children
-  over overloaded files. Use when modifying key Rust crates (zakura-chain,
-  zakura-consensus, zakura-header-chain, zakura-network, zakura-rpc,
-  zakura-script, zakura-state), or when the user asks for readability,
-  naming, module decomposition, or facade-package refactors in those crates.
+  over overloaded files. For key Rust crates (zakura-chain, zakura-consensus,
+  zakura-header-chain, zakura-network, zakura-rpc, zakura-script, zakura-state),
+  confirm with the user during planning before applying; do not auto-apply
+  mid-implementation. Also use when the user asks for readability, naming,
+  module decomposition, or facade-package refactors in those crates.
 ---
 
 # Human-Readable Core Rust
 
 Apply this skill when editing the key Rust crates listed in the description.
+
+Confirm application with user during planning process instead of auto-applying. If already implementing the plan, do not auto-apply and do not interrupt the plan.
+
 Write for a human reviewer who should understand the architecture and each API
 without asking an AI to reconstruct intent.
 

--- a/.agents/skills/core-rust-readability/SKILL.md
+++ b/.agents/skills/core-rust-readability/SKILL.md
@@ -1,12 +1,19 @@
 ---
-description: Keep core Rust code semantically named, discoverable, cohesive, and understandable as a black box
-globs: crates/{zakura-chain,zakura-consensus,zakura-header-chain,zakura-network,zakura-rpc,zakura-script,zakura-state}/**/*.rs
-alwaysApply: false
+name: core-rust-readability
+description: >-
+  Keep core Rust code semantically named, discoverable, cohesive, and
+  understandable as a black box. Prefer facade modules with private children
+  over overloaded files. Use when modifying key Rust crates (zakura-chain,
+  zakura-consensus, zakura-header-chain, zakura-network, zakura-rpc,
+  zakura-script, zakura-state), or when the user asks for readability,
+  naming, module decomposition, or facade-package refactors in those crates.
 ---
 
 # Human-Readable Core Rust
 
-Write for a human reviewer who should understand the architecture and each API without asking an AI to reconstruct intent.
+Apply this skill when editing the key Rust crates listed in the description.
+Write for a human reviewer who should understand the architecture and each API
+without asking an AI to reconstruct intent.
 
 ## Semantic Naming
 

--- a/.cursor/rules/core-rust-readability.mdc
+++ b/.cursor/rules/core-rust-readability.mdc
@@ -1,1 +1,0 @@
-../../.agents/rules/core-rust-readability.mdc


### PR DESCRIPTION
## Motivation

Auto-attached / glob-scoped rules make context control opaque. Prefer a skill over always-on rules so context is not forced on every core-crate read.

## Solution

- Move the core Rust readability guidance (including Module Packages) to [`.agents/skills/core-rust-readability/SKILL.md`](.agents/skills/core-rust-readability/SKILL.md).
- Recommend the skill for key Rust crates, but confirm with the user during planning instead of auto-applying; if implementation is already underway, do not auto-apply or interrupt.
- Remove the `.agents/rules` / `.cursor/rules` auto-attached copies.
- Do not add an `AGENTS.md` pointer.

## Testing

Docs-only. Verified the skill exists under `.agents/skills/` and rule shims are gone.

## Changelog

Not applicable (no Rust or `Cargo.toml` changes).