### PR TITLE
test(header-chain): simplify planner architecture guard

### DIFF
--- a/crates/zakura-header-chain/src/lib.rs
+++ b/crates/zakura-header-chain/src/lib.rs
@@ -75,23 +75,9 @@ mod tests {
         }
     }
 
-    /// The retained DAG mutates only through one planned, verified transition,
-    /// and planning derives its write set incrementally.
+    /// Planning derives its write set incrementally and keeps retention private.
     #[test]
-    fn architecture_keeps_dag_mutation_and_planning_encapsulated() {
-        for raw_entry_point in [
-            "pub fn insert(",
-            "pub fn add_eligibility_reason(",
-            "pub fn remove_operator_invalidation(",
-            "pub fn set_consensus_body_invalid(",
-            "pub fn set_body_validation_state(",
-            "pub fn set_header_validation_state(",
-        ] {
-            assert!(
-                !include_str!("graph/mod.rs").contains(raw_entry_point),
-                "raw DAG mutation entry point escaped: {raw_entry_point}"
-            );
-        }
+    fn architecture_keeps_planning_encapsulated() {
         let public_surface = include_str!("lib.rs")
             .split("#[cfg(test)]")
             .next()
@@ -130,10 +116,6 @@ mod tests {
                 .join("src/transition/planner")
                 .as_path(),
             &mut sources,
-        );
-        assert!(
-            !sources.is_empty(),
-            "the planner guard must inspect real planner sources"
         );
         for (path, source) in &sources {
             for forbidden in [

--- a/docs/changelog/unreleased/662.md
+++ b/docs/changelog/unreleased/662.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only simplifies internal architecture tests and has no operator- or
+crate-consumer-visible effect.


### PR DESCRIPTION
## Motivation

Follow up on review feedback from [#646](https://github.com/zakura-core/zakura/pull/646): the restored architecture test included a brittle source-string visibility check and a redundant nonempty assertion.

## Solution

Remove the mutation visibility source scan and the redundant assertion. Keep the checks that retention remains private and planning does not derive its write set by diffing whole graphs.

## Testing

- `rustfmt --edition 2021 --check crates/zakura-header-chain/src/lib.rs`
- `cargo test -p zakura-header-chain architecture_keeps_planning_encapsulated`
- `markdownlint docs/changelog/unreleased/662.md --config .github/.markdownlint.yaml`
- `./scripts/changelog.py check`

## Changelog

Internal-only test cleanup; `docs/changelog/unreleased/662.md` records the explicit exclusion.

### Specifications & References

Follow-up to [#646](https://github.com/zakura-core/zakura/pull/646).