### PR TITLE
docs(skills): clarify public vs internal API comment specs

### DIFF
--- a/.agents/skills/core-rust-readability/SKILL.md
+++ b/.agents/skills/core-rust-readability/SKILL.md
@@ -28,9 +28,31 @@ without asking an AI to reconstruct intent.
 
 ## Black-Box Contracts
 
-- Document core traits and non-obvious methods with concise specifications covering purpose, validations, important side effects, and postconditions or invariants.
-- Explain domain terms and enum variants whose meaning is not self-evident.
-- Organize long implementations into clearly named logical groups. Comments should explain intent and constraints, not restate syntax.
+Treat documented functions as black boxes: a reader should know when to call
+them, what changes, and what must remain true—without reading the body.
+Comments explain intent and constraints, not syntax. Prefer key details over
+completeness; omit anything inferable from the signature or name. Explain
+domain terms and enum variants whose meaning is not self-evident. Organize
+long implementations into clearly named logical groups.
+
+### Public APIs
+
+Document crate-public and other caller-facing entry points with a focused
+specification:
+
+- purpose and caller ownership before/after the call;
+- important effects (success vs failure; what durable or in-memory state
+  changes, and what does not);
+- invariants, postconditions, and freshness/stale rules the caller must respect.
+
+Use short structured sections such as `# Returns` only when they clarify the
+caller path. Avoid narrative walkthroughs of internal phases.
+
+### Internal APIs
+
+Keep `pub(crate)`, `pub(super)`, and private helpers brief: purpose plus the
+one or two constraints a future editor must not violate. Do not restate the
+public caller lifecycle or install/publish contract on internal helpers.
 
 ## Cohesive Abstractions
 


### PR DESCRIPTION
## Motivation

The core-rust-readability skill asked for concise specs, but did not distinguish
caller-facing entry points from internal helpers. Reviewers need public APIs
documented as black boxes (effects, invariants, ownership) without encouraging
verbose phase walkthroughs on either public or private surfaces.

## Solution

Update `.agents/skills/core-rust-readability/SKILL.md` Black-Box Contracts to:

- Treat documented functions as black boxes: when to call, what changes, what
  must remain true—without reading the body.
- Prefer key details over completeness; omit signature-inferable noise.
- Public APIs: purpose, caller ownership, success/failure effects, invariants
  and freshness rules; structured `# Returns` only when it clarifies.
- Internal APIs: brief purpose plus one or two must-not-violate constraints;
  do not restate the public lifecycle.

## Testing

- `markdownlint` on `.agents/skills/core-rust-readability/SKILL.md` (via Docker
  `markdownlint-cli` with `.github/.markdownlint.yaml`) — passed.
- No Rust/`Cargo.toml` changes; local compilation skipped (docs-only / low-risk).
- Changelog not required (skill Markdown only).

## Changelog

Not applicable — no Rust source or `Cargo.toml` changes.

### Specifications & References

- Skill: `.agents/skills/core-rust-readability/SKILL.md`
- Related practice: header-chain transition engine public vs internal docs