### PR TITLE
fix(network): start blocksync fuzz past the empty-state quiet period

### DIFF
--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -527,6 +527,45 @@ async fn empty_state_body_queries_wait_for_the_latest_header_quiet_period() {
     reactor_task.abort();
 }
 
+#[tokio::test]
+async fn past_genesis_body_queries_ignore_far_ahead_header_quiet_period() {
+    let finalized = zakura_header_chain::Frontier::new(block::Height(0), block::Hash([1; 32]));
+    let verified = zakura_header_chain::Frontier::new(block::Height(1), block::Hash([2; 32]));
+    let header = zakura_header_chain::Frontier::new(
+        block::Height(EMPTY_STATE_HEADER_QUIET_MIN_LAG + 100),
+        block::Hash([3; 32]),
+    );
+    let (_snapshot_tx, snapshot_rx) = watch::channel(Some(committed_snapshot(
+        1, 1, 1, finalized, verified, header,
+    )));
+    let startup = BlockSyncStartup::new_with_committed_snapshots(
+        BlockSyncFrontiers {
+            finalized_height: finalized.height,
+            verified_block_tip: verified.height,
+            verified_block_hash: verified.hash,
+        },
+        (header.height, header.hash),
+        snapshot_rx,
+        ZakuraBlockSyncConfig::default(),
+    );
+    let (_handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+
+    let action = next_action(&mut actions).await;
+    assert!(
+        matches!(
+            action,
+            BlockSyncAction::QueryNeededBlocks {
+                from: block::Height(2),
+                best_header_tip,
+                ..
+            } if best_header_tip == header.height
+        ),
+        "body work past genesis must start immediately even with a far-ahead header tip, got {action:?}",
+    );
+
+    reactor_task.abort();
+}
+
 #[test]
 fn state_is_only_frontier_publisher() {
     const BLOCK_DRIVER: &str =

--- a/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
+++ b/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
@@ -61,16 +61,23 @@ pub(crate) async fn run_scenario(
 
     let initial_header = scenario.initial_best_header.min(target);
     let initial_header_hash = corpus_hash(&corpus, initial_header);
+    // Production genesis sync waits 30s before downloading bodies when the
+    // header tip is a full checkpoint gap ahead of height 0. These scenarios
+    // start with a fully known, static header chain, so that wait would stall
+    // every ≥400-block run and fire before timing-sensitive peer degradations.
+    // Starting one block past genesis keeps the quiet period from arming.
+    let initial_verified = target.min(block::Height(1)).min(initial_header);
+    let initial_verified_hash = corpus_hash(&corpus, initial_verified);
 
     // The commit driver advances one shared mock frontier as bodies apply.
     // The timeline driver rolls it back after a verified reset.
-    let apply = MockApplyFrontier::new(corpus.clone());
+    let apply = MockApplyFrontier::with_committed_height(corpus.clone(), initial_verified);
     let initial = fuzz_snapshot(
         1,
         1,
         1,
         zakura_header_chain::Frontier::new(block::Height(0), genesis_hash),
-        zakura_header_chain::Frontier::new(block::Height(0), genesis_hash),
+        zakura_header_chain::Frontier::new(initial_verified, initial_verified_hash),
         zakura_header_chain::Frontier::new(initial_header, initial_header_hash),
     );
     let (snapshots, committed_snapshots) = watch::channel(Some(initial));
@@ -79,8 +86,8 @@ pub(crate) async fn run_scenario(
     let mut startup = crate::zakura::BlockSyncStartup::new_with_committed_snapshots(
         BlockSyncFrontiers {
             finalized_height: block::Height(0),
-            verified_block_tip: block::Height(0),
-            verified_block_hash: genesis_hash,
+            verified_block_tip: initial_verified,
+            verified_block_hash: initial_verified_hash,
         },
         (initial_header, initial_header_hash),
         committed_snapshots,
@@ -91,7 +98,7 @@ pub(crate) async fn run_scenario(
 
     let (handle, actions, reactor_task) = crate::zakura::spawn_block_sync_reactor(startup);
 
-    let (committed_tx, mut committed_rx) = watch::channel(block::Height(0));
+    let (committed_tx, mut committed_rx) = watch::channel(initial_verified);
 
     let mut tasks = Vec::new();
     tasks.push(spawn_action_driver(

--- a/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
+++ b/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
@@ -65,8 +65,17 @@ pub(crate) async fn run_scenario(
     // header tip is a full checkpoint gap ahead of height 0. These scenarios
     // start with a fully known, static header chain, so that wait would stall
     // every ≥400-block run and fire before timing-sensitive peer degradations.
-    // Starting one block past genesis keeps the quiet period from arming.
-    let initial_verified = target.min(block::Height(1)).min(initial_header);
+    // Leave genesis only when that quiet period would otherwise arm, so shorter
+    // scenarios still download from height 1.
+    //
+    // Keep in lockstep with `EMPTY_STATE_HEADER_QUIET_MIN_LAG` in
+    // `block_sync/reactor.rs`.
+    const EMPTY_STATE_HEADER_QUIET_MIN_LAG: u32 = 400;
+    let initial_verified = if initial_header.0 >= EMPTY_STATE_HEADER_QUIET_MIN_LAG {
+        target.min(block::Height(1)).min(initial_header)
+    } else {
+        block::Height(0)
+    };
     let initial_verified_hash = corpus_hash(&corpus, initial_verified);
 
     // The commit driver advances one shared mock frontier as bodies apply.

--- a/crates/zakura-network/src/zakura/testkit/mock_blocksync.rs
+++ b/crates/zakura-network/src/zakura/testkit/mock_blocksync.rs
@@ -190,10 +190,29 @@ pub(crate) struct MockApplyOutcome {
 
 impl MockApplyFrontier {
     pub(crate) fn new(corpus: SyntheticBlockCorpus) -> Self {
+        Self::with_committed_height(corpus, block::Height(0))
+    }
+
+    /// Start with `height` already on the mock commit frontier.
+    ///
+    /// The block-sync fuzzer uses this to begin one block past genesis so the
+    /// production empty-state header quiet period does not delay body download.
+    pub(crate) fn with_committed_height(
+        corpus: SyntheticBlockCorpus,
+        height: block::Height,
+    ) -> Self {
+        let frontier_hash = if height == block::Height(0) {
+            mainnet_genesis_hash()
+        } else {
+            corpus
+                .block_at(height)
+                .map(|block| block.hash())
+                .unwrap_or_else(mainnet_genesis_hash)
+        };
         Self {
             inner: Arc::new(StdMutex::new(MockApplyFrontierState {
-                frontier: block::Height(0),
-                frontier_hash: mainnet_genesis_hash(),
+                frontier: height,
+                frontier_hash,
             })),
             corpus,
         }
@@ -1000,6 +1019,18 @@ fn mock_apply_frontier_commits_duplicates_and_rejects_gaps() {
     let third = apply.apply(&block_3);
     assert_eq!(third.result, BlockApplyResult::Committed);
     assert_eq!(third.frontiers.verified_block_tip, block::Height(3));
+}
+
+#[test]
+fn mock_apply_frontier_can_start_past_genesis() {
+    let corpus =
+        SyntheticBlockCorpus::generate(3, SYNTHETIC_CORPUS_SEED, SyntheticBlockShape::default());
+    let apply = MockApplyFrontier::with_committed_height(corpus.clone(), block::Height(1));
+    let block_2 = corpus.block_at(block::Height(2)).expect("height 2 exists");
+
+    let outcome = apply.apply(&block_2);
+    assert_eq!(outcome.result, BlockApplyResult::Committed);
+    assert_eq!(outcome.frontiers.verified_block_tip, block::Height(2));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]

--- a/docs/changelog/unreleased/680.md
+++ b/docs/changelog/unreleased/680.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only changes the block-sync fuzzer harness and unit tests. Production genesis body-download behavior is unchanged.


### PR DESCRIPTION
## Motivation

Main's Zakura E2E `zakura-blocksync-fuzz` job failed after the fork-aware header-chain engine landed. Four scenarios stalled at height 0 with `max_outstanding=0`:

- `fuzz_high_bw_fast_peer` (500 blocks, 30s deadline)
- `fuzz_mixed_block_sizes` (400 blocks, 30s deadline)
- `fuzz_peer_wedges_after_progress_is_parked` (400 blocks, 20s deadline)
- `fuzz_peer_that_stops_reading_is_parked` (400 blocks, 5s deadline; 0 parks)

Root cause: production genesis sync waits 30s before downloading bodies when the header tip is a full checkpoint gap (≥400) ahead of height 0. The fuzzer starts with a fully known, static header chain at the target height, so that wait armed on every ≥400-block scenario. Timing-sensitive wedge tests never issued `GetBlocks` before their peers degraded.

## Solution

When a fuzzer scenario's initial header lag would arm that quiet period, start one block past genesis so body download begins immediately. Shorter scenarios still start at height 0, so request-count assertions such as `fuzz_silent_dropping_peer` stay meaningful. Production genesis behavior is unchanged.

A reactor unit test covers the production gate the harness relies on: once the verified tip is past genesis, a far-ahead header tip must dispatch `QueryNeededBlocks` immediately.

## Testing

- `cargo nextest run -p zakura-network --locked -E 'test(past_genesis_body_queries_ignore_far_ahead_header_quiet_period) + test(mock_apply_frontier_can_start_past_genesis) + test(fuzz_high_bw_fast_peer) + test(fuzz_mixed_block_sizes) + test(fuzz_peer_that_stops_reading) + test(fuzz_peer_wedges_after_progress)'` — 6 passed
- `cargo nextest run --profile zakura-blocksync-fuzz --locked --no-fail-fast` — 21 passed, including the four previously failing scenarios and `fuzz_silent_dropping_peer`

## Changelog

Internal test-harness fix only. See `docs/changelog/unreleased/680.md`.