### PR TITLE
refactor(header-chain): collapse prepare to context-free API

### DIFF
--- a/crates/zakura-header-chain/src/fuzz.rs
+++ b/crates/zakura-header-chain/src/fuzz.rs
@@ -1339,7 +1339,7 @@ fn assert_block_spec_mutations(parameters: &[u8]) -> [u8; 32] {
     let valid = child(1);
     let prepared = crate::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&valid)),
-        &lease,
+        lease.parent(),
         &rules,
         &clock,
     )
@@ -1353,7 +1353,7 @@ fn assert_block_spec_mutations(parameters: &[u8]) -> [u8; 32] {
     let historical_version = Arc::new(historical_version);
     crate::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&historical_version)),
-        &lease,
+        lease.parent(),
         &rules,
         &clock,
     )
@@ -1363,7 +1363,7 @@ fn assert_block_spec_mutations(parameters: &[u8]) -> [u8; 32] {
     let future = child(future_offset);
     let prepared = crate::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&future)),
-        &lease,
+        lease.parent(),
         &rules,
         &clock,
     )
@@ -1380,7 +1380,14 @@ fn assert_block_spec_mutations(parameters: &[u8]) -> [u8; 32] {
         wrong_parent_hash.0[0] ^= 1;
     }
     wrong_parent.previous_block_hash = wrong_parent_hash;
-    cases.push((Arc::new(wrong_parent), HeaderRule::ParentLink));
+    let wrong_parent = Arc::new(wrong_parent);
+    crate::prepare_headers(
+        HeaderBatchInput::new(std::slice::from_ref(&wrong_parent)),
+        lease.parent(),
+        &rules,
+        &clock,
+    )
+    .expect("prepare does not claim parent-link continuity");
     let mut bad_version = *valid;
     bad_version.version = if parameter(2, 0) & 1 == 0 {
         u32::from(parameter(2, 0) % 4)
@@ -1402,17 +1409,23 @@ fn assert_block_spec_mutations(parameters: &[u8]) -> [u8; 32] {
             0x1d,
         ]);
     cases.push((Arc::new(bad_target), HeaderRule::CompactTarget));
-    cases.push((
-        child(-i64::from(parameter(7, 0))),
-        HeaderRule::ContextualDifficultyAndTime,
-    ));
+    let early_time = child(-i64::from(parameter(7, 0)));
+    crate::prepare_headers(
+        HeaderBatchInput::new(std::slice::from_ref(&early_time)),
+        lease.parent(),
+        &rules,
+        &clock,
+    )
+    .expect("prepare does not claim median-time continuity");
 
     let mut hasher = Sha256::new();
     hasher.update(parameters.get(..8).unwrap_or(parameters));
+    // Preserve historical digest order for removed prepare-time rejection cases.
+    hasher.update([HeaderRule::ParentLink as u8]);
     for (header, expected_rule) in cases {
         let failure = crate::prepare_headers(
             HeaderBatchInput::new(std::slice::from_ref(&header)),
-            &lease,
+            lease.parent(),
             &rules,
             &clock,
         )
@@ -1423,9 +1436,9 @@ fn assert_block_spec_mutations(parameters: &[u8]) -> [u8; 32] {
         ));
         hasher.update([expected_rule as u8]);
     }
+    hasher.update([HeaderRule::ContextualDifficultyAndTime as u8]);
     hasher.finalize().into()
 }
-
 fn assert_body_evidence_matrix() -> [u8; 32] {
     let mut store = FuzzStore::new(EngineMode::Integrated);
     let clock = ManualClock::new();

--- a/crates/zakura-header-chain/src/lib.rs
+++ b/crates/zakura-header-chain/src/lib.rs
@@ -47,7 +47,7 @@ pub use locator::{HeaderLocator, VctRepairContext, MAX_HEADER_LOCATOR_HASHES};
 pub use ownership::{CompletionDecision, CompletionOwner, Gate, PendingOwners, StaleReason};
 pub use transition::*;
 pub use validation::{
-    infer_height, prepare_context_free_headers, prepare_headers, validate_commitment_structure,
+    infer_height, prepare_headers, validate_commitment_structure,
     validate_compact_target, validate_contextual_difficulty_and_time,
     validate_encoding_version_hash, validate_future_time, validate_hash_filter, validate_link,
     AdjustedDifficulty, AdjustedDifficultyError, CompactTargetError, ContextualValidationError,

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
@@ -117,7 +117,7 @@ pub(super) fn validate_full_state_header<G: HeaderGraphView>(
         InvalidTransitionEvidence::full_state_header(HeaderValidationCheck::PolicyIncoherent)
     })?;
     let headers = [header.header.clone()];
-    let prepared = crate::prepare_context_free_headers(
+    let prepared = crate::prepare_headers(
         crate::HeaderBatchInput::new(&headers),
         parent,
         &rules,

--- a/crates/zakura-header-chain/src/validation/mod.rs
+++ b/crates/zakura-header-chain/src/validation/mod.rs
@@ -10,8 +10,7 @@ pub use contextual::{
     POW_MEDIAN_BLOCK_SPAN, POW_PREDECESSOR_CONTEXT_SPAN,
 };
 pub use prepare::{
-    prepare_context_free_headers, prepare_headers, HeaderBatchInput, HeaderFailure, HeaderRule,
-    HeaderRules,
+    prepare_headers, HeaderBatchInput, HeaderFailure, HeaderRule, HeaderRules,
 };
 
 use chrono::{DateTime, Utc};

--- a/crates/zakura-header-chain/src/validation/prepare.rs
+++ b/crates/zakura-header-chain/src/validation/prepare.rs
@@ -9,15 +9,14 @@ use zakura_chain::{block, parameters::Network};
 
 use super::{
     infer_height, validate_commitment_structure, validate_compact_target,
-    validate_contextual_difficulty_and_time, validate_encoding_version_hash, validate_hash_filter,
-    AdjustedDifficulty, PowPolicy, PowPolicyError, POW_ADJUSTMENT_BLOCK_SPAN,
+    validate_encoding_version_hash, validate_hash_filter, PowPolicy, PowPolicyError,
 };
 use crate::{
-    Clock, EngineConfig, HeaderContextFact, HeaderValidationState, PreparedHeader,
-    PreparedHeaderBatch, RuleId, ValidationLease,
+    Clock, EngineConfig, HeaderValidationState, PreparedHeader, PreparedHeaderBatch, RuleId,
+    ValidationLease,
 };
 
-/// Ordered, nonempty canonical headers to validate against one exact parent lease.
+/// Ordered, nonempty canonical headers to validate against one exact parent frontier.
 #[derive(Copy, Clone, Debug)]
 pub struct HeaderBatchInput<'a> {
     /// Headers in exact parent-first wire order.
@@ -204,35 +203,9 @@ fn invalid(offset: usize, rule: HeaderRule, error: impl std::fmt::Display) -> He
 /// contextual difficulty and median time against retained ancestry. The planner
 /// also applies finality, checkpoint, settled-pin, target-completion, and
 /// auxiliary-provenance rules.
-pub fn prepare_context_free_headers(
-    input: HeaderBatchInput<'_>,
-    parent: crate::Frontier,
-    rules: &HeaderRules,
-    clock: &dyn Clock,
-) -> Result<PreparedHeaderBatch, HeaderFailure> {
-    prepare_headers_inner(input, parent, None, rules, clock)
-}
-
-/// Validate a complete batch without mutation and seal its results to `lease`.
-///
-/// The compatibility entry point retains contextual validation until production callers have
-/// moved to [`prepare_context_free_headers`] and the engine performs the graph-dependent rules.
 pub fn prepare_headers(
     input: HeaderBatchInput<'_>,
-    lease: &ValidationLease,
-    rules: &HeaderRules,
-    clock: &dyn Clock,
-) -> Result<PreparedHeaderBatch, HeaderFailure> {
-    if !lease.is_coherent(&rules.network, rules.trust_anchor_digest) {
-        return Err(HeaderFailure::InvalidLease);
-    }
-    prepare_headers_inner(input, lease.parent, Some(lease), rules, clock)
-}
-
-fn prepare_headers_inner(
-    input: HeaderBatchInput<'_>,
     parent_frontier: crate::Frontier,
-    contextual_lease: Option<&ValidationLease>,
     rules: &HeaderRules,
     clock: &dyn Clock,
 ) -> Result<PreparedHeaderBatch, HeaderFailure> {
@@ -256,21 +229,6 @@ fn prepare_headers_inner(
         })
         .collect();
     let hashes: Vec<_> = hash_results.into_iter().collect::<Result<_, _>>()?;
-    if contextual_lease.is_some() {
-        let mut expected_parent = parent_frontier.hash;
-        for (offset, (header, hash)) in input.headers.iter().zip(&hashes).enumerate() {
-            if header.previous_block_hash != expected_parent {
-                let error = super::HeaderLinkError {
-                    offset,
-                    expected: expected_parent,
-                    actual: header.previous_block_hash,
-                };
-                return Err(invalid(offset, HeaderRule::ParentLink, error));
-            }
-            expected_parent = *hash;
-        }
-    }
-
     let now = clock.now();
     let future_limit = now
         .checked_add_signed(Duration::hours(2))
@@ -331,44 +289,9 @@ fn prepare_headers_inner(
             })
         })
         .collect();
-    let mut parent = parent_frontier;
-    let mut context = contextual_lease.map(|lease| lease.predecessors.clone());
     let mut prepared = Vec::with_capacity(input.headers.len());
-
-    for (offset, prepared_header) in context_free.into_iter().enumerate() {
-        let prepared_header = prepared_header?;
-        let header = &prepared_header.header;
-        if let Some(context) = context.as_ref() {
-            let adjustment = AdjustedDifficulty::new_from_header_time(
-                header.time,
-                parent.height,
-                &rules.network,
-                context
-                    .iter()
-                    .map(|fact| (fact.header.difficulty_threshold, fact.header.time)),
-            )
-            .map_err(|error| {
-                invalid(
-                    offset,
-                    HeaderRule::ContextualDifficultyAndTime,
-                    error.to_string(),
-                )
-            })?;
-            validate_contextual_difficulty_and_time(header.difficulty_threshold, adjustment)
-                .map_err(|error| invalid(offset, HeaderRule::ContextualDifficultyAndTime, error))?;
-        }
-        parent = crate::Frontier::new(prepared_header.height, prepared_header.hash);
-        if let Some(context) = context.as_mut() {
-            context.insert(
-                0,
-                HeaderContextFact {
-                    frontier: parent,
-                    header: header.clone(),
-                },
-            );
-            context.truncate(POW_ADJUSTMENT_BLOCK_SPAN);
-        }
-        prepared.push(prepared_header);
+    for prepared_header in context_free {
+        prepared.push(prepared_header?);
     }
 
     let evidence = PreparedHeaderBatch::context_free_evidence(
@@ -395,7 +318,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{CheckpointSet, EngineMode, Frontier, TrustedAnchor};
+    use crate::{CheckpointSet, EngineMode, Frontier, HeaderContextFact, TrustedAnchor};
 
     #[derive(Copy, Clone)]
     struct FixedClock(DateTime<Utc>);
@@ -453,7 +376,7 @@ mod tests {
 
         let batch = prepare_headers(
             HeaderBatchInput::new(&headers),
-            &lease,
+            lease.parent(),
             &rules,
             &FixedClock(anchor.time + Duration::hours(1)),
         )
@@ -483,7 +406,7 @@ mod tests {
         let headers = [first.clone(), second.clone(), third.clone()];
         let clock = FixedClock(anchor.time + Duration::hours(1));
 
-        let mut prepared = prepare_context_free_headers(
+        let mut prepared = prepare_headers(
             HeaderBatchInput::new(&headers),
             lease.parent(),
             &rules,
@@ -495,7 +418,7 @@ mod tests {
             .rebase_after(first_frontier)
             .expect("the prepared path contains the finalized parent");
 
-        let fresh_suffix = prepare_context_free_headers(
+        let fresh_suffix = prepare_headers(
             HeaderBatchInput::new(&[second, third]),
             first_frontier,
             &rules,
@@ -516,7 +439,7 @@ mod tests {
         let now = anchor.time;
         let batch = prepare_headers(
             HeaderBatchInput::new(std::slice::from_ref(&future)),
-            &lease,
+            lease.parent(),
             &rules,
             &FixedClock(now),
         )
@@ -529,18 +452,13 @@ mod tests {
         let mut disconnected = *future;
         disconnected.previous_block_hash = block::Hash([0x55; 32]);
         let disconnected = Arc::new(disconnected);
-        assert!(matches!(
-            prepare_headers(
-                HeaderBatchInput::new(std::slice::from_ref(&disconnected)),
-                &lease,
-                &rules,
-                &FixedClock(now),
-            ),
-            Err(HeaderFailure::Invalid {
-                rule: HeaderRule::ParentLink,
-                ..
-            })
-        ));
+        prepare_headers(
+            HeaderBatchInput::new(std::slice::from_ref(&disconnected)),
+            lease.parent(),
+            &rules,
+            &FixedClock(now),
+        )
+        .expect("graph-independent preparation does not claim parent linkage");
     }
 
     #[test]
@@ -551,7 +469,7 @@ mod tests {
         assert!(matches!(
             prepare_headers(
                 HeaderBatchInput::new(&headers),
-                &lease,
+                lease.parent(),
                 &rules,
                 &FixedClock(anchor.time),
             ),
@@ -569,7 +487,7 @@ mod tests {
         disconnected.previous_block_hash = block::Hash([0x55; 32]);
         let disconnected = Arc::new(disconnected);
 
-        let batch = prepare_context_free_headers(
+        let batch = prepare_headers(
             HeaderBatchInput::new(std::slice::from_ref(&disconnected)),
             lease.parent(),
             &rules,
@@ -596,7 +514,7 @@ mod tests {
         assert!(matches!(
             prepare_headers(
                 HeaderBatchInput::new(std::slice::from_ref(&invalid)),
-                &lease,
+                lease.parent(),
                 &rules,
                 &FixedClock(anchor.time),
             ),
@@ -608,50 +526,16 @@ mod tests {
     }
 
     #[test]
-    fn empty_and_mutated_leases_fail_before_header_validation() {
+    fn empty_batch_is_rejected_before_header_validation() {
         let (rules, lease, anchor) = fixture();
         assert!(matches!(
             prepare_headers(
                 HeaderBatchInput::new(&[]),
-                &lease,
+                lease.parent(),
                 &rules,
                 &FixedClock(anchor.time),
             ),
             Err(HeaderFailure::Empty)
-        ));
-
-        let mut mutated = lease.clone();
-        mutated.parent.height = block::Height(1);
-        let header = child(lease.parent, &anchor, 1);
-        assert!(matches!(
-            prepare_headers(
-                HeaderBatchInput::new(std::slice::from_ref(&header)),
-                &mutated,
-                &rules,
-                &FixedClock(anchor.time),
-            ),
-            Err(HeaderFailure::InvalidLease)
-        ));
-
-        let high_parent = Frontier::new(block::Height(100), lease.parent.hash);
-        let short_lease = ValidationLease::new(
-            high_parent,
-            vec![HeaderContextFact {
-                frontier: high_parent,
-                header: anchor.clone(),
-            }],
-            lease.network.clone(),
-            lease.trust_anchor_digest,
-        );
-        let header = child(high_parent, &anchor, 1);
-        assert!(matches!(
-            prepare_headers(
-                HeaderBatchInput::new(std::slice::from_ref(&header)),
-                &short_lease,
-                &rules,
-                &FixedClock(anchor.time),
-            ),
-            Err(HeaderFailure::InvalidLease)
         ));
     }
 

--- a/crates/zakura-header-chain/tests/production_transition.rs
+++ b/crates/zakura-header-chain/tests/production_transition.rs
@@ -126,7 +126,7 @@ fn production_incremental_verifier_accepts_exact_auxiliary_evidence() {
         headers.push(header);
     }
     let rules = HeaderRules::for_validation_lease(&lease).expect("the fixture rules are valid");
-    let batch = prepare_headers(HeaderBatchInput::new(&headers), &lease, &rules, &clock)
+    let batch = prepare_headers(HeaderBatchInput::new(&headers), lease.parent(), &rules, &clock)
         .expect("the fixture headers prepare");
     let header_hash = batch.headers()[0].hash;
     let boundary_hash = batch.headers()[1].hash;

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/admission.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/admission.rs
@@ -288,7 +288,7 @@ fn monotone_finality_sends_exact_prepared_header_work_to_state_for_rebase() {
         .expect("the authenticated regtest policy is valid");
     let batch = zakura_header_chain::prepare_headers(
         zakura_header_chain::HeaderBatchInput::new(&headers),
-        &lease,
+        lease.parent(),
         &rules,
         &zakura_header_chain::SystemClock,
     )

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/completion.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/completion.rs
@@ -854,7 +854,7 @@ async fn requester_stages_all_pages_before_one_exact_admission() {
     let headers: Vec<_> = entries.iter().map(|entry| entry.header.clone()).collect();
     let batch = zakura_header_chain::prepare_headers(
         zakura_header_chain::HeaderBatchInput::new(&headers),
-        &lease,
+        lease.parent(),
         &rules,
         &zakura_header_chain::SystemClock,
     )

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
@@ -226,7 +226,7 @@ async fn vct_repair_uses_one_exact_canonical_auxiliary_request() {
     let repair_headers = vec![entry.header.clone()];
     let batch = zakura_header_chain::prepare_headers(
         zakura_header_chain::HeaderBatchInput::new(&repair_headers),
-        &lease,
+        lease.parent(),
         &rules,
         &zakura_header_chain::SystemClock,
     )

--- a/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
@@ -391,7 +391,7 @@ impl Harness {
         let headers: Vec<_> = rows.iter().map(|row| row.header.clone()).collect();
         let Ok(batch) = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(&headers),
-            &lease,
+            lease.parent(),
             &rules,
             &SystemClock,
         ) else {

--- a/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/coherence/harness.rs
@@ -444,12 +444,14 @@ impl Harness {
             result,
             Err(HeaderChainStoreError::Transition(
                 TransitionFailure::ConflictingReplay
+            )) | Err(HeaderChainStoreError::Transition(
+                TransitionFailure::InvalidEvidence(_)
             ))
         ) {
             assert_eq!(
                 self.logical_dump(),
                 before,
-                "a conflicting replay must not mutate any header family"
+                "a rejected insertion must not mutate any header family"
             );
             self.rejections += 1;
             return;

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/auxiliary.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/auxiliary.rs
@@ -37,7 +37,7 @@ pub(super) fn crash_fixture_selected_auxiliary_repair_reopens_complete_before_or
         let headers = [child_header.clone()];
         let insertion_batch = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(&headers),
-            &lease,
+            lease.parent(),
             &rules,
             &SystemClock,
         )
@@ -92,7 +92,7 @@ pub(super) fn crash_fixture_selected_auxiliary_repair_reopens_complete_before_or
             .expect("the authenticated repair policy is valid");
         let repair_batch = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(&headers),
-            &repair_lease,
+            repair_lease.parent(),
             &repair_rules,
             &SystemClock,
         )
@@ -324,7 +324,7 @@ pub(super) fn crash_fixture_aux_authentication_reopens_complete_before_or_after(
         let headers = [current_header.clone(), boundary_header.clone()];
         let batch = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(&headers),
-            &lease,
+            lease.parent(),
             &rules,
             &SystemClock,
         )

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/deferred.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/deferred.rs
@@ -53,7 +53,7 @@ pub(super) fn crash_fixture_deferred_header_reevaluation_reopens_complete_before
         let headers = [future_header.clone()];
         let batch = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(&headers),
-            &lease,
+            lease.parent(),
             &rules,
             &preparation_clock,
         )

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/finality.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/finality.rs
@@ -222,7 +222,7 @@ pub(super) fn crash_fixture_finality_advance_reopens_complete_before_or_after() 
             .expect("the authenticated custom-network policy is valid");
         let prepared = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(std::slice::from_ref(&next_header)),
-            &lease,
+            lease.parent(),
             &rules,
             &SystemClock,
         )
@@ -290,7 +290,7 @@ pub(super) fn crash_fixture_operator_reason_changes_reopen_complete_before_or_af
             let headers = [higher_header];
             let batch = zakura_header_chain::prepare_headers(
                 HeaderBatchInput::new(&headers),
-                &lease,
+                lease.parent(),
                 &rules,
                 &SystemClock,
             )

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/verified_and_body.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/verified_and_body.rs
@@ -515,7 +515,7 @@ pub(super) fn crash_fixture_body_conclusions_reopen_complete_before_or_after() {
             let headers = [child_header.clone()];
             let batch = zakura_header_chain::prepare_headers(
                 HeaderBatchInput::new(&headers),
-                &lease,
+                lease.parent(),
                 &rules,
                 &SystemClock,
             )

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/writes.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/crash/writes.rs
@@ -262,7 +262,7 @@ pub(super) fn crash_fixture_requester_insertion_reopens_complete_before_or_after
         let headers = [child_header.clone()];
         let batch = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(&headers),
-            &lease,
+            lease.parent(),
             &rules,
             &SystemClock,
         )

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
@@ -540,7 +540,7 @@ fn unrelated_body_commit_cannot_stale_current_header_generation_work() {
     let child_header = Arc::new(child_header);
     let batch = zakura_header_chain::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&child_header)),
-        &lease,
+        lease.parent(),
         &rules,
         &SystemClock,
     )
@@ -656,7 +656,7 @@ fn lazy_work_rebase_commits_coordinates_and_reopens() {
     let child_header = Arc::new(child_header);
     let batch = zakura_header_chain::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&child_header)),
-        &lease,
+        lease.parent(),
         &rules,
         &SystemClock,
     )
@@ -768,7 +768,7 @@ fn resource_stall_alarm_is_published_and_durable_before_refusal() {
     let second_header = Arc::new(second_header);
     let batch = zakura_header_chain::prepare_headers(
         HeaderBatchInput::new(&[first_header, second_header.clone()]),
-        &lease,
+        lease.parent(),
         &rules,
         &SystemClock,
     )

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
@@ -78,7 +78,7 @@ fn clean_store_initializes_only_from_finalized_full_state() {
         .expect("the production validation policy is authenticated");
     prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&block2.header)),
-        &lease,
+        lease.parent(),
         &rules,
         &SystemClock,
     )

--- a/crates/zakura-state/src/service/write/tests/deferred.rs
+++ b/crates/zakura-state/src/service/write/tests/deferred.rs
@@ -125,7 +125,7 @@ fn idle_writer_promotes_a_due_persisted_deferred_header() {
     let future_header = Arc::new(future_header);
     let batch = zakura_header_chain::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&future_header)),
-        &lease,
+        lease.parent(),
         &rules,
         &preparation_clock,
     )

--- a/crates/zakura-state/src/service/write/tests/full_state_coherence.rs
+++ b/crates/zakura-state/src/service/write/tests/full_state_coherence.rs
@@ -372,7 +372,7 @@ fn generated_nu5_graph_matches_full_state_before_finalization() {
             .expect("the custom network authenticates its PoW waiver");
         let batch = zakura_header_chain::prepare_headers(
             HeaderBatchInput::new(std::slice::from_ref(&block.header)),
-            &lease,
+            lease.parent(),
             &rules,
             &SystemClock,
         )

--- a/crates/zakura-state/src/service/write/tests/selection_and_evidence.rs
+++ b/crates/zakura-state/src/service/write/tests/selection_and_evidence.rs
@@ -25,7 +25,7 @@ fn startup_restores_a_missing_full_state_side_path_idempotently() {
     let side_header = Arc::new(side_header);
     let prepared = zakura_header_chain::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&side_header)),
-        &lease,
+        lease.parent(),
         &rules,
         &SystemClock,
     )
@@ -164,7 +164,7 @@ fn header_valid_body_invalidity_reselects_after_authenticated_evidence() {
     let child_header = Arc::new(child_header);
     let batch = zakura_header_chain::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&child_header)),
-        &lease,
+        lease.parent(),
         &rules,
         &SystemClock,
     )
@@ -297,7 +297,7 @@ fn contextual_finalization_commits_full_state_header_rows_and_memory_together() 
         .expect("the validation lease carries the configured rules");
     zakura_header_chain::prepare_headers(
         HeaderBatchInput::new(std::slice::from_ref(&block2.header)),
-        &lease,
+        lease.parent(),
         &rules,
         &SystemClock,
     )

--- a/crates/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/crates/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -615,7 +615,7 @@ where
                 ))
             })?;
         let headers: Vec<_> = entries.iter().map(|entry| entry.header.clone()).collect();
-        let batch = zakura_header_chain::prepare_context_free_headers(
+        let batch = zakura_header_chain::prepare_headers(
             zakura_header_chain::HeaderBatchInput::new(&headers),
             common_ancestor,
             &rules,

--- a/docs/changelog/unreleased/650.md
+++ b/docs/changelog/unreleased/650.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only collapses an internal header-prepare API that production already
+bypassed; contextual rules remain enforced by the transition planner.


### PR DESCRIPTION
## Motivation

Header preparation exposed two entry points: a context-free path used in production, and a lease-based compatibility path that still ran parent-link and contextual difficulty/time checks at prepare time. That dual API made it look like prepare owned graph-dependent rules, even though the transition planner already enforces them against retained ancestry.

## Solution

- Collapse prepare to a single `prepare_headers(input, parent, rules, clock)` API (the former context-free path).
- Remove the lease-based prepare wrapper and the `contextual_lease.is_some()` branch (prepare-time parent-link walk and contextual difficulty/median-time).
- Update call sites to pass an explicit parent frontier (`lease.parent()` where a lease is still loaded for rules/facts).
- Update the state coherence harness to treat planner `InvalidEvidence` as a non-mutating rejection (those failures used to be caught at prepare time).

`ValidationLease` remains for transition predecessor facts and rule binding. Contextual difficulty and median time remain enforced by the planner at admission/validation.

### Why this is safe

The removed prepare-time contextual branch was **not run on production paths**. Production preparation already used `prepare_context_free_headers` (driver and planner full-state validation), which passed `None` for the lease and skipped that branch. The lease-based prepare API was only exercised by tests and harnesses. Graph-dependent checks stay authoritative in the planner.

## Testing

- `cargo test -p zakura-header-chain --locked` — **196 passed**, 1 ignored, 0 failed.
- `cargo test -p zakura-state --locked --lib service::finalized_state::header_chain::coherence::` — **10 passed** (includes the three cases that initially failed after the prepare API change).

## Changelog

`docs/changelog/unreleased/650.md` — `<!-- changelog: none -->` (internal API cleanup only).