### PR TITLE
feat(deploy): add per-node status pages to the cluster dashboard

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -187,6 +187,9 @@ jobs:
           # not written to any node (manage_config = false).
           rpc_listen_addr = "0.0.0.0:8232"
           log_file        = "/root/logs/zakura-tracing.log"
+          # Verified on the fleet: the nine regional nodes keep state here, the
+          # compat host does not. Used only for the dashboard's disk probe.
+          state_cache_dir = "/mnt/data/zakura-cache"
 
           # Public mainnet node ids (crates/zakura-network/src/zakura/handler.rs). Used by
           # the dashboard to label each host; not deployed to the nodes.
@@ -255,6 +258,7 @@ jobs:
           service_name = "zakurad-compat"
           log_file   = ""
           rpc_listen_addr = "127.0.0.1:8232"
+          state_cache_dir = "/mnt/data/import-zebra"
           EOF
 
       - name: Build deployer binary
@@ -355,6 +359,7 @@ jobs:
           rpc_listen_addr = "[::1]:8232"
           rpc_auth = "cookie"
           rpc_config_path = "/mnt/data/runtime/zcashd/.cookie"
+          state_cache_dir = "/mnt/data/runtime/zcashd"
           # P2P sidecar (post -zebra-compat): supervised with -connect=127.0.0.1:8233.
           process_pattern = "zcashd .*-connect=127.0.0.1:8233"
           EOF

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -369,7 +369,7 @@ jobs:
           [Service]
           Type=simple
           WorkingDirectory=/opt/zakura-mainnet-dashboard
-          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --upgrade-height 3428143 --target-spacing 75 --state-file /var/lib/zakura-mainnet-dashboard/orphan-pairs.json
+          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --state-file /var/lib/zakura-mainnet-dashboard/orphan-pairs.json
           Restart=always
           RestartSec=5
 

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -140,6 +140,7 @@ jobs:
           storage_mode    = "archive"
           p2p_stack       = "dual"
           metrics_endpoint = "127.0.0.1:9999"
+          health_listen_addr = "127.0.0.1:8080"
           tracing_filter  = "info,zakura_network::zakura=info"
           checkpoint_sync = false
           vct_fast_sync   = false
@@ -251,7 +252,7 @@ jobs:
           [Service]
           Type=simple
           WorkingDirectory=/opt/zakura-testnet-dashboard
-          ExecStart=/usr/bin/python3 /opt/zakura-testnet-dashboard/zakura-cluster-status.py --config /opt/zakura-testnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network testnet --interval 10 --stale-after 300 --upgrade-height 4134000 --target-spacing 7.5 --state-file /var/lib/zakura-testnet-dashboard/orphan-pairs.json
+          ExecStart=/usr/bin/python3 /opt/zakura-testnet-dashboard/zakura-cluster-status.py --config /opt/zakura-testnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network testnet --interval 10 --stale-after 300 --state-file /var/lib/zakura-testnet-dashboard/orphan-pairs.json
           Restart=always
           RestartSec=5
 

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -28,6 +28,18 @@ Copy `nodes.example.toml` to `nodes.toml` and edit. Each `[[nodes]]` entry needs
 `[defaults]` supplies fleet-wide values (service name, paths, network, ssh
 `port`); any field can be overridden per node. `nodes.toml` is gitignored.
 
+Two optional keys turn on the node's observability endpoints, which the status
+dashboard reads over its own ssh probe:
+
+- `metrics_endpoint` — renders `[metrics] endpoint_addr`, the Prometheus
+  `/metrics` exporter.
+- `health_listen_addr` — renders `[health] listen_addr`, serving `/healthy` and
+  `/ready`.
+
+Both are unauthenticated, so bind them to loopback. `zakurad` panics if either
+address is already in use, so check the port on the node before enabling one.
+Neither is rendered on a fleet running `manage_config = false`.
+
 ## Commands
 
 ```bash
@@ -109,10 +121,8 @@ The workflow also refreshes a simple fleet status dashboard on
 
 The dashboard reads the generated deployer node config and polls each node over
 SSH. It shows the running commit from the node log, last restart time, current
-RPC height, whether the height advanced in the last five minutes, and an upgrade
-ETA for Ironwood testnet activation height `4134000`. The ETA uses observed
-cluster block movement when enough samples are available, otherwise it falls back
-to `--target-spacing 7.5`.
+RPC height, and whether the height advanced in the last five minutes. Node names
+link to `/node/<name>` for per-node host vitals, sync pipeline, and peer detail.
 
 The same service exposes the narrow public website API at
 `/ironwood-status.json` and its liveness check at `/healthz`. The public response
@@ -166,9 +176,7 @@ python3 deploy/runner/zakura-cluster-status.py \
   --config deploy/deployer/nodes.toml \
   --host 0.0.0.0 \
   --port 8090 \
-  --network testnet \
-  --upgrade-height 4134000 \
-  --target-spacing 7.5
+  --network testnet
 ```
 
 ## GitHub Actions mainnet fleet deploy
@@ -237,20 +245,14 @@ The gateway allowlists `sendrawtransaction`, rate-limits at 30 req/min/IP, and
 load-balances across the mainnet `:8232` backends listed in
 `deploy/gateway/mainnet/backends.toml`.
 
-It is the same `zakura-cluster-status.py` as testnet, launched with
-`--upgrade-height 3428143` for the Ironwood mainnet activation height. The ETA
-uses observed cluster block movement when enough samples are available,
-otherwise it falls back to `--target-spacing 75` (post-Blossom mainnet spacing).
-Manual run:
+It is the same `zakura-cluster-status.py` as testnet. Manual run:
 
 ```bash
 python3 deploy/runner/zakura-cluster-status.py \
   --config deploy/deployer/nodes.toml \
   --host 0.0.0.0 \
   --port 8090 \
-  --network mainnet \
-  --upgrade-height 3428143 \
-  --target-spacing 75
+  --network mainnet
 ```
 
 The mainnet workflow also installs a Slack watchdog on `us-east-0`:

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -65,6 +65,9 @@ DEFAULTS = {
     # One of: default | legacy | zakura | dual.
     "p2p_stack": "dual",
     "metrics_endpoint": "",  # e.g. "127.0.0.1:9100" -> renders [metrics]; "" omits it
+    # e.g. "127.0.0.1:8080" -> renders [health] (/healthy, /ready); "" omits it.
+    # Both endpoints are unauthenticated, so keep them on loopback.
+    "health_listen_addr": "",
     "tracing_filter": "",    # e.g. "info,zakura_network::zakura=debug"; "" uses zakurad default
     "checkpoint_sync": True,
     # Setting this false keeps checkpoint sync on while selecting the legacy non-VCT path.
@@ -108,6 +111,7 @@ class Node:
     storage_mode: str
     p2p_stack: str
     metrics_endpoint: str
+    health_listen_addr: str
     tracing_filter: str
     checkpoint_sync: bool
     vct_fast_sync: bool
@@ -234,6 +238,7 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
                 merged["p2p_stack"], where=f"[[nodes]] {name}"
             ),
             metrics_endpoint=merged["metrics_endpoint"],
+            health_listen_addr=merged["health_listen_addr"],
             tracing_filter=merged["tracing_filter"],
             checkpoint_sync=merged["checkpoint_sync"],
             vct_fast_sync=merged["vct_fast_sync"],
@@ -460,6 +465,9 @@ def render_node_config(node: Node) -> str:
     else:
         rpc_block = "# listen_addr disabled"
     metrics_block = f'[metrics]\nendpoint_addr = "{node.metrics_endpoint}"\n' if node.metrics_endpoint else ""
+    health_block = (
+        f'[health]\nlisten_addr = "{node.health_listen_addr}"\n' if node.health_listen_addr else ""
+    )
     filter_line = f'filter = "{node.tracing_filter}"' if node.tracing_filter else "# filter unset (zakurad default)"
     network_cache_line = (
         f'cache_dir = "{node.network_cache_dir}"' if node.network_cache_dir else "# cache_dir unset (zakurad default)"
@@ -477,6 +485,7 @@ def render_node_config(node: Node) -> str:
         "P2P_STACK": node.p2p_stack,
         "ZAKURA_BLOCK": render_zakura_block(node.zakura),
         "METRICS_BLOCK": metrics_block,
+        "HEALTH_BLOCK": health_block,
         "TRACING_FILTER": filter_line,
         "LOG_FILE": node.log_file,
         "RPC_BLOCK": rpc_block,

--- a/deploy/deployer/nodes.example.toml
+++ b/deploy/deployer/nodes.example.toml
@@ -17,6 +17,11 @@ listen_addr     = "[::]:8233"
 rpc_listen_addr = ""                        # empty = RPC disabled; e.g. "0.0.0.0:8232"
 storage_mode    = "archive"                 # "archive" serves all history; "pruned" does not
 p2p_stack       = "dual"                     # legacy | zakura | dual | default
+# Observability endpoints. Both are unauthenticated, so keep them on loopback;
+# the status dashboard reads them over its existing ssh probe. Empty = omitted.
+# zakurad panics if either address is already bound, so check the port first.
+# metrics_endpoint   = "127.0.0.1:9999"     # Prometheus /metrics
+# health_listen_addr = "127.0.0.1:8080"     # /healthy and /ready
 # port          = 22                        # optional non-default ssh port
 
 # Optional fleet-wide Zakura settings, rendered into [network.zakura] on every

--- a/deploy/deployer/templates/zakura.toml
+++ b/deploy/deployer/templates/zakura.toml
@@ -16,6 +16,7 @@ storage_mode = "{{STORAGE_MODE}}"
 {{RPC_BLOCK}}
 
 {{METRICS_BLOCK}}
+{{HEALTH_BLOCK}}
 [consensus]
 checkpoint_sync = {{CHECKPOINT_SYNC}}
 vct_fast_sync = {{VCT_FAST_SYNC}}

--- a/deploy/deployer/test_deploy.py
+++ b/deploy/deployer/test_deploy.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 import sys
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -117,7 +118,9 @@ class BuildCacheTests(unittest.TestCase):
             })
 
 
-class MountRenderingTests(unittest.TestCase):
+class NodeBuilder:
+    """Shared minimal node fixture for the rendering tests."""
+
     def node(self, **overrides):
         data = {
             "name": "node-a",
@@ -139,6 +142,7 @@ class MountRenderingTests(unittest.TestCase):
             "storage_mode": "archive",
             "p2p_stack": "dual",
             "metrics_endpoint": "",
+            "health_listen_addr": "",
             "tracing_filter": "",
             "checkpoint_sync": True,
             "vct_fast_sync": True,
@@ -151,6 +155,8 @@ class MountRenderingTests(unittest.TestCase):
         data.update(overrides)
         return deploy.Node(**data)
 
+
+class MountRenderingTests(NodeBuilder, unittest.TestCase):
     def test_render_service_requires_data_mount_for_data_paths(self):
         service = deploy.render_service(self.node(
             state_cache_dir="/mnt/data/zakura-cache",
@@ -165,6 +171,71 @@ class MountRenderingTests(unittest.TestCase):
 
         self.assertNotIn("RequiresMountsFor=/mnt/data", service)
         self.assertNotIn("AssertPathIsMountPoint=/mnt/data", service)
+
+
+class ObservabilityRenderingTests(NodeBuilder, unittest.TestCase):
+    """The [metrics] and [health] sections are opt-in and must round-trip as TOML."""
+
+    def test_endpoints_render_when_configured(self):
+        config = tomllib.loads(deploy.render_node_config(self.node(
+            metrics_endpoint="127.0.0.1:9999",
+            health_listen_addr="127.0.0.1:8080",
+        )))
+
+        self.assertEqual(config["metrics"], {"endpoint_addr": "127.0.0.1:9999"})
+        self.assertEqual(config["health"], {"listen_addr": "127.0.0.1:8080"})
+
+    def test_endpoints_omitted_when_unset(self):
+        config = tomllib.loads(deploy.render_node_config(self.node()))
+
+        self.assertNotIn("metrics", config)
+        self.assertNotIn("health", config)
+
+    def test_health_renders_independently_of_metrics(self):
+        config = tomllib.loads(deploy.render_node_config(self.node(
+            health_listen_addr="127.0.0.1:8080",
+        )))
+
+        self.assertNotIn("metrics", config)
+        self.assertEqual(config["health"], {"listen_addr": "127.0.0.1:8080"})
+
+
+class ConfigKeyTests(unittest.TestCase):
+    def write_config(self, tmp: str, body: str) -> Path:
+        path = Path(tmp) / "nodes.toml"
+        path.write_text(body)
+        return path
+
+    def test_health_listen_addr_is_a_known_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, """
+                [defaults]
+                health_listen_addr = "127.0.0.1:8080"
+
+                [[nodes]]
+                name = "node-a"
+                ssh_string = "root@example"
+                commit = "main"
+            """.replace("                ", ""))
+
+            nodes = deploy.load_nodes(path, None)
+
+            self.assertEqual(nodes[0].health_listen_addr, "127.0.0.1:8080")
+
+    def test_unknown_key_still_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, """
+                [defaults]
+                health_listen_address = "127.0.0.1:8080"
+
+                [[nodes]]
+                name = "node-a"
+                ssh_string = "root@example"
+                commit = "main"
+            """.replace("                ", ""))
+
+            with self.assertRaises(deploy.DeployError):
+                deploy.load_nodes(path, None)
 
 
 if __name__ == "__main__":

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -16,12 +16,42 @@ serves both the existing fleet dashboard and a narrow public API:
 - `OPTIONS /ironwood-status.json` handles the allow-listed CORS preflight.
 - `GET /healthz` reports service liveness.
 - `GET /data` retains the existing fleet dashboard and watchdog response.
+- `GET /node/<name>` serves the per-node detail page.
+- `GET /data/node/<name>` returns that node's detail payload.
 
 The public Ironwood response is unavailable with HTTP `503` if the service
 cannot verify a matching network, Ironwood pool, tip, or source client, or if
 the most recent complete observation is more than 120 seconds old. The endpoint
 is rate-limited and permits cross-origin reads from `https://zakura.com`.
 Testnet additionally permits the two development origins on port `1111`.
+
+### Per-Node Detail
+
+Node names in the fleet table link to `/node/<name>`. Both routes serve the same
+HTML; the page branches on `location.pathname`, so the CSS and formatters are
+shared and there is no second template to keep in sync.
+
+The detail page leads with host vitals — free disk on the state directory,
+available memory, process RSS, load, uptime, systemd restart count and kernel OOM
+kills — then chain position, the sync pipeline, and peers. None of the vitals
+need a metrics endpoint, so they populate on every node including `zcashd-compat`.
+
+The sync and peer panels read the node's Prometheus exporter. The probe scrapes
+`http://<metrics_endpoint>/metrics` from inside the node and filters it against a
+small allowlist before returning, so a few KB crosses the ssh pipe rather than the
+full ~350-name surface. Set `metrics_endpoint` and `health_listen_addr` in the
+deployer config to populate these; where they are unset the panels say so instead
+of rendering blanks.
+
+Sparklines come from an in-memory per-node ring buffer sized by
+`--history-window` (default 3h). This history is deliberately not persisted:
+`--state-file` carries the durable orphan-pair and stall timers, and losing
+sparklines across a dashboard restart is acceptable.
+
+The probe collects a redacted tail of the node's `ERROR`/`WARN` log lines, but
+the page does not serve it unless the dashboard runs with `--expose-logs`. These
+dashboards are public and unauthenticated, so log text stays off by default even
+though peer addresses are already redacted on the node.
 
 ### Tip Agreement and Orphan Pairs
 

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
+import os
+import re
+import subprocess
 import sys
 import tempfile
 import threading
@@ -11,7 +15,9 @@ import time
 import unittest
 import urllib.error
 import urllib.request
+from http.server import BaseHTTPRequestHandler
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT_PATH = Path(__file__).with_name("zakura-cluster-status.py")
@@ -46,8 +52,6 @@ def collector(network: str = "testnet"):
         [node()],
         interval=10,
         stale_after=300,
-        upgrade_height=0,
-        target_spacing=7.5,
         network=network,
     )
 
@@ -77,6 +81,215 @@ def public_row(
         "last_seen_at": observed_at,
         "rpc_metadata_error": None,
     }
+
+
+class RemoteProbeTests(unittest.TestCase):
+    """Run the probe the way a node does: as a standalone script over stdin.
+
+    The probe is a string executed on the far side of ssh, so the only faithful
+    way to exercise it is to run it as its own process against stub endpoints.
+    """
+
+    EXPOSITION = b"""# a comment the exporter never actually emits
+zakura_build_info{version="1.1.0-rc1"} 1
+zcash_net_peers 74
+zakura_p2p_conn_active 12
+sync_header_verification_lag 3
+zcash_net_in_messages{command="inv",addr="redacted"} 5
+zcash_net_in_bytes_total 12345
+not_an_allowlisted_metric 999
+sync_stage_duration_seconds{quantile="0.5"} 0.02
+zcash_net_peers_connected{user_agent="/Zakura:1.1.0/",remote_version="170160"} 40
+zcash_net_peers_connected{user_agent="/Zakura:1.1.0/",remote_version="170140"} 2
+zcash_net_peers_connected{user_agent="/MagicBean:6.2.0/",remote_version="170160"} 33
+zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
+"""
+
+    def setUp(self):
+        exposition = self.EXPOSITION
+
+        class StubHandler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def reply(self, code, body):
+                self.send_response(code)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self):
+                if self.path == "/metrics":
+                    return self.reply(200, exposition)
+                if self.path == "/healthy":
+                    return self.reply(200, b"ok")
+                if self.path == "/ready":
+                    return self.reply(503, b"lag=47 blocks")
+                return self.reply(404, b"nope")
+
+        self.server = status.ThreadingHTTPServer(("127.0.0.1", 0), StubHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.endpoint = f"127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def stub_journalctl(self, stack, *, exit_code: int, stdout: str = "") -> dict:
+        """Put a fake journalctl first on PATH so OOM counting is hermetic."""
+        directory = stack.enter_context(tempfile.TemporaryDirectory())
+        script = Path(directory) / "journalctl"
+        script.write_text(
+            "#!/bin/sh\n"
+            + ("printf '%s'\n" % stdout.replace("'", "") if stdout else "")
+            + f"exit {exit_code}\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        return {"PATH": f"{directory}:{os.environ.get('PATH', '')}"}
+
+    def run_probe(self, env: dict | None = None, **overrides) -> dict:
+        args = {
+            "service": "",
+            "bin_path": "/bin/true",
+            "log_file": "",
+            "rpc_url": "",
+            "probe_kind": "zebra",
+            "process_pattern": "",
+            "rpc_auth": "",
+            "rpc_user": "",
+            "rpc_password": "",
+            "rpc_config_path": "",
+            "container_name": "",
+            "metrics_endpoint": "",
+            "health_listen_addr": "",
+            "state_cache_dir": tempfile.gettempdir(),
+            "want_metrics": "1",
+        }
+        args.update(overrides)
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+            handle.write(status.REMOTE_PROBE)
+            script = handle.name
+        try:
+            completed = subprocess.run(
+                [sys.executable, script, *args.values()],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env={**os.environ, **(env or {})},
+            )
+        finally:
+            Path(script).unlink()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return json.loads(completed.stdout)
+
+    def test_metrics_scrape_keeps_only_allowlisted_series(self):
+        probe = self.run_probe(metrics_endpoint=self.endpoint)
+
+        self.assertNotIn("metrics_error", probe)
+        self.assertEqual(probe["metrics_version"], "1.1.0-rc1")
+        self.assertEqual(
+            probe["metrics"],
+            {
+                "zcash_net_peers": 74.0,
+                "zakura_p2p_conn_active": 12.0,
+                "sync_header_verification_lag": 3.0,
+                "zcash_net_in_bytes_total": 12345.0,
+            },
+        )
+
+    def test_peer_versions_come_from_the_user_agent_label(self):
+        # zakurad's getpeerinfo omits subver, so the exporter label is the only
+        # source for a peer version breakdown.
+        probe = self.run_probe(metrics_endpoint=self.endpoint)
+
+        self.assertEqual(
+            probe["peer_user_agents"],
+            [["/Zakura:1.1.0/", 42], ["/MagicBean:6.2.0/", 33]],
+        )
+        self.assertNotIn("zcash_net_peers_connected", probe["metrics"])
+
+    def test_metrics_scrape_can_be_skipped(self):
+        probe = self.run_probe(metrics_endpoint=self.endpoint, want_metrics="")
+
+        self.assertTrue(probe["metrics_skipped"])
+        self.assertNotIn("metrics", probe)
+        self.assertNotIn("metrics_error", probe)
+
+    def test_no_oom_kills_reports_zero_rather_than_unknown(self):
+        # journalctl exits 1 when its grep matches nothing, which is the common
+        # case on a healthy node and must not read as "unknown".
+        with contextlib.ExitStack() as stack:
+            env = self.stub_journalctl(stack, exit_code=1)
+            probe = self.run_probe(env=env)
+
+        self.assertEqual(probe["host"]["oom_kills_24h"], 0)
+
+    def test_oom_kills_are_counted_by_line(self):
+        with contextlib.ExitStack() as stack:
+            env = self.stub_journalctl(
+                stack,
+                exit_code=0,
+                stdout="oom-kill: one\\noom-kill: two\\n",
+            )
+            probe = self.run_probe(env=env)
+
+        self.assertEqual(probe["host"]["oom_kills_24h"], 2)
+
+    def test_health_probe_keeps_status_and_body(self):
+        probe = self.run_probe(health_listen_addr=self.endpoint)
+
+        self.assertEqual(probe["health"]["healthy"], {"status": 200, "body": "ok"})
+        # The body is the diagnostic: /ready explains *why* it is not ready.
+        self.assertEqual(
+            probe["health"]["ready"],
+            {"status": 503, "body": "lag=47 blocks"},
+        )
+
+    def test_unconfigured_endpoints_report_rather_than_fail(self):
+        probe = self.run_probe()
+
+        self.assertEqual(probe["metrics_error"], "metrics endpoint not configured")
+        self.assertEqual(probe["health_error"], "health endpoint not configured")
+        self.assertNotIn("host_error", probe)
+
+    def test_host_vitals_are_collected_without_any_endpoint(self):
+        probe = self.run_probe()
+
+        host = probe["host"]
+        self.assertEqual(host["disk_path"], tempfile.gettempdir())
+        self.assertGreater(host["disk_total_bytes"], 0)
+        self.assertIn("mem_total_bytes", host)
+        self.assertIn("load1", host)
+        self.assertIn("uptime_seconds", host)
+
+    def test_log_tail_redacts_addresses_and_bounds_line_length(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "zakura.log"
+            log.write_text(
+                "INFO fine\n"
+                "ERROR peer 203.0.113.10 timed out\n"
+                "WARN " + ("x" * 500) + "\n",
+                encoding="utf-8",
+            )
+
+            probe = self.run_probe(log_file=str(log))
+
+        lines = probe["log_errors"]
+        self.assertEqual(len(lines), 2)
+        self.assertIn("x.x.x.x", lines[0])
+        self.assertNotIn("203.0.113.10", lines[0])
+        self.assertLessEqual(len(lines[1]), 303)
+
+    def test_unreachable_metrics_endpoint_is_reported_not_raised(self):
+        # Port 1 is reserved and never listening, so the scrape must fail.
+        probe = self.run_probe(metrics_endpoint="127.0.0.1:1")
+
+        self.assertIn("metrics_error", probe)
+        self.assertNotIn("metrics", probe)
+        self.assertIn("host", probe)
 
 
 class IronwoodStatusTests(unittest.TestCase):
@@ -241,7 +454,6 @@ class TipAgreementTests(unittest.TestCase):
         )
         self.assertEqual(split["status"], "split")
         self.assertTrue(split["split"])
-        self.assertTrue(split["compat_split"])
 
     def test_enrich_chain_roles(self):
         rows = [
@@ -323,8 +535,6 @@ class TipAgreementTests(unittest.TestCase):
                 [node()],
                 interval=10,
                 stale_after=300,
-                upgrade_height=0,
-                target_spacing=7.5,
                 network="testnet",
                 state_file=state_file,
             )
@@ -349,8 +559,6 @@ class TipAgreementTests(unittest.TestCase):
                 [node()],
                 interval=10,
                 stale_after=300,
-                upgrade_height=0,
-                target_spacing=7.5,
                 network="testnet",
                 state_file=state_file,
             )
@@ -370,8 +578,6 @@ class TipAgreementTests(unittest.TestCase):
                 [node()],
                 interval=10,
                 stale_after=300,
-                upgrade_height=0,
-                target_spacing=7.5,
                 network="testnet",
                 state_file=state_file,
             )
@@ -383,8 +589,6 @@ class TipAgreementTests(unittest.TestCase):
                 [node()],
                 interval=10,
                 stale_after=300,
-                upgrade_height=0,
-                target_spacing=7.5,
                 network="testnet",
                 state_file=state_file,
             )
@@ -453,6 +657,204 @@ class TipAgreementTests(unittest.TestCase):
         )
         self.assertEqual(other["fork_depth"], 2)
         self.assertEqual(other["fork_depth_label"], "depth 2")
+
+
+class ViewSwitchingTests(unittest.TestCase):
+    """The fleet and node views share one page and are toggled with [hidden].
+
+    A class that sets its own `display` beats the UA stylesheet's `[hidden]`
+    rule, so without an authoritative override a hidden section stays on screen
+    showing its unrendered `...` placeholders.
+    """
+
+    def setUp(self):
+        self.page = status.PAGE
+        self.markup = self.page[: self.page.index("<script>")]
+
+    def test_page_forces_hidden_elements_to_stay_hidden(self):
+        self.assertIn("[hidden] { display: none !important; }", self.page)
+
+    def test_every_toggled_section_is_covered_by_the_override(self):
+        toggled = re.findall(
+            r'<(?:section|div) class="([^"]+)"[^>]*data-view="[^"]+"', self.markup
+        )
+        self.assertTrue(toggled, "expected the view switcher to tag some sections")
+
+        override = self.page.index("[hidden] { display: none !important; }")
+        for classes in toggled:
+            primary = classes.split()[0]
+            rule = re.search(
+                r"\n\.%s \{(.*?)\}" % re.escape(primary), self.page, re.S
+            )
+            if rule is None or "display:" not in rule.group(1):
+                continue
+            # !important wins regardless of order, but keep the override early
+            # so the intent stays readable.
+            self.assertLess(
+                override,
+                rule.start(),
+                f".{primary} sets display and must be covered by the override",
+            )
+
+    def test_both_views_are_present_in_one_template(self):
+        self.assertIn('data-view="fleet"', self.markup)
+        self.assertIn('data-view="node"', self.markup)
+
+
+class NodeDetailTests(unittest.TestCase):
+    def probe(self, **overrides) -> dict:
+        base = {
+            "height": 4_200_000,
+            "headers": 4_200_000,
+            "block_hash": "a" * 64,
+            "active_state": "active",
+            "process_running": True,
+            "peer_count": 74,
+            "metrics": {"zcash_net_peers": 74.0},
+            "health": {"healthy": {"status": 200, "body": "ok"}},
+            "log_errors": ["ERROR something"],
+            "host": {
+                "disk_total_bytes": 1000,
+                "disk_free_bytes": 250,
+                "rss_bytes": 4096,
+                "restart_count": 2,
+            },
+        }
+        base.update(overrides)
+        return base
+
+    def test_disk_free_pct_needs_both_totals(self):
+        self.assertEqual(
+            status.disk_free_pct({"disk_total_bytes": 1000, "disk_free_bytes": 250}),
+            25.0,
+        )
+        self.assertIsNone(status.disk_free_pct({"disk_free_bytes": 250}))
+        self.assertIsNone(status.disk_free_pct({"disk_total_bytes": 0, "disk_free_bytes": 0}))
+
+    def test_fleet_payload_drops_deep_fields_but_keeps_vitals(self):
+        collected = collector()
+        collected.rows = [collected.row_for(node(), self.probe(), now=1_000.0)]
+
+        row = collected.snapshot()["rows"][0]
+
+        for key in status.NODE_DETAIL_KEYS:
+            self.assertNotIn(key, row)
+        self.assertEqual(row["vitals"]["disk_free_pct"], 25.0)
+        self.assertEqual(row["vitals"]["restart_count"], 2)
+        self.assertEqual(row["peer_count"], 74)
+
+    def test_node_payload_carries_the_deep_fields(self):
+        collected = collector()
+        collected.rows = [collected.row_for(node(), self.probe(), now=1_000.0)]
+
+        payload = collected.node_snapshot("node-a")
+
+        self.assertEqual(payload["node"]["metrics"], {"zcash_net_peers": 74.0})
+        self.assertEqual(payload["node"]["health_endpoint"]["healthy"]["status"], 200)
+        self.assertEqual(payload["config"]["metrics_endpoint"], "")
+        self.assertIsNone(collected.node_snapshot("does-not-exist"))
+
+    def test_log_lines_are_withheld_unless_expose_logs_is_set(self):
+        guarded = collector()
+        guarded.rows = [guarded.row_for(node(), self.probe(), now=1_000.0)]
+        self.assertEqual(guarded.node_snapshot("node-a")["node"]["log_errors"], [])
+        self.assertTrue(guarded.node_snapshot("node-a")["node"]["log_errors_suppressed"])
+
+        exposed = status.ClusterCollector(
+            [node()],
+            interval=10,
+            stale_after=300,
+            network="testnet",
+            expose_logs=True,
+        )
+        exposed.rows = [exposed.row_for(node(), self.probe(), now=1_000.0)]
+
+        self.assertEqual(
+            exposed.node_snapshot("node-a")["node"]["log_errors"],
+            ["ERROR something"],
+        )
+
+    def test_skipped_scrape_reuses_the_last_metrics(self):
+        collected = collector()
+        collected.rows = [collected.row_for(node(), self.probe(), now=1_000.0)]
+
+        # A poll that skipped the scrape must not blank the panels.
+        skipped = collected.row_for(
+            node(),
+            self.probe(metrics=None, metrics_skipped=True),
+            now=1_010.0,
+        )
+
+        self.assertEqual(skipped["metrics"], {"zcash_net_peers": 74.0})
+        self.assertEqual(skipped["metrics_at"], 1_000.0)
+
+    def test_first_poll_always_scrapes(self):
+        collected = collector()
+
+        self.assertTrue(collected.should_scrape_metrics("node-a", 1_000.0))
+
+    def test_scrape_interval_scales_with_the_last_scrape_cost(self):
+        collected = collector()
+        collected.last_metrics["node-a"] = {
+            "metrics_at": 1_000.0,
+            "metrics_scrape_seconds": 0.03,
+        }
+
+        # A cheap endpoint (0.03s * 30 = 0.9s) refreshes on every poll.
+        self.assertTrue(collected.should_scrape_metrics("node-a", 1_010.0))
+
+        # An expensive one (0.6s * 30 = 18s) backs off instead.
+        collected.last_metrics["node-a"]["metrics_scrape_seconds"] = 0.6
+        self.assertFalse(collected.should_scrape_metrics("node-a", 1_010.0))
+        self.assertTrue(collected.should_scrape_metrics("node-a", 1_019.0))
+
+    def test_scrape_backoff_is_capped(self):
+        collected = collector()
+        collected.last_metrics["node-a"] = {
+            "metrics_at": 1_000.0,
+            "metrics_scrape_seconds": 60.0,
+        }
+
+        self.assertFalse(collected.should_scrape_metrics("node-a", 1_100.0))
+        self.assertTrue(
+            collected.should_scrape_metrics("node-a", 1_000.0 + status.MAX_METRICS_INTERVAL)
+        )
+
+    def test_explicit_interval_overrides_the_adaptive_one(self):
+        collected = status.ClusterCollector(
+            [node()],
+            interval=10,
+            stale_after=300,
+            network="testnet",
+            metrics_min_interval=60.0,
+        )
+        collected.last_metrics["node-a"] = {
+            "metrics_at": 1_000.0,
+            "metrics_scrape_seconds": 0.01,
+        }
+
+        self.assertFalse(collected.should_scrape_metrics("node-a", 1_030.0))
+        self.assertTrue(collected.should_scrape_metrics("node-a", 1_060.0))
+
+    def test_history_drops_samples_older_than_the_window(self):
+        collected = status.ClusterCollector(
+            [node()],
+            interval=10,
+            stale_after=300,
+            network="testnet",
+            history_window=100,
+        )
+        for offset in range(0, 30):
+            rows = [collected.row_for(node(), self.probe(height=4_200_000 + offset), now=1_000.0 + offset * 10)]
+            collected.rows = rows
+            collected.record_node_history(1_000.0 + offset * 10, rows)
+
+        samples = list(collected.history["node-a"])
+
+        # 100s of retention at a 10s cadence keeps the newest 11 samples.
+        self.assertEqual(len(samples), 11)
+        self.assertEqual(samples[-1]["height"], 4_200_029)
+        self.assertGreaterEqual(samples[0]["t"], samples[-1]["t"] - 100)
 
 
 class RateLimiterTests(unittest.TestCase):
@@ -567,6 +969,57 @@ class HttpHandlerTests(unittest.TestCase):
     def test_unknown_route_returns_404(self):
         with self.assertRaises(urllib.error.HTTPError) as context:
             urllib.request.urlopen(f"{self.base_url}/unknown")
+
+        self.assertEqual(context.exception.code, 404)
+        context.exception.close()
+
+    def test_node_route_serves_the_same_page_as_the_fleet(self):
+        with urllib.request.urlopen(f"{self.base_url}/") as response:
+            fleet = response.read()
+        with urllib.request.urlopen(f"{self.base_url}/node/node-a") as response:
+            detail = response.read()
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(
+            response.headers["Content-Type"],
+            "text/html; charset=utf-8",
+        )
+        # One template, two routes: the client branches on location.pathname.
+        self.assertEqual(fleet, detail)
+
+    def test_page_and_data_are_never_cached(self):
+        # The HTML has no fingerprint, so a cached copy keeps showing an old
+        # build after a dashboard deploy.
+        for path in ("/", "/node/node-a", "/data", "/data/node/node-a"):
+            with self.subTest(path=path):
+                with urllib.request.urlopen(f"{self.base_url}{path}") as response:
+                    response.read()
+
+                self.assertEqual(
+                    response.headers["Cache-Control"],
+                    "no-store, must-revalidate",
+                )
+
+    def test_node_route_rejects_an_unknown_name(self):
+        with self.assertRaises(urllib.error.HTTPError) as context:
+            urllib.request.urlopen(f"{self.base_url}/node/not-a-node")
+
+        self.assertEqual(context.exception.code, 404)
+        context.exception.close()
+
+    def test_node_data_route_returns_the_detail_payload(self):
+        with urllib.request.urlopen(f"{self.base_url}/data/node/node-a") as response:
+            payload = json.load(response)
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(payload["node"]["name"], "node-a")
+        self.assertEqual(payload["network"], "testnet")
+        self.assertIn("history", payload)
+        self.assertIn("config", payload)
+
+    def test_node_data_route_404s_for_an_unknown_name(self):
+        with self.assertRaises(urllib.error.HTTPError) as context:
+            urllib.request.urlopen(f"{self.base_url}/data/node/not-a-node")
 
         self.assertEqual(context.exception.code, 404)
         context.exception.close()

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -34,8 +34,6 @@ IRONWOOD_ACTIVATION_HEIGHTS = {
     "mainnet": 3_428_143,
     "testnet": 4_134_000,
 }
-DEFAULT_UPGRADE_HEIGHT = IRONWOOD_ACTIVATION_HEIGHTS["testnet"]
-DEFAULT_TARGET_SPACING = 7.5
 RPC_CHAIN_NAMES = {
     "mainnet": "main",
     "testnet": "test",
@@ -54,11 +52,39 @@ PUBLIC_ORIGINS = {
         "http://localhost:1111",
     }),
 }
-HEIGHT_HISTORY_WINDOW = 60 * 60
-MIN_OBSERVED_BLOCKS = 3
-MIN_OBSERVED_SECONDS = 120
-MIN_SECONDS_PER_BLOCK = 1.0
-MAX_SECONDS_PER_BLOCK = 10 * 60.0
+# Per-node sparkline retention. Kept in memory only: --state-file carries the
+# durable orphan-pair and stall history, and losing sparklines across a
+# dashboard restart is acceptable.
+DEFAULT_NODE_HISTORY_WINDOW = 3 * 60 * 60
+# Rendering the exposition costs the node real CPU, and that cost grows with
+# peer-labelled counter cardinality: ~0.03s on a freshly restarted node, ~0.6s
+# after several days. Rather than a fixed cadence, back off in proportion to
+# what the last scrape actually cost, so a cheap endpoint refreshes every poll
+# and an expensive one cannot burn more than about 1/COST_FACTOR of a core.
+METRICS_COST_FACTOR = 30
+MAX_METRICS_INTERVAL = 120.0
+# Deep per-node fields. Carried on every row so the node view can read them, but
+# stripped from the fleet-wide /data payload, which the Slack watchdog polls.
+NODE_DETAIL_KEYS = (
+    "host",
+    "metrics",
+    "metrics_error",
+    "metrics_version",
+    "metrics_bytes",
+    "metrics_series",
+    "metrics_scrape_seconds",
+    "metrics_at",
+    "health_endpoint",
+    "health_endpoint_error",
+    "log_errors",
+    "peer_subversions",
+    "peer_user_agents",
+    "peer_info_error",
+    "mempool_size",
+    "mempool_bytes",
+    "node_errors",
+    "node_errors_at",
+)
 RECENT_REORG_LIMIT = 40
 # Sampled best-chain ancestor offsets used to estimate fork depth between tips.
 ANCESTOR_DEPTHS = (1, 2, 5, 10, 32)
@@ -87,6 +113,10 @@ DEFAULTS = {
     "process_pattern": "",
     "container_name": "",
     "port": None,
+    # Node-local observability endpoints, both loopback-bound and unauthenticated.
+    # The probe reads them from inside the node, so they never need exposing.
+    "metrics_endpoint": "",
+    "health_listen_addr": "",
 }
 
 
@@ -106,6 +136,9 @@ class Node:
     process_pattern: str
     container_name: str
     node_id: str
+    metrics_endpoint: str = ""
+    health_listen_addr: str = ""
+    state_cache_dir: str = ""
     port: object = None
 
     def ssh_cmd(self, *remote: str) -> list[str]:
@@ -152,6 +185,9 @@ def load_nodes(config_path: Path) -> list[Node]:
                 process_pattern=merged["process_pattern"],
                 container_name=merged["container_name"],
                 node_id=node_ids_by_host.get(ssh_host(merged["ssh_string"]), ""),
+                metrics_endpoint=merged["metrics_endpoint"],
+                health_listen_addr=merged["health_listen_addr"],
+                state_cache_dir=merged["state_cache_dir"],
                 port=merged["port"],
             )
         )
@@ -205,10 +241,14 @@ def rpc_url_for(listen_addr: str) -> str:
 REMOTE_PROBE = r"""
 import base64
 import json
+import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
+import time
+import urllib.error
 import urllib.request
 
 (
@@ -223,7 +263,11 @@ import urllib.request
     rpc_password,
     rpc_config_path,
     container_name,
-) = sys.argv[1:12]
+    metrics_endpoint,
+    health_listen_addr,
+    state_cache_dir,
+    want_metrics,
+) = sys.argv[1:16]
 
 out = {
     "service": service,
@@ -232,6 +276,88 @@ out = {
     "rpc_url": rpc_url,
     "probe_kind": probe_kind,
 }
+
+# Prometheus series the per-node view actually renders. The exporter emits the
+# full ~350-name surface, so filtering here keeps the ssh response a few KB
+# instead of a few hundred. Names are the exporter's sanitized form ('.' -> '_').
+WANTED_METRICS = frozenset((
+    "sync_estimated_distance_to_tip",
+    "sync_estimated_network_tip_height",
+    "sync_downloads_in_flight",
+    "sync_downloaded_block_count",
+    "sync_verified_block_count",
+    "sync_header_verification_lag",
+    "sync_header_headers_per_second",
+    "sync_header_headers_received_total",
+    "sync_header_failure_total",
+    # The header-sync work-queue family, as emitted by the deployed 1.1 binaries.
+    # Both families are listed so the allowlist spans a rolling upgrade; names
+    # that a given build does not emit simply never match.
+    "sync_header_work_last_progress_age_seconds",
+    "sync_header_work_oldest_missing_age_seconds",
+    "sync_header_work_oldest_missing_height",
+    "sync_header_work_in_flight_count",
+    "sync_header_work_pending_count",
+    "sync_header_work_buffered_count",
+    "sync_header_work_buffered_headers",
+    "sync_header_work_committing_count",
+    "sync_header_work_epoch",
+    "sync_header_root_auth_lead_blocks",
+    "sync_header_root_auth_work_in_flight_batches",
+    "sync_header_root_auth_work_pending_batches",
+    "sync_header_peer_violation",
+    "sync_header_fill_stop",
+    "sync_block_applying",
+    "sync_block_outstanding",
+    "sync_block_backlog_at_cap",
+    "sync_block_missing_bodies",
+    "sync_block_best_header_tip_height",
+    "sync_block_verified_tip_height",
+    "sync_block_fill_stop",
+    "sync_block_budget_reserved_bytes",
+    "sync_block_reorder_buffered_bytes",
+    "state_memory_best_chain_length",
+    "state_memory_chain_count",
+    "sync_header_chain_dag_nodes",
+    "sync_header_chain_dag_leaf_tips",
+    "sync_header_chain_dag_eligible_tips",
+    "sync_header_chain_frontier_header_best_height",
+    "sync_header_chain_frontier_verified_best_height",
+    "sync_header_chain_frontier_finalized_height",
+    "sync_header_chain_frontier_divergence",
+    "sync_header_chain_reorg_depth",
+    "sync_zakura_apply_phase",
+    "sync_zakura_apply_epoch",
+    "sync_zakura_legacy_fallback_active",
+    "zcash_net_peers",
+    "zcash_net_in_bytes_total",
+    "zcash_net_out_bytes_total",
+    "zcash_net_peer_handshake_failures_total",
+    "zakura_p2p_conn_active",
+    "zakura_p2p_connected_peers",
+    "zakura_p2p_healthy_peers",
+    "zakura_p2p_reactor_active_connections",
+    "zakura_p2p_handshake_upgrade_error",
+    "pool_num_ready",
+    "pool_num_unready",
+    "crawler_in_flight_handshakes",
+    "candidate_set_recently_live",
+    "candidate_set_responded",
+    "candidate_set_gossiped",
+    "candidate_set_pending",
+    "candidate_set_failed",
+    "candidate_set_disconnected",
+    "state_finalized_block_height",
+    "zakura_state_rocksdb_total_disk_size_bytes",
+    "zcash_chain_verified_block_total",
+    "zcash_mempool_size_transactions",
+))
+# A live mainnet/testnet exposition runs to ~12 MB because several net counters
+# are labelled per peer address. This is only a runaway guard, not a budget.
+MAX_METRICS_BYTES = 64 * 1024 * 1024
+# Carries the peer version breakdown in a user_agent label.
+PEER_AGENT_METRIC = "zcash_net_peers_connected"
+IPV4 = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
 
 def run(cmd, timeout=6):
     return subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
@@ -271,6 +397,110 @@ def container_logs(name):
         return ""
     proc = run(["docker", "logs", "--tail", "1000", name])
     return (proc.stdout or "") + (proc.stderr or "")
+
+def http_get(url, timeout=4, limit=4096):
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return response.status, response.read(limit).decode("utf-8", "replace").strip()
+    except urllib.error.HTTPError as error:
+        try:
+            body = error.read(limit).decode("utf-8", "replace").strip()
+        except Exception:
+            body = ""
+        return error.code, body
+
+def scrape_metrics(endpoint):
+    with urllib.request.urlopen("http://" + endpoint + "/metrics", timeout=5) as response:
+        raw = response.read(MAX_METRICS_BYTES).decode("utf-8", "replace")
+
+    values = {}
+    agents = {}
+    version = ""
+    series = 0
+    for line in raw.splitlines():
+        series += 1
+        if not line or line.startswith("#"):
+            continue
+        name, brace, rest = line.partition("{")
+        if brace:
+            labels, _, value = rest.rpartition("}")
+        else:
+            name, _, value = line.partition(" ")
+            labels = ""
+        name = name.strip()
+        if name == "zakura_build_info" and 'version="' in labels:
+            version = labels.split('version="', 1)[1].split('"', 1)[0]
+            continue
+        if name == PEER_AGENT_METRIC and 'user_agent="' in labels:
+            # zakurad's getpeerinfo has no subver field, so the peer version
+            # breakdown has to come from this label instead of the RPC.
+            agent = labels.split('user_agent="', 1)[1].split('"', 1)[0]
+            try:
+                agents[agent] = agents.get(agent, 0.0) + float(value)
+            except ValueError:
+                pass
+            continue
+        if name not in WANTED_METRICS:
+            continue
+        try:
+            number = float(value)
+        except ValueError:
+            continue
+        # A few wanted series carry labels; summing collapses them to one number.
+        values[name] = values.get(name, 0.0) + number
+    top_agents = sorted(
+        ((agent, int(count)) for agent, count in agents.items() if count > 0),
+        key=lambda item: (-item[1], item[0]),
+    )[:8]
+    return values, version, len(raw), series, top_agents
+
+def read_meminfo():
+    fields = {}
+    with open("/proc/meminfo", encoding="utf-8") as fh:
+        for line in fh:
+            key, _, rest = line.partition(":")
+            if key in ("MemTotal", "MemAvailable"):
+                fields[key] = int(rest.split()[0]) * 1024
+    return fields
+
+def process_rss_bytes(pid):
+    with open("/proc/{}/status".format(pid), encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1]) * 1024
+    return None
+
+def oom_kill_count():
+    proc = run([
+        "journalctl", "-k", "--since", "-24 hours", "--no-pager",
+        "-o", "cat", "-n", "200", "-g", "Out of memory|oom-kill|oom_reaper",
+    ], timeout=12)
+    lines = [line for line in proc.stdout.splitlines() if line.strip()]
+    if lines:
+        return len(lines)
+    # journalctl exits 1 when nothing matched, which is exactly the zero case.
+    # Only a real failure (missing journal, bad pattern) writes to stderr.
+    if proc.returncode not in (0, 1) or proc.stderr.strip():
+        return None
+    return 0
+
+def log_error_tail(path, limit=5):
+    if not path:
+        return []
+    command = "tail -c 2000000 {} 2>/dev/null | grep -aE '(ERROR|WARN)' | tail -{}".format(
+        shlex.quote(path), limit
+    )
+    proc = run(["bash", "-lc", command], timeout=12)
+    lines = []
+    for raw_line in proc.stdout.splitlines():
+        # Redact here rather than at the dashboard: these lines are served on a
+        # public page, and peer addresses must not leave the node.
+        line = IPV4.sub("x.x.x.x", raw_line.strip())
+        if len(line) > 300:
+            line = line[:300] + "..."
+        if line:
+            lines.append(line)
+    return lines
 
 def parse_zcash_conf(path):
     values = {}
@@ -346,7 +576,9 @@ try:
         proc = run(["systemctl", "show", service, "--no-pager",
                     "-p", "ActiveState",
                     "-p", "ActiveEnterTimestamp",
-                    "-p", "ExecMainStartTimestamp"])
+                    "-p", "ExecMainStartTimestamp",
+                    "-p", "MainPID",
+                    "-p", "NRestarts"])
         props = {}
         for line in proc.stdout.splitlines():
             if "=" in line:
@@ -358,6 +590,10 @@ try:
             or props.get("ActiveEnterTimestamp")
             or ""
         )
+        if (props.get("MainPID") or "0").isdigit() and props["MainPID"] != "0":
+            out["main_pid"] = int(props["MainPID"])
+        if (props.get("NRestarts") or "").isdigit():
+            out["restart_count"] = int(props["NRestarts"])
     elif out.get("process_running") is True:
         out["active_state"] = "active"
         out["last_restarted"] = process_start_time(process_pattern)
@@ -436,6 +672,113 @@ try:
 except Exception as error:
     out["node_id_error"] = str(error)
 
+try:
+    pid = out.get("main_pid")
+    if pid is None and container_name:
+        proc = run(["docker", "inspect", "--format", "{{.State.Pid}}", container_name])
+        candidate = proc.stdout.strip()
+        if proc.returncode == 0 and candidate.isdigit() and candidate != "0":
+            pid = int(candidate)
+    if pid is None and process_pattern:
+        proc = run(["pgrep", "-f", process_pattern])
+        if proc.returncode == 0 and proc.stdout.strip():
+            candidate = proc.stdout.strip().splitlines()[0].strip()
+            if candidate.isdigit():
+                pid = int(candidate)
+
+    host = {}
+    if pid is not None:
+        host["pid"] = pid
+        try:
+            host["rss_bytes"] = process_rss_bytes(pid)
+        except Exception as error:
+            host["rss_error"] = str(error)
+
+    disk_path = state_cache_dir or "/"
+    host["disk_path"] = disk_path
+    try:
+        usage = shutil.disk_usage(disk_path)
+        host["disk_total_bytes"] = usage.total
+        host["disk_free_bytes"] = usage.free
+    except Exception as error:
+        # Surface rather than silently falling back: a wrong state_cache_dir
+        # would otherwise report the root filesystem's free space as the node's.
+        host["disk_error"] = str(error)
+
+    try:
+        memory = read_meminfo()
+        host["mem_total_bytes"] = memory.get("MemTotal")
+        host["mem_available_bytes"] = memory.get("MemAvailable")
+    except Exception as error:
+        host["mem_error"] = str(error)
+
+    try:
+        load1, load5, load15 = os.getloadavg()
+        host["load1"] = load1
+        host["load5"] = load5
+        host["load15"] = load15
+    except Exception as error:
+        host["load_error"] = str(error)
+
+    try:
+        with open("/proc/uptime", encoding="utf-8") as fh:
+            host["uptime_seconds"] = float(fh.read().split()[0])
+    except Exception as error:
+        host["uptime_error"] = str(error)
+
+    try:
+        host["oom_kills_24h"] = oom_kill_count()
+    except Exception as error:
+        host["oom_error"] = str(error)
+
+    if "restart_count" in out:
+        host["restart_count"] = out["restart_count"]
+    out["host"] = host
+except Exception as error:
+    out["host_error"] = str(error)
+
+try:
+    out["log_errors"] = log_error_tail(log_file)
+except Exception as error:
+    out["log_errors_error"] = str(error)
+
+if metrics_endpoint and want_metrics:
+    try:
+        started = time.monotonic()
+        metric_values, metric_version, raw_bytes, series, agents = scrape_metrics(
+            metrics_endpoint
+        )
+        out["metrics"] = metric_values
+        out["metrics_bytes"] = raw_bytes
+        out["metrics_series"] = series
+        if agents:
+            out["peer_user_agents"] = agents
+        out["metrics_scrape_seconds"] = round(time.monotonic() - started, 3)
+        if metric_version:
+            out["metrics_version"] = metric_version
+    except Exception as error:
+        out["metrics_error"] = str(error)
+elif metrics_endpoint:
+    # Throttled: rendering the exposition costs the node real CPU, so the
+    # dashboard reuses its previous scrape between refreshes.
+    out["metrics_skipped"] = True
+else:
+    out["metrics_error"] = "metrics endpoint not configured"
+
+if health_listen_addr:
+    health = {}
+    for probe_path in ("healthy", "ready"):
+        try:
+            status, body = http_get(
+                "http://" + health_listen_addr + "/" + probe_path
+            )
+            health[probe_path] = {"status": status, "body": body[:200]}
+        except Exception as error:
+            health[probe_path] = {"error": str(error)}
+    out["health"] = health
+else:
+    out["health_error"] = "health endpoint not configured"
+
 if rpc_url:
     try:
         blockchain_info = rpc_call("getblockchaininfo")
@@ -508,8 +851,48 @@ if rpc_url:
         out["client_version"] = str(
             info.get("build") or info.get("version") or ""
         )
+        # Not a curated health field: LastWarnErrorLayer publishes the most
+        # recent WARN/ERROR log message from anywhere in the process, and
+        # getinfo returns it verbatim. Keep the timestamp so the page can say
+        # how old it is rather than implying it is a current verdict.
+        out["node_errors"] = str(info.get("errors") or "")
+        out["node_errors_at"] = info.get("errorstimestamp")
     except Exception as error:
         out["rpc_metadata_error"] = str(error)
+
+    try:
+        peers = rpc_call("getpeerinfo")
+        if not isinstance(peers, list):
+            raise RuntimeError("getpeerinfo returned a non-array result")
+
+        # Reduce on the node: a mainnet peer set runs to hundreds of entries and
+        # the dashboard only needs counts.
+        subversions = {}
+        inbound = 0
+        for peer in peers:
+            if not isinstance(peer, dict):
+                continue
+            if peer.get("inbound"):
+                inbound += 1
+            key = str(peer.get("subver") or "unknown")[:48]
+            subversions[key] = subversions.get(key, 0) + 1
+        out["peer_count"] = len(peers)
+        out["peer_inbound"] = inbound
+        # zakurad omits subver, so this is only meaningful for the zcashd probe.
+        if set(subversions) != {"unknown"}:
+            out["peer_subversions"] = sorted(
+                subversions.items(), key=lambda item: (-item[1], item[0])
+            )[:8]
+    except Exception as error:
+        out["peer_info_error"] = str(error)
+
+    try:
+        mempool = rpc_call("getmempoolinfo")
+        if isinstance(mempool, dict):
+            out["mempool_size"] = mempool.get("size")
+            out["mempool_bytes"] = mempool.get("bytes")
+    except Exception as error:
+        out["mempool_error"] = str(error)
 else:
     out["rpc_error"] = "RPC disabled in deployer config"
 
@@ -521,7 +904,7 @@ def ssh_capture_script(node: Node, script: str) -> subprocess.CompletedProcess:
     return subprocess.run(node.ssh_cmd("bash", "-s"), input=script, text=True, capture_output=True)
 
 
-def probe_node(node: Node) -> dict:
+def probe_node(node: Node, want_metrics: bool = True) -> dict:
     rpc_url = rpc_url_for(node.rpc_listen_addr)
     script = (
         "python3 - "
@@ -535,7 +918,11 @@ def probe_node(node: Node) -> dict:
         f"{shlex.quote(node.rpc_user)} "
         f"{shlex.quote(node.rpc_password)} "
         f"{shlex.quote(node.rpc_config_path)} "
-        f"{shlex.quote(node.container_name)} <<'PY'\n"
+        f"{shlex.quote(node.container_name)} "
+        f"{shlex.quote(node.metrics_endpoint)} "
+        f"{shlex.quote(node.health_listen_addr)} "
+        f"{shlex.quote(node.state_cache_dir)} "
+        f"{shlex.quote('1' if want_metrics else '')} <<'PY'\n"
         f"{REMOTE_PROBE}\n"
         "PY\n"
     )
@@ -593,18 +980,25 @@ class ClusterCollector:
         nodes: list[Node],
         interval: float,
         stale_after: float,
-        upgrade_height: int,
-        target_spacing: float,
         network: str,
         state_file: Path | None = None,
+        history_window: float = DEFAULT_NODE_HISTORY_WINDOW,
+        expose_logs: bool = False,
+        metrics_min_interval: float | None = None,
     ):
         self.nodes = nodes
         self.interval = interval
         self.stale_after = stale_after
-        self.upgrade_height = upgrade_height
-        self.target_spacing = target_spacing
         self.network = network
         self.state_file = state_file
+        self.history_window = history_window
+        self.expose_logs = expose_logs
+        # None selects the adaptive interval; a number pins it.
+        self.metrics_min_interval = metrics_min_interval
+        self.nodes_by_name = {node.name: node for node in nodes}
+        self.history: dict[str, deque[dict]] = {node.name: deque() for node in nodes}
+        # Last successful scrape per node, reused on the polls that skip it.
+        self.last_metrics: dict[str, dict] = {}
         self.ironwood_activation_height = IRONWOOD_ACTIVATION_HEIGHTS[network]
         self.lock = threading.Lock()
         restored_progress = load_progress(state_file)
@@ -619,7 +1013,6 @@ class ClusterCollector:
             node.name: restored_progress.get(node.name, {}).get("last_advanced_at")
             for node in nodes
         }
-        self.height_history: list[tuple[float, int]] = []
         self.recent_reorgs: deque[dict] = deque(
             load_orphan_pairs(state_file),
             maxlen=RECENT_REORG_LIMIT,
@@ -644,8 +1037,12 @@ class ClusterCollector:
 
     def poll_once(self) -> None:
         rows = []
+        started = time.time()
         with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(self.nodes))) as pool:
-            futures = {pool.submit(probe_node, node): node for node in self.nodes}
+            futures = {
+                pool.submit(probe_node, node, self.should_scrape_metrics(node.name, started)): node
+                for node in self.nodes
+            }
             for future in concurrent.futures.as_completed(futures):
                 node = futures[future]
                 try:
@@ -663,7 +1060,7 @@ class ClusterCollector:
             self.rows = rows
             self.chain = chain
             self.last_poll = now
-            self.record_height_sample(now, rows)
+            self.record_node_history(now, rows)
             snapshot = self.progress_snapshot()
         # Snapshot under the lock, write outside it: the stall timers must
         # survive a restart or every node reports as freshly advanced on the
@@ -690,22 +1087,78 @@ class ClusterCollector:
         self.recent_reorgs.appendleft(event)
         self.persist_state()
 
-    def record_height_sample(self, now: float, rows: list[dict]) -> None:
-        heights = [row["height"] for row in rows if row.get("height") is not None]
-        if not heights:
-            return
+    def should_scrape_metrics(self, name: str, now: float) -> bool:
+        """Decide per node, from what its last scrape cost."""
+        snapshot = self.last_metrics.get(name)
+        scraped_at = (snapshot or {}).get("metrics_at")
+        if scraped_at is None:
+            return True
+        if self.metrics_min_interval is not None:
+            interval = self.metrics_min_interval
+        else:
+            cost = (snapshot or {}).get("metrics_scrape_seconds") or 0.0
+            interval = min(cost * METRICS_COST_FACTOR, MAX_METRICS_INTERVAL)
+        return now - scraped_at >= interval
 
-        best_height = max(heights)
-        if self.height_history and best_height < self.height_history[-1][1]:
-            best_height = self.height_history[-1][1]
-        self.height_history.append((now, best_height))
+    def record_node_history(self, now: float, rows: list[dict]) -> None:
+        cutoff = now - self.history_window
+        for row in rows:
+            samples = self.history.get(row["name"])
+            if samples is None:
+                continue
+            host = row.get("host") or {}
+            metrics = row.get("metrics") or {}
+            samples.append({
+                "t": round(now, 1),
+                "height": row.get("height"),
+                "header_lag": row.get("header_lag"),
+                "peers": row.get("peer_count"),
+                "disk_free_bytes": host.get("disk_free_bytes"),
+                "rss_bytes": host.get("rss_bytes"),
+                "load1": host.get("load1"),
+                "sync_lag": metrics.get("sync_estimated_distance_to_tip"),
+            })
+            while samples and samples[0]["t"] < cutoff:
+                samples.popleft()
 
-        cutoff = now - HEIGHT_HISTORY_WINDOW
-        self.height_history = [
-            (sample_time, height)
-            for sample_time, height in self.height_history
-            if sample_time >= cutoff
-        ]
+    def node_snapshot(self, name: str) -> dict | None:
+        with self.lock:
+            row = next((row for row in self.rows if row["name"] == name), None)
+            if row is None:
+                return None
+            row = dict(row)
+            samples = [dict(sample) for sample in self.history.get(name, ())]
+            reorgs = [
+                dict(event) for event in self.recent_reorgs if event.get("node") == name
+            ]
+            chain = dict(self.chain)
+            last_poll = self.last_poll
+
+        if not self.expose_logs:
+            # Off by default: the dashboard is public and log lines can carry
+            # operational detail even after the probe redacts addresses.
+            row["log_errors"] = []
+            row["log_errors_suppressed"] = True
+
+        node = self.nodes_by_name.get(name)
+        return {
+            "generated_at": time.time(),
+            "last_poll": last_poll,
+            "stale_after": self.stale_after,
+            "network": self.network,
+            "history_window": self.history_window,
+            "majority_height": chain.get("majority_height"),
+            "majority_hash": chain.get("majority_hash"),
+            "config": {
+                "metrics_endpoint": node.metrics_endpoint if node else "",
+                "health_listen_addr": node.health_listen_addr if node else "",
+                "state_cache_dir": node.state_cache_dir if node else "",
+                "probe_kind": node.probe_kind if node else "",
+            },
+            "node": row,
+            "history": samples,
+            "reorgs": reorgs,
+        }
 
     def row_for(self, node: Node, probe: dict, now: float) -> dict:
         previous_height = self.last_height.get(node.name)
@@ -810,6 +1263,32 @@ class ClusterCollector:
         if headers is not None and height is not None:
             header_lag = headers - height
 
+        # Metrics are scraped on a slower cadence than the poll, so a skipped
+        # poll reuses the last successful scrape instead of blanking the panels.
+        if probe.get("metrics_skipped"):
+            metrics_snapshot = self.last_metrics.get(node.name, {})
+        else:
+            metrics_snapshot = {
+                "metrics": probe.get("metrics") or {},
+                "metrics_error": probe.get("metrics_error"),
+                "metrics_version": probe.get("metrics_version") or "",
+                "metrics_bytes": coerce_int(probe.get("metrics_bytes")),
+                "metrics_series": coerce_int(probe.get("metrics_series")),
+                "metrics_scrape_seconds": probe.get("metrics_scrape_seconds"),
+                "peer_user_agents": probe.get("peer_user_agents") or [],
+                "metrics_at": now,
+            }
+            self.last_metrics[node.name] = metrics_snapshot
+
+        host = probe.get("host") or {}
+        vitals = {
+            "disk_free_pct": disk_free_pct(host),
+            "disk_free_bytes": host.get("disk_free_bytes"),
+            "restart_count": host.get("restart_count"),
+            "oom_kills_24h": host.get("oom_kills_24h"),
+            "peer_count": coerce_int(probe.get("peer_count")),
+        }
+
         return {
             "name": node.name,
             "ssh": node.ssh_string,
@@ -842,13 +1321,44 @@ class ClusterCollector:
             "client_name": probe.get("client_name") or "",
             "client_version": probe.get("client_version") or "",
             "rpc_metadata_error": probe.get("rpc_metadata_error"),
+            "peer_count": coerce_int(probe.get("peer_count")),
+            "peer_inbound": coerce_int(probe.get("peer_inbound")),
+            "vitals": vitals,
+            # Deep fields; see NODE_DETAIL_KEYS. Served from /data/node/<name>.
+            "host": host,
+            "metrics": metrics_snapshot.get("metrics") or {},
+            "metrics_error": metrics_snapshot.get("metrics_error"),
+            "metrics_version": metrics_snapshot.get("metrics_version") or "",
+            "metrics_bytes": metrics_snapshot.get("metrics_bytes"),
+            "metrics_series": metrics_snapshot.get("metrics_series"),
+            "metrics_scrape_seconds": metrics_snapshot.get("metrics_scrape_seconds"),
+            "metrics_at": metrics_snapshot.get("metrics_at"),
+            "peer_user_agents": metrics_snapshot.get("peer_user_agents") or [],
+            # Distinct from "health" above, which is this dashboard's own
+            # classification; this is what the node's /healthy and /ready say.
+            "health_endpoint": probe.get("health") or {},
+            "health_endpoint_error": probe.get("health_error"),
+            "log_errors": probe.get("log_errors") or [],
+            "peer_subversions": probe.get("peer_subversions") or [],
+            "peer_info_error": probe.get("peer_info_error"),
+            "mempool_size": coerce_int(probe.get("mempool_size")),
+            "mempool_bytes": coerce_int(probe.get("mempool_bytes")),
+            "node_errors": probe.get("node_errors") or "",
+            "node_errors_at": coerce_int(probe.get("node_errors_at")),
         }
 
     def snapshot(self) -> dict:
+        """Fleet-wide payload for the table and the Slack watchdog.
+
+        Deep per-node fields are dropped here so this stays small at a 10s poll;
+        the node view reads them from /data/node/<name> instead.
+        """
         with self.lock:
-            rows = [dict(row) for row in self.rows]
+            rows = [
+                {key: value for key, value in row.items() if key not in NODE_DETAIL_KEYS}
+                for row in self.rows
+            ]
             last_poll = self.last_poll
-            upgrade = self.upgrade_estimate(time.time())
             chain = dict(self.chain)
             chain["tip_groups"] = [dict(group) for group in chain.get("tip_groups", [])]
             chain["recent_reorgs"] = [
@@ -862,7 +1372,6 @@ class ClusterCollector:
             "network": self.network,
             "healthy": healthy,
             "total": len(rows),
-            "upgrade": upgrade,
             "chain": chain,
             "rows": rows,
         }
@@ -991,60 +1500,14 @@ class ClusterCollector:
             "client_version": client_version,
         }, None
 
-    def upgrade_estimate(self, now: float) -> dict:
-        # A non-positive upgrade height means there is no pending activation to
-        # count down to; the dashboard hides the upgrade cards.
-        if self.upgrade_height <= 0:
-            return {"enabled": False}
-
-        current_height = self.height_history[-1][1] if self.height_history else None
-        blocks_remaining = (
-            max(self.upgrade_height - current_height, 0)
-            if current_height is not None
-            else None
-        )
-        activated = blocks_remaining == 0 if blocks_remaining is not None else False
-
-        seconds_per_block = self.observed_seconds_per_block()
-        source = "observed"
-        if seconds_per_block is None:
-            seconds_per_block = self.target_spacing
-            source = "fallback"
-
-        eta_seconds = None
-        eta_at = None
-        if blocks_remaining is not None:
-            eta_seconds = blocks_remaining * seconds_per_block
-            eta_at = now + eta_seconds
-
-        return {
-            "enabled": True,
-            "height": self.upgrade_height,
-            "current_height": current_height,
-            "blocks_remaining": blocks_remaining,
-            "seconds_per_block": seconds_per_block,
-            "eta_seconds": eta_seconds,
-            "eta_at": eta_at,
-            "source": source,
-            "activated": activated,
-        }
-
-    def observed_seconds_per_block(self) -> float | None:
-        if len(self.height_history) < 2:
-            return None
-
-        newest_time, newest_height = self.height_history[-1]
-        for oldest_time, oldest_height in self.height_history:
-            blocks = newest_height - oldest_height
-            seconds = newest_time - oldest_time
-            if blocks < MIN_OBSERVED_BLOCKS or seconds < MIN_OBSERVED_SECONDS:
-                continue
-
-            seconds_per_block = seconds / blocks
-            if MIN_SECONDS_PER_BLOCK <= seconds_per_block <= MAX_SECONDS_PER_BLOCK:
-                return seconds_per_block
-
+def disk_free_pct(host: dict) -> float | None:
+    total = host.get("disk_total_bytes")
+    free = host.get("disk_free_bytes")
+    if not isinstance(total, (int, float)) or not total:
         return None
+    if not isinstance(free, (int, float)):
+        return None
+    return round(100.0 * free / total, 1)
 
 
 def coerce_int(value) -> int | None:
@@ -1058,7 +1521,6 @@ def empty_chain_summary() -> dict:
     return {
         "status": "unknown",
         "split": False,
-        "compat_split": False,
         "majority_height": None,
         "majority_hash": "",
         "max_height": None,
@@ -1239,20 +1701,6 @@ def tipped_rows(rows: list[dict]) -> list[dict]:
     ]
 
 
-def best_tip_row(rows: list[dict], client_name: str | None = None) -> dict | None:
-    candidates = tipped_rows(rows)
-    if client_name is not None:
-        candidates = [
-            row for row in candidates if row.get("client_name") == client_name
-        ]
-    if not candidates:
-        return None
-    return max(
-        candidates,
-        key=lambda row: (row["height"], row.get("block_hash") or ""),
-    )
-
-
 def compute_chain_summary(
     rows: list[dict],
     recent_reorgs: list[dict] | None = None,
@@ -1319,21 +1767,9 @@ def compute_chain_summary(
                 group["fork_depth"] = behind
                 group["fork_depth_label"] = f"{behind} behind"
 
-    zakurad_tip = best_tip_row(rows, "zakurad")
-    zcashd_tip = best_tip_row(rows, "zcashd")
-    compat_split = bool(
-        zakurad_tip
-        and zcashd_tip
-        and (
-            zakurad_tip["height"] != zcashd_tip["height"]
-            or zakurad_tip["block_hash"] != zcashd_tip["block_hash"]
-        )
-    )
-
     return {
         "status": status,
         "split": split,
-        "compat_split": compat_split,
         "majority_height": majority["height"] if majority else None,
         "majority_hash": majority["block_hash"] if majority else "",
         "max_height": max_height,
@@ -1421,6 +1857,10 @@ PAGE = r"""<!doctype html>
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 * { box-sizing: border-box; }
+/* The view switcher toggles [hidden]; without this any class that sets a
+   display value (.stats is grid, .view is flex) silently overrides the UA
+   stylesheet and leaves an unrendered section on screen. */
+[hidden] { display: none !important; }
 body {
   margin: 0;
   min-height: 100vh;
@@ -1571,14 +2011,8 @@ button { font: inherit; }
 .freshness { font-size: 0.76rem; color: var(--muted); white-space: nowrap; }
 .freshness b { color: var(--ink-2); font-weight: 600; }
 
-/* ---------- hero ---------- */
-.hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
-  gap: 16px;
-}
-.hero.is-single { grid-template-columns: minmax(0, 1fr); }
-.hero-head {
+/* ---------- fleet health card ---------- */
+.card-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
@@ -1594,29 +2028,6 @@ button { font: inherit; }
   font-variant-numeric: tabular-nums;
 }
 .big-sub { margin-top: 7px; color: var(--muted); font-size: 0.86rem; }
-.progress {
-  margin-top: 18px;
-  height: 8px;
-  border-radius: 999px;
-  background: var(--base);
-  border: 1px solid var(--line);
-  overflow: hidden;
-}
-.progress-fill {
-  height: 100%;
-  width: 0;
-  border-radius: 999px;
-  background: linear-gradient(90deg, #8b3f8f, var(--pink-hi));
-  transition: width 0.6s ease;
-}
-.progress-legend {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 7px;
-  font-size: 0.72rem;
-  color: var(--dim);
-}
 .facts {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
@@ -1945,7 +2356,6 @@ tbody tr.drawer > td { padding: 0; border-bottom: 1px solid var(--line); backgro
   color: var(--bad);
   font-size: 0.84rem;
 }
-.banner[hidden] { display: none; }
 footer {
   color: var(--muted);
   font-size: 0.8rem;
@@ -1953,9 +2363,79 @@ footer {
   padding-top: 6px;
 }
 
-@media (max-width: 1100px) {
-  .hero { grid-template-columns: 1fr; }
+/* ---------- node view ---------- */
+.view { display: flex; flex-direction: column; gap: 16px; }
+.node-link { color: inherit; text-decoration: none; border-radius: 4px; }
+.node-link:hover { color: var(--pink-hi); text-decoration: underline; }
+.node-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; flex-wrap: wrap; }
+.node-head h2 { font-size: clamp(1.1rem, 2.4vw, 1.45rem); font-weight: 680; letter-spacing: -0.02em; }
+.node-head .eyebrow { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; }
+.node-badges { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+.vitals { display: grid; grid-template-columns: repeat(auto-fit, minmax(148px, 1fr)); gap: 11px; margin-top: 14px; }
+.vital {
+  background: var(--raised);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  padding: 11px 13px;
+  min-width: 0;
 }
+.vital.is-ok { border-color: var(--ok-line); background: var(--ok-soft); }
+.vital.is-warn { border-color: var(--warn-line); background: var(--warn-soft); }
+.vital.is-bad { border-color: var(--bad-line); background: var(--bad-soft); }
+.vital.is-neutral { border-color: var(--line-hi); }
+.vital strong {
+  display: block;
+  margin-top: 5px;
+  font-size: 1.12rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+.vital small { display: block; margin-top: 3px; color: var(--dim); font-size: 0.71rem; }
+.meter { height: 5px; border-radius: 3px; background: var(--line); overflow: hidden; margin-top: 8px; }
+.meter i { display: block; height: 100%; background: var(--ok); }
+.meter.is-warn i { background: var(--warn); }
+.meter.is-bad i { background: var(--bad); }
+.sparks { display: grid; grid-template-columns: repeat(auto-fit, minmax(216px, 1fr)); gap: 12px; margin-top: 14px; }
+.spark {
+  background: var(--raised);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  padding: 10px 12px 8px;
+  min-width: 0;
+}
+.spark-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.spark-head b { font-size: 0.9rem; font-weight: 640; font-variant-numeric: tabular-nums; }
+.spark svg { display: block; width: 100%; height: 42px; margin-top: 7px; overflow: visible; }
+.spark-empty { margin-top: 12px; color: var(--dim); font-size: 0.74rem; }
+.node-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(316px, 1fr)); gap: 16px; }
+.kv { display: grid; gap: 7px; margin-top: 13px; }
+.kv-row { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; font-size: 0.83rem; }
+.kv-row > span { color: var(--muted); white-space: nowrap; }
+.kv-row > b {
+  font-weight: 620;
+  text-align: right;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-variant-numeric: tabular-nums;
+}
+.kv-row.is-bad > b { color: var(--bad); }
+.kv-row.is-warn > b { color: var(--warn); }
+.note-off { margin-top: 12px; color: var(--dim); font-size: 0.79rem; }
+.log-lines { display: grid; gap: 6px; margin-top: 12px; }
+.log-lines code {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+  background: var(--base);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  padding: 7px 9px;
+  overflow-wrap: anywhere;
+}
+
 @media (max-width: 720px) {
   .shell { width: calc(100% - 22px); padding-top: 16px; }
   .pad { padding: 16px; }
@@ -1982,76 +2462,38 @@ footer {
 
   <div class="banner" id="banner" hidden></div>
 
-  <section class="hero">
-    <article class="panel pad" id="activation-panel">
-      <div class="hero-head">
-        <div>
-          <p class="eyebrow">Network upgrade</p>
-          <h2 id="activation-title">Ironwood activation</h2>
-        </div>
-        <span class="badge" id="activation-badge">pending</span>
+  <section class="panel pad" data-view="fleet">
+    <div class="card-head">
+      <div>
+        <p class="eyebrow">Fleet health</p>
+        <h2>Nodes reporting</h2>
       </div>
-      <div class="big-value" id="activation-countdown">...</div>
-      <p class="big-sub" id="activation-eta">waiting for the first poll</p>
-      <div class="progress"><div class="progress-fill" id="activation-progress"></div></div>
-      <div class="progress-legend">
-        <span id="progress-from">...</span>
-        <span id="progress-to">...</span>
+      <span class="badge" id="client-mix">...</span>
+    </div>
+    <div class="big-value" id="healthy-count">...</div>
+    <p class="big-sub" id="healthy-sub">waiting for the first poll</p>
+    <div class="health-bar" id="health-bar"></div>
+    <div class="legend" id="health-legend"></div>
+    <div class="facts">
+      <div class="fact">
+        <span class="label">Leading height</span>
+        <strong id="fleet-max-height">...</strong>
+        <small id="fleet-spread">...</small>
       </div>
-      <div class="facts">
-        <div class="fact">
-          <span class="label">Current height</span>
-          <strong id="current-height">...</strong>
-        </div>
-        <div class="fact">
-          <span class="label">Target height</span>
-          <strong id="upgrade-height">...</strong>
-        </div>
-        <div class="fact">
-          <span class="label">Blocks left</span>
-          <strong id="blocks-remaining">...</strong>
-        </div>
-        <div class="fact">
-          <span class="label">Block time</span>
-          <strong id="block-time">...</strong>
-          <small id="block-time-source">...</small>
-        </div>
+      <div class="fact">
+        <span class="label">Slowest advance</span>
+        <strong id="fleet-slowest">...</strong>
+        <small id="fleet-slowest-node">...</small>
       </div>
-    </article>
-
-    <article class="panel pad">
-      <div class="hero-head">
-        <div>
-          <p class="eyebrow">Fleet health</p>
-          <h2>Nodes reporting</h2>
-        </div>
-        <span class="badge" id="client-mix">...</span>
+      <div class="fact">
+        <span class="label">Max header lag</span>
+        <strong id="fleet-max-lag">...</strong>
+        <small id="fleet-max-lag-node">...</small>
       </div>
-      <div class="big-value" id="healthy-count">...</div>
-      <p class="big-sub" id="healthy-sub">waiting for the first poll</p>
-      <div class="health-bar" id="health-bar"></div>
-      <div class="legend" id="health-legend"></div>
-      <div class="facts">
-        <div class="fact">
-          <span class="label">Leading height</span>
-          <strong id="fleet-max-height">...</strong>
-          <small id="fleet-spread">...</small>
-        </div>
-        <div class="fact">
-          <span class="label">Slowest advance</span>
-          <strong id="fleet-slowest">...</strong>
-          <small id="fleet-slowest-node">...</small>
-        </div>
-        <div class="fact">
-          <span class="label">Max header lag</span>
-          <strong id="fleet-max-lag">...</strong>
-          <small id="fleet-max-lag-node">...</small>
-        </div>
-      </div>
-    </article>
+    </div>
   </section>
 
-  <section class="stats">
+  <section class="stats" data-view="fleet">
     <div class="stat">
       <span class="label">Tip agreement</span>
       <div class="stat-value" id="tip-agreement">...</div>
@@ -2068,18 +2510,13 @@ footer {
       <small id="reorg-latest">...</small>
     </div>
     <div class="stat">
-      <span class="label">zakurad vs zcashd</span>
-      <div class="stat-value" id="compat-split">...</div>
-      <small id="compat-detail">...</small>
-    </div>
-    <div class="stat">
       <span class="label">Last poll</span>
       <div class="stat-value" id="last-poll">...</div>
       <small id="stale-window">...</small>
     </div>
   </section>
 
-  <section class="panel pad">
+  <section class="panel pad" data-view="fleet">
     <div class="section-head">
       <div>
         <p class="eyebrow">Chain tips</p>
@@ -2092,7 +2529,7 @@ footer {
     <div class="reorg-list" id="reorg-list"></div>
   </section>
 
-  <section class="panel pad">
+  <section class="panel pad" data-view="fleet">
     <div class="section-head">
       <div>
         <p class="eyebrow">Live node status</p>
@@ -2128,14 +2565,78 @@ footer {
     </div>
   </section>
 
+  <div class="view" id="node-view" data-view="node" hidden>
+    <section class="panel pad">
+      <div class="node-head">
+        <div>
+          <p class="eyebrow"><a class="node-link" href="/">&#8592; Fleet</a>
+            <span class="chip" id="node-network-chip">mainnet</span></p>
+          <h2 id="node-title">node</h2>
+          <p class="section-note" id="node-subtitle">Loading node detail...</p>
+        </div>
+        <div class="node-badges" id="node-badges"></div>
+      </div>
+    </section>
+
+    <section class="panel pad">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Host</p>
+          <h2>Vitals</h2>
+        </div>
+        <p class="section-note" id="node-vitals-note"></p>
+      </div>
+      <div class="vitals" id="node-vitals"></div>
+    </section>
+
+    <section class="panel pad">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Trend</p>
+          <h2 id="node-sparks-title">Recent history</h2>
+        </div>
+        <p class="section-note" id="node-sparks-note"></p>
+      </div>
+      <div class="sparks" id="node-sparks"></div>
+    </section>
+
+    <div class="node-grid">
+      <article class="panel pad">
+        <div class="section-head"><div><p class="eyebrow">Consensus</p><h2>Chain</h2></div></div>
+        <div class="kv" id="node-chain"></div>
+      </article>
+      <article class="panel pad">
+        <div class="section-head"><div><p class="eyebrow">Pipeline</p><h2>Sync</h2></div></div>
+        <div id="node-sync"></div>
+      </article>
+      <article class="panel pad">
+        <div class="section-head"><div><p class="eyebrow">Connectivity</p><h2>Peers and network</h2></div></div>
+        <div id="node-peers"></div>
+      </article>
+    </div>
+
+    <section class="panel pad">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Recent</p>
+          <h2>Events</h2>
+        </div>
+      </div>
+      <div class="subhead"><p class="eyebrow">Orphan pairs seen on this node</p></div>
+      <div class="reorg-list" id="node-reorgs"></div>
+      <div class="subhead"><p class="eyebrow">Last warning or error log line</p></div>
+      <div id="node-last-log"></div>
+      <div class="subhead"><p class="eyebrow">Recent log errors</p></div>
+      <div id="node-logs"></div>
+    </section>
+  </div>
+
   <footer>For snapshots and install instructions, see
     <a href="https://zakura.com/snapshots/" target="_blank" rel="noopener">https://zakura.com/snapshots/</a>
   </footer>
 </main>
 <script>
 const REFRESH_MS = 10000;
-// The progress bar shows the run-in to activation, not all of chain history.
-const PROGRESS_WINDOW = 10000;
 
 const state = {
   data: null,
@@ -2150,6 +2651,15 @@ const state = {
 };
 
 const el = (id) => document.getElementById(id);
+
+/* ---------- routing ---------- */
+// One template serves both routes: / renders the fleet, /node/<name> renders one
+// node. Keeping a single PAGE means the CSS and formatters are shared verbatim.
+const NODE_ROUTE = /^\/node\/(.+)$/.exec(location.pathname);
+const NODE_NAME = NODE_ROUTE ? decodeURIComponent(NODE_ROUTE[1]) : null;
+for (const section of document.querySelectorAll('[data-view]')) {
+  section.hidden = (section.dataset.view === 'node') !== Boolean(NODE_NAME);
+}
 
 /* ---------- formatting ---------- */
 function esc(value) {
@@ -2167,19 +2677,35 @@ function age(seconds) {
   if (seconds < 86400) return Math.round(seconds / 3600) + 'h';
   return Math.round(seconds / 86400) + 'd';
 }
-function countdown(seconds) {
-  if (seconds == null) return 'waiting for height';
-  if (seconds <= 0) return 'activated';
+function bytes(value) {
+  if (value == null || !isFinite(value)) return '—';
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let scaled = Number(value);
+  let unit = 0;
+  while (scaled >= 1024 && unit < units.length - 1) {
+    scaled /= 1024;
+    unit += 1;
+  }
+  return (unit > 0 && scaled < 100 ? scaled.toFixed(1) : Math.round(scaled)) + ' ' + units[unit];
+}
+function pctText(value) {
+  return value == null || !isFinite(value) ? '—' : Number(value).toFixed(1) + '%';
+}
+function duration(seconds) {
+  if (seconds == null || !isFinite(seconds)) return '—';
   const days = Math.floor(seconds / 86400);
   const hours = Math.floor((seconds % 86400) / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   if (days > 0) return days + 'd ' + hours + 'h';
   if (hours > 0) return hours + 'h ' + minutes + 'm';
-  return Math.max(1, minutes) + 'm';
+  return minutes + 'm';
 }
-function blockTime(seconds) {
-  if (seconds == null) return '—';
-  return (seconds < 10 ? Number(seconds).toFixed(1) : Math.round(seconds)) + 's';
+function decimal(value, places) {
+  return value == null || !isFinite(value) ? '—' : Number(value).toFixed(places == null ? 2 : places);
+}
+function metric(metrics, name) {
+  const value = (metrics || {})[name];
+  return typeof value === 'number' && isFinite(value) ? value : null;
 }
 function clockTime(epochSeconds) {
   if (!epochSeconds) return '—';
@@ -2316,49 +2842,6 @@ function renderFreshness() {
   const next = Math.max(0, Math.ceil(REFRESH_MS / 1000) - seconds);
   node.innerHTML = 'updated <b>' + seconds + 's</b> ago &middot; next in ' + next + 's';
 }
-function renderActivation(data) {
-  const upgrade = data.upgrade || {};
-  const panel = el('activation-panel');
-  const enabled = upgrade.enabled !== false;
-  panel.hidden = !enabled;
-  document.querySelector('.hero').classList.toggle('is-single', !enabled);
-  if (!enabled) return;
-
-  const badgeNode = el('activation-badge');
-  if (upgrade.activated) {
-    badgeNode.textContent = 'activated';
-    badgeNode.className = 'badge tone-ok';
-  } else {
-    badgeNode.textContent = 'pending';
-    badgeNode.className = 'badge tone-info';
-  }
-  el('activation-countdown').textContent = upgrade.activated
-    ? 'Activated'
-    : countdown(upgrade.eta_seconds);
-  el('activation-eta').textContent = upgrade.activated
-    ? 'The upgrade height has been reached.'
-    : (upgrade.eta_at
-      ? 'estimated ' + new Date(upgrade.eta_at * 1000).toLocaleString()
-      : 'waiting for block movement');
-
-  const remaining = upgrade.blocks_remaining;
-  const done = remaining == null
-    ? 0
-    : Math.min(1, Math.max(0, (PROGRESS_WINDOW - remaining) / PROGRESS_WINDOW));
-  el('activation-progress').style.width = (done * 100).toFixed(2) + '%';
-  el('progress-from').textContent = 'final ' + num(PROGRESS_WINDOW) + ' blocks';
-  el('progress-to').textContent = remaining == null
-    ? '—'
-    : (done * 100).toFixed(1) + '% complete';
-
-  el('current-height').textContent = num(upgrade.current_height);
-  el('upgrade-height').textContent = num(upgrade.height);
-  el('blocks-remaining').textContent = upgrade.activated ? '0' : num(remaining);
-  el('block-time').textContent = blockTime(upgrade.seconds_per_block);
-  el('block-time-source').textContent = upgrade.source === 'observed'
-    ? 'observed average'
-    : 'target spacing fallback';
-}
 function renderFleet(data) {
   const rows = data.rows || [];
   const counts = {};
@@ -2440,13 +2923,6 @@ function renderStats(data) {
   el('reorg-latest').textContent = reorgs.length
     ? 'latest ' + clockTime(reorgs[0].at)
     : 'none recorded';
-
-  el('compat-split').innerHTML = chain.compat_split
-    ? badge('diverged', 'bad')
-    : badge('aligned', 'ok');
-  el('compat-detail').textContent = chain.compat_split
-    ? 'best zakurad and zcashd tips differ'
-    : 'best zakurad and zcashd tips match';
 
   el('last-poll').textContent = data.last_poll
     ? new Date(data.last_poll * 1000).toLocaleTimeString()
@@ -2580,6 +3056,20 @@ function drawerHtml(row) {
     + fieldHtml('RPC metadata error', row.rpc_metadata_error, { bad: true, full: true })
     + '</div>';
 }
+// Silent-failure classes that the fleet table had no way to show before: a node
+// filling its disk, or one the kernel has been killing.
+function vitalBadges(row) {
+  const vitals = row.vitals || {};
+  const badges = [];
+  const diskPct = vitals.disk_free_pct;
+  if (diskPct != null && diskPct < 20) {
+    badges.push(badge('disk ' + pctText(diskPct), diskPct < 10 ? 'bad' : 'warn'));
+  }
+  if (vitals.oom_kills_24h) {
+    badges.push(badge('oom ' + vitals.oom_kills_24h, 'bad'));
+  }
+  return badges.join('');
+}
 function renderTable(data) {
   const chain = data.chain || {};
   const majorityHeight = chain.majority_height;
@@ -2626,10 +3116,12 @@ function renderTable(data) {
     return '<tr class="node-row ' + rowTone + (open ? ' is-open' : '') + '"'
       + ' data-node="' + esc(row.name) + '">'
       + '<td class="col-node"><div class="node-cell"><span class="twisty">&#9654;</span>'
-      + '<div class="stack"><span class="node-name">' + esc(row.name) + '</span>'
+      + '<div class="stack"><a class="node-link node-name" href="/node/'
+      + encodeURIComponent(row.name) + '" title="Open node detail">' + esc(row.name) + '</a>'
       + '<span class="node-sub" title="' + esc(row.node_id || '') + '">'
       + esc(row.node_id ? tinyHash(row.node_id) : 'node id unknown') + '</span></div></div></td>'
-      + '<td class="col-health">' + badge(HEALTH_LABEL[row.health] || row.health, healthTone) + '</td>'
+      + '<td class="col-health"><div class="stack">'
+      + badge(HEALTH_LABEL[row.health] || row.health, healthTone) + vitalBadges(row) + '</div></td>'
       + '<td class="col-chain"><div class="stack">'
       + badge(row.chain_role || 'unknown', chainTone)
       + (tipLabel ? badge(tipLabel, 'bad') : '') + '</div></td>'
@@ -2653,10 +3145,377 @@ function renderTable(data) {
         : '');
   }).join('');
 }
+/* ---------- node view ---------- */
+function kvRow(label, text, toneName) {
+  return kvRowHtml(label, esc(text), toneName);
+}
+function kvRowHtml(label, html, toneName) {
+  return '<div class="kv-row' + (toneName ? ' is-' + toneName : '') + '">'
+    + '<span>' + esc(label) + '</span><b>' + html + '</b></div>';
+}
+function vitalTile(label, value, options) {
+  const settings = options || {};
+  const toneClass = settings.tone ? ' is-' + settings.tone : '';
+  const meter = settings.fill == null
+    ? ''
+    : '<div class="meter' + toneClass + '"><i style="width:'
+      + Math.max(0, Math.min(100, settings.fill)).toFixed(1) + '%"></i></div>';
+  return '<div class="vital' + toneClass + '">'
+    + '<span class="label">' + esc(label) + '</span>'
+    + '<strong>' + esc(value) + '</strong>'
+    + (settings.sub ? '<small>' + esc(settings.sub) + '</small>' : '')
+    + meter + '</div>';
+}
+function sparkline(values, stroke) {
+  const points = values.filter((value) => value != null && isFinite(value));
+  if (points.length < 2) return '<div class="spark-empty">not enough samples yet</div>';
+  let min = Infinity;
+  let max = -Infinity;
+  for (const value of points) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  const span = (max - min) || 1;
+  const width = 100;
+  const height = 30;
+  const step = width / (points.length - 1);
+  const coords = points.map((value, index) =>
+    (index * step).toFixed(2) + ',' + (height - ((value - min) / span) * height).toFixed(2));
+  return '<svg viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none" aria-hidden="true">'
+    + '<polyline points="' + coords.join(' ') + '" fill="none" stroke="' + stroke + '"'
+    + ' stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"'
+    + ' vector-effect="non-scaling-stroke"></polyline></svg>';
+}
+function sparkCard(title, current, values, stroke) {
+  return '<div class="spark"><div class="spark-head"><span class="label">' + esc(title) + '</span>'
+    + '<b>' + esc(current) + '</b></div>' + sparkline(values, stroke) + '</div>';
+}
+function advanceRate(history) {
+  const points = history.filter((sample) => sample.height != null);
+  if (points.length < 2) return null;
+  const first = points[0];
+  const last = points[points.length - 1];
+  const elapsed = last.t - first.t;
+  if (elapsed <= 0) return null;
+  return ((last.height - first.height) / elapsed) * 60;
+}
+function endpointState(entry) {
+  if (!entry) return { tone: 'neutral', text: 'unknown' };
+  if (entry.error) return { tone: 'bad', text: 'unreachable' };
+  if (entry.status === 200) return { tone: 'ok', text: entry.body || 'ok' };
+  return { tone: 'warn', text: String(entry.status || '?') + ' ' + (entry.body || '') };
+}
+function renderNodeHeader(data) {
+  const row = data.node || {};
+  const network = data.network || 'mainnet';
+  const name = row.name || NODE_NAME;
+  el('node-network-chip').textContent = network;
+  document.title = name + ' - Zakura ' + network + ' node';
+  el('node-title').textContent = name;
+  const polledAge = data.last_poll == null ? null : (Date.now() / 1000) - data.last_poll;
+  el('node-subtitle').textContent = [
+    (row.client_name || 'node') + ' ' + (row.client_version || row.version || ''),
+    row.commit ? 'commit ' + shortCommit(row.commit) : '',
+    // Ticks on every refresh, so a frozen page is obvious at a glance.
+    data.last_poll == null ? 'waiting for the first poll' : 'probed ' + age(polledAge) + ' ago',
+  ].filter(Boolean).join(' · ');
+
+  const healthTone = tone(HEALTH_TONE, row.health);
+  el('node-badges').innerHTML = badge(HEALTH_LABEL[row.health] || row.health || 'unknown', healthTone)
+    + badge(row.chain_role || 'unknown', tone(CHAIN_TONE, row.chain_role))
+    + badge('service ' + (row.active_state || 'unknown'),
+      row.active_state === 'active' ? 'ok' : 'bad')
+    + (row.tip_event ? badge(tipEventLabel(row.tip_event) || row.tip_event, 'bad') : '');
+
+  const pill = el('state-pill');
+  pill.textContent = { healthy: 'Healthy', stale: 'Stale', rpc_error: 'RPC error', down: 'Down' }[row.health]
+    || 'Starting';
+  pill.className = 'state-pill is-' + (healthTone === 'neutral' ? 'warn' : healthTone);
+}
+function renderNodeVitals(data) {
+  const row = data.node || {};
+  const host = row.host || {};
+  const health = row.health_endpoint || {};
+  const tiles = [];
+
+  const diskPct = (row.vitals || {}).disk_free_pct;
+  const diskTone = diskPct == null ? null : (diskPct < 10 ? 'bad' : (diskPct < 20 ? 'warn' : null));
+  tiles.push(vitalTile('Disk free', pctText(diskPct), {
+    tone: diskTone,
+    fill: diskPct,
+    sub: host.disk_error
+      ? 'error: ' + host.disk_error
+      : bytes(host.disk_free_bytes) + ' of ' + bytes(host.disk_total_bytes)
+        + (host.disk_path ? ' on ' + host.disk_path : ''),
+  }));
+
+  const memTotal = host.mem_total_bytes;
+  const memFree = host.mem_available_bytes;
+  const memPct = memTotal && memFree != null ? (100 * memFree) / memTotal : null;
+  tiles.push(vitalTile('Memory available', pctText(memPct), {
+    tone: memPct == null ? null : (memPct < 8 ? 'bad' : (memPct < 15 ? 'warn' : null)),
+    fill: memPct,
+    sub: bytes(memFree) + ' of ' + bytes(memTotal),
+  }));
+
+  tiles.push(vitalTile('Process RSS', bytes(host.rss_bytes), {
+    sub: host.pid ? 'pid ' + host.pid : (host.rss_error || 'pid unknown'),
+  }));
+  tiles.push(vitalTile('Load (1m)', decimal(host.load1), {
+    sub: '5m ' + decimal(host.load5) + ' · 15m ' + decimal(host.load15),
+  }));
+  tiles.push(vitalTile('Host uptime', duration(host.uptime_seconds), {
+    sub: 'since boot',
+  }));
+  tiles.push(vitalTile('Service restarts', host.restart_count == null ? '—' : num(host.restart_count), {
+    tone: host.restart_count ? 'warn' : null,
+    // systemd NRestarts counts Restart= policy restarts, so this is a crash
+    // counter rather than a deploy counter.
+    sub: row.last_restarted ? 'last start ' + formatRestarted(row.last_restarted) : 'automatic restarts',
+  }));
+  tiles.push(vitalTile('OOM kills (24h)', host.oom_kills_24h == null ? '—' : num(host.oom_kills_24h), {
+    tone: host.oom_kills_24h ? 'bad' : null,
+    sub: host.oom_error ? 'error: ' + host.oom_error : 'kernel log',
+  }));
+
+  if (row.health_endpoint_error) {
+    tiles.push(vitalTile('Readiness', 'not enabled', { sub: row.health_endpoint_error }));
+  } else {
+    const healthy = endpointState(health.healthy);
+    const ready = endpointState(health.ready);
+    tiles.push(vitalTile('/healthy', healthy.text, { tone: healthy.tone, sub: 'peer threshold' }));
+    tiles.push(vitalTile('/ready', ready.text, { tone: ready.tone, sub: 'close to tip' }));
+  }
+
+  el('node-vitals').innerHTML = tiles.join('');
+  el('node-vitals-note').textContent = host.disk_path
+    ? 'State directory ' + host.disk_path
+    : 'Collected over the dashboard ssh probe';
+}
+function renderNodeSparks(data) {
+  const history = data.history || [];
+  const row = data.node || {};
+  const host = row.host || {};
+  const rate = advanceRate(history);
+
+  el('node-sparks-title').textContent = 'Last ' + duration(data.history_window);
+  el('node-sparks-note').textContent = history.length
+    ? history.length + ' samples · ' + (rate == null ? 'rate unknown' : decimal(rate, 1) + ' blocks/min')
+    : 'no samples yet';
+
+  el('node-sparks').innerHTML = [
+    sparkCard('Height', num(row.height), history.map((s) => s.height), 'var(--ok)'),
+    sparkCard('Header lag', row.header_lag == null ? '—' : num(row.header_lag),
+      history.map((s) => s.header_lag), 'var(--warn)'),
+    sparkCard('Distance to tip', row.metrics_error ? 'n/a' : num(metric(row.metrics, 'sync_estimated_distance_to_tip')),
+      history.map((s) => s.sync_lag), 'var(--pink-hi)'),
+    sparkCard('Peers', row.peer_count == null ? '—' : num(row.peer_count),
+      history.map((s) => s.peers), 'var(--ok)'),
+    sparkCard('Disk free', bytes(host.disk_free_bytes),
+      history.map((s) => s.disk_free_bytes), 'var(--warn)'),
+    sparkCard('Process RSS', bytes(host.rss_bytes),
+      history.map((s) => s.rss_bytes), 'var(--pink-hi)'),
+    sparkCard('Load (1m)', decimal(host.load1), history.map((s) => s.load1), 'var(--ink-2)'),
+  ].join('');
+}
+function renderNodeChain(data) {
+  const row = data.node || {};
+  const majority = data.majority_height;
+  const delta = (majority != null && row.height != null) ? row.height - majority : null;
+  const rate = advanceRate(data.history || []);
+  const rows = [
+    kvRow('Height', num(row.height)),
+    kvRow('Headers', num(row.headers)),
+    kvRow('Header lag', row.header_lag == null ? '—' : num(row.header_lag),
+      row.header_lag ? 'warn' : null),
+    kvRow('vs fleet majority', delta == null ? '—' : (delta > 0 ? '+' : '') + num(delta),
+      delta ? 'warn' : null),
+    kvRow('Advance rate', rate == null ? '—' : decimal(rate, 1) + ' blocks/min'),
+    kvRow('Tip last advanced', age(row.seconds_since_advanced) + ' ago'),
+    kvRowHtml('Tip hash', copyCell(row.block_hash, shortHash(row.block_hash), 'Copy tip hash')),
+    kvRowHtml('Parent hash', copyCell(row.previous_hash, shortHash(row.previous_hash), 'Copy parent hash')),
+    kvRow('RPC chain', String(row.rpc_chain || 'unknown')),
+    kvRow('Ironwood pool (zat)', row.ironwood_chain_balance_zat || '—'),
+    kvRow('Mempool', row.mempool_size == null ? '—' : num(row.mempool_size) + ' tx / ' + bytes(row.mempool_bytes)),
+  ];
+  if (row.detail) rows.push(kvRow('Detail', row.detail));
+  el('node-chain').innerHTML = rows.join('');
+}
+function metricsUnavailable(row) {
+  return '<p class="note-off">' + esc(row.metrics_error || 'metrics endpoint not enabled')
+    + '. Set <code>[metrics] endpoint_addr</code> on this node to populate this panel.</p>';
+}
+// Builds only the rows whose series this build actually emits. The header-sync
+// metric family was renamed between releases, so a fixed row list would leave a
+// column of em-dashes on one build or the other.
+function metricRows(metrics, spec) {
+  return spec
+    .filter((entry) => metric(metrics, entry[1]) != null)
+    .map((entry) => {
+      const value = metric(metrics, entry[1]);
+      const format = entry[2];
+      return kvRow(entry[0], format ? format(value) : num(Math.round(value)), entry[3]);
+    })
+    .join('');
+}
+const SYNC_ROWS = [
+  ['Distance to tip', 'sync_estimated_distance_to_tip'],
+  ['Network tip height', 'sync_estimated_network_tip_height'],
+  ['Finalized height', 'state_finalized_block_height'],
+  ['Header sync last progress', 'sync_header_work_last_progress_age_seconds', (v) => age(v)],
+  ['Oldest missing header age', 'sync_header_work_oldest_missing_age_seconds', (v) => age(v)],
+  ['Oldest missing height', 'sync_header_work_oldest_missing_height'],
+  ['Header work in flight', 'sync_header_work_in_flight_count'],
+  ['Header work pending', 'sync_header_work_pending_count'],
+  ['Header work buffered', 'sync_header_work_buffered_count'],
+  ['Header work committing', 'sync_header_work_committing_count'],
+  ['Header work epoch', 'sync_header_work_epoch'],
+  ['Root auth lead', 'sync_header_root_auth_lead_blocks'],
+  ['Root auth batches in flight', 'sync_header_root_auth_work_in_flight_batches'],
+  ['Header verification lag', 'sync_header_verification_lag'],
+  ['Headers/sec', 'sync_header_headers_per_second', (v) => decimal(v, 1)],
+  ['Headers received', 'sync_header_headers_received_total'],
+  ['Header failures', 'sync_header_failure_total'],
+  ['Header peer violations', 'sync_header_peer_violation'],
+  ['Best header tip', 'sync_block_best_header_tip_height'],
+  ['Verified tip', 'sync_block_verified_tip_height'],
+  ['Blocks applying', 'sync_block_applying'],
+  ['Blocks outstanding', 'sync_block_outstanding'],
+  ['Backlog at cap', 'sync_block_backlog_at_cap'],
+  ['Missing bodies', 'sync_block_missing_bodies'],
+  ['Reorder buffered', 'sync_block_reorder_buffered_bytes', (v) => bytes(v)],
+  ['Block budget reserved', 'sync_block_budget_reserved_bytes', (v) => bytes(v)],
+  ['DAG nodes', 'sync_header_chain_dag_nodes'],
+  ['DAG leaf tips', 'sync_header_chain_dag_leaf_tips'],
+  ['DAG eligible tips', 'sync_header_chain_dag_eligible_tips'],
+  ['Frontier divergence', 'sync_header_chain_frontier_divergence'],
+  ['Reorg depth', 'sync_header_chain_reorg_depth'],
+  ['Non-finalized chains', 'state_memory_chain_count'],
+  ['Best chain length', 'state_memory_best_chain_length'],
+  ['Apply phase', 'sync_zakura_apply_phase'],
+  ['Legacy fallback', 'sync_zakura_legacy_fallback_active',
+    (v) => (v ? 'engaged' : 'inactive')],
+];
+function renderNodeSync(data) {
+  const row = data.node || {};
+  if (row.metrics_error) {
+    el('node-sync').innerHTML = metricsUnavailable(row);
+    return;
+  }
+  const m = row.metrics || {};
+  el('node-sync').innerHTML = '<div class="kv">' + metricRows(m, SYNC_ROWS) + '</div>'
+    + '<p class="note-off">'
+    + (row.metrics_version ? 'exporter ' + esc(row.metrics_version) + ' · ' : '')
+    + 'scraped ' + age(row.metrics_at == null ? null : (Date.now() / 1000) - row.metrics_at) + ' ago'
+    + (row.metrics_series ? ' · ' + num(row.metrics_series) + ' series, ' + bytes(row.metrics_bytes) : '')
+    + (row.metrics_scrape_seconds ? ' in ' + decimal(row.metrics_scrape_seconds) + 's' : '')
+    + '</p>';
+}
+const PEER_ROWS = [
+  ['Legacy peer set', 'zcash_net_peers'],
+  ['Native connections', 'zakura_p2p_conn_active'],
+  ['Native connected peers', 'zakura_p2p_connected_peers'],
+  ['Native healthy peers', 'zakura_p2p_healthy_peers'],
+  ['Reactor connections', 'zakura_p2p_reactor_active_connections'],
+  ['Pool ready', 'pool_num_ready'],
+  ['Pool unready', 'pool_num_unready'],
+  ['Candidates responded', 'candidate_set_responded'],
+  ['Candidates recently live', 'candidate_set_recently_live'],
+  ['Candidates gossiped', 'candidate_set_gossiped'],
+  ['Candidates failed', 'candidate_set_failed'],
+  ['Handshakes in flight', 'crawler_in_flight_handshakes'],
+  ['Handshake failures', 'zcash_net_peer_handshake_failures_total'],
+  ['Mempool transactions', 'zcash_mempool_size_transactions'],
+];
+function renderNodePeers(data) {
+  const row = data.node || {};
+  const m = row.metrics || {};
+  // zakurad's getpeerinfo has no subver, so prefer the exporter's user_agent
+  // label and fall back to the RPC breakdown for the zcashd probe.
+  const subversions = (row.peer_user_agents || []).length
+    ? row.peer_user_agents
+    : (row.peer_subversions || []);
+  let html = '<div class="kv">'
+    + kvRow('Peers (RPC)', row.peer_count == null ? '—' : num(row.peer_count))
+    + kvRow('Inbound', row.peer_inbound == null ? '—' : num(row.peer_inbound));
+  if (!row.metrics_error) {
+    html += metricRows(m, PEER_ROWS)
+      + kvRow('Bytes in / out', bytes(metric(m, 'zcash_net_in_bytes_total'))
+        + ' / ' + bytes(metric(m, 'zcash_net_out_bytes_total')));
+  }
+  html += '</div>';
+  if (row.metrics_error) html += metricsUnavailable(row);
+  if (subversions.length) {
+    html += '<div class="subhead"><p class="eyebrow">Peer versions</p></div><div class="kv">'
+      + subversions.map((entry) => kvRow(String(entry[0]), num(entry[1]))).join('')
+      + '</div>';
+  } else if (row.peer_info_error) {
+    html += '<p class="note-off">getpeerinfo unavailable: ' + esc(row.peer_info_error) + '</p>';
+  }
+  el('node-peers').innerHTML = html;
+}
+function renderNodeEvents(data) {
+  const row = data.node || {};
+  const reorgs = data.reorgs || [];
+  el('node-reorgs').innerHTML = reorgs.length
+    ? reorgs.slice(0, 12).map((event) => {
+      const depth = event.depth_label
+        || (event.depth != null ? 'depth ' + event.depth : 'depth unknown');
+      return '<div class="reorg-item"><div class="reorg-top">'
+        + badge(tipEventLabel(event.kind) || event.kind, 'warn')
+        + badge(depth, 'neutral')
+        + '<span class="muted num" style="font-size:0.78rem">' + num(event.from_height)
+        + ' → ' + num(event.to_height) + '</span>'
+        + '<span class="muted" style="font-size:0.78rem">' + esc(clockTime(event.at)) + '</span>'
+        + '</div><div class="reorg-detail mono">' + esc(tinyHash(event.discarded_hash))
+        + ' → ' + esc(tinyHash(event.canonical_hash)) + '</div></div>';
+    }).join('')
+    : '<div class="empty">No tip switches recorded for this node.</div>';
+
+  // getinfo.errors is the node's most recent WARN/ERROR log line, not a health
+  // verdict, so label it as such and show its age: a routine per-peer warning
+  // overwrites this field continuously (see issue #655).
+  const lastLog = row.node_errors || '';
+  const lastLogAge = row.node_errors_at == null
+    ? null
+    : Math.max(0, (Date.now() / 1000) - row.node_errors_at);
+  el('node-last-log').innerHTML = lastLog
+    ? '<div class="kv">'
+      + kvRow('Logged', age(lastLogAge) + ' ago', lastLogAge != null && lastLogAge < 300 ? 'warn' : null)
+      + '</div><div class="log-lines"><code>' + esc(lastLog) + '</code></div>'
+      + '<p class="note-off">The node\'s most recent warning or error log line, as reported by'
+      + ' <code>getinfo.errors</code>. It is whatever logged last, not a health verdict.</p>'
+    : '<div class="empty">No warning or error reported by getinfo.</div>';
+
+  const logs = row.log_errors || [];
+  if (logs.length) {
+    el('node-logs').innerHTML = '<div class="log-lines">'
+      + logs.map((line) => '<code>' + esc(line) + '</code>').join('') + '</div>';
+  } else if (row.log_errors_suppressed) {
+    el('node-logs').innerHTML = '<p class="note-off">Log lines are not served on this public page.'
+      + ' Start the dashboard with <code>--expose-logs</code> to show the redacted tail.</p>';
+  } else {
+    el('node-logs').innerHTML = '<div class="empty">No recent errors or warnings in the node log.</div>';
+  }
+}
+function renderNode(data) {
+  renderNodeHeader(data);
+  renderNodeVitals(data);
+  renderNodeSparks(data);
+  renderNodeChain(data);
+  renderNodeSync(data);
+  renderNodePeers(data);
+  renderNodeEvents(data);
+  renderFreshness();
+}
+
 function render() {
   if (!state.data) return;
+  if (NODE_NAME) {
+    renderNode(state.data);
+    return;
+  }
   renderHeader(state.data);
-  renderActivation(state.data);
   renderFleet(state.data);
   renderStats(state.data);
   renderChain(state.data);
@@ -2666,8 +3525,9 @@ function render() {
 
 /* ---------- data ---------- */
 async function tick() {
+  const endpoint = NODE_NAME ? '/data/node/' + encodeURIComponent(NODE_NAME) : '/data';
   try {
-    const response = await fetch('/data', { cache: 'no-store' });
+    const response = await fetch(endpoint, { cache: 'no-store' });
     if (!response.ok) throw new Error('HTTP ' + response.status);
     state.data = await response.json();
     state.fetchedAt = Date.now();
@@ -2696,6 +3556,8 @@ document.addEventListener('click', (event) => {
     copyValue(copy);
     return;
   }
+  // Let the node link navigate instead of toggling the row's drawer.
+  if (event.target.closest('a.node-link')) return;
   const header = event.target.closest('thead th[data-sort]');
   if (header) {
     const key = header.dataset.sort;
@@ -2752,6 +3614,13 @@ setInterval(renderFreshness, 1000);
 
 COLLECTOR: ClusterCollector | None = None
 RATE_LIMITER = RateLimiter()
+# The page and its data both change every poll, and the HTML carries no
+# fingerprint. Without this a browser heuristically caches the page and keeps
+# serving a stale build after a dashboard deploy.
+NO_STORE = {
+    "Cache-Control": "no-store, must-revalidate",
+    "X-Content-Type-Options": "nosniff",
+}
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -2825,7 +3694,32 @@ class Handler(BaseHTTPRequestHandler):
         if parsed.path == "/data":
             assert COLLECTOR is not None
             body = json.dumps(COLLECTOR.snapshot()).encode()
-            return self.send_body(200, body, "application/json")
+            return self.send_body(200, body, "application/json", NO_STORE)
+        if parsed.path.startswith("/data/node/"):
+            assert COLLECTOR is not None
+            name = urllib.parse.unquote(parsed.path[len("/data/node/"):])
+            snapshot = COLLECTOR.node_snapshot(name)
+            if snapshot is None:
+                return self.send_json(
+                    404, {"error": "unknown node", "node": name}, NO_STORE
+                )
+            return self.send_body(
+                200, json.dumps(snapshot).encode(), "application/json", NO_STORE
+            )
+        if parsed.path.startswith("/node/"):
+            assert COLLECTOR is not None
+            name = urllib.parse.unquote(parsed.path[len("/node/"):])
+            if name not in COLLECTOR.nodes_by_name:
+                return self.send_body(
+                    404,
+                    b'not found\n\nUnknown node. Return to the fleet: <a href="/">/</a>\n',
+                    "text/html; charset=utf-8",
+                    {"X-Content-Type-Options": "nosniff"},
+                )
+            # Same bytes as the fleet page; the client branches on the path.
+            return self.send_body(
+                200, PAGE.encode(), "text/html; charset=utf-8", NO_STORE
+            )
         if parsed.path == "/ironwood-status.json":
             assert COLLECTOR is not None
             headers = self.public_headers()
@@ -2860,6 +3754,7 @@ class Handler(BaseHTTPRequestHandler):
                 200,
                 PAGE.encode(),
                 "text/html; charset=utf-8",
+                NO_STORE,
             )
         return self.send_body(
             404,
@@ -2906,21 +3801,26 @@ def main() -> None:
         help="mark a node stale if height has not advanced in this many seconds",
     )
     parser.add_argument(
-        "--upgrade-height",
-        type=int,
-        default=DEFAULT_UPGRADE_HEIGHT,
-        help="upgrade activation height to estimate; 0 hides the upgrade cards",
-    )
-    parser.add_argument(
-        "--target-spacing",
-        type=float,
-        default=DEFAULT_TARGET_SPACING,
-        help="fallback seconds per block before enough live samples are observed",
-    )
-    parser.add_argument(
         "--state-file",
         default="",
         help="optional JSON path for durable orphan-pair history",
+    )
+    parser.add_argument(
+        "--history-window",
+        type=float,
+        default=DEFAULT_NODE_HISTORY_WINDOW,
+        help="seconds of per-node sparkline history to retain in memory",
+    )
+    parser.add_argument(
+        "--expose-logs",
+        action="store_true",
+        help="serve each node's redacted log error tail on the public node page",
+    )
+    parser.add_argument(
+        "--metrics-min-interval",
+        type=float,
+        default=None,
+        help="seconds between metric scrapes; omit to adapt to the last scrape's cost",
     )
     args = parser.parse_args()
 
@@ -2930,10 +3830,11 @@ def main() -> None:
         nodes,
         args.interval,
         args.stale_after,
-        args.upgrade_height,
-        args.target_spacing,
         args.network,
         state_file=state_file,
+        history_window=args.history_window,
+        expose_logs=args.expose_logs,
+        metrics_min_interval=args.metrics_min_interval,
     )
     threading.Thread(target=COLLECTOR.loop, daemon=True).start()
 


### PR DESCRIPTION
## Motivation

The cluster status page answers exactly one question: is the fleet agreeing on a tip and advancing. It shows height, header lag, commit, tip hash and restart time. It cannot answer *why one node is unhealthy* — there is no disk, memory, peer, restart-count or sync-pipeline visibility anywhere in production.

Meanwhile the node already emits ~350 Prometheus series and has a purpose-built health endpoint, but both are opt-in and were only configured on some fleets, so the richest observability surface in the codebase was largely dark.

## Solution

Node names in the fleet table link to `/node/<name>`, a detail page that leads with host vitals, then chain position, the sync pipeline, and peers, with sparklines over a rolling window. Both routes serve the same template and branch on `location.pathname`, so the CSS, formatters and copy-to-clipboard helpers stay shared and there is no second template to keep in sync.

**Probe.** The existing SSH probe additionally collects host vitals (free disk on the state dir, memory, process RSS, load, uptime, systemd `NRestarts`, kernel OOM kills, and a redacted log tail), scrapes the node's Prometheus endpoint against a ~60-name allowlist, reads `/healthy` and `/ready`, and reduces `getpeerinfo`/`getmempoolinfo` on the node to counts. Vitals require no metrics endpoint, so they populate on every node including the zcashd probe. Anything unavailable is reported rather than blanked.

**Scrape cost.** Rendering the exposition costs a live node real CPU, and that cost grows with peer-labelled counter cardinality: measured ~0.03s on a freshly restarted node and ~0.6s (11.6 MB, 129k series) after several days. The scrape interval therefore scales with what the last scrape actually cost, capped at 120s, so a cheap endpoint refreshes every poll and an expensive one cannot burn more than about 1/30th of a core. `--metrics-min-interval` pins it if a fixed cadence is wanted.

**Deployer.** New `health_listen_addr` key renders `[health] listen_addr`, mirroring the existing `metrics_endpoint`. Both are unauthenticated and `zakurad` panics if either address is already bound, so the docs call out loopback binding and a port pre-flight. Testnet now sets it.

**Removals.** The Ironwood activation countdown is deleted now that the upgrade has activated, along with its estimator, height history and the `--upgrade-height`/`--target-spacing` flags — the installed unit files pass those flags, so both workflow `ExecStart` lines drop them in the same change or the service would fail to start. The `zakurad vs zcashd` tile is also removed; note the caveat in follow-ups.

**Compatibility.** `/data` keeps its existing shape for the Slack watchdog and only gains a small per-row `vitals` summary, which surfaces low disk and OOM kills as badges in the fleet table. `/ironwood-status.json`, the public API zakura.com consumes, is untouched and computes activation independently of the removed estimator.

## Testing

`python3 deploy/runner/test_zakura_cluster_status.py` (48), `test_zakura_cluster_watchdog.py` (10) and `deploy/deployer/test_deploy.py` (12) all pass; all three already run in `lint.yml`.

New coverage worth calling out, each written against a bug found while validating on the live testnet fleet:

- The remote probe is executed as its own process against stub HTTP endpoints, since that is how it actually runs on the far side of ssh. Covers allowlist filtering, `/healthy` and `/ready` status-and-body capture, unreachable and unconfigured endpoints, and log-tail redaction.
- `journalctl` exits 1 when its grep matches nothing, which was making "no OOM kills" read as "unknown". Stubbed on `PATH` so the assertion is hermetic.
- `zakurad`'s `getpeerinfo` has no `subver` field, so the peer version breakdown comes from the exporter's `user_agent` label instead.
- The scrape interval scaling, its cap, and the explicit override.
- Every `[data-view]` section is checked against the `[hidden]` override. A class that sets its own `display` beats the UA stylesheet's `[hidden]` rule, which left one unrendered section visible on node pages showing placeholder text.
- Route coverage for `/node/<name>` and `/data/node/<name>` including 404s, plus `Cache-Control: no-store` on all four routes — without it browsers heuristically cached the page and kept serving an old build after a deploy.

Manually verified end to end on the testnet fleet: `[health]` enabled on all three nodes with automatic config restore on failure, then the dashboard deployed and every route, panel and degradation path checked against live data.

## Changelog

<!-- changelog: none --> — no Rust or `Cargo.toml` changes; this is deploy tooling only.

### Follow-up Work

- **The `zakurad vs zcashd` tile is removed, and that is a real loss on mainnet.** It compared the best zakurad tip against the best zcashd tip — the cross-implementation consensus check that `zcashd-compat` exists to provide. On testnet there is no zcashd node, so `best_tip_row(rows, "zcashd")` always returned `None` and the tile showed a permanent green "aligned", claiming agreement with a client nobody was observing. The right fix is to render it only when a zcashd node is actually present, rather than delete it; happy to restore it that way.
- Mainnet nodes still have no `[metrics]` or `[health]` endpoints. Mainnet deploys are binary-only (`manage_config = false`), so enabling them needs a systemd drop-in setting `ZAKURA_METRICS__ENDPOINT_ADDR` and `ZAKURA_HEALTH__LISTEN_ADDR`, which is not in this PR. Until then the metrics-backed panels degrade to "not enabled" on the mainnet page.
- Peer-labelled counter cardinality grows without bound between restarts, which is what forces the adaptive scrape. See #655.
- `/data` publishes `ssh = root@<ip>` for every node on a public, unauthenticated page. Pre-existing, worth dropping separately.
