### PR TITLE
fix(chain): enforce max block time after local seed chain

### DIFF
--- a/crates/zakura-chain/src/local_genesis.rs
+++ b/crates/zakura-chain/src/local_genesis.rs
@@ -399,6 +399,7 @@ fn build_network(options: BuildNetworkOptions<'_>) -> Result<Network, crate::Box
         .with_target_difficulty_limit(target_difficulty)?
         .with_disable_pow(disable_pow)
         .with_slow_start_interval(Height(0))
+        .with_max_block_time_start_height(Height(activation_height))
         .with_activation_heights(activation_heights)?
         .with_halving_interval(144)?
         .with_funding_streams(vec![])
@@ -665,6 +666,34 @@ mod tests {
             .collect();
 
         assert_eq!(deltas, vec![25; generated.blocks.len() - 1]);
+    }
+
+    #[test]
+    fn generated_seed_chain_precedes_max_block_time_rule() {
+        let generated = generate_local_testnet_with_funded_keys(
+            vec!["alice".to_string(), "bob".to_string()],
+            LocalTestnetGenesisOptions {
+                target_spacing_secs: 5_401,
+                seeded_tip_time: Some(20_000),
+                ..Default::default()
+            },
+        )
+        .expect("local testnet should generate");
+
+        let seeded_tip_height = Height(
+            u32::try_from(generated.blocks.len() - 1)
+                .expect("the generated seed chain length fits in a block height"),
+        );
+        let post_seed_height = Height(
+            u32::try_from(generated.blocks.len())
+                .expect("the generated post-seed height fits in a block height"),
+        );
+        assert!(!generated
+            .network
+            .is_max_block_time_enforced(seeded_tip_height));
+        assert!(generated
+            .network
+            .is_max_block_time_enforced(post_seed_height));
     }
 
     #[test]

--- a/docs/changelog/unreleased/640.md
+++ b/docs/changelog/unreleased/640.md
@@ -1,8 +1,9 @@
 ## Changed
 
 - The maximum-block-time activation height is now a per-network parameter.
-  Configured networks and Regtest activate the MTP-plus-90-minutes rule at
-  height 2 instead of inheriting the public Testnet height, and Regtest accepts
-  a `max_block_time_start_height` config field. Mainnet and public Testnet
+  Configured networks and Regtest default to activating the MTP-plus-90-minutes
+  rule at height 2 instead of inheriting the public Testnet height, generated
+  local networks activate it after their seed chain, and Regtest accepts a
+  `max_block_time_start_height` config field. Mainnet and public Testnet
   behaviour is unchanged
   ([#640](https://github.com/zakura-core/zakura/pull/640)).


### PR DESCRIPTION
## Motivation

PR #640 makes the MTP-plus-90-minutes rule active from height 2 on configured networks. The local-testnet generator checkpoints every seed block but can space those blocks more than 90 minutes apart, so its checkpoint and header-range ingestion paths can disagree about whether the generated chain is valid.

## Solution

Activate the maximum-block-time rule at the existing post-seed activation height for generated local networks. This exempts only the authenticated seed chain and enforces the rule on the first subsequently mined block.

## Testing

- `cargo fmt --all -- --check` — passed
- `cargo test --locked -p zakura-chain` — passed (384 unit tests and 9 doc tests)
- `cargo clippy --locked -p zakura-chain --all-targets -- -D warnings` — passed
- `markdownlint docs/changelog/unreleased/640.md --config .github/.markdownlint.yaml` — passed

The regression uses two miners and a 5,401-second spacing, the deterministic boundary that would make height 2 one second too late if the rule activated inside the seed chain. It verifies the rule remains inactive at the generated tip and activates immediately afterward.

## Changelog

Updates the existing #640 changelog fragment because this fix is intended to merge into that PR.

### Specifications & References

- Parent PR: https://github.com/zakura-core/zakura/pull/640
- Audit finding: https://v12.sh/runs/6472/219218