### PR TITLE
refactor(chain)!: widen block work to exact 256-bit values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8357,7 +8357,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "4.2.0"
+version = "5.0.0"
 dependencies = [
  "bech32",
  "bitflags",

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "4.2.0"
+version = "5.0.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/src/primitives/zcash_history.rs
+++ b/crates/zakura-chain/src/primitives/zcash_history.rs
@@ -403,8 +403,7 @@ impl Version for zcash_history::V1 {
             .difficulty_threshold
             .to_work()
             .expect("work must be valid during contextual verification");
-        // There is no direct `std::primitive::u128` to `bigint::U256` conversion
-        let work = primitive_types::U256::from_big_endian(&work.as_u128().to_be_bytes());
+        let work = primitive_types::U256::from_big_endian(&work.as_u256().to_big_endian());
 
         match network_upgrade {
             NetworkUpgrade::Genesis

--- a/crates/zakura-chain/src/work/difficulty.rs
+++ b/crates/zakura-chain/src/work/difficulty.rs
@@ -103,7 +103,7 @@ pub const INVALID_COMPACT_DIFFICULTY: CompactDifficulty = CompactDifficulty(u32:
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ExpandedDifficulty(U256);
 
-/// A 128-bit unsigned "Work" value.
+/// A 256-bit unsigned "Work" value.
 ///
 /// Used to calculate the total work for each chain of blocks.
 ///
@@ -113,11 +113,8 @@ pub struct ExpandedDifficulty(U256);
 /// choose the best chain. But its precise value and bit pattern are not
 /// consensus-critical.
 ///
-/// We calculate work values according to the Zcash specification, but store
-/// them as u128, rather than the implied u256. We don't expect the total chain
-/// work to ever exceed 2^128. The current total chain work for Zcash is 2^58,
-/// and Bitcoin adds around 2^91 work per year. (Each extra bit represents twice
-/// as much work.)
+/// Zakura keeps work at its exact 256-bit width.
+/// This width preserves valid hard targets for cumulative-work comparisons.
 ///
 /// > a node chooses the “best” block chain visible to it by finding the chain of valid blocks
 /// > with the greatest total work. The work of a block with value nBits for the nBits field in
@@ -127,16 +124,16 @@ pub struct ExpandedDifficulty(U256);
 ///
 /// [section 7.7.5]: https://zips.z.cash/protocol/protocol.pdf#workdef
 #[derive(Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Work(u128);
+pub struct Work(U256);
 
 impl Work {
     /// Returns a value representing no work.
     pub fn zero() -> Self {
-        Self(0)
+        Self(U256::zero())
     }
 
-    /// Return the inner `u128` value.
-    pub fn as_u128(self) -> u128 {
+    /// Returns the exact inner 256-bit value.
+    pub fn as_u256(self) -> U256 {
         self.0
     }
 }
@@ -151,12 +148,22 @@ impl fmt::Debug for Work {
             // Use decimal, to compare with zcashd
             .field(&format_args!("{}", self.0))
             // Use log2, to compare with zcashd
-            .field(&format_args!("{:.5}", (self.0 as f64).log2()))
+            .field(&format_args!("{:.5}", u256_to_f64(self.0).log2()))
             .finish()
     }
 }
 
 impl CompactDifficulty {
+    /// Return the exact four-byte little-endian consensus representation.
+    pub const fn to_le_bytes(self) -> [u8; 4] {
+        self.0.to_le_bytes()
+    }
+
+    /// Construct from the exact four-byte little-endian consensus representation.
+    pub const fn from_le_bytes(bytes: [u8; 4]) -> Self {
+        Self(u32::from_le_bytes(bytes))
+    }
+
     /// CompactDifficulty exponent base.
     const BASE: u32 = 256;
 
@@ -254,8 +261,6 @@ impl CompactDifficulty {
     /// `GetBlockProof()` in zcashd.
     ///
     /// Returns None if the corresponding ExpandedDifficulty is None.
-    /// Also returns None on Work overflow, which should be impossible on a
-    /// valid chain.
     ///
     /// [Zcash Specification]: https://zips.z.cash/protocol/protocol.pdf#workdef
     pub fn to_work(self) -> Option<Work> {
@@ -398,12 +403,18 @@ impl TryFrom<ExpandedDifficulty> for Work {
         // 2^256, as it's too large for a u256. However, as 2^256 is at least as
         // large as `expanded + 1`, it is equal to
         // `((2^256 - expanded - 1) / (expanded + 1)) + 1`, or
-        let result = (!expanded.0 / (expanded.0 + 1)) + 1;
-        if result <= u128::MAX.into() {
-            Ok(Work(result.as_u128()))
-        } else {
-            Err(())
+        if expanded.0.is_zero() {
+            // A zero target has work 2^256, which is outside U256.
+            return Err(());
         }
+
+        if expanded.0 == U256::MAX {
+            // The mathematical denominator is 2^256, so the floor is one.
+            return Ok(Work(U256::one()));
+        }
+
+        let result = (!expanded.0 / (expanded.0 + 1)) + 1;
+        Ok(Work(result))
     }
 }
 
@@ -666,17 +677,27 @@ impl std::ops::Add for Work {
 ///
 /// See [`Work`] for details.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PartialCumulativeWork(u128);
+pub struct PartialCumulativeWork(U256);
 
 impl PartialCumulativeWork {
     /// Returns a value representing no work.
     pub fn zero() -> Self {
-        Self(0)
+        Self(U256::zero())
     }
 
-    /// Return the inner `u128` value.
-    pub fn as_u128(self) -> u128 {
+    /// Returns the exact inner 256-bit value.
+    pub fn as_u256(self) -> U256 {
         self.0
+    }
+
+    /// Adds exact per-block work, returning `None` at the 2^256 boundary.
+    pub fn checked_add(self, rhs: Work) -> Option<Self> {
+        self.0.checked_add(rhs.0).map(Self)
+    }
+
+    /// Subtracts exact per-block work, returning `None` on underflow.
+    pub fn checked_sub(self, rhs: Work) -> Option<Self> {
+        self.0.checked_sub(rhs.0).map(Self)
     }
 
     /// Returns a floating-point work multiplier that can be used for display.
@@ -690,9 +711,8 @@ impl PartialCumulativeWork {
             .to_work()
             .expect("target difficult limit is valid work");
 
-        // Convert to u128 then f64.
-        let pow_limit = pow_limit.as_u128() as f64;
-        let work = self.as_u128() as f64;
+        let pow_limit = u256_to_f64(pow_limit.as_u256());
+        let work = u256_to_f64(self.as_u256());
 
         work / pow_limit
     }
@@ -702,8 +722,7 @@ impl PartialCumulativeWork {
     pub fn difficulty_bits_for_display(&self) -> f64 {
         // This calculation is similar to `zcashd`'s bits display in its logs.
 
-        // Convert to u128 then f64.
-        let work = self.as_u128() as f64;
+        let work = u256_to_f64(self.as_u256());
 
         work.log2()
     }
@@ -751,16 +770,24 @@ impl From<Work> for PartialCumulativeWork {
     }
 }
 
+impl From<Work> for U256 {
+    fn from(work: Work) -> Self {
+        work.0
+    }
+}
+
+impl From<PartialCumulativeWork> for U256 {
+    fn from(work: PartialCumulativeWork) -> Self {
+        work.0
+    }
+}
+
 impl std::ops::Add<Work> for PartialCumulativeWork {
     type Output = PartialCumulativeWork;
 
     fn add(self, rhs: Work) -> Self::Output {
-        let result = self
-            .0
-            .checked_add(rhs.0)
-            .expect("Work values do not overflow");
-
-        PartialCumulativeWork(result)
+        self.checked_add(rhs)
+            .expect("cumulative work stays below the 2^256 boundary on any valid chain")
     }
 }
 
@@ -774,11 +801,8 @@ impl std::ops::Sub<Work> for PartialCumulativeWork {
     type Output = PartialCumulativeWork;
 
     fn sub(self, rhs: Work) -> Self::Output {
-        let result = self.0
-            .checked_sub(rhs.0)
-            .expect("PartialCumulativeWork values do not underflow: all subtracted Work values must have been previously added to the PartialCumulativeWork");
-
-        PartialCumulativeWork(result)
+        self.checked_sub(rhs)
+            .expect("subtracted block work was previously included in cumulative work")
     }
 }
 
@@ -786,4 +810,19 @@ impl std::ops::SubAssign<Work> for PartialCumulativeWork {
     fn sub_assign(&mut self, rhs: Work) {
         *self = *self - rhs;
     }
+}
+
+fn u256_to_f64(value: U256) -> f64 {
+    let bits = value.bits();
+    let mantissa_bits = usize::try_from(f64::MANTISSA_DIGITS)
+        .expect("the f64 mantissa width fits in usize on every supported target");
+    if bits <= mantissa_bits {
+        // An f64 represents values with at most 53 bits exactly.
+        return value.as_u64() as f64;
+    }
+
+    let shift = bits - mantissa_bits;
+    let significant = (value >> shift).as_u64();
+    // The f64 mantissa represents the 53 high bits in `significant` exactly.
+    significant as f64 * 2.0_f64.powi(i32::try_from(shift).expect("a U256 shift fits in i32"))
 }

--- a/crates/zakura-chain/src/work/difficulty/arbitrary.rs
+++ b/crates/zakura-chain/src/work/difficulty/arbitrary.rs
@@ -46,10 +46,11 @@ impl Arbitrary for Work {
     type Parameters = ();
 
     fn arbitrary_with(_args: ()) -> Self::Strategy {
-        // In the Zcash protocol, a Work is converted from an ExpandedDifficulty.
-        // But some randomised difficulties are impractically large, and will
-        // never appear in any real-world block. So we just use a random Work value.
-        (1..u128::MAX).prop_map(Work).boxed()
+        // State test generators use this established practical-work distribution.
+        // Deterministic vectors cover the full-width boundaries.
+        (1..u128::MAX)
+            .prop_map(|work| Work(U256::from(work)))
+            .boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;

--- a/crates/zakura-chain/src/work/difficulty/tests/prop.rs
+++ b/crates/zakura-chain/src/work/difficulty/tests/prop.rs
@@ -39,12 +39,11 @@ proptest! {
             let expanded_trip = compact_trip.to_expanded().expect("roundtrip expanded is valid");
             prop_assert_eq!(expanded_trunc, expanded_trip);
 
-            // Some impossibly hard compact values are not valid work values in Zebra
-            if let Some(work) = work {
-                // roundtrip
-                let work_trip = compact_trip.to_work().expect("roundtrip work is valid if work is valid");
-                prop_assert_eq!(work, work_trip);
-            }
+            let work = work.expect("every positive 256-bit target has representable work");
+            let work_trip = compact_trip
+                .to_work()
+                .expect("roundtrip positive target has representable work");
+            prop_assert_eq!(work, work_trip);
         }
     }
 
@@ -53,8 +52,8 @@ proptest! {
     /// Make sure the conversions don't panic, and that they compare correctly.
     #[test]
     fn prop_work_conversion(work in any::<Work>()) {
-        let work_zero = Work(0);
-        let work_max = Work(u128::MAX);
+        let work_zero = Work(U256::zero());
+        let work_max = Work(U256::MAX);
 
         prop_assert!(work > work_zero);
         // similarly, the maximum compact value has less precision than work
@@ -65,8 +64,14 @@ proptest! {
         prop_assert!(partial_work < PartialCumulativeWork::from(work_max));
 
         // Now try adding zero to convert to PartialCumulativeWork
-        prop_assert!(partial_work > work_zero + work_zero);
-        prop_assert!(partial_work < work_max + work_zero);
+        let zero_sum = PartialCumulativeWork::from(work_zero)
+            .checked_add(work_zero)
+            .expect("adding zero to zero is representable");
+        let max_sum = PartialCumulativeWork::from(work_max)
+            .checked_add(work_zero)
+            .expect("adding zero to the maximum is representable");
+        prop_assert!(partial_work > zero_sum);
+        prop_assert!(partial_work < max_sum);
     }
 
     /// Check that a random ExpandedDifficulty compares correctly with fixed block::Hash
@@ -161,9 +166,8 @@ proptest! {
             prop_assert!(compact1 == compact2);
         }
 
-        // Skip impossibly hard work values
-        prop_assume!(work1.is_some());
-        prop_assume!(work2.is_some());
+        prop_assert!(work1.is_some());
+        prop_assert!(work2.is_some());
 
         match expanded1_seed.cmp(&expanded2_seed) {
             Ordering::Greater => {
@@ -196,9 +200,7 @@ proptest! {
     #[test]
     fn prop_work_sum(work1 in any::<Work>(), work2 in any::<Work>()) {
 
-        // If the sum won't panic
-        if work1.0.checked_add(work2.0).is_some() {
-            let work_total = work1 + work2;
+        if let Some(work_total) = PartialCumulativeWork::from(work1).checked_add(work2) {
             prop_assert!(work_total >= PartialCumulativeWork::from(work1));
             prop_assert!(work_total >= PartialCumulativeWork::from(work2));
 
@@ -206,15 +208,13 @@ proptest! {
             prop_assert_eq!(work_total - work2, PartialCumulativeWork::from(work1));
         }
 
-        if work1.0.checked_add(work1.0).is_some() {
-            let work_total = work1 + work1;
+        if let Some(work_total) = PartialCumulativeWork::from(work1).checked_add(work1) {
             prop_assert!(work_total >= PartialCumulativeWork::from(work1));
 
             prop_assert_eq!(work_total - work1, PartialCumulativeWork::from(work1));
         }
 
-        if work2.0.checked_add(work2.0).is_some() {
-            let work_total = work2 + work2;
+        if let Some(work_total) = PartialCumulativeWork::from(work2).checked_add(work2) {
             prop_assert!(work_total >= PartialCumulativeWork::from(work2));
 
             prop_assert_eq!(work_total - work2, PartialCumulativeWork::from(work2));

--- a/crates/zakura-chain/src/work/difficulty/tests/vectors.rs
+++ b/crates/zakura-chain/src/work/difficulty/tests/vectors.rs
@@ -57,18 +57,18 @@ fn debug_format() {
         "ExpandedDifficulty(\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\")"
     );
 
-    assert_eq!(format!("{:?}", Work(0)), "Work(0x0, 0, -inf)");
-    assert_eq!(format!("{:?}", Work(1)), "Work(0x1, 1, 0.00000)");
+    assert_eq!(format!("{:?}", Work(U256::zero())), "Work(0x0, 0, -inf)");
+    assert_eq!(format!("{:?}", Work(U256::one())), "Work(0x1, 1, 0.00000)");
     assert_eq!(
-        format!("{:?}", Work(u8::MAX as u128)),
+        format!("{:?}", Work(U256::from(u8::MAX))),
         "Work(0xff, 255, 7.99435)"
     );
     assert_eq!(
-        format!("{:?}", Work(u64::MAX as u128)),
+        format!("{:?}", Work(U256::from(u64::MAX))),
         "Work(0xffffffffffffffff, 18446744073709551615, 64.00000)"
     );
     assert_eq!(
-        format!("{:?}", Work(u128::MAX)),
+        format!("{:?}", Work(U256::from(u128::MAX))),
         "Work(0xffffffffffffffffffffffffffffffff, 340282366920938463463374607431768211455, 128.00000)"
     );
 }
@@ -112,7 +112,7 @@ fn compact_extremes() {
 
     // Values equal to one
     let expanded_one = Some(ExpandedDifficulty(U256::one()));
-    let work_one = None;
+    let work_one = Some(Work(U256::one() << 255));
 
     let canonical_one = CompactDifficulty((1 << PRECISION) + (1 << 16));
     assert_eq!(canonical_one.to_expanded(), expanded_one);
@@ -132,7 +132,8 @@ fn compact_extremes() {
 
     // Maximum mantissa
     let expanded_mant = Some(ExpandedDifficulty(UNSIGNED_MANTISSA_MASK.into()));
-    let work_mant = None;
+    let expanded_mant_value = U256::from(UNSIGNED_MANTISSA_MASK);
+    let work_mant = Some(Work((!expanded_mant_value / (expanded_mant_value + 1)) + 1));
 
     let mant = CompactDifficulty(OFFSET as u32 * (1 << PRECISION) + UNSIGNED_MANTISSA_MASK);
     assert_eq!(mant.to_expanded(), expanded_mant);
@@ -143,9 +144,7 @@ fn compact_extremes() {
     let exponent: U256 = (31 * 8).into();
     let u256_exp = U256::from(2).pow(exponent);
     let expanded_exp = Some(ExpandedDifficulty(u256_exp));
-    let work_exp = Some(Work(
-        ((U256::MAX - u256_exp) / (u256_exp + 1) + 1).as_u128(),
-    ));
+    let work_exp = Some(Work((!u256_exp / (u256_exp + 1)) + 1));
 
     let canonical_exp =
         CompactDifficulty(((31 + OFFSET - 2) as u32) * (1 << PRECISION) + (1 << 16));
@@ -167,7 +166,7 @@ fn compact_extremes() {
     let exponent: U256 = (29 * 8).into();
     let u256_me = U256::from(UNSIGNED_MANTISSA_MASK) * U256::from(2).pow(exponent);
     let expanded_me = Some(ExpandedDifficulty(u256_me));
-    let work_me = Some(Work((!u256_me / (u256_me + 1) + 1).as_u128()));
+    let work_me = Some(Work((!u256_me / (u256_me + 1)) + 1));
 
     let me = CompactDifficulty((31 + 1) * (1 << PRECISION) + UNSIGNED_MANTISSA_MASK);
     assert_eq!(me.to_expanded(), expanded_me);
@@ -193,7 +192,7 @@ fn compact_extremes() {
     let difficulty_btc_main = CompactDifficulty(0x1d00ffff);
     let u256_btc_main = U256::from(0xffff) << 208;
     let expanded_btc_main = Some(ExpandedDifficulty(u256_btc_main));
-    let work_btc_main = Some(Work(0x100010001));
+    let work_btc_main = Some(Work(U256::from(0x100010001_u64)));
     assert_eq!(difficulty_btc_main.to_expanded(), expanded_btc_main);
     assert_eq!(
         difficulty_btc_main.to_expanded().unwrap().to_compact(),
@@ -206,7 +205,7 @@ fn compact_extremes() {
     let difficulty_btc_reg = CompactDifficulty(0x207fffff);
     let u256_btc_reg = U256::from(0x7fffff) << 232;
     let expanded_btc_reg = Some(ExpandedDifficulty(u256_btc_reg));
-    let work_btc_reg = Some(Work(0x2));
+    let work_btc_reg = Some(Work(U256::from(0x2_u8)));
     assert_eq!(difficulty_btc_reg.to_expanded(), expanded_btc_reg);
     assert_eq!(
         difficulty_btc_reg.to_expanded().unwrap().to_compact(),
@@ -215,18 +214,68 @@ fn compact_extremes() {
     assert_eq!(difficulty_btc_reg.to_work(), work_btc_reg);
 }
 
+/// HV-07: exact per-block work remains representable above `u128::MAX`.
+///
+/// The smallest target produces the largest representable work, so these
+/// boundary cases are sufficient to catch accidental narrowing to `u128`.
+#[test]
+fn per_block_work_preserves_values_above_u128() {
+    let target_one = CompactDifficulty((1 << PRECISION) + (1 << 16));
+    let work = target_one
+        .to_work()
+        .expect("a positive target has representable 256-bit work");
+
+    assert_eq!(work.as_u256(), U256::one() << 255);
+    assert!(work.as_u256() > U256::from(u128::MAX));
+    assert_eq!(
+        Work::try_from(ExpandedDifficulty(U256::MAX)),
+        Ok(Work(U256::one()))
+    );
+    assert_eq!(Work::try_from(ExpandedDifficulty(U256::zero())), Err(()));
+}
+
+/// HV-07: cumulative work reaches `U256::MAX` exactly and rejects overflow.
+///
+/// Testing the final successful addition and the immediately following
+/// overflow covers the full-width checked-add boundary.
+#[test]
+fn cumulative_work_checks_u256_boundary() {
+    let one = Work(U256::one());
+    let below_max = PartialCumulativeWork(U256::MAX - 1);
+    let max = below_max
+        .checked_add(one)
+        .expect("adding one below the limit reaches the exact limit");
+
+    assert_eq!(max.as_u256(), U256::MAX);
+    assert_eq!(max.checked_add(one), None);
+}
+
 /// Bitcoin test vectors for CompactDifficulty, and their corresponding
 /// ExpandedDifficulty and Work values.
 /// See <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
-static COMPACT_DIFFICULTY_CASES: &[(u32, Option<u128>, Option<u128>)] = &[
-    // These Work values will never happen in practice, because the corresponding
-    // difficulties are extremely high. So it is ok for us to reject them.
+static COMPACT_DIFFICULTY_CASES: &[(u32, Option<u128>, Option<&str>)] = &[
     (0x01003456, None /* 0x00 */, None),
-    (0x01123456, Some(0x12), None),
-    (0x02008000, Some(0x80), None),
-    (0x05009234, Some(0x92340000), None),
+    (
+        0x01123456,
+        Some(0x12),
+        Some("0d79435e50d79435e50d79435e50d79435e50d79435e50d79435e50d79435e50"),
+    ),
+    (
+        0x02008000,
+        Some(0x80),
+        Some("01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f01fc07f0"),
+    ),
+    (
+        0x05009234,
+        Some(0x92340000),
+        Some("00000001c040c95a099201bcaf85db4e7f2e21e18707c8d55a887643b95afb2f"),
+    ),
     (0x04923456, None /* -0x12345600 */, None),
-    (0x04123456, Some(0x12345600), None),
+    (
+        0x04123456,
+        Some(0x12345600),
+        Some("0000000e10005c64415f04ef3e387b97db388404db9fdfaab2b1918f6783471d"),
+    ),
 ];
 
 /// Test Bitcoin test vectors for CompactDifficulty.
@@ -240,7 +289,9 @@ fn compact_bitcoin_test_vectors() {
         /// SPANDOC: Convert compact to expanded and work {?compact, ?expected_expanded, ?expected_work}
         {
             let expected_expanded = expected_expanded.map(U256::from).map(ExpandedDifficulty);
-            let expected_work = expected_work.map(Work);
+            let expected_work = expected_work.map(|work| {
+                Work(U256::from_str_radix(work, 16).expect("golden work value is valid hex"))
+            });
 
             let compact = CompactDifficulty(compact);
             let actual_expanded = compact.to_expanded();
@@ -280,8 +331,8 @@ fn block_difficulty_for_network(network: Network) -> Result<(), Report> {
     let diff_one = ExpandedDifficulty(U256::one());
     let diff_max = ExpandedDifficulty(U256::MAX);
 
-    let work_zero = PartialCumulativeWork(0);
-    let work_max = PartialCumulativeWork(u128::MAX);
+    let work_zero = PartialCumulativeWork(U256::zero());
+    let work_max = PartialCumulativeWork(U256::MAX);
 
     let mut cumulative_work = PartialCumulativeWork::default();
     let mut previous_cumulative_work = PartialCumulativeWork::default();
@@ -334,7 +385,9 @@ fn block_difficulty_for_network(network: Network) -> Result<(), Report> {
             assert!(PartialCumulativeWork::from(work) > work_zero);
             assert!(PartialCumulativeWork::from(work) < work_max);
 
-            cumulative_work += work;
+            cumulative_work = cumulative_work
+                .checked_add(work)
+                .expect("valid production chain work remains representable");
             assert!(cumulative_work > work_zero);
             assert!(cumulative_work < work_max);
 

--- a/crates/zakura-chain/src/work/equihash.rs
+++ b/crates/zakura-chain/src/work/equihash.rs
@@ -99,27 +99,38 @@ impl Solution {
     /// proof-of-work parameters by choosing the on-wire solution length.
     #[allow(clippy::unwrap_in_result)]
     pub fn check(&self, header: &Header, network: &Network) -> Result<(), Error> {
+        self.validate_shape(network)?;
+
         // TODO:
         // - Add Equihash parameters field to `testnet::Parameters`
         // - Update `Solution::Regtest` variant to hold a `Vec` to support arbitrary parameters - rename to `Other`
-        let (n, k) = match (network.is_regtest(), self) {
+        let (n, k) = if network.is_regtest() {
+            (REGTEST_N, REGTEST_K)
+        } else {
+            (200, 9)
+        };
+
+        self.check_equihash(header, n, k)
+    }
+
+    /// Validate only the solution's encoded shape against the authenticated network parameters.
+    pub fn validate_shape(&self, network: &Network) -> Result<(), Error> {
+        match (network.is_regtest(), self) {
             // Mainnet and Testnet require the memory-hard (200, 9) parameters,
             // encoded as a 1344-byte `Common` solution.
-            (false, Solution::Common(_)) => (200, 9),
+            (false, Solution::Common(_)) => Ok(()),
             // Regtest requires the toy (48, 5) parameters used by zcashd.
-            (true, Solution::Regtest(_)) => (REGTEST_N, REGTEST_K),
+            (true, Solution::Regtest(_)) => Ok(()),
             // Reject a solution variant that does not match the active
             // network before selecting parameters. Otherwise the
             // attacker-controlled solution length could change the PoW
             // parameter set.
             (false, Solution::Regtest(_)) | (true, Solution::Common(_)) => {
-                return Err(Error::InvalidSolutionSize {
+                Err(Error::InvalidSolutionSize {
                     network: network.clone(),
                 })
             }
-        };
-
-        self.check_equihash(header, n, k)
+        }
     }
 
     /// Returns `Ok(())` if this solution is valid for `header` under the given

--- a/crates/zakura-chain/src/work/tests/vectors.rs
+++ b/crates/zakura-chain/src/work/tests/vectors.rs
@@ -17,6 +17,15 @@ const EQUIHASH_SOLUTION_BLOCK_OFFSET: usize = equihash::Solution::INPUT_LENGTH +
 const BLOCK_HEADER_LENGTH: usize = EQUIHASH_SOLUTION_BLOCK_OFFSET + 3 + equihash::SOLUTION_SIZE;
 
 #[test]
+fn compact_difficulty_consensus_bytes_round_trip() {
+    let bytes = [0x01, 0x02, 0x03, 0x04];
+    assert_eq!(
+        difficulty::CompactDifficulty::from_le_bytes(bytes).to_le_bytes(),
+        bytes
+    );
+}
+
+#[test]
 fn equihash_solution_test_vectors() {
     let _init_guard = zakura_test::init();
 

--- a/crates/zakura-chain/src/work/tests/vectors.rs
+++ b/crates/zakura-chain/src/work/tests/vectors.rs
@@ -26,6 +26,27 @@ fn compact_difficulty_consensus_bytes_round_trip() {
 }
 
 #[test]
+fn validate_shape_checks_the_solution_against_the_network() {
+    let regtest = Network::new_regtest(Default::default());
+
+    Solution::for_proposal_for_network(&regtest)
+        .validate_shape(&regtest)
+        .expect("Regtest keeps its own (48, 5) solution shape");
+
+    assert!(Solution::for_proposal().validate_shape(&regtest).is_err());
+
+    let mainnet = Network::Mainnet;
+
+    Solution::for_proposal()
+        .validate_shape(&mainnet)
+        .expect("Mainnet keeps the common (200, 9) solution shape");
+
+    assert!(Solution::for_proposal_for_network(&regtest)
+        .validate_shape(&mainnet)
+        .is_err());
+}
+
+#[test]
 fn equihash_solution_test_vectors() {
     let _init_guard = zakura_test::init();
 

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -71,7 +71,7 @@ tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower
 zakura-script = { path = "../zakura-script", version = "3.1.0" }
 zakura-state = { path = "../zakura-state", version = "6.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.1.0" }
-zakura-chain = { path = "../zakura-chain", version = "4.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
 
 zcash_protocol.workspace = true
 
@@ -97,7 +97,7 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 zakura-state = { path = "../zakura-state", version = "6.0.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -92,7 +92,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["async-error"] }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.1.0" }
 
 [dev-dependencies]
@@ -106,7 +106,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "4.0.0" }
+zakura-chain = { path = "../zakura-chain" , version = "5.0.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -112,7 +112,7 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = [
     "json-conversion",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "6.0.0" }
@@ -142,7 +142,7 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = [
     "proptest-impl",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "6.0.0", features = [

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -2897,9 +2897,7 @@ where
             _ => unreachable!("unmatched response to a solution rate request"),
         };
 
-        Ok(solution_rate
-            .try_into()
-            .expect("per-second solution rate always fits in u64"))
+        Ok(u64::try_from(solution_rate).unwrap_or(u64::MAX))
     }
 
     async fn get_network_info(&self) -> Result<GetNetworkInfoResponse> {

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -2873,6 +2873,53 @@ async fn rpc_getnetworksolps() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn rpc_getnetworksolps_saturates_to_response_width() {
+    let _init_guard = zakura_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool, 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let request = tokio::spawn(async move { rpc.get_network_sol_ps(None, None).await });
+
+    read_state
+        .expect_request(ReadRequest::SolutionRate {
+            num_blocks: DEFAULT_SOLUTION_RATE_WINDOW_SIZE
+                .try_into()
+                .expect("the positive default window size fits in usize"),
+            height: None,
+        })
+        .await
+        .respond(ReadResponse::SolutionRate(Some(u128::MAX)));
+
+    assert_eq!(
+        request
+            .await
+            .expect("the RPC task should not panic")
+            .expect("the RPC call should succeed"),
+        u64::MAX,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn getblocktemplate() {
     let _init_guard = zakura_test::init();
 

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "4.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -75,7 +75,7 @@ tracing = { workspace = true }
 sapling-crypto = { workspace = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "3.1.0" }
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -108,7 +108,7 @@ orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -29,7 +29,7 @@ use zakura_chain::{
     transaction::{self, Transaction},
     transparent,
     value_balance::ValueBalance,
-    work::difficulty::PartialCumulativeWork,
+    work::difficulty::{PartialCumulativeWork, U256},
 };
 
 use crate::{
@@ -2268,11 +2268,13 @@ impl DiskWriteBatch {
                 }
             }
 
+            // The comparison above is exact 256-bit. These fields are diagnostic only, so
+            // they saturate into the narrower reporting type rather than panicking.
             if new_work <= existing_work {
                 return Err(CommitHeaderRangeError::LowerWorkConflict {
                     height: first_conflicting_height,
-                    existing_work: existing_work.as_u128(),
-                    new_work: new_work.as_u128(),
+                    existing_work: saturating_work_for_display(existing_work),
+                    new_work: saturating_work_for_display(new_work),
                 });
             }
         }
@@ -2348,4 +2350,11 @@ impl DiskWriteBatch {
         let block_header_by_height = zakura_db.db.cf_handle("block_header_by_height").unwrap();
         self.zs_delete(&block_header_by_height, height);
     }
+}
+
+/// Narrows exact 256-bit cumulative work for error reporting, saturating at [`u128::MAX`].
+///
+/// Fork-choice comparisons stay exact; only the reported diagnostic is narrowed.
+fn saturating_work_for_display(work: PartialCumulativeWork) -> u128 {
+    work.as_u256().min(U256::from(u128::MAX)).low_u128()
 }

--- a/crates/zakura-state/src/service/read/difficulty.rs
+++ b/crates/zakura-state/src/service/read/difficulty.rs
@@ -9,7 +9,7 @@ use zakura_chain::{
     history_tree::HistoryTree,
     parameters::{Network, NetworkUpgrade, POST_BLOSSOM_POW_TARGET_SPACING},
     serialization::{DateTime32, Duration32},
-    work::difficulty::{CompactDifficulty, PartialCumulativeWork, Work},
+    work::difficulty::{CompactDifficulty, PartialCumulativeWork, Work, U256},
 };
 
 use crate::{
@@ -143,7 +143,12 @@ pub fn solution_rate(
         return None;
     }
 
-    Some(total_work.as_u128() / work_duration as u128)
+    // `work_duration` is positive here, so the cast cannot wrap.
+    let rate = total_work.as_u256() / U256::from(work_duration as u128);
+
+    // The RPC solution rate stays u128. Saturate rather than panic: cumulative work is
+    // exact 256-bit, so a custom-network chain could in principle exceed the narrower type.
+    Some(rate.min(U256::from(u128::MAX)).low_u128())
 }
 
 /// Do a consistency check by checking the finalized tip before and after all other database

--- a/crates/zakura-state/src/tests.rs
+++ b/crates/zakura-state/src/tests.rs
@@ -85,7 +85,7 @@ fn round_trip_work_expanded() {
     let _init_guard = zakura_test::init();
 
     proptest!(|(work_before in any::<Work>())| {
-        let work: U256 = work_before.as_u128().into();
+        let work: U256 = work_before.as_u256();
         let expanded = work_to_expanded(work);
         let work_after = Work::try_from(expanded).unwrap();
         prop_assert_eq!(work_before, work_after);

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -65,7 +65,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "3.1.0" }
-zakura-chain = { path = "../zakura-chain", version = "4.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -168,7 +168,7 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "4.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
 zakura-consensus = { path = "../zakura-consensus", version = "6.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.1.0" }
 zakura-network = { path = "../zakura-network", version = "6.0.0" }
@@ -322,7 +322,7 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "4.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "6.0.0", features = ["proptest-impl"] }
 zakura-network = { path = "../zakura-network", version = "6.0.0", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "6.0.0", features = ["proptest-impl"] }

--- a/docs/changelog/unreleased/637.md
+++ b/docs/changelog/unreleased/637.md
@@ -1,0 +1,13 @@
+## Changed
+
+- Block work and cumulative chain work are now stored at their exact 256-bit
+  width, so valid hard targets are representable instead of failing conversion.
+  Fork choice and the committed chain history root are unchanged for Mainnet and
+  Testnet, and no database migration is required
+  ([#637](https://github.com/zakura-core/zakura/pull/637)).
+
+## Removed
+
+- Removed `Work::as_u128` and `PartialCumulativeWork::as_u128` from
+  `zakura-chain` in favour of `as_u256`
+  ([#637](https://github.com/zakura-core/zakura/pull/637)).


### PR DESCRIPTION
## Motivation

`Work` and `PartialCumulativeWork` store the Zcash specification's implied 256-bit
work values in a `u128`. The specification defines block work as
`floor(2^256 / (ToTarget(nBits) + 1))`, so the narrower type cannot represent work
for hard targets, and `TryFrom<ExpandedDifficulty>` returned `Err` whenever the
computed value exceeded `u128::MAX`. On Mainnet total chain work is around 2^58, so
the truncation is invisible today, but it makes valid hard targets unrepresentable
and converts them into a failed conversion rather than a comparable value.

This is extracted as a standalone PR because it is a breaking change to a published
API and it alters consensus-adjacent conversion behaviour. It should be reviewed on
its own merits rather than merging as a silent dependency of a later crate.

## Solution

Store both types as `U256`:

- `Work::as_u128` / `PartialCumulativeWork::as_u128` become `as_u256`. This is the
  breaking part, so `zakura-chain` takes a major version bump to 5.0.0 and the 13
  workspace requirements move with it.
- `TryFrom<ExpandedDifficulty> for Work` replaces the `u128` overflow branch with
  explicit cases: a zero target has work 2^256 and stays `Err`, and `U256::MAX`
  returns `Ok(1)` because its mathematical denominator is 2^256.
- `PartialCumulativeWork` gains `checked_add` / `checked_sub`. The existing `Add`,
  `AddAssign`, `Sub` and `SubAssign` operators are kept with their previous
  panic-on-overflow semantics, so no caller changes its error handling here.
- Display paths (`difficulty_multiplier_for_display`, `difficulty_bits_for_display`,
  `Debug`) go through a `u256_to_f64` helper instead of `as u128 as f64`.
- `CompactDifficulty` gains `to_le_bytes` / `from_le_bytes` for the exact four-byte
  consensus representation.

Separately, `Solution::validate_shape` is extracted from `check_solution` so callers
can validate a solution's encoded shape against the network parameters without
running the Equihash check. `check_solution` calls it first and keeps its previous
behaviour.

Call-site updates are mechanical:

- `primitives/zcash_history.rs` builds the ZIP 221 V1 node work field from
  `as_u256().to_big_endian()` instead of `as_u128().to_be_bytes()`. Both produce the
  same `U256` for every value below 2^128, so the committed history root is
  unchanged for any real chain.
- `zakura-state` reports `LowerWorkConflict` work through a saturating helper. The
  fork-choice comparison above it stays exact 256-bit; only the diagnostic narrows.
- `read::difficulty::solution_rate` keeps its `Option<u128>` return type, so the
  `getnetworksolps` RPC response type is unchanged. The division is done in `U256`
  and saturates rather than panicking.

### Why this is safe

- **Not persisted.** Neither type has an `IntoDisk` / `FromDisk` impl; cumulative
  work is recomputed at load. No database format change and no migration.
- **Fork choice is unchanged for real chains.** Ordering is derived, and `U256`
  ordering agrees with `u128` ordering for every value below 2^128. Mainnet total
  chain work is around 2^58.
- **The reachable behaviour change is a panic removal.** Previously a target low
  enough to produce work above 2^128 made `to_work()` return `None`, which reached
  `.expect("work must be valid during contextual verification")` in the history-tree
  code. That is unreachable under any Mainnet or Testnet `powLimit` but constructible
  on regtest and custom networks. It now computes the exact value instead.

## Testing

Run on this branch:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo check --workspace --all-targets` — clean
- `cargo test -p zakura-chain` — 382 passed, 0 failed
- `cargo test -p zakura-state` — 458 passed, 0 failed, 3 ignored, plus 12 passing
  across the integration binaries

The `work/difficulty` vectors and proptests are updated to exercise the widened
type directly, including the new zero-target and `U256::MAX` boundaries and a
round-trip above `u128::MAX` that the previous representation could not hold.
`round_trip_work_expanded` in `zakura-state` now round-trips the exact 256-bit value.
`validate_shape_checks_the_solution_against_the_network` covers the extracted shape
check on both Mainnet and Regtest, in both directions.

## Changelog

Fragment added in `docs/changelog/unreleased/637.md`.

### Specifications & References

- Work definition: [Zcash protocol specification, section 7.7.5](https://zips.z.cash/protocol/protocol.pdf#workdef)
- nBits conversions: [section 7.7.4](https://zips.z.cash/protocol/protocol.pdf#nbits)

### Follow-up Work

This unblocks the `zakura-header-chain` crate, whose graph and transition code
requires exact 256-bit work and `Solution::validate_shape`. Note that #618 already
calls `work.as_u256()` in `crates/zakura-header-chain/src/graph.rs`, but that crate
has no `Cargo.toml` and is not a workspace member on that branch, so nothing compiles
it yet. This PR should land before the PR that adds the crate manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
