### PR TITLE
refactor(state): type the disk-format upgrade contract

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -15,6 +15,7 @@ use std::{
 
 use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender};
 use semver::Version;
+use thiserror::Error;
 use tracing::Span;
 
 use zakura_chain::{
@@ -45,51 +46,59 @@ pub(crate) mod drop_tx_locs_by_spends;
 #[cfg(feature = "indexer")]
 pub(crate) mod track_tx_locs_by_spends;
 
-/// Defines method signature for running disk format upgrades.
+/// Defines one ordered state database format upgrade.
+///
+/// The upgrade coordinator calls [`DiskFormatUpgrade::prepare`],
+/// [`DiskFormatUpgrade::run`], and [`DiskFormatUpgrade::validate`] before it writes the new format
+/// version. Implementations must support a retry after cancellation or failure.
 pub trait DiskFormatUpgrade {
-    /// Returns the version at which this upgrade is applied.
+    /// Returns the database format version that this upgrade establishes.
     fn version(&self) -> Version;
 
-    /// Returns the description of this upgrade.
+    /// Returns a short operation description for logs and timing metrics.
     fn description(&self) -> &'static str;
 
-    /// Runs disk format upgrade.
+    /// Applies the format upgrade to `state_database`.
+    ///
+    /// `initial_finalized_tip_height` reports the tip that startup observed before any upgrade.
+    /// An empty database supplies `None`. The coordinator does not update the format version when
+    /// this method returns an error.
     fn run(
         &self,
-        initial_tip_height: Height,
-        db: &ZakuraDb,
+        initial_finalized_tip_height: Option<Height>,
+        state_database: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange>;
+    ) -> Result<(), FormatChangeError>;
 
-    /// Check that state has been upgraded to this format correctly.
+    /// Validates the postconditions that this upgrade establishes.
     ///
-    /// The outer `Result` indicates whether the validation was cancelled (due to e.g. node shutdown).
-    /// The inner `Result` indicates whether the validation itself failed or not.
+    /// The outer result reports cancellation or an operational error. The inner result reports an
+    /// invalid postcondition without discarding its diagnostic message.
     fn validate(
         &self,
-        _db: &ZakuraDb,
+        _state_database: &ZakuraDb,
         _cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<Result<(), String>, CancelFormatChange> {
+    ) -> Result<Result<(), String>, FormatChangeError> {
         Ok(Ok(()))
     }
 
-    /// Prepare for disk format upgrade.
+    /// Prepares temporary or derived data that [`DiskFormatUpgrade::run`] consumes.
     fn prepare(
         &self,
-        _initial_tip_height: Height,
-        _upgrade_db: &ZakuraDb,
+        _initial_finalized_tip_height: Option<Height>,
+        _state_database: &ZakuraDb,
         _cancel_receiver: &Receiver<CancelFormatChange>,
         _older_disk_version: &Version,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
         Ok(())
     }
 
-    /// Returns true if the [`DiskFormatUpgrade`] needs to run a migration on existing data in the db.
+    /// Returns whether this upgrade mutates existing database rows.
     fn needs_migration(&self) -> bool {
         true
     }
 
-    /// Returns true if the upgrade is a major upgrade that can reuse the cache in the previous major db format version.
+    /// Returns whether a major upgrade can reuse the previous major version's cache.
     fn is_reusable_major_upgrade(&self) -> bool {
         let version = self.version();
         version.minor == 0 && version.patch == 0
@@ -217,7 +226,7 @@ pub struct DbFormatChangeThreadHandle {
     ///
     /// Panics from this thread are propagated into Zebra's state service.
     /// The task returns an error if the upgrade was cancelled by a shutdown.
-    update_task: Option<Arc<JoinHandle<Result<(), CancelFormatChange>>>>,
+    update_task: Option<Arc<JoinHandle<Result<(), FormatChangeError>>>>,
 
     /// A channel that tells the running format thread to finish early.
     cancel_handle: Sender<CancelFormatChange>,
@@ -226,6 +235,26 @@ pub struct DbFormatChangeThreadHandle {
 /// Marker type that is sent to cancel a format upgrade, and returned as an error on cancellation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct CancelFormatChange;
+
+/// An error that prevents the coordinator from updating the database format version.
+#[derive(Debug, Error)]
+pub enum FormatChangeError {
+    /// Shutdown cancels the format change.
+    #[error("database format change was cancelled")]
+    Cancelled,
+    /// RocksDB rejected a migration write.
+    #[error("database format migration storage write failed: {0}")]
+    MigrationStorage(String),
+    /// A migration or final format check found an invalid postcondition.
+    #[error("database format migration postcondition failed: {0}")]
+    InvalidPostcondition(String),
+}
+
+impl From<CancelFormatChange> for FormatChangeError {
+    fn from(_: CancelFormatChange) -> Self {
+        Self::Cancelled
+    }
+}
 
 #[cfg(test)]
 type StartupUpgradeHook = Arc<dyn Fn() + Send + Sync>;
@@ -401,11 +430,11 @@ impl DbFormatChange {
     ///
     /// The startup format change must already have completed synchronously.
     ///
-    /// `initial_tip_height` is the database height when it was opened, and `db` is the
+    /// `initial_finalized_tip_height` is the database height when it was opened. `db` is the
     /// database instance to upgrade or check.
     pub fn spawn_periodic_format_checks(
         db: ZakuraDb,
-        initial_tip_height: Option<Height>,
+        initial_finalized_tip_height: Option<Height>,
     ) -> DbFormatChangeThreadHandle {
         // # Correctness
         //
@@ -416,7 +445,7 @@ impl DbFormatChange {
         let span = Span::current();
         let update_task = thread::spawn(move || {
             span.in_scope(move || {
-                Self::periodic_format_check_loop(db, initial_tip_height, cancel_receiver)
+                Self::periodic_format_check_loop(db, initial_finalized_tip_height, cancel_receiver)
             })
         });
 
@@ -433,9 +462,9 @@ impl DbFormatChange {
     /// Periodically check that newly added blocks match the current format.
     fn periodic_format_check_loop(
         db: ZakuraDb,
-        initial_tip_height: Option<Height>,
+        initial_finalized_tip_height: Option<Height>,
         cancel_receiver: Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
         let Some(debug_validity_check_interval) = db.config().debug_validity_check_interval else {
             return Ok(());
         };
@@ -447,12 +476,12 @@ impl DbFormatChange {
                 cancel_receiver.recv_timeout(debug_validity_check_interval),
                 Err(RecvTimeoutError::Timeout)
             ) {
-                return Err(CancelFormatChange);
+                return Err(FormatChangeError::Cancelled);
             }
 
             Self::check_new_blocks(&db).run_format_change_or_check(
                 &db,
-                initial_tip_height,
+                initial_finalized_tip_height,
                 &cancel_receiver,
             )?;
         }
@@ -463,9 +492,9 @@ impl DbFormatChange {
     pub(crate) fn run_format_change_or_check(
         &self,
         db: &ZakuraDb,
-        initial_tip_height: Option<Height>,
+        initial_finalized_tip_height: Option<Height>,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
         // Mark the database as having finished applying any format upgrades if there are no
         // format upgrades that need to be applied.
         if !self.is_upgrade() {
@@ -475,7 +504,7 @@ impl DbFormatChange {
         match self {
             // Perform any required upgrades, then mark the state as upgraded.
             Upgrade { .. } => {
-                self.apply_format_upgrade(db, initial_tip_height, cancel_receiver)?;
+                self.apply_format_upgrade(db, initial_finalized_tip_height, cancel_receiver)?;
                 db.mark_finished_format_upgrades();
             }
 
@@ -525,8 +554,8 @@ impl DbFormatChange {
         #[cfg(feature = "indexer")]
         if let (
             Upgrade { .. } | CheckOpenCurrent { .. } | Downgrade { .. },
-            Some(initial_tip_height),
-        ) = (self, initial_tip_height)
+            Some(initial_finalized_tip_height),
+        ) = (self, initial_finalized_tip_height)
         {
             // Indexing transaction locations by their spent outpoints and revealed nullifiers.
             let timer = CodeTimer::start();
@@ -542,7 +571,7 @@ impl DbFormatChange {
                 .expect("unable to write database format version file to disk");
 
             info!("started checking/adding indexes for spending tx ids");
-            track_tx_locs_by_spends::run(initial_tip_height, db, cancel_receiver)?;
+            track_tx_locs_by_spends::run(initial_finalized_tip_height, db, cancel_receiver)?;
             info!("finished checking/adding indexes for spending tx ids");
 
             timer.finish_desc("indexing spending transaction ids");
@@ -551,8 +580,8 @@ impl DbFormatChange {
         #[cfg(not(feature = "indexer"))]
         if let (
             Upgrade { .. } | CheckOpenCurrent { .. } | Downgrade { .. },
-            Some(initial_tip_height),
-        ) = (self, initial_tip_height)
+            Some(initial_finalized_tip_height),
+        ) = (self, initial_finalized_tip_height)
         {
             let mut version = db
                 .format_version_on_disk()
@@ -564,7 +593,7 @@ impl DbFormatChange {
                 let timer = CodeTimer::start();
 
                 info!("started removing indexes for spending tx ids");
-                drop_tx_locs_by_spends::run(initial_tip_height, db, cancel_receiver)?;
+                drop_tx_locs_by_spends::run(initial_finalized_tip_height, db, cancel_receiver)?;
                 info!("finished removing indexes for spending tx ids");
 
                 // Remove build metadata to on-disk version file after indexes have been dropped.
@@ -584,12 +613,16 @@ impl DbFormatChange {
         //   (unless a future upgrade breaks these format checks)
         // - re-opening the current version should be valid, regardless of whether the upgrade
         //   or new block code created the format (or any combination).
-        Self::format_validity_checks_detailed(db, cancel_receiver)?.unwrap_or_else(|_| {
+        if let Err(message) = Self::format_validity_checks_detailed(db, cancel_receiver)? {
+            if self.is_upgrade() {
+                return Err(FormatChangeError::InvalidPostcondition(message));
+            }
+
             panic!(
-                "unexpected invalid database format: delete and re-sync the database at '{:?}'",
+                "unexpected invalid database format: delete and re-sync the database at '{:?}': {message}",
                 db.path()
-            )
-        });
+            );
+        }
 
         let initial_disk_version = self
             .initial_disk_version()
@@ -619,9 +652,9 @@ impl DbFormatChange {
     fn apply_format_upgrade(
         &self,
         db: &ZakuraDb,
-        initial_tip_height: Option<Height>,
+        initial_finalized_tip_height: Option<Height>,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
         let Upgrade {
             newer_running_version,
             older_disk_version,
@@ -633,40 +666,23 @@ impl DbFormatChange {
         #[cfg(test)]
         run_startup_upgrade_hook(db.path());
 
-        // # New Upgrades Sometimes Go Here
-        //
-        // If the format change is outside RocksDb, put new code above this comment!
-        let Some(initial_tip_height) = initial_tip_height else {
-            // If the database is empty, then the RocksDb format doesn't need any changes.
-            info!(
-                %newer_running_version,
-                %older_disk_version,
-                "marking empty database as upgraded"
-            );
-
-            Self::mark_as_upgraded_to(db, newer_running_version);
-
-            info!(
-                %newer_running_version,
-                %older_disk_version,
-                "empty database is fully upgraded"
-            );
-
-            return Ok(());
-        };
-
         // Apply or validate format upgrades
         for upgrade in format_upgrades(Some(older_disk_version.clone())) {
             if upgrade.needs_migration() {
                 let timer = CodeTimer::start();
 
-                upgrade.prepare(initial_tip_height, db, cancel_receiver, older_disk_version)?;
-                upgrade.run(initial_tip_height, db, cancel_receiver)?;
+                upgrade.prepare(
+                    initial_finalized_tip_height,
+                    db,
+                    cancel_receiver,
+                    older_disk_version,
+                )?;
+                upgrade.run(initial_finalized_tip_height, db, cancel_receiver)?;
 
                 // Before marking the state as upgraded, check that the upgrade completed successfully.
                 upgrade
                     .validate(db, cancel_receiver)?
-                    .expect("db should be valid after upgrade");
+                    .map_err(FormatChangeError::InvalidPostcondition)?;
 
                 timer.finish_desc(upgrade.description());
             }
@@ -678,6 +694,13 @@ impl DbFormatChange {
                 "Zakura automatically upgraded the database format"
             );
             Self::mark_as_upgraded_to(db, &upgrade.version());
+        }
+
+        if initial_finalized_tip_height.is_none() {
+            // An empty database has no spending indexes to build. The coordinator records the
+            // running build metadata because the empty index is complete.
+            db.update_format_version_on_disk(newer_running_version)
+                .map_err(|error| FormatChangeError::MigrationStorage(error.to_string()))?;
         }
 
         Ok(())
@@ -717,7 +740,7 @@ impl DbFormatChange {
     pub fn format_validity_checks_detailed(
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<Result<(), String>, CancelFormatChange> {
+    ) -> Result<Result<(), String>, FormatChangeError> {
         let timer = CodeTimer::start();
         let mut results = Vec::new();
 

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -703,6 +703,14 @@ impl DbFormatChange {
                 .map_err(|error| FormatChangeError::MigrationStorage(error.to_string()))?;
         }
 
+        // Every registered upgrade has run and been marked on disk. Operators and the
+        // `update_state_format` acceptance test rely on this line to observe completion.
+        info!(
+            %newer_running_version,
+            %older_disk_version,
+            "database is fully upgraded"
+        );
+
         Ok(())
     }
 

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/add_ironwood_tree.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/add_ironwood_tree.rs
@@ -15,7 +15,7 @@ use zakura_chain::{block::Height, ironwood};
 
 use crate::service::finalized_state::{DiskWriteBatch, ZakuraDb};
 
-use super::{CancelFormatChange, DiskFormatUpgrade};
+use super::{CancelFormatChange, DiskFormatUpgrade, FormatChangeError};
 
 /// Implements [`DiskFormatUpgrade`] for backfilling the genesis Ironwood tree and anchor.
 pub struct Upgrade;
@@ -32,10 +32,10 @@ impl DiskFormatUpgrade for Upgrade {
     #[allow(clippy::unwrap_in_result)]
     fn run(
         &self,
-        _initial_tip_height: Height,
+        _initial_finalized_tip_height: Option<Height>,
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
         check_cancelled(cancel_receiver)?;
 
         // Nothing to do for empty databases, or databases that already have the genesis tree
@@ -62,7 +62,7 @@ impl DiskFormatUpgrade for Upgrade {
         &self,
         db: &ZakuraDb,
         _cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<Result<(), String>, CancelFormatChange> {
+    ) -> Result<Result<(), String>, FormatChangeError> {
         if db.finalized_tip_height().is_none() {
             return Ok(Ok(()));
         }

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -18,7 +18,7 @@ use zakura_chain::{
 };
 
 use crate::service::finalized_state::{
-    disk_format::upgrade::{CancelFormatChange, DiskFormatUpgrade},
+    disk_format::upgrade::{CancelFormatChange, DiskFormatUpgrade, FormatChangeError},
     DiskWriteBatch, ZakuraDb,
 };
 
@@ -36,15 +36,18 @@ impl DiskFormatUpgrade for AddSubtrees {
 
     fn prepare(
         &self,
-        initial_tip_height: Height,
+        initial_finalized_tip_height: Option<Height>,
         upgrade_db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
         older_disk_version: &Version,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
+        let Some(initial_finalized_tip_height) = initial_finalized_tip_height else {
+            return Ok(());
+        };
         let first_version_for_adding_subtrees = Version::new(25, 2, 0);
         if older_disk_version >= &first_version_for_adding_subtrees {
             // Clear previous upgrade data, because it was incorrect.
-            reset(initial_tip_height, upgrade_db, cancel_receiver)?;
+            reset(initial_finalized_tip_height, upgrade_db, cancel_receiver)?;
         }
 
         Ok(())
@@ -58,10 +61,13 @@ impl DiskFormatUpgrade for AddSubtrees {
     /// Returns `Ok` if the upgrade completed, and `Err` if it was cancelled.
     fn run(
         &self,
-        initial_tip_height: Height,
+        initial_finalized_tip_height: Option<Height>,
         upgrade_db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
+        let Some(initial_finalized_tip_height) = initial_finalized_tip_height else {
+            return Ok(());
+        };
         // # Consensus
         //
         // Zebra stores exactly one note commitment tree for every block with sapling notes.
@@ -81,7 +87,7 @@ impl DiskFormatUpgrade for AddSubtrees {
 
         // Generate a list of sapling subtree inputs: previous and current trees, and their end heights.
         let subtrees = upgrade_db
-            .sapling_tree_by_reversed_height_range(..=initial_tip_height)
+            .sapling_tree_by_reversed_height_range(..=initial_finalized_tip_height)
             // We need both the tree and its previous tree for each shielded block.
             .tuple_windows()
             // Because the iterator is reversed, the larger tree is first.
@@ -96,7 +102,7 @@ impl DiskFormatUpgrade for AddSubtrees {
         for (prev_end_height, prev_tree, end_height, tree) in subtrees {
             // Return early if the upgrade is cancelled.
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                return Err(CancelFormatChange);
+                return Err(CancelFormatChange.into());
             }
 
             let subtree =
@@ -106,7 +112,7 @@ impl DiskFormatUpgrade for AddSubtrees {
 
         // Generate a list of orchard subtree inputs: previous and current trees, and their end heights.
         let subtrees = upgrade_db
-            .orchard_tree_by_reversed_height_range(..=initial_tip_height)
+            .orchard_tree_by_reversed_height_range(..=initial_finalized_tip_height)
             // We need both the tree and its previous tree for each shielded block.
             .tuple_windows()
             // Because the iterator is reversed, the larger tree is first.
@@ -121,7 +127,7 @@ impl DiskFormatUpgrade for AddSubtrees {
         for (prev_end_height, prev_tree, end_height, tree) in subtrees {
             // Return early if the upgrade is cancelled.
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                return Err(CancelFormatChange);
+                return Err(CancelFormatChange.into());
             }
 
             let subtree =
@@ -137,7 +143,7 @@ impl DiskFormatUpgrade for AddSubtrees {
         &self,
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<Result<(), String>, CancelFormatChange> {
+    ) -> Result<Result<(), String>, FormatChangeError> {
         // Fast-synced databases deliberately have no per-height note-commitment
         // trees or subtrees below the checkpoint handoff height, so the subtree
         // scans below do not apply to them.
@@ -171,7 +177,7 @@ impl DiskFormatUpgrade for AddSubtrees {
 #[allow(clippy::unwrap_in_result)]
 #[instrument(skip(upgrade_db, cancel_receiver))]
 pub fn reset(
-    _initial_tip_height: Height,
+    _initial_finalized_tip_height: Height,
     upgrade_db: &ZakuraDb,
     cancel_receiver: &Receiver<CancelFormatChange>,
 ) -> Result<(), CancelFormatChange> {

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -23,7 +23,7 @@ use crate::{
     DiskWriteBatch, HashOrHeight, TransactionLocation, WriteDisk,
 };
 
-use super::{CancelFormatChange, DiskFormatUpgrade};
+use super::DiskFormatUpgrade;
 
 /// Implements [`DiskFormatUpgrade`] for adding additionl block info to the
 /// database.
@@ -54,16 +54,19 @@ impl DiskFormatUpgrade for Upgrade {
     #[allow(clippy::unwrap_in_result)]
     fn run(
         &self,
-        initial_tip_height: zakura_chain::block::Height,
+        initial_finalized_tip_height: Option<zakura_chain::block::Height>,
         db: &crate::ZakuraDb,
         cancel_receiver: &crossbeam_channel::Receiver<super::CancelFormatChange>,
-    ) -> Result<(), super::CancelFormatChange> {
+    ) -> Result<(), super::FormatChangeError> {
+        let Some(initial_finalized_tip_height) = initial_finalized_tip_height else {
+            return Ok(());
+        };
         let network = db.network();
         let balance_by_transparent_addr = db.address_balance_cf();
         let chunk_size = rayon::current_num_threads();
         tracing::info!(chunk_size = ?chunk_size, "adding block info data");
 
-        let chunks = (0..=initial_tip_height.0).chunks(chunk_size);
+        let chunks = (0..=initial_finalized_tip_height.0).chunks(chunk_size);
         // Since transaction parsing is slow, we want to parallelize it.
         // Get chunks of block heights and load them in parallel.
         let seq_iter = chunks.into_iter().flat_map(|height_span| {
@@ -73,7 +76,7 @@ impl DiskFormatUpgrade for Upgrade {
                 .map(|h| {
                     // Return early if the upgrade is cancelled.
                     if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                        return Err(super::CancelFormatChange);
+                        return Err(super::FormatChangeError::Cancelled);
                     }
 
                     let height = Height(h);
@@ -237,12 +240,12 @@ impl DiskFormatUpgrade for Upgrade {
         &self,
         db: &crate::ZakuraDb,
         cancel_receiver: &crossbeam_channel::Receiver<super::CancelFormatChange>,
-    ) -> Result<Result<(), String>, super::CancelFormatChange> {
+    ) -> Result<Result<(), String>, super::FormatChangeError> {
         let network = db.network();
 
         // Return early before the next disk read if the upgrade was cancelled.
         if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-            return Err(super::CancelFormatChange);
+            return Err(super::CancelFormatChange.into());
         }
 
         // Read the finalized tip height or return early if the database is empty.
@@ -254,7 +257,7 @@ impl DiskFormatUpgrade for Upgrade {
         let start_height = (tip_height - 1_000).unwrap_or(Height::MIN);
 
         if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-            return Err(CancelFormatChange);
+            return Err(super::FormatChangeError::Cancelled);
         }
 
         // Check that all blocks in the range have a BlockInfo.
@@ -270,7 +273,7 @@ impl DiskFormatUpgrade for Upgrade {
         }
 
         if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-            return Err(CancelFormatChange);
+            return Err(super::FormatChangeError::Cancelled);
         }
 
         // Check that all recipient addresses of transparent transfers in the range have a non-zero received balance.
@@ -292,7 +295,7 @@ impl DiskFormatUpgrade for Upgrade {
         // Check that no address balances for that set of addresses have a received field of `0`.
         for address in addresses {
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                return Err(CancelFormatChange);
+                return Err(super::FormatChangeError::Cancelled);
             }
 
             let balance = db

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/cache_genesis_roots.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/cache_genesis_roots.rs
@@ -20,7 +20,7 @@ use super::CancelFormatChange;
 #[allow(clippy::unwrap_in_result)]
 #[instrument(skip(upgrade_db, cancel_receiver))]
 pub fn run(
-    _initial_tip_height: Height,
+    _initial_finalized_tip_height: Height,
     upgrade_db: &ZakuraDb,
     cancel_receiver: &Receiver<CancelFormatChange>,
 ) -> Result<(), CancelFormatChange> {

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/drop_tx_locs_by_spends.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/drop_tx_locs_by_spends.rs
@@ -15,7 +15,7 @@ use super::{super::super::DiskWriteBatch, CancelFormatChange};
 #[allow(clippy::unwrap_in_result)]
 #[instrument(skip(zakura_db, cancel_receiver))]
 pub fn run(
-    initial_tip_height: Height,
+    initial_finalized_tip_height: Height,
     zakura_db: &ZakuraDb,
     cancel_receiver: &Receiver<CancelFormatChange>,
 ) -> Result<(), CancelFormatChange> {
@@ -36,7 +36,7 @@ pub fn run(
         return Err(CancelFormatChange);
     }
 
-    (0..=initial_tip_height.0)
+    (0..=initial_finalized_tip_height.0)
         .into_par_iter()
         .try_for_each(|height| {
             let height = Height(height);

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
@@ -19,7 +19,7 @@ use super::CancelFormatChange;
 #[allow(clippy::unwrap_in_result)]
 #[instrument(skip(upgrade_db, cancel_receiver))]
 pub fn run(
-    _initial_tip_height: Height,
+    _initial_finalized_tip_height: Height,
     upgrade_db: &ZakuraDb,
     cancel_receiver: &Receiver<CancelFormatChange>,
 ) -> Result<(), CancelFormatChange> {

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/header_root_auth_frontier.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/header_root_auth_frontier.rs
@@ -6,7 +6,7 @@ use zakura_chain::block::Height;
 
 use crate::service::finalized_state::{DiskWriteBatch, HeaderRootAuthFrontierError, ZakuraDb};
 
-use super::{CancelFormatChange, DiskFormatUpgrade};
+use super::{CancelFormatChange, DiskFormatUpgrade, FormatChangeError};
 
 /// First format where commitment-root rows are authenticated before persistence.
 pub(crate) const UPGRADE_VERSION: Version = Version::new(28, 0, 2);
@@ -38,10 +38,10 @@ impl DiskFormatUpgrade for Upgrade {
 
     fn run(
         &self,
-        _initial_tip_height: Height,
+        _initial_finalized_tip_height: Option<Height>,
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
         check_cancelled(cancel_receiver)?;
         if let Err(error) = rebase_to_body_tip(db) {
             panic!("header-root authentication cutover failed closed: {error}");
@@ -54,7 +54,7 @@ impl DiskFormatUpgrade for Upgrade {
         &self,
         db: &ZakuraDb,
         _cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<Result<(), String>, CancelFormatChange> {
+    ) -> Result<Result<(), String>, FormatChangeError> {
         match db.validate_header_root_auth_state() {
             Ok(_) => Ok(Ok(())),
             Err(error) => Ok(Err(error.to_string())),
@@ -196,14 +196,15 @@ mod tests {
         .expect("legacy header-ahead roots write");
 
         let (_cancel_tx, cancel_rx) = crossbeam_channel::bounded(1);
-        DiskFormatUpgrade::run(&Upgrade, Height::MIN, &db, &cancel_rx)
+        DiskFormatUpgrade::run(&Upgrade, Some(Height::MIN), &db, &cancel_rx)
             .expect("first cutover is not cancelled");
-        DiskFormatUpgrade::run(&Upgrade, Height::MIN, &db, &cancel_rx)
+        DiskFormatUpgrade::run(&Upgrade, Some(Height::MIN), &db, &cancel_rx)
             .expect("re-running cutover is idempotent");
 
         assert_eq!(
-            DiskFormatUpgrade::validate(&Upgrade, &db, &cancel_rx),
-            Ok(Ok(())),
+            DiskFormatUpgrade::validate(&Upgrade, &db, &cancel_rx)
+                .expect("validation is not cancelled"),
+            Ok(()),
             "state remains valid after an idempotent re-run"
         );
         assert!(db.commitment_roots(Height::MIN).is_some());

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/no_migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/no_migration.rs
@@ -7,7 +7,7 @@ use zakura_chain::block::Height;
 
 use crate::service::finalized_state::ZakuraDb;
 
-use super::{CancelFormatChange, DiskFormatUpgrade};
+use super::{CancelFormatChange, DiskFormatUpgrade, FormatChangeError};
 
 /// Implements [`DiskFormatUpgrade`] for in-place upgrades that do not involve any migration
 /// of existing data into the new format.
@@ -38,10 +38,10 @@ impl DiskFormatUpgrade for NoMigration {
     #[allow(clippy::unwrap_in_result)]
     fn run(
         &self,
-        _initial_tip_height: Height,
+        _initial_finalized_tip_height: Option<Height>,
         _db: &ZakuraDb,
         _cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
         Ok(())
     }
 

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/prune_trees.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/prune_trees.rs
@@ -7,7 +7,7 @@ use zakura_chain::block::Height;
 
 use crate::service::finalized_state::{DiskWriteBatch, ZakuraDb};
 
-use super::{CancelFormatChange, DiskFormatUpgrade};
+use super::{CancelFormatChange, DiskFormatUpgrade, FormatChangeError};
 
 /// Implements [`DiskFormatUpgrade`] for pruning duplicate Sapling and Orchard note commitment trees from database
 pub struct PruneTrees;
@@ -24,10 +24,13 @@ impl DiskFormatUpgrade for PruneTrees {
     #[allow(clippy::unwrap_in_result)]
     fn run(
         &self,
-        initial_tip_height: Height,
+        initial_finalized_tip_height: Option<Height>,
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
+        let Some(initial_finalized_tip_height) = initial_finalized_tip_height else {
+            return Ok(());
+        };
         // Prune duplicate Sapling note commitment trees.
 
         // The last tree we checked.
@@ -37,10 +40,12 @@ impl DiskFormatUpgrade for PruneTrees {
 
         // Run through all the possible duplicate trees in the finalized chain.
         // The block after genesis is the first possible duplicate.
-        for (height, tree) in db.sapling_tree_by_height_range(Height(1)..=initial_tip_height) {
+        for (height, tree) in
+            db.sapling_tree_by_height_range(Height(1)..=initial_finalized_tip_height)
+        {
             // Return early if there is a cancel signal.
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                return Err(CancelFormatChange);
+                return Err(CancelFormatChange.into());
             }
 
             // Delete any duplicate trees.
@@ -64,10 +69,12 @@ impl DiskFormatUpgrade for PruneTrees {
 
         // Run through all the possible duplicate trees in the finalized chain.
         // The block after genesis is the first possible duplicate.
-        for (height, tree) in db.orchard_tree_by_height_range(Height(1)..=initial_tip_height) {
+        for (height, tree) in
+            db.orchard_tree_by_height_range(Height(1)..=initial_finalized_tip_height)
+        {
             // Return early if there is a cancel signal.
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                return Err(CancelFormatChange);
+                return Err(CancelFormatChange.into());
             }
 
             // Delete any duplicate trees.
@@ -91,7 +98,7 @@ impl DiskFormatUpgrade for PruneTrees {
         &self,
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<Result<(), String>, CancelFormatChange> {
+    ) -> Result<Result<(), String>, FormatChangeError> {
         // Runtime test: make sure we removed all duplicates.
         // We always run this test, even if the state has supposedly been upgraded.
         let mut result = Ok(());
@@ -101,7 +108,7 @@ impl DiskFormatUpgrade for PruneTrees {
         for (height, tree) in db.sapling_tree_by_height_range(..) {
             // Return early if the format check is cancelled.
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                return Err(CancelFormatChange);
+                return Err(CancelFormatChange.into());
             }
 
             if prev_tree == Some(tree.clone()) {
@@ -123,7 +130,7 @@ impl DiskFormatUpgrade for PruneTrees {
         for (height, tree) in db.orchard_tree_by_height_range(..) {
             // Return early if the format check is cancelled.
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {
-                return Err(CancelFormatChange);
+                return Err(CancelFormatChange.into());
             }
 
             if prev_tree == Some(tree.clone()) {

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/track_tx_locs_by_spends.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/track_tx_locs_by_spends.rs
@@ -20,7 +20,7 @@ use super::{super::super::DiskWriteBatch, CancelFormatChange};
 #[allow(clippy::unwrap_in_result)]
 #[instrument(skip(zakura_db, cancel_receiver))]
 pub fn run(
-    initial_tip_height: Height,
+    initial_finalized_tip_height: Height,
     zakura_db: &ZakuraDb,
     cancel_receiver: &Receiver<CancelFormatChange>,
 ) -> Result<(), CancelFormatChange> {
@@ -28,7 +28,7 @@ pub fn run(
         return Err(CancelFormatChange);
     }
 
-    (0..=initial_tip_height.0)
+    (0..=initial_finalized_tip_height.0)
         .into_par_iter()
         .try_for_each(|height| {
             let height = Height(height);

--- a/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/tree_keys_and_caches_upgrade.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/upgrade/tree_keys_and_caches_upgrade.rs
@@ -7,7 +7,10 @@ use zakura_chain::block::Height;
 
 use crate::service::finalized_state::ZakuraDb;
 
-use super::{cache_genesis_roots, fix_tree_key_type, CancelFormatChange, DiskFormatUpgrade};
+use super::{
+    cache_genesis_roots, fix_tree_key_type, CancelFormatChange, DiskFormatUpgrade,
+    FormatChangeError,
+};
 
 /// Implements [`DiskFormatUpgrade`] for updating the sprout and history tree key type from
 /// `Height` to the empty key `()` and the genesis note commitment trees to cache their roots
@@ -25,13 +28,16 @@ impl DiskFormatUpgrade for FixTreeKeyTypeAndCacheGenesisRoots {
     #[allow(clippy::unwrap_in_result)]
     fn run(
         &self,
-        initial_tip_height: Height,
+        initial_finalized_tip_height: Option<Height>,
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<(), CancelFormatChange> {
+    ) -> Result<(), FormatChangeError> {
+        let Some(initial_finalized_tip_height) = initial_finalized_tip_height else {
+            return Ok(());
+        };
         // It shouldn't matter what order these are run in.
-        cache_genesis_roots::run(initial_tip_height, db, cancel_receiver)?;
-        fix_tree_key_type::run(initial_tip_height, db, cancel_receiver)?;
+        cache_genesis_roots::run(initial_finalized_tip_height, db, cancel_receiver)?;
+        fix_tree_key_type::run(initial_finalized_tip_height, db, cancel_receiver)?;
         Ok(())
     }
 
@@ -40,7 +46,7 @@ impl DiskFormatUpgrade for FixTreeKeyTypeAndCacheGenesisRoots {
         &self,
         db: &ZakuraDb,
         cancel_receiver: &Receiver<CancelFormatChange>,
-    ) -> Result<Result<(), String>, CancelFormatChange> {
+    ) -> Result<Result<(), String>, FormatChangeError> {
         let results = [
             cache_genesis_roots::detailed_check(db, cancel_receiver)?,
             fix_tree_key_type::detailed_check(db, cancel_receiver)?,

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/vectors.rs
@@ -189,7 +189,7 @@ fn root_auth_cutover_deletes_header_ahead_rows_and_initializes_frontier() {
     let (_cancel_sender, cancel_receiver) = crossbeam_channel::bounded(1);
     DiskFormatUpgrade::run(
         &header_root_auth_frontier::Upgrade,
-        Height(0),
+        Some(Height(0)),
         &state,
         &cancel_receiver,
     )

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/commitment_roots_db.rs
@@ -2208,7 +2208,7 @@ mod tests {
             "retain terminal header witnesses in the authenticated frontier",
             Version::new(28, 0, 3),
         );
-        DiskFormatUpgrade::run(&upgrade, Height::MIN, &db, &cancel_receiver)
+        DiskFormatUpgrade::run(&upgrade, Some(Height::MIN), &db, &cancel_receiver)
             .expect("the marker-only upgrade completes");
         db.update_format_version_on_disk(&state_database_format_version_in_code())
             .expect("startup marks the marker-only upgrade complete");

--- a/docs/changelog/unreleased/677.md
+++ b/docs/changelog/unreleased/677.md
@@ -1,0 +1,15 @@
+## Fixed
+
+- Fixed database format migrations reporting every failure as a cancellation.
+  A migration whose postcondition did not hold, or whose write RocksDB rejected,
+  now surfaces a distinct error carrying the diagnostic message instead of
+  panicking with it discarded
+  ([#677](https://github.com/zakura-core/zakura/pull/677)).
+
+## Changed
+
+- An empty state database now runs the format-migration sequence like any other
+  database instead of being short-circuited and marked upgraded. Every migration
+  either skips an empty database explicitly or derives the tip from the database
+  itself, so the resulting on-disk format is unchanged
+  ([#677](https://github.com/zakura-core/zakura/pull/677)).


### PR DESCRIPTION
Authored by @evan-forbes as part of the fork-aware header-chain work in #586.
This PR carries the change on its own so #586's `zakura-state` diff is the new
header-chain persistence rather than a rewrite of the existing migration
plumbing. Split out and rebased by @p0mvn.

**This is not purely mechanical.** The split plan expected a signature-only
refactor; it also changes how an empty database starts up. That is described
below and is the part worth reviewing.

## Motivation

`DiskFormatUpgrade` took a bare `Height` and returned `CancelFormatChange` for
every failure, conflating three different outcomes: shutdown, a RocksDB write
failure, and a migration whose postcondition did not hold. The coordinator could
only distinguish them by panicking, and did — `.expect("db should be valid after
upgrade")` on a failed postcondition, and a bare `panic!` on a failed format
check, neither carrying the diagnostic message the check had already produced.

## Solution

**Typed errors.** `FormatChangeError` has `Cancelled`, `MigrationStorage`, and
`InvalidPostcondition` variants, plus `From<CancelFormatChange>` so migration
bodies keep their existing `?` on cancellation checks unchanged. A failed
postcondition during an upgrade returns `InvalidPostcondition` carrying the
message. Outside an upgrade, re-opening a database whose format is invalid still
panics, because that indicates a bug rather than a recoverable migration failure.

**`Option<Height>`, and the behavior change.** The tip parameter becomes
`Option<Height>` and is renamed `initial_finalized_tip_height`, which is what it
has always held. The coordinator previously short-circuited an empty database
*before* the migration loop, marking it upgraded without running anything. It now
runs the loop for every database and lets each migration decide:

| migration | empty-database handling |
| --- | --- |
| `add_subtrees`, `prune_trees`, `block_info_and_address_received`, `tree_keys_and_caches_upgrade` (and the `cache_genesis_roots` / `fix_tree_key_type` it drives) | early-return `Ok(())` on `None` |
| `add_ironwood_tree`, `header_root_auth_frontier` | ignore the parameter; already derive the tip from the database and handle emptiness |
| `no_migration` entries | `needs_migration()` is false, so they never run |

After the loop, an empty database records the running build metadata directly,
because its spending index is trivially complete.

**The registry, its versions, and the database format version are untouched.**
The `28.1.x` entries, `drop_header_root_auth_frontier`, and
`unauthenticated_commitment_roots` all belong to the VCT header-time
authentication change and deliberately stay in #586.

## Test coverage

- The full 461-test `zakura-state` suite passes, including
  `vct_format_changes_include_root_auth_metadata_updates`, which pins the
  registry contents and versions and is unchanged by this PR.
- The migration unit tests call `run` through the trait, so they exercise the new
  signature directly.
- The empty-database path — the one behavior change — is exercised end to end by
  a fresh-genesis node startup, which is how the runnable gate for this stack is
  configured.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-state --all-targets --all-features -- -D warnings`
- `cargo build --workspace --locked`
- `cargo test -p zakura-state` (458 passed, 3 ignored)
- Runnable gate: fresh Mainnet cache, stock config, real public v2 peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
