### PR TITLE
fix(chain): inherit Testnet max-time activation in ParametersBuilder

### DIFF
--- a/crates/zakura-chain/src/parameters/network/testnet.rs
+++ b/crates/zakura-chain/src/parameters/network/testnet.rs
@@ -852,7 +852,12 @@ impl ParametersBuilder {
 
     /// Converts the builder to a [`Parameters`] struct
     fn finish(self) -> Parameters {
-        let max_block_time_start_height = self.max_block_time_start_height.unwrap_or(Height(2));
+        // The builder defaults to public Testnet consensus parameters, so an unset
+        // activation height must inherit the public Testnet soft-fork height. Regtest
+        // and other networks that want Height(2) must set it explicitly.
+        let max_block_time_start_height = self
+            .max_block_time_start_height
+            .unwrap_or(TESTNET_MAX_TIME_START_HEIGHT);
         let Self {
             network_name,
             network_magic,
@@ -919,13 +924,9 @@ impl ParametersBuilder {
 
     /// Returns true if these [`Parameters`] should be compatible with the default Testnet parameters.
     pub fn is_compatible_with_default_parameters(&self) -> bool {
-        let max_block_time_start_height = self.max_block_time_start_height.unwrap_or_else(|| {
-            if self == &Self::default() {
-                TESTNET_MAX_TIME_START_HEIGHT
-            } else {
-                Height(2)
-            }
-        });
+        let max_block_time_start_height = self
+            .max_block_time_start_height
+            .unwrap_or(TESTNET_MAX_TIME_START_HEIGHT);
         let Self {
             network_name: _,
             network_magic,
@@ -1073,9 +1074,10 @@ impl Parameters {
             .with_lockbox_disbursements(lockbox_disbursements.unwrap_or_default())
             .with_checkpoints(checkpoints.unwrap_or_default())?;
 
-        if let Some(height) = max_block_time_start_height {
-            parameters = parameters.with_max_block_time_start_height(height);
-        }
+        // Regtest's local default is Height(2), matching zcashd-style private chains.
+        // Do not inherit the public Testnet soft-fork height from ParametersBuilder::finish().
+        parameters = parameters
+            .with_max_block_time_start_height(max_block_time_start_height.unwrap_or(Height(2)));
 
         if Some(true) == extend_funding_stream_addresses_as_required {
             parameters = parameters.extend_funding_streams();

--- a/crates/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/crates/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -356,11 +356,22 @@ fn configured_max_block_time_policy_is_local() {
     assert!(!public_testnet.is_max_block_time_enforced(Height(653_605)));
     assert!(public_testnet.is_max_block_time_enforced(Height(653_606)));
 
+    // Unset activation height inherits public Testnet's soft-fork height so a
+    // configured Testnet that otherwise matches public consensus does not reject
+    // historically valid pre-653,606 blocks.
     let custom = testnet::Parameters::build()
         .to_network()
         .expect("the default custom-network builder is valid");
-    assert!(!custom.is_max_block_time_enforced(Height(1)));
-    assert!(custom.is_max_block_time_enforced(Height(2)));
+    assert!(!custom.is_max_block_time_enforced(Height(653_605)));
+    assert!(custom.is_max_block_time_enforced(Height(653_606)));
+
+    let named = testnet::Parameters::build()
+        .with_network_name("NamedPublicCompatible")
+        .expect("the custom network name is valid")
+        .to_network()
+        .expect("a named public-compatible Testnet is valid");
+    assert!(!named.is_max_block_time_enforced(Height(653_605)));
+    assert!(named.is_max_block_time_enforced(Height(653_606)));
 
     let configured_height = Height(42);
     let configured = testnet::Parameters::build()
@@ -369,6 +380,10 @@ fn configured_max_block_time_policy_is_local() {
         .expect("the configured max-time policy is valid");
     assert!(!configured.is_max_block_time_enforced(Height(41)));
     assert!(configured.is_max_block_time_enforced(configured_height));
+
+    let default_regtest = Network::new_regtest(RegtestParameters::default());
+    assert!(!default_regtest.is_max_block_time_enforced(Height(1)));
+    assert!(default_regtest.is_max_block_time_enforced(Height(2)));
 
     let regtest_height = Height(42);
     let configured_regtest = Network::new_regtest(RegtestParameters {

--- a/docs/changelog/unreleased/673.md
+++ b/docs/changelog/unreleased/673.md
@@ -1,0 +1,10 @@
+## Fixed
+
+- Fixed configured Testnets inheriting the wrong max-block-time activation
+  height. `ParametersBuilder` defaulted an unset activation to height 2, so a
+  public-compatible custom Testnet enforced the median-time-past + 90 minute
+  rule from height 2 and rejected historically valid blocks below the public
+  soft-fork height. Regtest now sets height 2 explicitly, and every other
+  configured Testnet inherits the public activation height with the rest of the
+  Testnet defaults
+  ([#673](https://github.com/zakura-core/zakura/pull/673)).


### PR DESCRIPTION
Authored by @evan-forbes as part of the fork-aware header-chain work in #586.
This PR carries the change on its own so the consensus-parameter edit can be
reviewed in isolation, ahead of the engine, persistence, and reactor that land
in #586. Split out and rebased by @p0mvn.

## Motivation

`ParametersBuilder::finish` defaulted an unset `max_block_time_start_height` to
`Height(2)`. The builder otherwise defaults to public Testnet consensus
parameters, so a configured public-compatible Testnet enforced the
median-time-past + 90 minute rule from height 2 instead of the public soft-fork
height, and rejected historically valid blocks below it.
`is_compatible_with_default_parameters` papered over this with a special case
that returned `TESTNET_MAX_TIME_START_HEIGHT` only when the builder was
byte-identical to `Self::default()`.

## Solution

Default to `TESTNET_MAX_TIME_START_HEIGHT` in `finish`, so the activation height
is inherited with the rest of the public Testnet defaults, and drop the
now-redundant special case. Regtest is the network that actually wants
`Height(2)`, matching zcashd-style private chains, so `Parameters::from` sets it
explicitly instead of relying on the builder default.

## Test coverage

`configured_max_block_time_policy_is_local` covers both directions: a configured
Regtest still reports the rule unenforced below its local height and enforced at
it, while a Testnet built without an explicit height now reports the public
soft-fork height. `max_block_times_correct_enforcement` continues to hold across
network shapes.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --locked`
- `cargo test -p zakura-chain --lib -- parameters::network` (23 passed)
- Runnable gate: fresh Mainnet cache, stock config, real public v2 peers. Node
  started, migrated to database format 28.0.3, admitted peers, and advanced the
  tip 8,994 -> 22,655 over a 7 minute window with no panic and no validation
  error, then shut down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)