### PR TITLE
refactor(consensus)!: route context-free header checks through zakura-header-chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8428,7 +8428,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "6.1.0"
+version = "7.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8466,6 +8466,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "zakura-chain",
+ "zakura-header-chain",
  "zakura-node-services",
  "zakura-script",
  "zakura-state",

--- a/crates/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/crates/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -16,6 +16,7 @@ use crate::{
         ConsensusBranchId, Network, NetworkKind, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS,
         TESTNET_ACTIVATION_HEIGHTS,
     },
+    work::equihash::Solution,
 };
 
 /// Checks that every method in the `Parameters` impl for `zakura_chain::Network` has the same output
@@ -378,6 +379,12 @@ fn configured_max_block_time_policy_is_local() {
     assert_eq!(configured_regtest.kind(), NetworkKind::Regtest);
     assert!(!configured_regtest.is_max_block_time_enforced(Height(41)));
     assert!(configured_regtest.is_max_block_time_enforced(regtest_height));
+    Solution::for_proposal_for_network(&configured_regtest)
+        .validate_shape(&configured_regtest)
+        .expect("a configured Regtest keeps the authenticated (48, 5) solution shape");
+    assert!(Solution::for_proposal()
+        .validate_shape(&configured_regtest)
+        .is_err());
 }
 
 /// Regtest must not activate NU6.3 unless it is explicitly configured, and

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "6.1.0"
+version = "7.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -72,6 +72,7 @@ zakura-script = { path = "../zakura-script", version = "3.2.0" }
 zakura-state = { path = "../zakura-state", version = "6.2.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0" }
 zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 
 zcash_protocol.workspace = true
 

--- a/crates/zakura-consensus/src/block.rs
+++ b/crates/zakura-consensus/src/block.rs
@@ -73,6 +73,9 @@ pub enum VerifyBlockError {
     },
 
     #[error(transparent)]
+    PowPolicy(#[from] zakura_header_chain::PowPolicyError),
+
+    #[error(transparent)]
     Time(zakura_chain::block::BlockTimeError),
 
     /// Error when attempting to commit a block after semantic verification.
@@ -214,7 +217,8 @@ where
         let span = tracing::debug_span!("block", height = ?block.coinbase_height());
 
         async move {
-            let hash = block.hash();
+            let hash = zakura_header_chain::validate_encoding_version_hash(&block.header)
+                .map_err(BlockError::from)?;
             // Check that this block is actually a new block.
             tracing::trace!("checking that block is not already in state");
             match state_service
@@ -246,7 +250,8 @@ where
             // > The block data MUST be validated and checked against the server's usual
             // > acceptance rules (excluding the check for a valid proof-of-work).
             // <https://en.bitcoin.it/wiki/BIP_0023#Block_Proposal>
-            if request.is_proposal() || network.disable_pow() {
+            let pow_policy = zakura_header_chain::PowPolicy::for_network(&network)?;
+            if request.is_proposal() || pow_policy.is_authenticated_custom_waiver() {
                 check::difficulty_threshold_is_valid(&block.header, &network, &height, &hash)?;
             } else {
                 // Do the difficulty checks first, to raise the threshold for

--- a/crates/zakura-consensus/src/block/check.rs
+++ b/crates/zakura-consensus/src/block/check.rs
@@ -19,11 +19,9 @@ use zakura_chain::{
     },
     transaction::{self, Transaction},
     transparent::{Address, Output},
-    work::{
-        difficulty::{ExpandedDifficulty, ParameterDifficulty as _},
-        equihash,
-    },
+    work::{difficulty::ExpandedDifficulty, equihash},
 };
+use zakura_header_chain::{CompactTargetError, PowPolicy};
 
 use crate::{error::*, funding_stream_address};
 
@@ -79,27 +77,13 @@ pub fn difficulty_threshold_is_valid(
     height: &Height,
     hash: &Hash,
 ) -> Result<ExpandedDifficulty, BlockError> {
-    let difficulty_threshold = header
-        .difficulty_threshold
-        .to_expanded()
-        .ok_or(BlockError::InvalidDifficulty(*height, *hash))?;
-
-    // Note: the comparison in this function is a u256 integer comparison, like
-    // zcashd and bitcoin. Greater values represent *less* work.
-
-    // The PowLimit check is part of `Threshold()` in the spec, but it doesn't
-    // actually depend on any previous blocks.
-    if difficulty_threshold > network.target_difficulty_limit() {
-        Err(BlockError::TargetDifficultyLimit(
-            *height,
-            *hash,
-            difficulty_threshold,
-            network.clone(),
-            network.target_difficulty_limit(),
-        ))?;
+    match zakura_header_chain::validate_compact_target(header, network) {
+        Ok(target) => Ok(target),
+        Err(CompactTargetError::Invalid) => Err(BlockError::InvalidDifficulty(*height, *hash)),
+        Err(CompactTargetError::EasierThanLimit { target, limit }) => Err(
+            BlockError::TargetDifficultyLimit(*height, *hash, target, network.clone(), limit),
+        ),
     }
-
-    Ok(difficulty_threshold)
 }
 
 /// Returns `Ok(())` if `hash` passes:
@@ -127,13 +111,13 @@ pub fn difficulty_is_valid(
     // https://zips.z.cash/protocol/protocol.pdf#blockheader
     //
     // The difficulty filter is also context-free.
-    if hash > &difficulty_threshold {
-        Err(BlockError::DifficultyFilter(
+    if zakura_header_chain::validate_hash_filter(*hash, difficulty_threshold).is_err() {
+        return Err(BlockError::DifficultyFilter(
             *height,
             *hash,
             difficulty_threshold,
             network.clone(),
-        ))?;
+        ));
     }
 
     Ok(())
@@ -153,7 +137,7 @@ pub fn equihash_solution_is_valid(
     // The Equihash `(n, k)` parameters are bound to `network`, so a peer cannot
     // downgrade the proof of work to the trivial Regtest `(48, 5)` parameters
     // by sending a short 36-byte solution on Mainnet or Testnet.
-    header.solution.check(header, network)
+    PowPolicy::validating(network).validate_solution(header)
 }
 
 /// Returns `Ok()` with the deferred pool balance change of the coinbase transaction if the block
@@ -393,7 +377,7 @@ pub fn time_is_valid_at(
     height: &Height,
     hash: &Hash,
 ) -> Result<(), zakura_chain::block::BlockTimeError> {
-    header.time_is_valid_at(now, height, hash)
+    zakura_header_chain::validate_future_time(header, now, *height, *hash)
 }
 
 /// Check Merkle root validity.

--- a/crates/zakura-consensus/src/checkpoint.rs
+++ b/crates/zakura-consensus/src/checkpoint.rs
@@ -595,13 +595,16 @@ where
         &self,
         block: Arc<Block>,
     ) -> Result<CheckpointVerifiedBlock, VerifyCheckpointError> {
-        let hash = block.hash();
+        let hash = zakura_header_chain::validate_encoding_version_hash(&block.header)
+            .map_err(BlockError::from)?;
         let height = block
             .coinbase_height()
             .ok_or(VerifyCheckpointError::CoinbaseHeight { hash })?;
         self.check_height(height)?;
 
-        if self.network.disable_pow() {
+        let pow_policy = zakura_header_chain::PowPolicy::for_network(&self.network)
+            .map_err(VerifyBlockError::from)?;
+        if pow_policy.is_authenticated_custom_waiver() {
             crate::block::check::difficulty_threshold_is_valid(
                 &block.header,
                 &self.network,

--- a/crates/zakura-consensus/src/error.rs
+++ b/crates/zakura-consensus/src/error.rs
@@ -524,6 +524,9 @@ mod tests {
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum BlockError {
+    #[error(transparent)]
+    InvalidHeaderEncoding(#[from] zakura_header_chain::HeaderEncodingError),
+
     #[error("block contains invalid transactions")]
     Transaction(#[from] TransactionError),
 
@@ -622,7 +625,8 @@ impl BlockError {
         use BlockError::*;
 
         match self {
-            MissingHeight(_)
+            InvalidHeaderEncoding(_)
+            | MissingHeight(_)
             | MaxHeight(_, _, _)
             | InvalidDifficulty(_, _)
             | TargetDifficultyLimit(_, _, _, _, _)

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -115,7 +115,7 @@ proptest = { workspace = true, optional = true }
 zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "6.1.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
 zakura-network = { path = "../zakura-network", version = "6.1.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0", features = [
     "rpc-client",
@@ -145,7 +145,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "6.1.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = [
     "proptest-impl",
 ] }
 zakura-network = { path = "../zakura-network", version = "6.1.0", features = [

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -169,7 +169,7 @@ comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
 zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "6.1.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.1.0" }
 zakura-network = { path = "../zakura-network", version = "6.1.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0", features = ["rpc-client"] }
@@ -323,7 +323,7 @@ proptest-derive = { workspace = true }
 color-eyre = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "6.1.0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = ["proptest-impl"] }
 zakura-network = { path = "../zakura-network", version = "6.1.0", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "6.2.0", features = ["proptest-impl"] }
 

--- a/docs/changelog/unreleased/674.md
+++ b/docs/changelog/unreleased/674.md
@@ -1,0 +1,17 @@
+## Changed
+
+- Block and checkpoint verification now reject a block whose header carries an
+  invalid version or an unrepresentable timestamp before computing its hash.
+  Canonical deserialization already enforced the version rule, so this closes
+  the gap for in-memory headers that never went through the parser, such as
+  block proposals and locally constructed blocks
+  ([#674](https://github.com/zakura-core/zakura/pull/674)).
+
+## Security
+
+- Disabling proof of work now requires an authenticated custom network
+  configuration. A configuration claiming `disable_pow` for Mainnet or the
+  default public Testnet is refused with an error instead of silently waiving
+  Equihash verification. The waiver path still validates solution shape, so a
+  short Regtest-shaped solution cannot be accepted on a larger network
+  ([#674](https://github.com/zakura-core/zakura/pull/674)).


### PR DESCRIPTION
Authored by @evan-forbes as part of the fork-aware header-chain work in #586.
This PR carries the change on its own so the consensus-critical edits to the
existing block and checkpoint verifiers can be reviewed in isolation, ahead of
the engine, persistence, and reactor that land in #586. Split out and rebased by
@p0mvn.

## Motivation

`zakura-header-chain` already owns the context-free header rules, but the block
and checkpoint verifiers still carried their own inline copies. Two of those
copies were weaker than the engine's version, so the duplication was not merely
redundant.

## Solution

Four delegations are behaviour-preserving. The error mapping keeps every
existing `BlockError` variant and its payload:

| before | after |
| --- | --- |
| `difficulty_threshold_is_valid` inline | `validate_compact_target` |
| `difficulty_is_valid` inline | `validate_hash_filter` |
| `equihash_solution_is_valid` -> `Solution::check` | `PowPolicy::validating(..).validate_solution` |
| `time_is_valid_at` -> `Header::time_is_valid_at` | `validate_future_time` |

**Two checks do change behaviour, and are the ones worth the closest reading:**

- **Header encoding is validated before hashing.** Both verifiers derive the
  block hash through `validate_encoding_version_hash` instead of `Block::hash`.
  Canonical deserialization already rejects an invalid header version, so this
  closes the gap for in-memory headers that never went through the parser —
  block proposals and locally constructed blocks — and adds the timestamp bound
  that serialization only enforced on write. Failures surface as the new
  `BlockError::InvalidHeaderEncoding`, scored 100 like the other header
  rejections.
- **Disabling proof of work now requires an authenticated custom network.**
  `network.disable_pow()` silently waived Equihash for whatever network claimed
  it. `PowPolicy::for_network` refuses to build a waiver for Mainnet or the
  default public Testnet and returns `PowPolicyError` instead, which both
  verifiers propagate. The waiver path still validates solution shape, so a
  short Regtest-shaped solution cannot be smuggled onto a larger network.

Everything else in #586 that touches these files — the `body_verification_class`
classifiers — is header-sync plumbing rather than validation, and deliberately
stays in #586.

## Test coverage

`configured_max_block_time_policy_is_local` now also covers the waiver's shape
check directly: a configured Regtest accepts its own `(48, 5)` proposal solution
and rejects a default-shaped one. The existing zakura-consensus suite (180 tests)
covers the behaviour-preserving delegations, including the checkpoint and
semantic difficulty, Equihash, and time paths.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-consensus -p zakura-chain --all-targets -- -D warnings`
- `cargo test -p zakura-consensus` (180 passed)
- `cargo test -p zakura-chain --lib -- parameters::network::tests::vectors::configured`
- Runnable gate: fresh Mainnet cache, stock config, real public v2 peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
