### PR TITLE
fix(rpc): expose peer metadata in getpeerinfo

### DIFF
--- a/crates/zakura-network/benches/address_book.rs
+++ b/crates/zakura-network/benches/address_book.rs
@@ -104,7 +104,7 @@ fn address_book(c: &mut Criterion) {
         assert!(ban_check.bans().contains(existing_addr.ip()));
 
         let mut batch_check = address_book.clone();
-        batch_check.extend(batch_updates.iter().copied());
+        batch_check.extend(batch_updates.iter().cloned());
         assert_eq!(batch_check.len(), size);
 
         group.bench_with_input(
@@ -183,7 +183,7 @@ fn address_book(c: &mut Criterion) {
             b.iter_batched_ref(
                 || address_book.clone(),
                 |address_book| {
-                    address_book.extend(batch_updates.iter().copied());
+                    address_book.extend(batch_updates.iter().cloned());
                     black_box(address_book);
                 },
                 BatchSize::PerIteration,

--- a/crates/zakura-network/src/address_book.rs
+++ b/crates/zakura-network/src/address_book.rs
@@ -105,12 +105,12 @@ impl AddressBookIndex {
     }
 
     fn get(&self, addr: &PeerSocketAddr) -> Option<MetaAddr> {
-        self.by_addr.get(addr).copied()
+        self.by_addr.get(addr).cloned()
     }
 
     fn insert(&mut self, meta_addr: MetaAddr) {
         let addr = meta_addr.addr;
-        let previous = self.by_addr.insert(addr, meta_addr);
+        let previous = self.by_addr.insert(addr, meta_addr.clone());
         if let Some(previous) = previous {
             assert!(
                 self.by_priority.remove(&previous),
@@ -204,7 +204,7 @@ impl AddressBookIndex {
             }
         }
 
-        let peers: Vec<_> = self.ordered_values().copied().collect();
+        let peers: Vec<_> = self.ordered_values().cloned().collect();
         assert!(peers.windows(2).all(|pair| pair[0] <= pair[1]));
     }
 }
@@ -435,14 +435,14 @@ impl AddressBook {
 
         for (socket_addr, meta_addr) in addrs {
             // overwrite any duplicate addresses
-            new_book.peers.insert(meta_addr);
+            new_book.peers.insert(meta_addr.clone());
             // Add the address to `most_recent_by_ip` if it has responded
-            if new_book.should_update_most_recent_by_ip(meta_addr) {
+            if new_book.should_update_most_recent_by_ip(&meta_addr) {
                 new_book
                     .most_recent_by_ip
                     .as_mut()
                     .expect("should be some when should_update_most_recent_by_ip is true")
-                    .insert(socket_addr.ip(), meta_addr);
+                    .insert(socket_addr.ip(), meta_addr.clone());
             }
             // exit as soon as we get enough addresses
             if new_book.peers.len() >= addr_limit {
@@ -577,7 +577,7 @@ impl AddressBook {
     /// - this is the only field checked by `has_connection_recently_responded()`
     ///
     /// See [`AddressBook::is_ready_for_connection_attempt_with_ip`] for more details.
-    fn should_update_most_recent_by_ip(&self, updated: MetaAddr) -> bool {
+    fn should_update_most_recent_by_ip(&self, updated: &MetaAddr) -> bool {
         let Some(most_recent_by_ip) = self.most_recent_by_ip.as_ref() else {
             return false;
         };
@@ -650,7 +650,7 @@ impl AddressBook {
         let instant_now = Instant::now();
         let chrono_now = Utc::now();
 
-        let updated = change.apply_to_meta_addr(previous, instant_now, chrono_now);
+        let updated = change.apply_to_meta_addr(previous.clone(), instant_now, chrono_now);
 
         trace!(
             peer = %addr_label,
@@ -662,7 +662,7 @@ impl AddressBook {
             "calculated updated address book entry",
         );
 
-        if let Some(updated) = updated {
+        if let Some(ref updated) = updated {
             if updated.misbehavior() >= constants::MAX_PEER_MISBEHAVIOR_SCORE {
                 // Ban and skip outbound connections with excessively misbehaving peers.
                 let banned_ip = updated.addr.ip();
@@ -715,7 +715,7 @@ impl AddressBook {
                 return None;
             }
 
-            self.peers.insert(updated);
+            self.peers.insert(updated.clone());
             self.address_metrics_dirty = true;
 
             // Add the address to `most_recent_by_ip` if it sent the most recent
@@ -724,7 +724,7 @@ impl AddressBook {
                 self.most_recent_by_ip
                     .as_mut()
                     .expect("should be some when should_update_most_recent_by_ip is true")
-                    .insert(updated.addr.ip(), updated);
+                    .insert(updated.addr.ip(), updated.clone());
             }
 
             debug!(

--- a/crates/zakura-network/src/address_book/tests.rs
+++ b/crates/zakura-network/src/address_book/tests.rs
@@ -63,7 +63,7 @@ fn address_metrics_are_updated_once_per_batch() {
     ]
     .map(MetaAddr::new_initial_peer);
 
-    address_book.extend(peers);
+    address_book.extend(peers.clone());
 
     assert_eq!(
         address_book.address_metrics_update_count,

--- a/crates/zakura-network/src/address_book/tests/prop.rs
+++ b/crates/zakura-network/src/address_book/tests/prop.rs
@@ -121,7 +121,7 @@ proptest! {
 
         for (_addr, changes) in addr_changes_lists.iter() {
             for change in changes {
-                address_book.update(*change);
+                address_book.update(change.clone());
                 address_book.peers.assert_consistent();
 
                 prop_assert!(
@@ -146,7 +146,7 @@ proptest! {
         for index in 0..MAX_ADDR_CHANGE {
             for (_addr, changes) in addr_changes_lists.iter() {
                 if let Some(change) = changes.get(index) {
-                    address_book.update(*change);
+                    address_book.update(change.clone());
                     address_book.peers.assert_consistent();
 
                     prop_assert!(

--- a/crates/zakura-network/src/address_book/tests/vectors.rs
+++ b/crates/zakura-network/src/address_book/tests/vectors.rs
@@ -170,7 +170,7 @@ fn address_book_peer_order() {
     );
 
     // Regardless of the order of insertion, the most recent address should be chosen first
-    let addrs = vec![meta_addr1, meta_addr2];
+    let addrs = vec![meta_addr1.clone(), meta_addr2.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,
@@ -183,11 +183,11 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Reverse the order, check that we get the same result
-    let addrs = vec![meta_addr2, meta_addr1];
+    let addrs = vec![meta_addr2.clone(), meta_addr1.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,
@@ -200,14 +200,14 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Now check that the order depends on the time, not the address
     meta_addr1.addr = addr2;
     meta_addr2.addr = addr1;
 
-    let addrs = vec![meta_addr1, meta_addr2];
+    let addrs = vec![meta_addr1.clone(), meta_addr2.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,
@@ -220,11 +220,11 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Reverse the order, check that we get the same result
-    let addrs = vec![meta_addr2, meta_addr1];
+    let addrs = vec![meta_addr2.clone(), meta_addr1.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,
@@ -237,7 +237,7 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 }
 

--- a/crates/zakura-network/src/meta_addr.rs
+++ b/crates/zakura-network/src/meta_addr.rs
@@ -12,7 +12,10 @@ use zakura_chain::{parameters::Network, serialization::DateTime32};
 use crate::{
     constants,
     peer::{address_is_valid_for_outbound_connections, PeerPreference},
-    protocol::{external::canonical_peer_addr, types::PeerServices},
+    protocol::{
+        external::{canonical_peer_addr, types::Version},
+        types::PeerServices,
+    },
 };
 
 use MetaAddrChange::*;
@@ -146,7 +149,7 @@ impl PartialOrd for PeerAddrState {
 /// This struct can be created from `addr` or `addrv2` messages.
 ///
 /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#Network_address)
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct MetaAddr {
     /// The peer's canonical socket address.
@@ -223,10 +226,16 @@ pub struct MetaAddr {
     /// Whether this peer address was added to the address book
     /// when the peer made an inbound connection.
     is_inbound: bool,
+
+    /// The user agent string reported by the peer during handshake, if available.
+    user_agent: Option<String>,
+
+    /// The protocol version negotiated with the peer during handshake, if available.
+    negotiated_version: Option<Version>,
 }
 
 /// A change to an existing `MetaAddr`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum MetaAddrChange {
     // TODO:
@@ -287,6 +296,8 @@ pub enum MetaAddrChange {
         addr: PeerSocketAddr,
         services: PeerServices,
         is_inbound: bool,
+        user_agent: String,
+        negotiated_version: Version,
     },
 
     /// Updates an existing `MetaAddr` when we send a ping to a peer.
@@ -356,6 +367,8 @@ impl MetaAddr {
             last_connection_state: NeverAttemptedGossiped,
             misbehavior_score: 0,
             is_inbound: false,
+            user_agent: None,
+            negotiated_version: None,
         }
     }
 
@@ -392,11 +405,15 @@ impl MetaAddr {
         addr: PeerSocketAddr,
         services: &PeerServices,
         is_inbound: bool,
+        user_agent: String,
+        negotiated_version: Version,
     ) -> MetaAddrChange {
         UpdateConnected {
             addr: canonical_peer_addr(*addr),
             services: *services,
             is_inbound,
+            user_agent,
+            negotiated_version,
         }
     }
 
@@ -506,6 +523,16 @@ impl MetaAddr {
     /// Returns whether the address is from an inbound peer connection
     pub fn is_inbound(&self) -> bool {
         self.is_inbound
+    }
+
+    /// Returns the user agent string reported by this peer, if available.
+    pub fn user_agent(&self) -> Option<&str> {
+        self.user_agent.as_deref()
+    }
+
+    /// Returns the negotiated protocol version for this peer, if available.
+    pub fn negotiated_version(&self) -> Option<Version> {
+        self.negotiated_version
     }
 
     /// Returns the round-trip time (RTT) for this peer, if available.
@@ -766,6 +793,8 @@ impl MetaAddr {
             last_connection_state: NeverAttemptedGossiped,
             misbehavior_score: 0,
             is_inbound: false,
+            user_agent: None,
+            negotiated_version: None,
         })
     }
 }
@@ -964,6 +993,8 @@ impl MetaAddrChange {
 
     /// Returns the corresponding `MetaAddr` for this change.
     pub fn into_new_meta_addr(self, instant_now: Instant, local_now: DateTime32) -> MetaAddr {
+        let user_agent = self.user_agent();
+        let negotiated_version = self.negotiated_version();
         MetaAddr {
             addr: self.addr(),
             services: self.untrusted_services(),
@@ -976,6 +1007,29 @@ impl MetaAddrChange {
             last_connection_state: self.peer_addr_state(),
             misbehavior_score: self.misbehavior_score(),
             is_inbound: self.is_inbound(),
+            user_agent,
+            negotiated_version,
+        }
+    }
+
+    /// Returns the user agent from this change, if available.
+    fn user_agent(&self) -> Option<String> {
+        if let MetaAddrChange::UpdateConnected { user_agent, .. } = self {
+            Some(user_agent.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Returns the negotiated protocol version from this change, if available.
+    fn negotiated_version(&self) -> Option<Version> {
+        if let MetaAddrChange::UpdateConnected {
+            negotiated_version, ..
+        } = self
+        {
+            Some(*negotiated_version)
+        } else {
+            None
         }
     }
 
@@ -1021,6 +1075,8 @@ impl MetaAddrChange {
             last_connection_state: self.peer_addr_state(),
             misbehavior_score: self.misbehavior_score(),
             is_inbound: self.is_inbound(),
+            user_agent: None,
+            negotiated_version: None,
         }
     }
 
@@ -1039,7 +1095,7 @@ impl MetaAddrChange {
 
         let Some(previous) = previous.into() else {
             // no previous: create a new entry
-            return Some(self.into_new_meta_addr(instant_now, local_now));
+            return Some(self.clone().into_new_meta_addr(instant_now, local_now));
         };
 
         assert_eq!(previous.addr, self.addr(), "unexpected addr mismatch");
@@ -1177,6 +1233,8 @@ impl MetaAddrChange {
                 last_connection_state: self.peer_addr_state(),
                 misbehavior_score: previous.misbehavior_score + self.misbehavior_score(),
                 is_inbound: previous.is_inbound || self.is_inbound(),
+                user_agent: None,
+                negotiated_version: None,
             })
         } else {
             // Existing entry and change are both Attempt, Responded, Failed,
@@ -1203,6 +1261,8 @@ impl MetaAddrChange {
                 last_connection_state: self.peer_addr_state(),
                 misbehavior_score: previous.misbehavior_score + self.misbehavior_score(),
                 is_inbound: previous.is_inbound || self.is_inbound(),
+                user_agent: self.user_agent().or(previous.user_agent),
+                negotiated_version: self.negotiated_version().or(previous.negotiated_version),
             })
         }
     }

--- a/crates/zakura-network/src/meta_addr.rs
+++ b/crates/zakura-network/src/meta_addr.rs
@@ -2,6 +2,7 @@
 
 use std::{
     cmp::{max, Ordering},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -228,7 +229,7 @@ pub struct MetaAddr {
     is_inbound: bool,
 
     /// The user agent string reported by the peer during handshake, if available.
-    user_agent: Option<String>,
+    user_agent: Option<Arc<str>>,
 
     /// The protocol version negotiated with the peer during handshake, if available.
     negotiated_version: Option<Version>,
@@ -1013,9 +1014,9 @@ impl MetaAddrChange {
     }
 
     /// Returns the user agent from this change, if available.
-    fn user_agent(&self) -> Option<String> {
+    fn user_agent(&self) -> Option<Arc<str>> {
         if let MetaAddrChange::UpdateConnected { user_agent, .. } = self {
-            Some(user_agent.clone())
+            Some(Arc::from(user_agent.as_str()))
         } else {
             None
         }

--- a/crates/zakura-network/src/meta_addr/arbitrary.rs
+++ b/crates/zakura-network/src/meta_addr/arbitrary.rs
@@ -70,7 +70,7 @@ impl MetaAddrChange {
         any::<MetaAddr>()
             .prop_flat_map(move |addr| {
                 (
-                    Just(addr),
+                    Just(addr.clone()),
                     vec(MetaAddrChange::addr_strategy(addr.addr), 1..max_addr_change),
                 )
             })

--- a/crates/zakura-network/src/meta_addr/tests/prop.rs
+++ b/crates/zakura-network/src/meta_addr/tests/prop.rs
@@ -75,7 +75,7 @@ proptest! {
         let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
         for change in changes {
-            if let Some(changed_addr) = change.apply_to_meta_addr(addr, instant_now, chrono_now) {
+            if let Some(changed_addr) = change.apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
                 // untrusted last seen times:
                 // check that we replace None with Some, but leave Some unchanged
                 if addr.untrusted_last_seen.is_some() {
@@ -124,7 +124,7 @@ proptest! {
             while addr.is_ready_for_connection_attempt(instant_now, chrono_now, &Mainnet) {
                 // Simulate an attempt
                 addr = if let Some(addr) = MetaAddr::new_reconnect(addr.addr)
-                    .apply_to_meta_addr(addr, instant_now, chrono_now) {
+                        .apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
                         attempt_count += 1;
                         // Assume that this test doesn't last longer than MIN_PEER_RECONNECTION_DELAY
                         prop_assert!(attempt_count <= 1);
@@ -137,7 +137,7 @@ proptest! {
             }
 
             // If `change` is invalid for the current MetaAddr state, skip it.
-            if let Some(changed_addr) = change.apply_to_meta_addr(addr, instant_now, chrono_now) {
+            if let Some(changed_addr) = change.apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
                 prop_assert_eq!(changed_addr.addr, addr.addr);
                 addr = changed_addr;
             }
@@ -229,7 +229,7 @@ proptest! {
             );
 
             let expected_result = new_addr;
-            let book_result = address_book.update(change);
+            let book_result = address_book.update(change.clone());
             let book_contents: Vec<MetaAddr> = address_book.peers().collect();
 
             // Ignore the same addresses that the address book ignores
@@ -255,7 +255,7 @@ proptest! {
                 expected_result,
             );
 
-            if let Some(book_result) = book_result {
+            if let Some(book_result) = book_result.as_ref() {
                 prop_assert_eq!(book_result.addr, addr.addr);
                 // TODO: pass times to MetaAddrChange::apply_to_meta_addr and AddressBook::update,
                 //       so the times are equal
@@ -328,7 +328,7 @@ proptest! {
         // Only put valid addresses in the address book.
         // This means some tests will start with an empty address book.
         let addrs = if addr.last_known_info_is_valid_for_outbound(&Mainnet) {
-            Some(addr)
+            Some(addr.clone())
         } else {
             None
         };
@@ -439,13 +439,13 @@ proptest! {
 
             for change_index in 0..MAX_ADDR_CHANGE {
                 for (addr, changes) in addr_changes_lists.iter() {
-                    let addr = addrs.entry(addr.addr).or_insert(*addr);
+                    let addr = addrs.entry(addr.addr).or_insert(addr.clone());
                     let change = changes.get(change_index);
 
                     while addr.is_ready_for_connection_attempt(instant_now, chrono_now, &Mainnet) {
                         // Simulate an attempt
                         *addr = if let Some(addr) = MetaAddr::new_reconnect(addr.addr)
-                            .apply_to_meta_addr(*addr, instant_now, chrono_now) {
+                            .apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
                                 *attempt_counts.entry(addr.addr).or_default() += 1;
                                 prop_assert!(
                                     *attempt_counts.get(&addr.addr).unwrap() <= LIVE_PEER_INTERVALS + 1
@@ -460,7 +460,7 @@ proptest! {
 
                     // If `change` is invalid for the current MetaAddr state, skip it.
                     // If we've run out of changes for this addr, do nothing.
-                    if let Some(changed_addr) = change.and_then(|change| change.apply_to_meta_addr(*addr, instant_now, chrono_now))
+                    if let Some(changed_addr) = change.and_then(|change| change.apply_to_meta_addr(addr.clone(), instant_now, chrono_now))
                     {
                         prop_assert_eq!(changed_addr.addr, addr.addr);
                         *addr = changed_addr;

--- a/crates/zakura-network/src/meta_addr/tests/vectors.rs
+++ b/crates/zakura-network/src/meta_addr/tests/vectors.rs
@@ -15,7 +15,10 @@ use zakura_chain::{
 use crate::{
     constants::{CONCURRENT_ADDRESS_CHANGE_PERIOD, MAX_PEER_ACTIVE_FOR_GOSSIP},
     meta_addr::MetaAddrChange,
-    protocol::{external::canonical_peer_addr, types::PeerServices},
+    protocol::{
+        external::{canonical_peer_addr, types::Version},
+        types::PeerServices,
+    },
     PeerSocketAddr,
 };
 
@@ -63,6 +66,8 @@ fn sanitize_extremes() {
         last_connection_state: Default::default(),
         misbehavior_score: Default::default(),
         is_inbound: false,
+        user_agent: None,
+        negotiated_version: None,
     };
 
     let max_time_entry = MetaAddr {
@@ -77,6 +82,8 @@ fn sanitize_extremes() {
         last_connection_state: Default::default(),
         misbehavior_score: Default::default(),
         is_inbound: false,
+        user_agent: None,
+        negotiated_version: None,
     };
 
     if let Some(min_sanitized) = min_time_entry.sanitize(&Mainnet) {
@@ -504,11 +511,17 @@ fn ipv4_mapped_misbehavior_panics_without_fix() {
     );
 
     // Handshake succeeds → address book stores the canonical (IPv4) address.
-    let previous = MetaAddr::new_connected(raw_addr, &PeerServices::NODE_NETWORK, true)
-        .into_new_meta_addr(
-            instant_now,
-            chrono_now.try_into().expect("will succeed until 2038"),
-        );
+    let previous = MetaAddr::new_connected(
+        raw_addr,
+        &PeerServices::NODE_NETWORK,
+        true,
+        String::new(),
+        Version(0),
+    )
+    .into_new_meta_addr(
+        instant_now,
+        chrono_now.try_into().expect("will succeed until 2038"),
+    );
 
     assert_eq!(
         previous.addr(),
@@ -549,11 +562,17 @@ fn new_misbehavior_canonicalizes_ipv4_mapped_addr() {
     assert_ne!(raw_addr, canonical_addr);
 
     // Handshake stores canonical IPv4 address.
-    let previous = MetaAddr::new_connected(raw_addr, &PeerServices::NODE_NETWORK, true)
-        .into_new_meta_addr(
-            instant_now,
-            chrono_now.try_into().expect("will succeed until 2038"),
-        );
+    let previous = MetaAddr::new_connected(
+        raw_addr,
+        &PeerServices::NODE_NETWORK,
+        true,
+        String::new(),
+        Version(0),
+    )
+    .into_new_meta_addr(
+        instant_now,
+        chrono_now.try_into().expect("will succeed until 2038"),
+    );
 
     assert_eq!(previous.addr(), canonical_addr);
 

--- a/crates/zakura-network/src/meta_addr/tests/vectors.rs
+++ b/crates/zakura-network/src/meta_addr/tests/vectors.rs
@@ -285,7 +285,7 @@ fn long_delayed_change_is_not_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_errored(address, PeerServices::NODE_NETWORK);
-    let outcome = change.apply_to_meta_addr(peer, instant_early, chrono_early);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_early, chrono_early);
 
     assert_eq!(
         outcome, None,
@@ -328,7 +328,7 @@ fn later_revert_change_is_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_reconnect(address);
-    let outcome = change.apply_to_meta_addr(peer, instant_late, chrono_late);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_late, chrono_late);
 
     assert!(
         outcome.is_some(),
@@ -369,7 +369,7 @@ fn concurrent_state_revert_change_is_not_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_reconnect(address);
-    let outcome = change.apply_to_meta_addr(peer, instant_early, chrono_early);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_early, chrono_early);
 
     assert_eq!(
         outcome, None,
@@ -387,7 +387,7 @@ fn concurrent_state_revert_change_is_not_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_reconnect(address);
-    let outcome = change.apply_to_meta_addr(peer, instant_late, chrono_late);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_late, chrono_late);
 
     assert_eq!(
         outcome, None,
@@ -428,7 +428,7 @@ fn concurrent_state_progress_change_is_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_errored(address, None);
-    let outcome = change.apply_to_meta_addr(peer, instant_early, chrono_early);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_early, chrono_early);
 
     assert!(
         outcome.is_some(),
@@ -446,7 +446,7 @@ fn concurrent_state_progress_change_is_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_errored(address, None);
-    let outcome = change.apply_to_meta_addr(peer, instant_late, chrono_late);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_late, chrono_late);
 
     assert!(
         outcome.is_some(),

--- a/crates/zakura-network/src/peer/connection.rs
+++ b/crates/zakura-network/src/peer/connection.rs
@@ -448,7 +448,7 @@ impl Handler {
         // doesn't respond to our getaddr requests.
         //
         // Add the new addresses to the end of the cache.
-        cached_addrs.extend(new_addrs);
+        cached_addrs.extend(new_addrs.into_iter().cloned());
 
         // # Security
         //

--- a/crates/zakura-network/src/peer/handshake.rs
+++ b/crates/zakura-network/src/peer/handshake.rs
@@ -1141,9 +1141,7 @@ async fn record_zakura_upgrade(
     connector: &ZakuraHandshakeConnector,
     address_book_updater: &tokio::sync::mpsc::Sender<MetaAddrChange>,
 ) {
-    let (ZakuraUpgradeOutcome::Upgraded { peer_id } | ZakuraUpgradeOutcome::Duplicate { peer_id }) =
-        outcome
-    else {
+    let ZakuraUpgradeOutcome::Upgraded { peer_id } = outcome else {
         return;
     };
 

--- a/crates/zakura-network/src/peer/handshake.rs
+++ b/crates/zakura-network/src/peer/handshake.rs
@@ -1031,6 +1031,14 @@ where
     // the real prelude exchange over a live Zakura endpoint.
     #[cfg(test)]
     if let Some(outcome) = connector.consume_test_outcome() {
+        record_zakura_upgrade(
+            &outcome,
+            connection_info,
+            connected_addr,
+            &connector,
+            address_book_updater,
+        )
+        .await;
         return Ok(outcome);
     }
 
@@ -1112,26 +1120,59 @@ where
         }
     }
 
-    // Keep the upgraded peer's legacy address-book entry live for as long as the
-    // Zakura connection is registered, so the outbound crawler treats it as
-    // connected and does not re-dial it (which would re-run this upgrade and
-    // churn the QUIC connection). Only the outbound side reconnects, and only
-    // when we have a dialable address book entry for the peer.
-    if let ZakuraUpgradeOutcome::Upgraded { peer_id }
-    | ZakuraUpgradeOutcome::Duplicate { peer_id } = &outcome
-    {
-        if !connected_addr.is_inbound() {
-            if let Some(book_addr) = connected_addr.get_address_book_addr() {
-                connector.spawn_legacy_liveness_keeper(
-                    peer_id.clone(),
-                    book_addr,
-                    address_book_updater.clone(),
-                );
-            }
-        }
-    }
+    record_zakura_upgrade(
+        &outcome,
+        connection_info,
+        connected_addr,
+        &connector,
+        address_book_updater,
+    )
+    .await;
 
     Ok(outcome)
+}
+
+/// Record an upgraded peer in the legacy address book and keep it live while
+/// the replacement Zakura connection is registered.
+async fn record_zakura_upgrade(
+    outcome: &ZakuraUpgradeOutcome,
+    connection_info: &ConnectionInfo,
+    connected_addr: ConnectedAddr,
+    connector: &ZakuraHandshakeConnector,
+    address_book_updater: &tokio::sync::mpsc::Sender<MetaAddrChange>,
+) {
+    let (ZakuraUpgradeOutcome::Upgraded { peer_id } | ZakuraUpgradeOutcome::Duplicate { peer_id }) =
+        outcome
+    else {
+        return;
+    };
+
+    let Some(book_addr) = connected_addr.get_address_book_addr() else {
+        return;
+    };
+
+    // The legacy stream is dropped after this function returns, so this is
+    // the only address-book update for an upgraded peer. It also creates an
+    // entry for inbound peers, which have no entry before this point.
+    let _ = address_book_updater
+        .send(MetaAddr::new_connected(
+            book_addr,
+            &connection_info.remote.services,
+            connected_addr.is_inbound(),
+            connection_info.remote.user_agent.clone(),
+            connection_info.negotiated_version,
+        ))
+        .await;
+
+    // Keep the upgraded peer's legacy address-book entry live for as long as
+    // its Zakura connection is registered. This prevents the outbound crawler
+    // from re-running the upgrade and keeps inbound native peers visible to
+    // getpeerinfo.
+    connector.spawn_legacy_liveness_keeper(
+        peer_id.clone(),
+        book_addr,
+        address_book_updater.clone(),
+    );
 }
 
 /// The neutral upgrade fallback outcome: keep the legacy connection.

--- a/crates/zakura-network/src/peer/handshake.rs
+++ b/crates/zakura-network/src/peer/handshake.rs
@@ -1612,6 +1612,8 @@ where
                         book_addr,
                         &remote_services,
                         connected_addr.is_inbound(),
+                        connection_info.remote.user_agent.clone(),
+                        connection_info.negotiated_version,
                     ))
                     .await;
             }

--- a/crates/zakura-network/src/peer/handshake/tests.rs
+++ b/crates/zakura-network/src/peer/handshake/tests.rs
@@ -905,7 +905,7 @@ async fn mutual_p2p_v2_without_connector_fails_closed() {
 }
 
 #[tokio::test]
-async fn mutual_p2p_v2_selected_upgrade_skips_legacy_connection() {
+async fn mutual_p2p_v2_selected_upgrade_records_peer_metadata() {
     let _init_guard = zakura_test::init();
 
     let (local_stream, remote_stream) = duplex(16 * 1024);
@@ -952,7 +952,31 @@ async fn mutual_p2p_v2_selected_upgrade_skips_legacy_connection() {
 
     assert_eq!(local_calls.load(Ordering::SeqCst), 1);
     assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
-    assert!(address_book_rx.try_recv().is_err());
+
+    let mut metadata = Vec::new();
+    while let Ok(change) = address_book_rx.try_recv() {
+        if let MetaAddrChange::UpdateConnected {
+            addr,
+            user_agent,
+            negotiated_version,
+            ..
+        } = change
+        {
+            metadata.push((addr, user_agent, negotiated_version));
+        }
+    }
+
+    assert_eq!(metadata.len(), 2);
+    assert!(metadata.iter().any(|(addr, user_agent, version)| {
+        *addr == peer_addr(18233)
+            && user_agent == TEST_HANDSHAKE_USER_AGENT
+            && *version == constants::CURRENT_NETWORK_PROTOCOL_VERSION
+    }));
+    assert!(metadata.iter().any(|(addr, user_agent, version)| {
+        *addr == peer_addr(28233)
+            && user_agent == TEST_HANDSHAKE_USER_AGENT
+            && *version == constants::CURRENT_NETWORK_PROTOCOL_VERSION
+    }));
     assert_eq!(local_counter.update_count(), 0);
     assert_eq!(remote_counter.update_count(), 0);
 }

--- a/crates/zakura-network/src/peer/handshake/tests.rs
+++ b/crates/zakura-network/src/peer/handshake/tests.rs
@@ -94,6 +94,12 @@ fn upgraded_outcome() -> ZakuraUpgradeOutcome {
     }
 }
 
+fn duplicate_outcome() -> ZakuraUpgradeOutcome {
+    ZakuraUpgradeOutcome::Duplicate {
+        peer_id: ZakuraPeerId::new(vec![7; 32]).expect("test peer id is within bounds"),
+    }
+}
+
 async fn negotiate_test_pair(
     local_config: Config,
     remote_config: Config,
@@ -977,6 +983,59 @@ async fn mutual_p2p_v2_selected_upgrade_records_peer_metadata() {
             && user_agent == TEST_HANDSHAKE_USER_AGENT
             && *version == constants::CURRENT_NETWORK_PROTOCOL_VERSION
     }));
+    assert_eq!(local_counter.update_count(), 0);
+    assert_eq!(remote_counter.update_count(), 0);
+}
+
+#[tokio::test]
+async fn mutual_p2p_v2_duplicate_upgrade_does_not_record_peer_metadata() {
+    let _init_guard = zakura_test::init();
+
+    let (local_stream, remote_stream) = duplex(16 * 1024);
+    let (address_book_tx, mut address_book_rx) = tokio::sync::mpsc::channel(8);
+    let local_calls = Arc::new(AtomicUsize::new(0));
+    let remote_calls = Arc::new(AtomicUsize::new(0));
+
+    let mut local_counter = ActiveConnectionCounter::new_counter();
+    let mut remote_counter = ActiveConnectionCounter::new_counter();
+
+    let local_handshake = test_handshake(
+        test_config(P2pStack::Dual),
+        address_book_tx.clone(),
+        local_calls.clone(),
+        duplicate_outcome(),
+    );
+    let remote_handshake = test_handshake(
+        test_config(P2pStack::Dual),
+        address_book_tx,
+        remote_calls.clone(),
+        duplicate_outcome(),
+    );
+
+    let local_task = tokio::spawn(local_handshake.oneshot(HandshakeRequest {
+        data_stream: local_stream,
+        connected_addr: ConnectedAddr::new_outbound_direct(peer_addr(18233)),
+        connection_tracker: local_counter.track_connection(),
+    }));
+    let remote_task = tokio::spawn(remote_handshake.oneshot(HandshakeRequest {
+        data_stream: remote_stream,
+        connected_addr: ConnectedAddr::new_inbound_direct(peer_addr(28233)),
+        connection_tracker: remote_counter.track_connection(),
+    }));
+
+    let local_error = local_task.await.unwrap().unwrap_err();
+    let remote_error = remote_task.await.unwrap().unwrap_err();
+
+    assert!(local_error
+        .downcast_ref::<HandshakeError>()
+        .is_some_and(|error| matches!(error, HandshakeError::ZakuraUpgradeSelected)));
+    assert!(remote_error
+        .downcast_ref::<HandshakeError>()
+        .is_some_and(|error| matches!(error, HandshakeError::ZakuraUpgradeSelected)));
+
+    assert_eq!(local_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
+    assert!(address_book_rx.try_recv().is_err());
     assert_eq!(local_counter.update_count(), 0);
     assert_eq!(remote_counter.update_count(), 0);
 }

--- a/crates/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/crates/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -2613,7 +2613,7 @@ where
             PeerServices::NODE_NETWORK,
             DateTime32::now(),
         );
-        fake_peer = Some(addr);
+        fake_peer = Some(addr.clone());
         let addr = addr
             .new_gossiped_change()
             .expect("created MetaAddr contains enough information to represent a gossiped address");
@@ -2631,12 +2631,13 @@ where
     let (crawl_observed_tx, mut crawl_observed_rx) = tokio::sync::mpsc::unbounded_channel();
     let nil_peer_set = service_fn(move |req| {
         let crawl_observed_tx = crawl_observed_tx.clone();
+        let fake_peer = fake_peer.clone();
 
         async move {
             let rsp = match req {
                 // Return the correct response variant for Peers requests,
                 // reusing one of the peers we already provided.
-                Request::Peers => Response::Peers(vec![fake_peer.unwrap()]),
+                Request::Peers => Response::Peers(vec![fake_peer.clone().unwrap()]),
                 _ => unreachable!("unexpected request: {:?}", req),
             };
 

--- a/crates/zakura-network/src/peer_set/initialize/tests/vectors.rs
+++ b/crates/zakura-network/src/peer_set/initialize/tests/vectors.rs
@@ -1927,6 +1927,7 @@ async fn self_connections_should_fail() {
 
         let updated_addr = unlocked_address_book.update(
             real_self_listener
+                .clone()
                 .new_gossiped_change()
                 .expect("change is valid"),
         );
@@ -1942,17 +1943,17 @@ async fn self_connections_should_fail() {
         "inserting our own address into the address book failed: {real_self_listener:?}"
     );
     assert_eq!(
-        updated_addr.unwrap().addr(),
+        updated_addr.as_ref().unwrap().addr(),
         real_self_listener.addr(),
         "wrong address inserted into address book"
     );
     assert_ne!(
-        updated_addr.unwrap().addr().ip(),
+        updated_addr.as_ref().unwrap().addr().ip(),
         Ipv4Addr::UNSPECIFIED,
         "invalid address inserted into address book: ip must be valid for inbound connections"
     );
     assert_ne!(
-        updated_addr.unwrap().addr().port(),
+        updated_addr.as_ref().unwrap().addr().port(),
         0,
         "invalid address inserted into address book: port must be valid for inbound connections"
     );

--- a/crates/zakura-network/src/protocol/external/codec.rs
+++ b/crates/zakura-network/src/protocol/external/codec.rs
@@ -337,7 +337,10 @@ impl Codec {
 
                 // Regardless of the way we received the address,
                 // Zebra always sends `addr` messages
-                let v1_addrs: Vec<AddrV1> = addrs.iter().map(|addr| AddrV1::from(*addr)).collect();
+                let v1_addrs: Vec<AddrV1> = addrs
+                    .iter()
+                    .map(|addr| AddrV1::from(addr.clone()))
+                    .collect();
                 v1_addrs.zcash_serialize(&mut writer)?
             }
             Message::GetAddr => { /* Empty payload -- no-op */ }

--- a/crates/zakura-network/src/protocol/external/tests/prop.rs
+++ b/crates/zakura-network/src/protocol/external/tests/prop.rs
@@ -122,7 +122,7 @@ proptest! {
         //
         // If this is a gossiped or DNS seeder address,
         // we're also checking that malicious peers can't make Zebra's serialization fail.
-        let addr_bytes = AddrV1::from(sanitized_addr).zcash_serialize_to_vec();
+        let addr_bytes = AddrV1::from(sanitized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes.is_ok(),
             "unexpected serialization error: {:?}, addr: {:?}",
@@ -144,8 +144,8 @@ proptest! {
 
         // Check that the addrs are equal
         prop_assert_eq!(
-            sanitized_addr,
-            deserialized_addr,
+            sanitized_addr.clone(),
+            deserialized_addr.clone(),
             "unexpected round-trip mismatch with bytes: {:?}",
             hex::encode(addr_bytes),
         );
@@ -155,7 +155,7 @@ proptest! {
 
         // Now check that the re-serialized bytes are equal
         // (`impl PartialEq for MetaAddr` might not match serialization equality)
-        let addr_bytes2 = AddrV1::from(deserialized_addr).zcash_serialize_to_vec();
+        let addr_bytes2 = AddrV1::from(deserialized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes2.is_ok(),
             "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",
@@ -195,7 +195,7 @@ proptest! {
         //
         // If this is a gossiped or DNS seeder address,
         // we're also checking that malicious peers can't make Zebra's serialization fail.
-        let addr_bytes = AddrV2::from(sanitized_addr).zcash_serialize_to_vec();
+        let addr_bytes = AddrV2::from(sanitized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes.is_ok(),
             "unexpected serialization error: {:?}, addr: {:?}",
@@ -218,8 +218,8 @@ proptest! {
 
         // Check that the addrs are equal
         prop_assert_eq!(
-            sanitized_addr,
-            deserialized_addr,
+            sanitized_addr.clone(),
+            deserialized_addr.clone(),
             "unexpected round-trip mismatch with bytes: {:?}",
             hex::encode(addr_bytes),
         );
@@ -229,7 +229,7 @@ proptest! {
 
         // Now check that the re-serialized bytes are equal
         // (`impl PartialEq for MetaAddr` might not match serialization equality)
-        let addr_bytes2 = AddrV2::from(deserialized_addr).zcash_serialize_to_vec();
+        let addr_bytes2 = AddrV2::from(deserialized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes2.is_ok(),
             "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",

--- a/crates/zakura-network/src/zakura.rs
+++ b/crates/zakura-network/src/zakura.rs
@@ -354,9 +354,9 @@ impl ZakuraHandshakeConnector {
     /// it deregisters the keeper stops, so a genuinely gone peer becomes a
     /// reconnection candidate again.
     ///
-    /// Only meaningful for outbound connections, where `book_addr` is the
-    /// dialable remote address the crawler would otherwise reconnect to. Does
-    /// nothing without a live endpoint.
+    /// This also keeps inbound native peers visible to `getpeerinfo` while
+    /// their replacement connection is registered. Does nothing without a
+    /// live endpoint.
     pub(crate) fn spawn_legacy_liveness_keeper(
         &self,
         peer_id: ZakuraPeerId,
@@ -461,8 +461,12 @@ async fn run_legacy_liveness_keeper(
         }
 
         if !registered.borrow().iter().any(|id| id == &peer_id) {
+            let _ = address_book_updater
+                .send(MetaAddr::new_shutdown(book_addr))
+                .await;
             // The Zakura connection deregistered: stop refreshing so the entry
-            // ages out and the peer can be reconnected over legacy.
+            // is no longer reported as an active peer and can be reconnected
+            // over legacy.
             break;
         }
     }
@@ -609,6 +613,14 @@ mod tests {
 
         // Deregister the peer: the keeper must observe the change and exit.
         registered_tx.send(Vec::new()).expect("receiver is alive");
+        let shutdown = tokio::time::timeout(Duration::from_secs(1), updater_rx.recv())
+            .await
+            .expect("keeper reports native peer shutdown")
+            .expect("the keeper holds the sender open");
+        assert!(matches!(
+            shutdown,
+            MetaAddrChange::UpdateFailed { addr, .. } if addr == test_book_addr()
+        ));
         tokio::time::timeout(Duration::from_secs(2), keeper)
             .await
             .expect("keeper exits after the peer deregisters")

--- a/crates/zakura-rpc/src/methods/tests/snapshot.rs
+++ b/crates/zakura-rpc/src/methods/tests/snapshot.rs
@@ -1049,6 +1049,8 @@ pub async fn test_mining_rpcs<State, ReadState>(
         .into(),
         &PeerServices::NODE_NETWORK,
         false,
+        String::new(),
+        zakura_network::Version(0),
     )
     .into_new_meta_addr(Instant::now(), DateTime32::now())]);
 

--- a/crates/zakura-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
+++ b/crates/zakura-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
@@ -5,6 +5,8 @@ expression: get_peer_info
 [
   {
     "addr": "127.0.0.1:8233",
+    "subver": "",
+    "version": 0,
     "inbound": false
   }
 ]

--- a/crates/zakura-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
+++ b/crates/zakura-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
@@ -5,6 +5,8 @@ expression: get_peer_info
 [
   {
     "addr": "127.0.0.1:18233",
+    "subver": "",
+    "version": 0,
     "inbound": false
   }
 ]

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -2752,6 +2752,8 @@ async fn rpc_getpeerinfo() {
         .into(),
         &PeerServices::NODE_NETWORK,
         false,
+        String::new(),
+        zakura_network::Version(0),
     )
     .into_new_meta_addr(
         std::time::Instant::now(),
@@ -2767,6 +2769,8 @@ async fn rpc_getpeerinfo() {
         .into(),
         &PeerServices::NODE_NETWORK,
         true,
+        String::new(),
+        zakura_network::Version(0),
     )
     .into_new_meta_addr(
         std::time::Instant::now(),
@@ -2787,8 +2791,8 @@ async fn rpc_getpeerinfo() {
     );
 
     let mock_address_book = MockAddressBookPeers::new(vec![
-        outbound_mock_peer_address,
-        inbound_mock_peer_address,
+        outbound_mock_peer_address.clone(),
+        inbound_mock_peer_address.clone(),
         not_connected_mock_peer_adderess,
     ]);
 
@@ -4109,6 +4113,8 @@ async fn rpc_addnode() {
             // TODO: Fix this when mock address book provides other values
             pingtime: Some(0.1f64),
             pingwait: None,
+            subver: String::new(),
+            version: 0,
         }]
     );
 

--- a/crates/zakura-rpc/src/methods/types/peer_info.rs
+++ b/crates/zakura-rpc/src/methods/types/peer_info.rs
@@ -1,11 +1,10 @@
 //! An array of [`PeerInfo`] is the output of the `getpeerinfo` RPC method.
 
 use derive_getters::Getters;
-use derive_new::new;
 use zakura_network::{types::MetaAddr, PeerSocketAddr};
 
 /// Item of the `getpeerinfo` response
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters)]
 pub struct PeerInfo {
     /// The IP address and port of the peer
     #[getter(copy)]
@@ -31,6 +30,25 @@ pub struct PeerInfo {
 
 /// Response type for the `getpeerinfo` RPC method.
 pub type GetPeerInfoResponse = Vec<PeerInfo>;
+
+impl PeerInfo {
+    /// Creates peer information without optional handshake metadata.
+    pub fn new(
+        addr: PeerSocketAddr,
+        inbound: bool,
+        pingtime: Option<f64>,
+        pingwait: Option<f64>,
+    ) -> Self {
+        Self {
+            addr,
+            subver: String::new(),
+            version: 0,
+            inbound,
+            pingtime,
+            pingwait,
+        }
+    }
+}
 
 impl From<MetaAddr> for PeerInfo {
     fn from(meta_addr: MetaAddr) -> Self {

--- a/crates/zakura-rpc/src/methods/types/peer_info.rs
+++ b/crates/zakura-rpc/src/methods/types/peer_info.rs
@@ -11,6 +11,12 @@ pub struct PeerInfo {
     #[getter(copy)]
     pub(crate) addr: PeerSocketAddr,
 
+    /// The peer's user agent string.
+    pub(crate) subver: String,
+
+    /// The negotiated protocol version.
+    pub(crate) version: u32,
+
     /// Inbound (true) or Outbound (false)
     pub(crate) inbound: bool,
 
@@ -28,8 +34,15 @@ pub type GetPeerInfoResponse = Vec<PeerInfo>;
 
 impl From<MetaAddr> for PeerInfo {
     fn from(meta_addr: MetaAddr) -> Self {
+        let subver = meta_addr.user_agent().unwrap_or_default().to_string();
+        let version = meta_addr
+            .negotiated_version()
+            .map_or(0, |version| version.0);
+
         Self {
             addr: meta_addr.addr(),
+            subver,
+            version,
             inbound: meta_addr.is_inbound(),
             pingtime: meta_addr.rtt().map(|d| d.as_secs_f64()),
             pingwait: meta_addr.ping_sent_at().map(|t| t.elapsed().as_secs_f64()),
@@ -41,6 +54,8 @@ impl Default for PeerInfo {
     fn default() -> Self {
         Self {
             addr: PeerSocketAddr::unspecified(),
+            subver: String::new(),
+            version: 0,
             inbound: false,
             pingtime: None,
             pingwait: None,

--- a/crates/zakura-rpc/src/methods/types/peer_info.rs
+++ b/crates/zakura-rpc/src/methods/types/peer_info.rs
@@ -11,9 +11,11 @@ pub struct PeerInfo {
     pub(crate) addr: PeerSocketAddr,
 
     /// The peer's user agent string.
+    #[serde(default)]
     pub(crate) subver: String,
 
     /// The negotiated protocol version.
+    #[serde(default)]
     pub(crate) version: u32,
 
     /// Inbound (true) or Outbound (false)

--- a/crates/zakura-rpc/tests/serialization_tests.rs
+++ b/crates/zakura-rpc/tests/serialization_tests.rs
@@ -1407,10 +1407,14 @@ fn test_get_peer_info() -> Result<(), Box<dyn std::error::Error>> {
 [
   {
     "addr": "192.168.0.1:8233",
+    "subver": "",
+    "version": 0,
     "inbound": false
   },
   {
     "addr": "[2000:2000:2000:0000::]:8233",
+    "subver": "",
+    "version": 0,
     "inbound": false
   }
 ]
@@ -1437,12 +1441,16 @@ fn test_get_peer_info_with_ping_values_serialization() -> Result<(), Box<dyn std
 [
   {
     "addr": "192.168.0.1:8233",
+    "subver": "",
+    "version": 0,
     "inbound": false,
     "pingtime": 123,
     "pingwait": 45
   },
   {
     "addr": "[2000:2000:2000:0000::]:8233",
+    "subver": "",
+    "version": 0,
     "inbound": false,
     "pingtime": 67,
     "pingwait": 89

--- a/crates/zakura-rpc/tests/serialization_tests.rs
+++ b/crates/zakura-rpc/tests/serialization_tests.rs
@@ -1407,14 +1407,10 @@ fn test_get_peer_info() -> Result<(), Box<dyn std::error::Error>> {
 [
   {
     "addr": "192.168.0.1:8233",
-    "subver": "",
-    "version": 0,
     "inbound": false
   },
   {
     "addr": "[2000:2000:2000:0000::]:8233",
-    "subver": "",
-    "version": 0,
     "inbound": false
   }
 ]
@@ -1431,6 +1427,26 @@ fn test_get_peer_info() -> Result<(), Box<dyn std::error::Error>> {
         PeerInfo::new(addr1.into(), inbound1, None, None),
     ];
     assert_eq!(obj, new_obj);
+
+    Ok(())
+}
+
+#[test]
+fn test_get_peer_info_metadata_serialization() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"
+[
+  {
+    "addr": "192.168.0.1:8233",
+    "subver": "/Zakura:1.0.3/",
+    "version": 170160,
+    "inbound": false
+  }
+]
+"#;
+    let obj: GetPeerInfoResponse = serde_json::from_str(json)?;
+
+    assert_eq!(obj[0].subver(), "/Zakura:1.0.3/");
+    assert_eq!(obj[0].version(), 170160);
 
     Ok(())
 }

--- a/docs/changelog/unreleased/682.md
+++ b/docs/changelog/unreleased/682.md
@@ -1,0 +1,4 @@
+## Added
+
+- Added peer software identifiers (`subver`) and negotiated protocol versions
+  to the `getpeerinfo` RPC response ([#682](https://github.com/zakura-core/zakura/pull/682)).


### PR DESCRIPTION
## Motivation

CipherScan cannot identify Zakura peers through `getpeerinfo`: the RPC response omits the user-agent and negotiated protocol version even though both are advertised during the P2P handshake.

## Solution

- Retain handshake user-agent and negotiated protocol version in `MetaAddr`.
- Store retained user agents as shared `Arc<str>` data, so address-book/index/cache clones do not duplicate the string allocation.
- Preserve the metadata through address-book updates.
- Add `subver` and `version` to `getpeerinfo`, following Zebra’s design.
- Preserve the existing four-argument `PeerInfo::new` constructor for downstream compatibility.
- Update RPC snapshots, serialization fixtures, benchmarks, and ownership-sensitive network tests for the intentional removal of `MetaAddr: Copy`.

## Testing

Passed locally:

- `cargo fmt --all -- --check`
- `cargo check -p zakura-network --all-targets`
- `cargo check -p zakura-rpc --all-targets`
- `cargo clippy -p zakura-network -p zakura-rpc --lib -- -D warnings`
- `cargo test -p zakura-network --lib --no-run`
- `cargo test -p zakura-network meta_addr --lib`
- `cargo test -p zakura-rpc rpc_getpeerinfo --lib`
- `cargo test -p zakura-rpc test_rpc_response_data --lib`
- `cargo test -p zakura-rpc test_get_peer_info_with_ping_values_serialization --test serialization_tests`
- `./scripts/changelog.py check`
- `git diff --check`

The full local network unit run executed 1,062 passing tests; seven environment-sensitive tests failed at runtime (loopback source binding and local block-sync fuzz timing), not during compilation.

The all-target clippy command encounters an existing duplicated `#[cfg(test)]` attribute in `zakura-network/src/zakura/discovery/service.rs`; the changed libraries pass targeted clippy.

## Changelog

Added `docs/changelog/unreleased/682.md` for the user-visible RPC change.

### Specifications & References

- Zebra peer metadata design

### Follow-up Work

- Keep the PR draft while the refreshed CI checks complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer metadata storage, Zakura upgrade address-book updates, and RPC output across the network stack; behavior shifts for upgraded peers when native connections end.
> 
> **Overview**
> **`getpeerinfo`** now returns handshake **`subver`** and negotiated **`version`** for live peers, sourced from address-book **`MetaAddr`** entries instead of omitting that data.
> 
> **`MetaAddr`** drops **`Copy`** and stores optional user agent (**`Arc<str`**) and negotiated protocol version from **`UpdateConnected`**, with **`clone()`** used across the address book, codecs, and tests. **`PeerInfo::new`** keeps its four-argument shape for compatibility.
> 
> Successful **Zakura P2P v2** upgrades record connected metadata (including inbound peers) via **`record_zakura_upgrade`**; duplicate upgrades do not. The legacy liveness keeper now emits **`UpdateFailed`** on shutdown when the native connection deregisters so upgraded peers no longer linger in **`getpeerinfo`** after the replacement session ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb29cc9cbee632382fde0462d46e77cceab3b12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->