### PR TITLE
feat(deploy): enable node metrics and health endpoints on binary-only fleets

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -332,16 +332,18 @@ jobs:
 
       - name: Ensure node observability endpoints
         if: ${{ !inputs.no_restart }}
+        working-directory: deploy/deployer
+        env:
+          NODE: ${{ inputs.node }}
         run: |
           set -euo pipefail
 
           # Runs after the deploy so a bad drop-in cannot survive the binary
           # rollback. Idempotent: a node already serving both endpoints is left
           # alone, so this only restarts a node the first time it is enabled.
-          cd deploy/deployer
           args=(--config nodes.ci.toml)
-          if [ -n "${{ inputs.node }}" ]; then
-            args+=(--node "${{ inputs.node }}")
+          if [ -n "${NODE}" ]; then
+            args+=(--node "${NODE}")
           fi
 
           python3 deploy.py observability "${args[@]}"

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -190,6 +190,11 @@ jobs:
           # Verified on the fleet: the nine regional nodes keep state here, the
           # compat host does not. Used only for the dashboard's disk probe.
           state_cache_dir = "/mnt/data/zakura-cache"
+          # Loopback observability endpoints, installed by the `observability`
+          # step below as a systemd drop-in (manage_config = false renders no
+          # config) and read by the dashboard probe from inside each node.
+          metrics_endpoint   = "127.0.0.1:9999"
+          health_listen_addr = "127.0.0.1:8080"
 
           # Public mainnet node ids (crates/zakura-network/src/zakura/handler.rs). Used by
           # the dashboard to label each host; not deployed to the nodes.
@@ -325,6 +330,22 @@ jobs:
 
           python3 deploy.py status "${args[@]}"
 
+      - name: Ensure node observability endpoints
+        if: ${{ !inputs.no_restart }}
+        run: |
+          set -euo pipefail
+
+          # Runs after the deploy so a bad drop-in cannot survive the binary
+          # rollback. Idempotent: a node already serving both endpoints is left
+          # alone, so this only restarts a node the first time it is enabled.
+          cd deploy/deployer
+          args=(--config nodes.ci.toml)
+          if [ -n "${{ inputs.node }}" ]; then
+            args+=(--node "${{ inputs.node }}")
+          fi
+
+          python3 deploy.py observability "${args[@]}"
+
       - name: Install cluster status dashboard
         if: always()
         run: |
@@ -360,6 +381,8 @@ jobs:
           rpc_auth = "cookie"
           rpc_config_path = "/mnt/data/runtime/zcashd/.cookie"
           state_cache_dir = "/mnt/data/runtime/zcashd"
+          metrics_endpoint = ""
+          health_listen_addr = ""
           # P2P sidecar (post -zebra-compat): supervised with -connect=127.0.0.1:8233.
           process_pattern = "zcashd .*-connect=127.0.0.1:8233"
           EOF

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -38,7 +38,9 @@ dashboard reads over its own ssh probe:
 
 Both are unauthenticated, so bind them to loopback. `zakurad` panics if either
 address is already in use, so check the port on the node before enabling one.
-Neither is rendered on a fleet running `manage_config = false`.
+Neither is rendered on a fleet running `manage_config = false`; there,
+`deploy.py observability` turns the same endpoints on through a systemd drop-in
+instead.
 
 ## Commands
 
@@ -56,6 +58,14 @@ python3 deploy.py deploy --config nodes.toml --no-restart    # stage only
 
 # Service state + version per node.
 python3 deploy.py status --config nodes.toml
+
+# Ensure each node serves its loopback metrics + health endpoints. On a
+# manage_config = false fleet this installs a systemd drop-in setting
+# ZAKURA_METRICS__ENDPOINT_ADDR / ZAKURA_HEALTH__LISTEN_ADDR, which outrank the
+# hand-tuned config the deployer must not touch. Sequential, and a no-op on a
+# node already serving both, so it restarts a node only the first time.
+python3 deploy.py observability --config nodes.toml
+python3 deploy.py observability --config nodes.toml --check   # report, change nothing
 
 # Pull logs (deterministic log_file from the rendered config).
 python3 deploy.py logs fetch  --config nodes.toml              # -> logs/<name>.log

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -1024,6 +1024,173 @@ def cmd_status(args) -> int:
 
 
 # --------------------------------------------------------------------------- #
+# Observability endpoints
+# --------------------------------------------------------------------------- #
+
+# Fleets deployed with manage_config = false keep a hand-tuned config the
+# deployer must not touch, and the deployer does not even know its path. A
+# systemd drop-in setting ZAKURA_* env vars turns the endpoints on without
+# writing either the config or the unit: ZakuradConfig::load ranks env above the
+# TOML file.
+OBSERVABILITY_DROPIN = "10-observability.conf"
+
+OBSERVABILITY_SCRIPT = r"""
+set -euo pipefail
+
+SERVICE={service}
+DROPIN_DIR=/etc/systemd/system/${{SERVICE}}.service.d
+DROPIN="$DROPIN_DIR/{dropin}"
+METRICS={metrics}
+HEALTH={health}
+APPLY={apply}
+
+metrics_port="${{METRICS##*:}}"
+health_port="${{HEALTH##*:}}"
+
+probe() {{
+    curl -s -o /dev/null --max-time 4 "http://$1$2" 2>/dev/null && echo up || echo down
+}}
+
+metrics_state="$(probe "$METRICS" /metrics)"
+health_state="$(probe "$HEALTH" /healthy)"
+echo "before: metrics=$metrics_state health=$health_state dropin=$([ -f "$DROPIN" ] && echo present || echo absent)"
+
+if [ "$metrics_state" = up ] && [ "$health_state" = up ]; then
+    echo "result: already-enabled"
+    exit 0
+fi
+
+# Both servers panic if the bind fails, so never restart into a taken port.
+for port in "$metrics_port" "$health_port"; do
+    if ss -lntH "sport = :$port" 2>/dev/null | grep -q .; then
+        echo "result: port-busy ($port)"
+        exit 3
+    fi
+done
+
+if [ "$APPLY" != "1" ]; then
+    echo "result: would-enable"
+    exit 0
+fi
+
+systemctl is-active --quiet "$SERVICE" || {{ echo "result: service-inactive"; exit 4; }}
+
+mkdir -p "$DROPIN_DIR"
+cat > "$DROPIN" <<EOF
+# Managed by deploy/deployer/deploy.py (observability). Do not hand-edit.
+# Both endpoints are unauthenticated; keep them on loopback.
+[Service]
+Environment=ZAKURA_METRICS__ENDPOINT_ADDR=$METRICS
+Environment=ZAKURA_HEALTH__LISTEN_ADDR=$HEALTH
+EOF
+
+rollback() {{
+    echo "rolling back the drop-in and restarting" >&2
+    rm -f "$DROPIN"
+    rmdir "$DROPIN_DIR" 2>/dev/null || true
+    systemctl daemon-reload
+    systemctl restart "$SERVICE" || true
+    echo "result: reverted"
+    exit 5
+}}
+
+systemctl daemon-reload
+systemctl restart "$SERVICE" || rollback
+
+for _ in $(seq 1 60); do
+    sleep 2
+    systemctl is-active --quiet "$SERVICE" && break
+done
+systemctl is-active --quiet "$SERVICE" || rollback
+
+# The metrics exporter binds during config load, but the health server only
+# starts once state and the network are up, which on a mainnet node is tens of
+# seconds later. Wait for both rather than checking health the instant metrics
+# appears.
+for _ in $(seq 1 90); do
+    sleep 2
+    metrics_state="$(probe "$METRICS" /metrics)"
+    health_state="$(probe "$HEALTH" /healthy)"
+    [ "$metrics_state" = up ] && [ "$health_state" = up ] && break
+    systemctl is-active --quiet "$SERVICE" || rollback
+done
+
+metrics_state="$(probe "$METRICS" /metrics)"
+health_state="$(probe "$HEALTH" /healthy)"
+
+# Metrics binding is what proves the drop-in parsed and the process came up.
+# Without it the node is misconfigured and must go back.
+if [ "$metrics_state" != up ]; then
+    rollback
+fi
+
+echo "after: metrics=$metrics_state health=$health_state"
+if [ "$health_state" != up ]; then
+    # Still starting up. Rolling back a live node over a late-binding endpoint
+    # would be worse than reporting it.
+    echo "result: enabled-health-pending"
+    exit 0
+fi
+echo "result: enabled"
+"""
+
+
+def loopback_only(address: str, *, where: str) -> None:
+    """Both endpoints are unauthenticated, so refuse anything routable."""
+    host = address.rsplit(":", 1)[0].strip("[]")
+    if host not in ("127.0.0.1", "::1", "localhost"):
+        raise DeployError(
+            f"{where}: refusing to expose an unauthenticated endpoint on {address!r}; "
+            f"use a loopback address"
+        )
+
+
+def cmd_observability(args) -> int:
+    nodes = load_nodes(Path(args.config), args.node)
+    apply = not args.check
+    failures = 0
+
+    for node in nodes:
+        if not node.metrics_endpoint or not node.health_listen_addr:
+            print(f"  {node.name}: skipped (no metrics_endpoint/health_listen_addr configured)")
+            continue
+        loopback_only(node.metrics_endpoint, where=f"[[nodes]] {node.name} metrics_endpoint")
+        loopback_only(node.health_listen_addr, where=f"[[nodes]] {node.name} health_listen_addr")
+        if node.manage_config:
+            print(f"  {node.name}: skipped (manage_config = true renders the endpoints already)")
+            continue
+        if node.deploy_kind != "systemd" or not node.service_name:
+            print(f"  {node.name}: skipped (drop-ins need a systemd service)")
+            continue
+
+        script = OBSERVABILITY_SCRIPT.format(
+            service=shlex.quote(node.service_name),
+            dropin=OBSERVABILITY_DROPIN,
+            metrics=shlex.quote(node.metrics_endpoint),
+            health=shlex.quote(node.health_listen_addr),
+            apply="1" if apply else "0",
+        )
+        # Sequential on purpose: this restarts a validator.
+        proc = ssh_capture_script(node, script)
+        lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+        result = next(
+            (line.split(":", 1)[1].strip() for line in lines if line.startswith("result:")),
+            "unknown",
+        )
+        detail = " | ".join(line for line in lines if not line.startswith("result:"))
+        print(f"  {node.name}: {result}" + (f" [{detail}]" if detail else ""))
+        if proc.returncode != 0:
+            failures += 1
+            print(f"    stderr: {proc.stderr.strip()[:400]}", file=sys.stderr)
+            if apply:
+                raise DeployError(
+                    f"{node.name} failed to enable its endpoints; stopping before the next node"
+                )
+
+    return 1 if failures else 0
+
+
+# --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
 
@@ -1054,6 +1221,15 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("status", help="show service state + version per node")
     add_common(s)
     s.set_defaults(func=cmd_status)
+
+    o = sub.add_parser(
+        "observability",
+        help="ensure each node serves its loopback metrics + health endpoints",
+    )
+    add_common(o)
+    o.add_argument("--check", action="store_true",
+                   help="report what would change without touching any node")
+    o.set_defaults(func=cmd_observability)
 
     logs = sub.add_parser("logs", help="pull logs from nodes")
     logs_sub = logs.add_subparsers(dest="logs_command", required=True)

--- a/deploy/deployer/test_deploy.py
+++ b/deploy/deployer/test_deploy.py
@@ -1,5 +1,7 @@
+import argparse
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
 import tomllib
@@ -236,6 +238,106 @@ class ConfigKeyTests(unittest.TestCase):
 
             with self.assertRaises(deploy.DeployError):
                 deploy.load_nodes(path, None)
+
+
+class ObservabilityTests(NodeBuilder, unittest.TestCase):
+    """The drop-in restarts a validator, so the guards matter more than the happy path."""
+
+    def args(self, config_path, check=False, node=None):
+        return argparse.Namespace(config=str(config_path), node=node, check=check)
+
+    def write_config(self, tmp, body):
+        path = Path(tmp) / "nodes.toml"
+        path.write_text(body.replace("            ", ""))
+        return path
+
+    BASE = """
+            [defaults]
+            manage_config = false
+            metrics_endpoint = "127.0.0.1:9999"
+            health_listen_addr = "127.0.0.1:8080"
+
+            [[nodes]]
+            name = "node-a"
+            ssh_string = "root@example"
+            commit = "main"
+            """
+
+    def test_refuses_a_routable_metrics_endpoint(self):
+        with self.assertRaises(deploy.DeployError) as ctx:
+            deploy.loopback_only("0.0.0.0:9999", where="metrics_endpoint")
+
+        self.assertIn("loopback", str(ctx.exception))
+
+    def test_accepts_loopback_forms(self):
+        for address in ("127.0.0.1:9999", "[::1]:8080", "localhost:9999"):
+            deploy.loopback_only(address, where="metrics_endpoint")
+
+    def test_routable_endpoint_aborts_before_any_ssh(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(
+                tmp, self.BASE.replace('"127.0.0.1:9999"', '"0.0.0.0:9999"')
+            )
+            with mock.patch.object(deploy, "ssh_capture_script") as ssh:
+                with self.assertRaises(deploy.DeployError):
+                    deploy.cmd_observability(self.args(path))
+
+            ssh.assert_not_called()
+
+    def test_managed_config_nodes_are_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(
+                tmp, self.BASE.replace("manage_config = false", "manage_config = true")
+            )
+            with mock.patch.object(deploy, "ssh_capture_script") as ssh:
+                self.assertEqual(deploy.cmd_observability(self.args(path)), 0)
+
+            # Their endpoints come from the rendered config, not a drop-in.
+            ssh.assert_not_called()
+
+    def test_check_mode_does_not_apply(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, self.BASE)
+            captured = {}
+
+            def fake_ssh(node, script):
+                captured["script"] = script
+                return subprocess.CompletedProcess([], 0, "result: would-enable\n", "")
+
+            with mock.patch.object(deploy, "ssh_capture_script", fake_ssh):
+                self.assertEqual(deploy.cmd_observability(self.args(path, check=True)), 0)
+
+            self.assertIn("APPLY=0", captured["script"])
+
+    def test_apply_stops_the_run_when_a_node_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, self.BASE)
+
+            def fake_ssh(node, script):
+                return subprocess.CompletedProcess([], 5, "result: reverted\n", "boom")
+
+            with mock.patch.object(deploy, "ssh_capture_script", fake_ssh):
+                with self.assertRaises(deploy.DeployError):
+                    deploy.cmd_observability(self.args(path))
+
+    def test_script_carries_the_configured_addresses(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, self.BASE)
+            captured = {}
+
+            def fake_ssh(node, script):
+                captured["script"] = script
+                return subprocess.CompletedProcess([], 0, "result: enabled\n", "")
+
+            with mock.patch.object(deploy, "ssh_capture_script", fake_ssh):
+                deploy.cmd_observability(self.args(path))
+
+            script = captured["script"]
+            self.assertIn("ZAKURA_METRICS__ENDPOINT_ADDR=$METRICS", script)
+            self.assertIn("ZAKURA_HEALTH__LISTEN_ADDR=$HEALTH", script)
+            self.assertIn("METRICS=127.0.0.1:9999", script)
+            self.assertIn("HEALTH=127.0.0.1:8080", script)
+            self.assertIn("APPLY=1", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Every per-node page on the mainnet status dashboard reports its sync, peer, and
throughput panels as unavailable:

> metrics endpoint not configured. Set `[metrics] endpoint_addr` on this node to
> populate this panel.

The same is true of the health panel. Testnet does not have this problem: its
fleet config carries `metrics_endpoint` and `health_listen_addr`, and because
testnet runs `manage_config = true` the deployer renders both sections into the
node config it owns.

Mainnet is binary-only (`manage_config = false`). The deployer deliberately does
not touch the hand-tuned config on those hosts and does not even know its path,
so there was no supported way to turn the endpoints on, and the mainnet fleet
config therefore omitted both keys. The dashboard probe reads them from the
fleet config, so with the keys absent it never scrapes, and every mainnet node
renders the "not configured" placeholder.

## Solution

`deploy.py observability` turns the endpoints on without writing either the
config or the unit: it installs a systemd drop-in setting
`ZAKURA_METRICS__ENDPOINT_ADDR` and `ZAKURA_HEALTH__LISTEN_ADDR`, which
`ZakuradConfig::load` ranks above the TOML file.

The command restarts a validator, so it is deliberately careful:

- refuses a non-loopback address for either unauthenticated endpoint,
- skips fleets whose config the deployer already renders (`manage_config = true`),
- no-ops when both endpoints already answer, so it restarts a node only the
  first time it is enabled,
- pre-flights both ports, because the exporter and the health server each panic
  on bind failure,
- applies sequentially, one validator at a time,
- removes the drop-in and restarts if the node does not come back,
- `--check` reports without changing anything.

The metrics exporter binds during config load, but the health server only starts
once state and the network are up, tens of seconds later on a mainnet node. The
verifier waits for both and treats a still-pending health endpoint as
`enabled-health-pending` rather than rolling back a node that is coming up fine.

The mainnet workflow gains `metrics_endpoint` / `health_listen_addr` in
`[defaults]` (which is what feeds the dashboard probe) and an `Ensure node
observability endpoints` step that runs after the fleet deploy, so a bad drop-in
cannot survive the binary rollback path. The dashboard's extra `zcashd-compat`
entry pins both keys empty: it is a zcashd process with no Prometheus exporter.

## Testing

`python3 -m unittest test_deploy` — 19 tests pass, 7 of them new, covering
loopback enforcement (including that a routable address aborts before any SSH),
`manage_config = true` skipping, check-mode not applying, the rendered script
carrying the configured addresses, and an apply failure stopping the run before
the next node.

Verified against the live mainnet fleet:

- All 10 nodes already serve `127.0.0.1:9999/metrics` and `127.0.0.1:8080/healthy`
  (HTTP 200) with the drop-in present, so
  `deploy.py observability --check` reports `already-enabled` on every one and
  the next deploy restarts nothing.
- Ran the dashboard's own `probe_node` against `asia-0` with this config:
  `metrics_error` clears, and the probe returns 21,914 series (1.7 MB) in 0.23s,
  `sync_estimated_distance_to_tip = 0`, a healthy health endpoint, and peer user
  agents (`/Zebra:6.3.0/ 175`, `/Zebra:6.2.3/ 160`, `/Zakura:1.1.1/ 29`).
  Against the current fleet config the same probe returns
  `metrics endpoint not configured`, which is the reported bug.
- Confirmed testnet is unaffected: both keys are already in its workflow and its
  dashboard reports ~27k series per node with no metrics or health error.

Not run: the mainnet deploy workflow itself. The dashboard's `nodes.toml` is
rewritten by that workflow, so the panels populate on the next mainnet deploy.

## Changelog

No fragment: this changes only the deployer, its tests, and the mainnet deploy
workflow. No Rust source file or `Cargo.toml` is touched.

### Specifications & References

- Reported on the per-node dashboard pages, e.g.
  https://status.mainnet.zakura.valargroup.dev/node/asia-0
- Follows #659, which added those per-node pages and the metrics and health
  panels this PR supplies data for.
