### PR TITLE
ci(release): dry-run crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -68,11 +68,15 @@ jobs:
           echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
           echo "Release ${RELEASE_TAG} resolves to ${target_sha}."
 
-      - name: Checkout publishing tools from main
+      # The dispatch is restricted to main above, so this is main's tip as of
+      # the dispatch. Pinning the commit rather than the branch keeps a run
+      # using the tooling it was dispatched with, even if main advances while
+      # the run is queued.
+      - name: Checkout publishing tools from the dispatched commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Checkout the release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -92,9 +92,11 @@ jobs:
           # the action's default `-D warnings` would report new-since-the-tag
           # warnings as publishing failures.
           rustflags: ""
-          cache-key: publish-crates-poc
-          cache-on-failure: true
-          cache-save-if: false
+          # No cache: `cargo publish --dry-run` verifies each crate in its own
+          # target directory under target/package/, so almost nothing a cache
+          # could carry is reused, and the action would cache the tooling
+          # checkout rather than the release checkout that does the building.
+          cache: false
 
       - uses: ./.github/actions/setup-zakura-build
 

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,143 @@
+# No-upload proof of concept for crates.io Trusted Publishing.
+#
+# This workflow performs Cargo dry-run publishing before it requests an OIDC
+# token. The token is never exported to repository code, and there is
+# deliberately no registry upload command.
+name: Dry-run crate publishing
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published release tag to inspect, for example v1.0.3"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: publish-crates-poc-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  dry-run:
+    name: Plan and verify crate publication
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    outputs:
+      target_sha: ${{ steps.release.outputs.target_sha }}
+    steps:
+      - name: Resolve the published release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE_REF" != "refs/heads/main" ]; then
+            echo "Run this workflow from main, not ${SOURCE_REF}." >&2
+            exit 1
+          fi
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+            echo "release_tag must match vX.Y.Z or vX.Y.Z-rcN." >&2
+            exit 1
+          fi
+
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+          if [ "$(jq -r '.draft' <<<"$release_json")" != "false" ]; then
+            echo "Release ${RELEASE_TAG} is still a draft." >&2
+            exit 1
+          fi
+
+          ref_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}")"
+          object_type="$(jq -r '.object.type' <<<"$ref_json")"
+          target_sha="$(jq -r '.object.sha' <<<"$ref_json")"
+          while [ "$object_type" = "tag" ]; do
+            tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${target_sha}")"
+            object_type="$(jq -r '.object.type' <<<"$tag_json")"
+            target_sha="$(jq -r '.object.sha' <<<"$tag_json")"
+          done
+          if [ "$object_type" != "commit" ]; then
+            echo "Tag ${RELEASE_TAG} resolves to ${object_type}, not a commit." >&2
+            exit 1
+          fi
+
+          echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
+          echo "Release ${RELEASE_TAG} resolves to ${target_sha}."
+
+      - name: Checkout publishing tools from main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: main
+
+      - name: Checkout the release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ steps.release.outputs.target_sha }}
+          path: release
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          cache-key: publish-crates-poc
+          cache-on-failure: true
+          cache-save-if: false
+
+      - uses: ./.github/actions/setup-zakura-build
+
+      - name: Confirm the tag matches the zakura package
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: ./release/scripts/check-release-version.sh "$RELEASE_TAG"
+
+      - name: Plan and fully dry-run crate publishing
+        env:
+          ZAKURA_REPO_ROOT: ${{ github.workspace }}/release
+        run: ./scripts/publish-crates.sh verify --output "$RUNNER_TEMP/publish-plan.json"
+
+      - name: Summarize the dry-run
+        if: ${{ !cancelled() }}
+        env:
+          PLAN: ${{ runner.temp }}/publish-plan.json
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TARGET_SHA: ${{ steps.release.outputs.target_sha }}
+        run: |
+          if [ ! -f "$PLAN" ]; then
+            echo "No publish plan was produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Crates.io dry-run"
+            echo
+            echo "- Release: \`${RELEASE_TAG}\`"
+            echo "- Commit: \`${TARGET_SHA}\`"
+            echo
+            echo "| Crate | Version | Status |"
+            echo "| --- | --- | --- |"
+            jq -r '.packages[] | "| `\(.name)` | `\(.version)` | `\(.status)` |"' "$PLAN"
+            echo
+            jq -r '
+              "Selected: \(.counts.to_publish + .counts.initial_publish_required); " +
+              "already published: \(.counts.already_published); " +
+              "initial publishes required: \(.counts.initial_publish_required)."
+            ' "$PLAN"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  oidc-smoke:
+    name: Exchange and revoke crates.io OIDC token
+    needs: [dry-run]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: crates-io
+    permissions:
+      id-token: write
+    steps:
+      # Keep this as the only step: no repository code receives the real,
+      # short-lived production token returned by the action.
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -103,7 +103,8 @@ jobs:
       - name: Confirm the tag matches the zakura package
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
-        run: ./release/scripts/check-release-version.sh "$RELEASE_TAG"
+          ZAKURA_REPO_ROOT: ${{ github.workspace }}/release
+        run: ./scripts/check-release-version.sh "$RELEASE_TAG"
 
       - name: Plan and fully dry-run crate publishing
         env:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -84,6 +84,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
+          # This job compiles the release tag with a current stable toolchain, so
+          # the action's default `-D warnings` would report new-since-the-tag
+          # warnings as publishing failures.
+          rustflags: ""
           cache-key: publish-crates-poc
           cache-on-failure: true
           cache-save-if: false

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -80,6 +80,50 @@ elsewhere. Every release is initially a pre-release; see
 [Promotion and the "Latest" release](#promotion-and-the-latest-release) for
 when and how a release is promoted.
 
+## Crates.io Trusted Publishing Dry Run
+
+The manually dispatched
+[`Dry-run crate publishing`](../.github/workflows/publish-crates.yml) workflow
+is a no-upload proof of concept. It checks out an existing published release
+tag, computes the exact workspace versions absent from crates.io, and runs
+Cargo's complete dry-run publishing checks. A separate checkout-free job then
+exchanges GitHub's OIDC identity for a short-lived production crates.io token
+and immediately revokes it. The token is never passed to repository code, and
+the workflow contains no registry upload command.
+
+One-time setup requires two distinct permission levels:
+
+1. A repository administrator creates a GitHub Actions environment named
+   `crates-io`, restricts its deployment branch to `main`, and configures no
+   required reviewers, secrets, or variables. The environment constrains the
+   OIDC identity; manually dispatching the workflow is the POC's only trigger.
+2. An owner of each existing crate opens that crate's **Settings > Trusted
+   Publishing** page on crates.io and adds a GitHub Actions publisher with:
+   - repository owner `zakura-core`
+   - repository name `zakura`
+   - workflow filename `publish-crates.yml`
+   - environment `crates-io`
+
+Only a crates.io owner can configure a crate's trusted publisher. An existing
+owner can grant another maintainer access from the crate's Owners settings or
+with `cargo owner`. A crate that has never been published must first be
+published manually with a narrowly scoped token from a trusted maintainer
+machine; never store that bootstrap token in GitHub.
+
+After setup, an operator needs repository Write access or higher, but no
+crates.io account permission:
+
+1. Open **Actions > Dry-run crate publishing > Run workflow**.
+2. Select `main`, enter the existing release tag, and dispatch the run.
+3. Review the crate/version/status table in the workflow summary and confirm
+   both jobs pass.
+
+There is no deployment approval prompt. A successful OIDC exchange proves that
+at least one trusted-publisher configuration matches; Cargo dry-run does not
+exercise registry upload authorization for every crate. Audit every crate's
+configuration before adding real publication in a later change. Continue to
+use the manual crates.io publishing procedure during this POC.
+
 ## Promotion and the "Latest" Release
 
 Both release workflows publish every release with `prerelease: true`, whatever

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -124,6 +124,15 @@ exercise registry upload authorization for every crate. Audit every crate's
 configuration before adding real publication in a later change. Continue to
 use the manual crates.io publishing procedure during this POC.
 
+The `crates-io` environment deliberately carries no required reviewers, because
+nothing this workflow runs can upload. That changes when the POC graduates: the
+plan is to fold trusted publishing into the release CI, at which point the
+environment gains required reviewers like `release` above, and the trusted
+publisher's workflow filename moves to whichever workflow actually publishes.
+Until then the trusted-publisher entries grant only what the POC exercises —
+minting and revoking a token — so remove them if this POC is abandoned rather
+than wired into the release path.
+
 ## Promotion and the "Latest" Release
 
 Both release workflows publish every release with `prerelease: true`, whatever

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -94,9 +94,11 @@ the workflow contains no registry upload command.
 One-time setup requires two distinct permission levels:
 
 1. A repository administrator creates a GitHub Actions environment named
-   `crates-io`, restricts its deployment branch to `main`, and configures no
-   required reviewers, secrets, or variables. The environment constrains the
-   OIDC identity; manually dispatching the workflow is the POC's only trigger.
+   `crates-io`, restricts its deployment branch to `main`, configures a
+   required reviewer, and disables administrator bypass of protection rules.
+   Add no environment secrets or variables. The environment constrains the
+   OIDC identity; manually dispatching the workflow is the POC's only trigger,
+   and the `oidc-smoke` job waits for that reviewer before exchanging a token.
 2. An owner of each existing crate opens that crate's **Settings > Trusted
    Publishing** page on crates.io and adds a GitHub Actions publisher with:
    - repository owner `zakura-core`
@@ -115,23 +117,29 @@ crates.io account permission:
 
 1. Open **Actions > Dry-run crate publishing > Run workflow**.
 2. Select `main`, enter the existing release tag, and dispatch the run.
-3. Review the crate/version/status table in the workflow summary and confirm
+3. Ask a `crates-io` environment reviewer to approve the pending
+   `oidc-smoke` deployment.
+4. Review the crate/version/status table in the workflow summary and confirm
    both jobs pass.
 
-There is no deployment approval prompt. A successful OIDC exchange proves that
-at least one trusted-publisher configuration matches; Cargo dry-run does not
-exercise registry upload authorization for every crate. Audit every crate's
-configuration before adding real publication in a later change. Continue to
-use the manual crates.io publishing procedure during this POC.
+A successful OIDC exchange proves that at least one trusted-publisher
+configuration matches; Cargo dry-run does not exercise registry upload
+authorization for every crate. Audit every crate's configuration before adding
+real publication in a later change. Continue to use the manual crates.io
+publishing procedure during this POC.
 
-The `crates-io` environment deliberately carries no required reviewers, because
-nothing this workflow runs can upload. That changes when the POC graduates: the
-plan is to fold trusted publishing into the release CI, at which point the
-environment gains required reviewers like `release` above, and the trusted
-publisher's workflow filename moves to whichever workflow actually publishes.
-Until then the trusted-publisher entries grant only what the POC exercises —
-minting and revoking a token — so remove them if this POC is abandoned rather
-than wired into the release path.
+The `crates-io` environment has a required reviewer from day one, and
+administrator bypass of protection rules is disabled. Publishing to crates.io
+has historically been a separate decision from tagging — `v1.0.3-rc1`,
+`v1.1.0-rc0`, and `v1.2.0-rc0` were tagged but intentionally never published —
+so the reviewer preserves that decision point once this POC graduates to a
+real upload path. For the dry-run workflow, the `oidc-smoke` job pauses at
+"Review pending deployments" until a reviewer approves; ping a reviewer after
+dispatching. When trusted publishing is folded into the release CI, keep the
+reviewer on `crates-io` and move the trusted publisher's workflow filename to
+whichever workflow actually publishes. Until then the trusted-publisher
+entries grant only what the POC exercises — minting and revoking a token — so
+remove them if this POC is abandoned rather than wired into the release path.
 
 ## Promotion and the "Latest" Release
 

--- a/scripts/check-crate-publish-graph.sh
+++ b/scripts/check-crate-publish-graph.sh
@@ -49,12 +49,17 @@ for cmd in cargo curl git jq tar; do
   command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd" >&2; exit 1; }
 done
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tool_root="$(cd "$(dirname "$0")/.." && pwd)"
+repo_root="${ZAKURA_REPO_ROOT:-$tool_root}"
+[ -f "${repo_root}/Cargo.toml" ] || {
+  echo "ZAKURA_REPO_ROOT has no Cargo.toml: ${repo_root}" >&2
+  exit 1
+}
 cd "$repo_root"
 
 # The library is linted as a standalone shellcheck input in lint.yml.
 # shellcheck source=scripts/lib/crates-index.sh disable=SC1091
-. "${repo_root}/scripts/lib/crates-index.sh"
+. "${tool_root}/scripts/lib/crates-index.sh"
 
 allow_unpublishable="${ZAKURA_ALLOW_UNPUBLISHABLE_CRATE_GRAPH:-0}"
 

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -32,7 +32,19 @@ case "$RELEASE_TAG" in
 esac
 tag_version="${RELEASE_TAG#v}"
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# Defaults to this script's own checkout. Callers that inspect a different
+# tree — the crates.io dry run runs a pinned copy of this script against a
+# release-tag checkout — point ZAKURA_REPO_ROOT at the tree to check, so the
+# check's semantics come from the copy being run rather than from the tag.
+tool_root="$(cd "$(dirname "$0")/.." && pwd)"
+repo_root="${ZAKURA_REPO_ROOT:-$tool_root}"
+[ -f "${repo_root}/Cargo.toml" ] || {
+  echo "ZAKURA_REPO_ROOT has no Cargo.toml: ${repo_root}" >&2
+  exit 1
+}
+if [ "$repo_root" != "$tool_root" ]; then
+  echo "Checking the workspace at ${repo_root}."
+fi
 
 # --no-deps only reads the workspace manifests, so this works offline and
 # without a Cargo.lock.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Plan or fully dry-run the exact Zakura crate set absent from crates.io.
+#
+# This proof of concept deliberately has no publish mode and never accepts or
+# reads a registry token.
+#
+# Usage:
+#   ./scripts/publish-crates.sh plan [--output PATH]
+#   ./scripts/publish-crates.sh verify [--output PATH]
+set -euo pipefail
+
+tool_root="$(cd "$(dirname "$0")/.." && pwd)"
+repo_root="${ZAKURA_REPO_ROOT:-$tool_root}"
+[ -f "${repo_root}/Cargo.toml" ] || {
+  echo "ZAKURA_REPO_ROOT has no Cargo.toml: ${repo_root}" >&2
+  exit 1
+}
+cd "$repo_root"
+
+# The library is linted as a standalone shellcheck input in lint.yml.
+# shellcheck source=scripts/lib/crates-index.sh disable=SC1091
+. "${tool_root}/scripts/lib/crates-index.sh"
+
+mode="${1:-}"
+[ $# -gt 0 ] && shift
+case "$mode" in
+  plan | verify) ;;
+  *)
+    echo "Usage: $0 <plan|verify> [--output PATH]" >&2
+    exit 1
+    ;;
+esac
+
+output_path=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output)
+      output_path="${2:?--output needs a path}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+for cmd in cargo curl git jq; do
+  command -v "$cmd" >/dev/null || {
+    echo "Missing required tool: $cmd" >&2
+    exit 1
+  }
+done
+
+metadata="$(cargo metadata --format-version 1 --no-deps --locked)"
+publishable="$(jq -r '
+  .packages[]
+  | select(.publish == null or (.publish | length) > 0)
+  | [.name, .version]
+  | @tsv
+' <<<"$metadata")"
+
+packages_json='[]'
+publish_set=()
+initial_publish_required=()
+exclude_args=()
+
+echo "Crates.io dry-run plan (exact workspace versions):"
+while IFS=$'\t' read -r crate version; do
+  [ -n "$crate" ] || continue
+  published_versions="$(crates_index_versions "$crate")" || {
+    echo "Could not query the crates.io index for ${crate}." >&2
+    exit 1
+  }
+
+  if grep -Fxq -- "$version" <<<"$published_versions"; then
+    status="already_published"
+    exclude_args+=(--exclude "$crate")
+  elif [ -z "$published_versions" ]; then
+    status="initial_publish_required"
+    publish_set+=("${crate}@${version}")
+    initial_publish_required+=("${crate}@${version}")
+  else
+    status="to_publish"
+    publish_set+=("${crate}@${version}")
+  fi
+  printf '  %-30s %-18s %s\n' "$crate" "$version" "$status"
+
+  packages_json="$(
+    jq --arg name "$crate" --arg version "$version" --arg status "$status" \
+      '. + [{name: $name, version: $version, status: $status}]' \
+      <<<"$packages_json"
+  )"
+done <<<"$publishable"
+
+plan_json="$(
+  jq -n \
+    --arg mode "$mode" \
+    --argjson packages "$packages_json" \
+    '{
+      mode: $mode,
+      packages: $packages,
+      counts: {
+        publishable: ($packages | length),
+        already_published: ([$packages[] | select(.status == "already_published")] | length),
+        to_publish: ([$packages[] | select(.status == "to_publish")] | length),
+        initial_publish_required: ([$packages[] | select(.status == "initial_publish_required")] | length)
+      }
+    }'
+)"
+
+if [ -n "$output_path" ]; then
+  printf '%s\n' "$plan_json" > "$output_path"
+  echo "Wrote dry-run plan to ${output_path}."
+fi
+
+echo
+jq -r '
+  "Summary: \(.counts.to_publish) to publish, " +
+  "\(.counts.initial_publish_required) initial publishes required, " +
+  "\(.counts.already_published) already published"
+' <<<"$plan_json"
+
+if [ "${#initial_publish_required[@]}" -gt 0 ]; then
+  echo "NOTICE: bootstrap these crate names manually before production automation: ${initial_publish_required[*]}" >&2
+fi
+
+if [ "$mode" = "plan" ]; then
+  exit 0
+fi
+
+if [ "${#publish_set[@]}" -eq 0 ]; then
+  echo "Every publishable workspace version is already on crates.io; verification is a no-op."
+  exit 0
+fi
+
+if ! git diff --quiet HEAD -- Cargo.lock; then
+  echo "Cargo.lock must be clean before dry-run verification." >&2
+  exit 1
+fi
+lock_backup="$(mktemp)"
+cp Cargo.lock "$lock_backup"
+restore_lock() {
+  if ! cmp -s Cargo.lock "$lock_backup"; then
+    cp "$lock_backup" Cargo.lock
+  fi
+  rm -f "$lock_backup"
+}
+trap restore_lock EXIT
+
+echo
+echo "Checking the selected crates against the live crates.io dependency graph..."
+ZAKURA_REPO_ROOT="$repo_root" \
+ZAKURA_ALLOW_UNPUBLISHABLE_CRATE_GRAPH=0 \
+  "${tool_root}/scripts/check-crate-publish-graph.sh"
+
+echo
+echo "Building the selected packaged crates with Cargo dry-run publishing..."
+cargo publish --workspace --dry-run --locked "${exclude_args[@]}"
+
+echo
+echo "Dry-run verification passed: ${publish_set[*]}"


### PR DESCRIPTION
## Motivation

Before automating crates.io publication from the protected release pipeline, validate the exact crate selection and Trusted Publishing identity without exposing an upload path.

## Solution

- add a manually dispatched, no-upload Trusted Publishing workflow
- derive exact unpublished workspace versions from the live crates.io index and run Cargo's full publish dry run
- isolate the short-lived OIDC token in a checkout-free job where it is immediately revoked
- allow current publishing tools to inspect an immutable release checkout separately from the workflow tooling on `main`
- document the GitHub environment and per-crate crates.io access required for the POC

## Testing

- `shellcheck scripts/publish-crates.sh scripts/check-crate-publish-graph.sh scripts/release-t0.sh`
- `actionlint .github/workflows/publish-crates.yml`
- `markdownlint docs/release-tag-protection.md --config .github/.markdownlint.yaml`
- `ZAKURA_REPO_ROOT=<v1.1.1-worktree> ./scripts/publish-crates.sh verify`: passed as a no-op with all 13 publishable versions already present
- current `main` planning selected `zakura-chain@5.0.0` and `zakura-rpc@7.0.0`; verification correctly stopped because `cpu-equihash-solver` is not available on crates.io
- OIDC exchange not run yet: the `crates-io` environment and Trusted Publisher entries require owner/admin setup described below

## Changelog

No changelog fragment: this POC changes internal release automation only and does not modify Rust sources or Cargo manifests.

### Specifications & References

- [crates.io Trusted Publishing](https://crates.io/docs/trusted-publishing)
- Supersedes the implementation approach in [#157](https://github.com/zakura-core/zakura/pull/157) with a no-upload POC against the current release pipeline.

### Follow-up Work

- A repository admin must create the `crates-io` environment, restricted to `main`, with no reviewers, secrets, or variables.
- A crates.io owner must add the `publish-crates.yml` / `crates-io` Trusted Publisher entry to each existing crate.
- After the POC is validated, add real idempotent publication behind the existing `create-release` approval in a separate PR.

### AI Disclosure

Cursor assisted with the implementation, testing, and PR description; the release and registry security boundaries were reviewed explicitly during development.