### PR TITLE
fix(ci): accept release-state review attestations

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -399,10 +399,6 @@ jobs:
           ]
           lines += ["", "## Verification", ""]
           lines += [f"- [{mark(o)}] `{cmd}`" for cmd, o in checks]
-          lines.append(
-              "- ⏳ `cargo public-api diff latest` for changed published "
-              "libraries runs in the parallel release-PR CI matrix."
-          )
           if any(o != "success" for _, o in checks):
               lines += [
                   "",

--- a/.github/workflows/release-pr-readiness.yml
+++ b/.github/workflows/release-pr-readiness.yml
@@ -31,6 +31,7 @@ jobs:
               "new-crate-versions",
               "release-hold",
           }
+          allowed = required | {"release-state"}
 
           if manual_heading not in body:
               raise SystemExit(
@@ -53,7 +54,7 @@ jobs:
                   + ", ".join(duplicates)
               )
           missing = sorted(required - set(found))
-          unexpected = sorted(set(found) - required)
+          unexpected = sorted(set(found) - allowed)
           if missing or unexpected:
               details = []
               if missing:


### PR DESCRIPTION
## Motivation

The readiness check on [release PR #663](https://github.com/zakura-core/zakura/pull/663) rejected the conditionally generated `release-state` review marker as unexpected, even after every manual judgment item was checked. Generated release PR bodies also displayed a static hourglass message that looked like live CI progress.

## Solution

Allow `release-state` as an optional manual-judgment marker while continuing to require and validate the standard markers. Remove the redundant static public-API CI sentence from generated PR bodies.

## Testing

- `actionlint .github/workflows/prepare-release-pr.yml .github/workflows/release-pr-readiness.yml`
- `git diff --check`

## Changelog

Not required: this PR changes only internal GitHub Actions workflows.

### Specifications & References

- Follow-up to [#663](https://github.com/zakura-core/zakura/pull/663)
- [Original readiness failure](https://github.com/zakura-core/zakura/actions/runs/31768367564/job/94669562367)

### Follow-up Work

None.