### PR TITLE
fix(network): require fresh upgrade registrations

### DIFF
--- a/crates/zakura-network/src/peer/handshake.rs
+++ b/crates/zakura-network/src/peer/handshake.rs
@@ -54,7 +54,10 @@ use crate::{
         ZakuraHandshakeConfig, ZakuraLegacyNonces, ZakuraPeerId, ZakuraProtocolError,
         P2P_V2_UPGRADE_COMMAND, PRELUDE_MAGIC,
     },
-    zakura::{ZakuraHandshakeConnector, ZakuraRejectReason, ZakuraUpgradeOutcome},
+    zakura::{
+        ZakuraHandshakeConnector, ZakuraRegistrationWait, ZakuraRejectReason, ZakuraUpgradeOutcome,
+        ZakuraUpgradeRegistration,
+    },
     BoxError, Config, PeerSocketAddr, VersionMessage,
 };
 
@@ -1240,7 +1243,7 @@ where
     // Dial the responder's Zakura endpoint over QUIC and wait for the local
     // supervisor to register a usable outbound handle before dropping the
     // legacy connection.
-    if !connector
+    match connector
         .spawn_zakura_dial_to_hints_and_wait(
             &peer_id,
             &accept.iroh_node_id,
@@ -1248,10 +1251,10 @@ where
         )
         .await
     {
-        return Ok(neutral_upgrade_fallback());
+        ZakuraUpgradeRegistration::Fresh { .. } => Ok(ZakuraUpgradeOutcome::Upgraded { peer_id }),
+        ZakuraUpgradeRegistration::Duplicate => Ok(ZakuraUpgradeOutcome::Duplicate { peer_id }),
+        ZakuraUpgradeRegistration::Unavailable => Ok(neutral_upgrade_fallback()),
     }
-
-    Ok(ZakuraUpgradeOutcome::Upgraded { peer_id })
 }
 
 /// Selects the registration wait used by the responder upgrade path.
@@ -1262,15 +1265,13 @@ enum ResponderRegistrationWait {
 }
 
 impl ResponderRegistrationWait {
-    async fn wait(self, connector: &ZakuraHandshakeConnector, peer_id: &ZakuraPeerId) -> bool {
+    async fn wait(self, registration_wait: ZakuraRegistrationWait) -> bool {
         match self {
-            Self::Production => connector.wait_for_zakura_registration(peer_id).await,
+            Self::Production => registration_wait.wait().await.is_some(),
             #[cfg(test)]
-            Self::TestTimeout(timeout) => {
-                tokio::time::timeout(timeout, connector.wait_for_zakura_registration(peer_id))
-                    .await
-                    .unwrap_or(false)
-            }
+            Self::TestTimeout(timeout) => tokio::time::timeout(timeout, registration_wait.wait())
+                .await
+                .is_ok_and(|conn_id| conn_id.is_some()),
         }
     }
 }
@@ -1309,6 +1310,15 @@ where
         }
     };
 
+    let Ok(peer_id) = ZakuraPeerId::new(init.iroh_node_id.clone()) else {
+        send_upgrade_reject(peer_conn, config).await?;
+        return Ok(neutral_upgrade_fallback());
+    };
+    let Some(native_registration) = connector.prepare_zakura_registration_wait(&peer_id) else {
+        send_upgrade_reject(peer_conn, config).await?;
+        return Ok(neutral_upgrade_fallback());
+    };
+
     let mut responder_upgrade_nonce = [0u8; 32];
     OsRng.fill_bytes(&mut responder_upgrade_nonce);
 
@@ -1335,9 +1345,9 @@ where
     };
     peer_conn.send(Message::P2pV2Upgrade(accept_bytes)).await?;
 
-    let Ok(peer_id) = ZakuraPeerId::new(init.iroh_node_id.clone()) else {
-        return Ok(neutral_upgrade_fallback());
-    };
+    if native_registration.is_duplicate() {
+        return Ok(ZakuraUpgradeOutcome::Duplicate { peer_id });
+    }
 
     // The peer dials our advertised Zakura endpoint over QUIC after receiving
     // `Accept`, and our iroh router registers that inbound connection
@@ -1347,7 +1357,7 @@ where
     // and then never completes the native dial would make us discard a working
     // legacy connection with no Zakura replacement. This mirrors the initiator's
     // `spawn_zakura_dial_to_hints_and_wait` hand-off wait.
-    if !registration_wait.wait(connector, &peer_id).await {
+    if !registration_wait.wait(native_registration).await {
         return Ok(neutral_upgrade_fallback());
     }
 

--- a/crates/zakura-network/src/peer/handshake.rs
+++ b/crates/zakura-network/src/peer/handshake.rs
@@ -50,13 +50,14 @@ use crate::{
     },
     types::MetaAddr,
     zakura::{
+        legacy_upgrade_transcript, PendingUpgrade, ZakuraHandshakeConnector,
+        ZakuraRegistrationWait, ZakuraRejectReason, ZakuraUpgradeOutcome,
+        ZakuraUpgradeRegistration,
+    },
+    zakura::{
         P2pV2Upgrade, P2pV2UpgradeAccept, P2pV2UpgradeInit, P2pV2UpgradeReject,
         ZakuraHandshakeConfig, ZakuraLegacyNonces, ZakuraPeerId, ZakuraProtocolError,
         P2P_V2_UPGRADE_COMMAND, PRELUDE_MAGIC,
-    },
-    zakura::{
-        ZakuraHandshakeConnector, ZakuraRegistrationWait, ZakuraRejectReason, ZakuraUpgradeOutcome,
-        ZakuraUpgradeRegistration,
     },
     BoxError, Config, PeerSocketAddr, VersionMessage,
 };
@@ -1056,11 +1057,6 @@ where
         &node_config.network,
         node_config.zakura.dev_network.as_deref(),
     );
-    let nonces = ZakuraLegacyNonces {
-        local_zebra_nonce: connection_info.local.nonce,
-        remote_zebra_nonce: connection_info.remote.nonce,
-    };
-
     // The side that opened the legacy TCP connection initiates the prelude and
     // dials over QUIC; the accepting side responds and is dialed.
     let outcome = if connected_addr.is_inbound() {
@@ -1068,7 +1064,7 @@ where
             peer_conn,
             &connector,
             &upgrade_config,
-            nonces,
+            connection_info,
             local_node_id,
             local_direct_addresses,
             ResponderRegistrationWait::Production,
@@ -1079,7 +1075,7 @@ where
             peer_conn,
             &connector,
             &upgrade_config,
-            nonces,
+            connection_info,
             local_node_id,
             local_direct_addresses,
         )
@@ -1191,13 +1187,17 @@ async fn run_initiator_upgrade<PeerTransport>(
     peer_conn: &mut Framed<PeerTransport, Codec>,
     connector: &ZakuraHandshakeConnector,
     config: &ZakuraHandshakeConfig,
-    nonces: ZakuraLegacyNonces,
+    connection_info: &ConnectionInfo,
     local_node_id: Vec<u8>,
     local_direct_addresses: Vec<Vec<u8>>,
 ) -> Result<ZakuraUpgradeOutcome, HandshakeError>
 where
     PeerTransport: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
+    let nonces = ZakuraLegacyNonces {
+        local_zebra_nonce: connection_info.local.nonce,
+        remote_zebra_nonce: connection_info.remote.nonce,
+    };
     let mut upgrade_nonce = [0u8; 32];
     OsRng.fill_bytes(&mut upgrade_nonce);
 
@@ -1239,6 +1239,21 @@ where
     let Ok(peer_id) = ZakuraPeerId::new(accept.iroh_node_id.clone()) else {
         return Ok(neutral_upgrade_fallback());
     };
+    let Ok(transcript) = legacy_upgrade_transcript(
+        &connection_info.local,
+        &connection_info.remote,
+        &init,
+        &accept,
+    ) else {
+        return Ok(neutral_upgrade_fallback());
+    };
+    let pending = PendingUpgrade::new(
+        peer_id.clone(),
+        accept.selected_zakura_protocol,
+        init.upgrade_nonce,
+        accept.responder_upgrade_nonce,
+        transcript,
+    );
 
     // Dial the responder's Zakura endpoint over QUIC and wait for the local
     // supervisor to register a usable outbound handle before dropping the
@@ -1248,6 +1263,7 @@ where
             &peer_id,
             &accept.iroh_node_id,
             &accept.iroh_direct_addresses,
+            pending,
         )
         .await
     {
@@ -1285,7 +1301,7 @@ async fn run_responder_upgrade<PeerTransport>(
     peer_conn: &mut Framed<PeerTransport, Codec>,
     connector: &ZakuraHandshakeConnector,
     config: &ZakuraHandshakeConfig,
-    nonces: ZakuraLegacyNonces,
+    connection_info: &ConnectionInfo,
     local_node_id: Vec<u8>,
     local_direct_addresses: Vec<Vec<u8>>,
     registration_wait: ResponderRegistrationWait,
@@ -1293,6 +1309,10 @@ async fn run_responder_upgrade<PeerTransport>(
 where
     PeerTransport: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
+    let nonces = ZakuraLegacyNonces {
+        local_zebra_nonce: connection_info.local.nonce,
+        remote_zebra_nonce: connection_info.remote.nonce,
+    };
     // A well-formed unexpected variant or no prelude within the skip window: send
     // a neutral reject and keep legacy. A malformed prelude is not reached here;
     // `read_upgrade_prelude` disconnects on the first malformed upgrade message
@@ -1314,11 +1334,6 @@ where
         send_upgrade_reject(peer_conn, config).await?;
         return Ok(neutral_upgrade_fallback());
     };
-    let Some(native_registration) = connector.prepare_zakura_registration_wait(&peer_id) else {
-        send_upgrade_reject(peer_conn, config).await?;
-        return Ok(neutral_upgrade_fallback());
-    };
-
     let mut responder_upgrade_nonce = [0u8; 32];
     OsRng.fill_bytes(&mut responder_upgrade_nonce);
 
@@ -1340,10 +1355,38 @@ where
         max_open_streams: config.max_open_streams,
     };
 
-    let Ok(accept_bytes) = P2pV2Upgrade::Accept(accept).encode() else {
+    let Ok(transcript) = legacy_upgrade_transcript(
+        &connection_info.remote,
+        &connection_info.local,
+        &init,
+        &accept,
+    ) else {
+        send_upgrade_reject(peer_conn, config).await?;
         return Ok(neutral_upgrade_fallback());
     };
-    peer_conn.send(Message::P2pV2Upgrade(accept_bytes)).await?;
+    let pending = PendingUpgrade::new(
+        peer_id.clone(),
+        selected_zakura_protocol,
+        init.upgrade_nonce,
+        responder_upgrade_nonce,
+        transcript,
+    );
+    let Some(native_registration) = connector
+        .prepare_zakura_registration_wait(&peer_id, pending)
+        .await
+    else {
+        send_upgrade_reject(peer_conn, config).await?;
+        return Ok(neutral_upgrade_fallback());
+    };
+
+    let Ok(accept_bytes) = P2pV2Upgrade::Accept(accept).encode() else {
+        connector.cancel_pending_inbound_upgrade(&peer_id).await;
+        return Ok(neutral_upgrade_fallback());
+    };
+    if let Err(error) = peer_conn.send(Message::P2pV2Upgrade(accept_bytes)).await {
+        connector.cancel_pending_inbound_upgrade(&peer_id).await;
+        return Err(error.into());
+    }
 
     if native_registration.is_duplicate() {
         return Ok(ZakuraUpgradeOutcome::Duplicate { peer_id });
@@ -1358,6 +1401,7 @@ where
     // legacy connection with no Zakura replacement. This mirrors the initiator's
     // `spawn_zakura_dial_to_hints_and_wait` hand-off wait.
     if !registration_wait.wait(native_registration).await {
+        connector.cancel_pending_inbound_upgrade(&peer_id).await;
         return Ok(neutral_upgrade_fallback());
     }
 

--- a/crates/zakura-network/src/peer/handshake/tests.rs
+++ b/crates/zakura-network/src/peer/handshake/tests.rs
@@ -46,6 +46,28 @@ fn peer_addr(port: u16) -> PeerSocketAddr {
     SocketAddr::from((Ipv4Addr::LOCALHOST, port)).into()
 }
 
+fn upgrade_connection_info(nonces: ZakuraLegacyNonces) -> ConnectionInfo {
+    let addr = peer_addr(18233);
+    let version = |nonce| VersionMessage {
+        version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
+        services: PeerServices::NODE_NETWORK | PeerServices::NODE_P2P_V2,
+        timestamp: Utc::now(),
+        address_recv: AddrInVersion::new(addr, PeerServices::NODE_NETWORK),
+        address_from: AddrInVersion::new(addr, PeerServices::NODE_NETWORK),
+        nonce,
+        user_agent: "/Zebra:test/".to_string(),
+        start_height: block::Height(0),
+        relay: true,
+    };
+    ConnectionInfo {
+        connected_addr: ConnectedAddr::new_outbound_direct(addr),
+        local: version(nonces.local_zebra_nonce),
+        remote: version(nonces.remote_zebra_nonce),
+        negotiated_version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
+        is_protected_peer: false,
+    }
+}
+
 #[test]
 fn connected_addr_labels_require_explicit_opt_in() {
     let peer = ConnectedAddr::new_outbound_direct(
@@ -368,6 +390,7 @@ async fn responder_upgrade_keeps_legacy_when_native_dial_never_registers() {
         local_zebra_nonce: Nonce(0x1111_1111_1111_1111),
         remote_zebra_nonce: Nonce(0x2222_2222_2222_2222),
     };
+    let connection_info = upgrade_connection_info(nonces);
 
     // The responder advertises its own live Zakura hints in the `Accept`.
     let (local_node_id, local_direct_addresses) = connector
@@ -439,7 +462,7 @@ async fn responder_upgrade_keeps_legacy_when_native_dial_never_registers() {
         &mut responder_conn,
         &connector,
         &config,
-        nonces,
+        &connection_info,
         local_node_id,
         local_direct_addresses,
         ResponderRegistrationWait::TestTimeout(std::time::Duration::from_millis(50)),
@@ -485,6 +508,7 @@ async fn responder_upgrade_disconnects_on_malformed_prelude() {
         local_zebra_nonce: Nonce(0x1111_1111_1111_1111),
         remote_zebra_nonce: Nonce(0x2222_2222_2222_2222),
     };
+    let connection_info = upgrade_connection_info(nonces);
     // The malformed-prelude branch returns before any endpoint use, so a
     // connector without a live endpoint is enough to exercise the responder
     // path.
@@ -512,7 +536,7 @@ async fn responder_upgrade_disconnects_on_malformed_prelude() {
         &mut responder_conn,
         &connector,
         &config,
-        nonces,
+        &connection_info,
         vec![1u8; 32],
         vec![b"127.0.0.1:1".to_vec()],
         ResponderRegistrationWait::Production,
@@ -575,6 +599,7 @@ async fn initiator_upgrade_disconnects_on_malformed_prelude() {
         local_zebra_nonce: Nonce(0x3333_3333_3333_3333),
         remote_zebra_nonce: Nonce(0x4444_4444_4444_4444),
     };
+    let connection_info = upgrade_connection_info(nonces);
     let connector = crate::zakura::ZakuraHandshakeConnector::unavailable();
 
     let (initiator_stream, peer_stream) = duplex(16 * 1024);
@@ -608,7 +633,7 @@ async fn initiator_upgrade_disconnects_on_malformed_prelude() {
         &mut initiator_conn,
         &connector,
         &config,
-        nonces,
+        &connection_info,
         vec![1u8; 32],
         vec![b"127.0.0.1:1".to_vec()],
     );

--- a/crates/zakura-network/src/zakura.rs
+++ b/crates/zakura-network/src/zakura.rs
@@ -3,7 +3,7 @@
 //! This module reserves the iroh dependency, privacy-preserving endpoint posture,
 //! persistent identity storage surface, and bounded Zakura handshake wire types.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use iroh::{endpoint, Endpoint, NodeAddr, NodeId, RelayMode, SecretKey};
 use serde::{Deserialize, Serialize};
@@ -180,8 +180,8 @@ impl Default for ServicePeerSnapshot {
     }
 }
 
-/// How long the legacy->Zakura liveness keeper waits for the upgraded QUIC
-/// connection to register with the supervisor before giving up.
+/// How long a legacy->Zakura handoff waits for the upgraded QUIC connection to
+/// register with the supervisor before giving up.
 ///
 /// The native dial spawned by the upgrade is asynchronous, so the peer only
 /// appears in the supervisor's registered set a little later. If it never
@@ -195,6 +195,57 @@ const ZAKURA_LIVENESS_APPEAR_TIMEOUT: Duration = Duration::from_secs(15);
 /// so the `Responded` liveness never ages into a reconnection candidate while
 /// the Zakura connection is alive.
 const ZAKURA_LIVENESS_REFRESH_INTERVAL: Duration = Duration::from_secs(45);
+
+/// Result of waiting for a native registration during a legacy upgrade.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ZakuraUpgradeRegistration {
+    /// This upgrade observed a fresh authenticated native connection.
+    Fresh {
+        /// The supervisor generation assigned to the connection.
+        conn_id: ZakuraConnId,
+    },
+    /// The claimed peer identity was already registered before this upgrade.
+    Duplicate,
+    /// No matching native connection registered within the bounded wait.
+    Unavailable,
+}
+
+/// A registration snapshot captured before accepting a legacy upgrade.
+pub(crate) struct ZakuraRegistrationWait {
+    registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>>,
+    peer_id: ZakuraPeerId,
+    previous_conn_id: Option<ZakuraConnId>,
+}
+
+impl ZakuraRegistrationWait {
+    fn new(
+        mut registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>>,
+        peer_id: ZakuraPeerId,
+    ) -> Self {
+        let previous_conn_id = registered.borrow_and_update().get(&peer_id).copied();
+        Self {
+            registered,
+            peer_id,
+            previous_conn_id,
+        }
+    }
+
+    /// Returns whether this peer identity was registered before the upgrade.
+    pub(crate) fn is_duplicate(&self) -> bool {
+        self.previous_conn_id.is_some()
+    }
+
+    /// Wait for a registration generation that did not exist in the snapshot.
+    pub(crate) async fn wait(self) -> Option<ZakuraConnId> {
+        wait_for_fresh_zakura_peer(
+            self.registered,
+            self.peer_id,
+            self.previous_conn_id,
+            ZAKURA_LIVENESS_APPEAR_TIMEOUT,
+        )
+        .await
+    }
+}
 
 /// Returns an iroh endpoint builder with relays and external address lookup disabled.
 ///
@@ -293,19 +344,25 @@ impl ZakuraHandshakeConnector {
         peer_id: &ZakuraPeerId,
         node_id: &[u8],
         direct_addresses: &[Vec<u8>],
-    ) -> bool {
+    ) -> ZakuraUpgradeRegistration {
         let Some(endpoint) = self.endpoint.as_ref() else {
-            return false;
+            return ZakuraUpgradeRegistration::Unavailable;
         };
         let Some(node_addr) = node_addr_from_hints(node_id, direct_addresses) else {
-            return false;
+            return ZakuraUpgradeRegistration::Unavailable;
         };
-        let mut registered = endpoint.supervisor().subscribe();
-        if !endpoint.ensure_upgrade_native_dial(node_addr) {
-            return false;
+        let registration_wait = ZakuraRegistrationWait::new(
+            endpoint.supervisor().subscribe_registrations(),
+            peer_id.clone(),
+        );
+        if registration_wait.is_duplicate() {
+            return ZakuraUpgradeRegistration::Duplicate;
         }
-        if wait_for_zakura_peer(&mut registered, peer_id, ZAKURA_LIVENESS_APPEAR_TIMEOUT).await {
-            return true;
+        if !endpoint.ensure_upgrade_native_dial(node_addr) {
+            return ZakuraUpgradeRegistration::Unavailable;
+        }
+        if let Some(conn_id) = registration_wait.wait().await {
+            return ZakuraUpgradeRegistration::Fresh { conn_id };
         }
 
         // The hand-off did not complete within the wait window. The dial spawned
@@ -316,30 +373,35 @@ impl ZakuraHandshakeConnector {
         // drop the entry so a malicious legacy responder cannot leak unbounded
         // maintained dials and outbound QUIC traffic by repeating failed
         // upgrades with distinct node ids.
-        if !registered.borrow().iter().any(|id| id == peer_id) {
+        if !endpoint
+            .supervisor()
+            .subscribe_registrations()
+            .borrow()
+            .contains_key(peer_id)
+        {
             endpoint.cancel_upgrade_native_dial(peer_id);
         }
-        false
+        ZakuraUpgradeRegistration::Unavailable
     }
 
-    /// Wait until the upgraded peer's inbound native QUIC connection registers
-    /// with the local supervisor.
+    /// Capture the current registration generation before accepting an inbound
+    /// legacy upgrade.
     ///
     /// Used by the inbound legacy responder, which does not dial: after sending
     /// `Accept` the remote peer is expected to dial our advertised Zakura
     /// endpoint, and our iroh router registers that connection separately. The
-    /// outer handshake drops the legacy TCP connection once the upgrade is
-    /// reported, so the responder must confirm a usable Zakura replacement
-    /// exists first. Returns `false` (keep legacy) if the peer never registers
-    /// within [`ZAKURA_LIVENESS_APPEAR_TIMEOUT`] or this node has no live
-    /// endpoint, so a peer that sends a valid `Init` and then never completes
-    /// the native dial cannot make us silently drop a working legacy peer.
-    pub(crate) async fn wait_for_zakura_registration(&self, peer_id: &ZakuraPeerId) -> bool {
-        let Some(endpoint) = self.endpoint.as_ref() else {
-            return false;
-        };
-        let mut registered = endpoint.supervisor().subscribe();
-        wait_for_zakura_peer(&mut registered, peer_id, ZAKURA_LIVENESS_APPEAR_TIMEOUT).await
+    /// snapshot distinguishes a fresh replacement from an unrelated incumbent
+    /// with the same claimed identity. Returns `None` if this node has no live
+    /// endpoint.
+    pub(crate) fn prepare_zakura_registration_wait(
+        &self,
+        peer_id: &ZakuraPeerId,
+    ) -> Option<ZakuraRegistrationWait> {
+        let endpoint = self.endpoint.as_ref()?;
+        Some(ZakuraRegistrationWait::new(
+            endpoint.supervisor().subscribe_registrations(),
+            peer_id.clone(),
+        ))
     }
 
     /// Keep an upgraded peer's legacy address-book entry live for the lifetime
@@ -493,6 +555,29 @@ async fn wait_for_zakura_peer(
     .unwrap_or(false)
 }
 
+/// Wait until `peer_id` has a registration generation newer than the snapshot.
+async fn wait_for_fresh_zakura_peer(
+    mut registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>>,
+    peer_id: ZakuraPeerId,
+    previous_conn_id: Option<ZakuraConnId>,
+    appear_timeout: Duration,
+) -> Option<ZakuraConnId> {
+    tokio::time::timeout(appear_timeout, async {
+        loop {
+            let conn_id = registered.borrow_and_update().get(&peer_id).copied();
+            if conn_id.is_some() && conn_id != previous_conn_id {
+                return conn_id;
+            }
+            if registered.changed().await.is_err() {
+                return None;
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -580,6 +665,46 @@ mod tests {
             .parse::<std::net::SocketAddr>()
             .expect("valid socket addr")
             .into()
+    }
+
+    #[test]
+    fn registration_wait_detects_preexisting_peer() {
+        let peer_id = test_peer_id();
+        let registrations = HashMap::from([(peer_id.clone(), 7)]);
+        let (_registered_tx, registered_rx) = watch::channel(registrations);
+
+        let registration_wait = ZakuraRegistrationWait::new(registered_rx, peer_id);
+
+        assert!(registration_wait.is_duplicate());
+    }
+
+    #[tokio::test]
+    async fn registration_wait_requires_fresh_matching_generation() {
+        let peer_id = test_peer_id();
+        let (registered_tx, registered_rx) = watch::channel(HashMap::new());
+        let mut registration_wait =
+            tokio::spawn(ZakuraRegistrationWait::new(registered_rx, peer_id.clone()).wait());
+
+        let unrelated_peer =
+            ZakuraPeerId::new(vec![8u8; 32]).expect("32-byte node id is within bounds");
+        registered_tx
+            .send(HashMap::from([(unrelated_peer, 1)]))
+            .expect("registration waiter is alive");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut registration_wait)
+                .await
+                .is_err(),
+            "an unrelated registration must not complete the upgrade wait",
+        );
+
+        registered_tx
+            .send(HashMap::from([(peer_id, 2)]))
+            .expect("registration waiter is alive");
+        let conn_id = tokio::time::timeout(Duration::from_secs(1), registration_wait)
+            .await
+            .expect("the fresh peer registration completes the wait")
+            .expect("the registration waiter does not panic");
+        assert_eq!(conn_id, Some(2));
     }
 
     /// While the peer stays registered, the keeper repeatedly refreshes its

--- a/crates/zakura-network/src/zakura.rs
+++ b/crates/zakura-network/src/zakura.rs
@@ -210,29 +210,39 @@ pub(crate) enum ZakuraUpgradeRegistration {
     Unavailable,
 }
 
+/// Supervisor facts used to bind a legacy handoff to one native connection.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ZakuraRegistrationSnapshot {
+    conn_id: ZakuraConnId,
+    transcript_hash: [u8; TRANSCRIPT_HASH_BYTES],
+}
+
 /// A registration snapshot captured before accepting a legacy upgrade.
 pub(crate) struct ZakuraRegistrationWait {
-    registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>>,
+    registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraRegistrationSnapshot>>,
     peer_id: ZakuraPeerId,
-    previous_conn_id: Option<ZakuraConnId>,
+    previous: Option<ZakuraRegistrationSnapshot>,
+    expected_transcript_hash: [u8; TRANSCRIPT_HASH_BYTES],
 }
 
 impl ZakuraRegistrationWait {
     fn new(
-        mut registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>>,
+        mut registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraRegistrationSnapshot>>,
         peer_id: ZakuraPeerId,
+        expected_transcript_hash: [u8; TRANSCRIPT_HASH_BYTES],
     ) -> Self {
-        let previous_conn_id = registered.borrow_and_update().get(&peer_id).copied();
+        let previous = registered.borrow_and_update().get(&peer_id).copied();
         Self {
             registered,
             peer_id,
-            previous_conn_id,
+            previous,
+            expected_transcript_hash,
         }
     }
 
     /// Returns whether this peer identity was registered before the upgrade.
     pub(crate) fn is_duplicate(&self) -> bool {
-        self.previous_conn_id.is_some()
+        self.previous.is_some()
     }
 
     /// Wait for a registration generation that did not exist in the snapshot.
@@ -240,7 +250,8 @@ impl ZakuraRegistrationWait {
         wait_for_fresh_zakura_peer(
             self.registered,
             self.peer_id,
-            self.previous_conn_id,
+            self.previous,
+            self.expected_transcript_hash,
             ZAKURA_LIVENESS_APPEAR_TIMEOUT,
         )
         .await
@@ -344,6 +355,7 @@ impl ZakuraHandshakeConnector {
         peer_id: &ZakuraPeerId,
         node_id: &[u8],
         direct_addresses: &[Vec<u8>],
+        pending: PendingUpgrade,
     ) -> ZakuraUpgradeRegistration {
         let Some(endpoint) = self.endpoint.as_ref() else {
             return ZakuraUpgradeRegistration::Unavailable;
@@ -354,11 +366,13 @@ impl ZakuraHandshakeConnector {
         let registration_wait = ZakuraRegistrationWait::new(
             endpoint.supervisor().subscribe_registrations(),
             peer_id.clone(),
+            pending.legacy_upgrade_transcript,
         );
         if registration_wait.is_duplicate() {
             return ZakuraUpgradeRegistration::Duplicate;
         }
-        if !endpoint.ensure_upgrade_native_dial(node_addr) {
+        let expected_transcript_hash = pending.legacy_upgrade_transcript;
+        if !endpoint.ensure_transcript_bound_upgrade_dial(node_addr, pending) {
             return ZakuraUpgradeRegistration::Unavailable;
         }
         if let Some(conn_id) = registration_wait.wait().await {
@@ -366,18 +380,19 @@ impl ZakuraHandshakeConnector {
         }
 
         // The hand-off did not complete within the wait window. The dial spawned
-        // by `ensure_upgrade_native_dial` uses `RedialPolicy::maintain`, so it
+        // by `ensure_transcript_bound_upgrade_dial` uses `RedialPolicy::maintain`, so it
         // would keep redialing this peer-supplied address forever and retain its
-        // `upgrade_dials` entry. Unless the peer registered in the meantime
-        // (keep its maintained dial as the recovery path), cancel the dial and
-        // drop the entry so a malicious legacy responder cannot leak unbounded
-        // maintained dials and outbound QUIC traffic by repeating failed
-        // upgrades with distinct node ids.
-        if !endpoint
+        // `upgrade_dials` entry. Unless the transcript-bound peer registered in
+        // the meantime (keep its maintained dial as the recovery path), cancel
+        // the dial and drop the entry so a malicious legacy responder cannot
+        // leak unbounded maintained dials and outbound QUIC traffic by repeating
+        // failed upgrades with distinct node ids.
+        if endpoint
             .supervisor()
             .subscribe_registrations()
             .borrow()
-            .contains_key(peer_id)
+            .get(peer_id)
+            .is_none_or(|registration| registration.transcript_hash != expected_transcript_hash)
         {
             endpoint.cancel_upgrade_native_dial(peer_id);
         }
@@ -393,15 +408,33 @@ impl ZakuraHandshakeConnector {
     /// snapshot distinguishes a fresh replacement from an unrelated incumbent
     /// with the same claimed identity. Returns `None` if this node has no live
     /// endpoint.
-    pub(crate) fn prepare_zakura_registration_wait(
+    pub(crate) async fn prepare_zakura_registration_wait(
         &self,
         peer_id: &ZakuraPeerId,
+        pending: PendingUpgrade,
     ) -> Option<ZakuraRegistrationWait> {
         let endpoint = self.endpoint.as_ref()?;
-        Some(ZakuraRegistrationWait::new(
+        let registration_wait = ZakuraRegistrationWait::new(
             endpoint.supervisor().subscribe_registrations(),
             peer_id.clone(),
-        ))
+            pending.legacy_upgrade_transcript,
+        );
+        if !registration_wait.is_duplicate()
+            && endpoint
+                .insert_pending_inbound_upgrade(pending)
+                .await
+                .is_err()
+        {
+            return None;
+        }
+        Some(registration_wait)
+    }
+
+    /// Cancel a pending inbound transcript after its legacy handoff fails.
+    pub(crate) async fn cancel_pending_inbound_upgrade(&self, peer_id: &ZakuraPeerId) {
+        if let Some(endpoint) = &self.endpoint {
+            endpoint.cancel_pending_inbound_upgrade(peer_id).await;
+        }
     }
 
     /// Keep an upgraded peer's legacy address-book entry live for the lifetime
@@ -557,16 +590,20 @@ async fn wait_for_zakura_peer(
 
 /// Wait until `peer_id` has a registration generation newer than the snapshot.
 async fn wait_for_fresh_zakura_peer(
-    mut registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>>,
+    mut registered: watch::Receiver<HashMap<ZakuraPeerId, ZakuraRegistrationSnapshot>>,
     peer_id: ZakuraPeerId,
-    previous_conn_id: Option<ZakuraConnId>,
+    previous: Option<ZakuraRegistrationSnapshot>,
+    expected_transcript_hash: [u8; TRANSCRIPT_HASH_BYTES],
     appear_timeout: Duration,
 ) -> Option<ZakuraConnId> {
     tokio::time::timeout(appear_timeout, async {
         loop {
-            let conn_id = registered.borrow_and_update().get(&peer_id).copied();
-            if conn_id.is_some() && conn_id != previous_conn_id {
-                return conn_id;
+            let registration = registered.borrow_and_update().get(&peer_id).copied();
+            if let Some(registration) = registration.filter(|registration| {
+                Some(*registration) != previous
+                    && registration.transcript_hash == expected_transcript_hash
+            }) {
+                return Some(registration.conn_id);
             }
             if registered.changed().await.is_err() {
                 return None;
@@ -667,13 +704,21 @@ mod tests {
             .into()
     }
 
+    fn registration(conn_id: ZakuraConnId, transcript_byte: u8) -> ZakuraRegistrationSnapshot {
+        ZakuraRegistrationSnapshot {
+            conn_id,
+            transcript_hash: [transcript_byte; TRANSCRIPT_HASH_BYTES],
+        }
+    }
+
     #[test]
     fn registration_wait_detects_preexisting_peer() {
         let peer_id = test_peer_id();
-        let registrations = HashMap::from([(peer_id.clone(), 7)]);
+        let registrations = HashMap::from([(peer_id.clone(), registration(7, 1))]);
         let (_registered_tx, registered_rx) = watch::channel(registrations);
 
-        let registration_wait = ZakuraRegistrationWait::new(registered_rx, peer_id);
+        let registration_wait =
+            ZakuraRegistrationWait::new(registered_rx, peer_id, [1; TRANSCRIPT_HASH_BYTES]);
 
         assert!(registration_wait.is_duplicate());
     }
@@ -682,13 +727,15 @@ mod tests {
     async fn registration_wait_requires_fresh_matching_generation() {
         let peer_id = test_peer_id();
         let (registered_tx, registered_rx) = watch::channel(HashMap::new());
-        let mut registration_wait =
-            tokio::spawn(ZakuraRegistrationWait::new(registered_rx, peer_id.clone()).wait());
+        let expected_transcript = [2; TRANSCRIPT_HASH_BYTES];
+        let mut registration_wait = tokio::spawn(
+            ZakuraRegistrationWait::new(registered_rx, peer_id.clone(), expected_transcript).wait(),
+        );
 
         let unrelated_peer =
             ZakuraPeerId::new(vec![8u8; 32]).expect("32-byte node id is within bounds");
         registered_tx
-            .send(HashMap::from([(unrelated_peer, 1)]))
+            .send(HashMap::from([(unrelated_peer, registration(1, 2))]))
             .expect("registration waiter is alive");
         assert!(
             tokio::time::timeout(Duration::from_millis(20), &mut registration_wait)
@@ -698,13 +745,23 @@ mod tests {
         );
 
         registered_tx
-            .send(HashMap::from([(peer_id, 2)]))
+            .send(HashMap::from([(peer_id.clone(), registration(2, 3))]))
+            .expect("registration waiter is alive");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut registration_wait)
+                .await
+                .is_err(),
+            "a native registration with another transcript must not complete the wait",
+        );
+
+        registered_tx
+            .send(HashMap::from([(peer_id, registration(3, 2))]))
             .expect("registration waiter is alive");
         let conn_id = tokio::time::timeout(Duration::from_secs(1), registration_wait)
             .await
             .expect("the fresh peer registration completes the wait")
             .expect("the registration waiter does not panic");
-        assert_eq!(conn_id, Some(2));
+        assert_eq!(conn_id, Some(3));
     }
 
     /// While the peer stays registered, the keeper repeatedly refreshes its

--- a/crates/zakura-network/src/zakura/discovery/mod.rs
+++ b/crates/zakura-network/src/zakura/discovery/mod.rs
@@ -16,6 +16,6 @@ pub(crate) use candidate_dialer::{
 };
 pub(crate) use dialer::{parse_bootstrap_peer, spawn_native_bootstrap_dialer};
 pub use protocol::*;
-pub(crate) use redial::{native_dial_supervised, RedialPolicy};
+pub(crate) use redial::{native_dial_supervised, native_upgrade_dial_supervised, RedialPolicy};
 pub(crate) use runtime::{build_discovery_handle, default_advertised_services};
 pub use service::{DiscoveryPeerSession, DiscoveryService};

--- a/crates/zakura-network/src/zakura/discovery/redial.rs
+++ b/crates/zakura-network/src/zakura/discovery/redial.rs
@@ -1,11 +1,16 @@
 //! Supervised native Zakura dialing and redial policy.
 
-use std::{future::Future, pin::Pin, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use iroh::NodeAddr;
 use tokio::time::Instant;
 
-use crate::zakura::{ZakuraEndpoint, ZakuraLocalLimits, ZakuraPeerId};
+use crate::zakura::{PendingUpgrade, ZakuraEndpoint, ZakuraLocalLimits, ZakuraPeerId};
 
 /// A connection that served at least this long is treated as healthy, so the
 /// next re-dial after it drops starts from the initial (fast) backoff again
@@ -91,6 +96,28 @@ pub(crate) async fn native_dial_supervised(
     limits: ZakuraLocalLimits,
     policy: RedialPolicy,
 ) {
+    native_dial_supervised_inner(endpoint, node_addr, limits, policy, None).await;
+}
+
+/// Maintain a dial whose first successful control handshake must match a
+/// legacy upgrade transcript.
+pub(crate) async fn native_upgrade_dial_supervised(
+    endpoint: ZakuraEndpoint,
+    node_addr: NodeAddr,
+    limits: ZakuraLocalLimits,
+    policy: RedialPolicy,
+    pending: PendingUpgrade,
+) {
+    native_dial_supervised_inner(endpoint, node_addr, limits, policy, Some(pending)).await;
+}
+
+async fn native_dial_supervised_inner(
+    endpoint: ZakuraEndpoint,
+    node_addr: NodeAddr,
+    limits: ZakuraLocalLimits,
+    policy: RedialPolicy,
+    pending: Option<PendingUpgrade>,
+) {
     let Ok(peer_id) = ZakuraPeerId::new(node_addr.node_id.as_bytes().to_vec()) else {
         tracing::warn!(?node_addr, "invalid Zakura bootstrap node id; not dialing");
         return;
@@ -98,13 +125,33 @@ pub(crate) async fn native_dial_supervised(
 
     let shutdown = endpoint.background_shutdown_token();
     let registered = endpoint.supervisor().subscribe();
+    let pending = Arc::new(Mutex::new(pending));
     let supervised = run_dial_supervisor(peer_id, registered, policy, move || {
         let endpoint = endpoint.clone();
         let node_addr = node_addr.clone();
         let limits = limits.clone();
+        let pending_state = pending.clone();
+        let pending = pending_state
+            .lock()
+            .expect("pending upgrade mutex is never poisoned")
+            .clone();
         Box::pin(async move {
             let started = Instant::now();
-            match super::dialer::native_bootstrap_dial(&endpoint, node_addr, &limits).await {
+            let result = if let Some(pending) = pending {
+                crate::zakura::handler::serve_upgrade_dial_connection(
+                    &endpoint, node_addr, &limits, pending,
+                )
+                .await
+            } else {
+                super::dialer::native_bootstrap_dial(&endpoint, node_addr, &limits).await
+            };
+            if result.is_ok() {
+                pending_state
+                    .lock()
+                    .expect("pending upgrade mutex is never poisoned")
+                    .take();
+            }
+            match result {
                 Ok(()) if started.elapsed() >= ZAKURA_REDIAL_HEALTHY_CONNECTION => {
                     DialResult::Healthy
                 }

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -879,6 +879,7 @@ pub struct ZakuraSupervisorHandle {
     inner: Arc<Mutex<ZakuraSupervisorState>>,
     shutdown: CancellationToken,
     peer_set_tx: watch::Sender<Vec<ZakuraPeerId>>,
+    registration_set_tx: watch::Sender<HashMap<ZakuraPeerId, ZakuraConnId>>,
 }
 
 static NEXT_SUPERVISOR_ID: AtomicU64 = AtomicU64::new(1);
@@ -1025,6 +1026,7 @@ impl ZakuraSupervisorHandle {
             })),
             shutdown: CancellationToken::new(),
             peer_set_tx: watch::channel(Vec::new()).0,
+            registration_set_tx: watch::channel(HashMap::new()).0,
         }
     }
 
@@ -1053,6 +1055,13 @@ impl ZakuraSupervisorHandle {
     /// Subscribe to peer-set changes for event-driven tests and diagnostics.
     pub fn subscribe(&self) -> watch::Receiver<Vec<ZakuraPeerId>> {
         self.peer_set_tx.subscribe()
+    }
+
+    /// Subscribe to connection-generation changes for legacy upgrade handoffs.
+    pub(crate) fn subscribe_registrations(
+        &self,
+    ) -> watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>> {
+        self.registration_set_tx.subscribe()
     }
 
     /// Disconnect one active Zakura peer.
@@ -1138,8 +1147,14 @@ impl ZakuraSupervisorHandle {
                 state.increment_ip(remote_ip);
                 state.debug_assert_accounting();
                 let registered_ids: Vec<_> = state.active_by_peer.keys().cloned().collect();
+                let registrations = state
+                    .active_by_peer
+                    .iter()
+                    .map(|(peer_id, entry)| (peer_id.clone(), entry.conn_id))
+                    .collect();
                 set_active_connection_gauge(registered_ids.len());
                 self.peer_set_tx.send_replace(registered_ids);
+                self.registration_set_tx.send_replace(registrations);
                 let disconnect_token = state
                     .active_by_peer
                     .get(&peer_id)
@@ -1207,8 +1222,14 @@ impl ZakuraSupervisorHandle {
         state.supervisor.deregister_authenticated(peer_id);
         state.debug_assert_accounting();
         let registered_ids: Vec<_> = state.active_by_peer.keys().cloned().collect();
+        let registrations = state
+            .active_by_peer
+            .iter()
+            .map(|(peer_id, entry)| (peer_id.clone(), entry.conn_id))
+            .collect();
         set_active_connection_gauge(registered_ids.len());
         self.peer_set_tx.send_replace(registered_ids);
+        self.registration_set_tx.send_replace(registrations);
     }
 
     fn shutdown(&self) {
@@ -6381,12 +6402,15 @@ mod tests {
 
         let connector =
             crate::zakura::ZakuraHandshakeConnector::new_with_endpoint(endpoint.clone());
-        let upgraded = connector
+        let registration = connector
             .spawn_zakura_dial_to_hints_and_wait(&peer_id, &node_id, &direct_addresses)
             .await;
 
         assert!(
-            !upgraded,
+            matches!(
+                registration,
+                crate::zakura::ZakuraUpgradeRegistration::Unavailable
+            ),
             "an unreachable upgrade peer must not report a completed hand-off",
         );
         assert!(

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -55,16 +55,18 @@ use crate::{
         BlockSyncAction, BlockSyncFrontiers, BlockSyncHandle, BlockSyncService, BlockSyncStartup,
         BoxRunFuture, Clock, CloseCause, Frame, FramedRecv, FramedSend, FullStateFrontiers,
         HeaderSyncPassthroughService, HeaderSyncService, HeaderSyncStartup, OrderedSessionDemand,
-        OrderedStreamOpening, OrderedStreamPolicy, Peer, RealClock, Service, ServicePeerDirection,
-        ServiceRegistry, ServiceStream, SinkReject, Stream, StreamMode, StreamPrelude,
-        ZakuraAcceptedLimits, ZakuraBlockSyncConfig, ZakuraConnId, ZakuraControlAck,
-        ZakuraControlHello, ZakuraControlRole, ZakuraControlValidation, ZakuraHandshakeConfig,
-        ZakuraHandshakePath, ZakuraHeaderSyncConfig, ZakuraInitialLimits, ZakuraLimits,
-        ZakuraPeerId, ZakuraPeerSupervisor, ZakuraProtocolError, ZakuraRejectReason,
-        ZakuraUpgradeOutcome, CONTROL_ACK_MAGIC, CONTROL_HELLO_MAGIC, CONTROL_VERSION,
-        FRAME_HEADER_BYTES, MAX_CONTROL_PAYLOAD_BYTES, P2P_V2_ALPN, STREAM_PRELUDE_MAGIC,
-        TRANSCRIPT_HASH_BYTES, ZAKURA_CAP_HEADER_SYNC, ZAKURA_HEADER_SYNC_STREAM_VERSION,
-        ZAKURA_PROTOCOL_VERSION_1, ZAKURA_STREAM_BLOCK_SYNC, ZAKURA_STREAM_HEADER_SYNC,
+        OrderedStreamOpening, OrderedStreamPolicy, Peer, PendingUpgrade, PendingUpgradeRegistry,
+        RealClock, Service, ServicePeerDirection, ServiceRegistry, ServiceStream, SinkReject,
+        Stream, StreamMode, StreamPrelude, ZakuraAcceptedLimits, ZakuraBlockSyncConfig,
+        ZakuraConnId, ZakuraControlAck, ZakuraControlHello, ZakuraControlRole,
+        ZakuraControlValidation, ZakuraHandshakeConfig, ZakuraHandshakePath,
+        ZakuraHeaderSyncConfig, ZakuraInitialLimits, ZakuraLimits, ZakuraPeerId,
+        ZakuraPeerSupervisor, ZakuraProtocolError, ZakuraRegistrationSnapshot, ZakuraRejectReason,
+        ZakuraUpgradeOutcome, ZakuraValidationError, CONTROL_ACK_MAGIC, CONTROL_HELLO_MAGIC,
+        CONTROL_VERSION, FRAME_HEADER_BYTES, MAX_CONTROL_PAYLOAD_BYTES, P2P_V2_ALPN,
+        STREAM_PRELUDE_MAGIC, TRANSCRIPT_HASH_BYTES, ZAKURA_CAP_HEADER_SYNC,
+        ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_PROTOCOL_VERSION_1, ZAKURA_STREAM_BLOCK_SYNC,
+        ZAKURA_STREAM_HEADER_SYNC,
     },
 };
 use crate::{BoxError, Config, MAX_TX_INV_IN_SENT_MESSAGE};
@@ -530,7 +532,8 @@ pub struct ZakuraEndpoint {
     /// Maintained native dials started by the legacy->Zakura upgrade hand-off,
     /// keyed by the advertised peer id. The [`AbortHandle`] lets a failed
     /// hand-off cancel its maintain-forever dial instead of leaking it; see
-    /// [`Self::ensure_upgrade_native_dial`] and [`Self::cancel_upgrade_native_dial`].
+    /// [`Self::ensure_transcript_bound_upgrade_dial`] and
+    /// [`Self::cancel_upgrade_native_dial`].
     upgrade_dials: Arc<StdMutex<HashMap<ZakuraPeerId, AbortHandle>>>,
 }
 
@@ -711,7 +714,12 @@ impl ZakuraEndpoint {
     /// connection is still settling. Deduplicate those retries so repeated
     /// legacy upgrades do not create a swarm of independent maintained QUIC
     /// dial loops to the same peer.
-    pub(crate) fn ensure_upgrade_native_dial(&self, node_addr: NodeAddr) -> bool {
+    /// Ensure there is one maintained transcript-bound upgrade dial.
+    pub(crate) fn ensure_transcript_bound_upgrade_dial(
+        &self,
+        node_addr: NodeAddr,
+        pending: PendingUpgrade,
+    ) -> bool {
         let Ok(peer_id) = ZakuraPeerId::new(node_addr.node_id.as_bytes().to_vec()) else {
             return false;
         };
@@ -737,7 +745,14 @@ impl ZakuraEndpoint {
         );
         let task_peer_id = peer_id.clone();
         let dial = tokio::spawn(async move {
-            native_dial_supervised(endpoint.clone(), node_addr, limits, policy).await;
+            super::discovery::native_upgrade_dial_supervised(
+                endpoint.clone(),
+                node_addr,
+                limits,
+                policy,
+                pending,
+            )
+            .await;
             endpoint
                 .upgrade_dials
                 .lock()
@@ -746,6 +761,20 @@ impl ZakuraEndpoint {
         });
         upgrade_dials.insert(peer_id, dial.abort_handle());
         true
+    }
+
+    /// Register the exact legacy transcript expected on the next inbound QUIC
+    /// control handshake for this peer.
+    pub(crate) async fn insert_pending_inbound_upgrade(
+        &self,
+        pending: PendingUpgrade,
+    ) -> Result<(), ZakuraRejectReason> {
+        self.handler.insert_pending_inbound_upgrade(pending).await
+    }
+
+    /// Remove a pending inbound upgrade after its legacy handoff fails.
+    pub(crate) async fn cancel_pending_inbound_upgrade(&self, peer_id: &ZakuraPeerId) {
+        self.handler.cancel_pending_inbound_upgrade(peer_id).await;
     }
 
     /// Cancel and forget the maintained native dial started by the legacy
@@ -879,7 +908,7 @@ pub struct ZakuraSupervisorHandle {
     inner: Arc<Mutex<ZakuraSupervisorState>>,
     shutdown: CancellationToken,
     peer_set_tx: watch::Sender<Vec<ZakuraPeerId>>,
-    registration_set_tx: watch::Sender<HashMap<ZakuraPeerId, ZakuraConnId>>,
+    registration_set_tx: watch::Sender<HashMap<ZakuraPeerId, ZakuraRegistrationSnapshot>>,
 }
 
 static NEXT_SUPERVISOR_ID: AtomicU64 = AtomicU64::new(1);
@@ -898,6 +927,7 @@ struct ZakuraPeerConnectionEntry {
     /// Monotonic supervisor registration generation used by services to ignore
     /// stale add/remove work from a superseded connection.
     conn_id: ZakuraConnId,
+    transcript_hash: [u8; TRANSCRIPT_HASH_BYTES],
     outbound_handle: ZakuraPeerHandle,
     disconnect_token: CancellationToken,
     registered_at: Instant,
@@ -905,6 +935,21 @@ struct ZakuraPeerConnectionEntry {
 }
 
 impl ZakuraSupervisorState {
+    fn registration_snapshot(&self) -> HashMap<ZakuraPeerId, ZakuraRegistrationSnapshot> {
+        self.active_by_peer
+            .iter()
+            .map(|(peer_id, entry)| {
+                (
+                    peer_id.clone(),
+                    ZakuraRegistrationSnapshot {
+                        conn_id: entry.conn_id,
+                        transcript_hash: entry.transcript_hash,
+                    },
+                )
+            })
+            .collect()
+    }
+
     fn increment_ip(&mut self, remote_ip: Option<IpAddr>) {
         if let Some(remote_ip) = remote_ip {
             *self.active_by_ip.entry(remote_ip).or_default() += 1;
@@ -1060,7 +1105,7 @@ impl ZakuraSupervisorHandle {
     /// Subscribe to connection-generation changes for legacy upgrade handoffs.
     pub(crate) fn subscribe_registrations(
         &self,
-    ) -> watch::Receiver<HashMap<ZakuraPeerId, ZakuraConnId>> {
+    ) -> watch::Receiver<HashMap<ZakuraPeerId, ZakuraRegistrationSnapshot>> {
         self.registration_set_tx.subscribe()
     }
 
@@ -1134,6 +1179,7 @@ impl ZakuraSupervisorHandle {
                 state.next_registration_id += 1;
                 let entry = ZakuraPeerConnectionEntry {
                     conn_id,
+                    transcript_hash,
                     outbound_handle,
                     disconnect_token,
                     registered_at: Instant::now(),
@@ -1147,11 +1193,7 @@ impl ZakuraSupervisorHandle {
                 state.increment_ip(remote_ip);
                 state.debug_assert_accounting();
                 let registered_ids: Vec<_> = state.active_by_peer.keys().cloned().collect();
-                let registrations = state
-                    .active_by_peer
-                    .iter()
-                    .map(|(peer_id, entry)| (peer_id.clone(), entry.conn_id))
-                    .collect();
+                let registrations = state.registration_snapshot();
                 set_active_connection_gauge(registered_ids.len());
                 self.peer_set_tx.send_replace(registered_ids);
                 self.registration_set_tx.send_replace(registrations);
@@ -1222,11 +1264,7 @@ impl ZakuraSupervisorHandle {
         state.supervisor.deregister_authenticated(peer_id);
         state.debug_assert_accounting();
         let registered_ids: Vec<_> = state.active_by_peer.keys().cloned().collect();
-        let registrations = state
-            .active_by_peer
-            .iter()
-            .map(|(peer_id, entry)| (peer_id.clone(), entry.conn_id))
-            .collect();
+        let registrations = state.registration_snapshot();
         set_active_connection_gauge(registered_ids.len());
         self.peer_set_tx.send_replace(registered_ids);
         self.registration_set_tx.send_replace(registrations);
@@ -1692,6 +1730,7 @@ fn admit_inbound_message(
 pub(crate) struct NativeHandshakeNegotiated {
     pub(crate) limits: ZakuraAcceptedLimits,
     pub(crate) accepted_capabilities: u64,
+    pub(crate) transcript_hash: Option<[u8; TRANSCRIPT_HASH_BYTES]>,
 }
 
 pub(crate) fn service_registry(
@@ -1751,6 +1790,7 @@ pub struct ZakuraProtocolHandler {
     next_stream_id: Arc<AtomicU64>,
     admission: Arc<Semaphore>,
     pending_handshakes: Arc<Semaphore>,
+    pending_inbound_upgrades: Arc<Mutex<PendingUpgradeRegistry>>,
     shutdown: CancellationToken,
     // Bound iroh endpoint, used to recover the inbound peer's UDP source IP so
     // the per-IP admission cap applies to Router-accepted connections. Iroh's
@@ -1888,6 +1928,10 @@ impl ZakuraProtocolHandler {
             next_stream_id: Arc::new(AtomicU64::new(random_stream_session_seed())),
             admission: Arc::new(Semaphore::new(limits.max_connections)),
             pending_handshakes: Arc::new(Semaphore::new(limits.max_pending_handshakes)),
+            pending_inbound_upgrades: Arc::new(Mutex::new(PendingUpgradeRegistry::new(
+                limits.max_pending_handshakes,
+                super::ZAKURA_LIVENESS_APPEAR_TIMEOUT,
+            ))),
             shutdown: CancellationToken::new(),
             limits,
             endpoint: None,
@@ -1929,6 +1973,30 @@ impl ZakuraProtocolHandler {
     pub fn with_endpoint(mut self, endpoint: Endpoint) -> Self {
         self.endpoint = Some(endpoint);
         self
+    }
+
+    async fn insert_pending_inbound_upgrade(
+        &self,
+        pending: PendingUpgrade,
+    ) -> Result<(), ZakuraRejectReason> {
+        self.pending_inbound_upgrades
+            .lock()
+            .await
+            .insert(std::time::Instant::now(), pending)
+    }
+
+    async fn cancel_pending_inbound_upgrade(&self, peer_id: &ZakuraPeerId) {
+        self.pending_inbound_upgrades
+            .lock()
+            .await
+            .take(std::time::Instant::now(), peer_id);
+    }
+
+    async fn take_pending_inbound_upgrade(&self, peer_id: &ZakuraPeerId) -> Option<PendingUpgrade> {
+        self.pending_inbound_upgrades
+            .lock()
+            .await
+            .take(std::time::Instant::now(), peer_id)
     }
 
     async fn accept_connection(&self, connection: Connection) -> Result<(), AcceptError> {
@@ -1992,11 +2060,9 @@ impl ZakuraProtocolHandler {
                 accepted_capabilities: negotiated.accepted_capabilities,
                 role: "responder",
                 direction,
-                transcript_hash: native_connection_transcript_hash(
-                    direction,
-                    &local_node_id,
-                    &remote_node_id,
-                ),
+                transcript_hash: negotiated.transcript_hash.unwrap_or_else(|| {
+                    native_connection_transcript_hash(direction, &local_node_id, &remote_node_id)
+                }),
                 i_open_collision_winner: i_open_collision_winner(&local_node_id, &remote_node_id),
                 conn,
             },
@@ -2054,15 +2120,33 @@ impl ZakuraProtocolHandler {
         )
         .await?;
         let hello = ZakuraControlHello::decode(&hello_bytes)?;
+        let pending = self.take_pending_inbound_upgrade(remote_peer_id).await;
+        let pending = match (hello.handshake_path, pending) {
+            (ZakuraHandshakePath::Upgraded, Some(pending)) => Some(pending),
+            (ZakuraHandshakePath::Native, None) => None,
+            (ZakuraHandshakePath::Upgraded, None) | (ZakuraHandshakePath::Native, Some(_)) => {
+                return Err(ZakuraValidationError::TranscriptMismatch.into())
+            }
+        };
         let expected = ZakuraControlValidation {
             local: &handshake_config,
             authenticated_remote_id: remote_peer_id.as_bytes(),
-            selected_zakura_protocol: ZAKURA_PROTOCOL_VERSION_1,
-            handshake_path: ZakuraHandshakePath::Native,
+            selected_zakura_protocol: pending
+                .as_ref()
+                .map_or(ZAKURA_PROTOCOL_VERSION_1, |pending| {
+                    pending.selected_zakura_protocol
+                }),
+            handshake_path: hello.handshake_path,
             remote_role: ZakuraControlRole::Initiator,
-            initiator_upgrade_nonce: [0; 32],
-            responder_upgrade_nonce: [0; 32],
-            legacy_upgrade_transcript: [0; 32],
+            initiator_upgrade_nonce: pending
+                .as_ref()
+                .map_or([0; 32], |pending| pending.initiator_upgrade_nonce),
+            responder_upgrade_nonce: pending
+                .as_ref()
+                .map_or([0; 32], |pending| pending.responder_upgrade_nonce),
+            legacy_upgrade_transcript: pending
+                .as_ref()
+                .map_or([0; 32], |pending| pending.legacy_upgrade_transcript),
         };
         hello.validate(&expected)?;
 
@@ -2090,6 +2174,7 @@ impl ZakuraProtocolHandler {
         Ok(NativeHandshakeNegotiated {
             limits: accepted_limits,
             accepted_capabilities: ack.accepted_capabilities,
+            transcript_hash: pending.map(|pending| pending.legacy_upgrade_transcript),
         })
     }
 
@@ -3530,6 +3615,24 @@ pub(crate) async fn serve_native_dial_connection(
     node_addr: NodeAddr,
     limits: &ZakuraLocalLimits,
 ) -> Result<(), ZakuraHandlerError> {
+    serve_dial_connection(endpoint, node_addr, limits, None).await
+}
+
+pub(crate) async fn serve_upgrade_dial_connection(
+    endpoint: &ZakuraEndpoint,
+    node_addr: NodeAddr,
+    limits: &ZakuraLocalLimits,
+    pending: PendingUpgrade,
+) -> Result<(), ZakuraHandlerError> {
+    serve_dial_connection(endpoint, node_addr, limits, Some(pending)).await
+}
+
+async fn serve_dial_connection(
+    endpoint: &ZakuraEndpoint,
+    node_addr: NodeAddr,
+    limits: &ZakuraLocalLimits,
+    pending: Option<PendingUpgrade>,
+) -> Result<(), ZakuraHandlerError> {
     let conn_id = endpoint
         .handler
         .next_conn_id
@@ -3564,6 +3667,7 @@ pub(crate) async fn serve_native_dial_connection(
             limits,
             &handshake_config,
             &local_peer_id,
+            pending.as_ref(),
             &endpoint.handler.trace,
             &conn,
         )
@@ -3588,11 +3692,9 @@ pub(crate) async fn serve_native_dial_connection(
                 accepted_capabilities: negotiated.accepted_capabilities,
                 role: "initiator",
                 direction,
-                transcript_hash: native_connection_transcript_hash(
-                    direction,
-                    &local_node_id,
-                    &remote_node_id,
-                ),
+                transcript_hash: negotiated.transcript_hash.unwrap_or_else(|| {
+                    native_connection_transcript_hash(direction, &local_node_id, &remote_node_id)
+                }),
                 i_open_collision_winner: i_open_collision_winner(&local_node_id, &remote_node_id),
                 conn,
             },
@@ -3612,6 +3714,7 @@ pub(crate) async fn run_native_initiator_handshake_without_trace(
         limits,
         handshake_config,
         local_peer_id,
+        None,
         &ZakuraTrace::noop(),
         &ZakuraConnTrace::placeholder(),
     )
@@ -3623,6 +3726,7 @@ async fn run_native_initiator_handshake(
     limits: &ZakuraLocalLimits,
     handshake_config: &ZakuraHandshakeConfig,
     local_peer_id: &ZakuraPeerId,
+    pending: Option<&PendingUpgrade>,
     _trace: &ZakuraTrace,
     conn: &ZakuraConnTrace,
 ) -> Result<NativeHandshakeNegotiated, ZakuraHandlerError> {
@@ -3641,16 +3745,23 @@ async fn run_native_initiator_handshake(
     let hello = ZakuraControlHello {
         magic: CONTROL_HELLO_MAGIC,
         control_version: CONTROL_VERSION,
-        selected_zakura_protocol: ZAKURA_PROTOCOL_VERSION_1,
-        handshake_path: ZakuraHandshakePath::Native,
+        selected_zakura_protocol: pending.map_or(ZAKURA_PROTOCOL_VERSION_1, |pending| {
+            pending.selected_zakura_protocol
+        }),
+        handshake_path: if pending.is_some() {
+            ZakuraHandshakePath::Upgraded
+        } else {
+            ZakuraHandshakePath::Native
+        },
         role: ZakuraControlRole::Initiator,
         network_id: handshake_config.network_id,
         chain_id: handshake_config.chain_id,
         iroh_node_id: local_peer_id.as_bytes().to_vec(),
         peer_nonce: local_nonce,
-        initiator_upgrade_nonce: [0; 32],
-        responder_upgrade_nonce: [0; 32],
-        legacy_upgrade_transcript: [0; 32],
+        initiator_upgrade_nonce: pending.map_or([0; 32], |pending| pending.initiator_upgrade_nonce),
+        responder_upgrade_nonce: pending.map_or([0; 32], |pending| pending.responder_upgrade_nonce),
+        legacy_upgrade_transcript: pending
+            .map_or([0; 32], |pending| pending.legacy_upgrade_transcript),
         capabilities: handshake_config.supported_capabilities,
         required_channels: 0,
         initial_limits: limits.initial_limits(),
@@ -3665,7 +3776,7 @@ async fn run_native_initiator_handshake(
     .await?;
     let ack = ZakuraControlAck::decode(&ack_bytes)?;
     ack.validate(
-        ZAKURA_PROTOCOL_VERSION_1,
+        hello.selected_zakura_protocol,
         local_nonce,
         ack.peer_nonce,
         &limits.initial_limits(),
@@ -3680,6 +3791,7 @@ async fn run_native_initiator_handshake(
     Ok(NativeHandshakeNegotiated {
         limits: ack.accepted_limits,
         accepted_capabilities: ack.accepted_capabilities,
+        transcript_hash: pending.map(|pending| pending.legacy_upgrade_transcript),
     })
 }
 
@@ -6402,8 +6514,9 @@ mod tests {
 
         let connector =
             crate::zakura::ZakuraHandshakeConnector::new_with_endpoint(endpoint.clone());
+        let pending = PendingUpgrade::new(peer_id.clone(), 1, [1; 32], [2; 32], [3; 32]);
         let registration = connector
-            .spawn_zakura_dial_to_hints_and_wait(&peer_id, &node_id, &direct_addresses)
+            .spawn_zakura_dial_to_hints_and_wait(&peer_id, &node_id, &direct_addresses, pending)
             .await;
 
         assert!(

--- a/docs/changelog/unreleased/683.md
+++ b/docs/changelog/unreleased/683.md
@@ -1,0 +1,6 @@
+## Security
+
+- Required legacy-to-Zakura upgrades to observe a fresh native connection
+  registration before recording the handoff, preventing an already-connected
+  peer identity from satisfying another peer's upgrade
+  ([#683](https://github.com/zakura-core/zakura/pull/683)).

--- a/docs/changelog/unreleased/683.md
+++ b/docs/changelog/unreleased/683.md
@@ -1,6 +1,6 @@
 ## Security
 
-- Required legacy-to-Zakura upgrades to observe a fresh native connection
-  registration before recording the handoff, preventing an already-connected
-  peer identity from satisfying another peer's upgrade
+- Bound legacy-to-Zakura handoffs to a fresh native connection carrying the
+  exact negotiated upgrade nonces and legacy transcript, preventing an existing
+  or unrelated connection from satisfying another peer's upgrade
   ([#683](https://github.com/zakura-core/zakura/pull/683)).


### PR DESCRIPTION
## Motivation

PR #682 retains legacy peer metadata across a Zakura upgrade. Its handoff wait
could treat an unrelated native connection with the claimed peer ID as success,
including one established independently while the legacy prelude was in flight.
That could make the handshake appear upgraded without proving that the native
replacement belonged to this legacy exchange.

## Solution

Wire the existing legacy transcript-binding design into the live handoff while
preserving the existing public peer-ID subscription:

- both roles compute the canonical transcript over the exchanged `version`,
  `Init`, and `Accept` messages;
- the responder stores the expected peer ID, selected protocol, upgrade nonces,
  and transcript in the existing bounded, expiring pending-upgrade registry
  before sending `Accept`;
- the initiator sends those values in an `Upgraded` QUIC control hello, which the
  responder validates against the pending entry and authenticated Iroh identity;
- the legacy handoff waits for a fresh supervisor connection generation carrying
  that exact transcript hash, so incumbent, unrelated-peer, and same-peer native
  registrations cannot satisfy it;
- failed handoffs cancel their pending state and maintained upgrade dial.

This PR is stacked on #682.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura-network --all-targets`
- `cargo clippy -p zakura-network --lib -- -D warnings`
- `cargo clippy -p zakura-network --tests -- -D warnings -A clippy::duplicated-attributes`
- `cargo test -p zakura-network --lib registration_wait`
- `cargo test -p zakura-network --lib upgrade_`
- `./scripts/changelog.py check`
- `npm exec --yes markdownlint-cli -- docs/changelog/unreleased/683.md --config .github/.markdownlint.yaml`

The registration tests cover incumbents, unrelated peer IDs, wrong transcript
hashes, and the expected fresh transcript. The 15 upgrade-focused tests include
the live legacy TCP-to-QUIC handoff, malformed prelude handling, duplicate
metadata behavior, timeout fallback, and failed-dial cleanup.

The unsuppressed all-target Clippy command is currently blocked by a duplicate
`#[cfg(test)]` attribute in `zakura/discovery/service.rs` that is already present
on this PR's `main` ancestor. With that single baseline lint suppressed, the
complete network test target is Clippy-clean.

## Changelog

Added `docs/changelog/unreleased/683.md` under Security.

### Specifications & References

- Stacked on #682
- Uses the existing `PendingUpgradeRegistry`, `ZakuraHandshakePath::Upgraded`,
  and control-hello transcript fields
- Follow-up to the security review of retained `getpeerinfo` metadata

### Follow-up Work

None required for the reported handoff-association issue.
