### PR TITLE
perf(header-chain): apply graph deltas incrementally

### DIFF
--- a/crates/zakura-header-chain/src/graph/mod.rs
+++ b/crates/zakura-header-chain/src/graph/mod.rs
@@ -368,21 +368,6 @@ pub struct MemHeaderStore {
     consensus_invalid_body_tombstones: HashMap<block::Hash, ConsensusInvalidBodyTombstone>,
 }
 
-struct DerivedIndexChanges {
-    added_header_children: Vec<(block::Hash, block::Hash)>,
-    removed_header_children: Vec<(block::Hash, block::Hash)>,
-    add_eligible_header_tips: Vec<block::Hash>,
-    remove_eligible_header_tips: Vec<block::Hash>,
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum CanonicalHeaderHashAudit {
-    /// Recompute each canonical header hash from the complete serialized header.
-    Verify,
-    /// Trust hashes established by admission into an already-validated live graph.
-    TrustEstablished,
-}
-
 impl MemHeaderStore {
     /// Construct a store rooted at one trusted, already-validated work origin.
     pub fn new(
@@ -854,18 +839,6 @@ impl MemHeaderStore {
     /// finalized frontier. The constructor computes inherited eligibility and
     /// eligible header tips only after every source row passes validation.
     pub fn reconstruct(reconstruction: HeaderGraphReconstruction) -> Result<Self, GraphError> {
-        Self::reconstruct_with(reconstruction, CanonicalHeaderHashAudit::Verify)
-    }
-
-    /// Reconstruct derived graph indexes using the specified canonical-hash trust boundary.
-    ///
-    /// Live transition projection uses hashes already established at header admission. Durable
-    /// and recovery reconstruction must use [`CanonicalHeaderHashAudit::Verify`] because their
-    /// rows do not inherit that in-memory validation.
-    fn reconstruct_with(
-        reconstruction: HeaderGraphReconstruction,
-        canonical_header_hash_audit: CanonicalHeaderHashAudit,
-    ) -> Result<Self, GraphError> {
         let HeaderGraphReconstruction {
             finalized_frontier,
             header_nodes,
@@ -901,9 +874,7 @@ impl MemHeaderStore {
         }
         let anchor_coordinate = finalized_node.work_coordinate();
         for node in node_map.values() {
-            if canonical_header_hash_audit == CanonicalHeaderHashAudit::Verify
-                && node.header.hash() != node.hash
-            {
+            if node.header.hash() != node.hash {
                 return Err(GraphError::InvalidHeaderNode {
                     header: node.hash,
                     invariant: HeaderNodeInvariant::CanonicalHeaderHash,
@@ -1311,189 +1282,49 @@ impl MemHeaderStore {
     /// modifying the store. A delta that deletes and replaces the same hash also
     /// produces an error without modifying the store.
     pub(crate) fn apply_delta(&mut self, delta: &GraphDelta) -> Result<(), GraphError> {
-        let mut projected = self.project_delta(delta)?;
+        let application = GraphOverlay::from_delta(self, delta)?.into_delta_application();
+        debug_assert_eq!(application.base_revision, self.graph_revision);
         if delta.is_empty() {
             return Ok(());
         }
-        projected.graph_revision = self.graph_revision.checked_next()?;
-        *self = projected;
+        let next_revision = self.graph_revision.checked_next()?;
+
+        for hash in &application.deleted_header_hashes {
+            let node = self
+                .nodes
+                .remove(hash)
+                .expect("validated deletions reference retained graph nodes");
+            self.children.remove(hash);
+            if let Some(hashes) = self.heights.get_mut(&node.height) {
+                hashes.remove(hash);
+                if hashes.is_empty() {
+                    self.heights.remove(&node.height);
+                }
+            }
+        }
+        for (hash, node) in application.updated_header_nodes_by_hash {
+            if !self.nodes.contains_key(&hash) {
+                self.heights.entry(node.height).or_default().insert(hash);
+            }
+            self.nodes.insert(hash, node);
+        }
+        for (parent, removed) in application.removed_header_children {
+            if let Some(children) = self.children.get_mut(&parent) {
+                children.retain(|child| !removed.contains(child));
+                if children.is_empty() {
+                    self.children.remove(&parent);
+                }
+            }
+        }
+        for (parent, added) in application.added_header_children {
+            self.children.entry(parent).or_default().extend(added);
+        }
+        self.consensus_invalid_body_tombstones
+            .extend(application.new_consensus_invalid_body_tombstones_by_hash);
+        self.finalized_frontier = application.finalized_frontier;
+        self.eligible_header_tips = application.eligible_header_tips;
+        self.graph_revision = next_revision;
         Ok(())
-    }
-
-    /// This method validates a complete overlay-produced graph delta.
-    pub(crate) fn validate_delta(&self, delta: &GraphDelta) -> Result<(), GraphError> {
-        self.derive_index_changes(delta).map(|_| ())
-    }
-
-    fn derive_index_changes(&self, delta: &GraphDelta) -> Result<DerivedIndexChanges, GraphError> {
-        let projected = self.project_delta(delta)?;
-        let old_edges: HashSet<_> = self
-            .children
-            .iter()
-            .flat_map(|(parent, children)| children.iter().map(|child| (*parent, *child)))
-            .collect();
-        let new_edges: HashSet<_> = projected
-            .children
-            .iter()
-            .flat_map(|(parent, children)| children.iter().map(|child| (*parent, *child)))
-            .collect();
-        let mut added_header_children: Vec<_> = new_edges.difference(&old_edges).copied().collect();
-        let mut removed_header_children: Vec<_> =
-            old_edges.difference(&new_edges).copied().collect();
-        let mut add_eligible_header_tips: Vec<_> = projected
-            .eligible_header_tips
-            .difference(&self.eligible_header_tips)
-            .copied()
-            .collect();
-        let mut remove_eligible_header_tips: Vec<_> = self
-            .eligible_header_tips
-            .difference(&projected.eligible_header_tips)
-            .copied()
-            .collect();
-        added_header_children.sort_unstable_by_key(|(parent, child)| (parent.0, child.0));
-        removed_header_children.sort_unstable_by_key(|(parent, child)| (parent.0, child.0));
-        add_eligible_header_tips.sort_unstable_by_key(|hash| hash.0);
-        remove_eligible_header_tips.sort_unstable_by_key(|hash| hash.0);
-        Ok(DerivedIndexChanges {
-            added_header_children,
-            removed_header_children,
-            add_eligible_header_tips,
-            remove_eligible_header_tips,
-        })
-    }
-
-    fn project_delta(&self, delta: &GraphDelta) -> Result<Self, GraphError> {
-        if delta.base_revision != self.graph_revision {
-            return Err(GraphError::StaleDelta {
-                current_revision: self.graph_revision,
-                delta_base_revision: delta.base_revision,
-            });
-        }
-        let mut puts = HashMap::new();
-        for node in &delta.updated_header_nodes {
-            if puts.insert(node.hash, node.clone()).is_some() {
-                return Err(GraphError::DuplicateHeaderNode(node.hash));
-            }
-            if let Some(old) = self.nodes.get(&node.hash) {
-                let immutable_changed = old.header != node.header
-                    || old.hash != node.hash
-                    || old.parent_hash != node.parent_hash
-                    || old.height != node.height
-                    || old.block_work != node.block_work;
-                let coordinate_changed = old.work_coordinate() != node.work_coordinate();
-                let invalidity_changed = matches!(
-                    old.body_validation_state,
-                    BodyValidationState::ConsensusInvalid { .. }
-                ) && old.body_validation_state
-                    != node.body_validation_state;
-                if immutable_changed
-                    || invalidity_changed
-                    || (delta.work_coordinate_transition
-                        == overlay::WorkCoordinateTransition::PreserveCoordinates
-                        && coordinate_changed)
-                {
-                    return Err(GraphError::InvalidHeaderNode {
-                        header: node.hash,
-                        invariant: HeaderNodeInvariant::ImmutableFields,
-                    });
-                }
-            }
-        }
-        let mut deletes = HashSet::new();
-        for hash in &delta.deleted_header_hashes {
-            if !deletes.insert(*hash) || puts.contains_key(hash) {
-                return Err(GraphError::DuplicateHeaderNode(*hash));
-            }
-            if !self.nodes.contains_key(hash) {
-                return Err(GraphError::UnknownHeaderNode(*hash));
-            }
-        }
-        let finalized = delta.finalized_frontier.unwrap_or(self.finalized_frontier);
-        if finalized != self.finalized_frontier {
-            let mut cursor = finalized;
-            while cursor.height > self.finalized_frontier.height {
-                let node = puts
-                    .get(&cursor.hash)
-                    .or_else(|| self.nodes.get(&cursor.hash))
-                    .ok_or(GraphError::UnknownHeaderNode(cursor.hash))?;
-                if node.height != cursor.height {
-                    return Err(GraphError::UnknownHeaderNode(cursor.hash));
-                }
-                cursor = Frontier::new(block::Height(cursor.height.0 - 1), node.parent_hash);
-            }
-            if cursor != self.finalized_frontier {
-                return Err(GraphError::FinalizedFrontierNotDescendant {
-                    current: self.finalized_frontier.hash,
-                    candidate: finalized.hash,
-                });
-            }
-        }
-        let mut nodes: Vec<_> = self
-            .nodes
-            .values()
-            .filter(|node| !deletes.contains(&node.hash) && !puts.contains_key(&node.hash))
-            .cloned()
-            .collect();
-        nodes.extend(puts.into_values());
-        let mut tombstones = self.consensus_invalid_body_tombstones.clone();
-        let mut delta_tombstones = HashSet::new();
-        for tombstone in &delta.new_consensus_invalid_body_tombstones {
-            if !delta_tombstones.insert(tombstone.hash) {
-                return Err(GraphError::DuplicateHeaderNode(tombstone.hash));
-            }
-            if let Some(existing) = tombstones.get(&tombstone.hash) {
-                if existing != tombstone {
-                    return Err(GraphError::PermanentBodyInvalidity(tombstone.hash));
-                }
-            }
-            tombstones.insert(tombstone.hash, tombstone.clone());
-        }
-        if delta.work_coordinate_transition
-            == overlay::WorkCoordinateTransition::RebaseToFinalizedFrontier
-        {
-            let anchor = self
-                .header_node(self.finalized_frontier.hash)
-                .ok_or(GraphError::UnknownHeaderNode(self.finalized_frontier.hash))?
-                .work_coordinate();
-            for node in &nodes {
-                if node.work_coordinate().origin_hash() != self.finalized_frontier.hash {
-                    return Err(GraphError::InvalidHeaderNode {
-                        header: node.hash,
-                        invariant: HeaderNodeInvariant::WorkRebaseOrigin,
-                    });
-                }
-                if let Some(old) = self.nodes.get(&node.hash) {
-                    let expected = WorkCoordinate::new(
-                        self.finalized_frontier.hash,
-                        old.work_coordinate().suffix_after(anchor)?.as_u256(),
-                    );
-                    if node.work_coordinate() != expected {
-                        return Err(GraphError::InvalidHeaderNode {
-                            header: node.hash,
-                            invariant: HeaderNodeInvariant::WorkRebaseCoordinate,
-                        });
-                    }
-                }
-            }
-        }
-        let expected_nodes: HashMap<_, _> =
-            nodes.iter().map(|node| (node.hash, node.clone())).collect();
-        let mut projected = Self::reconstruct_with(
-            HeaderGraphReconstruction::new(finalized, nodes, tombstones.into_values()),
-            CanonicalHeaderHashAudit::TrustEstablished,
-        )?;
-        if projected.nodes != expected_nodes {
-            let hash = expected_nodes
-                .iter()
-                .find_map(|(hash, node)| (projected.nodes.get(hash) != Some(node)).then_some(*hash))
-                .unwrap_or(finalized.hash);
-            return Err(GraphError::InvalidHeaderNode {
-                header: hash,
-                invariant: HeaderNodeInvariant::DerivedHeaderState,
-            });
-        }
-        projected.graph_revision = self.graph_revision;
-        Ok(projected)
     }
 }
 
@@ -1695,10 +1526,11 @@ mod tests {
             .consensus_invalid_body_tombstones()
             .cloned()
             .collect::<Vec<_>>();
-        *store = MemHeaderStore::reconstruct_with(
-            HeaderGraphReconstruction::new(finalized, finalized_header_nodes, tombstones),
-            CanonicalHeaderHashAudit::TrustEstablished,
-        )?;
+        *store = MemHeaderStore::reconstruct(HeaderGraphReconstruction::new(
+            finalized,
+            finalized_header_nodes,
+            tombstones,
+        ))?;
         store.recompute_all_header_eligibility()?;
         Ok(deleted)
     }
@@ -2236,7 +2068,7 @@ mod tests {
     }
 
     #[test]
-    fn project_delta_trusts_established_header_hashes() {
+    fn live_delta_application_trusts_established_header_hashes() {
         let mut store = anchor_store();
         let anchor = store.finalized_frontier();
         let child = insert_child(&mut store, anchor.hash, 1);
@@ -2260,6 +2092,39 @@ mod tests {
             store
                 .header_node(child.hash)
                 .expect("the projected child remains retained")
+                .body_validation_state,
+            BodyValidationState::CommitmentMatched
+        );
+    }
+
+    #[test]
+    fn sparse_delta_does_not_revalidate_unchanged_nodes() {
+        let mut store = anchor_store();
+        let anchor = store.finalized_frontier();
+        let unchanged = insert_child(&mut store, anchor.hash, 1);
+        let changed = insert_child(&mut store, anchor.hash, 2);
+
+        store
+            .nodes
+            .get_mut(&unchanged.hash)
+            .expect("the unchanged child is retained")
+            .block_work = Work::zero();
+        let mut updated_changed = store
+            .nodes
+            .get(&changed.hash)
+            .expect("the changed child is retained")
+            .clone();
+        updated_changed.body_validation_state = BodyValidationState::CommitmentMatched;
+        let mut delta = GraphDelta::empty(&store);
+        delta.updated_header_nodes.push(updated_changed);
+
+        store
+            .apply_delta(&delta)
+            .expect("live sparse application validates only delta-affected nodes");
+        assert_eq!(
+            store
+                .header_node(changed.hash)
+                .expect("the changed child remains retained")
                 .body_validation_state,
             BodyValidationState::CommitmentMatched
         );
@@ -2373,6 +2238,39 @@ mod tests {
                 second.hash,
             )
         );
+    }
+
+    #[test]
+    fn sparse_rebase_rejects_an_omitted_surviving_node() {
+        let block = regtest_genesis_block();
+        let work = block
+            .header
+            .difficulty_threshold
+            .to_work()
+            .expect("the fixture target has valid work");
+        let anchor = Frontier::new(block::Height(0), block.hash());
+        let cumulative = U256::MAX
+            .checked_sub(work.as_u256())
+            .expect("the fixture work is below the coordinate maximum");
+        let mut store = MemHeaderStore::new(anchor, block.header.clone(), work, cumulative)
+            .expect("the anchor coordinate is valid");
+        let child = insert_child(&mut store, anchor.hash, 1);
+        let mut overlay = GraphOverlay::new(&store);
+        overlay
+            .rebase_work_coordinates_to_finalized_frontier()
+            .expect("the complete sparse rebase is valid");
+        let mut incomplete = overlay.delta();
+        incomplete
+            .updated_header_nodes
+            .retain(|node| node.hash != child.hash);
+
+        assert!(matches!(
+            GraphOverlay::from_delta(&store, &incomplete),
+            Err(GraphError::InvalidHeaderNode {
+                header,
+                invariant: HeaderNodeInvariant::WorkRebaseCoordinate,
+            }) if header == child.hash
+        ));
     }
 
     #[test]

--- a/crates/zakura-header-chain/src/graph/overlay.rs
+++ b/crates/zakura-header-chain/src/graph/overlay.rs
@@ -153,12 +153,16 @@ impl<'a> GraphOverlay<'a> {
         base_graph: &'a MemHeaderStore,
         delta: &GraphDelta,
     ) -> Result<Self, GraphError> {
+        // A delta is valid only for the exact graph revision from which it was derived.
         if delta.base_revision != base_graph.graph_revision {
             return Err(GraphError::StaleDelta {
                 current_revision: base_graph.graph_revision,
                 delta_base_revision: delta.base_revision,
             });
         }
+
+        // Index the sparse changes for overlay lookups, rejecting input that would be silently
+        // overwritten while collecting into maps or sets.
         let updated_header_nodes_by_hash = delta
             .updated_header_nodes
             .iter()
@@ -186,6 +190,7 @@ impl<'a> GraphOverlay<'a> {
             return Err(GraphError::DuplicateHeaderNode(duplicate));
         }
         for hash in &deleted_header_hashes {
+            // A node cannot be both updated and deleted, and deletions must refer to live nodes.
             if updated_header_nodes_by_hash.contains_key(hash) {
                 return Err(GraphError::DuplicateHeaderNode(*hash));
             }
@@ -210,6 +215,9 @@ impl<'a> GraphOverlay<'a> {
                 .expect("different map and sequence lengths imply a duplicate hash");
             return Err(GraphError::DuplicateHeaderNode(duplicate));
         }
+
+        // Derive only the child-index changes caused by added and deleted nodes. Existing updated
+        // nodes retain their parent relationship from the audited base graph.
         let mut added_header_children: HashMap<_, HashSet<_>> = HashMap::new();
         let mut removed_header_children: HashMap<_, HashSet<_>> = HashMap::new();
         for node in updated_header_nodes_by_hash.values() {
@@ -232,6 +240,9 @@ impl<'a> GraphOverlay<'a> {
                     .insert(node.hash);
             }
         }
+
+        // Project optional scalar changes and the resulting node count without materializing the
+        // complete graph.
         let finalized_frontier = delta
             .finalized_frontier
             .unwrap_or(base_graph.finalized_frontier);
@@ -259,6 +270,9 @@ impl<'a> GraphOverlay<'a> {
                 == WorkCoordinateTransition::RebaseToFinalizedFrontier,
             header_node_count,
         };
+
+        // Validate only invariants that can change at the sparse overlay boundary, then derive the
+        // eligible-tip index for the projected graph.
         overlay.validate_delta_nodes()?;
         overlay.refresh_delta_eligible_header_tips();
         Ok(overlay)

--- a/crates/zakura-header-chain/src/graph/overlay.rs
+++ b/crates/zakura-header-chain/src/graph/overlay.rs
@@ -5,7 +5,7 @@ use zakura_chain::block;
 
 use super::{
     ConsensusInvalidBodyTombstone, GraphError, GraphRevision, HeaderGraphEdit, HeaderGraphView,
-    InsertResult, MemHeaderStore,
+    HeaderNodeInvariant, InsertResult, MemHeaderStore,
 };
 use crate::{
     BodyValidationState, ChainScore, EligibilityReason, EligibilityState, EvidenceId, Frontier,
@@ -36,6 +36,23 @@ pub(crate) struct GraphDelta {
     pub(super) updated_header_nodes: Vec<HeaderNode>,
     pub(super) deleted_header_hashes: Vec<block::Hash>,
     pub(super) new_consensus_invalid_body_tombstones: Vec<ConsensusInvalidBodyTombstone>,
+}
+
+/// A revision-bound sparse graph update that has passed live-delta validation.
+///
+/// Keeping this application separate from [`GraphDelta`] leaves room for a future transition to
+/// carry the validated application across the durable commit boundary without changing the delta
+/// or the public transition API.
+pub(super) struct GraphDeltaApplication {
+    pub(super) base_revision: GraphRevision,
+    pub(super) finalized_frontier: Frontier,
+    pub(super) updated_header_nodes_by_hash: HashMap<block::Hash, HeaderNode>,
+    pub(super) deleted_header_hashes: HashSet<block::Hash>,
+    pub(super) added_header_children: HashMap<block::Hash, HashSet<block::Hash>>,
+    pub(super) removed_header_children: HashMap<block::Hash, HashSet<block::Hash>>,
+    pub(super) eligible_header_tips: HashSet<block::Hash>,
+    pub(super) new_consensus_invalid_body_tombstones_by_hash:
+        HashMap<block::Hash, ConsensusInvalidBodyTombstone>,
 }
 
 impl GraphDelta {
@@ -136,64 +153,407 @@ impl<'a> GraphOverlay<'a> {
         base_graph: &'a MemHeaderStore,
         delta: &GraphDelta,
     ) -> Result<Self, GraphError> {
-        let indexes = base_graph.derive_index_changes(delta)?;
+        if delta.base_revision != base_graph.graph_revision {
+            return Err(GraphError::StaleDelta {
+                current_revision: base_graph.graph_revision,
+                delta_base_revision: delta.base_revision,
+            });
+        }
         let updated_header_nodes_by_hash = delta
             .updated_header_nodes
             .iter()
             .cloned()
             .map(|node| (node.hash, node))
-            .collect();
-        let deleted_header_hashes = delta.deleted_header_hashes.iter().copied().collect();
+            .collect::<HashMap<_, _>>();
+        if updated_header_nodes_by_hash.len() != delta.updated_header_nodes.len() {
+            let mut seen = HashSet::new();
+            let duplicate = delta
+                .updated_header_nodes
+                .iter()
+                .find_map(|node| (!seen.insert(node.hash)).then_some(node.hash))
+                .expect("different map and sequence lengths imply a duplicate hash");
+            return Err(GraphError::DuplicateHeaderNode(duplicate));
+        }
+        let deleted_header_hashes: HashSet<_> =
+            delta.deleted_header_hashes.iter().copied().collect();
+        if deleted_header_hashes.len() != delta.deleted_header_hashes.len() {
+            let mut seen = HashSet::new();
+            let duplicate = delta
+                .deleted_header_hashes
+                .iter()
+                .find_map(|hash| (!seen.insert(*hash)).then_some(*hash))
+                .expect("different set and sequence lengths imply a duplicate hash");
+            return Err(GraphError::DuplicateHeaderNode(duplicate));
+        }
+        for hash in &deleted_header_hashes {
+            if updated_header_nodes_by_hash.contains_key(hash) {
+                return Err(GraphError::DuplicateHeaderNode(*hash));
+            }
+            if !base_graph.nodes.contains_key(hash) {
+                return Err(GraphError::UnknownHeaderNode(*hash));
+            }
+        }
+        let new_consensus_invalid_body_tombstones_by_hash = delta
+            .new_consensus_invalid_body_tombstones
+            .iter()
+            .cloned()
+            .map(|tombstone| (tombstone.hash, tombstone))
+            .collect::<HashMap<_, _>>();
+        if new_consensus_invalid_body_tombstones_by_hash.len()
+            != delta.new_consensus_invalid_body_tombstones.len()
+        {
+            let mut seen = HashSet::new();
+            let duplicate = delta
+                .new_consensus_invalid_body_tombstones
+                .iter()
+                .find_map(|tombstone| (!seen.insert(tombstone.hash)).then_some(tombstone.hash))
+                .expect("different map and sequence lengths imply a duplicate hash");
+            return Err(GraphError::DuplicateHeaderNode(duplicate));
+        }
         let mut added_header_children: HashMap<_, HashSet<_>> = HashMap::new();
         let mut removed_header_children: HashMap<_, HashSet<_>> = HashMap::new();
-        for (parent, child) in &indexes.added_header_children {
-            added_header_children
-                .entry(*parent)
-                .or_default()
-                .insert(*child);
+        for node in updated_header_nodes_by_hash.values() {
+            if !base_graph.nodes.contains_key(&node.hash) {
+                added_header_children
+                    .entry(node.parent_hash)
+                    .or_default()
+                    .insert(node.hash);
+            }
         }
-        for (parent, child) in &indexes.removed_header_children {
-            removed_header_children
-                .entry(*parent)
-                .or_default()
-                .insert(*child);
+        for hash in &deleted_header_hashes {
+            let node = base_graph
+                .nodes
+                .get(hash)
+                .expect("deleted hashes were checked against the base graph");
+            if node.hash != base_graph.finalized_frontier.hash {
+                removed_header_children
+                    .entry(node.parent_hash)
+                    .or_default()
+                    .insert(node.hash);
+            }
         }
-        let mut eligible_header_tips = base_graph.eligible_header_tips.clone();
-        for hash in &indexes.remove_eligible_header_tips {
-            eligible_header_tips.remove(hash);
-        }
-        eligible_header_tips.extend(indexes.add_eligible_header_tips.iter().copied());
-        Ok(Self {
+        let finalized_frontier = delta
+            .finalized_frontier
+            .unwrap_or(base_graph.finalized_frontier);
+        let header_node_count = base_graph
+            .nodes
+            .len()
+            .saturating_add(
+                updated_header_nodes_by_hash
+                    .keys()
+                    .filter(|hash| !base_graph.nodes.contains_key(*hash))
+                    .count(),
+            )
+            .saturating_sub(deleted_header_hashes.len());
+        let mut overlay = Self {
             base_graph,
             base_revision: delta.base_revision,
-            finalized_frontier: delta
-                .finalized_frontier
-                .unwrap_or(base_graph.finalized_frontier),
+            finalized_frontier,
             updated_header_nodes_by_hash,
             deleted_header_hashes,
             added_header_children,
             removed_header_children,
-            eligible_header_tips,
-            new_consensus_invalid_body_tombstones_by_hash: delta
-                .new_consensus_invalid_body_tombstones
-                .iter()
-                .cloned()
-                .map(|tombstone| (tombstone.hash, tombstone))
-                .collect(),
+            eligible_header_tips: base_graph.eligible_header_tips.clone(),
+            new_consensus_invalid_body_tombstones_by_hash,
             work_coordinates_rebased: delta.work_coordinate_transition
                 == WorkCoordinateTransition::RebaseToFinalizedFrontier,
-            header_node_count: base_graph
-                .nodes
-                .len()
-                .saturating_add(
-                    delta
-                        .updated_header_nodes
-                        .iter()
-                        .filter(|node| !base_graph.nodes.contains_key(&node.hash))
-                        .count(),
-                )
-                .saturating_sub(delta.deleted_header_hashes.len()),
-        })
+            header_node_count,
+        };
+        overlay.validate_delta_nodes()?;
+        overlay.refresh_delta_eligible_header_tips();
+        Ok(overlay)
+    }
+
+    /// Consume this validated projection into the exact owned mutations required by the live
+    /// graph. The returned application remains bound to this overlay's base revision.
+    pub(super) fn into_delta_application(self) -> GraphDeltaApplication {
+        GraphDeltaApplication {
+            base_revision: self.base_revision,
+            finalized_frontier: self.finalized_frontier,
+            updated_header_nodes_by_hash: self.updated_header_nodes_by_hash,
+            deleted_header_hashes: self.deleted_header_hashes,
+            added_header_children: self.added_header_children,
+            removed_header_children: self.removed_header_children,
+            eligible_header_tips: self.eligible_header_tips,
+            new_consensus_invalid_body_tombstones_by_hash: self
+                .new_consensus_invalid_body_tombstones_by_hash,
+        }
+    }
+
+    /// Validate every graph invariant whose truth can change in this sparse delta.
+    ///
+    /// Unchanged nodes inherit the base graph's audit; validation follows only changed boundaries.
+    fn validate_delta_nodes(&self) -> Result<(), GraphError> {
+        let finalized_node = self
+            .header_node(self.finalized_frontier.hash)
+            .ok_or(GraphError::UnknownHeaderNode(self.finalized_frontier.hash))?;
+        if finalized_node.height != self.finalized_frontier.height {
+            return Err(GraphError::InvalidHeaderNode {
+                header: self.finalized_frontier.hash,
+                invariant: HeaderNodeInvariant::FinalizedFrontierHeight,
+            });
+        }
+        if !finalized_node.is_eligible() {
+            return Err(GraphError::IneligibleFinalizedFrontier(
+                self.finalized_frontier.hash,
+            ));
+        }
+        self.validate_finalized_descendant()?;
+        self.validate_updated_nodes()?;
+        self.validate_deleted_nodes()?;
+        self.validate_tombstones()?;
+        self.validate_updated_eligibility()?;
+        Ok(())
+    }
+
+    /// Require the projected finalized frontier to be an exact descendant of the base frontier.
+    ///
+    /// The ancestry walk may cross nodes deleted by the same finality transition.
+    fn validate_finalized_descendant(&self) -> Result<(), GraphError> {
+        if self.finalized_frontier == self.base_graph.finalized_frontier {
+            return Ok(());
+        }
+        let mut cursor = self.finalized_frontier;
+        while cursor.height > self.base_graph.finalized_frontier.height {
+            let node = self
+                .updated_header_nodes_by_hash
+                .get(&cursor.hash)
+                .or_else(|| self.base_graph.nodes.get(&cursor.hash))
+                .ok_or(GraphError::UnknownHeaderNode(cursor.hash))?;
+            if node.height != cursor.height {
+                return Err(GraphError::UnknownHeaderNode(cursor.hash));
+            }
+            cursor = Frontier::new(block::Height(cursor.height.0 - 1), node.parent_hash);
+        }
+        if cursor != self.base_graph.finalized_frontier {
+            return Err(GraphError::FinalizedFrontierNotDescendant {
+                current: self.base_graph.finalized_frontier.hash,
+                candidate: self.finalized_frontier.hash,
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate canonical fields, immutable replacements, parent continuity, and work coordinates
+    /// for updated nodes. A graph-wide scan occurs only for an explicitly global work rebase.
+    fn validate_updated_nodes(&self) -> Result<(), GraphError> {
+        let current_anchor = self
+            .base_graph
+            .nodes
+            .get(&self.base_graph.finalized_frontier.hash)
+            .expect("the live graph retains its finalized frontier")
+            .work_coordinate();
+        for node in self.updated_header_nodes_by_hash.values() {
+            if node.header.previous_block_hash != node.parent_hash {
+                return Err(GraphError::InvalidHeaderNode {
+                    header: node.hash,
+                    invariant: HeaderNodeInvariant::CanonicalParentHash,
+                });
+            }
+            if node.header.difficulty_threshold.to_work() != Some(node.block_work) {
+                return Err(GraphError::InvalidHeaderNode {
+                    header: node.hash,
+                    invariant: HeaderNodeInvariant::CanonicalBlockWork,
+                });
+            }
+            if let Some(old) = self.base_graph.nodes.get(&node.hash) {
+                let immutable_changed = old.header != node.header
+                    || old.hash != node.hash
+                    || old.parent_hash != node.parent_hash
+                    || old.height != node.height
+                    || old.block_work != node.block_work;
+                let coordinate_changed = old.work_coordinate() != node.work_coordinate();
+                let invalidity_changed = matches!(
+                    old.body_validation_state,
+                    BodyValidationState::ConsensusInvalid { .. }
+                ) && old.body_validation_state
+                    != node.body_validation_state;
+                if immutable_changed
+                    || invalidity_changed
+                    || (!self.work_coordinates_rebased && coordinate_changed)
+                {
+                    return Err(GraphError::InvalidHeaderNode {
+                        header: node.hash,
+                        invariant: HeaderNodeInvariant::ImmutableFields,
+                    });
+                }
+            }
+            if node.hash == self.finalized_frontier.hash {
+                if node.eligibility.inherited_from.is_some() {
+                    return Err(GraphError::InvalidHeaderNode {
+                        header: node.hash,
+                        invariant: HeaderNodeInvariant::DerivedHeaderState,
+                    });
+                }
+                continue;
+            }
+            let parent = self
+                .header_node(node.parent_hash)
+                .ok_or(GraphError::UnknownParent {
+                    header: node.hash,
+                    parent: node.parent_hash,
+                })?;
+            if parent.height.next().ok() != Some(node.height) {
+                return Err(GraphError::InvalidHeaderNode {
+                    header: node.hash,
+                    invariant: HeaderNodeInvariant::ParentHeight,
+                });
+            }
+            if parent.work_coordinate().checked_add(node.block_work)? != node.work_coordinate() {
+                return Err(GraphError::InvalidHeaderNode {
+                    header: node.hash,
+                    invariant: HeaderNodeInvariant::CumulativeWork,
+                });
+            }
+        }
+        if self.work_coordinates_rebased {
+            for node in self.header_nodes() {
+                if node.work_coordinate().origin_hash() != self.base_graph.finalized_frontier.hash {
+                    return Err(GraphError::InvalidHeaderNode {
+                        header: node.hash,
+                        invariant: HeaderNodeInvariant::WorkRebaseOrigin,
+                    });
+                }
+                if let Some(old) = self.base_graph.nodes.get(&node.hash) {
+                    let expected = WorkCoordinate::new(
+                        self.base_graph.finalized_frontier.hash,
+                        old.work_coordinate()
+                            .suffix_after(current_anchor)?
+                            .as_u256(),
+                    );
+                    if node.work_coordinate() != expected {
+                        return Err(GraphError::InvalidHeaderNode {
+                            header: node.hash,
+                            invariant: HeaderNodeInvariant::WorkRebaseCoordinate,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Reject a deletion that leaves a retained child without its parent.
+    ///
+    /// The projected finalized root is the sole valid retained child of a deleted parent.
+    fn validate_deleted_nodes(&self) -> Result<(), GraphError> {
+        for hash in &self.deleted_header_hashes {
+            if let Some(children) = self.base_graph.children.get(hash) {
+                for child in children {
+                    if self.header_node(*child).is_some() && *child != self.finalized_frontier.hash
+                    {
+                        return Err(GraphError::UnknownParent {
+                            header: *child,
+                            parent: *hash,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Enforce append-only tombstones and exact agreement with retained consensus-invalid nodes.
+    fn validate_tombstones(&self) -> Result<(), GraphError> {
+        for (hash, tombstone) in &self.new_consensus_invalid_body_tombstones_by_hash {
+            if let Some(existing) = self.base_graph.consensus_invalid_body_tombstones.get(hash) {
+                if existing != tombstone {
+                    return Err(GraphError::PermanentBodyInvalidity(*hash));
+                }
+            }
+            if let Some(node) = self.header_node(*hash) {
+                if !matches!(
+                    &node.body_validation_state,
+                    BodyValidationState::ConsensusInvalid { evidence, rule }
+                        if *evidence == tombstone.evidence && *rule == tombstone.rule
+                ) {
+                    return Err(GraphError::InvalidHeaderNode {
+                        header: *hash,
+                        invariant: HeaderNodeInvariant::DerivedHeaderState,
+                    });
+                }
+            }
+        }
+        for node in self.updated_header_nodes_by_hash.values() {
+            let expected = match &node.body_validation_state {
+                BodyValidationState::ConsensusInvalid { evidence, rule } => Some((*evidence, rule)),
+                _ => None,
+            };
+            let tombstone = self
+                .new_consensus_invalid_body_tombstones_by_hash
+                .get(&node.hash)
+                .or_else(|| {
+                    self.base_graph
+                        .consensus_invalid_body_tombstones
+                        .get(&node.hash)
+                });
+            match (expected, tombstone) {
+                (Some((evidence, rule)), Some(tombstone))
+                    if evidence == tombstone.evidence && *rule == tombstone.rule => {}
+                (Some(_), _) => return Err(GraphError::PermanentBodyInvalidity(node.hash)),
+                (None, Some(_)) => return Err(GraphError::PermanentBodyInvalidity(node.hash)),
+                (None, None) => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Require updated nodes and their immediate children to carry the exact inherited
+    /// eligibility derived from their projected parents.
+    fn validate_updated_eligibility(&self) -> Result<(), GraphError> {
+        for node in self.updated_header_nodes_by_hash.values() {
+            if node.hash != self.finalized_frontier.hash {
+                let parent =
+                    self.header_node(node.parent_hash)
+                        .ok_or(GraphError::UnknownParent {
+                            header: node.hash,
+                            parent: node.parent_hash,
+                        })?;
+                let expected = (!parent.is_eligible()).then_some(parent.hash);
+                if node.eligibility.inherited_from != expected {
+                    return Err(GraphError::InvalidHeaderNode {
+                        header: node.hash,
+                        invariant: HeaderNodeInvariant::DerivedHeaderState,
+                    });
+                }
+            }
+            for child in self.header_children(node.hash) {
+                let child_node = self
+                    .header_node(child)
+                    .expect("projected children are retained projected nodes");
+                let expected = (!node.is_eligible()).then_some(node.hash);
+                if child_node.eligibility.inherited_from != expected {
+                    return Err(GraphError::InvalidHeaderNode {
+                        header: child,
+                        invariant: HeaderNodeInvariant::DerivedHeaderState,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Recompute eligible-tip membership only for changed nodes and their affected parents.
+    fn refresh_delta_eligible_header_tips(&mut self) {
+        let mut affected = HashSet::new();
+        for node in self.updated_header_nodes_by_hash.values() {
+            affected.insert(node.hash);
+            affected.insert(node.parent_hash);
+        }
+        for hash in &self.deleted_header_hashes {
+            affected.insert(*hash);
+            affected.insert(
+                self.base_graph
+                    .nodes
+                    .get(hash)
+                    .expect("deleted hashes were checked against the base graph")
+                    .parent_hash,
+            );
+        }
+        affected.insert(self.finalized_frontier.hash);
+        for hash in affected {
+            self.refresh_eligible_header_tip(hash);
+        }
     }
 
     pub(crate) const fn finalized_frontier(&self) -> Frontier {
@@ -1084,6 +1444,116 @@ mod tests {
             overlay.header_node_count(),
             base_graph.header_node_count().saturating_add(1)
         );
+    }
+
+    #[test]
+    fn validated_application_contains_exact_sparse_node_edge_and_tip_changes() {
+        let base_graph = store();
+        let anchor = base_graph.finalized_frontier();
+        let mut overlay = GraphOverlay::new(&base_graph);
+        let child = overlay
+            .insert(
+                header(anchor.hash, 1),
+                HeaderValidationState::Valid,
+                [],
+                BodyValidationState::Unknown,
+            )
+            .expect("the sparse child inserts");
+        let child = match child {
+            InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        };
+
+        let application = GraphOverlay::from_delta(&base_graph, &overlay.delta())
+            .expect("the sparse delta validates")
+            .into_delta_application();
+
+        assert_eq!(application.base_revision, base_graph.graph_revision);
+        assert_eq!(application.finalized_frontier, anchor);
+        assert_eq!(
+            application
+                .updated_header_nodes_by_hash
+                .get(&child.hash)
+                .map(|node| node.height),
+            Some(child.height)
+        );
+        assert!(application
+            .added_header_children
+            .get(&anchor.hash)
+            .is_some_and(|children| children.contains(&child.hash)));
+        assert!(!application.eligible_header_tips.contains(&anchor.hash));
+        assert!(application.eligible_header_tips.contains(&child.hash));
+    }
+
+    #[test]
+    fn sparse_deletion_rejects_a_retained_child() {
+        let mut base_graph = store();
+        let anchor = base_graph.finalized_frontier();
+        let parent = insert_child(&mut base_graph, anchor.hash, 1);
+        let child = insert_child(&mut base_graph, parent.hash, 2);
+        let mut delta = GraphDelta::empty(&base_graph);
+        delta.deleted_header_hashes.push(parent.hash);
+
+        assert_eq!(
+            GraphOverlay::from_delta(&base_graph, &delta).map(drop),
+            Err(GraphError::UnknownParent {
+                header: child.hash,
+                parent: parent.hash,
+            })
+        );
+    }
+
+    #[test]
+    fn sparse_tombstone_requires_matching_retained_body_state() {
+        let mut base_graph = store();
+        let anchor = base_graph.finalized_frontier();
+        let child = insert_child(&mut base_graph, anchor.hash, 1);
+        let mut delta = GraphDelta::empty(&base_graph);
+        delta
+            .new_consensus_invalid_body_tombstones
+            .push(ConsensusInvalidBodyTombstone {
+                hash: child.hash,
+                evidence: EvidenceId::from_digest([9; 32]),
+                rule: crate::BodyRuleId::new("test.sparse-tombstone"),
+            });
+
+        assert!(matches!(
+            GraphOverlay::from_delta(&base_graph, &delta),
+            Err(GraphError::InvalidHeaderNode {
+                header,
+                invariant: HeaderNodeInvariant::DerivedHeaderState,
+            }) if header == child.hash
+        ));
+    }
+
+    #[test]
+    fn sparse_eligibility_rejects_an_omitted_descendant_update() {
+        let mut base_graph = store();
+        let anchor = base_graph.finalized_frontier();
+        let parent = insert_child(&mut base_graph, anchor.hash, 1);
+        let child = insert_child(&mut base_graph, parent.hash, 2);
+        let mut overlay = GraphOverlay::new(&base_graph);
+        overlay
+            .add_eligibility_reason(
+                parent.hash,
+                EligibilityReason::OperatorInvalid {
+                    id: OperatorInvalidationId::new([7; 16]),
+                    reason_digest: [8; 32],
+                    evidence: EvidenceId::from_digest([9; 32]),
+                },
+            )
+            .expect("the parent invalidation propagates to its child");
+        let mut incomplete = overlay.delta();
+        incomplete
+            .updated_header_nodes
+            .retain(|node| node.hash != child.hash);
+
+        assert!(matches!(
+            GraphOverlay::from_delta(&base_graph, &incomplete),
+            Err(GraphError::InvalidHeaderNode {
+                header,
+                invariant: HeaderNodeInvariant::DerivedHeaderState,
+            }) if header == child.hash
+        ));
     }
 
     #[test]

--- a/crates/zakura-header-chain/src/transition/invariants/checkpoint_finality.rs
+++ b/crates/zakura-header-chain/src/transition/invariants/checkpoint_finality.rs
@@ -71,10 +71,6 @@ pub(crate) fn verify_incremental_checkpoint_finality(
     if source != plan.snapshot_before_commit {
         return Err(InvariantViolation::SnapshotBeforeCommit);
     }
-    engine_before_commit
-        .graph()
-        .validate_delta(plan.graph_delta())
-        .map_err(|error| super::graph_error_violation(error, plan))?;
     let delta_graph = GraphOverlay::from_delta(engine_before_commit.graph(), plan.graph_delta())
         .map_err(|error| super::graph_error_violation(error, plan))?;
     let delta_finalized = delta_graph.view_finalized_frontier();

--- a/crates/zakura-header-chain/src/transition/invariants/mod.rs
+++ b/crates/zakura-header-chain/src/transition/invariants/mod.rs
@@ -178,10 +178,6 @@ fn verify_plan_exhaustive(
     if source != plan.snapshot_before_commit {
         return Err(InvariantViolation::SnapshotBeforeCommit);
     }
-    engine_before_commit
-        .graph()
-        .validate_delta(plan.graph_delta())
-        .map_err(|error| graph_error_violation(error, plan))?;
     let source_metadata = engine_before_commit.metadata();
     let delta_graph = GraphOverlay::from_delta(engine_before_commit.graph(), plan.graph_delta())
         .map_err(|error| graph_error_violation(error, plan))?;

--- a/docs/changelog/unreleased/679.md
+++ b/docs/changelog/unreleased/679.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Improved checkpoint-sync performance by applying header graph updates incrementally
+  ([#679](https://github.com/zakura-core/zakura/pull/679)).


### PR DESCRIPTION
## Motivation

Checkpoint finality updates only a small graph delta, but the live commit path cloned every retained header, rebuilt every derived graph index, and compared the complete projected graph multiple times per block. After removing redundant header hashing, this graph-wide projection remained the state writer's dominant CPU cost and limited fast sync to about 20 blocks per second.

## Solution

- Validate only updated/deleted nodes and affected parent, finality, eligibility, tombstone, and work-coordinate boundaries.
- Represent the projected graph as a sparse `GraphOverlay` over the audited live graph rather than materializing a complete clone.
- Revalidate and consume a revision-bound `GraphDeltaApplication` to mutate node, height, child, eligible-tip, tombstone, and finality indexes in place.
- Keep durable/recovery reconstruction exhaustive, including canonical header hash verification.
- Preserve two safety gates: pre-commit verification and post-commit installation. The application type leaves room to remove the second sparse analysis later if profiling justifies it.

Live benchmarking at pre-Overwinter heights improved sustained sync from approximately 20.6 blocks/s to approximately 78 blocks/s. Commit p50 fell from approximately 42.5 ms to approximately 4.5 ms, and full graph reconstruction disappeared from the state-writer CPU profile.

## Testing

- `cargo test -p zakura-header-chain` — 216 passed, 1 ignored; integration test passed
- `cargo clippy -p zakura-header-chain --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- IDE diagnostics: clean
- Live Mainnet fast-sync trace benchmark with the release binary

Regression coverage includes sparse application contents, retained-child deletion, tombstone coherence, missing eligibility propagation, omitted work-coordinate rebases, unchanged-node trust, and durable canonical-hash auditing.

Markdownlint was unavailable locally because Node/npm is not installed; the draft documentation CI check will run it.

## Changelog

Added [`docs/changelog/unreleased/679.md`](https://github.com/zakura-core/zakura/blob/perf/header-chain-sparse-delta/docs/changelog/unreleased/679.md) for the operator-visible checkpoint-sync performance improvement.

### Follow-up Work

The remaining second sparse validation pass can be removed by carrying `GraphDeltaApplication` in `EngineTransition`, but should remain until profiling demonstrates material benefit.