### PR TITLE
test: fix two pre-existing test failures on main

### DIFF
--- a/crates/zakura-network/src/zakura/testkit/cluster.rs
+++ b/crates/zakura-network/src/zakura/testkit/cluster.rs
@@ -3223,18 +3223,37 @@ mod tests {
         cluster.nodes.push(node1);
         cluster.nodes.push(node2);
 
-        cluster.connect_full_mesh(Duration::from_secs(5)).await?;
-        cluster.await_all_connected(Duration::from_secs(5)).await?;
+        cluster.connect_full_mesh(TEST_NET_TIMEOUT).await?;
+        cluster.await_all_connected(TEST_NET_TIMEOUT).await?;
+        // Wait for every row the assertions below read, not only node 02's
+        // received status. Node 01's accepted-stream row is written when node 02
+        // opens its own header-sync stream, which is a separate exchange that can
+        // land after node 02 has already recorded the status it received.
         await_until(
-            "native header-sync status received",
-            Duration::from_secs(5),
+            "native header-sync status exchange traced on both nodes",
+            TEST_NET_TIMEOUT,
             || {
                 capture.reader().is_ok_and(|reader| {
-                    reader
-                        .node("02")
-                        .table("header_sync")
-                        .count(hs_trace::HEADER_STATUS_RECEIVED)
-                        >= 1
+                    let accepted_header_sync_stream = |node| {
+                        reader.node(node).table("stream").rows().iter().any(|row| {
+                            row.get("event").and_then(|event| event.as_str()) == Some("accepted")
+                                && row.get("stream_kind").and_then(|kind| kind.as_str())
+                                    == Some("header_sync")
+                        })
+                    };
+
+                    accepted_header_sync_stream("01")
+                        && accepted_header_sync_stream("02")
+                        && reader
+                            .node("01")
+                            .table("header_sync")
+                            .count(hs_trace::HEADER_STATUS_SENT)
+                            >= 1
+                        && reader
+                            .node("02")
+                            .table("header_sync")
+                            .count(hs_trace::HEADER_STATUS_RECEIVED)
+                            >= 1
                 })
             },
         )

--- a/crates/zakurad/tests/acceptance.rs
+++ b/crates/zakurad/tests/acceptance.rs
@@ -3268,6 +3268,15 @@ async fn getrawtransaction_confirmations_include_non_finalized_blocks() -> Resul
     Ok(())
 }
 
+/// Deadline for the mining phase of
+/// [`pruned_storage_mode_prunes_during_regtest_sync`].
+///
+/// Mining the retention window takes roughly a minute on an unloaded developer
+/// machine, and several times that on a contended CI runner. This covers the whole
+/// mining phase, so it is set well above the observed worst case while staying
+/// inside the `zakura-pruned-storage` nextest slow timeout.
+const PRUNED_STORAGE_MINING_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// Pruned storage mode deletes historical raw transaction data during regtest
 /// sync, while the node keeps committing new blocks.
 ///
@@ -3325,18 +3334,38 @@ async fn pruned_storage_mode_prunes_during_regtest_sync() -> Result<()> {
     // `tx_retention + MAX_BLOCK_REORG_HEIGHT`. Mine a margin past that so several
     // heights are pruned.
     let blocks_to_mine = tx_retention + MAX_BLOCK_REORG_HEIGHT + 50;
-    let mut mined = 0;
-    while mined < blocks_to_mine {
-        // Mine in batches to keep each `generate` RPC call bounded.
-        let batch = (blocks_to_mine - mined).min(250);
-        client.generate(batch).await?;
-        mined += batch;
-    }
+
+    // `with_timeout` arms an absolute deadline rather than a per-call one, and
+    // mining this many blocks takes longer than the launch deadline. Re-arm the
+    // deadline so it covers the whole mining phase; otherwise the wait for the
+    // pruning line below expires before it reads a single line of output.
+    zakurad = zakurad.with_timeout(PRUNED_STORAGE_MINING_TIMEOUT);
+
+    // Mine on a background task while this thread reads the node's log stream.
+    // Nothing drains the child's stdout while a `generate` call is in flight, so
+    // mining the whole window first fills the stdout pipe and blocks the node's
+    // log writer, which stops the pruning line from being emitted at all.
+    let mining = tokio::spawn({
+        let client = client.clone();
+        async move {
+            let mut mined = 0;
+            while mined < blocks_to_mine {
+                // Mine in batches to keep each `generate` RPC call bounded.
+                let batch = (blocks_to_mine - mined).min(250);
+                client.generate(batch).await?;
+                mined += batch;
+            }
+
+            Ok::<(), eyre::Report>(())
+        }
+    });
 
     // Commit-time pruning logs a line each time it deletes a height range.
     zakurad.expect_stdout_line_matches(
         "pruning raw transaction history outside the retention window",
     )?;
+
+    mining.await??;
 
     // The node keeps validating and committing new blocks over the partially
     // pruned history (this is what proves pruning didn't break future validation).

--- a/docs/changelog/unreleased/642.md
+++ b/docs/changelog/unreleased/642.md
@@ -1,0 +1,5 @@
+<!-- changelog: none -->
+
+This PR only fixes two tests that fail on `main` for harness-timing reasons. It
+changes no production code and has no operator- or crate-consumer-visible
+effect.


### PR DESCRIPTION
## Motivation

Two tests fail on a clean `main` checkout, independently of any feature work.

### `native_stream5_status_exchange_uses_handler_wire_path`

```
Error: WaitError { description: "native Zakura peer registration", timeout: 5s }
test result: FAILED ... finished in 8.92s
```

The test passes `Duration::from_secs(5)` to `connect_full_mesh`,
`await_all_connected`, and its trace `await_until`. Those waits cover a real
iroh/QUIC dial plus peer registration through the supervisor. Every comparable
wait in this module uses `TEST_NET_TIMEOUT` (30s), and `testkit/wait.rs`
documents why: under CPU contention a handshake or registration routinely takes
several seconds, which is not a correctness failure. This test was left on the
tight deadline, so it fails on any loaded host.

The wait also only covered node 02's `HEADER_STATUS_RECEIVED` row, while the
assertions that follow also read node 01's accepted-stream row. That row is
written when node 02 opens its own header-sync stream, a separate exchange that
can land after node 02 has recorded the status it received, so the assertion
could panic even with a generous connect deadline.

### `pruned_storage_mode_prunes_during_regtest_sync`

```
Error:
   0: stdout of command did not log any matches for the given regex,
      within the 45s command timeout
Match Regex: ["pruning raw transaction history outside the retention window"]
```

`TestChild::with_timeout` arms an **absolute** deadline
(`self.deadline = Instant::now() + timeout`), and
`expect_line_matching_regexes` loops `while !self.past_deadline()`. The test
arms `EXTENDED_LAUNCH_DELAY` (45s) at spawn, then mines
`tx_retention + MAX_BLOCK_REORG_HEIGHT + 50` = 2051 regtest blocks before
waiting for the pruning line. Instrumenting the mining loop shows that phase
alone takes ~52s:

```
PROBE generate(mined=0, batch=250) took 5.29s ok=true
...
PROBE generate(mined=2000, batch=51) took 1.33s ok=true
PROBE mining finished
```

By the time `expect_stdout_line_matches` runs, the deadline has already passed,
so it returns the "no matches within the 45s command timeout" error without
reading a single line. Pruning had in fact happened; the test could never
observe it.

A second defect sits behind the first. `TestChild` reads the child's stdout
lazily, through a blocking `BufRead::lines` iterator that is only pulled inside
an `expect_*` call, so nothing drains the pipe while an RPC is in flight. After
about 250 mined blocks the 64 KiB pipe buffer fills and the node's log writer
parks in `pipe_write` (confirmed by sampling `/proc/<pid>/task/*/wchan`), which
is why the captured output stops at height ~254. Mining still completes, but
the node stops emitting log lines, so the pruning line the test waits for is not
written while the pipe stays full.

## Solution

`native_stream5_status_exchange_uses_handler_wire_path`: use `TEST_NET_TIMEOUT`
for all three waits, matching the rest of the module, and widen the
`await_until` predicate to cover every trace row the following assertions read.
A missing row now reports a named wait timeout instead of an assertion panic.

`pruned_storage_mode_prunes_during_regtest_sync`: re-arm the child deadline with
a `PRUNED_STORAGE_MINING_TIMEOUT` that covers the mining phase, and mine on a
background task so this thread is inside `expect_stdout_line_matches` draining
the log stream for the whole phase. Draining keeps the stdout pipe from filling,
so the node keeps logging and the pruning line is observed as soon as it is
emitted, rather than after a window in which it could not be written at all.

## Testing

Both tests were reproduced failing on a clean `origin/main` worktree and pass
with the fixes:

- `cargo test -p zakura-network --lib
  zakura::testkit::cluster::tests::native_stream5_status_exchange_uses_handler_wire_path`
- `cargo test -p zakura --features default-release-binaries --test acceptance
  pruned_storage_mode_prunes_during_regtest_sync`

## Changelog

Test-only change; no operator- or crate-consumer-visible effect.
