### PR TITLE
fix(inbound): carry advertiser_addr on behind-tip drop, score forged heights

### DIFF
--- a/crates/zakurad/src/components/inbound.rs
+++ b/crates/zakurad/src/components/inbound.rs
@@ -49,7 +49,9 @@ use cached_peer_addr_response::CachedPeerAddrResponse;
 #[cfg(test)]
 mod tests;
 
-use downloads::{Downloads as BlockDownloads, GossipedTipChildHeightMismatch};
+use downloads::{
+    Downloads as BlockDownloads, GossipedBehindTipHeightMismatch, GossipedTipChildHeightMismatch,
+};
 
 /// The maximum amount of time an inbound service response can take.
 ///
@@ -491,6 +493,24 @@ impl Service<zn::Request> for Inbound {
 
                         // The outcome, including a replacement refused by the queue bounds, is
                         // logged by `retry_poisoned` itself.
+                        let _ = block_downloads.retry_poisoned(mismatch.hash);
+                        continue;
+                    }
+
+                    // A rewritten coinbase height on a behind-tip block (not a tip child) is
+                    // detected by a parent header lookup in the download task. The peer must be
+                    // scored and the hash re-requested, for the same reason as the tip-child
+                    // case: the poisoned response held the per-hash dedupe slot while it was
+                    // outstanding, so honest peers' `inv`s for the same hash were already
+                    // dropped as `AlreadyQueued`.
+                    if let Some(mismatch) = err.downcast_ref::<GossipedBehindTipHeightMismatch>() {
+                        if let Some(advertiser_addr) = advertiser_addr {
+                            let _ = misbehavior_sender.try_send((
+                                advertiser_addr,
+                                zn::constants::MAX_PEER_MISBEHAVIOR_SCORE,
+                            ));
+                        }
+
                         let _ = block_downloads.retry_poisoned(mismatch.hash);
                         continue;
                     }

--- a/crates/zakurad/src/components/inbound/downloads.rs
+++ b/crates/zakurad/src/components/inbound/downloads.rs
@@ -50,6 +50,23 @@ pub struct GossipedTipChildHeightMismatch {
     pub hash: block::Hash,
 }
 
+/// A downloaded block claims a height far behind the tip, but a parent header
+/// lookup proves the claimed height is inconsistent with the parent's height.
+/// The body has been poisoned (ZIP-244 scriptSig rewrite) and the peer must
+/// be scored and the hash re-requested.
+///
+/// This is a distinct type rather than a string error so [`super::Inbound`] can score the
+/// supplying peer for it, matching the `GossipedTipChildHeightMismatch` handler.
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+#[error(
+    "gossiped behind-tip block claimed height {height:?} but parent height is {parent_height:?}: {hash:?}"
+)]
+pub struct GossipedBehindTipHeightMismatch {
+    pub height: block::Height,
+    pub parent_height: block::Height,
+    pub hash: block::Hash,
+}
+
 /// Source key used for inbound block download ordering.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum AdvertiserSource {
@@ -596,6 +613,7 @@ where
         let network = self.network.clone();
         let verifier = self.verifier.clone();
         let state = self.state.clone();
+        let state_for_parent_lookup = self.state.clone();
         let latest_chain_tip = self.latest_chain_tip.clone();
         let full_verify_concurrency_limit = self.full_verify_concurrency_limit;
 
@@ -766,18 +784,56 @@ where
 
                 Err("gossiped block height too far ahead").map_err(|e| (e.into(), None))?;
             } else if block_height < min_accepted_height {
-                debug!(
-                    ?hash,
-                    ?block_height,
-                    ?tip_height,
-                    ?min_accepted_height,
-                    behind_tip_limit = ?zs::MAX_BLOCK_REORG_HEIGHT,
-                    "gossiped block height behind the finalized tip: dropped downloaded block",
-                );
-                metrics::counter!("gossip.min.height.limit.dropped.block.count").increment(1);
+                // Security: before discarding this block as genuinely old, check whether
+                // the claimed height is consistent with the parent header's height. If the
+                // parent is known and its height + 1 != block_height, the body has been
+                // poisoned (ZIP-244 scriptSig rewrite) and the peer must be scored.
+                let parent_header = state_for_parent_lookup
+                    .oneshot(zs::Request::BlockHeader(
+                        block.header.previous_block_hash.into(),
+                    ))
+                    .await;
 
-                Err("gossiped block height behind the finalized tip")
-                    .map_err(|e| (e.into(), None))?;
+                let is_forged = matches!(
+                    parent_header,
+                    Ok(zs::Response::BlockHeader { ref height, .. })
+                        if height.0 + 1 != block_height.0
+                );
+
+                if is_forged {
+                    let parent_height =
+                        if let Ok(zs::Response::BlockHeader { ref height, .. }) = parent_header {
+                            *height
+                        } else {
+                            block::Height(0)
+                        };
+
+                    debug!(
+                        ?hash, ?block_height, ?parent_height,
+                        "gossiped behind-tip block has a forged height: dropped and scored"
+                    );
+                    metrics::counter!("gossip.behind.tip.height.mismatch.count").increment(1);
+
+                    Err((
+                        BoxError::from(GossipedBehindTipHeightMismatch {
+                            height: block_height,
+                            parent_height,
+                            hash,
+                        }),
+                        advertiser_addr,
+                    ))?;
+                } else {
+                    // Genuinely old block (or unknown parent) — drop without scoring.
+                    debug!(
+                        ?hash, ?block_height, ?tip_height, ?min_accepted_height,
+                        behind_tip_limit = ?zs::MAX_BLOCK_REORG_HEIGHT,
+                        "gossiped block height behind the finalized tip: dropped downloaded block",
+                    );
+                    metrics::counter!("gossip.min.height.limit.dropped.block.count").increment(1);
+
+                    Err("gossiped block height behind the finalized tip")
+                        .map_err(|e| (e.into(), advertiser_addr))?;
+                }
             }
 
             let _source_guard = match source_lock {


### PR DESCRIPTION
## Motivation

Closes #648.

The inbound gossip download path checks forged coinbase heights on tip-child blocks via `tip_child_mismatch` and scores the peer 100 (ban). But the general behind-tip drop returns `None` as the advertiser address, so the inbound error handler silently skips scoring. A peer that serves a forged-height body for any block whose parent is not the node's own tip is never penalized.

## Solution

- Add `GossipedBehindTipHeightMismatch` error type, mirroring `GossipedTipChildHeightMismatch`.
- Before dropping a behind-tip block, perform a parent header lookup (`zs::Request::BlockHeader`) to check whether the claimed height is consistent with the parent's height.
- If the parent is known and `parent.height + 1 != block_height`, the body is forged (ZIP-244 scriptSig rewrite). Return the error with `advertiser_addr` so the inbound handler can score the peer 100 and re-request the hash.
- If the parent is unknown or the height is consistent, the block is genuinely old. Drop without scoring (but carry `advertiser_addr` for observability).
- Handle `GossipedBehindTipHeightMismatch` in the inbound error handler, same pattern as `GossipedTipChildHeightMismatch`: score 100 + `retry_poisoned`.

## What this does NOT change

- Consensus validation is unchanged.
- The sync path's `BehindTipHeightLimit` is unchanged (follow-up for consistency).
- Genuinely-old blocks near reorg boundaries are not penalized.

### Tests

Regression test to be added in a follow-up commit: serve a forged-height non-tip-child block, verify the peer is scored 100 and the hash is re-requested.

```console
cargo check -p zakura
cargo clippy -p zakura -- -D warnings
cargo test -p zakura components::inbound::
```

### Specifications & References

- Zebra advisory (sibling): GHSA-4f6v-mj46-gxg3
- `auth_download_height.rs` — `tip_child_mismatch` (tip-child check)
- ZIP-244: https://zips.z.cash/zip-0244

### AI Disclosure

Code changes were developed with assistance from Claude (Anthropic). The approach, error type design, and parent-header-lookup pattern were reviewed and validated by the author.