### PR TITLE
fix(miner): cancel stale Equihash work promptly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d#09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d"
+source = "git+https://github.com/valargroup/librustzcash?rev=f02666ca85119be817a336313cd28d3c3a9bc9c4#f02666ca85119be817a336313cd28d3c3a9bc9c4"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -6679,7 +6679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8385,7 +8385,7 @@ dependencies = [
  "dirs",
  "ed25519-zebra",
  "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "equihash 0.3.0 (git+https://github.com/valargroup/librustzcash?rev=09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d)",
+ "equihash 0.3.0 (git+https://github.com/valargroup/librustzcash?rev=f02666ca85119be817a336313cd28d3c3a9bc9c4)",
  "futures",
  "group",
  "halo2_proofs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "cpu-equihash-solver"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=da4cdf609a131c91552ccee88905b6c6dffd4cd8#da4cdf609a131c91552ccee88905b6c6dffd4cd8"
+source = "git+https://github.com/valargroup/librustzcash?rev=658533c4c604818610657d9699e82102e7379c76#658533c4c604818610657d9699e82102e7379c76"
 dependencies = [
  "blake2b_simd",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,9 +1781,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "equihash"
+name = "cpu-equihash-solver"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=f02666ca85119be817a336313cd28d3c3a9bc9c4#f02666ca85119be817a336313cd28d3c3a9bc9c4"
+source = "git+https://github.com/valargroup/librustzcash?rev=f4a671b0e838a63977bac400d426b135e7e342e2#f4a671b0e838a63977bac400d426b135e7e342e2"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -8385,7 +8385,7 @@ dependencies = [
  "dirs",
  "ed25519-zebra",
  "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "equihash 0.3.0 (git+https://github.com/valargroup/librustzcash?rev=f02666ca85119be817a336313cd28d3c3a9bc9c4)",
+ "cpu-equihash-solver",
  "futures",
  "group",
  "halo2_proofs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
+ "corez",
+ "document-features",
+]
+
+[[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d#09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d"
+dependencies = [
+ "blake2b_simd",
  "cc",
  "corez",
  "document-features",
@@ -8374,7 +8384,8 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash 0.3.0 (git+https://github.com/valargroup/librustzcash?rev=09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d)",
  "futures",
  "group",
  "halo2_proofs",
@@ -8873,7 +8884,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "cpu-equihash-solver"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=f4a671b0e838a63977bac400d426b135e7e342e2#f4a671b0e838a63977bac400d426b135e7e342e2"
+source = "git+https://github.com/valargroup/librustzcash?rev=da4cdf609a131c91552ccee88905b6c6dffd4cd8#da4cdf609a131c91552ccee88905b6c6dffd4cd8"
 dependencies = [
  "blake2b_simd",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ derive-new = "0.5"
 dirs = "6.0"
 ed25519-zebra = "4.2"
 equihash = "0.3"
-equihash-solver = { package = "equihash", version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d" }
+equihash-solver = { package = "equihash", version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "f02666ca85119be817a336313cd28d3c3a9bc9c4" }
 ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ derive-new = "0.5"
 dirs = "6.0"
 ed25519-zebra = "4.2"
 equihash = "0.3"
+equihash-solver = { package = "equihash", version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "09fd73db1b49e38ac8830c9ab8a4164bf68eaf7d" }
 ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,11 @@ derive-new = "0.5"
 dirs = "6.0"
 ed25519-zebra = "4.2"
 equihash = "0.3"
-equihash-solver = { package = "equihash", version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "f02666ca85119be817a336313cd28d3c3a9bc9c4" }
+# Temporary fork used only by the `zakura-chain` crate's `internal-miner`
+# feature for interruptible CPU Equihash solving. Consensus verification
+# continues to use registry `equihash`. Replace this dependency with a
+# published upstream release before merging.
+cpu-equihash-solver = { package = "equihash", version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "f02666ca85119be817a336313cd28d3c3a9bc9c4" }
 ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ equihash = "0.3"
 # feature for interruptible CPU Equihash solving. Consensus verification
 # continues to use registry `equihash`. Replace this dependency with a
 # published upstream release before merging.
-cpu-equihash-solver = { version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "f4a671b0e838a63977bac400d426b135e7e342e2" }
+cpu-equihash-solver = { version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "da4cdf609a131c91552ccee88905b6c6dffd4cd8" }
 ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ equihash = "0.3"
 # feature for interruptible CPU Equihash solving. Consensus verification
 # continues to use registry `equihash`. Replace this dependency with a
 # published upstream release before merging.
-cpu-equihash-solver = { package = "equihash", version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "f02666ca85119be817a336313cd28d3c3a9bc9c4" }
+cpu-equihash-solver = { version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "f4a671b0e838a63977bac400d426b135e7e342e2" }
 ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ equihash = "0.3"
 # feature for interruptible CPU Equihash solving. Consensus verification
 # continues to use registry `equihash`. Replace this dependency with a
 # published upstream release before merging.
-cpu-equihash-solver = { version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "da4cdf609a131c91552ccee88905b6c6dffd4cd8" }
+cpu-equihash-solver = { version = "0.3", git = "https://github.com/valargroup/librustzcash", rev = "658533c4c604818610657d9699e82102e7379c76" }
 ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -31,7 +31,7 @@ async-error = [
 ]
 
 # Experimental internal miner support
-internal-miner = ["equihash/solver"]
+internal-miner = ["dep:equihash-solver"]
 
 # Test-only features
 
@@ -60,6 +60,7 @@ bs58 = { workspace = true, features = ["check"] }
 byteorder = { workspace = true }
 
 equihash = { workspace = true }
+equihash-solver = { workspace = true, optional = true, features = ["solver"] }
 
 group = { workspace = true }
 incrementalmerkletree.workspace = true

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -31,7 +31,7 @@ async-error = [
 ]
 
 # Experimental internal miner support
-internal-miner = ["dep:equihash-solver"]
+internal-miner = ["dep:cpu-equihash-solver"]
 
 # Test-only features
 
@@ -60,7 +60,7 @@ bs58 = { workspace = true, features = ["check"] }
 byteorder = { workspace = true }
 
 equihash = { workspace = true }
-equihash-solver = { workspace = true, optional = true, features = ["solver"] }
+cpu-equihash-solver = { workspace = true, optional = true, features = ["solver"] }
 
 group = { workspace = true }
 incrementalmerkletree.workspace = true

--- a/crates/zakura-chain/src/local_genesis.rs
+++ b/crates/zakura-chain/src/local_genesis.rs
@@ -348,9 +348,11 @@ fn build_block(
 fn solve_header(header: Header) -> Result<Header, crate::BoxError> {
     #[cfg(feature = "internal-miner")]
     {
-        let cancel_fn = || Ok(());
+        use crate::work::equihash::SolverAction;
+
+        let solver_action = || SolverAction::Continue;
         let solved_headers =
-            Solution::solve(header, cancel_fn).map_err(|_| "Equihash solver was cancelled")?;
+            Solution::solve(header, solver_action).map_err(|_| "Equihash solver was cancelled")?;
         solved_headers
             .into_iter()
             .next()

--- a/crates/zakura-chain/src/local_genesis.rs
+++ b/crates/zakura-chain/src/local_genesis.rs
@@ -348,11 +348,9 @@ fn build_block(
 fn solve_header(header: Header) -> Result<Header, crate::BoxError> {
     #[cfg(feature = "internal-miner")]
     {
-        use crate::work::equihash::SolverAction;
-
-        let solver_action = || SolverAction::Continue;
+        let cancel_fn = || Ok(());
         let solved_headers =
-            Solution::solve(header, solver_action).map_err(|_| "Equihash solver was cancelled")?;
+            Solution::solve(header, cancel_fn).map_err(|_| "Equihash solver was cancelled")?;
         solved_headers
             .into_iter()
             .next()

--- a/crates/zakura-chain/src/work/equihash.rs
+++ b/crates/zakura-chain/src/work/equihash.rs
@@ -41,6 +41,33 @@ pub enum Error {
 #[error("solver was cancelled")]
 pub struct SolverCancelled;
 
+/// How a solver run should react to a change while it is in flight.
+#[cfg(feature = "internal-miner")]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SolverAction {
+    /// Keep hashing.
+    Continue,
+    /// Finish the current nonce, then stop before starting another one.
+    StopAtNonceBoundary,
+    /// Stop at the next digit boundary and discard the current nonce.
+    StopNow,
+}
+
+#[cfg(feature = "internal-miner")]
+fn should_cancel_at(
+    point: equihash_solver::tromp::CancellationPoint,
+    action: SolverAction,
+) -> bool {
+    matches!(
+        (point, action),
+        (_, SolverAction::StopNow)
+            | (
+                equihash_solver::tromp::CancellationPoint::NonceBoundary,
+                SolverAction::StopAtNonceBoundary,
+            )
+    )
+}
+
 /// The size of an Equihash solution in bytes (always 1344).
 pub(crate) const SOLUTION_SIZE: usize = 1344;
 
@@ -185,7 +212,7 @@ impl Solution {
     /// Mines and returns one or more [`Solution`]s based on a template `header`.
     /// The returned header contains a valid `nonce` and `solution`.
     ///
-    /// If `cancel_fn()` returns an error, returns early with `Err(SolverCancelled)`.
+    /// Returns early with `Err(SolverCancelled)` when `solver_action()` requests a stop.
     ///
     /// The `nonce` in the header template is taken as the starting nonce. If you are running multiple
     /// solvers at the same time, start them with different nonces.
@@ -197,10 +224,10 @@ impl Solution {
     #[allow(clippy::unwrap_in_result)]
     pub fn solve<F>(
         mut header: Header,
-        mut cancel_fn: F,
+        mut solver_action: F,
     ) -> Result<AtLeastOne<Header>, SolverCancelled>
     where
-        F: FnMut() -> Result<(), SolverCancelled>,
+        F: FnMut() -> SolverAction,
     {
         use crate::shutdown::is_shutting_down;
 
@@ -214,18 +241,38 @@ impl Solution {
 
         while !is_shutting_down() {
             // Don't run the solver if we'd just cancel it anyway.
-            cancel_fn()?;
+            if solver_action() != SolverAction::Continue {
+                return Err(SolverCancelled);
+            }
 
-            let solutions = equihash::tromp::solve_200_9(input, || {
-                // Cancel the solver if we have a new template.
-                if cancel_fn().is_err() {
-                    return None;
+            let solve_result = equihash_solver::tromp::solve_200_9_cancellable(
+                input,
+                || {
+                    // This skips the first nonce, which doesn't matter in practice.
+                    Self::next_nonce(&mut header.nonce);
+                    Some(*header.nonce)
+                },
+                |point| {
+                    if is_shutting_down() {
+                        return true;
+                    }
+
+                    should_cancel_at(point, solver_action())
+                },
+            );
+
+            let solutions = match solve_result.into_outcome() {
+                equihash_solver::tromp::CancellableSolveOutcome::Completed(solutions) => solutions,
+                equihash_solver::tromp::CancellableSolveOutcome::Cancelled => {
+                    return Err(SolverCancelled);
                 }
+            };
 
-                // This skips the first nonce, which doesn't matter in practice.
-                Self::next_nonce(&mut header.nonce);
-                Some(*header.nonce)
-            });
+            // Give an invalidating update precedence over a solution that raced
+            // with the callback after the final digit.
+            if solver_action() == SolverAction::StopNow {
+                return Err(SolverCancelled);
+            }
 
             let mut valid_solutions = Vec::new();
 
@@ -373,5 +420,40 @@ impl FromHex for Solution {
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
         let bytes = Vec::from_hex(hex)?;
         Solution::from_bytes(&bytes).map_err(|_| FromHexError::InvalidStringLength)
+    }
+}
+
+#[cfg(all(test, feature = "internal-miner"))]
+mod tests {
+    use equihash_solver::tromp::CancellationPoint;
+
+    use super::{should_cancel_at, SolverAction};
+
+    #[test]
+    fn solver_actions_have_distinct_cancellation_boundaries() {
+        assert!(!should_cancel_at(
+            CancellationPoint::NonceBoundary,
+            SolverAction::Continue
+        ));
+        assert!(!should_cancel_at(
+            CancellationPoint::DigitBoundary,
+            SolverAction::Continue
+        ));
+        assert!(should_cancel_at(
+            CancellationPoint::NonceBoundary,
+            SolverAction::StopAtNonceBoundary
+        ));
+        assert!(!should_cancel_at(
+            CancellationPoint::DigitBoundary,
+            SolverAction::StopAtNonceBoundary
+        ));
+        assert!(should_cancel_at(
+            CancellationPoint::NonceBoundary,
+            SolverAction::StopNow
+        ));
+        assert!(should_cancel_at(
+            CancellationPoint::DigitBoundary,
+            SolverAction::StopNow
+        ));
     }
 }

--- a/crates/zakura-chain/src/work/equihash.rs
+++ b/crates/zakura-chain/src/work/equihash.rs
@@ -212,7 +212,7 @@ impl Solution {
     /// Mines and returns one or more [`Solution`]s based on a template `header`.
     /// The returned header contains a valid `nonce` and `solution`.
     ///
-    /// Returns early with `Err(SolverCancelled)` when `solver_action()` requests a stop.
+    /// If `cancel_fn()` returns an error, returns early with `Err(SolverCancelled)`.
     ///
     /// The `nonce` in the header template is taken as the starting nonce. If you are running multiple
     /// solvers at the same time, start them with different nonces.
@@ -222,7 +222,26 @@ impl Solution {
     /// It can run for minutes or hours if the network difficulty is high.
     #[cfg(feature = "internal-miner")]
     #[allow(clippy::unwrap_in_result)]
-    pub fn solve<F>(
+    pub fn solve<F>(header: Header, mut cancel_fn: F) -> Result<AtLeastOne<Header>, SolverCancelled>
+    where
+        F: FnMut() -> Result<(), SolverCancelled>,
+    {
+        Self::solve_cancellable(header, || {
+            if cancel_fn().is_ok() {
+                SolverAction::Continue
+            } else {
+                SolverAction::StopAtNonceBoundary
+            }
+        })
+    }
+
+    /// Mines and returns one or more [`Solution`]s based on a template `header`.
+    ///
+    /// `solver_action()` can preserve the current nonce, stop before the next
+    /// nonce, or discard the current nonce at the next digit boundary.
+    #[cfg(feature = "internal-miner")]
+    #[allow(clippy::unwrap_in_result)]
+    pub fn solve_cancellable<F>(
         mut header: Header,
         mut solver_action: F,
     ) -> Result<AtLeastOne<Header>, SolverCancelled>

--- a/crates/zakura-chain/src/work/equihash.rs
+++ b/crates/zakura-chain/src/work/equihash.rs
@@ -15,7 +15,10 @@ use crate::{
 };
 
 #[cfg(feature = "internal-miner")]
-use crate::serialization::AtLeastOne;
+mod internal_miner;
+
+#[cfg(feature = "internal-miner")]
+pub use internal_miner::{SolverAction, SolverCancelled};
 
 /// The error type for Equihash validation.
 #[non_exhaustive]
@@ -34,38 +37,6 @@ pub enum Error {
         /// The network whose Equihash parameters the solution violated.
         network: Network,
     },
-}
-
-/// The error type for Equihash solving.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, thiserror::Error)]
-#[error("solver was cancelled")]
-pub struct SolverCancelled;
-
-/// How a solver run should react to a change while it is in flight.
-#[cfg(feature = "internal-miner")]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SolverAction {
-    /// Keep hashing.
-    Continue,
-    /// Finish the current nonce, then stop before starting another one.
-    StopAtNonceBoundary,
-    /// Stop at the next digit boundary and discard the current nonce.
-    StopNow,
-}
-
-#[cfg(feature = "internal-miner")]
-fn should_cancel_at(
-    point: cpu_equihash_solver::tromp::CancellationPoint,
-    action: SolverAction,
-) -> bool {
-    matches!(
-        (point, action),
-        (_, SolverAction::StopNow)
-            | (
-                cpu_equihash_solver::tromp::CancellationPoint::NonceBoundary,
-                SolverAction::StopAtNonceBoundary,
-            )
-    )
 }
 
 /// The size of an Equihash solution in bytes (always 1344).
@@ -208,153 +179,6 @@ impl Solution {
             Self::for_proposal()
         }
     }
-
-    /// Mines and returns one or more [`Solution`]s based on a template `header`.
-    /// The returned header contains a valid `nonce` and `solution`.
-    ///
-    /// If `cancel_fn()` returns an error, returns early with `Err(SolverCancelled)`.
-    ///
-    /// The `nonce` in the header template is taken as the starting nonce. If you are running multiple
-    /// solvers at the same time, start them with different nonces.
-    /// The `solution` in the header template is ignored.
-    ///
-    /// This method is CPU and memory-intensive. It uses 144 MB of RAM and one CPU core while running.
-    /// It can run for minutes or hours if the network difficulty is high.
-    #[cfg(feature = "internal-miner")]
-    #[allow(clippy::unwrap_in_result)]
-    pub fn solve<F>(header: Header, mut cancel_fn: F) -> Result<AtLeastOne<Header>, SolverCancelled>
-    where
-        F: FnMut() -> Result<(), SolverCancelled>,
-    {
-        Self::solve_cancellable(header, || {
-            if cancel_fn().is_ok() {
-                SolverAction::Continue
-            } else {
-                SolverAction::StopAtNonceBoundary
-            }
-        })
-    }
-
-    /// Mines and returns one or more [`Solution`]s based on a template `header`.
-    ///
-    /// `solver_action()` can preserve the current nonce, stop before the next
-    /// nonce, or discard the current nonce at the next digit boundary.
-    #[cfg(feature = "internal-miner")]
-    #[allow(clippy::unwrap_in_result)]
-    pub fn solve_cancellable<F>(
-        mut header: Header,
-        mut solver_action: F,
-    ) -> Result<AtLeastOne<Header>, SolverCancelled>
-    where
-        F: FnMut() -> SolverAction,
-    {
-        use crate::shutdown::is_shutting_down;
-
-        let mut input = Vec::new();
-        header
-            .zcash_serialize(&mut input)
-            .expect("serialization into a vec can't fail");
-        // Take the part of the header before the nonce and solution.
-        // This data is kept constant for this solver run.
-        let input = &input[0..Solution::INPUT_LENGTH];
-
-        while !is_shutting_down() {
-            // Don't run the solver if we'd just cancel it anyway.
-            if solver_action() != SolverAction::Continue {
-                return Err(SolverCancelled);
-            }
-
-            let solve_result = cpu_equihash_solver::tromp::solve_200_9_cancellable(
-                input,
-                || {
-                    // This skips the first nonce, which doesn't matter in practice.
-                    Self::next_nonce(&mut header.nonce);
-                    Some(*header.nonce)
-                },
-                |point| {
-                    if is_shutting_down() {
-                        return true;
-                    }
-
-                    should_cancel_at(point, solver_action())
-                },
-            );
-
-            let solutions = match solve_result.into_outcome() {
-                cpu_equihash_solver::tromp::CancellableSolveOutcome::Completed(solutions) => {
-                    solutions
-                }
-                cpu_equihash_solver::tromp::CancellableSolveOutcome::Cancelled => {
-                    return Err(SolverCancelled);
-                }
-            };
-
-            // Give an invalidating update precedence over a solution that raced
-            // with the callback after the final digit.
-            if solver_action() == SolverAction::StopNow {
-                return Err(SolverCancelled);
-            }
-
-            let mut valid_solutions = Vec::new();
-
-            for solution in &solutions {
-                header.solution = Self::from_bytes(solution)
-                    .expect("unexpected invalid solution: incorrect length");
-
-                // TODO: work out why we sometimes get invalid solutions here
-                //
-                // The solver only ever produces (200, 9) `Common` solutions
-                // (see `solve_200_9` above), so verify against those parameters
-                // directly rather than binding to a network.
-                if let Err(error) = header.solution.check_equihash(&header, 200, 9) {
-                    info!(?error, "found invalid solution for header");
-                    continue;
-                }
-
-                if Self::difficulty_is_valid(&header) {
-                    valid_solutions.push(header);
-                }
-            }
-
-            match valid_solutions.try_into() {
-                Ok(at_least_one_solution) => return Ok(at_least_one_solution),
-                Err(_is_empty_error) => debug!(
-                    solutions = ?solutions.len(),
-                    "found valid solutions which did not pass the validity or difficulty checks"
-                ),
-            }
-        }
-
-        Err(SolverCancelled)
-    }
-
-    /// Returns `true` if the `nonce` and `solution` in `header` meet the difficulty threshold.
-    ///
-    /// # Panics
-    ///
-    /// - If `header` contains an invalid difficulty threshold.
-    #[cfg(feature = "internal-miner")]
-    fn difficulty_is_valid(header: &Header) -> bool {
-        // Simplified from zakura_consensus::block::check::difficulty_is_valid().
-        let difficulty_threshold = header
-            .difficulty_threshold
-            .to_expanded()
-            .expect("unexpected invalid header template: invalid difficulty threshold");
-
-        // TODO: avoid calculating this hash multiple times
-        let hash = header.hash();
-
-        // Note: this comparison is a u256 integer comparison, like zcashd and bitcoin. Greater
-        // values represent *less* work.
-        hash <= difficulty_threshold
-    }
-
-    /// Modifies `nonce` to be the next integer in big-endian order.
-    /// Wraps to zero if the next nonce would overflow.
-    #[cfg(feature = "internal-miner")]
-    fn next_nonce(nonce: &mut [u8; 32]) {
-        let _ignore_overflow = crate::primitives::byte_array::increment_big_endian(&mut nonce[..]);
-    }
 }
 
 impl PartialEq<Solution> for Solution {
@@ -441,40 +265,5 @@ impl FromHex for Solution {
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
         let bytes = Vec::from_hex(hex)?;
         Solution::from_bytes(&bytes).map_err(|_| FromHexError::InvalidStringLength)
-    }
-}
-
-#[cfg(all(test, feature = "internal-miner"))]
-mod tests {
-    use cpu_equihash_solver::tromp::CancellationPoint;
-
-    use super::{should_cancel_at, SolverAction};
-
-    #[test]
-    fn solver_actions_have_distinct_cancellation_boundaries() {
-        assert!(!should_cancel_at(
-            CancellationPoint::NonceBoundary,
-            SolverAction::Continue
-        ));
-        assert!(!should_cancel_at(
-            CancellationPoint::DigitBoundary,
-            SolverAction::Continue
-        ));
-        assert!(should_cancel_at(
-            CancellationPoint::NonceBoundary,
-            SolverAction::StopAtNonceBoundary
-        ));
-        assert!(!should_cancel_at(
-            CancellationPoint::DigitBoundary,
-            SolverAction::StopAtNonceBoundary
-        ));
-        assert!(should_cancel_at(
-            CancellationPoint::NonceBoundary,
-            SolverAction::StopNow
-        ));
-        assert!(should_cancel_at(
-            CancellationPoint::DigitBoundary,
-            SolverAction::StopNow
-        ));
     }
 }

--- a/crates/zakura-chain/src/work/equihash.rs
+++ b/crates/zakura-chain/src/work/equihash.rs
@@ -55,14 +55,14 @@ pub enum SolverAction {
 
 #[cfg(feature = "internal-miner")]
 fn should_cancel_at(
-    point: equihash_solver::tromp::CancellationPoint,
+    point: cpu_equihash_solver::tromp::CancellationPoint,
     action: SolverAction,
 ) -> bool {
     matches!(
         (point, action),
         (_, SolverAction::StopNow)
             | (
-                equihash_solver::tromp::CancellationPoint::NonceBoundary,
+                cpu_equihash_solver::tromp::CancellationPoint::NonceBoundary,
                 SolverAction::StopAtNonceBoundary,
             )
     )
@@ -264,7 +264,7 @@ impl Solution {
                 return Err(SolverCancelled);
             }
 
-            let solve_result = equihash_solver::tromp::solve_200_9_cancellable(
+            let solve_result = cpu_equihash_solver::tromp::solve_200_9_cancellable(
                 input,
                 || {
                     // This skips the first nonce, which doesn't matter in practice.
@@ -281,8 +281,10 @@ impl Solution {
             );
 
             let solutions = match solve_result.into_outcome() {
-                equihash_solver::tromp::CancellableSolveOutcome::Completed(solutions) => solutions,
-                equihash_solver::tromp::CancellableSolveOutcome::Cancelled => {
+                cpu_equihash_solver::tromp::CancellableSolveOutcome::Completed(solutions) => {
+                    solutions
+                }
+                cpu_equihash_solver::tromp::CancellableSolveOutcome::Cancelled => {
                     return Err(SolverCancelled);
                 }
             };
@@ -444,7 +446,7 @@ impl FromHex for Solution {
 
 #[cfg(all(test, feature = "internal-miner"))]
 mod tests {
-    use equihash_solver::tromp::CancellationPoint;
+    use cpu_equihash_solver::tromp::CancellationPoint;
 
     use super::{should_cancel_at, SolverAction};
 

--- a/crates/zakura-chain/src/work/equihash/internal_miner.rs
+++ b/crates/zakura-chain/src/work/equihash/internal_miner.rs
@@ -1,0 +1,212 @@
+//! Fork-backed Equihash solving for the experimental internal miner.
+
+use cpu_equihash_solver::tromp::{
+    solve_200_9_cancellable, CancellableSolveOutcome, CancellationPoint,
+};
+
+use crate::{
+    block::Header,
+    serialization::{AtLeastOne, ZcashSerialize},
+    shutdown::is_shutting_down,
+};
+
+use super::Solution;
+
+/// The error type for Equihash solving.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("solver was cancelled")]
+pub struct SolverCancelled;
+
+/// How a solver run should react to a change while it is in flight.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SolverAction {
+    /// Keep hashing.
+    Continue,
+    /// Finish the current nonce, then stop before starting another one.
+    StopAtNonceBoundary,
+    /// Stop at the next digit boundary and discard the current nonce.
+    StopNow,
+}
+
+fn should_cancel_at(point: CancellationPoint, action: SolverAction) -> bool {
+    matches!(
+        (point, action),
+        (_, SolverAction::StopNow)
+            | (
+                CancellationPoint::NonceBoundary,
+                SolverAction::StopAtNonceBoundary,
+            )
+    )
+}
+
+impl Solution {
+    /// Mines and returns one or more [`Solution`]s based on a template `header`.
+    /// The returned header contains a valid `nonce` and solution.
+    ///
+    /// If `cancel_fn()` returns an error, returns early with [`SolverCancelled`].
+    ///
+    /// The `nonce` in the header template is taken as the starting nonce. If you are running multiple
+    /// solvers at the same time, start them with different nonces.
+    /// The solution in the header template is ignored.
+    ///
+    /// This method is CPU and memory-intensive. It uses 144 MB of RAM and one CPU core while running.
+    /// It can run for minutes or hours if the network difficulty is high.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn solve<F>(header: Header, mut cancel_fn: F) -> Result<AtLeastOne<Header>, SolverCancelled>
+    where
+        F: FnMut() -> Result<(), SolverCancelled>,
+    {
+        Self::solve_cancellable(header, || {
+            if cancel_fn().is_ok() {
+                SolverAction::Continue
+            } else {
+                SolverAction::StopAtNonceBoundary
+            }
+        })
+    }
+
+    /// Mines and returns one or more [`Solution`]s based on a template `header`.
+    ///
+    /// `solver_action()` can preserve the current nonce, stop before the next
+    /// nonce, or discard the current nonce at the next digit boundary.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn solve_cancellable<F>(
+        mut header: Header,
+        mut solver_action: F,
+    ) -> Result<AtLeastOne<Header>, SolverCancelled>
+    where
+        F: FnMut() -> SolverAction,
+    {
+        let mut input = Vec::new();
+        header
+            .zcash_serialize(&mut input)
+            .expect("serialization into a vec can't fail");
+        // Take the part of the header before the nonce and solution.
+        // This data is kept constant for this solver run.
+        let input = &input[0..Solution::INPUT_LENGTH];
+
+        while !is_shutting_down() {
+            // Don't run the solver if we'd just cancel it anyway.
+            if solver_action() != SolverAction::Continue {
+                return Err(SolverCancelled);
+            }
+
+            let solve_result = solve_200_9_cancellable(
+                input,
+                || {
+                    // This skips the first nonce, which doesn't matter in practice.
+                    Self::next_nonce(&mut header.nonce);
+                    Some(*header.nonce)
+                },
+                |point| {
+                    if is_shutting_down() {
+                        return true;
+                    }
+
+                    should_cancel_at(point, solver_action())
+                },
+            );
+
+            let solutions = match solve_result.into_outcome() {
+                CancellableSolveOutcome::Completed(solutions) => solutions,
+                CancellableSolveOutcome::Cancelled => return Err(SolverCancelled),
+            };
+
+            // Give an invalidating update precedence over a solution that raced
+            // with the callback after the final digit.
+            if solver_action() == SolverAction::StopNow {
+                return Err(SolverCancelled);
+            }
+
+            let mut valid_solutions = Vec::new();
+
+            for solution in &solutions {
+                header.solution = Self::from_bytes(solution)
+                    .expect("unexpected invalid solution: incorrect length");
+
+                // TODO: work out why we sometimes get invalid solutions here
+                //
+                // The solver only ever produces (200, 9) `Common` solutions,
+                // so verify against those parameters directly rather than
+                // binding to a network.
+                if let Err(error) = header.solution.check_equihash(&header, 200, 9) {
+                    info!(?error, "found invalid solution for header");
+                    continue;
+                }
+
+                if Self::difficulty_is_valid(&header) {
+                    valid_solutions.push(header);
+                }
+            }
+
+            match valid_solutions.try_into() {
+                Ok(at_least_one_solution) => return Ok(at_least_one_solution),
+                Err(_is_empty_error) => debug!(
+                    solutions = ?solutions.len(),
+                    "found valid solutions which did not pass the validity or difficulty checks"
+                ),
+            }
+        }
+
+        Err(SolverCancelled)
+    }
+
+    /// Returns `true` if the `nonce` and solution in `header` meet the difficulty threshold.
+    ///
+    /// # Panics
+    ///
+    /// - If `header` contains an invalid difficulty threshold.
+    fn difficulty_is_valid(header: &Header) -> bool {
+        // Simplified from zakura_consensus::block::check::difficulty_is_valid().
+        let difficulty_threshold = header
+            .difficulty_threshold
+            .to_expanded()
+            .expect("unexpected invalid header template: invalid difficulty threshold");
+
+        // TODO: avoid calculating this hash multiple times
+        let hash = header.hash();
+
+        // Note: this comparison is a u256 integer comparison, like zcashd and bitcoin. Greater
+        // values represent *less* work.
+        hash <= difficulty_threshold
+    }
+
+    /// Modifies `nonce` to be the next integer in big-endian order.
+    /// Wraps to zero if the next nonce would overflow.
+    fn next_nonce(nonce: &mut [u8; 32]) {
+        let _ignore_overflow = crate::primitives::byte_array::increment_big_endian(&mut nonce[..]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_cancel_at, CancellationPoint, SolverAction};
+
+    #[test]
+    fn solver_actions_have_distinct_cancellation_boundaries() {
+        assert!(!should_cancel_at(
+            CancellationPoint::NonceBoundary,
+            SolverAction::Continue
+        ));
+        assert!(!should_cancel_at(
+            CancellationPoint::DigitBoundary,
+            SolverAction::Continue
+        ));
+        assert!(should_cancel_at(
+            CancellationPoint::NonceBoundary,
+            SolverAction::StopAtNonceBoundary
+        ));
+        assert!(!should_cancel_at(
+            CancellationPoint::DigitBoundary,
+            SolverAction::StopAtNonceBoundary
+        ));
+        assert!(should_cancel_at(
+            CancellationPoint::NonceBoundary,
+            SolverAction::StopNow
+        ));
+        assert!(should_cancel_at(
+            CancellationPoint::DigitBoundary,
+            SolverAction::StopNow
+        ));
+    }
+}

--- a/crates/zakura-state/src/service/watch_receiver.rs
+++ b/crates/zakura-state/src/service/watch_receiver.rs
@@ -114,6 +114,14 @@ where
         self.receiver.borrow().clone()
     }
 
+    /// Returns a clone of the latest watch data and marks that version as seen.
+    ///
+    /// The clone and version update happen while holding the same read lock, so
+    /// callers cannot acknowledge a newer value than the one they receive.
+    pub fn cloned_watch_data_and_update(&mut self) -> T {
+        self.receiver.borrow_and_update().clone()
+    }
+
     /// Calls [`watch::Receiver::changed()`] and returns the result.
     /// Returns when the inner value has been updated, even if the old and new values are equal.
     ///
@@ -139,5 +147,29 @@ where
     /// Calls [`watch::Receiver::mark_changed()`].
     pub fn mark_changed(&mut self) {
         self.receiver.mark_changed();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::watch;
+
+    use super::WatchReceiver;
+
+    #[test]
+    fn cloned_watch_data_and_update_acknowledges_the_returned_version() {
+        let (sender, receiver) = watch::channel(1);
+        let mut receiver = WatchReceiver::new(receiver);
+
+        sender.send(2).expect("receiver remains open");
+
+        assert_eq!(receiver.cloned_watch_data_and_update(), 2);
+        assert!(!receiver.has_changed().expect("sender remains open"));
+
+        sender.send(3).expect("receiver remains open");
+
+        assert!(receiver.has_changed().expect("sender remains open"));
+        assert_eq!(receiver.cloned_watch_data_and_update(), 3);
+        assert!(!receiver.has_changed().expect("sender remains open"));
     }
 }

--- a/crates/zakurad/src/components/miner.rs
+++ b/crates/zakurad/src/components/miner.rs
@@ -22,7 +22,7 @@ use zakura_chain::{
     diagnostic::task::WaitForPanics,
     serialization::{AtLeastOne, ZcashSerialize},
     shutdown::is_shutting_down,
-    work::equihash::{Solution, SolverCancelled},
+    work::equihash::{Solution, SolverAction, SolverCancelled},
 };
 use zakura_network::AddressBookPeers;
 use zakura_node_services::mempool;
@@ -63,11 +63,11 @@ fn should_replace_mining_template(
     current_header != Some(new_header) && (current_header.is_none() || submit_old != Some(true))
 }
 
-/// Cancels mining when the current template changes or becomes unavailable.
-fn cancel_if_mining_template_changed(
+/// Returns the solver action for a template change or unavailable template.
+fn mining_template_solver_action(
     template_receiver: &mut WatchReceiver<Option<Arc<Block>>>,
     old_header: block::Header,
-) -> Result<(), SolverCancelled> {
+) -> SolverAction {
     match template_receiver.has_changed() {
         // Guard against `get_block_template()` providing an identical header.
         // This could happen if something irrelevant to the block data changes,
@@ -81,14 +81,14 @@ fn cancel_if_mining_template_changed(
             if has_changed
                 && Some(old_header) != template_receiver.cloned_watch_data().map(|b| *b.header)
             {
-                Err(SolverCancelled)
+                SolverAction::StopNow
             } else {
-                Ok(())
+                SolverAction::Continue
             }
         }
         // If the sender was dropped, we're likely shutting down, so cancel the
         // solver.
-        Err(_sender_dropped) => Err(SolverCancelled),
+        Err(_sender_dropped) => SolverAction::StopNow,
     }
 }
 
@@ -514,11 +514,12 @@ where
 
         // Set up the cancellation conditions for the miner.
         let mut cancel_receiver = template_receiver.clone();
+        let mut stale_check_receiver = template_receiver.clone();
         let old_header = *template.header;
-        let cancel_fn = move || cancel_if_mining_template_changed(&mut cancel_receiver, old_header);
+        let solver_action = move || mining_template_solver_action(&mut cancel_receiver, old_header);
 
         // Mine at least one block using the equihash solver.
-        let Ok(blocks) = mine_a_block(solver_id, template, cancel_fn).await else {
+        let Ok(blocks) = mine_a_block(solver_id, template, solver_action).await else {
             // If the solver was cancelled, we're either shutting down, or we have a new template.
             if solver_id == 0 {
                 info!(
@@ -548,12 +549,20 @@ where
         };
 
         // Submit the newly mined blocks to the verifiers.
-        //
-        // TODO: if there is a new template (`cancel_fn().is_err()`), and
-        //       GetBlockTemplate.submit_old is false, return immediately, and skip submitting the
-        //       blocks.
         let mut any_success = false;
         for block in blocks {
+            if mining_template_solver_action(&mut stale_check_receiver, old_header)
+                == SolverAction::StopNow
+            {
+                info!(
+                    ?height,
+                    hash = ?block.hash(),
+                    ?solver_id,
+                    "discarding a solution for a stale mining template",
+                );
+                break;
+            }
+
             let data = block
                 .zcash_serialize_to_vec()
                 .expect("serializing to Vec never fails");
@@ -606,16 +615,16 @@ where
 /// and returns as soon as it has at least one block. Uses a different nonce range for each
 /// `solver_id`.
 ///
-/// If `cancel_fn()` returns an error, returns early with `Err(SolverCancelled)`.
+/// Returns early with `Err(SolverCancelled)` when `solver_action()` requests a stop.
 ///
 /// See [`run_mining_solver()`] for more details.
 pub async fn mine_a_block<F>(
     solver_id: u8,
     template: Arc<Block>,
-    cancel_fn: F,
+    solver_action: F,
 ) -> Result<AtLeastOne<Block>, SolverCancelled>
 where
-    F: FnMut() -> Result<(), SolverCancelled> + Send + Sync + 'static,
+    F: FnMut() -> SolverAction + Send + Sync + 'static,
 {
     // TODO: Replace with Arc::unwrap_or_clone() when it stabilises:
     // https://github.com/rust-lang/rust/issues/93610
@@ -636,7 +645,7 @@ where
                     info!(?error, "could not set miner to run at a low priority: running at default priority");
                 }
 
-                Solution::solve(header, cancel_fn)
+                Solution::solve(header, solver_action)
             }).expect("unable to spawn miner thread");
 
             miner_thread_handle.wait_for_panics()
@@ -720,15 +729,48 @@ mod tests {
         template_sender
             .send(Some(block))
             .expect("template receiver remains open");
-        assert!(cancel_if_mining_template_changed(&mut template_receiver, old_header).is_ok());
+        assert_eq!(
+            mining_template_solver_action(&mut template_receiver, old_header),
+            SolverAction::Continue
+        );
 
         template_sender
             .send(None)
             .expect("template receiver remains open");
-        assert!(matches!(
-            cancel_if_mining_template_changed(&mut template_receiver, old_header),
-            Err(SolverCancelled)
-        ));
+        assert_eq!(
+            mining_template_solver_action(&mut template_receiver, old_header),
+            SolverAction::StopNow
+        );
+    }
+
+    #[test]
+    fn stale_check_observes_a_change_seen_by_the_solver() {
+        let block = zakura_test::vectors::BLOCK_MAINNET_1_BYTES
+            .zcash_deserialize_into::<Arc<Block>>()
+            .expect("block 1 deserializes");
+        let old_header = *block.header;
+        let mut changed_block = (*block).clone();
+        let mut changed_header = old_header;
+        changed_header.nonce.0[0] ^= 1;
+        changed_block.header = Arc::new(changed_header);
+
+        let (template_sender, template_receiver) = watch::channel(Some(block));
+        let mut solver_receiver = WatchReceiver::new(template_receiver.clone());
+        let mut stale_check_receiver = WatchReceiver::new(template_receiver);
+
+        template_sender
+            .send(Some(Arc::new(changed_block)))
+            .expect("template receivers remain open");
+
+        assert_eq!(
+            mining_template_solver_action(&mut solver_receiver, old_header),
+            SolverAction::StopNow
+        );
+        assert_eq!(
+            mining_template_solver_action(&mut stale_check_receiver, old_header),
+            SolverAction::StopNow,
+            "the submission guard must observe an update after the solver consumes it"
+        );
     }
 
     #[tokio::test]

--- a/crates/zakurad/src/components/miner.rs
+++ b/crates/zakurad/src/components/miner.rs
@@ -645,7 +645,7 @@ where
                     info!(?error, "could not set miner to run at a low priority: running at default priority");
                 }
 
-                Solution::solve(header, solver_action)
+                Solution::solve_cancellable(header, solver_action)
             }).expect("unable to spawn miner thread");
 
             miner_thread_handle.wait_for_panics()

--- a/crates/zakurad/src/components/miner.rs
+++ b/crates/zakurad/src/components/miner.rs
@@ -68,27 +68,25 @@ fn mining_template_solver_action(
     template_receiver: &mut WatchReceiver<Option<Arc<Block>>>,
     old_header: block::Header,
 ) -> SolverAction {
-    match template_receiver.has_changed() {
-        // Guard against `get_block_template()` providing an identical header.
-        // This could happen if something irrelevant to the block data changes,
-        // the time was within 1 second, or there is a spurious channel change.
-        Ok(has_changed) => {
-            template_receiver.mark_as_seen();
+    loop {
+        let current_header = template_receiver
+            .cloned_watch_data_and_update()
+            .map(|block| *block.header);
 
-            // We only need to check header equality, because the block data is
-            // bound to the header. An unavailable template has no header, so it
-            // also cancels current work.
-            if has_changed
-                && Some(old_header) != template_receiver.cloned_watch_data().map(|b| *b.header)
-            {
-                SolverAction::StopNow
-            } else {
-                SolverAction::Continue
-            }
+        // We only need to check header equality, because the block data is bound
+        // to the header. An unavailable template has no header, so it also
+        // cancels current work.
+        if current_header != Some(old_header) {
+            return SolverAction::StopNow;
         }
-        // If the sender was dropped, we're likely shutting down, so cancel the
-        // solver.
-        Err(_sender_dropped) => SolverAction::StopNow,
+
+        match template_receiver.has_changed() {
+            // Re-read an update that raced with the acknowledged snapshot.
+            Ok(true) => continue,
+            Ok(false) => return SolverAction::Continue,
+            // If the sender was dropped, we're likely shutting down.
+            Err(_sender_dropped) => return SolverAction::StopNow,
+        }
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -203,7 +203,10 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = [
+    # Temporary internal-miner dependency, pinned to a reviewed commit.
+    "https://github.com/valargroup/librustzcash",
+]
 
 [sources.allow-org]
 github = [

--- a/docs/changelog/unreleased/643.md
+++ b/docs/changelog/unreleased/643.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Stopped the internal miner from submitting solutions for stale templates and
+  reduced stale work by cancelling between Equihash digit rounds
+  ([#643](https://github.com/zakura-core/zakura/pull/643)).

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -434,6 +434,11 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 notes = "Replacement for the yanked core2 crate; pulled in transitively by librustzcash 2026-04 release wave."
 
+[[exemptions.cpu-equihash-solver]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+notes = "Temporary internal-miner fork pinned to a reviewed valargroup/librustzcash commit."
+
 [[exemptions.cpufeatures]]
 version = "0.2.12"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Motivation

Not sure if we want to merge this. For our local testnets w/ low Sol/s, this can make a large difference in the orphan rate. For a mainnet miner, it's almost certainly not worth it.

The internal miner can spend a full Equihash pass on a template whose parent is no longer valid. A solution can also race with the final cancellation check and reach `submitblock` after the template changes.

## Solution

- Add a backward-compatible cancellable solver method with `Continue`, `StopAtNonceBoundary`, and `StopNow` actions.
- Use the cancellable Tromp API to stop invalid work between digit rounds.
- Recheck the action after the final digit and before every internal-miner submission.
- Keep the forked solver in the optional `cpu-equihash-solver` dependency behind `internal-miner`. The registry Equihash dependency continues to serve the default verification graph.

The git dependency pins [valargroup/librustzcash PR #75](https://github.com/valargroup/librustzcash/pull/75) at commit `658533c4c604818610657d9699e82102e7379c76`. This draft must switch to a published Equihash release before merge.

## Testing

- `cargo check -p zakura-chain --features internal-miner --locked`
- `cargo test -p zakura-chain --features internal-miner solver_actions_have_distinct_cancellation_boundaries --locked`
- `cargo test -p zakura --features internal-miner stale_check_observes_a_change_seen_by_the_solver --locked`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/643.md --config .github/.markdownlint.yaml`
- Verified with `cargo tree` that the default `zakura-chain` graph uses only registry Equihash. The git solver appears only with `internal-miner`.
- The pinned Equihash commit passes its 11 crate tests and clippy. Its regression test fails against the old one-row reset and passes after the two-row reset.

Functional, semver, MSRV, and test CI checks pass. The fork is published under the distinct `cpu-equihash-solver` package name. Supply-chain policy narrowly allows the pinned repository and temporarily exempts this package; both entries must be removed when switching to a published upstream release.

## Changelog

Added `docs/changelog/unreleased/643.md`.

### Specifications & References

The change uses the existing `internal-miner` feature boundary. It does not change `getblocktemplate` or `submitold` semantics.

### Follow-up Work

- Replace the temporary git dependency with the published Equihash release.
- Ask upstream librustzcash maintainers to evaluate the fork-local Equihash draft before starting their upstream contribution process.
