### PR TITLE
refactor(node-services)!: add typed header-sync contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8565,6 +8565,7 @@ dependencies = [
  "tokio",
  "tower 0.4.13",
  "zakura-chain",
+ "zakura-header-chain",
 ]
 
 [[package]]

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -32,6 +32,7 @@ rpc-client = [
 
 [dependencies]
 zakura-chain = { path = "../zakura-chain" , version = "5.0.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/crates/zakura-node-services/src/header_chain.rs
+++ b/crates/zakura-node-services/src/header_chain.rs
@@ -1,0 +1,693 @@
+//! Typed boundary between header-sync policy and header-chain state.
+
+use std::{error::Error, fmt, future::Future, pin::Pin, sync::Arc};
+
+use zakura_chain::block;
+use zakura_header_chain::{
+    AuxDelivery, BodyWorkOwner, CommittedStallReceipt, Frontier, HeaderChainError, HeaderLocator,
+    HeaderSyncWorkOwner, HeaderWorkAuthority, InsertHeaders, SourceId, TargetCompletion,
+    VctRepairContext,
+};
+
+/// A boxed operation returned by [`Port`].
+pub type HeaderChainFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Process-local capability that authenticates values sealed by one header-chain adapter.
+///
+/// An adapter keeps this key private and uses clones only inside its own asynchronous tasks.
+/// The adapter cannot open values that a different key sealed.
+/// The adapter cannot use those values as retained-path handles.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct AdapterKey(Arc<()>);
+
+impl AdapterKey {
+    /// Create the unique capability for one header-chain adapter instance.
+    pub fn new() -> Self {
+        Self(Arc::new(()))
+    }
+
+    fn authenticates(&self, seal: &Arc<()>) -> bool {
+        Arc::ptr_eq(&self.0, seal)
+    }
+}
+
+impl Default for AdapterKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for AdapterKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdapterKey(<redacted>)")
+    }
+}
+
+/// A local failure while executing a header-chain port operation.
+#[derive(Clone, Debug)]
+pub enum PortError {
+    /// The adapter's operation deadline elapsed.
+    Timeout,
+    /// The backing service became unavailable or returned an invalid reply.
+    Unavailable {
+        /// Original failure, when the backing service supplied one.
+        source: Option<Arc<dyn Error + Send + Sync + 'static>>,
+    },
+}
+
+/// Result of resolving an exact selected-header auxiliary repair.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VctRepairContextReply {
+    /// The requested owner and height still identify the selected branch.
+    Resolved(VctRepairContext),
+    /// The owner or selected height is no longer current.
+    Stale,
+}
+
+/// Wire-neutral request for an immutable retained header path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcquirePath {
+    /// Stable requester identity.
+    pub source: SourceId,
+    /// Ordered-stream generation.
+    pub session_id: u64,
+    /// Exact generation and branch to retain.
+    pub scope: HeaderWorkAuthority,
+    /// Exact target branch.
+    pub target_tip_hash: block::Hash,
+    /// Requester-order locator hashes.
+    pub locator_hashes: Vec<block::Hash>,
+}
+
+/// An immutable retained path acquired from the header-chain port.
+#[derive(Clone)]
+pub struct RetainedHeaderPath {
+    adapter_seal: Arc<()>,
+    adapter_id: u64,
+    source: SourceId,
+    session_id: u64,
+    /// First requester-order locator intersection.
+    pub common_ancestor: Frontier,
+    /// Exact retained target.
+    pub target: Frontier,
+    /// Exact generation and branch fixed at acquisition.
+    pub scope: HeaderWorkAuthority,
+}
+
+impl RetainedHeaderPath {
+    /// Construct a retained path in a state adapter.
+    #[doc(hidden)]
+    pub fn from_adapter(
+        adapter_key: &AdapterKey,
+        adapter_id: u64,
+        source: SourceId,
+        session_id: u64,
+        common_ancestor: Frontier,
+        target: Frontier,
+        scope: HeaderWorkAuthority,
+    ) -> Self {
+        Self {
+            adapter_seal: adapter_key.0.clone(),
+            adapter_id,
+            source,
+            session_id,
+            common_ancestor,
+            target,
+            scope,
+        }
+    }
+
+    /// Return the opaque identity only to the adapter that issued this path.
+    #[doc(hidden)]
+    pub fn adapter_identity(&self, adapter_key: &AdapterKey) -> Option<(u64, SourceId, u64)> {
+        adapter_key.authenticates(&self.adapter_seal).then_some((
+            self.adapter_id,
+            self.source,
+            self.session_id,
+        ))
+    }
+
+    /// Return the non-authoritative handle used to correlate this path inside its caller.
+    ///
+    /// This value cannot authenticate the path without the issuing adapter's private key.
+    pub fn handle_id(&self) -> u64 {
+        self.adapter_id
+    }
+}
+
+impl fmt::Debug for RetainedHeaderPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RetainedHeaderPath")
+            .field("adapter_identity", &"<redacted>")
+            .field("common_ancestor", &self.common_ancestor)
+            .field("target", &self.target)
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
+impl PartialEq for RetainedHeaderPath {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.adapter_seal, &other.adapter_seal)
+            && self.adapter_id == other.adapter_id
+            && self.source == other.source
+            && self.session_id == other.session_id
+            && self.common_ancestor == other.common_ancestor
+            && self.target == other.target
+            && self.scope == other.scope
+    }
+}
+
+impl Eq for RetainedHeaderPath {}
+
+/// Result of acquiring an immutable retained path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AcquirePathReply {
+    /// The adapter retains the requested target path.
+    Acquired(Box<RetainedHeaderPath>),
+    /// The adapter no longer retains the target.
+    TargetNotRetained,
+    /// No requester locator lies on the retained target path.
+    NoLocatorIntersection,
+    /// Pruning removed the required target history.
+    HistoryPruned,
+    /// State cannot currently retain another path.
+    Busy,
+}
+
+/// A bounded read from an already acquired retained path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReadPath {
+    /// Common ancestor or previous page tip.
+    pub after_hash: block::Hash,
+    /// Maximum number of returned headers.
+    pub max_header_count: u32,
+    /// Whether the caller requested schema-v1 commitment roots.
+    pub want_tree_aux: bool,
+}
+
+/// One raw page from an immutable retained header path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetainedHeaderPathPage {
+    /// Exact page ancestor.
+    pub common_ancestor: Frontier,
+    /// Exact retained target.
+    pub target: Frontier,
+    /// Exact generation and branch fixed at acquisition.
+    pub scope: HeaderWorkAuthority,
+    /// Canonical headers in parent-first order.
+    pub headers: Vec<Arc<block::Header>>,
+    /// Parallel auxiliary deliveries for each retained header.
+    pub aux_deliveries: Vec<Vec<AuxDelivery>>,
+    /// Authoritative commitment roots loaded from finalized state, parallel to `headers`.
+    ///
+    /// These roots do not have peer-delivery provenance.
+    /// The page keeps the roots separate from `aux_deliveries`.
+    /// A serving adapter may use the roots for finalized historical pages.
+    pub finalized_tree_aux: Vec<Option<zakura_header_chain::TreeAuxRecordV1>>,
+    /// Whether this page reaches the immutable target.
+    pub complete: bool,
+}
+
+/// Result of reading an immutable retained path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReadPathReply {
+    /// The requested page remains available.
+    Page(Box<RetainedHeaderPathPage>),
+    /// The lease expired or became unavailable.
+    Unavailable,
+}
+
+/// One header and its unauthenticated parallel metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TargetEntry {
+    /// Canonical Zcash block header.
+    pub header: Arc<block::Header>,
+    /// Serialized-body-size hint.
+    /// Zero means unknown.
+    pub body_size: u32,
+    /// Optional schema-1 commitment record.
+    pub tree_aux: Option<zakura_header_chain::TreeAuxRecordV1>,
+}
+
+/// A header-target entry list bounded by the engine's production transition cap.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TargetEntries(Vec<TargetEntry>);
+
+impl TargetEntries {
+    /// Borrow the bounded entries in parent-first order.
+    pub fn as_slice(&self) -> &[TargetEntry] {
+        &self.0
+    }
+
+    /// Consume the bounded wrapper without reallocating its entries.
+    pub fn into_vec(self) -> Vec<TargetEntry> {
+        self.0
+    }
+
+    /// Return the number of entries.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the target contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl TryFrom<Vec<TargetEntry>> for TargetEntries {
+    type Error = TargetEntriesError;
+
+    fn try_from(entries: Vec<TargetEntry>) -> Result<Self, Self::Error> {
+        if entries.len() > zakura_header_chain::MAX_HEADERS_PER_TRANSITION_V1 {
+            return Err(TargetEntriesError {
+                actual: entries.len(),
+                maximum: zakura_header_chain::MAX_HEADERS_PER_TRANSITION_V1,
+            });
+        }
+        Ok(Self(entries))
+    }
+}
+
+/// A header-target list exceeded the frozen production transition cap.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TargetEntriesError {
+    /// Supplied entry count.
+    pub actual: usize,
+    /// Maximum accepted entry count.
+    pub maximum: usize,
+}
+
+impl fmt::Display for TargetEntriesError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "header target contains {} entries, maximum is {}",
+            self.actual, self.maximum
+        )
+    }
+}
+
+impl Error for TargetEntriesError {}
+
+/// Complete input to deterministic target preparation.
+#[derive(Clone, Debug)]
+pub struct PrepareHeaderTarget {
+    /// Stable supplier identity.
+    pub source: SourceId,
+    /// Exact asynchronous owner.
+    pub owner: HeaderSyncWorkOwner,
+    /// Exact initial locator intersection.
+    pub common_ancestor: Frontier,
+    /// Exact advertised target.
+    pub target: Frontier,
+    /// Response entries in parent-first order.
+    pub entries: TargetEntries,
+    /// Proof that the response satisfies its target purpose.
+    pub completion: TargetCompletion,
+}
+
+/// A target sealed by the port's preparation operation.
+#[derive(Clone)]
+pub struct PreparedHeaderTarget {
+    adapter_seal: Arc<()>,
+    insert: Box<InsertHeaders>,
+}
+
+impl PreparedHeaderTarget {
+    /// Seal an insertion in a state adapter.
+    #[doc(hidden)]
+    pub fn from_insert(adapter_key: &AdapterKey, insert: Box<InsertHeaders>) -> Self {
+        Self {
+            adapter_seal: adapter_key.0.clone(),
+            insert,
+        }
+    }
+
+    /// Consume a sealed target only in the adapter that prepared it.
+    #[doc(hidden)]
+    pub fn into_insert(self, adapter_key: &AdapterKey) -> Result<Box<InsertHeaders>, Self> {
+        if adapter_key.authenticates(&self.adapter_seal) {
+            Ok(self.insert)
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Return the work owner without exposing the sealed insertion.
+    pub fn owner(&self) -> HeaderSyncWorkOwner {
+        self.insert.owner
+    }
+
+    /// Return the supplier identity without exposing the sealed insertion.
+    pub fn source(&self) -> SourceId {
+        self.insert.source
+    }
+
+    /// Return the pursued target without exposing the sealed insertion.
+    pub fn target_tip_hash(&self) -> block::Hash {
+        self.insert.target_tip_hash
+    }
+
+    /// Return the number of sealed auxiliary deliveries.
+    pub fn auxiliary_delivery_count(&self) -> usize {
+        self.insert.aux.len()
+    }
+}
+
+impl fmt::Debug for PreparedHeaderTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedHeaderTarget")
+            .field("adapter_seal", &"<redacted>")
+            .field("owner", &self.insert.owner)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Result of target preparation.
+pub type PrepareHeaderTargetReply = Result<PreparedHeaderTarget, Arc<HeaderChainError>>;
+
+/// Result of atomically applying a prepared target.
+pub type ApplyHeaderTargetReply = Result<ApplyHeaderTargetOutcome, Arc<HeaderChainError>>;
+
+/// Successful state-side outcome of applying one prepared header target.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ApplyHeaderTargetOutcome {
+    /// State committed the target or recognized its idempotent replay.
+    Applied,
+    /// State committed the resource-stall outcome without admitting the target.
+    ResourceStalled(CommittedStallReceipt),
+}
+
+/// Header-chain operations that header-sync policy requires.
+///
+/// Each operation returns one typed future for its request and reply.
+/// An implementation enforces its local deadline.
+/// An implementation translates its backing service protocol into this contract.
+pub trait Port: Send + Sync + 'static {
+    /// Return a coherent locator for the current selected path.
+    fn continuation_locator(
+        &self,
+    ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, PortError>>;
+
+    /// Resolve selected-path context for the auxiliary repair at `height`.
+    fn vct_repair_context(
+        &self,
+        owner: BodyWorkOwner,
+        height: block::Height,
+    ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, PortError>>;
+
+    /// Retain the target path identified by `request`.
+    ///
+    /// An acquired reply pins the path until the caller releases it.
+    fn acquire_header_path(
+        &self,
+        request: AcquirePath,
+    ) -> HeaderChainFuture<'_, Result<AcquirePathReply, PortError>>;
+
+    /// Return one bounded page from a retained target path.
+    ///
+    /// The port returns [`ReadPathReply::Unavailable`] when the path is no longer retained.
+    fn read_header_path(
+        &self,
+        path: RetainedHeaderPath,
+        request: ReadPath,
+    ) -> HeaderChainFuture<'_, Result<ReadPathReply, PortError>>;
+
+    /// Release a retained target path.
+    ///
+    /// The port accepts repeated releases for the same path.
+    fn release_header_path(
+        &self,
+        path: RetainedHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<(), PortError>>;
+
+    /// Validate and seal a complete target outside the serialized state writer.
+    ///
+    /// The port returns a target that only its issuing adapter can apply.
+    fn prepare_header_target(
+        &self,
+        request: PrepareHeaderTarget,
+    ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply>;
+
+    /// Atomically apply a sealed target.
+    ///
+    /// The port returns the committed state result or the transition failure.
+    fn apply_header_target(
+        &self,
+        target: PreparedHeaderTarget,
+    ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply>;
+}
+
+impl std::fmt::Debug for dyn Port {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("Port")
+    }
+}
+
+/// A node uses this port when it has no durable header-chain state.
+#[derive(Debug, Default)]
+pub struct UnavailablePort;
+
+impl Port for UnavailablePort {
+    fn continuation_locator(
+        &self,
+    ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, PortError>> {
+        Box::pin(async { Err(PortError::Unavailable { source: None }) })
+    }
+
+    fn vct_repair_context(
+        &self,
+        _owner: BodyWorkOwner,
+        _height: block::Height,
+    ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, PortError>> {
+        Box::pin(async { Err(PortError::Unavailable { source: None }) })
+    }
+
+    fn acquire_header_path(
+        &self,
+        _request: AcquirePath,
+    ) -> HeaderChainFuture<'_, Result<AcquirePathReply, PortError>> {
+        Box::pin(async { Ok(AcquirePathReply::TargetNotRetained) })
+    }
+
+    fn read_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+        _request: ReadPath,
+    ) -> HeaderChainFuture<'_, Result<ReadPathReply, PortError>> {
+        Box::pin(async { Ok(ReadPathReply::Unavailable) })
+    }
+
+    fn release_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<(), PortError>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn prepare_header_target(
+        &self,
+        request: PrepareHeaderTarget,
+    ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply> {
+        Box::pin(async move {
+            Err(Arc::new(HeaderChainError::local_resource(
+                zakura_header_chain::ErrorSubject::Branch(request.owner.header_authority().branch),
+                None,
+            )))
+        })
+    }
+
+    fn apply_header_target(
+        &self,
+        target: PreparedHeaderTarget,
+    ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply> {
+        let owner = target.owner();
+        Box::pin(async move {
+            Err(Arc::new(HeaderChainError::local_resource(
+                zakura_header_chain::ErrorSubject::Branch(owner.header_authority().branch),
+                None,
+            )))
+        })
+    }
+}
+
+/// Inert port used by state-machine tests that drive completions explicitly.
+#[doc(hidden)]
+#[derive(Debug, Default)]
+pub struct InertHeaderChainPort;
+
+impl Port for InertHeaderChainPort {
+    fn continuation_locator(
+        &self,
+    ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, PortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn vct_repair_context(
+        &self,
+        _owner: BodyWorkOwner,
+        _height: block::Height,
+    ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, PortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn acquire_header_path(
+        &self,
+        _request: AcquirePath,
+    ) -> HeaderChainFuture<'_, Result<AcquirePathReply, PortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn read_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+        _request: ReadPath,
+    ) -> HeaderChainFuture<'_, Result<ReadPathReply, PortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn release_header_path(
+        &self,
+        _path: RetainedHeaderPath,
+    ) -> HeaderChainFuture<'_, Result<(), PortError>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn prepare_header_target(
+        &self,
+        _request: PrepareHeaderTarget,
+    ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply> {
+        Box::pin(std::future::pending())
+    }
+
+    fn apply_header_target(
+        &self,
+        _target: PreparedHeaderTarget,
+    ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply> {
+        Box::pin(std::future::pending())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct MinimalMock;
+
+    impl Port for MinimalMock {
+        fn continuation_locator(
+            &self,
+        ) -> HeaderChainFuture<'_, Result<Option<HeaderLocator>, PortError>> {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn vct_repair_context(
+            &self,
+            _owner: BodyWorkOwner,
+            _height: block::Height,
+        ) -> HeaderChainFuture<'_, Result<VctRepairContextReply, PortError>> {
+            Box::pin(async { Ok(VctRepairContextReply::Stale) })
+        }
+
+        fn acquire_header_path(
+            &self,
+            _request: AcquirePath,
+        ) -> HeaderChainFuture<'_, Result<AcquirePathReply, PortError>> {
+            Box::pin(async { Ok(AcquirePathReply::Busy) })
+        }
+
+        fn read_header_path(
+            &self,
+            _path: RetainedHeaderPath,
+            _request: ReadPath,
+        ) -> HeaderChainFuture<'_, Result<ReadPathReply, PortError>> {
+            Box::pin(async { Ok(ReadPathReply::Unavailable) })
+        }
+
+        fn release_header_path(
+            &self,
+            _path: RetainedHeaderPath,
+        ) -> HeaderChainFuture<'_, Result<(), PortError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn prepare_header_target(
+            &self,
+            _request: PrepareHeaderTarget,
+        ) -> HeaderChainFuture<'_, PrepareHeaderTargetReply> {
+            unreachable!("the mock need not construct a state service")
+        }
+
+        fn apply_header_target(
+            &self,
+            _target: PreparedHeaderTarget,
+        ) -> HeaderChainFuture<'_, ApplyHeaderTargetReply> {
+            unreachable!("the mock need not construct a state service")
+        }
+    }
+
+    #[tokio::test]
+    async fn port_is_object_safe_and_mockable_without_state_services() {
+        let port: Arc<dyn Port> = Arc::new(MinimalMock);
+        assert!(port.continuation_locator().await.unwrap().is_none());
+    }
+
+    #[test]
+    fn retained_path_identity_requires_the_issuing_adapter_key() {
+        let issuing_key = AdapterKey::new();
+        let foreign_key = AdapterKey::new();
+        let source = SourceId::from_digest([0x5a; 32]);
+        let common_ancestor = Frontier::new(block::Height(2), block::Hash([2; 32]));
+        let target = Frontier::new(block::Height(3), block::Hash([3; 32]));
+        let scope = HeaderWorkAuthority {
+            header_generation: zakura_header_chain::HeaderGeneration::new(4),
+            branch: zakura_header_chain::BranchId::new(common_ancestor.hash, target.hash),
+        };
+        let path = RetainedHeaderPath::from_adapter(
+            &issuing_key,
+            123_456_789,
+            source,
+            7,
+            common_ancestor,
+            target,
+            scope,
+        );
+
+        assert_eq!(
+            path.adapter_identity(&issuing_key),
+            Some((123_456_789, source, 7))
+        );
+        assert_eq!(path.adapter_identity(&foreign_key), None);
+        assert!(!format!("{path:?}").contains("123456789"));
+    }
+
+    #[test]
+    fn header_target_entries_enforce_the_engine_batch_cap() {
+        let entry = TargetEntry {
+            header: zakura_chain::block::genesis::regtest_genesis_block()
+                .header
+                .clone(),
+            body_size: 0,
+            tree_aux: None,
+        };
+        let limit = zakura_header_chain::MAX_HEADERS_PER_TRANSITION_V1;
+
+        let accepted = TargetEntries::try_from(vec![entry.clone(); limit])
+            .expect("the exact engine batch limit is accepted");
+        assert_eq!(accepted.len(), limit);
+
+        assert_eq!(
+            TargetEntries::try_from(vec![entry; limit + 1]),
+            Err(TargetEntriesError {
+                actual: limit + 1,
+                maximum: limit,
+            })
+        );
+    }
+}

--- a/crates/zakura-node-services/src/lib.rs
+++ b/crates/zakura-node-services/src/lib.rs
@@ -1,8 +1,10 @@
 //! The interfaces of some Zakura node services.
 
 pub use zakura_chain::parameters::checkpoint::constants;
+pub mod header_chain;
 pub mod mempool;
 pub mod service_traits;
+pub mod sync_lifecycle;
 
 #[cfg(any(test, feature = "rpc-client"))]
 pub mod rpc_client;

--- a/crates/zakura-node-services/src/sync_lifecycle.rs
+++ b/crates/zakura-node-services/src/sync_lifecycle.rs
@@ -1,0 +1,694 @@
+//! Process-local sync lifecycle values shared across state, network, and node orchestration.
+
+use std::fmt;
+use std::sync::Arc;
+
+use zakura_header_chain::Frontier;
+
+/// Checked monotonic identity for one lifecycle generation.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct LifecycleEpoch(u64);
+
+impl LifecycleEpoch {
+    /// The first lifecycle generation.
+    pub const INITIAL: Self = Self(0);
+
+    /// Construct an epoch from a durable or test value.
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the numeric epoch for metrics and serialization boundaries.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Advance without wrapping.
+    pub const fn checked_next(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(next) => Some(Self(next)),
+            None => None,
+        }
+    }
+}
+
+/// Authoritative process-local owner of bulk block applies.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ApplyPhase {
+    /// Legacy checkpoint sync owns applies before semantic handoff.
+    LegacyBootstrap {
+        /// Bootstrap ownership generation.
+        epoch: LifecycleEpoch,
+    },
+    /// Native Zakura block sync may begin new applies.
+    Native {
+        /// Native ownership generation.
+        epoch: LifecycleEpoch,
+    },
+    /// The coordinator closes native admission while previously authorized applies drain.
+    FallbackDraining {
+        /// Native generation that the coordinator drains.
+        epoch: LifecycleEpoch,
+    },
+    /// One fully drained legacy fallback lease owns applies.
+    LegacyFallback {
+        /// Drained generation owned by the fallback lease.
+        epoch: LifecycleEpoch,
+    },
+    /// The coordinator permanently rejects new bulk applies.
+    Failed {
+        /// Last valid generation before failure.
+        epoch: LifecycleEpoch,
+    },
+}
+
+impl ApplyPhase {
+    /// Return this phase's monotonic generation.
+    pub const fn epoch(self) -> LifecycleEpoch {
+        match self {
+            Self::LegacyBootstrap { epoch }
+            | Self::Native { epoch }
+            | Self::FallbackDraining { epoch }
+            | Self::LegacyFallback { epoch }
+            | Self::Failed { epoch } => epoch,
+        }
+    }
+
+    /// Return a stable metric/log label.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::LegacyBootstrap { .. } => "legacy_bootstrap",
+            Self::Native { .. } => "native",
+            Self::FallbackDraining { .. } => "fallback_draining",
+            Self::LegacyFallback { .. } => "legacy_fallback",
+            Self::Failed { .. } => "failed",
+        }
+    }
+
+    /// Apply one checked lifecycle transition without mutating the caller on failure.
+    pub fn transition(self, transition: ApplyTransition) -> Result<Self, LifecycleTransitionError> {
+        match transition {
+            ApplyTransition::FinishBootstrap => match self {
+                Self::LegacyBootstrap { epoch } => Ok(Self::Native {
+                    epoch: epoch
+                        .checked_next()
+                        .ok_or(LifecycleTransitionError::EpochExhausted)?,
+                }),
+                _ => Err(LifecycleTransitionError::IllegalPhase),
+            },
+            ApplyTransition::BeginFallback { expected_epoch } => {
+                check_epoch(self, expected_epoch)?;
+                match self {
+                    Self::Native { epoch } => Ok(Self::FallbackDraining { epoch }),
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            ApplyTransition::ActivateFallback { expected_epoch } => {
+                check_epoch(self, expected_epoch)?;
+                match self {
+                    Self::FallbackDraining { epoch } => Ok(Self::LegacyFallback { epoch }),
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            ApplyTransition::ResumeNative { expected_epoch } => {
+                check_epoch(self, expected_epoch)?;
+                match self {
+                    Self::FallbackDraining { epoch } | Self::LegacyFallback { epoch } => {
+                        Ok(Self::Native {
+                            epoch: epoch
+                                .checked_next()
+                                .ok_or(LifecycleTransitionError::EpochExhausted)?,
+                        })
+                    }
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            ApplyTransition::Fail { expected_epoch } => {
+                check_epoch(self, expected_epoch)?;
+                match self {
+                    Self::Failed { .. } => Err(LifecycleTransitionError::IllegalPhase),
+                    _ => Ok(Self::Failed {
+                        epoch: self.epoch(),
+                    }),
+                }
+            }
+        }
+    }
+}
+
+fn check_epoch(
+    phase: ApplyPhase,
+    expected: LifecycleEpoch,
+) -> Result<(), LifecycleTransitionError> {
+    let current = phase.epoch();
+    if current != expected {
+        return Err(LifecycleTransitionError::StaleEpoch { expected, current });
+    }
+    Ok(())
+}
+
+/// Requested apply-lifecycle edge.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ApplyTransition {
+    /// Complete checkpoint semantic handoff.
+    FinishBootstrap,
+    /// Stop new native applies and begin draining one native epoch.
+    BeginFallback {
+        /// Exact native generation to drain.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Authorize legacy fallback after the same epoch fully drains.
+    ActivateFallback {
+        /// Exact drained generation to authorize.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Drop/cancel the exact fallback lease and advance native ownership.
+    ResumeNative {
+        /// Exact fallback generation that the transition releases.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Fail the exact active generation closed while retaining its epoch for diagnosis.
+    Fail {
+        /// Exact generation that encountered the failure.
+        expected_epoch: LifecycleEpoch,
+    },
+}
+
+/// Rejected lifecycle transition.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum LifecycleTransitionError {
+    /// The current phase rejects the requested edge.
+    IllegalPhase,
+    /// The caller issued the request for an obsolete lifecycle generation.
+    StaleEpoch {
+        /// Requested generation.
+        expected: LifecycleEpoch,
+        /// Current generation.
+        current: LifecycleEpoch,
+    },
+    /// Advancing the monotonic counter would wrap.
+    EpochExhausted,
+}
+
+impl fmt::Display for LifecycleTransitionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IllegalPhase => formatter.write_str("illegal sync lifecycle transition"),
+            Self::StaleEpoch { expected, current } => write!(
+                formatter,
+                "stale sync lifecycle epoch {} (current {})",
+                expected.get(),
+                current.get()
+            ),
+            Self::EpochExhausted => formatter.write_str("sync lifecycle epoch exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for LifecycleTransitionError {}
+
+/// Coarse startup stage reported while attaching the durable header runtime.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderReconstructionStage {
+    /// Audit authoritative rows and derive any reconstructible repairs.
+    StartupAudit,
+    /// Reconcile the durable header runtime with authenticated full-state frontiers.
+    FullStateReconciliation,
+}
+
+/// Bounded progress facts for one header-runtime attachment attempt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct HeaderReconstructionProgress {
+    /// Current reconstruction stage.
+    pub stage: HeaderReconstructionStage,
+    /// Completed work units within the stage.
+    pub completed: u64,
+    /// Known total work units, or `None` before the audit determines it.
+    pub total: Option<u64>,
+    /// Fixed canonical finalized target for this attachment attempt.
+    pub target: Option<Frontier>,
+    /// Last canonical frontier durably committed with restart progress.
+    pub last_committed: Option<Frontier>,
+}
+
+/// Condition that keeps the node from attaching the durable header runtime.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderRuntimeDetachedReason {
+    /// Fresh state must first receive checkpoint-verified blocks through semantic sync.
+    AwaitingSemanticHandoff,
+    /// Durable header state exists and the state worker still owes runtime attachment.
+    AttachmentPending,
+}
+
+impl HeaderReconstructionProgress {
+    /// Initial progress before the startup audit has enumerated work.
+    pub const STARTING: Self = Self {
+        stage: HeaderReconstructionStage::StartupAudit,
+        completed: 0,
+        total: None,
+        target: None,
+        last_committed: None,
+    };
+}
+
+/// Authoritative attachment/readiness state of the durable header runtime.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HeaderRuntimeStatus {
+    /// Checkpoint semantic handoff has not started runtime attachment.
+    Detached {
+        /// Last attachment generation.
+        epoch: LifecycleEpoch,
+        /// Explicit startup condition that determines whether callers may bootstrap.
+        reason: HeaderRuntimeDetachedReason,
+    },
+    /// One attachment generation audits or reconciles durable state.
+    Reconstructing {
+        /// Exact attachment generation.
+        epoch: LifecycleEpoch,
+        /// Latest bounded progress report.
+        progress: HeaderReconstructionProgress,
+    },
+    /// The coherent reader and committed snapshot publisher are running.
+    Ready {
+        /// Ready attachment generation.
+        epoch: LifecycleEpoch,
+    },
+    /// Attachment failed closed with its root-cause message.
+    ///
+    /// The producer exited the state write worker.
+    /// The producer exit makes this state process-terminal.
+    /// Recovery reopens and audits durable state during a node restart.
+    Failed {
+        /// Failed attachment generation.
+        epoch: LifecycleEpoch,
+        /// Stable root-cause text propagated from state startup.
+        error: Arc<str>,
+    },
+}
+
+impl HeaderRuntimeStatus {
+    /// Return this status's monotonic attachment generation.
+    pub const fn epoch(&self) -> LifecycleEpoch {
+        match self {
+            Self::Detached { epoch, .. }
+            | Self::Reconstructing { epoch, .. }
+            | Self::Ready { epoch }
+            | Self::Failed { epoch, .. } => *epoch,
+        }
+    }
+
+    /// Whether the coherent runtime is ready for header service use.
+    pub const fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready { .. })
+    }
+
+    /// Apply one checked runtime transition without changing the caller on failure.
+    pub fn transition(
+        self,
+        transition: HeaderRuntimeTransition,
+    ) -> Result<Self, LifecycleTransitionError> {
+        match transition {
+            HeaderRuntimeTransition::BeginReconstruction => match self {
+                Self::Detached { epoch, .. } => Ok(Self::Reconstructing {
+                    epoch: epoch
+                        .checked_next()
+                        .ok_or(LifecycleTransitionError::EpochExhausted)?,
+                    progress: HeaderReconstructionProgress::STARTING,
+                }),
+                _ => Err(LifecycleTransitionError::IllegalPhase),
+            },
+            HeaderRuntimeTransition::ReportProgress {
+                expected_epoch,
+                progress,
+            } => {
+                check_header_epoch(&self, expected_epoch)?;
+                match self {
+                    Self::Reconstructing { epoch, .. } => {
+                        Ok(Self::Reconstructing { epoch, progress })
+                    }
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            HeaderRuntimeTransition::Ready { expected_epoch } => {
+                check_header_epoch(&self, expected_epoch)?;
+                match self {
+                    Self::Reconstructing { epoch, .. } => Ok(Self::Ready { epoch }),
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+            HeaderRuntimeTransition::Fail {
+                expected_epoch,
+                error,
+            } => {
+                check_header_epoch(&self, expected_epoch)?;
+                match self {
+                    Self::Detached { epoch, .. } | Self::Reconstructing { epoch, .. } => {
+                        Ok(Self::Failed { epoch, error })
+                    }
+                    _ => Err(LifecycleTransitionError::IllegalPhase),
+                }
+            }
+        }
+    }
+}
+
+fn check_header_epoch(
+    status: &HeaderRuntimeStatus,
+    expected: LifecycleEpoch,
+) -> Result<(), LifecycleTransitionError> {
+    let current = status.epoch();
+    if current != expected {
+        return Err(LifecycleTransitionError::StaleEpoch { expected, current });
+    }
+    Ok(())
+}
+
+/// Requested header-runtime lifecycle edge.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HeaderRuntimeTransition {
+    /// Start one checked attachment/reconstruction generation.
+    BeginReconstruction,
+    /// Replace progress only for the exact active generation.
+    ReportProgress {
+        /// Active attachment generation.
+        expected_epoch: LifecycleEpoch,
+        /// New bounded progress facts.
+        progress: HeaderReconstructionProgress,
+    },
+    /// Publish coherent readiness for the exact reconstructed generation.
+    Ready {
+        /// Active attachment generation.
+        expected_epoch: LifecycleEpoch,
+    },
+    /// Fail the exact detached or reconstructing generation closed after its producer exits.
+    Fail {
+        /// Generation that encountered the failure.
+        expected_epoch: LifecycleEpoch,
+        /// Root-cause text from state attachment.
+        error: Arc<str>,
+    },
+}
+
+/// Coordinator-owned header ordered-service demand.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HeaderServiceDemand {
+    /// Do not advertise or open header-sync sessions before runtime readiness.
+    Disabled {
+        /// Latest observed header-runtime generation.
+        runtime_epoch: LifecycleEpoch,
+    },
+    /// Advertise and schedule header sync exactly once for this readiness generation.
+    Enabled {
+        /// Monotonic capability/readiness generation.
+        capability_epoch: LifecycleEpoch,
+    },
+}
+
+impl HeaderServiceDemand {
+    /// Whether header capability advertisement and ordered sessions are authorized.
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled { .. })
+    }
+
+    /// Return the capability generation when header demand is enabled.
+    pub const fn capability_epoch(self) -> Option<LifecycleEpoch> {
+        match self {
+            Self::Disabled { .. } => None,
+            Self::Enabled { capability_epoch } => Some(capability_epoch),
+        }
+    }
+}
+
+/// Coordinator-owned block ordered-service demand.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BlockServiceDemand {
+    /// Keep body serving live while legacy/bootstrap owns bulk application.
+    ServingOnly {
+        /// Exact apply generation represented by this demand.
+        apply_epoch: LifecycleEpoch,
+    },
+    /// Keep body serving live and admit native body application.
+    ServingAndApplying {
+        /// Exact native apply generation represented by this demand.
+        apply_epoch: LifecycleEpoch,
+    },
+}
+
+impl BlockServiceDemand {
+    /// Whether native body application is authorized in this demand generation.
+    pub const fn is_applying(self) -> bool {
+        matches!(self, Self::ServingAndApplying { .. })
+    }
+
+    /// Return the exact apply generation represented by this demand.
+    pub const fn apply_epoch(self) -> LifecycleEpoch {
+        match self {
+            Self::ServingOnly { apply_epoch } | Self::ServingAndApplying { apply_epoch } => {
+                apply_epoch
+            }
+        }
+    }
+}
+
+/// One coordinator publication consumed by capability and ordered-service scheduling.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SyncServiceDemand {
+    /// Header capability/session demand.
+    pub header: HeaderServiceDemand,
+    /// Block serving/apply demand.
+    pub block: BlockServiceDemand,
+}
+
+impl SyncServiceDemand {
+    /// Derive the complete transport demand from authoritative lifecycle phases.
+    pub fn from_phases(apply: ApplyPhase, header: &HeaderRuntimeStatus) -> Self {
+        let header = match header {
+            HeaderRuntimeStatus::Ready { epoch } => HeaderServiceDemand::Enabled {
+                capability_epoch: *epoch,
+            },
+            _ => HeaderServiceDemand::Disabled {
+                runtime_epoch: header.epoch(),
+            },
+        };
+        let block = match apply {
+            ApplyPhase::Native { epoch } => {
+                BlockServiceDemand::ServingAndApplying { apply_epoch: epoch }
+            }
+            _ => BlockServiceDemand::ServingOnly {
+                apply_epoch: apply.epoch(),
+            },
+        };
+        Self { header, block }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_phase_model_accepts_only_declared_edges() {
+        let zero = LifecycleEpoch::INITIAL;
+        let one = zero
+            .checked_next()
+            .expect("the initial epoch has a successor");
+        let phases = [
+            ApplyPhase::LegacyBootstrap { epoch: zero },
+            ApplyPhase::Native { epoch: one },
+            ApplyPhase::FallbackDraining { epoch: one },
+            ApplyPhase::LegacyFallback { epoch: one },
+            ApplyPhase::Failed { epoch: one },
+        ];
+        let transitions = [
+            ApplyTransition::FinishBootstrap,
+            ApplyTransition::BeginFallback {
+                expected_epoch: one,
+            },
+            ApplyTransition::ActivateFallback {
+                expected_epoch: one,
+            },
+            ApplyTransition::ResumeNative {
+                expected_epoch: one,
+            },
+            ApplyTransition::Fail {
+                expected_epoch: one,
+            },
+        ];
+
+        for phase in phases {
+            for transition in transitions {
+                let transition = match transition {
+                    ApplyTransition::Fail { .. } => ApplyTransition::Fail {
+                        expected_epoch: phase.epoch(),
+                    },
+                    transition => transition,
+                };
+                let result = phase.transition(transition);
+                let legal = matches!(
+                    (phase, transition),
+                    (
+                        ApplyPhase::LegacyBootstrap { .. },
+                        ApplyTransition::FinishBootstrap | ApplyTransition::Fail { .. }
+                    ) | (
+                        ApplyPhase::Native { .. },
+                        ApplyTransition::BeginFallback { .. } | ApplyTransition::Fail { .. }
+                    ) | (
+                        ApplyPhase::FallbackDraining { .. },
+                        ApplyTransition::ActivateFallback { .. }
+                            | ApplyTransition::ResumeNative { .. }
+                            | ApplyTransition::Fail { .. }
+                    ) | (
+                        ApplyPhase::LegacyFallback { .. },
+                        ApplyTransition::ResumeNative { .. } | ApplyTransition::Fail { .. }
+                    )
+                );
+                assert_eq!(result.is_ok(), legal, "{phase:?} -> {transition:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn stale_and_exhausted_epochs_fail_without_wrapping() {
+        let current = ApplyPhase::Native {
+            epoch: LifecycleEpoch::new(7),
+        };
+        assert_eq!(
+            current.transition(ApplyTransition::BeginFallback {
+                expected_epoch: LifecycleEpoch::new(6),
+            }),
+            Err(LifecycleTransitionError::StaleEpoch {
+                expected: LifecycleEpoch::new(6),
+                current: LifecycleEpoch::new(7),
+            })
+        );
+
+        let exhausted = ApplyPhase::LegacyFallback {
+            epoch: LifecycleEpoch::new(u64::MAX),
+        };
+        assert_eq!(
+            exhausted.transition(ApplyTransition::ResumeNative {
+                expected_epoch: LifecycleEpoch::new(u64::MAX),
+            }),
+            Err(LifecycleTransitionError::EpochExhausted)
+        );
+    }
+
+    #[test]
+    fn stale_apply_failure_cannot_poison_a_new_epoch() {
+        let stale_epoch = LifecycleEpoch::new(1);
+        let current = ApplyPhase::Native { epoch: stale_epoch }
+            .transition(ApplyTransition::BeginFallback {
+                expected_epoch: stale_epoch,
+            })
+            .expect("the current native generation can begin fallback")
+            .transition(ApplyTransition::ResumeNative {
+                expected_epoch: stale_epoch,
+            })
+            .expect("resuming native advances the generation");
+
+        assert_eq!(current.epoch(), LifecycleEpoch::new(2));
+        assert_eq!(
+            current.transition(ApplyTransition::Fail {
+                expected_epoch: stale_epoch,
+            }),
+            Err(LifecycleTransitionError::StaleEpoch {
+                expected: stale_epoch,
+                current: LifecycleEpoch::new(2),
+            })
+        );
+    }
+
+    #[test]
+    fn header_runtime_requires_one_explicit_reconstruction_epoch() {
+        let detached = HeaderRuntimeStatus::Detached {
+            epoch: LifecycleEpoch::INITIAL,
+            reason: HeaderRuntimeDetachedReason::AttachmentPending,
+        };
+        let reconstructing = detached
+            .clone()
+            .transition(HeaderRuntimeTransition::BeginReconstruction)
+            .expect("detached runtime can begin reconstruction");
+        let epoch = reconstructing.epoch();
+        assert!(matches!(
+            reconstructing,
+            HeaderRuntimeStatus::Reconstructing { .. }
+        ));
+        let ready = reconstructing
+            .clone()
+            .transition(HeaderRuntimeTransition::Ready {
+                expected_epoch: epoch,
+            })
+            .expect("the active reconstruction can become ready");
+        assert_eq!(ready, HeaderRuntimeStatus::Ready { epoch });
+        assert_eq!(
+            detached.transition(HeaderRuntimeTransition::Ready {
+                expected_epoch: LifecycleEpoch::INITIAL,
+            }),
+            Err(LifecycleTransitionError::IllegalPhase)
+        );
+        assert!(matches!(
+            reconstructing.transition(HeaderRuntimeTransition::Ready {
+                expected_epoch: LifecycleEpoch::INITIAL,
+            }),
+            Err(LifecycleTransitionError::StaleEpoch { .. })
+        ));
+    }
+
+    #[test]
+    fn failed_header_runtime_is_process_terminal() {
+        let reconstructing = HeaderRuntimeStatus::Detached {
+            epoch: LifecycleEpoch::INITIAL,
+            reason: HeaderRuntimeDetachedReason::AttachmentPending,
+        }
+        .transition(HeaderRuntimeTransition::BeginReconstruction)
+        .expect("the attached state worker starts reconstruction");
+        let epoch = reconstructing.epoch();
+        let failed = reconstructing
+            .transition(HeaderRuntimeTransition::Fail {
+                expected_epoch: epoch,
+                error: "state write worker exited".into(),
+            })
+            .expect("the failed state worker publishes its terminal status");
+
+        assert_eq!(
+            failed
+                .clone()
+                .transition(HeaderRuntimeTransition::BeginReconstruction),
+            Err(LifecycleTransitionError::IllegalPhase)
+        );
+        assert_eq!(
+            failed.transition(HeaderRuntimeTransition::Ready {
+                expected_epoch: epoch,
+            }),
+            Err(LifecycleTransitionError::IllegalPhase)
+        );
+    }
+
+    #[test]
+    fn service_demand_keeps_serving_separate_from_native_applying() {
+        let ready = HeaderRuntimeStatus::Ready {
+            epoch: LifecycleEpoch::new(3),
+        };
+        let native = SyncServiceDemand::from_phases(
+            ApplyPhase::Native {
+                epoch: LifecycleEpoch::new(4),
+            },
+            &ready,
+        );
+        assert_eq!(
+            native.header.capability_epoch(),
+            Some(LifecycleEpoch::new(3))
+        );
+        assert!(native.block.is_applying());
+
+        let fallback = SyncServiceDemand::from_phases(
+            ApplyPhase::LegacyFallback {
+                epoch: LifecycleEpoch::new(4),
+            },
+            &ready,
+        );
+        assert_eq!(fallback.header, native.header);
+        assert!(!fallback.block.is_applying());
+        assert_eq!(fallback.block.apply_epoch(), LifecycleEpoch::new(4));
+    }
+}

--- a/docs/changelog/unreleased/668.md
+++ b/docs/changelog/unreleased/668.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only adds internal header-sync service contracts and has no operator-visible effect.


### PR DESCRIPTION
## Motivation

The fork-aware header-chain runtime needs stable, mockable contracts between sync policy and header-chain state without coupling network code directly to the state implementation.

This PR is stacked on [#658](https://github.com/zakura-core/zakura/pull/658).

## Solution

- add the typed header-chain port, request, response, and retained-path contracts;
- add explicit header-sync lifecycle and failure-state contracts; and
- connect `zakura-node-services` to `zakura-header-chain`.

This implementation is original work by Evan Forbes from [#586](https://github.com/zakura-core/zakura/pull/586), extracted and submitted as this focused PR.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura-node-services`
- `cargo test -p zakura-node-services --locked` — 11 passed
- `cargo clippy -p zakura-node-services --all-targets -- -D warnings`
- `markdownlint docs/changelog/unreleased/668.md --config .github/.markdownlint.yaml`
- `./scripts/changelog.py check`

## Changelog

`docs/changelog/unreleased/668.md` explicitly excludes this internal service-boundary refactor because it has no operator-visible effect.

### Specifications & References

- Original implementation: [#586](https://github.com/zakura-core/zakura/pull/586)
- Stacked engine crate: [#658](https://github.com/zakura-core/zakura/pull/658)