### PR TITLE
refactor(header-chain): share contextual difficulty/time check

### DIFF
--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
@@ -1,7 +1,7 @@
 //! Prepared header insertion and atomic auxiliary delivery admission.
 
 use super::super::{
-    AuxiliaryViolation, HeaderPathKind, HeaderPathProblem, HeaderValidationCheck, HeaderViolation,
+    AuxiliaryViolation, HeaderPathKind, HeaderPathProblem, HeaderViolation,
     InvalidTransitionEvidence, TransitionFailure,
 };
 use std::collections::{HashMap, HashSet};
@@ -10,7 +10,9 @@ use crate::graph::HeaderGraphView;
 use crate::{BodyValidationState, Frontier, GraphError, HeaderValidationState, TargetCompletion};
 
 use super::super::projected_state::ProjectedTransitionState;
-use super::header_validation::{anchor_reasons, retained_header_context};
+use super::header_validation::{
+    anchor_reasons, check_contextual_difficulty_and_time, retained_header_context,
+};
 use super::EventProjectionContext;
 
 /// Admit a prepared header batch and any accompanying unauthenticated auxiliary deliveries.
@@ -85,28 +87,14 @@ pub(super) fn admit_prepared_headers(
             )
             .into());
         }
-        let adjustment = crate::AdjustedDifficulty::new_from_header_time(
+        check_contextual_difficulty_and_time(
             prepared.header.time,
+            prepared.header.difficulty_threshold,
             parent.height,
             &context.config.network,
             contextual.iter().copied(),
-        )
-        .map_err(|_| {
-            InvalidTransitionEvidence::Header(crate::HeaderViolation::Validation {
-                source: crate::HeaderValidationSource::Prepared,
-                check: HeaderValidationCheck::IncompleteDifficultyContext,
-            })
-        })?;
-        crate::validate_contextual_difficulty_and_time(
-            prepared.header.difficulty_threshold,
-            adjustment,
-        )
-        .map_err(|_| {
-            InvalidTransitionEvidence::Header(crate::HeaderViolation::Validation {
-                source: crate::HeaderValidationSource::Prepared,
-                check: HeaderValidationCheck::ContextualValidation,
-            })
-        })?;
+            crate::HeaderValidationSource::Prepared,
+        )?;
         let validation = match prepared.validation {
             HeaderValidationState::DeferredUntil(until) if until <= context.clock.now() => {
                 HeaderValidationState::Valid

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_validation.rs
@@ -1,6 +1,12 @@
-//! Shared retained-context and full-state header validation for event handlers.
+//! Shared retained-context and contextual header checks for event handlers.
 
-use super::super::{HeaderValidationCheck, InvalidTransitionEvidence, TransitionFailure};
+use chrono::{DateTime, Utc};
+use zakura_chain::{block, parameters::Network, work::difficulty::CompactDifficulty};
+
+use super::super::{
+    HeaderValidationCheck, HeaderValidationSource, HeaderViolation, InvalidTransitionEvidence,
+    TransitionFailure,
+};
 use crate::graph::HeaderGraphView;
 use crate::{
     EligibilityReason, Frontier, HeaderValidationFacts, HeaderValidationState, StoreError,
@@ -105,6 +111,38 @@ pub(in crate::transition::planner) fn retained_header_context<G: HeaderGraphView
         .collect())
 }
 
+/// Apply branch-local difficulty and median-time rules for one parent-linked header.
+pub(in crate::transition::planner) fn check_contextual_difficulty_and_time(
+    header_time: DateTime<Utc>,
+    difficulty_threshold: CompactDifficulty,
+    parent_height: block::Height,
+    network: &Network,
+    predecessor_context: impl IntoIterator<Item = (CompactDifficulty, DateTime<Utc>)>,
+    source: HeaderValidationSource,
+) -> Result<(), TransitionFailure> {
+    let adjustment = crate::AdjustedDifficulty::new_from_header_time(
+        header_time,
+        parent_height,
+        network,
+        predecessor_context,
+    )
+    .map_err(|_| {
+        InvalidTransitionEvidence::Header(HeaderViolation::Validation {
+            source,
+            check: HeaderValidationCheck::IncompleteDifficultyContext,
+        })
+    })?;
+    crate::validate_contextual_difficulty_and_time(difficulty_threshold, adjustment).map_err(
+        |_| {
+            InvalidTransitionEvidence::Header(HeaderViolation::Validation {
+                source,
+                check: HeaderValidationCheck::ContextualValidation,
+            })
+        },
+    )?;
+    Ok(())
+}
+
 /// Validate a full-state header against observable and retained contextual rules.
 pub(super) fn validate_full_state_header<G: HeaderGraphView>(
     graph: &G,
@@ -142,23 +180,14 @@ pub(super) fn validate_full_state_header<G: HeaderGraphView>(
         .into());
     }
     let contextual = retained_header_context(graph, parent, facts, context)?;
-    let adjustment = crate::AdjustedDifficulty::new_from_header_time(
+    check_contextual_difficulty_and_time(
         header.header.time,
+        header.header.difficulty_threshold,
         parent.height,
         &context.config.network,
         contextual,
-    )
-    .map_err(|_| {
-        InvalidTransitionEvidence::full_state_header(
-            HeaderValidationCheck::IncompleteDifficultyContext,
-        )
-    })?;
-    crate::validate_contextual_difficulty_and_time(header.header.difficulty_threshold, adjustment)
-        .map_err(|_| {
-            InvalidTransitionEvidence::full_state_header(
-                HeaderValidationCheck::ContextualValidation,
-            )
-        })?;
+        HeaderValidationSource::FullState,
+    )?;
     Ok(prepared.block_work)
 }
 

--- a/crates/zakura-header-chain/src/validation/prepare.rs
+++ b/crates/zakura-header-chain/src/validation/prepare.rs
@@ -209,6 +209,7 @@ pub fn prepare_headers(
     rules: &HeaderRules,
     clock: &dyn Clock,
 ) -> Result<PreparedHeaderBatch, HeaderFailure> {
+    // Batch nonempty and within the per-transition header limit.
     if input.headers.is_empty() {
         return Err(HeaderFailure::Empty);
     }
@@ -219,6 +220,7 @@ pub fn prepare_headers(
         });
     }
 
+    // Supported encoded version and locally computed header hash.
     let hash_results: Vec<_> = input
         .headers
         .par_iter()
@@ -229,10 +231,14 @@ pub fn prepare_headers(
         })
         .collect();
     let hashes: Vec<_> = hash_results.into_iter().collect::<Result<_, _>>()?;
+
+    // Local-clock bound for future-timestamp classification.
     let now = clock.now();
     let future_limit = now
         .checked_add_signed(Duration::hours(2))
         .ok_or(HeaderFailure::ClockRange)?;
+
+    // Checked height inference from the supplied parent height.
     let mut parent_height = parent_frontier.height;
     let heights: Vec<_> = (0..input.headers.len())
         .map(|offset| {
@@ -242,6 +248,7 @@ pub fn prepare_headers(
             Ok(height)
         })
         .collect::<Result<_, HeaderFailure>>()?;
+
     let context_free: Vec<_> = input
         .headers
         .par_iter()
@@ -249,19 +256,27 @@ pub fn prepare_headers(
         .zip(&heights)
         .enumerate()
         .map(|(offset, ((header, hash), height))| {
+            // Height-dependent commitment interpretation.
             validate_commitment_structure(header, &rules.network, *height)
                 .map_err(|error| invalid(offset, HeaderRule::CommitmentStructure, error))?;
+
+            // Compact target canonical encoding and network limit.
             let target = validate_compact_target(header, &rules.network)
                 .map_err(|error| invalid(offset, HeaderRule::CompactTarget, error))?;
+
+            // Hash-to-target filter, unless authenticated custom policy waives PoW.
             if !rules.pow_policy.is_authenticated_custom_waiver() {
                 validate_hash_filter(*hash, target)
                     .map_err(|error| invalid(offset, HeaderRule::HashToTarget, error))?;
             }
+
+            // Equihash solution under the authenticated proof-of-work policy.
             rules
                 .pow_policy
                 .validate_solution(header)
                 .map_err(|error| invalid(offset, HeaderRule::Equihash, error))?;
 
+            // Accept current timestamps; assign an exact deadline to future ones.
             let canonical_header_time = header
                 .time
                 .with_nanosecond(0)
@@ -275,6 +290,8 @@ pub fn prepare_headers(
             } else {
                 HeaderValidationState::Valid
             };
+
+            // Exact per-block work from the compact target.
             let block_work = header
                 .difficulty_threshold
                 .to_work()
@@ -294,6 +311,7 @@ pub fn prepare_headers(
         prepared.push(prepared_header?);
     }
 
+    // Seal the batch to the parent, network policy, and trust-anchor digest.
     let evidence = PreparedHeaderBatch::context_free_evidence(
         parent_frontier,
         rules.trust_anchor_digest,

--- a/docs/changelog/unreleased/651.md
+++ b/docs/changelog/unreleased/651.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only deduplicates an internal planner helper and restores prepare
+comments; consensus behavior is unchanged.


### PR DESCRIPTION
## Motivation

Header admission and full-state header validation both applied the same `AdjustedDifficulty` + `validate_contextual_difficulty_and_time` sequence with duplicated error mapping. That made the shared consensus mechanism harder to see and easier to drift.

## Solution

- Add planner-local `check_contextual_difficulty_and_time` in `header_validation.rs`.
- Call it from `admit_prepared_headers` (`Prepared`) and `validate_full_state_header` (`FullState`).
- Restore section comments on the context-free `prepare_headers` stages.

No change to when or where contextual rules run—only one shared helper for the duplicated block.

## Testing

- `cargo test -p zakura-header-chain --lib transition::planner` — **66 passed**.

## Changelog

`docs/changelog/unreleased/651.md` — `<!-- changelog: none -->` (internal refactor only).