### PR TITLE
feat(chain): expose header-version validation and the fork-count cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8357,7 +8357,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "bech32",
  "bitflags",

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "4.1.0"
+version = "4.2.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/src/block.rs
+++ b/crates/zakura-chain/src/block.rs
@@ -44,6 +44,14 @@ pub use header::{BlockTimeError, CountedHeader, Header, ZCASH_BLOCK_VERSION};
 pub use height::{Height, HeightDiff, TryIntoHeight};
 pub use serialize::{SerializedBlock, MAX_BLOCK_BYTES};
 
+/// Re-assert the signed Zcash block-header version rule on an in-memory header.
+///
+/// Canonical deserialization already applies this check.
+/// Observable header validators repeat the check for locally constructed headers.
+pub fn validate_header_version(version: u32) -> Result<(), &'static str> {
+    serialize::validate_header_version(version)
+}
+
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use arbitrary::LedgerState;
 

--- a/crates/zakura-chain/src/block/header.rs
+++ b/crates/zakura-chain/src/block/header.rs
@@ -101,8 +101,7 @@ pub enum BlockTimeError {
 }
 
 impl Header {
-    /// TODO: Inline this function into zakura_consensus::block::check::time_is_valid_at.
-    /// See <https://github.com/ZcashFoundation/zebra/issues/1021> for more details.
+    /// Shared observable-header validation delegates to this canonical time calculation.
     #[allow(clippy::unwrap_in_result)]
     pub fn time_is_valid_at(
         &self,

--- a/crates/zakura-chain/src/block/serialize.rs
+++ b/crates/zakura-chain/src/block/serialize.rs
@@ -33,7 +33,7 @@ pub const MAX_BLOCK_BYTES: u64 = 2_000_000;
 ///
 /// All other blocks are deserialized when we receive them, and never modified,
 /// so the deserialisation would pick up any errors.
-fn check_version(version: u32) -> Result<(), &'static str> {
+pub(crate) fn validate_header_version(version: u32) -> Result<(), &'static str> {
     match version {
         // The Zcash specification says that:
         // "The current and only defined block version number for Zcash is 4."
@@ -64,7 +64,7 @@ fn check_version(version: u32) -> Result<(), &'static str> {
 impl ZcashSerialize for Header {
     #[allow(clippy::unwrap_in_result)]
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
-        check_version(self.version).map_err(io::Error::other)?;
+        validate_header_version(self.version).map_err(io::Error::other)?;
 
         writer.write_u32::<LittleEndian>(self.version)?;
         self.previous_block_hash.zcash_serialize(&mut writer)?;
@@ -86,7 +86,7 @@ impl ZcashSerialize for Header {
 impl ZcashDeserialize for Header {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         let version = reader.read_u32::<LittleEndian>()?;
-        check_version(version).map_err(SerializationError::Parse)?;
+        validate_header_version(version).map_err(SerializationError::Parse)?;
 
         Ok(Header {
             version,

--- a/crates/zakura-chain/src/parameters.rs
+++ b/crates/zakura-chain/src/parameters.rs
@@ -27,5 +27,7 @@ pub use network::{magic::Magic, subsidy, testnet, Network, NetworkKind};
 pub use network_upgrade::*;
 pub use transaction::*;
 
+pub use constants::MAX_NON_FINALIZED_CHAIN_FORKS;
+
 #[cfg(test)]
 mod tests;

--- a/crates/zakura-chain/src/parameters/constants.rs
+++ b/crates/zakura-chain/src/parameters/constants.rs
@@ -29,6 +29,12 @@ pub const SLOW_START_SHIFT: Height = Height(SLOW_START_INTERVAL.0 / 2);
 // TODO: change to HeightDiff
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = 1000;
 
+/// The maximum number of non-finalized chain forks Zakura will track.
+///
+/// The header-chain engine inherits this cap from full-state fork policy. Zakura
+/// drops the chain with the lowest work when the fork count reaches this cap.
+pub const MAX_NON_FINALIZED_CHAIN_FORKS: usize = 10;
+
 /// Magic numbers used to identify different Zcash networks.
 pub mod magics {
     use crate::parameters::network::magic::Magic;

--- a/docs/changelog/unreleased/638.md
+++ b/docs/changelog/unreleased/638.md
@@ -1,0 +1,6 @@
+<!-- changelog: none -->
+
+This PR only adds `zakura-chain` API surface for a future consumer. The renamed
+header-version check is called from the same serialization paths as before, and
+the new fork-count constant has no behaviour of its own, so there is no
+operator-visible change.


### PR DESCRIPTION
## Motivation

Two header-chain rules live inside `zakura-chain` but are not reachable from
outside it:

- The signed block-header version rule is `serialize::check_version`, a private
  function. Canonical deserialization applies it, but a validator holding an
  in-memory header it did not deserialize cannot re-assert it.
- The non-finalized fork count cap is a full-state policy number with no shared
  constant, so a second component tracking forks would have to restate it.

## Solution

- Rename `serialize::check_version` to `validate_header_version` and re-export a
  public wrapper from `block`. Both `ZcashSerialize` and `ZcashDeserialize` call
  the same function as before.
- Add `parameters::MAX_NON_FINALIZED_CHAIN_FORKS` (10), re-exported from
  `parameters`.

Both changes are additive. No encoding, deserialization, or validation behaviour
changes, so this is a minor version bump.

This is a prerequisite for the `zakura-header-chain` crate, extracted so the
crate's own PR does not carry unrelated `zakura-chain` API changes.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zakura-chain` — 378 passed, 0 failed, plus 9 passing in the
  integration binary

No new tests: the renamed function keeps its existing serialization coverage,
and the new constant has no behaviour of its own.

## Changelog

Fragment added after the draft PR was opened.

### Follow-up Work

Part of the `zakura-header-chain` prerequisite set, alongside #637. If #637 lands
first this branch needs a rebase, since both touch the `zakura-chain` version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
